### PR TITLE
MUL-6137: fix(daemon): preserve name-dispatching agent shims

### DIFF
--- a/server/internal/daemon/canonical_path.go
+++ b/server/internal/daemon/canonical_path.go
@@ -2,14 +2,52 @@
 
 package daemon
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 func canonicalPath(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
+// discoveredExecutablePath canonicalizes ordinary executable symlinks but
+// preserves entrypoints backed by a known name-dispatching shim. Volta's
+// volta-shim and Vite Plus's vp select the managed package from the invoked
+// name; spawning the final target directly turns `claude --version` into
+// `volta-shim --version` or `vp --version`, so the daemon reads the manager's
+// version instead of the agent's and drops the runtime (#6183, #6702).
+//
+// The entrypoint's parent is still canonicalized. This keeps paths stable when
+// their containing directory is a symlink or an ephemeral version-manager
+// prefix, while retaining the basename the dispatcher needs — the same
+// semantics buildLoginShellResolveScript has always applied via `pwd -P`.
 func discoveredExecutablePath(path string) string {
-	return canonicalExecutablePath(path)
+	real := canonicalExecutablePath(path)
+	if !isNameDispatchingAgentShim(real) {
+		return real
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return real
+	}
+	realDir, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return abs
+	}
+	return filepath.Join(realDir, filepath.Base(abs))
+}
+
+func isNameDispatchingAgentShim(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	// "vp" is intentionally admitted despite being a short, generic token:
+	// it is Vite Plus's shared dispatcher and, like Volta, selects the managed
+	// package from argv[0]. Keep this exact-match list limited to dispatchers
+	// confirmed to require the invoked entrypoint name. Do not strip executable
+	// extensions: these managers use wrappers or trampolines rather than
+	// name-dispatching symlinks, and that is a Windows shape this file never
+	// compiles for.
+	return base == "volta-shim" || base == "vp"
 }
 
 var executablePathForLaunch = executablePathForLaunchDefault

--- a/server/internal/daemon/canonical_path_test.go
+++ b/server/internal/daemon/canonical_path_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestIsNameDispatchingAgentShim_RequiresExactDispatcherName(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "Volta", path: filepath.Join("manager", "volta-shim"), want: true},
+		{name: "Vite Plus", path: filepath.Join("manager", "vp"), want: true},
+		{name: "case insensitive", path: filepath.Join("manager", "VP"), want: true},
+		{name: "short name prefix", path: filepath.Join("manager", "vpn"), want: false},
+		{name: "short name word", path: filepath.Join("manager", "vproxy"), want: false},
+		{name: "extension is not stripped", path: filepath.Join("manager", "volta-shim.exe"), want: false},
+		{name: "ordinary version target", path: filepath.Join("manager", "claude-2.1.216"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNameDispatchingAgentShim(tt.path); got != tt.want {
+				t.Fatalf("isNameDispatchingAgentShim(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -642,6 +642,9 @@ func shellArgsFromEnv(name string) ([]string, error) {
 // resolveAgentExecutablePath returns the executable entry point the daemon
 // should keep for an agent command. Bare command names are pinned to the path
 // resolved during startup so later PATH changes cannot redirect task launches.
+// Ordinary executables are pinned to their concrete target; entrypoints owned
+// by a name-dispatching shim keep the command name the manager needs to select
+// the right package (see discoveredExecutablePath).
 // On Windows this deliberately keeps the stable discovered junction path;
 // resolveAgentEntryWithHeal follows it for each launch so installer upgrades
 // that retarget a still-live junction take effect without a daemon restart.
@@ -843,8 +846,8 @@ var supportedLoginShells = map[string]struct{}{
 	"ksh":  {},
 }
 
-// resolveAgentsViaLoginShell asks the user's login shell to print the canonical
-// (symlink-resolved) absolute path to each name in `names`. It returns a map
+// resolveAgentsViaLoginShell asks the user's login shell to print an absolute,
+// invocation-safe path to each name in `names`. It returns a map
 // of name → path for whatever the shell could find, and an empty map if the
 // shell is unavailable / unsupported / times out / produces no usable output.
 //
@@ -945,7 +948,8 @@ var resolveAgentsViaLoginShell = func(names []string) map[string]string {
 //     still print the alias/function definition, and we'd rather drop it
 //     than hand back garbage),
 //  5. canonicalises the directory via `cd ... && pwd -P` so symlinked prefix
-//     dirs (fnm/nvm/volta) collapse to stable paths,
+//     dirs (fnm/nvm/volta) collapse to stable paths while the invoked command
+//     name is kept,
 //  6. if the resolved path lives in ~/.multica/hooks, searches the same
 //     shell-expanded PATH for the first executable outside that hooks dir,
 //  7. prints `<name>\t<canonical_path>` one entry per line for the caller.

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -15,6 +15,80 @@ import (
 	"github.com/multica-ai/multica/server/internal/cli"
 )
 
+func TestResolveAgentExecutablePath_PreservesDispatchShimName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	for _, shimName := range []string{"volta-shim", "vp"} {
+		t.Run(shimName, func(t *testing.T) {
+			managerDir := t.TempDir()
+			manager := filepath.Join(managerDir, shimName)
+			if err := os.WriteFile(manager, []byte("#!/bin/sh\nprintf '%s\\n' \"${0##*/}\"\n"), 0o755); err != nil {
+				t.Fatalf("write dispatcher: %v", err)
+			}
+
+			binDir := t.TempDir()
+			entrypoint := filepath.Join(binDir, "claude")
+			if err := os.Symlink(manager, entrypoint); err != nil {
+				t.Fatalf("symlink dispatcher: %v", err)
+			}
+			t.Setenv("PATH", binDir)
+
+			got, err := resolveAgentExecutablePath("claude")
+			if err != nil {
+				t.Fatalf("resolveAgentExecutablePath: %v", err)
+			}
+			realBinDir, err := filepath.EvalSymlinks(binDir)
+			if err != nil {
+				t.Fatalf("resolve bin directory: %v", err)
+			}
+			want := filepath.Join(realBinDir, "claude")
+			if got != want {
+				t.Fatalf("resolved path = %q, want command-preserving entrypoint %q", got, want)
+			}
+			output, err := exec.Command(got, "--version").CombinedOutput()
+			if err != nil {
+				t.Fatalf("run resolved entrypoint: %v: %s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != "claude" {
+				t.Fatalf("dispatcher observed command name %q, want claude", got)
+			}
+		})
+	}
+}
+
+func TestResolveAgentExecutablePath_CanonicalizesOrdinaryVersionTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	versionDir := t.TempDir()
+	target := filepath.Join(versionDir, "claude-2.1.216")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write versioned executable: %v", err)
+	}
+
+	binDir := t.TempDir()
+	entrypoint := filepath.Join(binDir, "claude")
+	if err := os.Symlink(target, entrypoint); err != nil {
+		t.Fatalf("symlink versioned executable: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	got, err := resolveAgentExecutablePath("claude")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(entrypoint)
+	if err != nil {
+		t.Fatalf("resolve versioned executable: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolved path = %q, want pinned version target %q", got, want)
+	}
+}
+
 func TestPatternsFromEnv_DefaultsWhenUnset(t *testing.T) {
 	t.Setenv("MULTICA_GC_ARTIFACT_PATTERNS", "")
 	defaults := []string{"node_modules", ".next", ".turbo"}


### PR DESCRIPTION
## What does this PR do?

Keeps the original agent command entrypoint when it resolves to a known name-dispatching shim (`volta-shim` or Vite Plus's `vp`). Those managers choose the managed package from the invoked command name, so spawning the fully resolved target changes `claude --version` into `volta-shim --version` / `vp --version` and prevents runtime registration.

Ordinary executable symlinks are still canonicalized to their concrete target, preserving the daemon's existing path-pinning and in-place-upgrade self-heal behavior. For dispatch shims, the parent directory is still canonicalized while the command basename is retained.

This also aligns the `exec.LookPath` discovery path with the existing login-shell fallback. `buildLoginShellResolveScript` already canonicalizes only the containing directory (`pwd -P`) and preserves the original executable basename, so it has always been safe for name-dispatching shims; this PR gives direct PATH discovery the same semantics.

### Thinking path

1. Runtime discovery is intentionally split into `exec.LookPath`, path canonicalization, then version detection.
2. Removing canonicalization wholesale would regress the anti-PATH-redirect guarantee and Homebrew/nvm/fnm upgrade recovery.
3. The failure is specific to managers whose final executable is a shared dispatcher and whose behavior depends on the invoked basename.
4. Therefore this change preserves only the two confirmed dispatcher targets and keeps the existing canonical path for every other executable.

## Related Issue

Closes #6183
Closes #6702

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added invocation-safe agent path canonicalization in `server/internal/daemon/config.go`.
- Preserved `claude`/`codex`-style entrypoint names for Volta and Vite Plus dispatchers.
- Added red/green regression coverage for both dispatcher names and a guard proving ordinary differently named version targets remain fully canonicalized.
- Kept one canonicalization implementation by delegating invocation-safe resolution to `canonicalExecutablePath`.
- Documented the exact-match `vp` admission and the managers' wrapper/trampoline behavior on Windows; executable extensions are intentionally not treated as Unix-style dispatch symlinks.
- Updated nearby resolver comments to document the invocation-name constraint.

## How to Test

1. Run `go test ./internal/daemon -run 'TestResolveAgentExecutablePath_' -count=1 -v`.
2. Run `go test -race ./internal/daemon -count=1`.
3. Run `go vet ./internal/daemon`.

The dispatcher test uses a test-created executable that prints its observed invocation basename. It proves the resolved path still invokes it as `claude`, while the ordinary-symlink test proves normal version targets remain pinned to their final path.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: daemon-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A: no user-facing contract; resolver comments updated)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks

- The preservation rule is deliberately limited to the exact confirmed Unix dispatcher basenames `volta-shim` and `vp`, so unrelated symlinks keep existing semantics. On Windows, Volta uses `.cmd` wrappers and Vite Plus uses trampoline executables, which preserve the tool identity without this symlink branch.
- Explicit `MULTICA_*_PATH` values still bypass canonicalization exactly as before.
- The hooks-directory exclusion now applies the same dispatcher-aware canonicalization to the real command it finds.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Scanned open issues and competing PRs, selected a high-impact unclaimed runtime-discovery bug, traced `exec.LookPath` through `filepath.EvalSymlinks` and version probing, wrote a failing fake-dispatcher regression test first, then implemented the narrow dispatcher-aware canonicalization and ran the daemon test suite with the race detector plus `go vet`.

## Screenshots (optional)

N/A — daemon-only change with no UI output.
