### PR TITLE
feat(issues): right-drag horizontal pan on the board (multica-ai#6700)

### DIFF
--- a/apps/desktop/scripts/verify-context-menu-order.js
+++ b/apps/desktop/scripts/verify-context-menu-order.js
@@ -9,27 +9,35 @@
  *      know at contextmenu time whether the user will pan, and must suppress
  *      unconditionally while a gesture is armed, deciding at release.
  *   2. A renderer `preventDefault()` on `contextmenu` fully suppresses the
- *      main-process `context-menu` event (0 triggers) — the single gate that
- *      keeps the native menu from also popping during a pan.
+ *      main-process `context-menu` event — the single gate that keeps the
+ *      native menu from also popping during a pan.
  *
- * This script re-derives both from a live Electron instance and prints the
- * observed order + trigger counts. It is a documentation/regression aid, not
- * part of `make check-worktree` (it needs a built app + a display).
+ * This script re-derives both from a live Electron instance using REAL trusted
+ * mouse events (Playwright's `page.mouse` dispatches through the OS input
+ * pipeline, so the renderer sees `isTrusted === true` events — unlike a
+ * synthetic `dispatchEvent`, which never reaches the main-process
+ * `context-menu` at all). Both sides of the gate are asserted:
+ *
+ *   - an unprevented trusted right-click DOES trigger main-process
+ *     `context-menu` (count increases);
+ *   - a trusted right-click whose renderer handler calls `preventDefault()`
+ *     does NOT trigger it (count unchanged), and the renderer observes
+ *     `defaultPrevented === true`.
  *
  * Usage:
  *   node apps/desktop/scripts/verify-context-menu-order.js [path/to/out/main/index.js]
  *
- * Exit code 0 when both premises hold; non-zero + message when a premise is
+ * Exit code 0 when all premises hold; non-zero + message when a premise is
  * violated so a CI/PR author can catch a platform behavior change early.
  */
 /* eslint-disable import-x/no-extraneous-dependencies -- playwright is a root devDependency; this is a manual verification aid, not part of the build */
-/* eslint-disable no-undef -- document/PointerEvent/MouseEvent appear only inside page.evaluate() callbacks that run in the browser context */
+/* eslint-disable no-undef -- document/MouseEvent appear only inside page.evaluate() callbacks that run in the browser context */
 import { _electron as electron } from "playwright";
 import { existsSync } from "node:fs";
 
 const mainJs =
   process.argv[2] ??
-  new URL("../../out/main/index.js", import.meta.url).pathname;
+  new URL("../out/main/index.js", import.meta.url).pathname;
 
 if (!existsSync(mainJs)) {
   console.error(`Missing Electron main bundle: ${mainJs}`);
@@ -37,121 +45,184 @@ if (!existsSync(mainJs)) {
   process.exit(1);
 }
 
-const ORDER = [];
-const mainProcessMenuTriggers = { count: 0 };
-
 const app = await electron.launch({
   args: [mainJs],
-  onConsole: (msg) => {
-    const text = msg.text();
-    if (text.startsWith("[contextmenu-order]")) {
-      ORDER.push(text.replace("[contextmenu-order] ", ""));
-    }
-  },
+  timeout: 30_000,
 });
 
 const page = await app.firstWindow();
 await page.waitForLoadState("domcontentloaded");
 
-// Instrument the renderer: report the event order for a right-click and a
-// right-click drag, and count main-process `context-menu` events with and
-// without preventDefault.
-const collected = await page.evaluate(async () => {
-  const sequence = [];
-
-  const div = document.createElement("div");
-  div.id = "cm-probe";
-  div.style.cssText = "position:fixed;left:0;top:0;width:400px;height:400px;";
-  document.body.appendChild(div);
-
-  for (const name of ["pointermove", "pointerdown", "mousedown", "contextmenu", "pointerup", "mouseup"]) {
-    div.addEventListener(name, () => sequence.push(name), true);
+// Instrument the MAIN process: count every `context-menu` event the main
+// window's webContents emits. Playwright's app.evaluate runs in the main
+// process, so the counter lives on a main-process global that the Node side
+// reads back through a second app.evaluate call.
+await app.evaluate(({ BrowserWindow, app }) => {
+  globalThis.__cmMainProcessCount = 0;
+  const count = () => {
+    globalThis.__cmMainProcessCount += 1;
+  };
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.on("context-menu", count);
   }
-
-  // Premise 1: right-click (press + release in place).
-  div.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2, pointerId: 1, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 2, pointerId: 1, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
-  const stillClickOrder = [...sequence];
-  sequence.length = 0;
-
-  // Premise 1b: right-drag (move past threshold before release).
-  div.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2, pointerId: 2, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 100 }));
-  div.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, button: 2, pointerId: 2, clientX: 200, clientY: 100 }));
-  div.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 2, pointerId: 2, clientX: 200, clientY: 100 }));
-  div.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 2, clientX: 200, clientY: 100 }));
-  const dragOrder = [...sequence];
-
-  div.remove();
-  return { stillClickOrder, dragOrder };
-});
-
-// Premise 2: renderer preventDefault gates the main-process menu. Use the app's
-// own IPC bridge for a menu-less contextmenu and observe the main-process count.
-const preventedCount = await page.evaluate(async () => {
-  // Expose a counter through a fresh event handler on a disposable element.
-  const el = document.createElement("div");
-  el.id = "cm-prevent";
-  document.body.appendChild(el);
-  const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 50, clientY: 50 });
-  el.dispatchEvent(ev);
-  const prevented = ev.defaultPrevented;
-  el.remove();
-  return { prevented };
-});
-
-// Main-process context-menu trigger count is surfaced by the probe window
-// title so we can read it back without extra IPC wiring.
-await app.evaluate(({ BrowserWindow }) => {
-  const win = BrowserWindow.getAllWindows()[0];
-  win.webContents.on("context-menu", () => {
-    mainProcessMenuTriggers.count += 1;
+  app.on("browser-window-created", (_event, win) => {
+    win.webContents.on("context-menu", count);
   });
 });
+
+const mainProcessCount = () =>
+  app.evaluate(() => globalThis.__cmMainProcessCount ?? 0);
+
+// ── Probe A: order-only listeners, NO preventDefault handler ────────────────
+// Measures the trusted-event order (premise 1) and the unprevented gate
+// (premise 2a): a real right-click must reach the main process.
 await page.evaluate(() => {
-  const el = document.createElement("div");
-  el.id = "cm-main-probe";
-  document.body.appendChild(el);
-  const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 60, clientY: 60 });
-  el.dispatchEvent(ev);
-  el.remove();
+  const probe = document.createElement("div");
+  probe.id = "cm-probe-a";
+  probe.style.cssText =
+    "position:fixed;left:0;top:0;width:600px;height:600px;z-index:999999;";
+  document.body.appendChild(probe);
+
+  window.__cmOrderA = [];
+  for (const name of [
+    "pointermove",
+    "pointerdown",
+    "mousedown",
+    "contextmenu",
+    "pointerup",
+    "mouseup",
+  ]) {
+    probe.addEventListener(name, () => window.__cmOrderA.push(name), true);
+  }
+  probe.addEventListener("contextmenu", (event) => {
+    window.__cmOrderA.push("defaultPrevented:" + event.defaultPrevented);
+  });
 });
 
-console.log("Right-click (no move) event order:", collected.stillClickOrder.join(" → "));
-console.log("Right-drag event order:          ", collected.dragOrder.join(" → "));
-console.log("Renderer preventDefault on contextmenu: ", preventedCount.prevented);
-console.log("Main-process context-menu triggers (prevented renderer event):", mainProcessMenuTriggers.count);
+const ORDER_A_POS = { x: 300, y: 300 };
 
-let ok = true;
-const cmIndexStill = collected.stillClickOrder.indexOf("contextmenu");
-const moveIndexStill = collected.stillClickOrder.indexOf("pointermove");
-if (cmIndexStill === -1) {
-  console.error("VIOLATION: no contextmenu observed on right-click");
-  ok = false;
-} else if (moveIndexStill !== -1 && cmIndexStill > moveIndexStill) {
-  // In the acceptance model contextmenu precedes any threshold move; if the
-  // first pointermove is a press-jitter move that is fine, we only care that
-  // contextmenu is not deferred past the first move on a stationary click.
+async function trustedRightClick(x, y) {
+  await page.mouse.move(x, y);
+  await page.mouse.down({ button: "right" });
+  await page.mouse.up({ button: "right" });
+  // Give the main-process IPC a beat to land before reading the counter.
+  await new Promise((resolve) => setTimeout(resolve, 300));
 }
 
-// The drag order must show contextmenu BEFORE the post-threshold pointermove.
-const cmIndexDrag = collected.dragOrder.indexOf("contextmenu");
-const firstMove = collected.dragOrder.findIndex((n) => n === "pointermove");
-if (cmIndexDrag === -1 || (firstMove !== -1 && cmIndexDrag > firstMove)) {
+// Premise 2a first (clean counter), then premise 1's stationary order.
+await page.evaluate(() => {
+  window.__cmOrderA.length = 0;
+});
+const countBeforeA = await mainProcessCount();
+await trustedRightClick(ORDER_A_POS.x, ORDER_A_POS.y);
+const countAfterA = await mainProcessCount();
+const orderA = await page.evaluate(() => [...window.__cmOrderA]);
+
+// Premise 1b: a trusted right-drag — contextmenu must precede the first
+// threshold-crossing pointermove.
+await page.evaluate(() => {
+  window.__cmOrderA.length = 0;
+});
+await page.mouse.move(ORDER_A_POS.x, ORDER_A_POS.y);
+await page.mouse.down({ button: "right" });
+await page.mouse.move(ORDER_A_POS.x - 120, ORDER_A_POS.y, { steps: 6 });
+await page.mouse.up({ button: "right" });
+await new Promise((resolve) => setTimeout(resolve, 300));
+const orderADrag = await page.evaluate(() => [...window.__cmOrderA]);
+
+// ── Probe B: preventDefault handler, no other listeners ─────────────────────
+// Premise 2b: a renderer preventDefault() must suppress the main-process
+// `context-menu`, and the event must carry defaultPrevented === true.
+await page.evaluate(() => {
+  const probe = document.createElement("div");
+  probe.id = "cm-probe-b";
+  probe.style.cssText =
+    "position:fixed;left:0;top:0;width:600px;height:600px;z-index:999999;";
+  document.body.appendChild(probe);
+
+  window.__cmPrevented = [];
+  probe.addEventListener("contextmenu", (event) => {
+    event.preventDefault();
+    window.__cmPrevented.push(event.defaultPrevented);
+  });
+});
+
+const countBeforeB = await mainProcessCount();
+await trustedRightClick(ORDER_A_POS.x + 200, ORDER_A_POS.y + 200);
+const countAfterB = await mainProcessCount();
+const prevented = await page.evaluate(() => [...window.__cmPrevented]);
+
+console.log(
+  "Trusted right-click (no move) event order:",
+  orderA.join(" → "),
+);
+console.log(
+  "Trusted right-drag event order:",
+  orderADrag.join(" → "),
+);
+console.log(
+  "Main-process context-menu triggers after unprevented right-click:",
+  countAfterA - countBeforeA,
+);
+console.log(
+  "Main-process context-menu triggers after preventDefault'd right-click:",
+  countAfterB - countBeforeB,
+);
+console.log("Renderer defaultPrevented after preventDefault():", prevented[0]);
+
+let ok = true;
+
+// Premise 1: contextmenu fires as part of a trusted stationary right-click.
+if (orderA.indexOf("contextmenu") === -1) {
+  console.error("VIOLATION: no contextmenu observed on trusted right-click");
+  ok = false;
+}
+
+// Premise 1b: on a trusted right-drag, contextmenu must precede the first
+// pointermove that happens AFTER the press (the initial move positions the
+// cursor before the button goes down and is not part of the gesture).
+const dragCmIndex = orderADrag.indexOf("contextmenu");
+const dragDownIndex = orderADrag.indexOf("pointerdown");
+const postPressMoves = orderADrag
+  .map((name, index) => ({ name, index }))
+  .filter(
+    (item) =>
+      item.name === "pointermove" &&
+      dragDownIndex !== -1 &&
+      item.index > dragDownIndex,
+  );
+const firstPostPressMove = postPressMoves[0]?.index ?? -1;
+if (dragCmIndex === -1) {
+  console.error("VIOLATION: no contextmenu observed on trusted right-drag");
+  ok = false;
+} else if (firstPostPressMove !== -1 && dragCmIndex > firstPostPressMove) {
   console.error(
-    `VIOLATION: contextmenu (${cmIndexDrag}) did not precede the threshold move (${firstMove}) in the drag sequence`,
+    `VIOLATION: contextmenu (${dragCmIndex}) did not precede the first post-press move (${firstPostPressMove}) in the trusted drag sequence`,
   );
   ok = false;
 }
 
-if (mainProcessMenuTriggers.count > 0) {
+// Premise 2a: an unprevented trusted right-click MUST trigger the main
+// process. With a synthetic dispatchEvent this stayed at 0 forever — a real
+// event must increment the counter.
+if (countAfterA - countBeforeA !== 1) {
   console.error(
-    `VIOLATION: a renderer-prevented contextmenu still triggered ${mainProcessMenuTriggers.count} main-process menu(s)`,
+    `VIOLATION: unprevented trusted right-click triggered ${countAfterA - countBeforeA} main-process menu(s), expected 1`,
+  );
+  ok = false;
+}
+
+// Premise 2b: a preventDefault'd trusted right-click must NOT trigger the main
+// process, and the renderer must observe defaultPrevented === true.
+if (countAfterB - countBeforeB !== 0) {
+  console.error(
+    `VIOLATION: preventDefault'd trusted right-click still triggered ${countAfterB - countBeforeB} main-process menu(s)`,
+  );
+  ok = false;
+}
+if (prevented[0] !== true) {
+  console.error(
+    `VIOLATION: renderer observed defaultPrevented=${prevented[0]} after preventDefault()`,
   );
   ok = false;
 }

--- a/apps/desktop/scripts/verify-context-menu-order.js
+++ b/apps/desktop/scripts/verify-context-menu-order.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Verify the contextmenu event-order contract the WS-226 v3 board right-drag
+ * pan design relies on (target runtime: Electron 39.8.7 + macOS).
+ *
+ * The deferred suppression state machine is built on two measured premises:
+ *   1. On a right-button press, `contextmenu` fires right after `mousedown`,
+ *      BEFORE any threshold-crossing `pointermove` — so the renderer cannot
+ *      know at contextmenu time whether the user will pan, and must suppress
+ *      unconditionally while a gesture is armed, deciding at release.
+ *   2. A renderer `preventDefault()` on `contextmenu` fully suppresses the
+ *      main-process `context-menu` event (0 triggers) — the single gate that
+ *      keeps the native menu from also popping during a pan.
+ *
+ * This script re-derives both from a live Electron instance and prints the
+ * observed order + trigger counts. It is a documentation/regression aid, not
+ * part of `make check-worktree` (it needs a built app + a display).
+ *
+ * Usage:
+ *   node apps/desktop/scripts/verify-context-menu-order.js [path/to/out/main/index.js]
+ *
+ * Exit code 0 when both premises hold; non-zero + message when a premise is
+ * violated so a CI/PR author can catch a platform behavior change early.
+ */
+/* eslint-disable import-x/no-extraneous-dependencies -- playwright is a root devDependency; this is a manual verification aid, not part of the build */
+/* eslint-disable no-undef -- document/PointerEvent/MouseEvent appear only inside page.evaluate() callbacks that run in the browser context */
+import { _electron as electron } from "playwright";
+import { existsSync } from "node:fs";
+
+const mainJs =
+  process.argv[2] ??
+  new URL("../../out/main/index.js", import.meta.url).pathname;
+
+if (!existsSync(mainJs)) {
+  console.error(`Missing Electron main bundle: ${mainJs}`);
+  console.error("Build it first (electron-vite build) and pass the path.");
+  process.exit(1);
+}
+
+const ORDER = [];
+const mainProcessMenuTriggers = { count: 0 };
+
+const app = await electron.launch({
+  args: [mainJs],
+  onConsole: (msg) => {
+    const text = msg.text();
+    if (text.startsWith("[contextmenu-order]")) {
+      ORDER.push(text.replace("[contextmenu-order] ", ""));
+    }
+  },
+});
+
+const page = await app.firstWindow();
+await page.waitForLoadState("domcontentloaded");
+
+// Instrument the renderer: report the event order for a right-click and a
+// right-click drag, and count main-process `context-menu` events with and
+// without preventDefault.
+const collected = await page.evaluate(async () => {
+  const sequence = [];
+
+  const div = document.createElement("div");
+  div.id = "cm-probe";
+  div.style.cssText = "position:fixed;left:0;top:0;width:400px;height:400px;";
+  document.body.appendChild(div);
+
+  for (const name of ["pointermove", "pointerdown", "mousedown", "contextmenu", "pointerup", "mouseup"]) {
+    div.addEventListener(name, () => sequence.push(name), true);
+  }
+
+  // Premise 1: right-click (press + release in place).
+  div.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2, pointerId: 1, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 2, pointerId: 1, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
+  const stillClickOrder = [...sequence];
+  sequence.length = 0;
+
+  // Premise 1b: right-drag (move past threshold before release).
+  div.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 2, pointerId: 2, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 2, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 100, clientY: 100 }));
+  div.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, button: 2, pointerId: 2, clientX: 200, clientY: 100 }));
+  div.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 2, pointerId: 2, clientX: 200, clientY: 100 }));
+  div.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button: 2, clientX: 200, clientY: 100 }));
+  const dragOrder = [...sequence];
+
+  div.remove();
+  return { stillClickOrder, dragOrder };
+});
+
+// Premise 2: renderer preventDefault gates the main-process menu. Use the app's
+// own IPC bridge for a menu-less contextmenu and observe the main-process count.
+const preventedCount = await page.evaluate(async () => {
+  // Expose a counter through a fresh event handler on a disposable element.
+  const el = document.createElement("div");
+  el.id = "cm-prevent";
+  document.body.appendChild(el);
+  const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 50, clientY: 50 });
+  el.dispatchEvent(ev);
+  const prevented = ev.defaultPrevented;
+  el.remove();
+  return { prevented };
+});
+
+// Main-process context-menu trigger count is surfaced by the probe window
+// title so we can read it back without extra IPC wiring.
+await app.evaluate(({ BrowserWindow }) => {
+  const win = BrowserWindow.getAllWindows()[0];
+  win.webContents.on("context-menu", () => {
+    mainProcessMenuTriggers.count += 1;
+  });
+});
+await page.evaluate(() => {
+  const el = document.createElement("div");
+  el.id = "cm-main-probe";
+  document.body.appendChild(el);
+  const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, button: 2, clientX: 60, clientY: 60 });
+  el.dispatchEvent(ev);
+  el.remove();
+});
+
+console.log("Right-click (no move) event order:", collected.stillClickOrder.join(" → "));
+console.log("Right-drag event order:          ", collected.dragOrder.join(" → "));
+console.log("Renderer preventDefault on contextmenu: ", preventedCount.prevented);
+console.log("Main-process context-menu triggers (prevented renderer event):", mainProcessMenuTriggers.count);
+
+let ok = true;
+const cmIndexStill = collected.stillClickOrder.indexOf("contextmenu");
+const moveIndexStill = collected.stillClickOrder.indexOf("pointermove");
+if (cmIndexStill === -1) {
+  console.error("VIOLATION: no contextmenu observed on right-click");
+  ok = false;
+} else if (moveIndexStill !== -1 && cmIndexStill > moveIndexStill) {
+  // In the acceptance model contextmenu precedes any threshold move; if the
+  // first pointermove is a press-jitter move that is fine, we only care that
+  // contextmenu is not deferred past the first move on a stationary click.
+}
+
+// The drag order must show contextmenu BEFORE the post-threshold pointermove.
+const cmIndexDrag = collected.dragOrder.indexOf("contextmenu");
+const firstMove = collected.dragOrder.findIndex((n) => n === "pointermove");
+if (cmIndexDrag === -1 || (firstMove !== -1 && cmIndexDrag > firstMove)) {
+  console.error(
+    `VIOLATION: contextmenu (${cmIndexDrag}) did not precede the threshold move (${firstMove}) in the drag sequence`,
+  );
+  ok = false;
+}
+
+if (mainProcessMenuTriggers.count > 0) {
+  console.error(
+    `VIOLATION: a renderer-prevented contextmenu still triggered ${mainProcessMenuTriggers.count} main-process menu(s)`,
+  );
+  ok = false;
+}
+
+await app.close();
+console.log(ok ? "PASS: both premises hold." : "FAIL: see violations above.");
+process.exit(ok ? 0 : 1);

--- a/apps/desktop/src/main/context-menu.test.ts
+++ b/apps/desktop/src/main/context-menu.test.ts
@@ -54,7 +54,8 @@ vi.mock("electron", () => {
   };
 });
 
-import { installContextMenu } from "./context-menu";
+import { installContextMenu, buildContextMenu, popContextMenuAt } from "./context-menu";
+import { parseShowContextMenuRequest } from "../shared/context-menu";
 
 type ContextMenuParams = {
   selectionText: string;
@@ -219,3 +220,140 @@ function invokeByLabel(label: string): void {
   if (!item) throw new Error(`menu item not found: ${label}`);
   item.click?.();
 }
+
+// --- buildContextMenu / popContextMenuAt (WS-227: renderer-triggered restore) ---
+
+describe("buildContextMenu", () => {
+  beforeEach(() => {
+    ctx.capturedItems.length = 0;
+    ctx.popupSpy.mockClear();
+    ctx.clipboardWriteText.mockClear();
+    ctx.openExternalSpy.mockClear();
+    ctx.browserWindowFromWebContents.mockReset();
+    ctx.preferredLanguagesRef.current = ["en-US"];
+  });
+
+  it("returns null for blank board space (no selection / no link / not editable)", () => {
+    const menu = buildContextMenu({
+      selectionText: "",
+      isEditable: false,
+      linkURL: "",
+      editFlags: { ...baseEditFlags },
+    });
+    expect(menu).toBeNull();
+    expect(ctx.popupSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds a copy item when the renderer reports a selection", () => {
+    const menu = buildContextMenu({
+      selectionText: "  selected text  ",
+      isEditable: false,
+      linkURL: "",
+      editFlags: { ...baseEditFlags, canCopy: true },
+    });
+    expect(menu).not.toBeNull();
+    expect(menuItemRoles()).toContain("copy");
+  });
+
+  it("builds the link items from renderer-supplied linkURL", () => {
+    const menu = buildContextMenu({
+      selectionText: "",
+      isEditable: false,
+      linkURL: "https://multica.ai/welcome",
+      editFlags: { ...baseEditFlags },
+    });
+    expect(menu).not.toBeNull();
+    expect(lastMenuLabels()).toContain("Open Link in Browser");
+    expect(lastMenuLabels()).toContain("Copy Link Address");
+  });
+});
+
+describe("popContextMenuAt (menu:show-context IPC)", () => {
+  beforeEach(() => {
+    ctx.capturedItems.length = 0;
+    ctx.popupSpy.mockClear();
+    ctx.clipboardWriteText.mockClear();
+    ctx.openExternalSpy.mockClear();
+    ctx.preferredLanguagesRef.current = ["en-US"];
+  });
+
+  it("pops the rebuilt menu at the given viewport coordinates", () => {
+    const window = { id: 1 } as never;
+    popContextMenuAt(window, {
+      selectionText: "",
+      isEditable: false,
+      linkURL: "https://multica.ai/x",
+      editFlags: { ...baseEditFlags },
+    }, 120, 240);
+
+    expect(ctx.popupSpy).toHaveBeenCalledTimes(1);
+    expect(ctx.popupSpy).toHaveBeenCalledWith({ window, x: 120, y: 240 });
+  });
+
+  it("does not popup for blank space (empty menu)", () => {
+    popContextMenuAt({ id: 1 } as never, {
+      selectionText: "",
+      isEditable: false,
+      linkURL: "",
+      editFlags: { ...baseEditFlags },
+    }, 0, 0);
+
+    expect(ctx.popupSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseShowContextMenuRequest (IPC boundary validation)", () => {
+  it("accepts a well-formed payload", () => {
+    const parsed = parseShowContextMenuRequest({
+      x: 100,
+      y: 200,
+      params: {
+        selectionText: "hi",
+        isEditable: false,
+        linkURL: "https://multica.ai",
+        editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: false },
+      },
+    });
+    expect(parsed).toEqual({
+      x: 100,
+      y: 200,
+      params: {
+        selectionText: "hi",
+        isEditable: false,
+        linkURL: "https://multica.ai",
+        editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: false },
+      },
+    });
+  });
+
+  it("rejects non-finite coordinates", () => {
+    expect(parseShowContextMenuRequest({ x: NaN, y: 1, params: validParams() })).toBeNull();
+    expect(parseShowContextMenuRequest({ x: 1, y: Infinity, params: validParams() })).toBeNull();
+  });
+
+  it("rejects coordinates outside the sane range", () => {
+    expect(parseShowContextMenuRequest({ x: 1_000_000, y: 1, params: validParams() })).toBeNull();
+  });
+
+  it("rejects missing / wrong-typed params", () => {
+    expect(parseShowContextMenuRequest({ x: 1, y: 1, params: undefined })).toBeNull();
+    expect(parseShowContextMenuRequest({ x: 1, y: 1, params: { ...validParams().params, selectionText: 42 } })).toBeNull();
+    expect(parseShowContextMenuRequest({ x: 1, y: 1, params: { ...validParams().params, editFlags: { ...baseEditFlags, canCopy: "yes" } } })).toBeNull();
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(parseShowContextMenuRequest(null)).toBeNull();
+    expect(parseShowContextMenuRequest("nope")).toBeNull();
+  });
+
+  function validParams() {
+    return {
+      params: {
+        selectionText: "hi",
+        isEditable: false,
+        linkURL: "https://multica.ai",
+        editFlags: { ...baseEditFlags },
+      },
+    };
+  }
+});

--- a/apps/desktop/src/main/context-menu.ts
+++ b/apps/desktop/src/main/context-menu.ts
@@ -7,6 +7,7 @@ import {
   type WebContents,
 } from "electron";
 import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { ShowContextMenuParams } from "../shared/context-menu";
 
 // Electron ships with no default right-click menu, so a user selecting text
 // in the renderer has no way to copy it. Mirror Chrome's minimal clipboard
@@ -21,72 +22,101 @@ import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
 // translation files.
 export function installContextMenu(webContents: WebContents): void {
   webContents.on("context-menu", (_event, params) => {
-    const { editFlags, selectionText, isEditable, linkURL } = params;
-    const hasSelection = selectionText.trim().length > 0;
-    // params.linkURL is the resolved absolute URL of the anchor under the
-    // cursor; Electron normalizes relative hrefs against the page URL for
-    // us, so we only need to gate on the http(s) scheme allowlist
-    // (mirrors openExternalSafely + the renderer's <a> usage). Empty for
-    // non-link right-clicks; other schemes (mailto:, javascript:, custom
-    // app schemes) are intentionally not surfaced — opening them via
-    // shell.openExternal would route through the OS handler and is
-    // outside what this menu promises.
-    const linkIsHttpUrl = !!linkURL && isSafeExternalHttpUrl(linkURL);
-    const labels = pickLabels();
-
-    const menu = new Menu();
-
-    if (isEditable && editFlags.canCut) {
-      menu.append(new MenuItem({ role: "cut" }));
-    }
-    if (hasSelection && editFlags.canCopy) {
-      menu.append(new MenuItem({ role: "copy" }));
-    }
-    if (isEditable && editFlags.canPaste) {
-      menu.append(new MenuItem({ role: "paste" }));
-    }
-    if (isEditable && editFlags.canSelectAll) {
-      if (menu.items.length > 0) {
-        menu.append(new MenuItem({ type: "separator" }));
-      }
-      menu.append(new MenuItem({ role: "selectAll" }));
-    }
-
-    // Link items — only when the cursor is over an actual http(s) <a>.
-    // Without these the renderer's <a target="_blank"> gives users no
-    // standard right-click affordance ("Open in new window", "Copy link
-    // address"); the default click handler does forward to
-    // setWindowOpenHandler → openExternalSafely, but discoverability via
-    // the keyboard / mouse context menu was missing.
-    if (linkIsHttpUrl) {
-      if (menu.items.length > 0) {
-        menu.append(new MenuItem({ type: "separator" }));
-      }
-      menu.append(
-        new MenuItem({
-          label: labels.openLink,
-          click: () => {
-            // openExternalSafely re-validates the scheme — defense in
-            // depth in case Electron ever surfaces a non-http linkURL
-            // we forgot to filter at this layer.
-            void openExternalSafely(linkURL);
-          },
-        }),
-      );
-      menu.append(
-        new MenuItem({
-          label: labels.copyLinkAddress,
-          click: () => {
-            clipboard.writeText(linkURL);
-          },
-        }),
-      );
-    }
-
-    if (menu.items.length === 0) return;
+    const menu = buildContextMenu(params);
+    if (!menu) return;
     const window = BrowserWindow.fromWebContents(webContents) ?? undefined;
     menu.popup({ window });
   });
+}
+
+/**
+ * Pure menu construction from the subset of `context-menu` params the menu
+ * reads. Shared by the native `context-menu` event and the renderer-triggered
+ * `menu:show-context` IPC (board right-drag pan restore): both rebuild the
+ * same clipboard/link menu. Returns null when there is nothing worth showing
+ * (e.g. a right-click on plain board blank space), so popup is skipped.
+ */
+export function buildContextMenu(params: ShowContextMenuParams): Menu | null {
+  const { editFlags, selectionText, isEditable, linkURL } = params;
+  const hasSelection = selectionText.trim().length > 0;
+  // params.linkURL is the resolved absolute URL of the anchor under the
+  // cursor; Electron normalizes relative hrefs against the page URL for
+  // us, so we only need to gate on the http(s) scheme allowlist
+  // (mirrors openExternalSafely + the renderer's <a> usage). Empty for
+  // non-link right-clicks; other schemes (mailto:, javascript:, custom
+  // app schemes) are intentionally not surfaced — opening them via
+  // shell.openExternal would route through the OS handler and is
+  // outside what this menu promises.
+  const linkIsHttpUrl = !!linkURL && isSafeExternalHttpUrl(linkURL);
+  const labels = pickLabels();
+
+  const menu = new Menu();
+
+  if (isEditable && editFlags.canCut) {
+    menu.append(new MenuItem({ role: "cut" }));
+  }
+  if (hasSelection && editFlags.canCopy) {
+    menu.append(new MenuItem({ role: "copy" }));
+  }
+  if (isEditable && editFlags.canPaste) {
+    menu.append(new MenuItem({ role: "paste" }));
+  }
+  if (isEditable && editFlags.canSelectAll) {
+    if (menu.items.length > 0) {
+      menu.append(new MenuItem({ type: "separator" }));
+    }
+    menu.append(new MenuItem({ role: "selectAll" }));
+  }
+
+  // Link items — only when the cursor is over an actual http(s) <a>.
+  // Without these the renderer's <a target="_blank"> gives users no
+  // standard right-click affordance ("Open in new window", "Copy link
+  // address"); the default click handler does forward to
+  // setWindowOpenHandler → openExternalSafely, but discoverability via
+  // the keyboard / mouse context menu was missing.
+  if (linkIsHttpUrl) {
+    if (menu.items.length > 0) {
+      menu.append(new MenuItem({ type: "separator" }));
+    }
+    menu.append(
+      new MenuItem({
+        label: labels.openLink,
+        click: () => {
+          // openExternalSafely re-validates the scheme — defense in
+          // depth in case Electron ever surfaces a non-http linkURL
+          // we forgot to filter at this layer.
+          void openExternalSafely(linkURL);
+        },
+      }),
+    );
+    menu.append(
+      new MenuItem({
+        label: labels.copyLinkAddress,
+        click: () => {
+          clipboard.writeText(linkURL);
+        },
+      }),
+    );
+  }
+
+  if (menu.items.length === 0) return null;
+  return menu;
+}
+
+/**
+ * Pop the native context menu at explicit viewport coordinates. Used by the
+ * `menu:show-context` IPC so the renderer can restore the menu it suppressed
+ * during a right-drag pan on blank board space.
+ */
+export function popContextMenuAt(
+  window: BrowserWindow,
+  params: ShowContextMenuParams,
+  x: number,
+  y: number,
+): void {
+  const menu = buildContextMenu(params);
+  if (!menu) return;
+  menu.popup({ window, x, y });
 }
 
 // Labels for the two link-related menu items in the user's OS-preferred

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,7 +8,8 @@ import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { setupLocalDirectory } from "./local-directory";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
-import { installContextMenu } from "./context-menu";
+import { installContextMenu, popContextMenuAt } from "./context-menu";
+import { parseShowContextMenuRequest } from "../shared/context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
 import { installNavigationGestures } from "./navigation-gestures";
 import { installNavigationGuard } from "./navigation-guard";
@@ -672,6 +673,18 @@ if (!gotTheLock) {
     // false configuration.
     ipcMain.handle("shell:openExternal", (_event, url: string) => {
       return openExternalSafely(url);
+    });
+
+    // Restore the native context menu the issues board suppressed during a
+    // right-drag pan (see shared/context-menu.ts for the payload contract).
+    // Sender + coordinates + params are validated: only a live window may
+    // popup, and only a well-formed payload can reach menu construction.
+    ipcMain.handle("menu:show-context", (event, request: unknown) => {
+      const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+      if (!sourceWindow) return;
+      const parsed = parseShowContextMenuRequest(request);
+      if (!parsed) return;
+      popContextMenuAt(sourceWindow, parsed.params, parsed.x, parsed.y);
     });
 
     // Renderer requests its own window close (e.g. Cmd+W on the last main

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -16,6 +16,7 @@ import type {
   DaemonPrefs,
   LocalRuntimeProbe,
 } from "../shared/daemon-types";
+import type { ShowContextMenuRequest } from "../shared/context-menu";
 
 interface DesktopAPI {
   /** App version + normalized OS, captured synchronously at preload time. */
@@ -46,6 +47,10 @@ interface DesktopAPI {
   onInviteOpen: (callback: (invitationId: string) => void) => () => void;
   /** Open a URL in the default browser. */
   openExternal: (url: string) => Promise<void>;
+  /** Restore the native context menu at viewport coordinates. Used by the
+   *  issues board to bring back the menu it suppressed during a right-drag
+   *  pan on blank board space. */
+  showContextMenu: (request: ShowContextMenuRequest) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
   downloadURL: (url: string) => Promise<void>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -19,6 +19,7 @@ import {
   readDesktopWindowContext,
   type IssueWindowRequest,
 } from "../shared/issue-window";
+import type { ShowContextMenuRequest } from "../shared/context-menu";
 import { AUTH_SESSION_STATE_CHANNEL } from "../shared/auth-session";
 import type {
   DaemonStatus,
@@ -146,6 +147,11 @@ const desktopAPI = {
     subscribeToMainRendererChannel("invite:open", callback),
   /** Open a URL in the default browser */
   openExternal: (url: string) => ipcRenderer.invoke("shell:openExternal", url),
+  /** Restore the native context menu at viewport coordinates. Used by the
+   *  issues board to bring back the menu it suppressed during a right-drag
+   *  pan on blank board space. */
+  showContextMenu: (request: ShowContextMenuRequest) =>
+    ipcRenderer.invoke("menu:show-context", request),
   /** Download a file by URL through Electron's native download system.
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.

--- a/apps/desktop/src/shared/context-menu.ts
+++ b/apps/desktop/src/shared/context-menu.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared contract for restoring the native context menu from the renderer.
+ *
+ * The issues board suppresses the `contextmenu` event during a right-button
+ * pan gesture (the event fires before any threshold move on the acceptance
+ * platform, so the renderer can't know at that point whether the user will
+ * pan). When the gesture ends without panning, the renderer rebuilds the
+ * menu it swallowed: cards go through a synthetic `contextmenu` (React
+ * path), blank space goes through this IPC — the main process reconstructs
+ * the same native menu it would have shown from the real `context-menu`
+ * event.
+ *
+ * `x`/`y` are viewport coordinates at the release point; `params` mirrors the
+ * subset of Electron's `context-menu` params the menu builder reads.
+ */
+
+export type ShowContextMenuParams = {
+  selectionText: string;
+  isEditable: boolean;
+  linkURL: string;
+  editFlags: {
+    canCut: boolean;
+    canCopy: boolean;
+    canPaste: boolean;
+    canSelectAll: boolean;
+  };
+};
+
+export type ShowContextMenuRequest = {
+  x: number;
+  y: number;
+  params: ShowContextMenuParams;
+};
+
+const MAX_MENU_COORDINATE = 100_000;
+
+/**
+ * Validate a renderer-supplied `menu:show-context` payload before it can drive
+ * a native `menu.popup`. Rejects malformed shapes, out-of-range coordinates,
+ * and absurdly long strings — the IPC channel is a privilege boundary, so the
+ * main process must not trust anything the renderer sends verbatim.
+ */
+export function parseShowContextMenuRequest(
+  value: unknown,
+): ShowContextMenuRequest | null {
+  if (!value || typeof value !== "object") return null;
+
+  const input = value as Record<string, unknown>;
+  if (typeof input.x !== "number" || !Number.isFinite(input.x)) return null;
+  if (typeof input.y !== "number" || !Number.isFinite(input.y)) return null;
+  if (
+    Math.abs(input.x) > MAX_MENU_COORDINATE ||
+    Math.abs(input.y) > MAX_MENU_COORDINATE
+  ) {
+    return null;
+  }
+
+  const params = input.params;
+  if (!params || typeof params !== "object") return null;
+  const p = params as Record<string, unknown>;
+  if (typeof p.selectionText !== "string") return null;
+  if (p.selectionText.length > 64_000) return null;
+  if (typeof p.isEditable !== "boolean") return null;
+  if (typeof p.linkURL !== "string") return null;
+  if (p.linkURL.length > 2048) return null;
+
+  const editFlags = p.editFlags;
+  if (!editFlags || typeof editFlags !== "object") return null;
+  const ef = editFlags as Record<string, unknown>;
+  if (typeof ef.canCut !== "boolean") return null;
+  if (typeof ef.canCopy !== "boolean") return null;
+  if (typeof ef.canPaste !== "boolean") return null;
+  if (typeof ef.canSelectAll !== "boolean") return null;
+
+  return {
+    x: input.x,
+    y: input.y,
+    params: {
+      selectionText: p.selectionText,
+      isEditable: p.isEditable,
+      linkURL: p.linkURL,
+      editFlags: {
+        canCut: ef.canCut,
+        canCopy: ef.canCopy,
+        canPaste: ef.canPaste,
+        canSelectAll: ef.canSelectAll,
+      },
+    },
+  };
+}

--- a/e2e/board-right-drag-pan.desktop.spec.ts
+++ b/e2e/board-right-drag-pan.desktop.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from "@playwright/test";
 import { _electron as electron, type ElectronApplication, type Page } from "playwright";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { createTestApi } from "./helpers";
+import type { TestApiClient } from "./fixtures";
 
 // WS-227 / multica-ai#6700: Electron smoke for the board right-drag pan.
 //
@@ -12,14 +14,21 @@ import { join } from "node:path";
 //   - `E2E_DESKTOP=1` must be set;
 //   - `apps/desktop/out/` must already be built
 //     (`pnpm --filter @multica/desktop exec electron-vite build`, with
-//     VITE_API_URL pointing at a local backend).
+//     VITE_API_URL pointing at a local backend — the same backend the
+//     `TestApiClient` fixtures below log in against).
 //
-// The native menu itself is a main-process `menu.popup` that cannot be
-// asserted from the renderer DOM — the popup suppression contract (renderer
-// preventDefault ⇒ main-process `context-menu` never fires) is covered by the
-// main-process unit tests. What this smoke adds: the pan actually scrolls in
-// real Electron, the card context menu does not open after a pan, and a
-// stationary right-click on a card still opens it.
+// Unlike the first revision, this smoke is self-contained: it logs in through
+// the existing E2E API fixture flow (send-code → verify-code → workspace →
+// onboarded → issue), injects the resulting token into the Electron renderer
+// before boot, and waits for the REAL board to render before touching the
+// mouse. It then asserts the acceptance behaviors with real trusted mouse
+// events:
+//   - right-drag pans horizontally (`scrollLeft` changes) while `scrollTop`
+//     stays untouched;
+//   - a pan never opens a card context menu (`role=menu` stays absent);
+//   - a stationary right-click on a card still restores its context menu.
+// The card-drag (left-button) non-regression is covered by the hook/BoardView
+// unit + integration tests.
 
 const DESKTOP_OUT = join(process.cwd(), "apps", "desktop", "out", "main", "index.js");
 const ENABLED = process.env.E2E_DESKTOP === "1" && existsSync(DESKTOP_OUT);
@@ -29,38 +38,113 @@ test.skip(!ENABLED, "Set E2E_DESKTOP=1 and build apps/desktop/out to run the Ele
 test.describe("Board right-drag pan — Electron smoke", () => {
   let app: ElectronApplication;
   let page: Page;
+  let api: TestApiClient;
+  let boardTitle: string;
+
+  const boardScroller = () => page.locator(".overflow-x-auto.gap-4").first();
+
+  async function resetBoardScroll() {
+    await boardScroller().evaluate((el) => {
+      el.scrollLeft = 0;
+    });
+  }
 
   test.beforeAll(async () => {
+    // 1. Log in via the shared E2E API fixture flow (creates the user,
+    //    workspace, onboarded marker) and seed an issue so the board has a
+    //    real card to right-click.
+    api = await createTestApi();
+    boardTitle = "E2E Desktop Pan " + Date.now();
+    await api.createIssue(boardTitle);
+    const token = api.getToken();
+    if (!token) throw new Error("E2E login did not return an auth token");
+
+    // 2. Launch the built Electron app and inject the session into the
+    //    renderer before it boots, so it auto-navigates to the workspace's
+    //    issues board instead of sitting on the login page.
     app = await electron.launch({ args: [DESKTOP_OUT] });
     page = await app.firstWindow();
     await page.waitForLoadState("domcontentloaded");
+    await page.addInitScript((t) => {
+      localStorage.setItem("multica_token", t);
+      localStorage.setItem("multica:chat:isOpen", "false");
+    }, token);
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    // 3. Reach the real board: the board scroller is the `.overflow-x-auto`
+    //    container with `gap-4` (the tab bar also scrolls horizontally).
+    const scroller = boardScroller();
+    await expect(scroller).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(boardTitle)).toBeVisible({ timeout: 15000 });
+    await resetBoardScroll();
   });
 
   test.afterAll(async () => {
-    await app.close();
+    if (app) await app.close();
+    if (api) await api.cleanup();
   });
 
-  test("right-drag pans the board and suppresses the card menu", async () => {
-    // Requires a logged-in session with a workspace/board to be truly
-    // meaningful; in the desktop harness this is provided via the injected
-    // login state (same TestApiClient flow as the chromium specs). The DOM
-    // assertions mirror the chromium spec once the board is reachable.
-    const scroller = page.locator(".overflow-x-auto").first();
-    await expect(scroller).toBeVisible({ timeout: 15000 });
+  test("right-drag pans the board horizontally and leaves scrollTop untouched", async () => {
+    const scroller = boardScroller();
+    await resetBoardScroll();
 
-    const before = await scroller.evaluate((el) => el.scrollLeft);
+    const before = await scroller.evaluate((el) => ({
+      scrollLeft: el.scrollLeft,
+      scrollTop: el.scrollTop,
+    }));
+
     const box = await scroller.boundingBox();
     if (!box) throw new Error("board scroller has no bounding box");
-
-    await page.mouse.move(box.x + box.width - 10, box.y + box.height / 2);
+    await page.mouse.move(box.x + box.width - 20, box.y + box.height / 2);
     await page.mouse.down({ button: "right" });
-    await page.mouse.move(box.x + box.width - 100, box.y + box.height / 2, {
-      steps: 5,
+    await page.mouse.move(box.x + box.width - 140, box.y + box.height / 2, {
+      steps: 6,
     });
     await page.mouse.up({ button: "right" });
 
-    const after = await scroller.evaluate((el) => el.scrollLeft);
-    expect(after).not.toBe(before);
+    const after = await scroller.evaluate((el) => ({
+      scrollLeft: el.scrollLeft,
+      scrollTop: el.scrollTop,
+    }));
+
+    // The board follows the cursor on the horizontal axis only.
+    expect(after.scrollLeft).not.toBe(before.scrollLeft);
+    expect(after.scrollTop).toBe(before.scrollTop);
+  });
+
+  test("a pan never opens a card context menu", async () => {
+    const scroller = boardScroller();
+    await resetBoardScroll();
+    await expect(page.getByText(boardTitle)).toBeVisible();
+
+    const box = await scroller.boundingBox();
+    if (!box) throw new Error("board scroller has no bounding box");
+    await page.mouse.move(box.x + box.width - 20, box.y + box.height / 2);
+    await page.mouse.down({ button: "right" });
+    await page.mouse.move(box.x + box.width - 150, box.y + box.height / 2, {
+      steps: 6,
+    });
+    await page.mouse.up({ button: "right" });
+
+    // The card's IssueActionsContextMenu (role=menu) must not appear.
     await expect(page.getByRole("menu")).toHaveCount(0);
+  });
+
+  test("a stationary right-click on a card still opens its context menu", async () => {
+    // Reset the board so the seeded card is in view.
+    await resetBoardScroll();
+    const card = page.locator(".group\\/card").first();
+    await expect(card).toBeVisible({ timeout: 15000 });
+
+    const box = await card.boundingBox();
+    if (!box) throw new Error("card has no bounding box");
+
+    // Press + release in place — no movement, so no pan, so the deferred
+    // menu must be restored at the release point.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down({ button: "right" });
+    await page.mouse.up({ button: "right" });
+
+    await expect(page.getByRole("menu")).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/board-right-drag-pan.desktop.spec.ts
+++ b/e2e/board-right-drag-pan.desktop.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { _electron as electron, type ElectronApplication, type Page } from "playwright";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// WS-227 / multica-ai#6700: Electron smoke for the board right-drag pan.
+//
+// This spec exercises the real Electron acceptance environment (renderer
+// preventDefault gating the main-process `context-menu` popup, which the
+// Chromium harness cannot see). It is gated so it stays out of the default
+// `make check-worktree` run:
+//   - `E2E_DESKTOP=1` must be set;
+//   - `apps/desktop/out/` must already be built
+//     (`pnpm --filter @multica/desktop exec electron-vite build`, with
+//     VITE_API_URL pointing at a local backend).
+//
+// The native menu itself is a main-process `menu.popup` that cannot be
+// asserted from the renderer DOM — the popup suppression contract (renderer
+// preventDefault ⇒ main-process `context-menu` never fires) is covered by the
+// main-process unit tests. What this smoke adds: the pan actually scrolls in
+// real Electron, the card context menu does not open after a pan, and a
+// stationary right-click on a card still opens it.
+
+const DESKTOP_OUT = join(process.cwd(), "apps", "desktop", "out", "main", "index.js");
+const ENABLED = process.env.E2E_DESKTOP === "1" && existsSync(DESKTOP_OUT);
+
+test.skip(!ENABLED, "Set E2E_DESKTOP=1 and build apps/desktop/out to run the Electron smoke");
+
+test.describe("Board right-drag pan — Electron smoke", () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    app = await electron.launch({ args: [DESKTOP_OUT] });
+    page = await app.firstWindow();
+    await page.waitForLoadState("domcontentloaded");
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+  });
+
+  test("right-drag pans the board and suppresses the card menu", async () => {
+    // Requires a logged-in session with a workspace/board to be truly
+    // meaningful; in the desktop harness this is provided via the injected
+    // login state (same TestApiClient flow as the chromium specs). The DOM
+    // assertions mirror the chromium spec once the board is reachable.
+    const scroller = page.locator(".overflow-x-auto").first();
+    await expect(scroller).toBeVisible({ timeout: 15000 });
+
+    const before = await scroller.evaluate((el) => el.scrollLeft);
+    const box = await scroller.boundingBox();
+    if (!box) throw new Error("board scroller has no bounding box");
+
+    await page.mouse.move(box.x + box.width - 10, box.y + box.height / 2);
+    await page.mouse.down({ button: "right" });
+    await page.mouse.move(box.x + box.width - 100, box.y + box.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up({ button: "right" });
+
+    const after = await scroller.evaluate((el) => el.scrollLeft);
+    expect(after).not.toBe(before);
+    await expect(page.getByRole("menu")).toHaveCount(0);
+  });
+});

--- a/e2e/board-right-drag-pan.spec.ts
+++ b/e2e/board-right-drag-pan.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
-import { loginAsDefault, reloadAppPage } from "./helpers";
-import { TestApiClient } from "./fixtures";
+import { loginAsDefault, reloadAppPage, createTestApi } from "./helpers";
+import type { TestApiClient } from "./fixtures";
 
 // WS-227 / multica-ai#6700: right-drag horizontal pan on the issues board.
 // These run in the existing Chromium harness (the board is the default issues
@@ -12,7 +12,7 @@ test.describe("Board right-drag pan (multica-ai#6700)", () => {
   let api: TestApiClient;
 
   test.beforeEach(async ({ page }) => {
-    api = new TestApiClient();
+    api = await createTestApi();
     await loginAsDefault(page);
   });
 
@@ -34,7 +34,10 @@ test.describe("Board right-drag pan (multica-ai#6700)", () => {
     await reloadAppPage(page);
 
     const scroller = await findBoardScroller(page);
-    const before = await scroller.evaluate((el) => el.scrollLeft);
+    const before = await scroller.evaluate((el) => ({
+      scrollLeft: el.scrollLeft,
+      scrollTop: el.scrollTop,
+    }));
 
     // Right-button press + horizontal move → the board follows the cursor.
     const box = await scroller.boundingBox();
@@ -46,8 +49,13 @@ test.describe("Board right-drag pan (multica-ai#6700)", () => {
     });
     await page.mouse.up({ button: "right" });
 
-    const after = await scroller.evaluate((el) => el.scrollLeft);
-    expect(after).not.toBe(before);
+    const after = await scroller.evaluate((el) => ({
+      scrollLeft: el.scrollLeft,
+      scrollTop: el.scrollTop,
+    }));
+    expect(after.scrollLeft).not.toBe(before.scrollLeft);
+    // Horizontal pan only — scrollTop never moves.
+    expect(after.scrollTop).toBe(before.scrollTop);
   });
 
   test("right-drag does not open a card context menu", async ({ page }) => {

--- a/e2e/board-right-drag-pan.spec.ts
+++ b/e2e/board-right-drag-pan.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from "@playwright/test";
+import { loginAsDefault, reloadAppPage } from "./helpers";
+import { TestApiClient } from "./fixtures";
+
+// WS-227 / multica-ai#6700: right-drag horizontal pan on the issues board.
+// These run in the existing Chromium harness (the board is the default issues
+// view). The desktop-native side (renderer preventDefault gating the main
+// process menu) is covered by the main-process unit tests + the Electron
+// smoke spec; here we assert the renderer behaviors that are observable in
+// any browser.
+test.describe("Board right-drag pan (multica-ai#6700)", () => {
+  let api: TestApiClient;
+
+  test.beforeEach(async ({ page }) => {
+    api = new TestApiClient();
+    await loginAsDefault(page);
+  });
+
+  test.afterEach(async () => {
+    if (api) {
+      await api.cleanup();
+    }
+  });
+
+  async function findBoardScroller(page: Page) {
+    await expect(
+      page.locator('.overflow-x-auto').first(),
+    ).toBeVisible({ timeout: 15000 });
+    return page.locator(".overflow-x-auto").first();
+  }
+
+  test("right-drag pans the board horizontally", async ({ page }) => {
+    await api.createIssue("E2E Pan " + Date.now());
+    await reloadAppPage(page);
+
+    const scroller = await findBoardScroller(page);
+    const before = await scroller.evaluate((el) => el.scrollLeft);
+
+    // Right-button press + horizontal move → the board follows the cursor.
+    const box = await scroller.boundingBox();
+    if (!box) throw new Error("board scroller has no bounding box");
+    await page.mouse.move(box.x + box.width - 10, box.y + box.height / 2);
+    await page.mouse.down({ button: "right" });
+    await page.mouse.move(box.x + box.width - 100, box.y + box.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up({ button: "right" });
+
+    const after = await scroller.evaluate((el) => el.scrollLeft);
+    expect(after).not.toBe(before);
+  });
+
+  test("right-drag does not open a card context menu", async ({ page }) => {
+    const title = "E2E Pan Menu " + Date.now();
+    await api.createIssue(title);
+    await reloadAppPage(page);
+
+    const scroller = await findBoardScroller(page);
+    await expect(page.getByText(title)).toBeVisible({ timeout: 15000 });
+
+    const box = await scroller.boundingBox();
+    if (!box) throw new Error("board scroller has no bounding box");
+    await page.mouse.move(box.x + box.width - 10, box.y + box.height / 2);
+    await page.mouse.down({ button: "right" });
+    await page.mouse.move(box.x + box.width - 120, box.y + box.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up({ button: "right" });
+
+    // The issue-actions context menu (role=menu) must not have appeared.
+    await expect(page.getByRole("menu")).toHaveCount(0);
+  });
+});

--- a/packages/views/issues/components/board-view.test.tsx
+++ b/packages/views/issues/components/board-view.test.tsx
@@ -1,0 +1,452 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * BoardView DOM integration for the right-drag pan + deferred context-menu
+ * suppression (WS-226 v3 / WS-227). Verifies the two behaviors a hook-only
+ * test cannot: that after an actual pan a card's IssueActionsContextMenu does
+ * NOT open, and that a stationary right-click on a card DOES restore it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { BoardView } from "./board-view";
+import { IssueContextMenuProvider } from "../actions";
+import { setApiInstance } from "@multica/core/api";
+import type { ApiClient } from "@multica/core/api/client";
+import type { Issue } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useWorkspaceSlug: () => "acme",
+    useRequiredWorkspaceSlug: () => "acme",
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+const mockAuthUser = { id: "user-1", email: "test@test.com", name: "Test User" };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => {
+      const state = { user: mockAuthUser, isAuthenticated: true };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ user: mockAuthUser, isAuthenticated: true }) },
+  ),
+  registerAuthStore: vi.fn(),
+  createAuthStore: vi.fn(),
+}));
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigation: () => ({
+    push: vi.fn(),
+    pathname: "/issues",
+    searchParams: new URLSearchParams(),
+    back: vi.fn(),
+    replace: vi.fn(),
+    getShareableUrl: (p: string) => `https://app.example${p}`,
+  }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@multica/core/issues/config", () => ({
+  ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  STATUS_CONFIG: {
+    backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+    todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+    in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10" },
+    in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10" },
+    done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10" },
+    blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10" },
+    cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+  },
+  PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_DISPLAY_ORDER: ["none", "urgent", "high", "medium", "low"],
+  PRIORITY_CONFIG: {
+    urgent: { label: "Urgent", bars: 4, color: "text-destructive" },
+    high: { label: "High", bars: 3, color: "text-warning" },
+    medium: { label: "Medium", bars: 2, color: "text-warning" },
+    low: { label: "Low", bars: 1, color: "text-info" },
+    none: { label: "No priority", bars: 0, color: "text-muted-foreground" },
+  },
+}));
+
+const mockViewState: Record<string, unknown> = {
+  grouping: "status",
+  sortBy: "position",
+  sortDirection: "asc",
+  cardProperties: { priority: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
+  cardPropertyIds: [],
+  swimlaneGrouping: "assignee",
+  swimlaneOrders: { parent: [], project: [], assignee: [] },
+  collapsedSwimlanes: { parent: [], project: [], assignee: [] },
+  setSwimlaneGrouping: vi.fn(),
+  setSwimlaneOrder: vi.fn(),
+  toggleSwimlaneCollapsed: vi.fn(),
+  hideStatus: vi.fn(),
+  showStatus: vi.fn(),
+  priorityFilters: [],
+  assigneeFilters: [],
+  includeNoAssignee: false,
+  creatorFilters: [],
+  projectFilters: [],
+  includeNoProject: false,
+  labelFilters: [],
+  propertyFilters: {},
+  agentRunningFilter: false,
+};
+vi.mock("@multica/core/issues/stores/view-store-context", () => ({
+  ViewStoreProvider: ({ children }: { children: ReactNode }) => children,
+  useViewStore: (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
+  useViewStoreApi: () => ({ getState: () => mockViewState, setState: vi.fn(), subscribe: vi.fn() }),
+}));
+
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    () => ({ open: vi.fn() }),
+    { getState: () => ({ open: vi.fn() }) },
+  ),
+}));
+
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({
+    queryKey: ["pins", "ws-1", "user-1"],
+    queryFn: () => Promise.resolve([]),
+  }),
+  useCreatePin: () => ({ mutate: vi.fn() }),
+  useDeletePin: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/issues/mutations", () => ({
+  useUpdateIssue: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/properties", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/properties")>();
+  return {
+    ...actual,
+    useSetIssueProperty: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+    useUnsetIssueProperty: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  };
+});
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "members"],
+    queryFn: () => Promise.resolve([]),
+  }),
+  agentListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "agents"],
+    queryFn: () => Promise.resolve([]),
+  }),
+  squadListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "squads"],
+    queryFn: () => Promise.resolve([]),
+  }),
+  assigneeFrequencyOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "assignee-frequency"],
+    queryFn: () => Promise.resolve([]),
+  }),
+}));
+
+const { mockActorNameResult } = vi.hoisted(() => ({
+  mockActorNameResult: {
+    getActorName: (_type: string, _id: string) => "Mock Actor",
+    getActorInitials: () => "MA",
+    getActorAvatarUrl: () => null,
+    getMemberName: () => "Mock Member",
+    getAgentName: () => "Mock Agent",
+    getSquadName: () => "Mock Squad",
+  },
+}));
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => mockActorNameResult,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: any) => children,
+  DragOverlay: () => null,
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  pointerWithin: vi.fn(),
+  closestCenter: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: any) => children,
+  verticalListSortingStrategy: {},
+  arrayMove: <T,>(arr: T[]): T[] => arr.slice(),
+  defaultAnimateLayoutChanges: () => false,
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({ data, itemContent, components }: any) => (
+    <div data-testid="virtuoso-mock">
+      {(data ?? []).map((item: any, i: number) => (
+        <div key={i}>{itemContent(i, item)}</div>
+      ))}
+      {components?.Footer ? <components.Footer /> : null}
+    </div>
+  ),
+  VirtuosoSeed: ({ data, itemContent, computeItemKey }: any) => (
+    <div data-testid="virtuoso-seed-mock">
+      {(data ?? []).map((item: any, i: number) => (
+        <div key={computeItemKey(i, item) ?? i}>{itemContent(i, item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+function makeIssue(overrides: Partial<Issue> & { id: string }): Issue {
+  return {
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `PROJ-${overrides.id}`,
+    title: `Issue ${overrides.id}`,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 100,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    properties: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderBoard(issues: Issue[]) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <I18nProvider resources={TEST_RESOURCES} locale="en">
+        <IssueContextMenuProvider>
+          <BoardView
+            issues={issues}
+            visibleStatuses={["todo", "in_progress", "done"]}
+            hiddenStatuses={[]}
+            onMoveIssue={vi.fn()}
+          />
+        </IssueContextMenuProvider>
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// The board's horizontal scroller. jsdom has no layout, so scrollLeft is backed
+// by a real value and clamped like the browser would.
+function findScroller(container: HTMLElement): HTMLDivElement {
+  const scroller = container.querySelector<HTMLDivElement>(".overflow-x-auto");
+  if (!scroller) throw new Error("board scroll container not found");
+  let scrollLeft = 0;
+  Object.defineProperty(scroller, "scrollLeft", {
+    configurable: true,
+    get: () => scrollLeft,
+    set: (value: number) => {
+      scrollLeft = Math.min(Math.max(value, 0), 2000);
+    },
+  });
+  return scroller;
+}
+
+function pointer(opts: Record<string, unknown> = {}) {
+  return {
+    pointerId: 1,
+    pointerType: "mouse",
+    button: 2,
+    clientX: 300,
+    clientY: 100,
+    ...opts,
+  };
+}
+
+const cardMenuOpened = () =>
+  document.querySelector<HTMLElement>("[data-popup-open]") !== null;
+
+function findFirstCard(): HTMLElement {
+  const card = document.querySelector<HTMLElement>(".group\\/card");
+  if (!card) throw new Error("board card not found");
+  return card;
+}
+
+describe("BoardView right-drag pan + deferred context menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockViewState.grouping = "status";
+    setApiInstance({
+      listProperties: () => Promise.resolve({ properties: [] }),
+      listMembers: () => Promise.resolve([]),
+      listAgents: () => Promise.resolve([]),
+      listSquads: () => Promise.resolve([]),
+      getAgentTaskSnapshot: () => Promise.resolve([]),
+      listChildrenByParents: () => Promise.resolve({ issues: [] }),
+      listProjects: () => Promise.resolve([]),
+      getBaseUrl: () => "",
+    } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("pans the board horizontally when right-dragging", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    const { container } = renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const scroller = findScroller(container);
+
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 200 }));
+    expect(scroller.scrollLeft).toBe(100);
+    fireEvent.pointerMove(scroller, pointer({ clientX: 240 }));
+    expect(scroller.scrollLeft).toBe(60);
+  });
+
+  it("does not open a card menu after a pan that ends on a card", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    const { container } = renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const scroller = findScroller(container);
+
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 150 }));
+    // Release over a card's viewport position.
+    fireEvent.pointerUp(scroller, pointer({ clientX: 150, clientY: 300 }));
+
+    await waitFor(() => expect(scroller.scrollLeft).toBe(150));
+    expect(cardMenuOpened()).toBe(false);
+  });
+
+  it("opens a card menu on a stationary right-click", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const card = findFirstCard();
+
+    // The restore path resolves the release target through elementFromPoint
+    // (jsdom stubs it to null). Route it to the card so the deferred menu
+    // reopens on the element under the cursor.
+    const original = document.elementFromPoint;
+    document.elementFromPoint = () => card as unknown as Element;
+
+    try {
+      // Stationary right-click over the card: pointerdown arms the gesture, the
+      // contextmenu is suppressed (deferred), and pointerup without movement
+      // restores the menu at the card.
+      fireEvent.pointerDown(card, pointer({ clientX: 300, clientY: 300 }));
+      fireEvent.contextMenu(card, pointer({ clientX: 300, clientY: 300 }));
+      fireEvent.pointerUp(card, pointer({ clientX: 300, clientY: 300 }));
+
+      // The card's IssueActionsContextMenu opens through the deferred restore.
+      await waitFor(() => expect(cardMenuOpened()).toBe(true));
+    } finally {
+      document.elementFromPoint = original;
+    }
+  });
+
+  it("does not restore any menu when releasing outside the board container", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    const { container } = renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const scroller = findScroller(container);
+    const scrollerRef = container.querySelector<HTMLElement>(".overflow-x-auto")!;
+
+    // Release point resolves to an element OUTSIDE the board scroller (e.g.
+    // the sidebar) — the suppressed menu must not come back there.
+    const original = document.elementFromPoint;
+    document.elementFromPoint = () => {
+      const outside = document.createElement("div");
+      outside.dataset.outside = "1";
+      document.body.appendChild(outside);
+      return outside;
+    };
+
+    try {
+      fireEvent.pointerDown(scroller, pointer({ clientX: 300, clientY: 300 }));
+      fireEvent.contextMenu(scroller, pointer({ clientX: 300, clientY: 300 }));
+      fireEvent.pointerUp(scroller, pointer({ clientX: 300, clientY: 300 }));
+
+      expect(scrollerRef.contains(
+        document.elementFromPoint(300, 300) as Element,
+      )).toBe(false);
+      expect(cardMenuOpened()).toBe(false);
+    } finally {
+      document.elementFromPoint = original;
+      document.querySelector("[data-outside]")?.remove();
+    }
+  });
+
+  it("keeps a plain right-click on a card working (no gesture)", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const card = findFirstCard();
+
+    // Without a pointer gesture (e.g. the context-menu key) the card's own
+    // onContextMenu opens the menu directly.
+    fireEvent.contextMenu(card, pointer({ clientX: 300, clientY: 300 }));
+
+    await waitFor(() => expect(cardMenuOpened()).toBe(true));
+  });
+});

--- a/packages/views/issues/components/board-view.test.tsx
+++ b/packages/views/issues/components/board-view.test.tsx
@@ -280,19 +280,38 @@ function renderBoard(issues: Issue[]) {
 }
 
 // The board's horizontal scroller. jsdom has no layout, so scrollLeft is backed
-// by a real value and clamped like the browser would.
-function findScroller(container: HTMLElement): HTMLDivElement {
+// by a real value and clamped like the browser would; scrollTop is tracked so
+// an accidental vertical write by the pan hook fails the test.
+function findScroller(container: HTMLElement): HTMLDivElement & {
+  __scrollTopWrites: number;
+} {
   const scroller = container.querySelector<HTMLDivElement>(".overflow-x-auto");
   if (!scroller) throw new Error("board scroll container not found");
   let scrollLeft = 0;
-  Object.defineProperty(scroller, "scrollLeft", {
-    configurable: true,
-    get: () => scrollLeft,
-    set: (value: number) => {
-      scrollLeft = Math.min(Math.max(value, 0), 2000);
+  let scrollTop = 0;
+  let scrollTopWrites = 0;
+  Object.defineProperties(scroller, {
+    scrollLeft: {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (value: number) => {
+        scrollLeft = Math.min(Math.max(value, 0), 2000);
+      },
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTopWrites += 1;
+        scrollTop = Math.max(0, value);
+      },
+    },
+    __scrollTopWrites: {
+      configurable: true,
+      get: () => scrollTopWrites,
     },
   });
-  return scroller;
+  return scroller as HTMLDivElement & { __scrollTopWrites: number };
 }
 
 function pointer(opts: Record<string, unknown> = {}) {
@@ -349,6 +368,31 @@ describe("BoardView right-drag pan + deferred context menu", () => {
     expect(scroller.scrollLeft).toBe(100);
     fireEvent.pointerMove(scroller, pointer({ clientX: 240 }));
     expect(scroller.scrollLeft).toBe(60);
+
+    // Only the horizontal axis pans — scrollTop is never written.
+    expect(scroller.scrollTop).toBe(0);
+    expect(scroller.__scrollTopWrites).toBe(0);
+  });
+
+  it("does not hijack a left-button card drag (dnd-kit owns it)", async () => {
+    const issues = [
+      makeIssue({ id: "a1", title: "Board Card A" }),
+      makeIssue({ id: "a2", title: "Board Card B", status: "in_progress" }),
+    ];
+    const { container } = renderBoard(issues);
+    await screen.findByText("Board Card A");
+    const scroller = findScroller(container);
+
+    // A left-button drag is dnd-kit's contract: the pan hook must neither
+    // scroll nor suppress/restore anything.
+    fireEvent.pointerDown(scroller, pointer({ button: 0, clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ button: 0, clientX: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ button: 0, clientX: 200 }));
+
+    expect(scroller.scrollLeft).toBe(0);
+    expect(scroller.scrollTop).toBe(0);
+    expect(scroller.__scrollTopWrites).toBe(0);
+    expect(cardMenuOpened()).toBe(false);
   });
 
   it("does not open a card menu after a pan that ends on a card", async () => {

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -43,6 +43,8 @@ import type {
   IssueGroupPageState,
 } from "../surface/use-issue-group-branches";
 import { useDragSettle } from "./use-drag-settle";
+import { useBoardRightDragPan } from "../hooks/use-board-right-drag-pan";
+import { showContextMenu, type ShowContextMenuParams } from "../../platform";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
@@ -153,6 +155,34 @@ function buildGroups(
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 const EMPTY_IDS: string[] = [];
+
+// Reconstruct the subset of Electron's native `context-menu` params at a point,
+// so the main process can rebuild the exact menu it would have shown there.
+// Approximations: editFlags mirrors what the browser reports for an editable
+// target + current selection, sufficient for the board's blank-space case
+// (no selection / not editable / no link → empty menu → no popup).
+function buildNativeMenuParams(target: Element): ShowContextMenuParams {
+  const anchor = target.closest("a");
+  const isEditable =
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable);
+  const selectionText =
+    typeof window !== "undefined" ? window.getSelection()?.toString() ?? "" : "";
+  const hasSelection = selectionText.trim().length > 0;
+  return {
+    selectionText,
+    isEditable,
+    linkURL: anchor?.href ?? "",
+    editFlags: {
+      canCut: isEditable && hasSelection,
+      canCopy: hasSelection,
+      canPaste: isEditable,
+      canSelectAll: isEditable,
+    },
+  };
+}
 
 function BoardViewImpl({
   issues,
@@ -393,6 +423,46 @@ function BoardViewImpl({
     })
   );
 
+  // Right-drag horizontal pan + deferred context-menu suppression (WS-226 v3).
+  // On a stationary right-click the suppressed menu is restored at the release
+  // point: cards reopen their React `IssueActionsContextMenu` via a synthetic
+  // `contextmenu` (their handler preventDefaults it), blank space rebuilds the
+  // native menu through the desktop bridge. A release OUTSIDE the board (the
+  // pointer was captured, so pointerup still lands here) restores nothing — the
+  // suppressed menu belonged to the board, not whatever is under the cursor.
+  const boardScrollerRef = useRef<HTMLDivElement | null>(null);
+  const restoreContextMenu = useCallback(
+    ({ x, y }: { x: number; y: number }) => {
+      if (typeof document === "undefined") return;
+      const target = document.elementFromPoint(x, y);
+      if (!target || !boardScrollerRef.current?.contains(target)) return;
+      const synthetic = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        button: 2,
+      });
+      target.dispatchEvent(synthetic);
+      // A card's React handler opened its menu and preventDefaulted the event;
+      // unprevented means blank board space → restore the native menu (no-op on
+      // web, which is the documented boundary).
+      if (!synthetic.defaultPrevented) {
+        showContextMenu(x, y, buildNativeMenuParams(target));
+      }
+    },
+    [],
+  );
+
+  const {
+    onPointerDown: panPointerDown,
+    onPointerMove: panPointerMove,
+    onPointerUp: panPointerUp,
+    onPointerCancel: panPointerCancel,
+    onLostPointerCapture: panLostPointerCapture,
+    onContextMenuCapture: panContextMenuCapture,
+  } = useBoardRightDragPan({ onRestoreMenu: restoreContextMenu });
+
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       isDraggingRef.current = true;
@@ -556,7 +626,16 @@ function BoardViewImpl({
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-2">
+      <div
+        ref={boardScrollerRef}
+        className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-2"
+        onPointerDown={panPointerDown}
+        onPointerMove={panPointerMove}
+        onPointerUp={panPointerUp}
+        onPointerCancel={panPointerCancel}
+        onLostPointerCapture={panLostPointerCapture}
+        onContextMenuCapture={panContextMenuCapture}
+      >
         {groups.length === 0 ? (
           groupBranches?.isError ? (
             <button

--- a/packages/views/issues/hooks/use-board-right-drag-pan.test.tsx
+++ b/packages/views/issues/hooks/use-board-right-drag-pan.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, cleanup } from "@testing-library/react";
+import { useRef } from "react";
+import {
+  useBoardRightDragPan,
+  RIGHT_PAN_THRESHOLD_PX,
+} from "./use-board-right-drag-pan";
+
+/**
+ * Minimal harness: a horizontally scrollable div with the hook's handlers
+ * attached, plus a spy `onRestoreMenu`. jsdom has no layout, so scrollLeft is
+ * backed by a real value and clamped like the browser does.
+ */
+function setup({
+  scrollable = true,
+  onRestoreMenu,
+}: {
+  scrollable?: boolean;
+  onRestoreMenu?: (release: { x: number; y: number }) => void;
+} = {}) {
+  const restore =
+    onRestoreMenu ?? vi.fn<(release: { x: number; y: number }) => void>();
+
+  function Harness() {
+    const ref = useRef<HTMLDivElement>(null);
+    const handlers = useBoardRightDragPan({ onRestoreMenu: restore });
+    return (
+      <div
+        ref={ref}
+        data-testid="scroller"
+        className="overflow-x-auto"
+        {...handlers}
+      >
+        <div style={{ width: 2000 }} />
+      </div>
+    );
+  }
+
+  const { getByTestId } = render(<Harness />);
+  const scroller = getByTestId("scroller") as HTMLDivElement;
+
+  // Mirror the browser's clamping; an unscrollable container stays at 0.
+  let scrollLeft = 0;
+  Object.defineProperty(scroller, "scrollLeft", {
+    configurable: true,
+    get: () => scrollLeft,
+    set: (value: number) => {
+      const max = scrollable ? 1500 : 0;
+      scrollLeft = Math.min(Math.max(value, 0), max);
+    },
+  });
+
+  return { scroller, restore, setScrollLeft: (v: number) => (scrollLeft = v) };
+}
+
+function pointer(opts: Record<string, unknown> = {}) {
+  return {
+    pointerId: 1,
+    pointerType: "mouse",
+    button: 2,
+    clientX: 300,
+    clientY: 100,
+    ...opts,
+  };
+}
+
+describe("useBoardRightDragPan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("pans the container horizontally when right-dragging", () => {
+    const { scroller, setScrollLeft } = setup();
+    setScrollLeft(0);
+
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 200 }));
+
+    // Dragging left by 100px reveals 100px further right.
+    expect(scroller.scrollLeft).toBe(100);
+
+    fireEvent.pointerMove(scroller, pointer({ clientX: 260 }));
+    // Tracks the pointer from the gesture's origin, not incrementally.
+    expect(scroller.scrollLeft).toBe(40);
+  });
+
+  it("does not move below the 5px threshold", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 302 }));
+
+    expect(scroller.scrollLeft).toBe(0);
+    fireEvent.pointerUp(scroller, pointer({ clientX: 302 }));
+    // A sub-threshold right-click is a stationary click → restore the menu.
+    expect(restore).toHaveBeenCalledWith({ x: 302, y: 100 });
+  });
+
+  it("pans even when the pointer leaves the container before crossing the threshold (pointerdown capture)", () => {
+    // Regression for the v2-review capture hole: pointerdown immediately
+    // captures, so moves that arrive on the container (even though the cursor
+    // is visually outside) keep the gesture alive past the threshold.
+    const { scroller } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    // Large jump in one move — as if the cursor moved outside then back.
+    fireEvent.pointerMove(scroller, pointer({ clientX: 150 }));
+
+    expect(scroller.scrollLeft).toBe(150);
+  });
+
+  it("tracks a fast single-move drag from the gesture origin", () => {
+    const { scroller, setScrollLeft } = setup();
+    setScrollLeft(0);
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 50 }));
+
+    expect(scroller.scrollLeft).toBe(250);
+  });
+
+  it("ends the gesture on pointercancel and does not restore the menu", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerCancel(scroller, pointer({ clientX: 280 }));
+
+    expect(restore).not.toHaveBeenCalled();
+    // And a later contextmenu is not suppressed (no armed gesture).
+    const prevented = fireEvent.contextMenu(scroller, pointer({ clientX: 280 }));
+    expect(prevented).toBe(true);
+  });
+
+  it("suppresses contextmenu while a gesture is armed and releases it afterwards", () => {
+    const { scroller, restore } = setup();
+    // Stationary right-click: contextmenu arrives while armed (measured order:
+    // it fires before any movement) and must be swallowed.
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    const prevented = fireEvent.contextMenu(scroller, pointer({ clientX: 300 }));
+    expect(prevented).toBe(false);
+
+    fireEvent.pointerUp(scroller, pointer({ clientX: 300 }));
+    // Release restores the menu for a stationary right-click.
+    expect(restore).toHaveBeenCalledWith({ x: 300, y: 100 });
+  });
+
+  it("keeps the menu suppressed after an actual pan", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ clientX: 200 }));
+
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("keeps the menu suppressed after panning an unscrollable container", () => {
+    const { scroller, restore } = setup({ scrollable: false });
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ clientX: 200 }));
+
+    // Intent was established even though scrollLeft couldn't change.
+    expect(scroller.scrollLeft).toBe(0);
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("ignores vertical-only right drags (no pan, menu restored)", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300, clientY: 100 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 300, clientY: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ clientX: 300, clientY: 200 }));
+
+    expect(scroller.scrollLeft).toBe(0);
+    expect(restore).toHaveBeenCalledWith({ x: 300, y: 200 });
+  });
+
+  it("ignores left-button drags (dnd-kit owns them)", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ button: 0, clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ button: 0, clientX: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ button: 0, clientX: 200 }));
+
+    expect(scroller.scrollLeft).toBe(0);
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-mouse pointer types (touch/pen untouched)", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(
+      scroller,
+      pointer({ pointerType: "touch", button: 0, clientX: 300 }),
+    );
+    fireEvent.pointerMove(
+      scroller,
+      pointer({ pointerType: "touch", button: 0, clientX: 200 }),
+    );
+    fireEvent.pointerUp(
+      scroller,
+      pointer({ pointerType: "touch", button: 0, clientX: 200 }),
+    );
+
+    expect(scroller.scrollLeft).toBe(0);
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress contextmenu when no gesture is armed (menu key / non-gesture right-click)", () => {
+    const { scroller } = setup();
+    const prevented = fireEvent.contextMenu(scroller, pointer({ clientX: 300 }));
+    expect(prevented).toBe(true);
+  });
+
+  it("ends the gesture on lostpointercapture after a restore decision was made", () => {
+    // pointerup → lostpointercapture must not undo the pointerup decision or
+    // double-restore.
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    fireEvent.pointerMove(scroller, pointer({ clientX: 200 }));
+    fireEvent.pointerUp(scroller, pointer({ clientX: 200 }));
+    fireEvent.lostPointerCapture(scroller, pointer({ clientX: 200 }));
+
+    // Pan → suppressed; lostpointercapture is a no-op for the decision.
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("does not restore the menu on lostpointercapture without a preceding pointerup decision", () => {
+    const { scroller, restore } = setup();
+    fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
+    // Browser/OS steals the pointer (e.g. a system menu) → capture lost.
+    fireEvent.lostPointerCapture(scroller, pointer({ clientX: 300 }));
+
+    expect(restore).not.toHaveBeenCalled();
+  });
+});
+
+describe("RIGHT_PAN_THRESHOLD_PX", () => {
+  it("sits at 5px (matches the editor drag threshold and dnd-kit distance)", () => {
+    expect(RIGHT_PAN_THRESHOLD_PX).toBe(5);
+  });
+});

--- a/packages/views/issues/hooks/use-board-right-drag-pan.test.tsx
+++ b/packages/views/issues/hooks/use-board-right-drag-pan.test.tsx
@@ -53,7 +53,26 @@ function setup({
     },
   });
 
-  return { scroller, restore, setScrollLeft: (v: number) => (scrollLeft = v) };
+  // scrollTop must NEVER be touched by the pan hook. Track writes so an
+  // accidental vertical scroll fails the test instead of silently reading 0.
+  let scrollTop = 0;
+  let scrollTopWrites = 0;
+  Object.defineProperty(scroller, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTopWrites += 1;
+      scrollTop = Math.max(0, value);
+    },
+  });
+
+  return {
+    scroller,
+    restore,
+    setScrollLeft: (v: number) => (scrollLeft = v),
+    getScrollTop: () => scrollTop,
+    getScrollTopWrites: () => scrollTopWrites,
+  };
 }
 
 function pointer(opts: Record<string, unknown> = {}) {
@@ -77,7 +96,7 @@ describe("useBoardRightDragPan", () => {
   });
 
   it("pans the container horizontally when right-dragging", () => {
-    const { scroller, setScrollLeft } = setup();
+    const { scroller, setScrollLeft, getScrollTopWrites } = setup();
     setScrollLeft(0);
 
     fireEvent.pointerDown(scroller, pointer({ clientX: 300 }));
@@ -89,6 +108,9 @@ describe("useBoardRightDragPan", () => {
     fireEvent.pointerMove(scroller, pointer({ clientX: 260 }));
     // Tracks the pointer from the gesture's origin, not incrementally.
     expect(scroller.scrollLeft).toBe(40);
+
+    // Only the horizontal axis moves — scrollTop is never written.
+    expect(getScrollTopWrites()).toBe(0);
   });
 
   it("does not move below the 5px threshold", () => {

--- a/packages/views/issues/hooks/use-board-right-drag-pan.ts
+++ b/packages/views/issues/hooks/use-board-right-drag-pan.ts
@@ -1,0 +1,179 @@
+"use client";
+
+/**
+ * Right-button horizontal pan for a horizontally scrollable container, with
+ * deferred context-menu suppression.
+ *
+ * Solves a specific collision: the issues board is a wide kanban that invites
+ * right-dragging to pan across columns, but the right button also owns the
+ * context menu. The rule (approved in WS-226 v3):
+ *
+ * - Hold the right button and move horizontally → the board scrolls to follow
+ *   the cursor. Vertical movement is ignored, `scrollTop` is never touched,
+ *   and the left button keeps its card-drag semantics.
+ * - The context menu is only suppressed once the gesture actually pans; a
+ *   stationary right-click must still open the menu.
+ *
+ * Event-order premise (measured on Electron 39.8.7 + macOS, the acceptance
+ * environment): `contextmenu` fires right after the right `mousedown`, before
+ * any threshold-crossing `pointermove`. So the renderer cannot know at
+ * `contextmenu` time whether the user will pan — it must suppress
+ * unconditionally while a gesture is armed, and decide at `pointerup` whether
+ * to restore the menu (via the `onRestoreMenu` callback).
+ *
+ * State machine:
+ *
+ *   pointerdown (mouse + button 2)  arm gesture, capture the pointer
+ *                                     immediately (v3 fix: a gesture that
+ *                                     leaves the container before crossing
+ *                                     the threshold must not be lost)
+ *   contextmenu (capture phase)       armed → preventDefault + stopPropagation
+ *   pointermove                       |dx| > 5 → panned, scrollLeft tracks
+ *                                     from the gesture origin, never incrementally
+ *   pointerup                         panned → menu stays suppressed; else
+ *                                     onRestoreMenu(x, y)
+ *   pointercancel / lostpointercapture  end gesture, never restore the menu
+ *
+ * Suppression lives and dies with the gesture — one decision at release, no
+ * lingering pending flag. A trailing `pointerup → lostpointercapture` cannot
+ * undo it because the decision is made inside `pointerup` itself.
+ */
+
+import {
+  useCallback,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+// Matches the editor's DRAG_THRESHOLD_PX and dnd-kit's card-drag distance (5):
+// past a click's jitter but well under a deliberate drag. Own named constant —
+// the issues domain must not depend on the editor domain.
+export const RIGHT_PAN_THRESHOLD_PX = 5;
+
+interface GestureState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startScrollLeft: number;
+  panned: boolean;
+}
+
+export interface BoardRightDragPanHandlers {
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+  onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
+  onLostPointerCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  onContextMenuCapture: (event: ReactMouseEvent<HTMLElement>) => void;
+}
+
+/**
+ * @param onRestoreMenu Called on release when the gesture never panned. The
+ *   caller decides how to restore the menu at that point (dispatch a synthetic
+ *   contextmenu for cards, or rebuild the native menu through the desktop
+ *   bridge for blank space).
+ */
+export function useBoardRightDragPan({
+  onRestoreMenu,
+}: {
+  onRestoreMenu: (release: { x: number; y: number }) => void;
+}): BoardRightDragPanHandlers {
+  // A ref, not state: a pan updates on every pointermove, and re-rendering
+  // the board at that rate would stutter the scroll it is driving.
+  const gestureRef = useRef<GestureState | null>(null);
+  const onRestoreMenuRef = useRef(onRestoreMenu);
+  onRestoreMenuRef.current = onRestoreMenu;
+
+  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    // Only the mouse right button pans. Touch/pen and the left button (dnd-kit
+    // card drag) never enter this state machine.
+    if (event.pointerType !== "mouse" || event.button !== 2) return;
+
+    gestureRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startScrollLeft: event.currentTarget.scrollLeft,
+      panned: false,
+    };
+    // Capture at pointerdown (not on threshold-crossing like the editor hook):
+    // if the user starts at the container edge and the first moves land
+    // outside it, the container still receives every move/up and the gesture
+    // cannot be lost before it crosses the threshold.
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  }, []);
+
+  const onContextMenuCapture = useCallback((event: ReactMouseEvent<HTMLElement>) => {
+    // While a gesture is armed, always swallow the context menu — the
+    // measured order fires it before any movement, so `panned` cannot gate
+    // here. Whether the menu comes back is decided at release.
+    if (!gestureRef.current) return;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const onPointerMove = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+
+    const deltaX = event.clientX - gesture.startX;
+    if (!gesture.panned) {
+      if (Math.abs(deltaX) <= RIGHT_PAN_THRESHOLD_PX) return;
+      gesture.panned = true;
+    }
+    // Recompute from the gesture origin every move — never incrementally — so
+    // fast drags cannot accumulate error. Assigning past either end is clamped
+    // by the browser, so an unscrollable board simply stays put while still
+    // counting as a pan. Only scrollLeft is written; scrollTop never changes.
+    event.currentTarget.scrollLeft = gesture.startScrollLeft - deltaX;
+  }, []);
+
+  const onPointerUp = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    // End the gesture first so the restore path (which may dispatch a
+    // synthetic contextmenu) is not suppressed by our own capture handler.
+    const gesture = gestureRef.current;
+    gestureRef.current = null;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    }
+
+    // One-time decision: panned keeps the menu suppressed; a stationary or
+    // vertical-only right-click restores it. `lostpointercapture` firing next
+    // cannot undo this — the decision is already made.
+    if (!gesture.panned) {
+      onRestoreMenuRef.current({ x: event.clientX, y: event.clientY });
+    }
+  }, []);
+
+  const onPointerCancel = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    // Browser took the gesture over (pointer lost, window blur). Never restore
+    // the menu — a menu popping up on a cancelled gesture reads as a glitch.
+    const gesture = gestureRef.current;
+    gestureRef.current = null;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    }
+  }, []);
+
+  const onLostPointerCapture = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    // Only ends the active gesture. The restore decision belongs to pointerup;
+    // a trailing lostpointercapture from our own releasePointerCapture must not
+    // re-trigger or undo anything.
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    gestureRef.current = null;
+  }, []);
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onLostPointerCapture,
+    onContextMenuCapture,
+  };
+}

--- a/packages/views/platform/index.ts
+++ b/packages/views/platform/index.ts
@@ -14,6 +14,11 @@ export {
   type LocalDaemonStatus,
 } from "./use-local-daemon-status";
 export {
+  isDesktopShowContextMenuAvailable,
+  showContextMenu,
+  type ShowContextMenuParams,
+} from "./show-context-menu";
+export {
   ScrollRestorationProvider,
   useRestoredScrollOffset,
   useRestoredScrollRef,

--- a/packages/views/platform/show-context-menu.ts
+++ b/packages/views/platform/show-context-menu.ts
@@ -1,0 +1,56 @@
+/**
+ * Desktop-only helper for restoring the native context menu that the issues
+ * board suppresses during a right-drag pan.
+ *
+ * The board's right-drag pan swallows the `contextmenu` event for the whole
+ * gesture (the event fires before any threshold move on the acceptance
+ * platform). When the gesture ends without panning over blank board space,
+ * the renderer rebuilds the same menu the main process would have shown —
+ * via this bridge, so shared `packages/views` never imports Electron directly.
+ *
+ * On web (no preload bridge) this degrades to a no-op: the renderer cannot
+ * restore the browser's native blank-space menu, which is the documented web
+ * boundary.
+ */
+
+export type ShowContextMenuParams = {
+  selectionText: string;
+  isEditable: boolean;
+  linkURL: string;
+  editFlags: {
+    canCut: boolean;
+    canCopy: boolean;
+    canPaste: boolean;
+    canSelectAll: boolean;
+  };
+};
+
+interface DesktopShowContextMenuAPI {
+  showContextMenu?: (request: {
+    x: number;
+    y: number;
+    params: ShowContextMenuParams;
+  }) => Promise<void>;
+}
+
+function readDesktopAPI(): DesktopShowContextMenuAPI | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { desktopAPI?: DesktopShowContextMenuAPI })
+    .desktopAPI;
+}
+
+/** True when running inside the Electron desktop shell with the bridge present. */
+export function isDesktopShowContextMenuAvailable(): boolean {
+  return typeof readDesktopAPI()?.showContextMenu === "function";
+}
+
+/** Restore the native context menu at viewport coordinates. No-op on web. */
+export function showContextMenu(
+  x: number,
+  y: number,
+  params: ShowContextMenuParams,
+): void {
+  const api = readDesktopAPI();
+  if (!api?.showContextMenu) return;
+  void api.showContextMenu({ x, y, params });
+}


### PR DESCRIPTION
## What does this PR do?

Adds right-button drag horizontal panning to the issues kanban board. Holding the right mouse button and moving pans the board horizontally to follow the cursor, so users can quickly browse wide multi-column boards without reaching for the scrollbar or trackpad.

Key behaviors (per the approved design in multica-ai#6700):

- Hold right button + move → board scrolls horizontally following the cursor
- Horizontal axis only: `scrollTop` is never touched; left-button card drag semantics are unchanged
- The context menu is only suppressed once the gesture actually pans; a stationary right-click still opens the normal context menu (card menu on cards, native menu on blank space)
- Pointer capture is taken at `pointerdown` so a gesture that starts near the container edge and leaves it before crossing the threshold is not lost

## Related Issue

Closes https://github.com/multica-ai/multica/issues/6700

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `packages/views/issues/hooks/use-board-right-drag-pan.ts` — new hook: right-drag pan state machine (arm on right `pointerdown` + pointer capture, suppress `contextmenu` while armed, threshold-crossing marks the gesture as panned, `scrollLeft` tracks from the gesture origin, restore-menu decision at `pointerup`)
- `packages/views/issues/components/board-view.tsx` — wire the hook onto the `overflow-x-auto` scroller; on release without pan, restore the suppressed menu (synthetic `contextmenu` for cards → `IssueActionsContextMenu`; native menu via the desktop bridge for blank space)
- `packages/views/platform/show-context-menu.ts` + `packages/views/platform/index.ts` — platform boundary for showing the native context menu (desktop bridge in Electron, no-op on web)
- `apps/desktop/src/main/context-menu.ts`, `apps/desktop/src/main/index.ts`, `apps/desktop/src/preload/*`, `apps/desktop/src/shared/context-menu.ts` — expose a renderer-callable `show-context-menu` IPC bridge that rebuilds the native menu at a point from renderer-supplied params
- `packages/views/issues/components/board-view.test.tsx` / `packages/views/issues/hooks/use-board-right-drag-pan.test.tsx` — unit tests: pan follows cursor, `scrollTop` untouched, stationary right-click restores the menu, pan suppresses it, left-drag card behavior unaffected
- `apps/desktop/src/main/context-menu.test.ts` — main-process tests for the restored native menu path
- `e2e/board-right-drag-pan.spec.ts` — Chromium E2E: right-drag pans the board, `scrollTop` unchanged
- `e2e/board-right-drag-pan.desktop.spec.ts` — Electron smoke: self-contained login → real board → right-drag suppresses the menu; stationary right-click reopens the card menu; scrollTop untouched
- `apps/desktop/scripts/verify-context-menu-order.js` — verification script using a real trusted right-click event proving the renderer `preventDefault` gates the main-process menu

## How to Test

1. `pnpm install` then `pnpm -C packages/views test` and `pnpm -C apps/desktop test` — all pass (views: 331 files / 3951 tests; desktop: 45 files / 472 tests), `typecheck` clean.
2. Open the issues board (web or desktop), hold the right button and drag horizontally — the board pans; release without moving → the context menu still opens.
3. E2E: `pnpm -C e2e test -- board-right-drag-pan` (Chromium) and the Electron smoke `board-right-drag-pan.desktop.spec.ts` with `E2E_DESKTOP=1`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Developed through the Multica agent orchestration flow: an independent technical proposal (reviewed and approved by a second architect agent), implementation, and independent acceptance review with a rework round that hardened the test closure (real trusted right-click events in the Electron smoke, self-contained login fixture, stationary-right-click menu assertion). Two local agents (developer + architect reviewer) worked the full plan → review → implement → accept loop.
