### PR TITLE
fix(daemon): resolve Windows installer junctions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,14 @@ jobs:
           go test ./internal/daemon/execenv -v -run '^(TestSeedUserCodexSkills|TestHydrateCodexSkills)' -count=1 -timeout=5m
           go test ./internal/daemon -v -run '^(TestCleanTaskArtifacts_DoesNotFollowDirectoryJunction|TestTaskSize_DoesNotCountDirectoryJunction)$' -count=1 -timeout=5m
 
+      - name: Test Windows agent executable junction resolution
+        working-directory: server
+        # The standalone Codex installer exposes bin as a directory junction.
+        # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
+        # only a real Windows filesystem proves both PATH discovery and an
+        # explicitly configured path reach the release executable.
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathCanonicalizes|TestTrimWindowsExtendedPathPrefix)' -count=1 -timeout=5m
+
       - name: Build Windows CLI helper entrypoint
         working-directory: server
         run: go build ./cmd/multica

--- a/server/internal/daemon/canonical_path.go
+++ b/server/internal/daemon/canonical_path.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package daemon
+
+import "path/filepath"
+
+func canonicalPath(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
+
+func canonicalConfiguredExecutablePath(path string) string {
+	return path
+}

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package daemon
+
+import (
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func canonicalPath(path string) (string, error) {
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, syscall.MAX_PATH)
+	for {
+		length, err := windows.GetFinalPathNameByHandle(handle, &buffer[0], uint32(len(buffer)), 0)
+		if err != nil {
+			return "", err
+		}
+		if length < uint32(len(buffer)) {
+			resolved := windows.UTF16ToString(buffer[:length])
+			return trimWindowsExtendedPathPrefix(resolved), nil
+		}
+		buffer = make([]uint16, length+1)
+	}
+}
+
+func trimWindowsExtendedPathPrefix(path string) string {
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		return `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	}
+	return strings.TrimPrefix(path, `\\?\`)
+}
+
+func canonicalConfiguredExecutablePath(path string) string {
+	return canonicalExecutablePath(path)
+}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -641,7 +641,7 @@ func resolveAgentExecutablePath(cmd string) (string, error) {
 		return "", err
 	}
 	if strings.ContainsAny(cmd, "/\\") {
-		return resolved, nil
+		return canonicalConfiguredExecutablePath(resolved), nil
 	}
 	if isInMulticaHooksDir(resolved) {
 		if unshadowed, err := lookPathExcludingMulticaHooks(cmd); err == nil {
@@ -748,7 +748,7 @@ func canonicalExecutablePath(path string) string {
 	if err != nil {
 		return path
 	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
+	if real, err := canonicalPath(abs); err == nil {
 		return real
 	}
 	return abs

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -1,0 +1,117 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalExecutablePathResolvesDirectoryJunction(t *testing.T) {
+	targetDir := t.TempDir()
+	targetBin := filepath.Join(targetDir, "bin")
+	if err := os.MkdirAll(targetBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetExecutable := filepath.Join(targetBin, "codex.exe")
+	if err := os.WriteFile(targetExecutable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	shimRoot := t.TempDir()
+	shimBin := filepath.Join(shimRoot, "bin")
+	createJunction(t, targetBin, shimBin)
+	shimExecutable := filepath.Join(shimBin, "codex.exe")
+
+	if _, err := filepath.EvalSymlinks(shimExecutable); err == nil {
+		t.Fatal("EvalSymlinks unexpectedly resolved a directory junction; test would not reproduce the bug")
+	}
+	if got := canonicalExecutablePath(shimExecutable); !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("canonicalExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "codex.exe")
+	if err := os.WriteFile(executable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := canonicalExecutablePath(executable); !strings.EqualFold(got, executable) {
+		t.Fatalf("canonicalExecutablePath() = %q, want %q", got, executable)
+	}
+}
+
+func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing", "codex.exe")
+	want, err := filepath.Abs(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := canonicalExecutablePath(missing); got != want {
+		t.Fatalf("canonicalExecutablePath() = %q, want fallback %q", got, want)
+	}
+}
+
+func TestTrimWindowsExtendedPathPrefix(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "drive path", path: `\\?\C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
+		{name: "UNC path", path: `\\?\UNC\server\share\codex.exe`, want: `\\server\share\codex.exe`},
+		{name: "ordinary path", path: `C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := trimWindowsExtendedPathPrefix(test.path); got != test.want {
+				t.Fatalf("trimWindowsExtendedPathPrefix(%q) = %q, want %q", test.path, got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
+	targetExecutable, shimBin := stageJunctionExecutable(t)
+	t.Setenv("PATH", shimBin)
+	t.Setenv("PATHEXT", ".EXE")
+
+	got, err := resolveAgentExecutablePath("codex")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testing.T) {
+	targetExecutable, shimBin := stageJunctionExecutable(t)
+	configured := filepath.Join(shimBin, "codex.exe")
+
+	got, err := resolveAgentExecutablePath(configured)
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func stageJunctionExecutable(t *testing.T) (targetExecutable, shimBin string) {
+	t.Helper()
+	targetBin := filepath.Join(t.TempDir(), "release", "bin")
+	if err := os.MkdirAll(targetBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetExecutable = filepath.Join(targetBin, "codex.exe")
+	if err := os.WriteFile(targetExecutable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shimBin = filepath.Join(t.TempDir(), "installer", "bin")
+	createJunction(t, targetBin, shimBin)
+	return targetExecutable, shimBin
+}

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -28,9 +28,7 @@ func TestCanonicalExecutablePathResolvesDirectoryJunction(t *testing.T) {
 	if _, err := filepath.EvalSymlinks(shimExecutable); err == nil {
 		t.Fatal("EvalSymlinks unexpectedly resolved a directory junction; test would not reproduce the bug")
 	}
-	if got := canonicalExecutablePath(shimExecutable); !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("canonicalExecutablePath() = %q, want junction target %q", got, targetExecutable)
-	}
+	assertResolvedExecutable(t, canonicalExecutablePath(shimExecutable), shimExecutable, targetExecutable)
 }
 
 func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
@@ -39,9 +37,7 @@ func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := canonicalExecutablePath(executable); !strings.EqualFold(got, executable) {
-		t.Fatalf("canonicalExecutablePath() = %q, want %q", got, executable)
-	}
+	assertSameFile(t, canonicalExecutablePath(executable), executable)
 }
 
 func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
@@ -83,9 +79,7 @@ func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	if !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
-	}
+	assertResolvedExecutable(t, got, filepath.Join(shimBin, "codex.exe"), targetExecutable)
 }
 
 func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testing.T) {
@@ -96,8 +90,29 @@ func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testin
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	if !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	assertResolvedExecutable(t, got, configured, targetExecutable)
+}
+
+func assertResolvedExecutable(t *testing.T, got, shim, target string) {
+	t.Helper()
+	if strings.EqualFold(got, shim) {
+		t.Fatalf("resolved executable still points at junction path %q", got)
+	}
+	assertSameFile(t, got, target)
+}
+
+func assertSameFile(t *testing.T, got, want string) {
+	t.Helper()
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat resolved executable %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatalf("stat expected executable %q: %v", want, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("resolved executable %q does not identify expected file %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

### Thinking path / root cause

Windows standalone Codex exposes its installer `bin` directory as an `IO_REPARSE_TAG_MOUNT_POINT` junction. The daemon already canonicalized PATH-discovered executables with `filepath.EvalSymlinks`, but Go 1.26.1 cannot traverse that junction shape and the helper silently kept the installer shim path. Separator-bearing configured commands also returned before canonicalization.

This change keeps the existing `EvalSymlinks` behavior on non-Windows systems and uses `GetFinalPathNameByHandleW` on Windows. Resolving the opened executable handle follows the installer junction (and the standalone `current` link) to the release executable, so Codex finds `bin\..\codex-resources`. Explicit configured paths use the same canonicalization only on Windows.

## Related Issue

Fixes #6762

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Add build-tagged executable canonicalization: `GetFinalPathNameByHandleW` on Windows, existing `EvalSymlinks` elsewhere.
- Canonicalize separator-bearing configured executable paths on Windows while preserving non-Windows behavior.
- Add Windows tests using a real `mklink /J` for PATH discovery and configured paths, plus regular-path, error-fallback, and DOS/UNC prefix cases.
- Run those regressions in the existing Windows CI job.

## How to Test

1. On Windows with Go 1.26.1: `cd server && go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathCanonicalizes|TestTrimWindowsExtendedPathPrefix)' -count=1 -timeout=5m`
2. On Windows: `cd server && go vet ./internal/daemon && go build ./...`
3. Cross-target check: `cd server && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/daemon && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/daemon`

Local results: all commands above completed successfully with Go 1.26.1. The Windows regression tests create and resolve a real directory junction. This machine has the MSIX Codex install, not the standalone installer layout, so a read-only smoke test against an existing standalone Codex junction was not available locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; no UI change)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented interface changes)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** I used Codex to read the issue discussion and repository guidance, trace both executable-resolution entry points, reproduce the Windows junction failure with a test before implementation, add the minimal build-tagged Win32 fix, run Windows and cross-target verification, and request an independent code review before opening this PR.

## Screenshots (optional)

Not applicable.