### PR TITLE
MUL-5992 fix(agent): keep Reasonix off the ask tool in unattended tasks

### DIFF
--- a/server/pkg/agent/reasonix.go
+++ b/server/pkg/agent/reasonix.go
@@ -43,6 +43,34 @@ func reasonixACPLaunchArgs() []string {
 	}
 }
 
+// reasonixUnattendedNotice tells Reasonix that this turn has no interactive
+// user, so it must not reach for the `ask` tool.
+//
+// Reasonix registers `ask` unconditionally and its ACP server wires an asker
+// for every session, so the runtime's own "no interactive user" fallback —
+// which answers the question with "decide for yourself" — is unreachable over
+// ACP. A question that does arrive can only be refused, and Reasonix reads an
+// unanswered question as a dismissal and cancels the whole turn.
+//
+// This rides the per-turn user message rather than the AGENTS.md runtime brief
+// because two agents can call `ask` in one turn: the executor, which reads
+// AGENTS.md, and the planner, which runs on its own system prompt and never
+// sees the workdir brief. The user message is the only surface both read.
+const reasonixUnattendedNotice = "Unattended Multica task: there is no interactive user in this session. " +
+	"Do NOT call the `ask` tool — nobody can answer it, and an unanswered question cancels the whole turn. " +
+	"When a decision is genuinely open, take the most conservative reversible option, keep going, " +
+	"and state the assumption you made in your final issue comment."
+
+// withReasonixUnattendedNotice appends the unattended notice to the per-turn
+// prompt. It lands last so it sits after any quoted issue or comment body the
+// daemon injected, and an empty prompt still carries the constraint.
+func withReasonixUnattendedNotice(prompt string) string {
+	if strings.TrimSpace(prompt) == "" {
+		return reasonixUnattendedNotice
+	}
+	return prompt + "\n\n" + reasonixUnattendedNotice
+}
+
 // reasonixReaderDrainGrace bounds how long the turn waits for trailing ACP
 // notifications after the session/prompt response. A var, not a const, so
 // tests can shorten it. Mirrors qoderReaderDrainGrace / traecliReaderDrainGrace.
@@ -374,12 +402,13 @@ func (b *reasonixBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 		// 4. Send the prompt and wait for PromptResponse. Reasonix loads
 		// AGENTS.md from cwd, so the daemon deliberately does not duplicate the
-		// runtime brief in this user message.
+		// runtime brief in this user message — only the unattended notice, which
+		// AGENTS.md cannot deliver to both agents in the turn.
 		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
-				{"type": "text", "text": prompt},
+				{"type": "text", "text": withReasonixUnattendedNotice(prompt)},
 			},
 		})
 		if err != nil {

--- a/server/pkg/agent/reasonix_execute_unix_test.go
+++ b/server/pkg/agent/reasonix_execute_unix_test.go
@@ -150,6 +150,41 @@ done
 	}
 }
 
+func TestReasonixPromptCarriesUnattendedNotice(t *testing.T) {
+	t.Parallel()
+	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "reasonix")
+	writeTestExecutable(t, fakePath, []byte(fakeACPRecordingScript(recordPath, "notice-session", "{}")))
+	backend, err := New("reasonix", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(reasonix): %v", err)
+	}
+	session, err := backend.Execute(context.Background(), "Reply to the comment.", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	if result := <-session.Result; result.Status != "completed" {
+		t.Fatalf("result = %+v", result)
+	}
+
+	frame := findRecordedFrame(t, recordPath, "session/prompt")
+	blocks := frame["params"].(map[string]any)["prompt"].([]any)
+	if len(blocks) != 1 {
+		t.Fatalf("prompt blocks = %+v, want one text block", blocks)
+	}
+	text := blocks[0].(map[string]any)["text"].(string)
+	if !strings.HasPrefix(text, "Reply to the comment.") {
+		t.Fatalf("prompt dropped the task text: %q", text)
+	}
+	if !strings.Contains(text, reasonixUnattendedNotice) {
+		t.Fatalf("prompt = %q, want the unattended notice appended", text)
+	}
+}
+
 func TestReasonixResumeFiltersUnsupportedSSEMCP(t *testing.T) {
 	t.Parallel()
 	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")

--- a/server/pkg/agent/reasonix_test.go
+++ b/server/pkg/agent/reasonix_test.go
@@ -72,6 +72,38 @@ func TestReasonixPermissionPolicy(t *testing.T) {
 	}
 }
 
+func TestReasonixUnattendedNoticeRidesEveryPrompt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{name: "appended after the task prompt", prompt: "Reply to the comment.", want: "Reply to the comment.\n\n" + reasonixUnattendedNotice},
+		{name: "empty prompt still carries the constraint", prompt: "   ", want: reasonixUnattendedNotice},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := withReasonixUnattendedNotice(tt.prompt); got != tt.want {
+				t.Fatalf("prompt = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// The notice exists to keep BOTH Reasonix agents off the ask tool — the
+	// executor and the planner, which never sees AGENTS.md. Naming the tool and
+	// the fallback behaviour is the whole payload; a reword that drops either
+	// leaves the planner with no instruction at all.
+	if !strings.Contains(reasonixUnattendedNotice, "`ask`") {
+		t.Fatalf("notice must name the ask tool: %q", reasonixUnattendedNotice)
+	}
+	if !strings.Contains(reasonixUnattendedNotice, "no interactive user") {
+		t.Fatalf("notice must state that no user can answer: %q", reasonixUnattendedNotice)
+	}
+}
+
 func TestReasonixPermissionMetadataWarningDetection(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Closes the unattended half of #6718 (MUL-5992).

## Problem

When a Reasonix ACP task runs unattended and the model calls `ask`, the daemon has no user to hand the question to. `selectReasonixPermissionOption` picks the offered `reject_once`, and Reasonix reads "no option selected" as a user dismissal and cancels the whole turn — the task fails even when the model only needed a decision it could have made itself.

Reasonix has exactly the fallback we want (`ask` returns "no interactive user — proceed with your best judgment" when no asker is wired), but it is unreachable over ACP: `ask` is registered unconditionally, and every ACP session calls `EnableInteractiveApproval()`, which wires the controller as the asker.

## Change

Append a short constraint to the per-turn user message: no interactive user this session, do not call `ask`, take the most conservative reversible option and state the assumption in the final issue comment.

It goes in the user message rather than the AGENTS.md runtime brief because **two** agents can call `ask` in one turn:

- the **executor**, which reads AGENTS.md, and
- the **planner**, which runs on its own system prompt (`DefaultPlannerPrompt` + memory) and never sees the workdir brief. Upstream keeps `ask` in the planner registry deliberately, and we launch with `--planner auto`.

The user message is the only surface both read.

## Deliberately not in this PR

- **No project-level `PreToolUse` hook** (`.reasonix/settings.json`). It would hard-block `ask`, but only for the executor — planner tool calls fire no hooks at all — so it cannot promise "ask is off" while adding a shell-exec sidecar, user-config merging, and Windows quoting to maintain.
- **No change to the permission policy.** A question that still arrives stays fail-closed: refused, never answered on the member's behalf by selecting the model's first option (its answer options ship as `allow_once`, so the generic rule would silently pick the recommended one).
- **Planner stays on.** `--planner off` would close the gap by removing the capability; not worth it.

The real fix belongs upstream — an ACP client declaring "no interactive user" so Reasonix skips `SetAsker` (or drops `ask`) for both registries. Filed at esengine/DeepSeek-Reasonix; this PR is the mitigation until that lands.

## Verification

- `go test ./pkg/agent/ -run Reasonix -count=1` — pass.
- Full `go test ./pkg/agent/ -count=1` has three unrelated pre-existing flakes under parallel load (`TestGrokAuthenticatesBeforeSession/resume`, `TestKimiBackendThinkingConfirmationFailureWarnsAndContinues`, `TestClaudeExecuteClassifiesContextExhaustionWithoutUsableProse`); each passes when run on its own, and none touches this code path.

New tests: the notice is appended after the task text (and survives an empty prompt), it keeps naming `ask` and the no-user condition, and the recorded `session/prompt` frame carries it on the wire.
