### PR TITLE
LZ-9 / LZ-11: fix(rich-content): support backslash LaTeX delimiters

### DIFF
--- a/packages/views/rich-content/latex-delimiters.test.ts
+++ b/packages/views/rich-content/latex-delimiters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { extractLatexDelimiters } from "./latex-delimiters";
+
+describe("extractLatexDelimiters", () => {
+  it("extracts paired inline and display LaTeX delimiters", () => {
+    const result = extractLatexDelimiters(
+      String.raw`Inline \(E=mc^2\).
+
+\[
+\begin{pmatrix}
+1 & 2 \\
+3 & 4
+\end{pmatrix}
+\]`,
+    );
+
+    expect(result.formulas).toEqual([
+      { kind: "inline", value: "E=mc^2" },
+      {
+        kind: "display",
+        value: "\n\\begin{pmatrix}\n1 & 2 \\\\\n3 & 4\n\\end{pmatrix}\n",
+      },
+    ]);
+    expect(result.markdown).not.toContain(String.raw`\(E=mc^2\)`);
+    expect(result.markdown).not.toContain(String.raw`\begin{pmatrix}`);
+  });
+
+  it("leaves delimiters literal in inline and fenced code", () => {
+    const markdown = [
+      "Keep `\\(x\\) and \\[y\\]` inside code",
+      "",
+      "~~~tex",
+      String.raw`\[z\]`,
+      "~~~",
+    ].join("\n");
+
+    expect(extractLatexDelimiters(markdown)).toEqual({
+      markdown,
+      formulas: [],
+    });
+  });
+
+  it("leaves delimiters literal in CommonMark list and quote fences", () => {
+    const markdown = [
+      "- ~~~~tex",
+      String.raw`  \[list\]`,
+      "  ~~~~",
+      "",
+      "> ```tex",
+      String.raw`> \(quote\)`,
+      "> ```",
+    ].join("\n");
+
+    expect(extractLatexDelimiters(markdown)).toEqual({
+      markdown,
+      formulas: [],
+    });
+  });
+
+  it("leaves deliberately escaped and incomplete delimiters literal", () => {
+    const markdown = [
+      String.raw`Literal \\(x\\) and \\[y\\].`,
+      String.raw`Streaming \(x + y`,
+      String.raw`Streaming \[x + y`,
+    ].join("\n");
+
+    expect(extractLatexDelimiters(markdown)).toEqual({
+      markdown,
+      formulas: [],
+    });
+  });
+
+  it("does not alter existing dollar math or currency text", () => {
+    const markdown = [
+      "$$x^2 + y^2$$",
+      "Item A costs $120 and item B costs $85.",
+    ].join("\n\n");
+
+    expect(extractLatexDelimiters(markdown)).toEqual({
+      markdown,
+      formulas: [],
+    });
+  });
+});

--- a/packages/views/rich-content/latex-delimiters.test.ts
+++ b/packages/views/rich-content/latex-delimiters.test.ts
@@ -81,4 +81,26 @@ describe("extractLatexDelimiters", () => {
       formulas: [],
     });
   });
+
+  it("ignores delimiters in HTML attributes and Markdown link destinations", () => {
+    const markdown = [
+      String.raw`<span title="\(attribute\)">plain</span>`,
+      String.raw`[target](https://example.com/\(literal\))`,
+    ].join("\n\n");
+
+    expect(extractLatexDelimiters(markdown)).toEqual({
+      markdown,
+      formulas: [],
+    });
+  });
+
+  it("never reuses a placeholder token found in user content", () => {
+    const userToken = "\uE000multica-latex-0\uE001";
+    const result = extractLatexDelimiters(
+      `${userToken} and ${String.raw`\(x\)`}`,
+    );
+
+    expect(result.formulas).toEqual([{ kind: "inline", value: "x" }]);
+    expect(result.markdown.split(userToken)).toHaveLength(2);
+  });
 });

--- a/packages/views/rich-content/latex-delimiters.ts
+++ b/packages/views/rich-content/latex-delimiters.ts
@@ -10,22 +10,28 @@ export type LatexFormula = {
 export type ExtractedLatex = {
   markdown: string;
   formulas: LatexFormula[];
+  tokenPrefix?: string;
 };
 
 type Range = { start: number; end: number };
 
-const TOKEN_START = "\uE000multica-latex-";
 const TOKEN_END = "\uE001";
-const TOKEN_RE = /\uE000multica-latex-(\d+)\uE001/g;
 
-/** CommonMark code ranges, including nested/list and streaming fences. */
-function codeRanges(source: string): Range[] {
-  const ranges: Range[] = [];
+/** Source ranges that CommonMark parsed as actual text or code. */
+function markdownRanges(source: string): { text: Range[]; code: Range[] } {
+  const text: Range[] = [];
+  const code: Range[] = [];
   const collect = (node: Root | Content) => {
     if (node.type === "code" || node.type === "inlineCode") {
       const start = node.position?.start.offset;
       const end = node.position?.end.offset;
-      if (start != null && end != null) ranges.push({ start, end });
+      if (start != null && end != null) code.push({ start, end });
+      return;
+    }
+    if (node.type === "text") {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (start != null && end != null) text.push({ start, end });
       return;
     }
     if ("children" in node) {
@@ -33,7 +39,10 @@ function codeRanges(source: string): Range[] {
     }
   };
   collect(fromMarkdown(source));
-  return ranges.sort((a, b) => a.start - b.start);
+  return {
+    text: text.sort((a, b) => a.start - b.start),
+    code: code.sort((a, b) => a.start - b.start),
+  };
 }
 
 function rangeAt(ranges: readonly Range[], offset: number): Range | undefined {
@@ -106,11 +115,12 @@ function isSingleSlash(source: string, offset: number): boolean {
 function findClosingDelimiter(
   source: string,
   start: number,
+  end: number,
   closing: ")" | "]",
   protectedRanges: readonly Range[],
 ): number {
   let offset = start;
-  while (offset < source.length - 1) {
+  while (offset < end - 1) {
     const protectedRange = rangeAt(protectedRanges, offset);
     if (protectedRange) {
       offset = protectedRange.end;
@@ -127,66 +137,88 @@ function findClosingDelimiter(
   return -1;
 }
 
+function uniqueTokenPrefix(source: string): string {
+  let namespace = 0;
+  let prefix: string;
+  do {
+    prefix = `\uE000multica-latex-${namespace}-`;
+    namespace++;
+  } while (source.includes(prefix));
+  return prefix;
+}
+
+function tokenPattern(prefix: string): RegExp {
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}(\\d+)${TOKEN_END}`, "g");
+}
+
 /**
  * Replace supported LaTeX pairs with Markdown-opaque tokens before parsing.
  *
  * A token is emitted only after its closing delimiter exists. This makes the
  * streaming path monotonic: partial `\(` / `\[` input stays source text, then
- * upgrades once the matching `\)` / `\]` arrives. Code and existing dollar
- * math are protected, while doubled backslashes remain deliberately literal.
+ * upgrades once the matching `\)` / `\]` arrives. Only source ranges parsed
+ * as mdast text are eligible, so HTML attributes, link destinations, code and
+ * other non-text fields stay untouched. Existing dollar math is protected and
+ * doubled backslashes remain deliberately literal.
  */
 export function extractLatexDelimiters(source: string): ExtractedLatex {
   if (!source || (!source.includes("\\(") && !source.includes("\\["))) {
     return { markdown: source, formulas: [] };
   }
 
-  const code = codeRanges(source);
-  const protectedRanges = [...code, ...dollarMathRanges(source, code)].sort(
-    (a, b) => a.start - b.start,
-  );
+  const ranges = markdownRanges(source);
+  const protectedRanges = [
+    ...ranges.code,
+    ...dollarMathRanges(source, ranges.code),
+  ].sort((a, b) => a.start - b.start);
+  const prefix = uniqueTokenPrefix(source);
   const formulas: LatexFormula[] = [];
   let markdown = "";
   let copiedThrough = 0;
-  let offset = 0;
 
-  while (offset < source.length - 1) {
-    const protectedRange = rangeAt(protectedRanges, offset);
-    if (protectedRange) {
-      offset = protectedRange.end;
-      continue;
-    }
-    if (!isSingleSlash(source, offset)) {
-      offset++;
-      continue;
-    }
+  for (const textRange of ranges.text) {
+    let offset = Math.max(textRange.start, copiedThrough);
+    while (offset < textRange.end - 1) {
+      const protectedRange = rangeAt(protectedRanges, offset);
+      if (protectedRange) {
+        offset = protectedRange.end;
+        continue;
+      }
+      if (!isSingleSlash(source, offset)) {
+        offset++;
+        continue;
+      }
 
-    const opener = source[offset + 1];
-    if (opener !== "(" && opener !== "[") {
-      offset++;
-      continue;
-    }
-    const closing = findClosingDelimiter(
-      source,
-      offset + 2,
-      opener === "(" ? ")" : "]",
-      protectedRanges,
-    );
-    if (closing === -1) {
-      offset += 2;
-      continue;
-    }
+      const opener = source[offset + 1];
+      if (opener !== "(" && opener !== "[") {
+        offset++;
+        continue;
+      }
+      const closing = findClosingDelimiter(
+        source,
+        offset + 2,
+        textRange.end,
+        opener === "(" ? ")" : "]",
+        protectedRanges,
+      );
+      if (closing === -1) {
+        offset += 2;
+        continue;
+      }
 
-    const value = source.slice(offset + 2, closing);
-    markdown += source.slice(copiedThrough, offset);
-    markdown += `${TOKEN_START}${formulas.length}${TOKEN_END}`;
-    formulas.push({ kind: opener === "(" ? "inline" : "display", value });
-    copiedThrough = closing + 2;
-    offset = copiedThrough;
+      const value = source.slice(offset + 2, closing);
+      markdown += source.slice(copiedThrough, offset);
+      markdown += `${prefix}${formulas.length}${TOKEN_END}`;
+      formulas.push({ kind: opener === "(" ? "inline" : "display", value });
+      copiedThrough = closing + 2;
+      offset = copiedThrough;
+    }
   }
 
   if (formulas.length === 0) return { markdown: source, formulas };
   markdown += source.slice(copiedThrough);
-  return { markdown, formulas };
+  return { markdown, formulas, tokenPrefix: prefix };
 }
 
 type MathNode = {
@@ -240,13 +272,17 @@ function mathNode(formula: LatexFormula): MathNode {
   };
 }
 
-function splitTokens(text: Text, formulas: readonly LatexFormula[]): Content[] {
-  TOKEN_RE.lastIndex = 0;
+function splitTokens(
+  text: Text,
+  formulas: readonly LatexFormula[],
+  pattern: RegExp,
+): Content[] {
+  pattern.lastIndex = 0;
   const nodes: Content[] = [];
   let copiedThrough = 0;
   let match: RegExpExecArray | null;
 
-  while ((match = TOKEN_RE.exec(text.value)) !== null) {
+  while ((match = pattern.exec(text.value)) !== null) {
     const index = Number(match[1]);
     const formula = formulas[index];
     if (!formula) continue;
@@ -264,14 +300,18 @@ function splitTokens(text: Text, formulas: readonly LatexFormula[]): Content[] {
   return nodes;
 }
 
-function lowerTokens(parent: Parent | Root, formulas: readonly LatexFormula[]) {
+function lowerTokens(
+  parent: Parent | Root,
+  formulas: readonly LatexFormula[],
+  pattern: RegExp,
+) {
   for (const child of parent.children) {
     if (child.type === "text") continue;
-    if ("children" in child) lowerTokens(child as Parent, formulas);
+    if ("children" in child) lowerTokens(child as Parent, formulas, pattern);
   }
 
   parent.children = parent.children.flatMap((child) =>
-    child.type === "text" ? splitTokens(child, formulas) : [child],
+    child.type === "text" ? splitTokens(child, formulas, pattern) : [child],
   );
 
   // Display math is a block. When its token appeared beside prose in one
@@ -306,8 +346,10 @@ function lowerTokens(parent: Parent | Root, formulas: readonly LatexFormula[]) {
 
 /** Lower opaque extraction tokens into the mdast math nodes remark-math owns. */
 export const remarkLatexDelimiters: Plugin<
-  [{ formulas: readonly LatexFormula[] }],
+  [{ formulas: readonly LatexFormula[]; tokenPrefix?: string }],
   Root
-> = ({ formulas }) => {
-  return (tree) => lowerTokens(tree, formulas);
+> = ({ formulas, tokenPrefix }) => {
+  if (!tokenPrefix) return;
+  const pattern = tokenPattern(tokenPrefix);
+  return (tree) => lowerTokens(tree, formulas, pattern);
 };

--- a/packages/views/rich-content/latex-delimiters.ts
+++ b/packages/views/rich-content/latex-delimiters.ts
@@ -1,0 +1,313 @@
+import type { Content, Parent, Root, Text } from "mdast";
+import type { Plugin } from "unified";
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+export type LatexFormula = {
+  kind: "inline" | "display";
+  value: string;
+};
+
+export type ExtractedLatex = {
+  markdown: string;
+  formulas: LatexFormula[];
+};
+
+type Range = { start: number; end: number };
+
+const TOKEN_START = "\uE000multica-latex-";
+const TOKEN_END = "\uE001";
+const TOKEN_RE = /\uE000multica-latex-(\d+)\uE001/g;
+
+/** CommonMark code ranges, including nested/list and streaming fences. */
+function codeRanges(source: string): Range[] {
+  const ranges: Range[] = [];
+  const collect = (node: Root | Content) => {
+    if (node.type === "code" || node.type === "inlineCode") {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (start != null && end != null) ranges.push({ start, end });
+      return;
+    }
+    if ("children" in node) {
+      for (const child of node.children) collect(child);
+    }
+  };
+  collect(fromMarkdown(source));
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+function rangeAt(ranges: readonly Range[], offset: number): Range | undefined {
+  let low = 0;
+  let high = ranges.length - 1;
+  while (low <= high) {
+    const middle = (low + high) >> 1;
+    const range = ranges[middle]!;
+    if (offset < range.start) {
+      high = middle - 1;
+    } else if (offset >= range.end) {
+      low = middle + 1;
+    } else {
+      return range;
+    }
+  }
+  return undefined;
+}
+
+/** Existing dollar math is already supported and must remain opaque here. */
+function dollarMathRanges(source: string, code: readonly Range[]): Range[] {
+  const ranges: Range[] = [];
+  let offset = 0;
+
+  while (offset < source.length - 1) {
+    const codeRange = rangeAt(code, offset);
+    if (codeRange) {
+      offset = codeRange.end;
+      continue;
+    }
+    if (source[offset] !== "$" || source[offset + 1] !== "$") {
+      offset++;
+      continue;
+    }
+
+    let cursor = offset + 2;
+    let closing = -1;
+    while (cursor < source.length - 1) {
+      const protectedRange = rangeAt(code, cursor);
+      if (protectedRange) {
+        cursor = protectedRange.end;
+        continue;
+      }
+      if (source[cursor] === "$" && source[cursor + 1] === "$") {
+        closing = cursor + 2;
+        break;
+      }
+      cursor++;
+    }
+
+    if (closing !== -1) {
+      ranges.push({ start: offset, end: closing });
+      offset = closing;
+    } else {
+      offset += 2;
+    }
+  }
+
+  return ranges;
+}
+
+function isSingleSlash(source: string, offset: number): boolean {
+  return (
+    source[offset] === "\\" &&
+    source[offset - 1] !== "\\" &&
+    source[offset + 1] !== "\\"
+  );
+}
+
+function findClosingDelimiter(
+  source: string,
+  start: number,
+  closing: ")" | "]",
+  protectedRanges: readonly Range[],
+): number {
+  let offset = start;
+  while (offset < source.length - 1) {
+    const protectedRange = rangeAt(protectedRanges, offset);
+    if (protectedRange) {
+      offset = protectedRange.end;
+      continue;
+    }
+    if (
+      isSingleSlash(source, offset) &&
+      source[offset + 1] === closing
+    ) {
+      return offset;
+    }
+    offset++;
+  }
+  return -1;
+}
+
+/**
+ * Replace supported LaTeX pairs with Markdown-opaque tokens before parsing.
+ *
+ * A token is emitted only after its closing delimiter exists. This makes the
+ * streaming path monotonic: partial `\(` / `\[` input stays source text, then
+ * upgrades once the matching `\)` / `\]` arrives. Code and existing dollar
+ * math are protected, while doubled backslashes remain deliberately literal.
+ */
+export function extractLatexDelimiters(source: string): ExtractedLatex {
+  if (!source || (!source.includes("\\(") && !source.includes("\\["))) {
+    return { markdown: source, formulas: [] };
+  }
+
+  const code = codeRanges(source);
+  const protectedRanges = [...code, ...dollarMathRanges(source, code)].sort(
+    (a, b) => a.start - b.start,
+  );
+  const formulas: LatexFormula[] = [];
+  let markdown = "";
+  let copiedThrough = 0;
+  let offset = 0;
+
+  while (offset < source.length - 1) {
+    const protectedRange = rangeAt(protectedRanges, offset);
+    if (protectedRange) {
+      offset = protectedRange.end;
+      continue;
+    }
+    if (!isSingleSlash(source, offset)) {
+      offset++;
+      continue;
+    }
+
+    const opener = source[offset + 1];
+    if (opener !== "(" && opener !== "[") {
+      offset++;
+      continue;
+    }
+    const closing = findClosingDelimiter(
+      source,
+      offset + 2,
+      opener === "(" ? ")" : "]",
+      protectedRanges,
+    );
+    if (closing === -1) {
+      offset += 2;
+      continue;
+    }
+
+    const value = source.slice(offset + 2, closing);
+    markdown += source.slice(copiedThrough, offset);
+    markdown += `${TOKEN_START}${formulas.length}${TOKEN_END}`;
+    formulas.push({ kind: opener === "(" ? "inline" : "display", value });
+    copiedThrough = closing + 2;
+    offset = copiedThrough;
+  }
+
+  if (formulas.length === 0) return { markdown: source, formulas };
+  markdown += source.slice(copiedThrough);
+  return { markdown, formulas };
+}
+
+type MathNode = {
+  type: "math" | "inlineMath";
+  value: string;
+  data:
+    | {
+        hName: "code";
+        hProperties: { className: ["language-math", "math-inline"] };
+        hChildren: [{ type: "text"; value: string }];
+      }
+    | {
+        hName: "pre";
+        hChildren: [
+          {
+            type: "element";
+            tagName: "code";
+            properties: { className: ["language-math", "math-display"] };
+            children: [{ type: "text"; value: string }];
+          },
+        ];
+      };
+};
+
+function mathNode(formula: LatexFormula): MathNode {
+  if (formula.kind === "inline") {
+    return {
+      type: "inlineMath",
+      value: formula.value,
+      data: {
+        hName: "code",
+        hProperties: { className: ["language-math", "math-inline"] },
+        hChildren: [{ type: "text", value: formula.value }],
+      },
+    };
+  }
+  return {
+    type: "math",
+    value: formula.value,
+    data: {
+      hName: "pre",
+      hChildren: [
+        {
+          type: "element",
+          tagName: "code",
+          properties: { className: ["language-math", "math-display"] },
+          children: [{ type: "text", value: formula.value }],
+        },
+      ],
+    },
+  };
+}
+
+function splitTokens(text: Text, formulas: readonly LatexFormula[]): Content[] {
+  TOKEN_RE.lastIndex = 0;
+  const nodes: Content[] = [];
+  let copiedThrough = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = TOKEN_RE.exec(text.value)) !== null) {
+    const index = Number(match[1]);
+    const formula = formulas[index];
+    if (!formula) continue;
+    if (match.index > copiedThrough) {
+      nodes.push({ type: "text", value: text.value.slice(copiedThrough, match.index) });
+    }
+    nodes.push(mathNode(formula) as Content);
+    copiedThrough = match.index + match[0].length;
+  }
+
+  if (copiedThrough === 0) return [text];
+  if (copiedThrough < text.value.length) {
+    nodes.push({ type: "text", value: text.value.slice(copiedThrough) });
+  }
+  return nodes;
+}
+
+function lowerTokens(parent: Parent | Root, formulas: readonly LatexFormula[]) {
+  for (const child of parent.children) {
+    if (child.type === "text") continue;
+    if ("children" in child) lowerTokens(child as Parent, formulas);
+  }
+
+  parent.children = parent.children.flatMap((child) =>
+    child.type === "text" ? splitTokens(child, formulas) : [child],
+  );
+
+  // Display math is a block. When its token appeared beside prose in one
+  // Markdown paragraph, lift it into sibling blocks while preserving the prose
+  // on either side as paragraphs.
+  parent.children = parent.children.flatMap((child) => {
+    if (child.type !== "paragraph") return [child];
+    const paragraphChildren = child.children as unknown as Content[];
+    if (!paragraphChildren.some((node) => node.type === "math")) return [child];
+
+    const blocks: Content[] = [];
+    let inline: Content[] = [];
+    const flushInline = () => {
+      if (inline.length > 0) {
+        blocks.push({ type: "paragraph", children: inline } as Content);
+        inline = [];
+      }
+    };
+
+    for (const node of paragraphChildren) {
+      if (node.type === "math") {
+        flushInline();
+        blocks.push(node);
+      } else {
+        inline.push(node);
+      }
+    }
+    flushInline();
+    return blocks;
+  });
+}
+
+/** Lower opaque extraction tokens into the mdast math nodes remark-math owns. */
+export const remarkLatexDelimiters: Plugin<
+  [{ formulas: readonly LatexFormula[] }],
+  Root
+> = ({ formulas }) => {
+  return (tree) => lowerTokens(tree, formulas);
+};

--- a/packages/views/rich-content/rich-content-parity.test.tsx
+++ b/packages/views/rich-content/rich-content-parity.test.tsx
@@ -501,3 +501,118 @@ describe("semantic parity beyond Mermaid", () => {
     expect(mermaidRenderMock).not.toHaveBeenCalled();
   });
 });
+
+const LATEX_FIXTURE = [
+  String.raw`Inline \(E=mc^2\).`,
+  "",
+  String.raw`\[`,
+  String.raw`\begin{aligned}`,
+  String.raw`a & = b + c \\`,
+  String.raw`d & = e + f`,
+  String.raw`\end{aligned}`,
+  String.raw`\]`,
+  "",
+  String.raw`\[\begin{pmatrix}1 & 2 \\ 3 & 4\end{pmatrix}\]`,
+  "",
+  "Existing $$x^2$$ and prices $120 / $85.",
+].join("\n");
+
+function expectLatexRendered(container: HTMLElement) {
+  expect(container.querySelectorAll(".katex").length).toBe(4);
+  expect(container.querySelectorAll(".katex-display").length).toBe(2);
+  expect(container.textContent).toContain("prices $120 / $85");
+}
+
+describe("LaTeX delimiter parity across the five surfaces", () => {
+  it("renders in an Issue description", () => {
+    const { container } = render(<ReadonlyContent content={LATEX_FIXTURE} />);
+    expectLatexRendered(container);
+  });
+
+  it("renders in a Comment", () => {
+    const { container } = render(
+      <ReadonlyContent content={LATEX_FIXTURE} attachments={[]} />,
+    );
+    expectLatexRendered(container);
+  });
+
+  it("renders in a Chat user message", () => {
+    const client = makeClient();
+    const { container } = render(
+      withClient(
+        <ChatMessageList
+          messages={[userMessage(LATEX_FIXTURE)] as never}
+          pendingTask={null}
+          availability={undefined}
+        />,
+        client,
+      ),
+    );
+    expectLatexRendered(container);
+  });
+
+  it("renders in a persisted Chat assistant message", () => {
+    const client = makeClient();
+    seedTimeline(client, LATEX_FIXTURE);
+    const { container } = render(
+      withClient(
+        <ChatMessageList
+          messages={[assistantMessage(LATEX_FIXTURE)] as never}
+          pendingTask={null}
+          availability={undefined}
+        />,
+        client,
+      ),
+    );
+    expectLatexRendered(container);
+  });
+
+  it("renders completed formulas in a live Chat assistant row", () => {
+    const client = makeClient();
+    seedTimeline(client, LATEX_FIXTURE);
+    const { container } = render(
+      withClient(
+        <ChatMessageList
+          messages={[]}
+          pendingTask={{ task_id: TASK_ID, status: "running" } as never}
+          availability={undefined}
+        />,
+        client,
+      ),
+    );
+    expectLatexRendered(container);
+  });
+
+  it("keeps an incomplete live delimiter as source until it closes", () => {
+    const client = makeClient();
+    const partial = String.raw`Working: \(x + y`;
+    seedTimeline(client, partial);
+    const { container, rerender } = render(
+      withClient(
+        <ChatMessageList
+          messages={[]}
+          pendingTask={{ task_id: TASK_ID, status: "running" } as never}
+          availability={undefined}
+        />,
+        client,
+      ),
+    );
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain("Working: (x + y");
+
+    seedTimeline(client, `${partial}\\)`);
+    rerender(
+      withClient(
+        <ChatMessageList
+          messages={[]}
+          pendingTask={{ task_id: TASK_ID, status: "running" } as never}
+          availability={undefined}
+        />,
+        client,
+      ),
+    );
+
+    expect(container.querySelector(".katex")).not.toBeNull();
+  });
+});

--- a/packages/views/rich-content/rich-content-parity.test.tsx
+++ b/packages/views/rich-content/rich-content-parity.test.tsx
@@ -615,4 +615,23 @@ describe("LaTeX delimiter parity across the five surfaces", () => {
 
     expect(container.querySelector(".katex")).not.toBeNull();
   });
+
+  it("preserves non-text fields and collision-shaped user content", () => {
+    const userToken = "\uE000multica-latex-0\uE001";
+    const content = [
+      String.raw`<span title="\(attribute\)">plain</span>`,
+      String.raw`[target](https://example.com/\(literal\))`,
+      `${userToken} and ${String.raw`\(x\)`}`,
+    ].join("\n\n");
+    const { container } = render(<ReadonlyContent content={content} />);
+
+    expect(container.querySelector("span[title]")?.getAttribute("title")).toBe(
+      String.raw`\(attribute\)`,
+    );
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.com/(literal)",
+    );
+    expect(container.textContent).toContain(userToken);
+    expect(container.querySelectorAll(".katex")).toHaveLength(1);
+  });
 });

--- a/packages/views/rich-content/rich-content.tsx
+++ b/packages/views/rich-content/rich-content.tsx
@@ -71,6 +71,10 @@ import { Attachment as AttachmentRenderer } from "../editor/attachment";
 import { computeClosedFenceOffsets } from "./streaming-fence";
 import { remarkRepairCjkStrongTrailingWhitespace } from "./cjk-emphasis";
 import {
+  extractLatexDelimiters,
+  remarkLatexDelimiters,
+} from "./latex-delimiters";
+import {
   CodeBlockShell,
   RichFenceBlock,
   StaticCodeBody,
@@ -462,14 +466,6 @@ const COMPONENTS: Partial<Components> = {
 // `satisfies` rather than a cast: the plugin lists are still checked against
 // react-markdown's own option types, so a bad plugin tuple fails here instead of
 // being silenced.
-const REMARK_PLUGINS = [
-  [remarkMath, { singleDollarTextMath: false }],
-  remarkBreaks,
-  [remarkGfm, { singleTilde: false }],
-  remarkCjkFriendly,
-  remarkRepairCjkStrongTrailingWhitespace,
-] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
-
 const REHYPE_PLUGINS = [
   rehypeRaw,
   [rehypeSanitize, markdownSanitizeSchema],
@@ -517,12 +513,31 @@ export const RichContent = memo(function RichContent({
   // late config arrival reprocesses exactly once.
   const cdnDomain = useConfigStore((s) => s.cdnDomain);
 
+  const latex = useMemo(() => extractLatexDelimiters(content), [content]);
+
   const processed = useMemo(
     () =>
       highlightToHtml(
-        preprocessMarkdown(content, { cdnDomain, autolinkIssueIdentifiers: true }),
+        preprocessMarkdown(latex.markdown, {
+          cdnDomain,
+          autolinkIssueIdentifiers: true,
+        }),
       ),
-    [content, cdnDomain],
+    [latex.markdown, cdnDomain],
+  );
+
+  const remarkPlugins = useMemo<
+    NonNullable<ReactMarkdownOptions["remarkPlugins"]>
+  >(
+    () => [
+      [remarkMath, { singleDollarTextMath: false }],
+      [remarkLatexDelimiters, { formulas: latex.formulas }],
+      remarkBreaks,
+      [remarkGfm, { singleTilde: false }],
+      remarkCjkFriendly,
+      remarkRepairCjkStrongTrailingWhitespace,
+    ],
+    [latex.formulas],
   );
 
   // Derived from the SAME string handed to ReactMarkdown, so offsets line up
@@ -544,7 +559,7 @@ export const RichContent = memo(function RichContent({
     () => (
       <ClosedFenceContext.Provider value={closedFences}>
         <ReactMarkdown
-          remarkPlugins={REMARK_PLUGINS}
+          remarkPlugins={remarkPlugins}
           rehypePlugins={REHYPE_PLUGINS}
           urlTransform={markdownUrlTransform}
           components={COMPONENTS}
@@ -553,7 +568,7 @@ export const RichContent = memo(function RichContent({
         </ReactMarkdown>
       </ClosedFenceContext.Provider>
     ),
-    [processed, closedFences],
+    [processed, closedFences, remarkPlugins],
   );
 
   return (

--- a/packages/views/rich-content/rich-content.tsx
+++ b/packages/views/rich-content/rich-content.tsx
@@ -531,13 +531,16 @@ export const RichContent = memo(function RichContent({
   >(
     () => [
       [remarkMath, { singleDollarTextMath: false }],
-      [remarkLatexDelimiters, { formulas: latex.formulas }],
+      [
+        remarkLatexDelimiters,
+        { formulas: latex.formulas, tokenPrefix: latex.tokenPrefix },
+      ],
       remarkBreaks,
       [remarkGfm, { singleTilde: false }],
       remarkCjkFriendly,
       remarkRepairCjkStrongTrailingWhitespace,
     ],
-    [latex.formulas],
+    [latex.formulas, latex.tokenPrefix],
   );
 
   // Derived from the SAME string handed to ReactMarkdown, so offsets line up


### PR DESCRIPTION
## What does this PR do?

Supports paired `\(...\)` inline and `\[...\]` display LaTeX delimiters in the canonical `RichContent` renderer. These delimiters currently reach Markdown as escapes, so the slashes disappear and raw TeX remains visible instead of reaching KaTeX.

The implementation extracts only complete, single-backslash delimiter pairs before Markdown parsing and lowers them into the same math nodes already used by `remark-math`. It deliberately leaves inline/fenced code, doubled literal backslashes, existing dollar math, currency text, and incomplete streaming delimiters untouched.

## Related Issue

Fixes #6838

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added a CommonMark-aware delimiter extractor and remark transformer under `packages/views/rich-content/`.
- Wired the transformer into the single `RichContent` pipeline; no Chat-only renderer or parser path was introduced.
- Added regression coverage for inline/display delimiters, matrices, multiline aligned formulas, `$$...$$`, currency, code, literal backslashes, CommonMark list/quote fences, and incomplete streaming input.
- Exercised the real Issue, Comment, Chat user, live assistant, and persisted assistant entry points.

## How to Test

1. Render `Inline \(E=mc^2\)` and confirm one inline KaTeX node appears.
2. Render a matrix or aligned expression inside `\[...\]` and confirm display KaTeX appears.
3. Confirm `$$x^2$$`, `$120 / $85`, inline/fenced code, and doubled backslashes retain their existing behavior.
4. Stream an unclosed `\(` or `\[` and confirm it stays text until the matching close arrives.

Local verification:

```text
npx --yes node@22 ../../node_modules/vitest/vitest.mjs run
Test Files 326 passed (326); Tests 3899 passed (3899)

pnpm typecheck
Tasks 6 successful, 6 total

pnpm --filter @multica/views lint
0 errors (21 pre-existing warnings outside this change)
```

## Thinking Path

1. `remark-math` with `singleDollarTextMath: false` is intentionally retained to protect currency text.
2. Converting the delimiters after Markdown parsing is too late because CommonMark has already consumed their backslashes.
3. Converting them blindly before parsing would mutate code and deliberately literal text.
4. The extractor therefore uses a CommonMark parse only to identify protected code spans, replaces complete eligible pairs with opaque tokens, then a remark transformer emits the same inline/display math node shapes as `remark-math`.
5. Incomplete pairs are never tokenized, so the streaming transition is monotonic: text first, KaTeX only after closure.

Risk: delimiter pairing follows the first eligible matching close and does not attempt to interpret TeX semantics. This matches the delimiter contract; malformed or unclosed input remains text.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; parser compatibility only)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Investigated the reported Chat screenshot and existing unified renderer, reproduced the delimiter loss at the Markdown boundary, implemented a protected-context extraction/lowering path, and validated it through focused and package-wide tests.

## Screenshots (optional)

Before: the reproduction screenshot is attached to #6838. The automated render tests provide the after-fix DOM readback across all five product surfaces.
