### PR TITLE
fix(db): bound ListInboxItems at 200 rows

### DIFF
--- a/server/cmd/server/inbox_list_limit_test.go
+++ b/server/cmd/server/inbox_list_limit_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestListInboxItemsRespectsLimit pins the LIMIT 200 on ListInboxItems (#6527).
+// Without the cap, a heavy inbox returns every non-archived row — multi-MB
+// payloads on every mark-read refetch. The archived list is already capped at
+// 200 (ListArchivedInboxItems); this test proves the active list is too.
+func TestListInboxItemsRespectsLimit(t *testing.T) {
+	queries := db.New(testPool)
+	ctx := context.Background()
+
+	recipientEmail := "inbox-limit-test@multica.ai"
+	recipientID := createTestUser(t, recipientEmail)
+	t.Cleanup(func() { cleanupTestUser(t, recipientEmail) })
+
+	// Insert more rows than the LIMIT (205 > 200) so a missing cap would
+	// return all 205. Use raw SQL for the bulk insert; each row is a
+	// standalone item (no issue_id) so it groups on its own id.
+	const insertCount = 205
+	for i := 0; i < insertCount; i++ {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO inbox_item (workspace_id, recipient_type, recipient_id, type, severity, title)
+			VALUES ($1, 'member', $2, 'issue_assigned', 'info', $3)
+		`, util.MustParseUUID(testWorkspaceID), util.MustParseUUID(recipientID),
+			fmt.Sprintf("limit test item %d", i))
+		if err != nil {
+			t.Fatalf("insert inbox item %d: %v", i, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM inbox_item WHERE recipient_id = $1`, util.MustParseUUID(recipientID))
+	})
+
+	items, err := queries.ListInboxItems(ctx, db.ListInboxItemsParams{
+		WorkspaceID:   util.MustParseUUID(testWorkspaceID),
+		RecipientType: "member",
+		RecipientID:   util.MustParseUUID(recipientID),
+	})
+	if err != nil {
+		t.Fatalf("ListInboxItems: %v", err)
+	}
+
+	if len(items) != 200 {
+		t.Errorf("ListInboxItems returned %d items, want 200 (LIMIT); the query cap from #6527 is missing", len(items))
+	}
+}

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -448,6 +448,7 @@ FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
 ORDER BY i.created_at DESC
+LIMIT 200
 `
 
 type ListInboxItemsParams struct {
@@ -475,6 +476,12 @@ type ListInboxItemsRow struct {
 	IssueStatus   pgtype.Text        `json:"issue_status"`
 }
 
+// Active inbox for the recipient. LIMIT bounds the response the same way
+// ListArchivedInboxItems does: v1 ships no pagination, and without a cap a
+// heavy inbox produces multi-MB payloads on every mark-read refetch (#6527).
+// Rows are newest-first, so truncation drops the OLDEST rows and can never
+// hide a group's newest row — the one the deduplicated UI renders. The unread
+// badge uses CountUnreadInbox (a separate count query) and is unaffected.
 func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) ([]ListInboxItemsRow, error) {
 	rows, err := q.db.Query(ctx, listInboxItems, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
 	if err != nil {

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -1,10 +1,17 @@
 -- name: ListInboxItems :many
+-- Active inbox for the recipient. LIMIT bounds the response the same way
+-- ListArchivedInboxItems does: v1 ships no pagination, and without a cap a
+-- heavy inbox produces multi-MB payloads on every mark-read refetch (#6527).
+-- Rows are newest-first, so truncation drops the OLDEST rows and can never
+-- hide a group's newest row — the one the deduplicated UI renders. The unread
+-- badge uses CountUnreadInbox (a separate count query) and is unaffected.
 SELECT i.*,
        iss.status as issue_status
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC;
+ORDER BY i.created_at DESC
+LIMIT 200;
 
 -- name: ListArchivedInboxItems :many
 -- Archived counterpart of ListInboxItems, backing the inbox's "Archived"


### PR DESCRIPTION
## Summary

`ListInboxItems` returned every non-archived inbox row with no LIMIT, so a heavy inbox produced multi-MB payloads (observed ~8MB / 6–7s) on every mark-read — the client invalidates into a full `GET /api/inbox` refetch. The archived counterpart (`ListArchivedInboxItems`) was already capped at `LIMIT 200`; the active list was not.

## Change

Add `LIMIT 200` to `ListInboxItems`, matching the cap `ListArchivedInboxItems` already ships. Rows are newest-first, so truncation drops the oldest rows and can never hide a group's newest row — the one the deduplicated UI renders. The unread badge uses `CountUnboxInbox`, a separate count query, so it is unaffected by the cap. v1 ships no pagination; this is the same bound the archived list already ships.

- `server/pkg/db/queries/inbox.sql` — add `LIMIT 200` + a comment explaining the bound (mirroring the archived query's comment).
- `server/pkg/db/generated/inbox.sql.go` — regenerated via `sqlc generate` (v1.31.1); the only change is the embedded SQL string gaining `LIMIT 200` and the comment surfacing as a Go doc comment. No struct or param changes — the LIMIT is a constant, not a parameter.
- `server/cmd/server/inbox_list_limit_test.go` — DB-backed regression test that inserts 205 inbox items and asserts `ListInboxItems` returns 200.

Fixes #6527
