### PR TITLE
DP-575: make /health ping the DB as a hard dependency

### DIFF
--- a/server/cmd/server/health.go
+++ b/server/cmd/server/health.go
@@ -36,6 +36,7 @@ type serverHealth struct {
 	cacheTTL           time.Duration
 	refreshMu          sync.Mutex
 	cache              atomic.Pointer[cachedReadiness]
+	livenessCache      atomic.Pointer[cachedLiveness]
 }
 
 type cachedReadiness struct {
@@ -44,8 +45,24 @@ type cachedReadiness struct {
 	expiresAt  time.Time
 }
 
+type cachedLiveness struct {
+	response   liveResponse
+	statusCode int
+	expiresAt  time.Time
+}
+
 type liveResponse struct {
-	Status string `json:"status"`
+	Status string     `json:"status"`
+	Checks liveChecks `json:"checks"`
+}
+
+// liveChecks reports the liveness of individual hard dependencies. DB is the
+// only one: every request path needs postgres, so a dead DB means /health must
+// not report ok — otherwise orchestrators keep routing traffic to a node that
+// cannot serve (false-green). The field mirrors readinessChecks so /health and
+// /readyz share a consistent shape.
+type liveChecks struct {
+	DB string `json:"db"`
 }
 
 type readinessResponse struct {
@@ -68,8 +85,73 @@ func newServerHealth(pool *pgxpool.Pool) *serverHealth {
 	}
 }
 
-func (h *serverHealth) liveHandler(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, liveResponse{Status: "ok"})
+func (h *serverHealth) liveHandler(w http.ResponseWriter, r *http.Request) {
+	resp, status := h.liveness(r.Context())
+	writeJSON(w, status, resp)
+}
+
+// liveness evaluates /health. The database is a hard dependency: every
+// application request path needs postgres, so /health must surface DB failure
+// rather than returning an unconditional ok. A dead DB makes the node
+// un-routable, and a 200 here is the false-green the old static handler
+// produced — orchestrators kept sending traffic to a node that could not
+// serve. We reuse the same cached-readiness machinery as /readyz so a
+// postgres outage does not multiply into one live ping per request.
+func (h *serverHealth) liveness(parent context.Context) (liveResponse, int) {
+	// Cache so a postgres outage (or a healthy DB) is not re-checked on every
+	// hit; /health is polled frequently by orchestrators and probes.
+	now := time.Now()
+	if cached := h.loadCachedLiveness(now); cached != nil {
+		return cached.response, cached.statusCode
+	}
+
+	h.refreshMu.Lock()
+	defer h.refreshMu.Unlock()
+
+	now = time.Now()
+	if cached := h.loadCachedLiveness(now); cached != nil {
+		return cached.response, cached.statusCode
+	}
+
+	resp, status := h.computeLiveness(parent)
+	h.livenessCache.Store(&cachedLiveness{
+		response:   resp,
+		statusCode: status,
+		expiresAt:  now.Add(h.cacheTTL),
+	})
+	return resp, status
+}
+
+func (h *serverHealth) loadCachedLiveness(now time.Time) *cachedLiveness {
+	cached := h.livenessCache.Load()
+	if cached == nil || !now.Before(cached.expiresAt) {
+		return nil
+	}
+	return cached
+}
+
+func (h *serverHealth) computeLiveness(parent context.Context) (liveResponse, int) {
+	resp := liveResponse{
+		Status: "ok",
+		Checks: liveChecks{DB: "ok"},
+	}
+
+	if h.db == nil {
+		resp.Status = "error"
+		resp.Checks.DB = "error"
+		return resp, http.StatusServiceUnavailable
+	}
+
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+
+	if err := h.db.Ping(ctx); err != nil {
+		resp.Status = "error"
+		resp.Checks.DB = "error"
+		return resp, http.StatusServiceUnavailable
+	}
+
+	return resp, http.StatusOK
 }
 
 func (h *serverHealth) readyHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/cmd/server/health_test.go
+++ b/server/cmd/server/health_test.go
@@ -44,6 +44,110 @@ func (r stubRow) Scan(dest ...any) error {
 	return nil
 }
 
+func TestServerHealthLiveHandlerDBPingFailure(t *testing.T) {
+	// The old liveHandler returned an unconditional {"status":"ok"} 200 — a
+	// postgres outage was a false-green. /health must now ping the DB and
+	// report 503 so orchestrators stop routing traffic to an un-routable node.
+	db := &stubReadinessDB{pingErr: errors.New("db unavailable")}
+	h := &serverHealth{
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	h.liveHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var resp liveResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Fatalf("status = %q, want %q", resp.Status, "error")
+	}
+	if resp.Checks.DB != "error" {
+		t.Fatalf("db check = %q, want %q", resp.Checks.DB, "error")
+	}
+}
+
+func TestServerHealthLiveHandlerDBOK(t *testing.T) {
+	db := &stubReadinessDB{}
+	h := &serverHealth{
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	h.liveHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp liveResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q, want %q", resp.Status, "ok")
+	}
+	if resp.Checks.DB != "ok" {
+		t.Fatalf("db check = %q, want %q", resp.Checks.DB, "ok")
+	}
+}
+
+func TestServerHealthLiveHandlerNilDB(t *testing.T) {
+	// A nil pool (DB never configured) must not panic and must report 503
+	// rather than the old static ok.
+	h := &serverHealth{
+		db:                 nil,
+		requiredMigrations: []string{"056_example"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	h.liveHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var resp liveResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Checks.DB != "error" {
+		t.Fatalf("db check = %q, want %q", resp.Checks.DB, "error")
+	}
+}
+
+func TestServerHealthLivenessCachesResult(t *testing.T) {
+	db := &stubReadinessDB{}
+	h := &serverHealth{
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
+		cacheTTL:           time.Minute,
+	}
+
+	resp1, status1 := h.liveness(context.Background())
+	resp2, status2 := h.liveness(context.Background())
+
+	if status1 != http.StatusOK || status2 != http.StatusOK {
+		t.Fatalf("expected cached liveness status 200, got %d and %d", status1, status2)
+	}
+	if resp1.Status != "ok" || resp2.Status != "ok" {
+		t.Fatalf("expected cached liveness status ok, got %q and %q", resp1.Status, resp2.Status)
+	}
+	if got := db.pingCalls.Load(); got != 1 {
+		t.Fatalf("Ping calls = %d, want 1", got)
+	}
+}
+
 func TestServerHealthReadyHandlerDBPingFailure(t *testing.T) {
 	db := &stubReadinessDB{pingErr: errors.New("db unavailable")}
 	h := &serverHealth{


### PR DESCRIPTION
## Problem

The `/health` endpoint returned a static `{"status":"ok"}` 200 **unconditionally** — it never touched postgres. So `postgres-down` was a **false-green**: orchestrators and probes kept routing traffic to a node that could not serve any request.

`/readyz` and `/healthz` already enforced DB + migration checks, but `/health` (the liveness probe) bypassed them entirely.

## Fix

`liveHandler` now pings the DB (2s timeout) and returns **503** with `checks.db = "error"` on failure, mirroring the readiness contract `/readyz` already enforces:

```json
// healthy
{"status":"ok","checks":{"db":"ok"}}

// postgres down
{"status":"error","checks":{"db":"error"}}   // HTTP 503
```

Results are cached on the same TTL gate as readiness (`readinessCacheTTL`, 3s) so a postgres outage is not multiplied into one live ping per probe.

### Files
- `server/cmd/server/health.go` — `liveResponse` gains a `checks.db` field; new `liveness`/`computeLiveness`/`loadCachedLiveness` path with its own `livenessCache` (separate from the readiness cache so a liveness miss never serves a stale readiness entry and vice-versa). nil-DB is handled without panic.
- `server/cmd/server/health_test.go` — 4 new tests: DB-ping failure (503), DB ok (200), nil pool (503, no panic), and cache single-eval.

## Verification

```
go test ./cmd/server/ -run TestServerHealth -count=1 -v
```

All 8 health tests pass (4 new liveness + 4 existing readiness).

Ref: DP-575