### PR TITLE
MUL-6051: fix(agents): use Lark and Slack marks outside Settings too

### DIFF
--- a/packages/views/agents/components/tabs/integrations-tab.tsx
+++ b/packages/views/agents/components/tabs/integrations-tab.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { MessagesSquare, Webhook } from "lucide-react";
 import type { Agent } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -11,7 +10,9 @@ import { dingtalkInstallationsOptions } from "@multica/core/dingtalk";
 import { wecomInstallationsOptions } from "@multica/core/wecom";
 import { memberListOptions } from "@multica/core/workspace/queries";
 import { LarkAgentBindButton } from "../../../settings/components/lark-tab";
+import { LarkMark } from "../../../settings/components/lark-mark";
 import { SlackAgentBindButton } from "../../../settings/components/slack-tab";
+import { SlackMark } from "../../../settings/components/slack-mark";
 import { DingTalkAgentBindButton } from "../../../settings/components/dingtalk-tab";
 import { DingTalkMark } from "../../../settings/components/dingtalk-mark";
 import { WecomAgentBindButton } from "../../../settings/components/wecom-tab";
@@ -126,7 +127,7 @@ export function IntegrationsTab({ agent }: { agent: Agent }) {
       <section className="rounded-lg border">
         <div className="flex items-start gap-3 p-4">
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-            <Webhook className="h-4 w-4" />
+            <LarkMark className="h-4 w-4" />
           </span>
           <div className="min-w-0 flex-1 space-y-1">
             <h3 className="text-body font-medium">{ts(($) => $.lark.section_title)}</h3>
@@ -173,7 +174,7 @@ export function IntegrationsTab({ agent }: { agent: Agent }) {
       <section className="rounded-lg border">
         <div className="flex items-start gap-3 p-4">
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-            <MessagesSquare className="h-4 w-4" />
+            <SlackMark className="h-4 w-4" />
           </span>
           <div className="min-w-0 flex-1 space-y-1">
             <h3 className="text-body font-medium">{ts(($) => $.slack.section_title)}</h3>

--- a/packages/views/settings/components/slack-tab.tsx
+++ b/packages/views/settings/components/slack-tab.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { ChevronRight, ExternalLink, MessagesSquare, Trash2 } from "lucide-react";
+import { ChevronRight, ExternalLink, Trash2 } from "lucide-react";
+import { SlackMark } from "./slack-mark";
 import { cn } from "@multica/ui/lib/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
@@ -367,7 +368,7 @@ export function SlackAgentBindButton({
         }
         data-testid="slack-agent-connect"
       >
-        <MessagesSquare className="h-3 w-3" />
+        <SlackMark className="h-3 w-3" />
         {t(($) => $.slack.bind_button)}
       </Button>
 


### PR DESCRIPTION
## What does this PR do?

Finishes what #6816 started. That PR gave the Settings → Integrations channel icons real brand marks, but two other places pick an icon per platform and both were left on the generic lucide fallbacks:

- **Agent detail → Capabilities → Integrations** — `Webhook` for Lark, `MessagesSquare` for Slack, sitting directly above DingTalk's and WeCom's real logos.
- **The Slack connect button** (`slack-tab.tsx`) — the same `MessagesSquare` bubble, next to WeCom's button which already uses `WecomMark`.

The agent detail tab is where most people actually meet these rows, so it's the surface where "which platform is this?" matters most. Mixed with two real logos, the stand-ins read as broken rather than neutral. WeCom's button moved off that same bubble in #6585; this finishes the job for Slack.

No new assets — reuses `LarkMark` and `SlackMark` from #6816.

## Related Issue

No linked issue. Follows up #6816 and #6807 (MUL-6051).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/agents/components/tabs/integrations-tab.tsx` — `Webhook` → `LarkMark`, `MessagesSquare` → `SlackMark`; the `lucide-react` import is gone since nothing else in the file used it. Tile size, `h-4 w-4` sizing, and layout are untouched.
- `packages/views/settings/components/slack-tab.tsx` — the `SlackAgentBindButton` icon is now `SlackMark` at `h-3 w-3`, matching `WecomAgentBindButton` one file over.

After this, `MessagesSquare` and `Webhook` no longer appear anywhere as a platform identifier; the remaining `Webhook` uses are the autopilot webhook-trigger feature, where the glyph is literally correct.

## How to Test

1. Agent detail → Capabilities → Integrations: Lark shows the Feishu mark, Slack shows Slack's pinwheel; DingTalk and WeCom unchanged.
2. Settings → Integrations → Slack: the "Connect" button carries Slack's mark instead of the speech bubble.
3. `pnpm --filter @multica/views exec vitest run agents/components/tabs/integrations-tab.test.tsx settings/components/slack-tab.test.tsx settings/components/integrations-tab.test.tsx settings/components/lark-tab.test.tsx settings/components/dingtalk-tab.test.tsx settings/components/wecom-tab.test.tsx`
4. `pnpm --filter @multica/views typecheck`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (6 files / 67 tests)
- [x] I have added or updated tests where applicable (no new behavior; the distinct-marks test added in #6816 covers the Settings side)
- [ ] If this change affects the UI, I have included before/after screenshots — verified against a rendered before/after of the agent detail card layout in dark mode; could not attach the image from the review environment
- [x] I have updated relevant documentation to reflect my changes (not applicable)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` (not applicable; no copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: swapping two icon components in existing slots. No behavior, copy, layout, sizing, or API change.

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** A reviewer pointed at the agent detail page still showing the old glyphs after #6816. Grepped every `MessagesSquare` / `Webhook` usage across `packages` and `apps` to separate platform-identity uses from the autopilot webhook feature, swapped the two identity sites, and confirmed nothing else was left.

## Screenshots (optional)

Not attached — see the note under Checklist.
