### PR TITLE
MUL-6056: fix(github): prove installation ownership before binding it to a workspace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -335,11 +335,23 @@ CORS_ALLOWED_ORIGINS=
 # REALTIME_METRICS_TOKEN=
 
 # GitHub App integration (Settings → GitHub "Connect GitHub")
-# Both must be set for the Connect button to enable and for webhooks to be
-# accepted; leave empty to disable the integration. See docs/github-integration.
+# All four must be set for the Connect button to enable; the webhook secret
+# alone gates webhook acceptance. Leave empty to disable the integration.
+# See docs/github-integration.
 # GITHUB_APP_SLUG is the tail of https://github.com/apps/<slug>.
 GITHUB_APP_SLUG=
 GITHUB_WEBHOOK_SECRET=
+# GITHUB_APP_CLIENT_ID / GITHUB_APP_CLIENT_SECRET are the App's "Client ID"
+# and a generated client secret, both on the App's settings page. The install
+# callback uses them to trade GitHub's user-authorization code for a
+# user-to-server token and confirm the installation being connected really
+# belongs to the person connecting it — without that proof anyone could bind
+# an unrelated organization's installation to their own workspace.
+# The App must also have "Request user authorization (OAuth) during
+# installation" enabled, otherwise GitHub never sends the code and every
+# connect attempt is refused.
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_CLIENT_SECRET=
 # Optional for webhook-only deployments, but required for PR-card CI /
 # mergeability and Settings → Repositories → Choose from GitHub. These
 # credentials let the server authenticate as the App, mint short-lived

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -159,6 +159,8 @@ allowlist の正確な判定順序は[ログインとサインアップ](/auth-s
 |---|---|---|
 | GitHub | `GITHUB_APP_SLUG` | GitHub App の slug |
 | GitHub | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC と接続 state の署名シークレット |
+| GitHub | `GITHUB_APP_CLIENT_ID` | App の Client ID。接続に必須で、インストールコールバックがこの installation の所有者を確認するために使います |
+| GitHub | `GITHUB_APP_CLIENT_SECRET` | Client ID と対になる client secret。用途は同じです |
 | GitHub | `GITHUB_APP_ID` | PR カードの CI ステータス・マージ可否と「GitHub から選択」リポジトリに必要です |
 | GitHub | `GITHUB_APP_PRIVATE_KEY` | App ID と対になる完全な PEM 秘密鍵。用途は同上 |
 | Lark | `MULTICA_LARK_SECRET_KEY` | base64 エンコードされた 32 バイトの資格情報暗号化キー |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -159,6 +159,8 @@ reverse proxy 뒤에 배포한다면 실제 proxy 네트워크를 입력해야 �
 |---|---|---|
 | GitHub | `GITHUB_APP_SLUG` | GitHub App slug |
 | GitHub | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC 및 연결 state 서명 키 |
+| GitHub | `GITHUB_APP_CLIENT_ID` | App Client ID. 연결에 필수이며 설치 콜백이 해당 installation의 소유자를 확인하는 데 사용합니다 |
+| GitHub | `GITHUB_APP_CLIENT_SECRET` | Client ID와 짝을 이루는 client secret. 용도는 동일합니다 |
 | GitHub | `GITHUB_APP_ID` | PR 카드의 CI 상태, merge 가능 여부, "GitHub에서 선택" 저장소에 필요 |
 | GitHub | `GITHUB_APP_PRIVATE_KEY` | App ID와 짝을 이루는 전체 PEM private key. 용도는 위와 같음 |
 | Feishu | `MULTICA_LARK_SECRET_KEY` | base64로 인코딩한 32바이트 자격 증명 암호화 키 |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -159,6 +159,8 @@ The `RATE_LIMIT_*` variables above only take effect once `REDIS_URL` is set; wit
 |---|---|---|
 | GitHub | `GITHUB_APP_SLUG` | GitHub App slug |
 | GitHub | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC and connect-state signing secret |
+| GitHub | `GITHUB_APP_CLIENT_ID` | App Client ID. Required to connect: the install callback uses it to confirm the installation belongs to the person connecting it |
+| GitHub | `GITHUB_APP_CLIENT_SECRET` | Client secret paired with the Client ID; same use |
 | GitHub | `GITHUB_APP_ID` | Needed for CI status and mergeability on PR cards and the "pick from GitHub" repository picker |
 | GitHub | `GITHUB_APP_PRIVATE_KEY` | Full PEM private key paired with the App ID; same uses as above |
 | Lark | `MULTICA_LARK_SECRET_KEY` | Base64-encoded 32-byte credential encryption key |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -159,6 +159,8 @@ MULTICA_PUBLIC_URL=https://api.multica.example.com
 |---|---|---|
 | GitHub | `GITHUB_APP_SLUG` | GitHub App slug |
 | GitHub | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC 与连接 state 签名密钥 |
+| GitHub | `GITHUB_APP_CLIENT_ID` | App 的 Client ID。连接 GitHub 必需：安装回调用它确认该 installation 属于当前操作者 |
+| GitHub | `GITHUB_APP_CLIENT_SECRET` | 与 Client ID 配对的 client secret，用途同上 |
 | GitHub | `GITHUB_APP_ID` | PR 卡片的 CI 状态、可合并性和"从 GitHub 选择"仓库都需要它 |
 | GitHub | `GITHUB_APP_PRIVATE_KEY` | 与 App ID 配套的完整 PEM 私钥，用途同上 |
 | 飞书 | `MULTICA_LARK_SECRET_KEY` | base64 编码的 32 字节凭据加密密钥 |

--- a/apps/docs/content/docs/github-integration.ja.mdx
+++ b/apps/docs/content/docs/github-integration.ja.mdx
@@ -113,7 +113,8 @@ GitHub の **Developer settings → GitHub Apps** で App を作成し、次の�
 | フィールド | 値 |
 |---|---|
 | Homepage URL | Multica のフロントエンド URL。例: `https://multica.example.com` |
-| Callback URL | 空欄 |
+| Callback URL | `https://<api-host>/api/github/setup`。Setup URL と同じエンドポイント |
+| Request user authorization (OAuth) during installation | 有効にする |
 | Setup URL | `https://<api-host>/api/github/setup`。**Redirect on update** を有効にする |
 | Webhook URL | `https://<api-host>/api/webhooks/github` |
 | Webhook secret | 長期保管するランダムな文字列 |
@@ -145,10 +146,14 @@ App の公開 URL から slug を確認します。たとえば `https://github.
 ```dotenv
 GITHUB_APP_SLUG=multica-acme
 GITHUB_WEBHOOK_SECRET=<webhook secret entered when creating the App>
+GITHUB_APP_CLIENT_ID=<the App's Client ID>
+GITHUB_APP_CLIENT_SECRET=<a client secret generated on the App's settings page>
 FRONTEND_ORIGIN=https://multica.example.com
 ```
 
-`GITHUB_APP_SLUG` と `GITHUB_WEBHOOK_SECRET` のいずれかがない場合、接続ボタンは無効になり、webhook エンドポイントもイベントを拒否します。
+接続ボタンが有効になるには 4 つすべてが必要です。webhook secret がない場合は、webhook エンドポイントもイベントを拒否します。
+
+`GITHUB_APP_CLIENT_ID` と `GITHUB_APP_CLIENT_SECRET` は、接続しようとしている installation が本当に操作者のものかをインストールコールバックで確認するために使います。Multica は GitHub が返すユーザー認可 code を user-to-server トークンに交換し、その installation がそのユーザーのものかを照合します。検証できない接続は拒否されるため、App では **Request user authorization (OAuth) during installation** を有効にし、callback URL を `/api/github/setup` に向けてください。
 
 次の 2 つの変数は、PR カードに CI の状態とマージ可能性を表示するために必要です。Multica は App として認証し、スナップショットを取得します。
 
@@ -171,7 +176,8 @@ API サービスを再起動し、**設定 → GitHub** から接続します。
 
 ## よくある問題
 
-- **接続ボタンを使用できない**: `GITHUB_APP_SLUG` と `GITHUB_WEBHOOK_SECRET` が API プロセスに設定されていることを確認します。
+- **接続ボタンを使用できない**: `GITHUB_APP_SLUG`、`GITHUB_WEBHOOK_SECRET`、`GITHUB_APP_CLIENT_ID`、`GITHUB_APP_CLIENT_SECRET` がすべて API プロセスに設定されていることを確認します。
+- **インストール直後に接続が失敗する**: App で **Request user authorization (OAuth) during installation** を有効にし、callback URL を `/api/github/setup` に設定してください。認可 code がないと、Multica はその installation が自分のものだと確認できず、紐づけを拒否します。理由はサーバーログに記録されます（`missing_authorization`、`installation_not_authorized`、`verification_failed`）。
 - **Webhook が 401 を返す**: GitHub App と API が同じ Webhook secret を使っていることを確認し、GitHub の **Recent Deliveries** から再配信します。
 - **PR が紐づかない**: リポジトリが App の許可範囲にあること、PR の自動紐づけが有効であること、番号が現在のワークスペースのものかを確認します。
 - **本文に番号を書いても表示されない**: `Closes MUL-123` を使うか、番号をブランチ名または PR タイトルに入れます。

--- a/apps/docs/content/docs/github-integration.ko.mdx
+++ b/apps/docs/content/docs/github-integration.ko.mdx
@@ -113,7 +113,8 @@ GitHub의 **Developer settings → GitHub Apps**에서 App을 만들고 다음 �
 | 필드 | 값 |
 |---|---|
 | Homepage URL | Multica 프런트엔드 주소. 예: `https://multica.example.com` |
-| Callback URL | 비워 둠 |
+| Callback URL | `https://<api-host>/api/github/setup` — Setup URL과 동일한 endpoint |
+| Request user authorization (OAuth) during installation | 활성화 |
 | Setup URL | `https://<api-host>/api/github/setup`, **Redirect on update** 활성화 |
 | Webhook URL | `https://<api-host>/api/webhooks/github` |
 | Webhook secret | 장기 보관할 임의 문자열 |
@@ -145,10 +146,14 @@ App의 공개 주소에서 slug를 확인합니다. 예를 들어 `https://githu
 ```dotenv
 GITHUB_APP_SLUG=multica-acme
 GITHUB_WEBHOOK_SECRET=<App을 만들 때 입력한 webhook secret>
+GITHUB_APP_CLIENT_ID=<App의 Client ID>
+GITHUB_APP_CLIENT_SECRET=<App 설정 페이지에서 생성한 client secret>
 FRONTEND_ORIGIN=https://multica.example.com
 ```
 
-`GITHUB_APP_SLUG`와 `GITHUB_WEBHOOK_SECRET` 중 하나라도 없으면 연결 버튼이 비활성화되고 webhook endpoint도 이벤트 처리를 거부합니다.
+연결 버튼이 활성화되려면 네 값이 모두 필요합니다. webhook secret이 없으면 webhook endpoint도 이벤트 처리를 거부합니다.
+
+`GITHUB_APP_CLIENT_ID`와 `GITHUB_APP_CLIENT_SECRET`은 연결하려는 installation이 실제로 연결하는 사람의 것인지 설치 콜백에서 확인하는 데 사용합니다. Multica는 GitHub가 돌려준 사용자 인증 code를 user-to-server 토큰으로 교환한 뒤, 해당 installation이 그 사용자의 것인지 대조합니다. 검증할 수 없는 연결은 거부되므로 App에서 **Request user authorization (OAuth) during installation**을 활성화하고 callback URL을 `/api/github/setup`으로 지정해야 합니다.
 
 다음 두 변수는 PR 카드에서 CI 상태와 merge 가능 여부를 표시하기 위해 필요합니다. Multica는 이 값으로 App 신원을 인증하고 snapshot을 가져옵니다.
 
@@ -171,7 +176,8 @@ API 서비스를 다시 시작한 뒤 **설정 → GitHub**에서 연결을 완�
 
 ## 자주 묻는 문제
 
-- **연결 버튼을 사용할 수 없음**: `GITHUB_APP_SLUG`와 `GITHUB_WEBHOOK_SECRET`이 API 프로세스에 전달되었는지 확인합니다.
+- **연결 버튼을 사용할 수 없음**: `GITHUB_APP_SLUG`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`이 모두 API 프로세스에 전달되었는지 확인합니다.
+- **설치 직후 연결이 실패함**: App에서 **Request user authorization (OAuth) during installation**을 활성화하고 callback URL을 `/api/github/setup`으로 설정해야 합니다. 인증 code가 없으면 Multica는 해당 installation이 본인 것인지 확인할 수 없어 연결을 거부하며, 서버 로그에 이유(`missing_authorization`, `installation_not_authorized`, `verification_failed`)가 남습니다.
 - **Webhook이 401을 반환함**: GitHub App과 API가 같은 Webhook secret을 사용하는지 확인하고 GitHub의 **Recent Deliveries**에서 다시 전달합니다.
 - **PR이 연결되지 않음**: 저장소가 App 승인 범위에 있는지, 자동 연결이 켜져 있는지, 번호가 현재 워크스페이스에 속하는지 확인합니다.
 - **본문에 번호를 썼지만 표시되지 않음**: `Closes MUL-123`을 사용하거나 번호를 브랜치 이름 또는 PR 제목에 넣습니다.

--- a/apps/docs/content/docs/github-integration.mdx
+++ b/apps/docs/content/docs/github-integration.mdx
@@ -114,7 +114,8 @@ Create the App under GitHub's **Developer settings → GitHub Apps** and fill in
 | Field | Value |
 |---|---|
 | Homepage URL | Your Multica frontend address, e.g. `https://multica.example.com` |
-| Callback URL | Leave blank |
+| Callback URL | `https://<api-host>/api/github/setup` — the same endpoint as the Setup URL |
+| Request user authorization (OAuth) during installation | Enabled |
 | Setup URL | `https://<api-host>/api/github/setup`, with **Redirect on update** enabled |
 | Webhook URL | `https://<api-host>/api/webhooks/github` |
 | Webhook secret | A random string you keep long-term |
@@ -146,10 +147,14 @@ Take the slug from the App's public URL. For example, the slug of `https://githu
 ```dotenv
 GITHUB_APP_SLUG=multica-acme
 GITHUB_WEBHOOK_SECRET=<the webhook secret you entered when creating the App>
+GITHUB_APP_CLIENT_ID=<the App's Client ID>
+GITHUB_APP_CLIENT_SECRET=<a client secret generated on the App's settings page>
 FRONTEND_ORIGIN=https://multica.example.com
 ```
 
-If either `GITHUB_APP_SLUG` or `GITHUB_WEBHOOK_SECRET` is missing, the connect button is disabled and the webhook endpoint refuses to process events.
+All four are required for the connect button to enable; the webhook endpoint additionally refuses to process events when the webhook secret is missing.
+
+`GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` are what let the install callback confirm that the installation being connected really belongs to the person connecting it: Multica trades GitHub's user-authorization code for a user-to-server token and checks the installation against that user's own installations. A connect it cannot verify is refused, so the App must have **Request user authorization (OAuth) during installation** enabled and its callback URL pointed at `/api/github/setup`.
 
 The next two variables are required for the PR card to show CI status and mergeability — Multica uses them to authenticate as the App and pull snapshots:
 
@@ -172,7 +177,8 @@ Restart the API server, then complete the connection in **Settings → GitHub**.
 
 ## Troubleshooting
 
-- **Connect button disabled**: check that `GITHUB_APP_SLUG` and `GITHUB_WEBHOOK_SECRET` reached the API process.
+- **Connect button disabled**: check that `GITHUB_APP_SLUG`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_CLIENT_ID`, and `GITHUB_APP_CLIENT_SECRET` all reached the API process.
+- **Connect fails right after installing**: the App needs **Request user authorization (OAuth) during installation** enabled and its callback URL set to `/api/github/setup`. Without the authorization code Multica cannot confirm the installation is yours and refuses to bind it; the server log names the reason (`missing_authorization`, `installation_not_authorized`, or `verification_failed`).
 - **Webhook returns 401**: confirm the GitHub App and the API use the same webhook secret, then redeliver from GitHub's **Recent Deliveries**.
 - **PR not linked**: check that the repository is in the App's authorized scope, auto-linking is on, and the identifier belongs to the current workspace.
 - **Identifier in the body but not shown**: switch to `Closes MUL-123`, or put the identifier in the branch name or PR title.

--- a/apps/docs/content/docs/github-integration.zh.mdx
+++ b/apps/docs/content/docs/github-integration.zh.mdx
@@ -114,7 +114,8 @@ Multica Cloud 无需执行本节。自托管需要先创建自己的 GitHub App�
 | 字段 | 值 |
 |---|---|
 | Homepage URL | Multica 前端地址，例如 `https://multica.example.com` |
-| Callback URL | 留空 |
+| Callback URL | `https://<api-host>/api/github/setup`，与 Setup URL 相同 |
+| Request user authorization (OAuth) during installation | 勾选 |
 | Setup URL | `https://<api-host>/api/github/setup`，并启用 **Redirect on update** |
 | Webhook URL | `https://<api-host>/api/webhooks/github` |
 | Webhook secret | 一段长期保存的随机字符串 |
@@ -146,10 +147,14 @@ Repository permissions：
 ```dotenv
 GITHUB_APP_SLUG=multica-acme
 GITHUB_WEBHOOK_SECRET=<创建 App 时填写的 webhook secret>
+GITHUB_APP_CLIENT_ID=<App 的 Client ID>
+GITHUB_APP_CLIENT_SECRET=<在 App 设置页生成的 client secret>
 FRONTEND_ORIGIN=https://multica.example.com
 ```
 
-`GITHUB_APP_SLUG` 和 `GITHUB_WEBHOOK_SECRET` 缺少任意一个时，连接按钮会被禁用，webhook 接口也会拒绝处理事件。
+这四个变量齐备时连接按钮才会启用；缺少 webhook secret 时，webhook 接口还会拒绝处理事件。
+
+`GITHUB_APP_CLIENT_ID` 和 `GITHUB_APP_CLIENT_SECRET` 用于在安装回调里确认「正在连接的 installation 确实属于当前操作者」：Multica 用 GitHub 返回的用户授权 code 换取 user-to-server token，再核对该 installation 是否在这个用户名下。无法验证的连接一律拒绝，因此 App 必须勾选 **Request user authorization (OAuth) during installation**，并把 callback URL 指向 `/api/github/setup`。
 
 下面两个变量是 PR 卡片显示 CI 状态与可合并性的必要条件——Multica 用它们以 App 身份鉴权并拉取快照：
 
@@ -172,7 +177,8 @@ make migrate-up
 
 ## 常见问题
 
-- **连接按钮不可用**：检查 `GITHUB_APP_SLUG` 和 `GITHUB_WEBHOOK_SECRET` 是否已进入 API 进程。
+- **连接按钮不可用**：检查 `GITHUB_APP_SLUG`、`GITHUB_WEBHOOK_SECRET`、`GITHUB_APP_CLIENT_ID`、`GITHUB_APP_CLIENT_SECRET` 是否都已进入 API 进程。
+- **安装完成后连接失败**：App 需要勾选 **Request user authorization (OAuth) during installation**，并把 callback URL 设为 `/api/github/setup`。拿不到授权 code 时，Multica 无法确认该 installation 属于你，会拒绝绑定；服务端日志会写明原因（`missing_authorization`、`installation_not_authorized` 或 `verification_failed`）。
 - **Webhook 返回 401**：确认 GitHub App 与 API 使用同一个 Webhook secret，然后在 GitHub 的 **Recent Deliveries** 中重新投递。
 - **PR 没有关联**：检查仓库是否在 App 授权范围内、自动关联是否开启，以及编号是否属于当前工作区。
 - **正文写了编号但没显示**：改用 `Closes MUL-123`，或把编号放到分支名、PR 标题中。

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -103,6 +103,11 @@ services:
       DISABLE_WORKSPACE_CREATION: ${DISABLE_WORKSPACE_CREATION:-}
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
+      # Required for "Connect GitHub": the install callback uses these to
+      # confirm the installation belongs to the person connecting it. The App
+      # also needs "Request user authorization (OAuth) during installation".
+      GITHUB_APP_CLIENT_ID: ${GITHUB_APP_CLIENT_ID:-}
+      GITHUB_APP_CLIENT_SECRET: ${GITHUB_APP_CLIENT_SECRET:-}
       # Public URL the API is reachable at from the open internet, no
       # trailing slash. Used to mint absolute webhook URLs for autopilot
       # webhook triggers. Leave unset behind a same-origin reverse proxy

--- a/packages/views/settings/components/github-tab.tsx
+++ b/packages/views/settings/components/github-tab.tsx
@@ -239,9 +239,11 @@ export function GitHubTab() {
             {canManage && !configured && (
               <p className="text-caption text-muted-foreground">
                 {t(($) => $.github.not_configured)}{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_APP_SLUG</code>{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_APP_SLUG</code>,{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_WEBHOOK_SECRET</code>,{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_APP_CLIENT_ID</code>{" "}
                 {t(($) => $.github.not_configured_and)}{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_WEBHOOK_SECRET</code>.
+                <code className="rounded bg-muted px-1 py-0.5 text-micro">GITHUB_APP_CLIENT_SECRET</code>.
               </p>
             )}
 

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
@@ -32,6 +33,11 @@ import (
 // githubAPIBase is the base URL for GitHub's REST API. Mutable so tests can
 // point App-authenticated calls at an httptest server without touching GitHub.
 var githubAPIBase = "https://api.github.com"
+
+// githubOAuthBase is the base URL for GitHub's web OAuth endpoints, which live
+// on the website host rather than the API host. Mutable for the same reason as
+// githubAPIBase.
+var githubOAuthBase = "https://github.com"
 
 const (
 	githubReturnToGitHub       = "github"
@@ -364,13 +370,32 @@ func githubAppSlug() string { return strings.TrimSpace(os.Getenv("GITHUB_APP_SLU
 // configure one value.
 func githubWebhookSecret() string { return strings.TrimSpace(os.Getenv("GITHUB_WEBHOOK_SECRET")) }
 
-// isGitHubConfigured returns true only when BOTH the install slug and the
-// webhook secret are set. The Connect button uses this single flag, so the
-// frontend never offers a flow that the backend would reject.
-func isGitHubConfigured() bool { return githubAppSlug() != "" && githubWebhookSecret() != "" }
+// githubAppClientID / githubAppClientSecret are the App's user-authorization
+// (user-to-server OAuth) credentials, found next to the App ID on the App's
+// settings page. They exist for exactly one purpose here: proving at install
+// time that whoever completed the flow actually controls the installation
+// they are about to bind — see verifyGitHubInstallationOwnership.
+func githubAppClientID() string { return strings.TrimSpace(os.Getenv("GITHUB_APP_CLIENT_ID")) }
+
+func githubAppClientSecret() string {
+	return strings.TrimSpace(os.Getenv("GITHUB_APP_CLIENT_SECRET"))
+}
+
+// isGitHubConfigured returns true only when the install slug, the webhook
+// secret, AND the user-authorization credentials are all set. The Connect
+// button uses this single flag, so the frontend never offers a flow that the
+// backend would reject — and the setup callback rejects every install it
+// cannot attribute to a GitHub user, so a deployment without the OAuth
+// credentials cannot complete a connect at all.
+func isGitHubConfigured() bool {
+	return githubAppSlug() != "" &&
+		githubWebhookSecret() != "" &&
+		githubAppClientID() != "" &&
+		githubAppClientSecret() != ""
+}
 
 // isGitHubRepositoryBrowseConfigured is deliberately separate from the
-// install-flow flag. The App slug + webhook secret are enough to connect an
+// install-flow flag. The install-flow credentials are enough to connect an
 // installation, but browsing its repositories also requires App JWT
 // credentials so the server can mint a short-lived installation token.
 func isGitHubRepositoryBrowseConfigured() bool {
@@ -378,14 +403,31 @@ func isGitHubRepositoryBrowseConfigured() bool {
 		strings.TrimSpace(os.Getenv("GITHUB_APP_PRIVATE_KEY")) != ""
 }
 
+// githubStateMaxAge bounds how long a signed install state stays usable. The
+// state is a bearer credential for "bind an installation into THIS workspace",
+// so it should outlive an unhurried GitHub install and nothing more. A leaked
+// install URL (browser history, referrer, a pasted link) stops being useful
+// once it expires.
+const githubStateMaxAge = 15 * time.Minute
+
+// githubStateClockSkew tolerates a state signed by a replica whose clock runs
+// slightly ahead of the one verifying it.
+const githubStateClockSkew = time.Minute
+
 // signState produces an opaque token that binds a workspace ID to the
 // install flow so the setup callback can recover the workspace without
-// trusting query params alone. Format: "<workspaceID>.<nonce>.<sigHex>".
+// trusting query params alone.
+// Format: "<workspaceID>.<returnTo>.<issuedAtUnix>.<nonce>.<sigHex>".
 func signState(workspaceID string) (string, error) {
 	return signStateForReturn(workspaceID, githubReturnToGitHub)
 }
 
 func signStateForReturn(workspaceID, returnTo string) (string, error) {
+	return signStateForReturnAt(workspaceID, returnTo, time.Now())
+}
+
+// signStateForReturnAt takes `now` so tests can produce an aged token.
+func signStateForReturnAt(workspaceID, returnTo string, now time.Time) (string, error) {
 	secret := githubWebhookSecret()
 	if secret == "" {
 		return "", errors.New("github integration is not configured")
@@ -397,15 +439,19 @@ func signStateForReturn(workspaceID, returnTo string) (string, error) {
 	if _, err := rand.Read(nonceBytes); err != nil {
 		return "", err
 	}
-	nonce := hex.EncodeToString(nonceBytes)
-	payload := workspaceID + "." + nonce
-	if returnTo != githubReturnToGitHub {
-		payload = workspaceID + "." + returnTo + "." + nonce
-	}
+	payload := strings.Join([]string{
+		workspaceID,
+		returnTo,
+		strconv.FormatInt(now.Unix(), 10),
+		hex.EncodeToString(nonceBytes),
+	}, ".")
+	return payload + "." + signGitHubState(secret, payload), nil
+}
+
+func signGitHubState(secret, payload string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(payload))
-	sig := hex.EncodeToString(mac.Sum(nil))
-	return payload + "." + sig, nil
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func verifyState(token string) (string, bool) {
@@ -414,30 +460,32 @@ func verifyState(token string) (string, bool) {
 }
 
 func verifyStateWithReturn(token string) (workspaceID, returnTo string, ok bool) {
+	return verifyStateWithReturnAt(token, time.Now())
+}
+
+func verifyStateWithReturnAt(token string, now time.Time) (workspaceID, returnTo string, ok bool) {
 	secret := githubWebhookSecret()
 	if secret == "" {
 		return "", "", false
 	}
 	parts := strings.Split(token, ".")
-	if len(parts) != 3 && len(parts) != 4 {
+	if len(parts) != 5 {
 		return "", "", false
 	}
-	workspaceID = parts[0]
-	returnTo = githubReturnToGitHub
-	nonceIndex := 1
-	if len(parts) == 4 {
-		returnTo = parts[1]
-		nonceIndex = 2
-		if !isAllowedGitHubReturnTo(returnTo) {
-			return "", "", false
-		}
+	workspaceID, returnTo = parts[0], parts[1]
+	if !isAllowedGitHubReturnTo(returnTo) {
+		return "", "", false
 	}
-	sig := parts[nonceIndex+1]
-	payload := strings.Join(parts[:nonceIndex+1], ".")
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(payload))
-	expected := hex.EncodeToString(mac.Sum(nil))
-	if !hmac.Equal([]byte(expected), []byte(sig)) {
+	payload := strings.Join(parts[:4], ".")
+	if !hmac.Equal([]byte(signGitHubState(secret, payload)), []byte(parts[4])) {
+		return "", "", false
+	}
+	issuedAt, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return "", "", false
+	}
+	age := now.Sub(time.Unix(issuedAt, 0))
+	if age > githubStateMaxAge || age < -githubStateClockSkew {
 		return "", "", false
 	}
 	return workspaceID, returnTo, true
@@ -490,12 +538,19 @@ func (h *Handler) GitHubConnect(w http.ResponseWriter, r *http.Request) {
 
 // GitHubSetupCallback (GET /api/github/setup) handles the redirect GitHub
 // sends after a user installs (or re-authorizes) the App. We expect
-// ?installation_id=<id>&state=<signed token>. We persist the installation
-// row (workspace ↔ installation_id mapping), then bounce the user back to
-// the new Settings → GitHub tab in the web app (RFC MUL-2414 §4.1). The
-// previous destination was the catch-all Settings page, which after the
-// GitHub-tab split would land users on the default profile tab instead of
-// the place that shows the connection they just completed.
+// ?installation_id=<id>&code=<user authorization code>&state=<signed token>.
+// We prove the installation belongs to the person finishing the flow, persist
+// the installation row (workspace ↔ installation_id mapping), then bounce the
+// user back to the new Settings → GitHub tab in the web app (RFC MUL-2414
+// §4.1). The previous destination was the catch-all Settings page, which
+// after the GitHub-tab split would land users on the default profile tab
+// instead of the place that shows the connection they just completed.
+//
+// The route is public (it is a browser redirect from github.com, so it
+// carries no Multica credential we can rely on) and both `installation_id`
+// and `code` are supplied by the caller. The state token authorizes only the
+// *workspace* half of the mapping; the *installation* half is authorized by
+// verifyGitHubInstallationOwnership below.
 func (h *Handler) GitHubSetupCallback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	installationIDStr := q.Get("installation_id")
@@ -530,6 +585,28 @@ func (h *Handler) GitHubSetupCallback(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, settingsURL+"&github_error=bad_workspace", http.StatusFound)
 		return
 	}
+	// Ownership proof, before ANY persistence: without it the numeric
+	// installation_id in the query is enough to bind an unrelated org's
+	// installation into this workspace, which leaks that org's private
+	// repository names and its whole PR event stream (MUL-6056).
+	//
+	// A callback for a binding this workspace already has grants nothing new,
+	// so it skips the proof: GitHub only issues a user-authorization code when
+	// the user authorizes the App, and the "redirect on update" callback that
+	// fires when someone edits an existing installation's repository selection
+	// carries none. Requiring one there would fail every update.
+	if !h.workspaceHasGitHubInstallation(r.Context(), wsUUID, installationID) {
+		if err := verifyGitHubInstallationOwnership(r.Context(), q.Get("code"), installationID); err != nil {
+			slog.Warn("github: refused unverified installation bind",
+				"err", err,
+				"installation_id", installationID,
+				"workspace_id", workspaceID,
+			)
+			http.Redirect(w, r, settingsURL+"&github_error="+githubOwnershipErrorCode(err), http.StatusFound)
+			return
+		}
+	}
+
 	// Resolve the installation against GitHub's API to capture display info.
 	// If the App auth is not configured we still create the row with the
 	// minimum we know; webhook events will refresh it as soon as one fires.
@@ -569,6 +646,226 @@ func (h *Handler) GitHubSetupCallback(w http.ResponseWriter, r *http.Request) {
 		"installation": githubInstallationToBroadcast(inst),
 	})
 	http.Redirect(w, r, settingsURL+"&github_connected=1", http.StatusFound)
+}
+
+// ── Install ownership proof ─────────────────────────────────────────────────
+
+// workspaceHasGitHubInstallation reports whether this workspace is already
+// bound to this installation. Fail-closed: a lookup error answers "no", which
+// costs a legitimate update the ownership proof it cannot produce, and that is
+// the right way to be wrong.
+func (h *Handler) workspaceHasGitHubInstallation(
+	ctx context.Context,
+	workspaceID pgtype.UUID,
+	installationID int64,
+) bool {
+	rows, err := h.Queries.ListGitHubInstallationsByInstallationID(ctx, installationID)
+	if err != nil {
+		slog.Warn("github: existing installation lookup failed", "err", err, "installation_id", installationID)
+		return false
+	}
+	for _, row := range rows {
+		if row.WorkspaceID == workspaceID {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	// errGitHubUserAuthorizationMissing means the setup redirect carried no
+	// user-authorization `code`. Almost always operator-actionable: the App
+	// needs "Request user authorization (OAuth) during installation" enabled.
+	errGitHubUserAuthorizationMissing = errors.New("github: setup callback carried no user authorization code")
+	// errGitHubInstallationNotAuthorized means GitHub told us this user
+	// cannot see the installation they asked us to bind. This is the attack
+	// signature, not a misconfiguration.
+	errGitHubInstallationNotAuthorized = errors.New("github: installation is not accessible to the installing user")
+)
+
+const (
+	githubUserInstallationsPageSize = 100
+	// githubUserInstallationsMaxPages caps the walk at 2000 installations so a
+	// hostile or pathological account cannot hold the callback open forever.
+	githubUserInstallationsMaxPages = 20
+)
+
+// verifyGitHubInstallationOwnership proves the person who completed the
+// install actually controls `installationID`.
+//
+// Everything the setup callback receives is caller-controlled: the numeric
+// installation id is a plain query param, and the state token only says which
+// workspace to bind into — it never names an installation. The only
+// trustworthy source for "does this person control that installation?" is
+// GitHub, so we trade the user-authorization code GitHub appends to the setup
+// redirect for a user-to-server token and ask GitHub which installations that
+// user can actually see.
+//
+// This is deliberately fail-closed: no code, a refused exchange, or an
+// unreachable API all abort the bind. Falling through on error would restore
+// the exact hole this closes, and isGitHubConfigured() already hides Connect
+// on deployments that cannot run this check.
+func verifyGitHubInstallationOwnership(ctx context.Context, code string, installationID int64) error {
+	clientID, clientSecret := githubAppClientID(), githubAppClientSecret()
+	if clientID == "" || clientSecret == "" {
+		return errors.New("github: user authorization credentials are not configured")
+	}
+	if strings.TrimSpace(code) == "" {
+		return errGitHubUserAuthorizationMissing
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	userToken, err := exchangeGitHubUserCode(ctx, client, clientID, clientSecret, code)
+	if err != nil {
+		return err
+	}
+	// The token never leaves this function and is never stored; revoking it
+	// mirrors how installation tokens are handled elsewhere in this file.
+	defer revokeGitHubUserToken(client, clientID, clientSecret, userToken)
+	return assertUserCanAccessInstallation(ctx, client, userToken, installationID)
+}
+
+// githubOwnershipErrorCode maps a verification failure to the `github_error`
+// code carried back to Settings. The frontend renders one generic "connect
+// failed" toast for all of them; the distinction is for operators reading
+// logs and support tickets.
+func githubOwnershipErrorCode(err error) string {
+	switch {
+	case errors.Is(err, errGitHubInstallationNotAuthorized):
+		return "installation_not_authorized"
+	case errors.Is(err, errGitHubUserAuthorizationMissing):
+		return "missing_authorization"
+	default:
+		return "verification_failed"
+	}
+}
+
+// exchangeGitHubUserCode trades the setup redirect's `code` for a
+// user-to-server access token. GitHub answers 200 with an `error` field for a
+// bad or replayed code, so the body is checked as well as the status.
+func exchangeGitHubUserCode(
+	ctx context.Context,
+	client *http.Client,
+	clientID, clientSecret, code string,
+) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+	endpoint := strings.TrimRight(githubOAuthBase, "/") + "/login/oauth/access_token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("exchange github user code: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, githubAPIResponseLimit))
+		return "", fmt.Errorf("exchange github user code: github status %d", resp.StatusCode)
+	}
+	var body struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, githubAPIResponseLimit)).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode github user token: %w", err)
+	}
+	if body.Error != "" {
+		return "", fmt.Errorf("exchange github user code: %s", body.Error)
+	}
+	if body.AccessToken == "" {
+		return "", errors.New("github returned an empty user access token")
+	}
+	return body.AccessToken, nil
+}
+
+// assertUserCanAccessInstallation returns nil only when GitHub lists
+// installationID among the installations the token's user can reach.
+func assertUserCanAccessInstallation(
+	ctx context.Context,
+	client *http.Client,
+	userToken string,
+	installationID int64,
+) error {
+	for page := 1; page <= githubUserInstallationsMaxPages; page++ {
+		endpoint := fmt.Sprintf(
+			"%s/user/installations?per_page=%d&page=%d",
+			strings.TrimRight(githubAPIBase, "/"),
+			githubUserInstallationsPageSize,
+			page,
+		)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return err
+		}
+		setGitHubAPIHeaders(req, userToken)
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("list user installations: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, githubAPIResponseLimit))
+			resp.Body.Close()
+			return fmt.Errorf("list user installations: github status %d", resp.StatusCode)
+		}
+		var body struct {
+			Installations []struct {
+				ID int64 `json:"id"`
+			} `json:"installations"`
+		}
+		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, githubAPIResponseLimit)).Decode(&body)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return fmt.Errorf("decode user installations: %w", decodeErr)
+		}
+		for _, installation := range body.Installations {
+			if installation.ID == installationID {
+				return nil
+			}
+		}
+		if len(body.Installations) < githubUserInstallationsPageSize {
+			break
+		}
+	}
+	return errGitHubInstallationNotAuthorized
+}
+
+// revokeGitHubUserToken drops the short-lived user token as soon as the
+// ownership check is done. Best-effort: the token is never persisted, so a
+// failure here only means it lives out its natural expiry.
+func revokeGitHubUserToken(client *http.Client, clientID, clientSecret, token string) {
+	if token == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	endpoint := fmt.Sprintf(
+		"%s/applications/%s/token",
+		strings.TrimRight(githubAPIBase, "/"),
+		url.PathEscape(clientID),
+	)
+	payload, err := json.Marshal(map[string]string{"access_token": token})
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(clientID, clientSecret)
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, githubAPIResponseLimit))
 }
 
 func (h *Handler) consumePendingGitHubInstallation(ctx context.Context, inst db.GithubInstallation) (db.GithubInstallation, error) {

--- a/server/internal/handler/github_install_ownership_test.go
+++ b/server/internal/handler/github_install_ownership_test.go
@@ -1,0 +1,345 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// stubGitHubInstallOwnership points the install-flow HTTP calls at a local
+// server that vouches for the `owned` installation ids, and returns the
+// authorization code a setup callback should carry. Requests the ownership
+// flow does not own fall through to `rest` (nil = 404), so callers can keep
+// controlling what fetchInstallationAccount sees.
+func stubGitHubInstallOwnership(t *testing.T, owned []int64, rest http.HandlerFunc) string {
+	t.Helper()
+	const (
+		code      = "test-user-auth-code"
+		userToken = "ghu_test_user_token"
+	)
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.test-client")
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "test-client-secret")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/login/oauth/access_token":
+			w.Header().Set("Content-Type", "application/json")
+			if err := r.ParseForm(); err != nil || r.Form.Get("code") != code {
+				_, _ = w.Write([]byte(`{"error":"bad_verification_code"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"access_token":"` + userToken + `","token_type":"bearer"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/user/installations":
+			if r.Header.Get("Authorization") != "Bearer "+userToken {
+				http.Error(w, "bad credentials", http.StatusUnauthorized)
+				return
+			}
+			installations := make([]map[string]any, 0, len(owned))
+			for _, id := range owned {
+				installations = append(installations, map[string]any{"id": id})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count":   len(installations),
+				"installations": installations,
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/applications/"):
+			w.WriteHeader(http.StatusNoContent)
+		case rest != nil:
+			rest(w, r)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	oldAPI, oldOAuth := githubAPIBase, githubOAuthBase
+	githubAPIBase, githubOAuthBase = srv.URL, srv.URL
+	t.Cleanup(func() { githubAPIBase, githubOAuthBase = oldAPI, oldOAuth })
+	return code
+}
+
+// TestSetupCallback_RejectsInstallationTheUserDoesNotControl is the regression
+// test for MUL-6056: a valid state token for the caller's own workspace plus
+// an arbitrary installation_id used to be enough to bind someone else's
+// installation, exposing that account's private repository names and its PR
+// event stream. The bind must not happen, and no row may be written.
+func TestSetupCallback_RejectsInstallationTheUserDoesNotControl(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "ownership-secret")
+	t.Setenv("FRONTEND_ORIGIN", "https://app.example.test")
+
+	const (
+		victimInstallationID   int64 = 91919191
+		attackerInstallationID int64 = 91919192
+	)
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, victimInstallationID)
+	})
+
+	// The attacker controls only their own installation.
+	code := stubGitHubInstallOwnership(t, []int64{attackerInstallationID}, nil)
+
+	state, err := signState(testWorkspaceID)
+	if err != nil {
+		t.Fatalf("signState: %v", err)
+	}
+	req := httptest.NewRequest("GET", fmt.Sprintf(
+		"/api/github/setup?installation_id=%d&code=%s&state=%s",
+		victimInstallationID, code, state,
+	), nil)
+	rec := httptest.NewRecorder()
+	testHandler.GitHubSetupCallback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("setup callback: got %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "github_error=installation_not_authorized") {
+		t.Fatalf("redirect = %q, want github_error=installation_not_authorized", loc)
+	}
+	rows, err := testHandler.Queries.ListGitHubInstallationsByInstallationID(ctx, victimInstallationID)
+	if err != nil {
+		t.Fatalf("list installations: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("callback bound %d row(s) for an installation the user does not control", len(rows))
+	}
+}
+
+// TestSetupCallback_FailsClosedWithoutOwnershipProof covers the two ways the
+// proof can be unavailable. Both must refuse the bind: falling through would
+// leave the original hole open for anyone who can suppress the code or hit a
+// deployment that never configured the OAuth credentials.
+func TestSetupCallback_FailsClosedWithoutOwnershipProof(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "ownership-secret")
+	t.Setenv("FRONTEND_ORIGIN", "https://app.example.test")
+	const installationID int64 = 91919193
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+	})
+
+	tests := []struct {
+		name      string
+		clientID  string
+		secret    string
+		code      string
+		wantError string
+	}{
+		{
+			name:      "no user authorization code in the redirect",
+			clientID:  "Iv1.test-client",
+			secret:    "test-client-secret",
+			code:      "",
+			wantError: "github_error=missing_authorization",
+		},
+		{
+			name:      "deployment has no user authorization credentials",
+			clientID:  "",
+			secret:    "",
+			code:      "test-user-auth-code",
+			wantError: "github_error=verification_failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_APP_CLIENT_ID", tc.clientID)
+			t.Setenv("GITHUB_APP_CLIENT_SECRET", tc.secret)
+			state, err := signState(testWorkspaceID)
+			if err != nil {
+				t.Fatalf("signState: %v", err)
+			}
+			req := httptest.NewRequest("GET", fmt.Sprintf(
+				"/api/github/setup?installation_id=%d&code=%s&state=%s",
+				installationID, tc.code, state,
+			), nil)
+			rec := httptest.NewRecorder()
+			testHandler.GitHubSetupCallback(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("setup callback: got %d, want 302", rec.Code)
+			}
+			if loc := rec.Header().Get("Location"); !strings.Contains(loc, tc.wantError) {
+				t.Fatalf("redirect = %q, want %s", loc, tc.wantError)
+			}
+			rows, err := testHandler.Queries.ListGitHubInstallationsByInstallationID(ctx, installationID)
+			if err != nil {
+				t.Fatalf("list installations: %v", err)
+			}
+			if len(rows) != 0 {
+				t.Fatalf("callback bound %d row(s) without an ownership proof", len(rows))
+			}
+		})
+	}
+}
+
+// TestSetupCallback_RefreshesAnExistingBindingWithoutACode covers GitHub's
+// "redirect on update" callback, which fires when someone edits an installed
+// App's repository selection and carries no user-authorization code. The
+// binding already exists, so re-affirming it grants nothing new and must not
+// be treated as a failed connect.
+func TestSetupCallback_RefreshesAnExistingBindingWithoutACode(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "ownership-secret")
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.test-client")
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "test-client-secret")
+	t.Setenv("GITHUB_APP_ID", "")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", "")
+	t.Setenv("FRONTEND_ORIGIN", "https://app.example.test")
+
+	const installationID int64 = 91919194
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+	})
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "already-connected",
+		AccountType:    "Organization",
+	}); err != nil {
+		t.Fatalf("seed installation: %v", err)
+	}
+
+	state, err := signState(testWorkspaceID)
+	if err != nil {
+		t.Fatalf("signState: %v", err)
+	}
+	req := httptest.NewRequest("GET", fmt.Sprintf(
+		"/api/github/setup?installation_id=%d&setup_action=update&state=%s",
+		installationID, state,
+	), nil)
+	rec := httptest.NewRecorder()
+	testHandler.GitHubSetupCallback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("setup callback: got %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "github_connected=1") {
+		t.Fatalf("redirect = %q, want github_connected=1", loc)
+	}
+}
+
+// TestVerifyGitHubInstallationOwnership_WalksPagesAndRevokes pins the two
+// details a single-page happy path would hide: an account with more than one
+// page of installations must still be matched, and the short-lived user token
+// must be handed back to GitHub once the check is done.
+func TestVerifyGitHubInstallationOwnership_WalksPagesAndRevokes(t *testing.T) {
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.test-client")
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "test-client-secret")
+	const wantedInstallationID int64 = 4242
+
+	var revoked atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login/oauth/access_token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"ghu_paged"}`))
+		case r.URL.Path == "/user/installations":
+			installations := make([]map[string]any, 0, githubUserInstallationsPageSize)
+			if r.URL.Query().Get("page") == "1" {
+				// A full page of unrelated installations forces a second fetch.
+				for i := 0; i < githubUserInstallationsPageSize; i++ {
+					installations = append(installations, map[string]any{"id": int64(1000 + i)})
+				}
+			} else {
+				installations = append(installations, map[string]any{"id": wantedInstallationID})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"installations": installations})
+		case r.Method == http.MethodDelete && r.URL.Path == "/applications/"+url.PathEscape("Iv1.test-client")+"/token":
+			revoked.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	oldAPI, oldOAuth := githubAPIBase, githubOAuthBase
+	githubAPIBase, githubOAuthBase = srv.URL, srv.URL
+	t.Cleanup(func() { githubAPIBase, githubOAuthBase = oldAPI, oldOAuth })
+
+	if err := verifyGitHubInstallationOwnership(context.Background(), "code", wantedInstallationID); err != nil {
+		t.Fatalf("ownership check rejected an installation on page 2: %v", err)
+	}
+	if !revoked.Load() {
+		t.Error("user access token was not revoked after the ownership check")
+	}
+
+	err := verifyGitHubInstallationOwnership(context.Background(), "code", 999999)
+	if !errors.Is(err, errGitHubInstallationNotAuthorized) {
+		t.Fatalf("unlisted installation: err = %v, want errGitHubInstallationNotAuthorized", err)
+	}
+}
+
+// TestState_ExpiresAfterMaxAge keeps a captured install URL from staying a
+// usable "bind into this workspace" credential forever.
+func TestState_ExpiresAfterMaxAge(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "state-ttl-secret")
+	wsID := "11111111-2222-3333-4444-555555555555"
+
+	fresh, err := signStateForReturnAt(wsID, githubReturnToGitHub, time.Now())
+	if err != nil {
+		t.Fatalf("signStateForReturnAt: %v", err)
+	}
+	if _, ok := verifyState(fresh); !ok {
+		t.Fatal("freshly signed state was rejected")
+	}
+
+	stale, err := signStateForReturnAt(wsID, githubReturnToGitHub, time.Now().Add(-githubStateMaxAge-time.Minute))
+	if err != nil {
+		t.Fatalf("signStateForReturnAt: %v", err)
+	}
+	if _, ok := verifyState(stale); ok {
+		t.Error("expired state token was accepted")
+	}
+
+	future, err := signStateForReturnAt(wsID, githubReturnToGitHub, time.Now().Add(githubStateClockSkew+time.Minute))
+	if err != nil {
+		t.Fatalf("signStateForReturnAt: %v", err)
+	}
+	if _, ok := verifyState(future); ok {
+		t.Error("state token issued beyond the tolerated clock skew was accepted")
+	}
+}
+
+// TestIsGitHubConfigured_RequiresUserAuthorizationCredentials pins that the
+// Connect button stays hidden on deployments that cannot prove ownership,
+// rather than offering a flow the callback would refuse.
+func TestIsGitHubConfigured_RequiresUserAuthorizationCredentials(t *testing.T) {
+	t.Setenv("GITHUB_APP_SLUG", "multica-test")
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "test-secret-123")
+	t.Setenv("GITHUB_APP_CLIENT_ID", "")
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "")
+	if isGitHubConfigured() {
+		t.Error("integration reported configured without user authorization credentials")
+	}
+
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.test-client")
+	if isGitHubConfigured() {
+		t.Error("integration reported configured with only half of the OAuth credentials")
+	}
+
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "test-client-secret")
+	if !isGitHubConfigured() {
+		t.Error("integration reported not configured with every credential set")
+	}
+}

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -243,8 +243,8 @@ func TestStateRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("signState: %v", err)
 	}
-	if parts := strings.Split(tok, "."); len(parts) != 3 {
-		t.Fatalf("default return state has %d parts, want legacy 3-part format", len(parts))
+	if parts := strings.Split(tok, "."); len(parts) != 5 {
+		t.Fatalf("state has %d parts, want workspace.returnTo.issuedAt.nonce.sig", len(parts))
 	}
 	got, ok := verifyState(tok)
 	if !ok {
@@ -276,8 +276,8 @@ func TestStateRoundTripWithRepositoryReturnTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("signStateForReturn: %v", err)
 	}
-	if parts := strings.Split(tok, "."); len(parts) != 4 {
-		t.Fatalf("repository return state has %d parts, want 4", len(parts))
+	if parts := strings.Split(tok, "."); len(parts) != 5 {
+		t.Fatalf("repository return state has %d parts, want 5", len(parts))
 	}
 	gotWorkspaceID, gotReturnTo, ok := verifyStateWithReturn(tok)
 	if !ok {
@@ -302,6 +302,8 @@ func TestStateRoundTripWithRepositoryReturnTarget(t *testing.T) {
 func TestGitHubConnectRepositoryReturnTarget(t *testing.T) {
 	t.Setenv("GITHUB_APP_SLUG", "multica-test")
 	t.Setenv("GITHUB_WEBHOOK_SECRET", "test-secret-123")
+	t.Setenv("GITHUB_APP_CLIENT_ID", "Iv1.test-client")
+	t.Setenv("GITHUB_APP_CLIENT_SECRET", "test-client-secret")
 	wsID := "11111111-2222-3333-4444-555555555555"
 
 	req := httptest.NewRequest(
@@ -2710,16 +2712,13 @@ func TestSetupCallback_ConsumesPendingInstallationCreated(t *testing.T) {
 		testPool.Exec(ctx, `DELETE FROM github_pending_installation WHERE installation_id = $1`, installationID)
 	})
 
-	// Force fetchInstallationAccount to take its degraded path. This pins that
-	// the final real account name comes from the earlier webhook, not the
-	// setup callback's synchronous GitHub API lookup.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// The installing user owns this installation, so the ownership check
+	// passes. Everything else 401s, which forces fetchInstallationAccount down
+	// its degraded path — that pins that the final real account name comes
+	// from the earlier webhook, not the setup callback's synchronous lookup.
+	code := stubGitHubInstallOwnership(t, []int64{installationID}, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "auth required", http.StatusUnauthorized)
-	}))
-	t.Cleanup(srv.Close)
-	oldBase := githubAPIBase
-	githubAPIBase = srv.URL
-	t.Cleanup(func() { githubAPIBase = oldBase })
+	})
 
 	body, _ := json.Marshal(map[string]any{
 		"action": "created",
@@ -2761,7 +2760,7 @@ func TestSetupCallback_ConsumesPendingInstallationCreated(t *testing.T) {
 		t.Fatalf("signState: %v", err)
 	}
 	setupReq := httptest.NewRequest("GET",
-		fmt.Sprintf("/api/github/setup?installation_id=%d&state=%s", installationID, state),
+		fmt.Sprintf("/api/github/setup?installation_id=%d&code=%s&state=%s", installationID, code, state),
 		nil,
 	)
 	setupRec := httptest.NewRecorder()


### PR DESCRIPTION
## What

`GET /api/github/setup` persisted the `installation_id` from its query string without ever checking that the person completing the flow had anything to do with that installation. The signed state token authorizes only the *workspace* half of the mapping — it never names an installation — so any Multica account holder could start a legitimate install in their own workspace, replace `installation_id` in the callback URL with another organization's, and bind it.

That was enough to read, silently and with no audit trail:

- the installation's full repository list, **including private repository names** (`ListGitHubInstallationRepositories` authorizes on `row.WorkspaceID == workspaceID`, which the attacker's fresh row satisfies);
- every pull request event for those repos — `handlePullRequestEvent` fans out to *every* workspace bound to that installation, mirroring and broadcasting title, author, branch, `html_url`, and repo owner/name.

`installation_id` is a small enumerable integer and the settings page echoes the resolved `account_login`, so it was targetable rather than blind.

## Fix

**Prove ownership before persisting.** The callback trades GitHub's user-authorization `code` for a user-to-server token and asserts the installation appears in that user's `GET /user/installations`. This is GitHub's standard answer for this flow and the only one that actually proves control — the state token, and a `github_pending_installation` cross-check, both prove something weaker that an attacker can produce for themselves.

Details worth reviewing:

- **Fail-closed.** No code, refused exchange, or unreachable API all abort the bind. Falling through on error would leave the hole exactly as it was.
- **No half-configured state.** `isGitHubConfigured()` now also requires `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET`, so a deployment that cannot run the check hides Connect instead of offering a flow the callback would refuse. Webhook acceptance still keys off the webhook secret alone, so **existing installations, webhook ingestion, and PR mirroring are unaffected**.
- **Updates still work.** GitHub only issues a code when the user authorizes the App; the "redirect on update" callback (someone edits an installed App's repo selection) carries none. A callback for a binding the workspace already has skips the proof — re-affirming an existing row grants nothing new.
- **State hardening.** The token gains a signed issued-at and a 15 minute lifetime, so a leaked install URL stops being a usable "bind into this workspace" credential. Single-use consumption would need a nonce store and is left as follow-up; it is defense in depth, not the fix.
- The user token is used only inside the check, never stored, and revoked on the way out.

Rejections redirect with `github_error=missing_authorization` / `installation_not_authorized` / `verification_failed` — the UI renders its existing generic toast; the codes are for operators reading logs.

## Deployment — needs config before this ships

Both are documented in `.env.example`, the self-host compose file, and `docs/github-integration` (all locales):

1. On the GitHub App: enable **Request user authorization (OAuth) during installation** and point the callback URL at `https://<api-host>/api/github/setup` (same endpoint as the Setup URL).
2. Set `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET`.

Until both are done the Connect button is hidden. Everything already connected keeps working.

## Suggested follow-up (not in this PR)

Audit production for one installation bound to unrelated workspaces. Legitimate multi-team setups look identical, so this only scopes what a human needs to look at:

```sql
SELECT installation_id,
       count(DISTINCT workspace_id) AS ws_count,
       array_agg(DISTINCT workspace_id) AS workspaces,
       array_agg(DISTINCT account_login) AS accounts
FROM github_installation
GROUP BY installation_id
HAVING count(DISTINCT workspace_id) > 1;
```

## Testing

- `go test ./internal/handler/` — full package, passes (100s).
- New `server/internal/handler/github_install_ownership_test.go`: the regression case (valid state + someone else's installation ⇒ refused, **no row written**), both fail-closed paths, the code-less update refresh, page-2 matching plus token revocation, state expiry and clock-skew bounds, and the config gate.
- `pnpm exec tsc --noEmit` in `packages/views`, plus `github-tab` and `repositories-tab` vitest suites.

Not reproduced against production — the analysis is from the code, and the tests exercise the callback end to end against a stubbed GitHub.

Refs MUL-6056
