### PR TITLE
refactor(daemon): drop the MULTICA_HERMES_TASK_MEMORY rollback switch (MUL-6021)

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -263,7 +263,6 @@ Agent-specific overrides:
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |
 | `MULTICA_HERMES_MODEL` | Override the Hermes model used |
-| `MULTICA_HERMES_TASK_MEMORY` | Revert Hermes memory to a fresh task-local `memories/` per task (see [Hermes agent memory](#hermes-agent-memory)) |
 | `MULTICA_PI_PATH` | Custom path to the `pi` binary |
 | `MULTICA_PI_MODEL` | Override the Pi model used |
 | `MULTICA_CURSOR_PATH` | Custom path to the `cursor-agent` binary |
@@ -326,7 +325,6 @@ Consequences worth knowing:
 - **Session history is not covered.** `state.db` and its WAL sidecars stay task-local: sharing a live SQLite database across one agent's concurrent tasks needs lock and consistency handling (plus Windows byte-range locks on `-shm`) that plain memory files do not. The agent remembers accumulated notes, not previous transcripts.
 - **Concurrent tasks of one agent are last-writer-wins.** Hermes rewrites its memory files whole, so two tasks writing memory at the same time can overwrite each other.
 - **Every Hermes agent gets the overlay in practice**, so every one of them gets a persistent memory store. The daemon builds the overlay only when a task carries skills, but the server appends Multica's built-in skills to every agent's skill set (`LoadAgentSkillBundles`), so that list is never empty — leaving an agent's own skill list empty does not opt out of the overlay, and is not a way to keep using the host's `~/.hermes/memories`.
-- `MULTICA_HERMES_TASK_MEMORY=1` on the daemon reverts to the previous behaviour, a fresh task-local `memories/` per task.
 
 `MULTICA_CLAUDE_ARGS`, `MULTICA_CODEX_ARGS`, `MULTICA_CODEBUDDY_ARGS`, `MULTICA_QWEN_ARGS`, and `MULTICA_QWENPAW_ARGS` are parsed with POSIX shellword quoting, so values such as `--model "gpt-5.1 codex" --sandbox read-only` are split like a shell command line. Agent arguments are applied in this order: hardcoded Multica defaults, daemon-wide env defaults, then per-agent `custom_args` from the task.
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -80,7 +80,7 @@ type PrepareParams struct {
 	// HermesMemoryStore is the agent's persistent Hermes memory store
 	// (HermesMemoryStorePath) the overlay links memories/ to, so memory outlives
 	// the task. Empty keeps memories/ task-local — no agent to key on, or the
-	// MULTICA_HERMES_TASK_MEMORY rollback switch is engaged.
+	// Multica profile dir could not be resolved.
 	HermesMemoryStore string
 	// HermesEnv is the sanitized effective env (agent custom_env minus the daemon
 	// blocklisted keys) used to expand ${VAR} in Hermes external_dirs so it

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -369,8 +369,8 @@ func hermesProfileDir(root, name string) (home string, mustExist bool, err error
 // silently seed from an empty dir and drop the user's auth/config. env is the
 // sanitized effective env used to expand ${VAR} in external_dirs so it matches
 // what the Hermes child sees. memoryStore is the agent's persistent memory store
-// (execenv.HermesMemoryStorePath) that memories/ is linked to; empty keeps the
-// pre-MUL-5932 task-local dir, which is what the rollback switch produces.
+// (execenv.HermesMemoryStorePath) that memories/ is linked to; empty keeps
+// memories/ task-local for this task.
 func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, workspaceSkills []SkillContextForEnv, env map[string]string, memoryStore string, logger *slog.Logger) error {
 	sharedHome := strings.TrimSpace(sourceHome)
 	if sharedHome == "" {
@@ -395,7 +395,7 @@ func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, work
 	}
 	// Memory: link memories/ at the agent's persistent store so it survives the
 	// task, or fall back to a fresh task-local dir when there is no store (no
-	// agent to key on, or the rollback switch is engaged). See hermes_memory.go.
+	// agent to key on, or an unresolvable profile dir). See hermes_memory.go.
 	if memoryStore != "" {
 		if err := mountHermesMemories(hermesHome, memoryStore, logger); err != nil {
 			return fmt.Errorf("mount agent memories: %w", err)

--- a/server/internal/daemon/execenv/hermes_memory.go
+++ b/server/internal/daemon/execenv/hermes_memory.go
@@ -70,36 +70,17 @@ const hermesMemoryStoreRoot = "hermes-state"
 // and the overlay home — Hermes resolves it relative to HERMES_HOME.
 const hermesMemoriesEntry = "memories"
 
-// MulticaHermesTaskMemoryEnv is the rollback switch. Anything truthy (1, true,
-// yes, on; case-insensitive) restores the pre-MUL-5932 behaviour of a fresh
-// task-local memories/ dir per task, for an operator who needs to revert without
-// waiting for a release. Everything else (including unset) keeps memory
-// agent-scoped and persistent.
-const MulticaHermesTaskMemoryEnv = "MULTICA_HERMES_TASK_MEMORY"
-
-// hermesTaskLocalMemoryForced reports whether the rollback switch is engaged.
-func hermesTaskLocalMemoryForced() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(MulticaHermesTaskMemoryEnv))) {
-	case "1", "true", "yes", "on":
-		return true
-	}
-	return false
-}
-
 // HermesMemoryStorePath returns the persistent memory store for (daemonProfile,
-// agentID, sourceHome), or "" when memory must stay task-local — the rollback
-// switch is engaged, there is no agent to key on, or the Multica profile dir
-// cannot be resolved. The daemon marks the returned path in-use for the task's
-// duration so PruneHermesMemoryStores never reclaims it mid-mount.
+// agentID, sourceHome), or "" when memory must stay task-local — there is no
+// agent to key on, or the Multica profile dir cannot be resolved. The daemon
+// marks the returned path in-use for the task's duration so
+// PruneHermesMemoryStores never reclaims it mid-mount.
 //
 // daemonProfile namespaces by Multica profile for free: profile dirs are already
 // disjoint, so a staging daemon's GC can never see a production daemon's stores
 // and no hashed namespace segment is needed (unlike the Codex store, which lives
 // in the shared ~/.codex).
 func HermesMemoryStorePath(daemonProfile, agentID, sourceHome string) string {
-	if hermesTaskLocalMemoryForced() {
-		return ""
-	}
 	agent := sanitizePathSegment(agentID)
 	if agent == "" {
 		return ""
@@ -158,11 +139,11 @@ func hashHermesHomePath(path string) string {
 // memory outlives the task. Idempotent across Reuse: a link already pointing at
 // the store is left alone.
 //
-// A real memories/ directory left by an older daemon (or by a task that ran with
-// the rollback switch on) is migrated into the store rather than discarded — but
-// only into an empty store, so an upgrade never overwrites memory the agent has
-// already accumulated. A migration that cannot complete fails the overlay rather
-// than dropping the directory it could not carry over.
+// A real memories/ directory left by an older daemon (or by a task that ran
+// without a store to key on) is migrated into the store rather than discarded —
+// but only into an empty store, so an upgrade never overwrites memory the agent
+// has already accumulated. A migration that cannot complete fails the overlay
+// rather than dropping the directory it could not carry over.
 func mountHermesMemories(hermesHome, storeDir string, logger *slog.Logger) error {
 	dst := filepath.Join(hermesHome, hermesMemoriesEntry)
 
@@ -364,11 +345,12 @@ func copyHermesMemoryTree(src, dst string) error {
 }
 
 // detachHermesMemories gives the overlay a real, task-local memories dir. It is
-// the rollback path (MULTICA_HERMES_TASK_MEMORY), so it must actively replace a
-// link left by a previous run against the persistent store: a reused overlay
-// still carries that link, and MkdirAll would follow it and silently succeed,
-// leaving the task writing to a store the daemon no longer guards from the GC.
-// An existing real directory is kept — that is this task's own memory.
+// the path taken when there is no store to key on (no agent, or an unresolvable
+// Multica profile dir), so it must actively replace a link left by a previous
+// run against the persistent store: a reused overlay still carries that link,
+// and MkdirAll would follow it and silently succeed, leaving the task writing to
+// a store the daemon no longer guards from the GC. An existing real directory is
+// kept — that is this task's own memory.
 func detachHermesMemories(hermesHome string) error {
 	dst := filepath.Join(hermesHome, hermesMemoriesEntry)
 	if fi, err := os.Lstat(dst); err == nil {

--- a/server/internal/daemon/execenv/hermes_memory_test.go
+++ b/server/internal/daemon/execenv/hermes_memory_test.go
@@ -64,8 +64,8 @@ func TestHermesMemoryStorePathLayout(t *testing.T) {
 	}
 }
 
-// TestHermesMemoryStorePathDisabled covers the two ways memory stays
-// task-local: no agent to key on, and the operator rollback switch.
+// TestHermesMemoryStorePathDisabled covers the task without an agent to key the
+// store on: memory has to stay task-local rather than land in a shared segment.
 func TestHermesMemoryStorePathDisabled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -73,11 +73,6 @@ func TestHermesMemoryStorePathDisabled(t *testing.T) {
 
 	if got := HermesMemoryStorePath("", "", ""); got != "" {
 		t.Fatalf("store path without an agent = %q, want empty", got)
-	}
-
-	t.Setenv(MulticaHermesTaskMemoryEnv, "1")
-	if got := HermesMemoryStorePath("", "agent-1", ""); got != "" {
-		t.Fatalf("store path with the rollback switch on = %q, want empty", got)
 	}
 }
 
@@ -144,10 +139,10 @@ func TestPrepareHermesHomeMemoryStoreIsolatesAgents(t *testing.T) {
 	}
 }
 
-// TestPrepareHermesHomeMemoryStoreRollback verifies the operator switch: with no
-// store the overlay keeps a plain task-local memories dir, i.e. the old
-// behaviour, and never leaves a dangling link behind.
-func TestPrepareHermesHomeMemoryStoreRollback(t *testing.T) {
+// TestPrepareHermesHomeWithoutStore verifies the no-store path: with nothing to
+// key a store on, the overlay keeps a plain task-local memories dir and never
+// leaves a dangling link behind.
+func TestPrepareHermesHomeWithoutStore(t *testing.T) {
 	t.Parallel()
 	sharedHome := t.TempDir()
 	hermesHome := filepath.Join(t.TempDir(), "hermes-home")
@@ -168,27 +163,28 @@ func TestPrepareHermesHomeMemoryStoreRollback(t *testing.T) {
 	}
 }
 
-// TestPrepareHermesHomeRollbackDetachesExistingStoreLink is the regression test
-// for the rollback switch on a reused workdir. The overlay still carries the
-// link to the persistent store from the previous run, and MkdirAll would follow
-// it and silently succeed — leaving the task writing to a store the daemon no
-// longer marks active, and the GC free to reclaim it mid-task.
-func TestPrepareHermesHomeRollbackDetachesExistingStoreLink(t *testing.T) {
+// TestPrepareHermesHomeWithoutStoreDetachesExistingStoreLink is the regression
+// test for a reused workdir whose next task has no store (no agent to key on, or
+// an unresolvable profile dir). The overlay still carries the link to the
+// persistent store from the previous run, and MkdirAll would follow it and
+// silently succeed — leaving the task writing to a store the daemon no longer
+// marks active, and the GC free to reclaim it mid-task.
+func TestPrepareHermesHomeWithoutStoreDetachesExistingStoreLink(t *testing.T) {
 	t.Parallel()
 	sharedHome := t.TempDir()
 	store := filepath.Join(t.TempDir(), "hermes-state", "agent-1", "default")
 	hermesHome := filepath.Join(t.TempDir(), "hermes-home")
 	skills := []SkillContextForEnv{{Name: "deploy", Content: "# Deploy"}}
 
-	// Run once with the store mounted, as a pre-rollback task would.
+	// Run once with the store mounted.
 	if err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, store, testLogger()); err != nil {
 		t.Fatalf("prepare with store: %v", err)
 	}
 	mustWrite(t, filepath.Join(hermesHome, "memories", "MEMORY.md"), "persistent memory")
 
-	// Operator flips MULTICA_HERMES_TASK_MEMORY=1; the same overlay is reused.
+	// The same overlay is reused by a task that resolves no store.
 	if err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", testLogger()); err != nil {
-		t.Fatalf("prepare after rollback: %v", err)
+		t.Fatalf("prepare without store: %v", err)
 	}
 
 	fi, err := os.Lstat(filepath.Join(hermesHome, "memories"))
@@ -196,21 +192,22 @@ func TestPrepareHermesHomeRollbackDetachesExistingStoreLink(t *testing.T) {
 		t.Fatalf("lstat memories: %v", err)
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("rollback left the store link in place; the task still writes to the persistent store")
+		t.Fatalf("the store link is still in place; the task still writes to the persistent store")
 	}
 	if _, err := os.Stat(filepath.Join(hermesHome, "memories", "MEMORY.md")); !os.IsNotExist(err) {
-		t.Fatalf("rollback should give the task an empty memories dir (err = %v)", err)
+		t.Fatalf("a task without a store should get an empty memories dir (err = %v)", err)
 	}
-	// The store itself must survive, so flipping the switch back restores memory.
+	// The store itself must survive, so the agent's next task with a store
+	// resolved still finds its memory.
 	if _, err := os.Stat(filepath.Join(store, "MEMORY.md")); err != nil {
-		t.Fatalf("rollback destroyed the persistent store: %v", err)
+		t.Fatalf("detaching destroyed the persistent store: %v", err)
 	}
 }
 
-// TestPrepareHermesHomeRollbackKeepsTaskLocalMemories checks the other reuse
+// TestPrepareHermesHomeWithoutStoreKeepsTaskLocalMemories checks the other reuse
 // case: with no store, an existing real memories dir is this task's own memory
 // and must be preserved across reuse.
-func TestPrepareHermesHomeRollbackKeepsTaskLocalMemories(t *testing.T) {
+func TestPrepareHermesHomeWithoutStoreKeepsTaskLocalMemories(t *testing.T) {
 	t.Parallel()
 	sharedHome := t.TempDir()
 	hermesHome := filepath.Join(t.TempDir(), "hermes-home")


### PR DESCRIPTION
## Summary

Removes the `MULTICA_HERMES_TASK_MEMORY` rollback switch added alongside the persistent Hermes agent memory store (#6693). The migration to the per-agent store landed correctly, so the escape hatch no longer earns its keep.

Two reasons beyond "we don't need it anymore":

- **It didn't cover the failure it looked like it covered.** The Hermes overlay already depends on directory links to mirror the user's `~/.hermes` (`linkSharedHermesEntry`), so a host that cannot create them fails at the mirror step whatever this env is set to. The `memories/` link is the same capability used once more, not a new hard dependency.
- **Flipping it was lossy in both directions.** With the switch on, `HermesMemoryStorePath` returned empty, so the daemon never called `markActiveStore` and never refreshed the store's mtime — leaving it idle in the GC's eyes and reclaimable after `GCHermesMemoryTTL` (90d). Flipping it back discarded whatever the task-local dir had accumulated, because a populated store is never migrated into.

The finer-grained lever documented in `CLI_AND_DAEMON.md` remains: delete `<profile dir>/hermes-state/<agent>/<profile>/` to wipe one agent's memory.

## Changes

- Drop `MulticaHermesTaskMemoryEnv` / `hermesTaskLocalMemoryForced()` and the early return in `HermesMemoryStorePath`.
- Keep the task-local path (`detachHermesMemories`) untouched — it is still what a task with no agent to key on, or an unresolvable Multica profile dir, gets. Comments and the three overlay tests are reframed from "rollback switch" to that no-store case.
- Remove the two `CLI_AND_DAEMON.md` references to the env.

No behavior change for any daemon that never set the variable, which is the documented default.

## Verification

- `go vet ./internal/daemon/execenv/` — clean
- `go test ./internal/daemon/... -count=1` — all pass (daemon, execenv, repocache)
- `gofmt -l internal/daemon/execenv` — clean
- Grepped the repo for remaining references to the env / helper: none, including built-in skills and docs.

MUL-6021
