### PR TITLE
fix(agents): use DingTalk brand icon

### DIFF
--- a/packages/views/agents/components/tabs/integrations-tab.test.tsx
+++ b/packages/views/agents/components/tabs/integrations-tab.test.tsx
@@ -171,6 +171,12 @@ describe("IntegrationsTab", () => {
     expect(screen.getByTestId("slack-bind-button").getAttribute("data-agent-id")).toBe("agent-1");
   });
 
+  it("renders the DingTalk brand mark in the DingTalk integration card", () => {
+    renderTab(<IntegrationsTab agent={agent} />);
+    const section = screen.getByText("DingTalk").closest("section");
+    expect(section?.querySelector('[data-testid="dingtalk-mark"].h-5.w-5')).toBeTruthy();
+  });
+
   it("shows the coming-soon notice when the install transport is not wired", () => {
     installationsRef.current = {
       installations: [],

--- a/packages/views/agents/components/tabs/integrations-tab.tsx
+++ b/packages/views/agents/components/tabs/integrations-tab.tsx
@@ -13,6 +13,7 @@ import { memberListOptions } from "@multica/core/workspace/queries";
 import { LarkAgentBindButton } from "../../../settings/components/lark-tab";
 import { SlackAgentBindButton } from "../../../settings/components/slack-tab";
 import { DingTalkAgentBindButton } from "../../../settings/components/dingtalk-tab";
+import { DingTalkMark } from "../../../settings/components/dingtalk-mark";
 import { WecomAgentBindButton } from "../../../settings/components/wecom-tab";
 import { WecomMark } from "../../../settings/components/wecom-mark";
 import { useT } from "../../../i18n";
@@ -212,7 +213,7 @@ export function IntegrationsTab({ agent }: { agent: Agent }) {
       <section className="rounded-lg border">
         <div className="flex items-start gap-3 p-4">
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-            <MessagesSquare className="h-4 w-4" />
+            <DingTalkMark className="h-5 w-5" />
           </span>
           <div className="min-w-0 flex-1 space-y-1">
             <h3 className="text-body font-medium">{ts(($) => $.dingtalk.section_title)}</h3>

--- a/packages/views/settings/components/dingtalk-mark.tsx
+++ b/packages/views/settings/components/dingtalk-mark.tsx
@@ -1,0 +1,38 @@
+// The SVG path in DingTalkMark below is adapted from `docs/images/dingtalk.svg`
+// in DingTalk's official OpenClaw connector, used under the MIT License. Source:
+// https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/5e2b4d9356ee8f80c4617142d823d2ca7de0f3d9/docs/images/dingtalk.svg
+// The original fixed fill was changed to currentColor for theme compatibility.
+//
+// Copyright (c) 2026 DingTalk Real Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export function DingTalkMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      aria-hidden="true"
+      data-testid="dingtalk-mark"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M37.05 22.783c-6.758-5.216-14.378-12.128-22.73-19.538-.655-.585-1.242-.354-1.536.42-1.88 4.973-.058 9.386 2.889 11.932s7.368 4.912 10.058 6.155c.105.049.013.203-.093.163-4.953-2.182-8.397-3.765-13.07-7.368-.497-.388-1.01-.242-1.07.521-.384 4.748 2.657 8.483 6.058 9.745 2.1.781 4.398 1.212 6.53 1.474.109.015.084.178-.027.178-2.747.01-6.058-.654-8.935-1.751-.606-.233-.818.25-.722.633.491 2.008 2.974 5.076 6.926 5.73a12 12 0 0 0 2.228.115c.164 0 .208.089.154.217q-2.685 4.6-2.803 4.797c-.091.152-.036.275.156.275h3.543c.164 0 .264.106.18.246l-4.958 8.196c-.191.328.035.565.395.301s15.212-11.133 15.636-11.448c.195-.142.148-.327-.124-.327h-3.18c-.206 0-.252-.14-.111-.28.14-.141 3.602-3.594 4.837-4.888 1.283-1.35 1.938-3.825-.231-5.498" />
+    </svg>
+  );
+}

--- a/packages/views/settings/components/dingtalk-tab.test.tsx
+++ b/packages/views/settings/components/dingtalk-tab.test.tsx
@@ -113,6 +113,12 @@ function resetFixtures() {
 describe("DingTalkAgentBindButton", () => {
   beforeEach(resetFixtures);
 
+  it("renders the DingTalk brand mark in the connect button", () => {
+    renderUI(<DingTalkAgentBindButton agentId="agent-1" agentName="Bot" />);
+    const button = screen.getByTestId("dingtalk-agent-connect");
+    expect(button.querySelector('[data-testid="dingtalk-mark"].h-4.w-4')).toBeTruthy();
+  });
+
   it("opens the BYO dialog and submits the pasted AppKey + AppSecret", async () => {
     mockRegisterBYO.mockResolvedValue({ id: "i1", agent_id: "agent-1", status: "active" });
     renderUI(<DingTalkAgentBindButton agentId="agent-1" agentName="Bot" />);

--- a/packages/views/settings/components/dingtalk-tab.tsx
+++ b/packages/views/settings/components/dingtalk-tab.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { ChevronRight, ExternalLink, MessagesSquare, Trash2 } from "lucide-react";
+import { ChevronRight, ExternalLink, Trash2 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
@@ -28,6 +28,7 @@ import {
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { memberListOptions } from "@multica/core/workspace/queries";
+import { DingTalkMark } from "./dingtalk-mark";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { dingtalkInstallationsOptions, dingtalkKeys } from "@multica/core/dingtalk";
 import { api } from "@multica/core/api";
@@ -361,7 +362,7 @@ export function DingTalkAgentBindButton({
         }
         data-testid="dingtalk-agent-connect"
       >
-        <MessagesSquare className="h-3 w-3" />
+        <DingTalkMark className="h-4 w-4" />
         {t(($) => $.dingtalk.bind_button)}
       </Button>
 


### PR DESCRIPTION
## What does this PR do?

Replaces the generic chat-bubble icon used for DingTalk in Agents → Capabilities → Integrations with a reusable DingTalk brand mark. The same mark now appears in both the integration card and the “Connect DingTalk” button.

The mark comes from DingTalk Real Team's official OpenClaw connector under the MIT License. The component preserves the pinned source and full license notice, uses `currentColor` for theme compatibility, and calibrates its rendered sizes to match adjacent channel icons.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `packages/views/settings/components/dingtalk-mark.tsx` using DingTalk's official MIT-licensed brand asset with a pinned source and license header.
- Replaced the generic DingTalk integration-card icon with the brand mark at a visually balanced size.
- Replaced the generic “Connect DingTalk” button icon with the same brand mark.
- Added stable `data-testid`-based regression coverage for both rendering surfaces without coupling tests to SVG path details.

## How to Test

1. Run `pnpm --filter @multica/views typecheck`.
2. Run ESLint for the five changed files.
3. Run `pnpm --filter @multica/views test` and confirm all views tests pass.
4. Open Agents → Capabilities → Integrations and confirm the DingTalk card and connect button use the DingTalk mark with visual weight consistent with the other channels.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) — not applicable; no runtime, tool, or tab was added
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) — not applicable; no copy changed
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
The user supplied a replacement SVG and iteratively reviewed its visual size and weight. Codex located the shared Agents integration surfaces, implemented a reusable current-color SVG component, calibrated separate card/button sizes, and added targeted regression assertions. In response to review, Codex replaced the third-party redraw with the official DingTalk asset from DingTalk Real Team's MIT-licensed connector, preserved the source and license notice, and decoupled tests from artwork-specific SVG attributes.

## Screenshots

<img width="718" height="167" alt="image" src="https://github.com/user-attachments/assets/97ff85bc-6e53-47f2-9c8c-70ed3ae1c309" />
<img width="717" height="164" alt="image" src="https://github.com/user-attachments/assets/9e7c2150-6fa2-4ec9-a12c-45c8c59ff77d" />


## Validation

- `pnpm --filter @multica/views typecheck` — passed
- ESLint on all changed files — passed
- Targeted DingTalk integration tests — 2 files passed, 17 tests passed
- `pnpm --filter @multica/views test` — 318 files passed, 3,772 tests passed

## Risk

Low. This is a presentation-only change in the shared web/desktop views package. It does not change channel behavior, permissions, state, API contracts, or installation flows.
