### PR TITLE
feat(issues): preview an issue on mention hover

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -6,11 +6,11 @@ import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Issue, IssueProperty, Project, UpdateIssueRequest } from "@multica/core/types";
-import { stripChannelMediaMarkers } from "@multica/core/types";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { propertyListOptions } from "@multica/core/properties";
 import { CustomPropertyValueDisplay } from "./pickers/custom-property-picker";
+import { descriptionPreview } from "./description-preview";
 import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
 import { CalendarClock, CalendarDays } from "lucide-react";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -32,22 +32,6 @@ import { useT } from "../../i18n";
 
 function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
-}
-
-// Flatten description Markdown into the card's one-line preview. Channel-media
-// provenance is server-owned merge metadata, not authored content, so it is
-// stripped first: the image Markdown it annotates is removed a line below, and
-// without this the bare HTML comment survives every remaining pass and becomes
-// visible preview text. Exported for tests.
-export function descriptionPreview(markdown: string): string {
-  return stripChannelMediaMarkers(markdown)
-    .replace(/!file\[[^\]]*\]\([^)]*\)/g, "")
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/[*_`~]+/g, "")
-    .replace(/^[\s>#]+/gm, "")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 /** Stops event from bubbling to Link/drag handlers */

--- a/packages/views/issues/components/description-preview.test.ts
+++ b/packages/views/issues/components/description-preview.test.ts
@@ -25,4 +25,30 @@ describe("descriptionPreview", () => {
       descriptionPreview("# Title\n\n**bold** text and [a link](https://example.com)"),
     ).toBe("Title bold text and a link");
   });
+
+  // The editor serializes link brackets escaped. Without unescaping first, the
+  // link rule leaves the leading `\` untouched and captures the trailing one,
+  // so the preview reads `\repro script\`.
+  it("unwraps a link whose brackets the editor escaped", () => {
+    expect(descriptionPreview("See \\[repro script\\](https://example.com)")).toBe(
+      "See repro script",
+    );
+  });
+
+  it("still unwraps a link written without escapes", () => {
+    expect(descriptionPreview("See [repro script](https://example.com)")).toBe(
+      "See repro script",
+    );
+  });
+
+  it("drops the backslashes from escaped emphasis and punctuation", () => {
+    expect(descriptionPreview("it costs \\$5 \\*not\\* \\$10")).toBe("it costs $5 not $10");
+  });
+
+  // A backslash before a letter is not a Markdown escape, so prose keeps it.
+  it("leaves a literal backslash in prose alone", () => {
+    expect(descriptionPreview("open C:\\Users\\zain to continue")).toBe(
+      "open C:\\Users\\zain to continue",
+    );
+  });
 });

--- a/packages/views/issues/components/description-preview.test.ts
+++ b/packages/views/issues/components/description-preview.test.ts
@@ -41,6 +41,24 @@ describe("descriptionPreview", () => {
     );
   });
 
+  // The editor autolinks a raw URL inside a link label, producing a nested
+  // link destination like `([https://x](https://x))`. A destination pattern
+  // that stops at the first `)` leaves the outer paren stranded in the
+  // preview.
+  it("unwraps a link whose destination is itself a nested link", () => {
+    expect(
+      descriptionPreview(
+        "This is **very** flaky and needs a \\[repro script\\]([https://example.com](https://example.com)) before we fix it.",
+      ),
+    ).toBe("This is very flaky and needs a repro script before we fix it.");
+  });
+
+  it("unwraps a link whose destination legitimately contains parentheses", () => {
+    expect(
+      descriptionPreview("See [wiki](https://en.wikipedia.org/wiki/Foo_(bar)) for details"),
+    ).toBe("See wiki for details");
+  });
+
   it("drops the backslashes from escaped emphasis and punctuation", () => {
     expect(descriptionPreview("it costs \\$5 \\*not\\* \\$10")).toBe("it costs $5 not $10");
   });

--- a/packages/views/issues/components/description-preview.test.ts
+++ b/packages/views/issues/components/description-preview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { descriptionPreview } from "./board-card";
+import { descriptionPreview } from "./description-preview";
 
 const ATTACHMENT_ID = "0f8a1b2c-3d4e-4f50-9a6b-7c8d9e0f1a2b";
 const IMAGE = `![](/api/attachments/${ATTACHMENT_ID}/download)`;

--- a/packages/views/issues/components/description-preview.ts
+++ b/packages/views/issues/components/description-preview.ts
@@ -22,9 +22,15 @@ export function descriptionPreview(markdown: string): string {
       // punctuation. A backslash before anything else (a letter, a space) is a
       // literal backslash in prose and is left alone.
       .replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1")
-      .replace(/!file\[[^\]]*\]\([^)]*\)/g, "")
-      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      // The destination group tolerates one level of balanced parentheses,
+      // e.g. `(https://en.wikipedia.org/wiki/Foo_(bar))` or a nested link
+      // produced when a URL inside a link label gets autolinked, which
+      // serializes as `[label]([https://x](https://x))`. A naive `[^)]+`
+      // stops at the first `)` and leaves the outer one stranded in the
+      // preview text — do not simplify this back to `[^)]+`.
+      .replace(/!file\[[^\]]*\]\((?:[^()]|\([^()]*\))*\)/g, "")
+      .replace(/!\[[^\]]*\]\((?:[^()]|\([^()]*\))*\)/g, "")
+      .replace(/\[([^\]]+)\]\((?:[^()]|\([^()]*\))*\)/g, "$1")
       .replace(/[*_`~]+/g, "")
       .replace(/^[\s>#]+/gm, "")
       .replace(/\s+/g, " ")

--- a/packages/views/issues/components/description-preview.ts
+++ b/packages/views/issues/components/description-preview.ts
@@ -10,12 +10,24 @@ import { stripChannelMediaMarkers } from "@multica/core/types";
  * remaining pass and becomes visible preview text.
  */
 export function descriptionPreview(markdown: string): string {
-  return stripChannelMediaMarkers(markdown)
-    .replace(/!file\[[^\]]*\]\([^)]*\)/g, "")
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/[*_`~]+/g, "")
-    .replace(/^[\s>#]+/gm, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    stripChannelMediaMarkers(markdown)
+      // Backslash-escaped punctuation is unescaped first, and the order is
+      // load-bearing. The editor serializes a link as `\[label\](url)`, so the
+      // link rule below sees `\[label\]` and its `[^\]]+` capture swallows the
+      // trailing backslash while the leading one survives — the preview then
+      // reads `\label\`. Unescaping after any structural rule is too late,
+      // because the escapes are what stop those rules from matching.
+      // The character class is CommonMark's escapable set: all ASCII
+      // punctuation. A backslash before anything else (a letter, a space) is a
+      // literal backslash in prose and is left alone.
+      .replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1")
+      .replace(/!file\[[^\]]*\]\([^)]*\)/g, "")
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/[*_`~]+/g, "")
+      .replace(/^[\s>#]+/gm, "")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
 }

--- a/packages/views/issues/components/description-preview.ts
+++ b/packages/views/issues/components/description-preview.ts
@@ -1,0 +1,21 @@
+import { stripChannelMediaMarkers } from "@multica/core/types";
+
+/**
+ * Flatten description Markdown into a one-line plain-text preview. Shared by
+ * every surface that shows a description snippet next to an issue.
+ *
+ * Channel-media provenance is server-owned merge metadata, not authored
+ * content, so it is stripped first: the image Markdown it annotates is removed
+ * a line below, and without this the bare HTML comment survives every
+ * remaining pass and becomes visible preview text.
+ */
+export function descriptionPreview(markdown: string): string {
+  return stripChannelMediaMarkers(markdown)
+    .replace(/!file\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[*_`~]+/g, "")
+    .replace(/^[\s>#]+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -53,6 +53,12 @@ vi.mock("./status-icon", () => ({
   StatusIcon: () => <svg data-testid="status-icon" />,
 }));
 
+vi.mock("./priority-icon", () => ({
+  PriorityIcon: ({ priority }: { priority: string }) => (
+    <svg data-testid="priority-icon" data-priority={priority} />
+  ),
+}));
+
 const mockUseQuery = vi.mocked(useQuery);
 
 type Issue = {
@@ -60,6 +66,7 @@ type Issue = {
   identifier: string;
   title: string;
   status: string;
+  priority: string;
   description?: string | null;
   assignee_type?: string | null;
   assignee_id?: string | null;
@@ -70,6 +77,7 @@ const BASE_ISSUE: Issue = {
   identifier: "MUL-3405",
   title: "A very long issue title that the inline chip never shows",
   status: "todo",
+  priority: "none",
 };
 
 /**
@@ -139,6 +147,26 @@ describe("IssueHoverCard", () => {
       await screen.findByText("A very long issue title that the inline chip never shows"),
     ).toBeInTheDocument();
     expect(mockUseQuery).toHaveBeenCalled();
+  });
+
+  it("shows the priority glyph ahead of the status icon", async () => {
+    mockQueries({ ...BASE_ISSUE, priority: "high" });
+
+    await openCard();
+
+    const priority = screen.getByTestId("priority-icon");
+    expect(priority).toHaveAttribute("data-priority", "high");
+    // Ordering: priority leads the header, the status icon follows it.
+    expect(priority.nextElementSibling).toBe(screen.getByTestId("status-icon"));
+  });
+
+  it("omits the priority glyph when the issue has no priority", async () => {
+    mockQueries({ ...BASE_ISSUE, priority: "none" });
+
+    await openCard();
+
+    expect(screen.getByTestId("status-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("priority-icon")).not.toBeInTheDocument();
   });
 
   it("shows the assignee avatar and name, without nesting another hover card", async () => {

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -46,8 +46,13 @@ vi.mock("../../common/actor-avatar", () => ({
   ),
 }));
 
+// A spy, not a stub: `useActorName` subscribes to the workspace member list,
+// so "was this hook mounted at all" is the assertion that keeps the assignee
+// row from being inlined back into the card body.
+const mockUseActorName = vi.hoisted(() => vi.fn(() => ({ getActorName: () => "zain" })));
+
 vi.mock("@multica/core/workspace/hooks", () => ({
-  useActorName: () => ({ getActorName: () => "zain" }),
+  useActorName: mockUseActorName,
 }));
 
 vi.mock("./status-icon", () => ({
@@ -157,6 +162,7 @@ function paragraphCount(): number {
 describe("IssueHoverCard", () => {
   beforeEach(() => {
     mockUseQuery.mockReset();
+    mockUseActorName.mockClear();
     mockIssue(BASE_ISSUE);
   });
 
@@ -231,6 +237,7 @@ describe("IssueHoverCard", () => {
     expect(avatar).toHaveAttribute("data-hover-card", "false");
     expect(avatar).toHaveAttribute("data-profile-link", "false");
     expect(screen.getByText("zain")).toBeInTheDocument();
+    expect(mockUseActorName).toHaveBeenCalled();
   });
 
   it("omits the assignee when the issue is unassigned", async () => {
@@ -240,6 +247,8 @@ describe("IssueHoverCard", () => {
 
     expect(screen.queryByTestId("actor-avatar")).not.toBeInTheDocument();
     expect(screen.queryByText("zain")).not.toBeInTheDocument();
+    // The member directory stays unfetched: the row that reads it never mounts.
+    expect(mockUseActorName).not.toHaveBeenCalled();
   });
 
   it("shows sub-issue progress when the workspace map has an entry", async () => {

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+import { IssueHoverCard } from "./issue-hover-card";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/issues/queries", () => ({
+  issueDetailOptions: (_workspaceId: string, issueId: string) => ({
+    queryKey: ["issue", issueId],
+  }),
+  childIssueProgressOptions: (workspaceId: string) => ({
+    queryKey: ["child-progress", workspaceId],
+  }),
+}));
+
+// The real ActorAvatar pulls in navigation, presence, and four profile cards.
+// The card only needs to know it rendered for the right actor.
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: ({
+    actorType,
+    actorId,
+    enableHoverCard,
+    profileLink,
+  }: {
+    actorType: string;
+    actorId: string;
+    enableHoverCard?: boolean;
+    profileLink?: boolean;
+  }) => (
+    <span
+      data-testid="actor-avatar"
+      data-actor-type={actorType}
+      data-actor-id={actorId}
+      data-hover-card={String(enableHoverCard)}
+      data-profile-link={String(profileLink)}
+    />
+  ),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "zain" }),
+}));
+
+vi.mock("./status-icon", () => ({
+  StatusIcon: () => <svg data-testid="status-icon" />,
+}));
+
+const mockUseQuery = vi.mocked(useQuery);
+
+type Issue = {
+  id: string;
+  identifier: string;
+  title: string;
+  status: string;
+  description?: string | null;
+  assignee_type?: string | null;
+  assignee_id?: string | null;
+};
+
+const BASE_ISSUE: Issue = {
+  id: "issue-1",
+  identifier: "MUL-3405",
+  title: "A very long issue title that the inline chip never shows",
+  status: "todo",
+};
+
+/**
+ * Routes each query the card body makes to its own fixture, keyed by the first
+ * segment of the query key the mocked options factories produce.
+ */
+function mockQueries(
+  issue: Issue | undefined,
+  progress?: Map<string, { done: number; total: number }>,
+): void {
+  mockUseQuery.mockImplementation((options: unknown) => {
+    const [key] = (options as { queryKey: string[] }).queryKey;
+    if (key === "issue") return { data: issue } as ReturnType<typeof useQuery>;
+    if (key === "child-progress") return { data: progress } as ReturnType<typeof useQuery>;
+    throw new Error(`Unexpected query key: ${String(key)}`);
+  });
+}
+
+async function openCard(): Promise<void> {
+  const user = userEvent.setup();
+  render(
+    <IssueHoverCard issueId="issue-1" delay={0}>
+      <span>MUL-3405</span>
+    </IssueHoverCard>,
+  );
+  await user.hover(screen.getByText("MUL-3405"));
+  await screen.findByTestId("status-icon");
+}
+
+/** Paragraphs inside the open card: the title, plus the snippet when shown. */
+function paragraphCount(): number {
+  const title = screen.getByText(BASE_ISSUE.title);
+  return title.parentElement?.querySelectorAll("p").length ?? 0;
+}
+
+describe("IssueHoverCard", () => {
+  beforeEach(() => {
+    mockUseQuery.mockReset();
+    mockQueries(BASE_ISSUE);
+  });
+
+  it("does not fetch issue detail until the card opens", () => {
+    render(
+      <IssueHoverCard issueId="issue-1" delay={0}>
+        <span>MUL-3405</span>
+      </IssueHoverCard>,
+    );
+
+    // Assert the trigger actually rendered BEFORE asserting the absent fetch.
+    // Without this, a component that throws or renders nothing would satisfy
+    // the deferred-fetch assertion and the guarantee would be untested.
+    expect(screen.getByText("MUL-3405")).toBeInTheDocument();
+    expect(mockUseQuery).not.toHaveBeenCalled();
+  });
+
+  it("reveals the full title on hover", async () => {
+    const user = userEvent.setup();
+    render(
+      <IssueHoverCard issueId="issue-1" delay={0}>
+        <span>MUL-3405</span>
+      </IssueHoverCard>,
+    );
+
+    await user.hover(screen.getByText("MUL-3405"));
+
+    expect(
+      await screen.findByText("A very long issue title that the inline chip never shows"),
+    ).toBeInTheDocument();
+    expect(mockUseQuery).toHaveBeenCalled();
+  });
+
+  it("shows the assignee avatar and name, without nesting another hover card", async () => {
+    mockQueries({ ...BASE_ISSUE, assignee_type: "member", assignee_id: "user-9" });
+
+    await openCard();
+
+    const avatar = screen.getByTestId("actor-avatar");
+    expect(avatar).toHaveAttribute("data-actor-type", "member");
+    expect(avatar).toHaveAttribute("data-actor-id", "user-9");
+    expect(avatar).toHaveAttribute("data-hover-card", "false");
+    expect(avatar).toHaveAttribute("data-profile-link", "false");
+    expect(screen.getByText("zain")).toBeInTheDocument();
+  });
+
+  it("omits the assignee when the issue is unassigned", async () => {
+    mockQueries({ ...BASE_ISSUE, assignee_type: null, assignee_id: null });
+
+    await openCard();
+
+    expect(screen.queryByTestId("actor-avatar")).not.toBeInTheDocument();
+    expect(screen.queryByText("zain")).not.toBeInTheDocument();
+  });
+
+  it("shows sub-issue progress when the workspace map has an entry", async () => {
+    mockQueries(BASE_ISSUE, new Map([["issue-1", { done: 2, total: 5 }]]));
+
+    await openCard();
+
+    expect(screen.getByText("2/5")).toBeInTheDocument();
+  });
+
+  it("omits progress when the issue has no children", async () => {
+    mockQueries(BASE_ISSUE, new Map([["other-issue", { done: 1, total: 3 }]]));
+
+    await openCard();
+
+    expect(screen.queryByText(/\d+\/\d+/)).not.toBeInTheDocument();
+  });
+
+  it("omits progress when the issue has an entry with no children counted", async () => {
+    mockQueries(BASE_ISSUE, new Map([["issue-1", { done: 0, total: 0 }]]));
+
+    await openCard();
+
+    expect(screen.queryByText(/\d+\/\d+/)).not.toBeInTheDocument();
+  });
+
+  it("shows a flattened description snippet clamped to two lines", async () => {
+    mockQueries({
+      ...BASE_ISSUE,
+      description: "**Set up** your first runtime so [Mika](/agents/mika) can pick up work",
+    });
+
+    await openCard();
+
+    const snippet = screen.getByText("Set up your first runtime so Mika can pick up work");
+    expect(snippet).toHaveClass("line-clamp-2");
+  });
+
+  // Both no-description cases count paragraphs rather than probing for absent
+  // text: an always-rendered block would emit an empty <p>, which no text query
+  // can see. The title is the only paragraph a description-less card may have.
+  it("omits the description block when there is no description", async () => {
+    mockQueries({ ...BASE_ISSUE, description: null });
+
+    await openCard();
+
+    expect(screen.getByText(BASE_ISSUE.title)).toBeInTheDocument();
+    expect(paragraphCount()).toBe(1);
+  });
+
+  it("omits the description block when the description flattens to nothing", async () => {
+    // An image-only description: every visible token is stripped by the
+    // preview, so rendering it would leave an empty paragraph.
+    mockQueries({
+      ...BASE_ISSUE,
+      description: "![](/api/attachments/abc/download)",
+    });
+
+    await openCard();
+
+    expect(screen.getByText(BASE_ISSUE.title)).toBeInTheDocument();
+    expect(paragraphCount()).toBe(1);
+  });
+});

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -189,8 +189,26 @@ describe("IssueHoverCard", () => {
 
     const priority = screen.getByTestId("priority-icon");
     expect(priority).toHaveAttribute("data-priority", "high");
-    // Ordering: priority leads the header, the status icon follows it.
-    expect(priority.nextElementSibling).toBe(screen.getByTestId("status-icon"));
+    // Ordering: priority leads the header, the status icon follows it. Both
+    // glyphs sit inside their own naming wrapper, so compare the wrappers.
+    expect(priority.parentElement?.nextElementSibling).toContainElement(
+      screen.getByTestId("status-icon"),
+    );
+  });
+
+  it("names the status and priority glyphs for assistive tech", async () => {
+    mockIssue({ ...BASE_ISSUE, status: "in_progress", priority: "high" });
+
+    await openCard();
+
+    // Localized names from the shipped issues namespace — no key of this
+    // card's own. Removing either aria-label drops the element from the query.
+    expect(screen.getByLabelText("In Progress")).toContainElement(
+      screen.getByTestId("status-icon"),
+    );
+    expect(screen.getByLabelText("High")).toContainElement(
+      screen.getByTestId("priority-icon"),
+    );
   });
 
   it("omits the priority glyph when the issue has no priority", async () => {

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { useQuery } from "@tanstack/react-query";
+import { renderWithI18n } from "../../test/i18n";
 import { IssueHoverCard } from "./issue-hover-card";
 
 vi.mock("@tanstack/react-query", () => ({
@@ -80,31 +81,71 @@ const BASE_ISSUE: Issue = {
   priority: "none",
 };
 
+const NOT_FOUND_TEXT = "This issue does not exist or has been deleted in this workspace.";
+
+/** The three query states the card body branches on, as react-query reports them. */
+type DetailState =
+  | { phase: "pending" }
+  | { phase: "error" }
+  | { phase: "success"; issue: Issue | undefined };
+
 /**
  * Routes each query the card body makes to its own fixture, keyed by the first
- * segment of the query key the mocked options factories produce.
+ * segment of the query key the mocked options factories produce. The detail
+ * fixture carries `isPending`/`isError` explicitly because the body branches on
+ * them, not on `data` alone.
  */
 function mockQueries(
-  issue: Issue | undefined,
+  detail: DetailState,
   progress?: Map<string, { done: number; total: number }>,
 ): void {
   mockUseQuery.mockImplementation((options: unknown) => {
     const [key] = (options as { queryKey: string[] }).queryKey;
-    if (key === "issue") return { data: issue } as ReturnType<typeof useQuery>;
-    if (key === "child-progress") return { data: progress } as ReturnType<typeof useQuery>;
+    if (key === "issue") {
+      return {
+        data: detail.phase === "success" ? detail.issue : undefined,
+        isPending: detail.phase === "pending",
+        isError: detail.phase === "error",
+      } as unknown as ReturnType<typeof useQuery>;
+    }
+    if (key === "child-progress") {
+      return { data: progress, isPending: false, isError: false } as unknown as ReturnType<
+        typeof useQuery
+      >;
+    }
     throw new Error(`Unexpected query key: ${String(key)}`);
   });
 }
 
-async function openCard(): Promise<void> {
-  const user = userEvent.setup();
-  render(
-    <IssueHoverCard issueId="issue-1" delay={0}>
+/** Shorthand for the common case: the detail query settled with an issue. */
+function mockIssue(
+  issue: Issue,
+  progress?: Map<string, { done: number; total: number }>,
+): void {
+  mockQueries({ phase: "success", issue }, progress);
+}
+
+function renderCard(fallbackLabel?: string): void {
+  renderWithI18n(
+    <IssueHoverCard issueId="issue-1" delay={0} fallbackLabel={fallbackLabel}>
       <span>MUL-3405</span>
     </IssueHoverCard>,
   );
+}
+
+async function openCard(): Promise<void> {
+  const user = userEvent.setup();
+  renderCard();
   await user.hover(screen.getByText("MUL-3405"));
   await screen.findByTestId("status-icon");
+}
+
+/** Opens a card whose detail query never resolves into an issue. */
+async function openFailedCard(fallbackLabel = "MUL-7"): Promise<void> {
+  const user = userEvent.setup();
+  renderCard(fallbackLabel);
+  await user.hover(screen.getByText("MUL-3405"));
+  await screen.findByText(NOT_FOUND_TEXT);
 }
 
 /** Paragraphs inside the open card: the title, plus the snippet when shown. */
@@ -116,15 +157,11 @@ function paragraphCount(): number {
 describe("IssueHoverCard", () => {
   beforeEach(() => {
     mockUseQuery.mockReset();
-    mockQueries(BASE_ISSUE);
+    mockIssue(BASE_ISSUE);
   });
 
   it("does not fetch issue detail until the card opens", () => {
-    render(
-      <IssueHoverCard issueId="issue-1" delay={0}>
-        <span>MUL-3405</span>
-      </IssueHoverCard>,
-    );
+    renderCard();
 
     // Assert the trigger actually rendered BEFORE asserting the absent fetch.
     // Without this, a component that throws or renders nothing would satisfy
@@ -135,11 +172,7 @@ describe("IssueHoverCard", () => {
 
   it("reveals the full title on hover", async () => {
     const user = userEvent.setup();
-    render(
-      <IssueHoverCard issueId="issue-1" delay={0}>
-        <span>MUL-3405</span>
-      </IssueHoverCard>,
-    );
+    renderCard();
 
     await user.hover(screen.getByText("MUL-3405"));
 
@@ -150,7 +183,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("shows the priority glyph ahead of the status icon", async () => {
-    mockQueries({ ...BASE_ISSUE, priority: "high" });
+    mockIssue({ ...BASE_ISSUE, priority: "high" });
 
     await openCard();
 
@@ -161,7 +194,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("omits the priority glyph when the issue has no priority", async () => {
-    mockQueries({ ...BASE_ISSUE, priority: "none" });
+    mockIssue({ ...BASE_ISSUE, priority: "none" });
 
     await openCard();
 
@@ -170,7 +203,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("shows the assignee avatar and name, without nesting another hover card", async () => {
-    mockQueries({ ...BASE_ISSUE, assignee_type: "member", assignee_id: "user-9" });
+    mockIssue({ ...BASE_ISSUE, assignee_type: "member", assignee_id: "user-9" });
 
     await openCard();
 
@@ -183,7 +216,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("omits the assignee when the issue is unassigned", async () => {
-    mockQueries({ ...BASE_ISSUE, assignee_type: null, assignee_id: null });
+    mockIssue({ ...BASE_ISSUE, assignee_type: null, assignee_id: null });
 
     await openCard();
 
@@ -192,7 +225,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("shows sub-issue progress when the workspace map has an entry", async () => {
-    mockQueries(BASE_ISSUE, new Map([["issue-1", { done: 2, total: 5 }]]));
+    mockIssue(BASE_ISSUE, new Map([["issue-1", { done: 2, total: 5 }]]));
 
     await openCard();
 
@@ -200,7 +233,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("omits progress when the issue has no children", async () => {
-    mockQueries(BASE_ISSUE, new Map([["other-issue", { done: 1, total: 3 }]]));
+    mockIssue(BASE_ISSUE, new Map([["other-issue", { done: 1, total: 3 }]]));
 
     await openCard();
 
@@ -208,7 +241,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("omits progress when the issue has an entry with no children counted", async () => {
-    mockQueries(BASE_ISSUE, new Map([["issue-1", { done: 0, total: 0 }]]));
+    mockIssue(BASE_ISSUE, new Map([["issue-1", { done: 0, total: 0 }]]));
 
     await openCard();
 
@@ -216,7 +249,7 @@ describe("IssueHoverCard", () => {
   });
 
   it("shows a flattened description snippet clamped to two lines", async () => {
-    mockQueries({
+    mockIssue({
       ...BASE_ISSUE,
       description: "**Set up** your first runtime so [Mika](/agents/mika) can pick up work",
     });
@@ -231,7 +264,7 @@ describe("IssueHoverCard", () => {
   // text: an always-rendered block would emit an empty <p>, which no text query
   // can see. The title is the only paragraph a description-less card may have.
   it("omits the description block when there is no description", async () => {
-    mockQueries({ ...BASE_ISSUE, description: null });
+    mockIssue({ ...BASE_ISSUE, description: null });
 
     await openCard();
 
@@ -242,7 +275,7 @@ describe("IssueHoverCard", () => {
   it("omits the description block when the description flattens to nothing", async () => {
     // An image-only description: every visible token is stripped by the
     // preview, so rendering it would leave an empty paragraph.
-    mockQueries({
+    mockIssue({
       ...BASE_ISSUE,
       description: "![](/api/attachments/abc/download)",
     });
@@ -251,5 +284,34 @@ describe("IssueHoverCard", () => {
 
     expect(screen.getByText(BASE_ISSUE.title)).toBeInTheDocument();
     expect(paragraphCount()).toBe(1);
+  });
+
+  it("keeps the skeleton while the detail query is pending", async () => {
+    mockQueries({ phase: "pending" });
+    const user = userEvent.setup();
+    renderCard("MUL-7");
+
+    await user.hover(screen.getByText("MUL-3405"));
+
+    expect(await screen.findByTestId("issue-hover-card-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText(NOT_FOUND_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("replaces the skeleton with the not-found state when the detail query fails", async () => {
+    mockQueries({ phase: "error" });
+
+    await openFailedCard();
+
+    expect(screen.queryByTestId("issue-hover-card-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("MUL-7")).toBeInTheDocument();
+  });
+
+  it("replaces the skeleton with the not-found state when the query settles with no issue", async () => {
+    mockQueries({ phase: "success", issue: undefined });
+
+    await openFailedCard();
+
+    expect(screen.queryByTestId("issue-hover-card-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("MUL-7")).toBeInTheDocument();
   });
 });

--- a/packages/views/issues/components/issue-hover-card.test.tsx
+++ b/packages/views/issues/components/issue-hover-card.test.tsx
@@ -304,6 +304,17 @@ describe("IssueHoverCard", () => {
     expect(paragraphCount()).toBe(1);
   });
 
+  it("breaks a long unbroken title instead of overflowing the card", async () => {
+    const title = "https://example.com/a/very/long/path/that/never/offers/a/break/opportunity";
+    mockIssue({ ...BASE_ISSUE, title });
+
+    await openCard();
+
+    const titleEl = screen.getByText(title);
+    expect(titleEl).toHaveClass("break-words");
+    expect(titleEl).not.toHaveClass("truncate");
+  });
+
   it("keeps the skeleton while the detail query is pending", async () => {
     mockQueries({ phase: "pending" });
     const user = userEvent.setup();

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -74,6 +74,41 @@ export function IssueHoverCard({
   );
 }
 
+/**
+ * Assignee row of the card.
+ *
+ * Its own component so `useActorName` — which subscribes to the workspace
+ * member list, a query nothing else on this path warms — mounts only for cards
+ * that actually have an assignee to name. Inlining it back into the body would
+ * make the first hover on any mention pull the member directory.
+ */
+function IssueHoverCardAssignee({
+  actorType,
+  actorId,
+}: {
+  actorType: string;
+  actorId: string;
+}) {
+  const { getActorName } = useActorName();
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {/* This is already a hover card, and the agent live-peek variant would
+          fire its own request — so no nested card, no link. */}
+      <ActorAvatar
+        actorType={actorType}
+        actorId={actorId}
+        size="sm"
+        enableHoverCard={false}
+        profileLink={false}
+        className="shrink-0"
+      />
+      <span className="min-w-0 truncate text-caption text-foreground">
+        {getActorName(actorType, actorId)}
+      </span>
+    </span>
+  );
+}
+
 function IssueHoverCardBody({
   issueId,
   fallbackLabel,
@@ -87,7 +122,6 @@ function IssueHoverCardBody({
   // detail, not a per-issue children fetch: opening a card reuses the cache.
   const { data: childProgress } = useQuery(childIssueProgressOptions(wsId));
   const { t } = useT("issues");
-  const { getActorName } = useActorName();
 
   // A skeleton rather than localized loading text: only the pending phase gets
   // it, so a settled query never animates forever.
@@ -168,21 +202,7 @@ function IssueHoverCardBody({
       {(hasAssignee || hasProgress) && (
         <div className="mt-1 flex items-center justify-between gap-3">
           {hasAssignee ? (
-            <span className="flex min-w-0 items-center gap-1.5">
-              {/* This is already a hover card, and the agent live-peek variant
-                  would fire its own request — so no nested card, no link. */}
-              <ActorAvatar
-                actorType={assigneeType}
-                actorId={assigneeId}
-                size="sm"
-                enableHoverCard={false}
-                profileLink={false}
-                className="shrink-0"
-              />
-              <span className="min-w-0 truncate text-caption text-foreground">
-                {getActorName(assigneeType, assigneeId)}
-              </span>
-            </span>
+            <IssueHoverCardAssignee actorType={assigneeType} actorId={assigneeId} />
           ) : (
             <span />
           )}

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -11,6 +11,7 @@ import {
   HoverCardContent,
 } from "@multica/ui/components/ui/hover-card";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { useT } from "../../i18n";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { descriptionPreview } from "./description-preview";
 import { PriorityIcon } from "./priority-icon";
@@ -20,6 +21,12 @@ import { StatusIcon } from "./status-icon";
 interface IssueHoverCardProps {
   issueId: string;
   children: ReactNode;
+  /**
+   * Identifier to name the issue with when the detail fetch fails (e.g.
+   * "MUL-7"). The same label the chip degrades to, so a card that cannot load
+   * still says which issue it is about.
+   */
+  fallbackLabel?: string;
   /**
    * Open delay override, in milliseconds. Exists for tests only — production
    * passes nothing, so the card uses Base UI's default of 600ms. Tests pass 0
@@ -47,7 +54,12 @@ interface IssueHoverCardProps {
  * would fire one per mention on render. (The chip inside the trigger has its
  * own unresolved-issue fetch; that is independent of this.)
  */
-export function IssueHoverCard({ issueId, children, delay }: IssueHoverCardProps) {
+export function IssueHoverCard({
+  issueId,
+  children,
+  fallbackLabel,
+  delay,
+}: IssueHoverCardProps) {
   return (
     <HoverCard>
       {/* Rendered as a span, not the trigger's default anchor: the children are
@@ -56,29 +68,55 @@ export function IssueHoverCard({ issueId, children, delay }: IssueHoverCardProps
         {children}
       </HoverCardTrigger>
       <HoverCardContent align="start" className="w-auto min-w-56 max-w-80">
-        <IssueHoverCardBody issueId={issueId} />
+        <IssueHoverCardBody issueId={issueId} fallbackLabel={fallbackLabel} />
       </HoverCardContent>
     </HoverCard>
   );
 }
 
-function IssueHoverCardBody({ issueId }: { issueId: string }) {
+function IssueHoverCardBody({
+  issueId,
+  fallbackLabel,
+}: {
+  issueId: string;
+  fallbackLabel?: string;
+}) {
   const wsId = useWorkspaceId();
-  const { data: issue } = useQuery(issueDetailOptions(wsId, issueId));
+  const detail = useQuery(issueDetailOptions(wsId, issueId));
   // One workspace-wide progress snapshot shared with the issues list and issue
   // detail, not a per-issue children fetch: opening a card reuses the cache.
   const { data: childProgress } = useQuery(childIssueProgressOptions(wsId));
+  const { t } = useT("issues");
   const { getActorName } = useActorName();
 
-  // A skeleton rather than localized loading text — the card carries no copy of
-  // its own, so it needs no translation keys.
-  if (!issue) {
+  // A skeleton rather than localized loading text: only the pending phase gets
+  // it, so a settled query never animates forever.
+  if (detail.isPending) {
     return (
-      <div className="flex flex-col gap-1.5">
+      <div data-testid="issue-hover-card-skeleton" className="flex flex-col gap-1.5">
         <Skeleton className="h-3 w-20" />
         <Skeleton className="h-4 w-48" />
         <Skeleton className="mt-1.5 h-3 w-44" />
         <Skeleton className="mt-1.5 h-4 w-24" />
+      </div>
+    );
+  }
+
+  const issue = detail.data;
+
+  // Terminal state for every way the detail can fail to arrive: an error after
+  // retries, a deleted issue, or a mention the viewer cannot read. Named with
+  // the identifier the way the chip degrades, so the card still says which
+  // issue it is about.
+  if (detail.isError || !issue) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        {fallbackLabel && (
+          <span className="text-caption font-medium text-muted-foreground">
+            {fallbackLabel}
+          </span>
+        )}
+        <p className="text-caption text-muted-foreground">{t(($) => $.detail.not_found)}</p>
       </div>
     );
   }

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -42,8 +42,7 @@ interface IssueHoverCardProps {
  * its `min(18rem, 100%)` cap — so a long title arrives truncated. The card
  * carries what the chip cannot: the full untruncated title, priority, a
  * description snippet, the assignee, and sub-issue progress. Member and agent
- * mentions
- * already preview this way via MentionHoverCard
+ * mentions already preview this way via MentionHoverCard
  * (packages/ui/components/common/mention-hover-card.tsx); this is the issue
  * equivalent, and lives here rather than in packages/ui because it reads
  * workspace queries.

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -135,12 +135,23 @@ function IssueHoverCardBody({
   return (
     <div className="flex flex-col gap-1.5">
       {/* Priority, status, identifier — the same lead-with-priority order as
-          BoardCardContent, at the icon size the status glyph already uses. No
-          aria-label: naming it would need a translation key, and this card
-          deliberately carries no copy of its own. */}
+          BoardCardContent, at the icon size the status glyph already uses.
+          StatusIcon and PriorityIcon both render a bare <svg> that forwards no
+          aria props, so each glyph is named by an `role="img"` wrapper: on a
+          role-less span an aria-label is dropped by assistive tech. */}
       <div className="flex items-center gap-1.5">
-        {hasPriority && <PriorityIcon priority={issue.priority} />}
-        <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+        {hasPriority && (
+          <span role="img" aria-label={t(($) => $.priority[issue.priority])} className="flex">
+            <PriorityIcon priority={issue.priority} />
+          </span>
+        )}
+        <span
+          role="img"
+          aria-label={t(($) => $.status[issue.status])}
+          className="flex shrink-0"
+        >
+          <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+        </span>
         <span className="text-caption font-medium text-muted-foreground">
           {issue.identifier}
         </span>

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -33,8 +33,9 @@ interface IssueHoverCardProps {
  *
  * The inline chip shows status, identifier, and as much title as fits inside
  * its `min(18rem, 100%)` cap — so a long title arrives truncated. The card
- * carries what the chip cannot: the full untruncated title, a description
- * snippet, the assignee, and sub-issue progress. Member and agent mentions
+ * carries what the chip cannot: the full untruncated title, priority, a
+ * description snippet, the assignee, and sub-issue progress. Member and agent
+ * mentions
  * already preview this way via MentionHoverCard
  * (packages/ui/components/common/mention-hover-card.tsx); this is the issue
  * equivalent, and lives here rather than in packages/ui because it reads

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -13,6 +13,7 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { descriptionPreview } from "./description-preview";
+import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
 import { StatusIcon } from "./status-icon";
 
@@ -87,10 +88,19 @@ function IssueHoverCardBody({ issueId }: { issueId: string }) {
   const hasAssignee = !!assigneeType && !!assigneeId;
   const progress = childProgress?.get(issue.id);
   const hasProgress = !!progress && progress.total > 0;
+  // Board cards and list rows render the glyph into a fixed grid slot, so the
+  // "none" dash holds a column there. This card has no column to hold, leaving
+  // the dash a mark carrying no information in an already dense popup.
+  const hasPriority = !!issue.priority && issue.priority !== "none";
 
   return (
     <div className="flex flex-col gap-1.5">
+      {/* Priority, status, identifier — the same lead-with-priority order as
+          BoardCardContent, at the icon size the status glyph already uses. No
+          aria-label: naming it would need a translation key, and this card
+          deliberately carries no copy of its own. */}
       <div className="flex items-center gap-1.5">
+        {hasPriority && <PriorityIcon priority={issue.priority} />}
         <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
         <span className="text-caption font-medium text-muted-foreground">
           {issue.identifier}

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { childIssueProgressOptions, issueDetailOptions } from "@multica/core/issues/queries";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useActorName } from "@multica/core/workspace/hooks";
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from "@multica/ui/components/ui/hover-card";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { ActorAvatar } from "../../common/actor-avatar";
+import { descriptionPreview } from "./description-preview";
+import { ProgressRing } from "./progress-ring";
+import { StatusIcon } from "./status-icon";
+
+interface IssueHoverCardProps {
+  issueId: string;
+  children: ReactNode;
+  /**
+   * Open delay override, in milliseconds. Exists for tests only — production
+   * passes nothing, so the card uses Base UI's default of 600ms. Tests pass 0
+   * so hover assertions don't need to wait out the real delay.
+   */
+  delay?: number;
+}
+
+/**
+ * Detail for an issue mention, on hover.
+ *
+ * The inline chip is a bare identifier, and a truncated one in narrow prose.
+ * The card carries what the chip cannot: the full title, a description
+ * snippet, the assignee, and sub-issue progress.
+ *
+ * Every query lives in IssueHoverCardBody rather than here on purpose: Base UI
+ * mounts the popup only while the card is open, so this component adds no
+ * request of its own until a card opens. Moving a query up into IssueHoverCard
+ * would fire one per mention on render. (The chip inside the trigger has its
+ * own unresolved-issue fetch; that is independent of this.)
+ */
+export function IssueHoverCard({ issueId, children, delay }: IssueHoverCardProps) {
+  return (
+    <HoverCard>
+      {/* Rendered as a span, not the trigger's default anchor: the children are
+          already an AppLink, and an anchor inside an anchor is invalid. */}
+      <HoverCardTrigger delay={delay} render={<span />}>
+        {children}
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-auto min-w-56 max-w-80">
+        <IssueHoverCardBody issueId={issueId} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function IssueHoverCardBody({ issueId }: { issueId: string }) {
+  const wsId = useWorkspaceId();
+  const { data: issue } = useQuery(issueDetailOptions(wsId, issueId));
+  // One workspace-wide progress snapshot shared with the issues list and issue
+  // detail, not a per-issue children fetch: opening a card reuses the cache.
+  const { data: childProgress } = useQuery(childIssueProgressOptions(wsId));
+  const { getActorName } = useActorName();
+
+  // A skeleton rather than localized loading text — the card carries no copy of
+  // its own, so it needs no translation keys.
+  if (!issue) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="mt-1.5 h-3 w-44" />
+        <Skeleton className="mt-1.5 h-4 w-24" />
+      </div>
+    );
+  }
+
+  const preview = issue.description ? descriptionPreview(issue.description) : "";
+  const assigneeType = issue.assignee_type;
+  const assigneeId = issue.assignee_id;
+  const hasAssignee = !!assigneeType && !!assigneeId;
+  const progress = childProgress?.get(issue.id);
+  const hasProgress = !!progress && progress.total > 0;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+        <span className="text-caption font-medium text-muted-foreground">
+          {issue.identifier}
+        </span>
+      </div>
+      <p className="text-body text-foreground">{issue.title}</p>
+
+      {preview && (
+        <p className="mt-1 text-caption text-muted-foreground line-clamp-2">{preview}</p>
+      )}
+
+      {(hasAssignee || hasProgress) && (
+        <div className="mt-1 flex items-center justify-between gap-3">
+          {hasAssignee ? (
+            <span className="flex min-w-0 items-center gap-1.5">
+              {/* This is already a hover card, and the agent live-peek variant
+                  would fire its own request — so no nested card, no link. */}
+              <ActorAvatar
+                actorType={assigneeType}
+                actorId={assigneeId}
+                size="sm"
+                enableHoverCard={false}
+                profileLink={false}
+                className="shrink-0"
+              />
+              <span className="min-w-0 truncate text-caption text-foreground">
+                {getActorName(assigneeType, assigneeId)}
+              </span>
+            </span>
+          ) : (
+            <span />
+          )}
+          {hasProgress && (
+            <span className="inline-flex shrink-0 items-center gap-1">
+              <ProgressRing done={progress.done} total={progress.total} size={12} />
+              <span className="text-caption font-medium tabular-nums text-muted-foreground">
+                {progress.done}/{progress.total}
+              </span>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -156,7 +156,10 @@ function IssueHoverCardBody({
           {issue.identifier}
         </span>
       </div>
-      <p className="text-body text-foreground">{issue.title}</p>
+      {/* The full title is the point of the card, so it never truncates — but
+          an unbroken token (a pasted URL) would blow past the max-w-80 cap
+          without a break opportunity. */}
+      <p className="text-body text-foreground break-words">{issue.title}</p>
 
       {preview && (
         <p className="mt-1 text-caption text-muted-foreground line-clamp-2">{preview}</p>

--- a/packages/views/issues/components/issue-hover-card.tsx
+++ b/packages/views/issues/components/issue-hover-card.tsx
@@ -30,9 +30,14 @@ interface IssueHoverCardProps {
 /**
  * Detail for an issue mention, on hover.
  *
- * The inline chip is a bare identifier, and a truncated one in narrow prose.
- * The card carries what the chip cannot: the full title, a description
- * snippet, the assignee, and sub-issue progress.
+ * The inline chip shows status, identifier, and as much title as fits inside
+ * its `min(18rem, 100%)` cap — so a long title arrives truncated. The card
+ * carries what the chip cannot: the full untruncated title, a description
+ * snippet, the assignee, and sub-issue progress. Member and agent mentions
+ * already preview this way via MentionHoverCard
+ * (packages/ui/components/common/mention-hover-card.tsx); this is the issue
+ * equivalent, and lives here rather than in packages/ui because it reads
+ * workspace queries.
  *
  * Every query lives in IssueHoverCardBody rather than here on purpose: Base UI
  * mounts the popup only while the card is open, so this component adds no

--- a/packages/views/issues/components/issue-mention-card.test.tsx
+++ b/packages/views/issues/components/issue-mention-card.test.tsx
@@ -66,6 +66,37 @@ describe("IssueMentionCard", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  // The real IssueHoverCard is deliberately not mocked: the point of these two
+  // is that mentions get the card for real, and that wrapping the link in a
+  // trigger did not cost the link anything. Neither opens the card — the card's
+  // own contents are covered in issue-hover-card.test.tsx, and hovering here
+  // would only duplicate that file's query and avatar mocks.
+  it("wraps the mention in a real hover-card trigger", () => {
+    renderCard(makeAdapter());
+
+    const trigger = screen
+      .getByTestId("issue-chip")
+      .closest('[data-slot="hover-card-trigger"]');
+    expect(trigger).toBeInTheDocument();
+    // A span, not the trigger's default anchor: the link is inside it, and
+    // nested anchors would break both the DOM and the assertions above.
+    expect(trigger?.tagName).toBe("SPAN");
+  });
+
+  it("keeps the chip a navigable link inside the trigger", () => {
+    const push = vi.fn();
+    renderCard(makeAdapter({ push }));
+
+    const anchor = screen.getByTestId("issue-chip").closest("a");
+    expect(anchor).toHaveAttribute("href", "/acme/issues/issue-1");
+    expect(
+      anchor?.closest('[data-slot="hover-card-trigger"]'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("issue-chip"));
+    expect(push).toHaveBeenCalledWith("/acme/issues/issue-1");
+  });
+
   it("cmd-click without an adapter (web) is left to the browser's native background-tab handling", () => {
     const push = vi.fn();
     renderCard(makeAdapter({ push }));

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -21,12 +21,14 @@ interface IssueMentionCardProps {
  * per-preference override.
  *
  * Hovering opens IssueHoverCard, which shows the detail the chip has no room
- * for. No `delay` is passed, so it opens on Base UI's default dwell.
+ * for. No `delay` is passed, so it opens on Base UI's default dwell. The same
+ * `fallbackLabel` the chip degrades to names the card when the detail fetch
+ * fails.
  */
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
   return (
-    <IssueHoverCard issueId={issueId}>
+    <IssueHoverCard issueId={issueId} fallbackLabel={fallbackLabel}>
       <AppLink
         href={p.issueDetail(issueId)}
         newTabTitle={fallbackLabel}

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -3,6 +3,7 @@
 import { AppLink } from "../../navigation";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { IssueChip } from "./issue-chip";
+import { IssueHoverCard } from "./issue-hover-card";
 
 interface IssueMentionCardProps {
   issueId: string;
@@ -18,20 +19,25 @@ interface IssueMentionCardProps {
  * AppLink owns the click semantics: plain click navigates in place, modifier
  * and middle clicks open tabs. There is deliberately no per-surface or
  * per-preference override.
+ *
+ * Hovering opens IssueHoverCard, which shows the detail the chip has no room
+ * for. No `delay` is passed, so it opens on Base UI's default dwell.
  */
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
   return (
-    <AppLink
-      href={p.issueDetail(issueId)}
-      newTabTitle={fallbackLabel}
-      className="issue-mention align-middle"
-    >
-      <IssueChip
-        issueId={issueId}
-        fallbackLabel={fallbackLabel}
-        className="cursor-pointer hover:bg-accent transition-colors"
-      />
-    </AppLink>
+    <IssueHoverCard issueId={issueId}>
+      <AppLink
+        href={p.issueDetail(issueId)}
+        newTabTitle={fallbackLabel}
+        className="issue-mention align-middle"
+      >
+        <IssueChip
+          issueId={issueId}
+          fallbackLabel={fallbackLabel}
+          className="cursor-pointer hover:bg-accent transition-colors"
+        />
+      </AppLink>
+    </IssueHoverCard>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Adds a hover card to inline issue mentions, showing what the chip cannot: the **full untruncated title**, **priority**, a **description snippet**, the **assignee**, and **sub-issue progress**.

This is the part of #6625 that never depended on the display-mode preference. @Bohan-J suggested it land standalone; that's what this is. Rebuilt from scratch against current `main` rather than cherry-picked, because #6744 and #6667 both changed the ground underneath it.

#6744 made the case stronger rather than weaker. Bounding the chip at `min(18rem, 100%)` was the right fix for the prose problem, and it means a long title now arrives truncated — `Investigate and fix the flaky webs…`. The card is where the rest of it goes.

## Related Issue

Closes #6784

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue) — see the `descriptionPreview` fix below

## Changes Made

**New:**
- `packages/views/issues/components/issue-hover-card.tsx` — the card. `IssueHoverCard` (trigger + popup) and an inner `IssueHoverCardBody` that owns every query.
- `packages/views/issues/components/description-preview.ts` — `descriptionPreview()` moved out of `board-card.tsx`, where a shared util was living inside a component. Its test moved with it via `git mv`. No re-export shim, per the repo's rule against internal compatibility layers.

**Modified:**
- `packages/views/issues/components/issue-mention-card.tsx` — wraps the existing `AppLink` in `IssueHoverCard`. Nothing else; click semantics are untouched.
- `packages/views/issues/components/board-card.tsx` — imports `descriptionPreview` from its new home.

**Deliberately untouched** — `issue-chip.tsx` and `editor/extensions/mention-view.tsx` are byte-identical to `main` (same blob hashes, not just an empty diff). The editor gets the card for free, because #6667 already pointed `MentionView` at `IssueMentionCard`.

### Implementation notes for reviewers

**The detail query is deferred by placement, not by an `enabled` flag.** `useQuery` lives in `IssueHoverCardBody`, which Base UI mounts only while the popup is open. Hoisting it into the outer component would fire one detail request per mention on render — a paragraph with eight mentions would issue eight. There's a test asserting zero calls before open, and it asserts the trigger rendered *first*, so a component that renders nothing can't satisfy it vacuously.

**Enrichment cost.** ~~The assignee uses `ActorAvatar` against the members/agents/squads lists `useWorkspacePresencePrefetch` already loads app-wide at `staleTime: Infinity` — no extra request.~~

**Correction (review round 1):** that was wrong, and @Bohan-J caught it. `packages/core/agents/use-workspace-presence-prefetch.ts:25-28` warms agents, runtimes, the agent task snapshot, and squads — **not** the member directory. `useActorName()` subscribes to `memberListOptions`, so as originally written the first hover on *any* mention could pull the member list even when there was no assignee to render. The assignee row is now its own component, mounted only when the issue has an assignee, which confines that query to cards that actually name someone. Leaving the original claim struck through rather than silently editing it.

`ActorAvatar` is passed `enableHoverCard={false}` and `profileLink={false}`, since nesting a hover card inside a hover card is a bug and the agent live-peek variant fires its own request. Sub-issue progress uses `childIssueProgressOptions` — one workspace-wide snapshot shared with the issues list and issue detail, deliberately not `childIssuesOptions`, which is per-issue and `refetchOnMount: "always"`.

**No new strings.** The card now uses three existing keys — `issues:detail.not_found` for the failure state, and the shipped `status.*` / `priority.*` maps for the icon labels — and still adds nothing to the four locale bundles, so there is nothing new for `parity.test.ts` to enforce. Loading is still a `Skeleton` rather than localized text.

**Priority is omitted when it's `none`.** Board cards and list rows render the "none" dash because it holds a column in a fixed grid; this card has no column to hold, so the dash would be a mark carrying no information in an already dense popup. Flagging it because it's a deliberate divergence from those surfaces, not an oversight.

### The `descriptionPreview` fix (please look at this separately)

Moving the function surfaced a real defect in it, which affects board cards today and would have affected this card:

The editor serializes link brackets escaped, so a description round-tripped through it is stored as `\[repro script\](https://example.com)`. The link rule's `[^\]]+` capture swallowed the trailing backslash while the leading one never matched, and the preview read `\repro script\`. Fixed by unescaping backslash-escaped ASCII punctuation *first* — order is load-bearing, since the escapes are what stop the later structural rules from matching.

A second case fell out of testing against real stored data: when a URL inside a link label gets autolinked, the editor produces a **nested** link — `\[repro script\]([https://example.com](https://example.com))`. The destination pattern `[^)]+` stopped at the first `)`, consumed through the inner link, and stranded the outer paren: `…needs a repro script) before we fix it.` The destination now tolerates one level of balanced parens, which also fixes legitimate URLs like `https://en.wikipedia.org/wiki/Foo_(bar)`. Applied to the image and file rules too, which had the same fragility.

Both are improvements to board cards as a side effect. Happy to split them into their own PR if you'd rather review them apart from the card.

## How to Test

1. `make dev`, open an issue whose description or comments reference other issues.
2. Hover a mention and wait out the standard delay. The card shows priority, status, identifier, the full title, a description snippet, the assignee, and sub-issue progress.
3. Reference an issue with a **long title** so the inline chip truncates at the 18rem cap — the card shows the whole title.
4. Hover a bare issue (no description, unassigned, no sub-issues, no priority). Rows drop out cleanly; no empty gaps or stray separators.
5. Type an identifier into a comment composer so it autolinks, then hover the chip. Same card — the editor path routes through `IssueMentionCard`.
6. Click and cmd-click a mention: plain click navigates in place, cmd-click opens a background tab, per #6667. Unchanged by this PR.

Verified locally: `pnpm typecheck` clean across 6 packages; `pnpm test` — views 3826, core 1346, desktop 462, web 199, docs 17; `pnpm lint` 0 errors.

Browser-verified in both themes, including a card with every field populated, a partial card, a minimal card, the editor path, and click/cmd-click behavior.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
    - No docs change appears owed: no page under `apps/docs/content/docs/` describes mention rendering, and the equivalent member/agent preview (`MentionHoverCard`) has none either. No changelog entry either — `changelog.entries` lives in `apps/web/features/landing/i18n/*` and is written at release time, one commit per version. Say the word if you'd rather it came with the change.
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and docs — n/a, this adds none of those
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — n/a, no strings added
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Known gaps

- **Touch devices have no hover**, so tapping navigates instead of previewing. Unchanged from how `MentionHoverCard` behaves for member and agent mentions.
- **Sub-issue progress is `staleTime: Infinity`** and shared with the issues list, so a long-open card can show a stale `done/total`. Same tradeoff the existing surfaces make, now visible in one more place.
- `apps/mobile` is untouched — it renders bare identifier text and has no chip to preview.

## AI Disclosure

**AI tool used:** Claude Code (Opus 5)

**Prompt / approach:** Same workflow as #6625 — spec, then plan, then task-by-task execution with a reviewer subagent gating each task, plus hands-on browser verification driving the real app.

Two things that came out of the verification pass rather than the code review, both worth naming because neither would have been caught by tests:

- The description snippet leaked backslashes and, separately, a stray `)`. I only found the second one after dumping the actual stored markdown out of Postgres rather than trusting a theory about the cause — the real content turned out to contain a nested link the regex couldn't parse.
- A first report claimed `it costs \$5` was also broken. It wasn't: the stored bytes were `\\$5`, an escaped backslash, so rendering `\$5` is the faithful round-trip. Worth mentioning because it would have been easy to "fix" correct behavior.

## Screenshots

_Attaching shortly — the card with every field populated, the truncated chip beside the full title, partial and minimal cards, the editor path, and light mode._
<img width="710" height="420" alt="01-hover-card-everything" src="https://github.com/user-attachments/assets/52b5df1d-8754-4ffd-82e8-e4db115bdc3d" />
<img width="1440" height="900" alt="02-truncated-chip-vs-full-title" src="https://github.com/user-attachments/assets/c6cd96d0-47b0-4126-bfff-b7d3cf39cf34" />
<img width="1440" height="757" alt="03-hover-card-partial" src="https://github.com/user-attachments/assets/40bc6920-0688-47ca-89c6-ce53352eb178" />
<img width="1440" height="757" alt="04-hover-card-minimal" src="https://github.com/user-attachments/assets/2868c0f3-068c-4620-aac0-684d6075e1e4" />
<img width="1440" height="900" alt="05-editor-hover" src="https://github.com/user-attachments/assets/1b4a29d7-8b3a-42e5-86d2-61acefb6cc77" />
<img width="710" height="420" alt="06-hover-card-light-mode" src="https://github.com/user-attachments/assets/9e07a95e-94d4-4f86-b89f-385fe0f2e63a" />

