### PR TITLE
docs(skills): remove implicit reply routing guidance (MUL-6021)

### DIFF
--- a/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
@@ -99,15 +99,6 @@ first, then removes those agent IDs as a post-filter. A missing or empty field
 preserves the old behavior. A valid UUID that is not in the computed trigger set
 is a no-op; a malformed UUID is rejected at the request boundary.
 
-For plain member-authored replies, implicit routing respects the direct
-conversation target. Replying directly to an agent can trigger that agent, and
-a member-authored thread that already has an agent owner can continue that
-conversation. But a reply directly under another member does NOT fall back to
-the issue's agent or squad assignee when the thread has no agent owner. Use an
-explicit `@agent` or `@squad` mention when that human-to-human reply should also
-start agent work. Top-level member comments can still use the issue assignee
-fallback.
-
 ## @all is the broadcast type
 
 `@all` uses the literal `all`, never a UUID:


### PR DESCRIPTION
## Summary

- Remove the nine-line explanation of member-authored implicit reply routing from the main `multica-mentioning` skill body.
- Keep the backend routing behavior, regression coverage, user-facing docs, and source-map evidence unchanged.
- Reduce the on-demand skill body from 231 lines / 13,318 bytes to 222 lines / 12,766 bytes (net `-9` lines / `-552` bytes).

The removed paragraph describes a server-side decision that happens before an agent runs. It does not help the agent construct an explicit mention or decide what that mention enqueues, so it is better kept in the user docs and low-frequency diagnostic reference instead of the action-oriented skill body.

## Verification

- `go test ./internal/service -run 'TestBuiltinSkills|TestMentioningSkill' -count=1`
- `git diff --check`

The broader `go test ./internal/service ./internal/handler -count=1` command could not complete against the local test database because its schema is stale and lacks current-main columns including `disabled_runtime_skills` and `session_rollout_missing`. This PR changes only Markdown skill content and does not modify the database or handler behavior.
