### PR TITLE
NEW-31: add offline map source collector

### DIFF
--- a/server/cmd/new31_map_collector/README.md
+++ b/server/cmd/new31_map_collector/README.md
@@ -1,0 +1,40 @@
+# NEW31-MAP-v1 collector
+
+This command is a single-purpose, read-only source adapter for the NEW31-MAP-v1
+mapping review. It does not import data, run migrations, or start with the API
+server.
+
+The reviewed contract must classify every source column as either allowlisted or
+denied. The collector fails closed when PostgreSQL is not exactly 17.10, a table
+or column drifts, an enum is unknown, a core reference is orphaned, permissions
+could expand, a task is nonterminal, an attachment is missing or corrupt, or
+usage semantics are invalid.
+
+Run it only against an isolated PostgreSQL 17.10 restore and its matching upload
+snapshot. Set `DATABASE_URL` through the controlled runtime environment before
+running:
+
+```bash
+go run ./cmd/new31_map_collector \
+  --contract /controlled/path/new31-map-v1.json \
+  --hmac-key-file /controlled/path/run.key \
+  --attachments-root /controlled/path/uploads \
+  --output /controlled/path/report.json
+```
+
+Requirements:
+
+- `run.key` must contain at least 32 random bytes and grant no group/other
+  access. The command overwrites, syncs, and removes it immediately after read,
+  then clears the in-memory key on exit.
+- The database role must be read-only. The command also sets
+  `default_transaction_read_only=on`, uses one connection, and collects inside a
+  `REPEATABLE READ READ ONLY` transaction.
+- The output path must not exist. The report is created with mode `0600` and
+  contains only contract field names, counts, keyed anonymous IDs, HMAC
+  evidence, and rejection reason codes.
+- A rejected collection still writes the redacted report and exits nonzero.
+
+`internal/mapcollector/testdata` is synthetic PostgreSQL 17.10 fixture data. It
+contains no production identifiers or source DDL and is not a production source
+contract.

--- a/server/cmd/new31_map_collector/main.go
+++ b/server/cmd/new31_map_collector/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/mapcollector"
+)
+
+type config struct {
+	contractPath   string
+	keyFile        string
+	outputPath     string
+	attachmentsDir string
+	timeout        time.Duration
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var cfg config
+	flag.StringVar(&cfg.contractPath, "contract", "", "path to the reviewed NEW31-MAP-v1 allowlist contract")
+	flag.StringVar(&cfg.keyFile, "hmac-key-file", "", "path to a mode 0600 temporary run-key file; destroyed immediately after reading")
+	flag.StringVar(&cfg.outputPath, "output", "", "path for the redacted JSON report")
+	flag.StringVar(&cfg.attachmentsDir, "attachments-root", "", "root containing fixture or restored attachment objects")
+	flag.DurationVar(&cfg.timeout, "timeout", 30*time.Minute, "collector deadline")
+	flag.Parse()
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		return fmt.Errorf("DATABASE_URL is required; no default connection is permitted")
+	}
+	contract, canonical, err := mapcollector.LoadContract(cfg.contractPath)
+	if err != nil {
+		return err
+	}
+	key, err := mapcollector.ReadAndDestroyKeyFile(cfg.keyFile)
+	if err != nil {
+		return err
+	}
+	defer clear(key)
+
+	baseCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(baseCtx, cfg.timeout)
+	defer cancel()
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return fmt.Errorf("parse DATABASE_URL: %w", err)
+	}
+	poolConfig.ConnConfig.RuntimeParams["default_transaction_read_only"] = "on"
+	poolConfig.ConnConfig.RuntimeParams["application_name"] = "new31-map-v1-collector"
+	poolConfig.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return fmt.Errorf("connect to source fixture: %w", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("ping source fixture: %w", err)
+	}
+	report, err := mapcollector.Collect(ctx, pool, contract, canonical, key, cfg.attachmentsDir)
+	if err != nil {
+		return err
+	}
+	encoded, err := report.Marshal()
+	if err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	if err := writeExclusive(cfg.outputPath, encoded); err != nil {
+		return err
+	}
+	if !report.Accepted {
+		return fmt.Errorf("collection rejected: %d fail-closed findings; inspect redacted report", len(report.Rejections))
+	}
+	return nil
+}
+
+func (c config) validate() error {
+	if c.contractPath == "" || c.keyFile == "" || c.outputPath == "" || c.attachmentsDir == "" {
+		return errors.New("--contract, --hmac-key-file, --output, and --attachments-root are required")
+	}
+	if c.timeout <= 0 || c.timeout > 30*time.Minute {
+		return errors.New("--timeout must be greater than zero and no more than 30m")
+	}
+	for _, input := range []string{c.contractPath, c.keyFile} {
+		inputAbs, err := filepath.Abs(input)
+		if err != nil {
+			return err
+		}
+		outputAbs, err := filepath.Abs(c.outputPath)
+		if err != nil {
+			return err
+		}
+		if inputAbs == outputAbs {
+			return errors.New("output path must not overwrite an input")
+		}
+	}
+	return nil
+}
+
+func writeExclusive(path string, content []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return fmt.Errorf("create output report: %w", err)
+	}
+	ok := false
+	defer func() {
+		_ = f.Close()
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := f.Write(content); err != nil {
+		return fmt.Errorf("write output report: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync output report: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close output report: %w", err)
+	}
+	ok = true
+	return nil
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.13
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5
+	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
 	github.com/go-redis/redismock/v9 v9.2.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -48,6 +48,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/internal/mapcollector/collector.go
+++ b/server/internal/mapcollector/collector.go
@@ -1,0 +1,724 @@
+package mapcollector
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Collector struct {
+	contract       *Contract
+	contractBytes  []byte
+	key            []byte
+	attachmentsDir string
+	records        map[string][]record
+	report         Report
+}
+
+func Collect(ctx context.Context, pool *pgxpool.Pool, contract *Contract, contractBytes, key []byte, attachmentsDir string) (*Report, error) {
+	if len(key) < 32 {
+		return nil, fmt.Errorf("HMAC key must contain at least 32 bytes")
+	}
+	c := &Collector{
+		contract:       contract,
+		contractBytes:  contractBytes,
+		key:            key,
+		attachmentsDir: attachmentsDir,
+		records:        make(map[string][]record),
+	}
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, fmt.Errorf("begin read-only snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+
+	if err := c.initializeReport(ctx, tx); err != nil {
+		return nil, err
+	}
+	if err := c.validateSchema(ctx, tx); err != nil {
+		return nil, err
+	}
+	if err := c.collectTables(ctx, tx); err != nil {
+		return nil, err
+	}
+	c.collectDomains()
+	c.collectUniqueViolations()
+	c.collectReferences()
+	c.collectOwners()
+	c.collectPermissions()
+	if err := c.collectAttachments(); err != nil {
+		return nil, err
+	}
+	c.collectUsage()
+	c.collectTasks()
+	c.report.Accepted = len(c.report.Rejections) == 0
+	return &c.report, nil
+}
+
+func (c *Collector) initializeReport(ctx context.Context, tx pgx.Tx) error {
+	var versionNumber string
+	if err := tx.QueryRow(ctx, `SELECT current_setting('server_version_num')::text`).Scan(&versionNumber); err != nil {
+		return fmt.Errorf("read PostgreSQL version: %w", err)
+	}
+	if versionNumber != "170010" || c.contract.PostgresVersion != "17.10" {
+		return fmt.Errorf("PostgreSQL version drift: got server_version_num %q, require 170010", versionNumber)
+	}
+	snapshotHash, err := c.databaseHMAC(ctx, tx, "snapshot:"+c.contract.SnapshotLabel)
+	if err != nil {
+		return err
+	}
+	expected := c.keyedDigest([]byte("snapshot:" + c.contract.SnapshotLabel))
+	if !hmac.Equal(snapshotHash, expected) {
+		return fmt.Errorf("typed database HMAC does not match in-process HMAC")
+	}
+	c.report = Report{
+		MappingVersion:  MappingVersion,
+		SnapshotIDHash:  hex.EncodeToString(snapshotHash),
+		PostgresVersion: c.contract.PostgresVersion,
+		Schema:          c.contract.Schema,
+		ContractSHA256:  contractHash(c.contractBytes),
+		Rejections:      []Rejection{},
+	}
+	return nil
+}
+
+func (c *Collector) databaseHMAC(ctx context.Context, tx pgx.Tx, value string) ([]byte, error) {
+	var digest []byte
+	var extensionSchema string
+	if err := tx.QueryRow(ctx, `
+		SELECT n.nspname::text
+		  FROM pg_extension e
+		  JOIN pg_namespace n ON n.oid = e.extnamespace
+		 WHERE e.extname = 'pgcrypto'::text
+	`).Scan(&extensionSchema); err != nil {
+		return nil, fmt.Errorf("resolve pgcrypto extension schema: %w", err)
+	}
+	// Every hmac argument and the result are explicitly typed. This avoids the
+	// text/bytea overload ambiguity that stopped the original field collection.
+	query := fmt.Sprintf(`
+		SELECT %s.hmac(
+			convert_to($1::text, 'UTF8'),
+			$2::bytea,
+			'sha256'::text
+		)::bytea
+	`, quoteIdentifier(extensionSchema))
+	err := tx.QueryRow(ctx, query, value, c.key).Scan(&digest)
+	if err != nil {
+		return nil, fmt.Errorf("compute typed database HMAC: %w", err)
+	}
+	return digest, nil
+}
+
+func (c *Collector) validateSchema(ctx context.Context, tx pgx.Tx) error {
+	for i := range c.contract.Tables {
+		table := &c.contract.Tables[i]
+		rows, err := tx.Query(ctx, `
+			SELECT column_name::text, data_type::text, is_nullable::text
+			  FROM information_schema.columns
+			 WHERE table_schema = $1::text
+			   AND table_name = $2::text
+			 ORDER BY ordinal_position
+		`, c.contract.Schema, table.Name)
+		if err != nil {
+			return fmt.Errorf("inspect table %s: %w", table.Name, err)
+		}
+		actual := make(map[string]schemaColumn)
+		for rows.Next() {
+			var name, dataType, nullable string
+			if err := rows.Scan(&name, &dataType, &nullable); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan schema for %s: %w", table.Name, err)
+			}
+			actual[name] = schemaColumn{dataType: dataType, nullable: nullable == "YES"}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("read schema for %s: %w", table.Name, err)
+		}
+		rows.Close()
+		if len(actual) == 0 {
+			return fmt.Errorf("schema drift: required table %s.%s is missing", c.contract.Schema, table.Name)
+		}
+		expectedNames := make(map[string]struct{}, len(table.Fields)+len(table.DeniedColumns))
+		for _, field := range table.Fields {
+			expectedNames[field.Name] = struct{}{}
+			column, ok := actual[field.Name]
+			if !ok {
+				return fmt.Errorf("schema drift: required field %s.%s is missing", table.Name, field.Name)
+			}
+			if column.dataType != field.Type || column.nullable != field.Nullable {
+				return fmt.Errorf("schema drift: field %s.%s is %s nullable=%t, require %s nullable=%t", table.Name, field.Name, column.dataType, column.nullable, field.Type, field.Nullable)
+			}
+		}
+		for _, denied := range table.DeniedColumns {
+			expectedNames[denied] = struct{}{}
+			if _, ok := actual[denied]; !ok {
+				return fmt.Errorf("schema drift: denied field %s.%s is missing", table.Name, denied)
+			}
+		}
+		if len(actual) != len(expectedNames) {
+			unknown := make([]string, 0)
+			for name := range actual {
+				if _, ok := expectedNames[name]; !ok {
+					unknown = append(unknown, name)
+				}
+			}
+			sort.Strings(unknown)
+			return fmt.Errorf("schema drift: table %s has unclassified columns %v", table.Name, unknown)
+		}
+	}
+	return nil
+}
+
+type schemaColumn struct {
+	dataType string
+	nullable bool
+}
+
+func (c *Collector) collectTables(ctx context.Context, tx pgx.Tx) error {
+	for i := range c.contract.Tables {
+		table := &c.contract.Tables[i]
+		columns := make([]string, 0, len(table.Fields))
+		for _, field := range table.Fields {
+			columns = append(columns, quoteIdentifier(field.Name))
+		}
+		query := fmt.Sprintf("SELECT %s FROM %s.%s ORDER BY %s", strings.Join(columns, ", "), quoteIdentifier(c.contract.Schema), quoteIdentifier(table.Name), quoteIdentifier(table.IDField))
+		rows, err := tx.Query(ctx, query)
+		if err != nil {
+			return fmt.Errorf("query allowlisted fields for %s: %w", table.Name, err)
+		}
+		report := TableReport{
+			Domain:        table.Domain,
+			Name:          table.Name,
+			DeniedColumns: sortedCopy(table.DeniedColumns),
+			EnumCoverage:  make(map[string]map[string]int),
+		}
+		for _, field := range table.Fields {
+			report.Fields = append(report.Fields, FieldReport{Name: field.Name, Type: field.Type, Nullable: field.Nullable, Role: field.Role})
+			if len(field.Enum) > 0 {
+				report.EnumCoverage[field.Name] = make(map[string]int)
+				for _, value := range field.Enum {
+					report.EnumCoverage[field.Name][value] = 0
+				}
+			}
+		}
+		for rows.Next() {
+			values, err := rows.Values()
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("read row for %s: %w", table.Name, err)
+			}
+			rowValues := make(map[string]any, len(table.Fields))
+			for idx, field := range table.Fields {
+				rowValues[field.Name] = normalizeValue(values[idx])
+			}
+			canonical, err := json.Marshal(rowValues)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("canonicalize row for %s: %w", table.Name, err)
+			}
+			canonical, err = jsoncanonicalizer.Transform(canonical)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("RFC 8785 canonicalize row for %s: %w", table.Name, err)
+			}
+			idValue := scalarString(rowValues[table.IDField])
+			anonymousDigest := c.keyedDigest([]byte(table.Name + ":" + idValue))
+			rowDigest := c.keyedDigest(canonical)
+			rec := record{table: table, values: rowValues, anonymousID: hex.EncodeToString(anonymousDigest), bucket: int(anonymousDigest[0]), rowHMAC: rowDigest}
+			c.records[table.Name] = append(c.records[table.Name], rec)
+			report.RowCount++
+			for _, field := range table.Fields {
+				if len(field.Enum) == 0 || rowValues[field.Name] == nil {
+					continue
+				}
+				value := scalarString(rowValues[field.Name])
+				if _, ok := report.EnumCoverage[field.Name][value]; !ok {
+					c.reject(table.Domain, table.Name, rec.anonymousID, "ENUM_UNKNOWN", "fatal", "reject", nil, false, []byte(field.Name+":"+value))
+					continue
+				}
+				report.EnumCoverage[field.Name][value]++
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterate %s: %w", table.Name, err)
+		}
+		rows.Close()
+		report.Buckets = bucketize(c.key, c.records[table.Name])
+		c.report.Tables = append(c.report.Tables, report)
+	}
+	return nil
+}
+
+func (c *Collector) keyedDigest(value []byte) []byte {
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write(value)
+	return mac.Sum(nil)
+}
+
+func normalizeValue(value any) any {
+	switch v := value.(type) {
+	case time.Time:
+		return v.UTC().Format(time.RFC3339Nano)
+	case []byte:
+		return hex.EncodeToString(v)
+	default:
+		return value
+	}
+}
+
+func scalarString(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64)
+	default:
+		encoded, _ := json.Marshal(v)
+		return string(encoded)
+	}
+}
+
+func bucketize(key []byte, records []record) []BucketReport {
+	buckets := make([][][]byte, 256)
+	for _, rec := range records {
+		buckets[rec.bucket] = append(buckets[rec.bucket], append([]byte(nil), rec.rowHMAC...))
+	}
+	reports := make([]BucketReport, 256)
+	for i := range buckets {
+		sort.Slice(buckets[i], func(a, b int) bool { return bytes.Compare(buckets[i][a], buckets[i][b]) < 0 })
+		mac := hmac.New(sha256.New, key)
+		for _, digest := range buckets[i] {
+			_, _ = mac.Write(digest)
+		}
+		reports[i] = BucketReport{Bucket: i, Count: len(buckets[i]), HMAC256: hex.EncodeToString(mac.Sum(nil))}
+	}
+	return reports
+}
+
+func (c *Collector) collectDomains() {
+	byDomain := make(map[string][]record)
+	for _, records := range c.records {
+		for _, rec := range records {
+			byDomain[rec.table.Domain] = append(byDomain[rec.table.Domain], rec)
+		}
+	}
+	domains := make([]string, 0, len(byDomain))
+	for domain := range byDomain {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+	for _, domain := range domains {
+		c.report.Domains = append(c.report.Domains, DomainReport{
+			Name:     domain,
+			RowCount: len(byDomain[domain]),
+			Buckets:  bucketize(c.key, byDomain[domain]),
+		})
+	}
+}
+
+func (c *Collector) collectUniqueViolations() {
+	for i := range c.contract.Tables {
+		table := &c.contract.Tables[i]
+		for _, unique := range table.Unique {
+			seen := make(map[string]string)
+			for _, rec := range c.records[table.Name] {
+				parts := make([]string, len(unique.Fields))
+				for idx, field := range unique.Fields {
+					parts[idx] = scalarString(rec.values[field])
+				}
+				key := strings.Join(parts, "\x00")
+				if previous, ok := seen[key]; ok {
+					c.reject(table.Domain, table.Name, rec.anonymousID, "IDENTITY_COLLISION", "fatal", "reject", []string{previous}, false, []byte(unique.Name+":"+key))
+				} else {
+					seen[key] = rec.anonymousID
+				}
+			}
+		}
+	}
+}
+
+func (c *Collector) collectReferences() {
+	for _, ref := range c.contract.References {
+		targets := make(map[string]record)
+		for _, target := range c.records[ref.ToTable] {
+			targets[recordKey(target, ref.ToFields)] = target
+		}
+		report := ReferenceReport{Name: ref.Name, Domain: ref.Domain}
+		links := make(map[string]string)
+		for _, source := range c.records[ref.FromTable] {
+			report.RowsChecked++
+			key, allNull, someNull := nullableRecordKey(source, ref.FromFields)
+			if allNull {
+				report.NullCount++
+				if !ref.AllowNull {
+					report.OrphanCount++
+					c.reject(ref.Domain, ref.FromTable, source.anonymousID, reasonForReference(ref), "fatal", "reject", nil, false, []byte(ref.Name+":null"))
+				}
+				continue
+			}
+			if someNull {
+				report.OrphanCount++
+				c.reject(ref.Domain, ref.FromTable, source.anonymousID, reasonForReference(ref), "fatal", "reject", nil, false, []byte(ref.Name+":partial-null"))
+				continue
+			}
+			target, ok := targets[key]
+			if !ok {
+				report.OrphanCount++
+				c.reject(ref.Domain, ref.FromTable, source.anonymousID, reasonForReference(ref), "fatal", "reject", nil, false, []byte(ref.Name+":"+key))
+				continue
+			}
+			if ref.FromWorkspaceField != "" && scalarString(source.values[ref.FromWorkspaceField]) != scalarString(target.values[ref.ToWorkspaceField]) {
+				report.CrossWorkspaceCount++
+				c.reject(ref.Domain, ref.FromTable, source.anonymousID, "CROSS_WORKSPACE_REF", "fatal", "reject", []string{target.anonymousID}, false, []byte(ref.Name+":"+key))
+			}
+			if ref.Acyclic {
+				links[source.anonymousID] = target.anonymousID
+			}
+		}
+		if ref.Acyclic {
+			cycles := cycleMembers(links)
+			report.CycleCount = len(cycles)
+			for _, anonymousID := range cycles {
+				c.reject(ref.Domain, ref.FromTable, anonymousID, "PARENT_CYCLE", "fatal", "reject", []string{links[anonymousID]}, false, []byte(ref.Name+":"+anonymousID))
+			}
+		}
+		c.report.References = append(c.report.References, report)
+	}
+}
+
+func (c *Collector) collectOwners() {
+	if c.contract.Owners == nil {
+		return
+	}
+	o := c.contract.Owners
+	report := &OwnerReport{WorkspacesChecked: len(c.records[o.WorkspaceTable])}
+	ownerCounts := make(map[string]int)
+	for _, member := range c.records[o.MemberTable] {
+		if scalarString(member.values[o.MemberRoleField]) == o.OwnerRole {
+			ownerCounts[scalarString(member.values[o.MemberWorkspaceField])]++
+		}
+	}
+	for _, workspace := range c.records[o.WorkspaceTable] {
+		workspaceID := scalarString(workspace.values[o.WorkspaceIDField])
+		if ownerCounts[workspaceID] == 0 {
+			report.MissingOwnerCount++
+			c.reject("identity_workspace", o.WorkspaceTable, workspace.anonymousID, "MISSING_OWNER", "fatal", "reject", nil, false, []byte("workspace-owner:"+workspaceID))
+		}
+	}
+	c.report.Owners = report
+}
+
+func reasonForReference(ref ReferenceContract) string {
+	name := strings.ToLower(ref.Name + " " + ref.Domain)
+	if strings.Contains(name, "owner") {
+		return "MISSING_OWNER"
+	}
+	if strings.Contains(name, "attachment") {
+		return "ATTACHMENT_OBJECT_MISSING"
+	}
+	return "REFERENCE_ORPHAN"
+}
+
+func recordKey(rec record, fields []string) string {
+	parts := make([]string, len(fields))
+	for i, field := range fields {
+		parts[i] = scalarString(rec.values[field])
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func nullableRecordKey(rec record, fields []string) (string, bool, bool) {
+	parts := make([]string, len(fields))
+	nullCount := 0
+	for i, field := range fields {
+		if rec.values[field] == nil {
+			nullCount++
+		} else {
+			parts[i] = scalarString(rec.values[field])
+		}
+	}
+	return strings.Join(parts, "\x00"), nullCount == len(fields), nullCount > 0 && nullCount < len(fields)
+}
+
+func cycleMembers(edges map[string]string) []string {
+	cycleSet := make(map[string]struct{})
+	for start := range edges {
+		positions := make(map[string]int)
+		path := make([]string, 0)
+		current := start
+		for current != "" {
+			if pos, ok := positions[current]; ok {
+				for _, member := range path[pos:] {
+					cycleSet[member] = struct{}{}
+				}
+				break
+			}
+			positions[current] = len(path)
+			path = append(path, current)
+			current = edges[current]
+		}
+	}
+	cycles := make([]string, 0, len(cycleSet))
+	for member := range cycleSet {
+		cycles = append(cycles, member)
+	}
+	sort.Strings(cycles)
+	return cycles
+}
+
+func (c *Collector) collectPermissions() {
+	if c.contract.Permissions == nil {
+		return
+	}
+	p := c.contract.Permissions
+	report := &PermissionReport{
+		TargetTypeCounts:  make(map[string]int),
+		ScopeCounts:       make(map[string]int),
+		ActionCounts:      make(map[string]int),
+		InheritanceCounts: make(map[string]int),
+	}
+	targetCounts := make(map[string]int)
+	agents := make(map[string]record)
+	for _, agent := range c.records[p.AgentTable] {
+		agents[scalarString(agent.values[p.AgentIDField])] = agent
+	}
+	members := make(map[string]record)
+	for _, member := range c.records[p.MemberTable] {
+		members[scalarString(member.values[p.MemberIDField])] = member
+	}
+	allowedTargets := make(map[string]struct{}, len(p.AllowedTargets))
+	for _, target := range p.AllowedTargets {
+		allowedTargets[target] = struct{}{}
+	}
+	for _, target := range c.records[p.TargetTable] {
+		targetType := scalarString(target.values[p.TargetTypeField])
+		agentID := scalarString(target.values[p.TargetAgentField])
+		targetID := scalarString(target.values[p.TargetIDField])
+		targetCounts[agentID]++
+		report.ScopeCounts[c.classifiedEnum(p.TargetTable, p.ScopeField, scalarString(target.values[p.ScopeField]))]++
+		report.ActionCounts[c.classifiedEnum(p.TargetTable, p.ActionField, scalarString(target.values[p.ActionField]))]++
+		report.InheritanceCounts[c.classifiedEnum(p.TargetTable, p.InheritanceField, scalarString(target.values[p.InheritanceField]))]++
+		if _, ok := allowedTargets[targetType]; !ok {
+			report.TargetTypeCounts["__unknown__"]++
+			c.reject("permissions", p.TargetTable, target.anonymousID, "PERMISSION_UNPROVEN", "fatal", "downgrade_private", nil, false, []byte(targetType))
+		} else {
+			report.TargetTypeCounts[targetType]++
+		}
+		agent, agentOK := agents[agentID]
+		validTarget := agentOK
+		if validTarget {
+			agentWorkspace := scalarString(agent.values[p.AgentWorkspaceField])
+			switch targetType {
+			case p.WorkspaceTargetType:
+				validTarget = targetID == agentWorkspace
+			case p.MemberTargetType:
+				member, ok := members[targetID]
+				validTarget = ok && scalarString(member.values[p.MemberWorkspaceField]) == agentWorkspace
+			default:
+				validTarget = false
+			}
+		}
+		if !validTarget {
+			report.InvalidTargetCount++
+			c.reject("permissions", p.TargetTable, target.anonymousID, "PERMISSION_UNPROVEN", "fatal", "downgrade_private", nil, false, []byte("invalid-target:"+targetType+":"+targetID))
+		}
+	}
+	for _, agent := range c.records[p.AgentTable] {
+		mode := scalarString(agent.values[p.ModeField])
+		count := targetCounts[scalarString(agent.values[p.AgentIDField])]
+		switch mode {
+		case p.PrivateMode:
+			report.PrivateCount++
+			if count > 0 {
+				report.PrivateWithTargetCount++
+				c.reject("permissions", p.AgentTable, agent.anonymousID, "PERMISSION_UNPROVEN", "fatal", "downgrade_private", nil, false, []byte("private-with-target"))
+			}
+		case p.PublicMode:
+			report.PublicToCount++
+			if count == 0 {
+				report.PublicWithoutTargetCount++
+				c.reject("permissions", p.AgentTable, agent.anonymousID, "PERMISSION_UNPROVEN", "fatal", "downgrade_private", nil, false, []byte("public-without-target"))
+			}
+		default:
+			c.reject("permissions", p.AgentTable, agent.anonymousID, "PERMISSION_UNPROVEN", "fatal", "downgrade_private", nil, false, []byte(mode))
+		}
+	}
+	c.report.Permissions = report
+}
+
+func (c *Collector) collectAttachments() error {
+	if c.contract.Attachments == nil {
+		return nil
+	}
+	a := c.contract.Attachments
+	report := &AttachmentReport{StorageTypeCounts: make(map[string]int)}
+	root, err := filepath.Abs(c.attachmentsDir)
+	if err != nil {
+		return fmt.Errorf("resolve attachments root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolve attachments root symlinks: %w", err)
+	}
+	for _, rec := range c.records[a.Table] {
+		report.RowsChecked++
+		storageType := scalarString(rec.values[a.StorageTypeField])
+		report.StorageTypeCounts[c.classifiedEnum(a.Table, a.StorageTypeField, storageType)]++
+		rel := scalarString(rec.values[a.StorageKeyField])
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			resolved, err = filepath.Abs(resolved)
+		}
+		if err == nil && resolved != root && !strings.HasPrefix(resolved, root+string(os.PathSeparator)) {
+			c.reject("attachments", a.Table, rec.anonymousID, "ATTACHMENT_PATH_ESCAPE", "fatal", "reject", nil, false, []byte(rel))
+			continue
+		}
+		if err != nil {
+			report.MissingCount++
+			c.reject("attachments", a.Table, rec.anonymousID, "ATTACHMENT_OBJECT_MISSING", "fatal", "reject", nil, true, []byte(rel))
+			continue
+		}
+		file, err := os.Open(resolved)
+		if err != nil {
+			report.MissingCount++
+			c.reject("attachments", a.Table, rec.anonymousID, "ATTACHMENT_OBJECT_MISSING", "fatal", "reject", nil, true, []byte(rel))
+			continue
+		}
+		hash := sha256.New()
+		size, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil || closeErr != nil {
+			return fmt.Errorf("hash attachment object: %v / %v", copyErr, closeErr)
+		}
+		report.TotalBytes += size
+		wantSize, err := strconv.ParseInt(scalarString(rec.values[a.SizeField]), 10, 64)
+		if err != nil || wantSize != size {
+			report.SizeMismatchCount++
+			c.reject("attachments", a.Table, rec.anonymousID, "ATTACHMENT_SIZE_MISMATCH", "fatal", "reject", nil, true, hash.Sum(nil))
+		}
+		wantHash := strings.ToLower(scalarString(rec.values[a.SHA256Field]))
+		gotHash := hex.EncodeToString(hash.Sum(nil))
+		if wantHash != gotHash {
+			report.HashMismatchCount++
+			c.reject("attachments", a.Table, rec.anonymousID, "ATTACHMENT_HASH_MISMATCH", "fatal", "reject", nil, true, hash.Sum(nil))
+		}
+	}
+	c.report.Attachments = report
+	return nil
+}
+
+func (c *Collector) collectUsage() {
+	if c.contract.Usage == nil {
+		return
+	}
+	u := c.contract.Usage
+	report := &UsageReport{UnitFields: u.UnitFields, Totals: make(map[string]string)}
+	totals := make(map[string]int64)
+	for _, rec := range c.records[u.Table] {
+		report.RowsChecked++
+		if rec.values[u.TaskField] == nil || scalarString(rec.values[u.TaskField]) == "" {
+			c.reject("usage", u.Table, rec.anonymousID, "USAGE_SEMANTICS_UNKNOWN", "fatal", "reject", nil, false, []byte("missing-task"))
+		}
+		for field := range u.UnitFields {
+			value, err := strconv.ParseInt(scalarString(rec.values[field]), 10, 64)
+			if err != nil || value < 0 {
+				c.reject("usage", u.Table, rec.anonymousID, "USAGE_SEMANTICS_UNKNOWN", "fatal", "reject", nil, false, []byte(field))
+				continue
+			}
+			totals[field] += value
+		}
+	}
+	for field, total := range totals {
+		report.Totals[field] = strconv.FormatInt(total, 10)
+	}
+	c.report.Usage = report
+}
+
+func (c *Collector) collectTasks() {
+	if c.contract.Tasks == nil {
+		return
+	}
+	t := c.contract.Tasks
+	report := &TaskReport{StatusCounts: make(map[string]int)}
+	terminal := make(map[string]struct{}, len(t.TerminalStatuses))
+	for _, status := range t.TerminalStatuses {
+		terminal[status] = struct{}{}
+	}
+	for _, rec := range c.records[t.Table] {
+		report.RowsChecked++
+		status := scalarString(rec.values[t.StatusField])
+		report.StatusCounts[c.classifiedEnum(t.Table, t.StatusField, status)]++
+		if _, ok := terminal[status]; !ok {
+			report.NonterminalCount++
+			c.reject("tasks", t.Table, rec.anonymousID, "NONTERMINAL_TASK", "fatal", "stop_snapshot", nil, true, []byte(status))
+		}
+		if t.OriginatorField != "" && rec.values[t.OriginatorField] != nil && scalarString(rec.values[t.OriginatorField]) != scalarString(rec.values[t.AccountableField]) {
+			report.AttributionInvalidCount++
+			c.reject("tasks", t.Table, rec.anonymousID, "ATTRIBUTION_INVALID", "fatal", "reject", nil, false, []byte("originator-accountable"))
+		}
+	}
+	c.report.Tasks = report
+}
+
+func (c *Collector) classifiedEnum(tableName, fieldName, value string) string {
+	for i := range c.contract.Tables {
+		if c.contract.Tables[i].Name != tableName {
+			continue
+		}
+		for _, field := range c.contract.Tables[i].Fields {
+			if field.Name != fieldName {
+				continue
+			}
+			for _, allowed := range field.Enum {
+				if value == allowed {
+					return value
+				}
+			}
+		}
+	}
+	return "__unknown__"
+}
+
+func (c *Collector) reject(domain, entityType, anonymousID, reason, severity, action string, dependencies []string, retryable bool, evidence []byte) {
+	evidenceMAC := hmac.New(sha256.New, c.key)
+	_, _ = evidenceMAC.Write(evidence)
+	c.report.Rejections = append(c.report.Rejections, Rejection{
+		MappingVersion: MappingVersion,
+		SnapshotIDHash: c.report.SnapshotIDHash,
+		Domain:         domain,
+		EntityType:     entityType,
+		AnonymousID:    anonymousID,
+		ReasonCode:     reason,
+		Severity:       severity,
+		PlannedAction:  action,
+		DependencyIDs:  append([]string(nil), dependencies...),
+		BatchID:        "collector-preflight",
+		Retryable:      retryable,
+		EvidenceHash:   hex.EncodeToString(evidenceMAC.Sum(nil)),
+	})
+}

--- a/server/internal/mapcollector/contract.go
+++ b/server/internal/mapcollector/contract.go
@@ -1,0 +1,278 @@
+package mapcollector
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+var identifierPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+var allowedFieldRoles = map[string]struct{}{
+	"": {}, "stable_id": {}, "workspace_ref": {}, "owner_ref": {},
+	"parent_ref": {}, "task_ref": {}, "ordering": {}, "enum": {},
+	"time": {}, "tombstone": {}, "storage_key": {}, "storage_type": {},
+	"size": {}, "byte_hash": {}, "usage": {}, "cost": {},
+}
+
+func LoadContract(path string) (*Contract, []byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read contract: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var contract Contract
+	if err := dec.Decode(&contract); err != nil {
+		return nil, nil, fmt.Errorf("decode contract: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, nil, fmt.Errorf("decode contract: trailing JSON value")
+		}
+		return nil, nil, fmt.Errorf("decode contract trailing data: %w", err)
+	}
+	if err := contract.Validate(); err != nil {
+		return nil, nil, err
+	}
+	canonical, err := json.Marshal(contract)
+	if err != nil {
+		return nil, nil, fmt.Errorf("canonicalize contract: %w", err)
+	}
+	canonical, err = jsoncanonicalizer.Transform(canonical)
+	if err != nil {
+		return nil, nil, fmt.Errorf("RFC 8785 canonicalize contract: %w", err)
+	}
+	return &contract, canonical, nil
+}
+
+func (c *Contract) Validate() error {
+	if c.MappingVersion != MappingVersion {
+		return fmt.Errorf("mapping_version must be %q", MappingVersion)
+	}
+	if c.SnapshotLabel == "" {
+		return fmt.Errorf("snapshot_label is required")
+	}
+	if c.PostgresVersion != "17.10" {
+		return fmt.Errorf("postgres_version must be 17.10")
+	}
+	if err := validIdentifier("schema", c.Schema); err != nil {
+		return err
+	}
+	if len(c.Tables) == 0 {
+		return fmt.Errorf("at least one table is required")
+	}
+	tables := make(map[string]*TableContract, len(c.Tables))
+	for i := range c.Tables {
+		t := &c.Tables[i]
+		if err := validIdentifier("table", t.Name); err != nil {
+			return err
+		}
+		if t.Domain == "" || t.IDField == "" || len(t.Fields) == 0 {
+			return fmt.Errorf("table %s requires domain, id_field, and fields", t.Name)
+		}
+		if _, exists := tables[t.Name]; exists {
+			return fmt.Errorf("duplicate table %s", t.Name)
+		}
+		tables[t.Name] = t
+		fields := make(map[string]struct{}, len(t.Fields))
+		for _, f := range t.Fields {
+			if err := validIdentifier("field", f.Name); err != nil {
+				return err
+			}
+			if f.Type == "" {
+				return fmt.Errorf("field %s.%s requires type", t.Name, f.Name)
+			}
+			if _, ok := allowedFieldRoles[f.Role]; !ok {
+				return fmt.Errorf("field %s.%s has unknown role %q", t.Name, f.Name, f.Role)
+			}
+			if _, exists := fields[f.Name]; exists {
+				return fmt.Errorf("duplicate field %s.%s", t.Name, f.Name)
+			}
+			fields[f.Name] = struct{}{}
+			if len(f.Enum) > 0 {
+				if err := uniqueStrings("enum "+t.Name+"."+f.Name, f.Enum); err != nil {
+					return err
+				}
+			}
+		}
+		if _, ok := fields[t.IDField]; !ok {
+			return fmt.Errorf("table %s id_field %s is not allowlisted", t.Name, t.IDField)
+		}
+		for _, denied := range t.DeniedColumns {
+			if err := validIdentifier("denied column", denied); err != nil {
+				return err
+			}
+			if _, ok := fields[denied]; ok {
+				return fmt.Errorf("field %s.%s cannot be both allowed and denied", t.Name, denied)
+			}
+		}
+		if err := uniqueStrings("denied columns for "+t.Name, t.DeniedColumns); err != nil {
+			return err
+		}
+		for _, unique := range t.Unique {
+			if unique.Name == "" || len(unique.Fields) == 0 {
+				return fmt.Errorf("table %s has invalid unique contract", t.Name)
+			}
+			if err := requireFields(t, unique.Fields); err != nil {
+				return fmt.Errorf("unique %s: %w", unique.Name, err)
+			}
+		}
+	}
+	for _, ref := range c.References {
+		if ref.Name == "" || ref.Domain == "" || len(ref.FromFields) == 0 || len(ref.FromFields) != len(ref.ToFields) {
+			return fmt.Errorf("reference %q has invalid name/domain/field arity", ref.Name)
+		}
+		from, fromOK := tables[ref.FromTable]
+		to, toOK := tables[ref.ToTable]
+		if !fromOK || !toOK {
+			return fmt.Errorf("reference %s names unknown table", ref.Name)
+		}
+		if err := requireFields(from, ref.FromFields); err != nil {
+			return fmt.Errorf("reference %s: %w", ref.Name, err)
+		}
+		if err := requireFields(to, ref.ToFields); err != nil {
+			return fmt.Errorf("reference %s: %w", ref.Name, err)
+		}
+		if (ref.FromWorkspaceField == "") != (ref.ToWorkspaceField == "") {
+			return fmt.Errorf("reference %s must specify both workspace fields", ref.Name)
+		}
+		if ref.FromWorkspaceField != "" {
+			if err := requireFields(from, []string{ref.FromWorkspaceField}); err != nil {
+				return fmt.Errorf("reference %s: %w", ref.Name, err)
+			}
+			if err := requireFields(to, []string{ref.ToWorkspaceField}); err != nil {
+				return fmt.Errorf("reference %s: %w", ref.Name, err)
+			}
+		}
+	}
+	if c.Owners != nil {
+		o := c.Owners
+		if tables[o.WorkspaceTable] == nil || tables[o.MemberTable] == nil || o.OwnerRole == "" {
+			return fmt.Errorf("owners names unknown table or empty owner_role")
+		}
+		if err := requireFields(tables[o.WorkspaceTable], []string{o.WorkspaceIDField}); err != nil {
+			return err
+		}
+		if err := requireFields(tables[o.MemberTable], []string{o.MemberWorkspaceField, o.MemberRoleField}); err != nil {
+			return err
+		}
+	}
+	if c.Permissions != nil {
+		p := c.Permissions
+		if tables[p.AgentTable] == nil || tables[p.TargetTable] == nil || tables[p.MemberTable] == nil {
+			return fmt.Errorf("permissions names unknown table")
+		}
+		if err := requireFields(tables[p.AgentTable], []string{p.AgentIDField, p.AgentWorkspaceField, p.ModeField}); err != nil {
+			return err
+		}
+		if err := requireFields(tables[p.TargetTable], []string{p.TargetAgentField, p.TargetTypeField, p.TargetIDField, p.ScopeField, p.ActionField, p.InheritanceField}); err != nil {
+			return err
+		}
+		if err := requireFields(tables[p.MemberTable], []string{p.MemberIDField, p.MemberWorkspaceField}); err != nil {
+			return err
+		}
+		if p.PrivateMode == "" || p.PublicMode == "" || p.PrivateMode == p.PublicMode || len(p.AllowedTargets) == 0 || p.WorkspaceTargetType == "" || p.MemberTargetType == "" {
+			return fmt.Errorf("permissions modes and allowed_targets are required")
+		}
+	}
+	if c.Attachments != nil {
+		a := c.Attachments
+		if tables[a.Table] == nil {
+			return fmt.Errorf("attachments names unknown table")
+		}
+		if err := requireFields(tables[a.Table], []string{a.StorageKeyField, a.StorageTypeField, a.SizeField, a.SHA256Field}); err != nil {
+			return err
+		}
+	}
+	if c.Usage != nil {
+		u := c.Usage
+		if tables[u.Table] == nil || len(u.UnitFields) == 0 {
+			return fmt.Errorf("usage table and unit_fields are required")
+		}
+		fields := []string{u.TaskField}
+		for field, unit := range u.UnitFields {
+			if unit == "" {
+				return fmt.Errorf("usage field %s requires a unit", field)
+			}
+			fields = append(fields, field)
+		}
+		if err := requireFields(tables[u.Table], fields); err != nil {
+			return err
+		}
+	}
+	if c.Tasks != nil {
+		t := c.Tasks
+		if tables[t.Table] == nil || len(t.TerminalStatuses) == 0 {
+			return fmt.Errorf("tasks table and terminal_statuses are required")
+		}
+		if err := requireFields(tables[t.Table], []string{t.StatusField}); err != nil {
+			return err
+		}
+		if (t.OriginatorField == "") != (t.AccountableField == "") {
+			return fmt.Errorf("tasks must specify both attribution fields")
+		}
+		if t.OriginatorField != "" {
+			if err := requireFields(tables[t.Table], []string{t.OriginatorField, t.AccountableField}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validIdentifier(kind, value string) error {
+	if !identifierPattern.MatchString(value) {
+		return fmt.Errorf("invalid %s identifier %q", kind, value)
+	}
+	return nil
+}
+
+func requireFields(table *TableContract, required []string) error {
+	fields := make(map[string]struct{}, len(table.Fields))
+	for _, f := range table.Fields {
+		fields[f.Name] = struct{}{}
+	}
+	for _, name := range required {
+		if _, ok := fields[name]; !ok {
+			return fmt.Errorf("field %s.%s is not allowlisted", table.Name, name)
+		}
+	}
+	return nil
+}
+
+func uniqueStrings(name string, values []string) error {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("%s contains duplicate %q", name, value)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+func contractHash(canonical []byte) string {
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:])
+}
+
+func sortedCopy(values []string) []string {
+	copyOf := append([]string(nil), values...)
+	sort.Strings(copyOf)
+	return copyOf
+}
+
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}

--- a/server/internal/mapcollector/contract_test.go
+++ b/server/internal/mapcollector/contract_test.go
@@ -1,0 +1,103 @@
+package mapcollector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadContractRejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "contract.json")
+	if err := os.WriteFile(path, []byte(`{"mapping_version":"NEW31-MAP-v1","unexpected":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadContract(path); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("expected unknown field rejection, got %v", err)
+	}
+}
+
+func TestLoadContractRejectsTrailingJSONValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "contract.json")
+	valid, err := os.ReadFile(filepath.Join("testdata", "contract.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid = append(valid, []byte(` {}`)...)
+	if err := os.WriteFile(path, valid, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadContract(path); err == nil || !strings.Contains(err.Error(), "trailing JSON value") {
+		t.Fatalf("expected trailing value rejection, got %v", err)
+	}
+}
+
+func TestReadAndDestroyKeyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.key")
+	key := []byte("0123456789abcdef0123456789abcdef")
+	if err := os.WriteFile(path, key, 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadAndDestroyKeyFile(path)
+	if err != nil {
+		t.Fatalf("ReadAndDestroyKeyFile: %v", err)
+	}
+	defer clear(got)
+	if string(got) != string(key) {
+		t.Fatalf("key changed while reading")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("key file still exists: %v", err)
+	}
+}
+
+func TestReadAndDestroyKeyFileRejectsBroadPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.key")
+	if err := os.WriteFile(path, []byte("0123456789abcdef0123456789abcdef"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAndDestroyKeyFile(path); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("expected permission rejection, got %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("rejected key file should remain for operator handling: %v", err)
+	}
+}
+
+func TestReadAndDestroyKeyFileRejectsSymlink(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.key")
+	if err := os.WriteFile(target, []byte("0123456789abcdef0123456789abcdef"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "link.key")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAndDestroyKeyFile(link); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("symlink target was modified: %v", err)
+	}
+}
+
+func TestCycleMembers(t *testing.T) {
+	got := cycleMembers(map[string]string{"a": "b", "b": "c", "c": "b", "d": ""})
+	if strings.Join(got, ",") != "b,c" {
+		t.Fatalf("cycleMembers = %v, want [b c]", got)
+	}
+}
+
+func TestLoadContractUsesRFC8785CanonicalJSON(t *testing.T) {
+	path := filepath.Join("testdata", "contract.json")
+	_, canonical, err := LoadContract(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(canonical), "\n") || strings.Contains(string(canonical), "  ") {
+		t.Fatalf("canonical contract contains presentation whitespace")
+	}
+	if !strings.HasPrefix(string(canonical), `{"attachments":`) {
+		t.Fatalf("canonical contract keys are not lexicographically ordered: %.40s", canonical)
+	}
+}

--- a/server/internal/mapcollector/integration_test.go
+++ b/server/internal/mapcollector/integration_test.go
@@ -1,0 +1,322 @@
+package mapcollector
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var fixtureKey = []byte("fixture-run-key-32-bytes-exactly!!")
+
+func TestCollectorFixtureDeterminismAndSensitiveBoundary(t *testing.T) {
+	adminURL := integrationDatabaseURL(t)
+	contract, canonical := loadFixtureContract(t)
+	first := collectFixture(t, adminURL, contract, canonical, "source")
+	second := collectFixture(t, adminURL, contract, canonical, "restore")
+
+	firstJSON, err := first.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON, err := second.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("equivalent source/restore reports differ\nsource=%s\nrestore=%s", firstJSON, secondJSON)
+	}
+	if !first.Accepted || len(first.Rejections) != 0 {
+		t.Fatalf("baseline fixture rejected: %+v", first.Rejections)
+	}
+	if first.Tasks == nil || first.Tasks.NonterminalCount != 0 || first.Tasks.AttributionInvalidCount != 0 {
+		t.Fatalf("unexpected task report: %+v", first.Tasks)
+	}
+	if first.Attachments == nil || first.Attachments.RowsChecked != 2 || first.Attachments.TotalBytes != 34 || first.Attachments.MissingCount != 0 || first.Attachments.HashMismatchCount != 0 {
+		t.Fatalf("unexpected attachment report: %+v", first.Attachments)
+	}
+	for _, table := range first.Tables {
+		if len(table.Buckets) != 256 {
+			t.Fatalf("table %s buckets = %d, want 256", table.Name, len(table.Buckets))
+		}
+		for _, bucket := range table.Buckets {
+			if len(bucket.HMAC256) != 64 {
+				t.Fatalf("table %s bucket %d digest length = %d", table.Name, bucket.Bucket, len(bucket.HMAC256))
+			}
+		}
+	}
+	if len(first.Domains) == 0 {
+		t.Fatal("domain coverage is empty")
+	}
+	for _, domain := range first.Domains {
+		if len(domain.Buckets) != 256 {
+			t.Fatalf("domain %s buckets = %d, want 256", domain.Name, len(domain.Buckets))
+		}
+	}
+	workspaceTable := findTableReport(t, first, "workspace")
+	anonymousWorkspace := keyedDigestForTest(fixtureKey, []byte("workspace:workspace-a"))
+	if workspaceTable.Buckets[int(anonymousWorkspace[0])].Count == 0 {
+		t.Fatalf("workspace-a not assigned to anonymous-ID bucket %d", anonymousWorkspace[0])
+	}
+	output := string(firstJSON)
+	for _, forbidden := range []string{"owner-a@example.invalid", "sensitive body", "secret-name.txt", "https://example.invalid", "token-do-not-output", `{"secret":"provider"}`} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("report leaked forbidden content %q", forbidden)
+		}
+	}
+	for _, requiredField := range []string{"mapping_version", "snapshot_id_hash", "enum_coverage", "orphan_count", "nonterminal_count", "storage_type_counts", "unit_fields"} {
+		if !strings.Contains(output, `"`+requiredField+`"`) {
+			t.Fatalf("report missing redacted field %q", requiredField)
+		}
+	}
+}
+
+func findTableReport(t *testing.T, report *Report, name string) TableReport {
+	t.Helper()
+	for _, table := range report.Tables {
+		if table.Name == name {
+			return table
+		}
+	}
+	t.Fatalf("table report %s not found", name)
+	return TableReport{}
+}
+
+func keyedDigestForTest(key, value []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(value)
+	return mac.Sum(nil)
+}
+
+func TestCollectorFailClosedFindings(t *testing.T) {
+	adminURL := integrationDatabaseURL(t)
+	contract, canonical := loadFixtureContract(t)
+	report := collectMutatedFixture(t, adminURL, contract, canonical, `
+		INSERT INTO map_fixture.issue VALUES
+		  ('issue-unknown', 'workspace-a', 'missing-parent', 'future_status', 99, 'do not output title', 'do not output body');
+		INSERT INTO map_fixture.task VALUES
+		  ('task-queued', 'workspace-a', 'missing-agent', 'queued', 'member-owner-a', 'member-admin-a', '', ''),
+		  ('task-dispatched', 'workspace-a', 'agent-private', 'dispatched', NULL, NULL, '', ''),
+		  ('task-running', 'workspace-a', 'agent-private', 'running', NULL, NULL, '', ''),
+		  ('task-waiting', 'workspace-a', 'agent-private', 'waiting', NULL, NULL, '', '');
+		INSERT INTO map_fixture.agent_target VALUES
+		  ('target-private', 'agent-private', 'workspace', 'workspace-a', 'invocation', 'invoke', 'none'),
+		  ('target-unknown', 'agent-public', 'future_scope', 'workspace-a', 'future_permission_scope', 'future_action', 'future_inheritance'),
+		  ('target-cross-workspace', 'agent-public', 'member', 'member-user-b', 'invocation', 'invoke', 'none');
+		INSERT INTO map_fixture.attachment VALUES
+		  ('attachment-missing', 'workspace-a', 'issue-root', 'member-owner-a', 'local', 'objects/missing.bin', 1, repeat('0', 64), 'do-not-output.bin', 'https://example.invalid/missing'),
+		  ('attachment-corrupt', 'workspace-b', 'issue-root', 'member-user-b', 'local', 'objects/object-a.bin', 999, repeat('f', 64), 'do-not-output-corrupt.bin', 'https://example.invalid/corrupt');
+		INSERT INTO map_fixture.usage VALUES
+		  ('usage-invalid', '', -1, 0, -2, 'do not output provider payload');
+		DELETE FROM map_fixture.member WHERE id = 'member-owner-b';
+	`)
+	if report.Accepted {
+		t.Fatal("mutated fixture was accepted")
+	}
+	reasons := make(map[string]int)
+	for _, rejection := range report.Rejections {
+		reasons[rejection.ReasonCode]++
+	}
+	for _, reason := range []string{
+		"ENUM_UNKNOWN", "REFERENCE_ORPHAN", "CROSS_WORKSPACE_REF", "NONTERMINAL_TASK",
+		"ATTRIBUTION_INVALID", "PERMISSION_UNPROVEN", "MISSING_OWNER", "ATTACHMENT_OBJECT_MISSING",
+		"ATTACHMENT_HASH_MISMATCH", "ATTACHMENT_SIZE_MISMATCH", "USAGE_SEMANTICS_UNKNOWN",
+	} {
+		if reasons[reason] == 0 {
+			t.Fatalf("missing rejection reason %s: %#v", reason, reasons)
+		}
+	}
+	if report.Tasks == nil || report.Tasks.NonterminalCount != 4 {
+		t.Fatalf("nonterminal task count = %+v, want 4", report.Tasks)
+	}
+	if report.Attachments == nil || report.Attachments.MissingCount != 1 || report.Attachments.HashMismatchCount != 1 || report.Attachments.SizeMismatchCount != 1 {
+		t.Fatalf("attachment failures = %+v", report.Attachments)
+	}
+	assertAllContractEnumsObserved(t, contract, report)
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"future_status", "future_scope", "do not output", "missing.bin", "https://example.invalid"} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("rejection report leaked %q", forbidden)
+		}
+	}
+}
+
+func assertAllContractEnumsObserved(t *testing.T, contract *Contract, report *Report) {
+	t.Helper()
+	for _, tableContract := range contract.Tables {
+		tableReport := findTableReport(t, report, tableContract.Name)
+		for _, field := range tableContract.Fields {
+			for _, allowed := range field.Enum {
+				if tableReport.EnumCoverage[field.Name][allowed] == 0 {
+					t.Fatalf("allowed enum %s.%s=%s was not covered", tableContract.Name, field.Name, allowed)
+				}
+			}
+		}
+	}
+}
+
+func TestCollectorRejectsAttachmentSymlinkEscape(t *testing.T) {
+	adminURL := integrationDatabaseURL(t)
+	contract, canonical := loadFixtureContract(t)
+	_, pool := fixtureDatabase(t, adminURL, "symlink_escape")
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.bin")
+	if err := os.WriteFile(outside, []byte("fixture-object-a\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape.bin")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE map_fixture.attachment
+		   SET storage_key = 'escape.bin'
+		 WHERE id = 'attachment-a'
+	`); err != nil {
+		t.Fatal(err)
+	}
+	report, err := Collect(context.Background(), pool, contract, canonical, fixtureKey, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Accepted {
+		t.Fatal("symlink escape fixture was accepted")
+	}
+	found := false
+	for _, rejection := range report.Rejections {
+		if rejection.ReasonCode == "ATTACHMENT_PATH_ESCAPE" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing ATTACHMENT_PATH_ESCAPE rejection: %+v", report.Rejections)
+	}
+}
+
+func TestCollectorRejectsSchemaDrift(t *testing.T) {
+	adminURL := integrationDatabaseURL(t)
+	contract, canonical := loadFixtureContract(t)
+	dbName, pool := fixtureDatabase(t, adminURL, "schema_drift")
+	_ = dbName
+	if _, err := pool.Exec(context.Background(), `ALTER TABLE map_fixture.workspace ADD COLUMN unclassified_secret text`); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Collect(context.Background(), pool, contract, canonical, fixtureKey, "testdata")
+	if err == nil || !strings.Contains(err.Error(), "unclassified columns") {
+		t.Fatalf("expected schema drift rejection, got %v", err)
+	}
+}
+
+func integrationDatabaseURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("MAPCOLLECTOR_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("MAPCOLLECTOR_TEST_DATABASE_URL is required for PostgreSQL 17.10 integration tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := pgx.Connect(ctx, url)
+	if err != nil {
+		t.Skipf("PostgreSQL fixture is unavailable: %v", err)
+	}
+	defer conn.Close(ctx)
+	var versionNumber string
+	if err := conn.QueryRow(ctx, `SELECT current_setting('server_version_num')`).Scan(&versionNumber); err != nil || versionNumber != "170010" {
+		t.Skipf("PostgreSQL 17.10 required, got server_version_num %q (%v)", versionNumber, err)
+	}
+	return url
+}
+
+func loadFixtureContract(t *testing.T) (*Contract, []byte) {
+	t.Helper()
+	contract, canonical, err := LoadContract(filepath.Join("testdata", "contract.json"))
+	if err != nil {
+		t.Fatalf("load fixture contract: %v", err)
+	}
+	return contract, canonical
+}
+
+func collectFixture(t *testing.T, adminURL string, contract *Contract, canonical []byte, suffix string) *Report {
+	t.Helper()
+	_, pool := fixtureDatabase(t, adminURL, suffix)
+	report, err := Collect(context.Background(), pool, contract, canonical, fixtureKey, "testdata")
+	if err != nil {
+		t.Fatalf("collect fixture: %v", err)
+	}
+	return report
+}
+
+func collectMutatedFixture(t *testing.T, adminURL string, contract *Contract, canonical []byte, mutation string) *Report {
+	t.Helper()
+	_, pool := fixtureDatabase(t, adminURL, "mutated")
+	if _, err := pool.Exec(context.Background(), mutation); err != nil {
+		t.Fatalf("mutate fixture: %v", err)
+	}
+	report, err := Collect(context.Background(), pool, contract, canonical, fixtureKey, "testdata")
+	if err != nil {
+		t.Fatalf("collect mutated fixture: %v", err)
+	}
+	return report
+}
+
+func fixtureDatabase(t *testing.T, adminURL, suffix string) (string, *pgxpool.Pool) {
+	t.Helper()
+	name := fmt.Sprintf("new31_map_%s_%d", suffix, time.Now().UnixNano())
+	ctx := context.Background()
+	admin, err := pgx.Connect(ctx, adminURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(ctx, fmt.Sprintf(`CREATE DATABASE %q`, name)); err != nil {
+		admin.Close(ctx)
+		t.Fatalf("create fixture database: %v", err)
+	}
+	admin.Close(ctx)
+	t.Cleanup(func() {
+		conn, err := pgx.Connect(context.Background(), adminURL)
+		if err != nil {
+			t.Logf("connect for cleanup: %v", err)
+			return
+		}
+		defer conn.Close(context.Background())
+		if _, err := conn.Exec(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS %q WITH (FORCE)`, name)); err != nil {
+			t.Logf("drop fixture database: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, replaceDatabase(adminURL, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	fixture, err := os.ReadFile(filepath.Join("testdata", "fixture.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(fixture)); err != nil {
+		t.Fatalf("apply fixture: %v", err)
+	}
+	return name, pool
+}
+
+func replaceDatabase(url, name string) string {
+	index := strings.LastIndex(url, "/")
+	if index < 0 {
+		return url
+	}
+	rest := url[index+1:]
+	if query := strings.Index(rest, "?"); query >= 0 {
+		return url[:index+1] + name + rest[query:]
+	}
+	return url[:index+1] + name
+}

--- a/server/internal/mapcollector/key.go
+++ b/server/internal/mapcollector/key.go
@@ -1,0 +1,63 @@
+package mapcollector
+
+import (
+	"fmt"
+	"os"
+)
+
+func ReadAndDestroyKeyFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat HMAC key file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("HMAC key path must be a regular file, not a symlink or device")
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("HMAC key file permissions must not grant group or other access")
+	}
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read HMAC key file: %w", err)
+	}
+	if len(key) < 32 {
+		clear(key)
+		return nil, fmt.Errorf("HMAC key must contain at least 32 bytes")
+	}
+	if err := destroyFile(path, info.Size()); err != nil {
+		clear(key)
+		return nil, err
+	}
+	return key, nil
+}
+
+func destroyFile(path string, size int64) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open HMAC key file for destruction: %w", err)
+	}
+	zero := make([]byte, 4096)
+	remaining := size
+	for remaining > 0 {
+		chunk := int64(len(zero))
+		if remaining < chunk {
+			chunk = remaining
+		}
+		if _, err := f.Write(zero[:chunk]); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("overwrite HMAC key file: %w", err)
+		}
+		remaining -= chunk
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync destroyed HMAC key file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close destroyed HMAC key file: %w", err)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove destroyed HMAC key file: %w", err)
+	}
+	return nil
+}

--- a/server/internal/mapcollector/testdata/contract.json
+++ b/server/internal/mapcollector/testdata/contract.json
@@ -1,0 +1,150 @@
+{
+  "mapping_version": "NEW31-MAP-v1",
+  "snapshot_label": "fixture-source-restore-equivalent",
+  "postgres_version": "17.10",
+  "schema": "map_fixture",
+  "tables": [
+    {
+      "name": "workspace",
+      "domain": "identity_workspace",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "visibility", "type": "text", "nullable": false, "role": "enum", "enum": ["private", "public"]},
+        {"name": "created_at", "type": "timestamp with time zone", "nullable": false, "role": "time"}
+      ],
+      "denied_columns": ["display_name"],
+      "unique": [{"name": "workspace_id", "fields": ["id"]}]
+    },
+    {
+      "name": "member",
+      "domain": "identity_workspace",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "role", "type": "text", "nullable": false, "role": "enum", "enum": ["owner", "admin", "member"]}
+      ],
+      "denied_columns": ["email"],
+      "unique": [{"name": "member_id", "fields": ["id"]}]
+    },
+    {
+      "name": "agent",
+      "domain": "agent_permissions",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "owner_member_id", "type": "text", "nullable": false, "role": "owner_ref"},
+        {"name": "permission_mode", "type": "text", "nullable": false, "role": "enum", "enum": ["private", "public_to"]}
+      ],
+      "denied_columns": ["instructions", "secret_config"]
+    },
+    {
+      "name": "agent_target",
+      "domain": "agent_permissions",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "agent_id", "type": "text", "nullable": false, "role": "parent_ref"},
+        {"name": "target_type", "type": "text", "nullable": false, "role": "enum", "enum": ["workspace", "member"]},
+        {"name": "target_id", "type": "text", "nullable": false, "role": "owner_ref"},
+        {"name": "scope", "type": "text", "nullable": false, "role": "enum", "enum": ["invocation"]},
+        {"name": "action", "type": "text", "nullable": false, "role": "enum", "enum": ["invoke"]},
+        {"name": "inheritance", "type": "text", "nullable": false, "role": "enum", "enum": ["none"]}
+      ],
+      "denied_columns": []
+    },
+    {
+      "name": "issue",
+      "domain": "project_issue_comment",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "parent_id", "type": "text", "nullable": true, "role": "parent_ref"},
+        {"name": "status", "type": "text", "nullable": false, "role": "enum", "enum": ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"]},
+        {"name": "position", "type": "integer", "nullable": false, "role": "ordering"}
+      ],
+      "denied_columns": ["title", "body"]
+    },
+    {
+      "name": "comment",
+      "domain": "project_issue_comment",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "issue_id", "type": "text", "nullable": false, "role": "parent_ref"},
+        {"name": "parent_id", "type": "text", "nullable": true, "role": "parent_ref"}
+      ],
+      "denied_columns": ["body"]
+    },
+    {
+      "name": "task",
+      "domain": "chat_task",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "agent_id", "type": "text", "nullable": false, "role": "owner_ref"},
+        {"name": "status", "type": "text", "nullable": false, "role": "enum", "enum": ["queued", "dispatched", "running", "waiting", "completed", "failed", "cancelled"]},
+        {"name": "originator_member_id", "type": "text", "nullable": true, "role": "owner_ref"},
+        {"name": "accountable_member_id", "type": "text", "nullable": true, "role": "owner_ref"}
+      ],
+      "denied_columns": ["result", "error_text"]
+    },
+    {
+      "name": "attachment",
+      "domain": "attachments",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "workspace_id", "type": "text", "nullable": false, "role": "workspace_ref"},
+        {"name": "issue_id", "type": "text", "nullable": false, "role": "owner_ref"},
+        {"name": "uploader_member_id", "type": "text", "nullable": false, "role": "owner_ref"},
+        {"name": "storage_type", "type": "text", "nullable": false, "role": "enum", "enum": ["local", "object"]},
+        {"name": "storage_key", "type": "text", "nullable": false, "role": "storage_key"},
+        {"name": "size_bytes", "type": "bigint", "nullable": false, "role": "size"},
+        {"name": "byte_sha256", "type": "text", "nullable": false, "role": "byte_hash"}
+      ],
+      "denied_columns": ["filename", "source_url"]
+    },
+    {
+      "name": "usage",
+      "domain": "usage",
+      "id_field": "id",
+      "fields": [
+        {"name": "id", "type": "text", "nullable": false, "role": "stable_id"},
+        {"name": "task_id", "type": "text", "nullable": false, "role": "task_ref"},
+        {"name": "input_tokens", "type": "bigint", "nullable": false, "role": "usage"},
+        {"name": "output_tokens", "type": "bigint", "nullable": false, "role": "usage"},
+        {"name": "cost_microusd", "type": "bigint", "nullable": false, "role": "cost"}
+      ],
+      "denied_columns": ["provider_payload"]
+    }
+  ],
+  "references": [
+    {"name": "member_workspace", "domain": "identity_workspace", "from_table": "member", "from_fields": ["workspace_id"], "to_table": "workspace", "to_fields": ["id"], "allow_null": false},
+    {"name": "agent_owner", "domain": "agent_permissions", "from_table": "agent", "from_fields": ["owner_member_id"], "to_table": "member", "to_fields": ["id"], "allow_null": false, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "target_agent", "domain": "agent_permissions", "from_table": "agent_target", "from_fields": ["agent_id"], "to_table": "agent", "to_fields": ["id"], "allow_null": false},
+    {"name": "issue_workspace", "domain": "project_issue_comment", "from_table": "issue", "from_fields": ["workspace_id"], "to_table": "workspace", "to_fields": ["id"], "allow_null": false},
+    {"name": "issue_parent", "domain": "project_issue_comment", "from_table": "issue", "from_fields": ["parent_id"], "to_table": "issue", "to_fields": ["id"], "allow_null": true, "acyclic": true, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "comment_issue", "domain": "project_issue_comment", "from_table": "comment", "from_fields": ["issue_id"], "to_table": "issue", "to_fields": ["id"], "allow_null": false, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "comment_parent", "domain": "project_issue_comment", "from_table": "comment", "from_fields": ["parent_id"], "to_table": "comment", "to_fields": ["id"], "allow_null": true, "acyclic": true, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "task_agent", "domain": "chat_task", "from_table": "task", "from_fields": ["agent_id"], "to_table": "agent", "to_fields": ["id"], "allow_null": false, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "attachment_issue", "domain": "attachments", "from_table": "attachment", "from_fields": ["issue_id"], "to_table": "issue", "to_fields": ["id"], "allow_null": false, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "attachment_uploader", "domain": "attachments", "from_table": "attachment", "from_fields": ["uploader_member_id"], "to_table": "member", "to_fields": ["id"], "allow_null": false, "from_workspace_field": "workspace_id", "to_workspace_field": "workspace_id"},
+    {"name": "usage_task", "domain": "usage", "from_table": "usage", "from_fields": ["task_id"], "to_table": "task", "to_fields": ["id"], "allow_null": false}
+  ],
+  "owners": {"workspace_table": "workspace", "workspace_id_field": "id", "member_table": "member", "member_workspace_field": "workspace_id", "member_role_field": "role", "owner_role": "owner"},
+  "permissions": {
+    "agent_table": "agent", "agent_id_field": "id", "agent_workspace_field": "workspace_id", "mode_field": "permission_mode", "private_mode": "private", "public_mode": "public_to",
+    "target_table": "agent_target", "target_agent_field": "agent_id", "target_type_field": "target_type", "target_id_field": "target_id",
+    "scope_field": "scope", "action_field": "action", "inheritance_field": "inheritance", "allowed_targets": ["workspace", "member"],
+    "workspace_target_type": "workspace", "member_target_type": "member", "member_table": "member", "member_id_field": "id", "member_workspace_field": "workspace_id"
+  },
+  "attachments": {"table": "attachment", "storage_key_field": "storage_key", "storage_type_field": "storage_type", "size_field": "size_bytes", "sha256_field": "byte_sha256"},
+  "usage": {"table": "usage", "task_field": "task_id", "unit_fields": {"input_tokens": "token", "output_tokens": "token", "cost_microusd": "micro_usd"}},
+  "tasks": {"table": "task", "status_field": "status", "terminal_statuses": ["completed", "failed", "cancelled"], "originator_field": "originator_member_id", "accountable_field": "accountable_member_id"}
+}

--- a/server/internal/mapcollector/testdata/fixture.sql
+++ b/server/internal/mapcollector/testdata/fixture.sql
@@ -1,0 +1,114 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SCHEMA map_fixture;
+
+CREATE TABLE map_fixture.workspace (
+  id text PRIMARY KEY,
+  visibility text NOT NULL,
+  created_at timestamptz NOT NULL,
+  display_name text NOT NULL
+);
+CREATE TABLE map_fixture.member (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  role text NOT NULL,
+  email text NOT NULL
+);
+CREATE TABLE map_fixture.agent (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  owner_member_id text NOT NULL,
+  permission_mode text NOT NULL,
+  instructions text NOT NULL,
+  secret_config text NOT NULL
+);
+CREATE TABLE map_fixture.agent_target (
+  id text PRIMARY KEY,
+  agent_id text NOT NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  scope text NOT NULL,
+  action text NOT NULL,
+  inheritance text NOT NULL
+);
+CREATE TABLE map_fixture.issue (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  parent_id text,
+  status text NOT NULL,
+  position integer NOT NULL,
+  title text NOT NULL,
+  body text NOT NULL
+);
+CREATE TABLE map_fixture.comment (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  issue_id text NOT NULL,
+  parent_id text,
+  body text NOT NULL
+);
+CREATE TABLE map_fixture.task (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  agent_id text NOT NULL,
+  status text NOT NULL,
+  originator_member_id text,
+  accountable_member_id text,
+  result text NOT NULL,
+  error_text text NOT NULL
+);
+CREATE TABLE map_fixture.attachment (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL,
+  issue_id text NOT NULL,
+  uploader_member_id text NOT NULL,
+  storage_type text NOT NULL,
+  storage_key text NOT NULL,
+  size_bytes bigint NOT NULL,
+  byte_sha256 text NOT NULL,
+  filename text NOT NULL,
+  source_url text NOT NULL
+);
+CREATE TABLE map_fixture.usage (
+  id text PRIMARY KEY,
+  task_id text NOT NULL,
+  input_tokens bigint NOT NULL,
+  output_tokens bigint NOT NULL,
+  cost_microusd bigint NOT NULL,
+  provider_payload text NOT NULL
+);
+
+INSERT INTO map_fixture.workspace VALUES
+  ('workspace-a', 'private', '2026-01-01T00:00:00Z', 'sensitive workspace alpha'),
+  ('workspace-b', 'public', '2026-01-02T00:00:00Z', 'sensitive workspace beta');
+INSERT INTO map_fixture.member VALUES
+  ('member-owner-a', 'workspace-a', 'owner', 'owner-a@example.invalid'),
+  ('member-admin-a', 'workspace-a', 'admin', 'admin-a@example.invalid'),
+  ('member-owner-b', 'workspace-b', 'owner', 'owner-b@example.invalid'),
+  ('member-user-b', 'workspace-b', 'member', 'user-b@example.invalid');
+INSERT INTO map_fixture.agent VALUES
+  ('agent-private', 'workspace-a', 'member-owner-a', 'private', 'private instructions', 'token-do-not-output'),
+  ('agent-public', 'workspace-a', 'member-owner-a', 'public_to', 'public instructions', 'secret-do-not-output');
+INSERT INTO map_fixture.agent_target VALUES
+  ('target-workspace', 'agent-public', 'workspace', 'workspace-a', 'invocation', 'invoke', 'none'),
+  ('target-member', 'agent-public', 'member', 'member-admin-a', 'invocation', 'invoke', 'none');
+INSERT INTO map_fixture.issue VALUES
+  ('issue-root', 'workspace-a', NULL, 'done', 1, 'sensitive title root', 'sensitive body root'),
+  ('issue-child', 'workspace-a', 'issue-root', 'cancelled', 2, 'sensitive title child', 'sensitive body child'),
+  ('issue-other', 'workspace-b', NULL, 'backlog', 1, 'sensitive title other', 'sensitive body other'),
+  ('issue-todo', 'workspace-a', NULL, 'todo', 3, 'sensitive title todo', 'sensitive body todo'),
+  ('issue-progress', 'workspace-a', NULL, 'in_progress', 4, 'sensitive title progress', 'sensitive body progress'),
+  ('issue-review', 'workspace-a', NULL, 'in_review', 5, 'sensitive title review', 'sensitive body review'),
+  ('issue-blocked', 'workspace-a', NULL, 'blocked', 6, 'sensitive title blocked', 'sensitive body blocked');
+INSERT INTO map_fixture.comment VALUES
+  ('comment-root', 'workspace-a', 'issue-root', NULL, 'sensitive comment root'),
+  ('comment-reply', 'workspace-a', 'issue-root', 'comment-root', 'sensitive comment reply');
+INSERT INTO map_fixture.task VALUES
+  ('task-done', 'workspace-a', 'agent-private', 'completed', 'member-owner-a', 'member-owner-a', 'sensitive result', ''),
+  ('task-failed', 'workspace-a', 'agent-public', 'failed', 'member-admin-a', 'member-admin-a', '', 'sensitive failure'),
+  ('task-cancelled', 'workspace-a', 'agent-private', 'cancelled', NULL, NULL, '', '');
+INSERT INTO map_fixture.attachment VALUES
+  ('attachment-a', 'workspace-a', 'issue-root', 'member-owner-a', 'local', 'objects/object-a.bin', 17, '11a94902119a24aebe4fa998e6a647a27328f23cc256af89909695db24bce211', 'secret-name.txt', 'https://example.invalid/private/object'),
+  ('attachment-b', 'workspace-a', 'issue-child', 'member-admin-a', 'object', 'objects/object-a.bin', 17, '11a94902119a24aebe4fa998e6a647a27328f23cc256af89909695db24bce211', 'another-secret.bin', 'https://example.invalid/private/object-b');
+INSERT INTO map_fixture.usage VALUES
+  ('usage-a', 'task-done', 100, 20, 12345, '{"secret":"provider"}'),
+  ('usage-b', 'task-failed', 10, 5, 456, '{"secret":"provider"}');

--- a/server/internal/mapcollector/testdata/objects/object-a.bin
+++ b/server/internal/mapcollector/testdata/objects/object-a.bin
@@ -1,0 +1,1 @@
+fixture-object-a

--- a/server/internal/mapcollector/types.go
+++ b/server/internal/mapcollector/types.go
@@ -1,0 +1,230 @@
+package mapcollector
+
+import "encoding/json"
+
+const MappingVersion = "NEW31-MAP-v1"
+
+type Contract struct {
+	MappingVersion  string              `json:"mapping_version"`
+	SnapshotLabel   string              `json:"snapshot_label"`
+	PostgresVersion string              `json:"postgres_version"`
+	Schema          string              `json:"schema"`
+	Tables          []TableContract     `json:"tables"`
+	References      []ReferenceContract `json:"references"`
+	Owners          *OwnerContract      `json:"owners,omitempty"`
+	Permissions     *PermissionContract `json:"permissions,omitempty"`
+	Attachments     *AttachmentContract `json:"attachments,omitempty"`
+	Usage           *UsageContract      `json:"usage,omitempty"`
+	Tasks           *TaskContract       `json:"tasks,omitempty"`
+}
+
+type TableContract struct {
+	Name          string           `json:"name"`
+	Domain        string           `json:"domain"`
+	IDField       string           `json:"id_field"`
+	Fields        []FieldContract  `json:"fields"`
+	DeniedColumns []string         `json:"denied_columns"`
+	Unique        []UniqueContract `json:"unique,omitempty"`
+}
+
+type FieldContract struct {
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Nullable bool     `json:"nullable"`
+	Role     string   `json:"role,omitempty"`
+	Enum     []string `json:"enum,omitempty"`
+}
+
+type UniqueContract struct {
+	Name   string   `json:"name"`
+	Fields []string `json:"fields"`
+}
+
+type ReferenceContract struct {
+	Name               string   `json:"name"`
+	Domain             string   `json:"domain"`
+	FromTable          string   `json:"from_table"`
+	FromFields         []string `json:"from_fields"`
+	ToTable            string   `json:"to_table"`
+	ToFields           []string `json:"to_fields"`
+	AllowNull          bool     `json:"allow_null"`
+	Acyclic            bool     `json:"acyclic,omitempty"`
+	FromWorkspaceField string   `json:"from_workspace_field,omitempty"`
+	ToWorkspaceField   string   `json:"to_workspace_field,omitempty"`
+}
+
+type PermissionContract struct {
+	AgentTable           string   `json:"agent_table"`
+	AgentIDField         string   `json:"agent_id_field"`
+	AgentWorkspaceField  string   `json:"agent_workspace_field"`
+	ModeField            string   `json:"mode_field"`
+	PrivateMode          string   `json:"private_mode"`
+	PublicMode           string   `json:"public_mode"`
+	TargetTable          string   `json:"target_table"`
+	TargetAgentField     string   `json:"target_agent_field"`
+	TargetTypeField      string   `json:"target_type_field"`
+	TargetIDField        string   `json:"target_id_field"`
+	ScopeField           string   `json:"scope_field"`
+	ActionField          string   `json:"action_field"`
+	InheritanceField     string   `json:"inheritance_field"`
+	AllowedTargets       []string `json:"allowed_targets"`
+	WorkspaceTargetType  string   `json:"workspace_target_type"`
+	MemberTargetType     string   `json:"member_target_type"`
+	MemberTable          string   `json:"member_table"`
+	MemberIDField        string   `json:"member_id_field"`
+	MemberWorkspaceField string   `json:"member_workspace_field"`
+}
+
+type OwnerContract struct {
+	WorkspaceTable       string `json:"workspace_table"`
+	WorkspaceIDField     string `json:"workspace_id_field"`
+	MemberTable          string `json:"member_table"`
+	MemberWorkspaceField string `json:"member_workspace_field"`
+	MemberRoleField      string `json:"member_role_field"`
+	OwnerRole            string `json:"owner_role"`
+}
+
+type AttachmentContract struct {
+	Table            string `json:"table"`
+	StorageKeyField  string `json:"storage_key_field"`
+	StorageTypeField string `json:"storage_type_field"`
+	SizeField        string `json:"size_field"`
+	SHA256Field      string `json:"sha256_field"`
+}
+
+type UsageContract struct {
+	Table      string            `json:"table"`
+	TaskField  string            `json:"task_field"`
+	UnitFields map[string]string `json:"unit_fields"`
+}
+
+type TaskContract struct {
+	Table            string   `json:"table"`
+	StatusField      string   `json:"status_field"`
+	TerminalStatuses []string `json:"terminal_statuses"`
+	OriginatorField  string   `json:"originator_field,omitempty"`
+	AccountableField string   `json:"accountable_field,omitempty"`
+}
+
+type Report struct {
+	MappingVersion  string            `json:"mapping_version"`
+	SnapshotIDHash  string            `json:"snapshot_id_hash"`
+	PostgresVersion string            `json:"postgres_version"`
+	Schema          string            `json:"schema"`
+	ContractSHA256  string            `json:"contract_sha256"`
+	Domains         []DomainReport    `json:"domains"`
+	Tables          []TableReport     `json:"tables"`
+	References      []ReferenceReport `json:"references"`
+	Permissions     *PermissionReport `json:"permissions,omitempty"`
+	Owners          *OwnerReport      `json:"owners,omitempty"`
+	Attachments     *AttachmentReport `json:"attachments,omitempty"`
+	Usage           *UsageReport      `json:"usage,omitempty"`
+	Tasks           *TaskReport       `json:"tasks,omitempty"`
+	Rejections      []Rejection       `json:"rejections"`
+	Accepted        bool              `json:"accepted"`
+}
+
+type TableReport struct {
+	Domain        string                    `json:"domain"`
+	Name          string                    `json:"name"`
+	RowCount      int                       `json:"row_count"`
+	Fields        []FieldReport             `json:"fields"`
+	DeniedColumns []string                  `json:"denied_columns"`
+	EnumCoverage  map[string]map[string]int `json:"enum_coverage,omitempty"`
+	Buckets       []BucketReport            `json:"buckets"`
+}
+
+type DomainReport struct {
+	Name     string         `json:"name"`
+	RowCount int            `json:"row_count"`
+	Buckets  []BucketReport `json:"buckets"`
+}
+
+type FieldReport struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Nullable bool   `json:"nullable"`
+	Role     string `json:"role,omitempty"`
+}
+
+type BucketReport struct {
+	Bucket  int    `json:"bucket"`
+	Count   int    `json:"count"`
+	HMAC256 string `json:"hmac_sha256"`
+}
+
+type ReferenceReport struct {
+	Name                string `json:"name"`
+	Domain              string `json:"domain"`
+	RowsChecked         int    `json:"rows_checked"`
+	NullCount           int    `json:"null_count"`
+	OrphanCount         int    `json:"orphan_count"`
+	CrossWorkspaceCount int    `json:"cross_workspace_count"`
+	CycleCount          int    `json:"cycle_count"`
+}
+
+type PermissionReport struct {
+	PrivateCount             int            `json:"private_count"`
+	PublicToCount            int            `json:"public_to_count"`
+	TargetTypeCounts         map[string]int `json:"target_type_counts"`
+	PrivateWithTargetCount   int            `json:"private_with_target_count"`
+	PublicWithoutTargetCount int            `json:"public_without_target_count"`
+	InvalidTargetCount       int            `json:"invalid_target_count"`
+	ScopeCounts              map[string]int `json:"scope_counts"`
+	ActionCounts             map[string]int `json:"action_counts"`
+	InheritanceCounts        map[string]int `json:"inheritance_counts"`
+}
+
+type OwnerReport struct {
+	WorkspacesChecked int `json:"workspaces_checked"`
+	MissingOwnerCount int `json:"missing_owner_count"`
+}
+
+type AttachmentReport struct {
+	RowsChecked       int            `json:"rows_checked"`
+	StorageTypeCounts map[string]int `json:"storage_type_counts"`
+	TotalBytes        int64          `json:"total_bytes"`
+	MissingCount      int            `json:"missing_count"`
+	HashMismatchCount int            `json:"hash_mismatch_count"`
+	SizeMismatchCount int            `json:"size_mismatch_count"`
+}
+
+type UsageReport struct {
+	RowsChecked int               `json:"rows_checked"`
+	UnitFields  map[string]string `json:"unit_fields"`
+	Totals      map[string]string `json:"totals"`
+}
+
+type TaskReport struct {
+	RowsChecked             int            `json:"rows_checked"`
+	StatusCounts            map[string]int `json:"status_counts"`
+	NonterminalCount        int            `json:"nonterminal_count"`
+	AttributionInvalidCount int            `json:"attribution_invalid_count"`
+}
+
+type Rejection struct {
+	MappingVersion string   `json:"mapping_version"`
+	SnapshotIDHash string   `json:"snapshot_id_hash"`
+	Domain         string   `json:"domain"`
+	EntityType     string   `json:"entity_type"`
+	AnonymousID    string   `json:"anonymous_id,omitempty"`
+	ReasonCode     string   `json:"reason_code"`
+	Severity       string   `json:"severity"`
+	PlannedAction  string   `json:"planned_action"`
+	DependencyIDs  []string `json:"anonymous_dependency_ids"`
+	BatchID        string   `json:"batch_id"`
+	Retryable      bool     `json:"retryable"`
+	EvidenceHash   string   `json:"evidence_hash"`
+}
+
+type record struct {
+	table       *TableContract
+	values      map[string]any
+	anonymousID string
+	bucket      int
+	rowHMAC     []byte
+}
+
+func (r *Report) Marshal() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}


### PR DESCRIPTION
## Summary

Adds the offline NEW31-MAP-v1 source collector and its fixtures/tests for controlled migration analysis.

## Validation

- Local implementation checks completed on the fixed head.
- Runtime and deployment execution remain gated by architecture and test review.