### PR TITLE
MUL-6046 AGE-505: add safe persistent mobile chat outbox

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
@@ -111,6 +111,11 @@ export default function ChatTab() {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [agentPickerOpen, setAgentPickerOpen] = useState(false);
+  const [editingOutbox, setEditingOutbox] = useState<{
+    clientId: string;
+    draftKey: string;
+    previousDraft: string;
+  } | null>(null);
 
   // Bridge to the chat-sessions formSheet route. Mirror local
   // activeSessionId into the store so the picker can render the current
@@ -213,6 +218,14 @@ export default function ChatTab() {
   const enqueueOutbox = useChatOutboxStore((s) => s.enqueue);
   const updateOutbox = useChatOutboxStore((s) => s.update);
   const removeOutbox = useChatOutboxStore((s) => s.remove);
+
+  // Session switches cannot leave another session's queued text in the
+  // composer. Put the draft that preceded editing back where it came from.
+  useEffect(() => {
+    if (!editingOutbox || editingOutbox.draftKey === draftKey) return;
+    setDraft(editingOutbox.draftKey, editingOutbox.previousDraft);
+    setEditingOutbox(null);
+  }, [draftKey, editingOutbox, setDraft]);
 
   // ── Realtime ───────────────────────────────────────────────────────────
   useChatSessionRealtime(activeSessionId, () => {
@@ -329,8 +342,8 @@ export default function ChatTab() {
           error.status >= 400 &&
           error.status < 500
         ) {
-          // A 401 clears this user partition through auth-store. Marking it
-          // failed first avoids a retry race while that cleanup runs.
+          // Auth expiry must retain unsent content. Mark this local item
+          // failed and let the user authenticate again before a manual retry.
           updateOutbox(head.clientId, (item) =>
             permanentlyFailedChatOutboxItem(item, message),
           );
@@ -371,6 +384,34 @@ export default function ChatTab() {
       }
       if (!userId || !wsSlug) return;
 
+      if (editingOutbox) {
+        const item = useChatOutboxStore
+          .getState()
+          .items.find((candidate) => candidate.clientId === editingOutbox.clientId);
+        if (!item || item.status === "sending") {
+          setEditingOutbox(null);
+          return;
+        }
+
+        // An edited instruction is logically a new manual-delivery attempt.
+        // Keep its queue position, but give it a new local id and clear retry
+        // state so it cannot be mistaken for an earlier payload.
+        updateOutbox(item.clientId, (current) => ({
+          ...current,
+          content,
+          attachmentIds: [...new Set([...current.attachmentIds, ...attachmentIds])],
+          clientId: createChatOutboxClientId(),
+          status: "queued",
+          attemptCount: 0,
+          retryable: true,
+          lastError: null,
+          nextAttemptAt: null,
+        }));
+        clearDraft(editingOutbox.draftKey);
+        setEditingOutbox(null);
+        return;
+      }
+
       const isNewSession = !activeSessionId;
       const sessionId = await ensureSession(content);
       if (!sessionId) return;
@@ -409,6 +450,8 @@ export default function ChatTab() {
       promoteNewDraft,
       clearDraft,
       enqueueOutbox,
+      editingOutbox,
+      updateOutbox,
       netInfo.isConnected,
       userId,
       wsSlug,
@@ -426,35 +469,21 @@ export default function ChatTab() {
   const editOutboxItem = useCallback(
     (item: ChatOutboxItem) => {
       if (item.status === "sending") return;
-      Alert.prompt(
-        "Edit unsent message",
-        undefined,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Save",
-            onPress: (content?: string) => {
-              const next = content?.trim();
-              if (!next) return;
-              updateOutbox(item.clientId, (current) => ({
-                ...current,
-                content: next,
-                clientId: createChatOutboxClientId(),
-                status: "queued",
-                attemptCount: 0,
-                retryable: true,
-                lastError: null,
-                nextAttemptAt: null,
-              }));
-            },
-          },
-        ],
-        "plain-text",
-        item.content,
-      );
+      setEditingOutbox({
+        clientId: item.clientId,
+        draftKey,
+        previousDraft: draft,
+      });
+      setDraft(draftKey, item.content);
     },
-    [updateOutbox],
+    [draft, draftKey, setDraft],
   );
+
+  const cancelOutboxEdit = useCallback(() => {
+    if (!editingOutbox) return;
+    setDraft(editingOutbox.draftKey, editingOutbox.previousDraft);
+    setEditingOutbox(null);
+  }, [editingOutbox, setDraft]);
 
   const handleOutboxPress = useCallback(
     (item: ChatOutboxItem) => {
@@ -620,6 +649,7 @@ export default function ChatTab() {
         <ChatMessageList
           messages={visibleMessages}
           outboxItems={activeOutboxItems}
+          editingOutboxClientId={editingOutbox?.clientId}
           loading={messagesLoading}
           hasSessions={sessions.length > 0}
           agentName={currentAgent?.name}
@@ -650,6 +680,8 @@ export default function ChatTab() {
           allowStop={pendingTask?.status !== "queued"}
           disabled={disabled}
           disabledReason={disabledReason}
+          editingOutboxClientId={editingOutbox?.clientId}
+          onCancelOutboxEdit={cancelOutboxEdit}
         />
       </KeyboardAvoidingView>
 

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
@@ -32,6 +32,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ActionSheetIOS,
   Alert,
   KeyboardAvoidingView,
   Platform,
@@ -40,17 +41,17 @@ import {
 import { router } from "expo-router";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNetInfo } from "@react-native-community/netinfo";
 import type {
   Agent,
   ChatMessage,
   ChatPendingTask,
 } from "@multica/core/types";
 import {
-  enqueuePendingChatTask,
   hideQueuedChatMessages,
   removePendingChatTask,
 } from "@multica/core/chat/pending";
-import { api } from "@/data/api";
+import { ApiError, api } from "@/data/api";
 import { useAuthStore } from "@/data/auth-store";
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { agentListOptions } from "@/data/queries/agents";
@@ -71,6 +72,15 @@ import {
   DRAFT_NEW_SESSION,
   useChatDraftsStore,
 } from "@/data/stores/chat-drafts-store";
+import { useChatOutboxStore } from "@/data/stores/chat-outbox-store";
+import {
+  createChatOutboxClientId,
+  MAX_CHAT_OUTBOX_ATTEMPTS,
+  nextChatOutboxItem,
+  nextFailedChatOutboxItem,
+  permanentlyFailedChatOutboxItem,
+  type ChatOutboxItem,
+} from "@/data/stores/chat-outbox";
 import { useChatSessionPickerStore } from "@/data/stores/chat-session-picker-store";
 import { useChatSessionRealtime } from "@/data/realtime/use-chat-session-realtime";
 import {
@@ -184,6 +194,7 @@ export default function ChatTab() {
   }, [selectedAgentId, availableAgents, activeSession, agents]);
 
   const availability = useWorkspaceAgentAvailability();
+  const netInfo = useNetInfo();
   const presenceDetail = useAgentPresence(wsId, currentAgent?.id);
   const presenceAvailability =
     presenceDetail === "loading" ? undefined : presenceDetail.availability;
@@ -198,6 +209,10 @@ export default function ChatTab() {
   const setDraft = useChatDraftsStore((s) => s.setDraft);
   const clearDraft = useChatDraftsStore((s) => s.clearDraft);
   const promoteNewDraft = useChatDraftsStore((s) => s.promoteNewDraft);
+  const outboxItems = useChatOutboxStore((s) => s.items);
+  const enqueueOutbox = useChatOutboxStore((s) => s.enqueue);
+  const updateOutbox = useChatOutboxStore((s) => s.update);
+  const removeOutbox = useChatOutboxStore((s) => s.remove);
 
   // ── Realtime ───────────────────────────────────────────────────────────
   useChatSessionRealtime(activeSessionId, () => {
@@ -252,6 +267,86 @@ export default function ChatTab() {
     [activeSessionId, currentAgent, createSession],
   );
 
+  const attemptOutboxSend = useCallback(
+    async (sessionId: string, requestedClientId?: string) => {
+      const head = nextChatOutboxItem(
+        useChatOutboxStore.getState().items,
+        sessionId,
+      );
+      if (!head) return;
+      if (requestedClientId && head.clientId !== requestedClientId) {
+        Alert.alert(
+          "Send in order",
+          "An earlier unsent message must be sent or removed first.",
+        );
+        return;
+      }
+
+      updateOutbox(head.clientId, (item) => ({
+        ...item,
+        status: "sending",
+        lastError: null,
+        nextAttemptAt: null,
+      }));
+      try {
+        // A short send-specific ceiling avoids a false-online connection
+        // leaving this visible message without feedback for thirty seconds.
+        const result = await api.sendChatMessage(sessionId, head.content, {
+          attachmentIds:
+            head.attachmentIds.length > 0 ? head.attachmentIds : undefined,
+          timeoutMs: 8_000,
+        });
+        removeOutbox(head.clientId);
+        const sent: ChatMessage = {
+          id: result.message_id,
+          chat_session_id: sessionId,
+          role: "user",
+          content: head.content,
+          task_id: result.task_id,
+          created_at: result.created_at,
+        };
+        qc.setQueryData<ChatMessage[]>(chatKeys.messages(sessionId), (old) =>
+          old?.some((message) => message.id === sent.id)
+            ? old
+            : [...(old ?? []), sent],
+        );
+        seedAcceptedPendingTask(qc, {
+          chat_session_id: sessionId,
+          task_id: result.task_id,
+          created_at: result.created_at,
+          message_id: result.message_id,
+          content: head.content,
+          optimistic_task_id: `outbox-${head.clientId}`,
+          supports_queue: result.supports_queue,
+          queued: result.queued,
+        });
+        void qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unable to send message";
+        if (
+          error instanceof ApiError &&
+          error.status >= 400 &&
+          error.status < 500
+        ) {
+          // A 401 clears this user partition through auth-store. Marking it
+          // failed first avoids a retry race while that cleanup runs.
+          updateOutbox(head.clientId, (item) =>
+            permanentlyFailedChatOutboxItem(item, message),
+          );
+          return;
+        }
+        updateOutbox(head.clientId, (item) =>
+          nextFailedChatOutboxItem(
+            item,
+            `${message}. Check this chat before sending again.`,
+          ),
+        );
+      }
+    },
+    [qc, removeOutbox, updateOutbox],
+  );
+
   const handleSend = useCallback(
     async (
       content: string,
@@ -267,96 +362,153 @@ export default function ChatTab() {
         return;
       }
 
+      if (!activeSessionId && netInfo.isConnected === false) {
+        Alert.alert(
+          "Connect to start a new chat",
+          "New chats need an internet connection before messages can be queued.",
+        );
+        return;
+      }
+      if (!userId || !wsSlug) return;
+
       const isNewSession = !activeSessionId;
       const sessionId = await ensureSession(content);
       if (!sessionId) return;
-
-      const sentAt = new Date().toISOString();
-      const optimistic: ChatMessage = {
-        id: `optimistic-${Date.now()}`,
-        chat_session_id: sessionId,
-        role: "user",
-        content,
-        task_id: null,
-        created_at: sentAt,
-      };
-      const optimisticTaskId = `optimistic-${optimistic.id}`;
-      qc.setQueryData<ChatMessage[]>(chatKeys.messages(sessionId), (old) =>
-        old ? [...old, optimistic] : [optimistic],
-      );
-      qc.setQueryData<ChatPendingTask>(
-        chatKeys.pendingTask(sessionId),
-        (old) =>
-          enqueuePendingChatTask(
-            old,
-            {
-              task_id: optimisticTaskId,
-              status: "queued",
-              created_at: sentAt,
-              message_id: optimistic.id,
-              content,
-            },
-            Boolean(old?.task_id),
-          ),
-      );
       if (isNewSession) {
         promoteNewDraft(sessionId);
         setActiveSessionId(sessionId);
       }
 
-      try {
-        const result = await api.sendChatMessage(sessionId, content, {
-          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        });
-        // Replace the local bubble before reconciling pending state. When the
-        // server says this is a follow-up, its real message id lets the shared
-        // queue filter hide it immediately instead of waiting for the refetch.
-        qc.setQueryData<ChatMessage[]>(chatKeys.messages(sessionId), (old) =>
-          old?.map((message) =>
-            message.id === optimistic.id
-              ? {
-                  ...message,
-                  id: result.message_id,
-                  task_id: result.task_id,
-                  created_at: result.created_at,
-                }
-              : message,
-          ),
-        );
-        seedAcceptedPendingTask(qc, {
-          chat_session_id: sessionId,
-          task_id: result.task_id,
-          created_at: result.created_at,
-          message_id: result.message_id,
-          content,
-          optimistic_task_id: optimisticTaskId,
-          supports_queue: result.supports_queue,
-          queued: result.queued,
-        });
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-        if (options.clearDraft !== false) {
-          clearDraft(sessionId);
-        }
-      } catch (err) {
-        qc.setQueryData<ChatMessage[]>(chatKeys.messages(sessionId), (old) =>
-          old ? old.filter((m) => m.id !== optimistic.id) : old,
-        );
-        qc.setQueryData<ChatPendingTask>(
-          chatKeys.pendingTask(sessionId),
-          (old) => removePendingChatTask(old, optimisticTaskId),
-        );
-        throw err;
+      const item: ChatOutboxItem = {
+        clientId: createChatOutboxClientId(),
+        sessionId,
+        workspaceSlug: wsSlug,
+        userId,
+        content,
+        attachmentIds,
+        createdAt: new Date().toISOString(),
+        status: "queued",
+        attemptCount: 0,
+        retryable: true,
+        lastError:
+          netInfo.isConnected === false ? "Waiting for a connection" : null,
+        nextAttemptAt: null,
+      };
+      enqueueOutbox(item);
+      if (options.clearDraft !== false) clearDraft(sessionId);
+      if (netInfo.isConnected !== false) {
+        await attemptOutboxSend(sessionId, item.clientId);
       }
     },
     [
       activeSessionId,
+      attemptOutboxSend,
       currentAgent,
       runtimeBound,
       ensureSession,
-      qc,
       promoteNewDraft,
       clearDraft,
+      enqueueOutbox,
+      netInfo.isConnected,
+      userId,
+      wsSlug,
     ],
+  );
+
+  const activeOutboxItems = useMemo(
+    () =>
+      activeSessionId
+        ? outboxItems.filter((item) => item.sessionId === activeSessionId)
+        : [],
+    [activeSessionId, outboxItems],
+  );
+
+  const editOutboxItem = useCallback(
+    (item: ChatOutboxItem) => {
+      if (item.status === "sending") return;
+      Alert.prompt(
+        "Edit unsent message",
+        undefined,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Save",
+            onPress: (content?: string) => {
+              const next = content?.trim();
+              if (!next) return;
+              updateOutbox(item.clientId, (current) => ({
+                ...current,
+                content: next,
+                clientId: createChatOutboxClientId(),
+                status: "queued",
+                attemptCount: 0,
+                retryable: true,
+                lastError: null,
+                nextAttemptAt: null,
+              }));
+            },
+          },
+        ],
+        "plain-text",
+        item.content,
+      );
+    },
+    [updateOutbox],
+  );
+
+  const handleOutboxPress = useCallback(
+    (item: ChatOutboxItem) => {
+      if (item.status === "sending") {
+        Alert.alert(
+          "Cancel local retry?",
+          "This stops future local retries. It cannot recall a message that may already have reached the server.",
+          [
+            { text: "Keep sending", style: "cancel" },
+            {
+              text: "Cancel local retry",
+              style: "destructive",
+              onPress: () => removeOutbox(item.clientId),
+            },
+          ],
+        );
+        return;
+      }
+      const canRetry =
+        item.retryable && item.attemptCount < MAX_CHAT_OUTBOX_ATTEMPTS;
+      const options = canRetry
+        ? ["Cancel", "Edit", "Send now", "Remove"]
+        : ["Cancel", "Edit", "Remove"];
+      const removeIndex = options.length - 1;
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options,
+          cancelButtonIndex: 0,
+          destructiveButtonIndex: removeIndex,
+        },
+        (index) => {
+          if (index === 1) {
+            editOutboxItem(item);
+            return;
+          }
+          if (canRetry && index === 2) {
+            if (
+              item.nextAttemptAt &&
+              new Date(item.nextAttemptAt).getTime() > Date.now()
+            ) {
+              Alert.alert(
+                "Try again shortly",
+                "This message is backing off after its last failure.",
+              );
+              return;
+            }
+            void attemptOutboxSend(item.sessionId, item.clientId);
+            return;
+          }
+          if (index === removeIndex) removeOutbox(item.clientId);
+        },
+      );
+    },
+    [attemptOutboxSend, editOutboxItem, removeOutbox],
   );
 
   // ── Cancel in-flight ───────────────────────────────────────────────────
@@ -467,6 +619,7 @@ export default function ChatTab() {
       >
         <ChatMessageList
           messages={visibleMessages}
+          outboxItems={activeOutboxItems}
           loading={messagesLoading}
           hasSessions={sessions.length > 0}
           agentName={currentAgent?.name}
@@ -478,6 +631,7 @@ export default function ChatTab() {
           pendingTask={pendingTask}
           liveTaskMessages={liveTaskMessages}
           availability={presenceAvailability}
+          onOutboxPress={handleOutboxPress}
         />
         {runtimeBound ? (
           <OfflineBanner

--- a/apps/mobile/app/(app)/[workspace]/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/_layout.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { ComponentProps } from "react";
 import { Redirect, Stack, useLocalSearchParams } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import { workspaceListOptions } from "@/data/queries/workspaces";
 import { useWorkspaceStore } from "@/data/workspace-store";
+import { useAuthStore } from "@/data/auth-store";
 import { RealtimeProvider } from "@/data/realtime/realtime-provider";
 import { useInboxRealtime } from "@/data/realtime/use-inbox-realtime";
 import { useIssuesRealtime } from "@/data/realtime/use-issues-realtime";
@@ -14,8 +15,10 @@ import { usePinsRealtime } from "@/data/realtime/use-pins-realtime";
 import { usePresenceRealtime } from "@/data/realtime/use-presence-realtime";
 import { useWorkspacePresencePrefetch } from "@/lib/use-workspace-presence-prefetch";
 import { ModalCloseButton } from "@/components/ui/modal-close-button";
-import { useNewIssueDraftResetOnWorkspaceChange } from "@/data/stores/new-issue-draft-store";
-import { useNewProjectDraftResetOnWorkspaceChange } from "@/data/stores/new-project-draft-store";
+import { hydrateNewIssueDraft } from "@/data/stores/new-issue-draft-store";
+import { hydrateNewProjectDraft } from "@/data/stores/new-project-draft-store";
+import { hydrateChatDrafts } from "@/data/stores/chat-drafts-store";
+import { hydrateChatOutbox } from "@/data/stores/chat-outbox-store";
 import { useChatSessionPickerResetOnWorkspaceChange } from "@/data/stores/chat-session-picker-store";
 
 /**
@@ -103,8 +106,13 @@ export default function WorkspaceLayout() {
   const { workspace: slug } = useLocalSearchParams<{ workspace: string }>();
   const { data: workspaces, isLoading } = useQuery(workspaceListOptions());
   const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
+  const user = useAuthStore((s) => s.user);
+  const userId = user?.id ?? null;
+  const [hydratedDraftScope, setHydratedDraftScope] = useState<string | null>(null);
 
   const matched = workspaces?.find((w) => w.slug === slug);
+  const matchedId = matched?.id ?? null;
+  const matchedSlug = matched?.slug ?? null;
 
   useEffect(() => {
     if (matched) {
@@ -112,18 +120,38 @@ export default function WorkspaceLayout() {
     }
   }, [matched, setCurrentWorkspace]);
 
-  // Wipe cross-route Zustand draft stores whenever the active workspace
-  // changes — a draft picked under workspace A (assignee id, draft
-  // session id, etc.) is invalid in workspace B and must not leak.
-  useNewIssueDraftResetOnWorkspaceChange(matched?.id ?? null);
-  useNewProjectDraftResetOnWorkspaceChange(matched?.id ?? null);
   useChatSessionPickerResetOnWorkspaceChange(matched?.id ?? null);
+
+  const draftScope = userId && matchedSlug ? `${userId}:${matchedSlug}` : null;
+  useEffect(() => {
+    let cancelled = false;
+    if (!userId || !matchedSlug || !matchedId) {
+      setHydratedDraftScope(null);
+      return () => { cancelled = true; };
+    }
+    void Promise.all([
+      hydrateChatDrafts(userId, matchedSlug),
+      hydrateChatOutbox(userId, matchedSlug),
+      hydrateNewIssueDraft(userId, matchedSlug),
+      hydrateNewProjectDraft(userId, matchedSlug),
+    ])
+      .catch((error) => {
+        // Draft persistence is a resilience enhancement; a local storage
+        // failure must not strand an otherwise valid workspace route.
+        console.warn("Failed to restore local drafts", error);
+      })
+      .finally(() => {
+        if (!cancelled) setHydratedDraftScope(`${userId}:${matchedSlug}`);
+      });
+    return () => { cancelled = true; };
+  }, [userId, matchedId, matchedSlug]);
 
   // Wait for the workspaces list before deciding membership — otherwise a
   // valid deep link would briefly redirect away on cold start.
   if (isLoading) return null;
 
   if (!matched) return <Redirect href="/select-workspace" />;
+  if (draftScope !== hydratedDraftScope) return null;
 
   // Tabs hide their own header; pushed screens (issue/[id]) get a native
   // iOS Stack header with the standard back button + swipe-to-dismiss.

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,8 +1,11 @@
-import { Stack, Redirect } from "expo-router";
+import { Stack, Redirect, usePathname } from "expo-router";
 import { useAuthStore } from "@/data/auth-store";
+import { NetworkOfflineBanner } from "@/components/network-offline-banner";
 
 /**
- * Auth-required layout. Redirects to /login when no user is loaded.
+ * Auth-required layout. A valid credential remains admitted while offline;
+ * only the one-time upgrade edge case without a user snapshot lands on the
+ * explicit /offline screen.
  *
  * Workspace membership is enforced one level deeper at [workspace]/_layout —
  * not here — because select-workspace.tsx itself is auth-required but
@@ -10,6 +13,14 @@ import { useAuthStore } from "@/data/auth-store";
  */
 export default function AppLayout() {
   const user = useAuthStore((s) => s.user);
-  if (!user) return <Redirect href="/login" />;
-  return <Stack screenOptions={{ headerShown: false }} />;
+  const hasToken = useAuthStore((s) => s.hasToken);
+  const pathname = usePathname();
+  if (!hasToken) return <Redirect href="/login" />;
+  if (!user && pathname !== "/offline") return <Redirect href="/offline" />;
+  return (
+    <>
+      <NetworkOfflineBanner />
+      <Stack screenOptions={{ headerShown: false }} />
+    </>
+  );
 }

--- a/apps/mobile/app/(app)/offline.tsx
+++ b/apps/mobile/app/(app)/offline.tsx
@@ -1,0 +1,43 @@
+import { ActivityIndicator, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router } from "expo-router";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { useAuthStore } from "@/data/auth-store";
+
+/**
+ * Upgrade edge case: a pre-offline-release session has a token but no saved
+ * user snapshot. It is intentionally not treated as a login failure.
+ */
+export default function OfflineAccountInfo() {
+  const initialize = useAuthStore((s) => s.initialize);
+  const logout = useAuthStore((s) => s.logout);
+  const isLoading = useAuthStore((s) => s.isLoading);
+
+  const retry = async () => {
+    await initialize();
+    const { user, hasToken } = useAuthStore.getState();
+    if (user) router.replace("/");
+    else if (!hasToken) router.replace("/login");
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <View className="flex-1 justify-center gap-4 px-6">
+        <Text className="text-2xl font-semibold text-foreground">
+          Account info unavailable offline
+        </Text>
+        <Text className="text-sm leading-5 text-muted-foreground">
+          This session is still saved on this device, but it was created before
+          offline account details could be stored. Connect once to restore it.
+        </Text>
+        <Button variant="outline" onPress={retry} disabled={isLoading}>
+          {isLoading ? <ActivityIndicator /> : <Text>Retry</Text>}
+        </Button>
+        <Button variant="destructive" onPress={() => void logout()}>
+          <Text>Sign out</Text>
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -7,12 +7,14 @@ import { useWorkspaceStore } from "@/data/workspace-store";
  * Entry redirect. AuthInitializer (in _layout.tsx) finishes auth + slug
  * hydration before this renders meaningfully — until then, isLoading is true.
  *
- *   no user            → /login
+ *   no credential      → /login
+ *   credential, no user snapshot → /offline (upgrade edge case)
  *   user, no slug      → /select-workspace
  *   user, slug         → /[slug]/inbox
  */
 export default function Index() {
   const user = useAuthStore((s) => s.user);
+  const hasToken = useAuthStore((s) => s.hasToken);
   const isLoading = useAuthStore((s) => s.isLoading);
   const slug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
 
@@ -24,7 +26,8 @@ export default function Index() {
     );
   }
 
-  if (!user) return <Redirect href="/login" />;
+  if (!hasToken) return <Redirect href="/login" />;
+  if (!user) return <Redirect href="/offline" />;
   if (!slug) return <Redirect href="/select-workspace" />;
   return <Redirect href={`/${slug}/inbox`} />;
 }

--- a/apps/mobile/components/chat/chat-composer.tsx
+++ b/apps/mobile/components/chat/chat-composer.tsx
@@ -32,6 +32,7 @@ import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { MessageComposer } from "@/components/composer/message-composer";
+import { Text } from "@/components/ui/text";
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
@@ -57,6 +58,10 @@ interface Props {
   disabled?: boolean;
   /** When `disabled`, replaces the pill label with the reason. */
   disabledReason?: string;
+  /** The queued item currently being edited in the shared composer. */
+  editingOutboxClientId?: string | null;
+  /** Restore the draft that was present before editing the queued item. */
+  onCancelOutboxEdit?: () => void;
 }
 
 const IS_IOS = process.env.EXPO_OS === "ios";
@@ -70,6 +75,8 @@ export function ChatComposer({
   allowStop = true,
   disabled = false,
   disabledReason,
+  editingOutboxClientId = null,
+  onCancelOutboxEdit,
 }: Props) {
   const wsSlug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
 
@@ -96,29 +103,56 @@ export function ChatComposer({
   }, [onStop]);
 
   return (
-    <MessageComposer
-      value={value}
-      onChangeText={onChangeText}
-      onSubmit={onSubmit}
-      mentionPickerPath={{
-        pathname: "/[workspace]/mention-picker",
-        params: { workspace: wsSlug ?? "", mode: "chat" },
-      }}
-      placeholder={sending ? "Agent is working…" : "Message…"}
-      pillLabel={
-        sending
-          ? "Agent is working…"
-          : disabled
-            ? (disabledReason ?? "Chat unavailable")
-            : "Message…"
-      }
-      pillIcon="chatbubble-ellipses-outline"
-      disabled={disabled}
-      disabledReason={disabledReason}
-      isSending={sending}
-      renderStop={allowStop ? () => <StopButton onPress={handleStop} /> : undefined}
-      manageKeyboard={false}
-    />
+    <View>
+      {editingOutboxClientId ? (
+        <View className="mx-3 mb-1 flex-row items-center gap-2 rounded-lg border border-primary/25 bg-primary/10 px-3 py-2">
+          <Ionicons name="create-outline" size={16} color="#2563eb" />
+          <Text className="flex-1 text-sm font-medium text-foreground">
+            Editing unsent message
+          </Text>
+          <Pressable
+            onPress={onCancelOutboxEdit}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel editing unsent message"
+            className="rounded-md px-1 py-0.5 active:opacity-70"
+          >
+            <Text className="text-sm font-medium text-primary">Cancel</Text>
+          </Pressable>
+        </View>
+      ) : null}
+      <MessageComposer
+        value={value}
+        onChangeText={onChangeText}
+        onSubmit={onSubmit}
+        mentionPickerPath={{
+          pathname: "/[workspace]/mention-picker",
+          params: { workspace: wsSlug ?? "", mode: "chat" },
+        }}
+        placeholder={
+          sending
+            ? "Agent is working…"
+            : editingOutboxClientId
+              ? "Edit unsent message…"
+              : "Message…"
+        }
+        pillLabel={
+          sending
+            ? "Agent is working…"
+            : disabled
+              ? (disabledReason ?? "Chat unavailable")
+              : editingOutboxClientId
+                ? "Edit unsent message…"
+                : "Message…"
+        }
+        pillIcon="chatbubble-ellipses-outline"
+        disabled={disabled}
+        disabledReason={disabledReason}
+        isSending={sending}
+        renderStop={allowStop ? () => <StopButton onPress={handleStop} /> : undefined}
+        expandTrigger={editingOutboxClientId}
+        manageKeyboard={false}
+      />
+    </View>
   );
 }
 

--- a/apps/mobile/components/chat/chat-message-list.tsx
+++ b/apps/mobile/components/chat/chat-message-list.tsx
@@ -51,6 +51,7 @@ import type {
   ChatQuickAction,
   TaskMessagePayload,
 } from "@multica/core/types";
+import type { ChatOutboxItem } from "@/data/stores/chat-outbox";
 import type { AgentAvailability } from "@multica/core/agents";
 import { taskMessagesOptions } from "@/data/queries/chat";
 import { Text } from "@/components/ui/text";
@@ -99,6 +100,9 @@ interface Props {
   /** Resolved availability — drives the StatusPill's "Offline" /
    *  "Reconnecting" stages. Pass `undefined` while loading. */
   availability?: AgentAvailability;
+  /** Locally persisted sends that have not been confirmed by the server. */
+  outboxItems?: ChatOutboxItem[];
+  onOutboxPress?: (item: ChatOutboxItem) => void;
 }
 
 export function ChatMessageList({
@@ -112,6 +116,8 @@ export function ChatMessageList({
   pendingTask,
   liveTaskMessages,
   availability,
+  outboxItems = [],
+  onOutboxPress,
 }: Props) {
   // Top-level selection subscription gates the outer "tap-outside-to-dismiss"
   // Pressable below. When null, the Pressable stays disabled and every tap
@@ -136,8 +142,22 @@ export function ChatMessageList({
       })),
     [messages],
   );
+  const listItems = useMemo(
+    () =>
+      [
+        ...messages.map((message) => ({ kind: "message" as const, message })),
+        ...outboxItems.map((item) => ({ kind: "outbox" as const, item })),
+      ].sort((a, b) => {
+        const aDate =
+          a.kind === "message" ? a.message.created_at : a.item.createdAt;
+        const bDate =
+          b.kind === "message" ? b.message.created_at : b.item.createdAt;
+        return aDate.localeCompare(bDate);
+      }),
+    [messages, outboxItems],
+  );
 
-  if (loading && messages.length === 0) {
+  if (loading && listItems.length === 0) {
     return (
       <View className="flex-1 items-center justify-center">
         <ActivityIndicator />
@@ -145,7 +165,7 @@ export function ChatMessageList({
     );
   }
 
-  if (messages.length === 0) {
+  if (listItems.length === 0) {
     // Empty new-chat state. Lives here (rather than the parent screen) so
     // the empty state and the rendered list share spacing/layout rules.
     return (
@@ -197,16 +217,28 @@ export function ChatMessageList({
         scroll position). Cheap because sessions are switched, not
         re-rendered every keystroke. */}
     <FlashList
-      key={messages[0]?.id ?? "empty"}
-      data={messages}
-      keyExtractor={(m) => m.id}
-      renderItem={({ item }) => (
-        <MessageRow
-          message={item}
-          onQuickAction={onQuickAction}
-          quickActionsDisabled={quickActionsDisabled}
-        />
-      )}
+      key={
+        listItems[0]?.kind === "message"
+          ? listItems[0].message.id
+          : (listItems[0]?.item.clientId ?? "empty")
+      }
+      data={listItems}
+      keyExtractor={(item) =>
+        item.kind === "message"
+          ? item.message.id
+          : `outbox-${item.item.clientId}`
+      }
+      renderItem={({ item }) =>
+        item.kind === "message" ? (
+          <MessageRow
+            message={item.message}
+            onQuickAction={onQuickAction}
+            quickActionsDisabled={quickActionsDisabled}
+          />
+        ) : (
+          <OutboxMessageRow item={item.item} onPress={onOutboxPress} />
+        )
+      }
       ItemSeparatorComponent={MessageSeparator}
       ListFooterComponent={
         showLiveSection ? (
@@ -254,6 +286,50 @@ export function ChatMessageList({
     />
     </Pressable>
     </ImageSequenceProvider>
+  );
+}
+
+function OutboxMessageRow({
+  item,
+  onPress,
+}: {
+  item: ChatOutboxItem;
+  onPress?: (item: ChatOutboxItem) => void;
+}) {
+  const status =
+    item.status === "sending"
+      ? "Sending…"
+      : item.status === "failed"
+        ? item.lastError ?? "Could not send"
+        : item.lastError ?? "Not sent · Tap to manage";
+  return (
+    <Pressable
+      onPress={() => onPress?.(item)}
+      disabled={!onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Unsent message: ${status}`}
+    >
+      <View className="self-end max-w-[80%] gap-1.5 rounded-2xl border border-dashed border-muted-foreground/40 bg-muted/60 px-3.5 py-2 opacity-80">
+        <Markdown content={item.content} attachments={[]} compact />
+        <View className="flex-row items-center gap-1">
+          <Ionicons
+            name={
+              item.status === "failed"
+                ? "alert-circle-outline"
+                : "time-outline"
+            }
+            size={13}
+            color="#71717a"
+          />
+          <Text
+            className="flex-1 text-xs text-muted-foreground"
+            numberOfLines={2}
+          >
+            {status}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/components/chat/chat-message-list.tsx
+++ b/apps/mobile/components/chat/chat-message-list.tsx
@@ -102,6 +102,8 @@ interface Props {
   availability?: AgentAvailability;
   /** Locally persisted sends that have not been confirmed by the server. */
   outboxItems?: ChatOutboxItem[];
+  /** The queued item whose content is loaded into the bottom composer. */
+  editingOutboxClientId?: string | null;
   onOutboxPress?: (item: ChatOutboxItem) => void;
 }
 
@@ -117,6 +119,7 @@ export function ChatMessageList({
   liveTaskMessages,
   availability,
   outboxItems = [],
+  editingOutboxClientId,
   onOutboxPress,
 }: Props) {
   // Top-level selection subscription gates the outer "tap-outside-to-dismiss"
@@ -236,7 +239,11 @@ export function ChatMessageList({
             quickActionsDisabled={quickActionsDisabled}
           />
         ) : (
-          <OutboxMessageRow item={item.item} onPress={onOutboxPress} />
+          <OutboxMessageRow
+            item={item.item}
+            editing={item.item.clientId === editingOutboxClientId}
+            onPress={onOutboxPress}
+          />
         )
       }
       ItemSeparatorComponent={MessageSeparator}
@@ -291,13 +298,17 @@ export function ChatMessageList({
 
 function OutboxMessageRow({
   item,
+  editing,
   onPress,
 }: {
   item: ChatOutboxItem;
+  editing: boolean;
   onPress?: (item: ChatOutboxItem) => void;
 }) {
   const status =
-    item.status === "sending"
+    editing
+      ? "Editing in composer"
+      : item.status === "sending"
       ? "Sending…"
       : item.status === "failed"
         ? item.lastError ?? "Could not send"
@@ -314,7 +325,9 @@ function OutboxMessageRow({
         <View className="flex-row items-center gap-1">
           <Ionicons
             name={
-              item.status === "failed"
+              editing
+                ? "create-outline"
+                : item.status === "failed"
                 ? "alert-circle-outline"
                 : "time-outline"
             }

--- a/apps/mobile/components/network-offline-banner.tsx
+++ b/apps/mobile/components/network-offline-banner.tsx
@@ -1,0 +1,25 @@
+import { useNetInfo } from "@react-native-community/netinfo";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Text } from "@/components/ui/text";
+
+/** Persistent network state, deliberately not a transient toast. */
+export function NetworkOfflineBanner() {
+  const netInfo = useNetInfo();
+  const insets = useSafeAreaInsets();
+  const isOffline = netInfo.isConnected === false;
+
+  if (!isOffline) return null;
+
+  return (
+    <View
+      className="absolute left-0 right-0 z-50 bg-amber-500 px-4 py-2"
+      style={{ top: insets.top }}
+      accessibilityRole="alert"
+    >
+      <Text className="text-center text-xs font-medium text-black">
+        You&apos;re offline. Showing the last synced content.
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -191,11 +191,12 @@ class ApiClient {
 
   private async fetch<T>(
     path: string,
-    init: RequestInit & { signal?: AbortSignal } = {},
+    init: RequestInit & { signal?: AbortSignal; timeoutMs?: number } = {},
   ): Promise<T> {
     const rid = createRequestId();
     const start = Date.now();
-    const method = init.method ?? "GET";
+    const { timeoutMs = FETCH_TIMEOUT_MS, ...requestInit } = init;
+    const method = requestInit.method ?? "GET";
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -203,7 +204,7 @@ class ApiClient {
       "X-Client-OS": "ios",
       "X-Client-Version": "0.1.0",
       "X-Request-ID": rid,
-      ...((init.headers as Record<string, string>) ?? {}),
+      ...((requestInit.headers as Record<string, string>) ?? {}),
     };
     if (this.token) {
       headers["Authorization"] = `Bearer ${this.token}`;
@@ -228,9 +229,9 @@ class ApiClient {
     //       spinner stuck on the screen indefinitely.
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
-      controller.abort(new Error(`request timed out after ${FETCH_TIMEOUT_MS}ms`));
-    }, FETCH_TIMEOUT_MS);
-    const callerSignal = init.signal;
+      controller.abort(new Error(`request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const callerSignal = requestInit.signal;
     const onCallerAbort = () => controller.abort(callerSignal?.reason);
     if (callerSignal) {
       if (callerSignal.aborted) controller.abort(callerSignal.reason);
@@ -242,7 +243,7 @@ class ApiClient {
     let res: Response;
     try {
       res = await fetch(`${API_URL}${path}`, {
-        ...init,
+        ...requestInit,
         signal: controller.signal,
         headers,
       });
@@ -261,7 +262,7 @@ class ApiClient {
           duration: `${duration}ms`,
         });
         throw new ApiError(
-          `Request timed out after ${FETCH_TIMEOUT_MS}ms`,
+          `Request timed out after ${timeoutMs}ms`,
           0,
           undefined,
         );
@@ -1046,7 +1047,7 @@ class ApiClient {
   async sendChatMessage(
     sessionId: string,
     content: string,
-    opts?: { attachmentIds?: string[] },
+    opts?: { attachmentIds?: string[]; timeoutMs?: number },
   ): Promise<SendChatMessageResponse> {
     // Strict parse — we need task_id + created_at to anchor the optimistic
     // StatusPill. Fallback would silently break the elapsed-time timer.
@@ -1064,6 +1065,7 @@ class ApiClient {
       {
         method: "POST",
         body: JSON.stringify(body),
+        timeoutMs: opts?.timeoutMs,
       },
     );
     const parsed = SendChatMessageResponseSchema.safeParse(raw);

--- a/apps/mobile/data/auth-store.test.ts
+++ b/apps/mobile/data/auth-store.test.ts
@@ -26,6 +26,7 @@ const secureStorage = {
 const restoreQueryCacheForUser = vi.fn();
 const clearQueryCacheForUser = vi.fn();
 const clearDraftsForUser = vi.fn();
+const clearChatOutboxForUser = vi.fn();
 const clearChatOutbox = vi.fn();
 
 vi.mock("./api", () => ({ api, ApiError }));
@@ -37,7 +38,10 @@ vi.mock("./query-persistence", () => ({
   restoreQueryCacheForUser,
   clearQueryCacheForUser,
 }));
-vi.mock("./stores/draft-persistence", () => ({ clearDraftsForUser }));
+vi.mock("./stores/draft-persistence", () => ({
+  clearDraftsForUser,
+  clearChatOutboxForUser,
+}));
 vi.mock("./stores/chat-outbox-store", () => ({ clearChatOutbox }));
 
 const { useAuthStore } = await import("./auth-store");
@@ -53,6 +57,7 @@ describe("useAuthStore.initialize", () => {
     restoreQueryCacheForUser.mockResolvedValue(undefined);
     clearQueryCacheForUser.mockResolvedValue(undefined);
     clearDraftsForUser.mockResolvedValue(undefined);
+    clearChatOutboxForUser.mockResolvedValue(undefined);
     clearChatOutbox.mockReset();
     useAuthStore.setState({
       user: null,
@@ -105,7 +110,7 @@ describe("useAuthStore.initialize", () => {
     });
   });
 
-  it("clears the token, cached user, query cache, and drafts on a real 401", async () => {
+  it("keeps drafts and the outbox when a cold start receives a real 401", async () => {
     secureStorage.getToken.mockResolvedValue("expired-token");
     secureStorage.getCachedUser.mockResolvedValue(USER);
     api.getMe.mockRejectedValue(new ApiError("expired", 401));
@@ -115,8 +120,9 @@ describe("useAuthStore.initialize", () => {
     expect(secureStorage.clearToken).toHaveBeenCalledOnce();
     expect(secureStorage.clearCachedUser).toHaveBeenCalledOnce();
     expect(clearQueryCacheForUser).toHaveBeenCalledWith(USER.id);
-    expect(clearDraftsForUser).toHaveBeenCalledWith(USER.id);
-    expect(clearChatOutbox).toHaveBeenCalledOnce();
+    expect(clearDraftsForUser).not.toHaveBeenCalled();
+    expect(clearChatOutboxForUser).not.toHaveBeenCalled();
+    expect(clearChatOutbox).not.toHaveBeenCalled();
     expect(useAuthStore.getState()).toMatchObject({
       user: null,
       hasToken: false,
@@ -125,12 +131,23 @@ describe("useAuthStore.initialize", () => {
     });
   });
 
-  it("clears every draft partition when a 401 has no cached user snapshot", async () => {
+  it("does not clear any local partition when a 401 has no cached user snapshot", async () => {
     secureStorage.getToken.mockResolvedValue("expired-token");
     api.getMe.mockRejectedValue(new ApiError("expired", 401));
 
     await useAuthStore.getState().initialize();
 
-    expect(clearDraftsForUser).toHaveBeenCalledWith(null);
+    expect(clearDraftsForUser).not.toHaveBeenCalled();
+    expect(clearChatOutboxForUser).not.toHaveBeenCalled();
+  });
+
+  it("clears this user's drafts and outbox only on explicit logout", async () => {
+    useAuthStore.setState({ user: USER, hasToken: true });
+
+    await useAuthStore.getState().logout();
+
+    expect(clearDraftsForUser).toHaveBeenCalledWith(USER.id);
+    expect(clearChatOutboxForUser).toHaveBeenCalledWith(USER.id);
+    expect(clearChatOutbox).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/data/auth-store.test.ts
+++ b/apps/mobile/data/auth-store.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@multica/core/types";
+
+const api = {
+  setToken: vi.fn(),
+  getMe: vi.fn(),
+  sendCode: vi.fn(),
+  verifyCode: vi.fn(),
+};
+
+class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
+const secureStorage = {
+  clearCachedUser: vi.fn(),
+  clearToken: vi.fn(),
+  getCachedUser: vi.fn(),
+  getToken: vi.fn(),
+  setCachedUser: vi.fn(),
+  setToken: vi.fn(),
+};
+
+const restoreQueryCacheForUser = vi.fn();
+const clearQueryCacheForUser = vi.fn();
+const clearDraftsForUser = vi.fn();
+const clearChatOutbox = vi.fn();
+
+vi.mock("./api", () => ({ api, ApiError }));
+vi.mock("./secure-storage", () => secureStorage);
+vi.mock("./workspace-store", () => ({
+  useWorkspaceStore: { getState: () => ({ restoreSlug: vi.fn() }) },
+}));
+vi.mock("./query-persistence", () => ({
+  restoreQueryCacheForUser,
+  clearQueryCacheForUser,
+}));
+vi.mock("./stores/draft-persistence", () => ({ clearDraftsForUser }));
+vi.mock("./stores/chat-outbox-store", () => ({ clearChatOutbox }));
+
+const { useAuthStore } = await import("./auth-store");
+
+const USER = { id: "user-1", email: "offline@example.com" } as User;
+
+describe("useAuthStore.initialize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    secureStorage.getToken.mockResolvedValue(null);
+    secureStorage.getCachedUser.mockResolvedValue(null);
+    api.getMe.mockResolvedValue(USER);
+    restoreQueryCacheForUser.mockResolvedValue(undefined);
+    clearQueryCacheForUser.mockResolvedValue(undefined);
+    clearDraftsForUser.mockResolvedValue(undefined);
+    clearChatOutbox.mockReset();
+    useAuthStore.setState({
+      user: null,
+      isLoading: true,
+      hasToken: false,
+      isOffline: false,
+    });
+  });
+
+  it("keeps the login gate closed when no token exists", async () => {
+    await useAuthStore.getState().initialize();
+
+    expect(api.getMe).not.toHaveBeenCalled();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: false,
+      isLoading: false,
+    });
+  });
+
+  it("hydrates a saved user after a non-401 network failure", async () => {
+    secureStorage.getToken.mockResolvedValue("token");
+    secureStorage.getCachedUser.mockResolvedValue(USER);
+    api.getMe.mockRejectedValue(new Error("network unavailable"));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(restoreQueryCacheForUser).toHaveBeenCalledWith(USER.id);
+    expect(useAuthStore.getState()).toMatchObject({
+      user: USER,
+      hasToken: true,
+      isOffline: true,
+      isLoading: false,
+    });
+  });
+
+  it("keeps a legacy token admitted when offline but no snapshot exists", async () => {
+    secureStorage.getToken.mockResolvedValue("token");
+    api.getMe.mockRejectedValue(new Error("network unavailable"));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: true,
+      isOffline: true,
+      isLoading: false,
+    });
+  });
+
+  it("clears the token, cached user, query cache, and drafts on a real 401", async () => {
+    secureStorage.getToken.mockResolvedValue("expired-token");
+    secureStorage.getCachedUser.mockResolvedValue(USER);
+    api.getMe.mockRejectedValue(new ApiError("expired", 401));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).toHaveBeenCalledOnce();
+    expect(secureStorage.clearCachedUser).toHaveBeenCalledOnce();
+    expect(clearQueryCacheForUser).toHaveBeenCalledWith(USER.id);
+    expect(clearDraftsForUser).toHaveBeenCalledWith(USER.id);
+    expect(clearChatOutbox).toHaveBeenCalledOnce();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: false,
+      isOffline: false,
+      isLoading: false,
+    });
+  });
+
+  it("clears every draft partition when a 401 has no cached user snapshot", async () => {
+    secureStorage.getToken.mockResolvedValue("expired-token");
+    api.getMe.mockRejectedValue(new ApiError("expired", 401));
+
+    await useAuthStore.getState().initialize();
+
+    expect(clearDraftsForUser).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/mobile/data/auth-store.ts
+++ b/apps/mobile/data/auth-store.ts
@@ -25,7 +25,10 @@ import {
   clearQueryCacheForUser,
   restoreQueryCacheForUser,
 } from "./query-persistence";
-import { clearDraftsForUser } from "./stores/draft-persistence";
+import {
+  clearChatOutboxForUser,
+  clearDraftsForUser,
+} from "./stores/draft-persistence";
 import { clearChatOutbox } from "./stores/chat-outbox-store";
 
 interface AuthState {
@@ -75,8 +78,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         await clearToken();
         await clearCachedUser();
         await clearQueryCacheForUser(cachedUser?.id ?? null);
-        await clearDraftsForUser(cachedUser?.id ?? null);
-        clearChatOutbox();
+        // A 401 invalidates server access, not the user's unsent work. Keep
+        // drafts and outbox entries so signing in again can restore them.
         api.setToken(null);
         set({ user: null, hasToken: false, isLoading: false, isOffline: false });
         return;
@@ -116,6 +119,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     await clearCachedUser();
     await clearQueryCacheForUser(userId);
     await clearDraftsForUser(userId);
+    await clearChatOutboxForUser(userId);
     clearChatOutbox();
     api.setToken(null);
     set({ user: null, hasToken: false, isOffline: false });

--- a/apps/mobile/data/auth-store.ts
+++ b/apps/mobile/data/auth-store.ts
@@ -12,12 +12,29 @@
 import { create } from "zustand";
 import type { User } from "@multica/core/types";
 import { api, ApiError } from "./api";
-import { clearToken, getToken, setToken } from "./secure-storage";
+import {
+  clearCachedUser,
+  clearToken,
+  getCachedUser,
+  getToken,
+  setCachedUser,
+  setToken,
+} from "./secure-storage";
 import { useWorkspaceStore } from "./workspace-store";
+import {
+  clearQueryCacheForUser,
+  restoreQueryCacheForUser,
+} from "./query-persistence";
+import { clearDraftsForUser } from "./stores/draft-persistence";
+import { clearChatOutbox } from "./stores/chat-outbox-store";
 
 interface AuthState {
   user: User | null;
   isLoading: boolean;
+  /** Credential presence is distinct from an online account lookup. */
+  hasToken: boolean;
+  /** True when startup fell back to a local user snapshot after a non-401. */
+  isOffline: boolean;
   initialize: () => Promise<void>;
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
@@ -27,9 +44,11 @@ interface AuthState {
   setUser: (user: User) => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   isLoading: true,
+  hasToken: false,
+  isOffline: false,
 
   initialize: async () => {
     // Restore the persisted workspace slug alongside the auth token so the
@@ -39,21 +58,41 @@ export const useAuthStore = create<AuthState>((set) => ({
 
     const token = await getToken();
     if (!token) {
-      set({ isLoading: false });
+      set({ hasToken: false, isLoading: false, isOffline: false });
       return;
     }
     api.setToken(token);
+    const cachedUser = await getCachedUser();
     try {
       const user = await api.getMe();
-      set({ user, isLoading: false });
+      await setCachedUser(user);
+      await restoreQueryCacheForUser(user.id);
+      set({ user, hasToken: true, isLoading: false, isOffline: false });
     } catch (err) {
       // Only clear token on a genuine 401. Network blips / 5xx keep the
       // token so the next launch (or a manual refresh) can retry.
       if (err instanceof ApiError && err.status === 401) {
         await clearToken();
+        await clearCachedUser();
+        await clearQueryCacheForUser(cachedUser?.id ?? null);
+        await clearDraftsForUser(cachedUser?.id ?? null);
+        clearChatOutbox();
         api.setToken(null);
+        set({ user: null, hasToken: false, isLoading: false, isOffline: false });
+        return;
       }
-      set({ user: null, isLoading: false });
+      if (cachedUser) {
+        await restoreQueryCacheForUser(cachedUser.id);
+      }
+      // A non-401 must never turn a valid local credential into a logout.
+      // An older install may have a token but no snapshot; the route renders
+      // an explicit offline account-info screen rather than /login.
+      set({
+        user: cachedUser,
+        hasToken: true,
+        isLoading: false,
+        isOffline: true,
+      });
     }
   },
 
@@ -64,16 +103,26 @@ export const useAuthStore = create<AuthState>((set) => ({
   verifyCode: async (email, code) => {
     const { token, user } = await api.verifyCode(email, code);
     await setToken(token);
+    await setCachedUser(user);
     api.setToken(token);
-    set({ user });
+    await restoreQueryCacheForUser(user.id);
+    set({ user, hasToken: true, isOffline: false });
     return user;
   },
 
   logout: async () => {
+    const userId = get().user?.id ?? (await getCachedUser())?.id ?? null;
     await clearToken();
+    await clearCachedUser();
+    await clearQueryCacheForUser(userId);
+    await clearDraftsForUser(userId);
+    clearChatOutbox();
     api.setToken(null);
-    set({ user: null });
+    set({ user: null, hasToken: false, isOffline: false });
   },
 
-  setUser: (user) => set({ user }),
+  setUser: (user) => {
+    void setCachedUser(user);
+    set({ user });
+  },
 }));

--- a/apps/mobile/data/query-client.ts
+++ b/apps/mobile/data/query-client.ts
@@ -22,7 +22,9 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000, // 1 minute
-      gcTime: 10 * 60 * 1000, // 10 minutes
+      // Must outlive the seven-day persisted cache window; a shorter gcTime
+      // would make TanStack discard hydrated data before its intended expiry.
+      gcTime: 7 * 24 * 60 * 60 * 1000,
       retry: 1,
       refetchOnWindowFocus: true, // honored via focusManager bridge below
     },

--- a/apps/mobile/data/query-persistence.ts
+++ b/apps/mobile/data/query-persistence.ts
@@ -1,0 +1,73 @@
+/**
+ * User-scoped offline query cache.
+ *
+ * The persister is attached only after authentication is resolved so the
+ * storage key can include the user id. This prevents one account's cached
+ * workspace, inbox, issue, or chat data from hydrating for another account.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
+import {
+  persistQueryClientRestore,
+  persistQueryClientSubscribe,
+} from "@tanstack/react-query-persist-client";
+import { queryClient } from "./query-client";
+
+const CACHE_PREFIX = "multica_query_cache:";
+const CACHE_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
+const CACHE_BUSTER = "offline-cache-v1";
+
+let activeUserId: string | null = null;
+let unsubscribe: (() => void) | null = null;
+
+function storageKey(userId: string) {
+  return `${CACHE_PREFIX}${userId}`;
+}
+
+function createPersister(userId: string) {
+  return createAsyncStoragePersister({
+    storage: AsyncStorage,
+    key: storageKey(userId),
+  });
+}
+
+const dehydrateOptions = {
+  // Never retain an outbox. Failed/paused writes must be retried manually.
+  shouldDehydrateMutation: () => false,
+  // Only completed read data can be useful on an offline cold start.
+  shouldDehydrateQuery: (query: { state: { status: string } }) =>
+    query.state.status === "success",
+};
+
+/** Restore and begin persisting one account's successful read queries. */
+export async function restoreQueryCacheForUser(userId: string): Promise<void> {
+  if (activeUserId === userId) return;
+
+  unsubscribe?.();
+  unsubscribe = null;
+  queryClient.clear();
+
+  const persister = createPersister(userId);
+  await persistQueryClientRestore({
+    queryClient,
+    persister,
+    maxAge: CACHE_MAX_AGE,
+    buster: CACHE_BUSTER,
+  });
+  activeUserId = userId;
+  unsubscribe = persistQueryClientSubscribe({
+    queryClient,
+    persister,
+    buster: CACHE_BUSTER,
+    dehydrateOptions,
+  });
+}
+
+/** Remove the in-memory and persisted query state for a signed-out user. */
+export async function clearQueryCacheForUser(userId: string | null): Promise<void> {
+  unsubscribe?.();
+  unsubscribe = null;
+  activeUserId = null;
+  queryClient.clear();
+  if (userId) await AsyncStorage.removeItem(storageKey(userId));
+}

--- a/apps/mobile/data/secure-storage.ts
+++ b/apps/mobile/data/secure-storage.ts
@@ -4,8 +4,10 @@
  * with packages/core/auth/store.ts even though storage backends differ.
  */
 import * as SecureStore from "expo-secure-store";
+import type { User } from "@multica/core/types";
 
 const TOKEN_KEY = "multica_token";
+const USER_KEY = "multica_user";
 
 export async function getToken(): Promise<string | null> {
   return SecureStore.getItemAsync(TOKEN_KEY);
@@ -17,4 +19,29 @@ export async function setToken(token: string): Promise<void> {
 
 export async function clearToken(): Promise<void> {
   await SecureStore.deleteItemAsync(TOKEN_KEY);
+}
+
+/**
+ * A last-known-good account snapshot lets an otherwise valid session enter
+ * the app when a cold start cannot reach the API. It is not an auth decision:
+ * the server's 401 response remains the only signal that invalidates a token.
+ */
+export async function getCachedUser(): Promise<User | null> {
+  const raw = await SecureStore.getItemAsync(USER_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as User;
+  } catch {
+    // Treat corrupted local state as absent instead of preventing startup.
+    await SecureStore.deleteItemAsync(USER_KEY);
+    return null;
+  }
+}
+
+export async function setCachedUser(user: User): Promise<void> {
+  await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
+}
+
+export async function clearCachedUser(): Promise<void> {
+  await SecureStore.deleteItemAsync(USER_KEY);
 }

--- a/apps/mobile/data/stores/chat-drafts-store.ts
+++ b/apps/mobile/data/stores/chat-drafts-store.ts
@@ -1,15 +1,16 @@
 /**
- * Per-session chat drafts. In-memory only — drafts survive tab switches and
- * navigation, but are lost on app cold start. v1 doesn't persist (an
- * SecureStore-backed write on every keystroke would be wasteful; if user
- * feedback shows people lose work to backgrounding kills, persist via the
- * usual debounced flush pattern in v2).
+ * Per-session chat drafts, persisted in AsyncStorage per user + workspace.
+ * AsyncStorage is appropriate for the potentially long free-form text and
+ * avoids SecureStore's small per-value capacity.
  *
  * Key conventions:
  *   - Real session id (UUID) for any existing session
  *   - DRAFT_NEW_SESSION sentinel for the not-yet-created new-chat input
  */
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { draftStorageKey, readDraftPartition } from "./draft-persistence";
 
 export const DRAFT_NEW_SESSION = "__new__";
 
@@ -22,7 +23,7 @@ interface ChatDraftsState {
   promoteNewDraft: (newSessionId: string) => void;
 }
 
-export const useChatDraftsStore = create<ChatDraftsState>((set, get) => ({
+export const useChatDraftsStore = create<ChatDraftsState>()(persist((set, get) => ({
   drafts: {},
   setDraft: (sessionId, text) => {
     const current = get().drafts;
@@ -54,4 +55,23 @@ export const useChatDraftsStore = create<ChatDraftsState>((set, get) => ({
     delete next[DRAFT_NEW_SESSION];
     set({ drafts: next });
   },
+}), {
+  name: "multica_draft:chat:unscoped",
+  storage: createJSONStorage(() => AsyncStorage),
+  skipHydration: true,
+  partialize: (state) => ({ drafts: state.drafts }),
 }));
+
+/** Hydrate this workspace's drafts before rendering its routes. */
+export async function hydrateChatDrafts(userId: string, workspaceSlug: string) {
+  const name = draftStorageKey("chat", userId, workspaceSlug);
+  const persisted = await readDraftPartition<Pick<ChatDraftsState, "drafts">>(
+    "chat",
+    userId,
+    workspaceSlug,
+  );
+  useChatDraftsStore.persist.setOptions({
+    name,
+  });
+  useChatDraftsStore.setState({ drafts: persisted?.drafts ?? {} });
+}

--- a/apps/mobile/data/stores/chat-outbox-store.test.ts
+++ b/apps/mobile/data/stores/chat-outbox-store.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const backingStore = new Map<string, string>();
+const storage = {
+  getItem: vi.fn(async (key: string) => backingStore.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: string) => {
+    backingStore.set(key, value);
+  }),
+  removeItem: vi.fn(async (key: string) => {
+    backingStore.delete(key);
+  }),
+};
+
+vi.mock("@react-native-async-storage/async-storage", () => ({ default: storage }));
+
+const { clearChatOutbox, hydrateChatOutbox, useChatOutboxStore } =
+  await import("./chat-outbox-store");
+
+const keyFor = (userId: string, workspaceSlug: string) =>
+  `multica_draft:outbox:${userId}:${workspaceSlug}`;
+
+const queuedItem = {
+  clientId: "00000000-0000-4000-8000-000000000001",
+  sessionId: "session-1",
+  workspaceSlug: "workspace-a",
+  userId: "user-a",
+  content: "Send this after reconnecting",
+  attachmentIds: [],
+  createdAt: "2026-08-12T00:00:00.000Z",
+  status: "queued",
+  attemptCount: 0,
+  retryable: true,
+  lastError: null,
+  nextAttemptAt: null,
+};
+
+const persist = (items: unknown[]) =>
+  JSON.stringify({ state: { items }, version: 0 });
+
+describe("chat outbox persistence", () => {
+  beforeEach(() => {
+    backingStore.clear();
+    vi.clearAllMocks();
+    useChatOutboxStore.persist.setOptions({
+      name: "multica_draft:outbox:unscoped",
+    });
+    useChatOutboxStore.setState({ items: [] });
+    backingStore.clear();
+    vi.clearAllMocks();
+  });
+
+  it("restores a queue after relaunch without overwriting its partition", async () => {
+    const key = keyFor("user-a", "workspace-a");
+    backingStore.set(key, persist([queuedItem]));
+
+    await hydrateChatOutbox("user-a", "workspace-a");
+
+    expect(useChatOutboxStore.getState().items).toEqual([queuedItem]);
+    expect(JSON.parse(backingStore.get(key) ?? "")).toMatchObject({
+      state: { items: [queuedItem] },
+    });
+  });
+
+  it("switches to an empty scope without destroying the previous queue", async () => {
+    const firstKey = keyFor("user-a", "workspace-a");
+    backingStore.set(firstKey, persist([queuedItem]));
+
+    await hydrateChatOutbox("user-a", "workspace-a");
+    await hydrateChatOutbox("user-b", "workspace-b");
+
+    expect(useChatOutboxStore.getState().items).toEqual([]);
+    expect(JSON.parse(backingStore.get(firstKey) ?? "")).toMatchObject({
+      state: { items: [queuedItem] },
+    });
+  });
+
+  it("clears memory without recreating the partition after auth cleanup", async () => {
+    const key = keyFor("user-a", "workspace-a");
+    backingStore.set(key, persist([queuedItem]));
+    await hydrateChatOutbox("user-a", "workspace-a");
+    vi.clearAllMocks();
+
+    clearChatOutbox();
+
+    expect(useChatOutboxStore.getState().items).toEqual([]);
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/data/stores/chat-outbox-store.test.ts
+++ b/apps/mobile/data/stores/chat-outbox-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatOutboxItem } from "./chat-outbox";
 
 const backingStore = new Map<string, string>();
 const storage = {
@@ -19,7 +20,7 @@ const { clearChatOutbox, hydrateChatOutbox, useChatOutboxStore } =
 const keyFor = (userId: string, workspaceSlug: string) =>
   `multica_draft:outbox:${userId}:${workspaceSlug}`;
 
-const queuedItem = {
+const queuedItem: ChatOutboxItem = {
   clientId: "00000000-0000-4000-8000-000000000001",
   sessionId: "session-1",
   workspaceSlug: "workspace-a",
@@ -84,5 +85,26 @@ describe("chat outbox persistence", () => {
 
     expect(useChatOutboxStore.getState().items).toEqual([]);
     expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("persists an enqueued message across a simulated process restart", async () => {
+    const key = keyFor("user-a", "workspace-a");
+    await hydrateChatOutbox("user-a", "workspace-a");
+
+    useChatOutboxStore.getState().enqueue(queuedItem);
+
+    await vi.waitFor(() =>
+      expect(JSON.parse(backingStore.get(key) ?? "")).toMatchObject({
+        state: { items: [queuedItem] },
+      }),
+    );
+
+    // `resetModules` gives the second hydrate a fresh Zustand store while
+    // retaining the AsyncStorage backing map, like a full app relaunch.
+    vi.resetModules();
+    const reloaded = await import("./chat-outbox-store");
+    await reloaded.hydrateChatOutbox("user-a", "workspace-a");
+
+    expect(reloaded.useChatOutboxStore.getState().items).toEqual([queuedItem]);
   });
 });

--- a/apps/mobile/data/stores/chat-outbox-store.ts
+++ b/apps/mobile/data/stores/chat-outbox-store.ts
@@ -1,0 +1,75 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { draftStorageKey, readDraftPartition } from "./draft-persistence";
+import type { ChatOutboxItem } from "./chat-outbox";
+
+let skipNextOutboxWrite = false;
+
+const outboxStorage = {
+  getItem: (name: string) => AsyncStorage.getItem(name),
+  setItem: (name: string, value: string) => {
+    if (skipNextOutboxWrite) return Promise.resolve();
+    return AsyncStorage.setItem(name, value);
+  },
+  removeItem: (name: string) => AsyncStorage.removeItem(name),
+};
+
+interface ChatOutboxState {
+  items: ChatOutboxItem[];
+  enqueue: (item: ChatOutboxItem) => void;
+  update: (clientId: string, update: (item: ChatOutboxItem) => ChatOutboxItem) => void;
+  remove: (clientId: string) => void;
+}
+
+export const useChatOutboxStore = create<ChatOutboxState>()(
+  persist(
+    (set) => ({
+      items: [],
+      enqueue: (item) => set((state) => ({ items: [...state.items, item] })),
+      update: (clientId, update) =>
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.clientId === clientId ? update(item) : item,
+          ),
+        })),
+      remove: (clientId) =>
+        set((state) => ({
+          items: state.items.filter((item) => item.clientId !== clientId),
+        })),
+    }),
+    {
+      name: "multica_draft:outbox:unscoped",
+      storage: createJSONStorage(() => outboxStorage),
+      skipHydration: true,
+      partialize: (state) => ({ items: state.items }),
+    },
+  ),
+);
+
+/** Hydrate one account/workspace partition before its chat screen renders. */
+export async function hydrateChatOutbox(userId: string, workspaceSlug: string) {
+  const name = draftStorageKey("outbox", userId, workspaceSlug);
+  const persisted = await readDraftPartition<Pick<ChatOutboxState, "items">>(
+    "outbox",
+    userId,
+    workspaceSlug,
+  );
+  useChatOutboxStore.persist.setOptions({
+    name,
+  });
+  useChatOutboxStore.setState({ items: persisted?.items ?? [] });
+}
+
+/** Remove the currently hydrated account's in-memory queue on logout or 401. */
+export function clearChatOutbox() {
+  // `setState` writes through Zustand persist. Suppress this one write because
+  // auth cleanup has already removed the active partition; recreating it with
+  // an empty value would leave a zombie key behind.
+  skipNextOutboxWrite = true;
+  try {
+    useChatOutboxStore.setState({ items: [] });
+  } finally {
+    skipNextOutboxWrite = false;
+  }
+}

--- a/apps/mobile/data/stores/chat-outbox.test.ts
+++ b/apps/mobile/data/stores/chat-outbox.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CHAT_OUTBOX_ATTEMPTS,
+  nextChatOutboxItem,
+  nextFailedChatOutboxItem,
+  permanentlyFailedChatOutboxItem,
+  type ChatOutboxItem,
+} from "./chat-outbox";
+
+const NOW = new Date("2026-08-12T00:00:00.000Z");
+
+function item(overrides: Partial<ChatOutboxItem> = {}): ChatOutboxItem {
+  return {
+    clientId: "00000000-0000-4000-8000-000000000001",
+    sessionId: "session-1",
+    workspaceSlug: "workspace",
+    userId: "user-1",
+    content: "Hello",
+    attachmentIds: [],
+    createdAt: "2026-08-12T00:00:00.000Z",
+    status: "queued",
+    attemptCount: 0,
+    retryable: true,
+    lastError: null,
+    nextAttemptAt: null,
+    ...overrides,
+  };
+}
+
+describe("chat outbox state machine", () => {
+  it("enforces FIFO and never skips an unconfirmed head", () => {
+    const first = item({ status: "failed" });
+    const second = item({
+      clientId: "00000000-0000-4000-8000-000000000002",
+      createdAt: "2026-08-12T00:00:01.000Z",
+    });
+
+    expect(nextChatOutboxItem([second, first], "session-1", NOW)).toBeNull();
+  });
+
+  it("applies exponential backoff and stops at the retry ceiling", () => {
+    const afterFirstFailure = nextFailedChatOutboxItem(item(), "Network unavailable", NOW);
+    expect(afterFirstFailure).toMatchObject({
+      status: "queued",
+      attemptCount: 1,
+      nextAttemptAt: "2026-08-12T00:00:01.000Z",
+    });
+    expect(nextChatOutboxItem([afterFirstFailure], "session-1", NOW)).toBeNull();
+
+    const final = nextFailedChatOutboxItem(
+      item({ attemptCount: MAX_CHAT_OUTBOX_ATTEMPTS - 1 }),
+      "Network unavailable",
+      NOW,
+    );
+    expect(final).toMatchObject({
+      status: "failed",
+      attemptCount: MAX_CHAT_OUTBOX_ATTEMPTS,
+      retryable: false,
+      nextAttemptAt: null,
+    });
+  });
+
+  it("moves 4xx failures directly to failed", () => {
+    const failed = permanentlyFailedChatOutboxItem(item(), "Chat session is archived");
+    expect(failed).toMatchObject({
+      status: "failed",
+      attemptCount: 1,
+      retryable: false,
+      lastError: "Chat session is archived",
+      nextAttemptAt: null,
+    });
+  });
+});

--- a/apps/mobile/data/stores/chat-outbox.ts
+++ b/apps/mobile/data/stores/chat-outbox.ts
@@ -1,0 +1,101 @@
+/**
+ * Local-only chat delivery state.
+ *
+ * The server currently has no idempotency-key contract for chat sends. These
+ * helpers therefore deliberately do not schedule background or connectivity
+ * driven retries: a lost response can mean the server already accepted the
+ * message. A user may explicitly retry after checking the conversation.
+ */
+export type ChatOutboxStatus = "queued" | "sending" | "failed";
+
+export interface ChatOutboxItem {
+  clientId: string;
+  sessionId: string;
+  workspaceSlug: string;
+  userId: string;
+  content: string;
+  attachmentIds: string[];
+  createdAt: string;
+  status: ChatOutboxStatus;
+  attemptCount: number;
+  retryable: boolean;
+  lastError: string | null;
+  nextAttemptAt: string | null;
+}
+
+export const MAX_CHAT_OUTBOX_ATTEMPTS = 3;
+export const CHAT_OUTBOX_RETRY_BASE_MS = 1_000;
+
+export function createChatOutboxClientId(): string {
+  // RFC 4122-shaped v4 identifier. It is retained even though the current
+  // server cannot consume it, so a later API idempotency contract has a
+  // stable client identity for every already-persisted local item.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+    const random = Math.floor(Math.random() * 16);
+    const value = char === "x" ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+export function sortChatOutbox(items: ChatOutboxItem[]): ChatOutboxItem[] {
+  return [...items].sort((a, b) => {
+    const byCreatedAt = a.createdAt.localeCompare(b.createdAt);
+    return byCreatedAt !== 0 ? byCreatedAt : a.clientId.localeCompare(b.clientId);
+  });
+}
+
+/** The first unconfirmed item blocks every later item in that session. */
+export function nextChatOutboxItem(
+  items: ChatOutboxItem[],
+  sessionId: string,
+  now = new Date(),
+): ChatOutboxItem | null {
+  const head = sortChatOutbox(items.filter((item) => item.sessionId === sessionId))[0];
+  if (!head || head.status !== "queued") return null;
+  if (head.nextAttemptAt && new Date(head.nextAttemptAt) > now) return null;
+  return head;
+}
+
+export function retryDelayMs(attemptCount: number): number {
+  return CHAT_OUTBOX_RETRY_BASE_MS * 2 ** Math.max(0, attemptCount - 1);
+}
+
+export function nextFailedChatOutboxItem(
+  item: ChatOutboxItem,
+  error: string,
+  now = new Date(),
+): ChatOutboxItem {
+  const attemptCount = item.attemptCount + 1;
+  if (attemptCount >= MAX_CHAT_OUTBOX_ATTEMPTS) {
+    return {
+      ...item,
+      attemptCount,
+      status: "failed",
+      retryable: false,
+      lastError: error,
+      nextAttemptAt: null,
+    };
+  }
+  return {
+    ...item,
+    attemptCount,
+    status: "queued",
+    retryable: true,
+    lastError: error,
+    nextAttemptAt: new Date(now.getTime() + retryDelayMs(attemptCount)).toISOString(),
+  };
+}
+
+export function permanentlyFailedChatOutboxItem(
+  item: ChatOutboxItem,
+  error: string,
+): ChatOutboxItem {
+  return {
+    ...item,
+    attemptCount: item.attemptCount + 1,
+    status: "failed",
+    retryable: false,
+    lastError: error,
+    nextAttemptAt: null,
+  };
+}

--- a/apps/mobile/data/stores/draft-persistence.test.ts
+++ b/apps/mobile/data/stores/draft-persistence.test.ts
@@ -23,7 +23,8 @@ const { hydrateNewIssueDraft, useNewIssueDraftStore } =
   await import("./new-issue-draft-store");
 const { hydrateNewProjectDraft, useNewProjectDraftStore } =
   await import("./new-project-draft-store");
-const { clearDraftsForUser } = await import("./draft-persistence");
+const { clearChatOutboxForUser, clearDraftsForUser } =
+  await import("./draft-persistence");
 
 const keyFor = (kind: string, userId: string, workspaceSlug: string) =>
   `multica_draft:${kind}:${userId}:${workspaceSlug}`;
@@ -97,15 +98,27 @@ describe("scoped draft persistence", () => {
     });
   });
 
-  it("clears every draft partition when a 401 has no cached user id", async () => {
+  it("does not clear any partition without a user id", async () => {
     backingStore.set(keyFor("chat", "user-a", "workspace-a"), persist({ drafts: {} }));
     backingStore.set(keyFor("outbox", "user-b", "workspace-b"), persist({ items: [] }));
     backingStore.set("unrelated", "keep");
 
     await clearDraftsForUser(null);
 
-    expect(backingStore.has(keyFor("chat", "user-a", "workspace-a"))).toBe(false);
-    expect(backingStore.has(keyFor("outbox", "user-b", "workspace-b"))).toBe(false);
+    expect(backingStore.has(keyFor("chat", "user-a", "workspace-a"))).toBe(true);
+    expect(backingStore.has(keyFor("outbox", "user-b", "workspace-b"))).toBe(true);
     expect(backingStore.get("unrelated")).toBe("keep");
+  });
+
+  it("clears the outbox only for an explicit logout of that user", async () => {
+    const ownOutbox = keyFor("outbox", "user-a", "workspace-a");
+    const otherOutbox = keyFor("outbox", "user-b", "workspace-b");
+    backingStore.set(ownOutbox, persist({ items: [] }));
+    backingStore.set(otherOutbox, persist({ items: [] }));
+
+    await clearChatOutboxForUser("user-a");
+
+    expect(backingStore.has(ownOutbox)).toBe(false);
+    expect(backingStore.has(otherOutbox)).toBe(true);
   });
 });

--- a/apps/mobile/data/stores/draft-persistence.test.ts
+++ b/apps/mobile/data/stores/draft-persistence.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const backingStore = new Map<string, string>();
+const storage = {
+  getItem: vi.fn(async (key: string) => backingStore.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: string) => {
+    backingStore.set(key, value);
+  }),
+  removeItem: vi.fn(async (key: string) => {
+    backingStore.delete(key);
+  }),
+  getAllKeys: vi.fn(async () => [...backingStore.keys()]),
+  multiRemove: vi.fn(async (keys: string[]) => {
+    keys.forEach((key) => backingStore.delete(key));
+  }),
+};
+
+vi.mock("@react-native-async-storage/async-storage", () => ({ default: storage }));
+
+const { hydrateChatDrafts, useChatDraftsStore } =
+  await import("./chat-drafts-store");
+const { hydrateNewIssueDraft, useNewIssueDraftStore } =
+  await import("./new-issue-draft-store");
+const { hydrateNewProjectDraft, useNewProjectDraftStore } =
+  await import("./new-project-draft-store");
+const { clearDraftsForUser } = await import("./draft-persistence");
+
+const keyFor = (kind: string, userId: string, workspaceSlug: string) =>
+  `multica_draft:${kind}:${userId}:${workspaceSlug}`;
+const persist = (state: object) => JSON.stringify({ state, version: 0 });
+
+describe("scoped draft persistence", () => {
+  beforeEach(() => {
+    backingStore.clear();
+    vi.clearAllMocks();
+    useChatDraftsStore.persist.setOptions({ name: "multica_draft:chat:unscoped" });
+    useNewIssueDraftStore.persist.setOptions({ name: "multica_draft:new-issue:unscoped" });
+    useNewProjectDraftStore.persist.setOptions({ name: "multica_draft:new-project:unscoped" });
+    useChatDraftsStore.setState({ drafts: {} });
+    useNewIssueDraftStore.setState({
+      status: "todo",
+      priority: "none",
+      assignee: null,
+      dueDate: null,
+      project: null,
+    });
+    useNewProjectDraftStore.setState({ status: "planned", priority: "none" });
+    backingStore.clear();
+    vi.clearAllMocks();
+  });
+
+  it("restores each draft kind and preserves one workspace when switching away", async () => {
+    const userId = "user-a";
+    const firstWorkspace = "workspace-a";
+    const chatKey = keyFor("chat", userId, firstWorkspace);
+    const issueKey = keyFor("new-issue", userId, firstWorkspace);
+    const projectKey = keyFor("new-project", userId, firstWorkspace);
+    backingStore.set(chatKey, persist({ drafts: { "session-1": "Keep me" } }));
+    backingStore.set(issueKey, persist({ status: "in_progress", priority: "high" }));
+    backingStore.set(projectKey, persist({ status: "active", priority: "high" }));
+
+    await hydrateChatDrafts(userId, firstWorkspace);
+    await hydrateNewIssueDraft(userId, firstWorkspace);
+    await hydrateNewProjectDraft(userId, firstWorkspace);
+
+    expect(useChatDraftsStore.getState().drafts).toEqual({ "session-1": "Keep me" });
+    expect(useNewIssueDraftStore.getState()).toMatchObject({
+      status: "in_progress",
+      priority: "high",
+    });
+    expect(useNewProjectDraftStore.getState()).toMatchObject({
+      status: "active",
+      priority: "high",
+    });
+
+    await hydrateChatDrafts(userId, "workspace-b");
+    await hydrateNewIssueDraft(userId, "workspace-b");
+    await hydrateNewProjectDraft(userId, "workspace-b");
+
+    expect(useChatDraftsStore.getState().drafts).toEqual({});
+    expect(useNewIssueDraftStore.getState()).toMatchObject({
+      status: "todo",
+      priority: "none",
+    });
+    expect(useNewProjectDraftStore.getState()).toMatchObject({
+      status: "planned",
+      priority: "none",
+    });
+    expect(JSON.parse(backingStore.get(chatKey) ?? "")).toMatchObject({
+      state: { drafts: { "session-1": "Keep me" } },
+    });
+    expect(JSON.parse(backingStore.get(issueKey) ?? "")).toMatchObject({
+      state: { status: "in_progress", priority: "high" },
+    });
+    expect(JSON.parse(backingStore.get(projectKey) ?? "")).toMatchObject({
+      state: { status: "active", priority: "high" },
+    });
+  });
+
+  it("clears every draft partition when a 401 has no cached user id", async () => {
+    backingStore.set(keyFor("chat", "user-a", "workspace-a"), persist({ drafts: {} }));
+    backingStore.set(keyFor("outbox", "user-b", "workspace-b"), persist({ items: [] }));
+    backingStore.set("unrelated", "keep");
+
+    await clearDraftsForUser(null);
+
+    expect(backingStore.has(keyFor("chat", "user-a", "workspace-a"))).toBe(false);
+    expect(backingStore.has(keyFor("outbox", "user-b", "workspace-b"))).toBe(false);
+    expect(backingStore.get("unrelated")).toBe("keep");
+  });
+});

--- a/apps/mobile/data/stores/draft-persistence.ts
+++ b/apps/mobile/data/stores/draft-persistence.ts
@@ -41,14 +41,37 @@ export async function readDraftPartition<T extends object>(
   }
 }
 
-/** Clear every workspace draft and unsent message owned by a user on logout/401. */
+function isOwnedDraftKey(key: string, userId: string): boolean {
+  return key.startsWith(DRAFT_PREFIX) && key.includes(`:${userId}:`);
+}
+
+/**
+ * Clear text/form drafts for an explicit logout. Unsent chat outbox entries
+ * are intentionally excluded: a 401 must never erase a user's message.
+ */
 export async function clearDraftsForUser(userId: string | null): Promise<void> {
+  if (!userId) {
+    console.warn("Skipping local draft cleanup without a user id");
+    return;
+  }
   const keys = await AsyncStorage.getAllKeys();
-  const prefix = `${DRAFT_PREFIX}`;
   const ownedKeys = keys.filter(
-    (key) =>
-      key.startsWith(prefix) &&
-      (userId === null || key.includes(`:${userId}:`)),
+    (key) => isOwnedDraftKey(key, userId) && !key.startsWith(`${DRAFT_PREFIX}outbox:`),
   );
   if (ownedKeys.length > 0) await AsyncStorage.multiRemove(ownedKeys);
+}
+
+/** Remove one user's unsent messages only during an explicit logout. */
+export async function clearChatOutboxForUser(userId: string | null): Promise<void> {
+  if (!userId) {
+    console.warn("Skipping local outbox cleanup without a user id");
+    return;
+  }
+  const keys = await AsyncStorage.getAllKeys();
+  const ownedOutboxKeys = keys.filter(
+    (key) =>
+      key.startsWith(`${DRAFT_PREFIX}outbox:`) &&
+      isOwnedDraftKey(key, userId),
+  );
+  if (ownedOutboxKeys.length > 0) await AsyncStorage.multiRemove(ownedOutboxKeys);
 }

--- a/apps/mobile/data/stores/draft-persistence.ts
+++ b/apps/mobile/data/stores/draft-persistence.ts
@@ -1,0 +1,54 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const DRAFT_PREFIX = "multica_draft:";
+
+export function draftStorageKey(
+  kind: "chat" | "new-issue" | "new-project" | "outbox",
+  userId: string,
+  workspaceSlug: string,
+) {
+  return `${DRAFT_PREFIX}${kind}:${userId}:${workspaceSlug}`;
+}
+
+/**
+ * Read a target partition before switching a Zustand persist store to it.
+ *
+ * Calling `store.setState` after changing persist's `name` writes through to
+ * that new name. Reading first prevents a scope switch from replacing an
+ * existing partition with the previous scope's empty in-memory state.
+ */
+export async function readDraftPartition<T extends object>(
+  kind: "chat" | "new-issue" | "new-project" | "outbox",
+  userId: string,
+  workspaceSlug: string,
+): Promise<T | null> {
+  const raw = await AsyncStorage.getItem(draftStorageKey(kind, userId, workspaceSlug));
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !("state" in parsed) ||
+      !parsed.state ||
+      typeof parsed.state !== "object"
+    ) {
+      return null;
+    }
+    return parsed.state as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Clear every workspace draft and unsent message owned by a user on logout/401. */
+export async function clearDraftsForUser(userId: string | null): Promise<void> {
+  const keys = await AsyncStorage.getAllKeys();
+  const prefix = `${DRAFT_PREFIX}`;
+  const ownedKeys = keys.filter(
+    (key) =>
+      key.startsWith(prefix) &&
+      (userId === null || key.includes(`:${userId}:`)),
+  );
+  if (ownedKeys.length > 0) await AsyncStorage.multiRemove(ownedKeys);
+}

--- a/apps/mobile/data/stores/new-issue-draft-store.ts
+++ b/apps/mobile/data/stores/new-issue-draft-store.ts
@@ -21,13 +21,16 @@
  * that's the only place that calls it on workspace-id transitions.
  */
 import { useEffect, useRef } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type {
   IssuePriority,
   IssueStatus,
   Project,
 } from "@multica/core/types";
 import type { AssigneeValue } from "@/components/issue/pickers/assignee-picker-body";
+import { draftStorageKey, readDraftPartition } from "./draft-persistence";
 
 interface NewIssueDraftState {
   status: IssueStatus;
@@ -54,7 +57,7 @@ const INITIAL: Pick<
   project: null,
 };
 
-export const useNewIssueDraftStore = create<NewIssueDraftState>((set) => ({
+export const useNewIssueDraftStore = create<NewIssueDraftState>()(persist((set) => ({
   ...INITIAL,
   setStatus: (next) => set({ status: next }),
   setPriority: (next) => set({ priority: next }),
@@ -62,7 +65,29 @@ export const useNewIssueDraftStore = create<NewIssueDraftState>((set) => ({
   setDueDate: (next) => set({ dueDate: next }),
   setProject: (next) => set({ project: next }),
   reset: () => set({ ...INITIAL }),
+}), {
+  name: "multica_draft:new-issue:unscoped",
+  storage: createJSONStorage(() => AsyncStorage),
+  skipHydration: true,
+  partialize: (state) => ({
+    status: state.status,
+    priority: state.priority,
+    assignee: state.assignee,
+    dueDate: state.dueDate,
+    project: state.project,
+  }),
 }));
+
+export async function hydrateNewIssueDraft(userId: string, workspaceSlug: string) {
+  const name = draftStorageKey("new-issue", userId, workspaceSlug);
+  const persisted = await readDraftPartition<
+    Pick<NewIssueDraftState, "status" | "priority" | "assignee" | "dueDate" | "project">
+  >("new-issue", userId, workspaceSlug);
+  useNewIssueDraftStore.persist.setOptions({
+    name,
+  });
+  useNewIssueDraftStore.setState({ ...INITIAL, ...persisted });
+}
 
 /**
  * Clears the new-issue draft store whenever the active workspace id

--- a/apps/mobile/data/stores/new-project-draft-store.ts
+++ b/apps/mobile/data/stores/new-project-draft-store.ts
@@ -20,8 +20,11 @@
  * `useNewProjectDraftResetOnWorkspaceChange()`, the only caller.
  */
 import { useEffect, useRef } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { ProjectPriority, ProjectStatus } from "@multica/core/types";
+import { draftStorageKey, readDraftPartition } from "./draft-persistence";
 
 interface NewProjectDraftState {
   status: ProjectStatus;
@@ -36,12 +39,28 @@ const INITIAL: Pick<NewProjectDraftState, "status" | "priority"> = {
   priority: "none",
 };
 
-export const useNewProjectDraftStore = create<NewProjectDraftState>((set) => ({
+export const useNewProjectDraftStore = create<NewProjectDraftState>()(persist((set) => ({
   ...INITIAL,
   setStatus: (next) => set({ status: next }),
   setPriority: (next) => set({ priority: next }),
   reset: () => set({ ...INITIAL }),
+}), {
+  name: "multica_draft:new-project:unscoped",
+  storage: createJSONStorage(() => AsyncStorage),
+  skipHydration: true,
+  partialize: (state) => ({ status: state.status, priority: state.priority }),
 }));
+
+export async function hydrateNewProjectDraft(userId: string, workspaceSlug: string) {
+  const name = draftStorageKey("new-project", userId, workspaceSlug);
+  const persisted = await readDraftPartition<
+    Pick<NewProjectDraftState, "status" | "priority">
+  >("new-project", userId, workspaceSlug);
+  useNewProjectDraftStore.persist.setOptions({
+    name,
+  });
+  useNewProjectDraftStore.setState({ ...INITIAL, ...persisted });
+}
 
 /**
  * Clears the new-project draft store whenever the active workspace id

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@multica/core": "workspace:*",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-segmented-control/segmented-control": "2.5.7",
@@ -40,7 +41,9 @@
     "@shikijs/langs": "^4.0.2",
     "@shikijs/themes": "^4.0.2",
     "@shopify/flash-list": "2.0.2",
+    "@tanstack/query-async-storage-persister": "5.96.2",
     "@tanstack/react-query": "^5.96.2",
+    "@tanstack/react-query-persist-client": "5.96.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "expo": "~55.0.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       '@multica/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@react-native-async-storage/async-storage':
+        specifier: 2.2.0
+        version: 2.2.0(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
       '@react-native-community/datetimepicker':
         specifier: 8.6.0
         version: 8.6.0(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -383,9 +386,15 @@ importers:
       '@shopify/flash-list':
         specifier: 2.0.2
         version: 2.0.2(@babel/runtime@7.29.2)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@tanstack/query-async-storage-persister':
+        specifier: 5.96.2
+        version: 5.96.2
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.0)
+      '@tanstack/react-query-persist-client':
+        specifier: 5.96.2
+        version: 5.96.2(@tanstack/react-query@5.96.2(react@19.2.0))(react@19.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -741,7 +750,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -3382,6 +3391,11 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-native-async-storage/async-storage@2.2.0':
+    resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
+    peerDependencies:
+      react-native: ^0.0.0-0 || >=0.65 <1.0
+
   '@react-native-community/datetimepicker@8.6.0':
     resolution: {integrity: sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==}
     peerDependencies:
@@ -3971,14 +3985,26 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/query-async-storage-persister@5.96.2':
+    resolution: {integrity: sha512-lYJm+TwzOEUVkxCJapLSzRXPzmPpv7Vy3zSB1RXYQ6+vznEgXBqLjn+ZwBRvHpkRda9VXis64wv44rPIi9nCwg==}
+
   '@tanstack/query-core@5.96.2':
     resolution: {integrity: sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==}
 
   '@tanstack/query-devtools@5.96.2':
     resolution: {integrity: sha512-vBTB1Qhbm3nHSbEUtQwks/EdcAtFfEapr1WyBW4w2ExYKuXVi3jIxUIHf5MlSltiHuL7zNyUuanqT/7sI2sb6g==}
 
+  '@tanstack/query-persist-client-core@5.96.2':
+    resolution: {integrity: sha512-BYsP8folbvxzZsNnWJxSenEAdepGNfv809150U78D84yt/THi33EwfUCcdKWFbma5XKwlaFQGWMJKeWnVJ6GVA==}
+
   '@tanstack/react-query-devtools@5.96.2':
     resolution: {integrity: sha512-nTFKLGuTOFvmFRvcyZ3ArWC/DnMNPoBh6h/2yD6rsf7TCTJCQt+oUWOp2uKPTIuEPtF/vN9Kw5tl5mD1Kbposw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.96.2
+      react: ^18 || ^19
+
+  '@tanstack/react-query-persist-client@5.96.2':
+    resolution: {integrity: sha512-smQ38oVPlnvkG+G7R60IAD9X6azJLRjHEd7twml9XBLYM31ncPDP0tUKy/Gv/4ItVmKTtjZ5VabXpVZxnaWSww==}
     peerDependencies:
       '@tanstack/react-query': ^5.96.2
       react: ^18 || ^19
@@ -7325,6 +7351,10 @@ packages:
     resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
     engines: {node: '>=12'}
 
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -7958,6 +7988,10 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-options@3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -13466,6 +13500,11 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+
   '@react-native-community/datetimepicker@8.6.0(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
       invariant: 2.2.4
@@ -14070,15 +14109,30 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
 
+  '@tanstack/query-async-storage-persister@5.96.2':
+    dependencies:
+      '@tanstack/query-core': 5.96.2
+      '@tanstack/query-persist-client-core': 5.96.2
+
   '@tanstack/query-core@5.96.2': {}
 
   '@tanstack/query-devtools@5.96.2': {}
+
+  '@tanstack/query-persist-client-core@5.96.2':
+    dependencies:
+      '@tanstack/query-core': 5.96.2
 
   '@tanstack/react-query-devtools@5.96.2(@tanstack/react-query@5.96.2(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/query-devtools': 5.96.2
       '@tanstack/react-query': 5.96.2(react@19.2.3)
       react: 19.2.3
+
+  '@tanstack/react-query-persist-client@5.96.2(@tanstack/react-query@5.96.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@tanstack/query-persist-client-core': 5.96.2
+      '@tanstack/react-query': 5.96.2(react@19.2.0)
+      react: 19.2.0
 
   '@tanstack/react-query@5.96.2(react@19.2.0)':
     dependencies:
@@ -18230,6 +18284,8 @@ snapshots:
 
   is-obj@3.0.0: {}
 
+  is-plain-obj@2.1.0: {}
+
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
@@ -18950,6 +19006,10 @@ snapshots:
   memoize-one@6.0.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-options@3.0.4:
+    dependencies:
+      is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- persist unsent existing-session chat messages by account and workspace, render them in the conversation, and support native iOS edit/remove actions
- use an 8 second foreground send ceiling to surface false-online failures promptly
- deliberately disable automatic reconnect/background flushing: the current server endpoint has no client idempotency key or safe dedupe lookup
- keep offline new-chat text as a draft and require a connection to create a session

## Safety
A manual retry is the only retry path after an uncertain result. FIFO prevents a later message overtaking an earlier unconfirmed one; 4xx failures are terminal; logout and 401 clear the local partition.

## Validation
- `pnpm --dir apps/mobile typecheck`
- `pnpm --dir apps/mobile test -- chat-outbox.test.ts chat-outbox-store.test.ts auth-store.test.ts` (14 files, 71 tests)
- `pnpm --dir apps/mobile lint` (0 errors; 7 existing warnings in untouched files)
- `git diff --check`

## Follow-up
Automatic foreground flush requires a server contract that accepts a client message id and returns the same accepted result on replay. This PR intentionally makes no server changes.