### PR TITLE
MUL-5992 fix(daemon): deny the Reasonix ask tool per task (supersedes #6745)

### DIFF
--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -404,6 +404,15 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		env.QwenpawWorkspace = qwenpawWorkspace
 	}
 
+	// For Reasonix, deny the `ask` tool for this task through a project-scoped
+	// reasonix.toml. Degraded, not fatal: without it the task still runs under
+	// the backend's fail-closed question handling.
+	if params.Provider == "reasonix" {
+		if err := writeReasonixProjectConfig(workDir, manifest, logger); err != nil {
+			logger.Warn("execenv: write reasonix project config failed", "error", err)
+		}
+	}
+
 	// For Cursor, materialize managed MCP into project-local config and use
 	// an isolated CURSOR_DATA_DIR for the per-workdir approval sidecar. Cursor
 	// still reads ~/.cursor/mcp.json, but only servers with approval entries in
@@ -618,6 +627,15 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 			logger.Warn("execenv: refresh claude skill settings failed", "error", err)
 		} else {
 			env.ClaudeSettingsPath = settingsPath
+		}
+	}
+
+	// Re-deny Reasonix's `ask` tool on reuse: CleanupSidecars above removed the
+	// prior run's reasonix.toml, so without this the next turn would run with
+	// the tool available again.
+	if params.Provider == "reasonix" {
+		if err := writeReasonixProjectConfig(params.WorkDir, manifest, logger); err != nil {
+			logger.Warn("execenv: refresh reasonix project config failed", "error", err)
 		}
 	}
 

--- a/server/internal/daemon/execenv/reasonix_permissions.go
+++ b/server/internal/daemon/execenv/reasonix_permissions.go
@@ -1,0 +1,73 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+)
+
+// reasonixProjectConfigFile is Reasonix's project-scoped config. Reasonix
+// resolves configuration as flag > project ./reasonix.toml > user config.toml >
+// defaults, rooted at the session cwd — which for a task is the workdir — so a
+// file written here binds to this task only and leaves the runtime owner's
+// interactive sessions alone.
+const reasonixProjectConfigFile = "reasonix.toml"
+
+// reasonixProjectConfig turns off Reasonix's `ask` tool for the task.
+//
+// `ask` puts a multiple-choice question to a human mid-turn. An unattended task
+// has no human: Reasonix wires an asker for every ACP session, so the runtime's
+// own "no interactive user — decide for yourself" fallback is unreachable, the
+// daemon can only refuse the question, and Reasonix reads a refusal as a
+// dismissal and cancels the whole turn. The task fails over a decision the model
+// could have made itself.
+//
+// A deny rule is the one lever that covers the whole turn. Reasonix checks deny
+// rules before the read-only allow fallthrough, so it applies to `ask` despite
+// `ask` being read-only, and the executor, the planner, and sub-agents all
+// decide against the same policy — where a tool-call hook would only ever reach
+// the executor. The model gets "denied by permission policy" back as an ordinary
+// tool result and keeps working.
+//
+// Deny is a replacing list, not an additive one: for the duration of a task in
+// this workdir this is the effective deny list, so a deny rule in the runtime
+// owner's global config does not apply here. That is accepted — the daemon
+// already constrains these runs through --workspace-only and the ACP permission
+// policy, which is where task-level restriction belongs.
+const reasonixProjectConfig = `# Managed by Multica. Written per task, removed when the task env is cleaned up.
+# Edits are not preserved.
+
+[permissions]
+# No human can answer a question in an unattended task, and an unanswered
+# question cancels the Reasonix turn. Denying the tool instead lets the model
+# take its own decision and keep going.
+deny = ["ask"]
+`
+
+// writeReasonixProjectConfig lays down the per-task reasonix.toml in workDir.
+//
+// A reasonix.toml that came with the repository is left untouched: sidecar
+// cleanup is a pure deletion of paths the daemon created, so it must never
+// overwrite user content. That case is a warning rather than a failure — the
+// task still runs, `ask` stays available, and a question that does arrive hits
+// the existing fail-closed permission handling in the reasonix backend.
+func writeReasonixProjectConfig(workDir string, manifest *sidecarManifest, logger *slog.Logger) error {
+	if workDir == "" {
+		return nil
+	}
+	path := filepath.Join(workDir, reasonixProjectConfigFile)
+	err := recordWriteFile(path, []byte(reasonixProjectConfig), 0o644, manifest)
+	if errors.Is(err, errPathPreExists) {
+		if logger != nil {
+			logger.Warn("execenv: project reasonix.toml already exists; leaving it untouched — the reasonix ask tool stays enabled for this task",
+				"path", path,
+			)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("write %s: %w", reasonixProjectConfigFile, err)
+	}
+	return nil
+}

--- a/server/internal/daemon/execenv/reasonix_permissions.go
+++ b/server/internal/daemon/execenv/reasonix_permissions.go
@@ -32,9 +32,11 @@ const reasonixProjectConfigFile = "reasonix.toml"
 //
 // Deny is a replacing list, not an additive one: for the duration of a task in
 // this workdir this is the effective deny list, so a deny rule in the runtime
-// owner's global config does not apply here. That is accepted — the daemon
-// already constrains these runs through --workspace-only and the ACP permission
-// policy, which is where task-level restriction belongs.
+// owner's global config does not apply here. That is a deliberate, accepted
+// widening of what the agent may run in a task workdir — not something the
+// daemon's other constraints (--workspace-only, the ACP permission policy) make
+// equivalent. Extending the global list instead would mean parsing the runtime
+// owner's config to restate it, which is its own failure mode.
 const reasonixProjectConfig = `# Managed by Multica. Written per task, removed when the task env is cleaned up.
 # Edits are not preserved.
 

--- a/server/internal/daemon/execenv/reasonix_permissions_test.go
+++ b/server/internal/daemon/execenv/reasonix_permissions_test.go
@@ -1,0 +1,129 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareDeniesReasonixAskTool(t *testing.T) {
+	t.Parallel()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-reasonix-001",
+		TaskID:         "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		AgentName:      "Reasonix Agent",
+		Provider:       "reasonix",
+		Task:           TaskContextForEnv{IssueID: "b1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	configPath := filepath.Join(env.WorkDir, reasonixProjectConfigFile)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", reasonixProjectConfigFile, err)
+	}
+	if !strings.Contains(string(data), "[permissions]") || !strings.Contains(string(data), `deny = ["ask"]`) {
+		t.Fatalf("project config does not deny ask:\n%s", data)
+	}
+
+	// The sidecar is daemon-owned state, so CleanupSidecars must take it back
+	// out — a local_directory run has to be byte-exactly reversible.
+	if err := CleanupSidecars(env.RootDir); err != nil {
+		t.Fatalf("CleanupSidecars: %v", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("reasonix.toml survived sidecar cleanup (stat err = %v)", err)
+	}
+}
+
+func TestReuseRewritesReasonixAskDeny(t *testing.T) {
+	t.Parallel()
+	params := PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-reasonix-003",
+		TaskID:         "c1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		AgentName:      "Reasonix Agent",
+		Provider:       "reasonix",
+		Task:           TaskContextForEnv{IssueID: "c1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	}
+	env, err := Prepare(params, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	// Reuse rolls back the prior run's sidecars before rebuilding them, so the
+	// deny rule has to be re-laid — otherwise the second turn of a task would
+	// run with the ask tool available again.
+	reused := Reuse(ReuseParams{
+		WorkspacesRoot: params.WorkspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "reasonix",
+		Task:           params.Task,
+	}, testLogger())
+	if reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	data, err := os.ReadFile(filepath.Join(reused.WorkDir, reasonixProjectConfigFile))
+	if err != nil {
+		t.Fatalf("read %s after reuse: %v", reasonixProjectConfigFile, err)
+	}
+	if !strings.Contains(string(data), `deny = ["ask"]`) {
+		t.Fatalf("reused task lost the ask deny rule:\n%s", data)
+	}
+}
+
+func TestReasonixProjectConfigKeepsRepositoryFile(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	repoConfig := "[permissions]\nallow = [\"bash\"]\n"
+	configPath := filepath.Join(workDir, reasonixProjectConfigFile)
+	if err := os.WriteFile(configPath, []byte(repoConfig), 0o644); err != nil {
+		t.Fatalf("seed repository reasonix.toml: %v", err)
+	}
+
+	// A repository's own config belongs to the user: the daemon leaves it
+	// byte-for-byte alone rather than trading it for the ask deny rule, and
+	// reports success so the task still runs (with ask enabled, caught by the
+	// backend's fail-closed question handling).
+	manifest := &sidecarManifest{}
+	if err := writeReasonixProjectConfig(workDir, manifest, testLogger()); err != nil {
+		t.Fatalf("writeReasonixProjectConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", reasonixProjectConfigFile, err)
+	}
+	if string(data) != repoConfig {
+		t.Fatalf("repository reasonix.toml was rewritten:\n%s", data)
+	}
+	// Nothing was created, so cleanup must not claim the user's file.
+	if len(manifest.Files) != 0 {
+		t.Fatalf("manifest recorded a file it did not write: %+v", manifest.Files)
+	}
+}
+
+func TestReasonixProjectConfigSkippedForOtherProviders(t *testing.T) {
+	t.Parallel()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-hermes-001",
+		TaskID:         "d1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		AgentName:      "Hermes Agent",
+		Provider:       "hermes",
+		Task:           TaskContextForEnv{IssueID: "d1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if _, err := os.Stat(filepath.Join(env.WorkDir, reasonixProjectConfigFile)); !os.IsNotExist(err) {
+		t.Fatalf("reasonix.toml written for a non-reasonix provider (stat err = %v)", err)
+	}
+}

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -61,11 +61,6 @@ var agentGitExcludePatterns = []string{
 	".deveco",
 	"CODEBUDDY.md",
 	".codebuddy",
-	// Reasonix's project config, written per task to deny the `ask` tool.
-	// Excluding it only hides the daemon's own copy: a repository that tracks
-	// its own reasonix.toml keeps it (git ignores excludes for tracked paths),
-	// and the daemon never overwrites one it did not create.
-	"reasonix.toml",
 }
 
 const repoCacheGitTimeout = 10 * time.Minute

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -61,6 +61,11 @@ var agentGitExcludePatterns = []string{
 	".deveco",
 	"CODEBUDDY.md",
 	".codebuddy",
+	// Reasonix's project config, written per task to deny the `ask` tool.
+	// Excluding it only hides the daemon's own copy: a repository that tracks
+	// its own reasonix.toml keeps it (git ignores excludes for tracked paths),
+	// and the daemon never overwrites one it did not create.
+	"reasonix.toml",
 }
 
 const repoCacheGitTimeout = 10 * time.Minute

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -897,6 +897,55 @@ func TestCreateWorktreeExcludesCodebuddySidecars(t *testing.T) {
 	}
 }
 
+// TestCreateWorktreeDoesNotExcludeReasonixProjectConfig guards the layering
+// that makes a `reasonix.toml` exclude wrong. The daemon writes that file at
+// the WorkDir, and a managed checkout is a directory *inside* the WorkDir, so
+// this exclude list — which only reaches the checkout's .git/info/exclude —
+// could never hide the daemon's copy. All it would do is make a project config
+// an agent legitimately creates inside the repository invisible to git status
+// for every provider.
+func TestCreateWorktreeDoesNotExcludeReasonixProjectConfig(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     workDir,
+		AgentName:   "Reasonix",
+		TaskID:      "reasonix-exclude-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	// The daemon's sidecar is a sibling of the checkout, not a file in it.
+	if filepath.Dir(result.Path) != workDir {
+		t.Fatalf("checkout %q is not a child of the work dir %q", result.Path, workDir)
+	}
+	if strings.Contains(gitInfoExclude(t, result.Path), "reasonix.toml") {
+		t.Fatalf("reasonix.toml is excluded inside the checkout, hiding a project config the agent may create:\n%s", gitInfoExclude(t, result.Path))
+	}
+
+	configPath := filepath.Join(result.Path, "reasonix.toml")
+	if err := os.WriteFile(configPath, []byte("[permissions]\n"), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	// git check-ignore exits 1 when the path is NOT ignored — the outcome this
+	// test wants, so the agent can still commit the file it wrote.
+	cmd := exec.Command("git", "-C", result.Path, "check-ignore", "-q", "reasonix.toml")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("git ignores a repository reasonix.toml created inside the checkout")
+	}
+}
+
 func gitInfoExclude(t *testing.T, worktreePath string) string {
 	t.Helper()
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")

--- a/server/pkg/agent/reasonix.go
+++ b/server/pkg/agent/reasonix.go
@@ -43,34 +43,6 @@ func reasonixACPLaunchArgs() []string {
 	}
 }
 
-// reasonixUnattendedNotice tells Reasonix that this turn has no interactive
-// user, so it must not reach for the `ask` tool.
-//
-// Reasonix registers `ask` unconditionally and its ACP server wires an asker
-// for every session, so the runtime's own "no interactive user" fallback —
-// which answers the question with "decide for yourself" — is unreachable over
-// ACP. A question that does arrive can only be refused, and Reasonix reads an
-// unanswered question as a dismissal and cancels the whole turn.
-//
-// This rides the per-turn user message rather than the AGENTS.md runtime brief
-// because two agents can call `ask` in one turn: the executor, which reads
-// AGENTS.md, and the planner, which runs on its own system prompt and never
-// sees the workdir brief. The user message is the only surface both read.
-const reasonixUnattendedNotice = "Unattended Multica task: there is no interactive user in this session. " +
-	"Do NOT call the `ask` tool — nobody can answer it, and an unanswered question cancels the whole turn. " +
-	"When a decision is genuinely open, take the most conservative reversible option, keep going, " +
-	"and state the assumption you made in your final issue comment."
-
-// withReasonixUnattendedNotice appends the unattended notice to the per-turn
-// prompt. It lands last so it sits after any quoted issue or comment body the
-// daemon injected, and an empty prompt still carries the constraint.
-func withReasonixUnattendedNotice(prompt string) string {
-	if strings.TrimSpace(prompt) == "" {
-		return reasonixUnattendedNotice
-	}
-	return prompt + "\n\n" + reasonixUnattendedNotice
-}
-
 // reasonixReaderDrainGrace bounds how long the turn waits for trailing ACP
 // notifications after the session/prompt response. A var, not a const, so
 // tests can shorten it. Mirrors qoderReaderDrainGrace / traecliReaderDrainGrace.
@@ -402,13 +374,12 @@ func (b *reasonixBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 		// 4. Send the prompt and wait for PromptResponse. Reasonix loads
 		// AGENTS.md from cwd, so the daemon deliberately does not duplicate the
-		// runtime brief in this user message — only the unattended notice, which
-		// AGENTS.md cannot deliver to both agents in the turn.
+		// runtime brief in this user message.
 		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
-				{"type": "text", "text": withReasonixUnattendedNotice(prompt)},
+				{"type": "text", "text": prompt},
 			},
 		})
 		if err != nil {

--- a/server/pkg/agent/reasonix_execute_unix_test.go
+++ b/server/pkg/agent/reasonix_execute_unix_test.go
@@ -150,41 +150,6 @@ done
 	}
 }
 
-func TestReasonixPromptCarriesUnattendedNotice(t *testing.T) {
-	t.Parallel()
-	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")
-	fakePath := filepath.Join(t.TempDir(), "reasonix")
-	writeTestExecutable(t, fakePath, []byte(fakeACPRecordingScript(recordPath, "notice-session", "{}")))
-	backend, err := New("reasonix", Config{ExecutablePath: fakePath, Logger: slog.Default()})
-	if err != nil {
-		t.Fatalf("New(reasonix): %v", err)
-	}
-	session, err := backend.Execute(context.Background(), "Reply to the comment.", ExecOptions{Timeout: 5 * time.Second})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	go func() {
-		for range session.Messages {
-		}
-	}()
-	if result := <-session.Result; result.Status != "completed" {
-		t.Fatalf("result = %+v", result)
-	}
-
-	frame := findRecordedFrame(t, recordPath, "session/prompt")
-	blocks := frame["params"].(map[string]any)["prompt"].([]any)
-	if len(blocks) != 1 {
-		t.Fatalf("prompt blocks = %+v, want one text block", blocks)
-	}
-	text := blocks[0].(map[string]any)["text"].(string)
-	if !strings.HasPrefix(text, "Reply to the comment.") {
-		t.Fatalf("prompt dropped the task text: %q", text)
-	}
-	if !strings.Contains(text, reasonixUnattendedNotice) {
-		t.Fatalf("prompt = %q, want the unattended notice appended", text)
-	}
-}
-
 func TestReasonixResumeFiltersUnsupportedSSEMCP(t *testing.T) {
 	t.Parallel()
 	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")

--- a/server/pkg/agent/reasonix_test.go
+++ b/server/pkg/agent/reasonix_test.go
@@ -72,38 +72,6 @@ func TestReasonixPermissionPolicy(t *testing.T) {
 	}
 }
 
-func TestReasonixUnattendedNoticeRidesEveryPrompt(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		prompt string
-		want   string
-	}{
-		{name: "appended after the task prompt", prompt: "Reply to the comment.", want: "Reply to the comment.\n\n" + reasonixUnattendedNotice},
-		{name: "empty prompt still carries the constraint", prompt: "   ", want: reasonixUnattendedNotice},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := withReasonixUnattendedNotice(tt.prompt); got != tt.want {
-				t.Fatalf("prompt = %q, want %q", got, tt.want)
-			}
-		})
-	}
-
-	// The notice exists to keep BOTH Reasonix agents off the ask tool — the
-	// executor and the planner, which never sees AGENTS.md. Naming the tool and
-	// the fallback behaviour is the whole payload; a reword that drops either
-	// leaves the planner with no instruction at all.
-	if !strings.Contains(reasonixUnattendedNotice, "`ask`") {
-		t.Fatalf("notice must name the ask tool: %q", reasonixUnattendedNotice)
-	}
-	if !strings.Contains(reasonixUnattendedNotice, "no interactive user") {
-		t.Fatalf("notice must state that no user can answer: %q", reasonixUnattendedNotice)
-	}
-}
-
 func TestReasonixPermissionMetadataWarningDetection(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Supersedes #6745 (MUL-5992), which this PR reverts in its first commit. Same goal — an unattended Reasonix task must not die on an `ask` — but actually turning the tool off instead of asking the model not to reach for it.

## Why the swap

#6745 appended a "no interactive user, don't call `ask`" line to the per-turn prompt. That was the best host-side lever I had found: `ask` is registered unconditionally, and a `PreToolUse` hook would only ever reach the executor, because planner tool calls fire no hooks at all.

Reasonix has a better one. `[permissions] deny = ["ask"]` genuinely disables the tool, for the whole turn:

- `Policy.DecideSubject` checks deny rules **before** the read-only allow fallthrough, so the rule applies to `ask` even though `ask` is read-only.
- The executor, the planner (which keeps `ask` deliberately, and which we run with `--planner auto`), and sub-agents all decide against the same policy — no half-covered chain.
- The model gets `blocked: denied by permission policy — this tool/command is on the deny list. Do not retry it; choose another approach or stop and explain.` back as an ordinary tool result, and the turn continues.

And it doesn't have to be global. Reasonix resolves config as flag > project `./reasonix.toml` > user `config.toml` > defaults, rooted at the ACP session cwd — the task workdir. The project merge restores CLI/Secrets/Remote/Desktop/Telemetry from the user's global config, but not `Permissions`, so a project file's rules are honoured while staying scoped to this task.

## Change

`Prepare` and `Reuse` write `{WorkDir}/reasonix.toml` for reasonix tasks through the sidecar manifest, so `CleanupSidecars` takes it back out. `Reuse` rewrites it, since cleanup runs first — otherwise the second turn of a task would run with the tool available again.

A `reasonix.toml` that came with the repository is left byte-for-byte alone and logged — the manifest contract is that cleanup is a pure deletion of paths we created, so we never overwrite user content. Those tasks keep today's fail-closed question handling.

No git-exclude entry, deliberately. The agent's cwd is `env.WorkDir` while a managed checkout is a directory *inside* it, so `agentGitExcludePatterns` — which only reaches the checkout's `.git/info/exclude` — could never hide this sidecar; all it would do is hide a `reasonix.toml` an agent legitimately creates inside a repository, for every provider. A regression test pins that layering. For a repo task the sidecar sits outside the checkout entirely; for a local_directory task it is untracked for the duration of the run and removed at teardown, which is how `AGENTS.md` and the other WorkDir sidecars already behave.

Deliberately unchanged: the fail-closed question path in `selectReasonixPermissionOption` stays as the backstop, and the planner stays on.

## Trade-off, accepted

A project `deny` list replaces rather than extends the user's global one, so for the duration of a task in this workdir a runtime owner's global deny rules don't apply. That is a deliberate widening of what the agent may run in a task workdir, accepted by the maintainer — not something the daemon's other constraints make equivalent. Extending the global list instead would mean parsing the runtime owner's config to restate it, which is its own failure mode.

## Upstream

The real fix is a session capability so Reasonix skips `SetAsker` (or drops `ask`) when the client declares it has no interactive user — filed at [esengine/DeepSeek-Reasonix#8238](https://github.com/esengine/DeepSeek-Reasonix/issues/8238), including why a fix must cover both registries. Until that lands, local_directory tasks whose repository ships its own `reasonix.toml` stay on the fail-closed path.

## Verification

`go test ./internal/daemon/execenv/ ./internal/daemon/repocache/ ./pkg/agent/ -count=1` — all pass.

New tests:

- `Prepare` writes the deny rule and `CleanupSidecars` removes it again.
- `Reuse` re-lays it after the rollback that precedes it.
- A repository-provided `reasonix.toml` is neither rewritten nor recorded in the manifest.
- Non-reasonix providers get no file.
- `TestCreateWorktreeDoesNotExcludeReasonixProjectConfig` — the checkout is a child of the WorkDir, `.git/info/exclude` carries no `reasonix.toml`, and `git check-ignore` does not ignore one written inside the checkout. Verified to fail when the pattern is put back.
