### PR TITLE
WS-3503: add private recruitment inbox processor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -388,6 +388,28 @@ MULTICA_LARK_CALLBACK_BASE_URL=
 # environment handling.
 MULTICA_LARK_WS_PROXY_URL=
 
+# Private recruitment inbox processor (optional, separate service process).
+# Run `./recruitment_inbox`; the general Multica server does not consume these
+# variables. Put secret values in the deployment secret manager, not this file.
+RECRUITMENT_INBOX_FEISHU_APP_ID=
+RECRUITMENT_INBOX_FEISHU_APP_SECRET=
+RECRUITMENT_INBOX_ALLOWED_CHAT_ID=
+RECRUITMENT_INBOX_BOT_OPEN_ID=
+# Base64-encoded random 32+ byte HMAC key for opaque ledger/idempotency IDs.
+RECRUITMENT_INBOX_HASH_KEY=
+RECRUITMENT_INBOX_OPENAI_API_KEY=
+RECRUITMENT_INBOX_OPENAI_BASE_URL=
+RECRUITMENT_INBOX_MODEL=gpt-5.6-luna
+RECRUITMENT_INBOX_IMAGE_MODEL=gpt-5.6-luna
+RECRUITMENT_INBOX_AUDIO_MODEL=gpt-4o-mini-transcribe
+RECRUITMENT_INBOX_ROLE_VERSION=v1
+RECRUITMENT_INBOX_HTTP_ADDR=:8080
+RECRUITMENT_INBOX_WORKERS=2
+# Optional proxy/mock overrides. Production Feishu defaults need none.
+RECRUITMENT_INBOX_FEISHU_HTTP_BASE_URL=
+RECRUITMENT_INBOX_FEISHU_CALLBACK_BASE_URL=
+RECRUITMENT_INBOX_FEISHU_WS_PROXY_URL=
+
 # DingTalk bot integration (Settings → Integrations "Bind to DingTalk")
 # Off until MULTICA_DINGTALK_SECRET_KEY is set — a base64-encoded 32-byte key
 # that encrypts each Bot's AppSecret at rest. Leave empty to disable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSIO
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/migrate ./cmd/migrate
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/backfill_task_usage_hourly ./cmd/backfill_task_usage_hourly
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/backfill_codex_usage_cache ./cmd/backfill_codex_usage_cache
+RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/recruitment_inbox ./cmd/recruitment_inbox
 
 # --- Runtime stage ---
 FROM alpine:3.21
@@ -34,6 +35,7 @@ COPY --from=builder /src/server/bin/multica .
 COPY --from=builder /src/server/bin/migrate .
 COPY --from=builder /src/server/bin/backfill_task_usage_hourly .
 COPY --from=builder /src/server/bin/backfill_codex_usage_cache .
+COPY --from=builder /src/server/bin/recruitment_inbox .
 COPY server/migrations/ ./migrations/
 COPY LICENSE NOTICE ./
 COPY docker/entrypoint.sh .

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ build: ## Build the server, CLI, and migrate binaries into server/bin
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server ./cmd/server
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
 	cd server && go build -o bin/migrate ./cmd/migrate
+	cd server && go build -o bin/recruitment_inbox ./cmd/recruitment_inbox
 
 test: ## Run Go tests after ensuring the target DB exists and migrations are applied
 	$(REQUIRE_ENV)

--- a/deploy/helm/multica/templates/recruitment-inbox.yaml
+++ b/deploy/helm/multica/templates/recruitment-inbox.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.recruitmentInbox.enabled }}
+{{- $backendImageTag := default .Chart.AppVersion .Values.images.backend.tag -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-recruitment-inbox
+  labels:
+    {{- include "multica.labels" . | nindent 4 }}
+    app.kubernetes.io/component: recruitment-inbox
+spec:
+  # Feishu long-connection event delivery and this processor's in-memory work
+  # queue are safest as one replica. The durable ledger still deduplicates
+  # replay after restart.
+  replicas: {{ .Values.recruitmentInbox.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: multica
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: recruitment-inbox
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ (lookup "v1" "Secret" .Release.Namespace .Values.existingSecret).data | toYaml | sha256sum }}
+      labels:
+        {{- include "multica.labels" . | nindent 8 }}
+        app.kubernetes.io/component: recruitment-inbox
+    spec:
+      containers:
+        - name: recruitment-inbox
+          image: "{{ .Values.images.backend.repository }}:{{ $backendImageTag }}"
+          imagePullPolicy: {{ .Values.images.backend.pullPolicy }}
+          command: ["./recruitment_inbox"]
+          ports:
+            - containerPort: 8080
+              name: health
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          env:
+            - name: RECRUITMENT_INBOX_HTTP_ADDR
+              value: ":8080"
+            - name: RECRUITMENT_INBOX_ROLE_VERSION
+              value: {{ .Values.recruitmentInbox.config.roleVersion | quote }}
+            - name: RECRUITMENT_INBOX_MODEL
+              value: {{ .Values.recruitmentInbox.config.model | quote }}
+            - name: RECRUITMENT_INBOX_IMAGE_MODEL
+              value: {{ .Values.recruitmentInbox.config.imageModel | quote }}
+            - name: RECRUITMENT_INBOX_AUDIO_MODEL
+              value: {{ .Values.recruitmentInbox.config.audioModel | quote }}
+            - name: RECRUITMENT_INBOX_WORKERS
+              value: {{ .Values.recruitmentInbox.config.workers | quote }}
+            {{- if not .Values.postgres.external.enabled }}
+            - name: DATABASE_URL
+              value: {{ include "multica.databaseUrl" . | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.recruitmentInbox.resources | nindent 12 }}
+      {{- with .Values.recruitmentInbox.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.recruitmentInbox.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -148,6 +148,31 @@ backend:
   tolerations: []
 
 # -----------------------------------------------------------------------------
+# Private recruitment inbox processor (disabled by default)
+# -----------------------------------------------------------------------------
+recruitmentInbox:
+  # Enabling creates one standalone always-on pod from the backend image. It
+  # consumes only the RECRUITMENT_INBOX_* keys in existingSecret and does not
+  # route source messages through Multica chat/task storage.
+  enabled: false
+  replicas: 1
+  config:
+    roleVersion: v1
+    model: gpt-5.6-luna
+    imageModel: gpt-5.6-luna
+    audioModel: gpt-4o-mini-transcribe
+    workers: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  affinity: {}
+  tolerations: []
+
+# -----------------------------------------------------------------------------
 # Frontend (Next.js standalone)
 # -----------------------------------------------------------------------------
 frontend:

--- a/server/cmd/recruitment_inbox/main.go
+++ b/server/cmd/recruitment_inbox/main.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
+	"github.com/multica-ai/multica/server/internal/recruitinbox"
+	"github.com/multica-ai/multica/server/pkg/llm"
+)
+
+type config struct {
+	AppID           string
+	AppSecret       string
+	AllowedChatID   string
+	BotOpenID       string
+	HashKey         []byte
+	DatabaseURL     string
+	OpenAIKey       string
+	OpenAIBaseURL   string
+	Model           string
+	ImageModel      string
+	AudioModel      string
+	RoleVersion     string
+	HTTPAddr        string
+	LarkHTTPURL     string
+	LarkCallbackURL string
+	LarkWSProxyURL  string
+	Workers         int
+}
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(log)
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Error("recruit inbox: invalid configuration", "error_code", "config_invalid")
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	ledger, err := recruitinbox.OpenPostgres(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Error("recruit inbox: ledger unavailable", "error_code", "ledger_unavailable")
+		os.Exit(1)
+	}
+	defer ledger.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: cfg.OpenAIKey, BaseURL: cfg.OpenAIBaseURL, DefaultModel: cfg.Model})
+	analyzer, err := recruitinbox.NewOpenAIAnalyzer(llmClient, cfg.Model, cfg.ImageModel, cfg.AudioModel)
+	if err != nil {
+		log.Error("recruit inbox: analyzer unavailable", "error_code", "analyzer_unavailable")
+		os.Exit(1)
+	}
+	creds := lark.InstallationCredentials{AppID: cfg.AppID, AppSecret: cfg.AppSecret, Region: lark.RegionFeishu}
+	larkClient := lark.NewHTTPAPIClient(lark.HTTPClientConfig{BaseURL: cfg.LarkHTTPURL, Logger: log})
+	transport := &feishuTransport{api: larkClient, creds: creds, allowedChatID: cfg.AllowedChatID}
+	processor, err := recruitinbox.NewProcessor(recruitinbox.Config{
+		AllowedChatID: cfg.AllowedChatID,
+		BotOpenID:     cfg.BotOpenID,
+		HashKey:       cfg.HashKey,
+		RoleVersion:   cfg.RoleVersion,
+		Logger:        log,
+	}, ledger, analyzer, transport)
+	if err != nil {
+		log.Error("recruit inbox: processor unavailable", "error_code", "processor_unavailable")
+		os.Exit(1)
+	}
+
+	queue := make(chan recruitinbox.Inbound, 64)
+	var inFlight sync.Map
+	enqueue := func(in recruitinbox.Inbound) {
+		if _, loaded := inFlight.LoadOrStore(in.MessageID, struct{}{}); loaded {
+			return
+		}
+		select {
+		case queue <- in:
+		default:
+			// The event is already durable. Release the in-memory claim; the
+			// pending scanner will fetch and enqueue it after workers catch up.
+			inFlight.Delete(in.MessageID)
+		}
+	}
+	var workers sync.WaitGroup
+	for i := 0; i < cfg.Workers; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for in := range queue {
+				workCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+				if err := processor.Process(workCtx, in); err != nil {
+					log.Error("recruit inbox: event processing infrastructure failure", "error_code", "processing_infrastructure_failure")
+				}
+				cancel()
+				inFlight.Delete(in.MessageID)
+			}
+		}()
+	}
+
+	var connected atomic.Bool
+	go serveHealth(ctx, cfg.HTTPAddr, ledger, &connected, log)
+	if err := recoverPending(ctx, processor, transport, enqueue, log); err != nil {
+		log.Error("recruit inbox: pending recovery failed", "error_code", "pending_recovery_failed")
+	}
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		scanPending(ctx, processor, transport, enqueue, log)
+	}()
+
+	connector, err := buildConnector(cfg, creds, &connected, log)
+	if err != nil {
+		log.Error("recruit inbox: connector initialization failed", "error_code", "connector_initialization_failed")
+		os.Exit(1)
+	}
+	inst := lark.Installation{AppID: cfg.AppID, BotOpenID: cfg.BotOpenID, Region: string(lark.RegionFeishu), ID: pgtype.UUID{Valid: false}}
+
+	for ctx.Err() == nil {
+		err := connector.Run(ctx, inst, func(eventCtx context.Context, msg lark.InboundMessage) (lark.DispatchResult, error) {
+			in := inboundFromLark(msg)
+			claimed, err := processor.Admit(eventCtx, in)
+			if err != nil {
+				return lark.DispatchResult{}, err
+			}
+			if claimed {
+				enqueue(in)
+			}
+			return lark.DispatchResult{}, nil
+		})
+		connected.Store(false)
+		if ctx.Err() != nil {
+			break
+		}
+		log.Warn("recruit inbox: Feishu connection ended", "error_code", "feishu_connection_ended")
+		timer := time.NewTimer(5 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+		_ = err
+	}
+	close(queue)
+	done := make(chan struct{})
+	go func() {
+		workers.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(95 * time.Second):
+		log.Error("recruit inbox: worker shutdown timed out", "error_code", "worker_shutdown_timeout")
+	}
+}
+
+func loadConfig() (config, error) {
+	hashKey, err := base64.StdEncoding.DecodeString(strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_HASH_KEY")))
+	if err != nil {
+		return config{}, errors.New("invalid RECRUITMENT_INBOX_HASH_KEY")
+	}
+	workers, _ := strconv.Atoi(os.Getenv("RECRUITMENT_INBOX_WORKERS"))
+	if workers <= 0 || workers > 8 {
+		workers = 2
+	}
+	cfg := config{
+		AppID:           strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_FEISHU_APP_ID")),
+		AppSecret:       strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_FEISHU_APP_SECRET")),
+		AllowedChatID:   strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_ALLOWED_CHAT_ID")),
+		BotOpenID:       strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_BOT_OPEN_ID")),
+		HashKey:         hashKey,
+		DatabaseURL:     strings.TrimSpace(os.Getenv("DATABASE_URL")),
+		OpenAIKey:       strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_OPENAI_API_KEY")),
+		OpenAIBaseURL:   strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_OPENAI_BASE_URL")),
+		Model:           strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_MODEL")),
+		ImageModel:      strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_IMAGE_MODEL")),
+		AudioModel:      strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_AUDIO_MODEL")),
+		RoleVersion:     strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_ROLE_VERSION")),
+		HTTPAddr:        strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_HTTP_ADDR")),
+		LarkHTTPURL:     strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_FEISHU_HTTP_BASE_URL")),
+		LarkCallbackURL: strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_FEISHU_CALLBACK_BASE_URL")),
+		LarkWSProxyURL:  strings.TrimSpace(os.Getenv("RECRUITMENT_INBOX_FEISHU_WS_PROXY_URL")),
+		Workers:         workers,
+	}
+	if cfg.Model == "" {
+		cfg.Model = "gpt-5.6-luna"
+	}
+	if cfg.HTTPAddr == "" {
+		cfg.HTTPAddr = ":8080"
+	}
+	if cfg.RoleVersion == "" {
+		cfg.RoleVersion = "v1"
+	}
+	if cfg.AppID == "" || cfg.AppSecret == "" || cfg.AllowedChatID == "" || cfg.DatabaseURL == "" || len(cfg.HashKey) < 32 || (cfg.OpenAIKey == "" && cfg.OpenAIBaseURL == "") {
+		return config{}, errors.New("required secret/config missing")
+	}
+	return cfg, nil
+}
+
+func buildConnector(cfg config, creds lark.InstallationCredentials, connected *atomic.Bool, log *slog.Logger) (*lark.WSLongConnConnector, error) {
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = 15 * time.Second
+	if cfg.LarkWSProxyURL != "" {
+		proxyURL, err := url.Parse(cfg.LarkWSProxyURL)
+		if err != nil {
+			return nil, err
+		}
+		dialer.Proxy = http.ProxyURL(proxyURL)
+	}
+	fetcher, err := lark.NewHTTPConnectionTokenFetcher(lark.HTTPConnectionTokenConfig{BaseURL: cfg.LarkCallbackURL, Logger: log})
+	if err != nil {
+		return nil, err
+	}
+	return lark.NewWSLongConnConnector(lark.WSConnectorConfig{
+		Dialer:          wsDialer{dialer: &dialer},
+		EndpointFetcher: fetcher,
+		FrameDecoder:    lark.NewLarkJSONFrameDecoder(),
+		CredentialsProvider: lark.CredentialsProviderFunc(func(context.Context, lark.Installation) (lark.InstallationCredentials, error) {
+			return creds, nil
+		}),
+		Logger:         log,
+		OnConnected:    func() { connected.Store(true) },
+		OnDisconnected: func() { connected.Store(false) },
+	})
+}
+
+type wsDialer struct{ dialer *websocket.Dialer }
+
+func (d wsDialer) DialContext(ctx context.Context, urlStr string, header http.Header) (lark.WSConn, *http.Response, error) {
+	return d.dialer.DialContext(ctx, urlStr, header)
+}
+
+type feishuTransport struct {
+	api           lark.APIClient
+	creds         lark.InstallationCredentials
+	allowedChatID string
+}
+
+func (t *feishuTransport) Get(ctx context.Context, messageID string) (recruitinbox.Inbound, error) {
+	items, err := t.api.GetMessage(ctx, t.creds, messageID)
+	if err != nil {
+		return recruitinbox.Inbound{}, err
+	}
+	if len(items) == 0 {
+		return recruitinbox.Inbound{}, errors.New("Feishu message not found")
+	}
+	it := items[0]
+	return recruitinbox.Inbound{MessageID: it.MessageID, ChatID: t.allowedChatID, SenderType: it.SenderType, MessageType: it.MessageType, Content: it.Content, CreatedAt: parseMillis(it.CreateTime)}, nil
+}
+
+func (t *feishuTransport) Download(ctx context.Context, messageID string, ref recruitinbox.ResourceRef) (recruitinbox.Resource, error) {
+	streamer, ok := t.api.(interface {
+		DownloadMessageResourceStream(context.Context, lark.InstallationCredentials, lark.DownloadResourceParams) (lark.DownloadedResourceStream, error)
+	})
+	if !ok {
+		return recruitinbox.Resource{}, errors.New("streaming resource API unavailable")
+	}
+	got, err := streamer.DownloadMessageResourceStream(ctx, t.creds, lark.DownloadResourceParams{MessageID: messageID, FileKey: ref.Key, Type: ref.Kind})
+	if err != nil {
+		return recruitinbox.Resource{}, err
+	}
+	return recruitinbox.Resource{Body: got.Body, Filename: got.Filename, ContentType: got.ContentType}, nil
+}
+
+func (t *feishuTransport) Reply(ctx context.Context, chatID, text, key string) (string, error) {
+	return t.api.SendTextMessage(ctx, lark.SendTextParams{InstallationID: t.creds, ChatID: lark.ChatID(chatID), Text: text, IdempotencyKey: key})
+}
+
+func inboundFromLark(msg lark.InboundMessage) recruitinbox.Inbound {
+	return recruitinbox.Inbound{MessageID: msg.MessageID, ChatID: string(msg.ChatID), SenderID: string(msg.SenderOpenID), SenderType: msg.SenderType, MessageType: msg.MessageType, Content: msg.Content, CreatedAt: parseMillis(msg.CreateTime)}
+}
+
+func parseMillis(raw string) time.Time {
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.UnixMilli(n)
+}
+
+func recoverPending(ctx context.Context, p *recruitinbox.Processor, transport *feishuTransport, enqueue func(recruitinbox.Inbound), log *slog.Logger) error {
+	records, err := p.Pending(ctx)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		in, err := transport.Get(ctx, record.SourceMessageID)
+		if err != nil {
+			log.Warn("recruit inbox: could not recover pending event", "message_key", record.MessageKey, "error_code", "pending_source_unavailable")
+			continue
+		}
+		enqueue(in)
+	}
+	return nil
+}
+
+func scanPending(ctx context.Context, p *recruitinbox.Processor, transport *feishuTransport, enqueue func(recruitinbox.Inbound), log *slog.Logger) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := recoverPending(ctx, p, transport, enqueue, log); err != nil {
+				log.Error("recruit inbox: pending scan failed", "error_code", "pending_scan_failed")
+			}
+		}
+	}
+}
+
+func serveHealth(ctx context.Context, addr string, ledger recruitinbox.Ledger, connected *atomic.Bool, log *slog.Logger) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		checkCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		if !connected.Load() || ledger.Health(checkCtx) != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "not_ready"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	})
+	server := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Error("recruit inbox: health server stopped", "error_code", "health_server_stopped")
+	}
+}

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -279,6 +279,11 @@ type SendTextParams struct {
 	InstallationID InstallationCredentials
 	ChatID         ChatID
 	Text           string
+	// IdempotencyKey maps to Feishu's documented `uuid` field on the send
+	// endpoint. Empty preserves the historical behavior. Dedicated processors
+	// should derive a stable, non-sensitive value from the inbound message ID so
+	// an ambiguous transport retry cannot create a duplicate reply.
+	IdempotencyKey string
 	// ReplyTarget threads the text reply back into a Lark topic; see
 	// ReplyTarget. Empty keeps the chat-level send.
 	ReplyTarget ReplyTarget

--- a/server/internal/integrations/lark/feishu_types.go
+++ b/server/internal/integrations/lark/feishu_types.go
@@ -21,7 +21,12 @@ type InboundMessage struct {
 	ChatType     ChatType
 	MessageID    string
 	SenderOpenID OpenID
-	Body         string
+	// SenderType is the official event sender_type (normally "user" or
+	// "app"). Consumers that listen to every message in an allowlisted chat
+	// use it to reject bot-authored messages before any processing, preventing
+	// reply loops without relying on display names or message content.
+	SenderType string
+	Body       string
 	// Content is the raw msg_type-specific JSON string Lark sends in
 	// event.message.content. Text/post decoding consumes it immediately; media
 	// ingestion keeps it so the adapter can extract image_key/file_key before

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -270,21 +270,29 @@ func (c *httpAPIClient) invalidateToken(appID string) {
 // goes to the chat-level send endpoint keyed by receive_id=chat_id, the
 // historical behavior. Body is map[string]any (not map[string]string)
 // because reply_in_thread is a bool.
-func outboundMessageRequest(chatID ChatID, msgType, content string, target ReplyTarget) (string, map[string]any) {
+func outboundMessageRequest(chatID ChatID, msgType, content, idempotencyKey string, target ReplyTarget) (string, map[string]any) {
 	if target.IsSet() {
-		return "/open-apis/im/v1/messages/" + url.PathEscape(target.MessageID) + "/reply", map[string]any{
+		body := map[string]any{
 			"msg_type":        msgType,
 			"content":         content,
 			"reply_in_thread": target.InThread,
 		}
+		if idempotencyKey != "" {
+			body["uuid"] = idempotencyKey
+		}
+		return "/open-apis/im/v1/messages/" + url.PathEscape(target.MessageID) + "/reply", body
 	}
 	q := url.Values{}
 	q.Set("receive_id_type", "chat_id")
-	return "/open-apis/im/v1/messages?" + q.Encode(), map[string]any{
+	body := map[string]any{
 		"receive_id": string(chatID),
 		"msg_type":   msgType,
 		"content":    content,
 	}
+	if idempotencyKey != "" {
+		body["uuid"] = idempotencyKey
+	}
+	return "/open-apis/im/v1/messages?" + q.Encode(), body
 }
 
 // SendInteractiveCard posts a fresh interactive card into a chat and
@@ -301,7 +309,7 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	if err != nil {
 		return "", err
 	}
-	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, "", p.ReplyTarget)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -345,7 +353,7 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode text content: %w", err)
 	}
-	path, body := outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.IdempotencyKey, p.ReplyTarget)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -408,7 +416,7 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode markdown card: %w", err)
 	}
-	path, body := outboundMessageRequest(p.ChatID, "interactive", string(cardBytes), p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "interactive", string(cardBytes), "", p.ReplyTarget)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -605,6 +605,9 @@ func TestHTTPClient_SendTextMessage_HappyPath(t *testing.T) {
 			if body["msg_type"] != "text" {
 				t.Errorf("msg_type: got %q want text (NOT interactive — chat replies are plain bubbles)", body["msg_type"])
 			}
+			if body["uuid"] != "opaque-idempotency-key" {
+				t.Errorf("uuid: got %q want opaque-idempotency-key", body["uuid"])
+			}
 			// content is a JSON-encoded string Lark requires: the outer
 			// HTTP body is JSON, and `content` is another JSON
 			// document INSIDE it. Decode and inspect.
@@ -623,6 +626,7 @@ func TestHTTPClient_SendTextMessage_HappyPath(t *testing.T) {
 		InstallationID: testCreds(),
 		ChatID:         ChatID("oc_chat_42"),
 		Text:           "Hello world",
+		IdempotencyKey: "opaque-idempotency-key",
 	})
 	if err != nil {
 		t.Fatalf("send: %v", err)

--- a/server/internal/integrations/lark/ws_connector.go
+++ b/server/internal/integrations/lark/ws_connector.go
@@ -138,6 +138,13 @@ type WSConnectorConfig struct {
 
 	// Logger optional; defaults to slog.Default.
 	Logger *slog.Logger
+
+	// OnConnected / OnDisconnected are optional lifecycle hooks for dedicated
+	// services that expose transport readiness. Hooks must return quickly and
+	// must not inspect message content. OnDisconnected runs exactly once for
+	// every successfully-dialed connection, on every exit path.
+	OnConnected    func()
+	OnDisconnected func()
 }
 
 func (c WSConnectorConfig) withDefaults() WSConnectorConfig {
@@ -214,6 +221,12 @@ func (c *WSLongConnConnector) Run(ctx context.Context, inst Installation, emit E
 	conn, _, err := c.cfg.Dialer.DialContext(ctx, endpoint.URL, endpoint.Headers)
 	if err != nil {
 		return fmt.Errorf("dial ws: %w", err)
+	}
+	if c.cfg.OnConnected != nil {
+		c.cfg.OnConnected()
+	}
+	if c.cfg.OnDisconnected != nil {
+		defer c.cfg.OnDisconnected()
 	}
 
 	// runCtx fans out cancellation to the watchdog + ping goroutines

--- a/server/internal/integrations/lark/ws_frame_decoder.go
+++ b/server/internal/integrations/lark/ws_frame_decoder.go
@@ -72,6 +72,7 @@ func (d *LarkJSONFrameDecoder) Decode(payload []byte, inst Installation) (Inboun
 		ChatType:     normalizeChatType(evt.Message.ChatType),
 		MessageID:    evt.Message.MessageID,
 		SenderOpenID: OpenID(evt.Sender.SenderID.OpenID),
+		SenderType:   evt.Sender.SenderType,
 		MessageType:  evt.Message.MessageType,
 		Content:      evt.Message.Content,
 		CreateTime:   evt.Message.CreateTime,

--- a/server/internal/integrations/lark/ws_frame_decoder_test.go
+++ b/server/internal/integrations/lark/ws_frame_decoder_test.go
@@ -51,6 +51,9 @@ func TestLarkJSONFrameDecoderTextMessageInP2P(t *testing.T) {
 	if msg.SenderOpenID != "ou_user" {
 		t.Errorf("SenderOpenID = %q", msg.SenderOpenID)
 	}
+	if msg.SenderType != "user" {
+		t.Errorf("SenderType = %q", msg.SenderType)
+	}
 	if msg.Body != "hello" {
 		t.Errorf("Body = %q", msg.Body)
 	}

--- a/server/internal/recruitinbox/README.md
+++ b/server/internal/recruitinbox/README.md
@@ -1,0 +1,76 @@
+# Private recruitment inbox processor
+
+This binary is intentionally separate from Multica's general Feishu channel.
+It listens to official `im.message.receive_v1` long-connection events for one
+secret-configured chat, replies as the Feishu bot, and never writes the source
+message into Multica issues, chats, task transcripts, object storage, or logs.
+
+## Runtime contract
+
+- Run `./recruitment_inbox` as a single always-on service replica. Feishu's
+  official long connection supplies event authenticity; the server-provided
+  WebSocket endpoint is bootstrapped with the app credentials and every data
+  frame is ACKed using the official binary protocol.
+- The allowlisted chat identifier, Feishu credentials, OpenAI credential, and
+  HMAC key come only from the deployment secret manager. Do not put their
+  values in source, CI logs, Multica metadata, or issue comments.
+- A message is durably claimed before ACK. OCR/transcription runs off the ACK
+  path. Terminal transitions clear the temporary source message ID.
+- The Feishu send `uuid` is a stable HMAC-derived idempotency key. Connector
+  redelivery and ambiguous retries therefore cannot create a second reply.
+- Image/audio bytes are held in memory only for the bounded extraction call
+  and the response body is closed immediately. No temporary media file or
+  object-store copy is created.
+- Every reply states that the service only records/analyzes information.
+  Consequential instructions ask for `确认生效`; this processor contains no
+  executor for rejection, publishing, contact, scheduling, offers, forwarding,
+  candidate-state changes, or budget/rule activation.
+
+## Persistent schema
+
+`recruitment_inbox_event` contains only:
+
+- HMAC message key (and the acceptance-approved source message ID only while
+  `processing`, required for crash recovery and cleared at terminal state)
+- boolean/count structured summary; no extracted text or values
+- role-version pointer
+- processing state, timestamps, error code
+- HMAC sent-message key and send status
+
+It has no chat-ID, raw-message, content, resource-key, filename, transcript,
+resume, contact, salary, or evaluation column.
+
+## Secret/config key names
+
+Required: `DATABASE_URL`, `RECRUITMENT_INBOX_FEISHU_APP_ID`,
+`RECRUITMENT_INBOX_FEISHU_APP_SECRET`,
+`RECRUITMENT_INBOX_ALLOWED_CHAT_ID`, `RECRUITMENT_INBOX_HASH_KEY`, and either
+`RECRUITMENT_INBOX_OPENAI_API_KEY` or
+`RECRUITMENT_INBOX_OPENAI_BASE_URL`.
+
+Recommended: `RECRUITMENT_INBOX_BOT_OPEN_ID`,
+`RECRUITMENT_INBOX_ROLE_VERSION`, `RECRUITMENT_INBOX_MODEL`,
+`RECRUITMENT_INBOX_IMAGE_MODEL`, and `RECRUITMENT_INBOX_AUDIO_MODEL`.
+
+The Feishu app needs the official message receive event plus least-privilege bot
+scopes for reading message resources and sending messages. The bot must be a
+member of the designated private group.
+
+## Health, alerting, and rollback
+
+- Liveness: `GET /health`
+- Readiness: `GET /readyz` (requires PostgreSQL and an active Feishu socket)
+- Alert on readiness failure, restart loop, and log `error_code` counts. Logs
+  carry only error categories and HMAC message keys.
+- Disable immediately by scaling the service to zero or revoking the Feishu app
+  event subscription. Roll back the image to the prior revision; the table is
+  backward-compatible and may remain. Delete its migration only after the
+  service is stopped and retention requirements are confirmed.
+
+Do not test with production candidate material until a deployed revision is
+healthy and an explicitly designated synthetic test flow is approved.
+
+For the bundled Helm chart, set `recruitmentInbox.enabled=true` after adding
+the required secret keys to `existingSecret`. Disable/rollback with
+`--set recruitmentInbox.enabled=false`; the Deployment is then removed while
+the audit-minimal table remains available for the agreed retention window.

--- a/server/internal/recruitinbox/openai.go
+++ b/server/internal/recruitinbox/openai.go
@@ -1,0 +1,164 @@
+package recruitinbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
+
+	"github.com/multica-ai/multica/server/pkg/llm"
+)
+
+const analyzerSystemPrompt = `You are the private recruitment intake analyzer. Return one JSON object only.
+Extract only job-relevant facts: role, whether budget is present (never copy the amount), start date, owner, project lead, rule change, rule type, affected scope, missing fields, uncertainties, proposed next step, whether the instruction is consequential, and at most one clarification question.
+Set consequential=true for candidate rejection, publishing a job, external contact, interview scheduling, an offer, salary or budget change, forwarding, or activating/changing a rule. Never claim an action was executed. Do not infer protected traits. Keep arrays concise. The word JSON is intentional.`
+
+type OpenAIAnalyzer struct {
+	client     *llm.Client
+	model      string
+	imageModel string
+	audioModel string
+}
+
+func NewOpenAIAnalyzer(client *llm.Client, model, imageModel, audioModel string) (*OpenAIAnalyzer, error) {
+	if client == nil || !client.Enabled() {
+		return nil, errors.New("recruit inbox: OpenAI client is not configured")
+	}
+	if strings.TrimSpace(model) == "" {
+		model = client.DefaultModel()
+	}
+	if strings.TrimSpace(imageModel) == "" {
+		imageModel = model
+	}
+	if strings.TrimSpace(audioModel) == "" {
+		audioModel = "gpt-4o-mini-transcribe"
+	}
+	return &OpenAIAnalyzer{client: client, model: model, imageModel: imageModel, audioModel: audioModel}, nil
+}
+
+func (a *OpenAIAnalyzer) AnalyzeText(ctx context.Context, text string) (Extraction, error) {
+	raw, err := a.client.GenerateJSON(ctx, a.model, analyzerSystemPrompt, text, 0, 1600)
+	if err != nil {
+		return Extraction{}, err
+	}
+	return decodeExtraction(raw)
+}
+
+func (a *OpenAIAnalyzer) AnalyzeImage(ctx context.Context, image []byte, contentType string) (Extraction, error) {
+	if contentType == "" {
+		contentType = "image/jpeg"
+	}
+	dataURL := "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(image)
+	params := openai.ChatCompletionNewParams{
+		Model: shared.ChatModel(a.imageModel),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(analyzerSystemPrompt),
+			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+				openai.TextContentPart("OCR the image and analyze its recruitment content. Return JSON only."),
+				openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: dataURL, Detail: "high"}),
+			}),
+		},
+		ResponseFormat:      openai.ChatCompletionNewParamsResponseFormatUnion{OfJSONObject: &shared.ResponseFormatJSONObjectParam{}},
+		MaxCompletionTokens: openai.Int(1600),
+		Store:               openai.Bool(false),
+	}
+	if isGPT56Model(a.imageModel) {
+		params.ReasoningEffort = shared.ReasoningEffortNone
+	}
+	completion, err := a.client.Chat(ctx, params)
+	if err != nil {
+		return Extraction{}, err
+	}
+	if len(completion.Choices) == 0 {
+		return Extraction{}, errors.New("recruit inbox: image analyzer returned no choices")
+	}
+	return decodeExtraction(completion.Choices[0].Message.Content)
+}
+
+func (a *OpenAIAnalyzer) AnalyzeFile(ctx context.Context, data []byte, filename, contentType string) (Extraction, error) {
+	if strings.HasPrefix(strings.ToLower(contentType), "text/") || hasTextExtension(filename) {
+		return a.AnalyzeText(ctx, string(data))
+	}
+	params := openai.ChatCompletionNewParams{
+		Model: shared.ChatModel(a.imageModel),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(analyzerSystemPrompt),
+			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+				openai.TextContentPart("Analyze this supported recruitment document. Return JSON only."),
+				openai.FileContentPart(openai.ChatCompletionContentPartFileFileParam{
+					FileData: param.NewOpt(base64.StdEncoding.EncodeToString(data)),
+					Filename: param.NewOpt(filename),
+				}),
+			}),
+		},
+		ResponseFormat:      openai.ChatCompletionNewParamsResponseFormatUnion{OfJSONObject: &shared.ResponseFormatJSONObjectParam{}},
+		MaxCompletionTokens: openai.Int(1600),
+		Store:               openai.Bool(false),
+	}
+	if isGPT56Model(a.imageModel) {
+		params.ReasoningEffort = shared.ReasoningEffortNone
+	}
+	completion, err := a.client.Chat(ctx, params)
+	if err != nil {
+		return Extraction{}, err
+	}
+	if len(completion.Choices) == 0 {
+		return Extraction{}, errors.New("recruit inbox: file analyzer returned no choices")
+	}
+	return decodeExtraction(completion.Choices[0].Message.Content)
+}
+
+func hasTextExtension(filename string) bool {
+	filename = strings.ToLower(strings.TrimSpace(filename))
+	return strings.HasSuffix(filename, ".txt") || strings.HasSuffix(filename, ".md") || strings.HasSuffix(filename, ".csv")
+}
+
+func isGPT56Model(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return model == "gpt-5.6" || strings.HasPrefix(model, "gpt-5.6-")
+}
+
+func (a *OpenAIAnalyzer) Transcribe(ctx context.Context, audio io.Reader, filename string) (string, error) {
+	data, err := io.ReadAll(audio)
+	if err != nil {
+		return "", err
+	}
+	response, err := a.client.SDK().Audio.Transcriptions.New(ctx, openai.AudioTranscriptionNewParams{
+		File:           openai.File(bytes.NewReader(data), filename, "application/octet-stream"),
+		Model:          openai.AudioModel(a.audioModel),
+		Language:       param.NewOpt("zh"),
+		ResponseFormat: "json",
+	})
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(response.Text) == "" {
+		return "", errors.New("recruit inbox: transcription was empty")
+	}
+	return response.Text, nil
+}
+
+func decodeExtraction(raw string) (Extraction, error) {
+	var out Extraction
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return Extraction{}, fmt.Errorf("recruit inbox: decode analysis: %w", err)
+	}
+	if strings.ContainsAny(out.Clarification, "\r\n") {
+		out.Clarification = strings.TrimSpace(strings.Split(strings.ReplaceAll(out.Clarification, "\r\n", "\n"), "\n")[0])
+	}
+	if len(out.MissingFields) > 12 {
+		out.MissingFields = out.MissingFields[:12]
+	}
+	if len(out.Uncertainties) > 12 {
+		out.Uncertainties = out.Uncertainties[:12]
+	}
+	return out, nil
+}

--- a/server/internal/recruitinbox/postgres.go
+++ b/server/internal/recruitinbox/postgres.go
@@ -1,0 +1,77 @@
+package recruitinbox
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PostgresLedger struct {
+	pool *pgxpool.Pool
+}
+
+func OpenPostgres(ctx context.Context, databaseURL string) (*PostgresLedger, error) {
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	return &PostgresLedger{pool: pool}, nil
+}
+
+func (l *PostgresLedger) Claim(ctx context.Context, key, sourceMessageID string, at time.Time) (bool, error) {
+	tag, err := l.pool.Exec(ctx, `INSERT INTO recruitment_inbox_event(message_key, source_message_id, processing_state, received_at, updated_at) VALUES($1, $2, 'processing', $3, $3) ON CONFLICT(message_key) DO NOTHING`, key, sourceMessageID, at.UTC())
+	return tag.RowsAffected() == 1, err
+}
+
+func (l *PostgresLedger) Pending(ctx context.Context) ([]Record, error) {
+	rows, err := l.pool.Query(ctx, `SELECT message_key, source_message_id, received_at, updated_at FROM recruitment_inbox_event WHERE processing_state='processing' ORDER BY received_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Record
+	for rows.Next() {
+		var rec Record
+		if err := rows.Scan(&rec.MessageKey, &rec.SourceMessageID, &rec.ReceivedAt, &rec.UpdatedAt); err != nil {
+			return nil, err
+		}
+		rec.State = StateProcessing
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+func (l *PostgresLedger) MarkReplied(ctx context.Context, key string, summary Summary, roleVersion, sentKey string, at time.Time) error {
+	raw, err := json.Marshal(summary)
+	if err != nil {
+		return err
+	}
+	_, err = l.pool.Exec(ctx, `UPDATE recruitment_inbox_event SET source_message_id='', structured_summary=$1::jsonb, role_version=$2, processing_state='replied', updated_at=$3, error_code='', sent_message_key=$4, sent_status='sent' WHERE message_key=$5`, raw, roleVersion, at.UTC(), sentKey, key)
+	return err
+}
+
+func (l *PostgresLedger) MarkIgnored(ctx context.Context, key string, at time.Time) error {
+	_, err := l.pool.Exec(ctx, `UPDATE recruitment_inbox_event SET source_message_id='', processing_state='ignored', updated_at=$1 WHERE message_key=$2`, at.UTC(), key)
+	return err
+}
+
+func (l *PostgresLedger) MarkDeadLetter(ctx context.Context, key, errorCode, sentKey string, at time.Time) error {
+	status := "failed"
+	if sentKey != "" {
+		status = "sent"
+	}
+	_, err := l.pool.Exec(ctx, `UPDATE recruitment_inbox_event SET source_message_id='', processing_state='dead_letter', updated_at=$1, error_code=$2, sent_message_key=$3, sent_status=$4 WHERE message_key=$5`, at.UTC(), errorCode, sentKey, status, key)
+	return err
+}
+
+func (l *PostgresLedger) Health(ctx context.Context) error { return l.pool.Ping(ctx) }
+func (l *PostgresLedger) Close() error {
+	l.pool.Close()
+	return nil
+}

--- a/server/internal/recruitinbox/processor.go
+++ b/server/internal/recruitinbox/processor.go
@@ -1,0 +1,366 @@
+package recruitinbox
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+const (
+	ErrorAnalyze     = "analyze_failed"
+	ErrorDownload    = "resource_download_failed"
+	ErrorUnsupported = "unsupported_file"
+	ErrorReply       = "reply_failed"
+	ErrorInvalid     = "invalid_event"
+	maxImageBytes    = 20 << 20
+	maxAudioBytes    = 25 << 20
+	maxFileBytes     = 20 << 20
+	guardrail        = "本回复只记录和分析信息，不会自动生效规则、改变候选人状态或执行招聘动作。"
+	failureNotice    = guardrail + "\n处理失败，请稍后重试；如仍失败，请改发文字或受支持的导出格式。"
+)
+
+type Config struct {
+	AllowedChatID string
+	BotOpenID     string
+	HashKey       []byte
+	RoleVersion   string
+	Now           func() time.Time
+	Logger        *slog.Logger
+}
+
+type Processor struct {
+	cfg      Config
+	ledger   Ledger
+	analyzer Analyzer
+	feishu   FeishuClient
+}
+
+func NewProcessor(cfg Config, ledger Ledger, analyzer Analyzer, feishu FeishuClient) (*Processor, error) {
+	if strings.TrimSpace(cfg.AllowedChatID) == "" {
+		return nil, errors.New("recruit inbox: allowed chat id is required")
+	}
+	if len(cfg.HashKey) < 32 {
+		return nil, errors.New("recruit inbox: hash key must be at least 32 bytes")
+	}
+	if ledger == nil || analyzer == nil || feishu == nil {
+		return nil, errors.New("recruit inbox: ledger, analyzer, and Feishu client are required")
+	}
+	if cfg.RoleVersion == "" {
+		cfg.RoleVersion = "v1"
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Processor{cfg: cfg, ledger: ledger, analyzer: analyzer, feishu: feishu}, nil
+}
+
+// Admit verifies the runtime allowlist and bot-loop guards, then durably claims
+// the Feishu message ID before returning. A long-connection handler should ACK
+// only after this succeeds, enqueueing Process separately so OCR/transcription
+// never consumes Feishu's short ACK budget.
+func (p *Processor) Admit(ctx context.Context, in Inbound) (bool, error) {
+	if in.ChatID != p.cfg.AllowedChatID || isBotAuthored(in, p.cfg.BotOpenID) {
+		return false, nil
+	}
+	if in.MessageID == "" {
+		return false, nil
+	}
+	messageKey := p.hash("inbound", in.MessageID)
+	claimed, err := p.ledger.Claim(ctx, messageKey, in.MessageID, nonZeroTime(in.CreatedAt, p.cfg.Now()))
+	if err != nil {
+		return false, fmt.Errorf("recruit inbox: claim ledger: %w", err)
+	}
+	return claimed, nil
+}
+
+// Process handles an already-claimed event. The source body, chat ID, resource
+// key, transcript, and extracted values never enter logs or persistent storage.
+func (p *Processor) Process(ctx context.Context, in Inbound) error {
+	messageKey := p.hash("inbound", in.MessageID)
+	extraction, code, err := p.extract(ctx, in)
+	if err != nil {
+		p.cfg.Logger.Warn("recruit inbox: extraction failed", "message_key", messageKey, "error_code", code)
+		return p.deadLetter(ctx, in, messageKey, code)
+	}
+	reply := RenderReply(extraction)
+	sentID, err := p.feishu.Reply(ctx, in.ChatID, reply, p.idempotencyKey("reply", in.MessageID))
+	if err != nil {
+		p.cfg.Logger.Warn("recruit inbox: reply failed", "message_key", messageKey, "error_code", ErrorReply)
+		// Do not send a second failure notification after an ambiguous send error:
+		// Feishu may have accepted the first reply. The stable uuid makes connector
+		// redelivery safe, and the ledger keeps this event in dead-letter state.
+		if markErr := p.ledger.MarkDeadLetter(ctx, messageKey, ErrorReply, "", p.cfg.Now()); markErr != nil {
+			return fmt.Errorf("recruit inbox: reply and dead-letter failed: %w", markErr)
+		}
+		return nil
+	}
+	return p.ledger.MarkReplied(ctx, messageKey, summarize(extraction), p.cfg.RoleVersion, p.hash("sent", sentID), p.cfg.Now())
+}
+
+// Handle is the synchronous convenience used by tests and bounded callers.
+func (p *Processor) Handle(ctx context.Context, in Inbound) error {
+	claimed, err := p.Admit(ctx, in)
+	if err != nil || !claimed {
+		return err
+	}
+	return p.Process(ctx, in)
+}
+
+func (p *Processor) Pending(ctx context.Context) ([]Record, error) {
+	return p.ledger.Pending(ctx)
+}
+
+func (p *Processor) extract(ctx context.Context, in Inbound) (Extraction, string, error) {
+	switch in.MessageType {
+	case "text", "post":
+		text, err := textContent(in.Content)
+		if err != nil || strings.TrimSpace(text) == "" {
+			return Extraction{}, ErrorInvalid, errors.New("empty or invalid text content")
+		}
+		out, err := p.analyzer.AnalyzeText(ctx, text)
+		applyDeterministicGuard(text, &out)
+		return out, ErrorAnalyze, err
+	case "image":
+		ref, err := resourceRef(in.MessageType, in.Content)
+		if err != nil {
+			return Extraction{}, ErrorInvalid, err
+		}
+		resource, err := p.feishu.Download(ctx, in.MessageID, ref)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		defer resource.Body.Close()
+		data, err := readBounded(resource.Body, maxImageBytes)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		out, err := p.analyzer.AnalyzeImage(ctx, data, resource.ContentType)
+		return out, ErrorAnalyze, err
+	case "audio", "media":
+		ref, err := resourceRef(in.MessageType, in.Content)
+		if err != nil {
+			return Extraction{}, ErrorInvalid, err
+		}
+		resource, err := p.feishu.Download(ctx, in.MessageID, ref)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		defer resource.Body.Close()
+		data, err := readBounded(resource.Body, maxAudioBytes)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		transcript, err := p.analyzer.Transcribe(ctx, bytes.NewReader(data), safeAudioFilename(resource.Filename, in.MessageType))
+		if err != nil {
+			return Extraction{}, ErrorAnalyze, err
+		}
+		out, err := p.analyzer.AnalyzeText(ctx, transcript)
+		applyDeterministicGuard(transcript, &out)
+		return out, ErrorAnalyze, err
+	case "file":
+		ref, err := resourceRef(in.MessageType, in.Content)
+		if err != nil {
+			return Extraction{}, ErrorInvalid, err
+		}
+		resource, err := p.feishu.Download(ctx, in.MessageID, ref)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		defer resource.Body.Close()
+		filename := firstNonEmpty(resource.Filename, ref.Filename)
+		if !supportedFile(filename, resource.ContentType) {
+			return Extraction{}, ErrorUnsupported, errors.New("unsupported file")
+		}
+		data, err := readBounded(resource.Body, maxFileBytes)
+		if err != nil {
+			return Extraction{}, ErrorDownload, err
+		}
+		out, err := p.analyzer.AnalyzeFile(ctx, data, filename, resource.ContentType)
+		return out, ErrorAnalyze, err
+	default:
+		return Extraction{}, ErrorUnsupported, errors.New("unsupported message type")
+	}
+}
+
+func (p *Processor) deadLetter(ctx context.Context, in Inbound, messageKey, code string) error {
+	sentID, sendErr := p.feishu.Reply(ctx, in.ChatID, failureNotice, p.idempotencyKey("dead-letter", in.MessageID))
+	sentKey := ""
+	if sendErr == nil {
+		sentKey = p.hash("sent", sentID)
+	}
+	if err := p.ledger.MarkDeadLetter(ctx, messageKey, code, sentKey, p.cfg.Now()); err != nil {
+		return fmt.Errorf("recruit inbox: mark dead letter: %w", err)
+	}
+	return nil
+}
+
+func (p *Processor) hash(namespace, value string) string {
+	return hex.EncodeToString(p.hmac(namespace, value))
+}
+
+func (p *Processor) idempotencyKey(namespace, value string) string {
+	return base64.RawURLEncoding.EncodeToString(p.hmac(namespace, value))
+}
+
+func (p *Processor) hmac(namespace, value string) []byte {
+	mac := hmac.New(sha256.New, p.cfg.HashKey)
+	_, _ = io.WriteString(mac, namespace)
+	_, _ = io.WriteString(mac, "\x00")
+	_, _ = io.WriteString(mac, value)
+	return mac.Sum(nil)
+}
+
+func isBotAuthored(in Inbound, botOpenID string) bool {
+	return in.SenderType == "app" || in.SenderType == "bot" ||
+		(botOpenID != "" && in.SenderID == botOpenID)
+}
+
+func textContent(raw string) (string, error) {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return "", err
+	}
+	var parts []string
+	collectText(v, &parts)
+	return strings.TrimSpace(strings.Join(parts, "\n")), nil
+}
+
+func collectText(value any, parts *[]string) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if key == "text" {
+				if text, ok := child.(string); ok && strings.TrimSpace(text) != "" {
+					*parts = append(*parts, text)
+					continue
+				}
+			}
+			collectText(child, parts)
+		}
+	case []any:
+		for _, child := range v {
+			collectText(child, parts)
+		}
+	}
+}
+
+func resourceRef(messageType, raw string) (ResourceRef, error) {
+	var v struct {
+		ImageKey string `json:"image_key"`
+		FileKey  string `json:"file_key"`
+		FileName string `json:"file_name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return ResourceRef{}, err
+	}
+	if messageType == "image" && v.ImageKey != "" {
+		return ResourceRef{Key: v.ImageKey, Kind: "image", Filename: "image"}, nil
+	}
+	if v.FileKey != "" {
+		return ResourceRef{Key: v.FileKey, Kind: "file", Filename: v.FileName}, nil
+	}
+	return ResourceRef{}, errors.New("resource key missing")
+}
+
+func readBounded(r io.Reader, max int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > max {
+		return nil, errors.New("resource too large")
+	}
+	return b, nil
+}
+
+func safeAudioFilename(name, messageType string) string {
+	name = strings.TrimSpace(name)
+	if name != "" {
+		if strings.HasSuffix(strings.ToLower(name), ".opus") {
+			return name[:len(name)-5] + ".ogg"
+		}
+		return name
+	}
+	if messageType == "audio" {
+		return "voice.ogg"
+	}
+	return "media.mp4"
+}
+
+func applyDeterministicGuard(text string, out *Extraction) {
+	if out == nil {
+		return
+	}
+	lower := strings.ToLower(text)
+	for _, keyword := range []string{
+		"拒绝", "淘汰", "发布职位", "发布招聘", "联系候选人", "约面", "安排面试",
+		"发 offer", "发offer", "录用", "调整薪资", "修改薪资", "调整预算", "修改预算",
+		"转发给", "确认生效", "立即生效", "启用规则", "修改规则", "change the rule",
+		"reject candidate", "publish the job", "contact the candidate", "schedule interview",
+		"send offer", "change salary", "change budget", "forward to",
+	} {
+		if strings.Contains(lower, keyword) {
+			out.Consequential = true
+			return
+		}
+	}
+}
+
+func supportedFile(filename, contentType string) bool {
+	filename = strings.ToLower(strings.TrimSpace(filename))
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	for _, suffix := range []string{".pdf", ".txt", ".md", ".csv"} {
+		if strings.HasSuffix(filename, suffix) {
+			return true
+		}
+	}
+	switch contentType {
+	case "application/pdf", "text/plain", "text/markdown", "text/csv":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonZeroTime(v, fallback time.Time) time.Time {
+	if v.IsZero() {
+		return fallback
+	}
+	return v
+}
+
+func summarize(v Extraction) Summary {
+	return Summary{
+		RolePresent:        strings.TrimSpace(v.Role) != "",
+		BudgetPresent:      v.BudgetPresent,
+		StartDatePresent:   strings.TrimSpace(v.StartDate) != "",
+		OwnerPresent:       strings.TrimSpace(v.Owner) != "",
+		ProjectLeadPresent: strings.TrimSpace(v.ProjectLead) != "",
+		RuleChange:         v.RuleChange,
+		Consequential:      v.Consequential,
+		MissingFieldCount:  len(v.MissingFields),
+		UncertaintyCount:   len(v.Uncertainties),
+	}
+}

--- a/server/internal/recruitinbox/processor_test.go
+++ b/server/internal/recruitinbox/processor_test.go
@@ -1,0 +1,312 @@
+package recruitinbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type memoryLedger struct{ records map[string]Record }
+
+func newMemoryLedger() *memoryLedger { return &memoryLedger{records: map[string]Record{}} }
+func (m *memoryLedger) Claim(_ context.Context, key, source string, at time.Time) (bool, error) {
+	if _, ok := m.records[key]; ok {
+		return false, nil
+	}
+	m.records[key] = Record{MessageKey: key, SourceMessageID: source, State: StateProcessing, ReceivedAt: at, UpdatedAt: at}
+	return true, nil
+}
+func (m *memoryLedger) Pending(context.Context) ([]Record, error) { return nil, nil }
+func (m *memoryLedger) MarkReplied(_ context.Context, key string, summary Summary, roleVersion, sent string, at time.Time) error {
+	r := m.records[key]
+	r.SourceMessageID, r.Summary, r.RoleVersion, r.State, r.SentMessageKey, r.SentStatus, r.UpdatedAt = "", summary, roleVersion, StateReplied, sent, "sent", at
+	m.records[key] = r
+	return nil
+}
+func (m *memoryLedger) MarkIgnored(context.Context, string, time.Time) error { return nil }
+func (m *memoryLedger) MarkDeadLetter(_ context.Context, key, code, sent string, at time.Time) error {
+	r := m.records[key]
+	r.SourceMessageID, r.State, r.ErrorCode, r.SentMessageKey, r.UpdatedAt = "", StateDeadLetter, code, sent, at
+	m.records[key] = r
+	return nil
+}
+func (m *memoryLedger) Health(context.Context) error { return nil }
+func (m *memoryLedger) Close() error                 { return nil }
+
+type fakeAnalyzer struct {
+	textCalls  int
+	imageCalls int
+	audioCalls int
+	fileCalls  int
+	lastText   string
+	out        Extraction
+}
+
+func (a *fakeAnalyzer) AnalyzeText(_ context.Context, text string) (Extraction, error) {
+	a.textCalls++
+	a.lastText = text
+	return a.out, nil
+}
+func (a *fakeAnalyzer) AnalyzeImage(context.Context, []byte, string) (Extraction, error) {
+	a.imageCalls++
+	return a.out, nil
+}
+func (a *fakeAnalyzer) AnalyzeFile(context.Context, []byte, string, string) (Extraction, error) {
+	a.fileCalls++
+	return a.out, nil
+}
+func (a *fakeAnalyzer) Transcribe(context.Context, io.Reader, string) (string, error) {
+	a.audioCalls++
+	return "transcribed requirement", nil
+}
+
+type trackedBody struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (b *trackedBody) Close() error { b.closed = true; return nil }
+
+type fakeFeishu struct {
+	replies     []string
+	replyKeys   []string
+	downloads   int
+	body        *trackedBody
+	replyErr    error
+	filename    string
+	contentType string
+}
+
+func (f *fakeFeishu) Get(context.Context, string) (Inbound, error) { return Inbound{}, nil }
+func (f *fakeFeishu) Download(context.Context, string, ResourceRef) (Resource, error) {
+	f.downloads++
+	if f.body == nil {
+		f.body = &trackedBody{Reader: bytes.NewReader([]byte("media"))}
+	}
+	filename := f.filename
+	if filename == "" {
+		filename = "voice.ogg"
+	}
+	contentType := f.contentType
+	if contentType == "" {
+		contentType = "image/png"
+	}
+	return Resource{Body: f.body, Filename: filename, ContentType: contentType}, nil
+}
+func (f *fakeFeishu) Reply(_ context.Context, _ string, text, key string) (string, error) {
+	f.replies = append(f.replies, text)
+	f.replyKeys = append(f.replyKeys, key)
+	if f.replyErr != nil {
+		return "", f.replyErr
+	}
+	return "sent-message", nil
+}
+
+func testProcessor(t *testing.T, analyzer *fakeAnalyzer, feishu *fakeFeishu) (*Processor, *memoryLedger) {
+	t.Helper()
+	ledger := newMemoryLedger()
+	p, err := NewProcessor(Config{AllowedChatID: "allowed", BotOpenID: "bot", HashKey: bytes.Repeat([]byte{7}, 32), RoleVersion: "role-v3", Now: func() time.Time { return time.Unix(100, 0) }}, ledger, analyzer, feishu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p, ledger
+}
+
+func textInbound(id string) Inbound {
+	return Inbound{MessageID: id, ChatID: "allowed", SenderID: "human", SenderType: "user", MessageType: "text", Content: `{"text":"new role"}`}
+}
+
+func TestDuplicateDeliveryProducesOneReply(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{}
+	p, ledger := testProcessor(t, a, f)
+	if err := p.Handle(context.Background(), textInbound("m1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Handle(context.Background(), textInbound("m1")); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.replies) != 1 || a.textCalls != 1 || len(ledger.records) != 1 {
+		t.Fatalf("replies=%d analysis=%d records=%d", len(f.replies), a.textCalls, len(ledger.records))
+	}
+	for _, r := range ledger.records {
+		if r.State != StateReplied || r.SourceMessageID != "" || r.RoleVersion != "role-v3" {
+			t.Fatalf("unexpected terminal record: %+v", r)
+		}
+		if r.MessageKey == "m1" || r.SentMessageKey == "sent-message" {
+			t.Fatal("persistent identifiers must be HMAC values")
+		}
+	}
+	if f.replyKeys[0] == "" || f.replyKeys[0] == "m1" {
+		t.Fatal("reply must carry a stable opaque idempotency key")
+	}
+	if len(f.replyKeys[0]) > 50 {
+		t.Fatalf("Feishu uuid exceeds 50-character limit: %d", len(f.replyKeys[0]))
+	}
+}
+
+func TestOtherChatAndBotMessagesAreSilent(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{}
+	p, ledger := testProcessor(t, a, f)
+	other := textInbound("m-other")
+	other.ChatID = "other"
+	bot := textInbound("m-bot")
+	bot.SenderType = "app"
+	for _, in := range []Inbound{other, bot} {
+		if err := p.Handle(context.Background(), in); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(f.replies) != 0 || a.textCalls != 0 || len(ledger.records) != 0 {
+		t.Fatalf("silent filters had side effects: replies=%d analysis=%d records=%d", len(f.replies), a.textCalls, len(ledger.records))
+	}
+}
+
+func TestImageAndAudioUseTransientMediaAndCloseIt(t *testing.T) {
+	for _, tc := range []struct {
+		name, kind, content  string
+		wantImage, wantAudio int
+	}{
+		{name: "image", kind: "image", content: `{"image_key":"img-secret"}`, wantImage: 1},
+		{name: "audio", kind: "audio", content: `{"file_key":"audio-secret"}`, wantAudio: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, f := &fakeAnalyzer{}, &fakeFeishu{}
+			p, _ := testProcessor(t, a, f)
+			in := textInbound("m-" + tc.name)
+			in.MessageType, in.Content = tc.kind, tc.content
+			if err := p.Handle(context.Background(), in); err != nil {
+				t.Fatal(err)
+			}
+			if a.imageCalls != tc.wantImage || a.audioCalls != tc.wantAudio || f.body == nil || !f.body.closed {
+				t.Fatalf("image=%d audio=%d closed=%v", a.imageCalls, a.audioCalls, f.body != nil && f.body.closed)
+			}
+			if tc.wantAudio == 1 && (a.textCalls != 1 || a.lastText != "transcribed requirement") {
+				t.Fatal("audio transcript was not analyzed")
+			}
+		})
+	}
+}
+
+func TestConsequentialInstructionRequiresConfirmationAndExecutesNothing(t *testing.T) {
+	a := &fakeAnalyzer{out: Extraction{Role: "工程师", RuleChange: true, Consequential: true, ProposedNextStep: "人工复核", Clarification: "适用哪个岗位"}}
+	f := &fakeFeishu{}
+	p, _ := testProcessor(t, a, f)
+	if err := p.Handle(context.Background(), textInbound("hard-gate")); err != nil {
+		t.Fatal(err)
+	}
+	got := f.replies[0]
+	for _, want := range []string{"只记录和分析信息", "确认生效", "不会执行该变更", "需要确认：适用哪个岗位？"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reply missing %q: %s", want, got)
+		}
+	}
+	if strings.Count(got, "需要确认：") != 1 {
+		t.Fatal("automated reply may ask at most one clarification question")
+	}
+}
+
+func TestDeterministicHardGateOverridesMissedModelClassification(t *testing.T) {
+	a := &fakeAnalyzer{out: Extraction{Consequential: false}}
+	f := &fakeFeishu{}
+	p, _ := testProcessor(t, a, f)
+	in := textInbound("hard-gate-fallback")
+	in.Content = `{"text":"立即拒绝候选人并调整预算"}`
+	if err := p.Handle(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(f.replies[0], "确认生效") || !strings.Contains(f.replies[0], "不会执行该变更") {
+		t.Fatalf("hard-gate fallback missing: %s", f.replies[0])
+	}
+}
+
+func TestPostContentIsFlattenedBeforeAnalysis(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{}
+	p, _ := testProcessor(t, a, f)
+	in := textInbound("post")
+	in.MessageType = "post"
+	in.Content = `{"zh_cn":{"title":"role","content":[[{"tag":"text","text":"backend engineer"}],[{"tag":"text","text":"start next month"}]]}}`
+	if err := p.Handle(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(a.lastText, "backend engineer") || !strings.Contains(a.lastText, "start next month") {
+		t.Fatalf("post content not flattened: %q", a.lastText)
+	}
+}
+
+func TestUnsupportedFileGetsSafeDeadLetterReply(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{filename: "archive.zip", contentType: "application/zip"}
+	p, ledger := testProcessor(t, a, f)
+	in := textInbound("file")
+	in.MessageType, in.Content = "file", `{"file_key":"private-key"}`
+	if err := p.Handle(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.replies) != 1 || !strings.Contains(f.replies[0], "改发文字或受支持的导出格式") {
+		t.Fatalf("unexpected failure reply: %v", f.replies)
+	}
+	for _, r := range ledger.records {
+		if r.State != StateDeadLetter || r.ErrorCode != ErrorUnsupported || r.SourceMessageID != "" {
+			t.Fatalf("unexpected record: %+v", r)
+		}
+	}
+}
+
+func TestSupportedFileIsAnalyzedTransiently(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{filename: "role.pdf", contentType: "application/pdf"}
+	p, _ := testProcessor(t, a, f)
+	in := textInbound("file-pdf")
+	in.MessageType, in.Content = "file", `{"file_key":"private-key","file_name":"role.pdf"}`
+	if err := p.Handle(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if a.fileCalls != 1 || f.body == nil || !f.body.closed || len(f.replies) != 1 {
+		t.Fatalf("file_calls=%d closed=%v replies=%d", a.fileCalls, f.body != nil && f.body.closed, len(f.replies))
+	}
+}
+
+func TestAmbiguousReplyFailureDoesNotSendSecondMessage(t *testing.T) {
+	a, f := &fakeAnalyzer{}, &fakeFeishu{replyErr: errors.New("timeout")}
+	p, ledger := testProcessor(t, a, f)
+	if err := p.Handle(context.Background(), textInbound("ambiguous")); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.replies) != 1 {
+		t.Fatalf("ambiguous send must not trigger a duplicate fallback reply: %d", len(f.replies))
+	}
+	for _, r := range ledger.records {
+		if r.State != StateDeadLetter || r.ErrorCode != ErrorReply {
+			t.Fatalf("unexpected record: %+v", r)
+		}
+	}
+}
+
+func TestPersistentSchemaHasNoPrivateContentColumns(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "migrations", "285_recruitment_inbox_event.up.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := strings.ToLower(string(raw))
+	for _, forbidden := range []string{"chat_id", "raw_message", "message_content", "resource_key", "filename", "transcript", "resume", "contact", "salary", "evaluation"} {
+		if strings.Contains(schema, forbidden) {
+			t.Fatalf("persistent schema must not contain forbidden field %q", forbidden)
+		}
+	}
+	for _, required := range []string{"message_key", "structured_summary", "role_version", "processing_state", "error_code", "sent_message_key", "sent_status"} {
+		if !strings.Contains(schema, required) {
+			t.Fatalf("persistent schema missing %q", required)
+		}
+	}
+	indexRaw, err := os.ReadFile(filepath.Join("..", "..", "migrations", "286_recruitment_inbox_event_message_key_index.up.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strings.ToUpper(string(indexRaw)), "CREATE UNIQUE INDEX CONCURRENTLY") {
+		t.Fatal("message-key uniqueness must use a concurrent index migration")
+	}
+}

--- a/server/internal/recruitinbox/render.go
+++ b/server/internal/recruitinbox/render.go
@@ -1,0 +1,68 @@
+package recruitinbox
+
+import (
+	"fmt"
+	"strings"
+)
+
+func RenderReply(v Extraction) string {
+	question := strings.TrimSpace(v.Clarification)
+	if question != "" && !strings.HasSuffix(question, "？") && !strings.HasSuffix(question, "?") {
+		question += "？"
+	}
+	lines := []string{
+		"已收到。",
+		guardrail,
+		"结构化提取：",
+		"- 角色：" + display(v.Role),
+		"- 预算：" + yesUnknown(v.BudgetPresent),
+		"- 到岗时间：" + display(v.StartDate),
+		"- 负责人：" + display(v.Owner),
+		"- 项目负责人：" + display(v.ProjectLead),
+		"- 规则变化：" + boolText(v.RuleChange),
+		"- 规则类型：" + display(v.RuleType),
+		"- 影响范围：" + display(v.AffectedScope),
+		"- 缺失信息：" + list(v.MissingFields),
+		"- 不确定项：" + list(v.Uncertainties),
+		"建议下一步：" + display(v.ProposedNextStep),
+	}
+	if v.Consequential {
+		lines = append(lines, "检测到可能影响规则、候选人状态或外部动作的指令；请回复“确认生效”后再由人工或受控流程执行。本处理器不会执行该变更。")
+	}
+	if question != "" {
+		lines = append(lines, "需要确认："+question)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func display(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "未提供"
+	}
+	return v
+}
+
+func yesUnknown(v bool) string {
+	if v {
+		return "已提及（数值不在持久化记录中）"
+	}
+	return "未提供"
+}
+
+func boolText(v bool) string {
+	if v {
+		return "是"
+	}
+	return "否"
+}
+
+func list(v []string) string {
+	if len(v) == 0 {
+		return "无"
+	}
+	if len(v) > 6 {
+		v = v[:6]
+	}
+	return fmt.Sprintf("%s", strings.Join(v, "、"))
+}

--- a/server/internal/recruitinbox/types.go
+++ b/server/internal/recruitinbox/types.go
@@ -1,0 +1,109 @@
+// Package recruitinbox implements a private, single-chat Feishu recruitment
+// intake processor. Its storage contract is intentionally narrower than the
+// general Multica chat channel: raw messages, chat IDs, resource keys, media,
+// resumes, contact details, salary values, and free-form evaluations are never
+// written to its ledger or logs.
+package recruitinbox
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+type State string
+
+const (
+	StateProcessing State = "processing"
+	StateReplied    State = "replied"
+	StateIgnored    State = "ignored"
+	StateDeadLetter State = "dead_letter"
+)
+
+type Inbound struct {
+	MessageID   string
+	ChatID      string
+	SenderID    string
+	SenderType  string
+	MessageType string
+	Content     string
+	CreatedAt   time.Time
+}
+
+type ResourceRef struct {
+	Key      string
+	Kind     string
+	Filename string
+}
+
+type Resource struct {
+	Body        io.ReadCloser
+	Filename    string
+	ContentType string
+}
+
+type Extraction struct {
+	Role             string   `json:"role"`
+	BudgetPresent    bool     `json:"budget_present"`
+	StartDate        string   `json:"start_date"`
+	Owner            string   `json:"owner"`
+	ProjectLead      string   `json:"project_lead"`
+	RuleChange       bool     `json:"rule_change"`
+	RuleType         string   `json:"rule_type"`
+	AffectedScope    string   `json:"affected_scope"`
+	MissingFields    []string `json:"missing_fields"`
+	Uncertainties    []string `json:"uncertainties"`
+	ProposedNextStep string   `json:"proposed_next_step"`
+	Consequential    bool     `json:"consequential"`
+	Clarification    string   `json:"clarification_question"`
+}
+
+type Summary struct {
+	RolePresent        bool
+	BudgetPresent      bool
+	StartDatePresent   bool
+	OwnerPresent       bool
+	ProjectLeadPresent bool
+	RuleChange         bool
+	Consequential      bool
+	MissingFieldCount  int
+	UncertaintyCount   int
+}
+
+// Record is the complete persistent schema. MessageKey is HMAC(message_id),
+// not the source ID; SentMessageKey receives the same treatment.
+type Record struct {
+	MessageKey      string
+	SourceMessageID string
+	Summary         Summary
+	RoleVersion     string
+	State           State
+	ReceivedAt      time.Time
+	UpdatedAt       time.Time
+	ErrorCode       string
+	SentMessageKey  string
+	SentStatus      string
+}
+
+type Ledger interface {
+	Claim(ctx context.Context, messageKey, sourceMessageID string, receivedAt time.Time) (bool, error)
+	Pending(ctx context.Context) ([]Record, error)
+	MarkReplied(ctx context.Context, messageKey string, summary Summary, roleVersion, sentMessageKey string, at time.Time) error
+	MarkIgnored(ctx context.Context, messageKey string, at time.Time) error
+	MarkDeadLetter(ctx context.Context, messageKey, errorCode, sentMessageKey string, at time.Time) error
+	Health(ctx context.Context) error
+	Close() error
+}
+
+type Analyzer interface {
+	AnalyzeText(ctx context.Context, text string) (Extraction, error)
+	AnalyzeImage(ctx context.Context, image []byte, contentType string) (Extraction, error)
+	AnalyzeFile(ctx context.Context, data []byte, filename, contentType string) (Extraction, error)
+	Transcribe(ctx context.Context, audio io.Reader, filename string) (string, error)
+}
+
+type FeishuClient interface {
+	Get(ctx context.Context, messageID string) (Inbound, error)
+	Download(ctx context.Context, messageID string, ref ResourceRef) (Resource, error)
+	Reply(ctx context.Context, chatID, text, idempotencyKey string) (string, error)
+}

--- a/server/migrations/285_recruitment_inbox_event.down.sql
+++ b/server/migrations/285_recruitment_inbox_event.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE recruitment_inbox_event;

--- a/server/migrations/285_recruitment_inbox_event.up.sql
+++ b/server/migrations/285_recruitment_inbox_event.up.sql
@@ -1,0 +1,16 @@
+-- Dedicated minimal ledger for the allowlisted private recruitment inbox.
+-- source_message_id is the acceptance-approved message ID and is cleared on
+-- every terminal transition. structured_summary contains boolean presence/risk
+-- flags and counts only; never source text or extracted values.
+CREATE TABLE recruitment_inbox_event (
+    message_key TEXT NOT NULL,
+    source_message_id TEXT NOT NULL,
+    structured_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+    role_version TEXT NOT NULL DEFAULT '',
+    processing_state TEXT NOT NULL CHECK (processing_state IN ('processing', 'replied', 'ignored', 'dead_letter')),
+    received_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    error_code TEXT NOT NULL DEFAULT '',
+    sent_message_key TEXT NOT NULL DEFAULT '',
+    sent_status TEXT NOT NULL DEFAULT ''
+);

--- a/server/migrations/286_recruitment_inbox_event_message_key_index.down.sql
+++ b/server/migrations/286_recruitment_inbox_event_message_key_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS recruitment_inbox_event_message_key_idx;

--- a/server/migrations/286_recruitment_inbox_event_message_key_index.up.sql
+++ b/server/migrations/286_recruitment_inbox_event_message_key_index.up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX CONCURRENTLY recruitment_inbox_event_message_key_idx
+ON recruitment_inbox_event (message_key);

--- a/server/pkg/llm/client.go
+++ b/server/pkg/llm/client.go
@@ -79,6 +79,17 @@ type Client struct {
 	enabled      bool
 }
 
+// SDK exposes the configured official OpenAI client to narrowly-scoped
+// internal integrations that need a modality the small wrapper does not yet
+// model (for example image input or audio transcription). Callers must still
+// check Enabled first and must not log request bodies.
+func (c *Client) SDK() *openai.Client {
+	if c == nil {
+		return nil
+	}
+	return &c.sdk
+}
+
 // New builds a Client from cfg. It never returns an error: an unconfigured
 // Config produces a disabled client whose calls return ErrNotConfigured, which
 // keeps wiring in main/router simple (no boot-time failure when the LLM layer
@@ -224,6 +235,7 @@ func (c *Client) GenerateJSON(ctx context.Context, model, systemPrompt, userProm
 	params := openai.ChatCompletionNewParams{
 		Messages: messages,
 		Model:    shared.ChatModel(strings.TrimSpace(model)),
+		Store:    openai.Bool(false),
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		},

--- a/server/pkg/llm/client_test.go
+++ b/server/pkg/llm/client_test.go
@@ -163,6 +163,9 @@ func TestGenerateJSONUsesGPT56CompatibleParameters(t *testing.T) {
 	if gotBody["model"] != "gpt-5.6-luna" {
 		t.Fatalf("expected configured GPT-5.6 model, got body %#v", gotBody)
 	}
+	if gotBody["store"] != false {
+		t.Fatalf("internal JSON calls must explicitly disable upstream storage, got body %#v", gotBody)
+	}
 }
 
 func TestGenerateJSONFallsBackToLegacyMaxTokens(t *testing.T) {


### PR DESCRIPTION
Closes WS-3503

## Summary
- add a standalone Feishu long-connection processor allowlisted to one secret-configured private chat
- support text/post, image OCR, supported file analysis, and audio/voice transcription with transient media only
- add HMAC message deduplication, Feishu send UUID idempotency, dead-letter handling, hard-gate confirmation copy, and redacted logs
- persist only the approved minimal boolean/count summary schema; ship an opt-in Helm deployment, health probes, secret key names, and rollback guidance

## Verification
- go test ./internal/recruitinbox ./cmd/recruitment_inbox ./internal/integrations/lark ./pkg/llm
- go build ./cmd/recruitment_inbox ./cmd/server ./cmd/migrate
- migrations 285/286 applied to a local PostgreSQL database and schema/index inspected
- Helm template renders with recruitmentInbox.enabled=true
- Docker builder target successfully compiles and includes recruitment_inbox

## Deployment status
The service is disabled by default. This run had no cloud target or production secret-manager values, so no production deployment or live Feishu acceptance flow was executed, and no Feishu messages were sent.