### PR TITLE
MUL-6050: fix(onboarding): stop advertising a WS prefix before a URL exists

### DIFF
--- a/packages/views/locales/en/onboarding.json
+++ b/packages/views/locales/en/onboarding.json
@@ -172,6 +172,7 @@
     "issue_prefix_label": "Issue prefix",
     "issue_prefix_prefix": "Issues will look like ",
     "issue_prefix_suffix": ". You can change this later in settings.",
+    "issue_prefix_pending": "Set the URL above and issue numbers will follow it — or type a prefix here.",
     "create_new_title": "Create a new workspace",
     "create_new_subtitle": "Start fresh — a separate space for a different side of your work.",
     "hint_opening": "Opening {{name}}.",

--- a/packages/views/locales/ja/onboarding.json
+++ b/packages/views/locales/ja/onboarding.json
@@ -172,6 +172,7 @@
     "issue_prefix_label": "タスクプレフィックス",
     "issue_prefix_prefix": "タスクは ",
     "issue_prefix_suffix": " のように表示されます。あとで設定から変更できます。",
+    "issue_prefix_pending": "上の URL を入力すると、タスク番号はそれに合わせて決まります。ここに直接入力することもできます。",
     "create_new_title": "新しいワークスペースを作成",
     "create_new_subtitle": "新しく始めましょう — 別の業務領域のための独立した場所です。",
     "hint_opening": "{{name}} を開いています。",

--- a/packages/views/locales/ko/onboarding.json
+++ b/packages/views/locales/ko/onboarding.json
@@ -172,6 +172,7 @@
     "issue_prefix_label": "태스크 접두사",
     "issue_prefix_prefix": "태스크는 ",
     "issue_prefix_suffix": "처럼 표시됩니다. 나중에 설정에서 바꿀 수 있습니다.",
+    "issue_prefix_pending": "위의 URL을 입력하면 태스크 번호가 그에 맞춰 정해집니다. 여기에 직접 입력할 수도 있습니다.",
     "create_new_title": "새 워크스페이스 만들기",
     "create_new_subtitle": "새로 시작합니다. 다른 업무 영역을 위한 별도 공간입니다.",
     "hint_opening": "{{name}} 여는 중.",

--- a/packages/views/locales/zh-Hans/onboarding.json
+++ b/packages/views/locales/zh-Hans/onboarding.json
@@ -172,6 +172,7 @@
     "issue_prefix_label": "任务前缀",
     "issue_prefix_prefix": "任务编号会像这样 ",
     "issue_prefix_suffix": "。之后可以在设置里修改。",
+    "issue_prefix_pending": "填好上面的 URL，任务编号会跟着它生成；也可以直接在这里输入前缀。",
     "create_new_title": "创建一个新工作区",
     "create_new_subtitle": "另起一个——把另一类工作放进单独的空间。",
     "hint_opening": "正在打开 {{name}}。",

--- a/packages/views/onboarding/steps/step-workspace.test.tsx
+++ b/packages/views/onboarding/steps/step-workspace.test.tsx
@@ -206,6 +206,38 @@ describe("StepWorkspace — issue prefix", () => {
     expect(screen.getByText("ACME-123")).toBeInTheDocument();
   });
 
+  // Reported against the first cut of this fix: typing a Chinese name and
+  // stopping there still showed "WS" — the placeholder invented one because a
+  // CJK-only name derives no slug. Nothing may advertise a prefix before there
+  // is one to derive from; "WS" in particular is the string this issue exists
+  // to remove.
+  it("shows no prefix at all while a CJK-only name leaves the slug empty", () => {
+    renderStep({ existing: null, disabled: false });
+
+    fireEvent.change(screen.getByLabelText("Workspace name"), {
+      target: { value: "蜘蛛侠" },
+    });
+
+    expect(screen.getByLabelText("URL")).toHaveValue("");
+    expect(prefixInput()).toHaveValue("");
+    expect(prefixInput().placeholder).toBe("");
+    expect(screen.queryByText(/WS/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/-123/)).not.toBeInTheDocument();
+    // The hint takes the example line's place so the field isn't a bare box.
+    expect(
+      screen.getByText("Set the URL above and issue numbers will follow it", {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+
+    // …and the moment a URL exists, the prefix follows it.
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "spider" },
+    });
+    expect(prefixInput()).toHaveValue("SPID");
+    expect(screen.getByText("SPID-123")).toBeInTheDocument();
+  });
+
   it("gives a Chinese-named workspace a slug-derived prefix instead of WS", () => {
     renderStep({ existing: null, disabled: false });
 

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -155,8 +155,9 @@ export function StepWorkspace({
   // What the workspace will actually be created with. Clearing the prefix
   // input reverts to the slug-derived default rather than blocking the CTA —
   // the placeholder shows that default, so an empty field is never a
-  // surprise. A valid slug always derives something, so this is only empty
-  // while the form itself can't be submitted.
+  // surprise. Empty only while the slug is (a CJK-only name derives none),
+  // which is also exactly when `canCreate` is false, so submit always carries
+  // a real prefix.
   const derivedPrefix = issuePrefix(slug);
   const effectivePrefix = prefix || derivedPrefix;
 
@@ -339,7 +340,14 @@ export function StepWorkspace({
         {slugError ? <FieldError>{slugError}</FieldError> : null}
       </Field>
       {/* Editable, pre-filled from the slug. Narrow input — the value is
-          capped at 10 chars, so a full-width field would read as a mistake. */}
+          capped at 10 chars, so a full-width field would read as a mistake.
+
+          Nothing is invented while the slug is empty: a CJK-only name derives
+          no slug (see nameToWorkspaceSlug), and the placeholder used to fill
+          that gap with "WS" — telling the user they were getting the exact
+          prefix this whole change exists to eliminate. Empty field plus a
+          hint is the honest state; the user is picking a URL next anyway,
+          and the prefix appears the moment they do. */}
       <Field>
         <FieldLabel htmlFor="ws-issue-prefix">
           {t(($) => $.step_workspace.issue_prefix_label)}
@@ -349,7 +357,7 @@ export function StepWorkspace({
           type="text"
           value={prefix}
           onChange={(e) => handlePrefixChange(e.target.value)}
-          placeholder={derivedPrefix || "WS"}
+          placeholder={derivedPrefix}
           autoComplete="off"
           autoCapitalize="characters"
           spellCheck={false}
@@ -361,11 +369,17 @@ export function StepWorkspace({
           }}
         />
         <FieldDescription>
-          {t(($) => $.step_workspace.issue_prefix_prefix)}
-          <span className="font-mono text-foreground">
-            {effectivePrefix || "WS"}-123
-          </span>
-          {t(($) => $.step_workspace.issue_prefix_suffix)}
+          {effectivePrefix ? (
+            <>
+              {t(($) => $.step_workspace.issue_prefix_prefix)}
+              <span className="font-mono text-foreground">
+                {effectivePrefix}-123
+              </span>
+              {t(($) => $.step_workspace.issue_prefix_suffix)}
+            </>
+          ) : (
+            t(($) => $.step_workspace.issue_prefix_pending)
+          )}
         </FieldDescription>
       </Field>
     </FieldGroup>


### PR DESCRIPTION
Follow-up to #6815, which shipped the slug-derived issue prefix. Reported right after it merged.

## The gap

Type a Chinese-only workspace name and stop there — the issue prefix field still reads `WS`, the exact string #6815 exists to eliminate:

- A CJK-only name derives no slug: `nameToWorkspaceSlug` returns `""` on purpose so the user picks an ASCII URL themselves.
- With no slug there is nothing to derive a prefix from, and the field's placeholder filled that gap with `WS`.

It was a placeholder rather than a value, and the create CTA is disabled while the URL is empty, so no workspace could actually have been created as `WS`. That distinction doesn't help the user: the screen tells a Chinese-named team they're getting `WS` on their default path.

## The fix

Nothing is invented while there is nothing to derive from. With an empty slug the prefix input is empty with no placeholder, and the `Issues will look like …-123` example line is replaced by a hint that the prefix follows the URL — or can be typed directly. As soon as a URL exists the prefix appears and follows it (`spider` → `SPID-123`). New copy in all four locales.

## Testing

`packages/views` suite green. Added a regression test walking the reported path exactly — Chinese name, URL untouched — asserting `WS` and any `-123` example are absent from the screen, then that the prefix appears once a URL is entered. Every prefix test in #6815 filled both name and URL, which is why this state slipped through.

`pnpm typecheck` and lint clean. No manual UI pass; the states above are asserted in the component test.
