### PR TITLE
fix(composer): handle Android compatibility mouse-down

### DIFF
--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { PointerEvent, ReactNode } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
 import { ArrowUp, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import {
@@ -40,7 +40,7 @@ interface SubmitButtonProps {
 }
 
 /** Keep the composer focused so Send and Stop do not dismiss Android's keyboard. */
-function keepFocusInComposer(event: PointerEvent<HTMLButtonElement>) {
+function keepFocusInComposer(event: SyntheticEvent<HTMLButtonElement>) {
   event.preventDefault();
 }
 
@@ -62,6 +62,7 @@ function SubmitButton({
         size="icon-sm"
         className="rounded-full"
         onPointerDown={keepFocusInComposer}
+        onMouseDown={keepFocusInComposer}
         onClick={onStop}
         aria-label={stopAriaLabel}
       >
@@ -84,6 +85,7 @@ function SubmitButton({
       aria-disabled={busy || undefined}
       aria-busy={loading || busy || undefined}
       onPointerDown={keepFocusInComposer}
+      onMouseDown={keepFocusInComposer}
       onClick={onClick}
       aria-label={ariaLabel}
     >

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -1433,6 +1433,13 @@ describe("ChatInput send keeps composer focus", () => {
     expect(fireEvent.pointerDown(sendButton)).toBe(false);
   });
 
+  it("cancels the send button's compatibility mouse-down on Android", async () => {
+    renderInput();
+    const sendButton = await readySendButton();
+
+    expect(fireEvent.mouseDown(sendButton)).toBe(false);
+  });
+
   it("still submits on tap — cancelling pointer-down suppresses focus, not activation", async () => {
     const onSend = vi.fn<ChatInputOnSend>((_content, _ids, commitInput) => {
       commitInput();
@@ -1452,6 +1459,12 @@ describe("ChatInput send keeps composer focus", () => {
     renderInput({ isRunning: true, onStop: vi.fn() });
 
     expect(fireEvent.pointerDown(screen.getByRole("button", { name: "Stop" }))).toBe(false);
+  });
+
+  it("cancels the stop button's compatibility mouse-down on Android", () => {
+    renderInput({ isRunning: true, onStop: vi.fn() });
+
+    expect(fireEvent.mouseDown(screen.getByRole("button", { name: "Stop" }))).toBe(false);
   });
 
   it("still stops on tap", () => {


### PR DESCRIPTION
## What changed

- Prevent the Send and Stop buttons from taking composer focus during compatibility `mousedown` events.
- Add regression coverage for both buttons.

## Why

Android can dispatch a compatibility mouse event after the pointer event. Handling only `pointerdown` allowed that later event to move focus away from the composer and dismiss the keyboard.

## Impact

The composer remains focused and the Android keyboard stays open when sending or stopping, while click activation continues to work normally.

## Validation

- `pnpm --filter @multica/views exec vitest run chat/components/chat-input.test.tsx`
- `pnpm --filter @multica/ui typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/ui lint`
- `pnpm --filter @multica/views lint`
