### PR TITLE
fix(editor): download web attachments via the signed capability URL

### DIFF
--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -157,8 +157,9 @@ describe("useDownloadAttachment (web)", () => {
   // #6092 mints a signed capability into `download_url` in proxy mode. A bare
   // `<a download>` navigation can authenticate to it with no Authorization
   // header and no session cookie, so the web path must prefer it over the
-  // cookie-gated slug endpoint that 401s to download.txt in token-mode /
-  // split-origin self-hosting.
+  // cookie-gated slug endpoint that 401s to download.txt in token-mode
+  // self-hosting, where auth is a bearer token in JS and a bare navigation
+  // carries no credential at all.
   it("navigates to the capability download_url in proxy mode, not the cookie-gated endpoint", async () => {
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
@@ -188,8 +189,10 @@ describe("useDownloadAttachment (web)", () => {
     expect(anchor!.getAttribute("href")).toBe(
       "/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
     );
-    // The capability already scopes the request to one attachment and one
-    // user, so the workspace slug is no longer part of the URL.
+    // The capability is itself the credential and is signed over exactly one
+    // attachment id, so the workspace slug is no longer part of the URL. It is
+    // not bound to a user — the signature covers (version, attachment id,
+    // expiry) only — so it stays a bearer capability for its 60-second life.
     expect(anchor!.getAttribute("href")).not.toContain("workspace_slug");
   });
 

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -154,6 +154,101 @@ describe("useDownloadAttachment (web)", () => {
     );
   });
 
+  // #6092 mints a signed capability into `download_url` in proxy mode. A bare
+  // `<a download>` navigation can authenticate to it with no Authorization
+  // header and no session cookie, so the web path must prefer it over the
+  // cookie-gated slug endpoint that 401s to download.txt in token-mode /
+  // split-origin self-hosting.
+  it("navigates to the capability download_url in proxy mode, not the cookie-gated endpoint", async () => {
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "https://static.example.test/file.md",
+      download_url:
+        "/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
+      filename: "file.md",
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    const anchor = appendSpy.mock.calls
+      .map(([node]) => node)
+      .find((node): node is HTMLAnchorElement =>
+        node instanceof HTMLAnchorElement,
+      );
+    expect(anchor).toBeDefined();
+    expect(anchor!.getAttribute("href")).toBe(
+      "/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
+    );
+    // The capability already scopes the request to one attachment and one
+    // user, so the workspace slug is no longer part of the URL.
+    expect(anchor!.getAttribute("href")).not.toContain("workspace_slug");
+  });
+
+  it("resolves the capability download_url against a configured API base (split origin)", async () => {
+    getBaseUrlMock.mockReturnValue("https://api.example.test/");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "https://static.example.test/file.md",
+      download_url:
+        "/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
+      filename: "file.md",
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    const anchor = appendSpy.mock.calls
+      .map(([node]) => node)
+      .find((node): node is HTMLAnchorElement =>
+        node instanceof HTMLAnchorElement,
+      );
+    expect(anchor!.href).toBe(
+      "https://api.example.test/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
+    );
+  });
+
+  // The capability carries its own identity, so a missing workspace slug —
+  // which aborts the legacy slug fallback below — must not block the download.
+  it("downloads via the capability even when the workspace slug is missing", async () => {
+    useWorkspaceSlugMock.mockReturnValueOnce(null);
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "https://static.example.test/file.md",
+      download_url:
+        "/api/attachments/att-1/signed-download?exp=1735689600&sig=abc123",
+      filename: "file.md",
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it("shows a toast and does not click a download link when the workspace slug is missing", async () => {
     useWorkspaceSlugMock.mockReturnValueOnce(null);
     getAttachmentMock.mockResolvedValueOnce({

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -224,9 +224,13 @@ describe("useDownloadAttachment (web)", () => {
     );
   });
 
-  // The capability carries its own identity, so a missing workspace slug —
-  // which aborts the legacy slug fallback below — must not block the download.
-  it("downloads via the capability even when the workspace slug is missing", async () => {
+  // Ordering guard, not a reachable user scenario: `api.getAttachment` resolves
+  // workspace context server-side and 400s when there is none, so the preflight
+  // would fail before this branch in real use. What this pins is purely the
+  // client-side order — `capabilityDownloadUrl` is consulted before the
+  // `workspaceSlug` guard — so a capability download never depends on the slug
+  // the legacy fallback needs.
+  it("consults the capability before the workspace-slug guard", async () => {
     useWorkspaceSlugMock.mockReturnValueOnce(null);
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -25,12 +25,20 @@ function attachmentDownloadEndpoint(
 //
 // In proxy mode the backend puts a signed, single-attachment capability into
 // `download_url` (a site-relative `/api/attachments/{id}/signed-download?...`
-// URL, added in #6092). It carries its own credential in the query string and
-// forces an attachment Content-Disposition server-side, so a top-level
-// `<a download>` navigation can open it with no `Authorization` header and no
-// session cookie. That is exactly the token-mode / split-origin case where the
-// cookie-gated unified endpoint 401s and the browser saves the error body as
-// `download.txt`.
+// URL, added in #6092). It carries its own credential in the query string, so a
+// top-level `<a download>` navigation authenticates on its own — no
+// `Authorization` header, no session cookie — which is what clears the 401 that
+// otherwise makes the browser save the error body as `download.txt`. That 401
+// is the token-mode case: auth is a bearer token held in JS, so a bare
+// navigation to the cookie-gated slug endpoint sends no credential at all.
+//
+// The capability does NOT force an attachment disposition — it streams through
+// `proxyAttachmentDownload` → `storage.ContentDisposition`, which returns
+// `inline` for image/video/audio/PDF. What makes the browser download rather
+// than preview is the request staying same-origin combined with the `download`
+// attribute. `resolvePublicFileUrl` leaves this URL same-origin whenever the app
+// reaches the API on its own origin; if it resolves cross-origin AND the file is
+// media, the capability previews in-tab instead — a row #6712 still tracks.
 //
 // Absolute CloudFront / S3 `download_url`s are deliberately NOT used here: they
 // are cross-origin and inline-tuned, so an `<a download>` to them previews the
@@ -136,11 +144,11 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
           return;
         }
         // Prefer the capability URL when the server minted one. A top-level
-        // `<a download>` navigation sends no `Authorization` header, and in
-        // token-mode / split-origin self-hosting the SameSite=Strict host-only
-        // session cookie does not apply either, so the cookie-gated slug
-        // endpoint 401s and the browser saves the error body as `download.txt`.
-        // The capability URL authenticates that bare navigation on its own.
+        // `<a download>` navigation sends no `Authorization` header, so in
+        // token-mode — where auth is a bearer token in JS rather than a cookie —
+        // the cookie-gated slug endpoint 401s and the browser saves the error
+        // body as `download.txt`. The capability URL carries its own credential
+        // in the query string, so it authenticates that bare navigation itself.
         const capability = capabilityDownloadUrl(fresh.download_url);
         if (capability) {
           triggerBrowserDownload(capability);

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -21,6 +21,28 @@ function attachmentDownloadEndpoint(
   return resolvePublicFileUrl(endpoint) ?? endpoint;
 }
 
+// The capability download URL the server minted, if any.
+//
+// In proxy mode the backend puts a signed, single-attachment capability into
+// `download_url` (a site-relative `/api/attachments/{id}/signed-download?...`
+// URL, added in #6092). It carries its own credential in the query string and
+// forces an attachment Content-Disposition server-side, so a top-level
+// `<a download>` navigation can open it with no `Authorization` header and no
+// session cookie. That is exactly the token-mode / split-origin case where the
+// cookie-gated unified endpoint 401s and the browser saves the error body as
+// `download.txt`.
+//
+// Absolute CloudFront / S3 `download_url`s are deliberately NOT used here: they
+// are cross-origin and inline-tuned, so an `<a download>` to them previews the
+// file instead of downloading it. Those modes keep entering through the unified
+// slug endpoint, and a server that predates #6092 returns no capability at all.
+function capabilityDownloadUrl(downloadUrl: string | undefined): string | null {
+  if (!downloadUrl) return null;
+  if (!downloadUrl.startsWith("/api/attachments/")) return null;
+  if (!downloadUrl.includes("/signed-download")) return null;
+  return resolvePublicFileUrl(downloadUrl);
+}
+
 function triggerBrowserDownload(url: string): void {
   const anchor = document.createElement("a");
   anchor.href = url;
@@ -54,10 +76,13 @@ function hasDesktopDownloadBridge(): boolean {
  *
  * Two execution shapes, picked at call time:
  *
- * - **Web**: first refreshes attachment metadata for the existing error
- *   feedback path, then clicks a temporary same-origin
- *   `/api/attachments/{id}/download?workspace_slug=...` anchor. The backend
- *   endpoint owns CloudFront / S3 presign / proxy selection and download
+ * - **Web**: refreshes attachment metadata (for the existing error feedback
+ *   path and to obtain the capability `download_url`), then clicks a temporary
+ *   anchor. It prefers the signed capability URL the backend mints in proxy
+ *   mode — the one a bare `<a download>` navigation can authenticate without a
+ *   header or cookie — and otherwise falls back to the same-origin
+ *   `/api/attachments/{id}/download?workspace_slug=...` endpoint. Either way the
+ *   backend owns CloudFront / S3 presign / proxy selection and download
  *   Content-Disposition, so large files stay in the browser's native download
  *   pipeline.
  *
@@ -101,16 +126,29 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
       }
 
       try {
-        // Keep the preflight metadata request so permission/API failures still
-        // produce the existing toast instead of a silent failed navigation. Do
-        // not use `download_url` here: in CloudFront mode it may already be a
-        // signed CDN URL, while the unified endpoint is the stable browser
-        // entry point that chooses cloudfront / presign / proxy server-side.
-        await api.getAttachment(attachmentId);
+        // The preflight metadata request is both the permission check (so API
+        // failures still produce the existing toast instead of a silent failed
+        // navigation) and where the server hands back the capability
+        // `download_url` it mints in proxy mode.
+        const fresh = await api.getAttachment(attachmentId);
         if (typeof document === "undefined") {
           failed();
           return;
         }
+        // Prefer the capability URL when the server minted one. A top-level
+        // `<a download>` navigation sends no `Authorization` header, and in
+        // token-mode / split-origin self-hosting the SameSite=Strict host-only
+        // session cookie does not apply either, so the cookie-gated slug
+        // endpoint 401s and the browser saves the error body as `download.txt`.
+        // The capability URL authenticates that bare navigation on its own.
+        const capability = capabilityDownloadUrl(fresh.download_url);
+        if (capability) {
+          triggerBrowserDownload(capability);
+          return;
+        }
+        // No capability (CloudFront / S3 signing, or a server that predates
+        // #6092): fall back to the cookie-authenticated unified endpoint, which
+        // still works wherever the session cookie applies.
         if (!workspaceSlug) {
           failed();
           return;

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -88,7 +88,7 @@ function hasDesktopDownloadBridge(): boolean {
  *   path and to obtain the capability `download_url`), then clicks a temporary
  *   anchor. It prefers the signed capability URL the backend mints in proxy
  *   mode — the one a bare `<a download>` navigation can authenticate without a
- *   header or cookie — and otherwise falls back to the same-origin
+ *   header or cookie — and otherwise falls back to the cookie-gated
  *   `/api/attachments/{id}/download?workspace_slug=...` endpoint. Either way the
  *   backend owns CloudFront / S3 presign / proxy selection and download
  *   Content-Disposition, so large files stay in the browser's native download


### PR DESCRIPTION
## Summary

`GET /api/attachments/{id}/download` is entered by a top-level browser navigation (an `<a download>` click), which cannot send `Authorization: Bearer`. The only credential such a navigation can present is the `multica_auth` session cookie (HttpOnly, SameSite=Strict, host-only). In token-mode sessions — where auth is a bearer token held in JS, not a cookie — a bare navigation carries no credential at all, so the endpoint answers `401` and the browser saves the error body to disk as `download.txt`.

#6092 fixed this for **desktop**: in proxy mode it mints a signed, single-attachment capability into `download_url` (`/api/attachments/{id}/signed-download?...`), and the Electron bridge downloads `download_url`. But the **web** branch of `useDownloadAttachment` never reads `download_url` — it always navigates to the cookie-gated `/api/attachments/{id}/download?workspace_slug=...` endpoint. So the capability that already fixes desktop was sitting unused on web.

## Change

Client-only, reuses #6092's capability — no server change:

- On web, prefer the capability `download_url` when the server minted one (the `/signed-download` URL, present in proxy mode). It carries its own credential in the query string, so a bare navigation authenticates with no header and no cookie — which is what clears the 401.
- Fall back to the existing cookie-gated slug endpoint for CloudFront/S3 signing modes and for servers that predate #6092.
- Absolute CloudFront/S3 `download_url`s are intentionally not used for the web `<a download>` path: cross-origin and inline-tuned, they would preview instead of download.

Correcting the framing from an earlier revision of this description: the capability clears the **auth** failure (the 401 → `download.txt`). It does **not** force an attachment disposition — it streams via `proxyAttachmentDownload` → `storage.ContentDisposition`, which returns `inline` for `image/*`, `video/*`, `audio/*` and `application/pdf`. What makes the browser download rather than preview is the request staying **same-origin** plus the `download` attribute; `resolvePublicFileUrl` keeps the capability same-origin whenever the app reaches the API on its own origin.

### Outcome after this PR

| scenario | result |
|---|---|
| same-origin, token-mode session | fixed, all file types |
| cross-origin, non-media file | fixed (stored disposition is already `attachment`) |
| cross-origin, image / PDF / video / audio | not fixed — previews in the current tab |
| presign or CloudFront + token-mode | unchanged, still 401s |

**Out of scope** (tracked in #6712, landing as a separate follow-up):

- **presign + token-mode** — the more common self-host setup: an absolute presigned `download_url` is rejected by `capabilityDownloadUrl` and falls back to the cookie-gated endpoint, which 401s in token-mode.
- **cross-origin media** — an image/PDF/video/audio capability resolved to a different origin previews in-tab rather than downloading.
- **CloudFront + token-mode** — unchanged, not regressed.

The fuller fix (a separate download-intent, credential-free URL field on the metadata endpoint, disposition-aware across all three storage modes) is deferred to a follow-up per #6712.

## Test plan

- `packages/views/editor/use-download-attachment.test.tsx`: added web coverage — proxy-mode navigates to the capability URL; the capability resolves against a configured API base (split origin); and an ordering guard that the capability is consulted before the `workspaceSlug` guard. Existing CloudFront → slug-endpoint behavior preserved.
- `pnpm --filter @multica/views test` ✅
- `pnpm --filter @multica/views typecheck` ✅
- `eslint` on changed files ✅

Refs #6712
