### PR TITLE
MUL-6015: WS-2: update Codex gpt-5.6 model labels

### DIFF
--- a/packages/views/agents/components/model-dropdown.test.tsx
+++ b/packages/views/agents/components/model-dropdown.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { RuntimeModelsResult } from "@multica/core/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import enAgents from "../../locales/en/agents.json";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+import { ModelDropdown } from "./model-dropdown";
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, agents: enAgents, issues: enIssues },
+};
+
+const CODEX_MODELS: RuntimeModelsResult = {
+  models: [
+    {
+      id: "gpt-5.6-sol",
+      label: "GPT-5.6 Sol",
+      provider: "openai",
+      default: true,
+    },
+    { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", provider: "openai" },
+    { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", provider: "openai" },
+  ],
+  supported: true,
+};
+
+vi.mock("@multica/core/runtimes", () => ({
+  runtimeModelsOptions: (runtimeId: string | null) => ({
+    enabled: Boolean(runtimeId),
+    queryKey: ["runtime-models", runtimeId],
+    queryFn: async () => CODEX_MODELS,
+  }),
+}));
+
+function renderDropdown() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const onChange = vi.fn();
+  const view = render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={queryClient}>
+        <ModelDropdown
+          runtimeId="rt-codex"
+          runtimeOnline
+          value=""
+          onChange={onChange}
+        />
+      </QueryClientProvider>
+    </I18nProvider>,
+  );
+  return { ...view, onChange };
+}
+
+function openDropdown(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    '[data-slot="popover-trigger"]',
+  );
+  if (!trigger) throw new Error("model dropdown trigger not rendered");
+  fireEvent.click(trigger);
+}
+
+describe("ModelDropdown", () => {
+  afterEach(() => cleanup());
+
+  it("offers the gpt-5.6 Codex models and submits their canonical IDs", async () => {
+    const { container, onChange } = renderDropdown();
+    openDropdown(container);
+
+    expect(await screen.findByText("GPT-5.6 Sol")).toBeTruthy();
+    expect(screen.getByText("GPT-5.6 Terra")).toBeTruthy();
+    expect(screen.getByText("GPT-5.6 Luna")).toBeTruthy();
+    expect(screen.getByText("gpt-5.6-sol")).toBeTruthy();
+    expect(screen.getByText("gpt-5.6-terra")).toBeTruthy();
+    expect(screen.getByText("gpt-5.6-luna")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("GPT-5.6 Terra"));
+    expect(onChange).toHaveBeenCalledWith("gpt-5.6-terra");
+  });
+});

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -450,9 +450,9 @@ func codexStaticModels() []Model {
 		}
 	}
 	return []Model{
-		{ID: "gpt-5.6-sol", Label: "GPT-5.6-Sol", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
-		{ID: "gpt-5.6-terra", Label: "GPT-5.6-Terra", Provider: "openai", Thinking: standardThinking("medium", true, true)},
-		{ID: "gpt-5.6-luna", Label: "GPT-5.6-Luna", Provider: "openai", Thinking: standardThinking("medium", true, false)},
+		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true, Thinking: standardThinking("low", true, true)},
+		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai", Thinking: standardThinking("medium", true, true)},
+		{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna", Provider: "openai", Thinking: standardThinking("medium", true, false)},
 		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Thinking: standardThinking("medium", false, false)},
 		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai", Thinking: standardThinking("medium", false, false)},
 		{ID: "gpt-5.4-mini", Label: "GPT-5.4-Mini", Provider: "openai", Thinking: standardThinking("medium", false, false)},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -599,6 +599,18 @@ func TestCodexStaticModelsMatchVerifiedFallbackCatalog(t *testing.T) {
 	if got := ids["gpt-5.3-codex"].Thinking; got == nil || !hasThinkingLevel(got, "xhigh") || hasThinkingLevel(got, "max") || hasThinkingLevel(got, "ultra") {
 		t.Errorf("unexpected gpt-5.3-codex thinking catalog: %+v", got)
 	}
+	for id, label := range map[string]string{
+		"gpt-5.6-sol":   "GPT-5.6 Sol",
+		"gpt-5.6-terra": "GPT-5.6 Terra",
+		"gpt-5.6-luna":  "GPT-5.6 Luna",
+	} {
+		if got := ids[id].Label; got != label {
+			t.Errorf("Codex model %q label = %q, want %q", id, got, label)
+		}
+		if ModelKnownIncompatibleWithProvider("codex", id) {
+			t.Errorf("Codex model %q must be accepted by the provider compatibility gate", id)
+		}
+	}
 }
 
 func TestModelKnownIncompatibleWithProvider(t *testing.T) {

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -375,6 +375,7 @@ func parseCodexModelCatalog(raw []byte) ([]Model, error) {
 		if label == "" {
 			label = m.Slug
 		}
+		label = normalizeCodexModelLabel(m.Slug, label)
 		models = append(models, Model{
 			ID:           m.Slug,
 			Label:        label,
@@ -387,6 +388,19 @@ func parseCodexModelCatalog(raw []byte) ([]Model, error) {
 		models[0].Default = true
 	}
 	return models, nil
+}
+
+func normalizeCodexModelLabel(id, label string) string {
+	switch id {
+	case "gpt-5.6-sol":
+		return "GPT-5.6 Sol"
+	case "gpt-5.6-terra":
+		return "GPT-5.6 Terra"
+	case "gpt-5.6-luna":
+		return "GPT-5.6 Luna"
+	default:
+		return label
+	}
 }
 
 func codexServiceTiersFromDebugModel(m codexDebugModel) []ModelServiceTier {

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -251,6 +251,18 @@ func TestParseCodexModelCatalog(t *testing.T) {
 				]
 			},
 			{
+				"slug": "gpt-5.6-terra",
+				"display_name": "GPT-5.6-Terra",
+				"visibility": "list",
+				"supported_reasoning_levels": []
+			},
+			{
+				"slug": "gpt-5.6-luna",
+				"display_name": "GPT-5.6-Luna",
+				"visibility": "list",
+				"supported_reasoning_levels": []
+			},
+			{
 				"slug": "hidden-model",
 				"display_name": "Hidden",
 				"visibility": "hide",
@@ -268,11 +280,34 @@ func TestParseCodexModelCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseCodexModelCatalog: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("expected two visible models, got %+v", got)
+	if len(got) != 4 {
+		t.Fatalf("expected four visible models, got %+v", got)
 	}
-	if got[0].ID != "gpt-5.6-sol" || got[0].Label != "GPT-5.6-Sol" || !got[0].Default {
+	if got[0].ID != "gpt-5.6-sol" || got[0].Label != "GPT-5.6 Sol" || !got[0].Default {
 		t.Errorf("unexpected first model: %+v", got[0])
+	}
+	for _, want := range []struct {
+		id    string
+		label string
+	}{
+		{"gpt-5.6-sol", "GPT-5.6 Sol"},
+		{"gpt-5.6-terra", "GPT-5.6 Terra"},
+		{"gpt-5.6-luna", "GPT-5.6 Luna"},
+	} {
+		var found *Model
+		for i := range got {
+			if got[i].ID == want.id {
+				found = &got[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("missing %s in dynamic Codex catalog: %+v", want.id, got)
+			continue
+		}
+		if found.Label != want.label {
+			t.Errorf("%s dynamic label = %q, want %q", want.id, found.Label, want.label)
+		}
 	}
 	if got[0].Thinking == nil || got[0].Thinking.DefaultLevel != "low" || !hasThinkingLevel(got[0].Thinking, "max") || !hasThinkingLevel(got[0].Thinking, "ultra") || !hasThinkingLevel(got[0].Thinking, "future") {
 		t.Errorf("unexpected per-model thinking catalog: %+v", got[0].Thinking)
@@ -280,8 +315,8 @@ func TestParseCodexModelCatalog(t *testing.T) {
 	if len(got[0].ServiceTiers) != 1 || got[0].ServiceTiers[0].ID != "priority" || got[0].ServiceTiers[0].Name != "Fast" {
 		t.Errorf("unexpected service-tier catalog: %+v", got[0].ServiceTiers)
 	}
-	if got[1].ID != "no-reasoning" || got[1].Thinking != nil {
-		t.Errorf("model without reasoning should remain selectable without a thinking picker: %+v", got[1])
+	if got[3].ID != "no-reasoning" || got[3].Thinking != nil {
+		t.Errorf("model without reasoning should remain selectable without a thinking picker: %+v", got[3])
 	}
 }
 


### PR DESCRIPTION
## Summary
- update Codex fallback catalog labels for gpt-5.6 Sol, Terra, and Luna while keeping canonical IDs unchanged
- add backend regression coverage for label display and Codex provider compatibility
- add ModelDropdown coverage for visible gpt-5.6 options and canonical ID submission

## Calibration
- Agent settings model options come from runtime model discovery via runtimeModelsOptions, shared by ModelDropdown and inspector ModelPicker.
- Codex fallback options are maintained in server/pkg/agent/models.go:codexStaticModels().
- The UI submits canonical IDs such as gpt-5.6-terra; labels are display-only.
- Backend create/update persists the model string and the Codex provider compatibility gate accepts these IDs from the same catalog.

## Verification
- go test ./pkg/agent -run 'TestCodexStaticModelsMatchVerifiedFallbackCatalog|TestModelKnownIncompatibleWithProvider' -count=1
- go test ./pkg/agent -count=1
- corepack pnpm --filter @multica/views exec vitest run agents/components/model-dropdown.test.tsx
- corepack pnpm --filter @multica/views typecheck