### PR TITLE
MUL-6057: fix(i18n): format dates in the UI language, not the browser's

### DIFF
--- a/packages/views/i18n/index.ts
+++ b/packages/views/i18n/index.ts
@@ -1,2 +1,3 @@
 export { useT } from "./use-t";
+export { useLocale } from "./use-locale";
 export { useTimeAgo } from "./use-time-ago";

--- a/packages/views/i18n/use-locale.ts
+++ b/packages/views/i18n/use-locale.ts
@@ -1,0 +1,16 @@
+import { useT } from "./use-t";
+
+// The locale to hand to `Intl` / `toLocaleDateString` / `toLocaleString`.
+//
+// This is the language the member picked for the UI, which is NOT the same
+// as `navigator.language`: someone reading a Chinese UI in an English-language
+// browser must still get Chinese month and weekday names. Formatting against
+// the browser language leaves half a screen in one language and half in
+// another, which is exactly the bug this hook exists to prevent.
+//
+// `resolvedLanguage` is the language i18next actually rendered the strings
+// with after fallback, so dates always agree with the text around them.
+export function useLocale(): string {
+  const { i18n } = useT();
+  return i18n.resolvedLanguage ?? i18n.language;
+}

--- a/packages/views/issues/components/gantt-view.test.tsx
+++ b/packages/views/issues/components/gantt-view.test.tsx
@@ -1,0 +1,135 @@
+import { createStore } from "zustand/vanilla";
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  type IssueViewState,
+  viewStoreSlice,
+} from "@multica/core/issues/stores/view-store";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import type { Issue } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueContextMenuProvider } from "../actions";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({ data: [] }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+// The row's start / due range lives in a tooltip. This test is about how the
+// dates are formatted, not about hover timing, so render the content inline.
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) => render,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+  useNavigation: () => ({ push: vi.fn(), pathname: "/issues" }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@multica/core/paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/paths")>();
+  return {
+    ...actual,
+    useWorkspaceSlug: () => "acme",
+    useRequiredWorkspaceSlug: () => "acme",
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+import { GanttView } from "./gantt-view";
+
+const ISSUE = {
+  id: "issue-1",
+  identifier: "MUL-1",
+  number: 1,
+  title: "Ship the thing",
+  description: "",
+  status: "todo",
+  priority: "medium",
+  workspace_id: "workspace-1",
+  project_id: null,
+  parent_issue_id: null,
+  assignee_id: null,
+  assignee_type: null,
+  creator_id: "user-1",
+  creator_type: "member",
+  labels: [],
+  position: 0,
+  stage: null,
+  start_date: "2026-03-02",
+  due_date: "2026-03-06",
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: "2026-03-01T00:00:00Z",
+} as unknown as Issue;
+
+function renderGantt(locale: "en" | "zh-Hans") {
+  const store = createStore<IssueViewState>()(viewStoreSlice);
+  return renderWithI18n(
+    <ViewStoreProvider store={store}>
+      <IssueContextMenuProvider>
+        <GanttView issues={[ISSUE]} />
+      </IssueContextMenuProvider>
+    </ViewStoreProvider>,
+    { locale },
+  );
+}
+
+describe("GanttView date localization", () => {
+  beforeAll(() => {
+    // The browser speaks English while the UI does not. Dates must follow the
+    // UI language, not this — see useLocale in packages/views/i18n.
+    vi.stubGlobal("navigator", {
+      ...globalThis.navigator,
+      language: "en-US",
+      languages: ["en-US"],
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-04T12:00:00Z"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("formats axis dates in the UI language, not the browser's", () => {
+    const { container, unmount } = renderGantt("zh-Hans");
+
+    expect(screen.getByText("2026年3月")).toBeTruthy();
+    // Nothing may fall back to the browser language.
+    expect(container.textContent ?? "").not.toMatch(/Mar\b/);
+
+    unmount();
+  });
+
+  it("formats the row's start / due range in the UI language", () => {
+    const { unmount } = renderGantt("zh-Hans");
+
+    const range = screen.getByText(/2026年3月2日/);
+    expect(range.textContent).toContain("2026年3月6日");
+
+    unmount();
+  });
+
+  it("still formats in English when the UI is English", () => {
+    const { container } = renderGantt("en");
+
+    expect(screen.getByText("Mar 2026")).toBeTruthy();
+    expect(container.textContent ?? "").not.toMatch(/年/);
+  });
+});

--- a/packages/views/issues/components/gantt-view.tsx
+++ b/packages/views/issues/components/gantt-view.tsx
@@ -23,7 +23,7 @@ import { StatusIcon } from "./status-icon";
 import { PriorityIcon } from "./priority-icon";
 import { IssueActionsContextMenu } from "../actions";
 import { sortIssues } from "../utils/sort";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 // ---------------------------------------------------------------------------
 // Date utilities — everything is UTC-day-aligned so a `due_date` ISO string
@@ -123,7 +123,7 @@ function GanttAxis({
   todayOffsetDays: number;
   width: number;
 }) {
-  const locale = typeof navigator !== "undefined" ? navigator.language : "en";
+  const locale = useLocale();
   const totalDays = daysBetween(range.start, range.end);
 
   const monthBlocks = useMemo(() => {
@@ -316,6 +316,7 @@ function ScheduledRow({
   totalDays: number;
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const p = useWorkspacePaths();
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery({
@@ -349,7 +350,6 @@ function ScheduledRow({
     }
   }
 
-  const locale = typeof navigator !== "undefined" ? navigator.language : "en";
   const fmt = (d: Date) =>
     d.toLocaleDateString(locale, {
       month: "short",

--- a/packages/views/runtimes/components/charts/activity-heatmap.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { RuntimeUsage } from "@multica/core/types";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 import { addDaysIso, estimateCost, formatUsd, todayIso, weekStartIso } from "../../utils";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 
 // 26 weeks (~6 months) gives the heatmap real presence in the wider chart
 // card and turns "long-view" into a meaningful tab — a 13-week strip looked
@@ -68,8 +68,8 @@ export function ActivityHeatmap({
   usage: RuntimeUsage[];
   tz: string;
 }) {
-  const { t, i18n } = useT("runtimes");
-  const locale = i18n.resolvedLanguage ?? i18n.language;
+  const { t } = useT("runtimes");
+  const locale = useLocale();
   const weekdayLabels = useMemo(() => fmtWeekdays(locale), [locale]);
   // Memo dep — estimateCost (called inside the body below) consults the
   // user-override store, so saving a custom rate must invalidate the cells.


### PR DESCRIPTION
## What does this PR do?

The gantt view formats dates against `navigator.language` — the **browser's** language, not the one the member picked for the UI. A member reading a Chinese UI in an English-language browser sees `Mar 2026` and `Mar 2, 2026 → Mar 6, 2026` sitting next to Chinese labels; a member on an English UI in a Chinese browser sees the reverse. The two languages have no reason to agree, and the one that should win is the one the rest of the screen is in.

This adds `useLocale()` alongside `useT` / `useTimeAgo` in `packages/views/i18n/`, so there is one answer to "which locale do I format with": i18next's `resolvedLanguage`, i.e. the language the surrounding strings were actually rendered in. The gantt view uses it in both of its formatting sites.

`packages/views/runtimes/components/charts/activity-heatmap.tsx` had the correct behaviour already but spelled the idiom out inline (`i18n.resolvedLanguage ?? i18n.language`); it now shares the hook so the codebase has a single spelling of this.

Found while reviewing #6812, which fixed the same class of bug in the runtime activity heatmap.

## Related Issue

N/A — found during review of #6812.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/i18n/use-locale.ts` (new) — `useLocale()`, returning `i18n.resolvedLanguage ?? i18n.language`, with a comment on why `navigator.language` is the wrong source.
- `packages/views/i18n/index.ts` — export it.
- `packages/views/issues/components/gantt-view.tsx` — `GanttAxis` and `ScheduledRow` use `useLocale()` instead of reading `navigator.language`.
- `packages/views/runtimes/components/charts/activity-heatmap.tsx` — use the shared hook instead of the inline idiom (no behaviour change).
- `packages/views/issues/components/gantt-view.test.tsx` (new) — renders the gantt with `navigator.language` stubbed to `en-US` and asserts the axis heading and the row's start/due range come out in the UI language; a second case pins that an English UI still renders English.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/components/gantt-view.test.tsx runtimes/components/charts/activity-heatmap.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views exec eslint i18n/use-locale.ts issues/components/gantt-view.tsx issues/components/gantt-view.test.tsx`

Manually: set the UI language to 简体中文 in Settings → Preferences with an English-language browser, open any project's issues in gantt view. Before this change the month headings read `Mar 2026`; after, `2026年3月`.

I confirmed the new test is a real guard by reverting the two `useLocale()` call sites to `navigator.language` — the two zh-Hans cases fail, the English one still passes (an English browser and an English UI agree, which is exactly why this went unnoticed).

Full suite on this branch: `pnpm --filter @multica/views test` → 329 files / 3930 tests pass. ESLint reports no errors on the changed files; the heatmap keeps its pre-existing `exhaustive-deps` warning for the intentional custom-pricing store dependency.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (n/a — no user-facing docs describe this formatting)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy and relevant docs (n/a)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (n/a — no copy changes; the Chinese strings here come from `Intl`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Risks:** low. The only behaviour change is which locale string reaches `toLocaleDateString`, and it is now always one of the four locales we ship (`en` / `zh-Hans` / `ja` / `ko`) rather than an arbitrary browser tag — a narrower input set than before.

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** Spotted during review of #6812 that `gantt-view.tsx` sourced its locale from `navigator.language` while the heatmap had just been fixed to use the UI language. Grepped the repo for other `navigator.language` readers (the only other one, `packages/core/i18n/browser-cookie-adapter.ts`, is correct — that is how the initial preference is detected), extracted the shared hook rather than duplicating the idiom a third time, then wrote the regression test and verified it fails without the fix.

## Screenshots (optional)

Not included — the change is a locale string reaching `toLocaleDateString`, and the test asserts the rendered output directly for both languages.
