### PR TITLE
fix(autopilots): use valid bug triage status

### DIFF
--- a/packages/views/autopilots/components/autopilots-page.test.ts
+++ b/packages/views/autopilots/components/autopilots-page.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const pageSource = readFileSync(
+  "autopilots/components/autopilots-page.tsx",
+  "utf8",
+);
+
+describe("built-in Autopilot templates", () => {
+  it("queries only backlog issues in the bug triage template", () => {
+    const prompt = pageSource.match(/id: "bug_triage",\s*prompt: `([^`]*)`/s)?.[1];
+
+    expect(prompt).toBeDefined();
+    expect(prompt?.split("\n", 1)[0]?.trimEnd()).toBe(
+      "1. List all backlog issues that have not been prioritized",
+    );
+    expect(prompt).not.toContain('status "triage"');
+  });
+});

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -165,7 +165,7 @@ const TEMPLATES: AutopilotTemplate[] = [
   },
   {
     id: "bug_triage",
-    prompt: `1. List all issues with status "triage" or "backlog" that have not been prioritized
+    prompt: `1. List all backlog issues that have not been prioritized
 2. For each issue, read the description and any attached logs or screenshots
 3. Assess severity (critical / high / medium / low) based on user impact and scope
 4. Set the priority field on the issue accordingly


### PR DESCRIPTION
## What does this PR do?

The built-in Bug triage Autopilot prompt referenced `triage`, but Multica's Issue status model only supports `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, and `cancelled`.

This changes the template's first step to query only unprioritized backlog issues. It does not add a status, migrate data, or alter existing user-created Autopilots.

## Related Issue

Fixes #6863

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/autopilots/components/autopilots-page.tsx` so the built-in Bug triage template lists unprioritized backlog issues only.
- Added `packages/views/autopilots/components/autopilots-page.test.ts` to pin the backlog-only instruction and reject the unsupported `triage` status literal.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run autopilots`.
2. Run `pnpm --filter @multica/views typecheck`.
3. Run `pnpm --filter @multica/views exec eslint autopilots/components/autopilots-page.tsx autopilots/components/autopilots-page.test.ts`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] UI screenshots are not applicable because this changes the seeded prompt text, not rendered UI layout
- [x] Documentation updates are not applicable to this narrowly scoped template correction
- [x] Landing copy/docs synchronization is not applicable; no runtime, coding tool, or UI tab was added
- [x] Chinese product copy was not changed
- [x] I have considered and documented the risk: the change affects only newly selected built-in template content and does not rewrite saved Autopilots
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Investigated issue #6863 and the repository's Issue status sources, confirmed there was a single English prompt source and no localized/seeded prompt copies, then used test-driven development: added a focused regression test, observed it fail on the unsupported `triage` literal, applied the one-line prompt fix, and ran scoped tests, type checking, linting, diff checks, and an independent code review.

## Screenshots (optional)

Not applicable; there is no visual layout change.
