### PR TITLE
MUL-6060 fix(editor): render Markdown H4-H6 instead of collapsing them to H1

### DIFF
--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -493,9 +493,13 @@ function EditorBubbleMenu({
       bulletList: e.isActive("bulletList"),
       orderedList: e.isActive("orderedList"),
       taskList: e.isActive("taskList"),
-      heading1: e.isActive("heading", { level: 1 }),
-      heading2: e.isActive("heading", { level: 2 }),
-      heading3: e.isActive("heading", { level: 3 }),
+      // The level itself, not one boolean per offered level: the schema accepts
+      // h1-h6 so the cursor can sit in an H4-H6 that Markdown brought in, and
+      // the dropdown has to report that honestly instead of falling through to
+      // "Normal text". It still only offers H1-H3 as choices (MUL-6060).
+      headingLevel: e.isActive("heading")
+        ? (e.getAttributes("heading").level as number | undefined)
+        : undefined,
     }),
   });
 
@@ -620,7 +624,7 @@ function EditorBubbleMenu({
               <TooltipContent side="top" sideOffset={8}>{t(($) => $.bubble_menu.link)}</TooltipContent>
             </Tooltip>
             <Separator orientation="vertical" className="mx-0.5 h-5" />
-            <HeadingDropdown editor={editor} onOpenChange={handleMenuOpenChange} activeLevel={fmt.heading1 ? 1 : fmt.heading2 ? 2 : fmt.heading3 ? 3 : undefined} />
+            <HeadingDropdown editor={editor} onOpenChange={handleMenuOpenChange} activeLevel={fmt.headingLevel} />
             <ListDropdown editor={editor} onOpenChange={handleMenuOpenChange} isBullet={fmt.bulletList} isOrdered={fmt.orderedList} isTask={fmt.taskList} />
             {/* Dedicated one-click toggle for checkbox task lists — turns the
                 current line(s) into a `- [ ]` task item or back to a paragraph.

--- a/packages/views/editor/extensions/heading-levels.test.ts
+++ b/packages/views/editor/extensions/heading-levels.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { createEditorExtensions } from ".";
+
+/**
+ * Markdown defines six heading levels; the editor schema must accept all six.
+ *
+ * Tiptap's Heading renders `h{level}` only for the levels it was configured
+ * with and falls back to `levels[0]` for anything else. With the old
+ * `levels: [1, 2, 3]`, `#### Identity & Trust` parsed to a level-4 node (the
+ * Markdown source and the saved value were always fine) but drew as an `<h1>`,
+ * so a fourth-level heading looked like the document title (MUL-6060).
+ *
+ * These tests exercise the production extension array, not a hand-built one,
+ * so narrowing `levels` again fails here.
+ */
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  document.body.innerHTML = "";
+});
+
+function makeProductionEditor(): Editor {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+
+  return new Editor({
+    element,
+    extensions: createEditorExtensions({
+      placeholder: "",
+      disableMentions: true,
+      enableSlashCommands: false,
+      onUploadFileRef: { current: undefined },
+    }),
+  });
+}
+
+/** The production load path — ContentEditor mounts markdown the same way. */
+function loadMarkdown(ed: Editor, markdown: string): void {
+  ed.commands.setContent(markdown, { contentType: "markdown" });
+}
+
+const ALL_LEVELS = [
+  "# Level one",
+  "",
+  "## Level two",
+  "",
+  "### Level three",
+  "",
+  "#### Level four",
+  "",
+  "##### Level five",
+  "",
+  "###### Level six",
+].join("\n");
+
+describe("heading levels in the schema", () => {
+  it("keeps a heading node at the level the Markdown asked for", () => {
+    editor = makeProductionEditor();
+    loadMarkdown(editor, ALL_LEVELS);
+
+    const levels = editor
+      .getJSON()
+      .content?.filter((node) => node.type === "heading")
+      .map((node) => node.attrs?.level);
+
+    expect(levels).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("renders # through ###### as h1 through h6", () => {
+    editor = makeProductionEditor();
+    loadMarkdown(editor, ALL_LEVELS);
+
+    const rendered = Array.from(
+      editor.view.dom.querySelectorAll("h1, h2, h3, h4, h5, h6"),
+    ).map((el) => [el.tagName.toLowerCase(), el.textContent]);
+
+    expect(rendered).toEqual([
+      ["h1", "Level one"],
+      ["h2", "Level two"],
+      ["h3", "Level three"],
+      ["h4", "Level four"],
+      ["h5", "Level five"],
+      ["h6", "Level six"],
+    ]);
+  });
+
+  it("renders no extra h1 — the H4-H6 fallback is gone", () => {
+    editor = makeProductionEditor();
+    loadMarkdown(editor, ALL_LEVELS);
+
+    expect(editor.view.dom.querySelectorAll("h1")).toHaveLength(1);
+  });
+});
+
+describe("markdown round-trip", () => {
+  it("serializes each level back to the same number of #", () => {
+    editor = makeProductionEditor();
+    loadMarkdown(editor, ALL_LEVELS);
+
+    expect(editor.getMarkdown().trim()).toBe(ALL_LEVELS);
+  });
+
+  it("preserves neighbouring levels when an H4 is edited", () => {
+    // Opening an issue, typing into a deep heading and saving must not promote
+    // it — or its siblings — to another level.
+    editor = makeProductionEditor();
+    loadMarkdown(editor, "#### Wave 1\n\nBody text\n\n##### Detail");
+
+    const headingEnd = editor.state.doc.child(0).nodeSize - 1;
+    editor.commands.insertContentAt(headingEnd, ": Plugin Spine");
+
+    const markdown = editor.getMarkdown();
+    expect(markdown).toContain("#### Wave 1: Plugin Spine");
+    expect(markdown).toContain("##### Detail");
+  });
+
+  it("turns a deep heading into a paragraph without leaving stray #", () => {
+    editor = makeProductionEditor();
+    loadMarkdown(editor, "###### Deep");
+    editor.commands.setTextSelection(2);
+    editor.commands.setParagraph();
+
+    expect(editor.getMarkdown().trim()).toBe("Deep");
+  });
+});
+
+describe("pasted and typed headings", () => {
+  it("keeps a pasted <h4> as a level-4 heading", () => {
+    // parseHTML derives its rules from the same `levels` list, so an
+    // unconfigured level is not merely mis-rendered — the tag is dropped and
+    // the text lands in a paragraph.
+    editor = makeProductionEditor();
+    editor.commands.setContent("<h4>From another editor</h4>", {
+      contentType: "html",
+    });
+
+    expect(editor.getJSON().content?.[0]).toMatchObject({
+      type: "heading",
+      attrs: { level: 4 },
+    });
+    expect(editor.getMarkdown().trim()).toBe("#### From another editor");
+  });
+
+  it("promotes typed '#### ' to a heading via the input rule", () => {
+    editor = makeProductionEditor();
+    typeText(editor, "#### Typed");
+
+    expect(editor.view.dom.querySelector("h4")?.textContent).toBe("Typed");
+  });
+});
+
+/**
+ * Feeds characters through `handleTextInput` first so input rules fire, exactly
+ * as ProseMirror processes real keystrokes. `setContent` bypasses them.
+ */
+function typeText(ed: Editor, text: string): void {
+  for (const ch of text) {
+    const { from, to } = ed.state.selection;
+    const handled = ed.view.someProp("handleTextInput", (f) =>
+      f(ed.view, from, to, ch, () => ed.state.tr),
+    );
+    if (!handled) ed.view.dispatch(ed.state.tr.insertText(ch, from, to));
+  }
+}

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -198,7 +198,14 @@ export function createEditorExtensions(
 
   return [
     StarterKit.configure({
-      heading: { levels: [1, 2, 3] },
+      // Every level Markdown can express. The Markdown parser keeps the source
+      // depth of `#`…`######`, but Heading.renderHTML falls back to `levels[0]`
+      // for any level it was not configured with — so `levels: [1, 2, 3]` made
+      // the editor draw every H4–H6 as an H1 (MUL-6060). The same list drives
+      // parseHTML, so it also decides whether a pasted `<h4>` survives as a
+      // heading. This is about rendering headings the content already has; the
+      // bubble menu still offers only H1–H3 as authoring choices.
+      heading: { levels: [1, 2, 3, 4, 5, 6] },
       link: false,
       codeBlock: false,
       // Underline has no Markdown representation. Tiptap's extension serializes

--- a/packages/views/editor/styles/prose.css
+++ b/packages/views/editor/styles/prose.css
@@ -14,6 +14,8 @@
  *   Body: 14px (text-body), line-height 1.625 (between GitHub 1.5 and Tailwind 1.714)
  *   Headings: h1=22px (1.57x), h2=18px (1.29x), h3=15px (1.07x) — compact but
  *     with clear hierarchy. Previous h3 was 14px (same as body = no differentiation).
+ *     h4=14px, h5=13px, h6=12px sit at or below body size, so below h3 the
+ *     hierarchy is carried by weight and color rather than by size alone.
  *   Paragraph spacing: 10px (was 8px; GitHub uses 10px, Tailwind prose-sm uses 16px)
  *   List indent: 20px for ul (was 16px; standard is 22-32px)
  *   Code block margin: 12px (was 8px; gives breathing room between code and prose)
@@ -60,6 +62,36 @@
   margin-top: 1rem;
   margin-bottom: 0.5rem;
   line-height: 1.4;
+}
+
+/* h4–h6: Markdown allows six levels and both renderers now emit all of them
+   (MUL-6060), but a compact 14px body leaves little room to keep stepping the
+   size down. Below h3 the hierarchy continues on weight first, then the small
+   steps the scale still has — body (14) bold, label (13), caption (12) muted —
+   so a deep heading stays legible without competing with h1–h3. */
+.rich-text-editor h4 {
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.45;
+}
+
+.rich-text-editor h5 {
+  font-size: var(--text-label);
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.rich-text-editor h6 {
+  font-size: var(--text-caption);
+  font-weight: 600;
+  color: var(--muted-foreground);
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
 }
 
 /* Paragraphs */


### PR DESCRIPTION
Fixes MUL-6060.

## Problem

`createEditorExtensions` configured Heading with `levels: [1, 2, 3]`, but `@tiptap/markdown` parses `#`…`######` at their source depth. Tiptap's Heading renders any level it was not configured with as `levels[0]`, so every H4–H6 was drawn as an `<h1>` — a fourth-level heading looked like the document title (repro: MUL-5921). The same list also builds `parseHTML`, so a pasted `<h4>` lost its heading entirely. The stored Markdown was never affected.

## Change

- `heading: { levels: [1, 2, 3, 4, 5, 6] }` — the schema now accepts every level Markdown can express.
- `prose.css` gains h4–h6 on the compact scale: 14px semibold, 13px semibold, 12px semibold muted. Below h3 the body is already 14px, so the hierarchy continues on weight and color instead of size alone. Both the Tiptap editor and the readonly `RichContent` renderer share these rules, so the two surfaces stay identical.
- The bubble menu reads the actual heading level instead of three per-level booleans, so a cursor inside an H4–H6 shows `H4`/`H5`/`H6` rather than falling through to "Normal text". It still offers only H1–H3 as authoring choices.

`packages/views` is shared, so web and desktop pick this up together.

## Tests

New `packages/views/editor/extensions/heading-levels.test.ts` drives the production extension array (narrowing `levels` again fails it): level attrs survive the parse, `#`…`######` render as `h1`…`h6`, round-trip emits the same number of `#`, editing inside an H4 leaves it and its siblings at their level, demoting an H6 leaves no stray `#`, a pasted `<h4>` stays a level-4 heading, and typing `#### ` promotes via the input rule.

Verified: `vitest run editor rich-content` (76 files, 1394 tests), `pnpm typecheck`, `pnpm lint` (0 errors).
