### PR TITLE
feat(codex): discover OpenCodex routed models

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -112,9 +113,15 @@ type modelCacheEntry struct {
 var (
 	modelCacheMu sync.Mutex
 	modelCache   = map[string]modelCacheEntry{}
+
+	openCodexModelCacheMu        sync.Mutex
+	openCodexModelCache          []Model
+	openCodexModelCacheExpiresAt time.Time
+	openCodexModelCacheValid     bool
 )
 
 const modelCacheTTL = 60 * time.Second
+const openCodexModelCacheTTL = 5 * time.Minute
 
 // ListModels returns the models supported by the given agent provider.
 // For providers with a known static catalog it returns the baked-in
@@ -155,7 +162,9 @@ func ListModels(ctx context.Context, providerType, executablePath string) (Catal
 		return Catalog{Models: models}, nil
 	case "codex":
 		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
-			return discovered(discoverCodexModels(ctx, executablePath), nil)
+			models := discoverCodexModels(ctx, executablePath)
+			models = mergeModels(models, discoverOpenCodexModels(ctx))
+			return discovered(models, nil)
 		})
 	case "antigravity":
 		// agy 1.0.6 added a `--model` flag plus an `agy models` catalog
@@ -403,6 +412,25 @@ func discoveryCacheKey(providerType, executablePath string) string {
 	return providerType + ":" + executablePath
 }
 
+// mergeModels appends models that are not already present in the primary
+// catalog. Primary entries win so their runtime-owned default, thinking, and
+// service-tier metadata remain authoritative.
+func mergeModels(primary, additional []Model) []Model {
+	merged := make([]Model, 0, len(primary)+len(additional))
+	seen := make(map[string]struct{}, len(primary)+len(additional))
+	for _, model := range append(primary, additional...) {
+		if model.ID == "" {
+			continue
+		}
+		if _, ok := seen[model.ID]; ok {
+			continue
+		}
+		seen[model.ID] = struct{}{}
+		merged = append(merged, model)
+	}
+	return merged
+}
+
 // ── Static catalogs ──
 
 // claudeStaticModels reflects the Claude Code CLI's accepted --model
@@ -579,6 +607,175 @@ func isOpenAIReasoningSeriesID(id string) bool {
 }
 
 // ── Dynamic discovery ──
+
+// discoverOpenCodexModels discovers provider/model routes configured in the
+// local OpenCodex proxy. OpenCodex models are valid Codex model overrides but
+// are not part of `codex debug models --bundled`, so without this merge they
+// can be used from the CLI yet remain absent from Multica's model picker.
+func discoverOpenCodexModels(ctx context.Context) []Model {
+	return cachedOpenCodexModels(func() ([]Model, error) {
+		return queryOpenCodexModels(ctx)
+	})
+}
+
+// cachedOpenCodexModels keeps the last successful OpenCodex catalog. Unlike
+// the short-lived general discovery cache, an expired successful result is
+// retained when a refresh fails so a transient proxy or network failure does
+// not make previously selectable routed models disappear from the UI.
+func cachedOpenCodexModels(load func() ([]Model, error)) []Model {
+	openCodexModelCacheMu.Lock()
+	if openCodexModelCacheValid && time.Now().Before(openCodexModelCacheExpiresAt) {
+		models := cloneModels(openCodexModelCache)
+		openCodexModelCacheMu.Unlock()
+		return models
+	}
+	openCodexModelCacheMu.Unlock()
+
+	models, err := load()
+	if err == nil && len(models) > 0 {
+		models = cloneModels(models)
+		openCodexModelCacheMu.Lock()
+		openCodexModelCache = models
+		openCodexModelCacheExpiresAt = time.Now().Add(openCodexModelCacheTTL)
+		openCodexModelCacheValid = true
+		openCodexModelCacheMu.Unlock()
+		return cloneModels(models)
+	}
+
+	openCodexModelCacheMu.Lock()
+	stale := cloneModels(openCodexModelCache)
+	valid := openCodexModelCacheValid
+	openCodexModelCacheMu.Unlock()
+	if valid {
+		slog.Debug("OpenCodex model refresh failed; using last successful catalog", "error", err)
+		return stale
+	}
+	return nil
+}
+
+func queryOpenCodexModels(ctx context.Context) ([]Model, error) {
+	executablePath, err := findOpenCodexExecutable()
+	if err != nil {
+		return nil, err
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, executablePath, "models", "--json")
+	hideAgentWindow(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	models, err := parseOpenCodexModels(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("OpenCodex returned an empty model catalog")
+	}
+	return models, nil
+}
+
+// findOpenCodexExecutable includes common user-local install locations because
+// a macOS app launched from Finder does not inherit the interactive shell PATH.
+func findOpenCodexExecutable() (string, error) {
+	if executablePath, err := exec.LookPath("ocx"); err == nil {
+		return executablePath, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{
+		filepath.Join(home, ".hermes", "node", "bin", "ocx"),
+		filepath.Join(home, ".local", "bin", "ocx"),
+		filepath.Join(home, ".opencode", "bin", "ocx"),
+	}
+	for _, candidate := range candidates {
+		info, statErr := os.Stat(candidate)
+		if statErr == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("ocx executable not found")
+}
+
+type openCodexModelsResponse struct {
+	Models []struct {
+		Provider         string   `json:"provider"`
+		Model            string   `json:"model"`
+		ReasoningEfforts []string `json:"reasoningEfforts"`
+	} `json:"models"`
+}
+
+func parseOpenCodexModels(raw []byte) ([]Model, error) {
+	var response openCodexModelsResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return nil, err
+	}
+	models := make([]Model, 0, len(response.Models))
+	seen := make(map[string]struct{}, len(response.Models))
+	for _, entry := range response.Models {
+		provider := strings.TrimSpace(entry.Provider)
+		modelID := strings.TrimSpace(entry.Model)
+		if provider == "" || modelID == "" {
+			continue
+		}
+		id := provider + "/" + modelID
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, Model{
+			ID:       id,
+			Label:    id,
+			Provider: provider,
+			Thinking: openCodexThinkingLevels(entry.ReasoningEfforts),
+		})
+	}
+	return models, nil
+}
+
+func openCodexThinkingLevels(efforts []string) *ModelThinking {
+	levels := make([]ThinkingLevel, 0, len(efforts))
+	seen := make(map[string]struct{}, len(efforts))
+	for _, raw := range efforts {
+		effort := strings.TrimSpace(raw)
+		if effort == "" || !isValidDynamicThinkingValue(effort) {
+			continue
+		}
+		if _, ok := seen[effort]; ok {
+			continue
+		}
+		seen[effort] = struct{}{}
+		label, ok := codexEffortLabel[effort]
+		if !ok {
+			label = strings.Title(effort) //nolint:staticcheck
+		}
+		levels = append(levels, ThinkingLevel{Value: effort, Label: label})
+	}
+	if len(levels) == 0 {
+		return nil
+	}
+	return &ModelThinking{SupportedLevels: levels}
+}
+
+func cloneModels(models []Model) []Model {
+	if models == nil {
+		return nil
+	}
+	cloned := make([]Model, len(models))
+	for i, model := range models {
+		cloned[i] = model
+		cloned[i].ServiceTiers = append([]ModelServiceTier(nil), model.ServiceTiers...)
+		if model.Thinking != nil {
+			thinking := *model.Thinking
+			thinking.SupportedLevels = append([]ThinkingLevel(nil), model.Thinking.SupportedLevels...)
+			cloned[i].Thinking = &thinking
+		}
+	}
+	return cloned
+}
 
 // discoverOpenCodeModels runs `opencode models --verbose` and parses its
 // output. The CLI prints `provider/model` rows, followed by JSON metadata

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,147 @@ import (
 	"testing"
 	"time"
 )
+
+func TestParseOpenCodexModels(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+  "models": [
+    {
+      "provider": "opencode-zen",
+      "model": "deepseek-v4-flash-free",
+      "reasoningEfforts": ["low", "high", "max", "high", "bad value"]
+    },
+    {
+      "provider": "agnes",
+      "model": "agnes-2.0-flash",
+      "reasoningEfforts": null
+    },
+    {
+      "provider": "opencode-zen",
+      "model": "deepseek-v4-flash-free",
+      "reasoningEfforts": ["low"]
+    }
+  ]
+}`)
+
+	got, err := parseOpenCodexModels(raw)
+	if err != nil {
+		t.Fatalf("parseOpenCodexModels: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("models len = %d, want 2: %+v", len(got), got)
+	}
+	deepseek := got[0]
+	if deepseek.ID != "opencode-zen/deepseek-v4-flash-free" ||
+		deepseek.Label != deepseek.ID ||
+		deepseek.Provider != "opencode-zen" {
+		t.Errorf("DeepSeek model = %+v", deepseek)
+	}
+	if deepseek.Thinking == nil {
+		t.Fatal("DeepSeek thinking catalog is nil")
+	}
+	if values := thinkingValues(deepseek.Thinking); !reflect.DeepEqual(values, []string{"low", "high", "max"}) {
+		t.Errorf("DeepSeek thinking levels = %v, want [low high max]", values)
+	}
+	if labels := []string{
+		deepseek.Thinking.SupportedLevels[0].Label,
+		deepseek.Thinking.SupportedLevels[1].Label,
+		deepseek.Thinking.SupportedLevels[2].Label,
+	}; !reflect.DeepEqual(labels, []string{"Low", "High", "Max"}) {
+		t.Errorf("DeepSeek thinking labels = %v, want [Low High Max]", labels)
+	}
+	agnes := got[1]
+	if agnes.ID != "agnes/agnes-2.0-flash" || agnes.Provider != "agnes" {
+		t.Errorf("Agnes model = %+v", agnes)
+	}
+	if agnes.Thinking != nil {
+		t.Errorf("Agnes thinking = %+v, want nil", agnes.Thinking)
+	}
+}
+
+func TestMergeModelsPreservesPrimaryMetadataAndDeduplicates(t *testing.T) {
+	t.Parallel()
+	primary := []Model{{
+		ID:       "gpt-5.6-sol",
+		Label:    "GPT-5.6-Sol",
+		Provider: "openai",
+		Default:  true,
+		ServiceTiers: []ModelServiceTier{{
+			ID:   "fast",
+			Name: "Fast",
+		}},
+		Thinking: &ModelThinking{
+			SupportedLevels: []ThinkingLevel{{Value: "high", Label: "High"}},
+			DefaultLevel:    "high",
+		},
+	}}
+	additional := []Model{
+		{ID: "gpt-5.6-sol", Label: "duplicate"},
+		{ID: "agnes/agnes-2.0-flash", Label: "agnes/agnes-2.0-flash", Provider: "agnes"},
+	}
+
+	got := mergeModels(primary, additional)
+	if len(got) != 2 {
+		t.Fatalf("merged len = %d, want 2: %+v", len(got), got)
+	}
+	if !reflect.DeepEqual(got[0], primary[0]) {
+		t.Errorf("primary metadata changed: got %+v, want %+v", got[0], primary[0])
+	}
+	if got[1].ID != "agnes/agnes-2.0-flash" {
+		t.Errorf("additional model = %+v", got[1])
+	}
+}
+
+func TestOpenCodexModelCacheUsesLastSuccessfulCatalogOnRefreshFailure(t *testing.T) {
+	openCodexModelCacheMu.Lock()
+	previousModels := openCodexModelCache
+	previousExpiry := openCodexModelCacheExpiresAt
+	previousValid := openCodexModelCacheValid
+	openCodexModelCache = nil
+	openCodexModelCacheExpiresAt = time.Time{}
+	openCodexModelCacheValid = false
+	openCodexModelCacheMu.Unlock()
+	t.Cleanup(func() {
+		openCodexModelCacheMu.Lock()
+		openCodexModelCache = previousModels
+		openCodexModelCacheExpiresAt = previousExpiry
+		openCodexModelCacheValid = previousValid
+		openCodexModelCacheMu.Unlock()
+	})
+
+	initial := []Model{{
+		ID:       "opencode-zen/deepseek-v4-flash-free",
+		Label:    "opencode-zen/deepseek-v4-flash-free",
+		Provider: "opencode-zen",
+		ServiceTiers: []ModelServiceTier{{
+			ID:   "free",
+			Name: "Free",
+		}},
+		Thinking: &ModelThinking{
+			SupportedLevels: []ThinkingLevel{{Value: "high", Label: "High"}},
+		},
+	}}
+	got := cachedOpenCodexModels(func() ([]Model, error) {
+		return initial, nil
+	})
+	if !reflect.DeepEqual(got, initial) {
+		t.Fatalf("initial cache result = %+v, want %+v", got, initial)
+	}
+
+	// Mutating a caller-owned result must not corrupt the cached catalog.
+	got[0].ServiceTiers[0].Name = "mutated"
+	got[0].Thinking.SupportedLevels[0].Label = "mutated"
+	openCodexModelCacheMu.Lock()
+	openCodexModelCacheExpiresAt = time.Now().Add(-time.Second)
+	openCodexModelCacheMu.Unlock()
+
+	stale := cachedOpenCodexModels(func() ([]Model, error) {
+		return nil, errors.New("temporary OpenCodex failure")
+	})
+	if !reflect.DeepEqual(stale, initial) {
+		t.Fatalf("stale cache result = %+v, want %+v", stale, initial)
+	}
+}
 
 func TestStaticModelCatalogsHaveValidEntries(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What does this PR do?

Extends the Codex runtime model catalog with custom routes reported by a local OpenCodex installation.

Codex can already execute routed IDs such as `opencode-zen/deepseek-v4-flash-free`, but Multica only reads `codex debug models --bundled`. As a result, working custom routes are absent from the agent model picker. This change merges `ocx models --json` into the native Codex catalog without replacing or aliasing built-in model names.

The discovery is optional and fail-safe: hosts without OpenCodex continue to receive the normal Codex catalog.

## Related Issue

Closes #6769

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/models.go`
  - Merge `ocx models --json` routes into Codex discovery using their real `provider/model` IDs.
  - Project OpenCodex `reasoningEfforts` into Multica's existing thinking-level catalog.
  - Preserve native Codex default, thinking, and service-tier metadata while deduplicating IDs.
  - Search common user-local `ocx` paths for macOS GUI processes that do not inherit an interactive shell `PATH`.
  - Cache the last successful OpenCodex catalog and reuse it when a refresh fails.
  - Limit discovery to non-sensitive model metadata; no credential/config parsing or credential logging is added.
- `server/pkg/agent/models_test.go`
  - Cover OpenCodex JSON parsing, real IDs, reasoning efforts, deduplication, native metadata preservation, and stale-cache fallback with deep-copy isolation.

## How to Test

1. Configure OpenCodex so `ocx models --json` returns one or more routed models.
2. Start a Codex runtime in Multica and open the agent model picker.
3. Confirm the routed IDs appear unchanged and advertised reasoning levels are selectable.
4. Stop or temporarily hide `ocx`, refresh after cache expiry, and confirm the last successful custom catalog remains available.
5. Run:

   ```bash
   cd server
   go test ./...
   go build ./...
   ```

Local result: all server tests and the full server build pass.

## Thinking path

1. The execution path already forwards the selected model string to Codex, so the routed model itself does not require a new Multica runtime.
2. The picker is populated from `ListModels`, whose Codex branch only returns the bundled Codex catalog.
3. OpenCodex already exposes the required non-secret catalog through `ocx models --json`, including provider, model, and reasoning efforts.
4. Therefore the smallest compatible change is to append that catalog at discovery time, preserve Codex-owned metadata, and degrade silently when OpenCodex is unavailable.
5. A separate last-successful cache prevents transient proxy/network failures from making saved choices disappear, while the general Codex discovery cache continues to control normal refresh frequency.

## Risks

- OpenCodex is optional and its JSON schema may evolve. Malformed or unavailable output is ignored, leaving the native Codex catalog unchanged.
- Common-path lookup is intentionally limited to executable files under known user-local install directories.
- Custom model availability still depends on the user's local OpenCodex provider configuration and credentials; this change only exposes routes already configured on that machine.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

The user reported that OpenCodex-routed models work in Codex but are not selectable in Multica Desktop. Codex was used to inspect the latest upstream model-discovery implementation, isolate the change in a clean worktree, adapt the solution to the current `Catalog`/thinking/service-tier structures, add tests, and run the complete server test/build suite.

## Screenshots (optional)

No frontend code changes. The existing picker renders the additional backend catalog entries without a new UI component.
