### PR TITLE
fix(daemon): keep runtimes online when version probes fail

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -1471,6 +1471,22 @@ func printDaemonStatusReport(w io.Writer, label string, health map[string]any) {
 	if reason, ok := health["reload_pending_reason"].(string); ok && reason != "" {
 		rows = append(rows, row{"Restart pending", reason})
 	}
+	if warnings, ok := health["agent_warnings"].(map[string]any); ok && len(warnings) > 0 {
+		providers := make([]string, 0, len(warnings))
+		for provider := range warnings {
+			providers = append(providers, provider)
+		}
+		sort.Strings(providers)
+		parts := make([]string, 0, len(providers))
+		for _, provider := range providers {
+			if reason, ok := warnings[provider].(string); ok && reason != "" {
+				parts = append(parts, provider+": "+reason)
+			}
+		}
+		if len(parts) > 0 {
+			rows = append(rows, row{"Agent warnings", strings.Join(parts, "; ")})
+		}
+	}
 	if agents, ok := health["agents"].([]any); ok && len(agents) > 0 {
 		parts := make([]string, len(agents))
 		for i, a := range agents {

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -162,6 +162,28 @@ func TestPrintDaemonStatusExplainsDeferredRestart(t *testing.T) {
 	}
 }
 
+func TestPrintDaemonStatusShowsAgentWarnings(t *testing.T) {
+	t.Parallel()
+
+	health := map[string]any{
+		"status": "running",
+		"pid":    float64(1234),
+		"uptime": "1m",
+		"agent_warnings": map[string]any{
+			"codex":  "version detection failed: exit 1",
+			"claude": "version probe timed out after 10s",
+		},
+	}
+
+	var out bytes.Buffer
+	printDaemonStatusReport(&out, "Daemon", health)
+	got := out.String()
+	want := "claude: version probe timed out after 10s; codex: version detection failed: exit 1"
+	if !strings.Contains(got, want) {
+		t.Fatalf("daemon status output = %q, want sorted agent warnings %q", got, want)
+	}
+}
+
 // TestPrintDaemonStatusOmitsVersionWhenMissing pins the back-compat contract:
 // when the daemon doesn't report cli_version (older daemon paired with a newer
 // CLI) or reports an empty string, the CLI must skip the line entirely instead

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -132,6 +133,50 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	t.Setenv("PATH", filepath.Join(root, "empty"))
 	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
 		t.Fatalf("cached self-heal not reused: got (%q, %q), want (%q, %q)", got.Path, ver, v2, "0.144.3")
+	}
+}
+
+// TestResolveAgentEntry_AdoptsLiveReplacementWhenVersionProbeFails reproduces
+// GH #6452: Homebrew deletes the pinned Caskroom path, publishes the replacement,
+// then Gatekeeper wedges the replacement's first `--version` invocation. A live
+// executable with a temporarily unreadable version must win over a pinned path
+// that no longer exists. The last known version stays paired with the replacement
+// until a later refresh can detect its real version.
+func TestResolveAgentEntry_AdoptsLiveReplacementWhenVersionProbeFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: v1, Command: "codex"}
+
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
+
+	origDetect := detectAgentVersion
+	detectAgentVersion = func(context.Context, string) (string, error) {
+		return "", errors.New("version probe timed out")
+	}
+	t.Cleanup(func() { detectAgentVersion = origDetect })
+
+	got, version := d.resolveAgentEntry(context.Background(), "codex", entry)
+	if got.Path != v2 {
+		t.Fatalf("self-heal kept deleted path %q, want live replacement %q", got.Path, v2)
+	}
+	if version != "0.144.1" {
+		t.Fatalf("fallback version = %q, want last known 0.144.1", version)
+	}
+	if cached := d.resolvedPaths["codex"]; cached.path != v2 || cached.version != "0.144.1" {
+		t.Fatalf("cached heal = %+v, want {%q, %q}", cached, v2, "0.144.1")
 	}
 }
 

--- a/server/internal/daemon/agents_refresh.go
+++ b/server/internal/daemon/agents_refresh.go
@@ -129,7 +129,7 @@ func (d *Daemon) agents() map[string]AgentEntry {
 
 // setSkippedAgents replaces the diagnostic "discovered but not registered" set
 // reported on /health. Called at the end of every registration round with the
-// providers that round dropped.
+// providers that round could not launch or rejected as below minimum.
 //
 // Purely diagnostic, and deliberately so: it is last-writer-wins across every
 // goroutine that probes, so nothing may steer behavior off it. A caller that
@@ -150,6 +150,43 @@ func (d *Daemon) skippedAgentsSnapshot() map[string]string {
 	}
 	out := make(map[string]string, len(d.skippedAgents))
 	for name, reason := range d.skippedAgents {
+		out[name] = reason
+	}
+	return out
+}
+
+// setAgentWarnings replaces the non-fatal provider diagnostics from the latest
+// registration round. These providers remain online; the map only explains the
+// metadata probe that degraded their registration.
+func (d *Daemon) setAgentWarnings(warnings map[string]string) {
+	d.agentWarningsMu.Lock()
+	defer d.agentWarningsMu.Unlock()
+	d.agentWarnings = warnings
+}
+
+func (d *Daemon) setAgentWarning(provider, reason string) {
+	d.agentWarningsMu.Lock()
+	defer d.agentWarningsMu.Unlock()
+	if d.agentWarnings == nil {
+		d.agentWarnings = make(map[string]string)
+	}
+	d.agentWarnings[provider] = reason
+}
+
+func (d *Daemon) clearAgentWarning(provider string) {
+	d.agentWarningsMu.Lock()
+	defer d.agentWarningsMu.Unlock()
+	delete(d.agentWarnings, provider)
+}
+
+func (d *Daemon) agentWarningsSnapshot() map[string]string {
+	d.agentWarningsMu.RLock()
+	defer d.agentWarningsMu.RUnlock()
+	if len(d.agentWarnings) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(d.agentWarnings))
+	for name, reason := range d.agentWarnings {
 		out[name] = reason
 	}
 	return out

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -378,12 +378,19 @@ type Daemon struct {
 	agentsAvailable atomic.Pointer[map[string]AgentEntry]
 
 	// skippedAgents records why a discovered provider did not make it into the
-	// last registration round (version undetectable, below minimum). Purely
+	// last registration round (executable unavailable, below minimum). Purely
 	// diagnostic: surfaced on /health so the UI can tell "not installed" apart
 	// from "installed but dropped", instead of silently showing nothing
 	// (MUL-5439). Guarded by skippedAgentsMu.
 	skippedAgentsMu sync.RWMutex
 	skippedAgents   map[string]string // provider -> human-readable reason
+
+	// agentWarnings records a non-fatal provider problem from the latest probe
+	// round. Unlike skippedAgents, these providers remain registered because the
+	// executable is present and only optional metadata (currently its version)
+	// could not be read. Guarded by agentWarningsMu and surfaced on /health.
+	agentWarningsMu sync.RWMutex
+	agentWarnings   map[string]string // provider -> human-readable reason
 
 	// demotedProviders remembers the built-in providers whose version was
 	// CONFIRMED below the minimum supported one and whose runtimes
@@ -603,6 +610,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		runtimeSet:                newRuntimeSetWatcher(),
 		agentVersions:             make(map[string]string),
 		skippedAgents:             make(map[string]string),
+		agentWarnings:             make(map[string]string),
 		resolvedPaths:             make(map[string]healedAgent),
 		wsHBLastAck:               make(map[string]time.Time),
 		activeEnvRoots:            make(map[string]int),
@@ -850,27 +858,27 @@ type healedAgent struct {
 //     second-guessed even if PATH now points elsewhere.
 //   - Pinned Path gone and no live heal -> re-resolve entry.Command once
 //     (preserving the ~/.multica/hooks exclusion and the login-shell fallback).
-//     Before adopting the re-resolved binary it is version-detected and run
-//     through the same minimum-version gate registration applies. This
-//     reproduces exactly what a daemon restart would resolve, so it is no less
-//     safe than the documented restart workaround — only automatic.
-//   - Re-resolution fails, the candidate can't be version-detected, or it is
-//     below the minimum supported version -> entry is returned unchanged so the
-//     candidate is never launched and the downstream error still surfaces.
+//     A detected version is run through the same minimum-version gate as
+//     registration. If version detection itself fails but the replacement is
+//     still executable, adopt it with the last known (possibly empty) version:
+//     a live path with unknown metadata is preferable to a deleted path.
+//   - Re-resolution fails or a detected version is below the supported minimum
+//     -> entry is returned unchanged so the rejected candidate is not launched.
 func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string) {
 	resolved, version, _ := d.resolveAgentEntryWithHeal(ctx, provider, entry)
 	return resolved, version
 }
 
-// healOutcome is what one self-heal attempt concluded. At most one half is
-// meaningful: adopted names a binary that cleared the same gates registration
-// applies, while rejected carries the typed verdict for a candidate that was
-// found and version-detected but refused for being below the minimum supported
-// version. rejected is nil unless the verdict is genuine — it is only ever set
-// from a *agent.BelowMinimumError, which by construction carries a version
-// that parsed.
+// healOutcome is what one self-heal attempt concluded. adopted names the live
+// replacement path; warning accompanies it only when the path was adopted with
+// an unknown/last-known version after its probe failed. rejected carries the
+// typed verdict for a candidate that was found and version-detected but refused
+// for being below the minimum supported version. rejected is nil unless the
+// verdict is genuine — it is only ever set from a *agent.BelowMinimumError,
+// which by construction carries a version that parsed.
 type healOutcome struct {
 	adopted  healedAgent
+	warning  error
 	rejected *agent.BelowMinimumError
 }
 
@@ -919,10 +927,12 @@ func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string,
 }
 
 // healAgentPath re-resolves command for provider and, if a usable binary is
-// found, records it and returns it. "Usable" means: it resolves, its version
-// can be detected, and that version meets the same minimum-version gate
-// registration enforces. Path and version are published together under
-// resolvedPathsMu so any observer of the path also sees the matching version;
+// found, records it and returns it. "Usable" means it resolves and is still
+// executable; when its version can be detected, that version must also meet the
+// same minimum-version gate registration enforces. If the version probe fails,
+// the last known (possibly empty) version is retained and the degraded state is
+// reported through agent_warnings. Path and version are published together
+// under resolvedPathsMu so any observer of the path also sees the paired version;
 // the shared d.agentVersion cache is refreshed too, for registration hygiene.
 // It returns a zero adopted pair when nothing usable was found, so the caller
 // keeps the (stale) pinned entry and the candidate is never launched. Runs
@@ -953,9 +963,23 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	// registration path applies (MUL-4486 review).
 	version, err := detectAgentVersion(ctx, newPath)
 	if err != nil {
-		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
-			"provider", provider, "command", command, "new_path", newPath, "error", err)
-		return healOutcome{}
+		// The command resolved before the probe, but an upgrade can still remove
+		// it while `--version` is running. Only adopt a candidate that remains
+		// launchable after the failed probe; otherwise keep the ordinary missing
+		// executable failure instead of caching another dead path.
+		if !agentExecutablePresent(newPath) {
+			d.logger.Warn("re-resolved agent executable disappeared during version detection; keeping pinned path",
+				"provider", provider, "command", command, "new_path", newPath, "error", err)
+			return healOutcome{}
+		}
+		version = d.agentVersion(provider)
+		adopted := d.rememberHealedAgent(provider, newPath, version)
+		reason := versionProbeFailureReason(err)
+		d.setAgentWarning(provider, reason)
+		d.logger.Warn("re-resolved agent executable has no fresh version; adopting live path",
+			"provider", provider, "command", command, "new_path", newPath,
+			"version", version, "warning", reason)
+		return healOutcome{adopted: adopted, warning: err}
 	}
 	if err := checkAgentMinVersion(provider, version); err != nil {
 		var tooOld *agent.BelowMinimumError
@@ -973,24 +997,27 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 		return healOutcome{rejected: tooOld}
 	}
 
-	adopted := healedAgent{path: newPath, version: version}
-	// Publish path + version atomically: any reader that sees the new path in
-	// resolveAgentEntry gets the matching version out of the same struct value.
+	adopted := d.rememberHealedAgent(provider, newPath, version)
+	d.clearAgentWarning(provider)
+
+	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
+		"provider", provider, "command", command, "new_path", newPath, "version", version)
+	return healOutcome{adopted: adopted}
+}
+
+// rememberHealedAgent publishes a replacement path and its best-known version
+// as one pair. The version may be empty when the executable is live but its
+// metadata probe failed; later successful probes refresh both caches.
+func (d *Daemon) rememberHealedAgent(provider, path, version string) healedAgent {
+	adopted := healedAgent{path: path, version: version}
 	d.resolvedPathsMu.Lock()
 	if d.resolvedPaths == nil {
 		d.resolvedPaths = make(map[string]healedAgent)
 	}
 	d.resolvedPaths[provider] = adopted
 	d.resolvedPathsMu.Unlock()
-	// Keep the registration version cache fresh too. The task path reads the
-	// version returned alongside the resolved path (above), not this map, so its
-	// staleness can never gate a launch — this is hygiene for the registration
-	// report and any future d.agentVersion reader.
 	d.setAgentVersion(provider, version)
-
-	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
-		"provider", provider, "command", command, "new_path", newPath, "version", version)
-	return healOutcome{adopted: adopted}
+	return adopted
 }
 
 func (d *Daemon) notifyRuntimeSetChanged() {
@@ -1967,20 +1994,23 @@ const (
 )
 
 // probeBuiltinRuntime resolves and version-detects one built-in provider,
-// retrying a fast failure up to runtimeVersionProbeAttempts times. The verdict
-// tells the caller how to treat a drop: builtinProbeUnavailable means the
-// version could not be read (or not understood) — transient, leave whatever is
-// registered alone — while builtinProbeBelowMinimum is a confirmed too-old
-// verdict the caller may demote on. See builtinProbeVerdict.
+// retrying a fast failure up to runtimeVersionProbeAttempts times. A live
+// executable whose version stays unreadable returns builtinProbeOK with a
+// diagnostic and its last known (possibly empty) version. The other verdicts
+// tell the caller how to treat an actual drop: builtinProbeUnavailable means no
+// executable can currently be launched (or the round was cancelled) — leave
+// whatever was registered alone — while builtinProbeBelowMinimum is a confirmed
+// too-old verdict the caller may demote on. See builtinProbeVerdict.
 //
-// The second return value is a short human-readable reason when the verdict is
-// not OK. It is surfaced on /health as skipped_agents so a user can tell "CLI
-// not installed" apart from "CLI installed but dropped at registration", which
-// was previously only visible in the daemon log (MUL-5439).
+// The second return value is a short human-readable diagnostic. For a non-OK
+// verdict it is surfaced on /health as skipped_agents; for an OK fallback it is
+// surfaced as agent_warnings so the runtime remains online without hiding the
+// failed metadata probe.
 func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry AgentEntry) (string, string, builtinProbeVerdict) {
 	var (
-		lastErr  error
-		attempts int
+		lastErr      error
+		lastResolved = entry
+		attempts     int
 	)
 	for attempts < runtimeVersionProbeAttempts {
 		if attempts > 0 {
@@ -2012,6 +2042,16 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 		// fixes: the upgrade that removed the old path may not have published
 		// the new one yet on the first attempt.
 		resolved, _, heal := d.resolveAgentEntryWithHeal(ctx, name, entry)
+		lastResolved = resolved
+		if heal.warning != nil {
+			lastErr = heal.warning
+			if attempts < runtimeVersionProbeAttempts && time.Since(startedAt) < runtimeVersionProbeRetryWindow {
+				d.logger.Debug("re-resolved agent version probe failed; retrying",
+					"name", name, "attempt", attempts, "error", heal.warning)
+				continue
+			}
+			break
+		}
 		// The pinned path is gone and the binary its command resolves to now is
 		// too old. Unlike the direct case below, this verdict is about whatever
 		// PATH resolves to at this instant — and the pinned path vanishing is
@@ -2083,12 +2123,36 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 		d.logger.Debug("agent version detected", "name", name, "version", version, "path", resolved.Path)
 		return version, "", builtinProbeOK
 	}
-	d.logger.Warn("skip registering runtime", "name", name, "attempts", attempts, "error", lastErr)
-	reason := "version detection failed"
-	if lastErr != nil {
-		reason = fmt.Sprintf("version detection failed: %v", lastErr)
+	reason := versionProbeFailureReason(lastErr)
+	// A version is optional metadata. If the path is still executable, keep the
+	// runtime online with its last known version (or blank on first startup) and
+	// expose the failed probe as a provider warning. Only a path that disappeared
+	// or a version explicitly proven below minimum is unavailable.
+	if ctx.Err() == nil && agentExecutablePresent(lastResolved.Path) {
+		version := d.agentVersion(name)
+		// Record even an empty first-known value. hasDetectedAgentVersions uses
+		// map membership to start the periodic refresh loop; without this marker,
+		// a daemon whose first probe failed would register successfully but never
+		// retry and replace the unknown version after the CLI recovers.
+		d.setAgentVersion(name, version)
+		d.logger.Warn("agent version unavailable; registering live executable with last known version",
+			"name", name, "path", lastResolved.Path, "version", version,
+			"attempts", attempts, "warning", reason)
+		return version, reason, builtinProbeOK
 	}
+	d.logger.Warn("skip registering runtime", "name", name, "attempts", attempts, "error", lastErr)
 	return "", reason, builtinProbeUnavailable
+}
+
+func versionProbeFailureReason(err error) string {
+	if err == nil {
+		return "version detection failed"
+	}
+	var timeout *agent.VersionProbeTimeoutError
+	if errors.As(err, &timeout) {
+		return fmt.Sprintf("version probe timed out: %v", timeout)
+	}
+	return fmt.Sprintf("version detection failed: %v", err)
 }
 
 // detectBuiltinRuntimes version-detects every configured built-in agent CLI and
@@ -2106,11 +2170,10 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 // well inside the UI's scanning window.
 //
 // Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
-// the live version — nothing is cached on the Daemon, so an in-place CLI
-// upgrade is still reported with its current version. A provider whose version
-// stays undetectable across probeBuiltinRuntime's bounded attempts, or which is
-// below the minimum supported version, is logged and skipped, exactly as the
-// serial loop did.
+// the live version. An executable whose version stays undetectable across the
+// bounded attempts is registered with its last known (possibly empty) version
+// and reported in agent_warnings. Only an unavailable executable or one with a
+// version confirmed below the supported minimum is omitted.
 //
 // The result describes the machine, not a workspace, so a caller registering a
 // batch of workspaces at once calls this ONCE and passes the payload to
@@ -2125,8 +2188,8 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 // probe — and demoting a runtime is not a decision to make on another round's
 // evidence.
 //
-// The third return value is THIS round's unavailable providers (version could
-// not be read), provider to reason. Callers that treat a register response as
+// The third return value is THIS round's unavailable providers (no executable
+// could be launched), provider to reason. Callers that treat a register response as
 // AUTHORITATIVE for a workspace's whole runtime set (the runtime_gone recovery
 // and the profile drift refresh, via applyRegisterResponseInPlace) must
 // preserve these providers' existing runtimes: they are absent from the
@@ -2148,6 +2211,7 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) ([]map[string]string
 		skipped     = map[string]string{}
 		belowMin    = map[string]string{}
 		unavailable = map[string]string{}
+		warnings    = map[string]string{}
 		g           errgroup.Group
 	)
 	g.SetLimit(runtimeVersionProbeConcurrency)
@@ -2167,6 +2231,9 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) ([]map[string]string
 				return nil
 			}
 			mu.Lock()
+			if reason != "" {
+				warnings[name] = reason
+			}
 			results = append(results, detected{name: name, version: version})
 			mu.Unlock()
 			return nil
@@ -2180,6 +2247,7 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) ([]map[string]string
 	// diagnostic honest: a provider that registered successfully this round must
 	// not stay listed as skipped.
 	d.setSkippedAgents(skipped)
+	d.setAgentWarnings(warnings)
 
 	// Source iteration (a map) and parallel completion order are both
 	// nondeterministic; sort by provider so the registration payload is stable
@@ -2257,9 +2325,9 @@ func (d *Daemon) registerRuntimesForWorkspaceLocked(ctx context.Context, workspa
 // registration payload must NOT be read as "this workspace should stop hosting
 // them", keyed by provider.
 //
-// Unavailable is the obvious half: the version could not be read, which is
-// transient, so dropping the rows would tear a working runtime down over one
-// failed probe.
+// Unavailable is the obvious half: no executable could be launched in this
+// round (or the round was cancelled), which can be transient, so dropping the
+// rows would tear a previously working runtime down over one failed probe.
 //
 // Below-minimum is the half that is easy to get wrong, because the verdict IS
 // confirmed — a version was read and rejected. What is missing on these paths is

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -61,7 +61,7 @@ type HealthResponse struct {
 	RepoCheckoutWaiters   int      `json:"repo_checkout_waiters,omitempty"`
 	Agents                []string `json:"agents"`
 	// SkippedAgents maps a provider that WAS discovered on this machine to the
-	// reason the last registration round dropped it (version undetectable,
+	// reason the last registration round dropped it (executable unavailable or
 	// below the minimum supported version). Purely diagnostic, and omitted when
 	// empty so older consumers see no change.
 	//
@@ -69,6 +69,10 @@ type HealthResponse struct {
 	// render as an absent runtime, which is what made GH #6077 unactionable for
 	// the reporter (MUL-5439).
 	SkippedAgents map[string]string `json:"skipped_agents,omitempty"`
+	// AgentWarnings maps providers that remain registered to a non-fatal probe
+	// problem. This makes an unknown/last-known version fallback visible without
+	// falsely reporting the runtime as offline.
+	AgentWarnings map[string]string `json:"agent_warnings,omitempty"`
 	// ReloadPendingReason explains why the daemon has confirmed a multica
 	// version change on disk but hasn't restarted into it yet — it was busy at
 	// the last barrier check and will retry when idle. Omitted when empty, so
@@ -160,6 +164,7 @@ func (d *Daemon) healthHandler(startedAt time.Time) http.HandlerFunc {
 			ResourceWaitTaskCount: d.resourceWaitTasks.Load(),
 			Agents:                agents,
 			SkippedAgents:         d.skippedAgentsSnapshot(),
+			AgentWarnings:         d.agentWarningsSnapshot(),
 
 			ReloadPendingReason: d.reloadPending(),
 			Workspaces:          wsList,

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -700,6 +700,68 @@ func TestDetectBuiltinRuntimes_DoesNotRetrySlowProbe(t *testing.T) {
 	}
 }
 
+// TestDetectBuiltinRuntimes_RegistersLiveExecutableWhenVersionProbeFails covers
+// the restart half of GH #6452. Version metadata is optional evidence; a path
+// that still resolves to an executable must remain dispatchable even when its
+// `--version` command is temporarily unreadable.
+func TestDetectBuiltinRuntimes_RegistersLiveExecutableWhenVersionProbeFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec-bit stub layout is POSIX-specific")
+	}
+	fx := newBatchFixture(t)
+	stubProbeRetry(t, time.Millisecond, time.Second)
+	d := fx.daemon
+	executable := filepath.Join(t.TempDir(), "claude")
+	writeExecStub(t, executable)
+	d.cfg.Agents = map[string]AgentEntry{"claude": {Path: executable}}
+	fx.setProbeErr(func(string, int) error { return errors.New("version probe timed out") })
+
+	runtimes, belowMin, unavailable := d.detectBuiltinRuntimes(context.Background())
+
+	if len(runtimes) != 1 || runtimes[0]["type"] != "claude" {
+		t.Fatalf("detected runtimes = %v, want claude kept online", runtimes)
+	}
+	if runtimes[0]["version"] != "" {
+		t.Errorf("version = %q, want unknown/empty", runtimes[0]["version"])
+	}
+	if len(belowMin) != 0 || len(unavailable) != 0 {
+		t.Errorf("belowMin=%v unavailable=%v, want no dropped provider", belowMin, unavailable)
+	}
+	if !d.hasDetectedAgentVersions() {
+		t.Fatal("unknown initial version was not cached; periodic refresh would never retry it")
+	}
+
+	rec := httptest.NewRecorder()
+	d.healthHandler(time.Now())(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var health map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	warnings, ok := health["agent_warnings"].(map[string]any)
+	if !ok || warnings["claude"] == "" {
+		t.Fatalf("agent_warnings = %v, want claude probe failure", health["agent_warnings"])
+	}
+
+	fx.setProbeErr(nil)
+	d.detectBuiltinRuntimes(context.Background())
+	if got := d.agentWarningsSnapshot(); len(got) != 0 {
+		t.Fatalf("agent warnings after successful reprobe = %v, want cleared", got)
+	}
+}
+
+func TestVersionProbeFailureReasonDistinguishesTimeout(t *testing.T) {
+	timeout := &agent.VersionProbeTimeoutError{
+		ExecutablePath: "/fake/claude",
+		Timeout:        10 * time.Second,
+	}
+	if got := versionProbeFailureReason(timeout); !strings.HasPrefix(got, "version probe timed out:") {
+		t.Fatalf("timeout reason = %q, want explicit timeout classification", got)
+	}
+	if got := versionProbeFailureReason(errors.New("exit status 1")); !strings.HasPrefix(got, "version detection failed:") {
+		t.Fatalf("ordinary failure reason = %q, want generic detection classification", got)
+	}
+}
+
 // vanishedPinnedPath lays out the MUL-4486 shape a probe retry has to reckon
 // with: a stable command name that resolves on PATH to a runnable stub, plus
 // the pinned absolute path an in-place upgrade already deleted. It returns the
@@ -743,16 +805,16 @@ func countingVersionProbe(t *testing.T, answer func(path string) (string, error)
 // slow-probe guard honest about where an attempt's time actually goes. When the
 // pinned path has vanished, resolveAgentEntry runs its own version probe on the
 // re-resolved candidate (MUL-4486) — which can burn the full 10s timeout on its
-// own. Timing only the outer probe would read the attempt as a fast failure
-// (the stale path fails instantly), retry, and pay the slow self-heal a second
-// time — exactly the doubled worst case the guard exists to prevent.
+// own. The failed probe must be carried out of the heal: probing that same live
+// replacement again would double the registration delay before the unknown-
+// version fallback can keep it online.
 func TestDetectBuiltinRuntimes_DoesNotRetryWhenSelfHealBurnsTheWindow(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PATH/exec-bit stub layout is POSIX-specific")
 	}
 	const probeWindow = 20 * time.Millisecond
 	stubProbeRetry(t, time.Millisecond, probeWindow)
-	missing, _ := vanishedPinnedPath(t)
+	missing, healed := vanishedPinnedPath(t)
 	probes := countingVersionProbe(t, func(path string) (string, error) {
 		if path == missing {
 			// The stale pinned path is gone: this fails immediately.
@@ -766,11 +828,11 @@ func TestDetectBuiltinRuntimes_DoesNotRetryWhenSelfHealBurnsTheWindow(t *testing
 	d := freshDaemon("")
 	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: missing, Command: "codex"}}
 
-	if runtimes, _, _ := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 0 {
-		t.Fatalf("detected %v, want none", runtimes)
+	if runtimes, _, _ := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 1 || runtimes[0]["type"] != "codex" {
+		t.Fatalf("detected %v, want codex kept online from healed path %q", runtimes, healed)
 	}
-	if got := probes.Load(); got != 2 {
-		t.Errorf("ran %d version probes, want 2 (one self-heal + one outer probe); the retry window must cover the whole attempt, not just the outer probe", got)
+	if got := probes.Load(); got != 1 {
+		t.Errorf("ran %d version probes, want 1 (the timed-out self-heal probe must not be repeated)", got)
 	}
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -387,6 +387,23 @@ func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 	return detectCLIVersion(ctx, executablePath)
 }
 
+// VersionProbeTimeoutError reports that an executable was found but its
+// `--version` process did not finish within the probe budget. It unwraps to
+// context.DeadlineExceeded so callers can use either typed diagnostics or the
+// standard timeout classification.
+type VersionProbeTimeoutError struct {
+	ExecutablePath string
+	Timeout        time.Duration
+}
+
+func (e *VersionProbeTimeoutError) Error() string {
+	return fmt.Sprintf("detect version for %s: timed out after %s", e.ExecutablePath, e.Timeout)
+}
+
+func (e *VersionProbeTimeoutError) Unwrap() error {
+	return context.DeadlineExceeded
+}
+
 // launchHeaders maps each supported agent type to the user-visible skeleton
 // that the daemon spawns before any custom_args are appended. This is
 // intentionally minimal — only the command + subcommand (or a short mode

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -176,6 +177,13 @@ func TestDetectVersionTimesOutOnHang(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("expected an error from a hanging --version probe, got nil")
+		}
+		var timeoutErr *VersionProbeTimeoutError
+		if !errors.As(err, &timeoutErr) {
+			t.Fatalf("error = %T %v, want *VersionProbeTimeoutError", err, err)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("timeout error %v does not unwrap to context.DeadlineExceeded", err)
 		}
 		if elapsed := time.Since(start); elapsed > 5*time.Second {
 			t.Fatalf("detection took %v; expected it to be bounded by the timeout", elapsed)

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -1107,7 +1107,8 @@ func cleanupMcpConfigTemp(path string) {
 var detectVersionTimeout = 10 * time.Second
 
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
+	parentCtx := ctx
+	ctx, cancel := context.WithTimeout(parentCtx, detectVersionTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, execPath, "--version")
@@ -1120,6 +1121,12 @@ func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
 	cmd.WaitDelay = 2 * time.Second
 	data, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded && parentCtx.Err() == nil {
+			return "", &VersionProbeTimeoutError{
+				ExecutablePath: execPath,
+				Timeout:        detectVersionTimeout,
+			}
+		}
 		return "", fmt.Errorf("detect version for %s: %w", execPath, err)
 	}
 	return extractVersionLine(string(data)), nil


### PR DESCRIPTION
## Summary

- adopt a live re-resolved executable when its pinned predecessor was deleted, even if version probing fails
- keep live runtimes registered with their last-known or unknown version while preserving confirmed minimum-version rejection
- classify version probe timeouts explicitly and surface provider warnings through health and daemon status
- avoid repeating a self-heal probe after it already consumed the timeout budget

## Validation

- go test ./internal/daemon ./pkg/agent ./cmd/multica -count=1
- go vet ./internal/daemon ./pkg/agent ./cmd/multica
- go build ./...
- git diff --check

Fixes #6452