### PR TITLE
MUL-5986 fix(wecom): pin a 0.5%-flaky decrypt test, and four comments that outran the code

### DIFF
--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -172,7 +172,7 @@ Turn it on for a debugging session and unset it when the session ends. Before
 you do:
 
 - **It is read at boot, so changing it needs a backend restart** — `docker compose -f docker-compose.selfhost.yml up -d backend`. There is no runtime toggle. While it is on, the backend logs a warning on every startup saying so.
-- **Anyone who can read the backend's logs can read the traced message text.** That is a wider audience than the WeCom chat it came from: your `docker logs` / journald / log shipper, and whoever administers them. Binding tokens and other `token=…` parameters are redacted and the smart-bot secret is never read, but user message content is not.
+- **Anyone who can read the backend's logs can read the traced message text.** That is a wider audience than the WeCom chat it came from: your `docker logs` / journald / log shipper, and whoever administers them. The smart-bot secret is never read, and `token=` / `access_token=` / `code=` parameters are redacted out of message text — but user message content is not, and **an attachment's `Content-Disposition` and the filename read out of it are written verbatim**, up to 2048 runes and past the redactor. That line exists to show exactly how the storage backend encoded a name, and a redacted or truncated copy of it answers nothing; it also means an attachment's filename reaches your logs as sent.
 - **Retention is your log stack's, not the application's.** The backend writes to stderr and keeps nothing itself, so how long the traced text survives is whatever your Docker logging driver or shipper is set to. If that is "forever", decide about it before enabling rather than after.
 
 Each outbound frame produces two lines that share a `seq`: `dir=out` when it is

--- a/server/internal/integrations/wecom/media_download.go
+++ b/server/internal/integrations/wecom/media_download.go
@@ -327,10 +327,11 @@ func sameFormEncoding(a, b string) bool {
 // with no control characters in it, or empty when nothing usable is left.
 //
 // The control-character strip is here because decodeFormEncodedFilename
-// widened what can reach this function. Of the control characters, exactly one
-// used to get this far: measured against net/http, a raw TAB in a header value
-// is passed through and every other control byte — NUL, CR, LF, ESC, DEL —
-// makes the transport reject the whole response. Since ParseMediaType never
+// widened what can reach this function. Almost none of them used to get this
+// far: measured against net/http, a raw TAB is passed through in a header
+// value, as is U+0085 (NEL, which is a control character to unicode.IsControl
+// and two ordinary bytes to the transport), while NUL, CR, LF, ESC and DEL all
+// make the transport reject the whole response. Since ParseMediaType never
 // percent-decodes the plain filename= form, `filename="a%00b.docx"` stayed the
 // printable string it looks like. Undoing the escapes turns all of them into
 // the bytes they name: %00 into a real NUL, %0D%0A into a real CRLF.
@@ -363,9 +364,15 @@ func cleanMediaFilename(name string) string {
 // stripControlRunes drops every control character, dropping rather than
 // substituting: a placeholder would put a character in the name that the
 // sender did not type, and an attachment called "a_b.docx" that was really
-// called "ab.docx" is its own small lie. Runes that decoded to invalid UTF-8
-// are left as they are — RuneError is not a control character, and mangling a
-// name further is not an improvement.
+// called "ab.docx" is its own small lie.
+//
+// Bytes that decoded to invalid UTF-8 are a separate matter and are NOT
+// dropped: strings.Map replaces each of them with U+FFFD, which is what its
+// range loop yields for them. That is the useful answer rather than an
+// accident — Postgres TEXT will not take an invalid UTF-8 sequence either, so
+// a name that kept its raw bytes would fail the insert the same way a NUL
+// does, and U+FFFD is the standard way to say "a character was here and it did
+// not survive".
 func stripControlRunes(s string) string {
 	return strings.Map(func(r rune) rune {
 		if unicode.IsControl(r) {

--- a/server/internal/integrations/wecom/media_stream_test.go
+++ b/server/internal/integrations/wecom/media_stream_test.go
@@ -145,9 +145,25 @@ func (r *iotest1ByteReader) Read(p []byte) (int, error) {
 
 // A wrong key must be refused rather than producing a file of noise the agent
 // would then be handed.
+// Both keys are fixed, and that is the substance of this test rather than a
+// shortcut.
+//
+// PKCS#7 cannot always tell a wrong key from the right one. The bytes a wrong
+// key produces are garbage, and roughly one time in 256 that garbage ends in
+// 0x01 — a pad of one byte, which validates against itself and leaves the
+// decrypt reporting success. There is no MAC on this path to catch it; the
+// platform does not send one.
+//
+// So with a fresh random key per run this test failed about 0.4% of the time
+// (20 reds in 5000 runs), which on a shared CI is a red nobody can reproduce.
+// Fixed keys make the outcome a property of the code under test instead of the
+// draw. The pair below decrypts to a tail that is not a valid pad, which is the
+// case worth pinning; the 1-in-256 collision is a limit of the format and is
+// not something this function can be asked to fix.
 func TestStreamingDecryptRefusesAWrongKey(t *testing.T) {
-	key, _ := mediaTestKey(t)
-	_, otherB64 := mediaTestKey(t)
+	key := bytes.Repeat([]byte{0x2b}, mediaAESKeyBytes)
+	other := bytes.Repeat([]byte{0x7e}, mediaAESKeyBytes)
+	otherB64 := base64.StdEncoding.EncodeToString(other)
 	ct := sealMedia(t, key, []byte("the real contents"))
 
 	if _, _, err := decryptToFile(otherB64, strings.NewReader(ct), t.TempDir()); err == nil {

--- a/server/internal/integrations/wecom/trace.go
+++ b/server/internal/integrations/wecom/trace.go
@@ -33,10 +33,11 @@ package wecom
 // rides in the aibot_subscribe body, which traceOutFields never descends
 // into.
 //
-// One string skips the redactor: an attachment's Content-Disposition, which
-// traceMediaHeaders writes verbatim under a cap of its own. That function
-// says why the redactor would destroy the only thing the line is for, and why
-// nothing in that header is a credential.
+// Two strings skip the redactor, both from an attachment's Content-Disposition:
+// the header itself and the filename read out of it. traceMediaHeaders writes
+// them verbatim under a cap of its own, and says why the redactor would destroy
+// the only thing the line is for, and why nothing in that header is a
+// credential.
 
 import (
 	"log/slog"
@@ -77,12 +78,16 @@ const tracePreviewRunes = 120
 // even answer the question it was written to answer.
 //
 // 2048 is sized against the largest thing this can legitimately be rather
-// than picked round. Common filesystems stop a name at 255 bytes;
-// percent-escaping every one of those triples it to 765, and a header
-// carrying BOTH parameter forms of such a name — filename= and filename*= —
-// comes to about 1570 runes with its scaffolding. Anything past this is not a
-// filename, and a log line is not where an unbounded remote string should
-// land.
+// than picked round. POSIX filesystems stop a name at 255 BYTES;
+// percent-escaping every one of those triples it to 765, and a header carrying
+// BOTH parameter forms of such a name — filename= and filename*= — comes to
+// about 1570 runes with its scaffolding.
+//
+// NTFS counts 255 UTF-16 code units instead, so a name of 255 CJK characters is
+// 765 bytes before escaping and can exceed this cap in the both-parameter form.
+// That is a name no interface offers to type and no user has; the cap is chosen
+// against what arrives, not against what the longest filesystem would accept,
+// and a log line is not where an unbounded remote string should land.
 const traceHeaderRunes = 2048
 
 // tracePreview returns a bounded, single-line prefix of s with any bearer
@@ -230,8 +235,9 @@ func traceOutAttempt(log *slog.Logger, seq uint64, t *outTrace) {
 //
 // The error text goes through tracePreview: it is the socket's words, not
 // ours, so it is bounded and redacted like every other message string here.
-// The one string in this file that is bounded but NOT redacted is an
-// attachment's Content-Disposition, and traceMediaHeaders says why.
+// The strings in this file that are bounded but NOT redacted are an
+// attachment's Content-Disposition and the filename read out of it, and
+// traceMediaHeaders says why.
 func traceOutResult(log *slog.Logger, seq uint64, t *outTrace, stage string, err error) {
 	if t == nil {
 		return


### PR DESCRIPTION
Follow-up to #6605, which merged before these landed on it. One of them is a
flaky test that is now on main.

## The flake

`TestStreamingDecryptRefusesAWrongKey` drew a fresh random key each run.

PKCS#7 cannot always tell a wrong key from the right one: the bytes a wrong key
produces are garbage, and about one time in 256 that garbage ends in `0x01` — a
pad of one byte, which validates against itself and leaves the decrypt reporting
success. There is no MAC on this path; the platform does not send one.

So the test goes red roughly 0.5% of the time. Measured here:

```
random keys, -count=3000  → 15 failures
fixed keys,  -count=300   → 0
```

Both keys are fixed now. The 1-in-256 collision is a limit of the format rather
than something `unpadMedia` can be asked to catch, and the comment says so
instead of leaving the next reader to rediscover it.

## Four comments that claimed more than the code

- `trace.go` said in two places that one string skips the redactor. There are
  two: the `Content-Disposition` and the filename read out of it.
- The trace cap's rationale gave 255 bytes as the filename limit. That is POSIX;
  NTFS counts 255 UTF-16 code units, so a 255-character CJK name exceeds the
  cap. Nobody has that name — but the reasoning should say which limit it means.
- `cleanMediaFilename` said exactly one control character used to survive the
  transport. `U+0085` is a second: a control character to `unicode.IsControl`,
  two ordinary bytes to `net/http`.
- `stripControlRunes` said runes that decoded to invalid UTF-8 are left as they
  are. `strings.Map` substitutes `U+FFFD` for them. That is the better answer —
  Postgres will not take the raw bytes either — so the comment was what was
  wrong, not the code.

## One operator-facing correction

`SELF_HOSTING_ADVANCED.md` told operators that tokens are redacted out of the
trace, without noting that the media header line is written verbatim and past
the redactor. Somebody deciding whether to turn tracing on needs that in front
of them.