### PR TITLE
MUL-6051: fix(settings): give Lark and Slack their own brand marks

### DIFF
--- a/packages/views/settings/components/integration-channel-icon.tsx
+++ b/packages/views/settings/components/integration-channel-icon.tsx
@@ -1,13 +1,19 @@
-import { MessagesSquare, Webhook } from "lucide-react";
 import { DingTalkMark } from "./dingtalk-mark";
+import { LarkMark } from "./lark-mark";
+import { SlackMark } from "./slack-mark";
 import { WecomMark } from "./wecom-mark";
 
 type IntegrationChannel = "lark" | "slack" | "dingtalk" | "wecom";
 
+// Every channel gets its own brand mark, never a generic lucide glyph: the icon
+// is what tells a reader which platform the section belongs to, and a stand-in
+// speech bubble or plug says nothing (see WecomMark, #6585). lucide-react ships
+// no brand icons, so a new channel needs its own `*-mark.tsx` before it can be
+// listed here.
 export function IntegrationChannelIcon({ channel }: { channel: IntegrationChannel }) {
   const icon = {
-    lark: <Webhook className="h-4 w-4" />,
-    slack: <MessagesSquare className="h-4 w-4" />,
+    lark: <LarkMark className="h-4 w-4" />,
+    slack: <SlackMark className="h-4 w-4" />,
     dingtalk: <DingTalkMark className="h-5 w-5" />,
     wecom: <WecomMark className="h-4 w-4" />,
   }[channel];

--- a/packages/views/settings/components/integrations-tab.test.tsx
+++ b/packages/views/settings/components/integrations-tab.test.tsx
@@ -111,6 +111,20 @@ describe("Settings IntegrationsTab", () => {
     }
   });
 
+  // Reaching for a generic lucide glyph is how Slack and WeCom ended up sharing
+  // one speech bubble, with nothing on the row saying which platform it was
+  // (#6585). Requiring four distinct shapes is the cheap guard against a
+  // regression to that.
+  it("gives every channel its own brand mark", () => {
+    renderTab();
+
+    const shapes = ["lark", "slack", "dingtalk", "wecom"].map(
+      (channel) => screen.getByTestId(`integration-channel-icon-${channel}`).innerHTML,
+    );
+
+    expect(new Set(shapes).size).toBe(shapes.length);
+  });
+
   it("hides Composio when the feature flag is on but the server reports 503", () => {
     composioErrorRef.current = new ApiError("unavailable", 503, "Service Unavailable");
 

--- a/packages/views/settings/components/lark-mark.tsx
+++ b/packages/views/settings/components/lark-mark.tsx
@@ -1,0 +1,46 @@
+// The SVG paths in LarkMark below are copied verbatim from
+// `packages/semi-icons/src/svgs/feishu_logo.svg` in ByteDance's Semi Design
+// icon set, used under the MIT License. Source:
+// https://github.com/DouyinFE/semi-design/blob/a542506ab2b9d6976d51e5e2df074e7ff09ece42/packages/semi-icons/src/svgs/feishu_logo.svg
+// The original per-path `fill="black"` was hoisted to currentColor on the root
+// for theme compatibility.
+//
+// Copyright (c) 2021 DouyinFE
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// The Lark (飞书) brand mark. lucide-react carries no brand icons, so the
+// Settings → Integrations channel icon fell back to the generic Webhook glyph,
+// which neither says which platform the section is for nor describes the flow
+// (Lark binds over a QR device flow — there is no webhook). Feishu is a
+// ByteDance product and Semi Design is ByteDance's own design system, so the
+// artwork is the vendor's own mark rather than a redrawing of it; see the
+// license notice above. Same 24x24 box and currentColor fill as WecomMark next
+// door, so every channel mark shares one sizing contract.
+export function LarkMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="currentColor">
+      <path d="M6.13732 3.80654C8.76716 5.98777 11.0232 8.49408 12.7428 11.4327L14.4397 9.75535C15.2458 8.96545 16.2113 8.34129 17.258 7.93496C16.7802 6.31936 16.0033 4.98005 14.9403 3.65376C14.8135 3.49449 14.6185 3.40346 14.4137 3.40346L6.28362 3.40021C6.06906 3.40021 5.9748 3.67001 6.13732 3.80654Z" />
+      <path d="M20.5703 14.1922L20.58 14.1793L20.6155 14.1146C20.6026 14.1372 20.5864 14.1631 20.5703 14.1922Z" />
+      <path d="M11.0361 14.5567C12.2714 15.0833 13.3766 15.5287 14.6899 15.883C17.0207 16.5136 19.2311 15.5709 20.3234 13.4872L21.6432 10.8541C21.939 10.2105 22.3128 9.6156 22.7647 9.07273C21.9715 8.78016 21.3149 8.63064 20.4534 8.63064C18.5518 8.63064 16.7606 9.36205 15.4018 10.6948L13.3831 12.6875C12.6647 13.3929 11.878 14.0203 11.0361 14.5567Z" />
+      <path d="M20.7945 13.7752L20.8039 13.7566L20.8101 13.7473C20.8039 13.7535 20.8007 13.7659 20.7945 13.7752Z" />
+      <path d="M1.62519 9.74885C1.47889 9.60906 1.23511 9.70983 1.23511 9.91463L1.23834 17.8724C1.23834 18.1 1.34887 18.3112 1.53416 18.4348C3.66663 19.8521 6.15343 20.5998 8.72151 20.5998C11.166 20.5998 13.5488 19.9171 15.6098 18.6266C16.3867 18.139 16.9979 17.7099 17.6512 17.0792C16.6013 17.388 15.4472 17.4075 14.2835 17.0922C9.37815 15.7594 5.20097 13.2044 1.62519 9.74885Z" />
+    </svg>
+  );
+}

--- a/packages/views/settings/components/slack-mark.tsx
+++ b/packages/views/settings/components/slack-mark.tsx
@@ -1,0 +1,40 @@
+// The SVG path in SlackMark below is copied verbatim from `icons/slack.svg` in
+// Bootstrap Icons, used under the MIT License. Source:
+// https://github.com/twbs/icons/blob/8d88686c03c3768a2d82ba4f20c3c4e1b100fa29/icons/slack.svg
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2019-2024 The Bootstrap Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// The Slack brand mark. lucide-react carries no brand icons, so the Settings →
+// Integrations channel icon fell back to the generic MessagesSquare speech
+// bubble — the same glyph WeCom used before WecomMark landed (#6585), and it
+// failed here for the same reason: nothing on the row said which platform it
+// was. Bootstrap Icons ships Slack's own mark under MIT with currentColor
+// already on the root. The 16x16 viewBox scales to whatever `className` sets,
+// exactly like the 24x24 and 48x48 marks next door.
+export function SlackMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" className={className} fill="currentColor">
+      <path d="M3.362 10.11c0 .926-.756 1.681-1.681 1.681S0 11.036 0 10.111.756 8.43 1.68 8.43h1.682zm.846 0c0-.924.756-1.68 1.681-1.68s1.681.756 1.681 1.68v4.21c0 .924-.756 1.68-1.68 1.68a1.685 1.685 0 0 1-1.682-1.68zM5.89 3.362c-.926 0-1.682-.756-1.682-1.681S4.964 0 5.89 0s1.68.756 1.68 1.68v1.682zm0 .846c.924 0 1.68.756 1.68 1.681S6.814 7.57 5.89 7.57H1.68C.757 7.57 0 6.814 0 5.89c0-.926.756-1.682 1.68-1.682zm6.749 1.682c0-.926.755-1.682 1.68-1.682S16 4.964 16 5.889s-.756 1.681-1.68 1.681h-1.681zm-.848 0c0 .924-.755 1.68-1.68 1.68A1.685 1.685 0 0 1 8.43 5.89V1.68C8.43.757 9.186 0 10.11 0c.926 0 1.681.756 1.681 1.68zm-1.681 6.748c.926 0 1.682.756 1.682 1.681S11.036 16 10.11 16s-1.681-.756-1.681-1.68v-1.682h1.68zm0-.847c-.924 0-1.68-.755-1.68-1.68s.756-1.681 1.68-1.681h4.21c.924 0 1.68.756 1.68 1.68 0 .926-.756 1.681-1.68 1.681z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #6807, which landed channel icons in Settings → Integrations but gave two of the four channels a generic lucide glyph instead of a brand mark: `Webhook` for Lark and `MessagesSquare` for Slack, while DingTalk and WeCom got their real marks.

That is the exact failure mode #6585 already fixed once. `wecom-mark.tsx` states it plainly:

> lucide-react carries no brand icons, so the WeCom connect button used the generic MessagesSquare speech bubble — the same glyph as Slack's — and nothing on the page said which platform it was.

An icon sitting in front of a section title is doing identification work, so a stand-in glyph fails at the one job it has. `Webhook` was doubly wrong for Lark: that bind flow is a QR device flow, and there is no webhook anywhere in it — the WeCom description one section below even advertises "no public callback URL required".

This adds the two missing marks so all four channels are identifiable, and closes the door on the next regression.

## Related Issue

No linked issue. Follows up #6807 (MUL-6051).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/settings/components/lark-mark.tsx` (new) — Lark (飞书) mark, copied verbatim from `feishu_logo.svg` in ByteDance's Semi Design icon set (MIT, Copyright (c) 2021 DouyinFE). Feishu is a ByteDance product and Semi is ByteDance's own design system, so this is the vendor's own mark rather than a redrawing of it — the same sourcing logic `wecom-mark.tsx` used with Tencent's TDesign. Per-path `fill="black"` hoisted to `currentColor` on the root; full license notice and a sha-pinned source URL in the file header, matching the existing marks.
- `packages/views/settings/components/slack-mark.tsx` (new) — Slack mark from Bootstrap Icons (MIT, Copyright (c) 2019-2024 The Bootstrap Authors). Already ships `currentColor`, so it drops in unchanged.
- `packages/views/settings/components/integration-channel-icon.tsx` — use `LarkMark` / `SlackMark`; lucide import dropped. A comment now records the rule: every channel needs its own `*-mark.tsx`, never a generic glyph.
- `packages/views/settings/components/integrations-tab.test.tsx` — assert the four channels render four **distinct** shapes. Two channels sharing one glyph is precisely how Slack and WeCom collided before #6585, and no existing test would have caught it.

Sizing, the `size-5` wrapper, `aria-hidden`, and the test ids from #6807 are untouched, so the accessible name of each heading is still just the channel title.

## How to Test

1. Open Settings → Integrations. Lark shows the Feishu mark and Slack shows Slack's pinwheel; DingTalk and WeCom are unchanged.
2. Check both light and dark themes — all four marks are `currentColor` on `text-muted-foreground`.
3. `pnpm --filter @multica/views exec vitest run settings/components/integrations-tab.test.tsx agents/components/tabs/integrations-tab.test.tsx settings/components/lark-tab.test.tsx settings/components/slack-tab.test.tsx settings/components/dingtalk-tab.test.tsx settings/components/wecom-tab.test.tsx`
4. `pnpm --filter @multica/views typecheck`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (6 files / 67 tests)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — verified against a rendered before/after preview (both themes, real tokens and real copy) rather than an attached image; see note below
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented behavior changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` (not applicable; no copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to two SVG assets and one icon map in the Settings presentation layer. No behavior, copy, or API surface changes. Both marks are MIT with the license text reproduced in the file header, following the precedent set by `github-mark.tsx`, `dingtalk-mark.tsx`, and `wecom-mark.tsx`.

**On the screenshot:** the marks were checked by rendering the real section-header markup (icon box, `text-body` title, `text-caption` description) with the actual `--text-*` and color token values, in light and dark, before and after. Both new marks read correctly at 16px. I could not attach the image to this PR from the review environment; happy to have a reviewer confirm visually.

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** Reviewing #6807 surfaced the generic-glyph problem and the #6585 precedent that had already settled it. Searched icon sets for suitably licensed monochrome marks for both platforms (Tencent TDesign carries neither; simple-icons no longer ships Slack), landed on Semi Design for Feishu and Bootstrap Icons for Slack, then wrote the marks to match the existing `*-mark.tsx` convention and added the distinct-shape regression test.

## Screenshots (optional)

Not attached — see the note under Checklist.
