### PR TITLE
MUL-5974 fix(cli): reject unknown --profile instead of reporting "stopped"

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -282,6 +282,92 @@ func healthPortForProfile(profile string) int {
 	return daemon.DefaultHealthPort + 1 + (h % 1000)
 }
 
+// unknownProfileError reports an explicitly named --profile that has no
+// directory under ~/.multica/profiles. It carries the known profile names so
+// both the text and JSON renderings can list them without re-reading the disk.
+type unknownProfileError struct {
+	Profile string
+	Known   []string
+}
+
+func (e *unknownProfileError) Error() string {
+	if len(e.Known) == 0 {
+		return fmt.Sprintf("unknown profile %q: no named profiles exist yet.\nCreate one with 'multica login --profile %s'", e.Profile, e.Profile)
+	}
+	return fmt.Sprintf("unknown profile %q\nKnown profiles: %s", e.Profile, strings.Join(e.Known, ", "))
+}
+
+// jsonPayload renders the error for `--output json`. Known stays a non-nil
+// slice so the field marshals as [] rather than null.
+func (e *unknownProfileError) jsonPayload() map[string]any {
+	known := e.Known
+	if known == nil {
+		known = []string{}
+	}
+	return map[string]any{
+		"status":         "unknown_profile",
+		"profile":        e.Profile,
+		"known_profiles": known,
+	}
+}
+
+// knownProfiles lists the named profiles that exist on disk, sorted by name.
+// A missing profiles root is not an error: it just means no named profile has
+// been created yet, which is the common case for a default-profile-only user.
+func knownProfiles() ([]string, error) {
+	root, err := profilesRootDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// requireKnownProfile rejects an explicitly named profile that does not exist.
+//
+// healthPortForProfile hashes ANY string into a port, so without this check a
+// mistyped --profile probes a port nothing is bound to and the command reports
+// a flat "stopped" — indistinguishable from a daemon that is genuinely not
+// running, even while the correctly-named daemon serves happily on another
+// port (#6694). Failing loudly with the known names turns that dead end into a
+// one-glance fix.
+//
+// The default profile is never validated: it owns ~/.multica directly, has no
+// entry under profiles/, and is always legitimate.
+//
+// Callers must invoke this AFTER their daemon-managed-task guard
+// (requireHumanLocalCommand, or daemonStatusHealthPort for status). Listing the
+// profiles root inside a task would disclose the Owner's profile names, which
+// those guards exist to prevent.
+func requireKnownProfile(profile string) error {
+	if profile == "" {
+		return nil
+	}
+	names, err := knownProfiles()
+	if err != nil {
+		return fmt.Errorf("list profiles: %w", err)
+	}
+	for _, name := range names {
+		if name == profile {
+			return nil
+		}
+	}
+	return &unknownProfileError{Profile: profile, Known: names}
+}
+
 // --- daemon start ---
 
 // daemonExecutable resolves the binary to spawn as the background daemon
@@ -957,6 +1043,9 @@ func runDaemonRestart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	profile := resolveProfile(cmd)
+	if err := requireKnownProfile(profile); err != nil {
+		return err
+	}
 	healthPort := healthPortForProfile(profile)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -1006,6 +1095,9 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	profile := resolveProfile(cmd)
+	if err := requireKnownProfile(profile); err != nil {
+		return err
+	}
 	healthPort := healthPortForProfile(profile)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -1092,13 +1184,28 @@ func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	output, _ := cmd.Flags().GetString("output")
+
+	// Safe to list profiles here: daemonStatusHealthPort already rejected an
+	// explicit --profile inside a daemon-managed task.
+	if err := requireKnownProfile(profile); err != nil {
+		var unknown *unknownProfileError
+		if output == "json" && errors.As(err, &unknown) {
+			// Keep stdout a single valid JSON document. The non-zero exit
+			// carries the failure, so errSilent suppresses the stderr copy.
+			if printErr := cli.PrintJSON(os.Stdout, unknown.jsonPayload()); printErr != nil {
+				return printErr
+			}
+			return errSilent
+		}
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	health := checkDaemonHealthOnPort(ctx, healthPort)
 
-	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {
 		return cli.PrintJSON(os.Stdout, health)
 	}
@@ -1190,6 +1297,9 @@ func runDaemonLogs(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	profile := resolveProfile(cmd)
+	if err := requireKnownProfile(profile); err != nil {
+		return err
+	}
 	logPath := daemonLogPathForProfile(profile)
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
 		return fmt.Errorf("no log file found at %s\nThe daemon may not have been started in background mode", logPath)

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -292,7 +293,9 @@ type unknownProfileError struct {
 
 func (e *unknownProfileError) Error() string {
 	if len(e.Known) == 0 {
-		return fmt.Sprintf("unknown profile %q: no named profiles exist yet.\nCreate one with 'multica login --profile %s'", e.Profile, e.Profile)
+		// The command is left unquoted so the shell-quoted profile name below
+		// stays the only quoting in the line and the hint pastes cleanly.
+		return fmt.Sprintf("unknown profile %q: no named profiles exist yet.\nCreate one with: multica login --profile %s", e.Profile, shellQuoteArg(e.Profile))
 	}
 	return fmt.Sprintf("unknown profile %q\nKnown profiles: %s", e.Profile, strings.Join(e.Known, ", "))
 }
@@ -311,26 +314,71 @@ func (e *unknownProfileError) jsonPayload() map[string]any {
 	}
 }
 
-// knownProfiles lists the named profiles that exist on disk, sorted by name.
+// profileConfigFileName is the file whose presence marks a directory under the
+// profiles root as an actual profile rather than just a parent of one. Kept in
+// step with cli.CLIConfigPathForProfile.
+const profileConfigFileName = "config.json"
+
+// profileExists reports whether an explicitly named profile has state on disk.
+//
+// The name is resolved through the same path logic the config layer uses
+// rather than matched against a flat directory listing, because a profile name
+// may contain separators: `multica --profile team/dev config set ...` creates
+// ~/.multica/profiles/team/dev. Matching against top-level entries would
+// reject that profile while offering its parent "team" as a suggestion.
+func profileExists(profile string) (bool, error) {
+	dir, err := cli.ProfileDir(profile)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+// knownProfiles lists the profiles that exist on disk, sorted by name, for use
+// as suggestions after a name misses. A profile is a directory under the
+// profiles root holding a config.json, at any depth — requiring that file is
+// what keeps a bare parent directory such as "team" out of a list where every
+// entry is meant to be directly usable as --profile.
+//
 // A missing profiles root is not an error: it just means no named profile has
-// been created yet, which is the common case for a default-profile-only user.
+// been created yet, the common case for a default-profile-only user.
 func knownProfiles() ([]string, error) {
 	root, err := profilesRootDir()
 	if err != nil {
 		return nil, err
 	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		if os.IsNotExist(err) {
+	names := make([]string, 0)
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// An unreadable subtree costs us suggestions, not correctness:
+			// skip it so the rest of the list still reaches the user.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() || d.Name() != profileConfigFileName {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, filepath.Dir(path))
+		if relErr != nil || rel == "." {
+			return nil
+		}
+		names = append(names, filepath.ToSlash(rel))
+		return nil
+	})
+	if walkErr != nil {
+		if os.IsNotExist(walkErr) {
 			return nil, nil
 		}
-		return nil, err
-	}
-	names := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() {
-			names = append(names, entry.Name())
-		}
+		return nil, walkErr
 	}
 	sort.Strings(names)
 	return names, nil
@@ -356,14 +404,18 @@ func requireKnownProfile(profile string) error {
 	if profile == "" {
 		return nil
 	}
+	exists, err := profileExists(profile)
+	if err != nil {
+		return fmt.Errorf("resolve profile %q: %w", profile, err)
+	}
+	if exists {
+		return nil
+	}
+	// Only now is the listing worth its disk walk, and only now can it be
+	// wrong in a way the user sees.
 	names, err := knownProfiles()
 	if err != nil {
 		return fmt.Errorf("list profiles: %w", err)
-	}
-	for _, name := range names {
-		if name == profile {
-			return nil
-		}
 	}
 	return &unknownProfileError{Profile: profile, Known: names}
 }

--- a/server/cmd/multica/cmd_daemon_unknown_profile_test.go
+++ b/server/cmd/multica/cmd_daemon_unknown_profile_test.go
@@ -24,8 +24,14 @@ func mkProfiles(t *testing.T, names ...string) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	for _, name := range names {
-		if err := os.MkdirAll(filepath.Join(home, ".multica", "profiles", name), 0o755); err != nil {
+		dir := filepath.Join(home, ".multica", "profiles", filepath.FromSlash(name))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("create profile %q: %v", name, err)
+		}
+		// A profile is a directory holding a config.json; the file is what
+		// separates a real profile from a bare parent directory.
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("write config for profile %q: %v", name, err)
 		}
 	}
 	return home
@@ -85,6 +91,46 @@ func TestRequireKnownProfile(t *testing.T) {
 		// real profile, so the fix is visible without further digging.
 		if !strings.Contains(msg, `"desktop-api.multica"`) || !strings.Contains(msg, "desktop-api.multica.ai") {
 			t.Fatalf("error message %q must name both the bad profile and the known ones", msg)
+		}
+	})
+
+	// Regression: profile names may contain separators. `multica --profile
+	// team/dev config set ...` creates ~/.multica/profiles/team/dev, so
+	// validating against a flat top-level listing would reject a profile the
+	// same CLI had just created, and suggest its parent "team" instead.
+	t.Run("nested profile created by the CLI is accepted", func(t *testing.T) {
+		mkProfiles(t, "team/dev", "dev")
+		if err := requireKnownProfile("team/dev"); err != nil {
+			t.Fatalf("requireKnownProfile(\"team/dev\") = %v, want nil", err)
+		}
+	})
+
+	t.Run("a bare parent directory is not offered as a profile", func(t *testing.T) {
+		mkProfiles(t, "team/dev")
+
+		// "team" exists on disk but holds no config.json, so it is a parent,
+		// not something the user could pass to --profile.
+		err := requireKnownProfile("nope")
+		var unknown *unknownProfileError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("requireKnownProfile = %v, want *unknownProfileError", err)
+		}
+		want := []string{"team/dev"}
+		if strings.Join(unknown.Known, ",") != strings.Join(want, ",") {
+			t.Fatalf("Known = %v, want %v", unknown.Known, want)
+		}
+	})
+
+	t.Run("login hint quotes an awkward profile name", func(t *testing.T) {
+		mkProfiles(t)
+
+		err := requireKnownProfile("my profile")
+		var unknown *unknownProfileError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("requireKnownProfile = %v, want *unknownProfileError", err)
+		}
+		if !strings.Contains(unknown.Error(), "--profile 'my profile'") {
+			t.Fatalf("error message %q should shell-quote the name so the hint is copy-pasteable", unknown.Error())
 		}
 	})
 
@@ -184,6 +230,24 @@ func TestDaemonStatusKnownProfileStillReportsStopped(t *testing.T) {
 	}
 	if !strings.Contains(out, "stopped") {
 		t.Fatalf("stdout = %q, want a stopped report", out)
+	}
+}
+
+// End-to-end counterpart of the nested-profile regression: `daemon status` on
+// a profile the CLI created as "team/dev" must fall through to the normal
+// health probe rather than stopping at validation.
+func TestDaemonStatusNestedProfileStillProbes(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t, "team/dev")
+
+	out, err := captureStdout(t, func() error {
+		return runDaemonStatus(daemonStatusCmdFor(t, "team/dev", ""), nil)
+	})
+	if err != nil {
+		t.Fatalf("runDaemonStatus = %v, want nil", err)
+	}
+	if !strings.Contains(out, "stopped") {
+		t.Fatalf("stdout = %q, want the probe result for a valid nested profile", out)
 	}
 }
 

--- a/server/cmd/multica/cmd_daemon_unknown_profile_test.go
+++ b/server/cmd/multica/cmd_daemon_unknown_profile_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+// mkProfiles creates ~/.multica/profiles/<name> for each name under a fresh
+// temp HOME and returns that HOME. It also moves the test off the current
+// working directory: inDaemonManagedExecutionContext() detects a daemon task
+// from a workdir marker as well as from env, so a suite running inside a
+// managed task would otherwise see every command as task-scoped.
+func mkProfiles(t *testing.T, names ...string) string {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, name := range names {
+		if err := os.MkdirAll(filepath.Join(home, ".multica", "profiles", name), 0o755); err != nil {
+			t.Fatalf("create profile %q: %v", name, err)
+		}
+	}
+	return home
+}
+
+// daemonStatusCmdFor builds a cobra command carrying the flags runDaemonStatus reads.
+func daemonStatusCmdFor(t *testing.T, profile, output string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("output", "table", "")
+	if profile != "" {
+		if err := cmd.Flags().Set("profile", profile); err != nil {
+			t.Fatalf("set profile flag: %v", err)
+		}
+	}
+	if output != "" {
+		if err := cmd.Flags().Set("output", output); err != nil {
+			t.Fatalf("set output flag: %v", err)
+		}
+	}
+	return cmd
+}
+
+func TestRequireKnownProfile(t *testing.T) {
+	t.Run("default profile is never validated", func(t *testing.T) {
+		mkProfiles(t)
+		if err := requireKnownProfile(""); err != nil {
+			t.Fatalf("requireKnownProfile(\"\") = %v, want nil", err)
+		}
+	})
+
+	t.Run("existing profile passes", func(t *testing.T) {
+		mkProfiles(t, "dev", "desktop-api.multica.ai")
+		if err := requireKnownProfile("desktop-api.multica.ai"); err != nil {
+			t.Fatalf("requireKnownProfile = %v, want nil", err)
+		}
+	})
+
+	t.Run("unknown profile lists the known ones sorted", func(t *testing.T) {
+		mkProfiles(t, "prod", "dev", "desktop-api.multica.ai")
+
+		err := requireKnownProfile("desktop-api.multica")
+		var unknown *unknownProfileError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("requireKnownProfile = %v, want *unknownProfileError", err)
+		}
+		if unknown.Profile != "desktop-api.multica" {
+			t.Fatalf("Profile = %q, want the name the user passed", unknown.Profile)
+		}
+		want := []string{"desktop-api.multica.ai", "dev", "prod"}
+		if strings.Join(unknown.Known, ",") != strings.Join(want, ",") {
+			t.Fatalf("Known = %v, want %v (sorted)", unknown.Known, want)
+		}
+		msg := unknown.Error()
+		// The whole point of #6694: the message must name the typo AND the
+		// real profile, so the fix is visible without further digging.
+		if !strings.Contains(msg, `"desktop-api.multica"`) || !strings.Contains(msg, "desktop-api.multica.ai") {
+			t.Fatalf("error message %q must name both the bad profile and the known ones", msg)
+		}
+	})
+
+	t.Run("no profiles root yet points at login", func(t *testing.T) {
+		mkProfiles(t)
+
+		err := requireKnownProfile("staging")
+		var unknown *unknownProfileError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("requireKnownProfile = %v, want *unknownProfileError", err)
+		}
+		if len(unknown.Known) != 0 {
+			t.Fatalf("Known = %v, want empty", unknown.Known)
+		}
+		if !strings.Contains(unknown.Error(), "multica login --profile staging") {
+			t.Fatalf("error message %q should tell the user how to create it", unknown.Error())
+		}
+	})
+}
+
+func TestDaemonStatusUnknownProfile(t *testing.T) {
+	t.Run("text mode fails without touching stdout", func(t *testing.T) {
+		clearDaemonTaskEnv(t)
+		mkProfiles(t, "desktop-api.multica.ai")
+
+		out, err := captureStdout(t, func() error {
+			return runDaemonStatus(daemonStatusCmdFor(t, "desktop-api.multica", ""), nil)
+		})
+		var unknown *unknownProfileError
+		if !errors.As(err, &unknown) {
+			t.Fatalf("runDaemonStatus = %v, want *unknownProfileError", err)
+		}
+		if strings.Contains(out, "stopped") {
+			t.Fatalf("stdout = %q, must not claim 'stopped' for an unknown profile", out)
+		}
+	})
+
+	t.Run("json mode prints one document and exits non-zero", func(t *testing.T) {
+		clearDaemonTaskEnv(t)
+		mkProfiles(t, "desktop-api.multica.ai", "dev")
+
+		out, err := captureStdout(t, func() error {
+			return runDaemonStatus(daemonStatusCmdFor(t, "desktop-api.multica", "json"), nil)
+		})
+		// errSilent keeps the stderr copy away while still exiting non-zero.
+		if !errors.Is(err, errSilent) {
+			t.Fatalf("runDaemonStatus = %v, want errSilent", err)
+		}
+		if code := cli.ExitCodeFor(err); code == 0 {
+			t.Fatalf("exit code = %d, want non-zero", code)
+		}
+
+		var payload struct {
+			Status        string   `json:"status"`
+			Profile       string   `json:"profile"`
+			KnownProfiles []string `json:"known_profiles"`
+		}
+		if err := json.Unmarshal([]byte(out), &payload); err != nil {
+			t.Fatalf("stdout is not a single valid JSON document: %v\n%s", err, out)
+		}
+		if payload.Status != "unknown_profile" {
+			t.Fatalf("status = %q, want unknown_profile", payload.Status)
+		}
+		if payload.Profile != "desktop-api.multica" {
+			t.Fatalf("profile = %q, want the name the user passed", payload.Profile)
+		}
+		want := []string{"desktop-api.multica.ai", "dev"}
+		if strings.Join(payload.KnownProfiles, ",") != strings.Join(want, ",") {
+			t.Fatalf("known_profiles = %v, want %v", payload.KnownProfiles, want)
+		}
+	})
+
+	t.Run("json mode renders known_profiles as [] not null", func(t *testing.T) {
+		clearDaemonTaskEnv(t)
+		mkProfiles(t)
+
+		out, _ := captureStdout(t, func() error {
+			return runDaemonStatus(daemonStatusCmdFor(t, "staging", "json"), nil)
+		})
+		if !strings.Contains(out, `"known_profiles": []`) {
+			t.Fatalf("stdout = %q, want an empty array rather than null", out)
+		}
+	})
+}
+
+// A known profile must keep reporting "stopped" when its daemon is not
+// running: the new check narrows nothing for legitimate names.
+func TestDaemonStatusKnownProfileStillReportsStopped(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t, "definitely-idle-profile")
+
+	out, err := captureStdout(t, func() error {
+		return runDaemonStatus(daemonStatusCmdFor(t, "definitely-idle-profile", ""), nil)
+	})
+	if err != nil {
+		t.Fatalf("runDaemonStatus = %v, want nil", err)
+	}
+	if !strings.Contains(out, "stopped") {
+		t.Fatalf("stdout = %q, want a stopped report", out)
+	}
+}
+
+// The default profile owns ~/.multica directly and has no profiles/ entry, so
+// it must never be validated — scripts calling plain `daemon status` are the
+// most common caller and must be untouched.
+func TestDaemonStatusDefaultProfileNeverValidated(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t)
+
+	out, err := captureStdout(t, func() error {
+		return runDaemonStatus(daemonStatusCmdFor(t, "", "json"), nil)
+	})
+	if err != nil {
+		t.Fatalf("runDaemonStatus = %v, want nil", err)
+	}
+	if strings.Contains(out, "unknown_profile") {
+		t.Fatalf("stdout = %q, default profile must not be validated", out)
+	}
+}
+
+// `daemon start` is deliberately NOT validated: creating a brand-new profile
+// still goes through the existing login flow, which needs to accept a name
+// that does not exist on disk yet.
+func TestDaemonStartAcceptsUnknownProfile(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t)
+
+	cmd := daemonStatusCmdFor(t, "brand-new-profile", "")
+	cmd.Flags().Bool("foreground", false, "")
+	err := runDaemonBackground(cmd)
+
+	var unknown *unknownProfileError
+	if errors.As(err, &unknown) {
+		t.Fatal("daemon start must not reject an unknown profile; it is how new profiles are created")
+	}
+	// It fails for the pre-existing reason instead: nobody is logged in.
+	if err == nil || !strings.Contains(err.Error(), "not logged in") {
+		t.Fatalf("runDaemonBackground = %v, want the not-logged-in error", err)
+	}
+}
+
+// The other lifecycle commands must reject an unknown profile too, and must do
+// it before acting: `stop` on a mistyped profile silently no-ops today, which
+// reads as "already stopped" for a daemon that is still running elsewhere.
+func TestDaemonLifecycleCommandsRejectUnknownProfile(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(*cobra.Command) error
+	}{
+		{"stop", func(c *cobra.Command) error { return runDaemonStop(c, nil) }},
+		{"restart", func(c *cobra.Command) error { return runDaemonRestart(c, nil) }},
+		{"logs", func(c *cobra.Command) error { return runDaemonLogs(c, nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearDaemonTaskEnv(t)
+			mkProfiles(t, "desktop-api.multica.ai")
+
+			cmd := daemonStatusCmdFor(t, "desktop-api.multica", "")
+			cmd.Flags().Bool("follow", false, "")
+			cmd.Flags().Int("lines", 50, "")
+
+			var unknown *unknownProfileError
+			if err := tc.run(cmd); !errors.As(err, &unknown) {
+				t.Fatalf("daemon %s = %v, want *unknownProfileError", tc.name, err)
+			}
+		})
+	}
+}
+
+// Ordering guard: inside a daemon-managed task the --profile rejection must
+// fire BEFORE requireKnownProfile, otherwise listing the profiles root would
+// disclose the Owner's profile names to a task.
+func TestDaemonStatusTaskContextRejectsProfileBeforeListing(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t, "owner-secret-profile")
+	t.Setenv("MULTICA_TASK_ID", "task-test")
+	t.Setenv("MULTICA_DAEMON_PORT", "19601")
+
+	out, err := captureStdout(t, func() error {
+		return runDaemonStatus(daemonStatusCmdFor(t, "whatever", "json"), nil)
+	})
+	if err == nil {
+		t.Fatal("runDaemonStatus = nil, want the task-context rejection")
+	}
+	var unknown *unknownProfileError
+	if errors.As(err, &unknown) {
+		t.Fatal("task-context guard must fire before profile validation")
+	}
+	if !strings.Contains(err.Error(), "not available inside a daemon-managed task") {
+		t.Fatalf("error = %v, want the task-context rejection", err)
+	}
+	if strings.Contains(out, "owner-secret-profile") {
+		t.Fatalf("stdout = %q, must never disclose Owner profile names inside a task", out)
+	}
+}


### PR DESCRIPTION
## Summary

`multica daemon status --profile <typo>` reported a flat `stopped`, which is indistinguishable from a daemon that genuinely is not running — even while the correctly-named daemon was serving happily on another port. That is what made #6694 read as "the CLI is lying to me".

Root cause: `healthPortForProfile` hashes **any** string into a port (`19514 + 1 + (sum(bytes) % 1000)`), and nothing validated that the profile exists. A one-character slip silently probes a port nothing is bound to.

Worked example from the issue — the Desktop app derives `desktop-<api-host>`, so the real profile is `desktop-api.multica.ai`:

| profile | port |
|---|---|
| default (no `--profile`) | 19514 |
| `desktop-api.multica` (typo) | 20433 |
| `desktop-api.multica.ai` (real) | **19681** |

## Change

Validate an explicitly named `--profile` against `~/.multica/profiles` and fail with the known names instead of guessing a port.

- Covers `status` / `stop` / `restart` / `logs`.
- **Not** `start`: creating a new profile still goes through the login flow, which must accept a name that is not on disk yet.
- The **default profile is never validated** — it owns `~/.multica` directly, has no `profiles/` entry, and is always legitimate. Plain `daemon status`, the common scripted caller, is untouched.
- Validation runs *after* each command's daemon-managed-task guard, so listing the profiles root can never disclose the Owner's profile names to a task. A test pins that ordering.
- `--output json` keeps stdout a single valid JSON document and signals failure through the exit code only (no duplicate stderr copy), so `jq -r .status` keeps working and now reads `unknown_profile` rather than a misleading `stopped`.

## Behaviour

```console
$ multica --profile desktop-api.multica daemon status
unknown profile "desktop-api.multica"
Known profiles: desktop-api.multica.ai, dev
$ echo $?
1

$ multica --profile desktop-api.multica daemon status --output json
{
  "known_profiles": [
    "desktop-api.multica.ai",
    "dev"
  ],
  "profile": "desktop-api.multica",
  "status": "unknown_profile"
}
$ echo $?
1
```

Unchanged paths:

```console
$ multica daemon status                                  # default profile
Daemon: stopped

$ multica --profile desktop-api.multica.ai daemon status # correct name
Daemon [desktop-api.multica.ai]:  running (pid 7163, uptime 12h1m49s)
```

## Testing

- `go build ./cmd/multica/`, `go vet ./cmd/multica/`, `gofmt` clean.
- New `cmd_daemon_unknown_profile_test.go` covers: default profile never validated; existing profile passes; unknown profile lists known names sorted; empty profiles root points at `login`; text mode does not touch stdout; JSON mode emits one document with a non-zero exit; `known_profiles` marshals as `[]` not `null`; a known-but-idle profile still reports `stopped`; `start` still accepts an unknown profile; `stop`/`restart`/`logs` all reject; and the task-context guard fires before any profile listing.
- Full `go test ./cmd/multica/` compared against `main`: identical failure sets (105 on both, all pre-existing environment failures from running the suite inside a daemon-managed task). No regressions introduced.
- End-to-end against a built binary with a synthetic `HOME`, output above.

## Scope

`Refs #6694` rather than `Closes` — this fixes the root cause (the misleading `stopped`), but the issue also asks that status say *"managed by the desktop app"*. That needs `profile` + `launched_by` on the daemon's `/health` response, plus cross-profile discovery, which are follow-ups. `daemon disk-usage` also takes `--profile` and is deliberately left alone here; it already has its own multi-root handling.
