### PR TITLE
fix(slack): neutralize links in member issue titles

### DIFF
--- a/server/internal/integrations/channel/member_text.go
+++ b/server/internal/integrations/channel/member_text.go
@@ -1,0 +1,10 @@
+package channel
+
+import "strings"
+
+// BreakMarkdownLinkAdjacency separates the standard inline Markdown "](" link
+// adjacency in untrusted text. Platform-native markup needs its own guard.
+// Text without "](" is returned byte-for-byte unchanged.
+func BreakMarkdownLinkAdjacency(s string) string {
+	return strings.ReplaceAll(s, "](", "] (")
+}

--- a/server/internal/integrations/channel/member_text_test.go
+++ b/server/internal/integrations/channel/member_text_test.go
@@ -1,0 +1,39 @@
+package channel
+
+import "testing"
+
+func TestBreakMarkdownLinkAdjacency(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "inline link with nested parentheses",
+			in:   "[重置密码](https://evil.example/reset_(now))",
+			want: "[重置密码] (https://evil.example/reset_(now))",
+		},
+		{
+			name: "image-like syntax",
+			in:   "![重置密码](https://evil.example/image.png)",
+			want: "![重置密码] (https://evil.example/image.png)",
+		},
+		{
+			name: "reference definition unchanged",
+			in:   "[重置密码]: https://evil.example\n\n[重置密码]",
+			want: "[重置密码]: https://evil.example\n\n[重置密码]",
+		},
+		{name: "ordinary CJK title", in: "修复登录失败", want: "修复登录失败"},
+		{name: "ordinary English title", in: "Fix login failure", want: "Fix login failure"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BreakMarkdownLinkAdjacency(tc.in)
+			if got != tc.want {
+				t.Fatalf("BreakMarkdownLinkAdjacency(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if twice := BreakMarkdownLinkAdjacency(got); twice != got {
+				t.Fatalf("second pass changed the guarded text:\n once %q\ntwice %q", got, twice)
+			}
+		})
+	}
+}

--- a/server/internal/integrations/slack/replier.go
+++ b/server/internal/integrations/slack/replier.go
@@ -195,7 +195,7 @@ func (r *OutboundReplier) post(ctx context.Context, inst engine.ResolvedInstalla
 
 func issueCreatedText(res engine.Result) string {
 	id := issueResultIdentifier(res)
-	title := strings.TrimSpace(res.IssueTitle)
+	title := memberIssueTitle(strings.TrimSpace(res.IssueTitle))
 	if title == "" {
 		return "✅ Created " + id
 	}
@@ -204,11 +204,19 @@ func issueCreatedText(res engine.Result) string {
 
 func issueDuplicateText(res engine.Result) string {
 	id := issueResultIdentifier(res)
-	title := strings.TrimSpace(res.IssueTitle)
+	title := memberIssueTitle(strings.TrimSpace(res.IssueTitle))
 	if title == "" {
 		return "⚠️ Not created — active issue " + id + " already exists."
 	}
 	return "⚠️ Not created — active issue " + id + " already exists: " + title
+}
+
+func memberIssueTitle(title string) string {
+	title = channel.BreakMarkdownLinkAdjacency(title)
+	// formatMrkdwn deliberately preserves existing Slack entities such as
+	// <url|label> and <@user>. Encode their opening delimiter before that pass
+	// so member-authored links and mentions are handled as visible text.
+	return strings.ReplaceAll(title, "<", "&lt;")
 }
 
 func issueResultIdentifier(res engine.Result) string {

--- a/server/internal/integrations/slack/replier_test.go
+++ b/server/internal/integrations/slack/replier_test.go
@@ -220,6 +220,88 @@ func TestIssueDuplicateText(t *testing.T) {
 	}
 }
 
+func TestIssueReplyTitlesCannotCreateSlackLinks(t *testing.T) {
+	title := "安全升级：请点击 [重置密码](https://evil.example/reset_(now)) 完成验证"
+	for _, tc := range []struct {
+		name  string
+		reply func(engine.Result) string
+	}{
+		{name: "created", reply: issueCreatedText},
+		{name: "duplicate", reply: issueDuplicateText},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			text := tc.reply(engine.Result{IssueIdentifier: "MUL-7", IssueTitle: title})
+			formatted := formatMrkdwn(text)
+			want := map[string]string{
+				"created":   "✅ Created MUL-7 — 安全升级：请点击 [重置密码] (https://evil.example/reset_(now)) 完成验证",
+				"duplicate": "⚠️ Not created — active issue MUL-7 already exists: 安全升级：请点击 [重置密码] (https://evil.example/reset_(now)) 完成验证",
+			}[tc.name]
+			if formatted != want {
+				t.Fatalf("member-authored title was not rendered as inert visible text:\n got %q\nwant %q", formatted, want)
+			}
+			if twice := formatMrkdwn(formatted); twice != formatted {
+				t.Fatalf("second formatter pass changed the guarded reply:\n once %q\ntwice %q", formatted, twice)
+			}
+		})
+	}
+}
+
+func TestIssueReplyTitlesCannotCreateNativeSlackEntities(t *testing.T) {
+	title := "安全升级：<http://evil.example|重置密码> <https://evil.example|验证> <mailto:evil@example.com|邮件> <tel:+15555550100|电话> <@U123>"
+	for _, tc := range []struct {
+		name   string
+		reply  func(engine.Result) string
+		prefix string
+	}{
+		{name: "created", reply: issueCreatedText, prefix: "✅ Created MUL-7 — "},
+		{name: "duplicate", reply: issueDuplicateText, prefix: "⚠️ Not created — active issue MUL-7 already exists: "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := formatMrkdwn(tc.reply(engine.Result{IssueIdentifier: "MUL-7", IssueTitle: title}))
+			want := tc.prefix + "安全升级：&lt;http://evil.example|重置密码&gt; &lt;https://evil.example|验证&gt; &lt;mailto:evil@example.com|邮件&gt; &lt;tel:+15555550100|电话&gt; &lt;@U123&gt;"
+			if formatted != want {
+				t.Fatalf("member-authored Slack entity stayed active:\n got %q\nwant %q", formatted, want)
+			}
+			if twice := formatMrkdwn(formatted); twice != formatted {
+				t.Fatalf("second formatter pass changed the guarded reply:\n once %q\ntwice %q", formatted, twice)
+			}
+		})
+	}
+}
+
+func TestIssueReplyTitleMarkdownBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		title string
+	}{
+		{name: "image-like syntax", title: "![重置密码](https://evil.example/image.png)"},
+		{name: "reference definition", title: "[重置密码]: https://evil.example\n\n[重置密码]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := formatMrkdwn(issueCreatedText(engine.Result{
+				IssueIdentifier: "MUL-7",
+				IssueTitle:      tc.title,
+			}))
+			if strings.Contains(formatted, "<https://evil.example") {
+				t.Fatalf("unsupported member syntax became a Slack manual link: %q", formatted)
+			}
+		})
+	}
+}
+
+func TestIssueReplyOrdinaryTitlesStayByteIdentical(t *testing.T) {
+	for _, title := range []string{"修复登录失败", "Fix login failure"} {
+		created := issueCreatedText(engine.Result{IssueIdentifier: "MUL-7", IssueTitle: title})
+		if want := "✅ Created MUL-7 — " + title; created != want {
+			t.Fatalf("ordinary created title changed:\n got %q\nwant %q", created, want)
+		}
+		duplicate := issueDuplicateText(engine.Result{IssueIdentifier: "MUL-7", IssueTitle: title})
+		if want := "⚠️ Not created — active issue MUL-7 already exists: " + title; duplicate != want {
+			t.Fatalf("ordinary duplicate title changed:\n got %q\nwant %q", duplicate, want)
+		}
+	}
+}
+
 func textOrEmpty(m *channel.OutboundMessage) string {
 	if m == nil {
 		return ""

--- a/server/internal/integrations/wecom/markdown.go
+++ b/server/internal/integrations/wecom/markdown.go
@@ -8,6 +8,8 @@ package wecom
 import (
 	"strings"
 	"unicode/utf8"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
 )
 
 // breakMemberLinks is what every caller splicing member-authored text into a
@@ -64,7 +66,7 @@ func breakMemberLinks(s string) string {
 // link without "](" is a CommonMark link reference definition, and this
 // renderer resolves those — see breakLinkReferenceDefinitions.
 func breakLinkAdjacency(s string) string {
-	return strings.ReplaceAll(s, "](", "] (")
+	return channel.BreakMarkdownLinkAdjacency(s)
 }
 
 // breakLinkReferenceDefinitions stops member-authored text from *defining* a


### PR DESCRIPTION
## What does this PR do?

### Summary

- Neutralizes standard Markdown link adjacency in member-authored Slack issue titles before Slack converts Markdown links into native manual links.
- Neutralizes member-authored Slack-native entities (`http`, `https`, `mailto`, `tel`, and mentions) while preserving the bot-authored issue identifier.
- Reuses the small adjacency helper in WeCom without changing its separately verified reference-definition hardening.

### Root cause

Slack's created and duplicate `/issue` replies concatenated `IssueTitle` directly into a bot-authored message. The send path then ran `formatMrkdwn`, which converted `[label](url)` into Slack's working `<url|label>` syntax and preserved member-supplied native Slack entities. A member could therefore make the bot appear to endorse a labeled link or mention.

DingTalk remains out of scope: its code path reaches a markdown payload, but no tenant rendering evidence is available, so this PR does not make an unverified escaping change or claim.

## Related Issue

Fixes #6622

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `channel.BreakMarkdownLinkAdjacency`, a pure and idempotent helper that changes only `](` adjacency.
- Hardened Slack created and duplicate issue-title replies against Markdown links and native Slack entities.
- Added formatter-level regressions for inline links, nested parentheses, image-like syntax, reference definitions, native entities, second-pass formatting, and ordinary CJK/English titles.
- Made WeCom's existing adjacency helper delegate to the shared helper; its renderer-specific reference-definition protection is unchanged.

## How to Test

1. `cd server && go test ./internal/integrations/slack ./internal/integrations/dingtalk ./internal/integrations/channel -count=1`
2. `cd server && go test ./internal/integrations/wecom -run 'Test(BreakLink|IssueConfirmation|IssueDuplicateTitle|InboxCardBudgetsTheSpacesTheDefinitionBreakInserts)' -count=1`
3. `cd server && go vet ./...`

A full `go test ./... -count=1` was also attempted on Windows. It reaches unrelated existing Windows/environment failures (including temp-file unlinking, path separator/home-directory assumptions, profile isolation, and fake executable naming); the scoped packages and checks above pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — not applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing docs change required
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs — not applicable
- [x] If this PR touches Chinese product copy, I checked conventions — test fixtures only; no product copy change
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Investigated issue #6622 and the merged WeCom hardening, reproduced the Slack formatter transformation, used test-driven development for created and duplicate replies, and requested an independent code review. The review found a Slack-native entity bypass; I added a failing regression and a Slack-local guard before re-running focused tests and `go vet`.

## Screenshots (optional)

Not applicable; this is formatter-level backend behavior and DingTalk was not tenant-tested.