### PR TITLE
MUL-6050: feat(onboarding): romanize Chinese workspace names into a slug

### DIFF
--- a/packages/views/onboarding/steps/step-workspace.test.tsx
+++ b/packages/views/onboarding/steps/step-workspace.test.tsx
@@ -206,16 +206,29 @@ describe("StepWorkspace — issue prefix", () => {
     expect(screen.getByText("ACME-123")).toBeInTheDocument();
   });
 
-  // Reported against the first cut of this fix: typing a Chinese name and
-  // stopping there still showed "WS" — the placeholder invented one because a
-  // CJK-only name derives no slug. Nothing may advertise a prefix before there
-  // is one to derive from; "WS" in particular is the string this issue exists
-  // to remove.
-  it("shows no prefix at all while a CJK-only name leaves the slug empty", () => {
+  // A Chinese name fills the whole form on its own: the URL romanizes from
+  // the name, and the prefix follows the URL like any other name would.
+  it("fills the URL and prefix from a Chinese name", () => {
     renderStep({ existing: null, disabled: false });
 
     fireEvent.change(screen.getByLabelText("Workspace name"), {
       target: { value: "蜘蛛侠" },
+    });
+
+    expect(screen.getByLabelText("URL")).toHaveValue("zhizhuxia");
+    expect(prefixInput()).toHaveValue("ZHIZ");
+    expect(screen.getByText("ZHIZ-123")).toBeInTheDocument();
+    expect(screen.queryByText(/WS/)).not.toBeInTheDocument();
+  });
+
+  // Romanization only covers Han, so kana / Hangul / emoji names still reach
+  // the empty state. Nothing may advertise a prefix there — "WS" in
+  // particular is the string this issue exists to remove.
+  it("shows no prefix at all when the name romanizes to nothing", () => {
+    renderStep({ existing: null, disabled: false });
+
+    fireEvent.change(screen.getByLabelText("Workspace name"), {
+      target: { value: "スパイダーマン" },
     });
 
     expect(screen.getByLabelText("URL")).toHaveValue("");
@@ -238,14 +251,15 @@ describe("StepWorkspace — issue prefix", () => {
     expect(screen.getByText("SPID-123")).toBeInTheDocument();
   });
 
-  it("gives a Chinese-named workspace a slug-derived prefix instead of WS", () => {
+  it("follows a hand-typed URL over the romanized one", () => {
     renderStep({ existing: null, disabled: false });
 
-    // A CJK-only name produces no slug, so the user types one — that ASCII
-    // choice is what the prefix now follows.
     fireEvent.change(screen.getByLabelText("Workspace name"), {
       target: { value: "前端团队" },
     });
+    expect(prefixInput().value).toBe("QIAN");
+
+    // Overriding the URL re-derives the prefix from what the user chose.
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "frontend" },
     });

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -155,9 +155,9 @@ export function StepWorkspace({
   // What the workspace will actually be created with. Clearing the prefix
   // input reverts to the slug-derived default rather than blocking the CTA —
   // the placeholder shows that default, so an empty field is never a
-  // surprise. Empty only while the slug is (a CJK-only name derives none),
-  // which is also exactly when `canCreate` is false, so submit always carries
-  // a real prefix.
+  // surprise. Empty only while the slug is (a name that romanizes to nothing
+  // derives none), which is also exactly when `canCreate` is false, so submit
+  // always carries a real prefix.
   const derivedPrefix = issuePrefix(slug);
   const effectivePrefix = prefix || derivedPrefix;
 
@@ -342,12 +342,13 @@ export function StepWorkspace({
       {/* Editable, pre-filled from the slug. Narrow input — the value is
           capped at 10 chars, so a full-width field would read as a mistake.
 
-          Nothing is invented while the slug is empty: a CJK-only name derives
-          no slug (see nameToWorkspaceSlug), and the placeholder used to fill
-          that gap with "WS" — telling the user they were getting the exact
-          prefix this whole change exists to eliminate. Empty field plus a
-          hint is the honest state; the user is picking a URL next anyway,
-          and the prefix appears the moment they do. */}
+          Nothing is invented while the slug is empty: a name that romanizes
+          to nothing — kana, Hangul, emoji — derives no slug (see
+          nameToWorkspaceSlug), and the placeholder used to fill that gap with
+          "WS", telling the user they were getting the exact prefix this whole
+          change exists to eliminate. Empty field plus a hint is the honest
+          state; the user is picking a URL next anyway, and the prefix appears
+          the moment they do. */}
       <Field>
         <FieldLabel htmlFor="ws-issue-prefix">
           {t(($) => $.step_workspace.issue_prefix_label)}

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -172,7 +172,9 @@ export function StepWorkspace({
   const handleNameChange = (value: string) => {
     setName(value);
     if (!slugTouched.current) {
-      applySlug(nameToWorkspaceSlug(value));
+      // Locale decides whether Han characters are read as Chinese; see
+      // nameToWorkspaceSlug.
+      applySlug(nameToWorkspaceSlug(value, locale));
     }
   };
 

--- a/packages/views/workspace/slug.test.ts
+++ b/packages/views/workspace/slug.test.ts
@@ -22,12 +22,31 @@ describe("nameToWorkspaceSlug", () => {
     expect(nameToWorkspaceSlug("a.b.c")).toBe("a-b-c");
   });
 
+  // MUL-6050: a Chinese name used to produce no slug at all, which left the
+  // create form with an empty URL *and* an empty issue prefix — the two
+  // fields that make a workspace identifiable.
+  it("romanizes Chinese names into a slug", () => {
+    expect(nameToWorkspaceSlug("蜘蛛侠")).toBe("zhizhuxia");
+    expect(nameToWorkspaceSlug("前端团队")).toBe("qianduantuandui");
+    expect(nameToWorkspaceSlug("测试")).toBe("ceshi");
+  });
+
+  // Each Han run is romanized whole so the phrase dictionary can pick the
+  // right reading for 多音字 — per-character conversion would give
+  // "zhangsha" / "zhongqing" / "yinxing" here.
+  it("resolves polyphonic characters from surrounding context", () => {
+    expect(nameToWorkspaceSlug("长沙组")).toBe("changshazu");
+    expect(nameToWorkspaceSlug("重庆团队")).toBe("chongqingtuandui");
+    expect(nameToWorkspaceSlug("银行")).toBe("yinhang");
+  });
+
   // Regression: previously fell back to literal "workspace" — caused two
   // separate non-ASCII-named workspaces on the same instance to 409 (slug
   // taken) and silently surfaced a confusing "/workspace/issues" URL.
-  it("returns empty string for non-ASCII-only names", () => {
-    expect(nameToWorkspaceSlug("测试")).toBe("");
+  // Romanization covers Han only; everything else still asks the user.
+  it("returns empty string for names that romanize to nothing", () => {
     expect(nameToWorkspaceSlug("こんにちは")).toBe("");
+    expect(nameToWorkspaceSlug("안녕하세요")).toBe("");
     expect(nameToWorkspaceSlug("🚀")).toBe("");
     expect(nameToWorkspaceSlug("مرحبا")).toBe("");
   });
@@ -38,9 +57,11 @@ describe("nameToWorkspaceSlug", () => {
     expect(nameToWorkspaceSlug("   ")).toBe("");
   });
 
-  it("preserves ASCII characters even when mixed with non-ASCII", () => {
-    expect(nameToWorkspaceSlug("测试 Team")).toBe("team");
-    expect(nameToWorkspaceSlug("Project 测试 1")).toBe("project-1");
+  it("keeps Latin and romanized segments apart when a name mixes them", () => {
+    expect(nameToWorkspaceSlug("测试 Team")).toBe("ceshi-team");
+    expect(nameToWorkspaceSlug("Project 测试 1")).toBe("project-ceshi-1");
+    // No separator in the source: the romanized run must not glue onto it.
+    expect(nameToWorkspaceSlug("Acme蜘蛛侠")).toBe("acme-zhizhuxia");
   });
 });
 

--- a/packages/views/workspace/slug.test.ts
+++ b/packages/views/workspace/slug.test.ts
@@ -40,6 +40,22 @@ describe("nameToWorkspaceSlug", () => {
     expect(nameToWorkspaceSlug("银行")).toBe("yinhang");
   });
 
+  // Han characters are shared but their readings are not, so a Japanese or
+  // Korean name must not be read as Mandarin: 東京 is "tokyo", not
+  // "dongjing". An empty field the user fills beats a wrong default they
+  // have to notice and undo.
+  it("does not romanize names that are not Chinese", () => {
+    // Kana is a certain signal, in any UI language.
+    expect(nameToWorkspaceSlug("東京チーム")).toBe("");
+    expect(nameToWorkspaceSlug("ひらがな会社")).toBe("");
+    // All-kanji names carry no signal, so the reader's locale decides.
+    expect(nameToWorkspaceSlug("東京支社", "ja")).toBe("");
+    expect(nameToWorkspaceSlug("大韓民国", "ko")).toBe("");
+    // …and the same name still romanizes for a Chinese-reading audience.
+    expect(nameToWorkspaceSlug("東京支社", "zh-Hans")).toBe("dongjingzhishe");
+    expect(nameToWorkspaceSlug("蜘蛛侠", "en")).toBe("zhizhuxia");
+  });
+
   // Regression: previously fell back to literal "workspace" — caused two
   // separate non-ASCII-named workspaces on the same instance to 409 (slug
   // taken) and silently surfaced a confusing "/workspace/issues" URL.

--- a/packages/views/workspace/slug.ts
+++ b/packages/views/workspace/slug.ts
@@ -10,6 +10,28 @@ const WORKSPACE_SLUG_SUFFIX_LENGTH = 4;
 /** Maximal runs of Han characters, including the extension-A and compatibility blocks. */
 const HAN_RUN = /[㐀-䶿一-鿿豈-﫿]+/g;
 
+/** Hiragana / katakana, including the halfwidth katakana block. */
+const KANA = /[\u3041-\u3096\u309B-\u30FF\uFF66-\uFF9F]/;
+
+/**
+ * Han characters are shared, their readings are not: 東京 is "dongjing" in
+ * Mandarin and "tokyo" in Japanese, and pinyin has nothing useful to say
+ * about a Japanese or Korean name. Skip romanization when the text or the
+ * reader's own language says the name isn't Chinese — those names fall back
+ * to the empty slug the form already handles, which is a blank field the
+ * user fills in rather than a wrong reading they have to notice and undo.
+ *
+ * Kana is a certain signal and works in any UI language; the locale catches
+ * all-kanji names, which carry no signal of their own. Neither sees a
+ * Japanese all-kanji name typed into a non-Japanese UI — that one still
+ * romanizes, and fixing it needs real Japanese romaji (a segmenter plus a
+ * reading dictionary), not another heuristic.
+ */
+function shouldRomanize(name: string, locale?: SupportedLocale): boolean {
+  if (locale === "ja" || locale === "ko") return false;
+  return !KANA.test(name);
+}
+
 /**
  * Romanize Han characters so a Chinese name can produce a slug at all.
  *
@@ -38,12 +60,20 @@ function romanizeHan(name: string): string {
  * collides for the second such workspace on the instance, and neither is
  * true of a romanized name.
  *
+ * Only Chinese names romanize: `shouldRomanize` opts out of Japanese and
+ * Korean, whose Han characters read differently. Pass the reader's `locale`
+ * wherever it is known.
+ *
  * Still returns empty string for names that romanize to nothing — kana-only,
- * Hangul-only, emoji-only — where the form leaves the field empty and asks
- * the user to type one.
+ * Hangul-only, emoji-only, or any name opted out above — where the form
+ * leaves the field empty and asks the user to type one.
  */
-export function nameToWorkspaceSlug(name: string): string {
-  return romanizeHan(name)
+export function nameToWorkspaceSlug(
+  name: string,
+  locale?: SupportedLocale,
+): string {
+  const romanized = shouldRomanize(name, locale) ? romanizeHan(name) : name;
+  return romanized
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");

--- a/packages/views/workspace/slug.ts
+++ b/packages/views/workspace/slug.ts
@@ -1,3 +1,4 @@
+import { pinyin } from "pinyin-pro";
 import type { SupportedLocale } from "@multica/core/i18n";
 import { CELESTIAL_WORKSPACE_NAMES } from "./celestial-workspace-names";
 
@@ -6,18 +7,43 @@ export const WORKSPACE_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const WORKSPACE_SLUG_SUFFIX_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 const WORKSPACE_SLUG_SUFFIX_LENGTH = 4;
 
+/** Maximal runs of Han characters, including the extension-A and compatibility blocks. */
+const HAN_RUN = /[㐀-䶿一-鿿豈-﫿]+/g;
+
+/**
+ * Romanize Han characters so a Chinese name can produce a slug at all.
+ *
+ * Each run is converted whole rather than per character: pinyin-pro resolves
+ * 多音字 from its phrase dictionary, so 长沙 is "changsha" (not "zhangsha")
+ * and 重庆 is "chongqing" (not "zhongqing") — but only when it can see the
+ * surrounding characters. Syllables are joined without separators ("蜘蛛侠"
+ * → "zhizhuxia") because one word should read as one slug segment; the
+ * surrounding spaces keep a run from gluing onto adjacent Latin text.
+ */
+function romanizeHan(name: string): string {
+  return name.replace(HAN_RUN, (run) => {
+    const syllables = pinyin(run, { toneType: "none", type: "array", v: true });
+    return ` ${syllables.join("")} `;
+  });
+}
+
 /**
  * Auto-generate a slug from a workspace name.
  *
- * Returns empty string when the name produces no valid characters (e.g.
- * Chinese / Japanese / emoji-only names). The form leaves the slug field
- * empty in this case and the user must type one — this is preferable to a
- * hardcoded fallback like "workspace" which (a) silently chooses a useless
- * URL slug and (b) causes 409 conflicts for the second non-ASCII-named
- * workspace on the same instance.
+ * Chinese names are romanized first (蜘蛛侠 → "zhizhuxia"), so the create
+ * form can fill in a URL — and, through it, an issue prefix — for a name
+ * with no Latin characters at all (MUL-6050). This is a derived default the
+ * user can still edit before creating, not a hardcoded one: the objection to
+ * a fixed fallback like "workspace" was that it picks a useless URL and
+ * collides for the second such workspace on the instance, and neither is
+ * true of a romanized name.
+ *
+ * Still returns empty string for names that romanize to nothing — kana-only,
+ * Hangul-only, emoji-only — where the form leaves the field empty and asks
+ * the user to type one.
  */
 export function nameToWorkspaceSlug(name: string): string {
-  return name
+  return romanizeHan(name)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");


### PR DESCRIPTION
Follow-up to #6815 / #6819. Reported on the create screen: a Chinese name leaves both the URL and the issue prefix empty, and the user has to invent them by hand.

## What changed

`nameToWorkspaceSlug` romanizes Han characters before slugifying, so a Chinese name fills the form the way an English one does:

| Name | URL | Issue prefix |
|---|---|---|
| 蜘蛛侠 | `zhizhuxia` | `ZHIZ` |
| 前端团队 | `qianduantuandui` | `QIAN` |
| Acme蜘蛛侠 | `acme-zhizhuxia` | `ACME` |

The prefix needs no new rule — it already derives from the slug (#6815), so romanizing the slug carries straight through. No server change: the server's `defaultIssuePrefixFromSlug` sees an ordinary ASCII slug.

## Polyphones

Each Han run is romanized whole rather than per character, so pinyin-pro resolves 多音字 from its phrase dictionary:

- 长沙组 → `changshazu`, not `zhangshazu`
- 重庆团队 → `chongqingtuandui`, not `zhongqingtuandui`
- 银行 → `yinhang`, not `yinxing`

Per-character conversion really does get these wrong — that ambiguity was the objection that killed the original pinyin proposal on MUL-6050. Handing the whole run to the dictionary answers it.

## Why this isn't the fallback that was rejected before

The old comment on `nameToWorkspaceSlug` argued against a fallback, but against a *hardcoded* one (`"workspace"`): it picks a useless URL, and the second non-ASCII-named workspace on the instance 409s on it. A romanized name is derived, meaningful, and as collision-prone as any English name — and it stays an editable default, not a decision made for the user.

## Scope

- No new dependency: `pinyin-pro` is already declared by `packages/views` and used by the editor's pinyin search. The onboarding route now pulls it in too (~320KB raw before compression, code-split with the route).
- Romanization covers Chinese only. It is skipped when the text or the reader's language says otherwise: kana anywhere in the name (certain, in any UI language) or a `ja` / `ko` UI locale (for all-kanji names, which carry no signal of their own). Those names, plus Hangul-only and emoji-only ones, derive no slug and keep the empty-prefix hint from #6819.
- Remaining hole: a Japanese all-kanji name typed into a non-Japanese UI still romanizes as Mandarin. Closing it needs real Japanese romaji — a segmenter plus a reading dictionary — rather than another heuristic.

## Testing

`packages/views` suite green (3855). New coverage in `slug.test.ts` for romanization, polyphones, mixed Latin/Han names, and the still-empty scripts; the onboarding component test asserts 蜘蛛侠 fills `zhizhuxia` / `ZHIZ` / `ZHIZ-123`, and the empty-state regression from #6819 moved to a kana name so it keeps guarding that path. `pnpm typecheck` and lint clean. No manual UI pass; the states are asserted in the component test.

