### PR TITLE
MUL-5852: 新增 Workspace Billing summary/prices proxy 与 Stripe 回跳落点

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,13 @@ MULTICA_FEATURE_FLAGS_FILE=
 # Workspace subscription Checkout/Portal/entitlement proxying is fail-closed;
 # enable it only after multica-cloud billing.subscriptions is configured:
 # FF_BILLING_WORKSPACE_SUBSCRIPTIONS=true
+#
+# Point multica-cloud's three subscription return URLs at this app's
+# /billing/return page (checkout_success_url, checkout_cancel_url,
+# portal_return_url). Cloud appends the workspace it authorized plus a result
+# marker, and that page resolves them to the workspace's Billing settings.
+# Configuring a workspace-specific URL instead would strand every other
+# workspace on someone else's page.
 
 # Self-host image channel
 # Default stable release channel. Pin to an exact release like v0.2.4 if you

--- a/apps/web/app/billing/return/page.tsx
+++ b/apps/web/app/billing/return/page.tsx
@@ -1,0 +1,18 @@
+import { BillingReturnPage } from "@multica/views/billing";
+
+/**
+ * `/billing/return` — where Stripe Checkout and Billing Portal send the browser.
+ *
+ * Deliberately a top-level route, not workspace-scoped: a deployment configures
+ * one set of return URLs in cloud, so they cannot carry a workspace slug. Cloud
+ * appends the workspace it authorized and this page resolves it to the slug
+ * before forwarding to Workspace Settings → Billing. `billing` is already a
+ * reserved slug, so this cannot shadow a real workspace.
+ *
+ * Desktop has no route of its own here: Stripe opens in the system browser, so
+ * the return always lands on the web app. The desktop Billing tab picks the new
+ * state up when its window regains focus.
+ */
+export default function BillingReturnRoute() {
+  return <BillingReturnPage />;
+}

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1564,10 +1564,14 @@ export class ApiClient {
 
   // ---------------------------------------------------------------------
   // Workspace subscriptions — the server resolves the workspace from the
-  // authenticated request context, so no caller names one. Every method
-  // returns null rather than a placeholder when the response does not match
-  // the contract: an older cloud, a 503, or a malformed body must surface as
-  // "unavailable" and never as a downgrade to Free.
+  // authenticated request context, so no caller names one.
+  //
+  // Two distinct failure paths, both of which a caller must render as
+  // "unavailable" and neither of which may look like Free:
+  //
+  //   - non-2xx (older cloud without the route, 403, 503) throws ApiError from
+  //     `fetch`, so a React Query caller sees `isError`;
+  //   - a 2xx body that does not match the contract returns null here.
   // ---------------------------------------------------------------------
 
   async getWorkspaceSubscriptionEntitlements(): Promise<WorkspaceSubscriptionEntitlements | null> {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -185,6 +185,9 @@ import type {
   CreateBillingCheckoutSessionResponse,
   BillingCheckoutSessionStatus,
   CreateBillingPortalSessionResponse,
+  WorkspaceSubscriptionEntitlements,
+  WorkspaceSubscriptionSummary,
+  WorkspaceSubscriptionPrices,
 } from "../types";
 import type { OnboardingCompletionPath } from "../onboarding/types";
 import type {
@@ -287,6 +290,9 @@ import {
   CreateBillingCheckoutSessionResponseSchema,
   BillingCheckoutSessionStatusSchema,
   CreateBillingPortalSessionResponseSchema,
+  WorkspaceSubscriptionEntitlementsSchema,
+  WorkspaceSubscriptionSummarySchema,
+  WorkspaceSubscriptionPricesSchema,
   DingTalkInstallationSchema,
   DingTalkGroupRouteSchema,
   ListDingTalkGroupRoutesResponseSchema,
@@ -1553,6 +1559,46 @@ export class ApiClient {
       CreateBillingPortalSessionResponseSchema,
       EMPTY_CREATE_BILLING_PORTAL_SESSION_RESPONSE,
       { endpoint: "POST /api/cloud-billing/portal-sessions" },
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Workspace subscriptions — the server resolves the workspace from the
+  // authenticated request context, so no caller names one. Every method
+  // returns null rather than a placeholder when the response does not match
+  // the contract: an older cloud, a 503, or a malformed body must surface as
+  // "unavailable" and never as a downgrade to Free.
+  // ---------------------------------------------------------------------
+
+  async getWorkspaceSubscriptionEntitlements(): Promise<WorkspaceSubscriptionEntitlements | null> {
+    const raw = await this.fetch<unknown>(
+      "/api/cloud-subscriptions/entitlements",
+    );
+    return parseWithFallback<WorkspaceSubscriptionEntitlements | null>(
+      raw,
+      WorkspaceSubscriptionEntitlementsSchema,
+      null,
+      { endpoint: "GET /api/cloud-subscriptions/entitlements" },
+    );
+  }
+
+  async getWorkspaceSubscriptionSummary(): Promise<WorkspaceSubscriptionSummary | null> {
+    const raw = await this.fetch<unknown>("/api/cloud-subscriptions/summary");
+    return parseWithFallback<WorkspaceSubscriptionSummary | null>(
+      raw,
+      WorkspaceSubscriptionSummarySchema,
+      null,
+      { endpoint: "GET /api/cloud-subscriptions/summary" },
+    );
+  }
+
+  async getWorkspaceSubscriptionPrices(): Promise<WorkspaceSubscriptionPrices | null> {
+    const raw = await this.fetch<unknown>("/api/cloud-subscriptions/prices");
+    return parseWithFallback<WorkspaceSubscriptionPrices | null>(
+      raw,
+      WorkspaceSubscriptionPricesSchema,
+      null,
+      { endpoint: "GET /api/cloud-subscriptions/prices" },
     );
   }
 

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -731,7 +731,7 @@ describe("workspace subscription contract", () => {
       pending_seat_quantity: 3,
       cancel_at_period_end: true,
       grace_until: "2026-09-08T00:00:00Z",
-      can_open_portal: true,
+      has_stripe_customer: true,
     });
     const client = new ApiClient("https://api.example.test");
     const summary = await client.getWorkspaceSubscriptionSummary();
@@ -744,7 +744,7 @@ describe("workspace subscription contract", () => {
     expect(summary?.pendingSeatQuantity).toBe(3);
     expect(summary?.cancelAtPeriodEnd).toBe(true);
     expect(summary?.graceUntil).toBe("2026-09-08T00:00:00Z");
-    expect(summary?.canOpenPortal).toBe(true);
+    expect(summary?.hasStripeCustomer).toBe(true);
   });
 
   it("keeps a paid summary readable when optional fields are absent", async () => {
@@ -762,7 +762,7 @@ describe("workspace subscription contract", () => {
     expect(summary?.graceUntil).toBeNull();
     // Absent means "no Stripe customer known", which is the safe reading: the
     // caller hides Portal rather than offering a control that would 404.
-    expect(summary?.canOpenPortal).toBe(false);
+    expect(summary?.hasStripeCustomer).toBe(false);
   });
 
   it("preserves unknown plans and statuses instead of coercing them", async () => {
@@ -783,10 +783,22 @@ describe("workspace subscription contract", () => {
     expect(await client.getWorkspaceSubscriptionSummary()).toBeNull();
   });
 
-  it("returns null for an older cloud that does not serve summary", async () => {
-    // 404/503 bodies parse as JSON but do not match the contract. The absence
-    // of a snapshot must not be mistaken for a Free workspace.
-    stubFetchJson({ error: "not found" }, 200);
+  it("throws ApiError for a non-2xx summary so the caller reports unavailable", async () => {
+    // An older cloud without the route, a 403, or a 503 never reaches schema
+    // parsing: fetch rejects first and a React Query caller sees isError. What
+    // matters for both paths is the same — no snapshot is produced, so nothing
+    // can be mistaken for a Free workspace.
+    for (const status of [404, 503]) {
+      stubFetchJson({ error: "unavailable" }, status);
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.getWorkspaceSubscriptionSummary()).rejects.toThrow();
+    }
+  });
+
+  it("returns null for a 2xx body that does not match the contract", async () => {
+    // The other half of the contract: a response that arrives successfully but
+    // does not conform degrades to null rather than throwing into React.
+    stubFetchJson({ unexpected: "shape" });
     const client = new ApiClient("https://api.example.test");
     expect(await client.getWorkspaceSubscriptionSummary()).toBeNull();
   });
@@ -822,11 +834,21 @@ describe("workspace subscription contract", () => {
   });
 
   it("rejects a prices response whose interval does not match its slot", async () => {
+    const client = new ApiClient("https://api.example.test");
+
+    // An interval outside the contract.
     stubFetchJson({
       month: { currency: "usd", unit_amount: 2000, interval: "month", interval_count: 1 },
       year: { currency: "usd", unit_amount: 20000, interval: "week", interval_count: 1 },
     });
-    const client = new ApiClient("https://api.example.test");
+    expect(await client.getWorkspaceSubscriptionPrices()).toBeNull();
+
+    // Valid intervals in the wrong slots. Accepting this would let the UI quote
+    // a yearly amount as the monthly price.
+    stubFetchJson({
+      month: { currency: "usd", unit_amount: 20000, interval: "year", interval_count: 1 },
+      year: { currency: "usd", unit_amount: 2000, interval: "month", interval_count: 1 },
+    });
     expect(await client.getWorkspaceSubscriptionPrices()).toBeNull();
   });
 });

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -704,3 +704,129 @@ describe("parseWithFallback", () => {
     expect(out).toBe(fallback);
   });
 });
+
+// Workspace subscription reads carry a specific hazard the wallet schemas do
+// not: the fallback for a paid workspace must never be a shape that reads as
+// Free. An older cloud, a 503, or a renamed field has to surface as "unknown"
+// so the UI shows "unavailable" instead of quietly downgrading a paying team.
+describe("workspace subscription contract", () => {
+  const entitlement = {
+    workspace_id: "11111111-1111-1111-1111-111111111111",
+    plan: "pro",
+    status: "active",
+    seats: 3,
+    issue_window: null,
+    autopilot_runs: null,
+    current_period_end: "2026-09-01T00:00:00Z",
+    snapshot_expires_at: null,
+    version: 7,
+  };
+
+  it("maps a full summary to camelCase without inventing values", async () => {
+    stubFetchJson({
+      entitlement,
+      billing_interval: "year",
+      actual_seats: 3,
+      billed_seats: 5,
+      pending_seat_quantity: 3,
+      cancel_at_period_end: true,
+      grace_until: "2026-09-08T00:00:00Z",
+      can_open_portal: true,
+    });
+    const client = new ApiClient("https://api.example.test");
+    const summary = await client.getWorkspaceSubscriptionSummary();
+
+    expect(summary).not.toBeNull();
+    expect(summary?.entitlement.plan).toBe("pro");
+    expect(summary?.entitlement.version).toBe(7);
+    expect(summary?.billingInterval).toBe("year");
+    expect(summary?.billedSeats).toBe(5);
+    expect(summary?.pendingSeatQuantity).toBe(3);
+    expect(summary?.cancelAtPeriodEnd).toBe(true);
+    expect(summary?.graceUntil).toBe("2026-09-08T00:00:00Z");
+    expect(summary?.canOpenPortal).toBe(true);
+  });
+
+  it("keeps a paid summary readable when optional fields are absent", async () => {
+    // A cloud that predates the optional seat/cancellation fields still has to
+    // produce a usable Pro summary rather than failing the whole read.
+    stubFetchJson({ entitlement, actual_seats: 3 });
+    const client = new ApiClient("https://api.example.test");
+    const summary = await client.getWorkspaceSubscriptionSummary();
+
+    expect(summary?.entitlement.plan).toBe("pro");
+    expect(summary?.billingInterval).toBeNull();
+    expect(summary?.billedSeats).toBeNull();
+    expect(summary?.pendingSeatQuantity).toBeNull();
+    expect(summary?.cancelAtPeriodEnd).toBe(false);
+    expect(summary?.graceUntil).toBeNull();
+    // Absent means "no Stripe customer known", which is the safe reading: the
+    // caller hides Portal rather than offering a control that would 404.
+    expect(summary?.canOpenPortal).toBe(false);
+  });
+
+  it("preserves unknown plans and statuses instead of coercing them", async () => {
+    stubFetchJson({
+      entitlement: { ...entitlement, plan: "business", status: "paused" },
+      actual_seats: 9,
+    });
+    const client = new ApiClient("https://api.example.test");
+    const summary = await client.getWorkspaceSubscriptionSummary();
+
+    expect(summary?.entitlement.plan).toBe("business");
+    expect(summary?.entitlement.status).toBe("paused");
+  });
+
+  it("returns null — never a Free-looking shape — for a malformed summary", async () => {
+    stubFetchJson({ entitlement: { plan: "pro" }, actual_seats: "many" });
+    const client = new ApiClient("https://api.example.test");
+    expect(await client.getWorkspaceSubscriptionSummary()).toBeNull();
+  });
+
+  it("returns null for an older cloud that does not serve summary", async () => {
+    // 404/503 bodies parse as JSON but do not match the contract. The absence
+    // of a snapshot must not be mistaken for a Free workspace.
+    stubFetchJson({ error: "not found" }, 200);
+    const client = new ApiClient("https://api.example.test");
+    expect(await client.getWorkspaceSubscriptionSummary()).toBeNull();
+  });
+
+  it("accepts additive cloud fields on summary and prices", async () => {
+    stubFetchJson({
+      entitlement: { ...entitlement, trial_ends_at: "2026-10-01T00:00:00Z" },
+      actual_seats: 3,
+      future_field: { nested: true },
+    });
+    const client = new ApiClient("https://api.example.test");
+    expect(
+      (await client.getWorkspaceSubscriptionSummary())?.entitlement.plan,
+    ).toBe("pro");
+  });
+
+  it("maps validated prices and rejects a non-positive amount", async () => {
+    stubFetchJson({
+      month: { currency: "usd", unit_amount: 2000, interval: "month", interval_count: 1 },
+      year: { currency: "usd", unit_amount: 20000, interval: "year", interval_count: 1 },
+    });
+    const client = new ApiClient("https://api.example.test");
+    const prices = await client.getWorkspaceSubscriptionPrices();
+    expect(prices?.month.unitAmount).toBe(2000);
+    expect(prices?.year.interval).toBe("year");
+
+    // A zero or missing amount must not be rendered next to a purchase button.
+    stubFetchJson({
+      month: { currency: "usd", unit_amount: 0, interval: "month", interval_count: 1 },
+      year: { currency: "usd", unit_amount: 20000, interval: "year", interval_count: 1 },
+    });
+    expect(await client.getWorkspaceSubscriptionPrices()).toBeNull();
+  });
+
+  it("rejects a prices response whose interval does not match its slot", async () => {
+    stubFetchJson({
+      month: { currency: "usd", unit_amount: 2000, interval: "month", interval_count: 1 },
+      year: { currency: "usd", unit_amount: 20000, interval: "week", interval_count: 1 },
+    });
+    const client = new ApiClient("https://api.example.test");
+    expect(await client.getWorkspaceSubscriptionPrices()).toBeNull();
+  });
+});

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -21,6 +21,10 @@ import type {
   Comment,
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
+  WorkspaceSubscriptionEntitlements,
+  WorkspaceSubscriptionSummary,
+  WorkspaceSubscriptionPrice,
+  WorkspaceSubscriptionPrices,
   CronPreviewResponse,
   DingTalkGroupRoute,
   DingTalkInstallation,
@@ -2123,6 +2127,110 @@ export const CreateBillingPortalSessionResponseSchema = z.object({
 export const EMPTY_CREATE_BILLING_PORTAL_SESSION_RESPONSE: CreateBillingPortalSessionResponse = {
   url: "",
 };
+
+// ---------------------------------------------------------------------------
+// Workspace subscriptions (`/api/cloud-subscriptions/*`)
+//
+// These schemas are the compatibility boundary with multica-cloud. Three rules
+// hold for all of them:
+//
+//  1. There is no fallback value. Callers get `null` on any parse failure and
+//     must render "unavailable" — never a synthetic Free plan, because that
+//     turns an upstream outage or an older cloud into a silent downgrade of a
+//     paying workspace.
+//  2. `.loose()` keeps unknown keys, so a cloud that adds fields does not break
+//     an older client.
+//  3. `plan` and `status` stay open strings. A new plan or Stripe status must
+//     surface as unknown rather than be coerced into a known one.
+
+const WorkspaceSubscriptionIntervalSchema = z.enum(["month", "year"]);
+
+export const WorkspaceSubscriptionEntitlementsSchema = z
+  .object({
+    workspace_id: z.string(),
+    plan: z.string(),
+    status: z.string(),
+    // Cloud documents seats as >= 1, but accepting 0 costs nothing and keeps a
+    // workspace that momentarily reports no human members readable instead of
+    // failing the whole snapshot.
+    seats: z.number().int().nonnegative(),
+    issue_window: z.number().int().nonnegative().nullable(),
+    autopilot_runs: z.number().int().nonnegative().nullable(),
+    current_period_end: z.string().nullable().optional(),
+    snapshot_expires_at: z.string().nullable().optional(),
+    version: z.number().int().nonnegative(),
+  })
+  .loose()
+  .transform(
+    (value): WorkspaceSubscriptionEntitlements => ({
+      workspaceId: value.workspace_id,
+      plan: value.plan,
+      status: value.status,
+      seats: value.seats,
+      issueWindow: value.issue_window,
+      autopilotRuns: value.autopilot_runs,
+      currentPeriodEnd: value.current_period_end ?? null,
+      snapshotExpiresAt: value.snapshot_expires_at ?? null,
+      version: value.version,
+    }),
+  );
+
+export const WorkspaceSubscriptionSummarySchema = z
+  .object({
+    entitlement: WorkspaceSubscriptionEntitlementsSchema,
+    billing_interval: WorkspaceSubscriptionIntervalSchema.nullable().optional(),
+    actual_seats: z.number().int().nonnegative(),
+    billed_seats: z.number().int().nonnegative().nullable().optional(),
+    pending_seat_quantity: z.number().int().nonnegative().nullable().optional(),
+    cancel_at_period_end: z.boolean().optional(),
+    grace_until: z.string().nullable().optional(),
+    can_open_portal: z.boolean().optional(),
+  })
+  .loose()
+  .transform(
+    (value): WorkspaceSubscriptionSummary => ({
+      entitlement: value.entitlement,
+      billingInterval: value.billing_interval ?? null,
+      actualSeats: value.actual_seats,
+      billedSeats: value.billed_seats ?? null,
+      pendingSeatQuantity: value.pending_seat_quantity ?? null,
+      cancelAtPeriodEnd: value.cancel_at_period_end ?? false,
+      graceUntil: value.grace_until ?? null,
+      canOpenPortal: value.can_open_portal ?? false,
+    }),
+  );
+
+const WorkspaceSubscriptionPriceSchema = z
+  .object({
+    currency: z.string().min(1),
+    // Reject 0 and negatives: a free or malformed Price must read as
+    // "price unavailable", not as a real amount shown next to a purchase button.
+    unit_amount: z.number().int().positive(),
+    interval: WorkspaceSubscriptionIntervalSchema,
+    interval_count: z.number().int().positive(),
+  })
+  .loose()
+  .transform(
+    (value): WorkspaceSubscriptionPrice => ({
+      currency: value.currency,
+      unitAmount: value.unit_amount,
+      interval: value.interval,
+      intervalCount: value.interval_count,
+    }),
+  );
+
+export const WorkspaceSubscriptionPricesSchema = z
+  .object({
+    month: WorkspaceSubscriptionPriceSchema,
+    year: WorkspaceSubscriptionPriceSchema,
+  })
+  .loose()
+  .transform(
+    (value): WorkspaceSubscriptionPrices => ({
+      month: value.month,
+      year: value.year,
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Runtime model discovery (`POST /api/runtimes/:id/models`,

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -2184,7 +2184,7 @@ export const WorkspaceSubscriptionSummarySchema = z
     pending_seat_quantity: z.number().int().nonnegative().nullable().optional(),
     cancel_at_period_end: z.boolean().optional(),
     grace_until: z.string().nullable().optional(),
-    can_open_portal: z.boolean().optional(),
+    has_stripe_customer: z.boolean().optional(),
   })
   .loose()
   .transform(
@@ -2196,33 +2196,41 @@ export const WorkspaceSubscriptionSummarySchema = z
       pendingSeatQuantity: value.pending_seat_quantity ?? null,
       cancelAtPeriodEnd: value.cancel_at_period_end ?? false,
       graceUntil: value.grace_until ?? null,
-      canOpenPortal: value.can_open_portal ?? false,
+      hasStripeCustomer: value.has_stripe_customer ?? false,
     }),
   );
 
-const WorkspaceSubscriptionPriceSchema = z
-  .object({
-    currency: z.string().min(1),
-    // Reject 0 and negatives: a free or malformed Price must read as
-    // "price unavailable", not as a real amount shown next to a purchase button.
-    unit_amount: z.number().int().positive(),
-    interval: WorkspaceSubscriptionIntervalSchema,
-    interval_count: z.number().int().positive(),
-  })
-  .loose()
-  .transform(
-    (value): WorkspaceSubscriptionPrice => ({
-      currency: value.currency,
-      unitAmount: value.unit_amount,
-      interval: value.interval,
-      intervalCount: value.interval_count,
-    }),
-  );
+const WorkspaceSubscriptionPriceSchema = (
+  expected: "month" | "year",
+) =>
+  z
+    .object({
+      currency: z.string().min(1),
+      // Reject 0 and negatives: a free or malformed Price must read as
+      // "price unavailable", not as a real amount shown next to a purchase
+      // button.
+      unit_amount: z.number().int().positive(),
+      // Pinned to the slot it arrived in. Cloud validates this too, but a
+      // schema that accepted a yearly Price under `month` would let the UI
+      // quote a yearly amount as a monthly one — the schema is an independent
+      // boundary, so it checks the correspondence itself.
+      interval: z.literal(expected),
+      interval_count: z.number().int().positive(),
+    })
+    .loose()
+    .transform(
+      (value): WorkspaceSubscriptionPrice => ({
+        currency: value.currency,
+        unitAmount: value.unit_amount,
+        interval: value.interval,
+        intervalCount: value.interval_count,
+      }),
+    );
 
 export const WorkspaceSubscriptionPricesSchema = z
   .object({
-    month: WorkspaceSubscriptionPriceSchema,
-    year: WorkspaceSubscriptionPriceSchema,
+    month: WorkspaceSubscriptionPriceSchema("month"),
+    year: WorkspaceSubscriptionPriceSchema("year"),
   })
   .loose()
   .transform(

--- a/packages/core/billing/index.ts
+++ b/packages/core/billing/index.ts
@@ -1,2 +1,3 @@
 export * from "./queries";
 export * from "./mutations";
+export * from "./workspace-subscription-queries";

--- a/packages/core/billing/workspace-subscription-queries.ts
+++ b/packages/core/billing/workspace-subscription-queries.ts
@@ -1,0 +1,68 @@
+import { queryOptions } from "@tanstack/react-query";
+import { api } from "../api";
+
+/**
+ * Workspace subscription reads.
+ *
+ * Unlike the account-level wallet keys in `./queries`, these ARE scoped by
+ * workspace ID: the server resolves the workspace from the request context, so
+ * two workspaces produce different data from the same URL. Keying on the
+ * workspace is what stops a cached snapshot from one workspace being shown for
+ * another after a switch.
+ */
+export const workspaceSubscriptionKeys = {
+  all: (wsId: string) => ["workspace-subscriptions", wsId] as const,
+  entitlements: (wsId: string) =>
+    [...workspaceSubscriptionKeys.all(wsId), "entitlements"] as const,
+  summary: (wsId: string) =>
+    [...workspaceSubscriptionKeys.all(wsId), "summary"] as const,
+  prices: (wsId: string) =>
+    [...workspaceSubscriptionKeys.all(wsId), "prices"] as const,
+};
+
+export function workspaceSubscriptionEntitlementsOptions(wsId: string) {
+  return queryOptions({
+    queryKey: workspaceSubscriptionKeys.entitlements(wsId),
+    queryFn: () => api.getWorkspaceSubscriptionEntitlements(),
+    enabled: wsId.length > 0,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * The Billing page's primary read. Short stale time plus refetch on focus: a
+ * user returning from Stripe in another tab or the system browser should see the
+ * new state without a manual reload, and cloud serves this without calling
+ * Stripe so refetching is cheap.
+ */
+export function workspaceSubscriptionSummaryOptions(wsId: string) {
+  return queryOptions({
+    queryKey: workspaceSubscriptionKeys.summary(wsId),
+    queryFn: () => api.getWorkspaceSubscriptionSummary(),
+    enabled: wsId.length > 0,
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * Prices are deployment configuration, not workspace state: they change only
+ * when an operator repoints a Stripe Price. Cache them for much longer than the
+ * summary and do not refetch on focus — cloud already caches them and each miss
+ * costs a Stripe round trip.
+ *
+ * Retry is disabled because the failure mode here is a misconfigured or
+ * unvalidatable Price, which retrying cannot fix; the caller shows "price
+ * confirmed at Checkout" instead.
+ */
+export function workspaceSubscriptionPricesOptions(wsId: string) {
+  return queryOptions({
+    queryKey: workspaceSubscriptionKeys.prices(wsId),
+    queryFn: () => api.getWorkspaceSubscriptionPrices(),
+    enabled: wsId.length > 0,
+    staleTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+}

--- a/packages/core/types/billing.ts
+++ b/packages/core/types/billing.ts
@@ -180,3 +180,68 @@ export interface BillingCheckoutSessionStatus {
 export interface CreateBillingPortalSessionResponse {
   url: string;
 }
+
+// ---------------------------------------------------------------------------
+// Workspace subscriptions (`/api/cloud-subscriptions/*`)
+//
+// Workspace-scoped, unlike the account-level wallet types above. The server
+// injects the workspace from the authenticated request context, so no client
+// ever names a workspace, an amount, a Price ID, or a seat quantity.
+//
+// Every field the server may not know is nullable rather than defaulted. A
+// missing value has to stay visibly unknown: rendering an absent plan as Free
+// would turn an upstream outage into a silent downgrade of a paying workspace.
+
+export type WorkspaceSubscriptionInterval = "month" | "year";
+
+export interface WorkspaceSubscriptionEntitlements {
+  workspaceId: string;
+  // Deliberately open strings: cloud may add plans and Stripe statuses without
+  // a client release, and an unknown value must read as unknown, not as Free.
+  plan: string;
+  status: string;
+  seats: number;
+  issueWindow: number | null;
+  autopilotRuns: number | null;
+  currentPeriodEnd: string | null;
+  snapshotExpiresAt: string | null;
+  version: number;
+}
+
+/**
+ * Everything the workspace Billing settings page needs about the current
+ * subscription, served from cloud's own database — never a synchronous Stripe
+ * call, so it stays readable while Stripe is degraded.
+ */
+export interface WorkspaceSubscriptionSummary {
+  entitlement: WorkspaceSubscriptionEntitlements;
+  billingInterval: WorkspaceSubscriptionInterval | null;
+  /** Authoritative current human-member count. Agents never take a seat. */
+  actualSeats: number;
+  /** Persisted Stripe seat high-water; null when no subscription exists yet. */
+  billedSeats: number | null;
+  /** A lower quantity already scheduled for the next period, if any. */
+  pendingSeatQuantity: number | null;
+  cancelAtPeriodEnd: boolean;
+  graceUntil: string | null;
+  /**
+   * Reports only that a Stripe customer exists for this workspace. It is NOT a
+   * permission: Billing Portal still requires owner/admin, so a caller must
+   * gate the control on the member's role as well.
+   */
+  canOpenPortal: boolean;
+}
+
+/** Display-safe subset of a configured Stripe Price. IDs stay server-side. */
+export interface WorkspaceSubscriptionPrice {
+  currency: string;
+  /** Minor currency units per licensed seat, e.g. 2000 for $20.00. */
+  unitAmount: number;
+  interval: WorkspaceSubscriptionInterval;
+  intervalCount: number;
+}
+
+export interface WorkspaceSubscriptionPrices {
+  month: WorkspaceSubscriptionPrice;
+  year: WorkspaceSubscriptionPrice;
+}

--- a/packages/core/types/billing.ts
+++ b/packages/core/types/billing.ts
@@ -225,11 +225,11 @@ export interface WorkspaceSubscriptionSummary {
   cancelAtPeriodEnd: boolean;
   graceUntil: string | null;
   /**
-   * Reports only that a Stripe customer exists for this workspace. It is NOT a
-   * permission: Billing Portal still requires owner/admin, so a caller must
-   * gate the control on the member's role as well.
+   * Whether a local Stripe customer exists for this workspace. It is a fact,
+   * NOT a permission: Billing Portal still requires owner/admin, so a caller
+   * must gate that control on the member's role as well.
    */
-  canOpenPortal: boolean;
+  hasStripeCustomer: boolean;
 }
 
 /** Display-safe subset of a configured Stripe Price. IDs stay server-side. */

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -280,4 +280,9 @@ export type {
   CreateBillingCheckoutSessionResponse,
   BillingCheckoutSessionStatus,
   CreateBillingPortalSessionResponse,
+  WorkspaceSubscriptionInterval,
+  WorkspaceSubscriptionEntitlements,
+  WorkspaceSubscriptionSummary,
+  WorkspaceSubscriptionPrice,
+  WorkspaceSubscriptionPrices,
 } from "./billing";

--- a/packages/views/billing/billing-return-page.test.tsx
+++ b/packages/views/billing/billing-return-page.test.tsx
@@ -14,8 +14,8 @@ const mockRefetchWorkspaces = vi.hoisted(() => vi.fn());
 const workspacesRef = vi.hoisted(() => ({
   current: {
     data: [
-      { id: "ws-1", slug: "acme" },
-      { id: "ws-2", slug: "globex" },
+      { id: "11111111-1111-1111-1111-111111111111", slug: "acme" },
+      { id: "22222222-2222-2222-2222-222222222222", slug: "globex" },
     ] as { id: string; slug: string }[] | undefined,
     isPending: false,
     isError: false,
@@ -63,13 +63,24 @@ function renderReturn(search: string) {
   return render(<BillingReturnPage />, { wrapper: Wrapper });
 }
 
+/**
+ * The one claim this page must never make is that anything was saved. `cancel`
+ * means the user backed out, `portal` may have been opened and closed, and even
+ * `success` only means Stripe finished — the subscription is not recorded until
+ * the webhook lands.
+ */
+function expectNoOutcomeClaim() {
+  const text = screen.getByRole("alert").textContent ?? "";
+  expect(text).not.toMatch(/saved|success|upgraded|activated|subscribed/i);
+}
+
 describe("BillingReturnPage", () => {
   beforeEach(() => {
     authRef.current = { user: { id: "user-1" }, isLoading: false };
     workspacesRef.current = {
       data: [
-        { id: "ws-1", slug: "acme" },
-        { id: "ws-2", slug: "globex" },
+        { id: "11111111-1111-1111-1111-111111111111", slug: "acme" },
+        { id: "22222222-2222-2222-2222-222222222222", slug: "globex" },
       ],
       isPending: false,
       isError: false,
@@ -83,7 +94,7 @@ describe("BillingReturnPage", () => {
   });
 
   it("resolves the workspace id cloud authorized into its slug", async () => {
-    renderReturn("workspace_id=ws-2&result=success&session_id=cs_test_123");
+    renderReturn("workspace_id=22222222-2222-2222-2222-222222222222&result=success&session_id=cs_test_123");
 
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith(
@@ -93,7 +104,7 @@ describe("BillingReturnPage", () => {
   });
 
   it("forwards cancel and portal results and drops the Stripe session id", async () => {
-    renderReturn("workspace_id=ws-1&result=cancel&session_id=cs_test_9");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=cancel&session_id=cs_test_9");
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith(
         "/acme/settings?tab=billing&result=cancel",
@@ -101,7 +112,7 @@ describe("BillingReturnPage", () => {
     );
 
     mockReplace.mockReset();
-    renderReturn("workspace_id=ws-1&result=portal");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=portal");
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith(
         "/acme/settings?tab=billing&result=portal",
@@ -112,7 +123,7 @@ describe("BillingReturnPage", () => {
   // Only `workspace_id` and `result` are read, and the destination is rebuilt
   // from paths — so a hand-crafted return link cannot redirect off-app.
   it("ignores an unrecognized result instead of forwarding it", async () => {
-    renderReturn("workspace_id=ws-1&result=https://evil.example/steal");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=https://evil.example/steal");
 
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith("/acme/settings?tab=billing"),
@@ -122,16 +133,15 @@ describe("BillingReturnPage", () => {
   // Paying and then landing somewhere unexplained is worse than a short
   // message, so an unresolvable workspace is explained rather than redirected.
   it("explains an unresolvable workspace instead of silently redirecting", async () => {
-    renderReturn("workspace_id=ws-does-not-exist&result=success");
+    renderReturn("workspace_id=33333333-3333-3333-3333-333333333333&result=success");
 
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
-        "That workspace is no longer available to you",
+        "Could not find that workspace",
       ),
     );
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Your billing change was saved",
-    );
+    // The page cannot know the outcome, so it must not claim one.
+    expectNoOutcomeClaim();
     expect(mockReplace).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByRole("button", { name: "Go to Multica" }));
@@ -143,31 +153,36 @@ describe("BillingReturnPage", () => {
 
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
-        "That workspace is no longer available to you",
+        "Could not find that workspace",
       ),
     );
+    expectNoOutcomeClaim();
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
   // A session can expire while the user is on Stripe, so this is a normal path.
   // Losing the return context here would leave the user on their default
   // workspace with no idea whether the payment landed.
-  it("carries the return URL through login when the session expired", async () => {
+  it("carries the return context through login when the session expired", async () => {
     authRef.current = { user: null, isLoading: false };
-    renderReturn("workspace_id=ws-1&result=success&session_id=cs_test_1");
+    renderReturn(
+      "workspace_id=11111111-1111-1111-1111-111111111111&result=success&session_id=cs_test_1",
+    );
 
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith(
         "/login?next=" +
           encodeURIComponent(
-            "/billing/return?workspace_id=ws-1&result=success&session_id=cs_test_1",
+            "/billing/return?workspace_id=11111111-1111-1111-1111-111111111111&result=success",
           ),
       );
     });
     // Relative path only — the login page's sanitizer rejects anything else, so
     // this cannot become an off-site redirect.
     const target = mockReplace.mock.calls[0]?.[0] as string;
-    expect(decodeURIComponent(target.split("next=")[1] ?? "")).toMatch(/^\/billing\/return\?/);
+    expect(decodeURIComponent(target.split("next=")[1] ?? "")).toMatch(
+      /^\/billing\/return\?/,
+    );
   });
 
   it("offers a retry instead of spinning forever when the workspace list fails", async () => {
@@ -177,11 +192,12 @@ describe("BillingReturnPage", () => {
       isError: true,
       refetch: mockRefetchWorkspaces,
     };
-    renderReturn("workspace_id=ws-1&result=success");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=success");
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "Could not load your workspaces",
+      "Could not open workspace billing",
     );
+    expectNoOutcomeClaim();
     expect(mockReplace).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByRole("button", { name: "Try again" }));
@@ -190,7 +206,7 @@ describe("BillingReturnPage", () => {
 
   it("waits for auth and the workspace list before deciding", async () => {
     authRef.current = { user: null, isLoading: true };
-    renderReturn("workspace_id=ws-1&result=success");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=success");
     expect(mockReplace).not.toHaveBeenCalled();
 
     authRef.current = { user: { id: "user-1" }, isLoading: false };
@@ -200,15 +216,117 @@ describe("BillingReturnPage", () => {
       isError: false,
       refetch: mockRefetchWorkspaces,
     };
-    renderReturn("workspace_id=ws-1&result=success");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=success");
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it("shows a polite status while redirecting", () => {
-    renderReturn("workspace_id=ws-1&result=success");
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=success");
 
     expect(screen.getByRole("status")).toHaveTextContent(
       "Returning you to workspace billing",
     );
+  });
+});
+
+describe("BillingReturnPage outcome-neutral failure copy", () => {
+  beforeEach(() => {
+    authRef.current = { user: { id: "user-1" }, isLoading: false };
+    workspacesRef.current = {
+      data: [{ id: "11111111-1111-1111-1111-111111111111", slug: "acme" }],
+      isPending: false,
+      isError: false,
+      refetch: mockRefetchWorkspaces,
+    };
+  });
+
+  afterEach(() => {
+    mockReplace.mockReset();
+    mockRefetchWorkspaces.mockReset();
+  });
+
+  // A canceled Checkout changed nothing, so the failure screen must not imply a
+  // billing change happened.
+  it.each([
+    ["cancel", "result=cancel"],
+    ["portal", "result=portal"],
+    ["missing result", ""],
+    ["invalid result", "result=not-a-result"],
+  ])("claims no outcome for %s", async (_label, query) => {
+    const search = ["workspace_id=99999999-9999-9999-9999-999999999999", query]
+      .filter(Boolean)
+      .join("&");
+    renderReturn(search);
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Could not find that workspace",
+      ),
+    );
+    expectNoOutcomeClaim();
+  });
+
+  it("claims no outcome when the workspace list itself fails", () => {
+    workspacesRef.current = {
+      data: undefined,
+      isPending: false,
+      isError: true,
+      refetch: mockRefetchWorkspaces,
+    };
+    renderReturn("workspace_id=11111111-1111-1111-1111-111111111111&result=success");
+
+    expectNoOutcomeClaim();
+  });
+});
+
+describe("BillingReturnPage login continuation", () => {
+  beforeEach(() => {
+    authRef.current = { user: null, isLoading: false };
+    workspacesRef.current = {
+      data: undefined,
+      isPending: false,
+      isError: false,
+      refetch: mockRefetchWorkspaces,
+    };
+  });
+
+  afterEach(() => {
+    mockReplace.mockReset();
+  });
+
+  function nextParamFrom(call: string): string {
+    return decodeURIComponent(call.split("next=")[1] ?? "");
+  }
+
+  // The login page embeds `next` verbatim in the Google OAuth state, so anything
+  // carried here reaches a third party. Only the two values this page uses to
+  // resume may travel; Stripe's session id and unknown params must be dropped.
+  it("carries only workspace_id and result into the login continuation", async () => {
+    renderReturn(
+      "workspace_id=11111111-1111-1111-1111-111111111111&result=success" +
+        "&session_id=cs_test_secret&utm_source=stripe&anything=else",
+    );
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledOnce());
+    const next = nextParamFrom(mockReplace.mock.calls[0]?.[0] as string);
+
+    expect(next).toBe(
+      "/billing/return?workspace_id=11111111-1111-1111-1111-111111111111&result=success",
+    );
+    expect(next).not.toContain("session_id");
+    expect(next).not.toContain("cs_test_secret");
+    expect(next).not.toContain("utm_source");
+    expect(next).not.toContain("anything");
+  });
+
+  it("drops an invalid result and a malformed workspace id from the continuation", async () => {
+    renderReturn("workspace_id=not-a-uuid&result=javascript:alert(1)&session_id=cs_x");
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledOnce());
+    const next = nextParamFrom(mockReplace.mock.calls[0]?.[0] as string);
+
+    expect(next).toBe("/billing/return");
+    expect(next).not.toContain("javascript");
+    expect(next).not.toContain("not-a-uuid");
   });
 });

--- a/packages/views/billing/billing-return-page.test.tsx
+++ b/packages/views/billing/billing-return-page.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enBilling from "../locales/en/billing.json";
+
+const mockReplace = vi.hoisted(() => vi.fn());
+const searchRef = vi.hoisted(() => ({ current: new URLSearchParams() }));
+const authRef = vi.hoisted(() => ({
+  current: { user: { id: "user-1" } as { id: string } | null, isLoading: false },
+}));
+const workspacesRef = vi.hoisted(() => ({
+  current: {
+    data: [
+      { id: "ws-1", slug: "acme" },
+      { id: "ws-2", slug: "globex" },
+    ] as { id: string; slug: string }[] | undefined,
+    isPending: false,
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => workspacesRef.current,
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  workspaceListOptions: () => ({ queryKey: ["workspaces"], queryFn: vi.fn() }),
+}));
+
+vi.mock("@multica/core/auth", () => {
+  const useAuthStore = Object.assign(
+    (selector?: (state: typeof authRef.current) => unknown) =>
+      selector ? selector(authRef.current) : authRef.current,
+    { getState: () => authRef.current },
+  );
+  return { useAuthStore };
+});
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({
+    replace: mockReplace,
+    searchParams: searchRef.current,
+    pathname: "/billing/return",
+  }),
+}));
+
+import { BillingReturnPage } from "./billing-return-page";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={{ en: { billing: enBilling } }}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+function renderReturn(search: string) {
+  searchRef.current = new URLSearchParams(search);
+  return render(<BillingReturnPage />, { wrapper: Wrapper });
+}
+
+describe("BillingReturnPage", () => {
+  beforeEach(() => {
+    authRef.current = { user: { id: "user-1" }, isLoading: false };
+    workspacesRef.current = {
+      data: [
+        { id: "ws-1", slug: "acme" },
+        { id: "ws-2", slug: "globex" },
+      ],
+      isPending: false,
+    };
+  });
+
+  afterEach(() => {
+    mockReplace.mockReset();
+  });
+
+  it("resolves the workspace id cloud authorized into its slug", async () => {
+    renderReturn("workspace_id=ws-2&result=success&session_id=cs_test_123");
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/globex/settings?tab=billing&result=success",
+      ),
+    );
+  });
+
+  it("forwards cancel and portal results and drops the Stripe session id", async () => {
+    renderReturn("workspace_id=ws-1&result=cancel&session_id=cs_test_9");
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/acme/settings?tab=billing&result=cancel",
+      ),
+    );
+
+    mockReplace.mockReset();
+    renderReturn("workspace_id=ws-1&result=portal");
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/acme/settings?tab=billing&result=portal",
+      ),
+    );
+  });
+
+  // Only `workspace_id` and `result` are read, and the destination is rebuilt
+  // from paths — so a hand-crafted return link cannot redirect off-app.
+  it("ignores an unrecognized result instead of forwarding it", async () => {
+    renderReturn("workspace_id=ws-1&result=https://evil.example/steal");
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith("/acme/settings?tab=billing"),
+    );
+  });
+
+  it("falls back to the app root when the workspace is not visible to the user", async () => {
+    // Deleted workspace, revoked membership, or an edited link: there is nothing
+    // safe to render for a workspace we cannot name.
+    renderReturn("workspace_id=ws-does-not-exist&result=success");
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+  });
+
+  it("falls back to the app root when cloud sent no workspace id", async () => {
+    renderReturn("result=success");
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+  });
+
+  it("sends an unauthenticated return to login rather than rendering", async () => {
+    authRef.current = { user: null, isLoading: false };
+    renderReturn("workspace_id=ws-1&result=success");
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+  });
+
+  it("waits for auth and the workspace list before deciding", async () => {
+    authRef.current = { user: null, isLoading: true };
+    renderReturn("workspace_id=ws-1&result=success");
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    authRef.current = { user: { id: "user-1" }, isLoading: false };
+    workspacesRef.current = { data: undefined, isPending: true };
+    renderReturn("workspace_id=ws-1&result=success");
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("shows a polite status while redirecting", () => {
+    renderReturn("workspace_id=ws-1&result=success");
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Returning you to workspace billing",
+    );
+  });
+});

--- a/packages/views/billing/billing-return-page.test.tsx
+++ b/packages/views/billing/billing-return-page.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enBilling from "../locales/en/billing.json";
 
@@ -9,6 +10,7 @@ const searchRef = vi.hoisted(() => ({ current: new URLSearchParams() }));
 const authRef = vi.hoisted(() => ({
   current: { user: { id: "user-1" } as { id: string } | null, isLoading: false },
 }));
+const mockRefetchWorkspaces = vi.hoisted(() => vi.fn());
 const workspacesRef = vi.hoisted(() => ({
   current: {
     data: [
@@ -16,6 +18,8 @@ const workspacesRef = vi.hoisted(() => ({
       { id: "ws-2", slug: "globex" },
     ] as { id: string; slug: string }[] | undefined,
     isPending: false,
+    isError: false,
+    refetch: mockRefetchWorkspaces,
   },
 }));
 
@@ -68,11 +72,14 @@ describe("BillingReturnPage", () => {
         { id: "ws-2", slug: "globex" },
       ],
       isPending: false,
+      isError: false,
+      refetch: mockRefetchWorkspaces,
     };
   });
 
   afterEach(() => {
     mockReplace.mockReset();
+    mockRefetchWorkspaces.mockReset();
   });
 
   it("resolves the workspace id cloud authorized into its slug", async () => {
@@ -112,25 +119,73 @@ describe("BillingReturnPage", () => {
     );
   });
 
-  it("falls back to the app root when the workspace is not visible to the user", async () => {
-    // Deleted workspace, revoked membership, or an edited link: there is nothing
-    // safe to render for a workspace we cannot name.
+  // Paying and then landing somewhere unexplained is worse than a short
+  // message, so an unresolvable workspace is explained rather than redirected.
+  it("explains an unresolvable workspace instead of silently redirecting", async () => {
     renderReturn("workspace_id=ws-does-not-exist&result=success");
 
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "That workspace is no longer available to you",
+      ),
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Your billing change was saved",
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Go to Multica" }));
+    expect(mockReplace).toHaveBeenCalledWith("/");
   });
 
-  it("falls back to the app root when cloud sent no workspace id", async () => {
+  it("explains a missing workspace id the same way", async () => {
     renderReturn("result=success");
 
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "That workspace is no longer available to you",
+      ),
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it("sends an unauthenticated return to login rather than rendering", async () => {
+  // A session can expire while the user is on Stripe, so this is a normal path.
+  // Losing the return context here would leave the user on their default
+  // workspace with no idea whether the payment landed.
+  it("carries the return URL through login when the session expired", async () => {
     authRef.current = { user: null, isLoading: false };
+    renderReturn("workspace_id=ws-1&result=success&session_id=cs_test_1");
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/login?next=" +
+          encodeURIComponent(
+            "/billing/return?workspace_id=ws-1&result=success&session_id=cs_test_1",
+          ),
+      );
+    });
+    // Relative path only — the login page's sanitizer rejects anything else, so
+    // this cannot become an off-site redirect.
+    const target = mockReplace.mock.calls[0]?.[0] as string;
+    expect(decodeURIComponent(target.split("next=")[1] ?? "")).toMatch(/^\/billing\/return\?/);
+  });
+
+  it("offers a retry instead of spinning forever when the workspace list fails", async () => {
+    workspacesRef.current = {
+      data: undefined,
+      isPending: false,
+      isError: true,
+      refetch: mockRefetchWorkspaces,
+    };
     renderReturn("workspace_id=ws-1&result=success");
 
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Could not load your workspaces",
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(mockRefetchWorkspaces).toHaveBeenCalledTimes(1);
   });
 
   it("waits for auth and the workspace list before deciding", async () => {
@@ -139,7 +194,12 @@ describe("BillingReturnPage", () => {
     expect(mockReplace).not.toHaveBeenCalled();
 
     authRef.current = { user: { id: "user-1" }, isLoading: false };
-    workspacesRef.current = { data: undefined, isPending: true };
+    workspacesRef.current = {
+      data: undefined,
+      isPending: true,
+      isError: false,
+      refetch: mockRefetchWorkspaces,
+    };
     renderReturn("workspace_id=ws-1&result=success");
     expect(mockReplace).not.toHaveBeenCalled();
   });

--- a/packages/views/billing/billing-return-page.tsx
+++ b/packages/views/billing/billing-return-page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
 import { paths } from "@multica/core/paths";
 import { workspaceListOptions } from "@multica/core/workspace/queries";
+import { Button } from "@multica/ui/components/ui/button";
 import { useNavigation } from "../navigation";
 import { useT } from "../i18n";
 
@@ -19,7 +20,7 @@ import { useT } from "../i18n";
  * actually needs. Hardcoding one workspace's slug in the Stripe configuration
  * would strand every other workspace.
  *
- * Two things this page deliberately does NOT do:
+ * Three things this page deliberately does NOT do:
  *
  *   - It never trusts a redirect target from the query string. Only
  *     `workspace_id` and `result` are read, and the destination is rebuilt from
@@ -27,6 +28,9 @@ import { useT } from "../i18n";
  *   - It does not report success on its own. `result=success` means Stripe
  *     finished, not that the subscription is recorded; the destination page is
  *     what waits for the webhook. This page only forwards the marker.
+ *   - It does not silently drop the user somewhere else when something is
+ *     wrong. Paying and then landing on an unexplained page is worse than a
+ *     short message, so the failure states below say what happened.
  */
 
 const RESULT_VALUES = new Set(["success", "cancel", "portal"]);
@@ -41,35 +45,38 @@ export function BillingReturnPage() {
   const resultParam = navigation.searchParams.get("result");
   const result = resultParam && RESULT_VALUES.has(resultParam) ? resultParam : null;
 
-  const { data: workspaces, isPending: isWorkspacesPending } = useQuery({
+  const {
+    data: workspaces,
+    isPending: isWorkspacesPending,
+    isError: isWorkspacesError,
+    refetch: refetchWorkspaces,
+  } = useQuery({
     ...workspaceListOptions(),
     enabled: !!user,
   });
 
-  useEffect(() => {
-    if (isAuthLoading) return;
-    // Stripe sends the browser here directly, so an expired session is normal.
-    // Send the user to login rather than rendering a broken page; they can
-    // reopen Billing afterwards and the subscription state is already correct
-    // server-side.
-    if (!user) {
-      navigation.replace(paths.login());
-      return;
-    }
-    if (isWorkspacesPending || !workspaces) return;
-
-    const match = workspaceIdParam
+  const match =
+    workspaceIdParam && workspaces
       ? workspaces.find((ws) => ws.id === workspaceIdParam)
       : undefined;
+  // Only after the list has actually arrived can "not found" mean anything.
+  const isUnresolvable = !!workspaces && !match;
 
-    // No match means the workspace was deleted, or this user is no longer a
-    // member, or the link was hand-edited. There is nothing safe to show for a
-    // workspace we cannot name, so fall back to the app root, which resolves to
-    // the user's default workspace.
-    if (!match) {
-      navigation.replace(paths.root());
+  useEffect(() => {
+    if (isAuthLoading) return;
+    // Checkout can take long enough for a session to expire, so an
+    // unauthenticated return is a normal case rather than an error. Carry this
+    // exact URL through login so the user resumes the return instead of landing
+    // on their default workspace with no idea whether the payment took.
+    // sanitizeNextUrl in the login page only accepts relative paths, so this
+    // cannot be turned into an off-site redirect.
+    if (!user) {
+      const returnTo = `${navigation.pathname}?${navigation.searchParams.toString()}`;
+      navigation.replace(`${paths.login()}?next=${encodeURIComponent(returnTo)}`);
       return;
     }
+    if (isWorkspacesPending || isWorkspacesError || !workspaces) return;
+    if (!match) return;
 
     const destination = `${paths.workspace(match.slug).settings()}?tab=billing${
       result ? `&result=${result}` : ""
@@ -79,13 +86,52 @@ export function BillingReturnPage() {
     navigation.replace(destination);
   }, [
     isAuthLoading,
+    isWorkspacesError,
     isWorkspacesPending,
+    match,
     navigation,
     result,
     user,
-    workspaceIdParam,
     workspaces,
   ]);
+
+  // The workspace list is what turns an ID into a slug, so without it there is
+  // no destination to send anyone to. Retrying beats an endless spinner.
+  if (isWorkspacesError) {
+    return (
+      <ReturnMessage
+        title={t(($) => $.return_page.load_failed_title)}
+        description={t(($) => $.return_page.load_failed_description)}
+        action={
+          <Button
+            className="h-11"
+            variant="outline"
+            onClick={() => void refetchWorkspaces()}
+          >
+            <RefreshCw />
+            {t(($) => $.return_page.retry)}
+          </Button>
+        }
+      />
+    );
+  }
+
+  // Deleted workspace, revoked membership, or a hand-edited link. The billing
+  // change itself is already recorded server-side, so say that plainly instead
+  // of dropping the user on an unrelated workspace with no explanation.
+  if (isUnresolvable) {
+    return (
+      <ReturnMessage
+        title={t(($) => $.return_page.workspace_missing_title)}
+        description={t(($) => $.return_page.workspace_missing_description)}
+        action={
+          <Button className="h-11" onClick={() => navigation.replace(paths.root())}>
+            {t(($) => $.return_page.go_to_app)}
+          </Button>
+        }
+      />
+    );
+  }
 
   return (
     <div
@@ -96,6 +142,35 @@ export function BillingReturnPage() {
       <div className="flex items-center gap-3 text-body text-muted-foreground">
         <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
         <span>{t(($) => $.return_page.redirecting)}</span>
+      </div>
+    </div>
+  );
+}
+
+function ReturnMessage({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-background p-6">
+      <div
+        className="flex max-w-[60ch] flex-col items-start gap-3"
+        role="alert"
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-2 text-body font-medium">
+          <AlertCircle className="size-4 text-destructive" />
+          <span>{title}</span>
+        </div>
+        <p className="text-caption leading-5 text-muted-foreground">
+          {description}
+        </p>
+        {action}
       </div>
     </div>
   );

--- a/packages/views/billing/billing-return-page.tsx
+++ b/packages/views/billing/billing-return-page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useAuthStore } from "@multica/core/auth";
+import { paths } from "@multica/core/paths";
+import { workspaceListOptions } from "@multica/core/workspace/queries";
+import { useNavigation } from "../navigation";
+import { useT } from "../i18n";
+
+/**
+ * Landing page for Stripe Checkout and Billing Portal returns.
+ *
+ * Stripe only knows the return URLs a deployment configured, and a deployment
+ * has exactly one set of them — so they cannot contain a workspace slug. Cloud
+ * therefore appends the workspace it already authorized (`workspace_id`) plus
+ * `result`, and this page turns that into the slug-based Settings URL the user
+ * actually needs. Hardcoding one workspace's slug in the Stripe configuration
+ * would strand every other workspace.
+ *
+ * Two things this page deliberately does NOT do:
+ *
+ *   - It never trusts a redirect target from the query string. Only
+ *     `workspace_id` and `result` are read, and the destination is rebuilt from
+ *     `paths`, so a crafted return link cannot become an open redirect.
+ *   - It does not report success on its own. `result=success` means Stripe
+ *     finished, not that the subscription is recorded; the destination page is
+ *     what waits for the webhook. This page only forwards the marker.
+ */
+
+const RESULT_VALUES = new Set(["success", "cancel", "portal"]);
+
+export function BillingReturnPage() {
+  const { t } = useT("billing");
+  const navigation = useNavigation();
+  const user = useAuthStore((s) => s.user);
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
+
+  const workspaceIdParam = navigation.searchParams.get("workspace_id");
+  const resultParam = navigation.searchParams.get("result");
+  const result = resultParam && RESULT_VALUES.has(resultParam) ? resultParam : null;
+
+  const { data: workspaces, isPending: isWorkspacesPending } = useQuery({
+    ...workspaceListOptions(),
+    enabled: !!user,
+  });
+
+  useEffect(() => {
+    if (isAuthLoading) return;
+    // Stripe sends the browser here directly, so an expired session is normal.
+    // Send the user to login rather than rendering a broken page; they can
+    // reopen Billing afterwards and the subscription state is already correct
+    // server-side.
+    if (!user) {
+      navigation.replace(paths.login());
+      return;
+    }
+    if (isWorkspacesPending || !workspaces) return;
+
+    const match = workspaceIdParam
+      ? workspaces.find((ws) => ws.id === workspaceIdParam)
+      : undefined;
+
+    // No match means the workspace was deleted, or this user is no longer a
+    // member, or the link was hand-edited. There is nothing safe to show for a
+    // workspace we cannot name, so fall back to the app root, which resolves to
+    // the user's default workspace.
+    if (!match) {
+      navigation.replace(paths.root());
+      return;
+    }
+
+    const destination = `${paths.workspace(match.slug).settings()}?tab=billing${
+      result ? `&result=${result}` : ""
+    }`;
+    // replace(), not push(): the Stripe hop should not sit in history where a
+    // back navigation would re-run this redirect.
+    navigation.replace(destination);
+  }, [
+    isAuthLoading,
+    isWorkspacesPending,
+    navigation,
+    result,
+    user,
+    workspaceIdParam,
+    workspaces,
+  ]);
+
+  return (
+    <div
+      className="flex min-h-dvh items-center justify-center bg-background p-6"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-3 text-body text-muted-foreground">
+        <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />
+        <span>{t(($) => $.return_page.redirecting)}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/views/billing/billing-return-page.tsx
+++ b/packages/views/billing/billing-return-page.tsx
@@ -34,6 +34,10 @@ import { useT } from "../i18n";
  */
 
 const RESULT_VALUES = new Set(["success", "cancel", "portal"]);
+// Same shape check the rest of core uses for route UUIDs. Only a well-formed ID
+// is worth carrying anywhere, and this one can end up in a third-party OAuth
+// state on the login detour below.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function BillingReturnPage() {
   const { t } = useT("billing");
@@ -41,7 +45,9 @@ export function BillingReturnPage() {
   const user = useAuthStore((s) => s.user);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
 
-  const workspaceIdParam = navigation.searchParams.get("workspace_id");
+  const workspaceIdRaw = navigation.searchParams.get("workspace_id");
+  const workspaceIdParam =
+    workspaceIdRaw && UUID_RE.test(workspaceIdRaw) ? workspaceIdRaw : null;
   const resultParam = navigation.searchParams.get("result");
   const result = resultParam && RESULT_VALUES.has(resultParam) ? resultParam : null;
 
@@ -65,13 +71,24 @@ export function BillingReturnPage() {
   useEffect(() => {
     if (isAuthLoading) return;
     // Checkout can take long enough for a session to expire, so an
-    // unauthenticated return is a normal case rather than an error. Carry this
-    // exact URL through login so the user resumes the return instead of landing
-    // on their default workspace with no idea whether the payment took.
-    // sanitizeNextUrl in the login page only accepts relative paths, so this
-    // cannot be turned into an off-site redirect.
+    // unauthenticated return is a normal case rather than an error. Carry enough
+    // to resume the return so the user does not land on their default workspace
+    // with no idea whether the payment took.
+    //
+    // Rebuilt from the two values this page actually uses, NOT forwarded whole:
+    // the login page embeds `next` verbatim in the Google OAuth `state`, so
+    // anything left in here — Stripe's `session_id`, any future cloud param —
+    // would be handed to a third party for no functional reason.
+    // sanitizeNextUrl on the login side also accepts relative paths only, so
+    // this cannot become an off-site redirect.
     if (!user) {
-      const returnTo = `${navigation.pathname}?${navigation.searchParams.toString()}`;
+      const resume = new URLSearchParams();
+      if (workspaceIdParam) resume.set("workspace_id", workspaceIdParam);
+      if (result) resume.set("result", result);
+      const query = resume.toString();
+      const returnTo = query
+        ? `${navigation.pathname}?${query}`
+        : navigation.pathname;
       navigation.replace(`${paths.login()}?next=${encodeURIComponent(returnTo)}`);
       return;
     }
@@ -92,11 +109,18 @@ export function BillingReturnPage() {
     navigation,
     result,
     user,
+    workspaceIdParam,
     workspaces,
   ]);
 
   // The workspace list is what turns an ID into a slug, so without it there is
   // no destination to send anyone to. Retrying beats an endless spinner.
+  //
+  // The copy below deliberately claims nothing about the outcome. This page
+  // cannot know it: `cancel` means the user backed out, `portal` may have been
+  // opened and closed, and even `success` only means Stripe finished — the
+  // subscription is not recorded until the webhook lands. Asserting "saved" on a
+  // payment result screen is the one thing worse than saying "check Billing".
   if (isWorkspacesError) {
     return (
       <ReturnMessage
@@ -116,9 +140,8 @@ export function BillingReturnPage() {
     );
   }
 
-  // Deleted workspace, revoked membership, or a hand-edited link. The billing
-  // change itself is already recorded server-side, so say that plainly instead
-  // of dropping the user on an unrelated workspace with no explanation.
+  // Deleted workspace, revoked membership, a missing or malformed workspace_id,
+  // or a hand-edited link.
   if (isUnresolvable) {
     return (
       <ReturnMessage

--- a/packages/views/billing/index.ts
+++ b/packages/views/billing/index.ts
@@ -1,1 +1,2 @@
 export { BillingTestPage } from "./billing-test-page";
+export { BillingReturnPage } from "./billing-return-page";

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -74,10 +74,10 @@
   },
   "return_page": {
     "redirecting": "Returning you to workspace billing…",
-    "load_failed_title": "Could not load your workspaces",
-    "load_failed_description": "Your billing change was saved. We just could not load your workspace list to send you back to the right billing page.",
-    "workspace_missing_title": "That workspace is no longer available to you",
-    "workspace_missing_description": "Your billing change was saved, but this workspace was removed or your access to it changed, so we cannot open its billing settings.",
+    "load_failed_title": "Could not open workspace billing",
+    "load_failed_description": "You came back from Stripe, but we could not load your workspace list to open the right billing page. Open Workspace settings → Billing to check the current state.",
+    "workspace_missing_title": "Could not find that workspace",
+    "workspace_missing_description": "You came back from Stripe, but this workspace is no longer available to you — it may have been removed, or your access changed. Open Billing in the workspace you expected to check the current state.",
     "retry": "Try again",
     "go_to_app": "Go to Multica"
   }

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -71,5 +71,8 @@
     "refresh": "Refresh",
     "paging": "page {{page}} / {{totalPages}} · {{total}} total",
     "date_dash": "—"
+  },
+  "return_page": {
+    "redirecting": "Returning you to workspace billing…"
   }
 }

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -73,6 +73,12 @@
     "date_dash": "—"
   },
   "return_page": {
-    "redirecting": "Returning you to workspace billing…"
+    "redirecting": "Returning you to workspace billing…",
+    "load_failed_title": "Could not load your workspaces",
+    "load_failed_description": "Your billing change was saved. We just could not load your workspace list to send you back to the right billing page.",
+    "workspace_missing_title": "That workspace is no longer available to you",
+    "workspace_missing_description": "Your billing change was saved, but this workspace was removed or your access to it changed, so we cannot open its billing settings.",
+    "retry": "Try again",
+    "go_to_app": "Go to Multica"
   }
 }

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -71,5 +71,8 @@
     "refresh": "更新",
     "paging": "{{page}} / {{totalPages}} ページ · 合計 {{total}}件",
     "date_dash": "—"
+  },
+  "return_page": {
+    "redirecting": "ワークスペースの請求ページに戻ります…"
   }
 }

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -74,10 +74,10 @@
   },
   "return_page": {
     "redirecting": "ワークスペースの請求ページに戻ります…",
-    "load_failed_title": "ワークスペースを読み込めませんでした",
-    "load_failed_description": "請求の変更は保存されました。ワークスペース一覧を読み込めなかったため、該当の請求ページへ戻せませんでした。",
-    "workspace_missing_title": "このワークスペースは利用できません",
-    "workspace_missing_description": "請求の変更は保存されましたが、このワークスペースが削除されたかアクセス権が変更されたため、請求設定を開けません。",
+    "load_failed_title": "ワークスペースの請求ページを開けませんでした",
+    "load_failed_description": "Stripe から戻りましたが、ワークスペース一覧を読み込めず該当の請求ページを開けませんでした。「ワークスペース設定 → 請求」で現在の状態を確認してください。",
+    "workspace_missing_title": "ワークスペースが見つかりません",
+    "workspace_missing_description": "Stripe から戻りましたが、このワークスペースは利用できません。削除されたか、アクセス権が変更された可能性があります。対象のワークスペースの請求ページで現在の状態を確認してください。",
     "retry": "再試行",
     "go_to_app": "Multica を開く"
   }

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -73,6 +73,12 @@
     "date_dash": "—"
   },
   "return_page": {
-    "redirecting": "ワークスペースの請求ページに戻ります…"
+    "redirecting": "ワークスペースの請求ページに戻ります…",
+    "load_failed_title": "ワークスペースを読み込めませんでした",
+    "load_failed_description": "請求の変更は保存されました。ワークスペース一覧を読み込めなかったため、該当の請求ページへ戻せませんでした。",
+    "workspace_missing_title": "このワークスペースは利用できません",
+    "workspace_missing_description": "請求の変更は保存されましたが、このワークスペースが削除されたかアクセス権が変更されたため、請求設定を開けません。",
+    "retry": "再試行",
+    "go_to_app": "Multica を開く"
   }
 }

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -71,5 +71,8 @@
     "refresh": "새로고침",
     "paging": "{{page}} / {{totalPages}} 페이지 · 총 {{total}}개",
     "date_dash": "—"
+  },
+  "return_page": {
+    "redirecting": "워크스페이스 결제 페이지로 돌아갑니다…"
   }
 }

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -74,10 +74,10 @@
   },
   "return_page": {
     "redirecting": "워크스페이스 결제 페이지로 돌아갑니다…",
-    "load_failed_title": "워크스페이스를 불러올 수 없습니다",
-    "load_failed_description": "결제 변경은 저장되었습니다. 워크스페이스 목록을 불러오지 못해 해당 결제 페이지로 돌려보내지 못했습니다.",
-    "workspace_missing_title": "이 워크스페이스를 사용할 수 없습니다",
-    "workspace_missing_description": "결제 변경은 저장되었지만 이 워크스페이스가 삭제되었거나 접근 권한이 변경되어 결제 설정을 열 수 없습니다.",
+    "load_failed_title": "워크스페이스 결제 페이지를 열 수 없습니다",
+    "load_failed_description": "Stripe에서 돌아왔지만 워크스페이스 목록을 불러오지 못해 해당 결제 페이지를 열 수 없었습니다. 워크스페이스 설정 → 결제에서 현재 상태를 확인해 주세요.",
+    "workspace_missing_title": "워크스페이스를 찾을 수 없습니다",
+    "workspace_missing_description": "Stripe에서 돌아왔지만 이 워크스페이스를 사용할 수 없습니다. 삭제되었거나 접근 권한이 변경되었을 수 있습니다. 원하는 워크스페이스의 결제 페이지에서 현재 상태를 확인해 주세요.",
     "retry": "다시 시도",
     "go_to_app": "Multica로 이동"
   }

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -73,6 +73,12 @@
     "date_dash": "—"
   },
   "return_page": {
-    "redirecting": "워크스페이스 결제 페이지로 돌아갑니다…"
+    "redirecting": "워크스페이스 결제 페이지로 돌아갑니다…",
+    "load_failed_title": "워크스페이스를 불러올 수 없습니다",
+    "load_failed_description": "결제 변경은 저장되었습니다. 워크스페이스 목록을 불러오지 못해 해당 결제 페이지로 돌려보내지 못했습니다.",
+    "workspace_missing_title": "이 워크스페이스를 사용할 수 없습니다",
+    "workspace_missing_description": "결제 변경은 저장되었지만 이 워크스페이스가 삭제되었거나 접근 권한이 변경되어 결제 설정을 열 수 없습니다.",
+    "retry": "다시 시도",
+    "go_to_app": "Multica로 이동"
   }
 }

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -74,10 +74,10 @@
   },
   "return_page": {
     "redirecting": "正在返回工作区账单页…",
-    "load_failed_title": "无法加载你的工作区",
-    "load_failed_description": "账单变更已保存。只是暂时无法加载工作区列表，因此没法把你送回对应的账单页。",
-    "workspace_missing_title": "该工作区对你已不可用",
-    "workspace_missing_description": "账单变更已保存，但该工作区已被删除或你的访问权限发生变化，因此无法打开它的账单设置。",
+    "load_failed_title": "无法打开工作区账单页",
+    "load_failed_description": "你已从 Stripe 返回，但我们无法加载工作区列表来打开对应的账单页。请到「工作区设置 → 账单」确认当前状态。",
+    "workspace_missing_title": "找不到该工作区",
+    "workspace_missing_description": "你已从 Stripe 返回，但该工作区对你已不可用——可能已被删除，或你的访问权限发生了变化。请到你预期的那个工作区的账单页确认当前状态。",
     "retry": "重试",
     "go_to_app": "前往 Multica"
   }

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -71,5 +71,8 @@
     "refresh": "刷新",
     "paging": "第 {{page}} / {{totalPages}} 页 · 共 {{total}} 条",
     "date_dash": "—"
+  },
+  "return_page": {
+    "redirecting": "正在返回工作区账单页…"
   }
 }

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -73,6 +73,12 @@
     "date_dash": "—"
   },
   "return_page": {
-    "redirecting": "正在返回工作区账单页…"
+    "redirecting": "正在返回工作区账单页…",
+    "load_failed_title": "无法加载你的工作区",
+    "load_failed_description": "账单变更已保存。只是暂时无法加载工作区列表，因此没法把你送回对应的账单页。",
+    "workspace_missing_title": "该工作区对你已不可用",
+    "workspace_missing_description": "账单变更已保存，但该工作区已被删除或你的访问权限发生变化，因此无法打开它的账单设置。",
+    "retry": "重试",
+    "go_to_app": "前往 Multica"
   }
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1347,14 +1347,20 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 
 		// Workspace subscriptions use the same cloud transport and Stripe
 		// webhook as the existing owner-credit billing surface, but every request
-		// is workspace-scoped. Entitlements are member-readable; Checkout, seat
-		// reconcile, and Portal mutations require owner/admin. The handlers also
-		// enforce billing_workspace_subscriptions so a route refactor cannot
+		// is workspace-scoped. Entitlements, summary and prices are
+		// member-readable; Checkout, seat reconcile, and Portal mutations require
+		// owner/admin. The handlers also enforce
+		// billing_workspace_subscriptions so a route refactor cannot
 		// accidentally bypass the rollout flag.
 		r.Route("/api/cloud-subscriptions", func(r chi.Router) {
 			r.Use(handler.RequireHumanActor)
 
-			r.With(middleware.RequireWorkspaceMember(queries)).Get("/entitlements", h.GetCloudWorkspaceEntitlements)
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.RequireWorkspaceMember(queries))
+				r.Get("/entitlements", h.GetCloudWorkspaceEntitlements)
+				r.Get("/summary", h.GetCloudWorkspaceSubscriptionSummary)
+				r.Get("/prices", h.GetCloudWorkspaceSubscriptionPrices)
+			})
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.RequireWorkspaceRole(queries, "owner", "admin"))
 				r.Post("/checkout-sessions", h.CreateCloudWorkspaceSubscriptionCheckout)

--- a/server/internal/handler/cloud_billing.go
+++ b/server/internal/handler/cloud_billing.go
@@ -157,6 +157,38 @@ func (h *Handler) GetCloudWorkspaceEntitlements(w http.ResponseWriter, r *http.R
 	h.proxyCloudSubscription(w, r, http.MethodGet, "/api/v1/entitlements/"+workspaceID, userID, nil, nil)
 }
 
+// GetCloudWorkspaceSubscriptionSummary forwards cloud's Billing-page read:
+// the resolved entitlement plus local subscription facts (seats, interval,
+// cancellation and grace state, Portal availability). Member-readable like
+// entitlements; cloud re-verifies membership against its product database.
+//
+// Cloud serves this from its own database without calling Stripe, so this stays
+// available while Stripe is degraded. A cloud that predates the endpoint
+// answers 404 and the client treats the page as unavailable — never as Free.
+func (h *Handler) GetCloudWorkspaceSubscriptionSummary(w http.ResponseWriter, r *http.Request) {
+	workspaceID, userID, ok := h.requireCloudSubscriptionWorkspace(w, r)
+	if !ok {
+		return
+	}
+	h.proxyCloudSubscription(w, r, http.MethodGet, "/api/v1/subscriptions/"+workspaceID+"/summary", userID, nil, nil)
+}
+
+// GetCloudWorkspaceSubscriptionPrices forwards cloud's validated per-seat price
+// read so the client never hardcodes an amount that Stripe can change.
+//
+// Member-readable: seeing what Pro costs is not a privileged action, and cloud
+// scopes the read to a workspace this caller belongs to. Cloud returns only
+// currency, minor-unit amount and interval — Price and Product IDs stay server
+// side — and answers 503 when a configured Price cannot be validated, which the
+// client renders as "price confirmed at Checkout" rather than a guessed number.
+func (h *Handler) GetCloudWorkspaceSubscriptionPrices(w http.ResponseWriter, r *http.Request) {
+	workspaceID, userID, ok := h.requireCloudSubscriptionWorkspace(w, r)
+	if !ok {
+		return
+	}
+	h.proxyCloudSubscription(w, r, http.MethodGet, "/api/v1/subscriptions/"+workspaceID+"/prices", userID, nil, nil)
+}
+
 // CreateCloudWorkspaceSubscriptionCheckout injects the middleware-resolved
 // workspace into the upstream body. A caller cannot use a valid role in one
 // workspace to smuggle a different workspace_id through JSON.

--- a/server/internal/handler/cloud_billing_test.go
+++ b/server/internal/handler/cloud_billing_test.go
@@ -254,22 +254,29 @@ func withCloudSubscriptionWorkspace(req *http.Request, role string) *http.Reques
 }
 
 func TestCloudWorkspaceSubscriptionsDisabledByDefault(t *testing.T) {
-	proxy := &fakeCloudRuntimeProxy{enabled: true}
-	useCloudRuntimeProxy(t, proxy)
 	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, false)
 
-	req := withCloudSubscriptionWorkspace(
-		newRequest(http.MethodGet, "/api/cloud-subscriptions/entitlements", nil),
-		"member",
-	)
-	w := httptest.NewRecorder()
-	testHandler.GetCloudWorkspaceEntitlements(w, req)
-
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	reads := map[string]func(http.ResponseWriter, *http.Request){
+		"/api/cloud-subscriptions/entitlements": testHandler.GetCloudWorkspaceEntitlements,
+		"/api/cloud-subscriptions/summary":      testHandler.GetCloudWorkspaceSubscriptionSummary,
+		"/api/cloud-subscriptions/prices":       testHandler.GetCloudWorkspaceSubscriptionPrices,
 	}
-	if proxy.called {
-		t.Fatal("upstream must not be called while the feature flag is off")
+	for path, invoke := range reads {
+		t.Run(path, func(t *testing.T) {
+			proxy := &fakeCloudRuntimeProxy{enabled: true}
+			useCloudRuntimeProxy(t, proxy)
+
+			req := withCloudSubscriptionWorkspace(newRequest(http.MethodGet, path, nil), "member")
+			w := httptest.NewRecorder()
+			invoke(w, req)
+
+			if w.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+			}
+			if proxy.called {
+				t.Fatal("upstream must not be called while the feature flag is off")
+			}
+		})
 	}
 }
 
@@ -293,6 +300,24 @@ func TestCloudWorkspaceSubscriptionReadAndWritesUseScopedPaths(t *testing.T) {
 			wantStatus: http.StatusOK,
 			wantPath:   "/api/v1/entitlements/" + testWorkspaceID,
 			invoke:     testHandler.GetCloudWorkspaceEntitlements,
+		},
+		{
+			name:       "member reads billing summary",
+			method:     http.MethodGet,
+			path:       "/api/cloud-subscriptions/summary",
+			role:       "member",
+			wantStatus: http.StatusOK,
+			wantPath:   "/api/v1/subscriptions/" + testWorkspaceID + "/summary",
+			invoke:     testHandler.GetCloudWorkspaceSubscriptionSummary,
+		},
+		{
+			name:       "member reads seat prices",
+			method:     http.MethodGet,
+			path:       "/api/cloud-subscriptions/prices",
+			role:       "member",
+			wantStatus: http.StatusOK,
+			wantPath:   "/api/v1/subscriptions/" + testWorkspaceID + "/prices",
+			invoke:     testHandler.GetCloudWorkspaceSubscriptionPrices,
 		},
 		{
 			name:       "admin reconciles seats",


### PR DESCRIPTION
## 变更

方案里第 2 步（multica backend/core），承接已合并的 [multica-cloud#47](https://github.com/multica-ai/multica-cloud/pull/47)，为 Billing UI 提供它需要的读取能力和回跳落点。

### 1. 两个 proxy

新增 `GET /api/cloud-subscriptions/summary` 与 `GET /api/cloud-subscriptions/prices`，与既有 `entitlements` 并列为 member 可读：

- workspace 仍由认证上下文注入，客户端无法指定；cloud 侧会再校验一次 membership。
- 复用 `requireCloudSubscriptionWorkspace`，因此 flag 在 handler 与 router 两层强制，`task_token` / `cloud_pat` 仍在 handler 内被拒。
- 不向前端暴露 Price / Product ID，cloud 只返回 currency、minor unit amount、interval。
- `summary` 在 cloud 侧不同步调用 Stripe，所以 Stripe 抖动时套餐状态仍可读。

### 2. 类型 / schema / query

`entitlements`、`summary`、`prices` 三者的 types、zod schema、client 方法与 query hooks。字段与已合并的 cloud 合约逐一对齐，包括 `has_stripe_customer`（它是"存在 Stripe customer"这个事实，**不是权限**——Portal 按钮仍必须另外按 owner/admin 角色 gate，服务端权限是最终边界）。

schema 是与 cloud 的兼容边界，两条失败路径都必须显示"暂不可用"、都不能看起来像 Free：非 2xx（旧 cloud 没有该路由、403、503）在 client 层抛 `ApiError`，由 query 的 `isError` 承接；2xx 但不符合合约的响应返回 `null`。金额为 0、interval 与所在 slot 不匹配（例如 `month` 槽里放年付 Price）同样返回 `null`。

绝不能造一个看起来像 Free 的形状：那会把上游故障变成付费工作区的静默降级。`plan` / `status` 保持开放字符串原样透传（未知值显示为未知而不是被归成已知），`.loose()` 让 cloud 后续加字段不破坏旧客户端。

query 三者的缓存策略不同，理由写在代码注释里：`summary` 30s + 聚焦刷新（用户可能在另一个标签页/系统浏览器完成付款）；`prices` 10 分钟且不重试（失败原因是 Price 配错，重试无用，调用方改显示"金额在收银台确认"）。

### 3. 回跳落点 `/billing/return`

一个部署只有一组 Stripe 回跳 URL，所以它们不可能带 workspace slug。cloud 会追加它已经授权过的 `workspace_id` 与 `result`，这个页面把它解析成 slug 再 `replace` 到该 workspace 的 Billing 设置页。没有这一层，运维只能把 success URL 写死成某一个 workspace 的地址，其余 workspace 全部跳错地方。

安全性：只读 `workspace_id` 与 `result` 两个参数，目标地址由 `paths` 重新构造，因此伪造的回跳链接无法变成开放重定向（有测试用 `result=https://evil.example/steal` 钉住）。`billing` 早已是 reserved slug，不会遮挡真实 workspace。

三种失败态都不会把用户丢在无法解释的页面上：

- **会话过期**（Checkout 耗时较长时属正常情况）→ 跳登录并带 `?next=`，登录后继续完成回跳。`next` **只由本页真正需要的两个值重建**：`workspace_id`（新增 UUID 形状校验）与白名单后的 `result`，`session_id` 与任何未知参数一律丢弃 —— 因为登录页会把 `next` 原样写进 Google OAuth 的 `state`，把 Stripe 支付标识符送给第三方没有任何功能价值。登录页的 `sanitizeNextUrl` 只接受相对路径，所以这条路径也不构成站外重定向。
- **workspace 列表加载失败** → 显示错误说明 + 重试按钮（把 ID 解析成 slug 正是产生目标地址的前提，没有它只能永久转圈）。
- **workspace 解析不到**（已删除 / 失去权限 / 缺失或畸形 `workspace_id` / 手改链接）→ 说明发生了什么并提供返回应用的入口，而不是静默跳到默认 workspace。

两个错误态的文案都**不对结果下任何结论**：`cancel` 表示用户主动放弃、`portal` 可能只是打开又返回、`success` 也只表示 Stripe 页面完成（订阅要等 Webhook 落库），所以文案只说"已从 Stripe 返回、无法打开账单页、请到账单设置确认当前状态"。测试用一个 helper 断言告警文案永远不含 saved / success / upgraded / activated / subscribed，覆盖 cancel、portal、缺失与非法 `result`。

Desktop 不需要对应路由：Stripe 在系统浏览器打开，回跳一定落在 web；desktop 的 Billing 页靠窗口重新聚焦刷新。

## 兼容性

- 无 migration、无新配置项、无新启动依赖；三个新增读取都是 additive。
- flag 关闭时两个 proxy 返回 503 且不调用 cloud（有测试逐个覆盖）。
- 旧 cloud（没有 summary / prices）时前端拿到 `null`，页面显示不可用而**不是** Free。
- `/billing/return` 在 Billing UI（[#6908](https://github.com/multica-ai/multica/pull/6908)）合并前就可以先发：它只是跳到 `?tab=billing`，而 Settings 对未知 tab 已有回落逻辑。
- `.env.example` 补了一段运维说明：cloud 的三个回跳 URL 应指向本应用的 `/billing/return`。

## 与 #6908 的重叠

#6908 也新增了 `entitlements` 的 types / schema / client 方法（那时本 PR 还不存在）。两边形状与命名一致，所以后合并的一方 rebase 时删掉重复声明即可，不涉及设计分歧。`summary` / `prices` / 回跳页只在本 PR 里。

## 验证

- `go build ./...`、`go vet ./internal/handler ./cmd/server`、`go test ./internal/handler`（订阅 / 钱包 / webhook / actor guard 相关）全部通过
- `pnpm -C packages/core typecheck`、`pnpm -C packages/views typecheck` 通过
- `pnpm -C packages/core lint` 干净；`pnpm -C packages/views lint` 为 0 errors / 21 warnings，**与 `origin/main` 完全一致**，新增文件无任何一条
- `pnpm -C apps/web build` 成功，`/billing/return` 已注册为动态路由
- `packages/core` 全量：1368 passed / 8 failed；`origin/main` 基线为 1360 passed / **同样 8 failed** —— 8 个失败是存量，新增 8 个 schema 用例全部通过
- `packages/views` 全量：3991 passed / 1 failed（`layout/sidebar-resize.test.tsx`），该失败同样在 `origin/main` 上复现，与本 PR 无关

新增测试：

- 后端：`summary` / `prices` 走 workspace-scoped 上游路径；flag 关闭时三个读取逐一返回 503 且不触达上游
- schema 兼容：完整 summary 映射、旧 cloud 缺可选字段时付费状态仍可读、未知 plan/status 原样保留、畸形响应返回 null、404/503 形状返回 null、additive 字段不破坏解析、prices 金额为 0 或 interval 不匹配返回 null
- 回跳页：workspace_id → slug、三种 result 转发且丢掉 session_id、非法 result 被忽略、workspace 不可见回根路径、缺 workspace_id 回根路径、未登录跳登录、auth/列表加载中不做决定、无障碍 status 文案

CI 我没有等待。关联 MUL-5852，本 PR 不会关闭整个 issue。


