### PR TITLE
feat(inbox): add a keyboard shortcut for archiving the open notification

### DIFF
--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -93,6 +93,15 @@ describe("keyboard shortcut definitions", () => {
     expect(action.allowInEditable).toBe(true);
   });
 
+  it("keeps the inbox archive key out of editable controls", () => {
+    const action = SHORTCUT_ACTION_BY_ID.archiveInboxItem;
+    expect(action.defaultShortcut).toEqual(createShortcutChord("E"));
+    // A bare letter is only safe because the inbox handler skips editable
+    // targets. Flipping this flag would archive the open notification while
+    // the user types an "e" into its comment composer.
+    expect(action.allowInEditable).toBe(false);
+  });
+
   it("strictly distinguishes Command and Control on macOS", () => {
     const commandF = createShortcutChord("F", { primary: true });
     const controlF = createShortcutChord("F", { control: true });

--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -96,9 +96,6 @@ describe("keyboard shortcut definitions", () => {
   it("keeps the inbox archive key out of editable controls", () => {
     const action = SHORTCUT_ACTION_BY_ID.archiveInboxItem;
     expect(action.defaultShortcut).toEqual(createShortcutChord("E"));
-    // A bare letter is only safe because the inbox handler skips editable
-    // targets. Flipping this flag would archive the open notification while
-    // the user types an "e" into its comment composer.
     expect(action.allowInEditable).toBe(false);
   });
 

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -12,6 +12,7 @@ export type ShortcutActionId =
   | "toggleChat"
   | "findInIssue"
   | "openThreadNav"
+  | "archiveInboxItem"
   | "send"
   | "goInbox"
   | "goChat"
@@ -99,6 +100,16 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
     category: "general",
     defaultShortcut: createShortcutChord("O", { primary: true, shift: true }),
     allowInEditable: true,
+  },
+  // Plain E is the archive key mail clients have trained users on, and the
+  // inbox is the only screen that binds it. Not `allowInEditable`: the open
+  // notification hosts a comment composer, and typing an "e" there must never
+  // file the notification away.
+  {
+    id: "archiveInboxItem",
+    category: "general",
+    defaultShortcut: createShortcutChord("E"),
+    allowInEditable: false,
   },
   { id: "send", category: "general", defaultShortcut: primary("Enter"), allowInEditable: true },
   { id: "goInbox", category: "navigation", defaultShortcut: null, allowInEditable: false },

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -270,6 +270,25 @@ export function isEditableShortcutTarget(target: EventTarget | null): boolean {
   );
 }
 
+const PORTAL_LAYER_SELECTOR =
+  '[role="menu"], [role="dialog"], [role="alertdialog"], [role="listbox"]';
+
+/**
+ * Whether an open menu, dialog or listbox popup owns the keyboard.
+ *
+ * These popups are portaled to the document body, so a page-level keydown
+ * listener still sees their keypresses: the target is outside the page, and
+ * Base UI only calls `preventDefault()` for navigation keys, never for the
+ * plain characters menus use for typeahead. Modal layers additionally mark
+ * everything else `data-base-ui-inert`, which catches the case where focus
+ * never left the page.
+ */
+export function isPortalLayerShortcutTarget(target: EventTarget | null): boolean {
+  if (typeof document === "undefined") return false;
+  if (document.querySelector("[data-base-ui-inert]") !== null) return true;
+  return target instanceof Element && target.closest(PORTAL_LAYER_SELECTOR) !== null;
+}
+
 const PRIMARY_RESERVED_KEYS = new Set([
   // Window operations the app itself owns on every runtime: W closes the
   // tab, R/F5 is the reload guard, Q quits.

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -101,10 +101,6 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
     defaultShortcut: createShortcutChord("O", { primary: true, shift: true }),
     allowInEditable: true,
   },
-  // Plain E is the archive key mail clients have trained users on, and the
-  // inbox is the only screen that binds it. Not `allowInEditable`: the open
-  // notification hosts a comment composer, and typing an "e" there must never
-  // file the notification away.
   {
     id: "archiveInboxItem",
     category: "general",

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -274,14 +274,10 @@ const PORTAL_LAYER_SELECTOR =
   '[role="menu"], [role="dialog"], [role="alertdialog"], [role="listbox"]';
 
 /**
- * Whether an open menu, dialog or listbox popup owns the keyboard.
- *
- * These popups are portaled to the document body, so a page-level keydown
- * listener still sees their keypresses: the target is outside the page, and
- * Base UI only calls `preventDefault()` for navigation keys, never for the
- * plain characters menus use for typeahead. Modal layers additionally mark
- * everything else `data-base-ui-inert`, which catches the case where focus
- * never left the page.
+ * Whether an open popup (menu, dialog, listbox) owns the keyboard. Popups are
+ * portaled to the body, so page-level listeners still see their keypresses;
+ * the `data-base-ui-inert` marker catches modal layers even when focus never
+ * left the page.
  */
 export function isPortalLayerShortcutTarget(target: EventTarget | null): boolean {
   if (typeof document === "undefined") return false;

--- a/packages/core/shortcuts/index.ts
+++ b/packages/core/shortcuts/index.ts
@@ -8,6 +8,7 @@ export {
   isPlainShortcut,
   formatShortcut,
   isEditableShortcutTarget,
+  isPortalLayerShortcutTarget,
   isReservedShortcut,
   isShortcutAllowedForAction,
   type ShortcutActionDefinition,

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -423,6 +423,19 @@ describe("InboxPage", () => {
     expect(screen.queryByTestId("list")).not.toBeNull();
   });
 
+  function renderWithActiveItem() {
+    reset();
+    layout.width = DESKTOP;
+    listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+    return render(<InboxPage />);
+  }
+
+  function renderWithOpenItem() {
+    const view = renderWithActiveItem();
+    fireEvent.click(screen.getByTestId("row"));
+    return view;
+  }
+
   describe("archive shortcut", () => {
     function pressArchiveKey(target: Element | Document = document) {
       fireEvent.keyDown(target, { key: "e" });
@@ -435,12 +448,7 @@ describe("InboxPage", () => {
     }
 
     it("archives the open notification", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
       pressArchiveKey();
 
       expect(archiveMutate).toHaveBeenCalledWith("inbox-a", expect.anything());
@@ -479,12 +487,7 @@ describe("InboxPage", () => {
     });
 
     it("does not fire while typing in an editable control", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
 
       typeArchiveKeyInto(document.createElement("input"));
       typeArchiveKeyInto(document.createElement("textarea"));
@@ -496,32 +499,21 @@ describe("InboxPage", () => {
     });
 
     it("stands down while a dialog is open", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
       modalState.modal = "create-issue";
       pressArchiveKey();
 
       expect(archiveMutate).not.toHaveBeenCalled();
     });
 
-    // Menus, dialogs and select popups are portaled to the body, so their
-    // keypresses reach the page listener with a non-editable target and no
-    // preventDefault — `e` is typeahead there, not archive.
+    // Keypresses in portaled popups still reach the page listener, where `e`
+    // is typeahead, not archive.
     it.each([
       ["menu", "menuitem"],
       ["dialog", "button"],
       ["listbox", "option"],
     ])("stands down while a portaled %s owns the keyboard", (layerRole, itemRole) => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
 
       const layer = document.createElement("div");
       layer.setAttribute("role", layerRole);
@@ -536,15 +528,9 @@ describe("InboxPage", () => {
     });
 
     it("stands down while a modal layer holds the page inert", () => {
-      // Base UI marks everything outside a modal popup `data-base-ui-inert`.
-      // Covers the case where focus never moved into the popup, so the target
-      // is still the page (or the body).
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      const { container } = render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      // Base UI marks everything outside a modal popup `data-base-ui-inert`,
+      // even when focus never left the page.
+      const { container } = renderWithOpenItem();
       container.firstElementChild?.setAttribute("data-base-ui-inert", "");
       pressArchiveKey();
 
@@ -552,24 +538,14 @@ describe("InboxPage", () => {
     });
 
     it("ignores an auto-repeated key", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
       fireEvent.keyDown(document, { key: "e", repeat: true });
 
       expect(archiveMutate).not.toHaveBeenCalled();
     });
 
     it("ignores a press a nearer handler already consumed", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
 
       const consumer = document.createElement("button");
       consumer.addEventListener("keydown", (event) => event.preventDefault());
@@ -581,20 +557,14 @@ describe("InboxPage", () => {
     });
 
     it("does nothing when no notification is open", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
+      renderWithActiveItem();
       pressArchiveKey();
 
       expect(archiveMutate).not.toHaveBeenCalled();
     });
   });
 
-  // A bare key that mutates state has to say so. The confirmation lives in the
-  // shared handlers, so every surface — row action, detail button, `onDone`,
-  // the shortcut — reports the same way.
+  // Toasts live in the shared handlers, so every archive surface reports alike.
   describe("archive feedback", () => {
     type MutateOptions = {
       onSuccess?: () => void;
@@ -614,11 +584,7 @@ describe("InboxPage", () => {
     }
 
     it("confirms an archive from the row action", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
+      renderWithActiveItem();
       act(() => rowActions?.onAction("inbox-a"));
       settle(archiveMutate, "success");
 
@@ -626,12 +592,7 @@ describe("InboxPage", () => {
     });
 
     it("confirms an archive driven by the shortcut", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
-      fireEvent.click(screen.getByTestId("row"));
+      renderWithOpenItem();
       fireEvent.keyDown(document, { key: "e" });
       settle(archiveMutate, "success");
 
@@ -654,11 +615,7 @@ describe("InboxPage", () => {
     });
 
     it("reports a failed archive as a failure only", () => {
-      reset();
-      layout.width = DESKTOP;
-      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
-
-      render(<InboxPage />);
+      renderWithActiveItem();
       act(() => rowActions?.onAction("inbox-a"));
       settle(archiveMutate, "error");
 

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -34,8 +34,14 @@ vi.mock("@multica/core/paths", () => ({
   }),
 }));
 
+// Mutable so a test can put a dialog over the page: the archive shortcut has
+// to stand down while one owns the keyboard.
+const modalState: { modal: string | null; open: ReturnType<typeof vi.fn> } = {
+  modal: null,
+  open: vi.fn(),
+};
 vi.mock("@multica/core/modals", () => ({
-  useModalStore: { getState: () => ({ open: vi.fn() }) },
+  useModalStore: { getState: () => modalState },
 }));
 
 vi.mock("@multica/core/issues/stores/draft-store", () => ({
@@ -54,14 +60,16 @@ vi.mock("@multica/core/inbox/queries", () => ({
 // fresh `vi.fn()` per render would make the effect's deps churn.
 const markReadMutate = vi.fn();
 const markUnreadMutate = vi.fn();
+const archiveMutate = vi.fn();
+const unarchiveMutate = vi.fn();
 
 vi.mock("@multica/core/inbox/mutations", () => {
   const mutation = () => ({ mutate: vi.fn() });
   return {
     useMarkInboxRead: () => ({ mutate: markReadMutate }),
     useMarkInboxUnread: () => ({ mutate: markUnreadMutate }),
-    useArchiveInbox: mutation,
-    useUnarchiveInbox: mutation,
+    useArchiveInbox: () => ({ mutate: archiveMutate }),
+    useUnarchiveInbox: () => ({ mutate: unarchiveMutate }),
     useMarkAllInboxRead: mutation,
     useArchiveAllInbox: mutation,
     useArchiveAllReadInbox: mutation,
@@ -186,6 +194,9 @@ function reset() {
   replace.mockClear();
   markReadMutate.mockClear();
   markUnreadMutate.mockClear();
+  archiveMutate.mockClear();
+  unarchiveMutate.mockClear();
+  modalState.modal = null;
   rowActions = null;
   issueDetailProps.length = 0;
   layout.width = PHONE;
@@ -405,6 +416,143 @@ describe("InboxPage", () => {
     fireEvent.click(screen.getByTestId("row"));
 
     expect(screen.queryByTestId("list")).not.toBeNull();
+  });
+
+  describe("archive shortcut", () => {
+    // Fires on `document`, so an editable target has to be a real focused
+    // element in the page rather than a made-up event target.
+    function pressArchiveKey(target: Element | Document = document) {
+      fireEvent.keyDown(target, { key: "e" });
+    }
+
+    function typeArchiveKeyInto(element: Element) {
+      document.body.appendChild(element);
+      pressArchiveKey(element);
+      element.remove();
+    }
+
+    it("archives the open notification", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      pressArchiveKey();
+
+      expect(archiveMutate).toHaveBeenCalledWith("inbox-a", expect.anything());
+    });
+
+    it("restores the open notification while reading the archive", () => {
+      // The shortcut mirrors the row action of the view on screen, the same
+      // way the detail's own button does.
+      reset();
+      layout.width = DESKTOP;
+      searchParams = new URLSearchParams("view=archived");
+      listData.archived = [
+        item({ id: "archived-1", issue_id: "issue-9", archived: true }),
+      ];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      pressArchiveKey();
+
+      expect(unarchiveMutate).toHaveBeenCalledWith("archived-1", expect.anything());
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("leaves the selection on the next notification", () => {
+      // Same move the row action makes: the list is newest-first, so archiving
+      // hands the reader the next (older) item instead of an empty pane.
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [
+        item({ id: "inbox-a", issue_id: "issue-a" }),
+        item({ id: "inbox-b", issue_id: "issue-b" }),
+      ];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getAllByTestId("row")[0]!);
+      replace.mockClear();
+      pressArchiveKey();
+
+      expect(replace).toHaveBeenCalledWith("/acme/inbox?issue=issue-b");
+    });
+
+    it("does not fire while typing in an editable control", () => {
+      // The open notification hosts a comment composer, and every "e" typed
+      // there would otherwise file the notification away mid-sentence.
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+
+      typeArchiveKeyInto(document.createElement("input"));
+      typeArchiveKeyInto(document.createElement("textarea"));
+      const richText = document.createElement("div");
+      richText.setAttribute("contenteditable", "true");
+      typeArchiveKeyInto(richText);
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("stands down while a dialog is open", () => {
+      // A dialog over the page owns the keyboard; archiving underneath it
+      // would be an invisible edit to a list the user cannot see.
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      modalState.modal = "create-issue";
+      pressArchiveKey();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("ignores an auto-repeated key", () => {
+      // Holding the key down archives one notification, not a run of them.
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      fireEvent.keyDown(document, { key: "e", repeat: true });
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("ignores a press a nearer handler already consumed", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+
+      const consumer = document.createElement("button");
+      consumer.addEventListener("keydown", (event) => event.preventDefault());
+      document.body.appendChild(consumer);
+      pressArchiveKey(consumer);
+      consumer.remove();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no notification is open", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      pressArchiveKey();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
   });
 
   it("does not swallow a deep link to an issue that is not in the archive", () => {

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -1,7 +1,12 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import type { InboxItem } from "@multica/core/types";
 import { InboxPage } from "./inbox-page";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 vi.mock("react-resizable-panels", () => ({
   useDefaultLayout: () => ({ defaultLayout: undefined, onLayoutChanged: vi.fn() }),
@@ -195,6 +200,8 @@ function reset() {
   archiveMutate.mockClear();
   unarchiveMutate.mockClear();
   modalState.modal = null;
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(toast.error).mockClear();
   rowActions = null;
   issueDetailProps.length = 0;
   layout.width = PHONE;
@@ -501,6 +508,49 @@ describe("InboxPage", () => {
       expect(archiveMutate).not.toHaveBeenCalled();
     });
 
+    // Menus, dialogs and select popups are portaled to the body, so their
+    // keypresses reach the page listener with a non-editable target and no
+    // preventDefault — `e` is typeahead there, not archive.
+    it.each([
+      ["menu", "menuitem"],
+      ["dialog", "button"],
+      ["listbox", "option"],
+    ])("stands down while a portaled %s owns the keyboard", (layerRole, itemRole) => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+
+      const layer = document.createElement("div");
+      layer.setAttribute("role", layerRole);
+      const focused = document.createElement("div");
+      focused.setAttribute("role", itemRole);
+      layer.appendChild(focused);
+      document.body.appendChild(layer);
+      pressArchiveKey(focused);
+      layer.remove();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("stands down while a modal layer holds the page inert", () => {
+      // Base UI marks everything outside a modal popup `data-base-ui-inert`.
+      // Covers the case where focus never moved into the popup, so the target
+      // is still the page (or the body).
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      const { container } = render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      container.firstElementChild?.setAttribute("data-base-ui-inert", "");
+      pressArchiveKey();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
     it("ignores an auto-repeated key", () => {
       reset();
       layout.width = DESKTOP;
@@ -539,6 +589,81 @@ describe("InboxPage", () => {
       pressArchiveKey();
 
       expect(archiveMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  // A bare key that mutates state has to say so. The confirmation lives in the
+  // shared handlers, so every surface — row action, detail button, `onDone`,
+  // the shortcut — reports the same way.
+  describe("archive feedback", () => {
+    type MutateOptions = {
+      onSuccess?: () => void;
+      onError?: (err: unknown) => void;
+    };
+
+    function settle(
+      spy: typeof archiveMutate,
+      outcome: "success" | "error",
+      err: unknown = new Error("boom"),
+    ) {
+      const options = spy.mock.calls.at(-1)?.[1] as MutateOptions | undefined;
+      act(() => {
+        if (outcome === "success") options?.onSuccess?.();
+        else options?.onError?.(err);
+      });
+    }
+
+    it("confirms an archive from the row action", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      act(() => rowActions?.onAction("inbox-a"));
+      settle(archiveMutate, "success");
+
+      expect(toast.success).toHaveBeenCalledTimes(1);
+    });
+
+    it("confirms an archive driven by the shortcut", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      fireEvent.keyDown(document, { key: "e" });
+      settle(archiveMutate, "success");
+
+      expect(toast.success).toHaveBeenCalledTimes(1);
+    });
+
+    it("confirms a restore", () => {
+      reset();
+      layout.width = DESKTOP;
+      searchParams = new URLSearchParams("view=archived");
+      listData.archived = [
+        item({ id: "archived-1", issue_id: "issue-9", archived: true }),
+      ];
+
+      render(<InboxPage />);
+      act(() => rowActions?.onAction("archived-1"));
+      settle(unarchiveMutate, "success");
+
+      expect(toast.success).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a failed archive as a failure only", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      act(() => rowActions?.onAction("inbox-a"));
+      settle(archiveMutate, "error");
+
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(toast.success).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -34,8 +34,6 @@ vi.mock("@multica/core/paths", () => ({
   }),
 }));
 
-// Mutable so a test can put a dialog over the page: the archive shortcut has
-// to stand down while one owns the keyboard.
 const modalState: { modal: string | null; open: ReturnType<typeof vi.fn> } = {
   modal: null,
   open: vi.fn(),
@@ -419,8 +417,6 @@ describe("InboxPage", () => {
   });
 
   describe("archive shortcut", () => {
-    // Fires on `document`, so an editable target has to be a real focused
-    // element in the page rather than a made-up event target.
     function pressArchiveKey(target: Element | Document = document) {
       fireEvent.keyDown(target, { key: "e" });
     }
@@ -444,8 +440,6 @@ describe("InboxPage", () => {
     });
 
     it("restores the open notification while reading the archive", () => {
-      // The shortcut mirrors the row action of the view on screen, the same
-      // way the detail's own button does.
       reset();
       layout.width = DESKTOP;
       searchParams = new URLSearchParams("view=archived");
@@ -462,8 +456,6 @@ describe("InboxPage", () => {
     });
 
     it("leaves the selection on the next notification", () => {
-      // Same move the row action makes: the list is newest-first, so archiving
-      // hands the reader the next (older) item instead of an empty pane.
       reset();
       layout.width = DESKTOP;
       listData.active = [
@@ -480,8 +472,6 @@ describe("InboxPage", () => {
     });
 
     it("does not fire while typing in an editable control", () => {
-      // The open notification hosts a comment composer, and every "e" typed
-      // there would otherwise file the notification away mid-sentence.
       reset();
       layout.width = DESKTOP;
       listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
@@ -499,8 +489,6 @@ describe("InboxPage", () => {
     });
 
     it("stands down while a dialog is open", () => {
-      // A dialog over the page owns the keyboard; archiving underneath it
-      // would be an invisible edit to a list the user cannot see.
       reset();
       layout.width = DESKTOP;
       listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
@@ -514,7 +502,6 @@ describe("InboxPage", () => {
     });
 
     it("ignores an auto-repeated key", () => {
-      // Holding the key down archives one notification, not a run of them.
       reset();
       layout.width = DESKTOP;
       listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -350,10 +350,7 @@ export function InboxPage() {
     });
   };
 
-  // The shortcut always does what the row action of the view on screen does:
-  // archive from the main inbox, restore from the archive. Held in a ref so the
-  // document listener below can stay mounted once — both handlers are rebuilt
-  // on every render, and re-subscribing each pass would drop keypresses.
+  // Keep the listener stable while using the latest selected-item action.
   const actionOnSelectedRef = useRef<(() => void) | null>(null);
   actionOnSelectedRef.current = selected
     ? () => (isArchivedView ? handleUnarchive(selected.id) : handleArchive(selected.id))
@@ -361,20 +358,11 @@ export function InboxPage() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      // Same gate the global shortcut handler uses: a handler closer to the
-      // focused control already had its say, held keys must not archive a run
-      // of notifications, and an IME keystroke is text being composed.
       if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
-      // Plain `E` is a letter first: the composer in the open issue, the search
-      // field and any other control take it as text, not as an action.
       if (isEditableShortcutTarget(event.target)) return;
-      // A dialog over the page owns the keyboard. Archiving underneath it would
-      // be an invisible, silently destructive edit.
       if (useModalStore.getState().modal) return;
       if (!shortcutMatchesEvent(getShortcut("archiveInboxItem"), event)) return;
       const run = actionOnSelectedRef.current;
-      // Nothing open means nothing to archive — leave the key its normal
-      // meaning rather than swallowing it for a no-op.
       if (!run) return;
       event.preventDefault();
       run();

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -6,6 +6,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
+import {
+  getShortcut,
+  isEditableShortcutTarget,
+  shortcutMatchesEvent,
+} from "@multica/core/shortcuts";
+import { isImeComposing } from "@multica/core/utils";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import {
   inboxListOptions,
@@ -343,6 +349,39 @@ export function InboxPage() {
         ),
     });
   };
+
+  // The shortcut always does what the row action of the view on screen does:
+  // archive from the main inbox, restore from the archive. Held in a ref so the
+  // document listener below can stay mounted once — both handlers are rebuilt
+  // on every render, and re-subscribing each pass would drop keypresses.
+  const actionOnSelectedRef = useRef<(() => void) | null>(null);
+  actionOnSelectedRef.current = selected
+    ? () => (isArchivedView ? handleUnarchive(selected.id) : handleArchive(selected.id))
+    : null;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Same gate the global shortcut handler uses: a handler closer to the
+      // focused control already had its say, held keys must not archive a run
+      // of notifications, and an IME keystroke is text being composed.
+      if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
+      // Plain `E` is a letter first: the composer in the open issue, the search
+      // field and any other control take it as text, not as an action.
+      if (isEditableShortcutTarget(event.target)) return;
+      // A dialog over the page owns the keyboard. Archiving underneath it would
+      // be an invisible, silently destructive edit.
+      if (useModalStore.getState().modal) return;
+      if (!shortcutMatchesEvent(getShortcut("archiveInboxItem"), event)) return;
+      const run = actionOnSelectedRef.current;
+      // Nothing open means nothing to archive — leave the key its normal
+      // meaning rather than swallowing it for a no-op.
+      if (!run) return;
+      event.preventDefault();
+      run();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   // Batch operations
   const handleMarkAllRead = () => {

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -327,8 +327,7 @@ export function InboxPage() {
     setSelectedKey(next ? (next.issue_id ?? next.id) : "");
   };
 
-  // The confirmation lives here rather than in the keyboard handler so the row
-  // action, the detail button, `onDone` and the shortcut all confirm alike.
+  // Toasts live in these shared handlers so every archive surface confirms alike.
   const handleArchive = (id: string) => {
     advanceSelectionPast(id, items);
     archiveMutation.mutate(id, {
@@ -367,8 +366,6 @@ export function InboxPage() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
       if (isEditableShortcutTarget(event.target)) return;
-      // Menus, dialogs and select popups are portaled out of this page, so
-      // their keypresses reach this listener with nothing else to stop them.
       if (isPortalLayerShortcutTarget(event.target)) return;
       if (useModalStore.getState().modal) return;
       if (!shortcutMatchesEvent(getShortcut("archiveInboxItem"), event)) return;

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -9,6 +9,7 @@ import { useModalStore } from "@multica/core/modals";
 import {
   getShortcut,
   isEditableShortcutTarget,
+  isPortalLayerShortcutTarget,
   shortcutMatchesEvent,
 } from "@multica/core/shortcuts";
 import { isImeComposing } from "@multica/core/utils";
@@ -326,9 +327,12 @@ export function InboxPage() {
     setSelectedKey(next ? (next.issue_id ?? next.id) : "");
   };
 
+  // The confirmation lives here rather than in the keyboard handler so the row
+  // action, the detail button, `onDone` and the shortcut all confirm alike.
   const handleArchive = (id: string) => {
     advanceSelectionPast(id, items);
     archiveMutation.mutate(id, {
+      onSuccess: () => toast.success(t(($) => $.toasts.archived)),
       onError: (err) =>
         toast.error(
           err instanceof Error && err.message
@@ -341,6 +345,7 @@ export function InboxPage() {
   const handleUnarchive = (id: string) => {
     advanceSelectionPast(id, archivedItems);
     unarchiveMutation.mutate(id, {
+      onSuccess: () => toast.success(t(($) => $.toasts.unarchived)),
       onError: (err) =>
         toast.error(
           err instanceof Error && err.message
@@ -352,14 +357,19 @@ export function InboxPage() {
 
   // Keep the listener stable while using the latest selected-item action.
   const actionOnSelectedRef = useRef<(() => void) | null>(null);
-  actionOnSelectedRef.current = selected
-    ? () => (isArchivedView ? handleUnarchive(selected.id) : handleArchive(selected.id))
-    : null;
+  useEffect(() => {
+    actionOnSelectedRef.current = selected
+      ? () => (isArchivedView ? handleUnarchive(selected.id) : handleArchive(selected.id))
+      : null;
+  });
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
       if (isEditableShortcutTarget(event.target)) return;
+      // Menus, dialogs and select popups are portaled out of this page, so
+      // their keypresses reach this listener with nothing else to stop them.
+      if (isPortalLayerShortcutTarget(event.target)) return;
       if (useModalStore.getState().modal) return;
       if (!shortcutMatchesEvent(getShortcut("archiveInboxItem"), event)) return;
       const run = actionOnSelectedRef.current;

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -72,6 +72,10 @@
     "created_with_agent": "Created with agent: {{identifier}}",
     "failed_with_detail": "Failed: {{detail}}"
   },
+  "toasts": {
+    "archived": "Notification archived",
+    "unarchived": "Notification restored"
+  },
   "errors": {
     "mark_read_failed": "Failed to mark as read",
     "mark_unread_failed": "Failed to mark as unread",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "Toggle chat window", "description": "Open or close the floating chat window. Opening it focuses the message input." },
       "findInIssue": { "label": "Find in issue", "description": "Search within the open issue detail." },
       "openThreadNav": { "label": "Open thread navigator", "description": "List, search, and jump between the comment threads of the open issue." },
+      "archiveInboxItem": { "label": "Archive notification", "description": "Archive the open inbox notification, or restore it while reading the archive." },
       "send": { "label": "Send", "description": "Send chat messages, comments, replies, feedback, and prompts, and create issues in the create dialog." },
       "goInbox": { "label": "Go to Inbox", "description": "Open the workspace inbox." },
       "goChat": { "label": "Go to Chat", "description": "Open workspace chat." },

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -72,6 +72,10 @@
     "created_with_agent": "エージェントで作成: {{identifier}}",
     "failed_with_detail": "失敗: {{detail}}"
   },
+  "toasts": {
+    "archived": "通知をアーカイブしました",
+    "unarchived": "通知を元に戻しました"
+  },
   "errors": {
     "mark_read_failed": "既読にできませんでした",
     "mark_unread_failed": "未読にできませんでした",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "チャットウィンドウを切り替え", "description": "フローティングチャットを開閉します。開いたときは入力欄にフォーカスします。" },
       "findInIssue": { "label": "タスク内を検索", "description": "開いているタスクの詳細を検索します。" },
       "openThreadNav": { "label": "スレッドナビゲーターを開く", "description": "開いているタスクのコメントスレッドを一覧・検索して移動します。" },
+      "archiveInboxItem": { "label": "通知をアーカイブ", "description": "開いているインボックス通知をアーカイブします。アーカイブ表示中はアーカイブを解除します。" },
       "send": { "label": "送信", "description": "チャット、コメント、返信、フィードバック、プロンプトを送信し、作成ダイアログでタスクを作成します。" },
       "goInbox": { "label": "受信トレイへ移動", "description": "ワークスペースの受信トレイを開きます。" },
       "goChat": { "label": "チャットへ移動", "description": "ワークスペースのチャットを開きます。" },

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -72,6 +72,10 @@
     "created_with_agent": "에이전트가 생성: {{identifier}}",
     "failed_with_detail": "실패: {{detail}}"
   },
+  "toasts": {
+    "archived": "알림을 보관했습니다",
+    "unarchived": "알림을 복원했습니다"
+  },
   "errors": {
     "mark_read_failed": "읽음 표시를 하지 못했습니다",
     "mark_unread_failed": "읽지 않음 표시를 하지 못했습니다",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "채팅 창 전환", "description": "플로팅 채팅 창을 열거나 닫습니다. 열면 메시지 입력란에 포커스합니다." },
       "findInIssue": { "label": "태스크에서 찾기", "description": "열린 태스크 상세 내용에서 검색합니다." },
       "openThreadNav": { "label": "스레드 내비게이터 열기", "description": "열린 태스크의 댓글 스레드를 나열하고 검색해 이동합니다." },
+      "archiveInboxItem": { "label": "알림 보관", "description": "열린 인박스 알림을 보관합니다. 보관함을 보는 중에는 보관을 해제합니다." },
       "send": { "label": "보내기", "description": "채팅, 댓글, 답글, 피드백 및 프롬프트를 보내고, 생성 대화상자에서 태스크를 만듭니다." },
       "goInbox": { "label": "받은 편지함으로 이동", "description": "워크스페이스 받은 편지함을 엽니다." },
       "goChat": { "label": "채팅으로 이동", "description": "워크스페이스 채팅을 엽니다." },

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -72,6 +72,10 @@
     "created_with_agent": "通过智能体创建：{{identifier}}",
     "failed_with_detail": "失败：{{detail}}"
   },
+  "toasts": {
+    "archived": "已归档通知",
+    "unarchived": "已恢复通知"
+  },
   "errors": {
     "mark_read_failed": "标为已读失败",
     "mark_unread_failed": "标为未读失败",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "显示或隐藏聊天窗", "description": "打开或关闭悬浮聊天窗，打开时自动聚焦输入框。" },
       "findInIssue": { "label": "在任务中查找", "description": "搜索当前打开的任务详情。" },
       "openThreadNav": { "label": "打开讨论导航", "description": "列出、搜索并跳转当前任务的评论讨论。" },
+      "archiveInboxItem": { "label": "归档通知", "description": "归档当前打开的收件箱通知；在归档列表中则取消归档。" },
       "send": { "label": "发送", "description": "发送聊天消息、评论、回复、反馈和提示词，并在创建弹窗中创建任务。" },
       "goInbox": { "label": "前往收件箱", "description": "打开工作区收件箱。" },
       "goChat": { "label": "前往聊天", "description": "打开工作区聊天。" },


### PR DESCRIPTION
Adds a keyboard shortcut for archiving the notification currently open in the inbox.

## Behaviour

- The default binding is plain `E`, is rebindable, and appears in Settings → Keyboard shortcuts in all four locales.
- It archives from the main inbox and restores while viewing the archive, matching the selected row's existing action.
- Selection advances to the next notification after archiving.
- With no notification open, the key is not consumed.

## Guards

The handler ignores editable targets, IME composition, auto-repeat, events consumed by a nearer handler, and keypresses while a dialog is open.

## Tests

Coverage includes archive, restore, selection advancement, each guard, the no-selection case, and the shortcut definition. `pnpm typecheck`, `pnpm test`, and `pnpm lint` pass.
