### PR TITLE
MUL-5971: coordinate skill bundle downloads

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -931,7 +931,14 @@ func (c *Client) postJSONViaWithRetry(ctx context.Context, httpClient *http.Clie
 		if attempt >= len(schedule) {
 			return err
 		}
-		if sleepErr := retrySleep(ctx, schedule[attempt]); sleepErr != nil {
+		delay := schedule[attempt]
+		// Do not spend the rest of a request's total deadline sleeping when no
+		// budget remains for the next HTTP attempt. This matters most for large
+		// bundle downloads, whose retries share one size-based context budget.
+		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+			return err
+		}
+		if sleepErr := retrySleep(ctx, delay); sleepErr != nil {
 			return err
 		}
 	}

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -375,6 +375,37 @@ func TestPostJSONWithRetry_CtxCancelStopsRetries(t *testing.T) {
 	}
 }
 
+func TestPostJSONWithRetry_DoesNotSleepPastDeadline(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	prev := retrySleep
+	var sleeps atomic.Int32
+	retrySleep = func(context.Context, time.Duration) error {
+		sleeps.Add(1)
+		return nil
+	}
+	defer func() { retrySleep = prev }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	c := NewClient(srv.URL)
+	err := c.postJSONWithRetry(ctx, "/x", map[string]any{}, nil, []time.Duration{time.Second})
+	if err == nil {
+		t.Fatal("expected first transient request to fail")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	if got := sleeps.Load(); got != 0 {
+		t.Fatalf("retry sleeps = %d, want 0 when delay exceeds remaining deadline", got)
+	}
+}
+
 func TestDefaultTerminalRetrySchedule_MatchesAgreedPlan(t *testing.T) {
 	// MUL-2780 settled on a 5-step exponential backoff (4s, 8s, 16s, 32s, 64s).
 	// Pin it so a future "tidy this up" refactor can't silently flatten or

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -343,7 +343,12 @@ type Daemon struct {
 	client     *Client
 	repoCache  repoCacheBackend
 	skillCache *SkillBundleCache
-	logger     *slog.Logger
+	// skillDownloads is daemon-global: every task shares both the per-ref
+	// flights and the HTTP download slots. skillDownloadsOnce keeps focused
+	// tests that construct Daemon literals zero-value safe.
+	skillDownloadsOnce sync.Once
+	skillDownloads     *skillBundleDownloadCoordinator
+	logger             *slog.Logger
 
 	mu           sync.Mutex
 	workspaces   map[string]*workspaceState
@@ -596,6 +601,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		client:                    client,
 		repoCache:                 repocache.New(cacheRoot, logger),
 		skillCache:                NewSkillBundleCache(skillCacheRoot),
+		skillDownloads:            newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads),
 		logger:                    logger,
 		workspaces:                make(map[string]*workspaceState),
 		runtimeIndex:              make(map[string]Runtime),
@@ -1718,6 +1724,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		"idle_watchdog", d.cfg.AgentIdleWatchdog,
 		"opencode_idle_watchdog", d.cfg.OpenCodeIdleWatchdog,
 		"max_concurrent_tasks", d.cfg.MaxConcurrentTasks,
+		"max_concurrent_skill_downloads", defaultMaxConcurrentSkillDownloads,
 		"gc_enabled", d.cfg.GCEnabled,
 		"auto_update", d.cfg.AutoUpdateEnabled,
 		"launched_by", d.cfg.LaunchedBy,
@@ -5467,29 +5474,46 @@ func (d *Daemon) ensureTaskSkillBundles(ctx context.Context, task *Task) error {
 		}
 	}
 
-	// Resolve each missing bundle in its own request, caching it the moment it
-	// arrives. The download is the slow part on jittery links, so fetching the
-	// whole set in one atomic body read meant a single timeout discarded all
-	// progress and the cache never converged — every dispatch re-downloaded
-	// everything and timed out again. Per-skill, each download fits its own
-	// size-scaled deadline and is persisted independently, so even a dispatch
-	// that ultimately fails leaves the skills it did fetch cached for the next
-	// one. (GitHub #4505 / MUL-3650)
+	// Leave part of the prepare hard limit for materializing the execution
+	// environment after the bundles arrive. A context without a deadline is
+	// used by focused tests and callers outside runTask, so it stays unbounded.
+	downloadWaitCtx, cancelDownloadWait := skillBundleDownloadWaitContext(ctx)
+	defer cancelDownloadWait()
+
+	// Resolve misses concurrently. The per-task limit bounds waiter goroutines;
+	// the daemon-global coordinator separately limits real HTTP requests and
+	// coalesces the same immutable ref across tasks. Every successful bundle is
+	// cached independently even if a sibling fails, preserving convergence
+	// across dispatches. (GitHub #4505 / #6691; MUL-3650 / MUL-5971)
+	var (
+		group      errgroup.Group
+		resolvedMu sync.Mutex
+	)
+	group.SetLimit(defaultMaxConcurrentSkillDownloads)
 	for _, ref := range misses {
-		started := time.Now()
-		bundle, err := d.resolveSkillBundle(ctx, task, ref)
-		if err != nil {
-			// Name the skill, its declared size, and how long we actually
-			// waited. The bare "resolve skill bundles: context deadline
-			// exceeded" this replaced was indistinguishable from a generic
-			// network fault, and cost a community thread three hours of
-			// guesswork (MUL-5370): size + elapsed separate "this bundle is
-			// too big for the link" from "the link is dead".
-			return fmt.Errorf("%w: skill %q (id=%s, %d bytes) after %s: %w",
-				errSkillBundleUnavailable, ref.Name, ref.ID, ref.SizeBytes,
-				time.Since(started).Round(time.Millisecond), err)
-		}
-		resolved[skillRefKey(bundle.Source, bundle.ID)] = bundle
+		ref := ref
+		group.Go(func() error {
+			started := time.Now()
+			bundle, err := d.resolveSkillBundle(downloadWaitCtx, task, ref)
+			if err != nil {
+				// Name the skill, its declared size, and how long we actually
+				// waited. The bare "resolve skill bundles: context deadline
+				// exceeded" this replaced was indistinguishable from a generic
+				// network fault, and cost a community thread three hours of
+				// guesswork (MUL-5370): size + elapsed separate "this bundle is
+				// too big for the link" from "the link is dead".
+				return fmt.Errorf("%w: skill %q (id=%s, %d bytes) after %s: %w",
+					errSkillBundleUnavailable, ref.Name, ref.ID, ref.SizeBytes,
+					time.Since(started).Round(time.Millisecond), err)
+			}
+			resolvedMu.Lock()
+			resolved[skillRefKey(bundle.Source, bundle.ID)] = bundle
+			resolvedMu.Unlock()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return err
 	}
 
 	skills := make([]SkillData, 0, len(task.Agent.SkillRefs))
@@ -5504,13 +5528,50 @@ func (d *Daemon) ensureTaskSkillBundles(ctx context.Context, task *Task) error {
 	return nil
 }
 
-// resolveSkillBundle downloads one skill bundle and writes it to the on-disk
-// cache before returning. The request runs under its own deadline, scaled to
-// the bundle's declared size rather than the daemon's fixed 30s control-plane
-// timeout, so a large bundle on a slow link is given room to finish instead of
-// being cut off mid-body. Caching on success is what lets the resolve converge
-// across dispatches. (GitHub #4505 / MUL-3650)
+// resolveSkillBundle joins or starts the daemon-global flight for one immutable
+// ref. The flight covers the second cache check through validated atomic store,
+// so concurrent tasks never issue duplicate HTTP requests for the same key.
 func (d *Daemon) resolveSkillBundle(ctx context.Context, task *Task, ref SkillRefData) (SkillData, error) {
+	coordinator := d.skillBundleDownloads()
+	return coordinator.do(ctx, skillBundleCacheKey(task.WorkspaceID, ref), func(flightCtx context.Context) (SkillData, error) {
+		if err := coordinator.acquire(flightCtx); err != nil {
+			return SkillData{}, err
+		}
+		defer coordinator.release()
+
+		// The initial scan and this flight can race with a preceding task that
+		// has just stored the same ref. Re-check only after owning both the
+		// singleflight key and a global slot, immediately before network I/O.
+		var cached SkillData
+		if err := d.skillCache.WithRefLock(task.WorkspaceID, ref, func() error {
+			if bundle, ok := d.skillCache.Load(task.WorkspaceID, ref); ok {
+				cached = bundle
+			}
+			return nil
+		}); err != nil {
+			return SkillData{}, fmt.Errorf("load skill bundle cache: %w", err)
+		}
+		if cached.ID != "" {
+			return cached, nil
+		}
+
+		return d.downloadAndCacheSkillBundle(flightCtx, task, ref)
+	})
+}
+
+func (d *Daemon) skillBundleDownloads() *skillBundleDownloadCoordinator {
+	d.skillDownloadsOnce.Do(func() {
+		if d.skillDownloads == nil {
+			d.skillDownloads = newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads)
+		}
+	})
+	return d.skillDownloads
+}
+
+// downloadAndCacheSkillBundle owns one real HTTP attempt sequence. Its timeout
+// includes retries and uses a conservative transfer floor; the waiting task's
+// earlier prepare-aware context can still stop waiting independently.
+func (d *Daemon) downloadAndCacheSkillBundle(ctx context.Context, task *Task, ref SkillRefData) (SkillData, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, skillBundleResolveTimeout(ref.SizeBytes))
 	defer cancel()
 
@@ -5540,33 +5601,47 @@ func (d *Daemon) resolveSkillBundle(ctx context.Context, task *Task, ref SkillRe
 }
 
 const (
-	// skillBundleResolveMinTimeout floors the per-skill resolve deadline so a
-	// tiny bundle still tolerates connection setup and round-trip latency.
-	skillBundleResolveMinTimeout = 30 * time.Second
+	// skillBundleResolveFixedBudget covers connection setup and first-byte
+	// latency before any payload throughput can be observed.
+	skillBundleResolveFixedBudget = 30 * time.Second
 	// skillBundleResolveMaxTimeout caps it so a wedged download cannot pin a
 	// task in prepare indefinitely.
 	skillBundleResolveMaxTimeout = 5 * time.Minute
-	// skillBundleResolveMinThroughput is the pessimistic floor throughput
-	// (bytes/sec) used to scale the deadline to bundle size — deliberately low
-	// to cover slow, jittery links rather than ideal bandwidth.
-	skillBundleResolveMinThroughput = 50 * 1024
+	// skillBundleResolveMinThroughput is deliberately pessimistic for slow,
+	// jittery links. Transfer time is rounded up so every declared byte gets a
+	// full throughput allowance.
+	skillBundleResolveMinThroughput = 10 * 1024
+	// skillBundlePrepareReserve is kept outside bundle waits so execenv setup
+	// and StartTask still have room inside the five-minute prepare hard limit.
+	skillBundlePrepareReserve = 30 * time.Second
 )
 
 // skillBundleResolveTimeout returns the deadline budget for downloading a
-// bundle of the given size: at least skillBundleResolveMinTimeout, scaled up at
-// skillBundleResolveMinThroughput, and capped at skillBundleResolveMaxTimeout.
+// bundle: fixed connect/first-byte time plus ceil(size / minimum throughput),
+// capped by the per-bundle maximum. The caller's context applies the remaining
+// prepare budget independently.
 func skillBundleResolveTimeout(sizeBytes int64) time.Duration {
 	if sizeBytes <= 0 {
-		return skillBundleResolveMinTimeout
+		return skillBundleResolveFixedBudget
 	}
-	scaled := time.Duration(sizeBytes/skillBundleResolveMinThroughput) * time.Second
-	if scaled < skillBundleResolveMinTimeout {
-		return skillBundleResolveMinTimeout
+	transferSeconds := sizeBytes / skillBundleResolveMinThroughput
+	if sizeBytes%skillBundleResolveMinThroughput != 0 {
+		transferSeconds++
 	}
-	if scaled > skillBundleResolveMaxTimeout {
+	maxTransferSeconds := int64((skillBundleResolveMaxTimeout - skillBundleResolveFixedBudget) / time.Second)
+	if transferSeconds >= maxTransferSeconds {
 		return skillBundleResolveMaxTimeout
 	}
-	return scaled
+	budget := skillBundleResolveFixedBudget + time.Duration(transferSeconds)*time.Second
+	return budget
+}
+
+func skillBundleDownloadWaitContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithDeadline(ctx, deadline.Add(-skillBundlePrepareReserve))
 }
 
 func (d *Daemon) startTaskPrepareLeaseExtender(ctx context.Context, task Task, taskLog *slog.Logger) func() {

--- a/server/internal/daemon/skill_bundle_resolve_test.go
+++ b/server/internal/daemon/skill_bundle_resolve_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,11 +22,14 @@ func TestSkillBundleResolveTimeout(t *testing.T) {
 		size int64
 		want time.Duration
 	}{
-		{"zero size floors to min", 0, skillBundleResolveMinTimeout},
-		{"negative size floors to min", -5, skillBundleResolveMinTimeout},
-		{"tiny bundle floors to min", 1024, skillBundleResolveMinTimeout},
-		{"scales with size above the floor", 2 * 1024 * 1024, 40 * time.Second},
+		{"zero size gets fixed budget", 0, skillBundleResolveFixedBudget},
+		{"negative size gets fixed budget", -5, skillBundleResolveFixedBudget},
+		{"one byte rounds up transfer time", 1, skillBundleResolveFixedBudget + time.Second},
+		{"exact throughput second", 10 * 1024, skillBundleResolveFixedBudget + time.Second},
+		{"partial throughput second rounds up", 10*1024 + 1, skillBundleResolveFixedBudget + 2*time.Second},
+		{"scales at conservative throughput", 2 * 1024 * 1024, 3*time.Minute + 55*time.Second},
 		{"huge bundle caps at max", 100 * 1024 * 1024, skillBundleResolveMaxTimeout},
+		{"max int does not overflow", int64(^uint64(0) >> 1), skillBundleResolveMaxTimeout},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -32,6 +37,31 @@ func TestSkillBundleResolveTimeout(t *testing.T) {
 				t.Fatalf("skillBundleResolveTimeout(%d) = %s, want %s", tc.size, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSkillBundleDownloadWaitContext_ReservesPrepareTime(t *testing.T) {
+	parentDeadline := time.Now().Add(2 * time.Minute)
+	parent, cancelParent := context.WithDeadline(context.Background(), parentDeadline)
+	defer cancelParent()
+
+	ctx, cancel := skillBundleDownloadWaitContext(parent)
+	defer cancel()
+	got, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("download wait context has no deadline")
+	}
+	want := parentDeadline.Add(-skillBundlePrepareReserve)
+	if !got.Equal(want) {
+		t.Fatalf("download deadline = %s, want %s", got, want)
+	}
+}
+
+func TestSkillBundleDownloadWaitContext_NoParentDeadline(t *testing.T) {
+	ctx, cancel := skillBundleDownloadWaitContext(context.Background())
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("background download wait context unexpectedly has a deadline")
 	}
 }
 
@@ -139,6 +169,9 @@ func TestEnsureTaskSkillBundles_CachesEachSuccessAcrossDispatches(t *testing.T) 
 	if _, ok := d.skillCache.Load("ws-1", refs[2]); ok {
 		t.Error("dispatch 1: skill-3 must not be cached after a failed download")
 	}
+	if len(task.Agent.Skills) != 0 {
+		t.Fatalf("dispatch 1: task received %d skills after a missing bundle; want none", len(task.Agent.Skills))
+	}
 	// A 500 is transient, so skill-3 is retried over the full schedule.
 	mu.Lock()
 	wantSkill3 := len(skillBundleResolveRetrySchedule) + 1
@@ -172,6 +205,346 @@ func TestEnsureTaskSkillBundles_CachesEachSuccessAcrossDispatches(t *testing.T) 
 		if task.Agent.Skills[i].ID != id {
 			t.Errorf("dispatch 2: skill[%d].ID = %q, want %q", i, task.Agent.Skills[i].ID, id)
 		}
+	}
+}
+
+func TestEnsureTaskSkillBundles_SingleflightAcrossTasks(t *testing.T) {
+	bundle := makeResolvableSkillBundle("shared-skill")
+	ref := skillRefFromBundle(bundle)
+
+	var calls atomic.Int32
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			close(requestStarted)
+		}
+		<-releaseRequest
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"bundles": []SkillData{bundle}})
+	}))
+	defer srv.Close()
+	defer releaseOnce.Do(func() { close(releaseRequest) })
+
+	coordinator := newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads)
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		skillCache:     NewSkillBundleCache(t.TempDir()),
+		skillDownloads: coordinator,
+	}
+
+	const taskCount = 20
+	start := make(chan struct{})
+	errCh := make(chan error, taskCount)
+	for i := 0; i < taskCount; i++ {
+		task := testTaskWithSkillRefs(fmt.Sprintf("task-%d", i), "ws-1", []SkillRefData{ref})
+		go func() {
+			<-start
+			errCh <- d.ensureTaskSkillBundles(context.Background(), task)
+		}()
+	}
+	close(start)
+
+	waitForSignal(t, requestStarted, "shared bundle request")
+	waitForSkillFlightWaiters(t, coordinator, skillBundleCacheKey("ws-1", ref), taskCount)
+	releaseOnce.Do(func() { close(releaseRequest) })
+
+	for i := 0; i < taskCount; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("task %d: ensure skill bundle: %v", i, err)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("resolve requests = %d, want 1", got)
+	}
+}
+
+func TestEnsureTaskSkillBundles_DownloadsMissesConcurrently(t *testing.T) {
+	const skillCount = defaultMaxConcurrentSkillDownloads
+	bundles := make(map[string]SkillData, skillCount)
+	refs := make([]SkillRefData, 0, skillCount)
+	for i := 0; i < skillCount; i++ {
+		bundle := makeResolvableSkillBundle(fmt.Sprintf("skill-%d", i))
+		bundles[bundle.ID] = bundle
+		refs = append(refs, skillRefFromBundle(bundle))
+	}
+
+	entered := make(chan struct{}, skillCount)
+	releaseRequests := make(chan struct{})
+	var releaseOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Skills []SkillRefData `json:"skills"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Skills) != 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		entered <- struct{}{}
+		<-releaseRequests
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"bundles": []SkillData{bundles[req.Skills[0].ID]}})
+	}))
+	defer srv.Close()
+	defer releaseOnce.Do(func() { close(releaseRequests) })
+
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		skillCache:     NewSkillBundleCache(t.TempDir()),
+		skillDownloads: newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads),
+	}
+	task := testTaskWithSkillRefs("task-1", "ws-1", refs)
+	errCh := make(chan error, 1)
+	go func() { errCh <- d.ensureTaskSkillBundles(context.Background(), task) }()
+	for i := 0; i < skillCount; i++ {
+		waitForSignal(t, entered, "concurrent bundle request")
+	}
+	releaseOnce.Do(func() { close(releaseRequests) })
+	if err := waitForError(t, errCh, "concurrent bundle resolution"); err != nil {
+		t.Fatalf("ensure skill bundles: %v", err)
+	}
+	if got := len(task.Agent.Skills); got != skillCount {
+		t.Fatalf("resolved skills = %d, want %d", got, skillCount)
+	}
+}
+
+func TestEnsureTaskSkillBundles_WaiterCancellationDoesNotCancelSharedDownload(t *testing.T) {
+	bundle := makeResolvableSkillBundle("shared-skill")
+	ref := skillRefFromBundle(bundle)
+
+	requestStarted := make(chan struct{})
+	probeRequest := make(chan struct{})
+	requestAlive := make(chan struct{})
+	requestCancelled := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-probeRequest
+		select {
+		case <-r.Context().Done():
+			close(requestCancelled)
+			return
+		default:
+			close(requestAlive)
+		}
+		select {
+		case <-r.Context().Done():
+			close(requestCancelled)
+			return
+		case <-releaseRequest:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"bundles": []SkillData{bundle}})
+		}
+	}))
+	defer srv.Close()
+	defer releaseOnce.Do(func() { close(releaseRequest) })
+
+	coordinator := newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads)
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		skillCache:     NewSkillBundleCache(t.TempDir()),
+		skillDownloads: coordinator,
+	}
+	task1 := testTaskWithSkillRefs("task-1", "ws-1", []SkillRefData{ref})
+	task2 := testTaskWithSkillRefs("task-2", "ws-1", []SkillRefData{ref})
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	err1 := make(chan error, 1)
+	go func() { err1 <- d.ensureTaskSkillBundles(ctx1, task1) }()
+	waitForSignal(t, requestStarted, "shared bundle request")
+
+	err2 := make(chan error, 1)
+	go func() { err2 <- d.ensureTaskSkillBundles(context.Background(), task2) }()
+	waitForSkillFlightWaiters(t, coordinator, skillBundleCacheKey("ws-1", ref), 2)
+
+	cancel1()
+	if err := waitForError(t, err1, "cancelled waiter"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled waiter error = %v, want context.Canceled", err)
+	}
+	close(probeRequest)
+	select {
+	case <-requestAlive:
+	case <-requestCancelled:
+		t.Fatal("cancelling one waiter cancelled the shared HTTP request")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out probing shared HTTP request")
+	}
+
+	releaseOnce.Do(func() { close(releaseRequest) })
+	if err := waitForError(t, err2, "remaining waiter"); err != nil {
+		t.Fatalf("remaining waiter failed: %v", err)
+	}
+}
+
+func TestSkillBundleDownloadCoordinator_CancelsWhenAllWaitersLeave(t *testing.T) {
+	coordinator := newSkillBundleDownloadCoordinator(defaultMaxConcurrentSkillDownloads)
+	started := make(chan struct{})
+	operationCancelled := make(chan struct{})
+	var calls atomic.Int32
+	fn := func(ctx context.Context) (SkillData, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-ctx.Done()
+		close(operationCancelled)
+		return SkillData{}, context.Cause(ctx)
+	}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	err1 := make(chan error, 1)
+	err2 := make(chan error, 1)
+	go func() {
+		_, err := coordinator.do(ctx1, "shared", fn)
+		err1 <- err
+	}()
+	waitForSignal(t, started, "shared operation")
+	go func() {
+		_, err := coordinator.do(ctx2, "shared", fn)
+		err2 <- err
+	}()
+	waitForSkillFlightWaiters(t, coordinator, "shared", 2)
+
+	cancel1()
+	if err := waitForError(t, err1, "first cancelled waiter"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("first waiter error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-operationCancelled:
+		t.Fatal("shared operation cancelled while one waiter remained")
+	default:
+	}
+
+	cancel2()
+	if err := waitForError(t, err2, "last cancelled waiter"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("last waiter error = %v, want context.Canceled", err)
+	}
+	waitForSignal(t, operationCancelled, "shared operation cancellation")
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("shared operation calls = %d, want 1", got)
+	}
+}
+
+func TestEnsureTaskSkillBundles_GlobalDownloadLimit(t *testing.T) {
+	const (
+		downloadLimit = defaultMaxConcurrentSkillDownloads
+		taskCount     = 8
+	)
+
+	bundles := make(map[string]SkillData, taskCount)
+	refs := make([]SkillRefData, 0, taskCount)
+	for i := 0; i < taskCount; i++ {
+		bundle := makeResolvableSkillBundle(fmt.Sprintf("skill-%d", i))
+		bundles[bundle.ID] = bundle
+		refs = append(refs, skillRefFromBundle(bundle))
+	}
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	entered := make(chan struct{}, taskCount)
+	releaseRequests := make(chan struct{})
+	var releaseOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Skills []SkillRefData `json:"skills"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Skills) != 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		current := inFlight.Add(1)
+		defer inFlight.Add(-1)
+		for {
+			peak := maxInFlight.Load()
+			if current <= peak || maxInFlight.CompareAndSwap(peak, current) {
+				break
+			}
+		}
+		entered <- struct{}{}
+		<-releaseRequests
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"bundles": []SkillData{bundles[req.Skills[0].ID]}})
+	}))
+	defer srv.Close()
+	defer releaseOnce.Do(func() { close(releaseRequests) })
+
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		skillCache:     NewSkillBundleCache(t.TempDir()),
+		skillDownloads: newSkillBundleDownloadCoordinator(downloadLimit),
+	}
+	errCh := make(chan error, taskCount)
+	for i, ref := range refs {
+		task := testTaskWithSkillRefs(fmt.Sprintf("task-%d", i), "ws-1", []SkillRefData{ref})
+		go func() { errCh <- d.ensureTaskSkillBundles(context.Background(), task) }()
+	}
+	for i := 0; i < downloadLimit; i++ {
+		waitForSignal(t, entered, "bounded bundle request")
+	}
+	select {
+	case <-entered:
+		t.Fatalf("more than %d bundle requests entered concurrently", downloadLimit)
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseOnce.Do(func() { close(releaseRequests) })
+
+	for i := 0; i < taskCount; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("task %d: ensure skill bundle: %v", i, err)
+		}
+	}
+	if got := maxInFlight.Load(); got > downloadLimit {
+		t.Fatalf("max concurrent downloads = %d, want <= %d", got, downloadLimit)
+	}
+}
+
+func testTaskWithSkillRefs(taskID, workspaceID string, refs []SkillRefData) *Task {
+	return &Task{
+		ID:          taskID,
+		RuntimeID:   "rt-1",
+		WorkspaceID: workspaceID,
+		Agent:       &AgentData{ID: "agent-1", SkillRefs: refs},
+	}
+}
+
+func waitForSkillFlightWaiters(t *testing.T, coordinator *skillBundleDownloadCoordinator, key string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		coordinator.mu.Lock()
+		flight := coordinator.flights[key]
+		got := 0
+		if flight != nil {
+			got = flight.waiters
+		}
+		coordinator.mu.Unlock()
+		if got >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("flight %q did not reach %d waiters", key, want)
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func waitForError(t *testing.T, ch <-chan error, name string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+		return nil
 	}
 }
 
@@ -288,5 +661,11 @@ func TestEnsureTaskSkillBundles_DeadlineIsLabelledStructurally(t *testing.T) {
 	want := taskfailure.ReasonSkillBundleUnavailable.String()
 	if got := taskRunFailureReason(err); got != want {
 		t.Errorf("taskRunFailureReason = %q, want %q (retryable platform-side reason)", got, want)
+	}
+	if _, ok := d.skillCache.Load("ws-1", ref); ok {
+		t.Error("deadline failure must not leave a cache entry")
+	}
+	if len(task.Agent.Skills) != 0 {
+		t.Fatalf("deadline failure injected %d incomplete skills into task", len(task.Agent.Skills))
 	}
 }

--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -75,11 +75,15 @@ func (c *SkillBundleCache) WithRefLock(workspaceID string, ref SkillRefData, fn 
 	if c == nil {
 		return fn()
 	}
-	key := workspaceID + "\x00" + ref.Source + "\x00" + ref.ID + "\x00" + ref.Hash
+	key := skillBundleCacheKey(workspaceID, ref)
 	lock := c.lockForKey(key)
 	lock.Lock()
 	defer lock.Unlock()
 	return fn()
+}
+
+func skillBundleCacheKey(workspaceID string, ref SkillRefData) string {
+	return workspaceID + "\x00" + ref.Source + "\x00" + ref.ID + "\x00" + ref.Hash
 }
 
 func (c *SkillBundleCache) lockForKey(key string) *sync.Mutex {

--- a/server/internal/daemon/skill_download.go
+++ b/server/internal/daemon/skill_download.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+)
+
+const defaultMaxConcurrentSkillDownloads = 4
+
+// skillBundleDownloadCoordinator bounds bundle downloads across the whole
+// daemon and coalesces concurrent cache misses for the same immutable ref. A
+// flight owns its context: individual task cancellation only removes that
+// waiter, while the shared operation is cancelled once nobody is waiting.
+type skillBundleDownloadCoordinator struct {
+	slots chan struct{}
+
+	mu      sync.Mutex
+	flights map[string]*skillBundleDownloadFlight
+}
+
+type skillBundleDownloadFlight struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	waiters  int
+	finished bool
+	bundle   SkillData
+	err      error
+}
+
+func newSkillBundleDownloadCoordinator(limit int) *skillBundleDownloadCoordinator {
+	if limit <= 0 {
+		limit = defaultMaxConcurrentSkillDownloads
+	}
+	return &skillBundleDownloadCoordinator{
+		slots:   make(chan struct{}, limit),
+		flights: make(map[string]*skillBundleDownloadFlight),
+	}
+}
+
+func (c *skillBundleDownloadCoordinator) do(
+	ctx context.Context,
+	key string,
+	fn func(context.Context) (SkillData, error),
+) (SkillData, error) {
+	if err := ctx.Err(); err != nil {
+		return SkillData{}, context.Cause(ctx)
+	}
+
+	var flight *skillBundleDownloadFlight
+	for {
+		c.mu.Lock()
+		flight = c.flights[key]
+		if flight == nil {
+			flightCtx, cancel := context.WithCancel(context.Background())
+			flight = &skillBundleDownloadFlight{
+				ctx:     flightCtx,
+				cancel:  cancel,
+				done:    make(chan struct{}),
+				waiters: 1,
+			}
+			c.flights[key] = flight
+			go c.run(key, flight, fn)
+			c.mu.Unlock()
+			break
+		}
+		if flight.waiters > 0 {
+			flight.waiters++
+			c.mu.Unlock()
+			break
+		}
+
+		// The last waiter has cancelled this flight, but its HTTP transport may
+		// still be unwinding. Wait for it to leave the map before starting a new
+		// request so an immediate task retry cannot overlap the abandoned one.
+		done := flight.done
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return SkillData{}, context.Cause(ctx)
+		case <-done:
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		c.leave(flight)
+		return SkillData{}, context.Cause(ctx)
+	case <-flight.done:
+		c.leave(flight)
+		return flight.bundle, flight.err
+	}
+}
+
+func (c *skillBundleDownloadCoordinator) run(
+	key string,
+	flight *skillBundleDownloadFlight,
+	fn func(context.Context) (SkillData, error),
+) {
+	bundle, err := fn(flight.ctx)
+
+	c.mu.Lock()
+	flight.bundle = bundle
+	flight.err = err
+	flight.finished = true
+	if c.flights[key] == flight {
+		delete(c.flights, key)
+	}
+	close(flight.done)
+	flight.cancel()
+	c.mu.Unlock()
+}
+
+func (c *skillBundleDownloadCoordinator) leave(flight *skillBundleDownloadFlight) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	flight.waiters--
+	if flight.waiters == 0 && !flight.finished {
+		flight.cancel()
+	}
+}
+
+func (c *skillBundleDownloadCoordinator) acquire(ctx context.Context) error {
+	select {
+	case c.slots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+func (c *skillBundleDownloadCoordinator) release() {
+	<-c.slots
+}


### PR DESCRIPTION
## Summary

- resolve cache-missing skill bundles concurrently while capping daemon-wide HTTP downloads at 4
- coalesce concurrent misses by `workspace/source/id/hash`, with independently cancellable waiters and shared cancellation only after the last waiter leaves
- budget each bundle as 30s connection/first-byte allowance plus `ceil(size / 10KiB/s)`, capped by the prepare deadline with 30s reserved for environment setup
- keep full bundle validation and atomic cache writes; failures still abort preparation instead of launching with missing skills
- skip retry backoff when it cannot fit inside the remaining request deadline

This PR intentionally does not change the server response format or add compression.

Related to #6691.

## Validation

- `go test ./internal/daemon -count=1`
- `go test -race ./internal/daemon -run 'TestSkillBundle|TestEnsureTaskSkillBundles|TestPostJSONWithRetry' -count=1`
- `go vet ./internal/daemon`
- `git diff --check`
