### PR TITLE
feat(issues): inherit parent's project and assignee when creating a sub-issue

### DIFF
--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -250,6 +250,48 @@ describe("useIssueActions", () => {
     });
   });
 
+  it("openCreateSubIssue seeds the parent's project and assignee so the sub-issue inherits them", () => {
+    const parentIssue = {
+      ...mockIssue,
+      project_id: "project-1",
+      assignee_type: "agent",
+      assignee_id: "agent-1",
+    } as Issue;
+    const { result } = renderHook(() => useIssueActions(parentIssue), { wrapper });
+
+    act(() => {
+      result.current.openCreateSubIssue();
+    });
+
+    expect(mockOpenModal).toHaveBeenLastCalledWith("create-issue", {
+      parent_issue_id: "issue-1",
+      parent_issue_identifier: "TES-1",
+      project_id: "project-1",
+      assignee_type: "agent",
+      assignee_id: "agent-1",
+    });
+  });
+
+  it("openCreateSubIssue omits assignee when the parent has none", () => {
+    const parentIssue = {
+      ...mockIssue,
+      project_id: "project-1",
+      assignee_type: null,
+      assignee_id: null,
+    } as Issue;
+    const { result } = renderHook(() => useIssueActions(parentIssue), { wrapper });
+
+    act(() => {
+      result.current.openCreateSubIssue();
+    });
+
+    expect(mockOpenModal).toHaveBeenLastCalledWith("create-issue", {
+      parent_issue_id: "issue-1",
+      parent_issue_identifier: "TES-1",
+      project_id: "project-1",
+    });
+  });
+
   it("removeParent clears parent_issue_id and stage in one write, never via the run-confirm modal", () => {
     const childIssue = {
       ...mockIssue,

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -169,7 +169,10 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
       ...(issueProjectId ? { project_id: issueProjectId } : {}),
       // Inherit the parent's assignee (member/agent/squad) so a sub-issue
       // created from the "Add sub-issue" entry starts with the same owner
-      // instead of defaulting to none (discussion #1728). Seed both fields
+      // (discussion #1728). The modal keys off whether these fields are
+      // present, not their value, so a seed overrides the sticky last-used
+      // assignee it would otherwise fall back to, while omitting both for
+      // an unassigned parent leaves that fallback intact. Seed the two
       // together — assignee_type is meaningless without assignee_id.
       ...(issueAssigneeType && issueAssigneeId
         ? { assignee_type: issueAssigneeType, assignee_id: issueAssigneeId }

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -61,6 +61,8 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   const issueId = issue?.id ?? null;
   const issueIdentifier = issue?.identifier ?? null;
   const issueProjectId = issue?.project_id ?? null;
+  const issueAssigneeType = issue?.assignee_type ?? null;
+  const issueAssigneeId = issue?.assignee_id ?? null;
   const issueStatus = issue?.status ?? null;
 
   const updateField = useCallback(
@@ -165,8 +167,22 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
       parent_issue_id: issueId,
       parent_issue_identifier: issueIdentifier,
       ...(issueProjectId ? { project_id: issueProjectId } : {}),
+      // Inherit the parent's assignee (member/agent/squad) so a sub-issue
+      // created from the "Add sub-issue" entry starts with the same owner
+      // instead of defaulting to none (discussion #1728). Seed both fields
+      // together — assignee_type is meaningless without assignee_id.
+      ...(issueAssigneeType && issueAssigneeId
+        ? { assignee_type: issueAssigneeType, assignee_id: issueAssigneeId }
+        : {}),
     });
-  }, [openModal, issueId, issueIdentifier, issueProjectId]);
+  }, [
+    openModal,
+    issueId,
+    issueIdentifier,
+    issueProjectId,
+    issueAssigneeType,
+    issueAssigneeId,
+  ]);
 
   const openSetParent = useCallback(() => {
     if (!issueId) return;


### PR DESCRIPTION
## Summary

Discussion #1728 ("Default Project") reports that creating a sub-issue from a parent is not contextual: it doesn't inherit the parent's Project or Agent, so the user has to set them manually every time.

On `main`, `openCreateSubIssue` in `packages/views/issues/actions/use-issue-actions.ts` already seeds the parent's `project_id` into the create-issue modal, and the modal already consumes a seeded `assignee_type`/`assignee_id` (see `create-issue.tsx`). The only remaining gap is that the assignee was never passed through — so a sub-issue defaulted to no owner.

## Change

- Seed the parent's assignee (`member`/`agent`/`squad`) alongside the project in `openCreateSubIssue`.
- Both fields are seeded together, since `assignee_type` is meaningless without `assignee_id`; when the parent is unassigned, nothing is seeded (unchanged behavior).
- No backend or API change: this reuses the create-issue modal's existing seed-consumption path.

## Test plan

- Added two cases to `use-issue-actions.test.tsx`:
  - `openCreateSubIssue` seeds the parent's project **and** assignee.
  - `openCreateSubIssue` omits the assignee when the parent has none.
- `pnpm --filter @multica/views exec vitest run use-issue-actions` — 13 passed.
- `pnpm --filter @multica/views typecheck` — clean.
- `go test ./internal/handler -run 'Issue|Create'` — ok (unaffected, confirms no backend regression).

Fixes #6724
Refs #1728