### PR TITLE
fix(desktop): stop the dark-mode keyline shifting colour where the tab merges into the frame (MUL-6106)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -264,6 +264,26 @@ describe("TabBar merged-tab chrome", () => {
     );
   });
 
+  // The flare's bottom row sits on top of the content card's top ring. Both
+  // draw --surface-border, so in dark mode the arc would composite over the
+  // ring rather than replace it and the two translucent keylines would stack
+  // into a markedly lighter line right at the straight-to-curve junction. The
+  // opaque --app-shell layer under the gradient makes the flare replace
+  // whatever it covers.
+  it("paints each flare on an opaque shell layer", () => {
+    const { getByLabelText } = render(<TabBar />);
+    const flares = getByLabelText("Issues")
+      .closest("[data-tab-frame]")
+      ?.querySelectorAll('[style*="radial-gradient"]');
+
+    expect(flares).toHaveLength(2);
+    for (const flare of flares ?? []) {
+      expect(flare.getAttribute("style")).toContain(
+        "var(--page-canvas) 10.2px), var(--app-shell)",
+      );
+    }
+  });
+
   it("draws the merged cap only on the active tab", () => {
     const { getByLabelText } = render(<TabBar />);
     expect(

--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -246,6 +246,34 @@ describe("TabBar active-tab title persistence", () => {
   });
 });
 
+describe("TabBar merged-tab chrome", () => {
+  // Dark mode's --surface-border is translucent, so a fill painted under the
+  // cap's own border tints its keyline lighter than the flare arcs and the
+  // content card's ring, leaving a visible step where the tab meets the frame.
+  // bg-clip-padding keeps the fill inside the border box.
+  it("keeps the active tab's page-canvas fill out from under its keyline", () => {
+    const { getByLabelText } = render(<TabBar />);
+    const cap = getByLabelText("Issues")
+      .closest("[data-tab-frame]")
+      ?.querySelector(".rounded-t-lg");
+
+    expect(cap).toHaveClass(
+      "border-surface-border",
+      "bg-page-canvas",
+      "bg-clip-padding",
+    );
+  });
+
+  it("draws the merged cap only on the active tab", () => {
+    const { getByLabelText } = render(<TabBar />);
+    expect(
+      getByLabelText("Projects")
+        .closest("[data-tab-frame]")
+        ?.querySelector(".rounded-t-lg"),
+    ).toBeNull();
+  });
+});
+
 describe("TabBar overflow", () => {
   it("keeps tabs readable in a bounded horizontal scroller", () => {
     state.byWorkspace.acme.tabs = Array.from({ length: 8 }, (_, index) => ({

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -48,14 +48,23 @@ const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 
 // Chrome-style merged tab: the active tab shares the content surface's fill
 // and flares into it through concave bottom corners. Each flare is a small
-// square whose radial gradient carves a quarter-circle notch (shell shows
-// through), strokes a 1px arc that continues the tab's side border into the
+// square whose radial gradient carves a quarter-circle notch (the shell fill
+// below), strokes a 1px arc that continues the tab's side border into the
 // content card's top ring, and fills the rest with the surface color. The
 // 0.4px stop spread anti-aliases the arc.
+//
+// The gradient sits on an opaque --app-shell layer rather than letting the
+// shell show through, because the flare's bottom row overlaps the content
+// card's top ring. In dark mode --surface-border is translucent
+// (oklch(1 0 0 / 10%)), so the arc would composite over the ring instead of
+// replacing it and the two keylines would stack into a markedly lighter line
+// right where the straight ring meets the curve. The shell layer makes the
+// flare opaque over everything it covers, so the arc reads the same tone
+// whether it crosses the ring or the bare shell.
 const TAB_FLARE_RADIUS = 10;
 const tabFlareBackground = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
-  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px)`;
+  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px), var(--app-shell)`;
 };
 
 type TabSnapshot = {

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -338,7 +338,13 @@ function SortableTabItem({
               isDragging && "opacity-60",
             )}
           >
-            <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas" />
+            {/* bg-clip-padding keeps the page-canvas fill out from under the
+                1px border. In dark mode --surface-border is translucent
+                (oklch(1 0 0 / 10%)), so a fill behind it would tint this
+                keyline lighter than the flare arcs and the content card's
+                ring, which both composite over --app-shell. That leaves a
+                visible step exactly where the tab merges into the frame. */}
+            <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas bg-clip-padding" />
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span
               className="absolute bottom-0 size-2.5"


### PR DESCRIPTION
On desktop in dark mode, the keyline visibly changed colour where the active tab merges into the content frame. There were two independent causes, both rooted in the same thing: `--surface-border` is translucent in dark mode (`oklch(1 0 0 / 10%)`) and opaque in light mode, so the same token renders differently depending on what is behind it, and renders *twice as bright* if it is drawn on top of itself.

## 1. The tab's border composited over the wrong backdrop

The cap painted its `--page-canvas` fill under its own 1px border (`background-clip` defaults to `border-box`), while the flare arcs and the card's ring composite over `--app-shell`:

| keyline | composites over | rendered |
| --- | --- | --- |
| active tab's cap border | `--page-canvas` | `rgb(41,41,43)` |
| flare arcs | `--app-shell` | `rgb(36,36,38)` |
| content card's ring (outset) | `--app-shell` | `rgb(34,35,36)` |

Fixed with `bg-clip-padding`, which keeps the fill inside the border box. This is the existing pattern here for translucent borders (`button.tsx`, `sheet.tsx`, `combobox.tsx`).

## 2. The flare stacked a second keyline on the frame's ring

The flare's bottom row overlaps the card's top ring, and both draw `--surface-border`. The arc composited *over* the ring rather than replacing it, so two translucent keylines stacked:

```
0.1 x 255 + 0.9 x 35 = 57
```

Measured across that 1px band: the straight ring reads **35**, and the moment it enters the flare it jumps to **56**. That is a step of 22, far more visible than the first defect, and it sits exactly at the straight-to-curve junction.

Fixed by painting the gradient on an opaque `--app-shell` layer, so the flare replaces every pixel it covers instead of tinting it. The notch still shows the shell, because that layer *is* the shell.

## Verification

A harness rendered the tab chrome from the class strings and the `tabFlareBackground()` template read directly out of `tab-bar.tsx` and `desktop-layout.tsx`, so the replica could not drift from the source. Painted pixels sampled along the seam:

| variant | tab border | arc at 45° | arc at junction | frame ring | spread |
| --- | --- | --- | --- | --- | --- |
| dark, before | 41 | 36 | 57 | 34 | 23 |
| dark, after | 36 | 36 | 36 | 34 | 2 |
| light, before | 228 | 228 | 228 | 228 | 0 |
| light, after | 228 | 228 | 228 | 228 | 0 |

The residual 2 in dark mode is the card's own `--surface-shadow` darkening its ring, which is present in light mode too.

Light mode is byte-identical either way, as expected from its opaque token. The flare's own top and left edges were also checked against the surrounding shell in both themes to confirm the opaque layer prints no visible square: they match exactly.

`pnpm typecheck`, `pnpm lint` and `pnpm test` pass for `@multica/desktop` (465 tests). The regression tests assert both mechanisms, and each was confirmed to fail when its fix is reverted. The harness was scratch tooling and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
