### PR TITLE
fix(agent): keep OpenCode runs completed on crash-on-exit after a terminal signal

### DIFF
--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -265,7 +265,16 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
-		} else if exitErr != nil && scanResult.status == "completed" {
+		} else if exitErr != nil && scanResult.status == "completed" && !scanResult.sawTerminalSignal {
+			// A non-zero exit only demotes a "completed" run when there is no
+			// positive evidence the run actually finished. OpenCode is a Bun
+			// binary that on Windows routinely crashes on process teardown with
+			// 0xc0000409 (STATUS_STACK_BUFFER_OVERRUN) AFTER emitting a full,
+			// clean event stream — so a run that reached a terminal signal
+			// (step_finish) must stay "completed" despite the crash-on-exit,
+			// mirroring the writeErr guard below (#5872). Runs that never
+			// signalled completion still fail here; genuine mid-run errors are
+			// already failed via the `error` event before this branch.
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
 		} else if exitErr != nil && scanResult.noTerminalSignal {

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -1859,3 +1859,58 @@ func equalStringSlice(a, b []string) bool {
 	}
 	return true
 }
+
+// fakeOpencodeCompletedThenCrashScript emits a full, clean event stream
+// (step_start -> text -> step_finish with usage) and then exits non-zero,
+// mimicking OpenCode's Bun binary crashing on process teardown (Windows
+// 0xc0000409) AFTER the run actually finished (#5872).
+func fakeOpencodeCompletedThenCrashScript() string {
+	return `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"step_start","timestamp":1000,"sessionID":"ses_x","part":{"type":"step-start"}}'
+printf '%s\n' '{"type":"text","timestamp":1001,"sessionID":"ses_x","part":{"type":"text","text":"All done."}}'
+printf '%s\n' '{"type":"step_finish","timestamp":1002,"sessionID":"ses_x","part":{"type":"step-finish","tokens":{"total":10,"input":8,"output":2}}}'
+exit 134
+`
+}
+
+// TestOpencodeBackendCompletedRunSurvivesCrashOnExit is the regression guard for
+// #5872: a run that reached a terminal signal (step_finish) must stay
+// "completed" even when the process exits non-zero on teardown — a crash-on-exit
+// after a clean stream is not a failed run.
+func TestOpencodeBackendCompletedRunSurvivesCrashOnExit(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "opencode")
+	writeTestExecutable(t, fakePath, []byte(fakeOpencodeCompletedThenCrashScript()))
+
+	backend, err := New("opencode", Config{ExecutablePath: fakePath, Logger: quietAntigravityLogger()})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "do the thing", ExecOptions{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Drain the message stream so the result goroutine can finish.
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("status = %q, want \"completed\" — a run that reached step_finish must not be demoted by a crash-on-exit (#5872); error=%q", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}


### PR DESCRIPTION
## Summary

OpenCode is a Bun binary that on Windows routinely crashes on process teardown with `0xc0000409` (STATUS_STACK_BUFFER_OVERRUN) **after** emitting a full, clean event stream. In `server/pkg/agent/opencode.go`, the result goroutine demoted any `"completed"` run to `"failed"` on a non-zero process exit — so a run that had already reached a terminal signal (`step_finish`) was reported as failed even though it finished (#5872).

## Change

Gate the `completed → failed` exit-code flip on `!scanResult.sawTerminalSignal`, mirroring the existing `writeErr` guard right below it: a non-zero exit only demotes a run when there is no positive evidence it actually finished.

- A run that reached `step_finish` (`sawTerminalSignal == true`) now stays `completed` despite a crash-on-exit.
- Runs that never signalled completion still fail here (unchanged).
- Genuine mid-run errors are already failed via the `error` event before this branch (unchanged).

## Test plan

- `server/pkg/agent/opencode_test.go`: `TestOpencodeBackendCompletedRunSurvivesCrashOnExit` runs the backend against a fake `opencode` that emits `step_start → text → step_finish` then `exit 134`, asserting `Status == "completed"`. Verified it fails before the change (`status = "failed"`) and passes after — a real regression guard.
- `go test ./pkg/agent` ✅ · `go vet ./pkg/agent` ✅ · `gofmt` clean

Fixes #5872