### PR TITLE
MUL-5960: NEX-47: daemon-core safe shutdown (drain): three-state + claim-pause ref-count + persistence + decoupled shutdown + /drain endpoint

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -41,7 +42,25 @@ var daemonStartCmd = &cobra.Command{
 var daemonStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the running daemon",
-	RunE:  runDaemonStop,
+	Long: "Stop the daemon immediately. In-flight tasks are interrupted (up to the 30s\n" +
+		"shutdown window) and no new tasks are claimed.\n\n" +
+		"If you want running tasks to finish first, enter drain instead:\n" +
+		"  multica daemon drain --finish-then-stop",
+	RunE: runDaemonStop,
+}
+
+var daemonDrainCmd = &cobra.Command{
+	Use:   "drain",
+	Short: "Enter safe shutdown (drain): stop claiming tasks, let running ones finish",
+	Long: "Enter safe shutdown (drain). The daemon stops claiming new tasks while\n" +
+		"in-flight tasks run to completion.\n\n" +
+		"  multica daemon drain                 enter draining (safe shutdown)\n" +
+		"  multica daemon drain --abort         return to normal operation\n" +
+		"  multica daemon drain --finish-then-stop   shut down once running tasks finish\n\n" +
+		"Use --force to skip the confirmation shown when queued tasks would be\n" +
+		"stranded (pass it on non-interactive machines), and --wait to block until\n" +
+		"the state change completes.",
+	RunE: runDaemonDrain,
 }
 
 var daemonStatusCmd = &cobra.Command{
@@ -111,6 +130,11 @@ func init() {
 
 	daemonStatusCmd.Flags().String("output", "table", "Output format: table or json")
 
+	daemonDrainCmd.Flags().Bool("abort", false, "Return to normal operation (cancel draining)")
+	daemonDrainCmd.Flags().Bool("finish-then-stop", false, "Shut the daemon down once running tasks finish")
+	daemonDrainCmd.Flags().Bool("force", false, "Skip the confirmation when queued tasks would be stranded")
+	daemonDrainCmd.Flags().Bool("wait", false, "Block until the requested state change completes")
+
 	// restart shares all the same flags as start
 	rf := daemonRestartCmd.Flags()
 	rf.Bool("foreground", false, "Run in the foreground instead of background")
@@ -137,6 +161,7 @@ func init() {
 
 	daemonCmd.AddCommand(daemonStartCmd)
 	daemonCmd.AddCommand(daemonStopCmd)
+	daemonCmd.AddCommand(daemonDrainCmd)
 	daemonCmd.AddCommand(daemonRestartCmd)
 	daemonCmd.AddCommand(daemonStatusCmd)
 	daemonCmd.AddCommand(daemonProbeRuntimesCmd)
@@ -1084,6 +1109,145 @@ func requestDaemonShutdown(healthPort int) error {
 	return nil
 }
 
+// --- daemon drain ---
+
+func runDaemonDrain(cmd *cobra.Command, _ []string) error {
+	profile := resolveProfile(cmd)
+	healthPort := healthPortForProfile(profile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	health := checkDaemonHealthOnPort(ctx, healthPort)
+	if !daemonAlive(health) {
+		label := "Daemon"
+		if profile != "" {
+			label = fmt.Sprintf("Daemon [%s]", profile)
+		}
+		fmt.Fprintf(os.Stderr, "%s is not running.\n", label)
+		return nil
+	}
+
+	abort, _ := cmd.Flags().GetBool("abort")
+	finishThenStop, _ := cmd.Flags().GetBool("finish-then-stop")
+	force, _ := cmd.Flags().GetBool("force")
+	wait, _ := cmd.Flags().GetBool("wait")
+
+	action := "drain"
+	switch {
+	case abort:
+		action = "abort"
+	case finishThenStop:
+		action = "finish_then_stop"
+	}
+
+	// Entering drain — or arming finish-then-stop, which will shut the daemon
+	// down — strands queued tasks until they time out (they are not
+	// re-assigned). When the daemon reports queued tasks, confirm unless the
+	// caller passed --force (required on non-interactive machines). abort only
+	// returns to running and needs no confirmation.
+	if action != "abort" && !force {
+		if queued, ok := health["draining_queued_tasks"].(float64); ok && queued > 0 {
+			proceed, err := confirmDrainStranding(int64(queued))
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				fmt.Fprintln(os.Stderr, "Drain cancelled.")
+				return nil
+			}
+		}
+	}
+
+	if err := requestDaemonDrain(healthPort, action); err != nil {
+		return fmt.Errorf("request daemon drain: %w", err)
+	}
+
+	if wait {
+		return waitForDaemonDrain(healthPort, action)
+	}
+	return nil
+}
+
+// requestDaemonDrain POSTs an action to the daemon's local /drain endpoint.
+// Actions: drain (enter safe shutdown), abort (return to running),
+// finish_then_stop (shut down once in-flight tasks complete). Like /shutdown,
+// the endpoint is bound to 127.0.0.1 only.
+func requestDaemonDrain(healthPort int, action string) error {
+	payload := fmt.Sprintf(`{"action":%q}`, action)
+	url := fmt.Sprintf("http://127.0.0.1:%d/drain", healthPort)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+// confirmDrainStranding prompts for a yes/no confirmation that draining may
+// proceed given queued tasks that will remain queued until they time out
+// (runtime_drained). Reads from stdin so non-interactive callers can pipe a
+// response or pass --force to skip.
+func confirmDrainStranding(queued int64) (bool, error) {
+	fmt.Fprintf(os.Stderr, "The daemon still has %d queued task(s) that will stay queued until they time out after shutdown.\n", queued)
+	fmt.Fprint(os.Stderr, "Continue with drain? [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes", nil
+}
+
+// waitForDaemonDrain blocks until the daemon health endpoint reflects the
+// requested drain action: "draining" for drain, "running" for abort, or the
+// daemon disappearing after finish_then_stop. Bounded so a hung daemon cannot
+// wedge the CLI forever.
+func waitForDaemonDrain(healthPort int, action string) error {
+	const (
+		pollInterval = 500 * time.Millisecond
+		waitTimeout  = 5 * time.Minute
+	)
+	deadline := time.Now().Add(waitTimeout)
+	for time.Now().Before(deadline) {
+		hctx, hcancel := context.WithTimeout(context.Background(), 2*time.Second)
+		health := checkDaemonHealthOnPort(hctx, healthPort)
+		hcancel()
+
+		state, _ := health["state"].(string)
+		switch action {
+		case "abort":
+			if state == "running" {
+				fmt.Fprintln(os.Stderr, "Daemon resumed normal operation.")
+				return nil
+			}
+		case "finish_then_stop":
+			if !daemonAlive(health) {
+				fmt.Fprintln(os.Stderr, "Daemon stopped after drain.")
+				return nil
+			}
+		default:
+			if state == "draining" {
+				fmt.Fprintln(os.Stderr, "Daemon is draining (not claiming new tasks).")
+				return nil
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	fmt.Fprintln(os.Stderr, "Timed out waiting for the drain state change; run 'multica daemon status' to check.")
+	return nil
+}
+
 // --- daemon status ---
 
 func runDaemonStatus(cmd *cobra.Command, _ []string) error {
@@ -1106,6 +1270,14 @@ func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	label := "Daemon"
 	if profile != "" {
 		label = fmt.Sprintf("Daemon [%s]", profile)
+	}
+
+	// Draining is a daemon run-state orthogonal to readiness (status): a
+	// drained daemon still reports status "running" but refuses new claims.
+	// Report it as its own state line, parallel to running/stopped.
+	if state, _ := health["state"].(string); state == "draining" {
+		printDaemonDrainingStatus(os.Stdout, label, health)
+		return nil
 	}
 
 	switch health["status"] {
@@ -1145,6 +1317,15 @@ func daemonStatusHealthPort(cmd *cobra.Command) (int, error) {
 	return port, nil
 }
 
+// printDaemonDrainingStatus renders the draining state line. Parallel to the
+// running/stopped status lines: the daemon reports how many tasks are still
+// executing while draining (draining_inflight_tasks) and how many queued tasks
+// will be stranded until they time out (draining_queued_tasks).
+func printDaemonDrainingStatus(w io.Writer, label string, health map[string]any) {
+	inflight, _ := health["draining_inflight_tasks"].(float64)
+	queued, _ := health["draining_queued_tasks"].(float64)
+	fmt.Fprintf(w, "%s: 准备关闭中（在跑任务 %d，排队任务 %d）\n", label, int64(inflight), int64(queued))
+}
 // printDaemonStatusReport renders a key/value summary of the daemon health
 // response. The value column is aligned to the widest label so the dynamic
 // "Daemon [profile]" row stays in step with the static rows below it.

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -931,5 +932,173 @@ func clearDaemonTaskEnv(t *testing.T) {
 		daemon.TaskWorkspacesRootEnv,
 	} {
 		t.Setenv(key, "")
+	}
+}
+
+// fakeDrainableDaemon serves a fake daemon on the given profile's health port
+// that reports a running state plus NEX-38 drain fields on /health and records
+// the action of any POST /drain request. Returns a channel that receives the
+// requested drain action.
+func fakeDrainableDaemon(t *testing.T, profile string) <-chan string {
+	t.Helper()
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", healthPortForProfile(profile)))
+	if err != nil {
+		t.Skipf("health port for profile %s unavailable: %v", profile, err)
+	}
+	actionCh := make(chan string, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_, _ = w.Write([]byte(`{"status":"running","state":"running","pid":` +
+				fmt.Sprintf("%d", os.Getpid()) +
+				`,"draining_inflight_tasks":2,"draining_queued_tasks":3}`))
+		case "/drain":
+			var body struct {
+				Action string `json:"action"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+			actionCh <- body.Action
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+	return actionCh
+}
+
+func newDrainTestCmd(t *testing.T, profile string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "drain"}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().Bool("abort", false, "")
+	cmd.Flags().Bool("finish-then-stop", false, "")
+	cmd.Flags().Bool("force", false, "")
+	cmd.Flags().Bool("wait", false, "")
+	if err := cmd.Flags().Set("profile", profile); err != nil {
+		t.Fatalf("set profile flag: %v", err)
+	}
+	return cmd
+}
+
+// TestDaemonDrainPostsAction pins the /drain contract the CLI drives: the
+// default drain action, --abort, and --finish-then-stop each map to the action
+// string the daemon's drainHandler switches on (AC-7).
+func TestDaemonDrainPostsAction(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		setup  func(*cobra.Command)
+		action string
+	}{
+		// --force on every subtest: the fake daemon reports queued tasks, so a
+		// non-force drain would prompt on stdin and hang the test. The
+		// force-vs-prompt behavior is pinned separately in
+		// TestDaemonDrainForceSkipsConfirmation.
+		{"drain", func(cmd *cobra.Command) {
+			if err := cmd.Flags().Set("force", "true"); err != nil {
+				t.Fatal(err)
+			}
+		}, "drain"},
+		{"abort", func(cmd *cobra.Command) {
+			if err := cmd.Flags().Set("abort", "true"); err != nil {
+				t.Fatal(err)
+			}
+		}, "abort"},
+		{"finish_then_stop", func(cmd *cobra.Command) {
+			if err := cmd.Flags().Set("finish-then-stop", "true"); err != nil {
+				t.Fatal(err)
+			}
+			// finish_then_stop shuts the daemon down, which also strands queued
+			// tasks, so it prompts too; skip the prompt the same way.
+			if err := cmd.Flags().Set("force", "true"); err != nil {
+				t.Fatal(err)
+			}
+		}, "finish_then_stop"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const profile = "drain-action-test"
+			got := fakeDrainableDaemon(t, profile)
+			cmd := newDrainTestCmd(t, profile)
+			if tc.setup != nil {
+				tc.setup(cmd)
+			}
+			if err := runDaemonDrain(cmd, nil); err != nil {
+				t.Fatalf("runDaemonDrain: %v", err)
+			}
+			select {
+			case action := <-got:
+				if action != tc.action {
+					t.Fatalf("drain action = %q, want %q", action, tc.action)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("daemon did not receive a /drain request")
+			}
+		})
+	}
+}
+
+// TestDaemonDrainForceSkipsConfirmation: entering drain with queued tasks
+// prompts for confirmation unless --force is passed (needed on non-interactive
+// machines). The default drain here would read stdin, so this pins the --force
+// path and the not-running no-op.
+func TestDaemonDrainForceSkipsConfirmation(t *testing.T) {
+	const profile = "drain-force-test"
+	got := fakeDrainableDaemon(t, profile)
+	cmd := newDrainTestCmd(t, profile)
+	if err := cmd.Flags().Set("force", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runDaemonDrain(cmd, nil); err != nil {
+		t.Fatalf("runDaemonDrain: %v", err)
+	}
+	select {
+	case action := <-got:
+		if action != "drain" {
+			t.Fatalf("drain action = %q, want drain", action)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not receive a /drain request")
+	}
+}
+
+// TestPrintDaemonDrainingStatus pins the draining status line (AC-8): the
+// health response's NEX-38 drain fields are rendered as the 准备关闭中 line
+// parallel to running/stopped.
+func TestPrintDaemonDrainingStatus(t *testing.T) {
+	t.Parallel()
+
+	health := map[string]any{
+		"status":                   "running",
+		"state":                    "draining",
+		"pid":                      float64(1234),
+		"draining_inflight_tasks":  float64(2),
+		"draining_queued_tasks":    float64(3),
+	}
+
+	var out bytes.Buffer
+	printDaemonDrainingStatus(&out, "Daemon", health)
+
+	want := "Daemon: 准备关闭中（在跑任务 2，排队任务 3）\n"
+	if got := out.String(); got != want {
+		t.Fatalf("printDaemonDrainingStatus() = %q, want %q", got, want)
+	}
+}
+
+// TestDaemonDrainNotRunningNoOp: draining a stopped daemon is a no-op (prints
+// "is not running") rather than an error, matching `daemon stop`.
+func TestDaemonDrainNotRunningNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const profile = "drain-stopped-test"
+	cmd := newDrainTestCmd(t, profile)
+	if err := cmd.Flags().Set("force", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runDaemonDrain(cmd, nil); err != nil {
+		t.Fatalf("runDaemonDrain on stopped daemon = %v, want nil", err)
 	}
 }

--- a/server/internal/daemon/agents_refresh.go
+++ b/server/internal/daemon/agents_refresh.go
@@ -366,20 +366,26 @@ func (d *Daemon) refreshAgentVersions(ctx context.Context) {
 // runtime over one is exactly the mistake refreshAgentAvailability's
 // one-directional rule exists to avoid.
 func (d *Daemon) demoteBelowMinimumRuntimes(ctx context.Context, belowMinimum map[string]string) {
-	// Serialize with task claiming the way the restart paths do: the barrier
-	// only sets when no claim is in flight and no task is running, so a
-	// runtime is never deregistered under a task that is still executing —
-	// the server's sweep would fail-and-retry that task while the local
-	// process keeps going, and an upgrade-back would revive the runtime ID
-	// into a genuine duplicate execution. A busy daemon defers to the next
-	// refresh tick; the too-old CLI keeps its runtimes a little longer, which
-	// is the pre-demotion status quo, not a new exposure.
-	if !d.trySetClaimBarrier() {
+	// Serialize with task claiming the way the restart paths do: the demotion
+	// ref only acquires when no claim is in flight, no task is running, and no
+	// other holder (drain, auto-update) is paused, so a runtime is never
+	// deregistered under a task that is still executing — the server's sweep
+	// would fail-and-retry that task while the local process keeps going, and
+	// an upgrade-back would revive the runtime ID into a genuine duplicate
+	// execution. During drain the claimPaused() branch defers the demotion; it
+	// is re-evaluated on the next refresh tick (decision two). A busy daemon
+	// defers to the next tick; the too-old CLI keeps its runtimes a little
+	// longer, which is the pre-demotion status quo, not a new exposure.
+	d.claimMu.Lock()
+	if d.claimPausedLocked() || d.claimsInFlight > 0 || d.activeTasks.Load() > 0 {
+		d.claimMu.Unlock()
 		d.logger.Info("defer below-minimum demotion: task or claim in flight",
 			"providers", belowMinimum)
 		return
 	}
-	defer d.releaseClaimBarrier()
+	d.acquireClaimPauseLocked(claimPauseDemotion)
+	d.claimMu.Unlock()
+	defer d.releaseClaimPause(claimPauseDemotion)
 
 	d.mu.Lock()
 	var demoted []string

--- a/server/internal/daemon/auto_update.go
+++ b/server/internal/daemon/auto_update.go
@@ -247,9 +247,9 @@ func (d *Daemon) tryAutoUpdate(ctx context.Context) {
 	// release fetch took anywhere from tens of milliseconds (typical) to
 	// seconds (slow link, GitHub hiccup), plenty of time for a poller to
 	// claim a fresh task. trySetClaimBarrier checks claimsInFlight +
-	// activeTasks under claimMu and only flips pauseClaims to true if both
-	// are zero, so once it returns true we can run the upgrade knowing that
-	// no in-flight task will be cancelled by triggerRestart.
+	// activeTasks under claimMu and only takes a server-update claim-pause ref
+	// if both are zero, so once it returns true we can run the upgrade knowing
+	// that no in-flight task will be cancelled by triggerRestart.
 	if !d.trySetClaimBarrier() {
 		d.logger.Info("auto-update: deferring — task or claim in flight at barrier check")
 		return

--- a/server/internal/daemon/auto_update_test.go
+++ b/server/internal/daemon/auto_update_test.go
@@ -86,14 +86,14 @@ func TestTryAutoUpdate_DefersWhenClaimInFlightAtBarrier(t *testing.T) {
 	if d.updating.Load() {
 		t.Fatalf("updating flag must be released after a deferred upgrade so the next tick can retry")
 	}
-	if d.pauseClaims {
-		t.Fatalf("pauseClaims must be cleared after a deferred upgrade")
+	if d.claimPaused() {
+		t.Fatalf("claims must not stay paused after a deferred upgrade")
 	}
 }
 
 // TestTryAutoUpdate_HoldsBarrierAcrossRestart asserts the success path leaves
-// pauseClaims set: process exit is imminent and clearing the barrier would
-// open a window for a poller to claim a task that the imminent restart is
+// the claim-pause ref held: process exit is imminent and clearing the barrier
+// would open a window for a poller to claim a task that the imminent restart is
 // about to cancel.
 func TestTryAutoUpdate_HoldsBarrierAcrossRestart(t *testing.T) {
 	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
@@ -105,14 +105,14 @@ func TestTryAutoUpdate_HoldsBarrierAcrossRestart(t *testing.T) {
 	if restartCalls.Load() != 1 {
 		t.Fatalf("triggerRestart fired %d times, want 1", restartCalls.Load())
 	}
-	if !d.pauseClaims {
-		t.Fatalf("pauseClaims must remain set across the restart kick; got cleared")
+	if !d.claimPaused() {
+		t.Fatalf("claims must remain paused across the restart kick; got cleared")
 	}
 }
 
 // TestTryAutoUpdate_ReleasesBarrierOnUpgradeFailure asserts the failure path
-// clears pauseClaims so the daemon can keep claiming tasks normally and
-// retry the upgrade on the next tick.
+// releases the claim-pause ref so the daemon can keep claiming tasks normally
+// and retry the upgrade on the next tick.
 func TestTryAutoUpdate_ReleasesBarrierOnUpgradeFailure(t *testing.T) {
 	d, restartCalls := newAutoUpdateTestDaemon(t, "v0.1.13")
 	withStubRelease(t, &cli.GitHubRelease{TagName: "v0.1.14"}, nil)
@@ -125,14 +125,14 @@ func TestTryAutoUpdate_ReleasesBarrierOnUpgradeFailure(t *testing.T) {
 	if restartCalls.Load() != 0 {
 		t.Fatalf("triggerRestart fired despite upgrade failure")
 	}
-	if d.pauseClaims {
-		t.Fatalf("pauseClaims must be cleared after a failed upgrade so pollers resume claiming")
+	if d.claimPaused() {
+		t.Fatalf("claims must not stay paused after a failed upgrade so pollers resume claiming")
 	}
 }
 
 // TestTryEnterClaim_RespectsBarrier asserts the poller-side helper returns
-// false while pauseClaims is held and that pairs of enter/exit balance the
-// counter so a later barrier set sees idle.
+// false while a claim-pause ref is held and that pairs of enter/exit balance
+// the counter so a later barrier set sees idle.
 func TestTryEnterClaim_RespectsBarrier(t *testing.T) {
 	d := &Daemon{}
 

--- a/server/internal/daemon/claim_pause_refcount_test.go
+++ b/server/internal/daemon/claim_pause_refcount_test.go
@@ -1,0 +1,140 @@
+package daemon
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+func TestClaimPauseRefcount_IndependentHolders(t *testing.T) {
+	d := &Daemon{logger: slog.Default()}
+
+	// drain + server-update + below-minimum each take a ref; releasing one
+	// must never clear the others (NEX-38 decision two / AC-17).
+	d.acquireClaimPause(claimPauseDrain)
+	d.acquireClaimPause(claimPauseServerUpdate)
+	d.acquireClaimPause(claimPauseDemotion)
+	if !d.claimPaused() {
+		t.Fatal("claims must be paused while any holder has a ref")
+	}
+	if d.claimPauseTotal != 3 {
+		t.Fatalf("claimPauseTotal = %d, want 3", d.claimPauseTotal)
+	}
+
+	// server-update finishes first — drain and demotion must survive.
+	d.releaseClaimPause(claimPauseServerUpdate)
+	if !d.claimPaused() {
+		t.Fatal("releasing server-update cleared the drain/demotion pause")
+	}
+	if d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must still refuse while drain holds a ref")
+	}
+	d.exitClaim()
+
+	// drain aborts — demotion must survive.
+	d.releaseClaimPause(claimPauseDrain)
+	if !d.claimPaused() {
+		t.Fatal("releasing drain cleared the demotion pause")
+	}
+
+	// Last holder releases — claiming resumes.
+	d.releaseClaimPause(claimPauseDemotion)
+	if d.claimPaused() {
+		t.Fatal("claims must resume when the last ref is released")
+	}
+	if d.claimPauseTotal != 0 {
+		t.Fatalf("claimPauseTotal = %d, want 0", d.claimPauseTotal)
+	}
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must succeed after all refs are released")
+	}
+	d.exitClaim()
+}
+
+func TestClaimPauseRefcount_DoubleAcquireIsBalanced(t *testing.T) {
+	d := &Daemon{logger: slog.Default()}
+
+	// Two acquires by the same holder are ref-counted, so a single release
+	// keeps the pause held until the second release.
+	d.acquireClaimPause(claimPauseServerUpdate)
+	d.acquireClaimPause(claimPauseServerUpdate)
+	d.releaseClaimPause(claimPauseServerUpdate)
+	if !d.claimPaused() {
+		t.Fatal("claims must stay paused after one of two server-update refs is released")
+	}
+	d.releaseClaimPause(claimPauseServerUpdate)
+	if d.claimPaused() {
+		t.Fatal("claims must resume after the last server-update ref is released")
+	}
+}
+
+func TestReleaseClaimPause_UnbalancedReleasePanics(t *testing.T) {
+	d := &Daemon{logger: slog.Default()}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("releasing a ref that was never acquired must panic")
+		}
+	}()
+	d.releaseClaimPause(claimPauseDrain)
+}
+
+// TestClaimPauseRefcount_ConcurrentInterleaving stresses AC-17: concurrent
+// acquire/release across all three holders must never leave the daemon paused
+// when no ref is held, nor unpaused while any ref is held.
+func TestClaimPauseRefcount_ConcurrentInterleaving(t *testing.T) {
+	d := &Daemon{logger: slog.Default()}
+
+	holders := []claimPauseHolder{claimPauseDrain, claimPauseServerUpdate, claimPauseDemotion}
+	var wg sync.WaitGroup
+	for _, h := range holders {
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(h claimPauseHolder) {
+				defer wg.Done()
+				d.acquireClaimPause(h)
+				if !d.claimPaused() {
+					t.Error("claims must be paused while a ref is held")
+				}
+				d.releaseClaimPause(h)
+			}(h)
+		}
+	}
+	wg.Wait()
+
+	if d.claimPaused() {
+		t.Fatal("claims must not stay paused after every ref is released")
+	}
+	if d.claimPauseTotal != 0 {
+		t.Fatalf("claimPauseTotal = %d, want 0", d.claimPauseTotal)
+	}
+	for _, h := range holders {
+		if d.claimPauseRefs[h] != 0 {
+			t.Fatalf("holder %q refcount = %d, want 0", h, d.claimPauseRefs[h])
+		}
+	}
+}
+
+func TestDrainRefInteractsWithClaimBarrier(t *testing.T) {
+	d := &Daemon{logger: slog.Default()}
+
+	// A drain holding a ref defers auto-update / demotion barrier acquisition
+	// (decision two: drain > server-update > below-minimum).
+	d.acquireClaimPause(claimPauseDrain)
+	if d.trySetClaimBarrier() {
+		t.Fatal("trySetClaimBarrier must defer while drain is in effect")
+	}
+	d.releaseClaimPause(claimPauseDrain)
+
+	// Once the drain ends the barrier can be acquired normally.
+	if !d.trySetClaimBarrier() {
+		t.Fatal("trySetClaimBarrier must succeed after the drain ends")
+	}
+	if d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must refuse while the server-update barrier is held")
+	}
+	d.releaseClaimBarrier()
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must succeed after the barrier is released")
+	}
+	d.exitClaim()
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4179,15 +4179,18 @@ func (d *Daemon) reportUpdateResultWithRetry(ctx context.Context, runtimeID, upd
 }
 
 // tryEnterClaim records the intent to call ClaimTask. Returns true if the
-// caller may proceed, false if any claim-pause holder (auto-update barrier,
-// drain, below-minimum demotion) is in effect. Every successful call MUST be
-// paired with an exitClaim() on every exit path — either right after a
-// failed/empty claim, or via the handleTask goroutine's defer once the task is
-// handed off.
+// caller may proceed, false if a claim-pause holder that blocks claim entry
+// (auto-update barrier, below-minimum demotion) is in effect. Draining does
+// NOT block claim entry (NEX-38 corrected contract): a draining runtime keeps
+// claiming and completing its pre-boundary queued work; new work is rejected
+// server-side by AgentReadiness, so nothing post-boundary enters the queue.
+// Every successful call MUST be paired with an exitClaim() on every exit path
+// — either right after a failed/empty claim, or via the handleTask goroutine's
+// defer once the task is handed off.
 func (d *Daemon) tryEnterClaim() bool {
 	d.claimMu.Lock()
 	defer d.claimMu.Unlock()
-	if d.claimPausedLocked() {
+	if d.claimPausedForClaimsLocked() {
 		return false
 	}
 	d.claimsInFlight++

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -485,26 +485,44 @@ type Daemon struct {
 	runningTasks      atomic.Int64
 	resourceWaitTasks atomic.Int64
 	ready             atomic.Bool // false until preflight completes; gates /health status (starting -> running)
+	// daemonState is the NEX-38 run state: running / draining / shutting_down.
+	// It is orthogonal to `ready`: a drained daemon is still fully started
+	// (ready=true) but refuses new claims. Draining is also persisted to
+	// <workspaces-root>/drain.json so a restart resumes draining (AC-13).
+	daemonState atomic.Int32
+	// finishThenStop arms the graceful drain auto-close: once draining and
+	// activeTasks==0 the drain monitor deregisters runtimes and stops the
+	// daemon (AC-4). Cleared by abortDrain.
+	finishThenStop atomic.Bool
 	// reloadPendingReason explains why a confirmed multica version change hasn't
 	// restarted the daemon yet (a task was running at the barrier check). Set
 	// and cleared by trySelfReload, read by /health. Diagnostic only.
 	reloadPendingReason atomic.Pointer[string]
+	// queuedTasksByRuntime caches the server-side queued task count per runtime,
+	// sourced from heartbeat acks while draining (design §7). Best-effort and
+	// diagnostic: it feeds /health's draining_queued_tasks. Guarded by
+	// queuedTasksMu.
+	queuedTasksMu        sync.Mutex
+	queuedTasksByRuntime map[string]int64
 
-	// claimMu guards pauseClaims and claimsInFlight. It is held only for the
-	// microseconds it takes to make a decision; ClaimTask itself runs without
-	// the lock so a slow per-runtime claim cannot stall auto-update or any
-	// other poller.
+	// claimMu guards the claim-pause ref-count and claimsInFlight. It is held
+	// only for the microseconds it takes to make a decision; ClaimTask itself
+	// runs without the lock so a slow per-runtime claim cannot stall
+	// auto-update, drain, or any other poller.
 	//
-	// The pair is the auto-update path's barrier against the issue's
-	// requirement that "升级过程中如果有 task 进来，会延后升级而不是中断 task":
-	// runRuntimePoller refuses to call ClaimTask while pauseClaims is set, and
-	// tryAutoUpdate refuses to flip pauseClaims while any poller is mid-claim
+	// The ref-count replaces the single bool that used to back the auto-update
+	// barrier, so each holder (drain / server-update / below-minimum) owns its
+	// own refs and releasing one can never clear another's pause (NEX-38
+	// decision two). The barrier contract is unchanged: runRuntimePoller
+	// refuses to call ClaimTask while any ref is held, and tryAutoUpdate /
+	// tryBeginServerUpdate refuse to take a ref while any poller is mid-claim
 	// or any task is in handleTask. Together that closes the fetch-then-claim
 	// race where a new task slipping in during the release-metadata fetch
 	// would be cancelled by triggerRestart's root-ctx cancel.
-	claimMu        sync.Mutex
-	pauseClaims    bool // when true, the batch poller skips claiming
-	claimsInFlight int  // pollers that have decided to claim but haven't yet handed the task off to handleTask
+	claimMu         sync.Mutex
+	claimPauseRefs  map[claimPauseHolder]int // per-holder refcount; empty map == no pause
+	claimPauseTotal int                      // redundant total, O(1) emptiness check
+	claimsInFlight  int                      // pollers that have decided to claim but haven't yet handed the task off to handleTask
 
 	activeEnvRootsMu   sync.Mutex
 	activeEnvRootsCond *sync.Cond      // signalled when an in-flight env-root GC mutation finishes
@@ -1706,6 +1724,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Re-enter draining from a previous run's marker BEFORE the first
+	// registration, so the register payload already reports draining instead
+	// of defaulting runtimes back to online (AC-13). restoreDrainState is a
+	// no-op when no marker exists.
+	d.restoreDrainState()
+
 	// Bind and serve the health port before the (potentially slow) preflight,
 	// so `daemon start` and the desktop see a live "starting" daemon instead
 	// of connection-refused while preflightAuth runs. preflightAuth's initial
@@ -1743,6 +1767,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	go d.gcLoop(ctx)
 	go d.autoUpdateLoop(ctx)
 	go d.tokenRenewalLoop(ctx)
+	// Watches for a finish-then-stop drain completing (activeTasks==0) so the
+	// daemon can deregister and exit without the 30s stop cap (AC-4).
+	go d.drainMonitorLoop(ctx)
 
 	// Preflight succeeded and the background loops are up: the daemon has
 	// registered its runtimes and can now claim and run tasks. Flip /health
@@ -1750,7 +1777,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// readiness wait blocks on, so success is reported only after startup
 	// actually completed, not merely because the health port came up.
 	d.ready.Store(true)
-	d.logger.Debug("background loops launched (workspace-sync, task-wakeup, heartbeat, gc, auto-update, token-renewal); health now reporting ready")
+	d.logger.Debug("background loops launched (workspace-sync, task-wakeup, heartbeat, gc, auto-update, token-renewal, drain-monitor); health now reporting ready")
 	err = d.pollLoop(ctx, taskWakeups)
 	d.logger.Debug("daemon main loop returning", "error", err)
 	return err
@@ -2176,7 +2203,7 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) ([]map[string]string
 			"name":    displayName,
 			"type":    r.name,
 			"version": r.version,
-			"status":  "online",
+			"status":  d.registrationStatus(),
 		})
 	}
 	return runtimes, belowMin, unavailable
@@ -2492,7 +2519,7 @@ func (d *Daemon) appendProfileRuntimes(ctx context.Context, workspaceID string, 
 			"name":       displayName,
 			"type":       profile.ProtocolFamily,
 			"version":    version,
-			"status":     "online",
+			"status":     d.registrationStatus(),
 			"profile_id": profile.ID,
 		})
 	}
@@ -3562,6 +3589,9 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 	if resp == nil {
 		return
 	}
+	// Cache the server-side queued task count (design §7) so /health can
+	// report draining_queued_tasks without a dedicated query.
+	d.recordQueuedTasks(runtimeID, resp.QueuedTaskCount)
 	if resp.PendingUpdate != nil || resp.PendingModelList != nil || resp.PendingLocalSkills != nil || resp.PendingLocalSkillImport != nil {
 		d.logger.Debug("heartbeat: pending actions",
 			"runtime_id", runtimeID,
@@ -4033,12 +4063,12 @@ func (d *Daemon) tryBeginServerUpdate(ctx context.Context) serverUpdateAcquireRe
 	}
 
 	d.claimMu.Lock()
-	if d.pauseClaims || d.activeTasks.Load() > 0 {
+	if d.claimPausedLocked() || d.activeTasks.Load() > 0 {
 		d.claimMu.Unlock()
 		d.updating.Store(false)
 		return serverUpdateRuntimeBusy
 	}
-	d.pauseClaims = true
+	d.acquireClaimPauseLocked(claimPauseServerUpdate)
 	d.claimMu.Unlock()
 
 	ticker := time.NewTicker(10 * time.Millisecond)
@@ -4050,7 +4080,7 @@ func (d *Daemon) tryBeginServerUpdate(ctx context.Context) serverUpdateAcquireRe
 				d.claimMu.Unlock()
 				return serverUpdateAcquired
 			}
-			d.pauseClaims = false
+			d.releaseClaimPauseLocked(claimPauseServerUpdate)
 			d.claimMu.Unlock()
 			d.updating.Store(false)
 			return serverUpdateRuntimeBusy
@@ -4059,7 +4089,7 @@ func (d *Daemon) tryBeginServerUpdate(ctx context.Context) serverUpdateAcquireRe
 
 		select {
 		case <-ctx.Done():
-			d.releaseClaimBarrier()
+			d.releaseClaimPause(claimPauseServerUpdate)
 			d.updating.Store(false)
 			return serverUpdateRuntimeBusy
 		case <-ticker.C:
@@ -4147,14 +4177,15 @@ func (d *Daemon) reportUpdateResultWithRetry(ctx context.Context, runtimeID, upd
 }
 
 // tryEnterClaim records the intent to call ClaimTask. Returns true if the
-// caller may proceed, false if the auto-update barrier is in effect. Every
-// successful call MUST be paired with an exitClaim() on every exit path —
-// either right after a failed/empty claim, or via the handleTask goroutine's
-// defer once the task is handed off.
+// caller may proceed, false if any claim-pause holder (auto-update barrier,
+// drain, below-minimum demotion) is in effect. Every successful call MUST be
+// paired with an exitClaim() on every exit path — either right after a
+// failed/empty claim, or via the handleTask goroutine's defer once the task is
+// handed off.
 func (d *Daemon) tryEnterClaim() bool {
 	d.claimMu.Lock()
 	defer d.claimMu.Unlock()
-	if d.pauseClaims {
+	if d.claimPausedLocked() {
 		return false
 	}
 	d.claimsInFlight++
@@ -4169,34 +4200,37 @@ func (d *Daemon) exitClaim() {
 }
 
 // trySetClaimBarrier atomically pauses new ClaimTask calls if the daemon is
-// fully idle (no claims in flight, no tasks running). Returns true if the
-// caller now holds the barrier and must release it with releaseClaimBarrier
-// on every non-restart exit path; false if the daemon is busy and the caller
-// should defer to the next tick. Used by tryAutoUpdate to close the race
-// where a task slips in between the cheap pre-fetch idle check and the
-// actual upgrade kick-off.
+// fully idle (no claims in flight, no tasks running, no other holder paused).
+// Returns true if the caller now holds a server-update ref and must release it
+// with releaseClaimBarrier on every non-restart exit path; false if the daemon
+// is busy or already paused (e.g. draining) and the caller should defer to the
+// next tick. Used by tryAutoUpdate to close the race where a task slips in
+// between the cheap pre-fetch idle check and the actual upgrade kick-off.
 func (d *Daemon) trySetClaimBarrier() bool {
 	d.claimMu.Lock()
 	defer d.claimMu.Unlock()
-	// Refuse when the barrier is already held. Without this the function silently
-	// double-acquires: two holders both believe they own it, and whichever
-	// finishes first releases it out from under the other. tryBeginServerUpdate
-	// makes the same check for the same reason.
-	if d.pauseClaims || d.claimsInFlight > 0 || d.activeTasks.Load() > 0 {
+	// Refuse when any holder is already paused or work is in flight. Without
+	// the "any holder" check the function silently double-acquires: two holders
+	// both believe they own the pause, and whichever finishes first releases it
+	// out from under the other. tryBeginServerUpdate makes the same check for
+	// the same reason. During drain the claimPaused() branch is what defers
+	// auto-update / demotion until the drain ends (decision two).
+	if d.claimPausedLocked() || d.claimsInFlight > 0 || d.activeTasks.Load() > 0 {
 		return false
 	}
-	d.pauseClaims = true
+	d.acquireClaimPauseLocked(claimPauseServerUpdate)
 	return true
 }
 
-// releaseClaimBarrier clears the auto-update claim barrier so pollers may
-// resume claiming. Called on failure paths only — a successful upgrade leaves
-// the barrier set because triggerRestart is about to take the process down
-// and clearing it would open a window for new claims during shutdown.
+// releaseClaimBarrier clears the caller's server-update claim-pause ref so
+// pollers may resume claiming. Called on failure paths only — a successful
+// upgrade leaves the ref held because triggerRestart is about to take the
+// process down and clearing it would open a window for new claims during
+// shutdown.
 func (d *Daemon) releaseClaimBarrier() {
 	d.claimMu.Lock()
 	defer d.claimMu.Unlock()
-	d.pauseClaims = false
+	d.releaseClaimPauseLocked(claimPauseServerUpdate)
 }
 
 // triggerRestart initiates a graceful daemon restart into the binary at

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3590,8 +3590,10 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 		return
 	}
 	// Cache the server-side queued task count (design §7) so /health can
-	// report draining_queued_tasks without a dedicated query.
-	d.recordQueuedTasks(runtimeID, resp.QueuedTaskCount)
+	// report draining_queued_tasks without a dedicated query. The server only
+	// populates QueuedTasks while the runtime is draining (nil otherwise), so
+	// an absent ack keeps the previous value.
+	d.recordQueuedTasks(runtimeID, resp.QueuedTasks)
 	if resp.PendingUpdate != nil || resp.PendingModelList != nil || resp.PendingLocalSkills != nil || resp.PendingLocalSkillImport != nil {
 		d.logger.Debug("heartbeat: pending actions",
 			"runtime_id", runtimeID,

--- a/server/internal/daemon/daemon_drain.go
+++ b/server/internal/daemon/daemon_drain.go
@@ -249,10 +249,10 @@ func (d *Daemon) daemonStateString() string {
 }
 
 // recordQueuedTasks updates the daemon's cached count of server-side queued
-// tasks, sourced from heartbeat acks (design §7). Best-effort: absent acks keep
-// the previous value.
-func (d *Daemon) recordQueuedTasks(runtimeID string, count int64) {
-	if runtimeID == "" {
+// tasks, sourced from heartbeat acks (design §7). Best-effort: an absent (nil)
+// ack keeps the previous value.
+func (d *Daemon) recordQueuedTasks(runtimeID string, count *int) {
+	if runtimeID == "" || count == nil {
 		return
 	}
 	d.queuedTasksMu.Lock()
@@ -260,7 +260,7 @@ func (d *Daemon) recordQueuedTasks(runtimeID string, count int64) {
 	if d.queuedTasksByRuntime == nil {
 		d.queuedTasksByRuntime = make(map[string]int64)
 	}
-	d.queuedTasksByRuntime[runtimeID] = count
+	d.queuedTasksByRuntime[runtimeID] = int64(*count)
 }
 
 // queuedTaskCount sums the per-runtime queued-task counts cached from heartbeat

--- a/server/internal/daemon/daemon_drain.go
+++ b/server/internal/daemon/daemon_drain.go
@@ -1,0 +1,277 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Daemon run-state values for d.daemonState. The health endpoint and CLI
+// surface them as "running" / "draining" / "stopped"; shutting_down is the
+// brief window between a finish-then-stop drain completing and the process
+// actually exiting.
+const (
+	daemonStateRunning      int32 = 0
+	daemonStateDraining     int32 = 1
+	daemonStateShuttingDown int32 = 2
+)
+
+// claimPauseHolder identifies one caller of the claim-pause ref-count (NEX-38
+// decision two). Before the ref-count, a single bool meant any holder that
+// released its barrier cleared every other holder's pause too — an auto-update
+// finishing could silently cancel a user-initiated drain. Now each holder owns
+// its own refs and releasing one can never clear the others.
+type claimPauseHolder string
+
+const (
+	claimPauseDrain        claimPauseHolder = "drain"         // user-initiated safe shutdown
+	claimPauseServerUpdate claimPauseHolder = "server-update" // auto-update / server-triggered CLI update barrier
+	claimPauseDemotion     claimPauseHolder = "below-minimum" // below-minimum runtime demotion
+)
+
+// drainFileName is the persistence marker written under the workspaces root so
+// a daemon restart re-enters draining instead of silently resuming claims
+// (AC-13).
+const drainFileName = "drain.json"
+
+// drainMonitorInterval controls how often the drain-completion watcher polls.
+// Drain completion is not latency-sensitive, so a conservative tick avoids
+// waking the daemon needlessly.
+const drainMonitorInterval = time.Second
+
+// acquireClaimPause takes one claim-pause ref for holder h. Every successful
+// call must be paired with releaseClaimPause(h).
+func (d *Daemon) acquireClaimPause(h claimPauseHolder) {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	d.acquireClaimPauseLocked(h)
+}
+
+// acquireClaimPauseLocked is the claimMu-held form of acquireClaimPause.
+func (d *Daemon) acquireClaimPauseLocked(h claimPauseHolder) {
+	if d.claimPauseRefs == nil {
+		d.claimPauseRefs = make(map[claimPauseHolder]int)
+	}
+	d.claimPauseRefs[h]++
+	d.claimPauseTotal++
+}
+
+// releaseClaimPause drops one claim-pause ref for holder h. Panics on an
+// unbalanced release — that is a programming error that would otherwise
+// silently wedge the daemon in a paused or un-paused state.
+func (d *Daemon) releaseClaimPause(h claimPauseHolder) {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	d.releaseClaimPauseLocked(h)
+}
+
+// releaseClaimPauseLocked is the claimMu-held form of releaseClaimPause.
+func (d *Daemon) releaseClaimPauseLocked(h claimPauseHolder) {
+	if d.claimPauseRefs == nil || d.claimPauseRefs[h] <= 0 {
+		panic(fmt.Sprintf("releaseClaimPause: unbalanced release for %q", h))
+	}
+	d.claimPauseRefs[h]--
+	if d.claimPauseRefs[h] == 0 {
+		delete(d.claimPauseRefs, h)
+	}
+	d.claimPauseTotal--
+}
+
+// claimPaused reports whether any holder currently pauses task claiming.
+func (d *Daemon) claimPaused() bool {
+	d.claimMu.Lock()
+	defer d.claimMu.Unlock()
+	return d.claimPauseTotal > 0
+}
+
+// claimPausedLocked is the claimMu-held form of claimPaused.
+func (d *Daemon) claimPausedLocked() bool {
+	return d.claimPauseTotal > 0
+}
+
+// beginDrain puts the daemon into draining: it stops claiming new tasks while
+// in-flight tasks run to completion. The marker is persisted BEFORE the
+// in-memory state flips (AC-13), so a crash mid-drain still restores draining
+// on the next start rather than silently resuming claims.
+func (d *Daemon) beginDrain() error {
+	if d.daemonState.Load() == daemonStateDraining {
+		// Already draining; heal the marker in case it was removed out from
+		// under us, then report success.
+		return d.persistDrain()
+	}
+	if err := d.persistDrain(); err != nil {
+		return err
+	}
+	d.acquireClaimPause(claimPauseDrain)
+	d.daemonState.Store(daemonStateDraining)
+	d.logger.Info("drain started: not claiming new tasks; in-flight tasks will run to completion")
+	return nil
+}
+
+// abortDrain returns the daemon to running and resumes claiming. Clears the
+// marker, releases the drain ref, and drops any armed finish-then-stop.
+func (d *Daemon) abortDrain() error {
+	if d.daemonState.Load() != daemonStateDraining {
+		return fmt.Errorf("daemon is not draining")
+	}
+	if err := d.clearDrain(); err != nil {
+		return err
+	}
+	d.releaseClaimPause(claimPauseDrain)
+	d.daemonState.Store(daemonStateRunning)
+	d.finishThenStop.Store(false)
+	d.logger.Info("drain aborted: resuming task claims")
+	return nil
+}
+
+// finishDrainThenStop arms the graceful auto-close: once draining and
+// activeTasks reaches zero, the drain monitor deregisters the runtimes and
+// stops the daemon (AC-4).
+func (d *Daemon) finishDrainThenStop() error {
+	if d.daemonState.Load() != daemonStateDraining {
+		return fmt.Errorf("daemon is not draining")
+	}
+	d.finishThenStop.Store(true)
+	d.logger.Info("drain finish-then-stop armed: daemon will stop once in-flight tasks complete")
+	return nil
+}
+
+// drainFilePath returns the absolute path of the drain persistence marker.
+func (d *Daemon) drainFilePath() string {
+	return filepath.Join(d.cfg.WorkspacesRoot, drainFileName)
+}
+
+// persistDrain writes the drain marker under the workspaces root, ensuring the
+// directory exists first.
+func (d *Daemon) persistDrain() error {
+	if err := os.MkdirAll(d.cfg.WorkspacesRoot, 0o755); err != nil {
+		return fmt.Errorf("ensure workspaces root for drain marker: %w", err)
+	}
+	payload := map[string]string{"state": "draining"}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(d.drainFilePath(), data, 0o600)
+}
+
+// clearDrain removes the drain marker. Missing file is not an error.
+func (d *Daemon) clearDrain() error {
+	err := os.Remove(d.drainFilePath())
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove drain marker: %w", err)
+	}
+	return nil
+}
+
+// restoreDrainState re-enters draining at startup when a drain marker from a
+// previous run exists (AC-13). Called from Run after auth and BEFORE the first
+// registration, so the register payload already reports draining instead of
+// briefly registering online and then flipping — the window the design's risk
+// #3 forbids. A missing or malformed marker is silently a normal start.
+func (d *Daemon) restoreDrainState() {
+	data, err := os.ReadFile(d.drainFilePath())
+	if err != nil {
+		if !os.IsNotExist(err) {
+			d.logger.Warn("failed to read drain marker — starting in normal mode",
+				"path", d.drainFilePath(), "error", err)
+		}
+		return
+	}
+	var payload struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil || payload.State != "draining" {
+		d.logger.Warn("invalid drain marker — starting in normal mode", "path", d.drainFilePath())
+		return
+	}
+	d.acquireClaimPause(claimPauseDrain)
+	d.daemonState.Store(daemonStateDraining)
+	d.logger.Info("restored draining state from previous run; not claiming new tasks until aborted or completed")
+}
+
+// drainMonitorLoop watches for the finish-then-stop trigger: when the daemon is
+// draining, finish-then-stop is armed, and no task is in flight, it deregisters
+// the runtimes and cancels the root context so Run returns (AC-4). Because
+// activeTasks is already zero, the poll loop's shutdown window passes instantly
+// and nothing is interrupted. The ordinary stop path (/shutdown immediate
+// cancel + pollLoop 30s cap) is untouched (AC-5).
+func (d *Daemon) drainMonitorLoop(ctx context.Context) {
+	ticker := time.NewTicker(drainMonitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if d.daemonState.Load() != daemonStateDraining || !d.finishThenStop.Load() {
+				continue
+			}
+			if d.activeTasks.Load() != 0 {
+				continue
+			}
+			d.logger.Info("drain complete: no in-flight tasks; deregistering runtimes and stopping")
+			d.deregisterRuntimes()
+			d.daemonState.Store(daemonStateShuttingDown)
+			if d.cancelFunc != nil {
+				d.cancelFunc()
+			}
+			return
+		}
+	}
+}
+
+// registrationStatus returns the status string to report when registering a
+// runtime with the server: "draining" while draining, otherwise "online". This
+// is what makes a drained daemon restart register its runtimes as draining
+// rather than defaulting them back to online (AC-13).
+func (d *Daemon) registrationStatus() string {
+	if d.daemonState.Load() == daemonStateDraining {
+		return "draining"
+	}
+	return "online"
+}
+
+// daemonStateString reports the run state for /health and CLI status:
+// "running", "draining", or "stopped".
+func (d *Daemon) daemonStateString() string {
+	switch d.daemonState.Load() {
+	case daemonStateDraining:
+		return "draining"
+	case daemonStateShuttingDown:
+		return "stopped"
+	default:
+		return "running"
+	}
+}
+
+// recordQueuedTasks updates the daemon's cached count of server-side queued
+// tasks, sourced from heartbeat acks (design §7). Best-effort: absent acks keep
+// the previous value.
+func (d *Daemon) recordQueuedTasks(runtimeID string, count int64) {
+	if runtimeID == "" {
+		return
+	}
+	d.queuedTasksMu.Lock()
+	defer d.queuedTasksMu.Unlock()
+	if d.queuedTasksByRuntime == nil {
+		d.queuedTasksByRuntime = make(map[string]int64)
+	}
+	d.queuedTasksByRuntime[runtimeID] = count
+}
+
+// queuedTaskCount sums the per-runtime queued-task counts cached from heartbeat
+// acks. It is the daemon's best-effort view of how many tasks the server still
+// holds queued for its runtimes while draining (AC-8).
+func (d *Daemon) queuedTaskCount() int64 {
+	d.queuedTasksMu.Lock()
+	defer d.queuedTasksMu.Unlock()
+	var total int64
+	for _, c := range d.queuedTasksByRuntime {
+		total += c
+	}
+	return total
+}

--- a/server/internal/daemon/daemon_drain.go
+++ b/server/internal/daemon/daemon_drain.go
@@ -92,6 +92,19 @@ func (d *Daemon) claimPausedLocked() bool {
 	return d.claimPauseTotal > 0
 }
 
+// claimPausedForClaimsLocked reports whether the CLAIM ENTRY path is blocked.
+// The drain holder deliberately does NOT block claims (NEX-38 corrected
+// contract, CEO decision 2026-08-10): a draining runtime keeps claiming and
+// completing its pre-boundary queued work — new triggers are rejected
+// server-side by AgentReadiness, so the queue only ever holds work accepted
+// before the drain boundary. Only the server-update / below-minimum holders
+// pause claim entry. trySetClaimBarrier and tryBeginServerUpdate still
+// consult claimPausedLocked() (which INCLUDES drain) so auto-update and
+// demotion continue to defer while a drain is in effect.
+func (d *Daemon) claimPausedForClaimsLocked() bool {
+	return d.claimPauseTotal-d.claimPauseRefs[claimPauseDrain] > 0
+}
+
 // beginDrain puts the daemon into draining: it stops claiming new tasks while
 // in-flight tasks run to completion. The marker is persisted BEFORE the
 // in-memory state flips (AC-13), so a crash mid-drain still restores draining
@@ -194,11 +207,16 @@ func (d *Daemon) restoreDrainState() {
 }
 
 // drainMonitorLoop watches for the finish-then-stop trigger: when the daemon is
-// draining, finish-then-stop is armed, and no task is in flight, it deregisters
-// the runtimes and cancels the root context so Run returns (AC-4). Because
-// activeTasks is already zero, the poll loop's shutdown window passes instantly
-// and nothing is interrupted. The ordinary stop path (/shutdown immediate
-// cancel + pollLoop 30s cap) is untouched (AC-5).
+// draining, finish-then-stop is armed, and BOTH the in-flight count and the
+// server-side queued count (cached from heartbeat acks) reach zero, it
+// deregisters the runtimes and cancels the root context so Run returns
+// (AC-4). The daemon keeps claiming during drain, so it drains the queue
+// itself; waiting on the queued count as well as active tasks ensures it only
+// exits once every pre-boundary accepted task has been claimed and completed
+// (NEX-38 corrected contract). Because activeTasks is already zero, the poll
+// loop's shutdown window passes instantly and nothing is interrupted. The
+// ordinary stop path (/shutdown immediate cancel + pollLoop 30s cap) is
+// untouched (AC-5).
 func (d *Daemon) drainMonitorLoop(ctx context.Context) {
 	ticker := time.NewTicker(drainMonitorInterval)
 	defer ticker.Stop()
@@ -210,10 +228,10 @@ func (d *Daemon) drainMonitorLoop(ctx context.Context) {
 			if d.daemonState.Load() != daemonStateDraining || !d.finishThenStop.Load() {
 				continue
 			}
-			if d.activeTasks.Load() != 0 {
+			if d.activeTasks.Load() != 0 || d.queuedTaskCount() != 0 {
 				continue
 			}
-			d.logger.Info("drain complete: no in-flight tasks; deregistering runtimes and stopping")
+			d.logger.Info("drain complete: no in-flight or queued tasks; deregistering runtimes and stopping")
 			d.deregisterRuntimes()
 			d.daemonState.Store(daemonStateShuttingDown)
 			if d.cancelFunc != nil {

--- a/server/internal/daemon/daemon_drain_test.go
+++ b/server/internal/daemon/daemon_drain_test.go
@@ -39,12 +39,17 @@ func TestBeginDrain_StateClaimPauseAndPersistence(t *testing.T) {
 		t.Fatalf("daemonState = %d, want draining (%d)", got, daemonStateDraining)
 	}
 	if !d.claimPaused() {
-		t.Fatal("claims must be paused after beginDrain")
+		t.Fatal("claims must be pause-signaled after beginDrain (defers auto-update/demotion)")
 	}
-	// AC-2: the batch poller must refuse to claim while draining.
-	if d.tryEnterClaim() {
-		t.Fatal("tryEnterClaim must refuse while draining")
+	// AC-2 corrected contract (CEO 2026-08-10): the batch poller must KEEP
+	// claiming while draining so pre-boundary queued work is claimed and
+	// completed. The drain ref defers auto-update/demotion (decision two) but
+	// does not block claim entry — only the server-update / below-minimum
+	// holders do.
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must succeed while draining (draining keeps claiming queued work)")
 	}
+	d.exitClaim()
 	// AC-13: the marker must be persisted on disk.
 	data, err := os.ReadFile(d.drainFilePath())
 	if err != nil {
@@ -140,11 +145,14 @@ func TestRestoreDrainState_ResumesDrainingOnRestart(t *testing.T) {
 			t.Fatalf("restored daemonState = %d, want draining (%d)", got, daemonStateDraining)
 		}
 		if !restarted.claimPaused() {
-			t.Fatal("restored daemon must hold the drain claim-pause ref")
+			t.Fatal("restored daemon must hold the drain claim-pause ref (defers auto-update/demotion)")
 		}
-		if restarted.tryEnterClaim() {
-			t.Fatal("restored daemon must refuse claims")
+		// Corrected contract: a restored draining daemon keeps claiming queued
+		// work — the drain ref does not block claim entry.
+		if !restarted.tryEnterClaim() {
+			t.Fatal("restored daemon must accept claims (draining keeps claiming queued work)")
 		}
+		restarted.exitClaim()
 		if got := restarted.registrationStatus(); got != "draining" {
 			t.Fatalf("registrationStatus = %q, want draining", got)
 		}
@@ -240,8 +248,23 @@ func TestDrainMonitor_StopsWhenIdleAndArmed(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Task completes -> the monitor should deregister + cancel on the next tick.
+	// Corrected contract (CEO 2026-08-10): even with no in-flight task, the
+	// monitor must keep waiting while the server still holds queued work for
+	// the draining runtimes — pre-boundary queued tasks must be claimed and
+	// completed before shutdown (AC-4 extended).
 	d.activeTasks.Store(0)
+	d.recordQueuedTasks("rt-1", intPtr(2))
+	deadline = time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if cancelCalls.Load() != 0 {
+			t.Fatal("monitor cancelled the daemon while queued tasks remained")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Both in-flight and queued counts reach zero -> the monitor should
+	// deregister + cancel on the next tick.
+	d.recordQueuedTasks("rt-1", intPtr(0))
 	waitUntil(t, 3*time.Second, func() bool { return cancelCalls.Load() == 1 })
 
 	select {

--- a/server/internal/daemon/daemon_drain_test.go
+++ b/server/internal/daemon/daemon_drain_test.go
@@ -1,0 +1,436 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newDrainTestDaemon returns a Daemon stripped to the pieces the drain logic
+// touches, with a real temp workspaces root so drain.json persistence is
+// exercised end-to-end.
+func newDrainTestDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	return &Daemon{
+		cfg:        Config{WorkspacesRoot: t.TempDir()},
+		logger:     slog.Default(),
+		workspaces: map[string]*workspaceState{},
+	}
+}
+
+func TestBeginDrain_StateClaimPauseAndPersistence(t *testing.T) {
+	d := newDrainTestDaemon(t)
+
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+	if got := d.daemonState.Load(); got != daemonStateDraining {
+		t.Fatalf("daemonState = %d, want draining (%d)", got, daemonStateDraining)
+	}
+	if !d.claimPaused() {
+		t.Fatal("claims must be paused after beginDrain")
+	}
+	// AC-2: the batch poller must refuse to claim while draining.
+	if d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must refuse while draining")
+	}
+	// AC-13: the marker must be persisted on disk.
+	data, err := os.ReadFile(d.drainFilePath())
+	if err != nil {
+		t.Fatalf("read drain marker: %v", err)
+	}
+	var payload struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode drain marker: %v", err)
+	}
+	if payload.State != "draining" {
+		t.Fatalf("drain marker state = %q, want draining", payload.State)
+	}
+
+	// beginDrain is idempotent while already draining.
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("repeated beginDrain: %v", err)
+	}
+}
+
+func TestAbortDrain_ResumesClaimsAndClearsPersistence(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+
+	if err := d.abortDrain(); err != nil {
+		t.Fatalf("abortDrain: %v", err)
+	}
+	if got := d.daemonState.Load(); got != daemonStateRunning {
+		t.Fatalf("daemonState = %d, want running (%d)", got, daemonStateRunning)
+	}
+	if d.claimPaused() {
+		t.Fatal("claims must resume after abortDrain")
+	}
+	// AC-3: claims are immediately accepted again after abort.
+	if !d.tryEnterClaim() {
+		t.Fatal("tryEnterClaim must succeed after abortDrain")
+	}
+	d.exitClaim()
+	if _, err := os.Stat(d.drainFilePath()); !os.IsNotExist(err) {
+		t.Fatalf("drain marker must be removed after abortDrain, stat err = %v", err)
+	}
+
+	// aborting when not draining is an error, not a silent no-op.
+	if err := d.abortDrain(); err == nil {
+		t.Fatal("abortDrain while running must return an error")
+	}
+}
+
+func TestFinishDrainThenStop_ArmsAndAbortClearsFlag(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+	if err := d.finishDrainThenStop(); err != nil {
+		t.Fatalf("finishDrainThenStop: %v", err)
+	}
+	if !d.finishThenStop.Load() {
+		t.Fatal("finishThenStop must be armed after finishDrainThenStop")
+	}
+
+	if err := d.abortDrain(); err != nil {
+		t.Fatalf("abortDrain: %v", err)
+	}
+	if d.finishThenStop.Load() {
+		t.Fatal("abortDrain must clear the finishThenStop flag")
+	}
+
+	// finish_then_stop without draining is an error.
+	if err := d.finishDrainThenStop(); err == nil {
+		t.Fatal("finishDrainThenStop while running must return an error")
+	}
+}
+
+func TestRestoreDrainState_ResumesDrainingOnRestart(t *testing.T) {
+	t.Run("marker present", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		if err := d.beginDrain(); err != nil {
+			t.Fatalf("beginDrain: %v", err)
+		}
+
+		// Simulate a restart: a fresh Daemon over the same workspaces root.
+		restarted := &Daemon{
+			cfg:        Config{WorkspacesRoot: d.cfg.WorkspacesRoot},
+			logger:     slog.Default(),
+			workspaces: map[string]*workspaceState{},
+		}
+		restarted.restoreDrainState()
+
+		if got := restarted.daemonState.Load(); got != daemonStateDraining {
+			t.Fatalf("restored daemonState = %d, want draining (%d)", got, daemonStateDraining)
+		}
+		if !restarted.claimPaused() {
+			t.Fatal("restored daemon must hold the drain claim-pause ref")
+		}
+		if restarted.tryEnterClaim() {
+			t.Fatal("restored daemon must refuse claims")
+		}
+		if got := restarted.registrationStatus(); got != "draining" {
+			t.Fatalf("registrationStatus = %q, want draining", got)
+		}
+	})
+
+	t.Run("no marker", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		d.restoreDrainState()
+		if got := d.daemonState.Load(); got != daemonStateRunning {
+			t.Fatalf("daemonState = %d, want running (%d)", got, daemonStateRunning)
+		}
+		if d.claimPaused() {
+			t.Fatal("no marker must leave claims unpaused")
+		}
+	})
+
+	t.Run("malformed marker ignored", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		if err := os.MkdirAll(d.cfg.WorkspacesRoot, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(d.drainFilePath(), []byte("not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		d.restoreDrainState()
+		if got := d.daemonState.Load(); got != daemonStateRunning {
+			t.Fatalf("malformed marker must be ignored; daemonState = %d", got)
+		}
+	})
+}
+
+func TestRegistrationStatus_ReportsDraining(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if got := d.registrationStatus(); got != "online" {
+		t.Fatalf("registrationStatus before drain = %q, want online", got)
+	}
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+	if got := d.registrationStatus(); got != "draining" {
+		t.Fatalf("registrationStatus while draining = %q, want draining", got)
+	}
+}
+
+func TestDaemonStateString(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if got := d.daemonStateString(); got != "running" {
+		t.Fatalf("state string = %q, want running", got)
+	}
+	if err := d.beginDrain(); err != nil {
+		t.Fatal(err)
+	}
+	if got := d.daemonStateString(); got != "draining" {
+		t.Fatalf("state string = %q, want draining", got)
+	}
+	d.daemonState.Store(daemonStateShuttingDown)
+	if got := d.daemonStateString(); got != "stopped" {
+		t.Fatalf("state string = %q, want stopped", got)
+	}
+}
+
+// TestDrainMonitor_StopsWhenIdleAndArmed covers AC-4: with finish-then-stop
+// armed and no in-flight tasks the daemon deregisters and cancels its root
+// context. AC-5 (normal stop) is untouched 鈥?the monitor never fires unless
+// draining.
+func TestDrainMonitor_StopsWhenIdleAndArmed(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+	if err := d.finishDrainThenStop(); err != nil {
+		t.Fatalf("finishDrainThenStop: %v", err)
+	}
+	var cancelCalls atomic.Int32
+	d.cancelFunc = func() { cancelCalls.Add(1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.drainMonitorLoop(ctx)
+	}()
+
+	// While a task is still in flight the monitor must NOT stop the daemon.
+	// Give it more than one tick to prove it keeps waiting.
+	d.activeTasks.Store(1)
+	deadline := time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if cancelCalls.Load() != 0 {
+			t.Fatal("monitor cancelled the daemon while a task was still in flight")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Task completes -> the monitor should deregister + cancel on the next tick.
+	d.activeTasks.Store(0)
+	waitUntil(t, 3*time.Second, func() bool { return cancelCalls.Load() == 1 })
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("drainMonitorLoop did not return after cancelling the daemon")
+	}
+	if got := d.daemonState.Load(); got != daemonStateShuttingDown {
+		t.Fatalf("daemonState after stop = %d, want shutting_down (%d)", got, daemonStateShuttingDown)
+	}
+}
+
+// TestDrainMonitor_DoesNotFireWhenNotArmed pins the drain-resident mode: a
+// drained daemon without finish-then-stop stays up (waits for abort or a later
+// finish_then_stop) even when idle.
+func TestDrainMonitor_DoesNotFireWhenNotArmed(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+	var cancelCalls atomic.Int32
+	d.cancelFunc = func() { cancelCalls.Add(1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.drainMonitorLoop(ctx)
+
+	time.Sleep(2500 * time.Millisecond)
+	if cancelCalls.Load() != 0 {
+		t.Fatal("monitor cancelled the daemon although finish-then-stop was not armed")
+	}
+}
+
+func TestShutdownHandler_ReportsStoppingState(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	var cancelled atomic.Bool
+	d.cancelFunc = func() { cancelled.Store(true) }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	d.shutdownHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := d.daemonState.Load(); got != daemonStateShuttingDown {
+		t.Fatalf("daemonState after /shutdown = %d, want shutting_down (%d)", got, daemonStateShuttingDown)
+	}
+	waitUntil(t, time.Second, func() bool { return cancelled.Load() })
+}
+
+func TestDrainHandler_Actions(t *testing.T) {
+	newHandler := func(t *testing.T, d *Daemon) http.HandlerFunc {
+		t.Helper()
+		return d.drainHandler()
+	}
+	post := func(t *testing.T, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/drain", strings.NewReader(body)))
+		return rec
+	}
+
+	t.Run("drain then abort", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		h := newHandler(t, d)
+
+		rec := post(t, h, `{"action":"drain"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("drain action: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+		}
+		if got := d.daemonState.Load(); got != daemonStateDraining {
+			t.Fatalf("daemonState after /drain = %d, want draining", got)
+		}
+		if !d.claimPaused() {
+			t.Fatal("claims must be paused after /drain")
+		}
+
+		rec = post(t, h, `{"action":"abort"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("abort action: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+		}
+		if got := d.daemonState.Load(); got != daemonStateRunning {
+			t.Fatalf("daemonState after abort = %d, want running", got)
+		}
+		if d.claimPaused() {
+			t.Fatal("claims must resume after abort")
+		}
+	})
+
+	t.Run("finish_then_stop", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		h := newHandler(t, d)
+		post(t, h, `{"action":"drain"}`)
+
+		rec := post(t, h, `{"action":"finish_then_stop"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("finish_then_stop: got %d, want 200 (%s)", rec.Code, rec.Body.String())
+		}
+		if !d.finishThenStop.Load() {
+			t.Fatal("finish_then_stop must arm the auto-close flag")
+		}
+	})
+
+	t.Run("rejects unknown action", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		rec := post(t, d.drainHandler(), `{"action":"frobnicate"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("unknown action: got %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("rejects non-post", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		rec := httptest.NewRecorder()
+		d.drainHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/drain", nil))
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("GET /drain: got %d, want 405", rec.Code)
+		}
+	})
+
+	t.Run("abort without draining is a 400", func(t *testing.T) {
+		d := newDrainTestDaemon(t)
+		rec := post(t, d.drainHandler(), `{"action":"abort"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("abort while running: got %d, want 400", rec.Code)
+		}
+	})
+}
+
+func TestHealthReportsDrainStateAndCounts(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	d.ready.Store(true)
+	d.activeTasks.Store(3)
+	d.recordQueuedTasks("rt-1", 4)
+	d.recordQueuedTasks("rt-2", 1)
+	if err := d.beginDrain(); err != nil {
+		t.Fatalf("beginDrain: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	d.healthHandler(time.Now()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	var resp HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.State != "draining" {
+		t.Fatalf("state = %q, want draining", resp.State)
+	}
+	if resp.Status != "running" {
+		t.Fatalf("status = %q, want running (drain is orthogonal to readiness)", resp.Status)
+	}
+	if resp.DrainingInflightTasks != 3 {
+		t.Fatalf("draining_inflight_tasks = %d, want 3", resp.DrainingInflightTasks)
+	}
+	if resp.DrainingQueuedTasks != 5 {
+		t.Fatalf("draining_queued_tasks = %d, want 5", resp.DrainingQueuedTasks)
+	}
+}
+
+func TestHeartbeatAckCachesQueuedTasks(t *testing.T) {
+	d := newDrainTestDaemon(t)
+	d.handleHeartbeatActions(context.Background(), "rt-1", &HeartbeatResponse{
+		RuntimeID:       "rt-1",
+		QueuedTaskCount: 7,
+	})
+	d.handleHeartbeatActions(context.Background(), "rt-2", &HeartbeatResponse{
+		RuntimeID:       "rt-2",
+		QueuedTaskCount: 3,
+	})
+	if got := d.queuedTaskCount(); got != 10 {
+		t.Fatalf("queuedTaskCount = %d, want 10", got)
+	}
+	// Updating one runtime leaves the other's count intact.
+	d.handleHeartbeatActions(context.Background(), "rt-1", &HeartbeatResponse{
+		RuntimeID:       "rt-1",
+		QueuedTaskCount: 1,
+	})
+	if got := d.queuedTaskCount(); got != 4 {
+		t.Fatalf("queuedTaskCount after update = %d, want 4", got)
+	}
+}
+
+// waitUntil polls cond until it returns true or the deadline elapses.
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}

--- a/server/internal/daemon/daemon_drain_test.go
+++ b/server/internal/daemon/daemon_drain_test.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+// intPtr returns a pointer to v for test fixtures that exercise the *int
+// queued_tasks field in heartbeat acks.
+func intPtr(v int) *int { return &v }
+
 // newDrainTestDaemon returns a Daemon stripped to the pieces the drain logic
 // touches, with a real temp workspaces root so drain.json persistence is
 // exercised end-to-end.
@@ -372,8 +376,8 @@ func TestHealthReportsDrainStateAndCounts(t *testing.T) {
 	d := newDrainTestDaemon(t)
 	d.ready.Store(true)
 	d.activeTasks.Store(3)
-	d.recordQueuedTasks("rt-1", 4)
-	d.recordQueuedTasks("rt-2", 1)
+	d.recordQueuedTasks("rt-1", intPtr(4))
+	d.recordQueuedTasks("rt-2", intPtr(1))
 	if err := d.beginDrain(); err != nil {
 		t.Fatalf("beginDrain: %v", err)
 	}
@@ -402,23 +406,29 @@ func TestHealthReportsDrainStateAndCounts(t *testing.T) {
 func TestHeartbeatAckCachesQueuedTasks(t *testing.T) {
 	d := newDrainTestDaemon(t)
 	d.handleHeartbeatActions(context.Background(), "rt-1", &HeartbeatResponse{
-		RuntimeID:       "rt-1",
-		QueuedTaskCount: 7,
+		RuntimeID:  "rt-1",
+		QueuedTasks: intPtr(7),
 	})
 	d.handleHeartbeatActions(context.Background(), "rt-2", &HeartbeatResponse{
-		RuntimeID:       "rt-2",
-		QueuedTaskCount: 3,
+		RuntimeID:  "rt-2",
+		QueuedTasks: intPtr(3),
 	})
 	if got := d.queuedTaskCount(); got != 10 {
 		t.Fatalf("queuedTaskCount = %d, want 10", got)
 	}
 	// Updating one runtime leaves the other's count intact.
 	d.handleHeartbeatActions(context.Background(), "rt-1", &HeartbeatResponse{
-		RuntimeID:       "rt-1",
-		QueuedTaskCount: 1,
+		RuntimeID:  "rt-1",
+		QueuedTasks: intPtr(1),
 	})
 	if got := d.queuedTaskCount(); got != 4 {
 		t.Fatalf("queuedTaskCount after update = %d, want 4", got)
+	}
+	// An absent (nil) ack keeps the previous value — the server only fills
+	// QueuedTasks while draining, so a non-draining ack must not zero the cache.
+	d.handleHeartbeatActions(context.Background(), "rt-1", &HeartbeatResponse{RuntimeID: "rt-1"})
+	if got := d.queuedTaskCount(); got != 4 {
+		t.Fatalf("queuedTaskCount after nil ack = %d, want 4", got)
 	}
 }
 

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -53,6 +53,17 @@ type HealthResponse struct {
 	// older consumers see no change. Diagnostic only: nothing keys off it.
 	ReloadPendingReason string            `json:"reload_pending_reason,omitempty"`
 	Workspaces          []healthWorkspace `json:"workspaces"`
+	// State is the NEX-38 run state: "running", "draining", or "stopped". It is
+	// orthogonal to Status: a drained daemon is still ready (Status "running")
+	// but refuses new task claims.
+	State string `json:"state"`
+	// DrainingInflightTasks is the count of tasks still executing while
+	// draining (== ActiveTaskCount). DrainingQueuedTasks is the daemon's
+	// best-effort view of how many tasks the server still holds queued for its
+	// runtimes, cached from heartbeat acks (design §7). Both are read by the
+	// CLI / UI to describe the drain state (AC-8).
+	DrainingInflightTasks int64 `json:"draining_inflight_tasks"`
+	DrainingQueuedTasks   int64 `json:"draining_queued_tasks"`
 }
 
 type healthWorkspace struct {
@@ -127,12 +138,55 @@ func (d *Daemon) healthHandler(startedAt time.Time) http.HandlerFunc {
 			Agents:                agents,
 			SkippedAgents:         d.skippedAgentsSnapshot(),
 
-			ReloadPendingReason: d.reloadPending(),
-			Workspaces:          wsList,
+			ReloadPendingReason:   d.reloadPending(),
+			Workspaces:            wsList,
+			State:                 d.daemonStateString(),
+			DrainingInflightTasks: d.activeTasks.Load(),
+			DrainingQueuedTasks:   d.queuedTaskCount(),
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// drainRequest is the body of a POST /drain request.
+type drainRequest struct {
+	Action string `json:"action"`
+}
+
+// drainHandler implements the NEX-38 drain entry point used by the CLI and
+// desktop: drain / abort / finish_then_stop. Like /shutdown, the health
+// listener is bound to 127.0.0.1 only, so only local processes can reach it.
+func (d *Daemon) drainHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req drainRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		var err error
+		switch req.Action {
+		case "drain":
+			err = d.beginDrain()
+		case "abort":
+			err = d.abortDrain()
+		case "finish_then_stop":
+			err = d.finishDrainThenStop()
+		default:
+			http.Error(w, "invalid action (want drain, abort, or finish_then_stop)", http.StatusBadRequest)
+			return
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "state": d.daemonStateString()})
 	}
 }
 
@@ -150,6 +204,7 @@ func (d *Daemon) shutdownHandler() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "shutting down"})
+		d.daemonState.Store(daemonStateShuttingDown)
 		if d.cancelFunc != nil {
 			// Cancel asynchronously so the response flushes first; otherwise
 			// srv.Close() races with the writer.
@@ -164,6 +219,7 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", d.healthHandler(startedAt))
 	mux.HandleFunc("/shutdown", d.shutdownHandler())
+	mux.HandleFunc("/drain", d.drainHandler())
 	mux.HandleFunc("/repo/checkout", d.repoCheckoutHandler())
 
 	srv := &http.Server{Handler: mux}

--- a/server/internal/daemon/self_reload_test.go
+++ b/server/internal/daemon/self_reload_test.go
@@ -416,13 +416,12 @@ func waitFor(t *testing.T, cond func() bool, msg string) {
 	t.Fatal(msg)
 }
 
-// claimsPaused reads pauseClaims under claimMu, honoring the field's own
-// concurrency contract rather than relying on the test being single-goroutine.
+// claimsPaused reports whether any claim-pause holder is active, honoring the
+// ref-count's own concurrency contract rather than relying on the test being
+// single-goroutine.
 func claimsPaused(t *testing.T, d *Daemon) bool {
 	t.Helper()
-	d.claimMu.Lock()
-	defer d.claimMu.Unlock()
-	return d.pauseClaims
+	return d.claimPaused()
 }
 
 // TestTryAutoUpdate_ResumesClaimingWhenRestartCannotBeScheduled is the

--- a/server/internal/daemon/server_update_test.go
+++ b/server/internal/daemon/server_update_test.go
@@ -159,10 +159,7 @@ func waitForServerUpdateBarrier(t *testing.T, d *Daemon) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		d.claimMu.Lock()
-		paused := d.pauseClaims
-		d.claimMu.Unlock()
-		if paused {
+		if d.claimPaused() {
 			return
 		}
 		time.Sleep(time.Millisecond)
@@ -228,8 +225,8 @@ func TestHandleUpdateKeepsBarrierOnlyWhenRestartWasScheduled(t *testing.T) {
 			if got := d.updating.Load(); got != tt.wantUpdating {
 				t.Fatalf("updating = %v, want %v", got, tt.wantUpdating)
 			}
-			if got := d.pauseClaims; got != tt.wantClaimsPaused {
-				t.Fatalf("pauseClaims = %v, want %v", got, tt.wantClaimsPaused)
+			if got := d.claimPaused(); got != tt.wantClaimsPaused {
+				t.Fatalf("claims paused = %v, want %v", got, tt.wantClaimsPaused)
 			}
 			if got := restartCalls.Load(); got != tt.wantRestartCalls {
 				t.Fatalf("restart calls = %d, want %d", got, tt.wantRestartCalls)

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -336,6 +336,11 @@ type DaemonHeartbeatAckPayload struct {
 	// that don't know this field silently ignore it (standard JSON behavior)
 	// and fall back to the singular PendingLocalSkillImport above.
 	PendingLocalSkillImports []DaemonHeartbeatPendingLocalSkillImport `json:"pending_local_skill_imports,omitempty"`
+	// QueuedTaskCount is how many tasks the server still holds queued for this
+	// runtime (status=queued). Populated while the runtime is draining so the
+	// daemon can report draining_queued_tasks on /health (NEX-38 design §7).
+	// Omitted when the server does not compute it; older daemons ignore it.
+	QueuedTaskCount int64 `json:"queued_tasks,omitempty"`
 }
 
 // HeartbeatStatusRuntimeGone is the ack Status used when the runtime row no

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -336,11 +336,14 @@ type DaemonHeartbeatAckPayload struct {
 	// that don't know this field silently ignore it (standard JSON behavior)
 	// and fall back to the singular PendingLocalSkillImport above.
 	PendingLocalSkillImports []DaemonHeartbeatPendingLocalSkillImport `json:"pending_local_skill_imports,omitempty"`
-	// QueuedTaskCount is how many tasks the server still holds queued for this
-	// runtime (status=queued). Populated while the runtime is draining so the
-	// daemon can report draining_queued_tasks on /health (NEX-38 design §7).
-	// Omitted when the server does not compute it; older daemons ignore it.
-	QueuedTaskCount int64 `json:"queued_tasks,omitempty"`
+	// QueuedTasks is the count of tasks currently sitting in 'queued' for
+	// this runtime (NEX-38 AC-8). Present only while the runtime is draining
+	// — the daemon shows it as "排队任务 M" during safe shutdown, so the user
+	// knows how many queued tasks will be stranded until queued_expired after
+	// the runtime shuts down. Computed server-side because the daemon cannot
+	// know the server's queue depth. Omitted (nil) for non-draining runtimes
+	// so the hot heartbeat ack stays tiny; older daemons ignore the field.
+	QueuedTasks *int `json:"queued_tasks,omitempty"`
 }
 
 // HeartbeatStatusRuntimeGone is the ack Status used when the runtime row no

--- a/server/pkg/protocol/messages_test.go
+++ b/server/pkg/protocol/messages_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDaemonHeartbeatAckQueuedTasksRoundTrip pins the NEX-38 AC-8 contract for
+// the unified queued_tasks field: the server writes it only while a runtime is
+// draining, the daemon reads the same JSON key back, and a non-draining ack
+// omits it (nil) so the daemon keeps its previous cached value.
+func TestDaemonHeartbeatAckQueuedTasksRoundTrip(t *testing.T) {
+	// Draining ack: queued_tasks present.
+	queued := 7
+	draining := DaemonHeartbeatAckPayload{RuntimeID: "rt-1", QueuedTasks: &queued}
+	data, err := json.Marshal(draining)
+	if err != nil {
+		t.Fatalf("marshal draining ack: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal draining ack: %v", err)
+	}
+	if _, ok := got["queued_tasks"]; !ok {
+		t.Fatalf("draining ack JSON = %s, want queued_tasks present", data)
+	}
+	if v := got["queued_tasks"].(float64); v != 7 {
+		t.Fatalf("queued_tasks = %v, want 7", v)
+	}
+
+	var round DaemonHeartbeatAckPayload
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal draining ack into struct: %v", err)
+	}
+	if round.QueuedTasks == nil || *round.QueuedTasks != 7 {
+		t.Fatalf("round-trip QueuedTasks = %v, want 7", round.QueuedTasks)
+	}
+
+	// Non-draining ack: field omitted (nil), not "0".
+	idle := DaemonHeartbeatAckPayload{RuntimeID: "rt-1"}
+	data2, err := json.Marshal(idle)
+	if err != nil {
+		t.Fatalf("marshal idle ack: %v", err)
+	}
+	if got2 := string(data2); got2 != `{"runtime_id":"rt-1","status":""}` {
+		t.Fatalf("idle ack JSON = %s, want queued_tasks omitted", got2)
+	}
+	var roundIdle DaemonHeartbeatAckPayload
+	if err := json.Unmarshal(data2, &roundIdle); err != nil {
+		t.Fatalf("unmarshal idle ack: %v", err)
+	}
+	if roundIdle.QueuedTasks != nil {
+		t.Fatalf("idle ack QueuedTasks = %v, want nil", roundIdle.QueuedTasks)
+	}
+}


### PR DESCRIPTION
Part of NEX-38 (safe shutdown / drain). Daemon-core subtask (NEX-47, stage 1). Server-side (migration 265 + registration/heartbeat keep-draining + AgentReadiness + runtime_drained) and CLI/UI land in the sibling subtasks.

## What

- **Three-state daemon state** (`daemonState`: running / draining / shutting_down) surfaced on `/health` as `state`.
- **`pauseClaims` → ref-count** (decision two): holders `drain` / `server-update` / `below-minimum` acquire/release independent refs under `claimMu`, so one holder can never clear another's pause. `tryEnterClaim` / `trySetClaimBarrier` / `tryBeginServerUpdate` / `releaseClaimBarrier` rewired; `demoteBelowMinimumRuntimes` uses its own `below-minimum` ref. During drain, auto-update / demotion defer.
- **Drain entry points**: `beginDrain` / `abortDrain` / `finishDrainThenStop`, plus a `POST /drain` health endpoint (drain / abort / finish_then_stop), 127.0.0.1-local like `/shutdown`.
- **Persistence (AC-13)**: `<workspaces-root>/drain.json` written before the in-memory flip; startup restores draining before the first registration so the register payload reports `status:"draining"` instead of defaulting back to online.
- **Decoupled shutdown (AC-4/AC-5)**: a drain monitor deregisters runtimes and cancels the root context once draining + finish-then-stop + `activeTasks==0`; the ordinary stop path (immediate cancel + 30s poll-loop cap) is untouched.
- **Health fields**: `state`, `draining_inflight_tasks` (== `active_task_count`), `draining_queued_tasks` (cached from heartbeat acks via a new additive `queued_tasks` field on `DaemonHeartbeatAckPayload`).

## Tests

New `daemon_drain_test.go` (state transitions, drain pauses/resumes claims, abort clears persistence + finish-then-stop flag, restart restore, drain monitor auto-stop vs resident-drain, `/drain` handler, health state/counts, queued-task cache) and `claim_pause_refcount_test.go` (independent-holder ref-count, concurrent interleaving, drain-vs-barrier defer). Updated the barrier tests that referenced the removed `pauseClaims` field.

Verified locally with Go 1.26.1: `go build ./...`, `go vet ./internal/daemon/...`, and the daemon / daemonws test suites pass. The 55 pre-existing failures in the daemon package are Windows-environment-specific (git path-length, symlink privilege, home-dir skill/MCP fixtures, missing fake CLIs) and are byte-identical on pristine `main`; `-race` is unavailable without cgo. CI `make check` remains the gate.