### PR TITLE
MUL-6113: fix(daemon): make the daemon log path discoverable

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -101,7 +101,23 @@ The daemon is the local agent runtime. It detects available AI CLIs on your mach
 multica daemon start
 ```
 
-By default, the daemon runs in the background and logs to `~/.multica/daemon.log`.
+By default, the daemon runs in the background and writes its log into the state
+directory of the profile it was started with — **not always `~/.multica/`**:
+
+| Profile | State directory |
+| --- | --- |
+| Default (no `--profile`) | `~/.multica/` |
+| Named (`--profile <name>`) | `~/.multica/profiles/<name>/` |
+
+That directory holds `daemon.log` (the log), `daemon.pid` (the background
+daemon's PID), and `daemon.err.log` (raw crash output; near-empty on a healthy
+daemon, since normal logging goes to `daemon.log`).
+
+The Desktop app runs its own named profile, so on a machine that has ever run
+both, `~/.multica/daemon.log` and `~/.multica/profiles/<name>/daemon.log` both
+exist and both read as plausible logs — only one is being written to. Don't
+guess: `multica daemon logs` prints the absolute path it resolved (see
+[Logs](#logs)).
 
 To run in the foreground (useful for debugging):
 
@@ -158,7 +174,29 @@ Shows PID, uptime, detected agents, and watched workspaces.
 multica daemon logs              # Last 50 lines
 multica daemon logs -f           # Follow (tail -f)
 multica daemon logs -n 100       # Last 100 lines
+multica daemon logs --profile staging
 ```
+
+Every run first prints the absolute path it resolved, so you always know which
+profile's log you are looking at:
+
+```
+$ multica daemon logs -n 100
+Reading /Users/you/.multica/profiles/desktop-mbp/daemon.log (profile: desktop-mbp)
+...
+```
+
+That line goes to stderr, before the tail starts — so it also shows up under
+`-f`, and piping or redirecting the command still yields log content only:
+
+```bash
+multica daemon logs -n 500 | grep ERROR   # the path line is not in the pipe
+```
+
+Without `--profile`, the default profile's log is read. If it doesn't exist the
+command says so and names the path it looked for, which is the fastest way to
+find out that the daemon you care about is running on a different profile —
+`multica daemon status --profile <name>` confirms which one is live.
 
 ### Supported Agents
 
@@ -374,7 +412,7 @@ multica daemon start --profile staging
 multica daemon start
 ```
 
-Each profile gets its own config directory (`~/.multica/profiles/<name>/`), daemon state, health port, and workspace root.
+Each profile gets its own config directory (`~/.multica/profiles/<name>/`), daemon state, health port, and workspace root. Daemon state means that profile's own `daemon.log`, `daemon.err.log`, and `daemon.pid` live in that directory too — see [Start](#start) for the layout, and pass `--profile <name>` to `daemon status` / `daemon logs` to act on it.
 
 ## Workspaces
 

--- a/apps/docs/content/docs/troubleshooting.ja.mdx
+++ b/apps/docs/content/docs/troubleshooting.ja.mdx
@@ -203,6 +203,8 @@ netstat -ano | findstr :8080       # Windows
 | Docker backend | `docker compose -f docker-compose.selfhost.yml logs -f backend` |
 | ブラウザ | 開発者ツールの Console と Network |
 
+どのファイルが現在有効なログかは、デーモンを起動したプロファイルによって決まります。以前のデーモンが残した古いログもそのまま読めてしまうため、誤ったファイルを調べてしまいがちです。当て推量でファイルを開かないでください: `multica daemon logs` は内容を流す前に、解決した絶対パスを表示します。名前付きプロファイルのログを読むときは `--profile <name>` を付けます。
+
 デーモンの起動過程を直接観察したい場合は、フォアグラウンドで実行します:
 
 ```bash

--- a/apps/docs/content/docs/troubleshooting.ko.mdx
+++ b/apps/docs/content/docs/troubleshooting.ko.mdx
@@ -203,6 +203,8 @@ netstat -ano | findstr :8080       # Windows
 | Docker backend | `docker compose -f docker-compose.selfhost.yml logs -f backend` |
 | 브라우저 | 개발자 도구의 Console과 Network |
 
+어떤 파일이 현재 사용 중인 로그인지는 데몬을 시작한 profile에 따라 달라집니다. 이전 데몬이 남긴 오래된 로그도 문제없이 읽히기 때문에 엉뚱한 파일을 보게 되기 쉽습니다. 추측으로 파일을 열지 말고 `multica daemon logs`를 사용하세요. 내용을 출력하기 전에 해석한 절대 경로를 먼저 표시합니다. 이름 있는 profile의 로그는 `--profile <name>`을 붙여서 확인합니다.
+
 데몬 시작 과정을 직접 확인해야 한다면 foreground에서 실행합니다.
 
 ```bash

--- a/apps/docs/content/docs/troubleshooting.mdx
+++ b/apps/docs/content/docs/troubleshooting.mdx
@@ -203,6 +203,8 @@ If it is another Multica checkout, run `make stop` in that directory first. Othe
 | Docker backend | `docker compose -f docker-compose.selfhost.yml logs -f backend` |
 | Browser | Console and Network in the developer tools |
 
+Which of those files is the live one depends on the profile the daemon was started with, and a stale log from an earlier daemon still reads perfectly — the easiest way to debug the wrong file. Don't open one by guess: `multica daemon logs` prints the absolute path it resolved before streaming it. Add `--profile <name>` to read a named profile's log.
+
 To observe the daemon's startup directly, run it in the foreground instead:
 
 ```bash

--- a/apps/docs/content/docs/troubleshooting.zh.mdx
+++ b/apps/docs/content/docs/troubleshooting.zh.mdx
@@ -203,6 +203,8 @@ netstat -ano | findstr :8080       # Windows
 | Docker backend | `docker compose -f docker-compose.selfhost.yml logs -f backend` |
 | 浏览器 | 开发者工具中的 Console 和 Network |
 
+哪个文件是当前活跃的日志，取决于守护进程启动时使用的 profile；早前守护进程残留的旧日志同样能正常读出来，最容易让人调错文件。不要靠猜去开文件：`multica daemon logs` 会在输出日志内容前先打印它解析到的绝对路径。读命名 profile 的日志时加上 `--profile <name>`。
+
 需要直接观察守护进程启动过程时，可以改为前台运行：
 
 ```bash

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -1495,6 +1495,36 @@ func printDaemonStatusReport(w io.Writer, label string, health map[string]any) {
 
 // --- daemon logs ---
 
+// tailLog is the seam tests replace to observe `daemon logs` without spawning
+// the platform tail implementation.
+var tailLog = tailLogFile
+
+// profileLabel names a profile for humans; the default profile has no name.
+func profileLabel(profile string) string {
+	if profile == "" {
+		return "default"
+	}
+	return profile
+}
+
+// daemonLogSourcePath resolves the daemon.log path for a profile —
+// ~/.multica/daemon.log for the default profile,
+// ~/.multica/profiles/<name>/daemon.log for a named one — and guarantees it is
+// absolute, because this path is shown to the user to paste into an editor or
+// another shell.
+//
+// A relative result means daemonDirForProfile could not resolve the home
+// directory and swallowed the error, leaving a bare "daemon.log". That is
+// reported instead of returned: it would resolve against the caller's cwd and
+// name a file with nothing to do with the daemon.
+func daemonLogSourcePath(profile string) (string, error) {
+	logPath := daemonLogPathForProfile(profile)
+	if !filepath.IsAbs(logPath) {
+		return "", fmt.Errorf("cannot resolve the state directory for profile %q", profileLabel(profile))
+	}
+	return logPath, nil
+}
+
 func runDaemonLogs(cmd *cobra.Command, _ []string) error {
 	if err := requireHumanLocalCommand("daemon logs"); err != nil {
 		return err
@@ -1503,7 +1533,10 @@ func runDaemonLogs(cmd *cobra.Command, _ []string) error {
 	if err := requireKnownProfile(profile); err != nil {
 		return err
 	}
-	logPath := daemonLogPathForProfile(profile)
+	logPath, err := daemonLogSourcePath(profile)
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
 		return fmt.Errorf("no log file found at %s\nThe daemon may not have been started in background mode", logPath)
 	}
@@ -1511,7 +1544,14 @@ func runDaemonLogs(cmd *cobra.Command, _ []string) error {
 	follow, _ := cmd.Flags().GetBool("follow")
 	lines, _ := cmd.Flags().GetInt("lines")
 
-	return tailLogFile(logPath, lines, follow)
+	// Name the file before streaming it. Which daemon.log is live is otherwise
+	// unknowable — a stale default-profile log reads fine and looks current —
+	// and this command is the only thing that knows the answer. It goes to
+	// stderr and is written before the tail starts so `-f` output and any
+	// downstream pipe stay clean.
+	fmt.Fprintf(cmd.ErrOrStderr(), "Reading %s (profile: %s)\n", logPath, profileLabel(profile))
+
+	return tailLog(logPath, lines, follow)
 }
 
 // daemonAlive reports whether a health response indicates a live daemon

--- a/server/cmd/multica/cmd_daemon_logs_test.go
+++ b/server/cmd/multica/cmd_daemon_logs_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// daemonLogsCmdFor builds a cobra command carrying the flags runDaemonLogs
+// reads, wired to a buffer so what the command tells the user is observable.
+func daemonLogsCmdFor(t *testing.T, profile string, lines int, follow bool) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := daemonStatusCmdFor(t, profile, "")
+	cmd.Flags().BoolP("follow", "f", false, "")
+	cmd.Flags().IntP("lines", "n", 50, "")
+	if err := cmd.Flags().Set("lines", strconv.Itoa(lines)); err != nil {
+		t.Fatalf("set lines flag: %v", err)
+	}
+	if follow {
+		if err := cmd.Flags().Set("follow", "true"); err != nil {
+			t.Fatalf("set follow flag: %v", err)
+		}
+	}
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+	return cmd, &errOut
+}
+
+// tailCall records what runDaemonLogs handed to the platform tail, plus what
+// the user had already been told at that moment.
+type tailCall struct {
+	called       bool
+	path         string
+	lines        int
+	follow       bool
+	stderrAtCall string
+}
+
+// stubTailLog replaces the tail seam so the test observes the command without
+// spawning `tail` (and without a follow-mode run that never returns).
+func stubTailLog(t *testing.T, errOut *bytes.Buffer) *tailCall {
+	t.Helper()
+	rec := &tailCall{}
+	prev := tailLog
+	t.Cleanup(func() { tailLog = prev })
+	tailLog = func(path string, lines int, follow bool) error {
+		rec.called = true
+		rec.path, rec.lines, rec.follow = path, lines, follow
+		rec.stderrAtCall = errOut.String()
+		return nil
+	}
+	return rec
+}
+
+func seedDaemonLog(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("hello from the daemon\n"), 0o644); err != nil {
+		t.Fatalf("seed daemon log: %v", err)
+	}
+}
+
+// The default profile and a named one resolve to different files, and only the
+// named-profile layout was missing from the docs — a Desktop install logs to
+// ~/.multica/profiles/<name>/daemon.log while ~/.multica/daemon.log may still
+// hold a readable, stale log from an earlier default-profile daemon (#6038).
+func TestDaemonLogSourcePathResolvesPerProfile(t *testing.T) {
+	t.Run("default profile", func(t *testing.T) {
+		home := mkProfiles(t)
+
+		got, err := daemonLogSourcePath("")
+		if err != nil {
+			t.Fatalf("daemonLogSourcePath(\"\") = %v, want nil", err)
+		}
+		want := filepath.Join(home, ".multica", "daemon.log")
+		if got != want {
+			t.Fatalf("daemonLogSourcePath(\"\") = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("named profile", func(t *testing.T) {
+		home := mkProfiles(t, "desktop-api.multica.ai")
+
+		got, err := daemonLogSourcePath("desktop-api.multica.ai")
+		if err != nil {
+			t.Fatalf("daemonLogSourcePath = %v, want nil", err)
+		}
+		want := filepath.Join(home, ".multica", "profiles", "desktop-api.multica.ai", "daemon.log")
+		if got != want {
+			t.Fatalf("daemonLogSourcePath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("result is absolute", func(t *testing.T) {
+		mkProfiles(t, "dev")
+		for _, profile := range []string{"", "dev"} {
+			got, err := daemonLogSourcePath(profile)
+			if err != nil {
+				t.Fatalf("daemonLogSourcePath(%q) = %v, want nil", profile, err)
+			}
+			if !filepath.IsAbs(got) {
+				t.Fatalf("daemonLogSourcePath(%q) = %q, want an absolute path", profile, got)
+			}
+		}
+	})
+}
+
+// The success path used to be silent about which file it was reading, so the
+// only command that knows the answer withheld it exactly when it worked. Both
+// profile layouts must announce the absolute path, for plain reads and for
+// -n / -f alike.
+func TestRunDaemonLogsAnnouncesResolvedPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile string
+		label   string
+		lines   int
+		follow  bool
+	}{
+		{"default profile", "", "default", 50, false},
+		{"default profile with lines", "", "default", 100, false},
+		{"named profile", "desktop-api.multica.ai", "desktop-api.multica.ai", 50, false},
+		{"named profile following", "desktop-api.multica.ai", "desktop-api.multica.ai", 50, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearDaemonTaskEnv(t)
+			mkProfiles(t, "desktop-api.multica.ai")
+
+			wantPath, err := daemonLogSourcePath(tc.profile)
+			if err != nil {
+				t.Fatalf("daemonLogSourcePath: %v", err)
+			}
+			seedDaemonLog(t, wantPath)
+
+			cmd, errOut := daemonLogsCmdFor(t, tc.profile, tc.lines, tc.follow)
+			rec := stubTailLog(t, errOut)
+
+			if err := runDaemonLogs(cmd, nil); err != nil {
+				t.Fatalf("runDaemonLogs = %v, want nil", err)
+			}
+
+			if !strings.Contains(errOut.String(), wantPath) {
+				t.Errorf("daemon logs output = %q, want the resolved path %q", errOut.String(), wantPath)
+			}
+			if !strings.Contains(errOut.String(), tc.label) {
+				t.Errorf("daemon logs output = %q, want the profile label %q", errOut.String(), tc.label)
+			}
+
+			if !rec.called {
+				t.Fatal("runDaemonLogs did not tail the log")
+			}
+			if rec.path != wantPath {
+				t.Errorf("tailed %q, want %q — the announced path must be the one read", rec.path, wantPath)
+			}
+			if rec.lines != tc.lines || rec.follow != tc.follow {
+				t.Errorf("tail(lines=%d, follow=%v), want (lines=%d, follow=%v)", rec.lines, rec.follow, tc.lines, tc.follow)
+			}
+			// In follow mode the tail never returns, so a path announced
+			// afterwards would never be seen; it must already be out.
+			if !strings.Contains(rec.stderrAtCall, wantPath) {
+				t.Errorf("path was not announced before tailing started (stderr at call = %q)", rec.stderrAtCall)
+			}
+		})
+	}
+}
+
+// The announcement goes to stderr, so `multica daemon logs | grep ...` and a
+// redirect to a file keep seeing log content only.
+func TestRunDaemonLogsAnnouncementDoesNotPolluteStdout(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	mkProfiles(t, "dev")
+
+	wantPath, err := daemonLogSourcePath("dev")
+	if err != nil {
+		t.Fatalf("daemonLogSourcePath: %v", err)
+	}
+	seedDaemonLog(t, wantPath)
+
+	cmd, errOut := daemonLogsCmdFor(t, "dev", 50, false)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	stubTailLog(t, errOut)
+
+	stdout, err := captureStdout(t, func() error { return runDaemonLogs(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runDaemonLogs = %v, want nil", err)
+	}
+	if strings.Contains(stdout, wantPath) || strings.Contains(out.String(), wantPath) {
+		t.Errorf("the path must not go to stdout (os.Stdout=%q, cmd out=%q)", stdout, out.String())
+	}
+}
+
+// The missing-file error already named a path; it must name the absolute one
+// for the profile that was asked for, not the default profile's.
+func TestRunDaemonLogsMissingFileNamesProfilePath(t *testing.T) {
+	clearDaemonTaskEnv(t)
+	home := mkProfiles(t, "desktop-api.multica.ai")
+
+	// A readable log for the DEFAULT profile exists — the exact trap from
+	// #6038. The error must still point at the requested profile's path.
+	seedDaemonLog(t, filepath.Join(home, ".multica", "daemon.log"))
+
+	cmd, errOut := daemonLogsCmdFor(t, "desktop-api.multica.ai", 50, false)
+	rec := stubTailLog(t, errOut)
+
+	err := runDaemonLogs(cmd, nil)
+	if err == nil {
+		t.Fatal("runDaemonLogs = nil, want the missing-log-file error")
+	}
+	want := filepath.Join(home, ".multica", "profiles", "desktop-api.multica.ai", "daemon.log")
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want it to name %q", err, want)
+	}
+	if rec.called {
+		t.Error("runDaemonLogs tailed a file it had just reported missing")
+	}
+}


### PR DESCRIPTION
## Problem

Debugging a daemon meant guessing which `daemon.log` was the live one. In #6038 an external reporter followed the docs to `~/.multica/daemon.log`, which had been stale for 17 hours — a leftover from an earlier default-profile daemon — but read perfectly. He only found the real log by ignoring the instructions and digging through the directory himself.

Two causes, both verified in code:

1. **`CLI_AND_DAEMON.md` documented only the default profile's path.** The real resolution is `daemonLogPathForProfile` → `ProfileDir(profile)/daemon.log`, and `cli.ProfileDir` splits: default profile → `~/.multica/`, named profile → `~/.multica/profiles/<name>/`. A Desktop install normally runs on a named profile, so the undocumented half is the common case.
2. **`multica daemon logs` printed the resolved path only when the file was missing.** The success path went straight to `tailLogFile` and never said which file it was reading — the one command that knows the answer withheld it exactly when it worked.

## Changes

**CLI** (`server/cmd/multica/cmd_daemon.go`)

- `daemon logs` now prints the absolute path and profile label it resolved before streaming:
  ```
  $ multica daemon logs -n 100
  Reading /Users/you/.multica/profiles/desktop-mbp/daemon.log (profile: desktop-mbp)
  ...
  ```
- The line goes to **stderr, before the tail starts** — so it also appears under `-f` (where anything printed after would never be reached), and `multica daemon logs | grep ERROR` still sees log content only.
- Path resolution is factored into `daemonLogSourcePath`, which errors instead of returning a bare `daemon.log` when the profile directory can't resolve. A path shown to a user has to be one they can actually open; a cwd-relative one names a file with nothing to do with the daemon.

**Docs**

- `CLI_AND_DAEMON.md`: both profile layouts as a table, plus `daemon.pid` / `daemon.err.log` which live in the same directory; the Logs section shows the printed path, the stderr/pipe behaviour, and `--profile`; the Profiles section spells out what "daemon state" contains.
- `apps/docs/.../troubleshooting.{mdx,zh,ja,ko}`: the Log locations table already listed both layouts, so it gains one paragraph — a stale log still reads fine, so use `daemon logs` and read the path it prints instead of opening a file by guess.

## Testing

New `server/cmd/multica/cmd_daemon_logs_test.go` (a `tailLog` seam lets the tests observe the command without spawning `tail`):

- `daemonLogSourcePath` resolves default → `~/.multica/daemon.log` and named → `~/.multica/profiles/<name>/daemon.log`, both absolute.
- `daemon logs` announces the resolved path and profile label across default/named × plain/`-n`/`-f`, tails exactly the path it announced, and announces **before** tailing starts.
- The announcement never reaches stdout.
- The missing-file error names the *requested* profile's path while a readable default-profile log exists — the #6038 trap.

Verified the tests fail without the fix (removing the print → 4 subtests fail).

```
go test ./cmd/multica/ -run 'TestDaemonLogSourcePath|TestRunDaemonLogs' -count=1   # ok
```

Full-package `go test ./cmd/multica/` has 103 pre-existing failures in this sandbox because it runs inside a daemon-managed task (a `.multica/daemon_task_context.json` marker in a parent directory makes local/human commands fail closed). The failure set is byte-identical with and without this change, and none are in the daemon-logs tests.

Also smoke-tested the built binary against a temp `HOME` holding both a stale default-profile log and a live named-profile one: correct path printed for each, stdout clean when stderr is dropped, `-f` prints the path immediately and then streams appended lines, and the missing-file error names the right absolute path.

## Out of scope

`daemon logs` and `daemon disk-usage --all-profiles` being refused inside a daemon-managed task shell — deliberately excluded, since it may be intentional design rather than a bug. Worth a separate issue.
