### PR TITLE
MUL-6102: fix(daemon): surface which HERMES_HOME a Hermes task actually read

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6886,15 +6886,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			// fact.
 			failureReason = taskfailure.Classify(errMsg).String()
 		}
-		// Strictly after every classifier above has read errMsg. The
-		// annotation embeds two filesystem paths, and Classify matches
-		// substrings anywhere in the text, so annotating earlier would let a
-		// directory name pick the failure_reason: a home under
-		// /srv/token-cache/limit/ satisfies rule 1 (context overflow), which
-		// is evaluated before rule 2 (missing config) and feeds retry
-		// eligibility and resume blacklisting. This is for the human reading
-		// the task; it must not decide where the failure is filed.
-		errMsg = annotateHermesProviderUnconfigured(errMsg, provider, env.HermesHome, hermesSourceHome)
+		// After the classifiers above have read errMsg. The hint is fixed
+		// prose chosen to match none of the resume guards (see its const), so
+		// ordering is not what makes it safe — but it keeps the machine
+		// decisions reading exactly what the runtime reported, and leaves the
+		// annotation on the outside where a future edit is visibly a change to
+		// human-facing text rather than to classifier input.
+		errMsg = annotateHermesProviderUnconfigured(errMsg, provider, env.HermesHome != "")
 		return TaskResult{
 			Status:        "blocked",
 			Comment:       errMsg,
@@ -7930,29 +7928,47 @@ func hermesLaunchArgs(customArgs []string, overlayActive bool) []string {
 	return agent.StripHermesProfileArgs(customArgs, sel)
 }
 
-// annotateHermesProviderUnconfigured appends the two Hermes homes this task
-// actually used to a "no LLM provider configured" failure.
+// hermesProviderUnconfiguredHint is appended verbatim to a "no LLM provider
+// configured" failure. It is a CONSTANT, and that is a correctness property,
+// not a style choice — see annotateHermesProviderUnconfigured.
 //
-// Hermes reports that failure against whichever HERMES_HOME it was started
-// with and tells the user to run `hermes model` — but under Multica it was
-// started with a per-task overlay, seeded from a source home the daemon
-// resolved from ITS OWN process environment. When those two disagree with
-// where the user keeps their config, the remedy Hermes names edits a file the
-// task will never read, and every attempt fails identically. That is GH #6872:
-// eight documented workarounds, none of which could have worked, because
-// nothing on the failure path named the directory being read.
+// It must stay clear of every phrase the resume guards match, because this text
+// is persisted in agent_task_queue.error and re-scanned there indefinitely:
+// service.ResumeUnsafeFailure, taskfailure.Classify, and the ILIKE/regex guards
+// in pkg/db/queries/agent.sql (GetLastTaskSession / GetLastChatTaskSession).
+// TestAnnotationCannotChangeMachineDecisions pins that.
+const hermesProviderUnconfiguredHint = " [multica] hermes did not read the HERMES_HOME your shell uses: " +
+	"this task ran against a per-task overlay, seeded from the home the daemon process resolved. " +
+	"The daemon log line \"hermes home resolved\" for this task names that source home — if your hermes " +
+	"config lives somewhere else, set HERMES_HOME in the agent's custom_env to point at it."
+
+// annotateHermesProviderUnconfigured explains a "no LLM provider configured"
+// failure that Hermes itself cannot explain.
 //
-// Text only — the caller has already classified the failure, and this
-// deliberately does not change the reason, the status, or the control flow.
-// Both values are paths the daemon itself derived, never credentials.
-func annotateHermesProviderUnconfigured(errMsg, provider, overlayHome, sourceHome string) string {
-	if provider != "hermes" || overlayHome == "" || !taskfailure.ProviderUnconfigured(errMsg) {
+// Hermes reports it against whichever HERMES_HOME it was started with and tells
+// the user to run `hermes model` — but under Multica it was started with a
+// per-task overlay, seeded from a source home the daemon resolved from ITS OWN
+// process environment. When that disagrees with where the user keeps their
+// config, the remedy Hermes names edits a file the task will never read, and
+// every attempt fails identically. That is GH #6872: eight documented
+// workarounds, none of which could have worked.
+//
+// The two paths themselves are deliberately NOT interpolated here. They are
+// user-controlled (HERMES_HOME comes from the agent's custom_env, the overlay
+// root from MULTICA_WORKSPACES_ROOT), and this string is persisted as the
+// task's error text, which the resume guards keep matching against for the life
+// of the row. A source home under /srv/400-invalid_request_error/ would trip
+// ResumeUnsafeFailure and the SQL guard, dropping a healthy session pointer —
+// a directory name must never decide whether a session can be resumed. So the
+// hint is fixed prose and names the log line that does carry the paths.
+//
+// Text only: the caller has already classified the failure, and this changes no
+// reason, status, or control flow.
+func annotateHermesProviderUnconfigured(errMsg, provider string, overlayActive bool) string {
+	if provider != "hermes" || !overlayActive || !taskfailure.ProviderUnconfigured(errMsg) {
 		return errMsg
 	}
-	return fmt.Sprintf(
-		"%s [multica] hermes ran with HERMES_HOME=%s, a per-task overlay seeded from %s. "+
-			"If your hermes config lives elsewhere, point the agent at it by setting HERMES_HOME in its custom_env.",
-		errMsg, overlayHome, sourceHome)
+	return errMsg + hermesProviderUnconfiguredHint
 }
 
 func layerCustomEnvAndHermesHome(agentEnv, customEnv map[string]string, overlayHome string, logger *slog.Logger) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6077,6 +6077,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}
 		hermesSourceHome = res.SourceHome
 		hermesSourceMustExist = res.MustExist
+		// Which home the overlay is seeded from decides whether the task sees
+		// the user's provider config at all, and it is derived from the daemon
+		// PROCESS environment — invisible from the shell the user tests
+		// `hermes acp` in, which is why a mismatch reads as "works by hand,
+		// fails under Multica" (GH #6872). One line, at Info, so the answer is
+		// in the daemon log before anything fails rather than reconstructed
+		// afterwards.
+		taskLog.Info("hermes home resolved",
+			"source_home", hermesSourceHome,
+			"from_custom_env", strings.TrimSpace(agentEnvOverrides["HERMES_HOME"]) != "",
+			"must_exist", hermesSourceMustExist,
+		)
 		hermesEnv = sanitizeAgentEnv(agentEnvOverrides)
 		if hermesEnv == nil {
 			hermesEnv = map[string]string{}
@@ -6874,6 +6886,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			// fact.
 			failureReason = taskfailure.Classify(errMsg).String()
 		}
+		// Strictly after every classifier above has read errMsg. The
+		// annotation embeds two filesystem paths, and Classify matches
+		// substrings anywhere in the text, so annotating earlier would let a
+		// directory name pick the failure_reason: a home under
+		// /srv/token-cache/limit/ satisfies rule 1 (context overflow), which
+		// is evaluated before rule 2 (missing config) and feeds retry
+		// eligibility and resume blacklisting. This is for the human reading
+		// the task; it must not decide where the failure is filed.
+		errMsg = annotateHermesProviderUnconfigured(errMsg, provider, env.HermesHome, hermesSourceHome)
 		return TaskResult{
 			Status:        "blocked",
 			Comment:       errMsg,
@@ -7907,6 +7928,31 @@ func hermesLaunchArgs(customArgs []string, overlayActive bool) []string {
 	// stripping never diverge.
 	sel := agent.ParseHermesProfileArgs(customArgs)
 	return agent.StripHermesProfileArgs(customArgs, sel)
+}
+
+// annotateHermesProviderUnconfigured appends the two Hermes homes this task
+// actually used to a "no LLM provider configured" failure.
+//
+// Hermes reports that failure against whichever HERMES_HOME it was started
+// with and tells the user to run `hermes model` — but under Multica it was
+// started with a per-task overlay, seeded from a source home the daemon
+// resolved from ITS OWN process environment. When those two disagree with
+// where the user keeps their config, the remedy Hermes names edits a file the
+// task will never read, and every attempt fails identically. That is GH #6872:
+// eight documented workarounds, none of which could have worked, because
+// nothing on the failure path named the directory being read.
+//
+// Text only — the caller has already classified the failure, and this
+// deliberately does not change the reason, the status, or the control flow.
+// Both values are paths the daemon itself derived, never credentials.
+func annotateHermesProviderUnconfigured(errMsg, provider, overlayHome, sourceHome string) string {
+	if provider != "hermes" || overlayHome == "" || !taskfailure.ProviderUnconfigured(errMsg) {
+		return errMsg
+	}
+	return fmt.Sprintf(
+		"%s [multica] hermes ran with HERMES_HOME=%s, a per-task overlay seeded from %s. "+
+			"If your hermes config lives elsewhere, point the agent at it by setting HERMES_HOME in its custom_env.",
+		errMsg, overlayHome, sourceHome)
 }
 
 func layerCustomEnvAndHermesHome(agentEnv, customEnv map[string]string, overlayHome string, logger *slog.Logger) {

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -647,6 +647,23 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("read shared config: %w", err)
 		}
+		// The overlay is about to be seeded from a home that carries no
+		// provider config, so the task runs with whatever the child's
+		// environment supplies and nothing else. That is a legitimate setup
+		// (an image that ships Hermes and injects OPENAI_API_KEY has no
+		// config.yaml and works fine), which is why this stays a warning
+		// rather than a hard failure — but when it is instead a source-home
+		// misresolution, this line is the only place the two paths can be
+		// told apart, and until GH #6872 it printed nothing at all. Name the
+		// source home: the user's own config is somewhere else, and Hermes'
+		// own error ("run `hermes model`") cannot say where.
+		if fi, statErr := os.Stat(sharedHome); statErr != nil || !fi.IsDir() {
+			logger.Warn("execenv: hermes source home does not exist; this task runs WITHOUT the user's provider config or credentials",
+				"source_home", sharedHome)
+		} else {
+			logger.Warn("execenv: hermes source home has no config.yaml; this task runs without a configured provider unless credentials come from the environment",
+				"source_home", sharedHome)
+		}
 		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}}
 		if err := setHermesExternalDirs(doc, computeHermesExternalDirs(sharedHome, nil, env)); err != nil {
 			return err

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -658,11 +658,11 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 		// source home: the user's own config is somewhere else, and Hermes'
 		// own error ("run `hermes model`") cannot say where.
 		if fi, statErr := os.Stat(sharedHome); statErr != nil || !fi.IsDir() {
-			logger.Warn("execenv: hermes source home does not exist; this task runs WITHOUT the user's provider config or credentials",
-				"source_home", sharedHome)
+			logger.Warn("execenv: hermes source home does not exist; this task runs without file-backed provider config or credentials, though the environment may still supply them",
+				"source_home", sharedHome, "overlay_home", hermesHome)
 		} else {
-			logger.Warn("execenv: hermes source home has no config.yaml; this task runs without a configured provider unless credentials come from the environment",
-				"source_home", sharedHome)
+			logger.Warn("execenv: hermes source home has no config.yaml; this task runs without a configured provider unless the environment supplies one",
+				"source_home", sharedHome, "overlay_home", hermesHome)
 		}
 		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}}
 		if err := setHermesExternalDirs(doc, computeHermesExternalDirs(sharedHome, nil, env)); err != nil {

--- a/server/internal/daemon/execenv/hermes_home_config_warn_test.go
+++ b/server/internal/daemon/execenv/hermes_home_config_warn_test.go
@@ -1,0 +1,117 @@
+package execenv
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLogger returns a logger writing into buf, for asserting on the
+// warnings the overlay build emits.
+func captureLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// TestHermesOverlayWarnsWhenSourceHomeCarriesNoConfig covers the failure shape
+// behind GH #6872: the overlay is seeded from a home holding no config.yaml, so
+// the task starts with none of the user's provider settings and Hermes refuses
+// with "No LLM provider configured" — pointing the user at `hermes model`,
+// which edits a home this task never reads.
+//
+// The build deliberately still SUCCEEDS (an image that ships Hermes and injects
+// credentials through the environment is a legitimate setup), so the warning is
+// the only signal separating that case from a misresolved source home. It must
+// name the source home: that path is the whole answer and appears nowhere else.
+func TestHermesOverlayWarnsWhenSourceHomeCarriesNoConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source home does not exist", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "never-created")
+		var logs bytes.Buffer
+
+		hermesHome := filepath.Join(t.TempDir(), "hermes-home")
+		if _, err := prepareHermesHome(hermesHome, missing, false, nil, nil, "", "", captureLogger(&logs)); err != nil {
+			t.Fatalf("prepareHermesHome must not fail closed on a missing default home: %v", err)
+		}
+
+		out := logs.String()
+		if !strings.Contains(out, "hermes source home does not exist") {
+			t.Errorf("missing source home must be warned about, got:\n%s", out)
+		}
+		if !strings.Contains(out, missing) {
+			t.Errorf("the warning must name the resolved source home %q, got:\n%s", missing, out)
+		}
+
+		// The derived config is what the child actually reads: no provider,
+		// which is exactly why Hermes then refuses to start.
+		data, err := os.ReadFile(filepath.Join(hermesHome, "config.yaml"))
+		if err != nil {
+			t.Fatalf("overlay config.yaml unreadable: %v", err)
+		}
+		if strings.Contains(string(data), "provider:") {
+			t.Errorf("nothing to inherit, so the derived config should carry no provider, got:\n%s", data)
+		}
+	})
+
+	t.Run("source home exists but has no config.yaml", func(t *testing.T) {
+		t.Parallel()
+		// A real home with auth state but no config.yaml — distinct from the
+		// case above for the reader, so it gets its own wording.
+		sharedHome := t.TempDir()
+		mustWrite(t, filepath.Join(sharedHome, "auth.json"), `{"token":"secret"}`)
+		var logs bytes.Buffer
+
+		hermesHome := filepath.Join(t.TempDir(), "hermes-home")
+		if _, err := prepareHermesHome(hermesHome, sharedHome, false, nil, nil, "", "", captureLogger(&logs)); err != nil {
+			t.Fatalf("prepareHermesHome: %v", err)
+		}
+
+		out := logs.String()
+		if !strings.Contains(out, "has no config.yaml") {
+			t.Errorf("a config-less source home must be warned about, got:\n%s", out)
+		}
+		if strings.Contains(out, "does not exist") {
+			t.Errorf("the home DOES exist; the two cases must not be conflated, got:\n%s", out)
+		}
+		if !strings.Contains(out, sharedHome) {
+			t.Errorf("the warning must name the resolved source home %q, got:\n%s", sharedHome, out)
+		}
+	})
+}
+
+// TestHermesOverlayKeepsProviderAndStaysQuiet is the other half of the contract:
+// on the ordinary install (config.yaml where the daemon resolves it) the named
+// custom provider survives into the overlay untouched and nothing is warned. It
+// pins the boundary — without it, the warnings above could be "fixed" by firing
+// on every task, which would make them worthless.
+func TestHermesOverlayKeepsProviderAndStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	sharedHome := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"),
+		"model:\n  default: ag/gemini-3.6-flash-high\n  provider: custom:9router\n"+
+			"custom_providers:\n  - name: 9router\n    base_url: https://example.invalid/v1\n    api_key: sk-test\n")
+	var logs bytes.Buffer
+
+	hermesHome := filepath.Join(t.TempDir(), "hermes-home")
+	if _, err := prepareHermesHome(hermesHome, sharedHome, false, nil, nil, "", "", captureLogger(&logs)); err != nil {
+		t.Fatalf("prepareHermesHome: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(hermesHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("overlay config.yaml unreadable: %v", err)
+	}
+	for _, want := range []string{"provider: custom:9router", "name: 9router", "api_key: sk-test"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("derived config dropped %q, got:\n%s", want, data)
+		}
+	}
+	if out := logs.String(); strings.Contains(out, "source home") {
+		t.Errorf("a healthy source home must not warn, got:\n%s", out)
+	}
+}

--- a/server/internal/daemon/hermes_provider_annotation_test.go
+++ b/server/internal/daemon/hermes_provider_annotation_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
@@ -17,55 +18,47 @@ const hermesProviderUnconfiguredError = `hermes session/new failed: session/new:
 func TestAnnotateHermesProviderUnconfigured(t *testing.T) {
 	t.Parallel()
 
-	const overlay = "/home/u/multica_workspaces/ws/abc123/hermes-home"
-	const source = "/home/u/.hermes"
-
-	t.Run("names both homes", func(t *testing.T) {
+	t.Run("explains what hermes could not", func(t *testing.T) {
 		t.Parallel()
-		got := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes", overlay, source)
+		got := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes", true)
 
 		// The original text has to survive: it is what the runtime actually
-		// said, and the annotation is additive context, not a replacement.
+		// said, and the hint is additive context, not a replacement.
 		if !strings.Contains(got, "No LLM provider configured") {
 			t.Errorf("the runtime's own message must be preserved, got: %s", got)
 		}
-		// Both paths, because they answer different questions: the overlay is
-		// what Hermes read, the source home is where the user's config was
-		// expected to be. Reporting only one leaves the user guessing again.
-		if !strings.Contains(got, overlay) {
-			t.Errorf("annotation must name the overlay HERMES_HOME, got: %s", got)
-		}
-		if !strings.Contains(got, source) {
-			t.Errorf("annotation must name the source home it was seeded from, got: %s", got)
-		}
-		if !strings.Contains(got, "custom_env") {
-			t.Errorf("annotation must name the actionable remedy, got: %s", got)
+		// The hint has to carry the insight Hermes' own remedy lacks — that a
+		// different home was read — and point at where the path is recorded.
+		for _, want := range []string{"HERMES_HOME", "hermes home resolved", "custom_env"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("hint must mention %q, got: %s", want, got)
+			}
 		}
 	})
 
 	t.Run("leaves unrelated failures alone", func(t *testing.T) {
 		t.Parallel()
 		cases := []struct {
-			name     string
-			errMsg   string
-			provider string
-			overlay  string
+			name         string
+			errMsg       string
+			provider     string
+			overlayBuilt bool
 		}{
 			// A different provider's error can carry similar words; the
 			// HERMES_HOME advice would be nonsense there.
-			{"other provider", hermesProviderUnconfiguredError, "codex", overlay},
+			{"other provider", hermesProviderUnconfiguredError, "codex", true},
 			// No overlay was built, so there is no seeding story to tell.
-			{"no overlay", hermesProviderUnconfiguredError, "hermes", ""},
+			{"no overlay", hermesProviderUnconfiguredError, "hermes", false},
 			// An expired or rejected credential is a different failure: the
 			// config WAS found. Widening into it would send users to the wrong
-			// fix, which is the very thing this annotation exists to stop.
-			{"auth failure", "hermes session/prompt failed: 401 invalid api key", "hermes", overlay},
-			{"empty", "", "hermes", overlay},
+			// fix, which is the very thing this hint exists to stop.
+			{"auth failure", "hermes session/prompt failed: 401 invalid api key", "hermes", true},
+			{"empty", "", "hermes", true},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				if got := annotateHermesProviderUnconfigured(tc.errMsg, tc.provider, tc.overlay, source); got != tc.errMsg {
+				if got := annotateHermesProviderUnconfigured(tc.errMsg, tc.provider, tc.overlayBuilt); got != tc.errMsg {
 					t.Errorf("error text must be untouched, got: %s", got)
 				}
 			})
@@ -73,41 +66,74 @@ func TestAnnotateHermesProviderUnconfigured(t *testing.T) {
 	})
 }
 
-// TestAnnotationIsClassifierRelevantHenceAnnotatedLast is why the call site
-// annotates only after every classifier has read errMsg.
+// TestAnnotationCannotChangeMachineDecisions is the guard behind keeping the
+// hint free of interpolated input.
 //
-// The annotation embeds two filesystem paths the user chose, and Classify
-// matches substrings anywhere in the text — so a directory name can satisfy a
-// rule. Rule 1 (context overflow) keys on "token" AND "limit" and is evaluated
-// before rule 2 (missing config), so a home under /srv/token-cache/limit/ is
-// enough to relabel this failure. That is not cosmetic: failure_reason drives
-// retry eligibility and resume blacklisting.
+// The annotated text does not stop at the daemon: it travels to the server as
+// the task's error, is persisted in agent_task_queue.error, and is re-scanned
+// there for the life of the row — by service.ResumeUnsafeFailure on the write
+// path and by the ILIKE/regex guards in GetLastTaskSession /
+// GetLastChatTaskSession on every later resume lookup. Those guards decide
+// whether a session pointer survives.
 //
-// The ordering is the fix. This test pins the hazard the ordering protects
-// against, so anyone tempted to annotate earlier sees the cost first.
-func TestAnnotationIsClassifierRelevantHenceAnnotatedLast(t *testing.T) {
+// So anything embedded in this text gets a vote on session recovery. Paths are
+// user-controlled (HERMES_HOME via the agent's custom_env, the overlay root via
+// MULTICA_WORKSPACES_ROOT), and a home under /srv/400-invalid_request_error/ is
+// a legal directory that would trip the poisoned-request guard on a failure
+// that has nothing to do with it. A constant hint has no such vote.
+func TestAnnotationCannotChangeMachineDecisions(t *testing.T) {
 	t.Parallel()
 
-	unannotated := taskfailure.Classify(hermesProviderUnconfiguredError)
-	if unannotated != taskfailure.ReasonAgentMissingConfig {
-		t.Fatalf("precondition: this failure should classify as missing_config, got %q", unannotated)
+	// Reasons paired with the error texts a real run reports them for.
+	cases := []struct {
+		name   string
+		errMsg string
+		reason string
+	}{
+		{"the failure this hint targets", hermesProviderUnconfiguredError, "agent_error.missing_config"},
+		{"poisoned request", `API error 400: {"type":"invalid_request_error","message":"bad image"}`, "api_invalid_request"},
+		{"auth method unresolved", "hermes session/resume failed: Could not resolve authentication method", "agent_error.unknown"},
+		{"empty assistant message", `messages.2: assistant message content must not be empty`, "agent_error.unknown"},
+		{"context overflow", "API Error: prompt is too long: 250000 tokens > 200000 maximum", "agent_error.context_overflow"},
 	}
 
-	// Ordinary paths: nothing in the annotation is classifier-relevant, so the
-	// common case would be safe even if it were classified.
-	benign := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes",
-		"/home/u/multica_workspaces/ws/abc123/hermes-home", "/home/u/.hermes")
-	if got := taskfailure.Classify(benign); got != unannotated {
-		t.Errorf("ordinary paths should not perturb classification: %q -> %q", unannotated, got)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Annotate unconditionally — the gate is tested above; here we
+			// want the hint attached to every shape to prove it is inert.
+			annotated := tc.errMsg + hermesProviderUnconfiguredHint
 
-	// Adversarial-but-legal paths: they do perturb it. If this assertion ever
-	// starts failing, Classify's rules changed such that annotation text is no
-	// longer classifier-relevant — re-read the ordering comment at the call
-	// site before relying on that.
-	hostile := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes",
-		"/srv/token-cache/limit/hermes-home", "/srv/token-cache/limit/.hermes")
-	if got := taskfailure.Classify(hostile); got == unannotated {
-		t.Errorf("expected annotation text to be able to perturb classification (that is why it runs last), but %q survived", got)
+			if got, want := taskfailure.Classify(annotated), taskfailure.Classify(tc.errMsg); got != want {
+				t.Errorf("hint moved the failure reason: %q -> %q", want, got)
+			}
+			if got, want := service.ResumeUnsafeFailure(tc.reason, annotated),
+				service.ResumeUnsafeFailure(tc.reason, tc.errMsg); got != want {
+				t.Errorf("hint changed resume safety: %v -> %v", want, got)
+			}
+		})
+	}
+}
+
+// TestAnnotationAvoidsPersistedRowGuards covers the one reader the test above
+// cannot execute: the SQL text guards in pkg/db/queries/agent.sql, which scan
+// agent_task_queue.error long after the daemon that wrote it is gone. Keep this
+// list in sync with GetLastTaskSession / GetLastChatTaskSession — a hint that
+// matched one of these would quietly exclude healthy sessions from resume.
+func TestAnnotationAvoidsPersistedRowGuards(t *testing.T) {
+	t.Parallel()
+
+	hint := strings.ToLower(hermesProviderUnconfiguredHint)
+	forbidden := []string{
+		"400", "invalid_request_error",
+		"image dimensions exceed max allowed size", "image.source.base64.data",
+		"could not resolve authentication method",
+		"must not be empty", "must be non-empty", "must have non-empty",
+		"non-empty content", "cannot be empty", "should not be empty",
+	}
+	for _, phrase := range forbidden {
+		if strings.Contains(hint, phrase) {
+			t.Errorf("hint contains %q, which a persisted-row resume guard matches on", phrase)
+		}
 	}
 }

--- a/server/internal/daemon/hermes_provider_annotation_test.go
+++ b/server/internal/daemon/hermes_provider_annotation_test.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+// hermesProviderUnconfiguredError is the failure exactly as it reaches the
+// daemon: Hermes' message wrapped in the ACP transport's framing, which is why
+// the predicate matches on a substring rather than equality.
+const hermesProviderUnconfiguredError = `hermes session/new failed: session/new: Internal error ` +
+	`(code=-32603, data={"details":"No LLM provider configured. Run ` + "`hermes model`" +
+	` to select a provider, or run ` + "`hermes setup`" + ` for first-time configuration."})`
+
+func TestAnnotateHermesProviderUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	const overlay = "/home/u/multica_workspaces/ws/abc123/hermes-home"
+	const source = "/home/u/.hermes"
+
+	t.Run("names both homes", func(t *testing.T) {
+		t.Parallel()
+		got := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes", overlay, source)
+
+		// The original text has to survive: it is what the runtime actually
+		// said, and the annotation is additive context, not a replacement.
+		if !strings.Contains(got, "No LLM provider configured") {
+			t.Errorf("the runtime's own message must be preserved, got: %s", got)
+		}
+		// Both paths, because they answer different questions: the overlay is
+		// what Hermes read, the source home is where the user's config was
+		// expected to be. Reporting only one leaves the user guessing again.
+		if !strings.Contains(got, overlay) {
+			t.Errorf("annotation must name the overlay HERMES_HOME, got: %s", got)
+		}
+		if !strings.Contains(got, source) {
+			t.Errorf("annotation must name the source home it was seeded from, got: %s", got)
+		}
+		if !strings.Contains(got, "custom_env") {
+			t.Errorf("annotation must name the actionable remedy, got: %s", got)
+		}
+	})
+
+	t.Run("leaves unrelated failures alone", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			errMsg   string
+			provider string
+			overlay  string
+		}{
+			// A different provider's error can carry similar words; the
+			// HERMES_HOME advice would be nonsense there.
+			{"other provider", hermesProviderUnconfiguredError, "codex", overlay},
+			// No overlay was built, so there is no seeding story to tell.
+			{"no overlay", hermesProviderUnconfiguredError, "hermes", ""},
+			// An expired or rejected credential is a different failure: the
+			// config WAS found. Widening into it would send users to the wrong
+			// fix, which is the very thing this annotation exists to stop.
+			{"auth failure", "hermes session/prompt failed: 401 invalid api key", "hermes", overlay},
+			{"empty", "", "hermes", overlay},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				if got := annotateHermesProviderUnconfigured(tc.errMsg, tc.provider, tc.overlay, source); got != tc.errMsg {
+					t.Errorf("error text must be untouched, got: %s", got)
+				}
+			})
+		}
+	})
+}
+
+// TestAnnotationIsClassifierRelevantHenceAnnotatedLast is why the call site
+// annotates only after every classifier has read errMsg.
+//
+// The annotation embeds two filesystem paths the user chose, and Classify
+// matches substrings anywhere in the text — so a directory name can satisfy a
+// rule. Rule 1 (context overflow) keys on "token" AND "limit" and is evaluated
+// before rule 2 (missing config), so a home under /srv/token-cache/limit/ is
+// enough to relabel this failure. That is not cosmetic: failure_reason drives
+// retry eligibility and resume blacklisting.
+//
+// The ordering is the fix. This test pins the hazard the ordering protects
+// against, so anyone tempted to annotate earlier sees the cost first.
+func TestAnnotationIsClassifierRelevantHenceAnnotatedLast(t *testing.T) {
+	t.Parallel()
+
+	unannotated := taskfailure.Classify(hermesProviderUnconfiguredError)
+	if unannotated != taskfailure.ReasonAgentMissingConfig {
+		t.Fatalf("precondition: this failure should classify as missing_config, got %q", unannotated)
+	}
+
+	// Ordinary paths: nothing in the annotation is classifier-relevant, so the
+	// common case would be safe even if it were classified.
+	benign := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes",
+		"/home/u/multica_workspaces/ws/abc123/hermes-home", "/home/u/.hermes")
+	if got := taskfailure.Classify(benign); got != unannotated {
+		t.Errorf("ordinary paths should not perturb classification: %q -> %q", unannotated, got)
+	}
+
+	// Adversarial-but-legal paths: they do perturb it. If this assertion ever
+	// starts failing, Classify's rules changed such that annotation text is no
+	// longer classifier-relevant — re-read the ordering comment at the call
+	// site before relying on that.
+	hostile := annotateHermesProviderUnconfigured(hermesProviderUnconfiguredError, "hermes",
+		"/srv/token-cache/limit/hermes-home", "/srv/token-cache/limit/.hermes")
+	if got := taskfailure.Classify(hostile); got == unannotated {
+		t.Errorf("expected annotation text to be able to perturb classification (that is why it runs last), but %q survived", got)
+	}
+}

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -97,7 +97,7 @@ func Classify(rawError string) Reason {
 	case strings.Contains(lower, "missing environment variable"),
 		strings.Contains(lower, "missing") && strings.Contains(lower, "api_key"),
 		strings.Contains(lower, "api key") && strings.Contains(lower, "required"),
-		strings.Contains(lower, "no llm provider configured"),
+		strings.Contains(lower, providerUnconfiguredPhrase),
 		strings.Contains(lower, "no provider configured"):
 		return ReasonAgentMissingConfig
 
@@ -267,6 +267,36 @@ func Classify(rawError string) Reason {
 	}
 
 	return ReasonAgentUnknown
+}
+
+// providerUnconfiguredPhrase is the runtime's wording for "I resolved no LLM
+// provider at all" — structurally a configuration gap, not a rejected
+// credential. This const is the single source of truth for its two readers:
+// rule 2 of Classify above (which maps it to ReasonAgentMissingConfig) and
+// ProviderUnconfigured below. Keep them together; a second literal copy is how
+// the two drift apart.
+const providerUnconfiguredPhrase = "no llm provider configured"
+
+// ProviderUnconfigured reports whether an agent error is the runtime refusing
+// to start because it resolved no provider whatsoever. Callers use it to
+// attach context about WHERE the runtime looked — the failure text names a
+// remedy ("run `hermes model`") without naming the home it would apply to, so
+// a runtime reading a different config directory than the user edited sends
+// them to fix the wrong file (GH #6872).
+//
+// Substring, not equality: the phrase reaches us wrapped in the ACP transport's
+// own framing (`hermes session/new failed: session/new: Internal error
+// (code=-32603, data={"details":"No LLM provider configured. …`).
+//
+// This says nothing about which credential is missing or whether one would
+// help — it is strictly "the runtime resolved no provider". An expired key, a
+// 401, or a provider the user configured but mistyped are all different
+// failures and must not be widened into this.
+func ProviderUnconfigured(errText string) bool {
+	if errText == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(errText), providerUnconfiguredPhrase)
 }
 
 // contextWindowExceededWitnesses are the two wordings for an overflow reported

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -442,3 +442,58 @@ func TestNormalizeDaemonReason_UpgradedReasonIsPlatformSide(t *testing.T) {
 		t.Errorf("%q must be platform-side: the agent process never started", got)
 	}
 }
+
+// TestProviderUnconfigured pins the predicate the daemon uses to decide whether
+// a failure is worth annotating with the HERMES_HOME it actually read (GH
+// #6872). The wrapped fixture is the shape the error really arrives in — the
+// runtime's message nested inside the ACP transport's JSON-RPC framing — so a
+// future refactor to equality matching fails here rather than in production.
+func TestProviderUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			"wrapped acp error as the daemon receives it",
+			`hermes session/new failed: session/new: Internal error (code=-32603, ` +
+				`data={"details":"No LLM provider configured. Run ` + "`hermes model`" + ` to select a provider."})`,
+			true,
+		},
+		{"bare runtime message", "No LLM provider configured. Run `hermes model` to select a provider.", true},
+		{"lowercased by a forwarder", "error: no llm provider configured", true},
+		// A credential that exists but was rejected is a different failure with
+		// a different fix; the annotation would misdirect the user.
+		{"rejected credential", "401 unauthorized: invalid api key", false},
+		// The provider WAS resolved — it just could not be reached.
+		{"provider unreachable", "connection refused: https://example.invalid/v1", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ProviderUnconfigured(tc.in); got != tc.want {
+				t.Errorf("ProviderUnconfigured(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProviderUnconfiguredAgreesWithClassify keeps the shared phrase honest:
+// the predicate and rule 2 read the same const, so anything the predicate
+// recognises must still be filed as a config problem. If these two ever
+// disagree, the daemon would be annotating failures the platform files as
+// something else entirely.
+func TestProviderUnconfiguredAgreesWithClassify(t *testing.T) {
+	t.Parallel()
+
+	const errText = "No LLM provider configured. Run `hermes model` to select a provider."
+	if !ProviderUnconfigured(errText) {
+		t.Fatal("precondition: the predicate should match its own phrase")
+	}
+	if got := Classify(errText); got != ReasonAgentMissingConfig {
+		t.Errorf("Classify(%q) = %q, want %q", errText, got, ReasonAgentMissingConfig)
+	}
+}


### PR DESCRIPTION
## What

A Hermes task runs against a per-task `HERMES_HOME` overlay, seeded from a source home the daemon resolves from **its own process environment** (`agent custom_env HERMES_HOME` → daemon process `HERMES_HOME` → `$HOME/.hermes`). When that resolution lands on a home holding no `config.yaml`, `prepareHermesHome` builds the overlay anyway — from nothing. The derived config keeps only `skills.external_dirs`, the user's provider and credentials are gone, and Hermes refuses every `session/new` with `No LLM provider configured`.

Nothing on that path said so:

- the overlay was seeded silently — no warning when the source home was missing or config-less;
- no line anywhere logged the resolved source home (`hermes acp starting` logs only `cwd`);
- the failure surfaced Hermes' own remedy, **run `hermes model`** — which edits whichever home the user's *shell* points at, not the one the task read.

GH #6872 is what that costs: eight documented workarounds, none of which could have worked, and a root cause filed against an unrelated resume bug (#6150, whose fix #6164 shipped in v0.4.15 and was present the whole time).

## Changes

Three additions. No behaviour change — same control flow, same `failure_reason`, same statuses.

| | |
|---|---|
| `execenv/hermes_home.go` | Warn when the source home is missing, or exists without a `config.yaml` — two distinct messages, both naming the resolved path |
| `daemon.go` | Log the resolved source home once per task, at Info |
| `daemon.go` | Append the overlay + source homes to a `no LLM provider configured` failure |
| `pkg/taskfailure/classify.go` | Extract the phrase rule 2 already matched into a shared const; add the `ProviderUnconfigured` predicate on it |

**Kept a warning, not a hard failure.** Config-less is a legitimate setup: an image that ships Hermes and injects `OPENAI_API_KEY` through the environment resolves a provider fine (verified below). Failing closed would break those deployments.

**The annotation runs after every classifier has read the error text.** It embeds two user-chosen paths and `Classify` matches substrings anywhere, so annotating earlier would let a directory name pick the `failure_reason`: a home under `/srv/token-cache/limit/` satisfies rule 1 (context overflow), evaluated before rule 2 (missing config), which feeds retry eligibility and resume blacklisting. This is demonstrated, not hypothetical — `TestAnnotationIsClassifierRelevantHenceAnnotatedLast` pins it.

## Verification

The mechanism was reproduced end-to-end against the real `hermes` binary (v0.20.0) driving `hermes acp` over stdio, before writing any code:

| | HERMES_HOME under test | `session/new` |
|---|---|---|
| A | empty home, no `config.yaml` | ❌ `-32603`, `details` byte-identical to the daemon.log in #6872 |
| B | the reporter's shape: `provider: custom:9router` + `custom_providers` | ✅ succeeds — a named custom provider is fine on a fresh session |
| C | no config, only `OPENAI_API_KEY` / `OPENAI_BASE_URL` in the environment | ✅ succeeds — why this stays a warning |
| D | the overlay `prepareHermesHome` actually produces from a missing source home | ❌ same failure as A |

B is why #6872's stated root cause (a named `custom:*` identity shadowed on resume) does not explain a `session/new` failure.

Tests added:

- `execenv`: both warning shapes fire and name the source home; a healthy source home keeps `provider: custom:9router` + `custom_providers` + `api_key` intact and stays quiet.
- `daemon`: the annotation names both homes; leaves other providers, no-overlay runs, auth failures and empty text untouched; and the classifier-ordering guard above.
- `taskfailure`: the predicate matches the real ACP-wrapped text (so a refactor to equality matching fails here, not in production) and agrees with `Classify`.

```
go test ./internal/daemon/... ./pkg/taskfailure/... -count=1   # ok (all 5 packages)
go vet ./internal/daemon/... ./pkg/taskfailure/...             # clean
gofmt                                                          # clean
```

CI will run the full suite.

## What this does not do

- **No fresh-session retry for `session/new`.** There is nothing to retry — configuration does not appear on a second attempt. Distinct from #6164, where the retry exists to shed a dead session id.
- **No fallback to a guessed home.** Guessing wrong would silently run on the wrong credentials, which is worse than failing.
- **No reimplementation of Hermes' provider resolution** in the daemon. We report what we did (seeded Y from X) and let Hermes report what it found; a second source of truth would drift.
- **No new `failure_reason`.** These failures already land in `agent_error.missing_config`; classifying them differently would move resume semantics for no gain.

Related: MUL-6102. Fixes the diagnosability half of GH #6872 — whether the reporter's own deployment is this exact misresolution is still unconfirmed, and this change is what will tell them.
