### PR TITLE
fix(chat): preserve idle footer spacing (MUL-5854)

### DIFF
--- a/packages/views/chat/components/chat-message-list.test.tsx
+++ b/packages/views/chat/components/chat-message-list.test.tsx
@@ -191,6 +191,35 @@ describe("ChatMessageList live timeline (MUL-3960 regression)", () => {
   });
 });
 
+describe("ChatMessageList footer spacing", () => {
+  it("keeps the bottom inset when no task is pending", () => {
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={new QueryClient()}>
+          <ChatMessageList
+            messages={[
+              {
+                id: "assistant-idle",
+                chat_session_id: "session-idle",
+                role: "assistant",
+                content: "Idle reply",
+                task_id: null,
+                created_at: "2026-08-12T00:00:00Z",
+              },
+            ]}
+            pendingTask={null}
+            availability="online"
+          />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+
+    const list = container.querySelector("[data-row-key]")?.parentElement;
+    expect(list?.lastElementChild).toHaveClass("pb-4");
+    expect(screen.queryByText(/working|queued/i)).not.toBeInTheDocument();
+  });
+});
+
 describe("ChatMessageList quick actions", () => {
   it("renders up to three suggestions and sends the hidden prompt", async () => {
     const qc = new QueryClient();

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -151,15 +151,15 @@ function ChatListHeader({ context }: { context?: ChatListContext }) {
 // constant bottom inset: without it the last row's own py-2 was the only gap
 // between the final reply (and its follow-up pills) and the composer.
 function ChatListFooter({ context }: { context?: ChatListContext }) {
-  if (!context) return null;
-  if (!context.showStatusPill || !context.pendingTask) return null;
   return (
     <div className={cn(CHAT_COLUMN, "pb-4 space-y-4")}>
-      <TaskStatusPill
-        pendingTask={context.pendingTask}
-        taskMessages={context.liveTaskMessages ?? []}
-        availability={context.availability}
-      />
+      {context?.showStatusPill && context.pendingTask ? (
+        <TaskStatusPill
+          pendingTask={context.pendingTask}
+          taskMessages={context.liveTaskMessages ?? []}
+          availability={context.availability}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Keeps the chat message list's intended 16px bottom inset when no task is pending.

`ChatListFooter` documented that its container should always render, but two early returns removed the entire footer in the common idle state. That left only the last message row's 8px padding between the final reply and the composer. The footer now always renders its spacing container and conditionally renders only the task status pill.

## Related Issue

Fixes #6558

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/chat/components/chat-message-list.tsx` so the footer spacing container remains mounted without a pending task.
- Added a regression test that renders an idle assistant reply and verifies the Footer still carries `pb-4` without rendering a status pill.

## How to Test

1. `pnpm --filter @multica/views exec vitest run chat/components/chat-message-list.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose`
2. `pnpm --filter @multica/views typecheck`

Both checks pass locally. The test run reports two pre-existing React `act(...)` warnings in unrelated quick-action cases.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; behavior now matches the existing inline contract)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Audited open issues for a scoped, reproducible UI defect; traced the Virtuoso Footer path; changed only the conditional rendering boundary; and added a regression test before running the focused views test and typecheck.

## Screenshots (optional)

Not included because this is an 8px spacing regression covered directly at the Footer contract; no visual styling or layout structure otherwise changes.
