### PR TITLE
MUL-5997: perf(tasks): dedupe agent-status reconciliation when cancelling multiple tasks

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2157,11 +2157,35 @@ func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UU
 	}
 	for _, t := range cancelled {
 		s.captureTaskCancelled(ctx, t)
-		s.ReconcileAgentStatus(ctx, t.AgentID)
 		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
+	}
+	// Reconcile once per distinct agent instead of once per cancelled row:
+	// cancelling an issue often stops several tasks owned by the same agent,
+	// and each reconcile is a DB write plus a status broadcast. Matches
+	// CancelTasksForAgent's single-reconcile shape (D#3319).
+	for _, agentID := range distinctAgentIDs(cancelled) {
+		s.ReconcileAgentStatus(ctx, agentID)
 	}
 	s.notifyTasksFinished(cancelled)
 	return nil
+}
+
+// distinctAgentIDs returns each agent id appearing in the cancelled rows once,
+// preserving first-seen order. Bulk cancellations frequently stop several tasks
+// owned by the same agent; reconciling per distinct agent (rather than per row)
+// collapses the redundant RefreshAgentStatusFromTasks writes and status
+// broadcasts down to one per agent without changing the final agent status.
+func distinctAgentIDs(cancelled []db.AgentTaskQueue) []pgtype.UUID {
+	seen := make(map[pgtype.UUID]struct{}, len(cancelled))
+	ids := make([]pgtype.UUID, 0, len(cancelled))
+	for _, t := range cancelled {
+		if _, dup := seen[t.AgentID]; dup {
+			continue
+		}
+		seen[t.AgentID] = struct{}{}
+		ids = append(ids, t.AgentID)
+	}
+	return ids
 }
 
 // CancelTasksForAgent cancels every active task belonging to an agent
@@ -2198,8 +2222,13 @@ func (s *TaskService) CancelTasksByTriggerComment(ctx context.Context, commentID
 	}
 	for _, t := range cancelled {
 		s.captureTaskCancelled(ctx, t)
-		s.ReconcileAgentStatus(ctx, t.AgentID)
 		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
+	}
+	// Reconcile once per distinct agent instead of once per cancelled row: an
+	// edited/deleted trigger comment can cancel several tasks owned by the same
+	// agent, and each reconcile is a DB write plus a status broadcast (D#3319).
+	for _, agentID := range distinctAgentIDs(cancelled) {
+		s.ReconcileAgentStatus(ctx, agentID)
 	}
 	s.notifyTasksFinished(cancelled)
 	return cancelled, nil

--- a/server/internal/service/task_cancel_reconcile_dedup_test.go
+++ b/server/internal/service/task_cancel_reconcile_dedup_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// distinctAgentIDs drives how many times CancelTasksForIssue and
+// CancelTasksByTriggerComment call ReconcileAgentStatus: one call per returned
+// id. These tests guard that multiple cancelled rows sharing an agent collapse
+// to a single reconcile, while distinct agents each still get one (D#3319).
+
+const (
+	dedupAgentA = "11111111-1111-1111-1111-111111111111"
+	dedupAgentB = "22222222-2222-2222-2222-222222222222"
+	dedupAgentC = "33333333-3333-3333-3333-333333333333"
+)
+
+func cancelledRowsForAgents(agentIDs ...string) []db.AgentTaskQueue {
+	rows := make([]db.AgentTaskQueue, 0, len(agentIDs))
+	for _, id := range agentIDs {
+		rows = append(rows, db.AgentTaskQueue{AgentID: util.MustParseUUID(id)})
+	}
+	return rows
+}
+
+func TestDistinctAgentIDs_SameAgentReconciledOnce(t *testing.T) {
+	// Three cancelled tasks, all owned by the same agent, must reconcile once.
+	rows := cancelledRowsForAgents(dedupAgentA, dedupAgentA, dedupAgentA)
+
+	got := distinctAgentIDs(rows)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 distinct agent (single reconcile), got %d", len(got))
+	}
+	if got[0] != util.MustParseUUID(dedupAgentA) {
+		t.Fatalf("expected agent %s, got %v", dedupAgentA, got[0])
+	}
+}
+
+func TestDistinctAgentIDs_MultipleAgentsEachOnce(t *testing.T) {
+	// Interleaved rows across three agents: each distinct agent once, in
+	// first-seen order, regardless of how many rows each contributes.
+	rows := cancelledRowsForAgents(
+		dedupAgentA, dedupAgentB, dedupAgentA, dedupAgentC, dedupAgentB, dedupAgentA,
+	)
+
+	got := distinctAgentIDs(rows)
+
+	want := []string{dedupAgentA, dedupAgentB, dedupAgentC}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d distinct agents, got %d", len(want), len(got))
+	}
+	for i, id := range want {
+		if got[i] != util.MustParseUUID(id) {
+			t.Fatalf("distinct agent[%d]: expected %s, got %v", i, id, got[i])
+		}
+	}
+}
+
+func TestDistinctAgentIDs_Empty(t *testing.T) {
+	if got := distinctAgentIDs(nil); len(got) != 0 {
+		t.Fatalf("expected no agents for empty input, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

`CancelTasksForIssue` and `CancelTasksByTriggerComment` in `server/internal/service/task.go` called `ReconcileAgentStatus` once **per cancelled row**. When a bulk cancellation (issue deletion, or an edited/deleted trigger comment) stops several tasks owned by the same agent, that agent was reconciled repeatedly — each reconcile is a `RefreshAgentStatusFromTasks` DB write plus an `agent:status` broadcast, all resolving to the same final status.

`CancelTasksForAgent` already reconciles once after its loop for this exact reason; the two sibling functions were left on the per-row pattern. This is a residual DB-performance win noted in discussion #3319.

## Change

- Added a small pure helper `distinctAgentIDs` that returns each affected agent id once (first-seen order), following the `map[pgtype.UUID]struct{}` seen-set pattern already used elsewhere in this file.
- Both cancel functions now capture + broadcast `task:cancelled` per row as before, then reconcile once per distinct agent.
- Behavior is identical: same final agent status, same per-row events; only the redundant reconciles are removed. Event ordering now matches `CancelTasksForAgent` (all `task:cancelled` before `agent:status`).

## Test plan

- Added `server/internal/service/task_cancel_reconcile_dedup_test.go` — pure unit tests asserting `distinctAgentIDs` (which drives the reconcile count) collapses multiple rows for one agent to a single entry, gives each distinct agent one entry in first-seen order, and handles empty input. No DB required.
- `cd server && go test ./internal/service -run "Cancel|Reconcile" -count=1` — pass
- `go vet ./internal/service` — pass
- `gofmt -l internal/service/task.go` — clean

Fixes #6725