### PR TITLE
MUL-5985: preserve Claude effort for context-tagged models

### DIFF
--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -136,13 +136,14 @@ export function AgentDetailInspector({
     (model: string) =>
       update(
         buildModelChangeUpdate({
+          provider: runtime?.provider ?? "",
           model,
           thinkingLevel: agent.thinking_level ?? "",
           serviceTier: agent.service_tier ?? "",
           catalog: modelCatalog,
         }),
       ),
-    [agent.service_tier, agent.thinking_level, modelCatalog, update],
+    [agent.service_tier, agent.thinking_level, modelCatalog, runtime?.provider, update],
   );
 
   return (
@@ -290,6 +291,7 @@ export function AgentDetailInspector({
             label={t(($) => $.inspector.prop_speed)}
             runtimeId={agent.runtime_id}
             runtimeOnline={!!isOnline}
+            provider={runtime?.provider ?? ""}
             model={agent.model ?? ""}
             value={agent.service_tier ?? ""}
             canEdit={canEdit}

--- a/packages/views/agents/components/inspector/model-capability.test.ts
+++ b/packages/views/agents/components/inspector/model-capability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeModel } from "@multica/core/types";
+import {
+  findModelCapabilityEntry,
+  modelIdForCapabilityLookup,
+} from "./model-capability";
+
+const CLAUDE_MODELS: RuntimeModel[] = [
+  { id: "claude-opus-5", label: "Claude Opus 5" },
+];
+
+describe("model capability lookup", () => {
+  it("inherits a base Claude model for valid context-window tags", () => {
+    expect(modelIdForCapabilityLookup("claude", "claude-opus-5[1m]")).toBe(
+      "claude-opus-5",
+    );
+    expect(modelIdForCapabilityLookup("claude", "claude-opus-5[500k]")).toBe(
+      "claude-opus-5",
+    );
+    expect(
+      findModelCapabilityEntry(
+        CLAUDE_MODELS,
+        "claude-opus-5[1m]",
+        "claude",
+      )?.id,
+    ).toBe("claude-opus-5");
+  });
+
+  it("keeps malformed Claude tags and other providers exact", () => {
+    expect(
+      modelIdForCapabilityLookup("claude", "claude-opus-5[weird]"),
+    ).toBe("claude-opus-5[weird]");
+    expect(modelIdForCapabilityLookup("codex", "gpt-5.6-sol[1m]")).toBe(
+      "gpt-5.6-sol[1m]",
+    );
+    expect(
+      findModelCapabilityEntry(
+        CLAUDE_MODELS,
+        "claude-opus-5[weird]",
+        "claude",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/views/agents/components/inspector/model-capability.ts
+++ b/packages/views/agents/components/inspector/model-capability.ts
@@ -1,0 +1,30 @@
+import type { RuntimeModel } from "@multica/core/types";
+
+// Claude Code appends a context-window modifier to some runtime-native model
+// IDs (for example, claude-opus-5[1m]). Restrict inheritance to a numeric
+// context size so arbitrary bracketed variants remain fail-closed.
+const CLAUDE_CONTEXT_WINDOW_TAG = /\[[1-9]\d*[km]\]$/;
+
+export function modelIdForCapabilityLookup(
+  provider: string,
+  model: string,
+): string {
+  return provider === "claude"
+    ? model.replace(CLAUDE_CONTEXT_WINDOW_TAG, "")
+    : model;
+}
+
+/**
+ * Resolves the catalog entry used for capability display and cleanup. The raw
+ * model remains the value persisted and sent to the runtime; only this lookup
+ * identity is normalized.
+ */
+export function findModelCapabilityEntry(
+  models: readonly RuntimeModel[],
+  model: string,
+  provider: string,
+): RuntimeModel | undefined {
+  if (!model) return undefined;
+  const lookupId = modelIdForCapabilityLookup(provider, model);
+  return models.find((entry) => entry.id === lookupId);
+}

--- a/packages/views/agents/components/inspector/model-change-cleanup.test.ts
+++ b/packages/views/agents/components/inspector/model-change-cleanup.test.ts
@@ -28,10 +28,17 @@ const MEDIUM_ONLY: RuntimeModel = {
 
 const CATALOG = [FAST_HIGH, PLAIN, MEDIUM_ONLY];
 
+const CLAUDE_MEDIUM_ONLY: RuntimeModel = {
+  id: "claude-sonnet-4-6",
+  label: "Claude Sonnet 4.6",
+  thinking: { supported_levels: [{ value: "medium", label: "Medium" }] },
+};
+
 describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("clears overrides the new model does not advertise", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "gpt-5.4-mini",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -47,6 +54,7 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("keeps overrides the new model still supports", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "gpt-5.6-sol",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -58,6 +66,7 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("clears only the unsupported half", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "gpt-5.5",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -72,6 +81,7 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("leaves overrides untouched when the catalog is not authoritative", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "gpt-5.4-mini",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -83,6 +93,7 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("leaves overrides untouched for an unresolvable runtime-default model", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -94,6 +105,7 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
   it("leaves overrides untouched for a model missing from the catalog", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "custom-local-build",
         thinkingLevel: "high",
         serviceTier: "priority",
@@ -102,9 +114,25 @@ describe("buildModelChangeUpdate (MUL-5390)", () => {
     ).toEqual({ model: "custom-local-build" });
   });
 
+  it("clears an unsupported override on a context-tagged Claude model", () => {
+    expect(
+      buildModelChangeUpdate({
+        provider: "claude",
+        model: "claude-sonnet-4-6[1m]",
+        thinkingLevel: "xhigh",
+        serviceTier: "",
+        catalog: [CLAUDE_MEDIUM_ONLY],
+      }),
+    ).toEqual({
+      model: "claude-sonnet-4-6[1m]",
+      thinking_level: "",
+    });
+  });
+
   it("never sends a clear when nothing is set", () => {
     expect(
       buildModelChangeUpdate({
+        provider: "codex",
         model: "gpt-5.4-mini",
         thinkingLevel: "",
         serviceTier: "",

--- a/packages/views/agents/components/inspector/model-change-cleanup.ts
+++ b/packages/views/agents/components/inspector/model-change-cleanup.ts
@@ -1,4 +1,5 @@
 import type { RuntimeModel } from "@multica/core/types";
+import { findModelCapabilityEntry } from "./model-capability";
 
 /**
  * The exact per-model catalog for the agent's runtime, or `null` when it is not
@@ -37,6 +38,7 @@ export type ModelChangeUpdate = {
  * combination the UI never intended.
  */
 export function buildModelChangeUpdate(input: {
+  provider: string;
   model: string;
   thinkingLevel: string;
   serviceTier: string;
@@ -46,7 +48,11 @@ export function buildModelChangeUpdate(input: {
   if (!input.thinkingLevel && !input.serviceTier) return update;
   if (input.catalog === null || !input.model) return update;
 
-  const entry = input.catalog.find((model) => model.id === input.model);
+  const entry = findModelCapabilityEntry(
+    input.catalog,
+    input.model,
+    input.provider,
+  );
   if (!entry) return update;
 
   const supportsThinking = (entry.thinking?.supported_levels ?? []).some(

--- a/packages/views/agents/components/inspector/service-tier-setting-field.test.tsx
+++ b/packages/views/agents/components/inspector/service-tier-setting-field.test.tsx
@@ -75,6 +75,7 @@ function renderField(
           label="Speed"
           runtimeId="runtime-1"
           runtimeOnline
+          provider="codex"
           model="gpt-5.6-sol"
           value=""
           canEdit

--- a/packages/views/agents/components/inspector/service-tier-setting-field.tsx
+++ b/packages/views/agents/components/inspector/service-tier-setting-field.tsx
@@ -3,10 +3,7 @@
 import { useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, Gauge } from "lucide-react";
-import type {
-  RuntimeModel,
-  RuntimeModelServiceTier,
-} from "@multica/core/types";
+import type { RuntimeModelServiceTier } from "@multica/core/types";
 import { runtimeModelsOptions } from "@multica/core/runtimes";
 import {
   PickerItem,
@@ -14,10 +11,11 @@ import {
 } from "../../../issues/components/pickers";
 import { SettingsRow } from "../../../settings/components/settings-layout";
 import { useT } from "../../../i18n";
+import { findModelCapabilityEntry } from "./model-capability";
 
 /**
  * Full-width service-tier field for Codex agents. Capability comes from the
- * exact model's live catalog rather than a hard-coded Fast switch. An empty
+ * resolved model's live catalog rather than a hard-coded Fast switch. An empty
  * model follows config.toml and cannot be resolved safely, so the field fails
  * closed unless a saved value needs to remain visible for explicit clearing.
  */
@@ -25,6 +23,7 @@ export function ServiceTierSettingField({
   label,
   runtimeId,
   runtimeOnline,
+  provider,
   model,
   value,
   canEdit,
@@ -33,6 +32,7 @@ export function ServiceTierSettingField({
   label: ReactNode;
   runtimeId: string | null;
   runtimeOnline: boolean;
+  provider: string;
   model: string;
   value: string;
   canEdit: boolean;
@@ -41,7 +41,11 @@ export function ServiceTierSettingField({
   const modelsQuery = useQuery(
     runtimeModelsOptions(runtimeOnline ? runtimeId : null),
   );
-  const entry = pickModelEntry(modelsQuery.data?.models ?? [], model);
+  const entry = findModelCapabilityEntry(
+    modelsQuery.data?.models ?? [],
+    model,
+    provider,
+  );
   const tiers = entry?.service_tiers ?? [];
 
   if (tiers.length === 0 && !value) return null;
@@ -151,12 +155,4 @@ function ServiceTierPicker({
       ) : null}
     </PropertyPicker>
   );
-}
-
-function pickModelEntry(
-  models: RuntimeModel[],
-  model: string,
-): RuntimeModel | undefined {
-  if (!model) return undefined;
-  return models.find((entry) => entry.id === model);
 }

--- a/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
@@ -211,6 +211,13 @@ describe("ThinkingPropRow", () => {
     expect((await screen.findAllByText("Follow CLI config")).length).toBeGreaterThan(0);
   });
 
+  it("inherits the base Claude model catalog for a context-tagged model", async () => {
+    renderRow({ model: "claude-sonnet-4-6[1m]", value: "" });
+
+    await screen.findByText("Thinking");
+    expect((await screen.findAllByText("Follow CLI config")).length).toBeGreaterThan(0);
+  });
+
   it("hides the picker for an empty codex model — it must not borrow the Default's catalog (MUL-4347)", async () => {
     // Empty model on codex follows config.toml, which can resolve to any
     // installed model. Previewing gpt-5.6-sol's levels (the flagged Default,

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -8,6 +8,7 @@ import { PropRow } from "../../../common/prop-row";
 import { SettingsRow } from "../../../settings/components/settings-layout";
 import { useT } from "../../../i18n";
 import { ThinkingPicker } from "./thinking-picker";
+import { findModelCapabilityEntry } from "./model-capability";
 
 /**
  * Thinking row for the agent inspector. Hidden when the active model has
@@ -116,7 +117,7 @@ function pickModelEntry(
   model: string,
   provider: string,
 ): RuntimeModel | undefined {
-  if (model) return models.find((m) => m.id === model);
+  if (model) return findModelCapabilityEntry(models, model, provider);
   // Empty model = "follow the runtime's own default". For codex that default
   // comes from the local config.toml and can be any installed model, so we
   // must NOT preview the flagged Default entry's effort catalog — gpt-5.6-sol

--- a/packages/views/agents/create/agent-configuration-panel.tsx
+++ b/packages/views/agents/create/agent-configuration-panel.tsx
@@ -404,6 +404,7 @@ export function AgentExecutionOverrides({
         label={t(($) => $.creation_studio.speed_label)}
         runtimeId={runtime?.id ?? null}
         runtimeOnline={runtimeOnline}
+        provider={runtime?.provider ?? ""}
         model={draft.model}
         value={draft.serviceTier}
         canEdit={!disabled}

--- a/server/internal/handler/agent_thinking_test.go
+++ b/server/internal/handler/agent_thinking_test.go
@@ -426,6 +426,7 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 
 	ctx := context.Background()
 	claudeRuntimeID := createClaudeProviderRuntime(t)
+	secondClaudeRuntimeID := createClaudeProviderRuntime(t)
 	codexRuntimeID := createCodexProviderRuntime(t)
 
 	t.Cleanup(func() {
@@ -483,6 +484,24 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "gpt-5.5" {
 			t.Errorf("expected exact target model preserved, got %v", resp["model"])
+		}
+	})
+
+	t.Run("runtime-only switch keeps context-tagged target model", func(t *testing.T) {
+		agentID := createAgentOnRuntimeWithModel(t, "runtime-model-switch-context-tag", claudeRuntimeID, "claude-opus-5[1m]")
+		body := map[string]any{
+			"runtime_id": secondClaudeRuntimeID,
+		}
+		w := httptest.NewRecorder()
+		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
+		testHandler.UpdateAgent(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 preserving context-tagged Claude model, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp map[string]any
+		_ = json.NewDecoder(w.Body).Decode(&resp)
+		if resp["model"] != "claude-opus-5[1m]" {
+			t.Errorf("expected context-tagged Claude model preserved, got %v", resp["model"])
 		}
 	})
 

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -289,10 +290,28 @@ func ModelKnownIncompatibleWithProvider(providerType, model string) bool {
 	if !ok {
 		return false
 	}
-	if accepted[model] {
+	if accepted[modelIDForCapabilityLookup(providerType, model)] {
 		return false
 	}
 	return isRuntimeSpecificModelID(model)
+}
+
+// claudeContextWindowTagRe recognises Claude Code's trailing context-window
+// model modifier (for example, claude-opus-5[1m]). Keep this narrower than a
+// generic bracket suffix: capability lookup may inherit the base model's
+// effort catalog only when the modifier is syntactically a context size.
+var claudeContextWindowTagRe = regexp.MustCompile(`\[[1-9][0-9]*[km]\]$`)
+
+// modelIDForCapabilityLookup returns the catalog identity for a runtime-native
+// model string. It never changes the value persisted on the agent or passed to
+// the provider CLI. Claude context-window variants share their base model's
+// capabilities; every other provider and malformed/unknown modifier retains
+// exact-match behavior.
+func modelIDForCapabilityLookup(providerType, model string) string {
+	if providerType != "claude" {
+		return model
+	}
+	return claudeContextWindowTagRe.ReplaceAllString(model, "")
 }
 
 func acceptedModelIDsForProvider(providerType string) (map[string]bool, bool) {

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -633,6 +633,30 @@ func TestModelKnownIncompatibleWithProvider(t *testing.T) {
 			want:     false,
 		},
 		{
+			name:     "claude context variant is compatible with claude",
+			provider: "claude",
+			model:    "claude-opus-5[1m]",
+			want:     false,
+		},
+		{
+			name:     "future-shaped claude context variant is compatible with claude",
+			provider: "claude",
+			model:    "claude-opus-5[500k]",
+			want:     false,
+		},
+		{
+			name:     "malformed claude context variant is incompatible with claude",
+			provider: "claude",
+			model:    "claude-opus-5[weird]",
+			want:     true,
+		},
+		{
+			name:     "unknown claude base stays incompatible after context normalization",
+			provider: "claude",
+			model:    "claude-fake-9[1m]",
+			want:     true,
+		},
+		{
 			name:     "provider-prefixed openai model is incompatible with codex",
 			provider: "codex",
 			model:    "openai/gpt-4o",

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -643,7 +643,7 @@ func ValidateThinkingLevel(ctx context.Context, providerType, executablePath, mo
 		return false, err
 	}
 	models := catalog.Models
-	target := model
+	target := modelIDForCapabilityLookup(providerType, model)
 	if target == "" {
 		// Default model = the entry the catalog marks as Default. If no
 		// entry is flagged, fall through to the no-match return; that

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -686,8 +686,37 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 		}
 	}
 
+	// Claude Code appends a bracketed context-window tag to the model ID for
+	// long-context sessions. Capability validation must inherit the base
+	// model's effort catalog without rewriting the model passed to the CLI.
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-opus-5[1m]", "xhigh")
+	if err != nil {
+		t.Fatalf("unexpected err for context-tagged opus-5: %v", err)
+	}
+	if !ok {
+		t.Error("xhigh should be valid on the opus-5[1m] context variant")
+	}
+
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-opus-5[500k]", "high")
+	if err != nil {
+		t.Fatalf("unexpected err for future context-tag shape: %v", err)
+	}
+	if !ok {
+		t.Error("high should be valid on a syntactically valid opus-5 context variant")
+	}
+
+	// Arbitrary bracket suffixes are not context-window tags. Keep malformed
+	// variants fail-closed even when their apparent base model is known.
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-opus-5[weird]", "high")
+	if err != nil {
+		t.Fatalf("unexpected err for malformed context tag: %v", err)
+	}
+	if ok {
+		t.Error("malformed context tag must fail closed")
+	}
+
 	// xhigh is NOT valid on Sonnet — should fail.
-	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-sonnet-4-6", "xhigh")
+	ok, err = ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-sonnet-4-6[1m]", "xhigh")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1181,6 +1210,35 @@ func TestBuildClaudeArgs_InjectsEffort(t *testing.T) {
 	effortIdx := argIndexOf(args, "--effort")
 	if modelIdx < 0 || effortIdx < 0 || modelIdx > effortIdx {
 		t.Errorf("expected --model before --effort: %v", args)
+	}
+}
+
+func TestBuildClaudeArgs_ContextTaggedModelKeepsModelAndEffort(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		resumeID string
+	}{
+		{name: "fresh"},
+		{name: "resume", resumeID: "session-123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := buildClaudeArgs(ExecOptions{
+				Model:           "claude-opus-5[1m]",
+				ThinkingLevel:   "xhigh",
+				ResumeSessionID: tc.resumeID,
+			}, slog.Default())
+			if !containsAdjacent(args, "--model", "claude-opus-5[1m]") {
+				t.Errorf("expected original context-tagged --model value: %v", args)
+			}
+			if !containsAdjacent(args, "--effort", "xhigh") {
+				t.Errorf("expected --effort xhigh: %v", args)
+			}
+			if tc.resumeID != "" && !containsAdjacent(args, "--resume", tc.resumeID) {
+				t.Errorf("expected --resume %s: %v", tc.resumeID, args)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 修复内容

- 将 Claude 的合法上下文窗口后缀（如 `[1m]`、`[500k]`）仅用于能力目录匹配，保留原始模型值用于持久化和 CLI `--model` 参数。
- 修复后端 thinking level 校验及 Claude→Claude runtime 切换时的模型兼容性判断，确保 `--effort` 不再被误清空。
- 前端 Thinking / Service Tier 展示与模型切换清理复用同一归一化规则；非法后缀仍按未知模型安全失败。

## 验证

- `go test ./pkg/agent -count=1`
- `go vet ./pkg/agent`
- `go test ./internal/handler -run '^$' -count=1`
- 受影响的 4 个 Views 测试文件：24/24 通过
- `pnpm --filter @multica/views typecheck`
- 受影响文件 ESLint 检查

## 本地验证说明

- 数据库型 handler 回归测试在当前共享本地数据库中，原有与新增子用例均因同一 fixture 查询返回 404；handler 包编译通过，相关纯逻辑回归测试通过。
- Views 全量测试在未改动的 `layout/sidebar-resize.test.tsx` 上复现 1 个本地 `localStorage` 断言失败；本次受影响测试全部通过。

Closes MUL-5985
Fixes #6705
