### PR TITLE
MUL-5510: fix(agent): preserve newlines in Antigravity streamed text

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -130,12 +130,22 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 
 		for scanner.Scan() {
 			line := scanner.Text()
+			// The daemon concatenates streamed MessageText with no separator
+			// (pendingText.WriteString), so the streamed text must carry the
+			// line breaks itself. Mirror output's construction — prefix the
+			// newline on every line after the first, and stream blank lines
+			// too — so the persisted task_message text reconstructs output
+			// exactly. Emitting bare, blank-skipped lines dropped every newline,
+			// collapsing block markdown (headings, lists) onto one line in
+			// chat (#6149).
+			chunk := line
 			if output.Len() > 0 {
 				output.WriteByte('\n')
+				chunk = "\n" + line
 			}
 			output.WriteString(line)
-			if strings.TrimSpace(line) != "" {
-				trySend(msgCh, Message{Type: MessageText, Content: line})
+			if chunk != "" {
+				trySend(msgCh, Message{Type: MessageText, Content: chunk})
 			}
 		}
 		if err := scanner.Err(); err != nil {

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -711,3 +711,73 @@ func TestAntigravityBackendRecoversEmptyStdoutFromTranscript(t *testing.T) {
 		t.Fatalf("expected recovered transcript reply to be emitted as MessageText, got %#v", messages)
 	}
 }
+
+// fakeAgyMarkdownReplyScript streams a blank-line-separated markdown reply to
+// stdout — a heading and a list, exactly the shape that renders as literal
+// `###`/`-` in chat when the streamed text loses its newlines (#6149).
+func fakeAgyMarkdownReplyScript() string {
+	return `#!/bin/sh
+cat <<'AGYREPLY'
+Intro line.
+
+### Heading
+
+- item one
+- item two
+AGYREPLY
+exit 0
+`
+}
+
+// TestAntigravityBackendStreamPreservesNewlines is the regression guard for
+// #6149: the daemon concatenates streamed MessageText with no separator
+// (pendingText.WriteString), so the adapter must emit the line breaks itself.
+// Before the fix each line was streamed without its "\n", so the reconstructed
+// task_message text glued every block onto one line and block markdown
+// (headings, lists) rendered as literal text.
+func TestAntigravityBackendStreamPreservesNewlines(t *testing.T) {
+	t.Parallel()
+
+	const wantReply = "Intro line.\n\n### Heading\n\n- item one\n- item two"
+
+	fakePath := filepath.Join(t.TempDir(), "agy")
+	writeTestExecutable(t, fakePath, []byte(fakeAgyMarkdownReplyScript()))
+
+	backend, err := New("antigravity", Config{ExecutablePath: fakePath, Logger: quietAntigravityLogger()})
+	if err != nil {
+		t.Fatalf("new antigravity backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// Reconstruct the persisted text the way the daemon does: concatenate every
+	// streamed MessageText with no separator.
+	var streamed strings.Builder
+	for msg := range session.Messages {
+		if msg.Type == MessageText {
+			streamed.WriteString(msg.Content)
+		}
+	}
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	if got := streamed.String(); got != wantReply {
+		t.Fatalf("streamed task_message text lost its line breaks (#6149):\n got  %q\n want %q", got, wantReply)
+	}
+}


### PR DESCRIPTION
## Summary

An agent's chat reply rendered with every line break gone: block markdown like `### Heading` and `- item` ended up mid-line and displayed as literal text (`bạn!### 🚀`, `gì?- **Quản lý**`). See #6149.

Root cause is the **Antigravity runtime adapter** (`server/pkg/agent/antigravity.go`). It scans the agent's stdout line by line and emitted each streamed `MessageText` as the bare line **without its `\n`** (and skipped blank lines). The daemon accumulates streamed text with `pendingText.WriteString(msg.Content)` — no separator — so the persisted `task_message` `type=text` rows lost every newline. The chat renders those rows (the timeline), which is why block markdown collapsed onto one line.

`chat_message.content` was unaffected — the adapter rebuilds `output` with newlines separately — so only the streamed/persisted timeline text was broken. Other backends (codex / claude / hermes / cursor) stream whole blocks that already carry their `\n`, so only Antigravity was affected; the daemon concatenation, the frontend `.join("")`, and `packages/ui/markdown` are all correct.

## Change

`server/pkg/agent/antigravity.go`: stream each line so it reconstructs `output` exactly — prefix the newline on every line after the first, and stream blank lines too (they are the paragraph separators). `output` itself is untouched, so `chat_message.content` stays identical; no change to the daemon, the frontend, or the renderer.

## Test plan

- `server/pkg/agent/antigravity_test.go`: `TestAntigravityBackendStreamPreservesNewlines` runs the backend against a fake `agy` that streams a blank-line-separated heading + list, reconstructs the streamed text the way the daemon does (concatenate `MessageText.Content` with no separator), and asserts it equals the reply **with** its newlines. Fails before the fix (everything glued onto one line), passes after.
- `go test ./pkg/agent` ✅ (full package, incl. the new test)
- `go vet ./pkg/agent` ✅
- `gofmt` clean

Fixes #6149