### PR TITLE
MUL-6036: fix(cli): stop treating daemon port as task context

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -255,12 +255,13 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 	taskContext := inDaemonManagedExecutionContext()
 	token := resolveToken(cmd)
 	if taskContext && !strings.HasPrefix(token, "mat_") {
-		// When the ONLY daemon signal is a workdir marker (no MULTICA_AGENT_ID /
-		// MULTICA_TASK_ID / MULTICA_DAEMON_PORT), the likeliest cause outside a
-		// real task is a leftover marker from a crashed daemon task in a
-		// local_directory. Name the exact file so a normal user can recover
-		// instead of hitting an opaque "requires mat_ token" error.
-		if !inAgentExecutionContext() && os.Getenv("MULTICA_DAEMON_PORT") == "" {
+		// When the only task signal is a workdir marker, the likeliest cause
+		// outside a real task is a leftover marker from a crashed daemon task in
+		// a local_directory. MULTICA_DAEMON_PORT does not change that conclusion:
+		// it may be a container-level health endpoint override. Name the exact
+		// marker so a normal user can recover instead of hitting an opaque
+		// "requires mat_ token" error.
+		if !inAgentExecutionContext() && strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) == "" {
 			if markerPath := daemonTaskContextMarkerPath(); markerPath != "" {
 				return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", markerPath)
 			}
@@ -333,17 +334,17 @@ func normalizeAPIBaseURL(raw string) string {
 // inAgentExecutionContext reports whether the CLI has explicit task identity
 // markers from a daemon-managed agent task.
 func inAgentExecutionContext() bool {
-	return os.Getenv("MULTICA_AGENT_ID") != "" || os.Getenv("MULTICA_TASK_ID") != ""
+	return strings.TrimSpace(os.Getenv("MULTICA_AGENT_ID")) != "" || strings.TrimSpace(os.Getenv("MULTICA_TASK_ID")) != ""
 }
 
-// inDaemonManagedExecutionContext reports whether the CLI is being invoked
-// from inside a daemon-managed agent task. MULTICA_DAEMON_PORT is included as
-// a defense-in-depth marker for subprocesses that lose MULTICA_AGENT_ID or
-// MULTICA_TASK_ID but still run under the daemon environment. In this context
-// workspace and token must come from daemon-provided env; falling back to
-// user-global ~/.multica/config.json can make agent writes land as a member.
+// inDaemonManagedExecutionContext reports whether the CLI has daemon-managed
+// task identity or isolation markers. MULTICA_DAEMON_PORT is deliberately not
+// a task marker: daemon containers may set it as a health endpoint override.
+// In a task, workspace and token must come from daemon-provided env; falling
+// back to user-global ~/.multica/config.json can make agent writes land as a
+// member.
 func inDaemonManagedExecutionContext() bool {
-	return inAgentExecutionContext() || os.Getenv("MULTICA_DAEMON_PORT") != "" || hasDaemonTaskContextMarker()
+	return inAgentExecutionContext() || strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) != "" || hasDaemonTaskContextMarker()
 }
 
 // requireTaskLocalConfigRoot prevents daemon-managed subprocesses that lost

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -142,10 +142,42 @@ func TestNewAPIClient_LeftoverMarkerActionableError(t *testing.T) {
 
 	if _, err := newAPIClient(testCmd()); err == nil {
 		t.Fatal("newAPIClient(): expected error for leftover daemon-task marker, got nil")
-	} else if !strings.Contains(err.Error(), execenv.TaskContextMarkerRelPath) {
+	} else if !strings.Contains(err.Error(), filepath.FromSlash(execenv.TaskContextMarkerRelPath)) {
 		t.Fatalf("error should name the marker path; got %q", err.Error())
 	} else if !strings.Contains(err.Error(), "leftover") {
 		t.Fatalf("error should hint it may be a leftover; got %q", err.Error())
+	}
+}
+
+func TestNewAPIClient_LeftoverMarkerWithDaemonPortRemainsActionable(t *testing.T) {
+	chdirWithDaemonTaskMarker(t)
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "20032")
+	t.Setenv(cli.TaskConfigRootEnv, "")
+	t.Setenv("MULTICA_TOKEN", "")
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+
+	if _, err := newAPIClient(testCmd()); err == nil {
+		t.Fatal("newAPIClient(): expected error for leftover daemon-task marker, got nil")
+	} else if !strings.Contains(err.Error(), "leftover") {
+		t.Fatalf("error should hint the marker may be leftover; got %q", err.Error())
+	}
+}
+
+func TestNewAPIClient_TaskConfigRootWithMarkerUsesGenericTaskError(t *testing.T) {
+	chdirWithDaemonTaskMarker(t)
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "20032")
+	t.Setenv(cli.TaskConfigRootEnv, filepath.Join(t.TempDir(), "task-config"))
+	t.Setenv("MULTICA_TOKEN", "")
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+
+	if _, err := newAPIClient(testCmd()); err == nil {
+		t.Fatal("newAPIClient(): expected task token error, got nil")
+	} else if strings.Contains(err.Error(), "leftover") {
+		t.Fatalf("active task config root was mislabeled as a leftover marker: %q", err.Error())
 	}
 }
 
@@ -214,14 +246,14 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("daemon port marker also skips config", func(t *testing.T) {
+	t.Run("daemon port alone still reads config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
 		t.Setenv("MULTICA_DAEMON_PORT", "27182")
 		t.Setenv("MULTICA_WORKSPACE_ID", "")
 
-		if got := resolveWorkspaceID(testCmd()); got != "" {
-			t.Fatalf("resolveWorkspaceID() = %q, want empty", got)
+		if got := resolveWorkspaceID(testCmd()); got != "config-file-ws" {
+			t.Fatalf("resolveWorkspaceID() = %q, want config-file-ws", got)
 		}
 	})
 
@@ -295,15 +327,15 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("daemon port marker without env never reads config", func(t *testing.T) {
+	t.Run("daemon port alone still reads config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
 		t.Setenv("MULTICA_DAEMON_PORT", "27182")
 		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
 		t.Setenv("MULTICA_TOKEN", "")
 
-		if got := resolveToken(testCmd()); got != "" {
-			t.Fatalf("resolveToken() = %q, want empty in daemon-managed context without MULTICA_TOKEN", got)
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token", got)
 		}
 	})
 
@@ -369,14 +401,14 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("daemon port set without agent context avoids config fallback", func(t *testing.T) {
+	t.Run("daemon port set without task context allows config fallback", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
 		t.Setenv("MULTICA_TOKEN", "")
 		t.Setenv("MULTICA_DAEMON_PORT", "19514")
 
-		if got := resolveToken(testCmd()); got != "" {
-			t.Fatalf("resolveToken() = %q, want empty (daemon port set, fail closed)", got)
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token", got)
 		}
 	})
 
@@ -392,9 +424,8 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 	})
 
 	// MULTICA_SERVER_URL is a user-facing env var that may be set in a
-	// normal shell. It is NOT a daemon identity signal — only
-	// MULTICA_DAEMON_PORT is. The config fallback must still work when
-	// SERVER_URL is set but no daemon signal is present.
+	// normal shell. It is not a daemon task identity signal. The config fallback
+	// must still work when SERVER_URL is set without a task marker.
 	t.Run("MULTICA_SERVER_URL alone does not block config fallback", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
@@ -466,7 +497,7 @@ func TestNewAPIClient_AgentContextRequiresTaskToken(t *testing.T) {
 	})
 }
 
-func TestNewAPIClient_DaemonPortRequiresTaskToken(t *testing.T) {
+func TestNewAPIClient_DaemonPortAllowsHumanToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
 	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
@@ -479,12 +510,12 @@ func TestNewAPIClient_DaemonPortRequiresTaskToken(t *testing.T) {
 		t.Fatalf("seed config: %v", err)
 	}
 
-	_, err := newAPIClient(testCmd())
-	if err == nil {
-		t.Fatal("newAPIClient(): expected error without task token")
+	client, err := newAPIClient(testCmd())
+	if err != nil {
+		t.Fatalf("newAPIClient(): %v", err)
 	}
-	if !strings.Contains(err.Error(), "mat_ token") {
-		t.Fatalf("newAPIClient() error = %q, want mat_ token guidance", err.Error())
+	if client.Token != "mul_profile_token" {
+		t.Fatalf("client token = %q, want profile token", client.Token)
 	}
 }
 
@@ -507,6 +538,41 @@ func TestNewAPIClient_WorkdirMarkerRequiresTaskToken(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mat_ token") {
 		t.Fatalf("newAPIClient() error = %q, want mat_ token guidance", err.Error())
+	}
+}
+
+func TestInDaemonManagedExecutionContextUsesTaskMarkers(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	tests := []struct {
+		name           string
+		agentID        string
+		taskID         string
+		daemonPort     string
+		taskConfigRoot string
+		want           bool
+	}{
+		{name: "no markers"},
+		{name: "daemon port alone is a health endpoint hint", daemonPort: "20032"},
+		{name: "blank daemon port is not a task marker", daemonPort: "  \t "},
+		{name: "blank task markers are ignored", agentID: " ", taskID: "\t", taskConfigRoot: "  "},
+		{name: "agent identity marks a task", agentID: "agent-123", want: true},
+		{name: "task identity marks a task", taskID: "task-456", want: true},
+		{name: "task config root marks a task", taskConfigRoot: filepath.Join(t.TempDir(), "task-config"), want: true},
+		{name: "task marker wins when daemon port is also set", taskID: "task-456", daemonPort: "20032", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MULTICA_AGENT_ID", tc.agentID)
+			t.Setenv("MULTICA_TASK_ID", tc.taskID)
+			t.Setenv("MULTICA_DAEMON_PORT", tc.daemonPort)
+			t.Setenv(cli.TaskConfigRootEnv, tc.taskConfigRoot)
+
+			if got := inDaemonManagedExecutionContext(); got != tc.want {
+				t.Fatalf("inDaemonManagedExecutionContext() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -76,8 +76,8 @@ func resolveToken(cmd *cobra.Command) string {
 	}
 	// Inside a daemon-managed task, never fall back to the user-global config
 	// token: that silent fallback is how agent writes land as the wrong actor.
-	// inDaemonManagedExecutionContext already covers the MULTICA_DAEMON_PORT
-	// signal for subprocesses that lost MULTICA_AGENT_ID / MULTICA_TASK_ID.
+	// The predicate covers task identity, isolation root, and workdir marker
+	// signals without confusing the daemon health endpoint with task identity.
 	if inDaemonManagedExecutionContext() {
 		return ""
 	}

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -449,11 +449,14 @@ func TestHumanAuthCommandsFailClosedInTaskContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loginCmd := testCmd()
-	loginCmd.Flags().String("token", "mul_fake_login", "")
-	_ = loginCmd.Flags().Set("token", "mul_fake_login")
 	for name, run := range map[string]func() error{
-		"login":  func() error { return runAuthLogin(loginCmd, nil) },
+		"interactive login": func() error { return runAuthLogin(testCmd(), nil) },
+		"token login": func() error {
+			loginCmd := testCmd()
+			loginCmd.Flags().String("token", "mul_fake_login", "")
+			_ = loginCmd.Flags().Set("token", "mul_fake_login")
+			return runAuthLogin(loginCmd, nil)
+		},
 		"logout": func() error { return runAuthLogout(testCmd(), nil) },
 	} {
 		err := run()
@@ -467,6 +470,103 @@ func TestHumanAuthCommandsFailClosedInTaskContext(t *testing.T) {
 	}
 	if string(after) != string(ownerBytes) {
 		t.Fatalf("owner config content changed: got %q", after)
+	}
+}
+
+func TestHumanLoginGuardAllowsDaemonPortWithoutTaskMarkers(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "20032")
+	t.Setenv("MULTICA_TASK_CONFIG_ROOT", "")
+
+	// runAuthLogin applies this guard before choosing token or interactive
+	// login, so both human login modes must remain available in a daemon
+	// container that only carries the health-port override.
+	if err := requireHumanLocalCommand("login"); err != nil {
+		t.Fatalf("login guard rejected daemon port without task markers: %v", err)
+	}
+}
+
+func TestHumanLoginGuardRejectsAuthoritativeTaskMarkers(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T)
+	}{
+		{
+			name: "task id",
+			setup: func(t *testing.T) {
+				t.Setenv("MULTICA_TASK_ID", "task-test")
+			},
+		},
+		{
+			name: "task config root",
+			setup: func(t *testing.T) {
+				t.Setenv("MULTICA_TASK_CONFIG_ROOT", filepath.Join(t.TempDir(), "task-config"))
+			},
+		},
+		{
+			name: "daemon workdir marker",
+			setup: func(t *testing.T) {
+				chdirWithDaemonTaskMarker(t)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			t.Setenv("MULTICA_AGENT_ID", "")
+			t.Setenv("MULTICA_TASK_ID", "")
+			t.Setenv("MULTICA_DAEMON_PORT", "")
+			t.Setenv("MULTICA_TASK_CONFIG_ROOT", "")
+			tc.setup(t)
+
+			if err := requireHumanLocalCommand("login"); err == nil || !strings.Contains(err.Error(), "not available inside a daemon-managed task") {
+				t.Fatalf("login guard error = %v, want daemon-managed task rejection", err)
+			}
+		})
+	}
+}
+
+func TestRunAuthLoginTokenAllowsDaemonPortWithoutTaskMarkers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "20032")
+	t.Setenv("MULTICA_TASK_CONFIG_ROOT", "")
+
+	const fakeToken = "mul_local_test_token"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+fakeToken {
+			t.Errorf("Authorization = %q, want local fake token", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"name": "Local User", "email": "local@example.test"})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := testCmd()
+	cmd.Flags().String("token", fakeToken, "")
+	if err := cmd.Flags().Set("token", fakeToken); err != nil {
+		t.Fatalf("set token flag: %v", err)
+	}
+	if err := runAuthLogin(cmd, nil); err != nil {
+		t.Fatalf("runAuthLogin: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".multica", "config.json"))
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if !strings.Contains(string(data), fakeToken) || !strings.Contains(string(data), srv.URL) {
+		t.Fatalf("saved config missing local login values: %s", data)
 	}
 }
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -1369,14 +1369,13 @@ func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	// not running, and the port is simply occupied. Say exactly that, and keep
 	// the top-level verdict "stopped" so scripts reading it stay correct.
 	//
-	// Only outside a daemon-managed task. There the port comes from the host
-	// daemon's own injection rather than a profile hash, so no collision is
-	// possible — and the task's profile is necessarily empty (--profile is
-	// rejected) while the host may run a named one, which would make every
-	// named-profile host look like a conflict and break the standing contract
-	// that `daemon status` in a task reports on the daemon hosting it.
+	// Only when the port came from the profile hash. An explicit
+	// MULTICA_DAEMON_PORT selects the endpoint directly, both in a task and in
+	// an ordinary daemon container. Comparing that daemon to the default
+	// profile would manufacture a conflict whenever the endpoint belongs to a
+	// named-profile daemon.
 	var conflict *daemonProfileMismatchError
-	if daemonAlive(health) && !inDaemonManagedExecutionContext() {
+	if daemonAlive(health) && strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) == "" {
 		errors.As(daemonIdentityMismatch(health, profile, healthPort), &conflict)
 	}
 
@@ -1412,28 +1411,30 @@ func runDaemonStatus(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// daemonStatusHealthPort resolves which daemon `status` should probe. Outside a
-// task that is the --profile-derived port. Inside a managed task it is the
-// daemon-injected MULTICA_DAEMON_PORT and nothing else: healthPortForProfile
-// hashes whatever profile name the caller passes, so deriving the port there
-// would let a task report on a daemon that is not the one hosting it — and for
-// a task hosted by a named-profile daemon it would silently probe the default
-// daemon instead. A missing port fails closed rather than guessing.
+// daemonStatusHealthPort resolves which daemon `status` should probe. An
+// explicit MULTICA_DAEMON_PORT is a health endpoint override in ordinary
+// environments and the daemon-injected endpoint inside a managed task. A task
+// may not replace it with --profile, because that could probe an unrelated
+// daemon; a missing task port fails closed rather than guessing.
 func daemonStatusHealthPort(cmd *cobra.Command) (int, error) {
 	profile := resolveProfile(cmd)
-	if !inDaemonManagedExecutionContext() {
+	taskContext := inDaemonManagedExecutionContext()
+	raw := strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT"))
+	if !taskContext && raw == "" {
 		return healthPortForProfile(profile), nil
 	}
-	if profile != "" {
+	if taskContext && profile != "" {
 		return 0, fmt.Errorf("daemon status --profile is not available inside a daemon-managed task")
 	}
-	raw := strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT"))
 	if raw == "" {
 		return 0, fmt.Errorf("daemon status inside a daemon-managed task requires the daemon-injected MULTICA_DAEMON_PORT")
 	}
 	port, err := strconv.Atoi(raw)
 	if err != nil || port <= 0 {
-		return 0, fmt.Errorf("invalid MULTICA_DAEMON_PORT %q inside a daemon-managed task", raw)
+		if taskContext {
+			return 0, fmt.Errorf("invalid MULTICA_DAEMON_PORT %q inside a daemon-managed task", raw)
+		}
+		return 0, fmt.Errorf("invalid MULTICA_DAEMON_PORT %q", raw)
 	}
 	return port, nil
 }

--- a/server/cmd/multica/cmd_daemon_identity_test.go
+++ b/server/cmd/multica/cmd_daemon_identity_test.go
@@ -374,6 +374,32 @@ func TestDaemonStatusInTaskContextReportsNamedProfileHost(t *testing.T) {
 	})
 }
 
+// A container-level MULTICA_DAEMON_PORT selects an explicit endpoint just as
+// the task-injected value does, but it does not make the CLI task-scoped. The
+// endpoint may belong to a named-profile daemon, so comparing its identity to
+// the default profile would manufacture a collision.
+func TestDaemonStatusWithExplicitPortReportsNamedProfileHost(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t)
+	stub := serveHealthAs(t, "host-named-profile", map[string]any{
+		"profile": "host-named-profile", "launched_by": "desktop",
+	})
+	t.Setenv("MULTICA_DAEMON_PORT", strconv.Itoa(stub.port))
+
+	out, err := captureStdout(t, func() error {
+		return runDaemonStatus(daemonStatusCmdFor(t, "", ""), nil)
+	})
+	if err != nil {
+		t.Fatalf("runDaemonStatus = %v, want nil", err)
+	}
+	if !strings.Contains(out, "running") {
+		t.Fatalf("stdout = %q, want the explicit-port daemon reported as running", out)
+	}
+	if strings.Contains(out, "hashes to the same port") {
+		t.Fatalf("stdout = %q, explicit endpoint must not be treated as a profile-hash collision", out)
+	}
+}
+
 // A profile field that is present but not a string is a daemon answering
 // wrongly, not an older daemon unable to answer. Collapsing it to "" would
 // read as a match for the default profile and hand lifecycle commands a daemon

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -868,6 +868,23 @@ func TestDaemonStatusHealthPortInTaskContext(t *testing.T) {
 		}
 	})
 
+	t.Run("daemon port alone selects the health endpoint without marking a task", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		clearDaemonTaskEnv(t)
+		t.Setenv("MULTICA_DAEMON_PORT", strconv.Itoa(injectedPort))
+
+		got, err := daemonStatusHealthPort(testCmd())
+		if err != nil {
+			t.Fatalf("daemonStatusHealthPort: %v", err)
+		}
+		if got != injectedPort {
+			t.Fatalf("health port = %d, want the explicit %d", got, injectedPort)
+		}
+		if inDaemonManagedExecutionContext() {
+			t.Fatal("MULTICA_DAEMON_PORT alone marked daemon status as task-scoped")
+		}
+	})
+
 	t.Run("inside a task uses the injected port", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		clearDaemonTaskEnv(t)
@@ -883,6 +900,21 @@ func TestDaemonStatusHealthPortInTaskContext(t *testing.T) {
 		}
 		if got == healthPortForProfile("") {
 			t.Fatal("injected port collided with the profile-derived port; the test proves nothing")
+		}
+	})
+
+	t.Run("task config root and daemon port use the injected port", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		clearDaemonTaskEnv(t)
+		t.Setenv("MULTICA_TASK_CONFIG_ROOT", filepath.Join(t.TempDir(), "task-config"))
+		t.Setenv("MULTICA_DAEMON_PORT", strconv.Itoa(injectedPort))
+
+		got, err := daemonStatusHealthPort(testCmd())
+		if err != nil {
+			t.Fatalf("daemonStatusHealthPort: %v", err)
+		}
+		if got != injectedPort {
+			t.Fatalf("health port = %d, want the injected %d", got, injectedPort)
 		}
 	})
 

--- a/server/cmd/multica/cmd_repo_test.go
+++ b/server/cmd/multica/cmd_repo_test.go
@@ -226,3 +226,24 @@ func TestRunRepoCheckoutForwardsManagedCheckoutMode(t *testing.T) {
 		t.Fatalf("ref = %q, want release/v2", got)
 	}
 }
+
+func TestRunRepoCheckoutStillUsesDaemonPortDirectly(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		json.NewEncoder(w).Encode(map[string]string{"path": "/work/repo"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_TASK_CONFIG_ROOT", "")
+	t.Setenv("MULTICA_DAEMON_PORT", strings.TrimPrefix(srv.URL, "http://127.0.0.1:"))
+
+	if err := runRepoCheckout(&cobra.Command{}, []string{"https://github.com/org/repo.git"}); err != nil {
+		t.Fatalf("runRepoCheckout: %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("repo checkout made %d requests, want 1", requestCount)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

### Summary

- Stops treating `MULTICA_DAEMON_PORT` by itself as proof that the CLI is running inside a daemon-managed task.
- Keeps login, token/workspace isolation, daemon status, disk-usage, and repo checkout behavior scoped to their actual markers and endpoint needs.
- Adds regression coverage for token and interactive login guards, authoritative task markers, whitespace/marker combinations, explicit daemon status endpoints, and repo checkout.

### Root cause

v0.4.22 added a correct fail-closed guard for human-local commands such as `login`, but the shared task-context predicate also treated `MULTICA_DAEMON_PORT` as task identity. Containerized daemon startup environments may set that variable only as a health endpoint override, so the login guard rejected ordinary startup authentication.

The predicate now uses trimmed agent/task identity, the daemon-owned task config root, or the daemon-owned workdir/root marker. The port remains a direct health/checkout endpoint input rather than task identity.

### Risk

The main risk is reopening the silent owner-PAT fallback fixed by #4204/#5044. Existing root/workdir marker tests and new task-config/identity tests verify that real or escaped daemon task processes still fail closed. Explicit-port daemon status also bypasses profile-hash collision checks because the endpoint was selected directly, while profile-derived status keeps collision detection.

## Related Issue

Fixes #6779

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_agent.go`: distinguish authoritative task markers from the daemon health port.
- `server/cmd/multica/cmd_auth.go`: retain fail-closed token fallback using the corrected task predicate.
- `server/cmd/multica/cmd_daemon.go`: preserve explicit-port status behavior without false profile collisions.
- CLI tests: cover port-only login, real task rejection, whitespace/combinations, status, disk-usage isolation, and repo checkout.

## How to Test

1. Run the focused CLI regression suite for login/task markers, daemon status, disk usage, and repo checkout.
2. Run the daemon task-environment and execenv root/workdir marker tests.
3. Run `go vet ./cmd/multica ./internal/daemon ./internal/daemon/execenv`.

Local results:
- Focused `server/cmd/multica` regression tests: pass.
- `server/internal/daemon` task environment test: pass.
- `server/internal/daemon/execenv` marker tests: pass.
- Targeted `go vet`: pass.

A full `go test ./cmd/multica` on this Windows checkout still hits pre-existing tests that assume Unix absolute paths or that setting only `HOME` changes `os.UserHomeDir`; the same failures reproduce from a clean `origin/main` worktree. The affected #6779 paths are covered by the passing focused suite above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Documentation note: the built-in runtime/repo skill documents `MULTICA_DAEMON_PORT` as the direct endpoint required by `repo checkout`; that contract is unchanged, so no built-in skill text needed modification.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Used Codex to trace the v0.4.21 to v0.4.22 history and every task-context caller, implement the fix test-first, compare full-package Windows failures against a clean upstream worktree, and run an independent code-review pass. The review found an explicit-port daemon status collision edge case, which was reproduced with a failing end-to-end test and fixed before submission.

## Screenshots (optional)

Not applicable (CLI-only change).
