### PR TITLE
fix(execenv): make Windows text reads UTF-8 safe

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -127,9 +127,14 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 		kindQuickCreate: true, kindChat: true,
 	}
 	issueKinds := map[taskKind]bool{kindIssue: true}
+	windowsKinds := map[taskKind]bool{}
+	if runtimeGOOS == "windows" {
+		windowsKinds = allKinds
+	}
 	checks := []sectionCheck{
 		{"# Multica Agent Runtime", allKinds},
 		{"## Background Task Safety", allKinds},
+		{"## Windows Text Encoding", windowsKinds},
 		{"## Agent Identity", allKinds},
 		{"## Available Commands", allKinds},
 		{"## Issue Body Formatting", allKinds},

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -29,9 +29,9 @@ import (
 //     Issue Metadata, Sub-issue, ...).
 //  2. Per-section prose compression — Available Commands, Issue
 //     Body Formatting, Metadata, Mentions, Sub-issue Creation,
-//     Comment Formatting, Always Use CLI, Background Task Safety, Task Initiator,
-//     Repositories, Output are all tightened. Every test-asserted phrase
-//     stays.
+//     Comment Formatting, Windows Text Encoding, Always Use CLI, Background
+//     Task Safety, Task Initiator, Repositories, Output are all tightened.
+//     Every test-asserted phrase stays.
 //
 // Background Task Safety is emitted by `writeBackgroundTaskSafetySlim`
 // below.
@@ -100,6 +100,23 @@ func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("- A repo's merge requirements — \"CI must be green before merge\", required reviews, branch protection — are GitHub's merge gate, NOT your delivery acceptance criteria, and do not license a wait.\n")
 	b.WriteString("- The one exception: when the trigger comment or the issue's acceptance criteria explicitly ask you for the CI result, that result IS the deliverable — wait for it as ONE foreground blocking call (`gh pr checks <pr> --watch`) inside this same turn and report the outcome. Nothing else re-opens this door.\n")
 	b.WriteString("- Never end a turn with a \"standing by\" / \"I'll report back when X finishes\" message — that becomes your final output and the task ends.\n\n")
+}
+
+// writeWindowsTextEncoding prevents a Windows PowerShell 5.1 read-side
+// encoding failure. UTF-8 files without a BOM are decoded through the machine's
+// ANSI code page when Get-Content receives no explicit encoding; by the time
+// that output reaches the agent adapter it is already valid-but-corrupted
+// Unicode, and some bytes may already have been replaced with '?'. The runtime
+// brief is the earliest boundary Multica controls for every provider and task
+// kind, so keep the rule here rather than trying to reverse mojibake in the
+// daemon, database, or UI.
+func writeWindowsTextEncoding(b *strings.Builder) {
+	if runtimeGOOS != "windows" {
+		return
+	}
+
+	b.WriteString("## Windows Text Encoding\n\n")
+	b.WriteString("On Windows PowerShell 5.1, repository, Multica-managed, and agent-authored text files may be UTF-8 without a BOM. Never read them with bare `Get-Content`, `cat`, `gc`, or `type`: PowerShell can decode the bytes through the machine's ANSI code page and turn non-ASCII text into mojibake before it reaches the model or transcript. Use `Get-Content -LiteralPath <path> -Raw -Encoding UTF8`; when `Select-String` reads a file directly, pass `-Encoding UTF8` there too. `chcp 65001`, `$OutputEncoding`, and `[Console]::OutputEncoding` affect console and native-process I/O, not how PowerShell 5.1 decodes files.\n\n")
 }
 
 // writeAgentIdentity emits the Agent Identity heading and (optionally) the
@@ -686,6 +703,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 //	Section               | comment | assign | autopilot | quick_create | chat
 //	----------------------+---------+--------+-----------+--------------+------
 //	Available Commands    |   full  |  full  |   full    |   minimal    | full
+//	Windows Text Encoding |    △    |   △    |     △     |      △       |  △
 //	Issue Body Formatting |    ✓    |   ✓    |     ✓     |      ✓       |  ✓
 //	Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
 //	Repositories          |    △    |   △    |     △     |      —       |  △
@@ -697,10 +715,10 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 //	Mentions              |    ✓    |   ✓    |     —     |      —       |  —
 //	Attachments           |    ✓    |   ✓    |     —     |      —       |  —
 //
-// Always-on rows — Header, Background Task Safety, Agent Identity,
-// Requesting User, Task Initiator, Workspace Context, Connected Apps,
-// Workflow, Always Use CLI, Output — are shared by every kind and emitted
-// unconditionally (or gated by their own data preconditions).
+// Always-on rows — Header, Background Task Safety, Windows Text Encoding,
+// Agent Identity, Requesting User, Task Initiator, Workspace Context,
+// Connected Apps, Workflow, Always Use CLI, Output — are shared by every kind
+// and emitted unconditionally (or gated by their own data preconditions).
 func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	var b strings.Builder
 	kind := classifyTask(ctx)
@@ -711,6 +729,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	// the per-turn user message (daemon.BuildPrompt) instead. See MUL-5377.
 	writeHeader(&b)
 	writeBackgroundTaskSafetySlim(&b)
+	writeWindowsTextEncoding(&b)
 	writeAgentIdentity(&b, ctx)
 	writeRequestingUser(&b, ctx)
 	writeWorkspaceContext(&b, ctx)

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -11,6 +11,57 @@ import (
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
 )
 
+// Windows PowerShell 5.1 decodes UTF-8 files without a BOM through the
+// machine's ANSI code page unless the command names UTF-8 explicitly. Keep the
+// read-side guardrail in every Windows runtime brief, independent of provider
+// and task kind, so repository and agent-authored text cannot turn into
+// mojibake before it reaches the model or transcript.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestWindowsTextEncodingGuidanceAcrossTaskKindsAndProviders(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	providers := []string{"codex", "claude", "opencode"}
+	kinds := []struct {
+		name string
+		ctx  TaskContextForEnv
+	}{
+		{name: "issue", ctx: TaskContextForEnv{IssueID: "issue-1"}},
+		{name: "autopilot", ctx: TaskContextForEnv{AutopilotRunID: "run-1"}},
+		{name: "quick-create", ctx: TaskContextForEnv{QuickCreatePrompt: "create an issue"}},
+		{name: "chat", ctx: TaskContextForEnv{ChatSessionID: "chat-1"}},
+	}
+
+	runtimeGOOS = "windows"
+	for _, provider := range providers {
+		for _, kind := range kinds {
+			out := buildMetaSkillContent(provider, kind.ctx)
+			for _, want := range []string{
+				"## Windows Text Encoding",
+				"Get-Content -LiteralPath <path> -Raw -Encoding UTF8",
+				"bare `Get-Content`, `cat`, `gc`, or `type`",
+				"`chcp 65001`",
+				"`$OutputEncoding`",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("windows %s/%s brief missing %q\n---\n%s", provider, kind.name, want, out)
+				}
+			}
+		}
+	}
+
+	runtimeGOOS = "linux"
+	for _, provider := range providers {
+		for _, kind := range kinds {
+			out := buildMetaSkillContent(provider, kind.ctx)
+			if strings.Contains(out, "## Windows Text Encoding") {
+				t.Errorf("linux %s/%s brief contains Windows-only text encoding guidance", provider, kind.name)
+			}
+		}
+	}
+}
+
 // Sub-issue Creation section — after MUL-2538 the platform posts the
 // child-done parent notification itself, so the brief no longer carries
 // any parent-notification rule (per Bohan's call on PR #3055: delete the


### PR DESCRIPTION
﻿## Summary

- add Windows-only runtime guidance that requires explicit UTF-8 decoding for PowerShell 5.1 text reads
- apply the guidance across Codex, Claude, and OpenCode task kinds
- test Windows inclusion and non-Windows omission

## Root cause

Windows PowerShell 5.1 can decode UTF-8 files without a BOM through the machine ANSI code page when `Get-Content` has no explicit `-Encoding`. Chinese and other non-ASCII text is therefore corrupted before command output reaches the agent adapter or transcript. The UI and backend only pass that already-corrupted string through, so attempting to repair it there would be lossy and unreliable.

## Validation

- `go test ./internal/daemon/execenv -run 'WindowsTextEncoding|BuildMetaSkillContentSlimKindMatrix|RuntimeConfig|Brief|Section|SkillVisibility|QuickCreate' -count=1`
- `go vet ./internal/daemon/execenv`
- `git diff --check`

The full `go test ./internal/daemon/execenv -count=1` was also attempted on Windows. Existing tests with Unix permission, path, and filesystem assumptions fail independently of this change; the focused suite and vet pass.
