### PR TITLE
fix(execenv): guard openclaw wrapper against $include-ing its own file

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -216,6 +217,24 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 	activePath, exists, err := openclawActiveConfigPath(bin, timeout)
 	if err != nil {
 		return OpenclawConfigResult{}, fmt.Errorf("locate openclaw active config: %w", err)
+	}
+	// **Self-include guard (issue #6630 second defect).** If the CLI
+	// resolves the active config to a file we ourselves write into envRoot
+	// — the per-task wrapper or the sanitized user snapshot — then
+	// $include'ing it would make the wrapper include itself and every task
+	// would fail with "Circular include detected". This happens when a
+	// stale OPENCLAW_CONFIG_PATH (e.g. a leftover workaround wrapper) or a
+	// re-run pointing at a previous task's envRoot reports our own file as
+	// the user's active config. Treat it as "no user config" (fresh-install
+	// branch) and warn loudly so the operator can clear the stale env var.
+	if exists && openclawIsOwnTaskFile(activePath, envRoot) {
+		if opts.Logger != nil {
+			opts.Logger.Warn("execenv: openclaw active config resolves to a multica-owned task file; omitting $include so the user's models and auth profiles will NOT be visible to this task (check OPENCLAW_CONFIG_PATH for a stale multica wrapper)",
+				"reported_path", activePath,
+				"env_root", envRoot)
+		}
+		exists = false
+		activePath = ""
 	}
 	if !exists && opts.Logger != nil {
 		// Not an error — a genuine fresh install lands here legitimately.
@@ -647,6 +666,42 @@ func appendOpenclawConfigFileCandidates(candidates []string, dir string) []strin
 // keying on the character rather than the host OS lets the Windows shape be
 // exercised from the normal Linux/macOS test job instead of only on a Windows
 // runner, the same trade isOpenclawShimPath makes above.
+// openclawIsOwnTaskFile reports whether path is one of the files this
+// package writes into envRoot: the per-task wrapper (openclawConfigFile)
+// or the sanitized user snapshot (openclawUserSnapshotFile). If the
+// openclaw CLI ever reports one of these as the *user's* active config,
+// $include'ing it would make the wrapper include itself and every task
+// would fail with "Circular include detected" — the second defect called
+// out in the #6630 thread, kept out of #6643. This happens when a stale
+// OPENCLAW_CONFIG_PATH (e.g. a leftover workaround wrapper) points at a
+// multica_workspaces/*/openclaw-config.json.
+func openclawIsOwnTaskFile(path, envRoot string) bool {
+	if path == "" || envRoot == "" {
+		return false
+	}
+	for _, name := range []string{openclawConfigFile, openclawUserSnapshotFile} {
+		if openclawPathEquals(path, filepath.Join(envRoot, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+// openclawPathEquals compares two paths for identity, normalizing
+// separators and (on Windows) case. The daemon and the openclaw CLI share
+// a host, so the host's own filesystem semantics apply; we key on the
+// separator character rather than the host OS for the same reason
+// openclawTildeRest accepts both forms — the Windows shape stays
+// exercisable from the Linux/macOS test job.
+func openclawPathEquals(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
 func openclawTildeRest(path string) (string, bool) {
 	if path == "~" {
 		return "", true

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1700,3 +1700,133 @@ func TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing(t *testing.T) {
 		t.Errorf("IncludeRoot = %q, want empty", result.IncludeRoot)
 	}
 }
+
+// TestPrepareOpenclawConfigSkipsSelfInclude — the second defect called out
+// in the #6630 thread (kept out of #6643): nothing verified that the config
+// path discovered by `openclaw config file` isn't a file we ourselves write
+// into envRoot. If a stale OPENCLAW_CONFIG_PATH points at a previous task's
+// multica_workspaces/*/openclaw-config.json (or the sanitized snapshot), the
+// wrapper would emit `$include: [itself]` and every task would fail with
+// "Circular include detected". The guard must treat that as "no user config"
+// (fresh-install branch) and warn loudly.
+func TestPrepareOpenclawConfigSkipsSelfInclude(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := t.TempDir()
+
+	// The CLI resolves the active config to the per-task wrapper path we are
+	// about to write — e.g. a stale OPENCLAW_CONFIG_PATH left over from a
+	// workaround wrapper pointing at a previous task's
+	// multica_workspaces/*/openclaw-config.json. The stale file already
+	// exists on disk (that is what makes it the *active* config), so
+	// materialize it before prepare runs.
+	wrapperPath := filepath.Join(envRoot, openclawConfigFile)
+	if err := os.WriteFile(wrapperPath, []byte(`{"agents":{"defaults":{"workspace":"/old/task"}}}`), 0o600); err != nil {
+		t.Fatalf("write stale wrapper: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: wrapperPath + "\n"},
+	})
+
+	var logs strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin, Logger: logger})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+
+	got := mustReadJSON(t, result.ConfigPath)
+	if _, ok := got["$include"]; ok {
+		t.Errorf("wrapper must not $include itself; got $include = %v", got["$include"])
+	}
+	if result.IncludeRoot != "" {
+		t.Errorf("IncludeRoot = %q, want empty (no cross-dir $include emitted)", result.IncludeRoot)
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "multica-owned task file") {
+		t.Errorf("self-include guard was not warned about; log was:\n%s", out)
+	}
+	// The prepared-config summary should record include_target=none so the
+	// consequence (no user models / auth) is visible at a glance.
+	if !strings.Contains(out, "include_target=none") {
+		t.Errorf("prepared-config log should record include_target=none; log was:\n%s", out)
+	}
+}
+
+// TestPrepareOpenclawConfigSkipsSelfIncludeSnapshot — same guard, but for the
+// sanitized user snapshot file. The snapshot lives in envRoot next to the
+// wrapper, so a stale OPENCLAW_CONFIG_PATH could equally point at it; the
+// wrapper must not $include that either.
+func TestPrepareOpenclawConfigSkipsSelfIncludeSnapshot(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := t.TempDir()
+
+	// Same guard, for the sanitized user snapshot file. The snapshot lives in
+	// envRoot next to the wrapper, so a stale OPENCLAW_CONFIG_PATH could
+	// equally point at it; the wrapper must not $include that either. The
+	// stale file already exists on disk, so materialize it first.
+	snapshotPath := filepath.Join(envRoot, openclawUserSnapshotFile)
+	if err := os.WriteFile(snapshotPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write stale snapshot: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: snapshotPath + "\n"},
+	})
+
+	var logs strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin, Logger: logger})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+
+	got := mustReadJSON(t, result.ConfigPath)
+	if _, ok := got["$include"]; ok {
+		t.Errorf("wrapper must not $include the multica-owned snapshot; got $include = %v", got["$include"])
+	}
+	if result.IncludeRoot != "" {
+		t.Errorf("IncludeRoot = %q, want empty", result.IncludeRoot)
+	}
+	if !strings.Contains(logs.String(), "multica-owned task file") {
+		t.Errorf("self-include guard was not warned about; log was:\n%s", logs.String())
+	}
+}
+
+// TestOpenclawIsOwnTaskFile — unit coverage for the path-identity helper that
+// backs the self-include guard: the wrapper and snapshot names inside envRoot
+// are owned, everything else (including look-alikes in other directories and
+// plain user configs) is not. Uses host-native separators throughout, and the
+// Windows case-insensitivity branch is exercised by the existing Windows test
+// job.
+func TestOpenclawIsOwnTaskFile(t *testing.T) {
+	envRoot := t.TempDir()
+	wrapper := filepath.Join(envRoot, openclawConfigFile)
+	snapshot := filepath.Join(envRoot, openclawUserSnapshotFile)
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"wrapper", wrapper, true},
+		{"snapshot", snapshot, true},
+		{"empty path", "", false},
+		{"empty envRoot", filepath.Join("", openclawConfigFile), false},
+		{"user config in envRoot", filepath.Join(envRoot, "openclaw.json"), false},
+		{"wrapper in other dir", filepath.Join(t.TempDir(), openclawConfigFile), false},
+		{"snapshot in other dir", filepath.Join(t.TempDir(), openclawUserSnapshotFile), false},
+		{"wrapper with extra suffix", wrapper + ".bak", false},
+		{"wrapper subdir", filepath.Join(envRoot, "sub", openclawConfigFile), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openclawIsOwnTaskFile(tc.path, envRoot); got != tc.want {
+				t.Errorf("openclawIsOwnTaskFile(%q, %q) = %v, want %v", tc.path, envRoot, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes the second defect called out in #6630 (kept out of #6643 to stay reviewable).

## Problem

Nothing verified that the active config path discovered by `openclaw config file` isn't a file the daemon itself writes into the task envRoot. When a stale `OPENCLAW_CONFIG_PATH` (e.g. a leftover workaround wrapper pointing at a previous task's `multica_workspaces/*/openclaw-config.json`, or the sanitized user snapshot) resolves to one of our own files, `buildPerTaskOpenclawConfig` emits `$include: [itself]` and every task fails with `Circular include detected` before the agent runs.

## Fix

- Detect the per-task wrapper (`openclaw-config.json`) and the sanitized user snapshot (`openclaw-user-snapshot.json`) inside envRoot with host-native path identity (case-insensitive on Windows, so the guard holds on the platform where the wrapper flow is exercised).
- When the CLI reports one of these as the active config, treat the discovery as a fresh install: omit `$include`, log a warning naming the consequence (user's models/auth profiles will NOT be visible to this task) and pointing at a stale `OPENCLAW_CONFIG_PATH`.
- Fail-safe by construction: the wrapper stays valid, it just runs without the user's models/auth until the env is fixed.

## Tests

- `TestPrepareOpenclawConfigSkipsSelfInclude` — stale wrapper path reported as active config → no `$include`, empty `IncludeRoot`, warning logged, `include_target=none`.
- `TestPrepareOpenclawConfigSkipsSelfIncludeSnapshot` — same guard for the snapshot file.
- `TestOpenclawIsOwnTaskFile` — table-driven coverage of the path-identity helper (wrapper/snapshot inside envRoot owned; look-alikes elsewhere not).

Verified: `go test ./internal/daemon/execenv/ -count=1` passes, `go vet` clean.