### PR TITLE
MUL-5979 fix(views): hide empty agent detail menu

### DIFF
--- a/packages/views/agents/components/agent-detail-page.test.tsx
+++ b/packages/views/agents/components/agent-detail-page.test.tsx
@@ -214,6 +214,39 @@ describe("AgentDetailPage DM button", () => {
     expect(screen.queryByRole("button", { name: "DM" })).not.toBeInTheDocument();
   });
 
+  it("hides the more-actions trigger when no menu actions are available", async () => {
+    // The gate must survive a caller who genuinely CAN archive: an admin
+    // passes `canEditAgent`, so `canArchive` is true. The only thing keeping
+    // the menu empty is the system agent's undefined `onArchive`. Assert the
+    // real aria label (locale `detail.more_actions_aria` = "Agent actions"),
+    // so removing the `hasMoreActions` gate would render the empty shell and
+    // fail this test.
+    agentsRef.current = [
+      { ...baseAgent, system_key: "mika" },
+    ];
+    membersRef.current = [{ user_id: "user-1", role: "admin" }];
+    renderPage();
+
+    await screen.findByRole("button", { name: "Assign work" });
+    expect(
+      screen.queryByLabelText("Agent actions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the more-actions trigger for an editable non-system agent", async () => {
+    // Positive counterpart: an owner of a normal agent has a real archive
+    // action, so the menu trigger must still render. Guards the gate against
+    // over-hiding.
+    agentsRef.current = [{ ...baseAgent, owner_id: "user-1" }];
+    membersRef.current = [{ user_id: "user-1", role: "member" }];
+    renderPage();
+
+    await screen.findByRole("button", { name: "Assign work" });
+    expect(
+      screen.getByLabelText("Agent actions"),
+    ).toBeInTheDocument();
+  });
+
   it("explains an unbound agent and blocks run actions without losing the profile", async () => {
     agentsRef.current = [
       {

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -459,6 +459,7 @@ function DetailHeader({
   const { t } = useT("agents");
   const timeAgo = useTimeAgo();
   const isArchived = !!agent.archived_at;
+  const hasMoreActions = !!onArchive;
 
   return (
     <header className="shrink-0 border-b bg-background px-4 pb-5 pt-3 sm:px-6">
@@ -539,26 +540,26 @@ function DetailHeader({
                 {t(($) => $.detail.assign_work)}
               </Button>
             )}
-            {!isArchived && canArchive ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button variant="ghost" size="icon-sm" />}
-              aria-label={t(($) => $.detail.more_actions_aria)}
-            >
-              <MoreHorizontal
-                className="h-4 w-4 text-muted-foreground"
-                aria-hidden="true"
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-auto">
-              {onArchive && (
-                <DropdownMenuItem variant="destructive" onClick={onArchive}>
-                  <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                  {t(($) => $.detail.more_archive)}
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+            {!isArchived && canArchive && hasMoreActions ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={<Button variant="ghost" size="icon-sm" />}
+                  aria-label={t(($) => $.detail.more_actions_aria)}
+                >
+                  <MoreHorizontal
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-auto">
+                  {onArchive && (
+                    <DropdownMenuItem variant="destructive" onClick={onArchive}>
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      {t(($) => $.detail.more_archive)}
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- hide the agent detail kebab trigger when there are no available menu actions
- add a regression test for system agents that previously showed an empty menu shell
- follow up on GitHub bug #6695

## Original screenshot
![Original bug screenshot](https://static.multica.ai/workspaces/9a5ae390-52b4-4621-83b6-53a90f8b87fa/019feab3-117c-7c59-bf18-7ae42a05417a.png)

## Testing
- pnpm -C packages/views exec vitest run agents/components/agent-detail-page.test.tsx
- pnpm -C packages/views typecheck


Closes #6695
