### PR TITLE
MUL-5961: feat(desktop): daemon draining UI (three-state) + four-language i18n (NEX-38/NEX-49)

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -20,6 +20,7 @@ import type {
   DaemonStatus,
   DaemonPrefs,
   LocalRuntimeProbe,
+  DaemonDrainAction,
 } from "../shared/daemon-types";
 import { daemonStatusAlive } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
@@ -149,6 +150,10 @@ function sendStatus(status: DaemonStatus): void {
 
 interface HealthPayload {
   status?: string;
+  /** Daemon three-state: running / draining / stopped (NEX-38). The daemon
+   *  keeps reporting `status: "running"` while draining — readiness is
+   *  orthogonal to the drain state, so the two fields are both read. */
+  state?: string;
   pid?: number;
   /** Daemon's runtime.GOOS. Absent on daemons older than the #3916 fix. */
   os?: string;
@@ -355,7 +360,7 @@ async function fetchHealth(): Promise<DaemonStatus> {
   }
 
   return {
-    state: "running",
+    state: data.state === "draining" ? "draining" : "running",
     pid: data.pid,
     uptime: data.uptime,
     daemonId: data.daemon_id,
@@ -820,7 +825,9 @@ function successfulRuntimeProbe(
 
 async function probeLocalRuntimes(): Promise<LocalRuntimeProbe> {
   const health = await fetchHealth();
-  if (health.state === "running") {
+  // A draining daemon still hosts its runtimes (heartbeats keep flowing), so
+  // count them as online for the probe.
+  if (health.state === "running" || health.state === "draining") {
     return successfulRuntimeProbe(health.agents ?? [], true);
   }
 
@@ -1003,6 +1010,42 @@ async function restartDaemon(): Promise<{ success: boolean; error?: string }> {
   return startDaemon();
 }
 
+/**
+ * Drive the daemon's safe-shutdown (drain) state machine over its `/drain`
+ * health endpoint (NEX-38). Unlike stop/restart this is a direct HTTP call to
+ * the daemon itself, not the CLI — so it works even for an externally-managed
+ * daemon (WSL2 etc.) whose process the host CLI can't reach, and it must not
+ * run through `lifecycleBlockedByForeignDaemon`. The renderer already hides
+ * the drain buttons for externally-managed daemons to match the CLI-driven
+ * toggles (#3916).
+ */
+async function drainDaemon(
+  action: DaemonDrainAction,
+): Promise<{ success: boolean; error?: string }> {
+  const active = await ensureActiveProfile();
+  if (!active) return { success: true };
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5_000);
+    const res = await fetch(`http://127.0.0.1:${active.port}/drain`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      return { success: false, error: `Daemon rejected drain (HTTP ${res.status})` };
+    }
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 async function pollOnce(): Promise<void> {
   const status = await fetchHealth();
   currentState = status.state;
@@ -1157,6 +1200,9 @@ export function setupDaemonManager(
   ipcMain.handle("daemon:start", () => withGuard(() => startDaemon()));
   ipcMain.handle("daemon:stop", () => withGuard(() => stopDaemon()));
   ipcMain.handle("daemon:restart", () => withGuard(() => restartDaemon()));
+  ipcMain.handle("daemon:drain", (_e, action: DaemonDrainAction) =>
+    withGuard(() => drainDaemon(action)),
+  );
   ipcMain.handle("daemon:get-status", () => fetchHealth());
   ipcMain.handle("daemon:probe-runtimes", () => probeLocalRuntimes());
   // The host's OS name, available regardless of daemon state. The Runtimes
@@ -1200,9 +1246,11 @@ export function setupDaemonManager(
     const bin = await resolveCliBinary();
     if (!bin) return;
     const health = await fetchHealth();
-    if (health.state === "running") {
-      // Daemon is up but may be running an older CLI than the one we just
-      // bundled. Restart it so the new binary actually takes effect.
+    if (daemonStatusAlive(health.state)) {
+      // Daemon is up (running, starting, or draining) but may be running an
+      // older CLI than the one we just bundled. Restart it so the new binary
+      // actually takes effect. Draining counts as alive — don't spawn a second
+      // daemon over it.
       await ensureRunningDaemonVersionMatches();
       return;
     }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -15,6 +15,7 @@ import type {
   DaemonStatus,
   DaemonPrefs,
   LocalRuntimeProbe,
+  DaemonDrainAction,
 } from "../shared/daemon-types";
 
 interface DesktopAPI {
@@ -119,6 +120,9 @@ interface DaemonAPI {
   start: () => Promise<{ success: boolean; error?: string }>;
   stop: () => Promise<{ success: boolean; error?: string }>;
   restart: () => Promise<{ success: boolean; error?: string }>;
+  drain: (
+    action: DaemonDrainAction,
+  ) => Promise<{ success: boolean; error?: string }>;
   getStatus: () => Promise<DaemonStatus>;
   probeRuntimes: () => Promise<LocalRuntimeProbe>;
   getHostName: () => Promise<string>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -23,6 +23,7 @@ import { AUTH_SESSION_STATE_CHANNEL } from "../shared/auth-session";
 import type {
   DaemonStatus,
   LocalRuntimeProbe,
+  DaemonDrainAction,
 } from "../shared/daemon-types";
 import {
   MAIN_RENDERER_CHANNEL_STATE_CHANNEL,
@@ -237,6 +238,10 @@ const daemonAPI = {
     ipcRenderer.invoke("daemon:stop"),
   restart: (): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke("daemon:restart"),
+  drain: (
+    action: DaemonDrainAction,
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke("daemon:drain", action),
   getStatus: (): Promise<DaemonStatus> =>
     ipcRenderer.invoke("daemon:get-status"),
   probeRuntimes: (): Promise<LocalRuntimeProbe> =>

--- a/apps/desktop/src/renderer/src/components/daemon-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/daemon-panel.tsx
@@ -328,7 +328,9 @@ export function DaemonPanel({
             <EmptyState
               hasLogs={logs.length > 0}
               hasFilter={hasActiveFilter}
-              isRunning={status.state === "running"}
+              isRunning={
+                status.state === "running" || status.state === "draining"
+              }
             />
           ) : (
             <div className="flex flex-col">
@@ -396,7 +398,8 @@ function ContextBadge({
   status: DaemonStatus;
   runtimeCount: number;
 }) {
-  const isRunning = status.state === "running";
+  const isRunning =
+    status.state === "running" || status.state === "draining";
   return (
     <span className="inline-flex items-center gap-1.5 rounded-md border bg-background px-1.5 py-0.5 text-caption font-normal">
       <span

--- a/apps/desktop/src/renderer/src/components/daemon-runtime-card.test.tsx
+++ b/apps/desktop/src/renderer/src/components/daemon-runtime-card.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import type { DaemonStatus } from "../../../shared/daemon-types";
 
@@ -25,14 +25,42 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+const runtimesTranslations = {
+  drainAction: "Safe shutdown",
+  drainCancel: "Cancel shutdown",
+  drainForceStop: "Shut down now",
+  stateDraining: "Draining",
+  drainInlineHint: "{{inflight}} running · {{queued}} queued",
+  drainConfirmTitle: "This will interrupt {{count}} running task(s).",
+  drainQueuedHint: "{{count}} queued task(s) will remain until they time out.",
+  drainDescription:
+    "No new tasks will be accepted; the daemon shuts down once running tasks finish.",
+};
+
+vi.mock("@multica/views/i18n", () => ({
+  useT: () => ({
+    t: (
+      selector: (resources: typeof runtimesTranslations) => string,
+      values?: Record<string, unknown>,
+    ) => {
+      const template = selector(runtimesTranslations);
+      return Object.entries(values ?? {}).reduce(
+        (result, [key, value]) => result.replace(`{{${key}}}`, String(value)),
+        template,
+      );
+    },
+  }),
+}));
+
 import { DaemonRuntimeActions } from "./daemon-runtime-card";
 
-function stubDaemonAPI(status: DaemonStatus) {
+function stubDaemonAPI(status: DaemonStatus, drain = vi.fn()) {
   Object.defineProperty(window, "daemonAPI", {
     configurable: true,
     value: {
       getStatus: vi.fn().mockResolvedValue(status),
       onStatusChange: vi.fn(() => () => {}),
+      drain,
     },
   });
 }
@@ -47,6 +75,8 @@ describe("DaemonRuntimeActions — externally managed daemon (#3916)", () => {
     expect(screen.getByText("Managed outside the app")).toBeInTheDocument();
     expect(screen.queryByText("Restart")).not.toBeInTheDocument();
     expect(screen.queryByText("Stop")).not.toBeInTheDocument();
+    // Drain is a lifecycle control the app can't drive either — hidden too.
+    expect(screen.queryByText("Safe shutdown")).not.toBeInTheDocument();
   });
 
   it("shows Stop/Restart for a normally-managed running daemon (no 误伤)", async () => {
@@ -64,3 +94,57 @@ describe("DaemonRuntimeActions — externally managed daemon (#3916)", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("DaemonRuntimeActions — draining state (NEX-38)", () => {
+  it("shows the draining badge, cancel, and force-stop buttons", async () => {
+    stubDaemonAPI({ state: "draining", daemonId: "d1" });
+    render(<DaemonRuntimeActions />);
+
+    expect(await screen.findByText("Draining")).toBeInTheDocument();
+    expect(screen.getByText("0 running · 0 queued")).toBeInTheDocument();
+    expect(screen.getByText("Cancel shutdown")).toBeInTheDocument();
+    expect(screen.getByText("Shut down now")).toBeInTheDocument();
+    // No start / stop / restart in the draining branch.
+    expect(screen.queryByText("Stop")).not.toBeInTheDocument();
+    expect(screen.queryByText("Restart")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start")).not.toBeInTheDocument();
+  });
+
+  it("calls daemon drain with `abort` when cancel is clicked", async () => {
+    const drain = vi.fn().mockResolvedValue({ success: true });
+    stubDaemonAPI({ state: "draining", daemonId: "d1" }, drain);
+    render(<DaemonRuntimeActions />);
+
+    fireEvent.click(await screen.findByText("Cancel shutdown"));
+    expect(drain).toHaveBeenCalledWith("abort");
+  });
+
+  it("asks for confirmation before force-stop, then drains with `finish_then_stop`", async () => {
+    const drain = vi.fn().mockResolvedValue({ success: true });
+    stubDaemonAPI({ state: "draining", daemonId: "d1" }, drain);
+    render(<DaemonRuntimeActions />);
+
+    fireEvent.click(await screen.findByText("Shut down now"));
+    expect(
+      await screen.findByText(
+        "This will interrupt 0 running task(s).",
+      ),
+    ).toBeInTheDocument();
+    // The dialog confirm is labelled "Shut down now" too — two elements now.
+    fireEvent.click(screen.getAllByText("Shut down now")[1]!);
+    await waitFor(() => expect(drain).toHaveBeenCalledWith("finish_then_stop"));
+  });
+
+  it("starts safe shutdown from the running state via `drain`", async () => {
+    const drain = vi.fn().mockResolvedValue({ success: true });
+    stubDaemonAPI(
+      { state: "running", daemonId: "d1", externallyManaged: false },
+      drain,
+    );
+    render(<DaemonRuntimeActions />);
+
+    fireEvent.click(await screen.findByText("Safe shutdown"));
+    await waitFor(() => expect(drain).toHaveBeenCalledWith("drain"));
+  });
+});
+

--- a/apps/desktop/src/renderer/src/components/daemon-runtime-card.tsx
+++ b/apps/desktop/src/renderer/src/components/daemon-runtime-card.tsx
@@ -8,6 +8,8 @@ import {
   ScrollText,
   LogIn,
   Info,
+  ShieldAlert,
+  Undo2,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -23,20 +25,23 @@ import {
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
 import { toast } from "sonner";
+import { useT } from "@multica/views/i18n";
 import { DaemonPanel } from "./daemon-panel";
 import { reauthenticateDaemon } from "../platform/daemon-reauth";
 import type { DaemonStatus } from "../../../shared/daemon-types";
-import { DAEMON_STATE_LABELS } from "../../../shared/daemon-types";
+import { DAEMON_STATE_COLORS, DAEMON_STATE_LABELS } from "../../../shared/daemon-types";
 
 /**
  * Desktop-only controls for the daemon embedded in this Electron app. The
  * shared runtimes page renders this inside the selected local machine header.
  */
 export function DaemonRuntimeActions() {
+  const { t } = useT("runtimes");
   const [status, setStatus] = useState<DaemonStatus>({ state: "stopped" });
   const [panelOpen, setPanelOpen] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
+  const [confirmForceStop, setConfirmForceStop] = useState(false);
 
   const wsId = useWorkspaceId();
   const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
@@ -59,6 +64,14 @@ export function DaemonRuntimeActions() {
         (t) =>
           localRuntimeIds.has(t.runtime_id) &&
           (t.status === "running" || t.status === "dispatched"),
+      ),
+    [snapshot, localRuntimeIds],
+  );
+
+  const queuedTasks = useMemo(
+    () =>
+      snapshot.filter(
+        (t) => localRuntimeIds.has(t.runtime_id) && t.status === "queued",
       ),
     [snapshot, localRuntimeIds],
   );
@@ -97,6 +110,36 @@ export function DaemonRuntimeActions() {
     }
   }, [affectedTasks.length, performStop]);
 
+  const handleDrain = useCallback(async () => {
+    setActionLoading(true);
+    const result = await window.daemonAPI.drain("drain");
+    if (!result.success) {
+      setActionLoading(false);
+      toast.error("Failed to start safe shutdown", {
+        description: result.error,
+      });
+    }
+  }, []);
+
+  const handleDrainAbort = useCallback(async () => {
+    setActionLoading(true);
+    const result = await window.daemonAPI.drain("abort");
+    if (!result.success) {
+      setActionLoading(false);
+      toast.error("Failed to cancel safe shutdown", {
+        description: result.error,
+      });
+    }
+  }, []);
+
+  const performForceStop = useCallback(async () => {
+    setActionLoading(true);
+    const result = await window.daemonAPI.drain("finish_then_stop");
+    if (!result.success) {
+      toast.error("Failed to shut down daemon", { description: result.error });
+    }
+  }, []);
+
   const handleRestart = useCallback(async () => {
     setActionLoading(true);
     const result = await window.daemonAPI.restart();
@@ -127,6 +170,7 @@ export function DaemonRuntimeActions() {
   }, []);
 
   const isRunning = status.state === "running";
+  const isDraining = status.state === "draining";
   // The daemon runs somewhere the app can't drive (e.g. inside WSL2): the
   // lifecycle CLI acts on the host process namespace and can't reach it. Hide
   // Stop/Restart so they don't silently no-op, mirroring the Settings tab. The
@@ -167,12 +211,69 @@ export function DaemonRuntimeActions() {
                 </Button>
                 <Button
                   size="sm"
+                  variant="outline"
+                  onClick={handleDrain}
+                  disabled={actionLoading}
+                >
+                  <ShieldAlert className="size-3.5 mr-1.5" />
+                  {t(($) => $.drainAction)}
+                </Button>
+                <Button
+                  size="sm"
                   variant="destructive"
                   onClick={handleStopClick}
                   disabled={actionLoading}
                 >
                   <Square className="size-3.5 mr-1.5" />
                   Stop
+                </Button>
+              </>
+            )}
+          </>
+        )}
+
+        {isDraining && (
+          <>
+            <span className="inline-flex items-center gap-1.5 text-caption text-muted-foreground">
+              <span
+                className={`size-1.5 shrink-0 rounded-full ${DAEMON_STATE_COLORS[status.state]}`}
+              />
+              <span>{t(($) => $.stateDraining)}</span>
+              <span className="tabular-nums">
+                {t(($) => $.drainInlineHint, {
+                  inflight: affectedTasks.length,
+                  queued: queuedTasks.length,
+                })}
+              </span>
+            </span>
+            <Button size="sm" variant="ghost" onClick={() => setPanelOpen(true)}>
+              <ScrollText className="size-3.5 mr-1.5" />
+              View logs
+            </Button>
+            {externallyManaged ? (
+              <span className="inline-flex items-center gap-1.5 text-caption text-muted-foreground">
+                <Info className="size-3.5 shrink-0" />
+                Managed outside the app
+              </span>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleDrainAbort}
+                  disabled={actionLoading}
+                >
+                  <Undo2 className="size-3.5 mr-1.5" />
+                  {t(($) => $.drainCancel)}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => setConfirmForceStop(true)}
+                  disabled={actionLoading}
+                >
+                  <Square className="size-3.5 mr-1.5" />
+                  {t(($) => $.drainForceStop)}
                 </Button>
               </>
             )}
@@ -243,6 +344,17 @@ export function DaemonRuntimeActions() {
           void performStop();
         }}
       />
+
+      <DrainForceStopDialog
+        open={confirmForceStop}
+        onOpenChange={setConfirmForceStop}
+        affectedCount={affectedTasks.length}
+        queuedCount={queuedTasks.length}
+        onConfirm={() => {
+          setConfirmForceStop(false);
+          void performForceStop();
+        }}
+      />
     </>
   );
 }
@@ -288,6 +400,63 @@ function StopConfirmDialog({
           </Button>
           <Button variant="destructive" onClick={onConfirm}>
             Stop daemon
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Second-confirm shown when the user picks "Shut down now" while the daemon is
+ * draining. Unlike a plain stop, draining is about finishing in-flight work —
+ * force-stopping mid-drain interrupts those tasks, so we spell out the damage
+ * and, when queued tasks exist, warn that they'll be left to time out (they are
+ * never reassigned — see NEX-38 decision one).
+ */
+function DrainForceStopDialog({
+  open,
+  onOpenChange,
+  affectedCount,
+  queuedCount,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  affectedCount: number;
+  queuedCount: number;
+  onConfirm: () => void;
+}) {
+  const { t } = useT("runtimes");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm" showCloseButton={false}>
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+            <AlertCircle className="h-5 w-5 text-destructive" />
+          </div>
+          <DialogHeader className="flex-1 gap-1">
+            <DialogTitle className="text-body font-semibold">
+              {t(($) => $.drainConfirmTitle, { count: affectedCount })}
+            </DialogTitle>
+            <DialogDescription className="text-caption leading-relaxed">
+              {t(($) => $.drainDescription)}
+              {queuedCount > 0 && (
+                <>
+                  {" "}
+                  {t(($) => $.drainQueuedHint, { count: queuedCount })}
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t(($) => $.drainCancel)}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            {t(($) => $.drainForceStop)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/renderer/src/platform/daemon-ipc-bridge.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-ipc-bridge.ts
@@ -13,6 +13,7 @@ import type { AgentRuntime } from "@multica/core/types";
 interface DaemonStatusLike {
   state:
     | "running"
+    | "draining"
     | "stopped"
     | "starting"
     | "stopping"
@@ -43,6 +44,15 @@ function mergeDaemonStatus(rt: AgentRuntime, status: DaemonStatusLike): AgentRun
     return {
       ...rt,
       status: "online",
+      last_seen_at: new Date().toISOString(),
+    };
+  }
+  // Draining keeps heartbeats flowing and finishes in-flight work, so the
+  // runtime stays alive — just not claiming new tasks (NEX-38).
+  if (status.state === "draining") {
+    return {
+      ...rt,
+      status: "draining",
       last_seen_at: new Date().toISOString(),
     };
   }

--- a/apps/desktop/src/shared/daemon-types.test.ts
+++ b/apps/desktop/src/shared/daemon-types.test.ts
@@ -13,6 +13,12 @@ describe("daemonStatusAlive", () => {
     expect(daemonStatusAlive("starting")).toBe(true);
   });
 
+  it("treats a draining daemon as alive (NEX-38)", () => {
+    // A draining daemon is still on the port and finishing in-flight work; it
+    // must not be treated as stopped (which would spawn a second daemon).
+    expect(daemonStatusAlive("draining")).toBe(true);
+  });
+
   it("treats stopped / unknown / missing as not alive", () => {
     expect(daemonStatusAlive("stopped")).toBe(false);
     expect(daemonStatusAlive("bogus")).toBe(false);

--- a/apps/desktop/src/shared/daemon-types.ts
+++ b/apps/desktop/src/shared/daemon-types.ts
@@ -1,5 +1,8 @@
 export type DaemonState =
   | "running"
+  // Safe shutdown in progress: no new tasks are accepted, but already-running
+  // tasks are allowed to finish before the daemon stops (NEX-38 drain).
+  | "draining"
   | "stopped"
   | "starting"
   | "stopping"
@@ -9,6 +12,16 @@ export type DaemonState =
   // cached PAT expired / was revoked, or the session token is dead). Without
   // this, an auth failure silently sticks at "starting" forever — see #3512.
   | "auth_expired";
+
+/**
+ * Actions the local daemon's `/drain` endpoint accepts. `drain` enters safe
+ * shutdown; `abort` cancels it back to running; `finish_then_stop` shuts the
+ * daemon down once in-flight tasks complete.
+ */
+export type DaemonDrainAction =
+  | "drain"
+  | "abort"
+  | "finish_then_stop";
 
 export interface DaemonStatus {
   state: DaemonState;
@@ -51,6 +64,7 @@ export type LocalRuntimeProbe =
 
 export const DAEMON_STATE_COLORS: Record<DaemonState, string> = {
   running: "bg-emerald-500",
+  draining: "bg-amber-500",
   stopped: "bg-muted-foreground/40",
   starting: "bg-amber-500 animate-pulse",
   stopping: "bg-amber-500 animate-pulse",
@@ -61,6 +75,7 @@ export const DAEMON_STATE_COLORS: Record<DaemonState, string> = {
 
 export const DAEMON_STATE_LABELS: Record<DaemonState, string> = {
   running: "Running",
+  draining: "Draining",
   stopped: "Stopped",
   starting: "Starting…",
   stopping: "Stopping…",
@@ -88,7 +103,12 @@ export function formatUptime(uptime?: string): string {
  * version-restart decisions still gate on the stricter "running".
  */
 export function daemonStatusAlive(status: string | undefined): boolean {
-  return status === "running" || status === "starting";
+  return (
+    status === "running" ||
+    status === "starting" ||
+    // A draining daemon is still alive — it just stopped claiming new tasks.
+    status === "draining"
+  );
 }
 
 /**
@@ -110,6 +130,8 @@ export function daemonStateDescription(state: DaemonState, runtimeCount: number)
         return "Running here · 1 runtime available for tasks.";
       }
       return `Running here · ${runtimeCount} runtimes available for tasks.`;
+    case "draining":
+      return "Draining · no new tasks are accepted; running tasks finish before shutdown.";
     case "stopped":
       return "Not running · this device can't take new tasks.";
     case "starting":

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -661,8 +661,10 @@ export const RuntimeSchema: z.ZodType<RuntimeDevice> = z.object({
   launch_header: z.string().default(""),
   // The two fields presence derivation actually reads. Status defaults to
   // "offline" — a runtime row with an unparseable status is treated as
-  // unreachable, which is the safe degrade for the dot.
-  status: z.enum(["online", "offline"]).catch("offline"),
+  // unreachable, which is the safe degrade for the dot. `draining` is the
+  // NEX-38 safe-shutdown state: keep it, so presence doesn't drop it to
+  // offline while the runtime finishes in-flight work.
+  status: z.enum(["online", "draining", "offline"]).catch("offline"),
   last_seen_at: z.string().nullable().default(null),
   device_info: z.string().default(""),
   metadata: z.record(z.string(), z.unknown()).default({}),

--- a/packages/core/runtimes/derive-health.test.ts
+++ b/packages/core/runtimes/derive-health.test.ts
@@ -32,6 +32,14 @@ describe("deriveRuntimeHealth", () => {
     ).toBe("online");
   });
 
+  it("returns online when status is draining (NEX-38)", () => {
+    // A draining runtime keeps heartbeating while finishing in-flight work, so
+    // it must not read as recently_lost / offline.
+    expect(
+      deriveRuntimeHealth(makeRuntime({ status: "draining", last_seen_at: null }), FIXED_NOW),
+    ).toBe("online");
+  });
+
   it("returns recently_lost when offline less than 5 minutes", () => {
     expect(
       deriveRuntimeHealth(

--- a/packages/core/runtimes/derive-health.ts
+++ b/packages/core/runtimes/derive-health.ts
@@ -13,7 +13,11 @@ const FIVE_MINUTES_MS = 5 * 60 * 1000;
 const ABOUT_TO_GC_THRESHOLD_MS = 6 * 24 * 3600 * 1000; // 6 days
 
 export function deriveRuntimeHealth(runtime: AgentRuntime, now: number): RuntimeHealth {
-  if (runtime.status === "online") return "online";
+  // `draining` is an alive state: the runtime keeps heartbeating while it
+  // finishes in-flight work, so it must not read as lost/offline.
+  if (runtime.status === "online" || runtime.status === "draining") {
+    return "online";
+  }
 
   // No last_seen timestamp ever recorded — treat as long-offline. This is
   // an unusual case (the back-end always sets last_seen_at on register),

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -70,7 +70,12 @@ export interface RuntimeDevice {
   runtime_mode: AgentRuntimeMode;
   provider: string;
   launch_header: string;
-  status: "online" | "offline";
+  /**
+   * Server-side runtime status. `draining` is the NEX-38 safe-shutdown state:
+   * the runtime stops claiming new tasks but keeps heartbeating and finishes
+   * in-flight work, so it stays "alive" for the offline sweeper.
+   */
+  status: "online" | "draining" | "offline";
   device_info: string;
   metadata: Record<string, unknown>;
   owner_id: string | null;

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -109,6 +109,14 @@
       "description": "Offline 6+ days. Auto-deleted at 7 days unless it reconnects."
     }
   },
+  "drainAction": "Safe shutdown",
+  "drainCancel": "Cancel shutdown",
+  "drainForceStop": "Shut down now",
+  "stateDraining": "Draining",
+  "drainInlineHint": "{{inflight}} running · {{queued}} queued",
+  "drainConfirmTitle": "This will interrupt {{count}} running task(s).",
+  "drainQueuedHint": "{{count}} queued task(s) will remain until they time out.",
+  "drainDescription": "No new tasks will be accepted; the daemon shuts down once running tasks finish.",
   "detail": {
     "all_runtimes": "All runtimes",
     "read_only": "Read-only",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -105,6 +105,14 @@
       "description": "6 日以上オフラインです。再接続しない限り、7 日目に自動削除されます。"
     }
   },
+  "drainAction": "安全なシャットダウン",
+  "drainCancel": "安全なシャットダウンをキャンセル",
+  "drainForceStop": "今すぐシャットダウン",
+  "stateDraining": "シャットダウン準備中",
+  "drainInlineHint": "実行中タスク {{inflight}} · 待機タスク {{queued}}",
+  "drainConfirmTitle": "実行中のタスク {{count}} 件を中断します。",
+  "drainQueuedHint": "待機中のタスク {{count}} 件はタイムアウトまで維持されます。",
+  "drainDescription": "新しいタスクは受け付けず、実行中のタスクが完了すると自動でシャットダウンします。",
   "detail": {
     "all_runtimes": "すべてのランタイム",
     "read_only": "読み取り専用",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -105,6 +105,14 @@
       "description": "6일 넘게 오프라인입니다. 다시 연결되지 않으면 7일째 자동 삭제됩니다."
     }
   },
+  "drainAction": "안전 종료",
+  "drainCancel": "안전 종료 취소",
+  "drainForceStop": "지금 종료",
+  "stateDraining": "안전 종료 중",
+  "drainInlineHint": "실행 중 작업 {{inflight}} · 대기 작업 {{queued}}",
+  "drainConfirmTitle": "실행 중인 작업 {{count}}개를 중단합니다.",
+  "drainQueuedHint": "대기 중인 작업 {{count}}개는 시간 초과까지 유지됩니다.",
+  "drainDescription": "새 작업을 받지 않으며 실행 중인 작업이 완료되면 자동으로 종료됩니다.",
   "detail": {
     "all_runtimes": "모든 런타임",
     "read_only": "읽기 전용",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -105,6 +105,14 @@
       "description": "离线 6 天以上。如不重连，将在 7 天时自动删除。"
     }
   },
+  "drainAction": "安全关闭",
+  "drainCancel": "取消安全关闭",
+  "drainForceStop": "立即关闭",
+  "stateDraining": "安全关闭中",
+  "drainInlineHint": "在跑任务 {{inflight}} · 排队任务 {{queued}}",
+  "drainConfirmTitle": "将打断 {{count}} 个在跑任务。",
+  "drainQueuedHint": "另有 {{count}} 个排队任务将保留至超时失败。",
+  "drainDescription": "不再接收新任务，在跑任务完成后自动关闭。",
   "detail": {
     "all_runtimes": "全部运行时",
     "read_only": "只读",

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -390,7 +390,12 @@ function currentMachineMetadata(
   runtimes: AgentRuntime[],
   key: "cli_version" | "launched_by",
 ): string | null {
-  const online = runtimes.filter((runtime) => runtime.status === "online");
+  // A draining runtime is still alive (heartbeats flow), so its metadata is
+  // as trustworthy as an online one's.
+  const online = runtimes.filter(
+    (runtime) =>
+      runtime.status === "online" || runtime.status === "draining",
+  );
   const candidates = online.length > 0 ? online : runtimes;
 
   for (const runtime of candidates.toSorted(compareRuntimeReports)) {


### PR DESCRIPTION
### Summary
NEX-49 (NEX-38 S3): UI ???? + ?? i18n?

- daemon-types: DaemonState ? draining,??/??/description/statusAlive + DaemonDrainAction ??
- IPC: preload + main ???? daemon:drain,??????? /drain ?? (drain/abort/finish_then_stop)
- daemon ??????: running [View logs] [Restart] [????] [Stop];draining [??????] [????]+??;off ? [Start]
- ?? runtimes ?????????????;/health state ?? draining;IPC bridge ?? draining
- core: RuntimeDevice.status + mobile zod schema ?? draining;deriveRuntimeHealth ? draining ???
- i18n: en/zh-Hans/ja/ko runtimes.json ?? 8 ?,parity.test ??

### ??
- pnpm typecheck(web/desktop/core/views/mobile)??
- packages/core 1354 tests?packages/views runtimes 191 tests?apps/desktop daemon ?? 10 tests?locales parity 177 tests ??
- apps/desktop ? scripts/package.test.mjs / untime-config-loader.test.ts ??? Electron ?????(????,???????)