### PR TITLE
MUL-6024 fix(agent): decide the openclaw cut-short verdict from one buffer snapshot

### DIFF
--- a/server/pkg/agent/openclaw_stdout.go
+++ b/server/pkg/agent/openclaw_stdout.go
@@ -79,19 +79,26 @@ func readOpenclawStdout(r io.Reader, idleGrace time.Duration) (buf []byte, cutSh
 		chunk := make([]byte, 32*1024)
 		for {
 			n, rerr := r.Read(chunk)
+			// One Read is one observation: a reader is allowed to return the
+			// final bytes and io.EOF together, and publishing those under two
+			// separate locks would let the ticker see "bytes arrived, stream
+			// still open" in between. On a loaded machine that gap can outlast
+			// idleGrace, and since the trailing bytes are exactly what makes
+			// the buffer parseable, the poll loop would report cutShort for a
+			// stream that had already ended cleanly.
+			mu.Lock()
 			if n > 0 {
-				mu.Lock()
 				acc = append(acc, chunk[:n]...)
 				lastByte = time.Now()
-				mu.Unlock()
 			}
 			if rerr != nil {
-				mu.Lock()
 				if rerr != io.EOF {
 					readErr = rerr
 				}
 				atEOF = true
-				mu.Unlock()
+			}
+			mu.Unlock()
+			if rerr != nil {
 				return
 			}
 		}
@@ -111,27 +118,30 @@ func readOpenclawStdout(r io.Reader, idleGrace time.Duration) (buf []byte, cutSh
 			return out, false, rerr
 
 		case <-ticker.C:
-			// Check the cheap conditions under the lock first and only copy the
-			// buffer once the silence threshold is actually met. Copying on every
-			// tick would allocate the whole accumulated result ~20 times per wait
-			// window, which for a large result is pure waste.
+			// Decide and snapshot under ONE lock. Re-reading acc after
+			// releasing it would mix a stale verdict with a fresh buffer: the
+			// terminal write can land in between, so the "still open, gone
+			// quiet" check would be answered from before it while the bytes
+			// being parsed came from after it. That is precisely the buffer
+			// that parses, so a cleanly-ended stream got reported as cut
+			// short, spuriously warning and cancelling a process that had
+			// already exited.
+			//
+			// The threshold is still evaluated before copying, so the common
+			// tick allocates nothing: copying the whole accumulated result on
+			// every tick would repeat ~20 times per wait window for no reason.
 			mu.Lock()
-			size := len(acc)
-			last := lastByte
-			done := atEOF
+			var out []byte
+			if !atEOF && len(acc) > 0 && time.Since(lastByte) >= idleGrace {
+				out = append([]byte(nil), acc...)
+			}
 			mu.Unlock()
 
-			if done {
-				continue // let the <-finished branch report the final state
-			}
-			if size == 0 || time.Since(last) < idleGrace {
+			// Either the stream has ended — let the <-finished branch report
+			// the final state — or it has not been quiet long enough yet.
+			if out == nil {
 				continue
 			}
-
-			mu.Lock()
-			out := append([]byte(nil), acc...)
-			mu.Unlock()
-
 			if _, ok := parseWholeBufferOpenclawResult(out); !ok {
 				continue
 			}


### PR DESCRIPTION
## Summary

`TestReadOpenclawStdoutWaitsForCompleteResult` fails intermittently on loaded CI runners — it took down the backend job on an unrelated PR (#6757):

```
--- FAIL: TestReadOpenclawStdoutWaitsForCompleteResult (0.70s)
    openclaw_stdout_test.go:363: cutShort = true after a clean EOF, want false
```

This is not a test-only problem. `readOpenclawStdout` really can report `cutShort` for a stream that ended cleanly, and `cutShort` makes the caller log `openclaw delivered its result but did not exit` and `cancel()` a process that has already exited (`openclaw.go:141`). The delivered result is still correct, so it is invisible to users — but the log is wrong and the cancel is pointless.

## The dominant race: two snapshots per tick

The poll loop took the verdict and the buffer under **separate** lock acquisitions:

```go
mu.Lock(); size := len(acc); last := lastByte; done := atEOF; mu.Unlock()   // verdict
if done { continue }
if size == 0 || time.Since(last) < idleGrace { continue }
mu.Lock(); out := append([]byte(nil), acc...); mu.Unlock()                  // buffer
```

The terminal write lands between those two often enough to matter. The verdict is then answered from *before* it (`done == false`, stale `lastByte` well past the grace) while the parsed bytes come from *after* it — and those trailing bytes are precisely what makes the buffer parseable. Result: `return out, true, nil` on a stream that had already reached EOF.

Fixed by evaluating the threshold and copying under one lock. The copy still only happens once the threshold is met, so the common tick allocates nothing — the original optimization is preserved.

## The mirror-image gap in the reader

A `Read` may return its final bytes together with `io.EOF` (what os/exec pipes do for a short-lived process). Publishing the append and the EOF under separate locks briefly exposed "bytes arrived, stream still open" — the same state the poll loop misreads. Both are now published under one lock, so one `Read` is one observation.

This second window is far narrower than the first; I could not get it to reproduce on its own. It is closed by construction rather than by a reproducing test, and the comment says so.

## Testing

- The previously flaky test, under `-race`: **4 failures / 40 runs before**, **0 / 100 after**.
- `go test ./pkg/agent -race` (full package): clean.
- `go build`, `go vet`, `gofmt`: clean.

No new test. I tried to build a deterministic reproducer for the narrow reader-side window — GOMAXPROCS(1) plus CPU-bound goroutines to force descheduling — and measured that it never failed against the unfixed code, so it would have been decoration that cost ~9s of CI. The existing test is a genuine reproducer for the dominant race and is the guard here; the numbers above are from it.

## Scope

Behaviour for the case this mechanism exists for is unchanged: a complete result followed by a process that will not exit still reports `cutShort = true` after the idle grace. Only the clean-EOF misreport goes away.

MUL-6024
