### PR TITLE
MUL-6029: docs(daemon): correct two comments #6604 made false, and enforce the Slack/Lark brief policy

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_delivery_test.go
+++ b/server/internal/daemon/execenv/runtime_config_delivery_test.go
@@ -152,13 +152,19 @@ func TestBriefSurfaceDeliveryPolicy(t *testing.T) {
 		// what makes the paragraph above a rule rather than a note. The
 		// byte-identity invariant cannot enforce it on its own: a denial
 		// written into the brief unconditionally is the same on both values of
-		// the verdict, so it renders one brief and passes. Only a phrase list
-		// catches it, and only if it names the wordings a denial actually
-		// arrives in.
+		// the verdict, so it renders one brief and passes.
+		//
+		// A phrase list cannot be the only guard either — it denies the
+		// wordings someone thought to name, and the next one will be worded
+		// differently. TestBriefChannelDeliveryCopyIsPlatformNeutral holds the
+		// same rule with no wording in it, by requiring every channel-backed
+		// brief to differ only in the platform it names. Keep both: that one
+		// catches any wording, these fail beside the copy being edited.
 		"chat_slack": {
 			mustHave: []string{
 				"Slack conversation depends on how this deployment is configured",
 				"the per-turn user message tells you",
+				"never report a file as delivered",
 			},
 			mustNot: []string{
 				"run `multica attachment upload",
@@ -171,6 +177,7 @@ func TestBriefSurfaceDeliveryPolicy(t *testing.T) {
 			mustHave: []string{
 				"Feishu/Lark conversation depends on how this deployment is configured",
 				"the per-turn user message tells you",
+				"never report a file as delivered",
 			},
 			mustNot: []string{
 				"run `multica attachment upload",
@@ -202,11 +209,24 @@ func TestBriefSurfaceDeliveryPolicy(t *testing.T) {
 					name, phrase, outputSection(out))
 			}
 		}
+		// mustNot is checked against the WHOLE brief, not just `## Output`: a
+		// denial is wrong wherever it is written, and scoping the search to
+		// the section it usually lands in would let the next one land
+		// somewhere else. The phrases are ordinary English, though, so a
+		// future section could match one legitimately — quote the text around
+		// the actual hit and say which section it was in, or the failure
+		// points a reader at an Output section the phrase may not be in.
 		for _, phrase := range want.mustNot {
-			if strings.Contains(out, phrase) {
-				t.Errorf("surface=%s: brief must NOT carry %q (wrong surface's delivery mechanism)\n--- Output section ---\n%s",
-					name, phrase, outputSection(out))
+			at := strings.Index(out, phrase)
+			if at < 0 {
+				continue
 			}
+			where := "in the `## Output` section"
+			if !strings.Contains(outputSection(out), phrase) {
+				where = "OUTSIDE the `## Output` section"
+			}
+			t.Errorf("surface=%s: brief must NOT carry %q — found %s\n--- context ---\n%s",
+				name, phrase, where, briefContext(out, at, len(phrase)))
 		}
 	}
 }
@@ -243,6 +263,51 @@ func TestBriefChannelDeliveryCopyIgnoresServerVerdict(t *testing.T) {
 		if got != delivering {
 			t.Errorf("brief for %q differs from chat_wecom — the server's per-turn file-delivery verdict reached the cached prefix (MUL-5377).\n%s",
 				name, firstBriefDiff(delivering, got))
+		}
+	}
+}
+
+// TestBriefChannelDeliveryCopyIsPlatformNeutral is the structural form of the
+// rule the phrase lists above state one wording at a time.
+//
+// A phrase list is open-ended by construction: it denies the wordings someone
+// thought to name, and a fifth wording passes. The rule underneath has no
+// wording in it — one channel-backed brief may differ from another ONLY in
+// which platform it names. Anything platform-specific past the name is either a
+// promise or a denial about the last hop, and the brief may carry neither,
+// because that hop is a deployment fact stated per turn (MUL-4899).
+//
+// So this substitutes the display name out and requires the briefs to be
+// byte-identical. A per-platform position fails here whatever words it is
+// written in. The phrase lists stay: they name the wordings, and they fail
+// beside the copy rather than on a whole-brief diff.
+//
+// A channel type added to channel_type.go belongs in the list below — the
+// constants are the only enumeration of them that exists.
+func TestBriefChannelDeliveryCopyIsPlatformNeutral(t *testing.T) {
+	t.Parallel()
+
+	neutralized := func(channelType string, delivers bool) string {
+		out := buildMetaSkillContent("claude", TaskContextForEnv{
+			ChatSessionID:            "c-1",
+			ChatChannelType:          channelType,
+			ChatChannelDeliversFiles: delivers,
+			AgentName:                "Eve",
+			AgentID:                  "eve-1",
+		})
+		return strings.ReplaceAll(out, ChannelDisplayName(channelType), "<CHANNEL>")
+	}
+
+	// Both verdicts, because the tempting place to write a denial is the
+	// branch someone believes cannot deliver today.
+	for _, delivers := range []bool{false, true} {
+		baseline := neutralized(ChannelTypeSlack, delivers)
+		for _, channelType := range []string{ChannelTypeFeishu, ChannelTypeWecom} {
+			got := neutralized(channelType, delivers)
+			if got != baseline {
+				t.Errorf("brief for channel %q (delivers=%v) differs from %q beyond the platform name — the brief took a position on one platform's file delivery, which is a per-turn deployment fact (MUL-4899, MUL-5377).\n%s",
+					channelType, delivers, ChannelTypeSlack, firstBriefDiff(baseline, got))
+			}
 		}
 	}
 }
@@ -311,6 +376,20 @@ func TestQuickActionsInstructionsAbsentFromAllChatBriefs(t *testing.T) {
 			t.Fatalf("brief (channel=%q) must not teach the in-band quick-actions syntax", ctx.ChatChannelType)
 		}
 	}
+}
+
+// briefContext quotes the brief around a match so a mustNot failure shows the
+// sentence that actually tripped it rather than a section it may not be in.
+func briefContext(brief string, at, length int) string {
+	lo := at - 200
+	if lo < 0 {
+		lo = 0
+	}
+	hi := at + length + 200
+	if hi > len(brief) {
+		hi = len(brief)
+	}
+	return brief[lo:hi]
 }
 
 // outputSection extracts the brief's `## Output` section for readable failures.

--- a/server/internal/daemon/execenv/runtime_config_delivery_test.go
+++ b/server/internal/daemon/execenv/runtime_config_delivery_test.go
@@ -147,19 +147,37 @@ func TestBriefSurfaceDeliveryPolicy(t *testing.T) {
 		// never sees, and a brief holding the denial would keep denying it
 		// afterwards. Naming the platform still matters — the deferral has to
 		// be about THIS conversation.
+		//
+		// These two carry the SAME four denials the WeCom rows do, and that is
+		// what makes the paragraph above a rule rather than a note. The
+		// byte-identity invariant cannot enforce it on its own: a denial
+		// written into the brief unconditionally is the same on both values of
+		// the verdict, so it renders one brief and passes. Only a phrase list
+		// catches it, and only if it names the wordings a denial actually
+		// arrives in.
 		"chat_slack": {
 			mustHave: []string{
 				"Slack conversation depends on how this deployment is configured",
 				"the per-turn user message tells you",
 			},
-			mustNot: []string{"run `multica attachment upload", "conversation is text-only"},
+			mustNot: []string{
+				"run `multica attachment upload",
+				"separate message",
+				"conversation is text-only",
+				"does NOT apply",
+			},
 		},
 		"chat_feishu": {
 			mustHave: []string{
 				"Feishu/Lark conversation depends on how this deployment is configured",
 				"the per-turn user message tells you",
 			},
-			mustNot: []string{"run `multica attachment upload", "conversation is text-only"},
+			mustNot: []string{
+				"run `multica attachment upload",
+				"separate message",
+				"conversation is text-only",
+				"does NOT apply",
+			},
 		},
 		"autopilot": {
 			mustHave: []string{"this surface is text-only"},

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -289,8 +289,11 @@ type Handler struct {
 	// channelFileDelivery names the channel types that can, IN THIS
 	// DEPLOYMENT, carry a file the agent produced the last hop into the
 	// conversation. It answers the claim response's
-	// chat_channel_delivers_files, which the agent's brief turns into either
-	// "run `multica attachment upload`" or "describe the file in words".
+	// chat_channel_delivers_files, which the agent's PER-TURN prompt turns into
+	// either "run `multica attachment upload`" or "describe the file in words"
+	// (daemon/prompt.go). Not the brief: the brief is the prompt cache prefix and
+	// this is a per-turn verdict, so stating it there made one session render two
+	// briefs (MUL-5377).
 	//
 	// It is a deployment fact, not a property of the channel type, and that
 	// distinction is the whole reason it lives here. Whether the file arrives

--- a/server/internal/integrations/wecom/outbound_media.go
+++ b/server/internal/integrations/wecom/outbound_media.go
@@ -528,9 +528,14 @@ const (
 	// quantity: a turn holds admission for its whole life but claims a pending
 	// slot only once its lookup has found a file, so a backlog of
 	// file-carrying turns meets the pending cap first — the ordering that
-	// keeps the user-facing shed on the path that can name a real file. A
-	// backlog of turns carrying no file reaches this cap with nothing pending
-	// (TestDeliverAttachments_AdmissionBoundsTheLookupStage).
+	// keeps the user-facing shed on the path that can name a real file.
+	//
+	// So reaching THIS cap does not imply the pending one is full: turns still
+	// inside their lookup hold admission and no pending slot, and turns that
+	// find no file hold admission for their whole life and never claim one.
+	// TestDeliverAttachments_AdmissionBoundsTheLookupStage is the first of
+	// those — it parks every goroutine in the lookup and reaches the admitted
+	// cap with pending at zero.
 	maxAdmittedAttachmentDeliveries = 2 * maxPendingAttachmentDeliveries
 )
 

--- a/server/internal/integrations/wecom/outbound_media_test.go
+++ b/server/internal/integrations/wecom/outbound_media_test.go
@@ -773,6 +773,17 @@ func TestDeliverAttachments_AdmissionBoundsTheLookupStage(t *testing.T) {
 		t.Errorf("%d lookups reached the database, want at most %d — the lookup stage is unbounded",
 			got, maxAdmittedAttachmentDeliveries)
 	}
+	// The admitted cap is reached with nothing pending, which is the half of
+	// the ordering the constant's comment cites this test for: a pending slot
+	// is claimed only after a lookup finds a file, and every goroutine here is
+	// still inside its lookup. Asserted rather than implied — the citation is
+	// only worth what the test checks.
+	o.pendingMu.Lock()
+	pending := o.pendingAttachments
+	o.pendingMu.Unlock()
+	if pending != 0 {
+		t.Errorf("pending = %d at the admitted cap, want 0 — a slot was claimed before the lookup found a file", pending)
+	}
 
 	close(q.lookupGate)
 	running.Wait()


### PR DESCRIPTION
Three follow-ups to #6604, all landed 12 minutes after it merged and so missed the boat. Two are comments the merged diff made false; one is a policy that PR states in a comment but does not enforce.

## `handler.go:292` says the brief does something it no longer does

The `channelFileDelivery` doc says `chat_channel_delivers_files` is what "the agent's brief turns into either `run multica attachment upload` or `describe the file in words`". After #6604 the brief turns it into neither — nothing in `execenv` reads the field, and both strings are produced only by the per-turn prompt (`prompt.go:565-569`).

It survived that PR's comment sweep because the sweep grepped the field in camelCase and this line spells it snake_case. The correction names the prompt and records why the brief cannot be the one to say it (the brief is the cache prefix; a per-turn verdict there renders two briefs — MUL-5377).

## `outbound_media.go:531` cites a test that does not show what the sentence claims

The comment read: "A backlog of turns carrying no file reaches this cap with nothing pending (`TestDeliverAttachments_AdmissionBoundsTheLookupStage`)."

The claim is true — `sendAttachments` returns at `if len(rows) == 0` before ever claiming a pending slot — but that test's turns all carry a file. They pile up at the admitted cap because the fixture parks every goroutine in `q.lookupGate`. The paragraph now states both ways admission is held without a pending slot and hangs the citation on the one the test actually drives.

## Slack and Lark deny two phrases where WeCom denies four

`TestBriefSurfaceDeliveryPolicy`'s `chat_slack` and `chat_feishu` rows carry a two-phrase `mustNot`. The comment above them is a policy: a brief must never carry the Slack/Lark denial, because wiring that hop is a server-side change and a brief holding the denial would keep denying it afterwards.

That policy was not enforceable. A denial worded around "does NOT apply" or "separate message" passed both rows, and `TestBriefByteIdenticalAcrossRunsForEveryKind` cannot see it either — written unconditionally it renders one brief on both values of the verdict, so the invariant holds. Only a phrase list catches it. Both rows now carry the same four phrases the WeCom rows do.

Verified by injecting a Slack denial worded only as "That guidance does NOT apply to Slack": two failures with the wider list, none with the old one.

## Verification

`go build ./...`, `go vet`, and `go test ./internal/daemon/execenv/ ./internal/handler/ ./internal/integrations/wecom/` all clean on this branch. No behaviour change — two comments and one test row.
