### PR TITLE
MUL-6011 feat(layout): open a workspace in a new window from the switcher

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
 
-const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, sidebarState, summary, workspaces } = vi.hoisted(() => ({
+const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, openExternal, pins, sidebarState, summary, workspaces } = vi.hoisted(() => ({
   appForeground: { current: true },
   sidebarState: { setOpenMobile: vi.fn() },
   chatSessions: { current: [] as { id?: string; unread_count?: number }[] },
@@ -12,6 +12,7 @@ const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, n
   deletePin: vi.fn(),
   inboxItems: { current: [] as { id: string; read: boolean }[] },
   navigation: { current: { pathname: "/acme/issues" } },
+  openExternal: vi.fn(),
   summary: { current: [] as { workspace_id: string; count: number }[] },
   workspaces: {
     current: [] as { id: string; name: string; slug: string; avatar_url: string | null }[],
@@ -87,7 +88,19 @@ vi.mock("@multica/ui/components/ui/collapsible", () => ({
 vi.mock("@multica/ui/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  TooltipTrigger: ({
+    children,
+    onClick,
+    render,
+  }: {
+    children?: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+    render?: React.ReactElement<{ "aria-label"?: string }>;
+  }) => (
+    <button type="button" aria-label={render?.props["aria-label"]} onClick={onClick}>
+      {children}
+    </button>
+  ),
 }));
 vi.mock("../common/use-app-foreground", () => ({
   useAppForeground: () => appForeground.current,
@@ -97,8 +110,13 @@ vi.mock("../auth", () => ({ useLogout: () => vi.fn() }));
 vi.mock("../issues/components/status-icon", () => ({ StatusIcon: () => <span /> }));
 vi.mock("../navigation", () => ({
   AppLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
-  useNavigation: () => ({ pathname: navigation.current.pathname, push: vi.fn() }),
+  useNavigation: () => ({
+    pathname: navigation.current.pathname,
+    push: vi.fn(),
+    getShareableUrl: (path: string) => `https://app.multica.test${path}`,
+  }),
 }));
+vi.mock("../platform", () => ({ openExternal }));
 vi.mock("../projects/components/project-icon", () => ({ ProjectIcon: () => <span /> }));
 vi.mock("../workspace/workspace-avatar", () => ({ WorkspaceAvatar: () => <span /> }));
 vi.mock("@multica/ui/components/common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
@@ -330,6 +348,36 @@ describe("workspace-switcher dropdown per-workspace dot", () => {
     summary.current = [{ workspace_id: "ws-1", count: 5 }];
     const { container } = render(<AppSidebar />);
     expect(rowDots(container)).toHaveLength(0);
+  });
+});
+
+describe("workspace-switcher open-in-new-window", () => {
+  beforeEach(() => {
+    openExternal.mockReset();
+    summary.current = [];
+    workspaces.current = [
+      { id: "ws-1", name: "Active WS", slug: "active", avatar_url: null },
+      { id: "ws-2", name: "Other WS", slug: "other", avatar_url: null },
+    ];
+  });
+
+  // The control is the ExternalLink icon; i18n isn't wired in this file, so we
+  // key off the stable lucide class rather than the (empty) translated label.
+  const openButtons = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll(".lucide-external-link")).map(
+      (svg) => svg.closest("button")!,
+    );
+
+  it("gives every workspace row an open-in-new-window control", () => {
+    const { container } = render(<AppSidebar />);
+    expect(openButtons(container)).toHaveLength(2);
+  });
+
+  it("opens the workspace's shareable URL externally without navigating", () => {
+    const { container } = render(<AppSidebar />);
+    fireEvent.click(openButtons(container)[1]!);
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal).toHaveBeenCalledWith("https://app.multica.test/other/issues");
   });
 });
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -24,7 +24,9 @@ import { Layers,
   Check,
   SquarePen,
   X,
+  ExternalLink,
 } from "lucide-react";
+import { openExternal } from "../platform";
 import { WorkspaceAvatar } from "../workspace/workspace-avatar";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
@@ -419,7 +421,7 @@ interface AppSidebarProps {
 
 export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }: AppSidebarProps = {}) {
   const { t } = useT("layout");
-  const { pathname, push } = useNavigation();
+  const { pathname, push, getShareableUrl } = useNavigation();
   const user = useAuthStore((s) => s.user);
   const userId = useAuthStore((s) => s.user?.id);
   const logout = useLogout();
@@ -661,6 +663,29 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                         {ws.id === workspace?.id && (
                           <Check className="h-3.5 w-3.5 text-primary" />
                         )}
+                        {/* Open this workspace in a separate window. On desktop
+                            this hands the shareable URL to the OS (a new native
+                            window); on web it opens a new browser window. The
+                            row itself still navigates in place — this button
+                            stops that so the two gestures never collide. */}
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={<button type="button" aria-label={t(($) => $.sidebar.open_in_new_window)} />}
+                            className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/dropdown-menu-item:opacity-100 group-focus/dropdown-menu-item:opacity-100"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              openExternal(
+                                getShareableUrl(paths.workspace(ws.slug).issues()),
+                              );
+                            }}
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" sideOffset={4}>
+                            {t(($) => $.sidebar.open_in_new_window)}
+                          </TooltipContent>
+                        </Tooltip>
                       </DropdownMenuItem>
                     ))}
                     {!workspaceCreationDisabled && (

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -43,6 +43,7 @@
     "unpin_tooltip": "Unpin",
     "workspaces_label": "Workspaces",
     "create_workspace": "Create workspace",
+    "open_in_new_window": "Open in new window",
     "pending_invitations_label": "Pending invitations",
     "invitation_workspace_fallback": "Workspace",
     "invitation_join": "Join",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -43,6 +43,7 @@
     "unpin_tooltip": "ピン留めを解除",
     "workspaces_label": "ワークスペース",
     "create_workspace": "ワークスペースを作成",
+    "open_in_new_window": "新しいウィンドウで開く",
     "pending_invitations_label": "保留中の招待",
     "invitation_workspace_fallback": "ワークスペース",
     "invitation_join": "参加",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -43,6 +43,7 @@
     "unpin_tooltip": "고정 해제",
     "workspaces_label": "워크스페이스",
     "create_workspace": "워크스페이스 만들기",
+    "open_in_new_window": "새 창에서 열기",
     "pending_invitations_label": "대기 중인 초대",
     "invitation_workspace_fallback": "워크스페이스",
     "invitation_join": "참가",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -43,6 +43,7 @@
     "unpin_tooltip": "取消固定",
     "workspaces_label": "工作区",
     "create_workspace": "创建工作区",
+    "open_in_new_window": "在新窗口中打开",
     "pending_invitations_label": "待处理的邀请",
     "invitation_workspace_fallback": "工作区",
     "invitation_join": "加入",


### PR DESCRIPTION
## What

Adds an "open in new window" affordance to each workspace row in the sidebar workspace switcher, so users can work on multiple workspaces in parallel windows (HOM-10).

- Each workspace row in the switcher dropdown gets an external-link icon (revealed on row hover / focus).
- Tooltip and `aria-label` read **"Open in new window"** (localized in en / zh-Hans / ja / ko).
- Clicking it opens that workspace's shareable URL via the existing cross-platform `openExternal` helper:
  - **Desktop** → hands the URL to the OS shell (a new native window).
  - **Web** → opens a new browser window/tab.
- The row itself still navigates in place; the button `preventDefault`/`stopPropagation`s so the two gestures never collide.

## Why

Requested in HOM-10 — being able to open a workspace in a separate window enables handling tasks in multiple windows at once. The described approach (an external-jump icon in the workspace dropdown with an "open in new window" tooltip) is implemented as specified.

## Testing

- `pnpm --filter @multica/views test` — 3774 passed (added 2 tests covering the new control: one per-row control exists, and clicking opens the correct shareable URL without navigating).
- `pnpm --filter @multica/views typecheck` — clean.
- `pnpm --filter @multica/views lint` — no new warnings/errors.
