### PR TITLE
feat(shortcuts): browser-style Cmd+[ / Cmd+] history navigation

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-navigation-input-bindings.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-navigation-input-bindings.test.tsx
@@ -55,24 +55,36 @@ describe("useNavigationInputBindings", () => {
     seedHistory();
   });
 
-  it.each([
-    ["[", "Cmd+["],
-    ["ArrowLeft", "Cmd+Left"],
-  ])("goes back on %s", (key) => {
+  it("goes back on Cmd+Left", () => {
     render(<Probe />);
-    const event = keydown({ key, metaKey: true });
+    const event = keydown({ key: "ArrowLeft", metaKey: true });
     expect(activeHistoryIndex()).toBe(0);
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it.each([
-    ["]", "Cmd+]"],
-    ["ArrowRight", "Cmd+Right"],
-  ])("goes forward on %s", (key) => {
+  it("goes forward on Cmd+Right", () => {
     useTabStore.getState().goBack();
     render(<Probe />);
-    keydown({ key, ctrlKey: true });
+    keydown({ key: "ArrowRight", ctrlKey: true });
     expect(activeHistoryIndex()).toBe(1);
+  });
+
+  // #6728: the Cmd/Ctrl+[ and +] chords moved to the shared shortcut registry
+  // (packages/core/shortcuts, driven by <GlobalShortcuts>). This hook must NOT
+  // also handle them — DesktopShell mounts both this window listener and the
+  // document-level GlobalShortcuts, so a bracket handled here too would
+  // double-navigate (one press = two steps, hidden below a history depth of 3
+  // by stepHistory's clamp). It must also not preventDefault, so the registry
+  // still receives the keydown.
+  it.each([
+    ["[", "Cmd+["],
+    ["]", "Cmd+]"],
+  ])("leaves %s to the shortcut registry (no double navigation)", (key) => {
+    render(<Probe />);
+    const before = activeHistoryIndex();
+    const event = keydown({ key, metaKey: true });
+    expect(activeHistoryIndex()).toBe(before);
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it("leaves the chord to editable targets (caret navigation wins)", () => {
@@ -87,7 +99,7 @@ describe("useNavigationInputBindings", () => {
 
   it("ignores the chord with extra modifiers held", () => {
     render(<Probe />);
-    keydown({ key: "[", metaKey: true, shiftKey: true });
+    keydown({ key: "ArrowLeft", metaKey: true, shiftKey: true });
     expect(activeHistoryIndex()).toBe(1);
   });
 
@@ -102,7 +114,7 @@ describe("useNavigationInputBindings", () => {
   it("stops listening after unmount", () => {
     const view = render(<Probe />);
     view.unmount();
-    keydown({ key: "[", metaKey: true });
+    keydown({ key: "ArrowLeft", metaKey: true });
     expect(activeHistoryIndex()).toBe(1);
   });
 });

--- a/apps/desktop/src/renderer/src/hooks/use-tab-history.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-history.ts
@@ -36,10 +36,13 @@ function isEditableTarget(target: EventTarget | null): boolean {
 
 /**
  * Keyboard and mouse back/forward for the active tab's history:
- * Cmd/Ctrl+[ / ] and Cmd/Ctrl+←/→ (browser convention), plus mouse side
- * buttons 3/4. The renderer's mouseup is the ONE cross-platform source for
- * side buttons — the main process deliberately does not forward
- * `app-command` (Windows/Linux emit both, which would double-navigate).
+ * Cmd/Ctrl+←/→ (browser convention), plus mouse side buttons 3/4. The
+ * Cmd/Ctrl+[ / ] chords are handled by the shared shortcut registry
+ * (packages/core/shortcuts via <GlobalShortcuts>) instead, so they stay
+ * rebindable and identical on web and desktop. The renderer's mouseup is the
+ * ONE cross-platform source for side buttons — the main process deliberately
+ * does not forward `app-command` (Windows/Linux emit both, which would
+ * double-navigate).
  */
 export function useNavigationInputBindings() {
   const { goBack, goForward } = useTabHistory();
@@ -48,8 +51,15 @@ export function useNavigationInputBindings() {
     const onKeyDown = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod || e.altKey || e.shiftKey) return;
-      const back = e.key === "[" || e.key === "ArrowLeft";
-      const forward = e.key === "]" || e.key === "ArrowRight";
+      // Cmd/Ctrl+[ and +] are intentionally NOT handled here: they are
+      // registered as goBack/goForward in packages/core/shortcuts and driven
+      // by <GlobalShortcuts>, so both web and desktop share one rebindable
+      // binding. Handling the brackets here too would double-navigate on
+      // desktop (DesktopShell mounts both this window listener and the
+      // document-level GlobalShortcuts), which only shows up on a history
+      // stack of 3+ because stepHistory clamps at the ends.
+      const back = e.key === "ArrowLeft";
+      const forward = e.key === "ArrowRight";
       if (!back && !forward) return;
       // In editable contexts these chords belong to the text field:
       // cmd+arrow moves the caret to the line edge, cmd+bracket indents.

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -206,6 +206,9 @@ export function DesktopNavigationProvider({
       back: () => {
         useTabStore.getState().goBack();
       },
+      forward: () => {
+        useTabStore.getState().goForward();
+      },
       // The active tab's virtual history, same source the shell's back button
       // reads. A tab opened straight onto a destination sits at index 0 and
       // has nothing behind it.

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -58,6 +58,7 @@ function NavigationProviderInner({
     push: router.push,
     replace: router.replace,
     back: router.back,
+    forward: router.forward,
     canGoBack: canGoBackInApp,
     pathname,
     searchParams: new URLSearchParams(searchParams.toString()),

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -13,6 +13,8 @@ export type ShortcutActionId =
   | "findInIssue"
   | "openThreadNav"
   | "send"
+  | "goBack"
+  | "goForward"
   | "goInbox"
   | "goChat"
   | "goMyIssues"
@@ -101,6 +103,13 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
     allowInEditable: true,
   },
   { id: "send", category: "general", defaultShortcut: primary("Enter"), allowInEditable: true },
+  // Browser-style history navigation (Mod+[ / Mod+]). Neither bracket is
+  // app-owned (PRIMARY_RESERVED_KEYS) nor browser-owned
+  // (BROWSER_ONLY_PRIMARY_RESERVED_KEYS), so both are recordable on every
+  // platform and runtime. `allowInEditable` is false so the chord never steps
+  // away from the page while the caret sits in an input, textarea, or editor.
+  { id: "goBack", category: "navigation", defaultShortcut: primary("["), allowInEditable: false },
+  { id: "goForward", category: "navigation", defaultShortcut: primary("]"), allowInEditable: false },
   { id: "goInbox", category: "navigation", defaultShortcut: null, allowInEditable: false },
   { id: "goChat", category: "navigation", defaultShortcut: null, allowInEditable: false },
   { id: "goMyIssues", category: "navigation", defaultShortcut: null, allowInEditable: false },

--- a/packages/views/layout/global-shortcuts.history.test.tsx
+++ b/packages/views/layout/global-shortcuts.history.test.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configureShortcutPlatform } from "@multica/core/shortcuts";
+import { NavigationProvider, type NavigationAdapter } from "../navigation";
+import { GlobalShortcuts } from "./global-shortcuts";
+
+// GlobalShortcuts pulls workspace paths and the sidebar/chat stores at render
+// time; none of that is exercised by the history chords, so stub them to keep
+// the test focused on the back/forward wiring and free of provider setup.
+vi.mock("@multica/ui/components/ui/sidebar", () => ({
+  useSidebar: () => ({ toggleSidebar: vi.fn() }),
+}));
+vi.mock("@multica/core/chat", () => ({
+  useChatStore: { getState: () => ({ floatingChatEnabled: false }) },
+}));
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    inbox: () => "/w/inbox",
+    chat: () => "/w/chat",
+    myIssues: () => "/w/my-issues",
+    issues: () => "/w/issues",
+    projects: () => "/w/projects",
+    autopilots: () => "/w/autopilots",
+    agents: () => "/w/agents",
+    squads: () => "/w/squads",
+    usage: () => "/w/usage",
+    runtimes: () => "/w/runtimes",
+    skills: () => "/w/skills",
+    settings: () => "/w/settings",
+  }),
+}));
+
+function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    pathname: "/w/issues",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (path) => path,
+    ...overrides,
+  };
+}
+
+function renderShortcuts(adapter: NavigationAdapter) {
+  return render(
+    <NavigationProvider value={adapter}>
+      <GlobalShortcuts />
+    </NavigationProvider>,
+  );
+}
+
+function pressBracket(key: "[" | "]", target?: EventTarget) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  (target ?? document).dispatchEvent(event);
+  return event;
+}
+
+describe("GlobalShortcuts history navigation", () => {
+  beforeEach(() => {
+    // Pin the platform so Cmd (metaKey) maps to the primary modifier, matching
+    // the Mod+[ / Mod+] defaults regardless of the host running the test.
+    configureShortcutPlatform("macos");
+  });
+
+  afterEach(() => {
+    configureShortcutPlatform(null);
+  });
+
+  it("steps back through history on Mod+[", () => {
+    const adapter = makeAdapter();
+    const { unmount } = renderShortcuts(adapter);
+
+    const event = pressBracket("[");
+
+    expect(adapter.back).toHaveBeenCalledTimes(1);
+    expect(adapter.forward).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    unmount();
+  });
+
+  it("steps forward through history on Mod+]", () => {
+    const adapter = makeAdapter();
+    const { unmount } = renderShortcuts(adapter);
+
+    const event = pressBracket("]");
+
+    expect(adapter.forward).toHaveBeenCalledTimes(1);
+    expect(adapter.back).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    unmount();
+  });
+
+  it("stays a no-op on an adapter without a forward stack", () => {
+    const adapter = makeAdapter({ forward: undefined });
+    const { unmount } = renderShortcuts(adapter);
+
+    // Must not throw even though forward() is undefined on this adapter.
+    expect(() => pressBracket("]")).not.toThrow();
+    expect(adapter.back).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("ignores the chord while focus is inside an editable field", () => {
+    const adapter = makeAdapter();
+    const { unmount } = renderShortcuts(adapter);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    pressBracket("[", input);
+
+    expect(adapter.back).not.toHaveBeenCalled();
+    input.remove();
+    unmount();
+  });
+});

--- a/packages/views/layout/global-shortcuts.tsx
+++ b/packages/views/layout/global-shortcuts.tsx
@@ -24,6 +24,8 @@ const GLOBAL_ACTIONS: readonly ShortcutActionId[] = [
   "createIssue",
   "toggleSidebar",
   "toggleChat",
+  "goBack",
+  "goForward",
   "goInbox",
   "goChat",
   "goMyIssues",
@@ -105,6 +107,16 @@ export function GlobalShortcuts() {
       }
       if (actionId === "toggleSidebar") {
         toggleSidebar();
+        return;
+      }
+      if (actionId === "goBack") {
+        navigation.back();
+        return;
+      }
+      if (actionId === "goForward") {
+        // Optional on the adapter: an isolated window without a forward stack
+        // leaves it undefined, in which case the chord is simply a no-op.
+        navigation.forward?.();
         return;
       }
       if (actionId === "createIssue") {

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -116,6 +116,8 @@
       "findInIssue": { "label": "Find in issue", "description": "Search within the open issue detail." },
       "openThreadNav": { "label": "Open thread navigator", "description": "List, search, and jump between the comment threads of the open issue." },
       "send": { "label": "Send", "description": "Send chat messages, comments, replies, feedback, and prompts, and create issues in the create dialog." },
+      "goBack": { "label": "Go back", "description": "Navigate back through history, like a browser." },
+      "goForward": { "label": "Go forward", "description": "Navigate forward through history, like a browser." },
       "goInbox": { "label": "Go to Inbox", "description": "Open the workspace inbox." },
       "goChat": { "label": "Go to Chat", "description": "Open workspace chat." },
       "goMyIssues": { "label": "Go to My Issues", "description": "Open issues assigned to you." },

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -116,6 +116,8 @@
       "findInIssue": { "label": "タスク内を検索", "description": "開いているタスクの詳細を検索します。" },
       "openThreadNav": { "label": "スレッドナビゲーターを開く", "description": "開いているタスクのコメントスレッドを一覧・検索して移動します。" },
       "send": { "label": "送信", "description": "チャット、コメント、返信、フィードバック、プロンプトを送信し、作成ダイアログでタスクを作成します。" },
+      "goBack": { "label": "戻る", "description": "ブラウザーのように履歴を戻ります。" },
+      "goForward": { "label": "進む", "description": "ブラウザーのように履歴を進みます。" },
       "goInbox": { "label": "受信トレイへ移動", "description": "ワークスペースの受信トレイを開きます。" },
       "goChat": { "label": "チャットへ移動", "description": "ワークスペースのチャットを開きます。" },
       "goMyIssues": { "label": "自分のタスクへ移動", "description": "自分に割り当てられたタスクを開きます。" },

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -116,6 +116,8 @@
       "findInIssue": { "label": "태스크에서 찾기", "description": "열린 태스크 상세 내용에서 검색합니다." },
       "openThreadNav": { "label": "스레드 내비게이터 열기", "description": "열린 태스크의 댓글 스레드를 나열하고 검색해 이동합니다." },
       "send": { "label": "보내기", "description": "채팅, 댓글, 답글, 피드백 및 프롬프트를 보내고, 생성 대화상자에서 태스크를 만듭니다." },
+      "goBack": { "label": "뒤로 가기", "description": "브라우저처럼 기록을 따라 뒤로 이동합니다." },
+      "goForward": { "label": "앞으로 가기", "description": "브라우저처럼 기록을 따라 앞으로 이동합니다." },
       "goInbox": { "label": "받은 편지함으로 이동", "description": "워크스페이스 받은 편지함을 엽니다." },
       "goChat": { "label": "채팅으로 이동", "description": "워크스페이스 채팅을 엽니다." },
       "goMyIssues": { "label": "내 태스크로 이동", "description": "나에게 할당된 태스크를 엽니다." },

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -116,6 +116,8 @@
       "findInIssue": { "label": "在任务中查找", "description": "搜索当前打开的任务详情。" },
       "openThreadNav": { "label": "打开讨论导航", "description": "列出、搜索并跳转当前任务的评论讨论。" },
       "send": { "label": "发送", "description": "发送聊天消息、评论、回复、反馈和提示词，并在创建弹窗中创建任务。" },
+      "goBack": { "label": "后退", "description": "像浏览器一样在历史记录中后退。" },
+      "goForward": { "label": "前进", "description": "像浏览器一样在历史记录中前进。" },
       "goInbox": { "label": "前往收件箱", "description": "打开工作区收件箱。" },
       "goChat": { "label": "前往聊天", "description": "打开工作区聊天。" },
       "goMyIssues": { "label": "前往我的任务", "description": "打开分配给你的任务。" },

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -36,4 +36,11 @@ export interface NavigationAdapter {
    * Read it through `useBackOrReplace()` rather than calling it directly.
    */
   canGoBack?: () => boolean;
+  /**
+   * Optional: step forward through history, the inverse of `back()`. Web wires
+   * this to `router.forward`; desktop to the active tab's virtual history. It is
+   * optional because not every adapter (e.g. an isolated popout window) owns a
+   * forward stack — callers must invoke it via `forward?.()`.
+   */
+  forward?: () => void;
 }

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -38,9 +38,13 @@ export interface NavigationAdapter {
   canGoBack?: () => boolean;
   /**
    * Optional: step forward through history, the inverse of `back()`. Web wires
-   * this to `router.forward`; desktop to the active tab's virtual history. It is
-   * optional because not every adapter (e.g. an isolated popout window) owns a
-   * forward stack — callers must invoke it via `forward?.()`.
+   * this to `router.forward`; the desktop shell to the active tab's virtual
+   * history. It is optional because not every adapter owns a forward stack: the
+   * dedicated issue window steps back with `navigate(-1)` and has no forward
+   * counterpart to offer. That window does not mount `<GlobalShortcuts>`, so
+   * today the history chords never reach it — the optionality keeps the adapter
+   * contract honest rather than serving a live no-op. Callers must still invoke
+   * it via `forward?.()`.
    */
   forward?: () => void;
 }


### PR DESCRIPTION
## Summary

Adds browser-style keyboard navigation through the shared in-app history:

- **Mod+[** (Cmd+[ / Ctrl+[) — go **back**
- **Mod+]** (Cmd+] / Ctrl+]) — go **forward**

Requested in discussion #1727 ("Keyboard Commands"). Works on both web and desktop.

## Change

- The two bindings are registered as configurable **navigation** actions (`goBack`, `goForward`) in the existing keyboard-shortcut registry (`packages/core/shortcuts`), so they appear under Settings → Keyboard Shortcuts and can be rebound or disabled like any other action. Neither bracket is app- or browser-reserved, so both are recordable on every platform/runtime.
- `NavigationAdapter` gains an optional `forward()` — web wires it to `router.forward`, desktop to the tab store's `goForward()`. `back()` already existed.
- `GlobalShortcuts` maps the two new actions to `navigation.back()` / `navigation.forward?.()`. The chords are ignored while focus is in an input, textarea, or contenteditable (`allowInEditable: false`).
- Added `goBack` / `goForward` labels+descriptions to all locale bundles (en, ja, ko, zh-Hans).

`forward()` is optional on the adapter so an isolated popout window without a forward stack simply no-ops.

## Test plan

- New `packages/views/layout/global-shortcuts.history.test.tsx`: asserts Mod+[ calls `back()`, Mod+] calls `forward()`, the chord is a no-op when the adapter has no `forward`, and it is ignored while an input is focused.
- Existing `packages/core/shortcuts` suite (incl. the "every shipped default is within the safety policy" guard) passes with the new defaults.
- Locale parity test passes with the new keys.
- `pnpm --filter @multica/views typecheck` and core/web/desktop typechecks pass.

Refs #1727