### PR TITLE
MUL-6045: Reach hover-only row controls on touch

### DIFF
--- a/packages/views/chat/components/chat-thread-list.test.tsx
+++ b/packages/views/chat/components/chat-thread-list.test.tsx
@@ -87,19 +87,22 @@ const sessions: ChatSession[] = [
   makeSession({ id: "s3", updated_at: "2026-07-08T01:00:00Z" }),
 ];
 
-function renderList(activeSessionId: string | null, onArchive = vi.fn()) {
+function renderList(
+  activeSessionId: string | null,
+  { onArchive = vi.fn(), onSelectSession = vi.fn() } = {},
+) {
   render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <ChatThreadList
         sessions={sessions}
         agents={[agent]}
         activeSessionId={activeSessionId}
-        onSelectSession={vi.fn()}
+        onSelectSession={onSelectSession}
         onArchive={onArchive}
       />
     </I18nProvider>,
   );
-  return onArchive;
+  return { onArchive, onSelectSession };
 }
 
 const ARCHIVE_LABEL = enChat.list.archive;
@@ -111,7 +114,7 @@ describe("ChatThreadList archive delegation", () => {
   });
 
   it("delegates the history-row Archive action to onArchive with that session", () => {
-    const onArchive = renderList("s2");
+    const { onArchive } = renderList("s2");
     // Rows render in order s1, s2, s3 → the second archive button is s2's.
     const archiveButtons = screen.getAllByRole("button", { name: ARCHIVE_LABEL });
     fireEvent.click(archiveButtons[1]!);
@@ -121,7 +124,7 @@ describe("ChatThreadList archive delegation", () => {
   });
 
   it("passes the archived row's session even when it isn't the open one", () => {
-    const onArchive = renderList("s1");
+    const { onArchive } = renderList("s1");
     const archiveButtons = screen.getAllByRole("button", { name: ARCHIVE_LABEL });
     // Archive s3 while s1 is the open one — the parent decides what to do.
     fireEvent.click(archiveButtons[2]!);
@@ -168,5 +171,67 @@ describe("ChatThreadList no_response preview (MUL-4351)", () => {
     expect(
       screen.queryByText("The agent finished this turn without a text reply."),
     ).not.toBeInTheDocument();
+  });
+});
+
+// Touch has no hover, so the hover strip's actions also live in a per-row menu.
+describe("ChatThreadList compact row menu", () => {
+  beforeEach(() => {
+    setActiveSession.mockClear();
+    archiveMutate.mockClear();
+  });
+
+  const openRowMenu = (index: number) =>
+    fireEvent.click(
+      screen.getAllByRole("button", { name: enChat.list.row_actions_aria })[index]!,
+    );
+
+  it("archives the row it belongs to", async () => {
+    const { onArchive } = renderList("s1");
+
+    openRowMenu(1);
+    fireEvent.click(await screen.findByRole("menuitem", { name: ARCHIVE_LABEL }));
+
+    expect(onArchive).toHaveBeenCalledTimes(1);
+    expect(onArchive.mock.calls[0]![0]).toMatchObject({ id: "s2" });
+  });
+
+  it("offers the same pin toggle the hover strip does", async () => {
+    renderList(null);
+
+    openRowMenu(0);
+
+    expect(await screen.findByRole("menuitem", { name: enChat.list.pin })).toBeInTheDocument();
+  });
+
+  it("does not select the row when the menu opens", () => {
+    const { onSelectSession } = renderList(null);
+
+    openRowMenu(0);
+
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatThreadList row keyboard semantics", () => {
+  it("selects the row on Enter", () => {
+    const { onSelectSession } = renderList(null);
+
+    const row = screen.getByText("Chat s1").closest("[tabindex]")!;
+    fireEvent.keyDown(row, { key: "Enter" });
+
+    expect(onSelectSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves Enter pressed inside a row control to that control", () => {
+    // Opening the action menu with the keyboard must not also select the row.
+    const { onSelectSession } = renderList(null);
+
+    fireEvent.keyDown(
+      screen.getAllByRole("button", { name: enChat.list.row_actions_aria })[0]!,
+      { key: "Enter" },
+    );
+
+    expect(onSelectSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/chat/components/chat-thread-list.test.tsx
+++ b/packages/views/chat/components/chat-thread-list.test.tsx
@@ -211,6 +211,25 @@ describe("ChatThreadList compact row menu", () => {
 
     expect(onSelectSession).not.toHaveBeenCalled();
   });
+
+  it("stays reachable on a wide viewport that cannot hover", () => {
+    // The menu and the hover strip must both switch on hover capability. Gating
+    // either on width strands a landscape phone: past `md` the menu would be
+    // hidden and the strip would wait for a hover that never arrives.
+    renderList(null);
+
+    const trigger = screen.getAllByRole("button", {
+      name: enChat.list.row_actions_aria,
+    })[0]!;
+    const strip = trigger.parentElement!.querySelector(
+      "[class*='group-hover/row']",
+    )!;
+
+    expect(trigger.className).toContain("[@media(hover:hover)]:hidden");
+    expect(trigger.className).not.toMatch(/(^|\s)(sm|md|lg|xl|2xl):hidden/);
+    expect(strip.className).toContain("[@media(hover:hover)]:group-hover/row:flex");
+    expect(strip.className).not.toMatch(/(^|\s)(sm|md|lg|xl|2xl):group-/);
+  });
 });
 
 describe("ChatThreadList row keyboard semantics", () => {

--- a/packages/views/chat/components/chat-thread-list.tsx
+++ b/packages/views/chat/components/chat-thread-list.tsx
@@ -260,8 +260,8 @@ export function ChatThreadList({
       previewNode = <span className="block truncate text-muted-foreground">{t(($) => $.list.no_messages)}</span>;
     }
 
-    // One list drives both action surfaces — the compact menu below `md` and
-    // the hover strip from `md` up — so they cannot drift. The archived view
+    // One list drives both action surfaces — the compact menu without hover
+    // and the hover strip with it — so they cannot drift. The archived view
     // is the only place hard-delete lives; the history view offers the
     // reversible archive instead.
     const rowActions: RowActionItem[] =
@@ -432,7 +432,7 @@ export function ChatThreadList({
         {/* Compact action menu — the touch equivalent of the hover strip
             below, which a pointer without hover can never reach. It takes real
             layout space (rather than overlaying the preview) and gives way to
-            the hover strip from `md` up. */}
+            the hover strip on a hover-capable pointer. */}
         {!isConfirmingAction && (
           <RowActionsMenu
             label={t(($) => $.list.row_actions_aria)}
@@ -444,7 +444,7 @@ export function ChatThreadList({
             changes the row height (which was making the list jump). Keyboard
             focus reveals them too, so they are reachable without a mouse. */}
         {!isConfirmingAction && (
-          <div className="absolute inset-y-0 right-1 hidden items-center gap-0.5 rounded-md bg-gradient-to-l from-accent from-40% to-transparent pl-10 pr-1 md:group-hover/row:flex md:group-focus-within/row:flex">
+          <div className="absolute inset-y-0 right-1 hidden items-center gap-0.5 rounded-md bg-gradient-to-l from-accent from-40% to-transparent pl-10 pr-1 [@media(hover:hover)]:group-hover/row:flex [@media(hover:hover)]:group-focus-within/row:flex">
             {rowActions.map((action) => (
               <RowAction
                 key={action.key}

--- a/packages/views/chat/components/chat-thread-list.tsx
+++ b/packages/views/chat/components/chat-thread-list.tsx
@@ -28,6 +28,11 @@ import {
 import { useChatStore } from "@multica/core/chat";
 import type { Agent, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
+import {
+  RowActionsMenu,
+  handleRowActivationKey,
+  type RowActionItem,
+} from "../../common/row-actions-menu";
 import { resolveClickIntent, useOptionalNavigation } from "../../navigation";
 import { createLogger } from "@multica/core/logger";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
@@ -255,6 +260,58 @@ export function ChatThreadList({
       previewNode = <span className="block truncate text-muted-foreground">{t(($) => $.list.no_messages)}</span>;
     }
 
+    // One list drives both action surfaces — the compact menu below `md` and
+    // the hover strip from `md` up — so they cannot drift. The archived view
+    // is the only place hard-delete lives; the history view offers the
+    // reversible archive instead.
+    const rowActions: RowActionItem[] =
+      view === "archived"
+        ? [
+            {
+              key: "unarchive",
+              icon: <ArchiveRestore className="size-3.5" />,
+              label: t(($) => $.list.unarchive),
+              onSelect: () =>
+                setArchived.mutate({ sessionId: session.id, archived: false }),
+            },
+            {
+              key: "delete",
+              icon: <Trash2 className="size-3.5" />,
+              label: t(($) => $.session_history.row_delete_aria),
+              danger: true,
+              onSelect: () => setConfirmingDeleteId(session.id),
+            },
+          ]
+        : [
+            {
+              key: "pin",
+              icon: session.pinned ? (
+                <PinOff className="size-3.5" />
+              ) : (
+                <Pin className="size-3.5 -rotate-45" />
+              ),
+              label: session.pinned
+                ? t(($) => $.list.unpin)
+                : t(($) => $.list.pin),
+              onSelect: () =>
+                setPinned.mutate({ sessionId: session.id, pinned: !session.pinned }),
+            },
+            isRunning
+              ? {
+                  key: "stop",
+                  icon: <Square className="size-3 fill-current" />,
+                  label: t(($) => $.session_history.row_stop_aria),
+                  danger: true,
+                  onSelect: () => setConfirmingStopId(session.id),
+                }
+              : {
+                  key: "archive",
+                  icon: <Archive className="size-3.5" />,
+                  label: t(($) => $.list.archive),
+                  onSelect: () => onArchive(session),
+                },
+          ];
+
     return (
       <div
         key={session.id}
@@ -293,9 +350,7 @@ export function ChatThreadList({
         }}
         onKeyDown={(e) => {
           if (isConfirmingAction) return;
-          if (e.key !== "Enter" && e.key !== " ") return;
-          e.preventDefault();
-          onSelectSession(session);
+          handleRowActivationKey(e, () => onSelectSession(session));
         }}
         className={cn(
           // Fixed height so nothing (hover actions, confirm prompts) can change
@@ -374,49 +429,31 @@ export function ChatThreadList({
             </div>
         </div>
 
-        {/* Hover actions — absolutely positioned so showing/hiding them never
-            changes the row height (which was making the list jump). The archived
-            view is the only place hard-delete lives; the history view offers the
-            reversible archive instead. */}
+        {/* Compact action menu — the touch equivalent of the hover strip
+            below, which a pointer without hover can never reach. It takes real
+            layout space (rather than overlaying the preview) and gives way to
+            the hover strip from `md` up. */}
         {!isConfirmingAction && (
-          <div className="absolute inset-y-0 right-1 hidden items-center gap-0.5 rounded-md bg-gradient-to-l from-accent from-40% to-transparent pl-10 pr-1 group-hover/row:flex">
-            {view === "archived" ? (
-              <>
-                <RowAction
-                  icon={<ArchiveRestore className="size-3.5" />}
-                  label={t(($) => $.list.unarchive)}
-                  onClick={() => setArchived.mutate({ sessionId: session.id, archived: false })}
-                />
-                <RowAction
-                  icon={<Trash2 className="size-3.5" />}
-                  label={t(($) => $.session_history.row_delete_aria)}
-                  danger
-                  onClick={() => setConfirmingDeleteId(session.id)}
-                />
-              </>
-            ) : (
-              <>
-                <RowAction
-                  icon={session.pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5 -rotate-45" />}
-                  label={session.pinned ? t(($) => $.list.unpin) : t(($) => $.list.pin)}
-                  onClick={() => setPinned.mutate({ sessionId: session.id, pinned: !session.pinned })}
-                />
-                {isRunning ? (
-                  <RowAction
-                    icon={<Square className="size-3 fill-current" />}
-                    label={t(($) => $.session_history.row_stop_aria)}
-                    danger
-                    onClick={() => setConfirmingStopId(session.id)}
-                  />
-                ) : (
-                  <RowAction
-                    icon={<Archive className="size-3.5" />}
-                    label={t(($) => $.list.archive)}
-                    onClick={() => onArchive(session)}
-                  />
-                )}
-              </>
-            )}
+          <RowActionsMenu
+            label={t(($) => $.list.row_actions_aria)}
+            groups={[rowActions]}
+          />
+        )}
+
+        {/* Hover actions — absolutely positioned so showing/hiding them never
+            changes the row height (which was making the list jump). Keyboard
+            focus reveals them too, so they are reachable without a mouse. */}
+        {!isConfirmingAction && (
+          <div className="absolute inset-y-0 right-1 hidden items-center gap-0.5 rounded-md bg-gradient-to-l from-accent from-40% to-transparent pl-10 pr-1 md:group-hover/row:flex md:group-focus-within/row:flex">
+            {rowActions.map((action) => (
+              <RowAction
+                key={action.key}
+                icon={action.icon}
+                label={action.label}
+                danger={action.danger}
+                onClick={action.onSelect}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1336,8 +1336,8 @@ function SessionDropdown({
           ? t(($) => $.session_history.row_subtitle.new_reply)
           : formatTimeAgo(session.updated_at);
 
-    // One list drives both action surfaces — the compact menu below `md` and
-    // the hover strip from `md` up — so they cannot drift.
+    // One list drives both action surfaces — the compact menu without hover
+    // and the hover strip with it — so they cannot drift.
     const rowActions: SessionRowAction[] = isRunning
       ? [
           {
@@ -1458,7 +1458,7 @@ function SessionDropdown({
             </div>
           ) : (
             <div className="flex shrink-0 items-center">
-              <div className="flex h-7 items-center justify-end gap-1.5 text-caption text-muted-foreground md:group-hover/history-row:hidden md:group-focus-within/history-row:hidden">
+              <div className="flex h-7 items-center justify-end gap-1.5 text-caption text-muted-foreground [@media(hover:hover)]:group-hover/history-row:hidden [@media(hover:hover)]:group-focus-within/history-row:hidden">
                 {isRunning && <Loader2 className="size-3 animate-spin" />}
                 {showCompleted && !isRunning && <Check className="size-3 text-emerald-500" />}
                 {showUnread && !isRunning && !showCompleted && (
@@ -1470,13 +1470,13 @@ function SessionDropdown({
                 )}
                 <span className={cn("truncate", (showUnread || showCompleted || isRunning) && "font-medium text-foreground")}>{trailingStatus}</span>
               </div>
-              {/* Touch has no hover: below `md` the status above stays put and
+              {/* Touch has no hover: without it the status above stays put and
                   these same actions move into the row's compact menu. */}
               <RowActionsMenu
                 label={t(($) => $.session_history.row_actions_aria)}
                 groups={[rowActions]}
               />
-              <div className="hidden h-7 items-center gap-0.5 md:group-hover/history-row:flex md:group-focus-within/history-row:flex">
+              <div className="hidden h-7 items-center gap-0.5 [@media(hover:hover)]:group-hover/history-row:flex [@media(hover:hover)]:group-focus-within/history-row:flex">
                 {rowActions.map((action) => (
                   <button
                     key={action.key}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -27,6 +27,11 @@ import {
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useAppForeground } from "../../common/use-app-foreground";
 import {
+  RowActionsMenu,
+  handleRowActivationKey,
+  type RowActionItem,
+} from "../../common/row-actions-menu";
+import {
   PickerEmpty,
   PickerItem,
   PickerSection,
@@ -1114,6 +1119,11 @@ function AgentPickerItem({
   );
 }
 
+interface SessionRowAction extends RowActionItem {
+  /** Extra visible text in the hover strip (the stop button reads "Stop"). */
+  stripText?: string;
+}
+
 /**
  * Session dropdown: a flat "Chat history" list of all non-archived
  * sessions. Selecting a session from a different agent implicitly
@@ -1326,6 +1336,34 @@ function SessionDropdown({
           ? t(($) => $.session_history.row_subtitle.new_reply)
           : formatTimeAgo(session.updated_at);
 
+    // One list drives both action surfaces — the compact menu below `md` and
+    // the hover strip from `md` up — so they cannot drift.
+    const rowActions: SessionRowAction[] = isRunning
+      ? [
+          {
+            key: "stop",
+            icon: <Square className="size-2.5 fill-current" />,
+            label: t(($) => $.session_history.row_stop_aria),
+            stripText: t(($) => $.session_history.stop_action),
+            danger: true,
+            onSelect: () => setConfirmingStopId(session.id),
+          },
+        ]
+      : [
+          {
+            key: "rename",
+            icon: <Pencil className="size-3.5" />,
+            label: t(($) => $.session_history.row_rename_aria),
+            onSelect: () => setRenamingId(session.id),
+          },
+          {
+            key: "archive",
+            icon: <Archive className="size-3.5" />,
+            label: t(($) => $.list.archive),
+            onSelect: () => handleArchive(session),
+          },
+        ];
+
     return (
       <div
         key={session.id}
@@ -1337,9 +1375,7 @@ function SessionDropdown({
         }}
         onKeyDown={(e) => {
           if (isRenaming || isConfirmingAction) return;
-          if (e.key !== "Enter" && e.key !== " ") return;
-          e.preventDefault();
-          handleSelectSession(session);
+          handleRowActivationKey(e, () => handleSelectSession(session));
         }}
         className={cn(
           "group/history-row relative flex min-h-11 min-w-0 cursor-default items-center gap-2 overflow-hidden rounded-md py-1.5 pl-2 pr-2 outline-none transition-colors hover:bg-accent/60 focus-visible:bg-accent/60 focus-visible:ring-1 focus-visible:ring-ring",
@@ -1422,7 +1458,7 @@ function SessionDropdown({
             </div>
           ) : (
             <div className="flex shrink-0 items-center">
-              <div className="flex h-7 items-center justify-end gap-1.5 text-caption text-muted-foreground group-hover/history-row:hidden">
+              <div className="flex h-7 items-center justify-end gap-1.5 text-caption text-muted-foreground md:group-hover/history-row:hidden md:group-focus-within/history-row:hidden">
                 {isRunning && <Loader2 className="size-3 animate-spin" />}
                 {showCompleted && !isRunning && <Check className="size-3 text-emerald-500" />}
                 {showUnread && !isRunning && !showCompleted && (
@@ -1434,9 +1470,16 @@ function SessionDropdown({
                 )}
                 <span className={cn("truncate", (showUnread || showCompleted || isRunning) && "font-medium text-foreground")}>{trailingStatus}</span>
               </div>
-              <div className="hidden h-7 items-center gap-0.5 group-hover/history-row:flex">
-                {isRunning && pendingTask && (
+              {/* Touch has no hover: below `md` the status above stays put and
+                  these same actions move into the row's compact menu. */}
+              <RowActionsMenu
+                label={t(($) => $.session_history.row_actions_aria)}
+                groups={[rowActions]}
+              />
+              <div className="hidden h-7 items-center gap-0.5 md:group-hover/history-row:flex md:group-focus-within/history-row:flex">
+                {rowActions.map((action) => (
                   <button
+                    key={action.key}
                     type="button"
                     onPointerDown={(e) => {
                       e.preventDefault();
@@ -1445,54 +1488,20 @@ function SessionDropdown({
                     onClick={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
-                      setConfirmingStopId(session.id);
+                      action.onSelect();
                     }}
-                    className="inline-flex h-7 items-center gap-1 rounded px-1.5 text-micro font-medium text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
-                    aria-label={t(($) => $.session_history.row_stop_aria)}
-                    title={t(($) => $.session_history.row_stop_aria)}
+                    className={
+                      action.danger
+                        ? "inline-flex h-7 items-center gap-1 rounded px-1.5 text-micro font-medium text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
+                        : "inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
+                    }
+                    aria-label={action.label}
+                    title={action.label}
                   >
-                    <Square className="size-2.5 fill-current" />
-                    {t(($) => $.session_history.stop_action)}
+                    {action.icon}
+                    {action.stripText}
                   </button>
-                )}
-                {!isRunning && (
-                  <>
-                    <button
-                      type="button"
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        setRenamingId(session.id);
-                      }}
-                      className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
-                      aria-label={t(($) => $.session_history.row_rename_aria)}
-                      title={t(($) => $.session_history.row_rename_aria)}
-                    >
-                      <Pencil className="size-3.5" />
-                    </button>
-                    <button
-                      type="button"
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        handleArchive(session);
-                      }}
-                      className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
-                      aria-label={t(($) => $.list.archive)}
-                      title={t(($) => $.list.archive)}
-                    >
-                      <Archive className="size-3.5" />
-                    </button>
-                  </>
-                )}
+                ))}
               </div>
             </div>
           )

--- a/packages/views/common/row-actions-menu.test.tsx
+++ b/packages/views/common/row-actions-menu.test.tsx
@@ -47,7 +47,10 @@ describe("RowActionsMenu", () => {
     expect(onRowClick).not.toHaveBeenCalled();
   });
 
-  it("hides from `md` up, where hover controls take over", () => {
+  it("hides only where the pointer can hover, never by viewport width", () => {
+    // A width breakpoint would strand every wide touch surface — a phone in
+    // landscape clears `md` while still having no hover, so it would lose this
+    // menu and get hover controls it cannot trigger.
     render(
       <RowActionsMenu
         label="Chat actions"
@@ -55,9 +58,10 @@ describe("RowActionsMenu", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Chat actions" }).className).toContain(
-      "md:hidden",
-    );
+    const trigger = screen.getByRole("button", { name: "Chat actions" });
+
+    expect(trigger.className).toContain("[@media(hover:hover)]:hidden");
+    expect(trigger.className).not.toMatch(/(^|\s)(sm|md|lg|xl|2xl):hidden/);
   });
 
   it("renders nothing when every group is empty", () => {

--- a/packages/views/common/row-actions-menu.test.tsx
+++ b/packages/views/common/row-actions-menu.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RowActionsMenu } from "./row-actions-menu";
+
+describe("RowActionsMenu", () => {
+  it("names its trigger so a screen reader can announce the row's actions", () => {
+    render(
+      <RowActionsMenu
+        label="Chat actions"
+        groups={[[{ key: "archive", icon: null, label: "Archive", onSelect: vi.fn() }]]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat actions" })).toBeInTheDocument();
+  });
+
+  it("runs the action the user picks", async () => {
+    const onSelect = vi.fn();
+    render(
+      <RowActionsMenu
+        label="Chat actions"
+        groups={[[{ key: "archive", icon: null, label: "Archive", onSelect }]]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat actions" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Archive" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays out of the row's own click handling", () => {
+    // The trigger sits inside a row that selects on click. Opening the menu
+    // must not also select the row.
+    const onRowClick = vi.fn();
+    render(
+      <div onClick={onRowClick}>
+        <RowActionsMenu
+          label="Chat actions"
+          groups={[[{ key: "archive", icon: null, label: "Archive", onSelect: vi.fn() }]]}
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat actions" }));
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("hides from `md` up, where hover controls take over", () => {
+    render(
+      <RowActionsMenu
+        label="Chat actions"
+        groups={[[{ key: "archive", icon: null, label: "Archive", onSelect: vi.fn() }]]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat actions" }).className).toContain(
+      "md:hidden",
+    );
+  });
+
+  it("renders nothing when every group is empty", () => {
+    // A running chat with no pending task has no action to offer; an empty
+    // trigger would be a dead control.
+    const { container } = render(<RowActionsMenu label="Chat actions" groups={[[], []]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/views/common/row-actions-menu.tsx
+++ b/packages/views/common/row-actions-menu.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Fragment, type KeyboardEvent, type ReactNode } from "react";
+import { MoreHorizontal } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@multica/ui/components/ui/dropdown-menu";
+
+export interface RowActionItem {
+  key: string;
+  icon: ReactNode;
+  label: string;
+  onSelect: () => void;
+  danger?: boolean;
+}
+
+/**
+ * Enter/Space activation for a `role="button"` row that hosts its own
+ * controls (this menu, inline buttons): a key pressed inside one of those
+ * controls belongs to that control, not to the row.
+ */
+export function handleRowActivationKey(
+  e: KeyboardEvent<HTMLElement>,
+  activate: () => void,
+) {
+  if (e.target !== e.currentTarget) return;
+  if (e.key !== "Enter" && e.key !== " ") return;
+  e.preventDefault();
+  activate();
+}
+
+/**
+ * A list row's actions, collected behind one always-visible trigger.
+ *
+ * This is the touch counterpart of the hover controls list rows reveal on a
+ * pointer surface: a coarse pointer has neither hover nor right-click, so it
+ * would otherwise never reach them. It renders below `md` and hides from `md`
+ * up, where the hover controls take over — the two must therefore offer the
+ * same actions.
+ *
+ * `groups` are rendered in order with a separator between them.
+ */
+export function RowActionsMenu({
+  label,
+  groups,
+}: {
+  /** Accessible name of the trigger, e.g. "Chat actions". */
+  label: string;
+  groups: RowActionItem[][];
+}) {
+  const filled = groups.filter((group) => group.length > 0);
+  if (filled.length === 0) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            aria-label={label}
+            // The row owns click-to-select; opening the menu must not select it.
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring data-popup-open:bg-accent data-popup-open:text-foreground md:hidden"
+          >
+            <MoreHorizontal className="size-4" />
+          </button>
+        }
+      />
+      <DropdownMenuContent align="end" className="w-auto">
+        {filled.map((group, index) => (
+          <Fragment key={group[0]!.key}>
+            {index > 0 && <DropdownMenuSeparator />}
+            {group.map((item) => (
+              <DropdownMenuItem
+                key={item.key}
+                variant={item.danger ? "destructive" : "default"}
+                onClick={item.onSelect}
+              >
+                {item.icon}
+                {item.label}
+              </DropdownMenuItem>
+            ))}
+          </Fragment>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/views/common/row-actions-menu.tsx
+++ b/packages/views/common/row-actions-menu.tsx
@@ -38,9 +38,13 @@ export function handleRowActivationKey(
  *
  * This is the touch counterpart of the hover controls list rows reveal on a
  * pointer surface: a coarse pointer has neither hover nor right-click, so it
- * would otherwise never reach them. It renders below `md` and hides from `md`
- * up, where the hover controls take over — the two must therefore offer the
- * same actions.
+ * would otherwise never reach them. It renders where the primary pointer
+ * cannot hover and hides where it can, letting the hover controls take over —
+ * the two must therefore offer the same actions.
+ *
+ * The switch is `hover`, not a width breakpoint: a phone in landscape clears
+ * `md` while still having no hover, which would otherwise leave it with the
+ * hover controls it can never trigger.
  *
  * `groups` are rendered in order with a separator between them.
  */
@@ -65,7 +69,7 @@ export function RowActionsMenu({
             // The row owns click-to-select; opening the menu must not select it.
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
-            className="inline-flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring data-popup-open:bg-accent data-popup-open:text-foreground md:hidden"
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring data-popup-open:bg-accent data-popup-open:text-foreground [@media(hover:hover)]:hidden"
           >
             <MoreHorizontal className="size-4" />
           </button>

--- a/packages/views/inbox/components/inbox-context-menu.test.tsx
+++ b/packages/views/inbox/components/inbox-context-menu.test.tsx
@@ -15,7 +15,8 @@ vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
 vi.mock("./inbox-detail-label", () => ({ InboxDetailLabel: () => null }));
 
 // Import after mocks.
-import { InboxContextMenuProvider, type InboxRowActions } from "./inbox-context-menu";
+import { InboxContextMenuProvider } from "./inbox-context-menu";
+import type { InboxRowActions } from "./inbox-item-actions";
 import { InboxListItem } from "./inbox-list-item";
 
 const TEST_RESOURCES = { en: { inbox: enInbox } };
@@ -90,7 +91,7 @@ function renderRow({
       </InboxContextMenuProvider>,
     ),
   );
-  const row = screen.getByText(entry.title).closest("button");
+  const row = screen.getByText(entry.title).closest('[role="button"]');
   if (!row) throw new Error("inbox row button not found");
   return { rowActions, row };
 }
@@ -174,5 +175,78 @@ describe("inbox row context menu", () => {
     await screen.findByText("Archive");
 
     expect(screen.queryByText("Open in new tab")).toBeNull();
+  });
+});
+
+// A touch pointer has neither hover nor right-click, so the row's compact menu
+// is the only way in. It must therefore offer what right-click offers.
+describe("inbox row compact menu", () => {
+  const openMenu = () =>
+    fireEvent.click(screen.getByRole("button", { name: "Notification actions" }));
+
+  it("archives from the menu in the main view", async () => {
+    const onAction = vi.fn();
+    renderRow({ entry: item({ id: "inbox-3" }), actions: { onAction } });
+
+    openMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Archive" }));
+
+    expect(onAction).toHaveBeenCalledWith("inbox-3");
+  });
+
+  it("toggles read state from the menu", async () => {
+    const onMarkUnread = vi.fn();
+    renderRow({ entry: item({ id: "inbox-7", read: true }), actions: { onMarkUnread } });
+
+    openMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Mark as unread" }));
+
+    expect(onMarkUnread).toHaveBeenCalledWith("inbox-7");
+  });
+
+  it("offers unarchive and drops the read toggle in the archived view", async () => {
+    renderRow({ entry: item({ read: true, archived: true }), view: "archived" });
+
+    openMenu();
+
+    expect(await screen.findByRole("menuitem", { name: "Unarchive" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Mark as unread" })).toBeNull();
+  });
+
+  it("opens the referenced issue in a new tab", async () => {
+    renderRow({ entry: item({ issue_id: "issue-9" }) });
+
+    openMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Open in new tab" }));
+
+    expect(navigationAdapter.openInNewTab).toHaveBeenCalledWith(
+      "/acme/issues/issue-9",
+      undefined,
+      { activate: true },
+    );
+  });
+
+  it("does not select the row when the menu opens", () => {
+    const onClick = vi.fn();
+    render(
+      wrap(
+        <InboxContextMenuProvider
+          view="inbox"
+          actions={{ onMarkRead: vi.fn(), onMarkUnread: vi.fn(), onAction: vi.fn() }}
+        >
+          <InboxListItem
+            item={item()}
+            view="inbox"
+            isSelected={false}
+            onClick={onClick}
+            onAction={vi.fn()}
+          />
+        </InboxContextMenuProvider>,
+      ),
+    );
+
+    openMenu();
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/inbox/components/inbox-context-menu.tsx
+++ b/packages/views/inbox/components/inbox-context-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Fragment,
   createContext,
   useCallback,
   useContext,
@@ -10,10 +11,7 @@ import {
   type MouseEvent,
   type ReactNode,
 } from "react";
-import { Archive, ArchiveRestore, Check, CircleDot, ExternalLink } from "lucide-react";
-import { paths, useWorkspaceSlug } from "@multica/core/paths";
 import type { InboxItem } from "@multica/core/types";
-import { useIntentNavigate } from "../../navigation";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -21,7 +19,7 @@ import {
   ContextMenuSeparator,
 } from "@multica/ui/components/ui/context-menu";
 import type { InboxView } from "./inbox-view";
-import { useT } from "../../i18n";
+import { useInboxItemActions, type InboxRowActions } from "./inbox-item-actions";
 
 /**
  * Right-click actions for inbox rows.
@@ -34,18 +32,11 @@ import { useT } from "../../i18n";
  *
  * Rows delegate: the row only reports (item, cursor position) up to this
  * singleton, which anchors the menu at the cursor via a virtual anchor element.
+ *
+ * The provider also hands the same action set back down (`useInboxRowActions`)
+ * so the row's own compact menu — the touch replacement for right-click and
+ * hover — offers exactly these actions.
  */
-
-/** Row-level actions the menu invokes, all keyed by inbox item id. */
-export interface InboxRowActions {
-  onMarkRead: (id: string) => void;
-  onMarkUnread: (id: string) => void;
-  /**
-   * Archive in the main list, unarchive in the archived one — the same
-   * reversal-of-the-current-view the row's hover button performs.
-   */
-  onAction: (id: string) => void;
-}
 
 interface ActiveMenu {
   item: InboxItem;
@@ -54,7 +45,12 @@ interface ActiveMenu {
 
 type OpenInboxContextMenu = (item: InboxItem, event: MouseEvent) => void;
 
-const InboxContextMenuContext = createContext<OpenInboxContextMenu | null>(null);
+interface InboxContextMenuValue {
+  open: OpenInboxContextMenu;
+  actions: InboxRowActions;
+}
+
+const InboxContextMenuContext = createContext<InboxContextMenuValue | null>(null);
 
 export function InboxContextMenuProvider({
   view,
@@ -90,8 +86,13 @@ export function InboxContextMenuProvider({
     setOpen(v);
   }, []);
 
+  const value = useMemo<InboxContextMenuValue>(
+    () => ({ open: openMenu, actions }),
+    [openMenu, actions],
+  );
+
   return (
-    <InboxContextMenuContext.Provider value={openMenu}>
+    <InboxContextMenuContext.Provider value={value}>
       {children}
       {/* Mounted on first use, kept mounted after — the popup itself unmounts
           while closed. */}
@@ -115,7 +116,15 @@ export function InboxContextMenuProvider({
  * crashing, which keeps `InboxListItem` renderable on its own.
  */
 export function useInboxContextMenu(): OpenInboxContextMenu | null {
-  return useContext(InboxContextMenuContext);
+  return useContext(InboxContextMenuContext)?.open ?? null;
+}
+
+/**
+ * The list's row actions, for the row's own compact menu. `null` without a
+ * provider, same graceful degradation as `useInboxContextMenu`.
+ */
+export function useInboxRowActions(): InboxRowActions | null {
+  return useContext(InboxContextMenuContext)?.actions ?? null;
 }
 
 function InboxContextMenuSingleton({
@@ -131,16 +140,7 @@ function InboxContextMenuSingleton({
   open: boolean;
   onOpenChange: (v: boolean) => void;
 }) {
-  const { t } = useT("inbox");
-  // Null-safe slug (not useWorkspacePaths, which throws): keeps the menu
-  // renderable outside a workspace route; the item just doesn't show.
-  const slug = useWorkspaceSlug();
-  const issueHref =
-    slug && item.issue_id
-      ? paths.workspace(slug).issueDetail(item.issue_id)
-      : null;
-  const intentNavigate = useIntentNavigate();
-  const isArchivedView = view === "archived";
+  const groups = useInboxItemActions(item, view, actions);
 
   // Point-sized virtual anchor at the right-click position, so the menu opens
   // at the cursor rather than at the row's top-left corner.
@@ -155,53 +155,17 @@ function InboxContextMenuSingleton({
   return (
     <ContextMenu open={open} onOpenChange={onOpenChange}>
       <ContextMenuContent anchor={anchor}>
-        {/* An explicit "Open in new tab" CTA is a foreground open — focus
-            follows, per the navigation spec's right-click row. Only rows that
-            reference an issue have somewhere to open. */}
-        {issueHref && (
-          <>
-            <ContextMenuItem
-              onClick={() => intentNavigate(issueHref, "foreground-tab")}
-            >
-              <ExternalLink className="h-4 w-4" />
-              {t(($) => $.context_menu.open_in_new_tab)}
-            </ContextMenuItem>
-            <ContextMenuSeparator />
-          </>
-        )}
-        {/* The read toggle is main-view only. Archived rows deliberately render
-            as read (archiving preserves `read` so a restore can bring the real
-            state back) and the unread count excludes archived items — so a
-            toggle here would report success and change nothing on screen. */}
-        {!isArchivedView && (
-          <>
-            {item.read === true ? (
-              <ContextMenuItem onClick={() => actions.onMarkUnread(item.id)}>
-                <CircleDot className="h-4 w-4" />
-                {t(($) => $.context_menu.mark_unread)}
+        {groups.map((group, index) => (
+          <Fragment key={group[0]?.key ?? index}>
+            {index > 0 && <ContextMenuSeparator />}
+            {group.map((action) => (
+              <ContextMenuItem key={action.key} onClick={action.onSelect}>
+                {action.icon}
+                {action.label}
               </ContextMenuItem>
-            ) : (
-              <ContextMenuItem onClick={() => actions.onMarkRead(item.id)}>
-                <Check className="h-4 w-4" />
-                {t(($) => $.context_menu.mark_read)}
-              </ContextMenuItem>
-            )}
-            <ContextMenuSeparator />
-          </>
-        )}
-        <ContextMenuItem onClick={() => actions.onAction(item.id)}>
-          {isArchivedView ? (
-            <>
-              <ArchiveRestore className="h-4 w-4" />
-              {t(($) => $.context_menu.unarchive)}
-            </>
-          ) : (
-            <>
-              <Archive className="h-4 w-4" />
-              {t(($) => $.context_menu.archive)}
-            </>
-          )}
-        </ContextMenuItem>
+            ))}
+          </Fragment>
+        ))}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/packages/views/inbox/components/inbox-item-actions.tsx
+++ b/packages/views/inbox/components/inbox-item-actions.tsx
@@ -23,8 +23,9 @@ export interface InboxRowActions {
  * The actions an inbox row offers, grouped the way separators divide them.
  *
  * Shared by the desktop right-click menu and the compact per-row menu that
- * replaces the hover button below `md`, so the two can never drift: a pointer
- * with no hover state gets exactly the actions a right-click gives.
+ * stands in for the hover button wherever the pointer cannot hover, so the two
+ * can never drift: a pointer with no hover state gets exactly the actions a
+ * right-click gives.
  *
  * `actions` may be null (no provider); the row then has nothing to offer.
  */

--- a/packages/views/inbox/components/inbox-item-actions.tsx
+++ b/packages/views/inbox/components/inbox-item-actions.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Archive, ArchiveRestore, Check, CircleDot, ExternalLink } from "lucide-react";
+import { paths, useWorkspaceSlug } from "@multica/core/paths";
+import type { InboxItem } from "@multica/core/types";
+import type { RowActionItem } from "../../common/row-actions-menu";
+import { useIntentNavigate } from "../../navigation";
+import { useT } from "../../i18n";
+import type { InboxView } from "./inbox-view";
+
+/** Row-level actions the menus invoke, all keyed by inbox item id. */
+export interface InboxRowActions {
+  onMarkRead: (id: string) => void;
+  onMarkUnread: (id: string) => void;
+  /**
+   * Archive in the main list, unarchive in the archived one — the same
+   * reversal-of-the-current-view the row's inline button performs.
+   */
+  onAction: (id: string) => void;
+}
+
+/**
+ * The actions an inbox row offers, grouped the way separators divide them.
+ *
+ * Shared by the desktop right-click menu and the compact per-row menu that
+ * replaces the hover button below `md`, so the two can never drift: a pointer
+ * with no hover state gets exactly the actions a right-click gives.
+ *
+ * `actions` may be null (no provider); the row then has nothing to offer.
+ */
+export function useInboxItemActions(
+  item: InboxItem,
+  view: InboxView,
+  actions: InboxRowActions | null,
+): RowActionItem[][] {
+  const { t } = useT("inbox");
+  // Null-safe slug (not useWorkspacePaths, which throws): keeps the menus
+  // renderable outside a workspace route; the item just doesn't show.
+  const slug = useWorkspaceSlug();
+  const intentNavigate = useIntentNavigate();
+  if (!actions) return [];
+
+  const issueHref =
+    slug && item.issue_id
+      ? paths.workspace(slug).issueDetail(item.issue_id)
+      : null;
+  const isArchivedView = view === "archived";
+
+  const groups: RowActionItem[][] = [];
+
+  // An explicit "Open in new tab" CTA is a foreground open — focus follows,
+  // per the navigation spec's right-click row. Only rows that reference an
+  // issue have somewhere to open.
+  if (issueHref) {
+    groups.push([
+      {
+        key: "open-in-new-tab",
+        label: t(($) => $.context_menu.open_in_new_tab),
+        icon: <ExternalLink className="h-4 w-4" />,
+        onSelect: () => intentNavigate(issueHref, "foreground-tab"),
+      },
+    ]);
+  }
+
+  // The read toggle is main-view only. Archived rows deliberately render as
+  // read (archiving preserves `read` so a restore can bring the real state
+  // back) and the unread count excludes archived items — so a toggle here
+  // would report success and change nothing on screen.
+  if (!isArchivedView) {
+    groups.push([
+      item.read === true
+        ? {
+            key: "mark-unread",
+            label: t(($) => $.context_menu.mark_unread),
+            icon: <CircleDot className="h-4 w-4" />,
+            onSelect: () => actions.onMarkUnread(item.id),
+          }
+        : {
+            key: "mark-read",
+            label: t(($) => $.context_menu.mark_read),
+            icon: <Check className="h-4 w-4" />,
+            onSelect: () => actions.onMarkRead(item.id),
+          },
+    ]);
+  }
+
+  groups.push([
+    {
+      key: "archive-toggle",
+      label: isArchivedView
+        ? t(($) => $.context_menu.unarchive)
+        : t(($) => $.context_menu.archive),
+      icon: isArchivedView ? (
+        <ArchiveRestore className="h-4 w-4" />
+      ) : (
+        <Archive className="h-4 w-4" />
+      ),
+      onSelect: () => actions.onAction(item.id),
+    },
+  ]);
+
+  return groups;
+}

--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -176,6 +176,21 @@ describe("InboxListItem keyboard semantics", () => {
     expect(container.querySelector("button")).not.toBeNull();
   });
 
+  it("gates the archive affordance on hover capability, not viewport width", () => {
+    // A width breakpoint hides this button on every wide surface, touch or
+    // not. On a pointer that cannot hover — a phone in landscape clears `md` —
+    // that left the row with no reachable archive at all, which is the whole
+    // problem the compact menu exists to solve.
+    const { container } = renderRow({ item: item(), view: "inbox" });
+
+    const actionButton = container.querySelector("button")!;
+
+    expect(actionButton.className).toContain(
+      "[@media(hover:hover)]:group-hover:inline-flex",
+    );
+    expect(actionButton.className).not.toMatch(/(^|\s)(sm|md|lg|xl|2xl):group-/);
+  });
+
   it("activates on Enter like the button it replaces", () => {
     const onClick = vi.fn();
     renderRow({ item: item(), view: "inbox", onClick });

--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -164,13 +164,69 @@ describe("InboxListItem issue activity", () => {
   });
 });
 
+describe("InboxListItem keyboard semantics", () => {
+  it("is a role=button host, so its own controls stay reachable", () => {
+    // Interactive descendants of a real <button> are invalid HTML and are not
+    // exposed to screen readers — the row carries an action button and a menu.
+    const { container } = renderRow({ item: item(), view: "inbox" });
+
+    const row = screen.getByTestId("actor-avatar").closest('[role="button"]')!;
+    expect(row.tagName).toBe("DIV");
+    expect(row.getAttribute("tabindex")).toBe("0");
+    expect(container.querySelector("button")).not.toBeNull();
+  });
+
+  it("activates on Enter like the button it replaces", () => {
+    const onClick = vi.fn();
+    renderRow({ item: item(), view: "inbox", onClick });
+
+    const row = screen.getByTestId("actor-avatar").closest('[role="button"]')!;
+    fireEvent.keyDown(row, { key: "Enter" });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves keys pressed inside its own controls alone", () => {
+    // Enter on the archive button must archive, not select the row.
+    const onClick = vi.fn();
+    const { container } = renderRow({ item: item(), view: "inbox", onClick });
+
+    fireEvent.keyDown(container.querySelector("button")!, { key: "Enter" });
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("runs the row action without selecting the row", () => {
+    const onClick = vi.fn();
+    const onAction = vi.fn();
+    const { container } = render(
+      <WorkspaceSlugProvider slug="acme">
+        <NavigationProvider value={makeAdapter()}>
+          <InboxListItem
+            item={item()}
+            view="inbox"
+            isSelected={false}
+            onClick={onClick}
+            onAction={onAction}
+          />
+        </NavigationProvider>
+      </WorkspaceSlugProvider>,
+    );
+
+    fireEvent.click(container.querySelector("button")!);
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
 describe("InboxListItem link semantics", () => {
   it("plain click keeps the master-detail selection and does not navigate", () => {
     const onClick = vi.fn();
     const push = vi.fn();
     renderRow({ item: item(), view: "inbox", onClick, adapter: makeAdapter({ push }) });
 
-    fireEvent.click(screen.getByTestId("actor-avatar").closest("button")!);
+    fireEvent.click(screen.getByTestId("actor-avatar").closest('[role="button"]')!);
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(push).not.toHaveBeenCalled();
   });
@@ -185,7 +241,7 @@ describe("InboxListItem link semantics", () => {
       adapter: makeAdapter({ openInNewTab }),
     });
 
-    fireEvent.click(screen.getByTestId("actor-avatar").closest("button")!, {
+    fireEvent.click(screen.getByTestId("actor-avatar").closest('[role="button"]')!, {
       metaKey: true,
     });
     expect(openInNewTab).toHaveBeenCalledWith("/acme/issues/issue-1", undefined);
@@ -196,7 +252,7 @@ describe("InboxListItem link semantics", () => {
     const openInNewTab = vi.fn();
     renderRow({ item: item(), view: "inbox", adapter: makeAdapter({ openInNewTab }) });
 
-    const row = screen.getByTestId("actor-avatar").closest("button")!;
+    const row = screen.getByTestId("actor-avatar").closest('[role="button"]')!;
     const event = new MouseEvent("auxclick", {
       bubbles: true,
       button: 1,
@@ -218,7 +274,7 @@ describe("InboxListItem link semantics", () => {
       adapter: makeAdapter({ openInNewTab }),
     });
 
-    fireEvent.click(screen.getByTestId("actor-avatar").closest("button")!, {
+    fireEvent.click(screen.getByTestId("actor-avatar").closest('[role="button"]')!, {
       metaKey: true,
     });
     expect(onClick).toHaveBeenCalledTimes(1);

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -132,8 +132,8 @@ export function InboxListItem({
           <div className="flex shrink-0 items-center gap-1">
             {/* Pointer-only affordance: revealed on hover, and on keyboard
                 focus anywhere in the row so it is reachable by Tab. Touch has
-                neither, so it stays hidden below `md` and the compact menu
-                below carries the same action. */}
+                neither, so it stays hidden on a pointer that cannot hover and
+                the compact menu below carries the same action. */}
             <button
               type="button"
               title={actionLabel}
@@ -142,7 +142,7 @@ export function InboxListItem({
                 e.stopPropagation();
                 onAction();
               }}
-              className="hidden rounded p-0.5 text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring md:group-hover:inline-flex md:group-focus-within:inline-flex"
+              className="hidden rounded p-0.5 text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring [@media(hover:hover)]:group-hover:inline-flex [@media(hover:hover)]:group-focus-within:inline-flex"
             >
               <ActionIcon className="h-3.5 w-3.5" />
             </button>

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -11,6 +11,8 @@ import type { InboxView } from "./inbox-view";
 import { InboxDetailLabel } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
 import { useInboxContextMenu } from "./inbox-context-menu";
+import { InboxRowMenu } from "./inbox-row-menu";
+import { handleRowActivationKey } from "../../common/row-actions-menu";
 import { useT } from "../../i18n";
 import { paths, useWorkspaceSlug } from "@multica/core/paths";
 import { resolveClickIntent, useIntentNavigate } from "../../navigation";
@@ -72,8 +74,13 @@ export function InboxListItem({
   const actorType = item.actor_type ?? item.recipient_type;
 
   return (
-    <button
-      type="button"
+    // A div, not a <button>: the row carries its own controls (the action
+    // button, the compact menu), and interactive descendants of a <button>
+    // are invalid HTML that screen readers cannot reach. `role="button"` plus
+    // the Enter/Space handler keeps the row's own keyboard behavior.
+    <div
+      role="button"
+      tabIndex={0}
       onClick={(e) => {
         // Plain click keeps the master-detail selection; a modifier click on
         // a row that references an issue opens that issue as its own tab.
@@ -86,6 +93,7 @@ export function InboxListItem({
         }
         onClick();
       }}
+      onKeyDown={(e) => handleRowActivationKey(e, onClick)}
       onAuxClick={(e) => {
         if (e.defaultPrevented || e.button !== 1 || !issueHref) return;
         e.preventDefault();
@@ -97,7 +105,7 @@ export function InboxListItem({
       onContextMenu={
         openContextMenu ? (e) => openContextMenu(item, e) : undefined
       }
-      className={`group flex w-full select-none items-center gap-3 rounded-md px-2 py-2.5 text-left transition-colors ${
+      className={`group flex w-full cursor-default select-none items-center gap-3 rounded-md px-2 py-2.5 text-left outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring ${
         isSelected
           ? "bg-accent"
           : "hover:bg-accent/50 data-[popup-open]:bg-accent/50"
@@ -122,25 +130,23 @@ export function InboxListItem({
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <span
-              role="button"
-              tabIndex={-1}
+            {/* Pointer-only affordance: revealed on hover, and on keyboard
+                focus anywhere in the row so it is reachable by Tab. Touch has
+                neither, so it stays hidden below `md` and the compact menu
+                below carries the same action. */}
+            <button
+              type="button"
               title={actionLabel}
               aria-label={actionLabel}
               onClick={(e) => {
                 e.stopPropagation();
                 onAction();
               }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.stopPropagation();
-                  onAction();
-                }
-              }}
-              className="hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:inline-flex"
+              className="hidden rounded p-0.5 text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring md:group-hover:inline-flex md:group-focus-within:inline-flex"
             >
               <ActionIcon className="h-3.5 w-3.5" />
-            </span>
+            </button>
+            <InboxRowMenu item={item} view={view} />
             {item.issue_status && (
               <StatusIcon status={item.issue_status} className="h-3.5 w-3.5 shrink-0" />
             )}
@@ -168,6 +174,6 @@ export function InboxListItem({
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }

--- a/packages/views/inbox/components/inbox-list.tsx
+++ b/packages/views/inbox/components/inbox-list.tsx
@@ -91,8 +91,8 @@ export function InboxList({
 
   const selectItem = useCallback(
     (item: InboxItem) => {
-      // Safari does not focus a <button> on click, so the container has to be
-      // focused explicitly or the arrow keys would stay dead after a click.
+      // Safari does not focus a clicked row control, so the container has to
+      // be focused explicitly or the arrow keys would stay dead after a click.
       focusList();
       onSelect(item);
     },
@@ -207,9 +207,8 @@ export function InboxList({
     <div
       ref={attachScrollEl}
       data-tab-scroll-root="list"
-      // Programmatically focusable only: the rows are buttons and already
-      // carry their own tab stops, so a tabbable container would just add a
-      // redundant one.
+      // Programmatically focusable only: the rows already carry their own tab
+      // stops, so a tabbable container would just add a redundant one.
       tabIndex={-1}
       onKeyDown={handleKeyDown}
       className="flex-1 min-h-0 overflow-y-auto outline-none"

--- a/packages/views/inbox/components/inbox-row-menu.tsx
+++ b/packages/views/inbox/components/inbox-row-menu.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { InboxItem } from "@multica/core/types";
+import { RowActionsMenu } from "../../common/row-actions-menu";
+import { useT } from "../../i18n";
+import { useInboxRowActions } from "./inbox-context-menu";
+import { useInboxItemActions } from "./inbox-item-actions";
+import type { InboxView } from "./inbox-view";
+
+/**
+ * The row's compact action menu. It carries the same actions as the desktop
+ * right-click menu, and is the only way to reach them on a touch pointer,
+ * which has neither hover nor right-click.
+ *
+ * Renders nothing without an `InboxContextMenuProvider`: the actions live on
+ * the list, and a row without them has nothing to offer.
+ */
+export function InboxRowMenu({
+  item,
+  view,
+}: {
+  item: InboxItem;
+  view: InboxView;
+}) {
+  const { t } = useT("inbox");
+  const actions = useInboxRowActions();
+  const groups = useInboxItemActions(item, view, actions);
+  if (!actions) return null;
+
+  return <RowActionsMenu label={t(($) => $.list.actions_aria)} groups={groups} />;
+}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -114,7 +114,8 @@
       "cancel": "Cancel",
       "confirm": "Delete",
       "confirming": "Deleting..."
-    }
+    },
+    "row_actions_aria": "Chat actions"
   },
   "window": {
     "new_chat_tooltip": "New chat",
@@ -219,7 +220,8 @@
     "pinned": "Pinned",
     "archive": "Archive",
     "unarchive": "Unarchive",
-    "archived_title": "Archived"
+    "archived_title": "Archived",
+    "row_actions_aria": "Chat actions"
   },
   "header": {
     "view_profile": "View agent profile",

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -28,7 +28,8 @@
     },
     "archived_title": "Archived",
     "archived_empty": "No archived notifications",
-    "unarchive_tooltip": "Unarchive"
+    "unarchive_tooltip": "Unarchive",
+    "actions_aria": "Notification actions"
   },
   "detail": {
     "select_prompt": "Select a notification to view details",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -110,7 +110,8 @@
       "cancel": "実行を続ける",
       "confirm": "実行を停止",
       "confirming": "停止中..."
-    }
+    },
+    "row_actions_aria": "チャットの操作"
   },
   "window": {
     "new_chat_tooltip": "新規チャット",
@@ -215,7 +216,8 @@
     "pinned": "ピン留め済み",
     "archive": "アーカイブ",
     "unarchive": "アーカイブ解除",
-    "archived_title": "アーカイブ済み"
+    "archived_title": "アーカイブ済み",
+    "row_actions_aria": "チャットの操作"
   },
   "header": {
     "view_profile": "Agent のプロフィール",

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -28,7 +28,8 @@
     },
     "archived_title": "アーカイブ済み",
     "archived_empty": "アーカイブされた通知はありません",
-    "unarchive_tooltip": "アーカイブ解除"
+    "unarchive_tooltip": "アーカイブ解除",
+    "actions_aria": "通知の操作"
   },
   "detail": {
     "select_prompt": "詳細を表示する通知を選択してください",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -110,7 +110,8 @@
       "cancel": "취소",
       "confirm": "삭제",
       "confirming": "삭제하는 중..."
-    }
+    },
+    "row_actions_aria": "채팅 작업"
   },
   "window": {
     "new_chat_tooltip": "새 채팅",
@@ -215,7 +216,8 @@
     "pinned": "고정됨",
     "archive": "보관",
     "unarchive": "보관 해제",
-    "archived_title": "보관됨"
+    "archived_title": "보관됨",
+    "row_actions_aria": "채팅 작업"
   },
   "header": {
     "view_profile": "Agent 프로필 보기",

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -28,7 +28,8 @@
     },
     "archived_title": "보관됨",
     "archived_empty": "보관된 알림이 없습니다",
-    "unarchive_tooltip": "보관 해제"
+    "unarchive_tooltip": "보관 해제",
+    "actions_aria": "알림 작업"
   },
   "detail": {
     "select_prompt": "자세히 볼 알림을 선택하세요",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -110,7 +110,8 @@
       "cancel": "取消",
       "confirm": "删除",
       "confirming": "删除中..."
-    }
+    },
+    "row_actions_aria": "聊天操作"
   },
   "window": {
     "new_chat_tooltip": "新对话",
@@ -215,7 +216,8 @@
     "pinned": "已置顶",
     "archive": "归档",
     "unarchive": "取消归档",
-    "archived_title": "已归档"
+    "archived_title": "已归档",
+    "row_actions_aria": "聊天操作"
   },
   "header": {
     "view_profile": "查看 Agent 资料",

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -28,7 +28,8 @@
     },
     "archived_title": "已归档",
     "archived_empty": "暂无已归档通知",
-    "unarchive_tooltip": "取消归档"
+    "unarchive_tooltip": "取消归档",
+    "actions_aria": "通知操作"
   },
   "detail": {
     "select_prompt": "选择一条通知查看详情",


### PR DESCRIPTION
## What changed

- Added a shared compact row-actions menu for inbox rows, chat thread rows, and floating chat-session history rows on mobile breakpoints.
- Reused one action model for each row's mobile menu, desktop hover controls, and inbox context menu so the available actions cannot drift.
- Made desktop hover controls keyboard-reachable with focus-within behavior.
- Reworked inbox row activation to avoid invalid nested interactive elements and prevent control keypresses from selecting the parent row.
- Added localized accessible labels in English, Japanese, Korean, and Simplified Chinese, plus focused component coverage.

## Why

These per-item controls were exposed only through hover or right-click. Touch devices provide neither interaction reliably, leaving archive, read-state, pin, rename, stop, and related actions inaccessible.

Desktop presentation remains unchanged: compact menus are hidden from the `md` breakpoint upward, where the existing hover controls remain in place.

## Validation

- `pnpm typecheck`
- `pnpm lint` (zero errors; existing warnings only)
- Focused `@multica/views` tests: 40 passed across the chat-thread, row-actions, inbox-context-menu, and inbox-list-item suites
- The source fork's full CI passed before the branch was squashed and rebased onto current upstream `main`
