### PR TITLE
feat(agents): support pasting environment files

### DIFF
--- a/packages/views/agents/components/tabs/env-file.test.ts
+++ b/packages/views/agents/components/tabs/env-file.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { isEnvFilePaste, parseEnvFile } from "./env-file";
 
 describe("parseEnvFile", () => {
-  it("parses Bash-style assignments while preserving values", () => {
+  it("parses dotenv-style assignments while preserving literal values", () => {
     expect(
       parseEnvFile(String.raw`
 # Agent credentials
@@ -12,8 +12,10 @@ EMPTY=
 URL=https://example.com/path?first=one&second=two
 HASH='value # kept'
 PLAIN=value # ignored comment
-ESCAPED=hello\ world
-ESCAPED_HASH=value\ # kept
+WIN_DIR=C:\Users\me\.ssh
+PASSWORD=p$ss${"`"}word
+JSON={"a":1}
+QUOTED='say "hello" with $HOME and C:\path'
 `),
     ).toEqual([
       { key: "API_KEY", value: "secret value" },
@@ -24,8 +26,10 @@ ESCAPED_HASH=value\ # kept
       },
       { key: "HASH", value: "value # kept" },
       { key: "PLAIN", value: "value" },
-      { key: "ESCAPED", value: "hello world" },
-      { key: "ESCAPED_HASH", value: "value # kept" },
+      { key: "WIN_DIR", value: String.raw`C:\Users\me\.ssh` },
+      { key: "PASSWORD", value: "p$ss`word" },
+      { key: "JSON", value: '{"a":1}' },
+      { key: "QUOTED", value: String.raw`say "hello" with $HOME and C:\path` },
     ]);
   });
 
@@ -40,12 +44,14 @@ ESCAPED_HASH=value\ # kept
     expect(parseEnvFile("FIRST=one\necho hello\nSECOND=two")).toBeNull();
     expect(parseEnvFile('BROKEN="unterminated')).toBeNull();
     expect(parseEnvFile('TOKEN="abc"#suffix')).toBeNull();
-    expect(parseEnvFile('EXPANDED="$HOME"')).toBeNull();
+    expect(parseEnvFile("FIRST=one\nFIRST=two")).toBeNull();
   });
 
   it("does not treat ordinary key text as an environment file", () => {
     expect(parseEnvFile("API_KEY")).toBeNull();
     expect(isEnvFilePaste("API_KEY")).toBe(false);
+    expect(isEnvFilePaste("API_KEY\n")).toBe(false);
+    expect(isEnvFilePaste("# database settings\n")).toBe(false);
     expect(isEnvFilePaste("API_KEY=value")).toBe(true);
     expect(isEnvFilePaste("FIRST=one\nSECOND=two")).toBe(true);
   });

--- a/packages/views/agents/components/tabs/env-file.test.ts
+++ b/packages/views/agents/components/tabs/env-file.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { isEnvFilePaste, parseEnvFile } from "./env-file";
+
+describe("parseEnvFile", () => {
+  it("parses Bash-style assignments while preserving values", () => {
+    expect(
+      parseEnvFile(String.raw`
+# Agent credentials
+export API_KEY="secret value"
+EMPTY=
+URL=https://example.com/path?first=one&second=two
+HASH='value # kept'
+PLAIN=value # ignored comment
+ESCAPED=hello\ world
+ESCAPED_HASH=value\ # kept
+`),
+    ).toEqual([
+      { key: "API_KEY", value: "secret value" },
+      { key: "EMPTY", value: "" },
+      {
+        key: "URL",
+        value: "https://example.com/path?first=one&second=two",
+      },
+      { key: "HASH", value: "value # kept" },
+      { key: "PLAIN", value: "value" },
+      { key: "ESCAPED", value: "hello world" },
+      { key: "ESCAPED_HASH", value: "value # kept" },
+    ]);
+  });
+
+  it("supports Windows line endings", () => {
+    expect(parseEnvFile("FIRST=one\r\nSECOND=two\r\n")).toEqual([
+      { key: "FIRST", value: "one" },
+      { key: "SECOND", value: "two" },
+    ]);
+  });
+
+  it("rejects partial files instead of silently dropping unsupported lines", () => {
+    expect(parseEnvFile("FIRST=one\necho hello\nSECOND=two")).toBeNull();
+    expect(parseEnvFile('BROKEN="unterminated')).toBeNull();
+    expect(parseEnvFile('TOKEN="abc"#suffix')).toBeNull();
+    expect(parseEnvFile('EXPANDED="$HOME"')).toBeNull();
+  });
+
+  it("does not treat ordinary key text as an environment file", () => {
+    expect(parseEnvFile("API_KEY")).toBeNull();
+    expect(isEnvFilePaste("API_KEY")).toBe(false);
+    expect(isEnvFilePaste("API_KEY=value")).toBe(true);
+    expect(isEnvFilePaste("FIRST=one\nSECOND=two")).toBe(true);
+  });
+});

--- a/packages/views/agents/components/tabs/env-file.ts
+++ b/packages/views/agents/components/tabs/env-file.ts
@@ -1,0 +1,128 @@
+export interface EnvAssignment {
+  key: string;
+  value: string;
+}
+
+const ASSIGNMENT_PATTERN =
+  /^(?:export[\t ]+)?([A-Za-z_][A-Za-z0-9_]*)[\t ]*=(.*)$/;
+const ASSIGNMENT_PREFIX_PATTERN =
+  /^(?:export[\t ]+)?[A-Za-z_][A-Za-z0-9_]*[\t ]*=/;
+
+function parseQuotedValue(rawValue: string): string | null {
+  const quote = rawValue[0];
+  if (quote !== '"' && quote !== "'") return null;
+
+  let value = "";
+  for (let index = 1; index < rawValue.length; index += 1) {
+    const character = rawValue[index];
+
+    if (character === quote) {
+      const remainder = rawValue.slice(index + 1);
+      return remainder.trim() === "" || /^[\t ]+#/.test(remainder)
+        ? value
+        : null;
+    }
+
+    if (quote === '"' && character === "\\") {
+      const nextCharacter = rawValue[index + 1];
+      if (
+        nextCharacter === '"' ||
+        nextCharacter === "\\" ||
+        nextCharacter === "$" ||
+        nextCharacter === "`"
+      ) {
+        value += nextCharacter;
+        index += 1;
+        continue;
+      }
+    }
+
+    if (quote === '"' && (character === "$" || character === "`")) {
+      return null;
+    }
+
+    value += character;
+  }
+
+  return null;
+}
+
+function parseUnquotedValue(
+  rawValue: string,
+  hadLeadingWhitespace: boolean,
+): string | null {
+  let value = "";
+  let previousCharacterWasEscaped = false;
+
+  for (let index = 0; index < rawValue.length; index += 1) {
+    const character = rawValue[index];
+
+    if (character === "\\") {
+      const nextCharacter = rawValue[index + 1];
+      if (nextCharacter === undefined) return null;
+
+      value += nextCharacter;
+      previousCharacterWasEscaped = true;
+      index += 1;
+      continue;
+    }
+
+    if (
+      character === "#" &&
+      ((index === 0 && hadLeadingWhitespace) ||
+        (/\s/.test(rawValue[index - 1] ?? "") && !previousCharacterWasEscaped))
+    ) {
+      return value.trimEnd();
+    }
+
+    if (
+      character === '"' ||
+      character === "'" ||
+      character === "$" ||
+      character === "`"
+    ) {
+      return null;
+    }
+
+    value += character;
+    previousCharacterWasEscaped = false;
+  }
+
+  return value.trimEnd();
+}
+
+function parseValue(rawValue: string): string | null {
+  const hadLeadingWhitespace = /^[\t ]/.test(rawValue);
+  const value = rawValue.trimStart();
+  if (value.startsWith('"') || value.startsWith("'")) {
+    return parseQuotedValue(value);
+  }
+
+  return parseUnquotedValue(value, hadLeadingWhitespace);
+}
+
+export function isEnvFilePaste(text: string): boolean {
+  return (
+    /[\r\n]/.test(text) || ASSIGNMENT_PREFIX_PATTERN.test(text.trimStart())
+  );
+}
+
+/** Parse a pasted Bash-style environment file without evaluating shell code. */
+export function parseEnvFile(text: string): EnvAssignment[] | null {
+  const assignments: EnvAssignment[] = [];
+
+  for (const line of text.replace(/\r\n?/g, "\n").split("\n")) {
+    const trimmedLine = line.trim();
+    if (trimmedLine === "" || trimmedLine.startsWith("#")) continue;
+
+    const match = ASSIGNMENT_PATTERN.exec(trimmedLine);
+    if (!match) return null;
+
+    const value = parseValue(match[2] ?? "");
+    if (value === null) return null;
+
+    assignments.push({ key: match[1] ?? "", value });
+  }
+
+  return assignments.length > 0 ? assignments : null;
+}

--- a/packages/views/agents/components/tabs/env-file.ts
+++ b/packages/views/agents/components/tabs/env-file.ts
@@ -12,36 +12,13 @@ function parseQuotedValue(rawValue: string): string | null {
   const quote = rawValue[0];
   if (quote !== '"' && quote !== "'") return null;
 
-  let value = "";
   for (let index = 1; index < rawValue.length; index += 1) {
-    const character = rawValue[index];
-
-    if (character === quote) {
+    if (rawValue[index] === quote) {
       const remainder = rawValue.slice(index + 1);
-      return remainder.trim() === "" || /^[\t ]+#/.test(remainder)
-        ? value
-        : null;
-    }
-
-    if (quote === '"' && character === "\\") {
-      const nextCharacter = rawValue[index + 1];
-      if (
-        nextCharacter === '"' ||
-        nextCharacter === "\\" ||
-        nextCharacter === "$" ||
-        nextCharacter === "`"
-      ) {
-        value += nextCharacter;
-        index += 1;
-        continue;
+      if (remainder.trim() === "" || /^[\t ]+#/.test(remainder)) {
+        return rawValue.slice(1, index);
       }
     }
-
-    if (quote === '"' && (character === "$" || character === "`")) {
-      return null;
-    }
-
-    value += character;
   }
 
   return null;
@@ -50,45 +27,20 @@ function parseQuotedValue(rawValue: string): string | null {
 function parseUnquotedValue(
   rawValue: string,
   hadLeadingWhitespace: boolean,
-): string | null {
-  let value = "";
-  let previousCharacterWasEscaped = false;
-
+): string {
   for (let index = 0; index < rawValue.length; index += 1) {
     const character = rawValue[index];
-
-    if (character === "\\") {
-      const nextCharacter = rawValue[index + 1];
-      if (nextCharacter === undefined) return null;
-
-      value += nextCharacter;
-      previousCharacterWasEscaped = true;
-      index += 1;
-      continue;
-    }
 
     if (
       character === "#" &&
       ((index === 0 && hadLeadingWhitespace) ||
-        (/\s/.test(rawValue[index - 1] ?? "") && !previousCharacterWasEscaped))
+        /\s/.test(rawValue[index - 1] ?? ""))
     ) {
-      return value.trimEnd();
+      return rawValue.slice(0, index).trimEnd();
     }
-
-    if (
-      character === '"' ||
-      character === "'" ||
-      character === "$" ||
-      character === "`"
-    ) {
-      return null;
-    }
-
-    value += character;
-    previousCharacterWasEscaped = false;
   }
 
-  return value.trimEnd();
+  return rawValue.trimEnd();
 }
 
 function parseValue(rawValue: string): string | null {
@@ -102,14 +54,22 @@ function parseValue(rawValue: string): string | null {
 }
 
 export function isEnvFilePaste(text: string): boolean {
-  return (
-    /[\r\n]/.test(text) || ASSIGNMENT_PREFIX_PATTERN.test(text.trimStart())
-  );
+  const trimmedText = text.trim();
+  if (!trimmedText) return false;
+
+  const meaningfulLines = trimmedText
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+
+  return meaningfulLines.some((line) => ASSIGNMENT_PREFIX_PATTERN.test(line));
 }
 
-/** Parse a pasted Bash-style environment file without evaluating shell code. */
+/** Parse a pasted dotenv-style file without evaluating or rewriting values. */
 export function parseEnvFile(text: string): EnvAssignment[] | null {
   const assignments: EnvAssignment[] = [];
+  const keys = new Set<string>();
 
   for (const line of text.replace(/\r\n?/g, "\n").split("\n")) {
     const trimmedLine = line.trim();
@@ -121,7 +81,11 @@ export function parseEnvFile(text: string): EnvAssignment[] | null {
     const value = parseValue(match[2] ?? "");
     if (value === null) return null;
 
-    assignments.push({ key: match[1] ?? "", value });
+    const key = match[1] ?? "";
+    if (keys.has(key)) return null;
+
+    keys.add(key);
+    assignments.push({ key, value });
   }
 
   return assignments.length > 0 ? assignments : null;

--- a/packages/views/agents/components/tabs/env-tab.test.tsx
+++ b/packages/views/agents/components/tabs/env-tab.test.tsx
@@ -72,7 +72,6 @@ describe("EnvTab", () => {
     expect(
       screen.getByText(/paste KEY=value lines into a key field/i),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /^add$/i }));
     const keyInput = screen.getByPlaceholderText("KEY");
     keyInput.focus();
     fireEvent.paste(keyInput, {
@@ -100,12 +99,38 @@ describe("EnvTab", () => {
     expect(screen.getAllByPlaceholderText("KEY")[0]).toHaveFocus();
   });
 
+  it("leaves a bare key with a trailing newline to native paste handling", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    const keyInput = screen.getByPlaceholderText("KEY");
+    const pasteAllowed = fireEvent.paste(keyInput, {
+      clipboardData: { getData: () => "API_KEY\n" },
+    });
+
+    expect(pasteAllowed).toBe(true);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("leaves a comment-only paste to native handling without an error", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    const pasteAllowed = fireEvent.paste(screen.getByPlaceholderText("KEY"), {
+      clipboardData: { getData: () => "# database settings\n" },
+    });
+
+    expect(pasteAllowed).toBe(true);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
   it("preserves special environment keys in the save payload", async () => {
     const user = userEvent.setup();
     renderTab();
 
     await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
-    await user.click(screen.getByRole("button", { name: /^add$/i }));
     fireEvent.paste(screen.getByPlaceholderText("KEY"), {
       clipboardData: { getData: () => "__proto__=secret" },
     });
@@ -123,7 +148,6 @@ describe("EnvTab", () => {
     renderTab();
 
     await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
-    await user.click(screen.getByRole("button", { name: /^add$/i }));
     const keyInput = screen.getByPlaceholderText("KEY");
     const pasteAllowed = fireEvent.paste(keyInput, {
       clipboardData: { getData: () => "FIRST=one\necho unsafe" },
@@ -133,6 +157,21 @@ describe("EnvTab", () => {
     expect(keyInput).toHaveValue("");
     expect(toastError).toHaveBeenCalledWith(
       "Couldn't parse pasted environment variables",
+    );
+  });
+
+  it("rejects duplicate keys during paste", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    const pasteAllowed = fireEvent.paste(screen.getByPlaceholderText("KEY"), {
+      clipboardData: { getData: () => "API_KEY=first\nAPI_KEY=second" },
+    });
+
+    expect(pasteAllowed).toBe(false);
+    expect(toastError).toHaveBeenCalledWith(
+      "Duplicate environment variable keys",
     );
   });
 });

--- a/packages/views/agents/components/tabs/env-tab.test.tsx
+++ b/packages/views/agents/components/tabs/env-tab.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Agent } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../../locales/en/common.json";
+import enAgents from "../../../locales/en/agents.json";
+
+const getAgentEnv = vi.hoisted(() => vi.fn());
+const updateAgentEnv = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/api", () => ({
+  api: { getAgentEnv, updateAgentEnv },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: vi.fn() },
+}));
+
+import { EnvTab } from "./env-tab";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+const agent: Agent = {
+  id: "agent-1",
+  workspace_id: "ws-1",
+  runtime_id: "runtime-1",
+  name: "Agent",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "local",
+  runtime_config: {},
+  custom_args: [],
+  visibility: "workspace",
+  permission_mode: "public_to",
+  invocation_targets: [{ target_type: "workspace", target_id: null }],
+  status: "idle",
+  max_concurrent_tasks: 1,
+  model: "",
+  owner_id: "user-1",
+  skills: [],
+  created_at: "2026-08-08T00:00:00Z",
+  updated_at: "2026-08-08T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
+};
+
+function renderTab() {
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <EnvTab agent={agent} />
+    </I18nProvider>,
+  );
+}
+
+describe("EnvTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAgentEnv.mockResolvedValue({ custom_env: {} });
+    updateAgentEnv.mockResolvedValue({ custom_env: {} });
+  });
+
+  it("turns pasted environment-file assignments into separate rows", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    expect(
+      screen.getByText(/paste KEY=value lines into a key field/i),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    const keyInput = screen.getByPlaceholderText("KEY");
+    keyInput.focus();
+    fireEvent.paste(keyInput, {
+      clipboardData: {
+        getData: () =>
+          'API_KEY="secret value"\nexport BASE_URL=https://example.com/api',
+      },
+    });
+
+    expect(
+      screen
+        .getAllByPlaceholderText("KEY")
+        .map((input) => (input as HTMLInputElement).value),
+    ).toEqual(["API_KEY", "BASE_URL"]);
+    expect(
+      screen
+        .getAllByPlaceholderText("value")
+        .map((input) => (input as HTMLInputElement).value),
+    ).toEqual(["secret value", "https://example.com/api"]);
+    expect(
+      screen
+        .getAllByPlaceholderText("value")
+        .every((input) => (input as HTMLInputElement).type === "password"),
+    ).toBe(true);
+    expect(screen.getAllByPlaceholderText("KEY")[0]).toHaveFocus();
+  });
+
+  it("preserves special environment keys in the save payload", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    fireEvent.paste(screen.getByPlaceholderText("KEY"), {
+      clipboardData: { getData: () => "__proto__=secret" },
+    });
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const payload = updateAgentEnv.mock.calls[0]?.[1] as {
+      custom_env: Record<string, string>;
+    };
+    expect(Object.hasOwn(payload.custom_env, "__proto__")).toBe(true);
+    expect(payload.custom_env.__proto__).toBe("secret");
+  });
+
+  it("rejects malformed environment-file pastes without changing the row", async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    await user.click(screen.getByRole("button", { name: /reveal & edit/i }));
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+    const keyInput = screen.getByPlaceholderText("KEY");
+    const pasteAllowed = fireEvent.paste(keyInput, {
+      clipboardData: { getData: () => "FIRST=one\necho unsafe" },
+    });
+
+    expect(pasteAllowed).toBe(false);
+    expect(keyInput).toHaveValue("");
+    expect(toastError).toHaveBeenCalledWith(
+      "Couldn't parse pasted environment variables",
+    );
+  });
+});

--- a/packages/views/agents/components/tabs/env-tab.tsx
+++ b/packages/views/agents/components/tabs/env-tab.tsx
@@ -1,21 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import {
-  Eye,
-  EyeOff,
-  Loader2,
-  Lock,
-  Plus,
-  Save,
-  Trash2,
-} from "lucide-react";
+import type { ClipboardEvent } from "react";
+import { Eye, EyeOff, Loader2, Lock, Plus, Save, Trash2 } from "lucide-react";
 import { api } from "@multica/core/api";
 import type { Agent } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
 import { toast } from "sonner";
 import { useT } from "../../../i18n";
+import { isEnvFilePaste, parseEnvFile } from "./env-file";
 
 // Env values never reach this component until the user clicks
 // "Reveal & edit" — the agent resource feed no longer carries
@@ -42,7 +36,7 @@ function envMapToEntries(env: Record<string, string>): EnvEntry[] {
 }
 
 function entriesToEnvMap(entries: EnvEntry[]): Record<string, string> {
-  const map: Record<string, string> = {};
+  const map = Object.create(null) as Record<string, string>;
   for (const entry of entries) {
     const key = entry.key.trim();
     if (key) {
@@ -130,6 +124,39 @@ export function EnvTab({
     );
   };
 
+  const handleEnvPaste = (
+    index: number,
+    event: ClipboardEvent<HTMLInputElement>,
+  ) => {
+    const text = event.clipboardData.getData("text/plain");
+    const assignments = parseEnvFile(text);
+    if (!assignments) {
+      if (isEnvFilePaste(text)) {
+        event.preventDefault();
+        toast.error(t(($) => $.tab_body.env.paste_invalid_toast));
+      }
+      return;
+    }
+
+    event.preventDefault();
+    setRevealed((prev) => {
+      const currentEntries = prev ?? [];
+      const currentEntry = currentEntries[index];
+      const pastedEntries = assignments.map(({ key, value }, pasteIndex) => ({
+        id: pasteIndex === 0 && currentEntry ? currentEntry.id : nextEnvId++,
+        key,
+        value,
+        visible: false,
+      }));
+
+      return [
+        ...currentEntries.slice(0, index),
+        ...pastedEntries,
+        ...currentEntries.slice(index + 1),
+      ];
+    });
+  };
+
   const toggleEnvVisibility = (index: number) => {
     setRevealed((prev) =>
       (prev ?? []).map((entry, i) =>
@@ -214,17 +241,20 @@ export function EnvTab({
   return (
     <div className="space-y-4">
       <div className="flex items-start justify-between gap-3">
-        <p className="text-caption text-muted-foreground">
-          {t(($) => $.tab_body.env.intro_prefix)}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-micro">
-            {"ANTHROPIC_API_KEY"}
-          </code>
-          {t(($) => $.tab_body.env.intro_separator)}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-micro">
-            {"ANTHROPIC_BASE_URL"}
-          </code>
-          {t(($) => $.tab_body.env.intro_suffix)}
-        </p>
+        <div className="space-y-1 text-caption text-muted-foreground">
+          <p>
+            {t(($) => $.tab_body.env.intro_prefix)}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-micro">
+              {"ANTHROPIC_API_KEY"}
+            </code>
+            {t(($) => $.tab_body.env.intro_separator)}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-micro">
+              {"ANTHROPIC_BASE_URL"}
+            </code>
+            {t(($) => $.tab_body.env.intro_suffix)}
+          </p>
+          <p>{t(($) => $.tab_body.env.paste_hint)}</p>
+        </div>
         <Button
           type="button"
           variant="outline"
@@ -244,6 +274,7 @@ export function EnvTab({
               <Input
                 value={entry.key}
                 onChange={(e) => updateEnvEntry(index, "key", e.target.value)}
+                onPaste={(event) => handleEnvPaste(index, event)}
                 placeholder={t(($) => $.tab_body.env.key_placeholder)}
                 className="w-[40%] font-mono text-caption"
               />
@@ -261,7 +292,11 @@ export function EnvTab({
                   type="button"
                   onClick={() => toggleEnvVisibility(index)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={entry.visible ? t(($) => $.tab_body.env.hide_value_aria) : t(($) => $.tab_body.env.show_value_aria)}
+                  aria-label={
+                    entry.visible
+                      ? t(($) => $.tab_body.env.hide_value_aria)
+                      : t(($) => $.tab_body.env.show_value_aria)
+                  }
                 >
                   {entry.visible ? (
                     <EyeOff className="h-3.5 w-3.5" />
@@ -290,7 +325,9 @@ export function EnvTab({
 
       <div className="flex items-center justify-end gap-3">
         {dirty && (
-          <span className="text-caption text-muted-foreground">{t(($) => $.tab_body.common.unsaved_changes)}</span>
+          <span className="text-caption text-muted-foreground">
+            {t(($) => $.tab_body.common.unsaved_changes)}
+          </span>
         )}
         <Button onClick={handleSave} disabled={!dirty || saving} size="sm">
           {saving ? (

--- a/packages/views/agents/components/tabs/env-tab.tsx
+++ b/packages/views/agents/components/tabs/env-tab.tsx
@@ -27,12 +27,16 @@ interface EnvEntry {
 }
 
 function envMapToEntries(env: Record<string, string>): EnvEntry[] {
-  return Object.entries(env).map(([key, value]) => ({
+  const entries = Object.entries(env).map(([key, value]) => ({
     id: nextEnvId++,
     key,
     value,
     visible: false,
   }));
+
+  return entries.length > 0
+    ? entries
+    : [{ id: nextEnvId++, key: "", value: "", visible: true }];
 }
 
 function entriesToEnvMap(entries: EnvEntry[]): Record<string, string> {
@@ -109,7 +113,12 @@ export function EnvTab({
   };
 
   const removeEnvEntry = (index: number) => {
-    setRevealed((prev) => (prev ?? []).filter((_, i) => i !== index));
+    setRevealed((prev) => {
+      const entries = (prev ?? []).filter((_, i) => i !== index);
+      return entries.length > 0
+        ? entries
+        : [{ id: nextEnvId++, key: "", value: "", visible: true }];
+    });
   };
 
   const updateEnvEntry = (
@@ -133,7 +142,23 @@ export function EnvTab({
     if (!assignments) {
       if (isEnvFilePaste(text)) {
         event.preventDefault();
-        toast.error(t(($) => $.tab_body.env.paste_invalid_toast));
+        const assignmentKeys = text
+          .replace(/\r\n?/g, "\n")
+          .split("\n")
+          .map(
+            (line) =>
+              /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line)?.[1],
+          )
+          .filter((key): key is string => key !== undefined);
+        const hasDuplicateKeys =
+          new Set(assignmentKeys).size < assignmentKeys.length;
+        toast.error(
+          t(($) =>
+            hasDuplicateKeys
+              ? $.tab_body.env.duplicate_keys_toast
+              : $.tab_body.env.paste_invalid_toast,
+          ),
+        );
       }
       return;
     }

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -463,6 +463,8 @@
       "intro_prefix": "Injected into the agent process at launch (e.g. ",
       "intro_separator": ", ",
       "intro_suffix": ").",
+      "paste_hint": "Paste KEY=value lines into a key field to add multiple variables.",
+      "paste_invalid_toast": "Couldn't parse pasted environment variables",
       "key_placeholder": "KEY",
       "value_placeholder": "value",
       "show_value_aria": "Show value",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -346,6 +346,8 @@
       "intro_prefix": "エージェントプロセスの起動時に注入されます（例: ",
       "intro_separator": ", ",
       "intro_suffix": "）。",
+      "paste_hint": "KEY=value 形式の行をキー欄に貼り付けると、複数の環境変数を追加できます。",
+      "paste_invalid_toast": "貼り付けた環境変数を解析できませんでした",
       "key_placeholder": "KEY",
       "value_placeholder": "value",
       "show_value_aria": "値を表示",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -354,6 +354,8 @@
       "intro_prefix": "에이전트 프로세스가 시작될 때 주입됩니다(예: ",
       "intro_separator": ", ",
       "intro_suffix": ").",
+      "paste_hint": "키 필드에 KEY=value 형식의 줄을 붙여넣으면 여러 환경 변수를 추가할 수 있습니다.",
+      "paste_invalid_toast": "붙여넣은 환경 변수를 파싱할 수 없습니다",
       "key_placeholder": "KEY",
       "value_placeholder": "value",
       "show_value_aria": "값 표시",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -453,6 +453,8 @@
       "intro_prefix": "在智能体进程启动时注入（例如 ",
       "intro_separator": "、",
       "intro_suffix": "）。",
+      "paste_hint": "将 KEY=value 格式的内容粘贴到 key 输入框，即可添加多个环境变量。",
+      "paste_invalid_toast": "无法解析粘贴的环境变量",
       "key_placeholder": "KEY",
       "value_placeholder": "值",
       "show_value_aria": "显示值",


### PR DESCRIPTION
## What does this PR do?

Environment variables can now be pasted as dotenv-style `KEY=value` lines into the key field. Each assignment is parsed into its own editable row, so users do not need to paste names and values separately.

The paste handler recognizes assignment-like input while leaving ordinary key and comment-only pastes unchanged. Values use literal dotenv semantics: surrounding quotes and inline comments are handled, while backslashes, dollar signs, backticks, JSON, and other value content are preserved without evaluation or rewriting. Malformed assignment-like input is rejected as a whole. Imported values remain masked.

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Parse `KEY=value` and `export KEY=value` lines into separate environment-variable rows.
- Support comments, surrounding quotes, empty values, CRLF line endings, and literal special characters without shell evaluation.
- Preserve existing rows and keyboard focus while keeping pasted values masked.
- Provide an immediately pasteable row when no variables are configured.
- Reject duplicate keys during paste and leave ordinary or comment-only pastes to native input handling.
- Show localized guidance and malformed-paste feedback in English, Japanese, Korean, and Simplified Chinese.
- Cover parser behavior, row population, focus, masking, malformed input, literal values, duplicate and special keys, and locale parity.

## Risks

- Shell-like content inside values is stored literally and is never evaluated by the parser.
- Malformed assignment-like input is rejected as a whole so partial files are not silently imported.
- Only assignment-like content is intercepted; ordinary key and comment-only pastes keep the existing input behavior.

## How to Test

1. Open an agent Environment Variables tab and select Reveal & edit.
2. Paste multiple `KEY=value` or `export KEY=value` lines into the key field.
3. Confirm each assignment appears in its own row with values masked.
4. Paste values containing backslashes, `$`, backticks, or JSON and confirm the exact literal values are preserved after save.
5. Paste malformed or duplicate assignments and confirm the row remains unchanged with an error message.
6. Paste a bare key with a trailing newline and confirm native single-key paste behavior is unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant inline guidance to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions guide
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge
