### PR TITLE
MUL-5738: fix(attachments): bound stalled text preview requests

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiClient, ApiError, CHAT_DRAFT_RESTORE_CAPABILITY } from "./client";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -1269,6 +1270,28 @@ describe("ApiClient", () => {
       await expect(client.getAttachmentTextContent("att-1")).rejects.toBeInstanceOf(
         PreviewUnsupportedError,
       );
+    });
+
+    it("aborts a stalled preview and throws PreviewTimeoutError", async () => {
+      const { PreviewTimeoutError } = await import("./client");
+      vi.useFakeTimers();
+      const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new ApiClient("https://api.example.test");
+      const assertion = expect(
+        client.getAttachmentTextContent("att-stalled"),
+      ).rejects.toBeInstanceOf(PreviewTimeoutError);
+
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
     });
   });
 

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -461,6 +461,18 @@ export class PreviewUnsupportedError extends Error {
   }
 }
 
+// Thrown when the content proxy does not return the complete preview body in
+// a bounded amount of time. Downloads use a separate path and remain
+// available as the recovery action.
+export class PreviewTimeoutError extends Error {
+  constructor() {
+    super("attachment inline preview timed out");
+    this.name = "PreviewTimeoutError";
+  }
+}
+
+const ATTACHMENT_PREVIEW_TIMEOUT_MS = 15_000;
+
 /**
  * Advertised in X-Client-Capabilities so the server knows this client can
  * recover a cancelled prompt from the durable draft-restore row (#5219).
@@ -2692,24 +2704,37 @@ export class ApiClient {
   // Routes through `fetchRaw` so it inherits the standard auth headers,
   // 401 → handleUnauthorized recovery, request-id logging, and ApiError
   // shape. 413 / 415 are translated to typed `Preview*Error` instances so
-  // the modal can render specific fallbacks instead of generic failure.
+  // the modal can render specific fallbacks instead of generic failure. A
+  // bounded request budget also keeps a stalled proxy read from pinning the
+  // preview in its loading state indefinitely.
   async getAttachmentTextContent(
     id: string,
   ): Promise<{ text: string; originalContentType: string }> {
-    let res: Response;
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, ATTACHMENT_PREVIEW_TIMEOUT_MS);
+
     try {
-      res = await this.fetchRaw(`/api/attachments/${id}/content`);
+      const res = await this.fetchRaw(`/api/attachments/${id}/content`, {
+        signal: controller.signal,
+      });
+      return {
+        text: await res.text(),
+        originalContentType: res.headers.get("X-Original-Content-Type") ?? "",
+      };
     } catch (err) {
+      if (timedOut) throw new PreviewTimeoutError();
       if (err instanceof ApiError) {
         if (err.status === 413) throw new PreviewTooLargeError();
         if (err.status === 415) throw new PreviewUnsupportedError();
       }
       throw err;
+    } finally {
+      clearTimeout(timeout);
     }
-    return {
-      text: await res.text(),
-      originalContentType: res.headers.get("X-Original-Content-Type") ?? "",
-    };
   }
 
   // Fetches the raw bytes of an attachment through the unified download

--- a/packages/core/api/index.ts
+++ b/packages/core/api/index.ts
@@ -4,6 +4,7 @@ export {
   dispatchReasonCode,
   errorCode,
   PreviewTooLargeError,
+  PreviewTimeoutError,
   PreviewUnsupportedError,
 } from "./client";
 export type {

--- a/packages/views/editor/attachment-preview-modal.test.tsx
+++ b/packages/views/editor/attachment-preview-modal.test.tsx
@@ -19,6 +19,7 @@ const {
   downloadMock,
   getBaseUrlMock,
   FakePreviewTooLargeError,
+  FakePreviewTimeoutError,
   FakePreviewUnsupportedError,
 } = vi.hoisted(() => {
   class FakePreviewTooLargeError extends Error {
@@ -33,6 +34,12 @@ const {
       this.name = "PreviewUnsupportedError";
     }
   }
+  class FakePreviewTimeoutError extends Error {
+    constructor() {
+      super("timeout");
+      this.name = "PreviewTimeoutError";
+    }
+  }
   return {
     getAttachmentTextContentMock: vi.fn(),
     downloadMock: vi.fn(),
@@ -40,6 +47,7 @@ const {
     // the desktop-renderer / standalone-shell case override per-test.
     getBaseUrlMock: vi.fn(() => ""),
     FakePreviewTooLargeError,
+    FakePreviewTimeoutError,
     FakePreviewUnsupportedError,
   };
 });
@@ -50,6 +58,7 @@ vi.mock("@multica/core/api", () => ({
     getBaseUrl: getBaseUrlMock,
   },
   PreviewTooLargeError: FakePreviewTooLargeError,
+  PreviewTimeoutError: FakePreviewTimeoutError,
   PreviewUnsupportedError: FakePreviewUnsupportedError,
 }));
 
@@ -114,6 +123,7 @@ vi.mock("../i18n", () => ({
           preview: "Preview",
           preview_loading: "Loading preview…",
           preview_failed: "Couldn't load preview",
+          preview_timeout: "Preview took too long. Download the file instead.",
           preview_too_large: "File is too large to preview. Please download.",
           preview_unsupported: "This file type can't be previewed.",
           close: "Close",
@@ -435,6 +445,34 @@ describe("AttachmentPreviewModal — error states", () => {
     await waitFor(() => {
       expect(screen.getByText("This file type can't be previewed.")).toBeTruthy();
     });
+  });
+
+  it("shows a download fallback when the content request times out", async () => {
+    getAttachmentTextContentMock.mockRejectedValueOnce(
+      new FakePreviewTimeoutError(),
+    );
+    const att = makeAttachment({
+      filename: "slow.md",
+      content_type: "text/markdown",
+    });
+    render(
+      <AttachmentPreviewModal
+        source={{ kind: "full", attachment: att }}
+        open
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Preview took too long. Download the file instead."),
+      ).toBeTruthy();
+    });
+    expect(
+      screen
+        .getAllByRole("button", { name: "Download" })
+        .some((button) => button.textContent === "Download"),
+    ).toBe(true);
   });
 
   it("shows the generic failed fallback on a transport error", async () => {

--- a/packages/views/editor/attachment-preview-modal.tsx
+++ b/packages/views/editor/attachment-preview-modal.tsx
@@ -73,7 +73,10 @@ import {
   type PreviewKind,
 } from "./utils/preview";
 import { useDownloadAttachment } from "./use-download-attachment";
-import { useAttachmentHtmlText } from "./hooks/use-attachment-html-text";
+import {
+  isAttachmentPreviewTimeout,
+  useAttachmentHtmlText,
+} from "./hooks/use-attachment-html-text";
 import { useResignedInlineMediaURL } from "./hooks/use-inline-media-url";
 import { useZoomCanvas, type ZoomCanvasApi } from "./hooks/use-zoom-canvas";
 import { ZoomCanvas, ZoomControls } from "./zoom-canvas";
@@ -926,6 +929,14 @@ function TextBackedPreview({
       return (
         <UnsupportedFallback
           message={t(($) => $.attachment.preview_unsupported)}
+          onDownload={onDownload}
+        />
+      );
+    }
+    if (isAttachmentPreviewTimeout(query.error)) {
+      return (
+        <UnsupportedFallback
+          message={t(($) => $.attachment.preview_timeout)}
           onDownload={onDownload}
         />
       );

--- a/packages/views/editor/hooks/use-attachment-html-text.ts
+++ b/packages/views/editor/hooks/use-attachment-html-text.ts
@@ -14,6 +14,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
 
+export function isAttachmentPreviewTimeout(error: unknown): boolean {
+  return error instanceof Error && error.name === "PreviewTimeoutError";
+}
+
 export function useAttachmentHtmlText(attachmentId: string | null | undefined) {
   return useQuery({
     queryKey: ["attachment-content", attachmentId ?? ""] as const,

--- a/packages/views/editor/html-attachment-preview.test.tsx
+++ b/packages/views/editor/html-attachment-preview.test.tsx
@@ -3,13 +3,25 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-const { getAttachmentTextContentMock } = vi.hoisted(() => ({
-  getAttachmentTextContentMock: vi.fn(),
-}));
+const { getAttachmentTextContentMock, FakePreviewTimeoutError } = vi.hoisted(
+  () => {
+    class FakePreviewTimeoutError extends Error {
+      constructor() {
+        super("timeout");
+        this.name = "PreviewTimeoutError";
+      }
+    }
+    return {
+      getAttachmentTextContentMock: vi.fn(),
+      FakePreviewTimeoutError,
+    };
+  },
+);
 
 vi.mock("@multica/core/api", () => ({
   api: { getAttachmentTextContent: getAttachmentTextContentMock },
   PreviewTooLargeError: class extends Error {},
+  PreviewTimeoutError: FakePreviewTimeoutError,
   PreviewUnsupportedError: class extends Error {},
 }));
 
@@ -22,6 +34,7 @@ vi.mock("../i18n", () => ({
           preview: "Preview",
           preview_loading: "Loading preview…",
           preview_failed: "Couldn't load preview",
+          preview_timeout: "Preview took too long. Download the file instead.",
           open_in_new_tab: "Open in new tab",
         },
       }),
@@ -237,6 +250,27 @@ describe("HtmlAttachmentPreview — toolbar actions", () => {
 });
 
 describe("HtmlAttachmentPreview — failure mode does not unmount the toolbar", () => {
+  it("shows an actionable error when the content request times out", async () => {
+    getAttachmentTextContentMock.mockRejectedValueOnce(
+      new FakePreviewTimeoutError(),
+    );
+    renderWithQuery(
+      <HtmlAttachmentPreview
+        attachmentId="att-1"
+        filename="report.html"
+        onPreview={() => {}}
+        onDownload={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Preview took too long. Download the file instead."),
+      ).toBeTruthy();
+    });
+    expect(screen.getByTitle("Download")).toBeTruthy();
+  });
+
   it("keeps Preview and Download enabled when fetch errors", async () => {
     getAttachmentTextContentMock.mockRejectedValueOnce(new Error("nope"));
     const onPreview = vi.fn();

--- a/packages/views/editor/html-preview-body.tsx
+++ b/packages/views/editor/html-preview-body.tsx
@@ -27,7 +27,10 @@ import {
 import { useT } from "../i18n";
 import { CodeBlockIframe } from "./code-block-iframe";
 import { withFragmentNavShim } from "./utils/iframe-fragment-nav";
-import { useAttachmentHtmlText } from "./hooks/use-attachment-html-text";
+import {
+  isAttachmentPreviewTimeout,
+  useAttachmentHtmlText,
+} from "./hooks/use-attachment-html-text";
 
 export type HtmlSource =
   | { kind: "inline"; html: string }
@@ -114,6 +117,8 @@ function AttachmentBody({
     const message =
       query.error instanceof PreviewTooLargeError
         ? t(($) => $.attachment.preview_too_large)
+        : isAttachmentPreviewTimeout(query.error)
+        ? t(($) => $.attachment.preview_timeout)
         : query.error instanceof PreviewUnsupportedError
         ? t(($) => $.attachment.preview_unsupported)
         : t(($) => $.attachment.preview_failed);

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -52,6 +52,7 @@
     "preview": "Preview",
     "preview_loading": "Loading preview…",
     "preview_failed": "Couldn't load preview",
+    "preview_timeout": "Preview took too long. Download the file instead.",
     "preview_too_large": "File is too large to preview. Please download.",
     "preview_unsupported": "This file type can't be previewed.",
     "close": "Close",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -52,6 +52,7 @@
     "preview": "プレビュー",
     "preview_loading": "プレビューを読み込み中…",
     "preview_failed": "プレビューを読み込めませんでした",
+    "preview_timeout": "プレビューの読み込みがタイムアウトしました。ファイルをダウンロードしてください。",
     "preview_too_large": "ファイルが大きすぎてプレビューできません。ダウンロードしてください。",
     "preview_unsupported": "このファイル形式はプレビューできません。",
     "close": "閉じる",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -52,6 +52,7 @@
     "preview": "미리보기",
     "preview_loading": "미리보기 불러오는 중...",
     "preview_failed": "미리보기를 불러오지 못했습니다",
+    "preview_timeout": "미리보기 시간이 초과되었습니다. 파일을 다운로드하세요.",
     "preview_too_large": "파일이 너무 커서 미리볼 수 없습니다. 다운로드하세요.",
     "preview_unsupported": "이 파일 형식은 미리보기를 지원하지 않습니다.",
     "close": "닫기",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -52,6 +52,7 @@
     "preview": "预览",
     "preview_loading": "加载预览中…",
     "preview_failed": "预览加载失败",
+    "preview_timeout": "预览加载超时，请下载文件查看。",
     "preview_too_large": "文件太大，无法在线预览，请下载查看。",
     "preview_unsupported": "该文件类型暂不支持预览。",
     "close": "关闭",


### PR DESCRIPTION
## What does this PR do?

Prevents text-backed attachment previews from remaining in the loading state forever when `/api/attachments/{id}/content` stalls.

The content request now has a 15-second end-to-end budget covering both response headers and body reads. On timeout it aborts the fetch, emits a typed preview error, and renders an explicit localized message with the existing Download recovery action. HTML, Markdown, and plain-text previews share this request path, so they receive the same bounded behavior.

This deliberately does not claim to fix the underlying object-storage stall described in the issue; it makes the client failure mode bounded and recoverable while that server-side cause is investigated.

## Related Issue

Fixes #6400

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added a 15-second abort budget to `getAttachmentTextContent`, including stalled response-body reads.
- Added `PreviewTimeoutError` and mapped it to a dedicated download-oriented fallback in inline HTML and full-screen text previews.
- Added timeout copy for English, Simplified Chinese, Japanese, and Korean with locale parity preserved.
- Added API and UI regression tests for abort behavior, inline HTML recovery, and full-screen Download fallback.

## How to Test

1. `pnpm --filter @multica/core exec vitest run api/client.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose`
2. `pnpm --filter @multica/views exec vitest run editor/html-attachment-preview.test.tsx editor/attachment-preview-modal.test.tsx locales/parity.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=dot`
3. `pnpm --filter @multica/core typecheck`
4. `pnpm --filter @multica/views typecheck`
5. Run the focused core/views ESLint checks shown in the commit validation.

All checks pass locally: 70 core tests and 220 views/parity tests. The views run retains one pre-existing TanStack Query warning in the non-image body layout test; there are no test failures or lint errors.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; the API comment and locale resources describe the contract)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Traced the issue from the loading placeholder through the shared TanStack Query hook and raw API client, verified there was no overlapping PR, added a bounded abort at the lowest shared request layer, preserved the Download escape path, and covered the API plus both inline/full-screen UI states.

## Screenshots (optional)

Not included because the changed state requires a deliberately stalled network response. The UI regression tests render both real timeout fallbacks and verify the localized message and Download action.
