### PR TITLE
MUL-6004 fix(issues): bound inline chips so long titles stop breaking prose

### DIFF
--- a/packages/views/issues/components/issue-chip.test.tsx
+++ b/packages/views/issues/components/issue-chip.test.tsx
@@ -45,11 +45,15 @@ describe("IssueChip", () => {
     });
   });
 
-  it("caps the chip to its parent container and truncates the title", () => {
+  it("caps the chip against both its content and its container, and truncates the title", () => {
     render(<IssueChip issueId="issue-1" />);
 
     const chip = screen.getByText("MUL-3405").closest(".issue-mention");
-    expect(chip).toHaveClass("min-w-0", "max-w-full");
+    // 18rem bounds the chip against a long title so it cannot dominate a line
+    // of prose (#6732); 100% keeps it inside a narrow parent such as a chat
+    // bubble. ProjectChip carries the identical cap — see its own test.
+    expect(chip).toHaveClass("min-w-0");
+    expect(chip).toHaveClass("max-w-[min(18rem,100%)]");
     expect(screen.getByText("A very long issue title that should stay inside a narrow chat bubble"))
       .toHaveClass("min-w-0", "truncate");
   });

--- a/packages/views/issues/components/issue-chip.tsx
+++ b/packages/views/issues/components/issue-chip.tsx
@@ -7,13 +7,23 @@ import { StatusIcon } from "./status-icon";
 
 /**
  * Compact, presentation-only representation of an issue —
- * `<StatusIcon> <identifier> <title>`, bordered, capped at the container width
- * (`max-w-full`) with the title truncating to an ellipsis. As an atomic inline
- * box it wraps to the next line as a unit when it doesn't fit at the current
- * position; the ellipsis only kicks in once a whole line can't hold it. The cap
- * lives here (single source of truth) — wrappers must NOT add their own flex
- * container around it, or a percentage cap gets dropped during the wrapper's
- * intrinsic sizing and the clickable box diverges from the truncated chip.
+ * `<StatusIcon> <identifier> <title>`, bordered, with the title truncating to
+ * an ellipsis once the chip hits its width cap.
+ *
+ * The cap is `min(18rem, 100%)` — two limits doing two different jobs:
+ *   - `18rem` bounds the chip against the *content*, so a long title can never
+ *     grow the chip wide enough to dominate a line of prose. Without it a chip
+ *     is an atomic inline box that wraps to the next line as a unit whenever it
+ *     doesn't fit at the current position, leaving a ragged gap on the line
+ *     above — the reference-dense-prose problem from #6732.
+ *   - `100%` bounds it against the *container*, keeping the chip inside narrow
+ *     parents such as a chat bubble.
+ * `ProjectChip` carries the identical cap; the two must not drift.
+ *
+ * The cap lives here (single source of truth) — wrappers must NOT add their own
+ * flex container around it, or a percentage cap gets dropped during the
+ * wrapper's intrinsic sizing and the clickable box diverges from the truncated
+ * chip.
  *
  * This is the single source of truth for the "issue-mention card" look.
  * It is intentionally **not** a link or button: callers wrap it in whatever
@@ -34,7 +44,7 @@ export interface IssueChipProps {
 }
 
 const BASE_CLASS =
-  "issue-mention inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-caption";
+  "issue-mention inline-flex min-w-0 max-w-[min(18rem,100%)] items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-caption";
 
 export function IssueChip({ issueId, fallbackLabel, className }: IssueChipProps) {
   const wsId = useWorkspaceId();

--- a/packages/views/projects/components/project-chip.test.tsx
+++ b/packages/views/projects/components/project-chip.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+import { ProjectChip } from "./project-chip";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: () => ({ queryKey: ["projects"] }),
+  projectDetailOptions: (_workspaceId: string, projectId: string) => ({
+    queryKey: ["project", projectId],
+  }),
+}));
+
+vi.mock("./project-icon", () => ({
+  ProjectIcon: ({ className }: { className?: string }) => (
+    <span data-testid="project-icon" className={className} />
+  ),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "Unknown project" }),
+}));
+
+const mockUseQuery = vi.mocked(useQuery);
+
+const LONG_TITLE =
+  "A very long project title that should stay inside a narrow chat bubble";
+
+describe("ProjectChip", () => {
+  beforeEach(() => {
+    mockUseQuery.mockImplementation((options: { queryKey?: readonly unknown[] }) => {
+      if (options.queryKey?.[0] === "projects") {
+        return {
+          data: [{ id: "project-1", title: LONG_TITLE, emoji: "🚀" }],
+        } as ReturnType<typeof useQuery>;
+      }
+      return { data: undefined } as ReturnType<typeof useQuery>;
+    });
+  });
+
+  // ProjectChip and IssueChip render the same inline-chip shape in the same
+  // prose. If only one of them bounds its width, reference-dense content breaks
+  // for that one — which is how #6732 happened. Locking the cap in both tests
+  // is what keeps them from drifting apart again.
+  it("carries the same width cap as IssueChip and truncates the title", () => {
+    render(<ProjectChip projectId="project-1" />);
+
+    const chip = screen.getByText(LONG_TITLE).closest(".project-chip");
+    expect(chip).toHaveClass("min-w-0");
+    expect(chip).toHaveClass("max-w-[min(18rem,100%)]");
+    expect(screen.getByText(LONG_TITLE)).toHaveClass("min-w-0", "truncate");
+  });
+
+  it("truncates the fallback label inside the chip width", () => {
+    render(<ProjectChip projectId="missing-project" fallbackLabel={LONG_TITLE} />);
+
+    expect(screen.getByText(LONG_TITLE)).toHaveClass("min-w-0", "truncate");
+  });
+});

--- a/packages/views/projects/components/project-chip.tsx
+++ b/packages/views/projects/components/project-chip.tsx
@@ -8,7 +8,10 @@ import { useT } from "../../i18n";
 
 /**
  * Compact presentational representation of a project —
- * `<emoji> <title>`, bordered, truncating to max-w-72. Mirror of IssueChip.
+ * `<emoji> <title>`, bordered, truncating once it hits its width cap. Mirror of
+ * IssueChip, including the `min(18rem, 100%)` cap — see that file for why the
+ * content limit and the container limit are both needed. The two chips share
+ * one rendering contract and must not drift.
  *
  * Not a link / button: callers wrap it in whatever interactive shell they
  * need. Pure UI — data is queried internally so callers can pass just an id.
@@ -22,7 +25,7 @@ export interface ProjectChipProps {
 }
 
 const BASE_CLASS =
-  "project-chip inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-caption max-w-72";
+  "project-chip inline-flex min-w-0 max-w-[min(18rem,100%)] items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-caption";
 
 export function ProjectChip({
   projectId,
@@ -46,7 +49,7 @@ export function ProjectChip({
     return (
       <span className={cls}>
         <ProjectIcon size="md" />
-        <span className="text-muted-foreground truncate">
+        <span className="min-w-0 truncate text-muted-foreground">
           {fallbackLabel ?? t(($) => $.chip.fallback_label)}
         </span>
       </span>
@@ -56,7 +59,7 @@ export function ProjectChip({
   return (
     <span className={cls}>
       <ProjectIcon project={project} size="md" />
-      <span className="text-foreground truncate">{project.title}</span>
+      <span className="min-w-0 truncate text-foreground">{project.title}</span>
     </span>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Bounds the width of inline issue and project chips so a long title can no longer break the paragraph around it.

`IssueChip` capped itself at `max-w-full`. In a body-text column that is effectively no cap: a chip carrying a 60-character title is an atomic inline box roughly 500px wide, and when it doesn't fit in the space left on the current line it wraps to the next line *whole*, stranding a ragged gap on the line above. The ellipsis only ever engaged once a chip couldn't fit on a line by itself. That is the reading problem reported in #6732.

The useful detail is that `ProjectChip` never had this problem, because it already carried a content cap (`max-w-72`). Two chips that render the same shape in the same prose disagreed about whether to bound themselves. So the defect here is the inconsistency, not the amount of information the chip shows.

Both now share one cap, `min(18rem, 100%)`:

- **`18rem`** bounds the chip against its **content**, so a long title cannot grow the chip wide enough to dominate a line.
- **`100%`** bounds it against its **container**, so the chip still fits a narrow parent such as a chat bubble.

`IssueChip` had only the second half; `ProjectChip` had only the first. Neither was complete on its own.

### Why a default, and not a preference

The rendering that everyone gets by default is the thing worth fixing. A setting only reaches the people who go looking for it, and it would leave the same chip un-bounded for everyone else — while adding a rendering mode that every content surface has to keep honouring from then on. Bounding the default costs one class, applies to every reader, and leaves the door open to a preference later if the bounded default still isn't enough for someone.

The chip keeps the status icon, the identifier and as much of the title as fits, so nothing becomes unreachable — a truncated title still shows its opening words, which is what makes it recognisable at a glance.

### Choosing 18rem

Three candidate caps were rendered against the same reference-dense comment (five chips, four distinct issues, two repeats) in a 1180px window and compared.

Taking `Inline issue references are hard to read in reference-dense prose` as the sample title:

| Cap | Renders as | Result |
| --- | --- | --- |
| `14rem` (224px) | `Inline issue references a…` | Prose flows well, but titles cut early enough that similar titles stop being distinguishable from each other |
| **`18rem` (288px)** | `Inline issue references are hard to r…` | Enough title to recognise the issue; prose reads as prose |
| `22rem` (352px) | `Inline issue references are hard to read in refer…` | Most title preserved, but chips still push text to the far right and the right edge stays visibly ragged |

`18rem` also happens to be exactly what `ProjectChip` already used, so this converges the two chips rather than inventing a third number.

Measured on that test comment: the paragraph goes from **9 rendered lines to 8** (217px → 194px tall), and chip widths from `[444, 377, 377, 502, 444]px` to a flat `288px`. All three candidates saved the same one line; they differ only in how much title survives and how ragged the right edge stays, which is why the choice is a judgement call rather than a measurement.

## Related Issue

Addresses #6732. Not marked `Closes` — that issue also proposes a per-reader density preference, and that part is a separate product decision, not something this PR settles.

#6625 from the same reporter proposes a three-mode preference for the same problem; this PR is deliberately narrower and does not touch that decision either way. Credit to @szainmehdi for the report, the screenshot, and for isolating exactly which surfaces the problem does and doesn't appear on.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/views/issues/components/issue-chip.tsx` — `max-w-full` → `max-w-[min(18rem,100%)]`. Docstring rewritten to say what each half of the cap is for, since the old one documented the wrapping behaviour that turned out to be the bug.
- `packages/views/projects/components/project-chip.tsx` — same cap, replacing `max-w-72`. Also adds the `min-w-0` that was missing on the chip and on both title spans: without it `truncate` cannot shrink the flex item, so a long project title overflowed the border box instead of ellipsing. That path is reachable now that the chip has a container-relative cap, so it is fixed here rather than left behind.
- `packages/views/issues/components/issue-chip.test.tsx` — the existing cap assertion updated to the new value.
- `packages/views/projects/components/project-chip.test.tsx` — **new.** `ProjectChip` had no test file, which is part of why it drifted from `IssueChip` unnoticed. Locks the shared cap and the truncation classes on both chips so the next divergence fails a test instead of shipping.

## How to Test

1. `make dev`, then open an issue and post a comment whose prose references several issues with long titles, repeating at least one — e.g. `The behaviour MUL-1 describes shows up when a thread keeps circling MUL-2, and MUL-2 left density alone.`
2. Before this change: chips run to the full column width, text after a chip gets pushed to the far right, and lines break in places the sentence does not.
3. After: every chip stops at 288px with the title ellipsing, and the paragraph reads as continuous prose.
4. Narrow the window (or use a chat bubble) until the container is under 288px — the chip tracks the container and stays inside it.
5. Repeat with a project mention to confirm both chips behave identically.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass — `pnpm typecheck` clean across 6 packages; `pnpm vitest run` in `packages/views` 3783 passing across 320 files; `pnpm lint` 0 errors
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — captured locally across all three candidate caps and used to pick `18rem`; the measurements from those captures are quoted above, but I have no way to attach the image files from this environment. Happy to have them added if wanted.
- [x] I have updated relevant documentation to reflect my changes — both component docstrings; no user-facing docs describe chip rendering
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — n/a
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — n/a, no copy changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risks

Low, and bounded to rendering. Titles longer than roughly 37 characters now ellipse inline where they previously showed in full — that is the intended trade, and the full title stays available on the issue itself. `apps/mobile` is untouched (it renders bare identifiers and has no chip). No API, schema, or behaviour change; click semantics are untouched.

## AI Disclosure

**AI tool used:** Claude Code (Opus 5), running as a Multica agent

**Prompt / approach:** Asked to review #6732 and decide whether to implement the fix as proposed. The review started from the component source rather than the proposal, which is where the `IssueChip` / `ProjectChip` inconsistency turned up and reframed the problem from "the chip shows too much" to "one of these two chips forgot to bound itself." The three candidate caps were then rendered in a local full-stack environment against seeded reference-dense content and compared before picking `18rem`.
