### PR TITLE
MUL-6051: fix(settings): clarify integration channel sections

### DIFF
--- a/packages/views/settings/components/dingtalk-tab.tsx
+++ b/packages/views/settings/components/dingtalk-tab.tsx
@@ -94,12 +94,6 @@ export function DingTalkTab() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-1">
-        <p className="text-body text-muted-foreground">
-          {t(($) => $.dingtalk.page_description)}
-        </p>
-      </section>
-
       {!configured ? (
         <Card>
           <CardContent className="space-y-2">

--- a/packages/views/settings/components/integration-channel-icon.tsx
+++ b/packages/views/settings/components/integration-channel-icon.tsx
@@ -1,0 +1,24 @@
+import { MessagesSquare, Webhook } from "lucide-react";
+import { DingTalkMark } from "./dingtalk-mark";
+import { WecomMark } from "./wecom-mark";
+
+type IntegrationChannel = "lark" | "slack" | "dingtalk" | "wecom";
+
+export function IntegrationChannelIcon({ channel }: { channel: IntegrationChannel }) {
+  const icon = {
+    lark: <Webhook className="h-4 w-4" />,
+    slack: <MessagesSquare className="h-4 w-4" />,
+    dingtalk: <DingTalkMark className="h-5 w-5" />,
+    wecom: <WecomMark className="h-4 w-4" />,
+  }[channel];
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={`integration-channel-icon-${channel}`}
+      className="flex size-5 shrink-0 items-center justify-center text-muted-foreground"
+    >
+      {icon}
+    </span>
+  );
+}

--- a/packages/views/settings/components/integrations-tab.test.tsx
+++ b/packages/views/settings/components/integrations-tab.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { ApiError } from "@multica/core/api";
 import { configStore } from "@multica/core/config";
@@ -93,6 +94,21 @@ describe("Settings IntegrationsTab", () => {
 
     expect(screen.getByTestId("composio-tab")).toBeInTheDocument();
     expect(queryCallsRef.current[0]?.enabled).toBe(true);
+  });
+
+  it("shows each channel description below its icon and title", () => {
+    renderTab();
+
+    for (const channel of ["lark", "slack", "dingtalk", "wecom"]) {
+      const icon = screen.getByTestId(`integration-channel-icon-${channel}`);
+      const title = icon.closest("h3");
+      const description = title?.nextElementSibling;
+      expect(title).not.toBeNull();
+      expect(description?.tagName).toBe("P");
+      expect(description).toHaveClass("text-caption", "text-muted-foreground");
+      expect(icon).not.toHaveClass("border");
+      expect(icon).not.toHaveClass("bg-muted/40");
+    }
   });
 
   it("hides Composio when the feature flag is on but the server reports 503", () => {

--- a/packages/views/settings/components/integrations-tab.tsx
+++ b/packages/views/settings/components/integrations-tab.tsx
@@ -13,6 +13,7 @@ import { useConfigStore, useFeatureEnabled } from "@multica/core/config";
 import { COMPOSIO_MCP_APPS_FLAG } from "@multica/core/feature-flags";
 import { useT } from "../../i18n";
 import { SettingsSection, SettingsTab } from "./settings-layout";
+import { IntegrationChannelIcon } from "./integration-channel-icon";
 
 // Integrations is the umbrella tab for third-party platform connections.
 // GitHub has its own top-level tab (see github-tab.tsx); everything else
@@ -39,7 +40,15 @@ export function IntegrationsTab() {
 
   return (
     <SettingsTab title={t(($) => $.page.tabs.integrations)}>
-      <SettingsSection title={t(($) => $.lark.section_title)}>
+      <SettingsSection
+        title={
+          <span className="flex items-center gap-2">
+            <IntegrationChannelIcon channel="lark" />
+            {t(($) => $.lark.section_title)}
+          </span>
+        }
+        description={t(($) => $.lark.page_description)}
+      >
         <LarkTab />
       </SettingsSection>
       {composioEnabled && !composioUnconfigured && (
@@ -47,10 +56,26 @@ export function IntegrationsTab() {
           <ComposioTab />
         </SettingsSection>
       )}
-      <SettingsSection title={t(($) => $.slack.section_title)}>
+      <SettingsSection
+        title={
+          <span className="flex items-center gap-2">
+            <IntegrationChannelIcon channel="slack" />
+            {t(($) => $.slack.section_title)}
+          </span>
+        }
+        description={t(($) => $.slack.page_description)}
+      >
         <SlackTab />
       </SettingsSection>
-      <SettingsSection title={t(($) => $.dingtalk.section_title)}>
+      <SettingsSection
+        title={
+          <span className="flex items-center gap-2">
+            <IntegrationChannelIcon channel="dingtalk" />
+            {t(($) => $.dingtalk.section_title)}
+          </span>
+        }
+        description={t(($) => $.dingtalk.page_description)}
+      >
         <DingTalkTab />
       </SettingsSection>
       {vcsAvailable && (
@@ -58,7 +83,15 @@ export function IntegrationsTab() {
           <VCSTab />
         </SettingsSection>
       )}
-      <SettingsSection title={t(($) => $.wecom.section_title)}>
+      <SettingsSection
+        title={
+          <span className="flex items-center gap-2">
+            <IntegrationChannelIcon channel="wecom" />
+            {t(($) => $.wecom.section_title)}
+          </span>
+        }
+        description={t(($) => $.wecom.page_description)}
+      >
         <WecomTab />
       </SettingsSection>
     </SettingsTab>

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -107,12 +107,6 @@ export function LarkTab() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-1">
-        <p className="text-body text-muted-foreground">
-          {t(($) => $.lark.page_description)}
-        </p>
-      </section>
-
       {!configured ? (
         <Card>
           <CardContent className="space-y-2">

--- a/packages/views/settings/components/slack-tab.tsx
+++ b/packages/views/settings/components/slack-tab.tsx
@@ -90,12 +90,6 @@ export function SlackTab() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-1">
-        <p className="text-body text-muted-foreground">
-          {t(($) => $.slack.page_description)}
-        </p>
-      </section>
-
       {!configured ? (
         <Card>
           <CardContent className="space-y-2">

--- a/packages/views/settings/components/wecom-tab.tsx
+++ b/packages/views/settings/components/wecom-tab.tsx
@@ -88,12 +88,6 @@ export function WecomTab() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-1">
-        <p className="text-body text-muted-foreground">
-          {t(($) => $.wecom.page_description)}
-        </p>
-      </section>
-
       {!configured ? (
         <Card>
           <CardContent className="space-y-2">


### PR DESCRIPTION
## What does this PR do?

Adds a compact icon before each chat channel title in Settings → Integrations and moves each channel description into the shared section header.

The page previously relied on text-only headings followed by descriptions rendered inside separate channel components. With multiple integrations stacked together, those sections were harder to scan and the information hierarchy felt cluttered. The channel icons provide a stronger visual anchor, while keeping the title and description in a consistent vertical structure reduces that sense of disorder.

The icon choices intentionally match the existing agent detail Integrations implementation. The agent detail page itself is unchanged.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added a Settings-only `IntegrationChannelIcon` component for Lark, Slack, DingTalk, and WeCom.
- Added compact icons to the corresponding channel section titles without borders or backgrounds.
- Moved channel descriptions into `SettingsSection` so they render directly below each title at the shared caption size.
- Removed duplicate descriptions from the individual channel tab components.
- Added coverage for title/description structure, icon presence, and icon styling.

## How to Test

1. Open Settings → Integrations and confirm Lark, Slack, DingTalk, and WeCom each show an icon immediately before the channel title.
2. Confirm each description appears below its title in caption text and that the icons have no border or background.
3. Run `pnpm exec vitest run packages/views/settings/components/integrations-tab.test.tsx packages/views/agents/components/tabs/integrations-tab.test.tsx`.
4. Run `pnpm --filter @multica/views typecheck`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented behavior changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable; no copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to the Settings → Integrations presentation layer. Existing channel behavior and the agent detail page are unchanged.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
Used Codex to inspect the existing agent detail Integrations icon choices, apply the same channel mapping only to Settings, iterate on spacing and visual hierarchy, and add focused regression coverage.

## Screenshots (optional)

Not included.
