### PR TITLE
MUL-6025: fix(daemon): resolve Windows installer junctions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
         # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
         # only a real Windows filesystem proves both PATH discovery and an
         # explicitly configured path reach the release executable.
-        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathCanonicalizes|TestTrimWindowsExtendedPathPrefix)' -count=1 -timeout=5m
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting))' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
         working-directory: server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
         # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
         # only a real Windows filesystem proves both PATH discovery and an
         # explicitly configured path reach the release executable.
-        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting))' -count=1 -timeout=5m
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
         working-directory: server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,14 @@ jobs:
           go test ./internal/daemon/execenv -v -run '^(TestSeedUserCodexSkills|TestHydrateCodexSkills)' -count=1 -timeout=5m
           go test ./internal/daemon -v -run '^(TestCleanTaskArtifacts_DoesNotFollowDirectoryJunction|TestTaskSize_DoesNotCountDirectoryJunction)$' -count=1 -timeout=5m
 
+      - name: Test Windows agent executable junction resolution
+        working-directory: server
+        # The standalone Codex installer exposes bin as a directory junction.
+        # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
+        # only a real Windows filesystem proves both PATH discovery and an
+        # explicitly configured path reach the release executable.
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathCanonicalizes|TestTrimWindowsExtendedPathPrefix)' -count=1 -timeout=5m
+
       - name: Build Windows CLI helper entrypoint
         working-directory: server
         run: go build ./cmd/multica

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
         # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
         # only a real Windows filesystem proves both PATH discovery and an
         # explicitly configured path reach the release executable.
-        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|ForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
         working-directory: server

--- a/server/internal/daemon/agents_refresh.go
+++ b/server/internal/daemon/agents_refresh.go
@@ -205,11 +205,11 @@ func (d *Daemon) refreshAgentAvailability() []string {
 // NOT restart. What a user needs when codex or claude upgrades is that
 // subsequent tasks run the new CLI under the new version's rules — not that
 // Multica's availability tracks a third party's release cadence. An in-place
-// upgrade leaves the pinned path valid, so the new binary is already what
-// launches; the two things left stale are the cached version (which keys
-// version-sensitive policy such as the Codex sandbox, read back through
-// resolveAgentEntry) and the version the server displays. Both are refreshed
-// here with running tasks untouched.
+// POSIX upgrade changes the binary behind the pinned path; a Windows installer
+// upgrade retargets the stable junction resolved by resolveAgentEntry. The two
+// things left stale are the cached version (which keys version-sensitive policy
+// such as the Codex sandbox) and the version the server displays. Both are
+// refreshed here with running tasks untouched.
 //
 // detectBuiltinRuntimes does the probing, which buys three properties for free:
 // probes fan out, a fast failure is retried (runtimeVersionProbeAttempts), and

--- a/server/internal/daemon/canonical_path.go
+++ b/server/internal/daemon/canonical_path.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package daemon
+
+import "path/filepath"
+
+func canonicalPath(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
+
+func canonicalConfiguredExecutablePath(path string) string {
+	return path
+}

--- a/server/internal/daemon/canonical_path.go
+++ b/server/internal/daemon/canonical_path.go
@@ -8,6 +8,14 @@ func canonicalPath(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
+func discoveredExecutablePath(path string) string {
+	return canonicalExecutablePath(path)
+}
+
+func executablePathForLaunch(string) (string, bool, error) {
+	return "", false, nil
+}
+
 func canonicalConfiguredExecutablePath(path string) string {
 	return path
 }

--- a/server/internal/daemon/canonical_path.go
+++ b/server/internal/daemon/canonical_path.go
@@ -12,7 +12,9 @@ func discoveredExecutablePath(path string) string {
 	return canonicalExecutablePath(path)
 }
 
-func executablePathForLaunch(string) (string, bool, error) {
+var executablePathForLaunch = executablePathForLaunchDefault
+
+func executablePathForLaunchDefault(string) (string, bool, error) {
 	return "", false, nil
 }
 

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -3,7 +3,7 @@
 package daemon
 
 import (
-	"strings"
+	"path/filepath"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -35,20 +35,29 @@ func canonicalPath(path string) (string, error) {
 			return "", err
 		}
 		if length < uint32(len(buffer)) {
-			resolved := windows.UTF16ToString(buffer[:length])
-			return trimWindowsExtendedPathPrefix(resolved), nil
+			return windows.UTF16ToString(buffer[:length]), nil
 		}
 		buffer = make([]uint16, length+1)
 	}
 }
 
-func trimWindowsExtendedPathPrefix(path string) string {
-	if strings.HasPrefix(path, `\\?\UNC\`) {
-		return `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+func discoveredExecutablePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
 	}
-	return strings.TrimPrefix(path, `\\?\`)
+	return abs
 }
 
 func canonicalConfiguredExecutablePath(path string) string {
-	return canonicalExecutablePath(path)
+	return discoveredExecutablePath(path)
+}
+
+func executablePathForLaunch(path string) (string, bool, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", true, err
+	}
+	resolved, err := canonicalPath(abs)
+	return resolved, true, err
 }

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package daemon
+
+import (
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func canonicalPath(path string) (string, error) {
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, syscall.MAX_PATH)
+	for {
+		length, err := windows.GetFinalPathNameByHandle(handle, &buffer[0], uint32(len(buffer)), 0)
+		if err != nil {
+			return "", err
+		}
+		if length < uint32(len(buffer)) {
+			resolved := windows.UTF16ToString(buffer[:length])
+			return trimWindowsExtendedPathPrefix(resolved), nil
+		}
+		buffer = make([]uint16, length+1)
+	}
+}
+
+func trimWindowsExtendedPathPrefix(path string) string {
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		return `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	}
+	return strings.TrimPrefix(path, `\\?\`)
+}
+
+func canonicalConfiguredExecutablePath(path string) string {
+	return canonicalExecutablePath(path)
+}

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -53,7 +53,9 @@ func canonicalConfiguredExecutablePath(path string) string {
 	return discoveredExecutablePath(path)
 }
 
-func executablePathForLaunch(path string) (string, bool, error) {
+var executablePathForLaunch = executablePathForLaunchWindows
+
+func executablePathForLaunchWindows(path string) (string, bool, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", true, err

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -749,10 +749,13 @@ func samePathDir(a, b string) bool {
 func canonicalExecutablePath(path string) string {
 	abs, err := filepath.Abs(path)
 	if err != nil {
+		slog.Debug("make agent executable path absolute failed; keeping configured path", "path", path, "error", err)
 		return path
 	}
 	if real, err := canonicalPath(abs); err == nil {
 		return real
+	} else {
+		slog.Debug("canonicalize agent executable path failed; keeping absolute path", "path", abs, "error", err)
 	}
 	return abs
 }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -641,7 +641,7 @@ func resolveAgentExecutablePath(cmd string) (string, error) {
 		return "", err
 	}
 	if strings.ContainsAny(cmd, "/\\") {
-		return resolved, nil
+		return canonicalConfiguredExecutablePath(resolved), nil
 	}
 	if isInMulticaHooksDir(resolved) {
 		if unshadowed, err := lookPathExcludingMulticaHooks(cmd); err == nil {
@@ -748,7 +748,7 @@ func canonicalExecutablePath(path string) string {
 	if err != nil {
 		return path
 	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
+	if real, err := canonicalPath(abs); err == nil {
 		return real
 	}
 	return abs

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -629,9 +629,12 @@ func shellArgsFromEnv(name string) ([]string, error) {
 	return args, nil
 }
 
-// resolveAgentExecutablePath returns the concrete executable path the daemon
+// resolveAgentExecutablePath returns the executable entry point the daemon
 // should keep for an agent command. Bare command names are pinned to the path
 // resolved during startup so later PATH changes cannot redirect task launches.
+// On Windows this deliberately keeps the stable discovered junction path;
+// resolveAgentEntryWithHeal follows it for each launch so installer upgrades
+// that retarget a still-live junction take effect without a daemon restart.
 // When ~/.multica/hooks shadows a real agent binary, skip that hooks directory:
 // previously generated hook wrappers can execute the same command name and
 // recurse forever if the daemon records or launches the wrapper.
@@ -648,7 +651,7 @@ func resolveAgentExecutablePath(cmd string) (string, error) {
 			return unshadowed, nil
 		}
 	}
-	return canonicalExecutablePath(resolved), nil
+	return discoveredExecutablePath(resolved), nil
 }
 
 // agentExecutablePresent reports whether path currently resolves to a runnable
@@ -702,7 +705,7 @@ func lookPathExcludingMulticaHooks(cmd string) (string, error) {
 		}
 		candidate := filepath.Join(dir, cmd)
 		if isExecutableFile(candidate) {
-			return canonicalExecutablePath(candidate), nil
+			return discoveredExecutablePath(candidate), nil
 		}
 	}
 	return "", exec.ErrNotFound

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -383,6 +383,68 @@ func TestResolveAgentEntryCanonicalizesRediscoveredJunction(t *testing.T) {
 	}
 }
 
+func TestResolveAgentEntryForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails(t *testing.T) {
+	targetExecutable, shimBin := stageJunctionExecutable(t)
+	stableExecutable := filepath.Join(shimBin, "codex.exe")
+	t.Setenv("PATH", shimBin)
+	t.Setenv("PATHEXT", ".EXE")
+
+	originalDetect := detectAgentVersion
+	detectCalled := false
+	detectAgentVersion = func(context.Context, string) (string, error) {
+		detectCalled = true
+		return "0.144.3", nil
+	}
+	t.Cleanup(func() { detectAgentVersion = originalDetect })
+
+	resolutionErr := errors.New("final path volume has no DOS name")
+	originalLaunchResolver := executablePathForLaunch
+	executablePathForLaunch = func(path string) (string, bool, error) {
+		if strings.EqualFold(path, stableExecutable) {
+			return "", true, resolutionErr
+		}
+		return originalLaunchResolver(path)
+	}
+	t.Cleanup(func() { executablePathForLaunch = originalLaunchResolver })
+
+	var logs bytes.Buffer
+	d := newSelfHealTestDaemon()
+	d.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: filepath.Join(t.TempDir(), "removed", "codex.exe"), Command: "codex"}
+
+	got, _, err := d.resolveAgentEntryForLaunch(context.Background(), "codex", entry)
+	if err == nil {
+		t.Fatalf("resolveAgentEntryForLaunch returned rediscovered unresolved path %q; want final-path failure", got.Path)
+	}
+	if !errors.Is(err, resolutionErr) {
+		t.Fatalf("resolveAgentEntryForLaunch error = %v, want %v", err, resolutionErr)
+	}
+	if detectCalled {
+		t.Fatal("detectAgentVersion was called for an unverified rediscovered launch target")
+	}
+	d.resolvedPathsMu.RLock()
+	_, cached := d.resolvedPaths["codex"]
+	d.resolvedPathsMu.RUnlock()
+	if cached {
+		t.Fatal("unverified rediscovered launch target was cached in resolvedPaths")
+	}
+	if strings.EqualFold(got.Path, stableExecutable) || sameFile(got.Path, targetExecutable) {
+		t.Fatalf("resolveAgentEntryForLaunch returned a launchable target %q after resolution failure", got.Path)
+	}
+
+	logText := logs.String()
+	if !strings.Contains(logText, "level=WARN") {
+		t.Fatalf("rediscovery resolution failure log = %q, want WARN", logText)
+	}
+	if !strings.Contains(logText, stableExecutable) {
+		t.Fatalf("rediscovery resolution failure log = %q, want path %q", logText, stableExecutable)
+	}
+	if !strings.Contains(logText, resolutionErr.Error()) {
+		t.Fatalf("rediscovery resolution failure log = %q, want error %q", logText, resolutionErr)
+	}
+}
+
 func TestCanonicalExecutablePathLaunchesBeyondMaxPath(t *testing.T) {
 	deep := t.TempDir()
 	for len(deep) < 280 {

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -1,0 +1,117 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalExecutablePathResolvesDirectoryJunction(t *testing.T) {
+	targetDir := t.TempDir()
+	targetBin := filepath.Join(targetDir, "bin")
+	if err := os.MkdirAll(targetBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetExecutable := filepath.Join(targetBin, "codex.exe")
+	if err := os.WriteFile(targetExecutable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	shimRoot := t.TempDir()
+	shimBin := filepath.Join(shimRoot, "bin")
+	createJunction(t, targetBin, shimBin)
+	shimExecutable := filepath.Join(shimBin, "codex.exe")
+
+	if _, err := filepath.EvalSymlinks(shimExecutable); err == nil {
+		t.Fatal("EvalSymlinks unexpectedly resolved a directory junction; test would not reproduce the bug")
+	}
+	if got := canonicalExecutablePath(shimExecutable); !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("canonicalExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "codex.exe")
+	if err := os.WriteFile(executable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := canonicalExecutablePath(executable); !strings.EqualFold(got, executable) {
+		t.Fatalf("canonicalExecutablePath() = %q, want %q", got, executable)
+	}
+}
+
+func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing", "codex.exe")
+	want, err := filepath.Abs(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := canonicalExecutablePath(missing); got != want {
+		t.Fatalf("canonicalExecutablePath() = %q, want fallback %q", got, want)
+	}
+}
+
+func TestTrimWindowsExtendedPathPrefix(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "drive path", path: `\\?\C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
+		{name: "UNC path", path: `\\?\UNC\server\share\codex.exe`, want: `\\server\share\codex.exe`},
+		{name: "ordinary path", path: `C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := trimWindowsExtendedPathPrefix(test.path); got != test.want {
+				t.Fatalf("trimWindowsExtendedPathPrefix(%q) = %q, want %q", test.path, got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
+	targetExecutable, shimBin := stageJunctionExecutable(t)
+	t.Setenv("PATH", shimBin)
+	t.Setenv("PATHEXT", ".EXE")
+
+	got, err := resolveAgentExecutablePath("codex")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testing.T) {
+	targetExecutable, shimBin := stageJunctionExecutable(t)
+	configured := filepath.Join(shimBin, "codex.exe")
+
+	got, err := resolveAgentExecutablePath(configured)
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if !strings.EqualFold(got, targetExecutable) {
+		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	}
+}
+
+func stageJunctionExecutable(t *testing.T) (targetExecutable, shimBin string) {
+	t.Helper()
+	targetBin := filepath.Join(t.TempDir(), "release", "bin")
+	if err := os.MkdirAll(targetBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	targetExecutable = filepath.Join(targetBin, "codex.exe")
+	if err := os.WriteFile(targetExecutable, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shimBin = filepath.Join(t.TempDir(), "installer", "bin")
+	createJunction(t, targetBin, shimBin)
+	return targetExecutable, shimBin
+}

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -3,9 +3,11 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,6 +78,27 @@ func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
 
 	if got := canonicalExecutablePath(missing); got != want {
 		t.Fatalf("canonicalExecutablePath() = %q, want fallback %q", got, want)
+	}
+}
+
+func TestCanonicalExecutablePathLogsFallbackError(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	missing := filepath.Join(t.TempDir(), "missing", "codex.exe")
+	canonicalExecutablePath(missing)
+
+	got := logs.String()
+	if !strings.Contains(got, "canonicalize agent executable path failed") {
+		t.Fatalf("canonicalization fallback log = %q, want failure message", got)
+	}
+	if !strings.Contains(got, missing) {
+		t.Fatalf("canonicalization fallback log = %q, want path %q", got, missing)
+	}
+	if !strings.Contains(got, "error=") {
+		t.Fatalf("canonicalization fallback log = %q, want error attribute", got)
 	}
 }
 

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -3,11 +3,38 @@
 package daemon
 
 import (
+	"context"
+	"errors"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
 )
+
+const (
+	longPathExecutableHelperEnv = "MULTICA_LONG_PATH_EXECUTABLE_HELPER"
+	longPathExecutableMarkerEnv = "MULTICA_LONG_PATH_EXECUTABLE_MARKER"
+)
+
+func TestLongPathExecutableHelper(t *testing.T) {
+	if os.Getenv(longPathExecutableHelperEnv) == "1" {
+		if marker := os.Getenv(longPathExecutableMarkerEnv); marker != "" {
+			executable, err := os.Executable()
+			if err != nil {
+				os.Exit(2)
+			}
+			if err := os.WriteFile(marker, []byte(executable), 0o600); err != nil {
+				os.Exit(3)
+			}
+		}
+		os.Exit(0)
+	}
+}
 
 func TestCanonicalExecutablePathResolvesDirectoryJunction(t *testing.T) {
 	targetDir := t.TempDir()
@@ -52,26 +79,8 @@ func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
 	}
 }
 
-func TestTrimWindowsExtendedPathPrefix(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		path string
-		want string
-	}{
-		{name: "drive path", path: `\\?\C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
-		{name: "UNC path", path: `\\?\UNC\server\share\codex.exe`, want: `\\server\share\codex.exe`},
-		{name: "ordinary path", path: `C:\tools\codex.exe`, want: `C:\tools\codex.exe`},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if got := trimWindowsExtendedPathPrefix(test.path); got != test.want {
-				t.Fatalf("trimWindowsExtendedPathPrefix(%q) = %q, want %q", test.path, got, test.want)
-			}
-		})
-	}
-}
-
-func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
-	targetExecutable, shimBin := stageJunctionExecutable(t)
+func TestResolveAgentExecutablePathKeepsPATHJunctionEntryPoint(t *testing.T) {
+	_, shimBin := stageJunctionExecutable(t)
 	t.Setenv("PATH", shimBin)
 	t.Setenv("PATHEXT", ".EXE")
 
@@ -79,18 +88,312 @@ func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	assertResolvedExecutable(t, got, filepath.Join(shimBin, "codex.exe"), targetExecutable)
+	if want := filepath.Join(shimBin, "codex.exe"); !strings.EqualFold(got, want) {
+		t.Fatalf("resolved PATH entry = %q, want stable junction entry %q", got, want)
+	}
 }
 
-func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testing.T) {
+func TestResolveAgentEntryFollowsRetargetedInstallerJunction(t *testing.T) {
+	originalDetect := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		return filepath.Base(filepath.Dir(filepath.Dir(path))), nil
+	}
+	t.Cleanup(func() { detectAgentVersion = originalDetect })
+
+	root := t.TempDir()
+	releases := filepath.Join(root, "releases")
+	installRelease := func(version string) string {
+		bin := filepath.Join(releases, version, "bin")
+		if err := os.MkdirAll(bin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		executable := filepath.Join(bin, "codex.exe")
+		copyTestExecutable(t, executable)
+		return executable
+	}
+	v1 := installRelease("0.144.1")
+	current := filepath.Join(root, "current")
+	createJunction(t, filepath.Dir(filepath.Dir(v1)), current)
+	visibleBin := filepath.Join(root, "visible", "bin")
+	createJunction(t, filepath.Join(current, "bin"), visibleBin)
+	stableExecutable := filepath.Join(visibleBin, "codex.exe")
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: stableExecutable, Command: stableExecutable}
+	got, version := d.resolveAgentEntry(context.Background(), "codex", entry)
+	assertResolvedExecutable(t, got.Path, stableExecutable, v1)
+	if version != "0.144.1" {
+		t.Fatalf("initial version = %q, want 0.144.1", version)
+	}
+	assertLaunchesExecutable(t, got.Path, v1)
+
+	v2 := installRelease("0.144.3")
+	if err := os.Remove(current); err != nil {
+		t.Fatalf("remove current junction: %v", err)
+	}
+	createJunction(t, filepath.Dir(filepath.Dir(v2)), current)
+
+	got, version = d.resolveAgentEntry(context.Background(), "codex", entry)
+	assertResolvedExecutable(t, got.Path, stableExecutable, v2)
+	if version != "0.144.3" {
+		t.Fatalf("version after retarget = %q, want 0.144.3", version)
+	}
+	assertLaunchesExecutable(t, got.Path, v2)
+}
+
+func TestResolveAgentEntryForLaunchRejectsUnverifiedInitialJunctionTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		detect    func(context.Context, string) (string, error)
+		check     func(error) bool
+		wantError string
+	}{
+		{
+			name: "version detection failure",
+			detect: func(context.Context, string) (string, error) {
+				return "", errors.New("version probe failed")
+			},
+			check:     func(err error) bool { return strings.Contains(err.Error(), "version probe failed") },
+			wantError: "version probe failed",
+		},
+		{
+			name: "below minimum version",
+			detect: func(context.Context, string) (string, error) {
+				return "0.9.0", nil
+			},
+			check: func(err error) bool {
+				var tooOld *agent.BelowMinimumError
+				return errors.As(err, &tooOld)
+			},
+			wantError: "BelowMinimumError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalDetect := detectAgentVersion
+			detectAgentVersion = tt.detect
+			t.Cleanup(func() { detectAgentVersion = originalDetect })
+
+			_, shimBin := stageJunctionExecutable(t)
+			stableExecutable := filepath.Join(shimBin, "codex.exe")
+			d := newSelfHealTestDaemon()
+			d.setAgentVersion("codex", "0.144.1")
+			entry := AgentEntry{Path: stableExecutable, Command: stableExecutable}
+
+			got, _, err := d.resolveAgentEntryForLaunch(context.Background(), "codex", entry)
+			if err == nil {
+				t.Fatalf("resolveAgentEntryForLaunch launched unverified target %q; want %s", got.Path, tt.wantError)
+			}
+			if !tt.check(err) {
+				t.Fatalf("resolveAgentEntryForLaunch error = %v, want %s", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestResolveAgentEntryDoesNotSharePreRetargetSingleflightResult(t *testing.T) {
+	root := t.TempDir()
+	releases := filepath.Join(root, "releases")
+	installRelease := func(version string) string {
+		bin := filepath.Join(releases, version, "bin")
+		if err := os.MkdirAll(bin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		executable := filepath.Join(bin, "codex.exe")
+		copyTestExecutable(t, executable)
+		return executable
+	}
+	v1 := installRelease("0.144.1")
+	v2 := installRelease("0.144.3")
+	current := filepath.Join(root, "current")
+	createJunction(t, filepath.Dir(filepath.Dir(v1)), current)
+	visibleBin := filepath.Join(root, "visible", "bin")
+	createJunction(t, filepath.Join(current, "bin"), visibleBin)
+	stableExecutable := filepath.Join(visibleBin, "codex.exe")
+
+	v1ProbeStarted := make(chan struct{})
+	releaseV1Probe := make(chan struct{})
+	v2ProbeStarted := make(chan struct{}, 1)
+	originalDetect := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		switch {
+		case sameFile(path, v1):
+			select {
+			case <-v1ProbeStarted:
+			default:
+				close(v1ProbeStarted)
+			}
+			<-releaseV1Probe
+			return "0.144.1", nil
+		case sameFile(path, v2):
+			select {
+			case v2ProbeStarted <- struct{}{}:
+			default:
+			}
+			return "0.144.3", nil
+		default:
+			return "", errors.New("unexpected version probe path")
+		}
+	}
+	t.Cleanup(func() { detectAgentVersion = originalDetect })
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: stableExecutable, Command: stableExecutable}
+	type resolution struct {
+		entry   AgentEntry
+		version string
+	}
+	first := make(chan resolution, 1)
+	go func() {
+		got, version := d.resolveAgentEntry(context.Background(), "codex", entry)
+		first <- resolution{entry: got, version: version}
+	}()
+	<-v1ProbeStarted
+
+	if err := os.Remove(current); err != nil {
+		t.Fatalf("remove current junction: %v", err)
+	}
+	createJunction(t, filepath.Dir(filepath.Dir(v2)), current)
+
+	second := make(chan resolution, 1)
+	go func() {
+		got, version := d.resolveAgentEntry(context.Background(), "codex", entry)
+		second <- resolution{entry: got, version: version}
+	}()
+
+	select {
+	case <-v2ProbeStarted:
+		// The post-retarget caller is verifying v2 independently of the blocked
+		// v1 probe, so it cannot inherit the predecessor's singleflight result.
+	case <-time.After(5 * time.Second):
+		close(releaseV1Probe)
+		got := <-second
+		t.Fatalf("post-retarget resolution shared the blocked v1 probe: got (%q, %q)", got.entry.Path, got.version)
+	}
+	close(releaseV1Probe)
+
+	got := <-second
+	assertResolvedExecutable(t, got.entry.Path, stableExecutable, v2)
+	if got.version != "0.144.3" {
+		t.Fatalf("post-retarget version = %q, want 0.144.3", got.version)
+	}
+	firstGot := <-first
+	assertResolvedExecutable(t, firstGot.entry.Path, stableExecutable, v2)
+	if firstGot.version != "0.144.3" {
+		t.Fatalf("pre-retarget caller final version = %q, want current 0.144.3", firstGot.version)
+	}
+}
+
+func TestResolveAgentEntryForLaunchFailsWhenJunctionKeepsRetargeting(t *testing.T) {
+	root := t.TempDir()
+	releases := filepath.Join(root, "releases")
+	installRelease := func(version string) string {
+		bin := filepath.Join(releases, version, "bin")
+		if err := os.MkdirAll(bin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		executable := filepath.Join(bin, "codex.exe")
+		copyTestExecutable(t, executable)
+		return executable
+	}
+	v1 := installRelease("0.144.1")
+	v2 := installRelease("0.144.3")
+	current := filepath.Join(root, "current")
+	retarget := func(target string) {
+		if err := os.Remove(current); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove current junction: %v", err)
+		}
+		createJunction(t, filepath.Dir(filepath.Dir(target)), current)
+	}
+	retarget(v1)
+	visibleBin := filepath.Join(root, "visible", "bin")
+	createJunction(t, filepath.Join(current, "bin"), visibleBin)
+	stableExecutable := filepath.Join(visibleBin, "codex.exe")
+
+	originalDetect := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		if sameFile(path, v1) {
+			retarget(v2)
+			return "0.144.1", nil
+		}
+		if sameFile(path, v2) {
+			retarget(v1)
+			return "0.144.3", nil
+		}
+		return "", errors.New("unexpected version probe path")
+	}
+	t.Cleanup(func() { detectAgentVersion = originalDetect })
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: stableExecutable, Command: stableExecutable}
+	got, _, err := d.resolveAgentEntryForLaunch(context.Background(), "codex", entry)
+	if err == nil {
+		t.Fatalf("resolveAgentEntryForLaunch returned stale target %q while junction kept retargeting", got.Path)
+	}
+	if !strings.Contains(err.Error(), "changed repeatedly") {
+		t.Fatalf("resolveAgentEntryForLaunch error = %v, want repeated-retarget failure", err)
+	}
+}
+
+func TestResolveAgentEntryCanonicalizesRediscoveredJunction(t *testing.T) {
+	originalDetect := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		return "0.144.3", nil
+	}
+	t.Cleanup(func() { detectAgentVersion = originalDetect })
+
 	targetExecutable, shimBin := stageJunctionExecutable(t)
+	t.Setenv("PATH", shimBin)
+	t.Setenv("PATHEXT", ".EXE")
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: filepath.Join(t.TempDir(), "removed", "codex.exe"), Command: "codex"}
+
+	got, version := d.resolveAgentEntry(context.Background(), "codex", entry)
+	assertResolvedExecutable(t, got.Path, filepath.Join(shimBin, "codex.exe"), targetExecutable)
+	if version != "0.144.3" {
+		t.Fatalf("rediscovered version = %q, want 0.144.3", version)
+	}
+}
+
+func TestCanonicalExecutablePathLaunchesBeyondMaxPath(t *testing.T) {
+	deep := t.TempDir()
+	for len(deep) < 280 {
+		deep = filepath.Join(deep, "release-segment-0123456789")
+	}
+	deep = `\\?\` + deep
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("create long release path: %v", err)
+	}
+
+	target := filepath.Join(deep, "codex.exe")
+	copyTestExecutable(t, target)
+	shimBin := filepath.Join(t.TempDir(), "bin")
+	createJunction(t, deep, shimBin)
+	shimExecutable := filepath.Join(shimBin, "codex.exe")
+
+	resolved := canonicalExecutablePath(shimExecutable)
+	if !strings.HasPrefix(resolved, `\\?\`) {
+		t.Fatalf("resolved long executable dropped extended-length prefix: %q", resolved)
+	}
+	assertLaunchesExecutable(t, resolved, target)
+}
+
+func TestResolveAgentExecutablePathKeepsConfiguredJunctionEntryPoint(t *testing.T) {
+	_, shimBin := stageJunctionExecutable(t)
 	configured := filepath.Join(shimBin, "codex.exe")
 
 	got, err := resolveAgentExecutablePath(configured)
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	assertResolvedExecutable(t, got, configured, targetExecutable)
+	if !strings.EqualFold(got, configured) {
+		t.Fatalf("resolved configured entry = %q, want stable junction entry %q", got, configured)
+	}
 }
 
 func assertResolvedExecutable(t *testing.T, got, shim, target string) {
@@ -113,6 +416,50 @@ func assertSameFile(t *testing.T, got, want string) {
 	}
 	if !os.SameFile(gotInfo, wantInfo) {
 		t.Fatalf("resolved executable %q does not identify expected file %q", got, want)
+	}
+}
+
+func sameFile(left, right string) bool {
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
+}
+
+func assertLaunchesExecutable(t *testing.T, executable, want string) {
+	t.Helper()
+	marker := filepath.Join(t.TempDir(), "launched-from")
+	cmd := exec.Command(executable, "-test.run=^TestLongPathExecutableHelper$")
+	cmd.Env = append(os.Environ(),
+		longPathExecutableHelperEnv+"=1",
+		longPathExecutableMarkerEnv+"="+marker,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("launch executable %q: %v\n%s", executable, err, output)
+	}
+	launchedFrom, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read launched executable marker: %v", err)
+	}
+	assertSameFile(t, string(launchedFrom), want)
+}
+
+func copyTestExecutable(t *testing.T, target string) {
+	t.Helper()
+	source, err := os.Open(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	destination, err := os.Create(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(destination, source); err != nil {
+		destination.Close()
+		t.Fatal(err)
+	}
+	if err := destination.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -28,9 +28,7 @@ func TestCanonicalExecutablePathResolvesDirectoryJunction(t *testing.T) {
 	if _, err := filepath.EvalSymlinks(shimExecutable); err == nil {
 		t.Fatal("EvalSymlinks unexpectedly resolved a directory junction; test would not reproduce the bug")
 	}
-	if got := canonicalExecutablePath(shimExecutable); !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("canonicalExecutablePath() = %q, want junction target %q", got, targetExecutable)
-	}
+	assertResolvedExecutable(t, canonicalExecutablePath(shimExecutable), shimExecutable, targetExecutable)
 }
 
 func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
@@ -39,9 +37,7 @@ func TestCanonicalExecutablePathKeepsRegularExecutable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := canonicalExecutablePath(executable); !strings.EqualFold(got, executable) {
-		t.Fatalf("canonicalExecutablePath() = %q, want %q", got, executable)
-	}
+	assertSameFile(t, canonicalExecutablePath(executable), executable)
 }
 
 func TestCanonicalExecutablePathFallsBackForMissingExecutable(t *testing.T) {
@@ -83,9 +79,7 @@ func TestResolveAgentExecutablePathCanonicalizesPATHJunction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	if !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
-	}
+	assertResolvedExecutable(t, got, filepath.Join(shimBin, "codex.exe"), targetExecutable)
 }
 
 func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testing.T) {
@@ -96,8 +90,29 @@ func TestResolveAgentExecutablePathCanonicalizesConfiguredJunctionPath(t *testin
 	if err != nil {
 		t.Fatalf("resolveAgentExecutablePath: %v", err)
 	}
-	if !strings.EqualFold(got, targetExecutable) {
-		t.Fatalf("resolveAgentExecutablePath() = %q, want junction target %q", got, targetExecutable)
+	assertResolvedExecutable(t, got, configured, targetExecutable)
+}
+
+func assertResolvedExecutable(t *testing.T, got, shim, target string) {
+	t.Helper()
+	if strings.EqualFold(got, shim) {
+		t.Fatalf("resolved executable still points at junction path %q", got)
+	}
+	assertSameFile(t, got, target)
+}
+
+func assertSameFile(t *testing.T, got, want string) {
+	t.Helper()
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat resolved executable %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatalf("stat expected executable %q: %v", want, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("resolved executable %q does not identify expected file %q", got, want)
 	}
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -880,7 +880,7 @@ func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string,
 	var launchOutcome healOutcome
 	if launchPath, handled, err := executablePathForLaunch(entry.Path); handled {
 		if err != nil {
-			d.logger.Debug("resolve agent executable for launch failed; keeping discovered path",
+			d.logger.Warn("resolve agent executable for launch failed; keeping discovered path",
 				"provider", provider, "path", entry.Path, "error", err)
 			launchOutcome.failure = err
 		} else if outcome, ok := d.resolveAgentLaunchTarget(ctx, provider, entry, launchPath); ok {
@@ -1013,8 +1013,9 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	}
 	if launchPath, handled, err := executablePathForLaunch(newPath); handled {
 		if err != nil {
-			d.logger.Debug("resolve re-discovered agent executable for launch failed; keeping discovered path",
+			d.logger.Warn("resolve re-discovered agent executable for launch failed; keeping discovered path",
 				"provider", provider, "path", newPath, "error", err)
+			return healOutcome{failure: err}
 		} else {
 			newPath = launchPath
 		}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -389,16 +389,13 @@ type Daemon struct {
 	// newer than that verdict" a fact rather than a hope. Guarded by d.mu.
 	demotionSeq uint64
 
-	// resolvedPathsMu guards resolvedPaths, the self-healed executable paths.
-	// The daemon pins each agent's absolute path at startup so a later PATH
-	// change can't redirect a task launch. When that pinned path later vanishes
-	// (a version manager did an in-place upgrade — Homebrew Cask, nvm/fnm),
-	// resolveAgentEntry re-resolves the original command once and records the
-	// result here so subsequent launches, model lists, and registrations reuse
-	// it without re-resolving. Path and detected version are stored together so
-	// any reader that observes the new path also observes the matching version
-	// (no "new binary under stale version policy" window). Keyed by provider.
-	// See MUL-4486.
+	// resolvedPathsMu guards concrete executable paths paired with the version
+	// detected for each. On POSIX these are self-heals cached after a pinned path
+	// vanishes (MUL-4486). On Windows they are launch targets resolved from a
+	// stable installer junction; that junction is followed on every launch so a
+	// retarget takes effect even while the old release remains installed. Path
+	// and version are stored together so no reader can launch a new binary under
+	// stale version policy. Keyed by provider.
 	resolvedPathsMu sync.RWMutex
 	resolvedPaths   map[string]healedAgent
 	// healGroup coalesces concurrent self-heal re-resolutions per provider so a
@@ -789,11 +786,13 @@ type healedAgent struct {
 }
 
 // resolveAgentEntry returns entry with a usable executable path plus the CLI
-// version that corresponds to that path, self-healing the pinned Path when it
-// has vanished from disk (MUL-4486).
+// version that corresponds to that path. It resolves retargetable Windows
+// installer junctions per launch and self-heals vanished pinned paths on other
+// platforms (MUL-4486).
 //
-// The daemon pins each agent's absolute, symlink-resolved path at startup so a
-// later PATH change cannot redirect a task launch. But a version manager
+// The daemon pins each agent's discovered entry point at startup so a later
+// PATH change cannot redirect a task launch. POSIX discovery also resolves
+// symlinks to a concrete path. But a version manager
 // (Homebrew Cask, nvm/fnm) upgrading in place deletes the old versioned
 // directory that pinned path points into and repoints the stable command name
 // at the new version — leaving the daemon holding a path that no longer exists
@@ -807,6 +806,8 @@ type healedAgent struct {
 // updating.
 //
 // Behaviour:
+//   - A Windows stable entry point -> its final target is verified and returned
+//     with the detected version; a retarget publishes the new pair atomically.
 //   - A previous self-heal that is still live -> returned with its paired
 //     version. This is checked first so that once we've re-resolved to a new
 //     binary, a reappearing stale path (a downgrade / reinstall recreating the
@@ -830,6 +831,24 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	return resolved, version
 }
 
+// resolveAgentEntryForLaunch is the strict task-launch boundary. Windows
+// installer junctions must yield a verified final target before the first
+// launch; otherwise the stable entry could retarget after registration and run
+// a binary whose version and minimum-version policy were never checked.
+func (d *Daemon) resolveAgentEntryForLaunch(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string, error) {
+	resolved, version, outcome := d.resolveAgentEntryWithHeal(ctx, provider, entry)
+	if outcome.rejected != nil {
+		return entry, d.agentVersion(provider), outcome.rejected
+	}
+	if outcome.failure != nil {
+		return entry, d.agentVersion(provider), fmt.Errorf("resolve agent executable %q for launch: %w", entry.Path, outcome.failure)
+	}
+	if outcome.adopted.path != "" {
+		return resolved, version, nil
+	}
+	return resolved, version, nil
+}
+
 // healOutcome is what one self-heal attempt concluded. At most one half is
 // meaningful: adopted names a binary that cleared the same gates registration
 // applies, while rejected carries the typed verdict for a candidate that was
@@ -840,6 +859,7 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 type healOutcome struct {
 	adopted  healedAgent
 	rejected *agent.BelowMinimumError
+	failure  error
 }
 
 // resolveAgentEntryWithHeal is resolveAgentEntry plus what the self-heal
@@ -852,6 +872,25 @@ type healOutcome struct {
 // fails, and reports "version detection failed" — which by design leaves the
 // runtime online, claiming tasks for a CLI that cannot launch.
 func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string, healOutcome) {
+	// Windows installer entry points are stable junctions whose final target can
+	// change while the old release remains installed. Resolve the final path on
+	// every launch and adopt a changed target only after pairing it with a freshly
+	// detected, supported version. Other platforms return handled=false and keep
+	// the existing pinned-path self-heal semantics below.
+	var launchOutcome healOutcome
+	if launchPath, handled, err := executablePathForLaunch(entry.Path); handled {
+		if err != nil {
+			d.logger.Debug("resolve agent executable for launch failed; keeping discovered path",
+				"provider", provider, "path", entry.Path, "error", err)
+			launchOutcome.failure = err
+		} else if outcome, ok := d.resolveAgentLaunchTarget(ctx, provider, entry, launchPath); ok {
+			entry.Path = outcome.adopted.path
+			return entry, outcome.adopted.version, outcome
+		} else {
+			launchOutcome = outcome
+		}
+	}
+
 	// A prior self-heal wins over the original pinned path: it carries a
 	// {path, version} pair we already verified together, so it can never regress
 	// to the mismatched pairing a reappearing stale path would produce.
@@ -860,11 +899,12 @@ func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string,
 	d.resolvedPathsMu.RUnlock()
 	if ok && agentExecutablePresent(healed.path) {
 		entry.Path = healed.path
-		return entry, healed.version, healOutcome{adopted: healed}
+		launchOutcome.adopted = healed
+		return entry, healed.version, launchOutcome
 	}
 
 	if agentExecutablePresent(entry.Path) {
-		return entry, d.agentVersion(provider), healOutcome{}
+		return entry, d.agentVersion(provider), launchOutcome
 	}
 
 	if entry.Command == "" {
@@ -884,6 +924,63 @@ func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string,
 	}
 	entry.Path = outcome.adopted.path
 	return entry, outcome.adopted.version, outcome
+}
+
+// resolveAgentLaunchTarget handles platforms whose stable discovered entry
+// point can retarget a different still-live executable. It returns ok only
+// when a verified {path, version} pair is available; a rejected or transiently
+// unreadable target falls through to the existing path handling so it is never
+// published under a stale version.
+func (d *Daemon) resolveAgentLaunchTarget(ctx context.Context, provider string, entry AgentEntry, launchPath string) (healOutcome, bool) {
+	const maxRetargetAttempts = 4
+	for attempt := 0; attempt < maxRetargetAttempts; attempt++ {
+		d.resolvedPathsMu.RLock()
+		cached, cachedOK := d.resolvedPaths[provider]
+		d.resolvedPathsMu.RUnlock()
+		if cachedOK && cached.path == launchPath && agentExecutablePresent(cached.path) {
+			return healOutcome{adopted: cached}, true
+		}
+
+		// Coalesce only callers that observed the same concrete release. A
+		// provider-only key can make a post-retarget caller inherit the previous
+		// release's result even though both files remain present.
+		key := provider + "\x00" + launchPath
+		v, _, _ := d.healGroup.Do(key, func() (any, error) {
+			d.resolvedPathsMu.RLock()
+			current, ok := d.resolvedPaths[provider]
+			d.resolvedPathsMu.RUnlock()
+			if ok && current.path == launchPath && agentExecutablePresent(current.path) {
+				return healOutcome{adopted: current}, nil
+			}
+			return d.adoptAgentPath(ctx, provider, entry.Command, launchPath, "resolved stable entry point for launch"), nil
+		})
+		outcome, _ := v.(healOutcome)
+
+		// The installer may retarget while version detection is running. Resolve
+		// again before returning and retry against the target visible now.
+		currentPath, _, err := executablePathForLaunch(entry.Path)
+		if err != nil {
+			if outcome.adopted.path != "" {
+				return outcome, true
+			}
+			outcome.failure = err
+			return outcome, false
+		}
+		if currentPath != launchPath {
+			launchPath = currentPath
+			continue
+		}
+		if outcome.adopted.path != "" {
+			return outcome, true
+		}
+		if cachedOK && agentExecutablePresent(cached.path) {
+			outcome.adopted = cached
+			return outcome, true
+		}
+		return outcome, false
+	}
+
+	return healOutcome{failure: errors.New("installer entry point changed repeatedly while resolving it")}, false
 }
 
 // healAgentPath re-resolves command for provider and, if a usable binary is
@@ -914,7 +1011,18 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	if !found {
 		return healOutcome{}
 	}
+	if launchPath, handled, err := executablePathForLaunch(newPath); handled {
+		if err != nil {
+			d.logger.Debug("resolve re-discovered agent executable for launch failed; keeping discovered path",
+				"provider", provider, "path", newPath, "error", err)
+		} else {
+			newPath = launchPath
+		}
+	}
+	return d.adoptAgentPath(ctx, provider, command, newPath, "re-resolved after pinned path vanished")
+}
 
+func (d *Daemon) adoptAgentPath(ctx context.Context, provider, command, newPath, reason string) healOutcome {
 	// Verify before adopting. An in-place "upgrade" that actually repoints at an
 	// older or broken install must not be launched under the daemon's stale
 	// version policy, and must not slip past the minimum-version gate that the
@@ -923,7 +1031,7 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	if err != nil {
 		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
 			"provider", provider, "command", command, "new_path", newPath, "error", err)
-		return healOutcome{}
+		return healOutcome{failure: err}
 	}
 	if err := checkAgentMinVersion(provider, version); err != nil {
 		var tooOld *agent.BelowMinimumError
@@ -934,7 +1042,7 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 			// transient case the below-minimum machinery must never act on.
 			d.logger.Warn("re-resolved agent executable version could not be validated; keeping pinned path",
 				"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
-			return healOutcome{}
+			return healOutcome{failure: err}
 		}
 		d.logger.Warn("re-resolved agent executable is below the minimum supported version; not adopting it",
 			"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
@@ -956,8 +1064,8 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	// report and any future d.agentVersion reader.
 	d.setAgentVersion(provider, version)
 
-	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
-		"provider", provider, "command", command, "new_path", newPath, "version", version)
+	d.logger.Info("adopted resolved agent executable",
+		"provider", provider, "command", command, "new_path", newPath, "version", version, "reason", reason)
 	return healOutcome{adopted: adopted}
 }
 
@@ -5673,7 +5781,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		// upgrade deleted (MUL-4486). Only reached when no custom profile owns
 		// the launch, so a custom runtime's path is never second-guessed and a
 		// custom-only host pays no wasted re-resolution.
-		entry, resolvedVersion = d.resolveAgentEntry(prepareCtx, provider, entry)
+		var resolveErr error
+		entry, resolvedVersion, resolveErr = d.resolveAgentEntryForLaunch(prepareCtx, provider, entry)
+		if resolveErr != nil {
+			return TaskResult{}, resolveErr
+		}
 	}
 	if !ok {
 		return TaskResult{}, fmt.Errorf("no agent configured for provider %q", provider)

--- a/server/internal/daemon/runtime_launch_windows_test.go
+++ b/server/internal/daemon/runtime_launch_windows_test.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHandleTaskReportsWindowsCodexProcessStartFailure(t *testing.T) {
+	invalidExecutable := filepath.Join(t.TempDir(), "codex.exe")
+	if err := os.WriteFile(invalidExecutable, []byte("not a Windows executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var failBody atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/fail"):
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode failure body: %v", err)
+			} else {
+				failBody.Store(body)
+			}
+		case strings.HasSuffix(r.URL.Path, "/status"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"running"}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := New(Config{
+		ServerBaseURL:  srv.URL,
+		WorkspacesRoot: t.TempDir(),
+		AgentTimeout:   5 * time.Second,
+	}, logger)
+	d.executionEnvironmentCommand = nil
+	d.client = NewClient(srv.URL)
+	d.cancelPollInterval = time.Hour
+	d.runtimeIndex["rt-custom-codex"] = Runtime{
+		ID:        "rt-custom-codex",
+		Provider:  "codex",
+		ProfileID: "profile-invalid-codex",
+	}
+	d.profileLaunchSpecs["profile-invalid-codex"] = profileLaunchSpec{
+		path:    invalidExecutable,
+		version: "0.147.0",
+	}
+
+	d.handleTask(context.Background(), Task{
+		ID:          "task-windows-launch-failure",
+		WorkspaceID: "workspace-windows-launch-failure",
+		RuntimeID:   "rt-custom-codex",
+		IssueID:     "issue-windows-launch-failure",
+		AgentID:     "agent-windows-launch-failure",
+		AuthToken:   "mat_windows_launch_failure",
+		Agent: &AgentData{
+			ID:   "agent-windows-launch-failure",
+			Name: "Windows launch failure agent",
+		},
+	}, 0)
+
+	body, _ := failBody.Load().(map[string]any)
+	if body == nil {
+		t.Fatal("runtime CreateProcess failure was not reported through the task /fail endpoint")
+	}
+	if got := body["error"]; got == nil || !strings.Contains(strings.ToLower(got.(string)), "start codex") {
+		t.Fatalf("task failure error = %v, want visible Codex process-start diagnostic", got)
+	}
+	if got := body["failure_reason"]; got != "agent_error.process_failure" {
+		t.Fatalf("task failure reason = %v, want agent_error.process_failure", got)
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -8,7 +8,7 @@ import (
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path string // path to CLI binary (pinned at startup; symlink-resolved to a concrete, possibly versioned, path)
+	Path string // stable startup-resolved CLI entry point; launch resolution may follow platform links to a concrete path
 	// Command is the bare command name or MULTICA_*_PATH value that Path was
 	// resolved from at startup. It is kept so the daemon can re-resolve Path
 	// if the pinned executable later vanishes — e.g. a version manager

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -258,6 +258,7 @@ func Classify(rawError string) Reason {
 		"panic",
 		"sigsegv",
 		"process exited",
+		"start codex:",
 		"pipe has been ended",
 		"file already closed",
 		"initialize failed",

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -214,6 +214,7 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 		// — the upstream classification should win because the
 		// process_failure rule is checked last.
 		{"exit status with 401 upstream", "exit status 1: API Error: 401 Unauthorized", ReasonAgentProviderAuthOrAccess},
+		{"windows codex process start", "start codex: fork/exec C:\\invalid\\codex.exe: %1 is not a valid Win32 application.", ReasonAgentProcessFailure},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
﻿## What does this PR do?

### Thinking path / root cause

Windows standalone Codex exposes its installer `bin` directory as an `IO_REPARSE_TAG_MOUNT_POINT` junction. The daemon already canonicalized PATH-discovered executables with `filepath.EvalSymlinks`, but Go 1.26.1 cannot traverse that junction shape and the helper silently kept the installer shim path. Separator-bearing configured commands also returned before canonicalization.

This change keeps the existing `EvalSymlinks` discovery behavior on non-Windows systems. On Windows, discovery retains the stable configured/PATH entry point and each task launch resolves its opened handle through `GetFinalPathNameByHandleW`. When the installer retargets `current`, the daemon re-detects and minimum-version-checks the new release, then atomically publishes the matching `{path, version}` pair. Concurrent and repeatedly changing targets fail closed rather than launching an unverified or stale binary.

The rediscovery path now applies the same strict boundary: if final-path resolution fails after a pinned path vanished, the daemon returns a launch failure immediately. It does not call version detection, does not adopt the rediscovered stable junction, does not write `resolvedPaths`, and does not launch the unresolved entry point. Both initial and rediscovery resolution failures now log at Warn with path and error.

The Win32 final path keeps its extended-length `\\?\` / `\\?\UNC\` form internally. This prevents a short shim from resolving into an unlaunchable release path beyond `MAX_PATH`; the Windows regression actually spawns an executable from such a path.

Runtime process-start errors already flow through the daemon task terminal callback. This PR makes direct Windows Codex `CreateProcess` failures an explicit `agent_error.process_failure`, verifies the real `cmd.Start` -> `executeAndDrain` -> `handleTask` -> `/fail` path with an invalid PE, and logs executable canonicalization fallbacks with both path and error. This direct process-start coverage is not the same as the post-start grandchild sandbox-helper native dialog; that remaining acceptance item is tracked separately in #6849.

## Related Issues

Refs #6762

Follow-up for the scoped-out grandchild native-dialog/task-failure boundary: #6849

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Add build-tagged Windows final-path resolution using `GetFinalPathNameByHandleW`, while preserving non-Windows discovery behavior.
- Keep stable Windows installer entry points in discovery and resolve/version-gate their current target at every launch.
- Preserve extended-length paths internally and prove an actual executable launch beyond `MAX_PATH`.
- Fail closed on first-launch detection/minimum-version failures, rediscovery final-path resolution failures, concurrent retargets, and bounded repeated retargets.
- Log canonicalization and launch-resolution fallback errors with path + error through the existing logger.
- Surface real direct Windows Codex process-start failures through the task `/fail` callback as `agent_error.process_failure`.
- Run all Windows junction, long-path, launch-boundary, and launch-error regressions in the existing `windows-execenv` job.

## How to Test

1. Windows / Go 1.26.1:
   `cd server && go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|ForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m`
2. Windows: `cd server && go test ./pkg/taskfailure -count=1`
3. Windows: `cd server && go vet ./internal/daemon ./pkg/taskfailure && go build ./...`
4. Linux cross-target: `cd server && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/daemon && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/daemon ./pkg/taskfailure`

Local results: all commands above completed successfully with Go 1.26.1. The Windows tests create real directory junction chains, retain v1 while retargeting only `current` to v2, launch v2 with its freshly detected version, exercise concurrent and repeatedly changing targets, reject an initial unverified junction target, reject a rediscovered junction target when final-path resolution fails, launch a resolved executable beyond `MAX_PATH`, and send an actual invalid-PE direct `CreateProcess` error through the task failure endpoint.

A full local `go test ./internal/daemon` was also attempted; unrelated environment-dependent tests failed against this machine's installed agent CLIs/skills/MCP configuration and Windows symlink privileges, while the task-specific selectors, package tests, vet/build, and cross-target checks above passed. This machine has the MSIX Codex install rather than the standalone installer layout, so no additional read-only smoke test against an existing standalone Codex junction was available.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; no UI change)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented interface changes)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** I used Codex to read the issue and maintainer review, reproduce the Windows junction lifecycle and launch-error gaps with failing tests before implementation, preserve stable discovery and long-path semantics, run Windows and cross-target verification, and request independent code reviews after each commit.

## Screenshots (optional)

Not applicable.