### PR TITLE
fix(skills): normalize imported Windows file paths

### DIFF
--- a/server/internal/daemon/skill_cache_test.go
+++ b/server/internal/daemon/skill_cache_test.go
@@ -42,6 +42,20 @@ func TestSkillBundleCacheRejectsCorruptBundle(t *testing.T) {
 	}
 }
 
+func TestValidateSkillBundleAcceptsCanonicalNestedPath(t *testing.T) {
+	bundle := testSkillBundle()
+	bundle.Files[0].Path = "templates/template.html"
+	ref := skillRefFromBundle(bundle)
+	bundle.Hash = ref.Hash
+	bundle.SizeBytes = ref.SizeBytes
+	bundle.Files[0].SHA256 = ref.Files[0].SHA256
+	bundle.Files[0].SizeBytes = ref.Files[0].SizeBytes
+
+	if !validateSkillBundle(ref, bundle) {
+		t.Fatal("canonical nested file path should produce a valid bundle")
+	}
+}
+
 func testSkillBundle() SkillData {
 	bundle := SkillData{
 		ID:      "skill-1",

--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -527,6 +528,28 @@ type reportedRuntimeLocalSkill struct {
 	Files       []CreateSkillFileRequest `json:"files,omitempty"`
 }
 
+func runtimeLocalSkillImportFiles(reported []CreateSkillFileRequest) ([]CreateSkillFileRequest, error) {
+	reportedPaths := make([]string, len(reported))
+	for i, file := range reported {
+		reportedPaths[i] = file.Path
+	}
+	canonicalPaths, err := skillpkg.CanonicalRuntimeLocalFilePaths(reportedPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]CreateSkillFileRequest, 0, len(reported))
+	for i, canonicalPath := range canonicalPaths {
+		if canonicalPath == "" {
+			continue
+		}
+		file := reported[i]
+		file.Path = canonicalPath
+		files = append(files, file)
+	}
+	return files, nil
+}
+
 func cleanOptionalString(value *string) *string {
 	if value == nil {
 		return nil
@@ -851,12 +874,10 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 		description = *req.Description
 	}
 
-	files := make([]CreateSkillFileRequest, 0, len(body.Skill.Files))
-	for _, f := range body.Skill.Files {
-		if !validateFilePath(f.Path) {
-			continue
-		}
-		files = append(files, f)
+	files, err := runtimeLocalSkillImportFiles(body.Skill.Files)
+	if err != nil {
+		h.failLocalSkillImport(w, r, requestID, err.Error())
+		return
 	}
 
 	config := map[string]any{

--- a/server/internal/handler/runtime_local_skills_overwrite_test.go
+++ b/server/internal/handler/runtime_local_skills_overwrite_test.go
@@ -286,6 +286,33 @@ func TestRuntimeLocalSkillImport_OverwritePreservesIdentityAndBindings(t *testin
 	}
 }
 
+func TestRuntimeLocalSkillImport_OverwriteCanonicalizesWindowsFilePath(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
+	name := fmt.Sprintf("overwrite-windows-path-%d", time.Now().UnixNano())
+	existingID := createImportTargetSkill(t, name, testUserID, nil)
+
+	got := runLocalSkillImport(t, runtimeID,
+		map[string]any{"skill_key": "review-helper", "action": "overwrite", "target_skill_id": existingID},
+		reportBundleBody(name, "overwritten description", "# overwritten", map[string]string{
+			`templates\template.html`: "template",
+		}),
+	)
+
+	if got.Status != RuntimeLocalSkillCompleted {
+		t.Fatalf("status = %s, want completed (error=%q)", got.Status, got.Error)
+	}
+	if got.Skill == nil || len(got.Skill.Files) != 1 {
+		t.Fatalf("imported files = %#v, want one file", got.Skill)
+	}
+	if got.Skill.Files[0].Path != "templates/template.html" {
+		t.Fatalf("file path = %q, want canonical slash path", got.Skill.Files[0].Path)
+	}
+}
+
 func TestRuntimeLocalSkillImport_OverwriteNonCreatorFails(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/runtime_local_skills_test.go
+++ b/server/internal/handler/runtime_local_skills_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -651,6 +652,88 @@ func TestReportLocalSkillImportResult_RejectsCrossWorkspaceDaemonToken(t *testin
 	testHandler.ReportLocalSkillImportResult(w, reportReq)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRuntimeLocalSkillImportFilesCanonicalizesWindowsPaths(t *testing.T) {
+	files, err := runtimeLocalSkillImportFiles([]CreateSkillFileRequest{
+		{Path: `templates\template.html`, Content: "template"},
+		{Path: "references/example.md", Content: "example"},
+	})
+	if err != nil {
+		t.Fatalf("runtimeLocalSkillImportFiles: %v", err)
+	}
+
+	want := []CreateSkillFileRequest{
+		{Path: "templates/template.html", Content: "template"},
+		{Path: "references/example.md", Content: "example"},
+	}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files = %#v, want %#v", files, want)
+	}
+}
+
+func TestRuntimeLocalSkillImportFilesRejectsUnsafePaths(t *testing.T) {
+	unsafe := []string{
+		"",
+		"\x00",
+		"file\x00.txt",
+		"/absolute.txt",
+		`C:\absolute.txt`,
+		`C:relative.txt`,
+		`\\server\share\file.txt`,
+		"../outside.txt",
+		`..\outside.txt`,
+		`safe\..\outside.txt`,
+	}
+	input := make([]CreateSkillFileRequest, 0, len(unsafe)+1)
+	for _, filePath := range unsafe {
+		input = append(input, CreateSkillFileRequest{Path: filePath, Content: "unsafe"})
+	}
+	input = append(input, CreateSkillFileRequest{Path: "safe/nested.txt", Content: "safe"})
+
+	files, err := runtimeLocalSkillImportFiles(input)
+	if err != nil {
+		t.Fatalf("runtimeLocalSkillImportFiles: %v", err)
+	}
+	want := []CreateSkillFileRequest{{Path: "safe/nested.txt", Content: "safe"}}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files = %#v, want %#v", files, want)
+	}
+}
+
+func TestRuntimeLocalSkillImportFilesRejectsCanonicalPathCollisions(t *testing.T) {
+	_, err := runtimeLocalSkillImportFiles([]CreateSkillFileRequest{
+		{Path: `templates\template.html`, Content: "windows"},
+		{Path: "templates/template.html", Content: "posix"},
+	})
+	if err == nil {
+		t.Fatal("expected canonical path collision to fail")
+	}
+}
+
+func TestRuntimeLocalSkillImport_CanonicalizesWindowsFilePath(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
+	name := fmt.Sprintf("windows-path-import-%d", time.Now().UnixNano())
+	got := runLocalSkillImport(t, runtimeID,
+		map[string]any{"skill_key": "windows-path-skill"},
+		reportBundleBody(name, "Windows path import", "# Windows Path", map[string]string{
+			`templates\template.html`: "template",
+		}),
+	)
+
+	if got.Status != RuntimeLocalSkillCompleted {
+		t.Fatalf("status = %s, want completed (error=%q)", got.Status, got.Error)
+	}
+	if got.Skill == nil || len(got.Skill.Files) != 1 {
+		t.Fatalf("imported files = %#v, want one file", got.Skill)
+	}
+	if got.Skill.Files[0].Path != "templates/template.html" {
+		t.Fatalf("file path = %q, want canonical slash path", got.Skill.Files[0].Path)
 	}
 }
 

--- a/server/internal/skill/import_path.go
+++ b/server/internal/skill/import_path.go
@@ -1,0 +1,48 @@
+package skill
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// CanonicalRuntimeLocalFilePath converts cross-platform separators to the
+// slash form used by skill bundles and rejects unsafe or ambiguous paths.
+func CanonicalRuntimeLocalFilePath(filePath string) (string, bool) {
+	canonical := strings.ReplaceAll(filePath, `\`, "/")
+	if canonical == "" || strings.Contains(canonical, "\x00") || strings.HasPrefix(canonical, "/") {
+		return "", false
+	}
+	if len(canonical) >= 2 && canonical[1] == ':' && isASCIILetter(canonical[0]) {
+		return "", false
+	}
+	clean := path.Clean(canonical)
+	if clean == "." || clean != canonical || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", false
+	}
+	return canonical, true
+}
+
+// CanonicalRuntimeLocalFilePaths canonicalizes a daemon-reported bundle while
+// preserving input indexes. Invalid entries are empty for callers to omit.
+// Paths that become duplicates after normalization reject the bundle.
+func CanonicalRuntimeLocalFilePaths(filePaths []string) ([]string, error) {
+	canonicalPaths := make([]string, len(filePaths))
+	seen := make(map[string]struct{}, len(filePaths))
+	for i, filePath := range filePaths {
+		canonical, ok := CanonicalRuntimeLocalFilePath(filePath)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[canonical]; exists {
+			return nil, fmt.Errorf("duplicate local skill file path after normalization: %s", canonical)
+		}
+		seen[canonical] = struct{}{}
+		canonicalPaths[i] = canonical
+	}
+	return canonicalPaths, nil
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}

--- a/server/internal/skill/import_path_test.go
+++ b/server/internal/skill/import_path_test.go
@@ -1,0 +1,43 @@
+package skill
+
+import "testing"
+
+func TestCanonicalRuntimeLocalFilePath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{name: "Windows nested path", input: `templates\template.html`, want: "templates/template.html", ok: true},
+		{name: "POSIX nested path", input: "references/example.md", want: "references/example.md", ok: true},
+		{name: "empty", input: ""},
+		{name: "NUL", input: "file\x00.txt"},
+		{name: "POSIX absolute", input: "/absolute.txt"},
+		{name: "Windows rooted", input: `\absolute.txt`},
+		{name: "Windows drive absolute", input: `C:\absolute.txt`},
+		{name: "Windows drive relative", input: `C:relative.txt`},
+		{name: "UNC", input: `\\server\share\file.txt`},
+		{name: "POSIX traversal", input: "../outside.txt"},
+		{name: "Windows traversal", input: `..\outside.txt`},
+		{name: "embedded traversal", input: `safe\..\outside.txt`},
+		{name: "non-canonical separator", input: "safe//file.txt"},
+		{name: "dot", input: "."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CanonicalRuntimeLocalFilePath(tt.input)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("CanonicalRuntimeLocalFilePath(%q) = (%q, %v), want (%q, %v)", tt.input, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestCanonicalRuntimeLocalFilePathsRejectsCollision(t *testing.T) {
+	_, err := CanonicalRuntimeLocalFilePaths([]string{`templates\template.html`, "templates/template.html"})
+	if err == nil {
+		t.Fatal("expected canonical path collision to fail")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Normalizes supporting-file paths reported by runtime-local skill imports before they are persisted, so Windows-style nested paths such as `templates\template.html` become the canonical `templates/template.html` form accepted by workspace skill bundle validation.

The normal daemon collector already uses `filepath.ToSlash`. The remaining gap was the server report boundary used by older or alternate reporters: it validated paths with host-dependent `filepath` semantics and persisted accepted values unchanged. A backslash path could therefore reach the database and later make `safeSkillFilePath` reject the entire bundle.

Normalization now happens once at that import trust boundary, before both create and overwrite persistence. Validation then uses platform-independent slash-path semantics.

This PR intentionally addresses only the path-separator defect that makes workspace skill bundles invalid. The CRLF observation in #6893 is self-consistent and non-blocking, so content line-ending normalization is explicitly out of scope here.

## Related Issue

Fixes #6893

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Canonicalize runtime-local import file separators in `server/internal/handler/runtime_local_skills.go` before the shared create/overwrite branches.
- Add platform-independent safety checks in `server/internal/skill/import_path.go` for empty/NUL, rooted/absolute, drive, UNC, traversal, and non-canonical paths.
- Reject paths that collide after slash normalization instead of allowing order-dependent overwrite behavior.
- Add focused tests for Windows/POSIX paths, unsafe inputs, collisions, create/overwrite responses, and daemon bundle acceptance.

## How to Test

1. `cd server && go test ./internal/skill -count=1 -v`
2. `cd server && go test ./internal/daemon -run '^(TestReportLocalSkillImportResult_RetriesOn500AndEventuallySucceeds|TestSkillBundleResolveTimeout|TestEnsureTaskSkillBundles_CachesEachSuccessAcrossDispatches|TestEnsureTaskSkillBundles_AcceptsServerSideSkillUpdate|TestEnsureTaskSkillBundles_RejectsPluginHashDrift|TestEnsureTaskSkillBundles_DeadlineIsLabelledStructurally|TestSkillBundleCacheLoadStore|TestSkillBundleCacheRejectsCorruptBundle|TestValidateSkillBundleAcceptsCanonicalNestedPath)$' -count=1 -v`
3. With PostgreSQL available, run `cd server && go test ./internal/handler -run '^(TestRuntimeLocalSkillImportFilesCanonicalizesWindowsPaths|TestRuntimeLocalSkillImportFilesRejectsUnsafePaths|TestRuntimeLocalSkillImportFilesRejectsCanonicalPathCollisions|TestRuntimeLocalSkillImport_CanonicalizesWindowsFilePath|TestRuntimeLocalSkillImport_OverwriteCanonicalizesWindowsFilePath)$' -count=1 -v`
4. `cd server && go vet ./internal/skill ./internal/handler ./internal/daemon`
5. `cd server && go build ./internal/skill ./internal/handler ./internal/daemon`

Local note: the database-backed handler tests were added and compile successfully, but this checkout had no PostgreSQL service available, so the package's `TestMain` skipped their execution locally. The non-database path tests, daemon tests, vet, Windows build, and Linux/amd64 cross-build ran successfully.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Safety/risk: the daemon's strict `safeSkillFilePath` consumer validation is unchanged. Invalid paths remain omitted as before; canonical collisions now fail the import explicitly because choosing one would make persisted content input-order dependent. Drive-letter paths are rejected intentionally at this Windows-report boundary. No content/line-ending normalization, binary-file support, database migration, historical cleanup, sibling skill-authoring API change, discovery, or symlink behavior is included.

## AI Disclosure

**AI tool used:** Yes

**Prompt / approach:** Assisted.

## Screenshots (optional)

Not applicable; backend-only change.

