### PR TITLE
fix(cli): detect desktop-app-managed daemon in 'daemon status'

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -1086,6 +1086,32 @@ func requestDaemonShutdown(healthPort int) error {
 
 // --- daemon status ---
 
+// findDesktopDaemonHealth scans ~/.multica/profiles/desktop-* for a running
+// daemon started by the desktop app. Returns its health map and true when found.
+func findDesktopDaemonHealth(ctx context.Context) (map[string]any, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, false
+	}
+	profilesDir := filepath.Join(home, ".multica", "profiles")
+	entries, err := os.ReadDir(profilesDir)
+	if err != nil {
+		return nil, false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "desktop-") {
+			continue
+		}
+		port := healthPortForProfile(entry.Name())
+		health := checkDaemonHealthOnPort(ctx, port)
+		if health["status"] == "running" {
+			health["profile"] = entry.Name()
+			return health, true
+		}
+	}
+	return nil, false
+}
+
 func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	profile := resolveProfile(cmd)
 	healthPort, err := daemonStatusHealthPort(cmd)
@@ -1097,6 +1123,14 @@ func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	health := checkDaemonHealthOnPort(ctx, healthPort)
+
+	// When the default profile daemon is stopped, check for a desktop-app-managed
+	// daemon that may be running under ~/.multica/profiles/desktop-*/.
+	if health["status"] == "stopped" && profile == "" {
+		if dHealth, ok := findDesktopDaemonHealth(ctx); ok {
+			health = dHealth
+		}
+	}
 
 	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {


### PR DESCRIPTION
## Summary
`multica daemon status` from the terminal always reports "stopped" for
daemons started by the desktop app. This happens because the desktop
app uses profile names like `desktop-multica.ai` with a distinct health
port (derived from the profile name via `healthPortForProfile`), while
the CLI `daemon status` only checks the default profile port (19514).

## Fix
Add `findDesktopDaemonHealth()` that scans `~/.multica/profiles/desktop-*/`
directories and probes each profile's health port using the same
`healthPortForProfile()` function. When the default profile daemon shows
"stopped" and no explicit `--profile` was given, this scan runs as a
fallback.

This respects the existing design boundary: CLI and desktop profiles
remain separate; the CLI merely discovers the desktop daemon when the
default daemon is not running.

## Testing
- `go build ./server/cmd/multica/` passes
- `go test ./server/cmd/multica/ -run "Daemon"` all pass
- No desktop profiles exist: reports "stopped" as before (no false positive)
- Desktop daemon running: reports "running" with profile info

Closes #6694