### PR TITLE
fix(issues): hold the drag settle lock until the table refetch lands

### DIFF
--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { setApiInstance } from "../api";
@@ -314,6 +314,89 @@ describe("useUpdateIssue — optimistic move keeps every bucketed board in sync"
 
     expect(inboxStatus("issue-1")).toBe("todo");
     expect(inboxStatus("issue-2")).toBe("todo");
+  });
+
+  it("parks the caller's onSettled until the table branch refetch lands (move only)", async () => {
+    // The drag surfaces release their frozen column mirror from this
+    // callback, and table branch caches reconcile ORDER through the tableAll
+    // refetch, not through the optimistic patch — a release that ran before
+    // the refetch would repaint the stale order (the drag flicker).
+    moveIssue.mockResolvedValue(makeIssue(1, { position: 5 }));
+    let fetchCount = 0;
+    let resolveRefetch!: () => void;
+    const tableKey = [...issueKeys.tableAll(WS_ID), "rows", "test", "page", null];
+    const tableQuery = renderHook(
+      () =>
+        useQuery({
+          queryKey: tableKey,
+          queryFn: () => {
+            fetchCount++;
+            if (fetchCount === 1) return Promise.resolve({ rows: [] });
+            return new Promise<{ rows: never[] }>((r) => {
+              resolveRefetch = () => r({ rows: [] });
+            });
+          },
+        }),
+      { wrapper: createWrapper(qc) },
+    );
+    await waitFor(() => expect(fetchCount).toBe(1));
+
+    const onSettled = vi.fn();
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+    act(() => {
+      result.current.mutate(
+        { id: "issue-1", position: 5, move_intent: { before_id: null, after_id: null } },
+        { onSettled },
+      );
+    });
+
+    // The settle invalidation refetches the active table query; the caller's
+    // callback must stay parked while that refetch is in flight.
+    await waitFor(() => expect(fetchCount).toBe(2));
+    expect(onSettled).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveRefetch();
+    });
+    await waitFor(() => expect(onSettled).toHaveBeenCalledTimes(1));
+    tableQuery.unmount();
+  });
+
+  it("releases the caller's onSettled promptly when the move fails", async () => {
+    // The rollback already restored the old order; the revert should paint
+    // without waiting out a refetch.
+    moveIssue.mockRejectedValue(new Error("boom"));
+    let fetchCount = 0;
+    const tableKey = [...issueKeys.tableAll(WS_ID), "rows", "test", "page", null];
+    const tableQuery = renderHook(
+      () =>
+        useQuery({
+          queryKey: tableKey,
+          queryFn: () => {
+            fetchCount++;
+            if (fetchCount === 1) return Promise.resolve({ rows: [] });
+            return new Promise<{ rows: never[] }>(() => {}); // refetch never lands
+          },
+        }),
+      { wrapper: createWrapper(qc) },
+    );
+    await waitFor(() => expect(fetchCount).toBe(1));
+
+    const onSettled = vi.fn();
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+    act(() => {
+      result.current.mutate(
+        { id: "issue-1", position: 5, move_intent: { before_id: null, after_id: null } },
+        { onSettled },
+      );
+    });
+
+    await waitFor(() => expect(onSettled).toHaveBeenCalledTimes(1));
+    tableQuery.unmount();
   });
 
   it("does not invalidate the board list on settle (no refetch flicker)", async () => {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -250,7 +250,9 @@ export function useUpdateIssue() {
           vars.status !== undefined ||
           Object.prototype.hasOwnProperty.call(vars, "project_id"),
       });
-      qc.invalidateQueries({ queryKey: issueKeys.tableAll(wsId) });
+      const tableRefetch = qc.invalidateQueries({
+        queryKey: issueKeys.tableAll(wsId),
+      });
       if (ctx) {
         invalidateStaleListKeys(qc, ctx.change.staleKeys);
       }
@@ -285,6 +287,18 @@ export function useUpdateIssue() {
       if (ctx?.parentId || newParentId) {
         qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
       }
+      // Drag surfaces render from a local column mirror frozen until their
+      // settle callback (mutate-level onSettled) releases it. Table branch
+      // caches reconcile ORDER through the invalidation above — the
+      // optimistic pass patches row fields in place, never row order — so a
+      // release that runs before the refetch lands repaints the stale order
+      // and the card visibly snaps back, then jumps again when the refetch
+      // arrives. Returning the promise parks the caller's callback until
+      // the authoritative order is in cache (TanStack awaits promises
+      // returned from hook-level callbacks before running mutate-level
+      // ones). On error the rollback already restored the old order and the
+      // revert should paint promptly, so the wait is skipped.
+      return vars.move_intent && !_err ? tableRefetch : undefined;
     },
   });
 }

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -988,6 +988,10 @@ function SwimLaneViewImpl({
   // localCells out from under the optimistic move. Mirrors board-view /
   // list-view. settleVersion forces the resync once the lock releases.
   const isSettlingRef = useRef(false);
+  // Mirrors useDragSettle's generation stamp: the release runs after the
+  // move's table refetch lands, so a second drop can engage the lock while
+  // the first release is still in flight.
+  const settleGenerationRef = useRef(0);
   const [settleVersion, setSettleVersion] = useState(0);
 
   const issueMap = useMemo(() => {
@@ -1270,6 +1274,7 @@ function SwimLaneViewImpl({
       }
 
       isSettlingRef.current = true;
+      const generation = ++settleGenerationRef.current;
       onMoveIssue(
         activeId,
         {
@@ -1279,6 +1284,7 @@ function SwimLaneViewImpl({
           ...getMoveAnchors(finalIds, activeId),
         },
         () => {
+          if (settleGenerationRef.current !== generation) return;
           isSettlingRef.current = false;
           setSettleVersion((v) => v + 1);
         },

--- a/packages/views/issues/components/use-drag-settle.test.ts
+++ b/packages/views/issues/components/use-drag-settle.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useDragSettle } from "./use-drag-settle";
+
+describe("useDragSettle — settle lock generations", () => {
+  it("releases the lock and bumps settleVersion on settle", () => {
+    const { result } = renderHook(() => useDragSettle(() => ({})));
+
+    const release = result.current.beginSettle();
+    expect(result.current.isSettlingRef.current).toBe(true);
+
+    act(() => release());
+    expect(result.current.isSettlingRef.current).toBe(false);
+    expect(result.current.settleVersion).toBe(1);
+  });
+
+  it("a superseded release cannot unlock a newer settle", () => {
+    // The release runs after the move's table refetch lands, so a second
+    // drop can engage the lock while the first release is still in flight.
+    // The stale release must neither unlock the newer settle nor bump the
+    // version (which would resync the newer optimistic move away).
+    const { result } = renderHook(() => useDragSettle(() => ({})));
+
+    const firstRelease = result.current.beginSettle();
+    const secondRelease = result.current.beginSettle();
+
+    act(() => firstRelease());
+    expect(result.current.isSettlingRef.current).toBe(true);
+    expect(result.current.settleVersion).toBe(0);
+
+    act(() => secondRelease());
+    expect(result.current.isSettlingRef.current).toBe(false);
+    expect(result.current.settleVersion).toBe(1);
+  });
+
+  it("a late release from a fully settled generation is a no-op", () => {
+    const { result } = renderHook(() => useDragSettle(() => ({})));
+
+    const firstRelease = result.current.beginSettle();
+    act(() => firstRelease());
+    const secondRelease = result.current.beginSettle();
+    act(() => secondRelease());
+    expect(result.current.settleVersion).toBe(2);
+
+    // Calling a consumed release again (double onSettled) changes nothing.
+    act(() => firstRelease());
+    expect(result.current.settleVersion).toBe(2);
+    expect(result.current.isSettlingRef.current).toBe(false);
+  });
+});

--- a/packages/views/issues/components/use-drag-settle.ts
+++ b/packages/views/issues/components/use-drag-settle.ts
@@ -101,9 +101,17 @@ export function useDragSettle(
    * Engage the settle lock and return the `onSettled` callback to hand to the
    * move mutation. The callback releases the lock and triggers a single resync.
    */
+  const settleGenerationRef = useRef(0);
   const beginSettle = useCallback(() => {
     isSettlingRef.current = true;
+    // The release now runs AFTER the move's table refetch lands (the
+    // mutation parks it — see useUpdateIssue.onSettled), so a second drop
+    // can engage the lock while the first release is still in flight. The
+    // generation stamp keeps that late release from unlocking the newer
+    // settle and resyncing its optimistic move away.
+    const generation = ++settleGenerationRef.current;
     return () => {
+      if (settleGenerationRef.current !== generation) return;
       isSettlingRef.current = false;
       setSettleVersion((v) => v + 1);
     };


### PR DESCRIPTION
## Problem

Dragging a card on the board flashed twice: it sat at the drop target, snapped back to its old slot when the move settled, then jumped to the target again ~0.5s later. List and swimlane had the same defect (cross-column drags were worse — the card briefly returned to its origin column).

## Root cause (log-verified)

The issue surfaces render from the **table branch caches** (saved-views pipeline, `POST /api/issues/table/rows` per branch). The cache coordinator's optimistic pass patches table rows **in place** — row fields update, row **order** doesn't. That's a documented design choice (`cache-coordinator.ts`): ordering reconciles through the `tableAll` invalidation on settle, which is correct for inline edits.

Drags broke the assumption: the drag surfaces freeze a local column mirror during the request and release it at mutation settle — **before** the reconciling refetch lands. Debug traces showed the exact sequence on every drag:

```
settle lock RELEASED → resync MOVES CARDS (stale cache order — flash 1)
table/rows refetch lands → resync MOVES CARDS (server order — flash 2)
```

`positionsMatch: true` throughout — the field was right, the array order wasn't. The old status-bucketed caches re-slot on position patch (`patchIssueInBuckets`), so this is a regression introduced when the surfaces moved to the table pipeline, not a flaw in the settle protocol itself.

## Fix

Keep the architecture's "order reconciles via invalidation" choice and supply its missing half — **don't repaint until reconciled**:

- `useUpdateIssue`'s hook-level `onSettled` returns the `tableAll` invalidation promise for successful moves. TanStack v5 awaits promises returned from hook-level callbacks before running mutate-level ones, so the drag surfaces' release callback now runs after the authoritative order is in cache and the resync is a visual no-op. Error paths skip the wait — the rollback already restored the old order and the revert should paint promptly.
- `beginSettle` (shared drag/settle hook) and swimlane's inline settle stamp each settle with a **generation**: with the release now async, a second drop can engage the lock while the first release is still in flight, and the stale release must not unlock the newer settle. (This race existed before, just with a narrower window.)

Considered and rejected: teaching the coordinator to re-slot rows optimistically across the table pipeline (cursor-chained page keys, hierarchy branches, compound swimlane groups, per-branch totals, facet counts). That re-implements server ordering/pagination client-side — exactly what the state-management rules warn against — and every divergence would be a new flicker source. The chosen fix is ~30 lines, zero new cache writes, and covers all three surfaces through the one callback they already share.

## Behavior notes

- Field edits (no `move_intent`) and move callers without a settle callback are untouched.
- Surfaces with no active table queries release immediately (the invalidation resolves at once).
- The settle lock now extends by one refetch (~300–500ms); remote changes don't repaint during it — same as during the drag itself.

## Tests

- `mutations.test.tsx`: the caller's `onSettled` parks until the table refetch resolves (controlled queryFn; this also empirically pins the TanStack callback-await semantics the fix relies on), and releases promptly on mutation error.
- `use-drag-settle.test.ts` (new): release + version bump, superseded release cannot unlock a newer settle, consumed release is a no-op.
- Existing "does not invalidate the board list on settle (no refetch flicker)" guards still pass.

## Verification

- `pnpm typecheck` ✅ (6/6)
- `pnpm lint` ✅ (0 errors; warnings pre-existing, none in touched files)
- `pnpm test` for core + views + desktop ✅ (1,348 + 3,775 + 462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)