### PR TITLE
fix(daemon): recover in-flight tasks when a runtime deregisters

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -907,6 +907,9 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 	// Track affected workspaces for WS notifications.
 	affectedWorkspaces := make(map[string]bool)
 
+	// Tasks still in flight on the runtimes going away, recovered below.
+	var orphaned []db.AgentTaskQueue
+
 	for i, rid := range req.RuntimeIDs {
 		// Look up the runtime and verify ownership.
 		rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUIDs[i])
@@ -925,6 +928,35 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("deregister: failed to set offline", "runtime_id", rid, "error", err)
 			continue
 		}
+
+		// Recover whatever this runtime was still executing. Deregistration is
+		// the one moment the server knows for certain that a runtime is going
+		// away, and until now it dropped that knowledge on the floor: the
+		// runtime went offline and its dispatched/running tasks were left
+		// behind, with nothing marking them failed and nothing retrying them.
+		//
+		// The startup path already does this — the daemon calls
+		// POST /runtimes/{id}/recover-orphans and RecoverOrphanedTasks funnels
+		// the rows through HandleFailedTasks for the retry. But that only
+		// rescues a task if the SAME runtime id comes back to ask for it, and
+		// a daemon that is replaced rather than restarted re-registers under
+		// fresh ids: a new host, a new container, a wiped state directory. The
+		// orphans stay pinned to ids nobody will ever query again, and the only
+		// thing that eventually notices is the stale-task sweeper, up to a
+		// 2.5h in-process timeout later.
+		//
+		// Doing it here closes the asymmetry with the same query and the same
+		// post-failure pipeline, so a graceful shutdown — which is what a
+		// rolling deploy or a scale-down is — costs a retry instead of a lost
+		// task.
+		rows, err := h.Queries.RecoverOrphanedTasksForRuntime(r.Context(), rt.ID)
+		if err != nil {
+			// Not fatal: the runtime is already offline, and the stale-task
+			// sweeper remains as the backstop it has always been.
+			slog.Warn("deregister: recover orphans failed", "runtime_id", rid, "error", err)
+		} else {
+			orphaned = append(orphaned, rows...)
+		}
 		obsmetrics.RecordEvent(h.Analytics, h.Metrics, analytics.RuntimeOffline(
 			uuidToString(rt.OwnerID),
 			wsID,
@@ -936,6 +968,14 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 		affectedWorkspaces[wsID] = true
 	}
 
+	// Same shared pipeline RecoverOrphanedTasks uses: task:failed events, agent
+	// status reconcile, issue rollback, and auto-retry for the reasons
+	// retryableReasons allows — runtime_recovery among them.
+	retried := 0
+	if len(orphaned) > 0 {
+		retried = h.TaskService.HandleFailedTasks(r.Context(), orphaned)
+	}
+
 	// Notify frontend clients so they re-fetch runtime list.
 	for wsID := range affectedWorkspaces {
 		h.publish(protocol.EventDaemonRegister, wsID, "system", "", map[string]any{
@@ -943,8 +983,16 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	slog.Info("daemon deregistered", "runtime_ids", req.RuntimeIDs)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	slog.Info("daemon deregistered",
+		"runtime_ids", req.RuntimeIDs,
+		"orphaned", len(orphaned),
+		"retried", retried,
+	)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "ok",
+		"orphaned": len(orphaned),
+		"retried":  retried,
+	})
 }
 
 type DaemonHeartbeatRequest struct {


### PR DESCRIPTION
## The gap

`DaemonDeregister` is the one moment the server knows for certain that a runtime is going away. Today it flips the runtime offline and drops that knowledge on the floor — whatever the runtime was executing stays `dispatched`/`running` with no failure, no `task:failed` event, no agent-status reconcile, and no retry.

The startup path already does the right thing. The daemon calls `POST /runtimes/{id}/recover-orphans`; `RecoverOrphanedTasksForRuntime` fails the leftovers with `failure_reason = 'runtime_recovery'`; `HandleFailedTasks` funnels them into the auto-retry that `retryableReasons` already permits.

**That only rescues a task if the same runtime id comes back to ask for it.** A daemon that is *replaced* rather than restarted re-registers under fresh ids — a new host, a new container, a wiped state directory — and the orphans stay pinned to ids nobody will ever query again. The only thing that eventually notices is the stale-task sweeper, up to a 2.5h in-process timeout later.

## How we hit it

We moved a daemon from a long-lived VM onto Kubernetes. Every rolling deploy silently dropped whatever was mid-flight: the replacement pod always comes up with new runtime ids, so `recover-orphans` at startup has nothing to find, and the previous pod's in-flight tasks are stranded.

Our daemon is never idle in practice — sampling every 30s for 24h, exactly one 30-second window had nothing running — so "restart when quiet" is not available to us as a workaround, and `terminationGracePeriodSeconds` buys nothing because the daemon deregisters and exits rather than draining.

## The change

In the deregister loop, after `SetAgentRuntimeOffline`, run the same `RecoverOrphanedTasksForRuntime` query and hand the rows to `TaskService.HandleFailedTasks` — the identical pipeline `RecoverOrphanedTasks` uses. A graceful shutdown now costs a retry instead of a lost task.

Deliberately unchanged:

- **Best-effort.** A failed recovery is logged and skipped; the runtime is already offline and the stale-task sweeper remains the backstop it has always been.
- **No new failure reason.** `runtime_recovery` already exists, is already in `retryableReasons`, and already describes exactly this.
- **No change to retry policy.** Autopilot tasks, exhausted budgets and non-retryable reasons are filtered by `retryEligible` as before.

The response now returns `orphaned`/`retried` counts, mirroring `RecoverOrphanedTasks`.

## Testing

`go build` and `go vet` clean; `go test ./internal/handler/` passes.

I did not add a test, and I want to flag that rather than leave it implicit: `internal/handler`'s suite needs a live Postgres (`TestMain` skips without `DATABASE_URL`), and the sibling path this mirrors — `RecoverOrphanedTasks` — has no test either, so there is no existing fixture to extend. I would rather not submit a DB-backed test I could not execute. Happy to add one if you point me at the pattern you would want.
