### PR TITLE
test(e2e): cover project status persistence

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -45,12 +45,18 @@ export interface TestTableIssue {
   number: number;
 }
 
+interface TestProject {
+  id: string;
+  title: string;
+}
+
 export class TestApiClient {
   private token: string | null = null;
   private workspaceSlug: string | null = null;
   private workspaceId: string | null = null;
   private email: string | null = null;
   private createdIssueIds: string[] = [];
+  private createdProjectIds: string[] = [];
   private seededIssueIds: string[] = [];
 
   async login(email: string, name: string) {
@@ -194,6 +200,19 @@ export class TestApiClient {
     return issue;
   }
 
+  async createProject(title: string, opts?: Record<string, unknown>): Promise<TestProject> {
+    const res = await this.authedFetch("/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ title, ...opts }),
+    });
+    if (!res.ok) {
+      throw new Error(`create project failed: ${res.status} ${await res.text()}`);
+    }
+    const project = (await res.json()) as TestProject;
+    this.createdProjectIds.push(project.id);
+    return project;
+  }
+
   /**
    * Insert a large, deterministic issue fixture in one transaction.
    *
@@ -305,6 +324,10 @@ export class TestApiClient {
     await this.authedFetch(`/api/issues/${id}`, { method: "DELETE" });
   }
 
+  async deleteProject(id: string) {
+    await this.authedFetch(`/api/projects/${id}`, { method: "DELETE" });
+  }
+
   async updateIssue(id: string, updates: Record<string, unknown>) {
     const res = await this.authedFetch(`/api/issues/${id}`, {
       method: "PUT",
@@ -339,6 +362,14 @@ export class TestApiClient {
       }
     }
     this.createdIssueIds = [];
+    for (const id of this.createdProjectIds) {
+      try {
+        await this.deleteProject(id);
+      } catch {
+        /* ignore — may already be deleted */
+      }
+    }
+    this.createdProjectIds = [];
   }
 
   getToken() {

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import { createTestApi, loginAsDefault, waitForPageText } from "./helpers";
+import type { TestApiClient } from "./fixtures";
+
+test.describe("Projects", () => {
+  let api: TestApiClient;
+
+  test.beforeEach(async ({ page }) => {
+    api = await createTestApi();
+    await loginAsDefault(page);
+  });
+
+  test.afterEach(async () => {
+    if (api) {
+      await api.cleanup();
+    }
+  });
+
+  test("can open a project and persist a status update", async ({ page }) => {
+    const project = await api.createProject(`E2E Project ${Date.now()}`);
+
+    await page.getByRole("link", { name: "Projects", exact: true }).click();
+    await expect(page).toHaveURL(/\/projects$/);
+    await waitForPageText(page, project.title);
+
+    const projectRow = page.getByRole("row").filter({ hasText: project.title });
+    await expect(projectRow).toBeVisible();
+    await projectRow.getByText(project.title, { exact: true }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}$`));
+    await waitForPageText(page, project.title);
+
+    const propertiesSection = page
+      .getByRole("button", { name: "Properties" })
+      .locator("..");
+    await propertiesSection.getByRole("button", { name: "Planned" }).click();
+
+    const updateResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        response.url().endsWith(`/api/projects/${project.id}`),
+    );
+    await page.getByRole("menuitem", { name: "In Progress" }).click();
+    expect((await updateResponse).ok()).toBe(true);
+    await expect(
+      propertiesSection.getByRole("button", { name: "In Progress" }),
+    ).toBeVisible();
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitForPageText(page, project.title);
+    await expect(
+      page
+        .getByRole("button", { name: "Properties" })
+        .locator("..")
+        .getByRole("button", { name: "In Progress" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds an end-to-end test for a real backend-backed project workflow. The test creates a project through the test API, navigates from the Projects list to its detail page, updates its status, reloads the page, and verifies that the change persisted.

Existing E2E coverage focuses primarily on issues, while Projects lacked coverage across routing, UI state, API mutations, and database persistence. This focused scenario protects that integration without relying on external services or an agent runtime.

Risk is limited to test infrastructure and selectors; production behavior is unchanged.

## Related Issue

N/A — this addresses an identified Projects E2E coverage gap.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `e2e/projects.spec.ts` to cover list navigation and persisted status updates.
- Extended `e2e/fixtures.ts` with project creation, deletion, tracking, and cleanup helpers.

## How to Test

1. Start the application and database with `make start`.
2. Run `pnpm exec playwright test e2e/projects.spec.ts`.
3. Optionally run `pnpm typecheck`.

Local validation:
- `pnpm typecheck` passed.
- Playwright successfully discovered the new test.
- The browser test was not executed locally because Docker/PostgreSQL was unavailable in WSL.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

I asked Cursor to identify an uncovered, low-dependency E2E workflow among Projects, Squads, Agents, and Autopilots. It reviewed the existing Playwright coverage and project UI/API paths, then implemented a focused Projects scenario using the repository’s existing `TestApiClient` setup and cleanup patterns. I reviewed the resulting changes and ran the available type and test-discovery checks.

## Screenshots (optional)

Not applicable. This PR changes test coverage only and does not alter the UI.