### PR TITLE
MUL-6118: fix(daemon): keep npm .cmd agent entry points launchable on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,8 +432,10 @@ jobs:
         # The standalone Codex installer exposes bin as a directory junction.
         # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
         # only a real Windows filesystem proves both PATH discovery and an
-        # explicitly configured path reach the release executable.
-        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchRejectsUnverifiedInitialJunctionTarget|ForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
+        # explicitly configured path reach the release executable. The same job
+        # covers the npm shape, where the entry point is a `.cmd` shim that only
+        # the command interpreter can run.
+        run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestTrimExtendedLengthPrefix|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchKeepsCmdShimLaunchable|ForLaunchRejectsUnverifiedInitialJunctionTarget|ForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
         working-directory: server

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -45,12 +45,30 @@ func trimExtendedLengthPrefix(path string) string {
 	default:
 		return path
 	}
-	// syscall.MAX_PATH counts the terminating NUL, so the usable length is one
-	// less. At or past that limit the prefix is what makes the path nameable.
-	if len(trimmed) >= syscall.MAX_PATH-1 {
+	if !fitsWithoutExtendedLengthPrefix(trimmed) {
 		return path
 	}
 	return trimmed
+}
+
+// fitsWithoutExtendedLengthPrefix reports whether path is short enough to be
+// used as a plain Win32 path.
+//
+// MAX_PATH counts UTF-16 code units and includes the terminating NUL, which is
+// why this cannot use len(path): Go measures UTF-8 bytes, and every non-ASCII
+// character costs more bytes than it does code units. A path under a user
+// directory with a CJK name would be over-counted, judged too long, and keep a
+// prefix it does not need — reintroducing the .cmd launch failure for exactly
+// the users least likely to be tested against.
+func fitsWithoutExtendedLengthPrefix(path string) bool {
+	// UTF16FromString returns the string plus its terminating NUL, which is the
+	// unit MAX_PATH is expressed in. It fails only on an embedded NUL, which no
+	// real path has — treat that as "keep the prefix" rather than guessing.
+	encoded, err := windows.UTF16FromString(path)
+	if err != nil {
+		return false
+	}
+	return len(encoded) <= syscall.MAX_PATH
 }
 
 func canonicalPath(path string) (string, error) {

--- a/server/internal/daemon/canonical_path_windows.go
+++ b/server/internal/daemon/canonical_path_windows.go
@@ -3,11 +3,55 @@
 package daemon
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+// extendedLengthPrefix and extendedLengthUNCPrefix are the forms
+// GetFinalPathNameByHandleW returns with VOLUME_NAME_DOS: a local path comes
+// back as `\\?\C:\dir\file`, a network path as `\\?\UNC\server\share\file`.
+const (
+	extendedLengthPrefix    = `\\?\`
+	extendedLengthUNCPrefix = `\\?\UNC\`
+)
+
+// trimExtendedLengthPrefix returns path in its plain Win32 form when it is
+// short enough not to need the extended-length prefix, and unchanged otherwise.
+//
+// The prefix is not cosmetic: past MAX_PATH it is the only way to name the
+// file, which is why long paths keep it. But it is also not universally
+// understood. cmd.exe rejects it outright, and an agent installed through npm
+// is entered via a `.cmd` shim that Windows can only run by handing the path to
+// the command interpreter — so a launch target that keeps the prefix cannot be
+// executed at all. Dropping it whenever it is not load-bearing keeps both
+// shapes launchable, and keeps resolved paths comparable with the configured
+// paths they are matched against. See #6883.
+func trimExtendedLengthPrefix(path string) string {
+	var trimmed string
+	switch {
+	case strings.HasPrefix(path, extendedLengthUNCPrefix):
+		trimmed = `\\` + path[len(extendedLengthUNCPrefix):]
+	case strings.HasPrefix(path, extendedLengthPrefix):
+		trimmed = path[len(extendedLengthPrefix):]
+		// Only a drive-qualified path (`C:\...`) is a valid Win32 path without
+		// the prefix. Anything else (a volume GUID, say) must keep it.
+		if len(trimmed) < 3 || trimmed[1] != ':' || !os.IsPathSeparator(trimmed[2]) {
+			return path
+		}
+	default:
+		return path
+	}
+	// syscall.MAX_PATH counts the terminating NUL, so the usable length is one
+	// less. At or past that limit the prefix is what makes the path nameable.
+	if len(trimmed) >= syscall.MAX_PATH-1 {
+		return path
+	}
+	return trimmed
+}
 
 func canonicalPath(path string) (string, error) {
 	pathUTF16, err := windows.UTF16PtrFromString(path)
@@ -35,7 +79,7 @@ func canonicalPath(path string) (string, error) {
 			return "", err
 		}
 		if length < uint32(len(buffer)) {
-			return windows.UTF16ToString(buffer[:length]), nil
+			return trimExtendedLengthPrefix(windows.UTF16ToString(buffer[:length])), nil
 		}
 		buffer = make([]uint16, length+1)
 	}

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -562,3 +562,103 @@ func stageJunctionExecutable(t *testing.T) (targetExecutable, shimBin string) {
 	createJunction(t, targetBin, shimBin)
 	return targetExecutable, shimBin
 }
+
+// TestCanonicalExecutablePathLaunchesCmdShim covers the npm install shape from
+// #6883: the discovered entry point is a `.cmd` shim (`%APPDATA%\npm\codex.cmd`),
+// which Windows can only run by handing the path to the command interpreter.
+// cmd.exe does not accept extended-length paths, so a launch target that keeps
+// the `\\?\` prefix cannot be executed at all. Every other case in this file
+// stages a real `.exe`, which hides that difference completely.
+func TestCanonicalExecutablePathLaunchesCmdShim(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "codex.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n> \"%~1\" echo launched\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved := canonicalExecutablePath(shim)
+	marker := filepath.Join(dir, "launched.txt")
+	if output, err := exec.Command(resolved, marker).CombinedOutput(); err != nil {
+		t.Fatalf("launch .cmd shim %q: %v\n%s", resolved, err, output)
+	}
+	if _, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("resolved .cmd shim %q did not run: %v", resolved, err)
+	}
+}
+
+// TestResolveAgentEntryForLaunchKeepsCmdShimLaunchable is the same property at
+// the boundary that actually launches tasks. resolveAgentEntryForLaunch is what
+// every built-in provider goes through on Windows, so a `.cmd` entry point has
+// to survive it in runnable form.
+func TestResolveAgentEntryForLaunchKeepsCmdShimLaunchable(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "codex.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n> \"%~1\" echo launched\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := resolveAgentExecutablePath(shim)
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	launchPath, handled, err := executablePathForLaunch(resolved)
+	if !handled {
+		t.Fatal("executablePathForLaunch reported unhandled on windows")
+	}
+	if err != nil {
+		t.Fatalf("executablePathForLaunch: %v", err)
+	}
+
+	marker := filepath.Join(dir, "launched.txt")
+	if output, err := exec.Command(launchPath, marker).CombinedOutput(); err != nil {
+		t.Fatalf("launch resolved .cmd entry %q: %v\n%s", launchPath, err, output)
+	}
+	if _, err := os.ReadFile(marker); err != nil {
+		t.Fatalf("resolved .cmd entry %q did not run: %v", launchPath, err)
+	}
+}
+
+// TestTrimExtendedLengthPrefix pins the rule: drop the prefix when the plain
+// Win32 path can stand on its own, keep it when it is what makes the path
+// nameable or when the remainder is not a drive-qualified path.
+func TestTrimExtendedLengthPrefix(t *testing.T) {
+	longTail := strings.Repeat(`segment\`, 40) + "codex.exe"
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "short drive path drops the prefix",
+			in:   `\\?\C:\Users\dev\AppData\Roaming\npm\codex.cmd`,
+			want: `C:\Users\dev\AppData\Roaming\npm\codex.cmd`,
+		},
+		{
+			name: "path past MAX_PATH keeps the prefix",
+			in:   `\\?\C:\` + longTail,
+			want: `\\?\C:\` + longTail,
+		},
+		{
+			name: "unc path becomes a plain unc path",
+			in:   `\\?\UNC\server\share\bin\codex.cmd`,
+			want: `\\server\share\bin\codex.cmd`,
+		},
+		{
+			name: "volume guid keeps the prefix",
+			in:   `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\bin\codex.exe`,
+			want: `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\bin\codex.exe`,
+		},
+		{
+			name: "plain path is untouched",
+			in:   `C:\bin\codex.exe`,
+			want: `C:\bin\codex.exe`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trimExtendedLengthPrefix(tc.in); got != tc.want {
+				t.Fatalf("trimExtendedLengthPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/config_windows_test.go
+++ b/server/internal/daemon/config_windows_test.go
@@ -644,6 +644,16 @@ func TestTrimExtendedLengthPrefix(t *testing.T) {
 			want: `\\server\share\bin\codex.cmd`,
 		},
 		{
+			// 100 CJK characters: 300 UTF-8 bytes but only 100 UTF-16 code
+			// units, so the whole path is ~123 units — comfortably inside
+			// MAX_PATH. Measuring bytes would call this too long and keep a
+			// prefix that breaks .cmd launches for anyone whose user directory
+			// is not ASCII.
+			name: "non-ascii path is measured in utf-16 code units",
+			in:   `\\?\C:\Users\` + strings.Repeat("目录", 50) + `\npm\codex.cmd`,
+			want: `C:\Users\` + strings.Repeat("目录", 50) + `\npm\codex.cmd`,
+		},
+		{
 			name: "volume guid keeps the prefix",
 			in:   `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\bin\codex.exe`,
 			want: `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\bin\codex.exe`,


### PR DESCRIPTION
## Summary

#6802 resolves every Windows agent launch target through `GetFinalPathNameByHandleW`, which returns the extended-length form — so launch paths are now `\\?\C:\...`. That prefix is deliberately kept, and past `MAX_PATH` it has to be: it is the only way to name the file.

It is also not universally understood. `cmd.exe` rejects it, and an agent installed through npm is entered via a `.cmd` shim (`%APPDATA%\npm\codex.cmd`) that Windows can only run by handing the path to the command interpreter. `executablePathForLaunch` applies to every built-in provider on Windows, not just the standalone Codex installer that motivated #6802, so this reaches npm-installed agents generally.

This drops the prefix whenever the plain Win32 path can stand on its own, and keeps it when:

- the path is at or past `MAX_PATH`, where the prefix is load-bearing, or
- the remainder is not drive-qualified (a volume GUID, say), where there is no plain form.

`\\?\UNC\server\share\...` is folded back to `\\server\share\...` rather than left prefixed.

## Why the existing tests did not catch this

Every Windows case in `config_windows_test.go` stages a real `.exe` — `copyTestExecutable` copies the test binary itself. A `.exe` launches fine with the prefix, so the `.cmd` path had no coverage at all. Codex also has no `.cmd` → `.ps1` rewrite of the kind copilot / cursor / pi use, so it launches the shim directly.

Added:

- `TestCanonicalExecutablePathLaunchesCmdShim` — a `.cmd` shim resolved through `canonicalExecutablePath` must actually execute (asserted by the marker file it writes, not just by exit status).
- `TestResolveAgentEntryForLaunchKeepsCmdShimLaunchable` — the same property at `executablePathForLaunch`, the boundary every task launch goes through.
- `TestTrimExtendedLengthPrefix` — pins the keep/drop rule, including the long-path and volume-GUID cases.

All three run in the existing "Test Windows agent executable junction resolution" CI job. `TestCanonicalExecutablePathLaunchesBeyondMaxPath` still asserts that long paths keep the prefix.

## Verification

- `GOOS=windows go build ./internal/daemon`, `GOOS=windows go vet ./internal/daemon`, `GOOS=windows go test -c ./internal/daemon` all pass locally.
- The behavioural assertions are Windows-only and run in CI — I could not execute them on this machine.

Worth reviewers knowing: the `.cmd` launch failure is inferred from `cmd.exe` not accepting extended-length paths, not observed on a Windows box. The CI job is what confirms or refutes it. If it turns out `.cmd` launches fine with the prefix, the normalization is still correct — resolved paths stay comparable with the configured paths they are matched against — but it is not load-bearing, and the PR should be re-titled accordingly.

Refs #6883, #6802
