### PR TITLE
MUL-5771 feat(daemon): allow configuring workspaces root

### DIFF
--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -275,7 +275,7 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 
 | コマンド | サブコマンド | 用途 | 主なフラグ |
 | --- | --- | --- | --- |
-| `daemon` | `start` | ローカルデーモンを起動 | `--foreground`、`--device-name`、`--runtime-name`、`--poll-interval`、`--heartbeat-interval`、`--agent-timeout`（`0` は上限なし）、`--max-concurrent-tasks`、`--no-auto-update`；それぞれに対応する `MULTICA_*` 環境変数があります |
+| `daemon` | `start` | ローカルデーモンを起動 | `--foreground`、`--device-name`、`--runtime-name`、`--workspaces-root`、`--poll-interval`、`--heartbeat-interval`、`--agent-timeout`（`0` は上限なし）、`--max-concurrent-tasks`、`--no-auto-update`；それぞれに対応する `MULTICA_*` 環境変数があります |
 | | `stop` / `status` / `restart` | 停止、状態の確認、再起動（`restart` は `start` と同じフラグ） | |
 | | `logs` | デーモンのログを表示 | `--follow`、`--lines` |
 | | `disk-usage` | ローカルのディスク使用量を表示 | `--by-workspace`、`--by-task`、`--top` |

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -275,7 +275,7 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 
 | 명령 | 하위 명령 | 용도 | 주요 flag |
 | --- | --- | --- | --- |
-| `daemon` | `start` | 로컬 데몬 시작 | `--foreground`, `--device-name`, `--runtime-name`, `--poll-interval`, `--heartbeat-interval`, `--agent-timeout`(`0`은 상한 없음), `--max-concurrent-tasks`, `--no-auto-update`. 모두 대응하는 `MULTICA_*` 환경 변수가 있음 |
+| `daemon` | `start` | 로컬 데몬 시작 | `--foreground`, `--device-name`, `--runtime-name`, `--workspaces-root`, `--poll-interval`, `--heartbeat-interval`, `--agent-timeout`(`0`은 상한 없음), `--max-concurrent-tasks`, `--no-auto-update`. 모두 대응하는 `MULTICA_*` 환경 변수가 있음 |
 | | `stop` / `status` / `restart` | 중지, 상태 확인, 다시 시작(`restart`와 `start`의 flag가 같음) | |
 | | `logs` | 데몬 로그 확인 | `--follow`, `--lines` |
 | | `disk-usage` | 로컬 디스크 사용량 확인 | `--by-workspace`, `--by-task`, `--top` |

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -296,7 +296,7 @@ The tables below cover every current top-level command, grouped the way the CLI 
 
 | Command | Subcommand | Purpose | Key flags |
 | --- | --- | --- | --- |
-| `daemon` | `start` | Start the local daemon | `--foreground`, `--device-name`, `--runtime-name`, `--poll-interval`, `--heartbeat-interval`, `--agent-timeout` (`0` means no limit), `--max-concurrent-tasks`, `--no-auto-update`; each has a matching `MULTICA_*` environment variable |
+| `daemon` | `start` | Start the local daemon | `--foreground`, `--device-name`, `--runtime-name`, `--workspaces-root`, `--poll-interval`, `--heartbeat-interval`, `--agent-timeout` (`0` means no limit), `--max-concurrent-tasks`, `--no-auto-update`; each has a matching `MULTICA_*` environment variable |
 | | `stop` / `status` / `restart` | Stop, check status, restart (`restart` takes the same flags as `start`) | |
 | | `logs` | View daemon logs | `--follow`, `--lines` |
 | | `disk-usage` | View local disk usage | `--by-workspace`, `--by-task`, `--top` |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -275,7 +275,7 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 
 | 命令 | 子命令 | 用途 | 关键 flag |
 | --- | --- | --- | --- |
-| `daemon` | `start` | 启动本机守护进程 | `--foreground`、`--device-name`、`--runtime-name`、`--poll-interval`、`--heartbeat-interval`、`--agent-timeout`（`0` 表示不设上限）、`--max-concurrent-tasks`、`--no-auto-update`；均有对应的 `MULTICA_*` 环境变量 |
+| `daemon` | `start` | 启动本机守护进程 | `--foreground`、`--device-name`、`--runtime-name`、`--workspaces-root`、`--poll-interval`、`--heartbeat-interval`、`--agent-timeout`（`0` 表示不设上限）、`--max-concurrent-tasks`、`--no-auto-update`；均有对应的 `MULTICA_*` 环境变量 |
 | | `stop` / `status` / `restart` | 停止、查看状态、重启（`restart` 与 `start` 同一套 flag） | |
 | | `logs` | 查看守护进程日志 | `--follow`、`--lines` |
 | | `disk-usage` | 查看本机磁盘占用 | `--by-workspace`、`--by-task`、`--top` |

--- a/apps/docs/content/docs/daemon-runtimes.ja.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.ja.mdx
@@ -44,6 +44,8 @@ multica daemon start
 | `multica daemon stop` | デーモンを停止する |
 | `multica daemon start --foreground` | デバッグ用に現在のターミナルで実行する |
 
+タスクの作業ディレクトリを別のディスクに置くには、`multica config set workspaces_root <path>` で現在のプロファイルにルートを保存するか、`daemon start` または `daemon restart` に `--workspaces-root <path>` を渡します。フラグは `MULTICA_WORKSPACES_ROOT` より優先され、環境変数はプロファイル設定より優先されます。ルートを変更しても既存のタスクディレクトリは移動されません。
+
 起動時、デーモンは `PATH` 上の対応する AI コーディングツールを検出し、あなたが接続を許可されているワークスペースにランタイムを登録します。ツールをインストールまたはログインした直後の場合は、デーモンを再起動すると再検出されます。
 
 デーモンは、組み込みで対応している AI コーディングツールを少なくとも 1 つ検出できないと起動しません。インストール方法と実行コマンド名は [AI コーディングツールのインストール](/install-agent-runtime)を参照してください。

--- a/apps/docs/content/docs/daemon-runtimes.ko.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.ko.mdx
@@ -44,6 +44,8 @@ multica daemon start
 | `multica daemon stop` | 데몬 중지 |
 | `multica daemon start --foreground` | 디버깅을 위해 현재 터미널에서 실행 |
 
+태스크 작업 디렉터리를 다른 디스크에 두려면 `multica config set workspaces_root <path>`로 현재 profile의 루트를 저장하거나 `daemon start` 또는 `daemon restart`에 `--workspaces-root <path>`를 전달합니다. flag는 `MULTICA_WORKSPACES_ROOT`보다 우선하고, 환경 변수는 profile 설정보다 우선합니다. 루트를 변경해도 기존 태스크 디렉터리는 이동되지 않습니다.
+
 시작할 때 데몬은 `PATH`에서 지원되는 AI 코딩 도구를 감지하고 사용자가 연결할 권한이 있는 워크스페이스에 런타임을 등록합니다. 도구를 방금 설치하거나 로그인했다면 데몬을 다시 시작해 다시 감지할 수 있습니다.
 
 데몬을 시작하려면 기본 지원 AI 코딩 도구를 하나 이상 감지해야 합니다. 설치 방법과 실행 파일 이름은 [AI 코딩 도구 설치](/install-agent-runtime)를 참고하세요.

--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -44,6 +44,8 @@ The daemon runs in the background by default. Common commands:
 | `multica daemon stop` | Stop the daemon |
 | `multica daemon start --foreground` | Run in the current terminal, for debugging |
 
+To place task workspaces on another disk, persist a root for the current profile with `multica config set workspaces_root <path>`, or pass `--workspaces-root <path>` to `daemon start` or `daemon restart`. The flag overrides `MULTICA_WORKSPACES_ROOT`, which overrides the profile config. Existing task directories are not moved when the root changes.
+
 On startup, the daemon detects supported AI coding tools on `PATH` and registers runtimes for the workspaces you are allowed to connect. If a tool was just installed or signed in, restart the daemon to detect it again.
 
 The daemon needs at least one built-in supported AI coding tool detected before it will start. Install methods and executable names are in [Install AI coding tools](/install-agent-runtime).

--- a/apps/docs/content/docs/daemon-runtimes.zh.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.zh.mdx
@@ -44,6 +44,8 @@ multica daemon start
 | `multica daemon stop` | 停止守护进程 |
 | `multica daemon start --foreground` | 在当前终端中运行，便于调试 |
 
+如需把 task 工作目录放到其他磁盘，可用 `multica config set workspaces_root <path>` 为当前 profile 持久化根目录，也可在 `daemon start` 或 `daemon restart` 中传入 `--workspaces-root <path>`。flag 的优先级高于 `MULTICA_WORKSPACES_ROOT`，环境变量又高于 profile 配置。修改根目录不会迁移已有的 task 目录。
+
 启动时，守护进程会检测 `PATH` 中受支持的 AI 编程工具，并为你有权连接的工作区注册运行时。如果一款工具刚刚安装或登录，重启守护进程即可重新检测。
 
 守护进程至少需要检测到一款内置支持的 AI 编程工具才能启动。安装方法和可执行文件名见[安装 AI 编程工具](/install-agent-runtime)。

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -237,6 +237,7 @@ multica config show
 | `workspace_id` | 空 | デフォルトのワークスペース |
 | `device_name` | ホスト名 | ランタイム一覧に表示されるデバイス名 |
 | `runtime_name` | `Local Agent` | ランタイムの表示名 |
+| `workspaces_root` | `~` 配下のプロファイル別パス | タスク作業ディレクトリのルート |
 | `max_concurrent_tasks` | `20` | 同時実行タスク上限。`0` または空は未設定を意味します |
 | `poll_interval` | `30s` | タスクのポーリング間隔 |
 | `heartbeat_interval` | `15s` | ハートビート間隔 |

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -253,6 +253,7 @@ multica config show
 - duration 系のキーは正の Go duration（`10s`、`2h` など）を受け付け、`0s` と負の値は拒否されます。唯一の例外は `agent_timeout` で、`0s` は有効な値として実行時間上限を明示的に無効化します。
 - 空文字列を渡すと永続化された値がクリアされ、環境変数または組み込みデフォルトに戻ります。例: `multica config set poll_interval ""`。
 - `max_concurrent_tasks` には非負の整数が必要です。
+- 相対パスの `workspaces_root` は保存時に絶対パスへ変換されます。
 
 ## 可観測性と分析
 

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -253,6 +253,7 @@ multica config show
 - duration key는 양의 Go duration(예: `10s`, `2h`)을 허용하며 `0s`와 음수는 거부합니다. 유일한 예외는 `agent_timeout`입니다. `0s`가 유효하며 실행 시간 제한을 명시적으로 끕니다.
 - 빈 문자열을 전달하면 저장된 값을 지우고 환경 변수 또는 내장 기본값으로 돌아갑니다. 예: `multica config set poll_interval ""`
 - `max_concurrent_tasks`는 0 이상의 정수여야 합니다.
+- 상대 `workspaces_root` 값은 저장할 때 절대 경로로 변환됩니다.
 
 ## 관측과 통계
 

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -237,6 +237,7 @@ multica config show
 | `workspace_id` | 비어 있음 | 기본 워크스페이스 |
 | `device_name` | host 이름 | 런타임 목록의 기기 이름 |
 | `runtime_name` | `Local Agent` | 런타임 표시 이름 |
+| `workspaces_root` | `~` 아래 profile별 경로 | 실행 태스크 작업 디렉터리의 루트 |
 | `max_concurrent_tasks` | `20` | 동시 실행 태스크 상한. `0` 또는 빈 값은 설정되지 않음을 의미 |
 | `poll_interval` | `30s` | 실행 태스크 polling 간격 |
 | `heartbeat_interval` | `15s` | heartbeat 간격 |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -253,6 +253,7 @@ A few value rules:
 - Duration keys accept positive Go durations (such as `10s`, `2h`); `0s` and negative values are rejected. The one exception is `agent_timeout`: `0s` is valid and explicitly disables the run time limit.
 - Passing an empty string clears a persisted value and falls back to the env var or built-in default, for example `multica config set poll_interval ""`.
 - `max_concurrent_tasks` requires a non-negative integer.
+- Relative `workspaces_root` values are converted to absolute paths when saved.
 
 ## Observability and analytics
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -237,6 +237,7 @@ Supported keys:
 | `workspace_id` | empty | Default workspace |
 | `device_name` | hostname | Device name shown in the runtime list |
 | `runtime_name` | `Local Agent` | Runtime display name |
+| `workspaces_root` | profile-aware path under `~` | Root directory for task working directories |
 | `max_concurrent_tasks` | `20` | Concurrent task ceiling; `0` or empty means unset |
 | `poll_interval` | `30s` | Task polling interval |
 | `heartbeat_interval` | `15s` | Heartbeat interval |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -253,6 +253,7 @@ multica config show
 - duration 类键接受正的 Go duration（如 `10s`、`2h`），`0s` 和负值会被拒绝。唯一例外是 `agent_timeout`：`0s` 合法，表示明确关闭执行时限。
 - 传空字符串清除已持久化的值，回到环境变量或内置默认，例如 `multica config set poll_interval ""`。
 - `max_concurrent_tasks` 要求非负整数。
+- 相对的 `workspaces_root` 值在保存时会转换为绝对路径。
 
 ## 观测与统计
 

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -237,6 +237,7 @@ multica config show
 | `workspace_id` | 空 | 默认工作区 |
 | `device_name` | 主机名 | 运行时列表中的设备名 |
 | `runtime_name` | `Local Agent` | 运行时显示名 |
+| `workspaces_root` | `~` 下按 profile 区分的路径 | 执行任务工作目录的根目录 |
 | `max_concurrent_tasks` | `20` | 并发执行任务上限；`0` 或留空表示未设置 |
 | `poll_interval` | `30s` | 执行任务轮询间隔 |
 | `heartbeat_interval` | `15s` | 心跳间隔 |

--- a/server/cmd/multica/cmd_config.go
+++ b/server/cmd/multica/cmd_config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -131,7 +132,11 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Set %s = %s\n", key, value)
+	storedValue := value
+	if key == "workspaces_root" {
+		storedValue = cfg.WorkspacesRoot
+	}
+	fmt.Fprintf(os.Stderr, "Set %s = %s\n", key, storedValue)
 	return nil
 }
 
@@ -158,7 +163,16 @@ func applyConfigSet(cfg *cli.CLIConfig, key, value string) error {
 	case "runtime_name":
 		cfg.RuntimeName = value
 	case "workspaces_root":
-		cfg.WorkspacesRoot = value
+		value = strings.TrimSpace(value)
+		if value == "" {
+			cfg.WorkspacesRoot = ""
+			return nil
+		}
+		root, err := filepath.Abs(value)
+		if err != nil {
+			return fmt.Errorf("resolve workspaces_root: %w", err)
+		}
+		cfg.WorkspacesRoot = root
 	case "max_concurrent_tasks":
 		if value == "" {
 			cfg.MaxConcurrentTasks = 0

--- a/server/cmd/multica/cmd_config.go
+++ b/server/cmd/multica/cmd_config.go
@@ -33,6 +33,7 @@ var configSetSupportedKeys = []string{
 	"workspace_id",
 	"device_name",
 	"runtime_name",
+	"workspaces_root",
 	"max_concurrent_tasks",
 	"poll_interval",
 	"heartbeat_interval",
@@ -49,11 +50,11 @@ var configSetCmd = &cobra.Command{
 	Short: "Set a CLI configuration value",
 	Long: "Supported keys: " +
 		"server_url, app_url, workspace_id, " +
-		"device_name, runtime_name, max_concurrent_tasks, poll_interval, " +
+		"device_name, runtime_name, workspaces_root, max_concurrent_tasks, poll_interval, " +
 		"heartbeat_interval, agent_timeout, " +
 		"codex_semantic_inactivity_timeout, codex_handshake_timeout, " +
 		"disable_auto_update, auto_update_check_interval, disable_auto_reload.\n\n" +
-		"The daemon keys (device_name, runtime_name, max_concurrent_tasks, " +
+		"The daemon keys (device_name, runtime_name, workspaces_root, max_concurrent_tasks, " +
 		"poll_interval, heartbeat_interval, agent_timeout, " +
 		"codex_semantic_inactivity_timeout, codex_handshake_timeout, " +
 		"disable_auto_update, auto_update_check_interval, disable_auto_reload) mirror their " +
@@ -97,6 +98,7 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "workspace_id:", valueOrDefault(cfg.WorkspaceID, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "device_name:", valueOrDefault(cfg.DeviceName, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "runtime_name:", valueOrDefault(cfg.RuntimeName, "(not set)"))
+	fmt.Fprintf(os.Stdout, "%-34s %s\n", "workspaces_root:", valueOrDefault(cfg.WorkspacesRoot, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "max_concurrent_tasks:", intOrDefault(cfg.MaxConcurrentTasks, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "poll_interval:", valueOrDefault(cfg.PollInterval, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "heartbeat_interval:", valueOrDefault(cfg.HeartbeatInterval, "(not set)"))
@@ -155,6 +157,8 @@ func applyConfigSet(cfg *cli.CLIConfig, key, value string) error {
 		cfg.DeviceName = value
 	case "runtime_name":
 		cfg.RuntimeName = value
+	case "workspaces_root":
+		cfg.WorkspacesRoot = value
 	case "max_concurrent_tasks":
 		if value == "" {
 			cfg.MaxConcurrentTasks = 0

--- a/server/cmd/multica/cmd_config_test.go
+++ b/server/cmd/multica/cmd_config_test.go
@@ -35,13 +35,16 @@ func TestRunConfigSetPersistsSupportedKeysInProfile(t *testing.T) {
 	if err := runConfigSet(cmd, []string{"workspace_id", "ws-123"}); err != nil {
 		t.Fatalf("runConfigSet workspace_id: %v", err)
 	}
+	if err := runConfigSet(cmd, []string{"workspaces_root", "/data/multica-dev"}); err != nil {
+		t.Fatalf("runConfigSet workspaces_root: %v", err)
+	}
 	_ = stderr.read()
 
 	cfg, err := cli.LoadCLIConfigForProfile("dev")
 	if err != nil {
 		t.Fatalf("LoadCLIConfigForProfile: %v", err)
 	}
-	if cfg.ServerURL != "http://127.0.0.1:8080" || cfg.AppURL != "http://127.0.0.1:3000" || cfg.WorkspaceID != "ws-123" {
+	if cfg.ServerURL != "http://127.0.0.1:8080" || cfg.AppURL != "http://127.0.0.1:3000" || cfg.WorkspaceID != "ws-123" || cfg.WorkspacesRoot != "/data/multica-dev" {
 		t.Fatalf("config = %#v, want persisted supported keys", cfg)
 	}
 }
@@ -64,6 +67,7 @@ func TestRunConfigShowIncludesProfileAndDefaults(t *testing.T) {
 		"workspace_id:",
 		"device_name:",
 		"runtime_name:",
+		"workspaces_root:",
 		"max_concurrent_tasks:",
 		"poll_interval:",
 		"heartbeat_interval:",
@@ -198,6 +202,7 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 	pairs := []struct{ key, val string }{
 		{"device_name", "vm-1-custom-name"},
 		{"runtime_name", "worker-a"},
+		{"workspaces_root", "/mnt/multica"},
 		{"max_concurrent_tasks", "4"},
 		{"poll_interval", "10s"},
 		{"heartbeat_interval", "5s"},
@@ -214,6 +219,7 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 	}
 	if cfg.DeviceName != "vm-1-custom-name" ||
 		cfg.RuntimeName != "worker-a" ||
+		cfg.WorkspacesRoot != "/mnt/multica" ||
 		cfg.MaxConcurrentTasks != 4 ||
 		cfg.PollInterval != "10s" ||
 		cfg.HeartbeatInterval != "5s" ||

--- a/server/cmd/multica/cmd_config_test.go
+++ b/server/cmd/multica/cmd_config_test.go
@@ -20,6 +20,7 @@ func newConfigTestCmd() *cobra.Command {
 
 func TestRunConfigSetPersistsSupportedKeysInProfile(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	workspacesRoot := filepath.Join(t.TempDir(), "multica-dev")
 
 	cmd := newConfigTestCmd()
 	_ = cmd.Flags().Set("profile", "dev")
@@ -35,7 +36,7 @@ func TestRunConfigSetPersistsSupportedKeysInProfile(t *testing.T) {
 	if err := runConfigSet(cmd, []string{"workspace_id", "ws-123"}); err != nil {
 		t.Fatalf("runConfigSet workspace_id: %v", err)
 	}
-	if err := runConfigSet(cmd, []string{"workspaces_root", "/data/multica-dev"}); err != nil {
+	if err := runConfigSet(cmd, []string{"workspaces_root", workspacesRoot}); err != nil {
 		t.Fatalf("runConfigSet workspaces_root: %v", err)
 	}
 	_ = stderr.read()
@@ -44,7 +45,7 @@ func TestRunConfigSetPersistsSupportedKeysInProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCLIConfigForProfile: %v", err)
 	}
-	if cfg.ServerURL != "http://127.0.0.1:8080" || cfg.AppURL != "http://127.0.0.1:3000" || cfg.WorkspaceID != "ws-123" || cfg.WorkspacesRoot != "/data/multica-dev" {
+	if cfg.ServerURL != "http://127.0.0.1:8080" || cfg.AppURL != "http://127.0.0.1:3000" || cfg.WorkspaceID != "ws-123" || cfg.WorkspacesRoot != workspacesRoot {
 		t.Fatalf("config = %#v, want persisted supported keys", cfg)
 	}
 }
@@ -199,10 +200,11 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 	t.Parallel()
 
 	cfg := cli.CLIConfig{}
+	workspacesRoot := filepath.Join(t.TempDir(), "multica")
 	pairs := []struct{ key, val string }{
 		{"device_name", "vm-1-custom-name"},
 		{"runtime_name", "worker-a"},
-		{"workspaces_root", "/mnt/multica"},
+		{"workspaces_root", workspacesRoot},
 		{"max_concurrent_tasks", "4"},
 		{"poll_interval", "10s"},
 		{"heartbeat_interval", "5s"},
@@ -219,7 +221,7 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 	}
 	if cfg.DeviceName != "vm-1-custom-name" ||
 		cfg.RuntimeName != "worker-a" ||
-		cfg.WorkspacesRoot != "/mnt/multica" ||
+		cfg.WorkspacesRoot != workspacesRoot ||
 		cfg.MaxConcurrentTasks != 4 ||
 		cfg.PollInterval != "10s" ||
 		cfg.HeartbeatInterval != "5s" ||
@@ -229,6 +231,26 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 		cfg.AutoUpdateCheckInterval != "12h" ||
 		cfg.DisableAutoReload != true {
 		t.Fatalf("cfg after set = %+v", cfg)
+	}
+}
+
+func TestApplyConfigSetNormalizesWorkspacesRoot(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	cfg := cli.CLIConfig{}
+	if err := applyConfigSet(&cfg, "workspaces_root", filepath.Join("data", "multica")); err != nil {
+		t.Fatalf("applyConfigSet: %v", err)
+	}
+	want := filepath.Join(cwd, "data", "multica")
+	if cfg.WorkspacesRoot != want {
+		t.Fatalf("WorkspacesRoot = %q, want absolute path %q", cfg.WorkspacesRoot, want)
+	}
+	if err := applyConfigSet(&cfg, "workspaces_root", ""); err != nil {
+		t.Fatalf("clear workspaces_root: %v", err)
+	}
+	if cfg.WorkspacesRoot != "" {
+		t.Fatalf("WorkspacesRoot = %q, want empty after clear", cfg.WorkspacesRoot)
 	}
 }
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -967,18 +967,17 @@ func runDaemonForeground(cmd *cobra.Command) error {
 		"MULTICA_AGENT_RUNTIME_NAME",
 		fileCfg.RuntimeName,
 	)
-	workspacesRootFlag := resolveDaemonStringOverride(
-		flagString(cmd, "workspaces-root"),
-		"MULTICA_WORKSPACES_ROOT",
-		fileCfg.WorkspacesRoot,
-	)
+	workspacesRoot, err := resolveWorkspacesRootForProfile(profile, flagString(cmd, "workspaces-root"))
+	if err != nil {
+		return err
+	}
 
 	overrides := daemon.Overrides{
 		ServerURL:      serverURL,
 		DaemonID:       flagString(cmd, "daemon-id"),
 		DeviceName:     deviceNameFlag,
 		RuntimeName:    runtimeNameFlag,
-		WorkspacesRoot: workspacesRootFlag,
+		WorkspacesRoot: workspacesRoot,
 		Profile:        profile,
 		HealthPort:     healthPortForProfile(profile),
 	}
@@ -1643,6 +1642,20 @@ func resolveDaemonStringOverride(flagValue, envName, cfgValue string) string {
 	return cfgValue
 }
 
+// resolveWorkspacesRootForProfile is the single human-CLI resolver for the
+// daemon's task workspace root. Keeping daemon start, disk-usage, aggregate
+// scans, and cross-profile hints on this path prevents diagnostics from
+// drifting away from the directory the daemon actually uses.
+func resolveWorkspacesRootForProfile(profile, flagValue string) (string, error) {
+	fileCfg, _ := cli.LoadCLIConfigForProfile(profile)
+	override := resolveDaemonStringOverride(
+		flagValue,
+		"MULTICA_WORKSPACES_ROOT",
+		fileCfg.WorkspacesRoot,
+	)
+	return daemon.ResolveWorkspacesRoot(profile, override)
+}
+
 // resolveDaemonDurationOverride is the numeric counterpart for
 // poll_interval. flagValue > 0 wins; otherwise, if the env var is unset
 // we parse cfgValue. Parse errors and non-positive values are surfaced
@@ -1840,7 +1853,7 @@ func checkTaskDiskUsageScope(profile, rootOverride string, allProfiles bool) err
 // with. Failing closed on a missing value keeps that guess out of the output.
 func resolveDiskUsageRoot(taskContext bool, profile, rootOverride string) (string, error) {
 	if !taskContext {
-		return daemon.ResolveWorkspacesRoot(profile, rootOverride)
+		return resolveWorkspacesRootForProfile(profile, rootOverride)
 	}
 	root := strings.TrimSpace(os.Getenv(daemon.TaskWorkspacesRootEnv))
 	if root == "" {
@@ -1972,12 +1985,10 @@ func runDaemonDiskUsageAggregate(cmd *cobra.Command, byWorkspace bool, top int, 
 // (e.g. when MULTICA_WORKSPACES_ROOT pins every profile to one directory) are
 // collapsed to a single entry.
 func enumerateDiskUsageRoots() ([]daemon.DiskUsageRoot, error) {
-	seen := map[string]bool{}
 	out := make([]daemon.DiskUsageRoot, 0)
 
-	if root, err := daemon.ResolveWorkspacesRoot("", ""); err == nil {
+	if root, err := resolveWorkspacesRootForProfile("", ""); err == nil {
 		out = append(out, daemon.DiskUsageRoot{Profile: "", Root: root})
-		seen[root] = true
 	}
 
 	profilesRoot, err := profilesRootDir()
@@ -1996,8 +2007,8 @@ func enumerateDiskUsageRoots() ([]daemon.DiskUsageRoot, error) {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		root, err := daemon.ResolveWorkspacesRoot(name, "")
-		if err != nil || seen[root] {
+		root, err := resolveWorkspacesRootForProfile(name, "")
+		if err != nil || containsDiskUsageRoot(out, root) {
 			continue
 		}
 		// Skip profile roots that were never created on disk — a configured
@@ -2005,10 +2016,18 @@ func enumerateDiskUsageRoots() ([]daemon.DiskUsageRoot, error) {
 		if info, statErr := os.Stat(root); statErr != nil || !info.IsDir() {
 			continue
 		}
-		seen[root] = true
 		out = append(out, daemon.DiskUsageRoot{Profile: name, Root: root})
 	}
 	return out, nil
+}
+
+func containsDiskUsageRoot(roots []daemon.DiskUsageRoot, candidate string) bool {
+	for _, root := range roots {
+		if samePath(root.Root, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func printAggregateDiskUsage(w io.Writer, agg daemon.AggregateDiskUsageReport, byWorkspace bool) {
@@ -2164,7 +2183,7 @@ type diskUsageProfileSuggestion struct {
 func diskUsageProfileSuggestions(currentProfile, currentRoot string) []diskUsageProfileSuggestion {
 	out := make([]diskUsageProfileSuggestion, 0)
 	if currentProfile != "" {
-		if root, err := daemon.ResolveWorkspacesRoot("", ""); err == nil && !samePath(root, currentRoot) {
+		if root, err := resolveWorkspacesRootForProfile("", ""); err == nil && !samePath(root, currentRoot) {
 			if taskCount := countDiskUsageTaskDirs(root); taskCount > 0 {
 				out = append(out, diskUsageProfileSuggestion{
 					Profile:   "",
@@ -2192,7 +2211,7 @@ func diskUsageProfileSuggestions(currentProfile, currentRoot string) []diskUsage
 		if profile == currentProfile {
 			continue
 		}
-		root, err := daemon.ResolveWorkspacesRoot(profile, "")
+		root, err := resolveWorkspacesRootForProfile(profile, "")
 		if err != nil || samePath(root, currentRoot) {
 			continue
 		}

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -97,6 +97,7 @@ func init() {
 	f.String("daemon-id", "", "Unique daemon identifier (env: MULTICA_DAEMON_ID)")
 	f.String("device-name", "", "Human-readable device name (env: MULTICA_DAEMON_DEVICE_NAME)")
 	f.String("runtime-name", "", "Runtime display name (env: MULTICA_AGENT_RUNTIME_NAME)")
+	f.String("workspaces-root", "", "Base directory for task workspaces (env: MULTICA_WORKSPACES_ROOT)")
 	f.Duration("poll-interval", 0, "Task poll interval (env: MULTICA_DAEMON_POLL_INTERVAL)")
 	f.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	f.Duration("agent-timeout", 0, "Absolute per-task wall-clock cap; 0 = no cap, rely on the watchdogs (env: MULTICA_AGENT_TIMEOUT)")
@@ -118,6 +119,7 @@ func init() {
 	rf.String("daemon-id", "", "Unique daemon identifier (env: MULTICA_DAEMON_ID)")
 	rf.String("device-name", "", "Human-readable device name (env: MULTICA_DAEMON_DEVICE_NAME)")
 	rf.String("runtime-name", "", "Runtime display name (env: MULTICA_AGENT_RUNTIME_NAME)")
+	rf.String("workspaces-root", "", "Base directory for task workspaces (env: MULTICA_WORKSPACES_ROOT)")
 	rf.Duration("poll-interval", 0, "Task poll interval (env: MULTICA_DAEMON_POLL_INTERVAL)")
 	rf.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	rf.Duration("agent-timeout", 0, "Absolute per-task wall-clock cap; 0 = no cap, rely on the watchdogs (env: MULTICA_AGENT_TIMEOUT)")
@@ -861,6 +863,9 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if v := flagString(cmd, "runtime-name"); v != "" {
 		args = append(args, "--runtime-name", v)
 	}
+	if v := flagString(cmd, "workspaces-root"); v != "" {
+		args = append(args, "--workspaces-root", v)
+	}
 	if d, _ := cmd.Flags().GetDuration("poll-interval"); d > 0 {
 		args = append(args, "--poll-interval", d.String())
 	}
@@ -962,14 +967,20 @@ func runDaemonForeground(cmd *cobra.Command) error {
 		"MULTICA_AGENT_RUNTIME_NAME",
 		fileCfg.RuntimeName,
 	)
+	workspacesRootFlag := resolveDaemonStringOverride(
+		flagString(cmd, "workspaces-root"),
+		"MULTICA_WORKSPACES_ROOT",
+		fileCfg.WorkspacesRoot,
+	)
 
 	overrides := daemon.Overrides{
-		ServerURL:   serverURL,
-		DaemonID:    flagString(cmd, "daemon-id"),
-		DeviceName:  deviceNameFlag,
-		RuntimeName: runtimeNameFlag,
-		Profile:     profile,
-		HealthPort:  healthPortForProfile(profile),
+		ServerURL:      serverURL,
+		DaemonID:       flagString(cmd, "daemon-id"),
+		DeviceName:     deviceNameFlag,
+		RuntimeName:    runtimeNameFlag,
+		WorkspacesRoot: workspacesRootFlag,
+		Profile:        profile,
+		HealthPort:     healthPortForProfile(profile),
 	}
 	pollFlag, _ := cmd.Flags().GetDuration("poll-interval")
 	pollOverride, err := resolveDaemonDurationOverride(pollFlag, "MULTICA_DAEMON_POLL_INTERVAL", fileCfg.PollInterval)
@@ -1607,7 +1618,8 @@ func envUnset(name string) bool {
 }
 
 // resolveDaemonStringOverride picks the value that goes into
-// daemon.Overrides for a string knob (device_name, runtime_name).
+// daemon.Overrides for a string knob (device_name, runtime_name,
+// workspaces_root).
 // Precedence, highest first:
 //
 //  1. flag (already resolved to string; empty means "not passed")

--- a/server/cmd/multica/cmd_daemon_diskusage_status_test.go
+++ b/server/cmd/multica/cmd_daemon_diskusage_status_test.go
@@ -495,3 +495,100 @@ func TestResolveDiskUsageRootTaskContext(t *testing.T) {
 		}
 	})
 }
+
+func TestRunDaemonDiskUsageHonorsProfileWorkspacesRoot(t *testing.T) {
+	pinHumanCLIContext(t)
+	home := t.TempDir()
+	customRoot := filepath.Join(t.TempDir(), "configured-workspaces")
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspacesRoot: customRoot}); err != nil {
+		t.Fatalf("SaveCLIConfig: %v", err)
+	}
+
+	cmd := newDiskUsageTestCmd(t)
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureStdout(t, func() error { return runDaemonDiskUsage(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runDaemonDiskUsage: %v", err)
+	}
+	var report daemon.DiskUsageReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if report.WorkspacesRoot != customRoot {
+		t.Fatalf("WorkspacesRoot = %q, want configured root %q", report.WorkspacesRoot, customRoot)
+	}
+}
+
+func TestResolveDiskUsageRootEnvOverridesProfileConfig(t *testing.T) {
+	pinHumanCLIContext(t)
+	home := t.TempDir()
+	configRoot := filepath.Join(t.TempDir(), "configured-workspaces")
+	envRoot := filepath.Join(t.TempDir(), "env-workspaces")
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", envRoot)
+	if err := cli.SaveCLIConfig(cli.CLIConfig{WorkspacesRoot: configRoot}); err != nil {
+		t.Fatalf("SaveCLIConfig: %v", err)
+	}
+
+	got, err := resolveDiskUsageRoot(false, "", "")
+	if err != nil {
+		t.Fatalf("resolveDiskUsageRoot: %v", err)
+	}
+	if got != envRoot {
+		t.Fatalf("root = %q, want env root %q", got, envRoot)
+	}
+}
+
+func TestEnumerateDiskUsageRootsUsesAndDeduplicatesProfileConfig(t *testing.T) {
+	pinHumanCLIContext(t)
+	home := t.TempDir()
+	defaultRoot := filepath.Join(t.TempDir(), "default-root")
+	sharedRoot := filepath.Join(t.TempDir(), "shared-root")
+	uniqueRoot := filepath.Join(t.TempDir(), "unique-root")
+	neverRanRoot := filepath.Join(t.TempDir(), "never-ran-root")
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+
+	configs := []struct {
+		profile string
+		root    string
+	}{
+		{"", defaultRoot},
+		{"alpha", sharedRoot},
+		{"beta", sharedRoot},
+		{"gamma", uniqueRoot},
+		{"never-ran", neverRanRoot},
+	}
+	for _, item := range configs {
+		if err := cli.SaveCLIConfigForProfile(cli.CLIConfig{WorkspacesRoot: item.root}, item.profile); err != nil {
+			t.Fatalf("save profile %q: %v", item.profile, err)
+		}
+	}
+	for _, root := range []string{defaultRoot, sharedRoot, uniqueRoot} {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	roots, err := enumerateDiskUsageRoots()
+	if err != nil {
+		t.Fatalf("enumerateDiskUsageRoots: %v", err)
+	}
+	want := []daemon.DiskUsageRoot{
+		{Profile: "", Root: defaultRoot},
+		{Profile: "alpha", Root: sharedRoot},
+		{Profile: "gamma", Root: uniqueRoot},
+	}
+	if len(roots) != len(want) {
+		t.Fatalf("roots = %+v, want %+v", roots, want)
+	}
+	for i := range want {
+		if roots[i] != want[i] {
+			t.Fatalf("roots[%d] = %+v, want %+v", i, roots[i], want[i])
+		}
+	}
+}

--- a/server/cmd/multica/cmd_daemon_precedence_test.go
+++ b/server/cmd/multica/cmd_daemon_precedence_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/daemon"
 )
 
 // TestResolveDaemonStringOverridePrecedence pins the three-tier order:
@@ -16,11 +19,11 @@ func TestResolveDaemonStringOverridePrecedence(t *testing.T) {
 	const envName = "TEST_MULTICA_STR_OVERRIDE"
 
 	cases := []struct {
-		name   string
-		flag   string
-		env    string // "" means unset
-		cfg    string
-		want   string
+		name string
+		flag string
+		env  string // "" means unset
+		cfg  string
+		want string
 	}{
 		{"flag wins over env and cfg", "flag-val", "env-val", "cfg-val", "flag-val"},
 		{"env suppresses cfg", "", "env-val", "cfg-val", ""},
@@ -44,6 +47,50 @@ func TestResolveDaemonStringOverridePrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveDaemonWorkspacesRootPrecedence(t *testing.T) {
+	flagRoot := filepath.Join(t.TempDir(), "flag")
+	envRoot := filepath.Join(t.TempDir(), "env")
+	configRoot := filepath.Join(t.TempDir(), "config")
+	t.Setenv("MULTICA_WORKSPACES_ROOT", envRoot)
+
+	got, err := daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride(flagRoot, "MULTICA_WORKSPACES_ROOT", configRoot))
+	if err != nil {
+		t.Fatalf("resolve flag root: %v", err)
+	}
+	if got != flagRoot {
+		t.Fatalf("flag root = %q, want %q", got, flagRoot)
+	}
+
+	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", configRoot))
+	if err != nil {
+		t.Fatalf("resolve env root: %v", err)
+	}
+	if got != envRoot {
+		t.Fatalf("env root = %q, want %q", got, envRoot)
+	}
+
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", configRoot))
+	if err != nil {
+		t.Fatalf("resolve config root: %v", err)
+	}
+	if got != configRoot {
+		t.Fatalf("config root = %q, want %q", got, configRoot)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", ""))
+	if err != nil {
+		t.Fatalf("resolve default root: %v", err)
+	}
+	wantDefault := filepath.Join(home, "multica_workspaces_dev")
+	if got != wantDefault {
+		t.Fatalf("default root = %q, want %q", got, wantDefault)
+	}
+}
+
 // TestResolveDaemonDurationOverridePrecedence covers the numeric path:
 // flag>0 wins, env suppresses cfg, cfg parsed on demand, invalid cfg
 // surfaces as an error so the daemon doesn't silently fall back.
@@ -51,12 +98,12 @@ func TestResolveDaemonDurationOverridePrecedence(t *testing.T) {
 	const envName = "TEST_MULTICA_DUR_OVERRIDE"
 
 	cases := []struct {
-		name    string
-		flag    time.Duration
-		env     string
-		cfg     string
-		want    time.Duration
-		errSub  string // substring of expected error, "" = no error
+		name   string
+		flag   time.Duration
+		env    string
+		cfg    string
+		want   time.Duration
+		errSub string // substring of expected error, "" = no error
 	}{
 		{"flag wins", 5 * time.Second, "10s", "20s", 5 * time.Second, ""},
 		{"env suppresses cfg", 0, "10s", "20s", 0, ""},

--- a/server/cmd/multica/cmd_daemon_precedence_test.go
+++ b/server/cmd/multica/cmd_daemon_precedence_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/multica-ai/multica/server/internal/daemon"
+	"github.com/multica-ai/multica/server/internal/cli"
 )
 
 // TestResolveDaemonStringOverridePrecedence pins the three-tier order:
@@ -48,12 +48,18 @@ func TestResolveDaemonStringOverridePrecedence(t *testing.T) {
 }
 
 func TestResolveDaemonWorkspacesRootPrecedence(t *testing.T) {
+	home := t.TempDir()
 	flagRoot := filepath.Join(t.TempDir(), "flag")
 	envRoot := filepath.Join(t.TempDir(), "env")
 	configRoot := filepath.Join(t.TempDir(), "config")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if err := cli.SaveCLIConfigForProfile(cli.CLIConfig{WorkspacesRoot: configRoot}, "dev"); err != nil {
+		t.Fatalf("SaveCLIConfigForProfile: %v", err)
+	}
 	t.Setenv("MULTICA_WORKSPACES_ROOT", envRoot)
 
-	got, err := daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride(flagRoot, "MULTICA_WORKSPACES_ROOT", configRoot))
+	got, err := resolveWorkspacesRootForProfile("dev", flagRoot)
 	if err != nil {
 		t.Fatalf("resolve flag root: %v", err)
 	}
@@ -61,7 +67,7 @@ func TestResolveDaemonWorkspacesRootPrecedence(t *testing.T) {
 		t.Fatalf("flag root = %q, want %q", got, flagRoot)
 	}
 
-	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", configRoot))
+	got, err = resolveWorkspacesRootForProfile("dev", "")
 	if err != nil {
 		t.Fatalf("resolve env root: %v", err)
 	}
@@ -70,7 +76,7 @@ func TestResolveDaemonWorkspacesRootPrecedence(t *testing.T) {
 	}
 
 	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
-	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", configRoot))
+	got, err = resolveWorkspacesRootForProfile("dev", "")
 	if err != nil {
 		t.Fatalf("resolve config root: %v", err)
 	}
@@ -78,10 +84,10 @@ func TestResolveDaemonWorkspacesRootPrecedence(t *testing.T) {
 		t.Fatalf("config root = %q, want %q", got, configRoot)
 	}
 
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	got, err = daemon.ResolveWorkspacesRoot("dev", resolveDaemonStringOverride("", "MULTICA_WORKSPACES_ROOT", ""))
+	if err := cli.SaveCLIConfigForProfile(cli.CLIConfig{}, "dev"); err != nil {
+		t.Fatalf("clear profile config: %v", err)
+	}
+	got, err = resolveWorkspacesRootForProfile("dev", "")
 	if err != nil {
 		t.Fatalf("resolve default root: %v", err)
 	}

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -105,6 +105,20 @@ func TestBuildDaemonStartArgsForwardsCodexHandshakeTimeout(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonStartArgsForwardsWorkspacesRoot(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workspaces-root", "", "")
+	if err := cmd.Flags().Set("workspaces-root", "/Volumes/Agent Workspaces"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	args := buildDaemonStartArgs(cmd)
+	want := []string{"daemon", "start", "--foreground", "--workspaces-root", "/Volumes/Agent Workspaces"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("buildDaemonStartArgs() = %q, want %q", args, want)
+	}
+}
+
 // TestBuildDaemonStartArgsForwardsNoAutoReload matters because `daemon start`
 // re-execs itself as a foreground child: a flag the parent parsed but doesn't
 // forward is silently dropped, so the opt-out would appear to work and not.
@@ -131,6 +145,16 @@ func TestNoAutoReloadFlagRegisteredOnBothDaemonCommands(t *testing.T) {
 	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonRestartCmd} {
 		if cmd.Flags().Lookup("no-auto-reload") == nil {
 			t.Errorf("daemon %s is missing --no-auto-reload", cmd.Name())
+		}
+	}
+}
+
+func TestWorkspacesRootFlagRegisteredOnBothDaemonCommands(t *testing.T) {
+	t.Parallel()
+
+	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonRestartCmd} {
+		if cmd.Flags().Lookup("workspaces-root") == nil {
+			t.Errorf("daemon %s is missing --workspaces-root", cmd.Name())
 		}
 	}
 }

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -717,6 +717,30 @@ func TestPrintDiskUsageOtherRootsHintSuggestsDefaultFromNamedProfile(t *testing.
 	}
 }
 
+func TestPrintDiskUsageOtherRootsHintUsesProfileConfig(t *testing.T) {
+	home := t.TempDir()
+	customRoot := filepath.Join(t.TempDir(), "custom-profile-root")
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+	if err := cli.SaveCLIConfigForProfile(cli.CLIConfig{WorkspacesRoot: customRoot}, "custom"); err != nil {
+		t.Fatalf("SaveCLIConfigForProfile: %v", err)
+	}
+	writeDiskUsageFile(t, filepath.Join(customRoot, "ws1", "task1", "workdir", "main.go"))
+
+	var out bytes.Buffer
+	printDiskUsageOtherRootsHint(&out, daemon.DiskUsageReport{
+		WorkspacesRoot: filepath.Join(home, "multica_workspaces"),
+	}, "", "", false)
+
+	got := out.String()
+	if !strings.Contains(got, customRoot) {
+		t.Fatalf("hint output = %q, want configured root %q", got, customRoot)
+	}
+	if strings.Contains(got, filepath.Join(home, "multica_workspaces_custom")) {
+		t.Fatalf("hint output = %q, must not suggest the profile's old default root", got)
+	}
+}
+
 func TestPrintDiskUsageOtherRootsHintSkipsExplicitRootOverride(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/server/internal/cli/config.go
+++ b/server/internal/cli/config.go
@@ -47,6 +47,14 @@ type CLIConfig struct {
 	// DefaultRuntimeName.
 	RuntimeName string `json:"runtime_name,omitempty"`
 
+	// WorkspacesRoot is the base directory where the daemon creates task
+	// workspaces. Persisting it per profile avoids relying on a process-wide
+	// environment variable and preserves profile isolation. Empty means "not
+	// set — use env / built-in default". Resolution precedence (highest wins):
+	// --workspaces-root flag, MULTICA_WORKSPACES_ROOT env, this field, the
+	// profile-aware built-in default.
+	WorkspacesRoot string `json:"workspaces_root,omitempty"`
+
 	// MaxConcurrentTasks caps the number of task executions the daemon
 	// processes in parallel. Persist here to avoid re-passing
 	// --max-concurrent-tasks on every daemon start / auto-restart. 0 means


### PR DESCRIPTION
## What does this PR do?

Adds the accepted configuration surfaces from #6445 for relocating daemon task workspaces:

- `multica config set workspaces_root <path>` persists a root in the current profile
- `multica daemon start --workspaces-root <path>` and `daemon restart` provide a one-shot override
- background starts forward the flag to the foreground child
- resolution follows `--flag > MULTICA_WORKSPACES_ROOT > profile config > built-in default`

The implementation feeds the selected value into the existing `daemon.ResolveWorkspacesRoot` path rather than introducing a second path resolver, so absolute-path normalization and profile-aware defaults remain unchanged.

**Thinking path:** the issue is not just about moving data to another disk. The environment-only setting is process-context-dependent and profile-blind, while the daemon's other operator settings already use a profile-scoped config plus flag/env precedence. Extending that established contract is smaller and more predictable than adding workspace migration or a separate storage subsystem.

## Related Issue

Closes #6445

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add `workspaces_root` to the profile CLI config schema, `config set`, and `config show`.
- Add `--workspaces-root` to daemon start/restart and preserve it across background re-exec.
- Cover config persistence, flag registration/forwarding, and the full four-level precedence chain.
- Update daemon/CLI/environment documentation in English, Chinese, Japanese, and Korean.

## How to Test

1. Run `go test ./cmd/multica ./internal/cli ./internal/daemon -count=1` from `server/`.
2. Run `go vet ./cmd/multica ./internal/cli ./internal/daemon`.
3. Run `pnpm --filter @multica/docs typecheck`.
4. Optionally set a profile-specific path with `multica --profile dev config set workspaces_root <path>`, start the daemon, and confirm `daemon disk-usage` reports that root.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots - N/A, CLI-only
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs - N/A
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: changing the configured root does not migrate task directories already present under the previous root. This matches the existing environment-variable behavior and is called out in the daemon documentation.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect the accepted issue and maintainer guidance, trace the existing daemon configuration and background re-exec paths, implement the smallest change consistent with the repository's precedence conventions, add focused regression coverage, and run the listed verification commands. The resulting diff and tests were reviewed before publishing.

## Screenshots (optional)

N/A - no UI change.
