### PR TITLE
fix(runtime-sweeper): rebind queued tasks off offlined runtimes

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -177,6 +177,19 @@ func sweepStaleRuntimes(ctx context.Context, queries *db.Queries, liveness handl
 		taskSvc.HandleFailedTasks(ctx, failedTasks)
 	}
 
+	// Rebind still-queued (not-yet-dispatched) tasks off the just-offlined
+	// runtimes onto their agent's current runtime binding, when that binding is
+	// a different, online runtime. Without this, queued tasks stay pinned to the
+	// dead runtime until the queued-TTL sweep fails them ~2h later, even though
+	// the agent has already been switched to a live runtime. The target daemon
+	// picks these up on its next claim poll; no extra event is required.
+	reboundTasks, err := queries.RebindQueuedTasksToAgentCurrentRuntime(ctx)
+	if err != nil {
+		slog.Warn("runtime sweeper: failed to rebind queued tasks to current runtime", "error", err)
+	} else if len(reboundTasks) > 0 {
+		slog.Info("runtime sweeper: rebound queued tasks to agent current runtime", "count", len(reboundTasks))
+	}
+
 	// Notify frontend clients so they re-fetch runtime list.
 	for wsID := range workspaces {
 		bus.Publish(events.Event{

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -303,6 +303,99 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 	return items, nil
 }
 
+const rebindQueuedTasksToAgentCurrentRuntime = `-- name: RebindQueuedTasksToAgentCurrentRuntime :many
+UPDATE agent_task_queue atq
+SET runtime_id = a.runtime_id
+FROM agent a, agent_runtime ar
+WHERE atq.agent_id = a.id
+  AND a.runtime_id = ar.id
+  AND ar.status = 'online'
+  AND atq.status = 'queued'
+  AND atq.runtime_id IS DISTINCT FROM a.runtime_id
+  AND atq.runtime_id IN (
+    SELECT id FROM agent_runtime WHERE status = 'offline'
+  )
+RETURNING atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for
+`
+
+// When a runtime goes offline, its still-queued (not-yet-dispatched) tasks stay
+// pinned to the dead runtime until the queued-TTL sweep fails them ~2h later.
+// This re-points those queued tasks at the agent's current runtime binding, but
+// only when that binding is a different, online runtime, so a live daemon can
+// claim them immediately. Tasks whose agent has no online current binding are
+// left for the offline/TTL sweeps to handle.
+func (q *Queries) RebindQueuedTasksToAgentCurrentRuntime(ctx context.Context) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, rebindQueuedTasksToAgentCurrentRuntime)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+			&i.RuntimeMcpOverlay,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+			&i.OriginatorUserID,
+			&i.RuntimeConnectedApps,
+			&i.CoalescedCommentIds,
+			&i.DeliveredCommentIds,
+			&i.ChatInputTaskID,
+			&i.ChatFinalizeDeferredAt,
+			&i.OriginatorSource,
+			&i.DelegatedFromTaskID,
+			&i.RetryOfTaskID,
+			&i.RerunOfTaskID,
+			&i.RuleVersionID,
+			&i.TriggerEvidenceKind,
+			&i.TriggerEvidenceRefID,
+			&i.AccountableUserID,
+			&i.SessionRolloutMissing,
+			&i.RetiredSessionID,
+			&i.QuickActionsDisabled,
+			&i.RegenerateQuickActionsFor,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findLegacyRuntimesByDaemonID = `-- name: FindLegacyRuntimesByDaemonID :many
 SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
 WHERE workspace_id = $1

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -239,6 +239,37 @@ WHERE status IN ('dispatched', 'running', 'waiting_local_directory')
   )
 RETURNING *;
 
+-- name: RebindQueuedTasksToAgentCurrentRuntime :many
+-- When a runtime goes offline, its still-queued (not-yet-dispatched) tasks stay
+-- pinned to the dead runtime until the queued-TTL sweep fails them ~2h later.
+-- That happens because the claim path (ListQueuedClaimCandidatesByRuntime) only
+-- ever returns candidates whose runtime_id matches the polling daemon's own
+-- online runtime: agent.runtime_id can change (e.g. the operator switches the
+-- agent to a different runtime), but agent_task_queue.runtime_id is NOT
+-- rewritten when it does — the same pinning gap documented on
+-- CancelAgentTasksByRuntimeOrAgent. The result is a queued task that no live
+-- daemon will ever claim.
+--
+-- This moves those orphaned queued tasks onto the agent's CURRENT runtime
+-- binding, but only when that binding is itself online, so the task becomes
+-- immediately claimable by the live daemon on its next poll. We never set
+-- runtime_id to NULL or to an offline runtime, so the
+-- agent_task_queue_active_requires_runtime invariant is preserved. Tasks whose
+-- agent has no current binding, or whose current binding is also offline, are
+-- left untouched for the queued-TTL sweep to handle.
+UPDATE agent_task_queue atq
+SET runtime_id = a.runtime_id
+FROM agent a, agent_runtime ar
+WHERE atq.agent_id = a.id
+  AND a.runtime_id = ar.id
+  AND ar.status = 'online'
+  AND atq.status = 'queued'
+  AND atq.runtime_id IS DISTINCT FROM a.runtime_id
+  AND atq.runtime_id IN (
+    SELECT id FROM agent_runtime WHERE status = 'offline'
+  )
+RETURNING atq.*;
+
 -- name: ListAgentRuntimesByOwner :many
 SELECT * FROM agent_runtime
 WHERE workspace_id = $1 AND owner_id = $2


### PR DESCRIPTION
### Summary
When a runtime goes offline, its still-**queued** (not-yet-dispatched) tasks stay pinned to the dead runtime and are never picked up by any live daemon. They sit stuck until the queued-TTL sweep fails them ~2h later — even when the agent has already been switched to a different, healthy runtime. This PR re-points those orphaned queued tasks onto the agent's current runtime binding during the stale-runtime sweep, so a live daemon claims them on its next poll.

### Problem
The task claim path `ListQueuedClaimCandidatesByRuntime` only returns candidates whose `runtime_id` matches the polling daemon's own online runtime. But `agent_task_queue.runtime_id` is **never rewritten** when an agent is switched to a different runtime (`agent.runtime_id` changes; the queued task's `runtime_id` does not).

So the following sequence produces a permanently stuck task:
1. Agent is bound to runtime **A**; tasks are queued against **A**.
2. Agent is switched to runtime **B** (now online).
3. Runtime **A** goes offline.
4. The queued tasks are still pinned to **A**. Daemon **B** never sees them (claim query filters on its own runtime), and daemon **A** is gone.

Existing recovery paths do not cover this case:
- `FailTasksForOfflineRuntimes` only touches `dispatched`/`running` tasks, not `queued`.
- The queued-TTL sweep eventually fails them, but only after ~2h, and as a *failure* rather than a recovery.

This is the "task stuck at the collector/officer" symptom observed in practice.

### Fix
Add a new query `RebindQueuedTasksToAgentCurrentRuntime`, invoked from `sweepStaleRuntimes` right after `FailTasksForOfflineRuntimes`. It re-points orphaned `queued` tasks onto the agent's current runtime binding, but only when that binding is itself online.

Guardrails baked into the query predicate:
- Only `status = 'queued'` rows are touched (dispatched/running keep their existing fail path).
- Only rows whose current `runtime_id` is an **offline** runtime are rebound.
- Only rebound when the agent's current binding is a **different**, **online** runtime (`runtime_id IS DISTINCT FROM a.runtime_id` + `ar.status = 'online'`).
- `runtime_id` is never set to `NULL` or to an offline runtime, so the `agent_task_queue_active_requires_runtime` invariant is preserved.
- Tasks whose agent has no current binding, or whose current binding is also offline, are left untouched for the queued-TTL sweep to handle.

The target daemon claims the rebound task on its next claim poll; no extra event/broadcast is required.

### Changes
- `server/pkg/db/queries/runtime.sql` — new `RebindQueuedTasksToAgentCurrentRuntime` query (+ doc comment explaining the invariant).
- `server/pkg/db/generated/runtime.sql.go` — regenerated sqlc output for the new query.
- `server/cmd/server/runtime_sweeper.go` — call the new query in `sweepStaleRuntimes` after `FailTasksForOfflineRuntimes`; log `count` when any task is rebound (`"rebound queued tasks to agent current runtime"`), warn on error without aborting the rest of the sweep.

3 files changed, 137 insertions(+).

The rebind query:
```sql
-- name: RebindQueuedTasksToAgentCurrentRuntime :many
UPDATE agent_task_queue atq
SET runtime_id = a.runtime_id
FROM agent a, agent_runtime ar
WHERE atq.agent_id = a.id
  AND a.runtime_id = ar.id
  AND ar.status = 'online'
  AND atq.status = 'queued'
  AND atq.runtime_id IS DISTINCT FROM a.runtime_id
  AND atq.runtime_id IN (
    SELECT id FROM agent_runtime WHERE status = 'offline'
  )
RETURNING atq.*;
```

### Testing
- `go build ./...` passes (built in a `golang:1.26` container against the server module).
- Reproduced and verified end-to-end against a live deployment DB (pre-fix backend image):
  - **Before fix** — inserted a `queued` task pinned to an offline runtime while its agent's current binding was a *different online* runtime. After multiple 30s sweep cycles the task stayed `queued`, `runtime_id` unchanged (offline), `failure_reason` empty — permanently stuck until the ~2h TTL.
  - **After applying the rebind query** — the same task's `runtime_id` was rewritten from the offline runtime to the agent's online runtime, `status` remained `queued` (not failed). A live daemon can then claim it on its next poll.
  - Boundary check — when the agent's current binding is also offline (or absent), the row is left untouched and falls through to the TTL sweep.
- Test data was inserted as a standalone row and deleted afterward; no real task/agent bindings were modified.

### Risk / rollout
- Low blast radius: the query is additive and guarded to only move `queued` rows off confirmed-offline runtimes onto confirmed-online bindings; the `active_requires_runtime` invariant is never violated.
- No schema/migration changes.
- No new events; relies on the existing claim-poll loop.
- Runs inside the existing sweep loop; a query error is logged as a warning and does not abort the rest of the sweep.
