### PR TITLE
MUL-6057: fix(i18n): localize runtime activity heatmap

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -290,13 +290,6 @@
     "heatmap_average": "avg {{value}}",
     "heatmap_window_total_one": "{{count}}-day total",
     "heatmap_window_total_other": "{{count}}-day total",
-    "heatmap_weekday_mon": "Mon",
-    "heatmap_weekday_tue": "Tue",
-    "heatmap_weekday_wed": "Wed",
-    "heatmap_weekday_thu": "Thu",
-    "heatmap_weekday_fri": "Fri",
-    "heatmap_weekday_sat": "Sat",
-    "heatmap_weekday_sun": "Sun",
     "tooltip_total": "Total"
   },
   "list": {

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -283,6 +283,20 @@
   "charts": {
     "heatmap_less": "Less",
     "heatmap_more": "More",
+    "heatmap_no_activity": "No activity",
+    "heatmap_busiest_day": "Busiest day",
+    "heatmap_most_active_weekday": "Most active weekday",
+    "heatmap_quietest_weekday": "Quietest weekday",
+    "heatmap_average": "avg {{value}}",
+    "heatmap_window_total_one": "{{count}}-day total",
+    "heatmap_window_total_other": "{{count}}-day total",
+    "heatmap_weekday_mon": "Mon",
+    "heatmap_weekday_tue": "Tue",
+    "heatmap_weekday_wed": "Wed",
+    "heatmap_weekday_thu": "Thu",
+    "heatmap_weekday_fri": "Fri",
+    "heatmap_weekday_sat": "Sat",
+    "heatmap_weekday_sun": "Sun",
     "tooltip_total": "Total"
   },
   "list": {

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -277,13 +277,6 @@
     "heatmap_quietest_weekday": "最も静かな曜日",
     "heatmap_average": "平均 {{value}}",
     "heatmap_window_total_other": "{{count}}日間の合計",
-    "heatmap_weekday_mon": "月",
-    "heatmap_weekday_tue": "火",
-    "heatmap_weekday_wed": "水",
-    "heatmap_weekday_thu": "木",
-    "heatmap_weekday_fri": "金",
-    "heatmap_weekday_sat": "土",
-    "heatmap_weekday_sun": "日",
     "tooltip_total": "合計"
   },
   "list": {

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -271,6 +271,19 @@
   "charts": {
     "heatmap_less": "少ない",
     "heatmap_more": "多い",
+    "heatmap_no_activity": "アクティビティなし",
+    "heatmap_busiest_day": "最も活発な日",
+    "heatmap_most_active_weekday": "最も活発な曜日",
+    "heatmap_quietest_weekday": "最も静かな曜日",
+    "heatmap_average": "平均 {{value}}",
+    "heatmap_window_total_other": "{{count}}日間の合計",
+    "heatmap_weekday_mon": "月",
+    "heatmap_weekday_tue": "火",
+    "heatmap_weekday_wed": "水",
+    "heatmap_weekday_thu": "木",
+    "heatmap_weekday_fri": "金",
+    "heatmap_weekday_sat": "土",
+    "heatmap_weekday_sun": "日",
     "tooltip_total": "合計"
   },
   "list": {

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -277,13 +277,6 @@
     "heatmap_quietest_weekday": "가장 한산한 요일",
     "heatmap_average": "평균 {{value}}",
     "heatmap_window_total_other": "{{count}}일 합계",
-    "heatmap_weekday_mon": "월",
-    "heatmap_weekday_tue": "화",
-    "heatmap_weekday_wed": "수",
-    "heatmap_weekday_thu": "목",
-    "heatmap_weekday_fri": "금",
-    "heatmap_weekday_sat": "토",
-    "heatmap_weekday_sun": "일",
     "tooltip_total": "합계"
   },
   "list": {

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -271,6 +271,19 @@
   "charts": {
     "heatmap_less": "적음",
     "heatmap_more": "많음",
+    "heatmap_no_activity": "활동 없음",
+    "heatmap_busiest_day": "가장 활발한 날짜",
+    "heatmap_most_active_weekday": "가장 활발한 요일",
+    "heatmap_quietest_weekday": "가장 한산한 요일",
+    "heatmap_average": "평균 {{value}}",
+    "heatmap_window_total_other": "{{count}}일 합계",
+    "heatmap_weekday_mon": "월",
+    "heatmap_weekday_tue": "화",
+    "heatmap_weekday_wed": "수",
+    "heatmap_weekday_thu": "목",
+    "heatmap_weekday_fri": "금",
+    "heatmap_weekday_sat": "토",
+    "heatmap_weekday_sun": "일",
     "tooltip_total": "합계"
   },
   "list": {

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -277,13 +277,6 @@
     "heatmap_quietest_weekday": "最不活跃星期几",
     "heatmap_average": "平均 {{value}}",
     "heatmap_window_total_other": "{{count}} 天总计",
-    "heatmap_weekday_mon": "周一",
-    "heatmap_weekday_tue": "周二",
-    "heatmap_weekday_wed": "周三",
-    "heatmap_weekday_thu": "周四",
-    "heatmap_weekday_fri": "周五",
-    "heatmap_weekday_sat": "周六",
-    "heatmap_weekday_sun": "周日",
     "tooltip_total": "总计"
   },
   "list": {

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -271,6 +271,19 @@
   "charts": {
     "heatmap_less": "少",
     "heatmap_more": "多",
+    "heatmap_no_activity": "无活动",
+    "heatmap_busiest_day": "最活跃日期",
+    "heatmap_most_active_weekday": "最活跃星期几",
+    "heatmap_quietest_weekday": "最不活跃星期几",
+    "heatmap_average": "平均 {{value}}",
+    "heatmap_window_total_other": "{{count}} 天总计",
+    "heatmap_weekday_mon": "周一",
+    "heatmap_weekday_tue": "周二",
+    "heatmap_weekday_wed": "周三",
+    "heatmap_weekday_thu": "周四",
+    "heatmap_weekday_fri": "周五",
+    "heatmap_weekday_sat": "周六",
+    "heatmap_weekday_sun": "周日",
     "tooltip_total": "总计"
   },
   "list": {

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -273,8 +273,8 @@
     "heatmap_more": "多",
     "heatmap_no_activity": "无活动",
     "heatmap_busiest_day": "最活跃日期",
-    "heatmap_most_active_weekday": "最活跃星期几",
-    "heatmap_quietest_weekday": "最不活跃星期几",
+    "heatmap_most_active_weekday": "最活跃星期",
+    "heatmap_quietest_weekday": "最不活跃星期",
     "heatmap_average": "平均 {{value}}",
     "heatmap_window_total_other": "{{count}} 天总计",
     "tooltip_total": "总计"

--- a/packages/views/runtimes/components/charts/activity-heatmap.test.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.test.tsx
@@ -1,10 +1,7 @@
-// @vitest-environment jsdom
-
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import type { RuntimeUsage } from "@multica/core/types";
-import { I18nProvider } from "@multica/core/i18n/react";
-import zhRuntimes from "../../../locales/zh-Hans/runtimes.json";
+import { renderWithI18n } from "../../../test/i18n";
 
 vi.mock("@multica/core/runtimes/custom-pricing-store", () => {
   const pricingState = { pricings: {} };
@@ -22,23 +19,41 @@ vi.mock("@multica/core/runtimes/custom-pricing-store", () => {
 
 import { ActivityHeatmap } from "./activity-heatmap";
 
-const USAGE: RuntimeUsage[] = [
-  {
+function usageOn(date: string, ticks: number): RuntimeUsage {
+  return {
     runtime_id: "runtime-1",
-    date: "2026-08-12",
+    date,
     provider: "anthropic",
     model: "claude-sonnet-4-6",
     input_tokens: 1_000,
     output_tokens: 0,
     cache_read_tokens: 0,
     cache_write_tokens: 0,
-    cost_usd_ticks: 20_000_000_000,
+    cost_usd_ticks: ticks,
     uncosted_input_tokens: 0,
     uncosted_output_tokens: 0,
     uncosted_cache_read_tokens: 0,
     uncosted_cache_write_tokens: 0,
-  },
+  };
+}
+
+// Spend on a Wednesday and a Monday only, so the window has a busiest
+// weekday (Wed) and a quietest one (Tue) that are distinct from each other
+// and from the Mon/Wed/Fri row labels.
+const USAGE: RuntimeUsage[] = [
+  usageOn("2026-08-12", 20_000_000_000),
+  usageOn("2026-08-03", 5_000_000_000),
 ];
+
+// Read one stat cell's value by its label. Asserting on the value node (not
+// on "does this string appear anywhere") matters here: the Mon/Wed/Fri row
+// labels render the same weekday names, so a document-wide text match would
+// pass even if the weekday insight fell back to English or picked the wrong
+// day.
+function statValue(label: string): string {
+  const cell = screen.getByText(label).closest("div");
+  return cell?.querySelector("dd")?.textContent ?? "";
+}
 
 describe("ActivityHeatmap localization", () => {
   beforeAll(() => {
@@ -51,22 +66,24 @@ describe("ActivityHeatmap localization", () => {
   });
 
   it("renders chart chrome, dates, and tooltips in the selected locale", () => {
-    const { container } = render(
-      <I18nProvider
-        locale="zh-Hans"
-        resources={{ "zh-Hans": { runtimes: zhRuntimes } }}
-      >
-        <ActivityHeatmap usage={USAGE} tz="Asia/Shanghai" />
-      </I18nProvider>,
+    const { container } = renderWithI18n(
+      <ActivityHeatmap usage={USAGE} tz="Asia/Shanghai" />,
+      { locale: "zh-Hans" },
     );
 
-    expect(screen.getByText("最活跃日期")).toBeTruthy();
-    expect(screen.getByText("最活跃星期几")).toBeTruthy();
-    expect(screen.getByText("最不活跃星期几")).toBeTruthy();
-    expect(screen.getByText("8月12日")).toBeTruthy();
-    expect(screen.getAllByText("周三").length).toBeGreaterThan(0);
+    expect(statValue("最活跃日期")).toContain("8月12日");
+    expect(statValue("最活跃星期")).toContain("周三");
+    expect(statValue("最不活跃星期")).toContain("周二");
     expect(screen.getByText(/天总计$/)).toBeTruthy();
     expect(screen.queryByText("Busiest day")).toBeNull();
+
+    // Row labels: Monday-first, only alternating rows are labelled.
+    const rowLabels = Array.from(
+      container.querySelectorAll("svg text"),
+      (node) => node.textContent,
+    );
+    expect(rowLabels).toEqual(expect.arrayContaining(["周一", "周三", "周五"]));
+    expect(rowLabels).not.toContain("周二");
 
     const titles = Array.from(container.querySelectorAll("title"), (title) =>
       title.textContent?.trim(),

--- a/packages/views/runtimes/components/charts/activity-heatmap.test.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { RuntimeUsage } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import zhRuntimes from "../../../locales/zh-Hans/runtimes.json";
+
+vi.mock("@multica/core/runtimes/custom-pricing-store", () => {
+  const pricingState = { pricings: {} };
+  const useCustomPricingStore = Object.assign(
+    (selector?: (state: typeof pricingState) => unknown) =>
+      selector ? selector(pricingState) : pricingState,
+    { getState: () => pricingState },
+  );
+
+  return {
+    useCustomPricingStore,
+    getCustomPricing: () => undefined,
+  };
+});
+
+import { ActivityHeatmap } from "./activity-heatmap";
+
+const USAGE: RuntimeUsage[] = [
+  {
+    runtime_id: "runtime-1",
+    date: "2026-08-12",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    input_tokens: 1_000,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    cost_usd_ticks: 20_000_000_000,
+    uncosted_input_tokens: 0,
+    uncosted_output_tokens: 0,
+    uncosted_cache_read_tokens: 0,
+    uncosted_cache_write_tokens: 0,
+  },
+];
+
+describe("ActivityHeatmap localization", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T12:00:00Z"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders chart chrome, dates, and tooltips in the selected locale", () => {
+    const { container } = render(
+      <I18nProvider
+        locale="zh-Hans"
+        resources={{ "zh-Hans": { runtimes: zhRuntimes } }}
+      >
+        <ActivityHeatmap usage={USAGE} tz="Asia/Shanghai" />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("最活跃日期")).toBeTruthy();
+    expect(screen.getByText("最活跃星期几")).toBeTruthy();
+    expect(screen.getByText("最不活跃星期几")).toBeTruthy();
+    expect(screen.getByText("8月12日")).toBeTruthy();
+    expect(screen.getAllByText("周三").length).toBeGreaterThan(0);
+    expect(screen.getByText(/天总计$/)).toBeTruthy();
+    expect(screen.queryByText("Busiest day")).toBeNull();
+
+    const titles = Array.from(container.querySelectorAll("title"), (title) =>
+      title.textContent?.trim(),
+    );
+    expect(titles.some((title) => title?.endsWith(": 无活动"))).toBe(true);
+  });
+});

--- a/packages/views/runtimes/components/charts/activity-heatmap.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.tsx
@@ -15,6 +15,9 @@ const CELL_GAP = 3;
 // aggregation (see #MUL-2382). Labelling alternating rows keeps the density
 // readable without tying the chart structure to one language.
 const LABELED_WEEKDAY_INDICES = new Set([0, 2, 4]);
+// 2026-01-05 is a Monday, so walking 7 days from here lines the formatted
+// names up with the Monday-first `dayOfWeek` index.
+const WEEKDAY_ANCHOR = Date.UTC(2026, 0, 5);
 
 // Cells use the brand-derived chart-1 hue with descending opacity instead
 // of a neutral foreground fade, so the heatmap reads as part of the same
@@ -32,6 +35,20 @@ function fmtDate(iso: string, locale: string): string {
     month: "short",
     day: "numeric",
   });
+}
+
+// Row labels come from Intl rather than the locale bundle: for every locale
+// we ship, its short weekday names are exactly the strings we would hand-
+// translate, and the month labels below already resolve the same way. One
+// less set of strings to keep in sync when a locale is added.
+function fmtWeekdays(locale: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+    timeZone: "UTC",
+  });
+  return Array.from({ length: 7 }, (_, i) =>
+    fmt.format(new Date(WEEKDAY_ANCHOR + i * 86_400_000)),
+  );
 }
 
 interface Insights {
@@ -53,15 +70,7 @@ export function ActivityHeatmap({
 }) {
   const { t, i18n } = useT("runtimes");
   const locale = i18n.resolvedLanguage ?? i18n.language;
-  const weekdayLabels = [
-    t(($) => $.charts.heatmap_weekday_mon),
-    t(($) => $.charts.heatmap_weekday_tue),
-    t(($) => $.charts.heatmap_weekday_wed),
-    t(($) => $.charts.heatmap_weekday_thu),
-    t(($) => $.charts.heatmap_weekday_fri),
-    t(($) => $.charts.heatmap_weekday_sat),
-    t(($) => $.charts.heatmap_weekday_sun),
-  ];
+  const weekdayLabels = useMemo(() => fmtWeekdays(locale), [locale]);
   // Memo dep — estimateCost (called inside the body below) consults the
   // user-override store, so saving a custom rate must invalidate the cells.
   const pricings = useCustomPricingStore((s) => s.pricings);
@@ -243,6 +252,10 @@ export function ActivityHeatmap({
                 fill={getHeatmapColor(c.level)}
                 className="transition-colors"
               >
+                {/* The tooltip date stays ISO on purpose: it is the exact
+                    day key behind the cell, and readers compare it against
+                    the API / CLI usage rows, which are ISO too. Only the
+                    prose around it is translated. */}
                 <title>
                   {c.date}:{" "}
                   {c.cost > 0

--- a/packages/views/runtimes/components/charts/activity-heatmap.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.tsx
@@ -12,10 +12,9 @@ const HEATMAP_WEEKS = 26;
 const CELL_SIZE = 16;
 const CELL_GAP = 3;
 // Monday-first row order, matching ISO 8601 and the rest of the Weekly
-// aggregation (see #MUL-2382). Rows labelled Mon / Wed / Fri keep the
-// density readable.
-const DAY_LABELS = ["Mon", "", "Wed", "", "Fri", "", ""];
-const WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+// aggregation (see #MUL-2382). Labelling alternating rows keeps the density
+// readable without tying the chart structure to one language.
+const LABELED_WEEKDAY_INDICES = new Set([0, 2, 4]);
 
 // Cells use the brand-derived chart-1 hue with descending opacity instead
 // of a neutral foreground fade, so the heatmap reads as part of the same
@@ -28,8 +27,8 @@ function getHeatmapColor(level: number): string {
   return `color-mix(in oklch, var(--color-chart-1) ${opacities[level - 1]}, transparent)`;
 }
 
-function fmtDate(iso: string): string {
-  return new Date(iso + "T00:00:00").toLocaleString("en", {
+function fmtDate(iso: string, locale: string): string {
+  return new Date(iso + "T00:00:00").toLocaleString(locale, {
     month: "short",
     day: "numeric",
   });
@@ -37,9 +36,9 @@ function fmtDate(iso: string): string {
 
 interface Insights {
   busiestDay: { date: string; cost: number } | null;
-  busyDayName: string | null;
+  busyDayIndex: number | null;
   busyDayAvg: number;
-  quietDayName: string | null;
+  quietDayIndex: number | null;
   quietDayAvg: number;
   totalCost: number;
   windowDays: number;
@@ -52,7 +51,17 @@ export function ActivityHeatmap({
   usage: RuntimeUsage[];
   tz: string;
 }) {
-  const { t } = useT("runtimes");
+  const { t, i18n } = useT("runtimes");
+  const locale = i18n.resolvedLanguage ?? i18n.language;
+  const weekdayLabels = [
+    t(($) => $.charts.heatmap_weekday_mon),
+    t(($) => $.charts.heatmap_weekday_tue),
+    t(($) => $.charts.heatmap_weekday_wed),
+    t(($) => $.charts.heatmap_weekday_thu),
+    t(($) => $.charts.heatmap_weekday_fri),
+    t(($) => $.charts.heatmap_weekday_sat),
+    t(($) => $.charts.heatmap_weekday_sun),
+  ];
   // Memo dep — estimateCost (called inside the body below) consults the
   // user-override store, so saving a custom rate must invalidate the cells.
   const pricings = useCustomPricingStore((s) => s.pricings);
@@ -123,7 +132,7 @@ export function ActivityHeatmap({
       const month = new Date(c.date + "T00:00:00").getMonth();
       if (month !== lastMonth && c.dayOfWeek === 0) {
         months.push({
-          label: new Date(c.date + "T00:00:00").toLocaleString("en", {
+          label: new Date(c.date + "T00:00:00").toLocaleString(locale, {
             month: "short",
           }),
           week: c.week,
@@ -150,41 +159,40 @@ export function ActivityHeatmap({
       const count = weekdayCount[i] ?? 0;
       return count > 0 ? s / count : 0;
     });
-    let busyDayName: string | null = null;
+    let busyDayIndex: number | null = null;
     let busyDayAvg = 0;
-    let quietDayName: string | null = null;
+    let quietDayIndex: number | null = null;
     let quietDayAvg = Number.POSITIVE_INFINITY;
     weekdayAvg.forEach((avg, i) => {
-      const name = WEEKDAY_NAMES[i] ?? "";
       if (avg > busyDayAvg) {
         busyDayAvg = avg;
-        busyDayName = name;
+        busyDayIndex = i;
       }
       if (avg < quietDayAvg) {
         quietDayAvg = avg;
-        quietDayName = name;
+        quietDayIndex = i;
       }
     });
     if (quietDayAvg === Number.POSITIVE_INFINITY) quietDayAvg = 0;
     // When the window has no spend at all, the busy / quiet weekday picks
     // are noise (every weekday averaged to 0). Suppress them.
     if (totalCost === 0) {
-      busyDayName = null;
-      quietDayName = null;
+      busyDayIndex = null;
+      quietDayIndex = null;
     }
 
     const insights: Insights = {
       busiestDay,
-      busyDayName,
+      busyDayIndex,
       busyDayAvg,
-      quietDayName,
+      quietDayIndex,
       quietDayAvg,
       totalCost,
       windowDays: allCells.length,
     };
 
     return { cells: cellsWithLevel, monthLabels: months, insights };
-  }, [usage, pricings, tz]);
+  }, [usage, pricings, tz, locale]);
 
   const labelWidth = 28;
   const svgWidth = labelWidth + HEATMAP_WEEKS * (CELL_SIZE + CELL_GAP);
@@ -211,8 +219,8 @@ export function ActivityHeatmap({
                 {m.label}
               </text>
             ))}
-            {DAY_LABELS.map((label, i) =>
-              label ? (
+            {weekdayLabels.map((label, i) =>
+              LABELED_WEEKDAY_INDICES.has(i) ? (
                 <text
                   key={i}
                   x={0}
@@ -237,7 +245,9 @@ export function ActivityHeatmap({
               >
                 <title>
                   {c.date}:{" "}
-                  {c.cost > 0 ? `$${c.cost.toFixed(2)}` : "No activity"}
+                  {c.cost > 0
+                    ? `$${c.cost.toFixed(2)}`
+                    : t(($) => $.charts.heatmap_no_activity)}
                 </title>
               </rect>
             ))}
@@ -256,7 +266,11 @@ export function ActivityHeatmap({
         </div>
       </div>
 
-      <InsightsRow insights={insights} />
+      <InsightsRow
+        insights={insights}
+        locale={locale}
+        weekdayLabels={weekdayLabels}
+      />
     </div>
   );
 }
@@ -264,12 +278,21 @@ export function ActivityHeatmap({
 // Horizontal stat strip beneath the heatmap. Mirrors the page-top KPI
 // hero pattern (label → big value → sub) but at smaller scale to stay
 // secondary. 4 columns on desktop, 2 on narrow screens.
-function InsightsRow({ insights }: { insights: Insights }) {
+function InsightsRow({
+  insights,
+  locale,
+  weekdayLabels,
+}: {
+  insights: Insights;
+  locale: string;
+  weekdayLabels: string[];
+}) {
+  const { t } = useT("runtimes");
   const {
     busiestDay,
-    busyDayName,
+    busyDayIndex,
     busyDayAvg,
-    quietDayName,
+    quietDayIndex,
     quietDayAvg,
     totalCost,
     windowDays,
@@ -277,21 +300,32 @@ function InsightsRow({ insights }: { insights: Insights }) {
   return (
     <dl className="grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3 sm:grid-cols-4">
       <Insight
-        label="Busiest day"
-        value={busiestDay ? fmtDate(busiestDay.date) : "—"}
+        label={t(($) => $.charts.heatmap_busiest_day)}
+        value={busiestDay ? fmtDate(busiestDay.date, locale) : "—"}
         sub={busiestDay ? formatUsd(busiestDay.cost) : null}
       />
       <Insight
-        label="Most active weekday"
-        value={busyDayName ?? "—"}
-        sub={busyDayName ? `avg ${formatUsd(busyDayAvg)}` : null}
+        label={t(($) => $.charts.heatmap_most_active_weekday)}
+        value={
+          busyDayIndex === null ? "—" : (weekdayLabels[busyDayIndex] ?? "—")
+        }
+        sub={busyDayIndex !== null
+          ? t(($) => $.charts.heatmap_average, { value: formatUsd(busyDayAvg) })
+          : null}
       />
       <Insight
-        label="Quietest weekday"
-        value={quietDayName ?? "—"}
-        sub={quietDayName ? `avg ${formatUsd(quietDayAvg)}` : null}
+        label={t(($) => $.charts.heatmap_quietest_weekday)}
+        value={
+          quietDayIndex === null ? "—" : (weekdayLabels[quietDayIndex] ?? "—")
+        }
+        sub={quietDayIndex !== null
+          ? t(($) => $.charts.heatmap_average, { value: formatUsd(quietDayAvg) })
+          : null}
       />
-      <Insight label={`${windowDays}-day total`} value={formatUsd(totalCost)} />
+      <Insight
+        label={t(($) => $.charts.heatmap_window_total, { count: windowDays })}
+        value={formatUsd(totalCost)}
+      />
     </dl>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Localizes the runtime activity heatmap end to end instead of leaving part of the chart in English for Chinese, Japanese, and Korean users.

The heatmap already translated its Less/More legend, but weekday rows, empty-cell tooltips, four insight labels, average/total copy, month names, and insight dates were hard-coded to English. This change routes all visible chart chrome through the existing `runtimes` namespace and formats dates with the active i18n locale.

## Related Issue

N/A - found during a focused runtime i18n audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added heatmap labels for English, Simplified Chinese, Japanese, and Korean with locale parity preserved.
- Replaced English weekday identifiers in the insight model with language-neutral weekday indices.
- Formatted month headings and busiest-day values with the selected locale.
- Added a Chinese-locale regression test covering labels, weekday/date formatting, totals, and empty-cell tooltips.

## How to Test

1. `pnpm --filter @multica/views exec vitest run runtimes/components/charts/activity-heatmap.test.tsx locales/parity.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views exec eslint runtimes/components/charts/activity-heatmap.tsx runtimes/components/charts/activity-heatmap.test.tsx`

All checks pass locally. ESLint retains the component's pre-existing exhaustive-deps warning for the intentional custom-pricing store invalidation dependency; there are no lint errors.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; locale resources are the canonical copy)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Audited user-visible runtime strings against the repository's i18n boundary, classified technical values versus translatable chrome, replaced hard-coded English with typed selectors and locale-aware date formatting, then added a non-English regression test plus locale parity coverage.

## Screenshots (optional)

Not included because the localized heatmap depends on workspace runtime usage data. The regression test renders the real component under `zh-Hans` and verifies the translated SVG and insight output directly.
