### PR TITLE
[MUL-6140] fix: scroll issue thread after posting

### DIFF
--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -107,6 +107,7 @@ interface CommentCardProps {
    */
   canModerate?: boolean;
   onReply: (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  onReplyAccepted?: (target: HTMLElement) => void;
   onEdit: (commentId: string, content: string, attachmentIds: string[], suppressAgentIds?: string[]) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
@@ -751,6 +752,7 @@ function CommentCardImpl({
   currentUserId,
   canModerate = false,
   onReply,
+  onReplyAccepted,
   onEdit,
   onDelete,
   onToggleReaction,
@@ -1138,6 +1140,7 @@ function CommentCardImpl({
                   avatarId={currentUserId ?? ""}
                   draftKey={`reply:${issueId}:${entry.id}`}
                   onSubmit={(content, attachmentIds, suppressAgentIds) => onReply(entry.id, content, attachmentIds, suppressAgentIds)}
+                  onAccepted={onReplyAccepted}
                 />
               </div>
             </>

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -106,8 +106,8 @@ interface CommentCardProps {
    * `CommentRow` has to rerun the rule per row.
    */
   canModerate?: boolean;
-  onReply: (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
-  onReplyAccepted?: (target: HTMLElement) => void;
+  onReply: (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<string | boolean>;
+  onReplyAccepted?: (commentId: string) => void;
   onEdit: (commentId: string, content: string, attachmentIds: string[], suppressAgentIds?: string[]) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -218,10 +218,12 @@ function renderCommentInput(onSubmit = vi.fn().mockResolvedValue(true)) {
 
 function renderReplyInput({
   onSubmit = vi.fn().mockResolvedValue(true),
+  onAccepted,
   size = "sm",
   draftKey,
 }: {
   onSubmit?: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  onAccepted?: (target: HTMLElement) => void;
   size?: "sm" | "default";
   draftKey?: `reply:${string}:${string}`;
 } = {}) {
@@ -232,6 +234,7 @@ function renderReplyInput({
       avatarType="member"
       avatarId="user-1"
       onSubmit={onSubmit}
+      onAccepted={onAccepted}
       size={size}
       draftKey={draftKey}
     />,
@@ -508,6 +511,18 @@ describe("comment composers", () => {
 
     await waitFor(() => expect(focusCalls.focused).toBeGreaterThan(0));
     expect(focusCalls.blurred).toBe(0);
+  });
+
+  it("reports the reply composer as the accepted scroll target", async () => {
+    const onAccepted = vi.fn();
+    const { container } = renderReplyInput({ onAccepted });
+
+    activateComposer("reply-composer-shell");
+    fireEvent.change(screen.getByTestId("editor"), { target: { value: "replied" } });
+    fireEvent.click(getSubmitButton(container));
+
+    await waitFor(() => expect(onAccepted).toHaveBeenCalledTimes(1));
+    expect(onAccepted.mock.calls[0]?.[0]).toBeInstanceOf(HTMLElement);
   });
 
   it("does not refocus the reply box when the send fails", async () => {

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -217,13 +217,13 @@ function renderCommentInput(onSubmit = vi.fn().mockResolvedValue(true)) {
 }
 
 function renderReplyInput({
-  onSubmit = vi.fn().mockResolvedValue(true),
+  onSubmit = vi.fn().mockResolvedValue("reply-new"),
   onAccepted,
   size = "sm",
   draftKey,
 }: {
-  onSubmit?: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
-  onAccepted?: (target: HTMLElement) => void;
+  onSubmit?: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<string | boolean>;
+  onAccepted?: (commentId: string) => void;
   size?: "sm" | "default";
   draftKey?: `reply:${string}:${string}`;
 } = {}) {
@@ -513,7 +513,7 @@ describe("comment composers", () => {
     expect(focusCalls.blurred).toBe(0);
   });
 
-  it("reports the reply composer as the accepted scroll target", async () => {
+  it("reports the new reply id as the accepted scroll target", async () => {
     const onAccepted = vi.fn();
     const { container } = renderReplyInput({ onAccepted });
 
@@ -522,7 +522,7 @@ describe("comment composers", () => {
     fireEvent.click(getSubmitButton(container));
 
     await waitFor(() => expect(onAccepted).toHaveBeenCalledTimes(1));
-    expect(onAccepted.mock.calls[0]?.[0]).toBeInstanceOf(HTMLElement);
+    expect(onAccepted).toHaveBeenCalledWith("reply-new");
   });
 
   it("does not refocus the reply box when the send fails", async () => {

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -20,9 +20,9 @@ interface CommentInputProps {
   /** Resolves true on success, false on failure. The composer keeps the text
    *  (editor locked + button spinning) until this settles, then clears only on
    *  success — a failed send must not silently discard the user's draft. */
-  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<string | boolean>;
   /** Called after the server accepts the comment and the composer is cleared. */
-  onAccepted?: (target: HTMLElement) => void;
+  onAccepted?: (commentId: string) => void;
 }
 
 function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
@@ -30,7 +30,6 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
   const { t: tEditor } = useT("editor");
   const sendShortcut = useShortcut("send");
   const editorRef = useRef<ContentEditorRef>(null);
-  const composerRef = useRef<HTMLDivElement>(null);
   // Sending mid-upload would strip the pending image's blob URL out of the
   // markdown and bind no attachment id — the comment posts without the file.
   const uploadGate = useUploadGate(editorRef);
@@ -138,6 +137,7 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
   // leave a mid-flight draft in place: dropping the caret then would yank it
   // out of the sentence the user is still typing.
   const editorScrubbedRef = useRef(false);
+  const acceptedCommentIdRef = useRef<string | null>(null);
 
   const { submitting, submit } = useComposerSubmit({
     editorRef,
@@ -167,7 +167,10 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
         content,
         activeIds.length > 0 ? activeIds : undefined,
         suppressAgentIds.length > 0 ? suppressAgentIds : undefined,
-      );
+      ).then((commentId) => {
+        acceptedCommentIdRef.current = typeof commentId === "string" ? commentId : null;
+        return !!commentId;
+      });
     },
     onAccepted: () => {
       // Success may only consume the entry it submitted (MUL-5181 P0): edits
@@ -187,14 +190,13 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
       setIsEmpty(true);
       setSuppressedAgentIds(new Set());
       editorScrubbedRef.current = true;
-      if (composerRef.current) onAccepted?.(composerRef.current);
+      if (acceptedCommentIdRef.current) onAccepted?.(acceptedCommentIdRef.current);
     },
   });
 
   return (
     <div
       {...dropZoneProps}
-      ref={composerRef}
       className="relative flex flex-col rounded-lg bg-card pb-8 ring-1 ring-border"
     >
       {/* Lock the editor while the send is in flight. ContentEditor can't

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -22,7 +22,7 @@ interface CommentInputProps {
    *  success — a failed send must not silently discard the user's draft. */
   onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
   /** Called after the server accepts the comment and the composer is cleared. */
-  onAccepted?: () => void;
+  onAccepted?: (target: HTMLElement) => void;
 }
 
 function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
@@ -30,6 +30,7 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
   const { t: tEditor } = useT("editor");
   const sendShortcut = useShortcut("send");
   const editorRef = useRef<ContentEditorRef>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
   // Sending mid-upload would strip the pending image's blob URL out of the
   // markdown and bind no attachment id — the comment posts without the file.
   const uploadGate = useUploadGate(editorRef);
@@ -186,13 +187,14 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
       setIsEmpty(true);
       setSuppressedAgentIds(new Set());
       editorScrubbedRef.current = true;
-      onAccepted?.();
+      if (composerRef.current) onAccepted?.(composerRef.current);
     },
   });
 
   return (
     <div
       {...dropZoneProps}
+      ref={composerRef}
       className="relative flex flex-col rounded-lg bg-card pb-8 ring-1 ring-border"
     >
       {/* Lock the editor while the send is in flight. ContentEditor can't

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -21,9 +21,11 @@ interface CommentInputProps {
    *  (editor locked + button spinning) until this settles, then clears only on
    *  success — a failed send must not silently discard the user's draft. */
   onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  /** Called after the server accepts the comment and the composer is cleared. */
+  onAccepted?: () => void;
 }
 
-function CommentInput({ issueId, onSubmit }: CommentInputProps) {
+function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
   const { t } = useT("issues");
   const { t: tEditor } = useT("editor");
   const sendShortcut = useShortcut("send");
@@ -184,6 +186,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
       setIsEmpty(true);
       setSuppressedAgentIds(new Set());
       editorScrubbedRef.current = true;
+      onAccepted?.();
     },
   });
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -946,8 +946,8 @@ describe("IssueDetail (shared)", () => {
     await waitFor(() => {
       expect(scrollToIndexSpy).toHaveBeenCalledTimes(2);
     });
-    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(1, { index: 2, align: "end" });
-    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(2, { index: 2, align: "end" });
+    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(1, { index: 2, align: "end", offset: 0 });
+    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(2, { index: 2, align: "end", offset: 0 });
     expect(scrollIntoViewSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -946,7 +946,7 @@ describe("IssueDetail (shared)", () => {
     fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "nearest" });
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "end" });
     });
     target.remove();
   });

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -434,6 +434,7 @@ vi.mock("@multica/core/issues/stores", async () => ({
 // background instead, which is mechanism-independent and observable without
 // layout.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
+const scrollToIndexSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("react-virtuoso", () => ({
   Virtuoso: forwardRef(function MockVirtuoso(
@@ -445,7 +446,7 @@ vi.mock("react-virtuoso", () => ({
       // since the deep-link cold-path drives the container's scrollTop on the
       // real DOM node, not Virtuoso's imperative API.
       scrollIntoView: vi.fn(),
-      scrollToIndex: vi.fn(),
+      scrollToIndex: scrollToIndexSpy,
     }));
     return (
       <div data-testid="virtuoso-mock">
@@ -461,6 +462,7 @@ vi.mock("react-virtuoso", () => ({
 // with a spy so the deep-link effect's call can be observed.
 beforeEach(() => {
   scrollIntoViewSpy.mockClear();
+  scrollToIndexSpy.mockClear();
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     writable: true,
@@ -919,7 +921,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(".sticky.bottom-0")).toBeNull();
   });
 
-  it("scrolls the posted comment into view after sending", async () => {
+  it("scrolls the posted comment with the same Virtuoso path as the minimap", async () => {
     mockApiObj.createComment.mockResolvedValue({
       id: "comment-new",
       issue_id: "issue-1",
@@ -931,11 +933,6 @@ describe("IssueDetail (shared)", () => {
       created_at: "2026-08-13T00:00:00Z",
       updated_at: "2026-08-13T00:00:00Z",
     });
-    const scrollIntoView = vi.fn();
-    const target = document.createElement("div");
-    target.id = "comment-comment-new";
-    Object.defineProperty(target, "scrollIntoView", { value: scrollIntoView });
-    document.body.appendChild(target);
     renderIssueDetail();
 
     await screen.findByText("Implement authentication");
@@ -946,9 +943,9 @@ describe("IssueDetail (shared)", () => {
     fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "end" });
+      expect(scrollToIndexSpy).toHaveBeenCalledWith({ index: 2, align: "end" });
     });
-    target.remove();
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
   });
 
   it("reserves the chat launcher's corner at the end of the mobile scroll", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -932,6 +932,10 @@ describe("IssueDetail (shared)", () => {
       updated_at: "2026-08-13T00:00:00Z",
     });
     const scrollIntoView = vi.fn();
+    const target = document.createElement("div");
+    target.id = "comment-comment-new";
+    Object.defineProperty(target, "scrollIntoView", { value: scrollIntoView });
+    document.body.appendChild(target);
     renderIssueDetail();
 
     await screen.findByText("Implement authentication");
@@ -939,12 +943,12 @@ describe("IssueDetail (shared)", () => {
     const editor = await screen.findByPlaceholderText("Leave a comment...");
     fireEvent.change(editor, { target: { value: "A new update" } });
     const composer = editor.closest<HTMLElement>("[aria-busy], .relative.flex.flex-col.rounded-lg")!;
-    Object.defineProperty(composer, "scrollIntoView", { value: scrollIntoView });
     fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
       expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "nearest" });
     });
+    target.remove();
   });
 
   it("reserves the chat launcher's corner at the end of the mobile scroll", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -919,7 +919,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(".sticky.bottom-0")).toBeNull();
   });
 
-  it("scrolls the issue timeline to the bottom after posting a comment", async () => {
+  it("scrolls the posted comment into view after sending", async () => {
     mockApiObj.createComment.mockResolvedValue({
       id: "comment-new",
       issue_id: "issue-1",
@@ -931,22 +931,19 @@ describe("IssueDetail (shared)", () => {
       created_at: "2026-08-13T00:00:00Z",
       updated_at: "2026-08-13T00:00:00Z",
     });
-    const scrollTo = vi.fn();
-    const { container } = renderIssueDetail();
+    const scrollIntoView = vi.fn();
+    renderIssueDetail();
 
     await screen.findByText("Implement authentication");
-    const scrollContainer = container.querySelector("[data-tab-scroll-root]") as HTMLDivElement;
-    Object.defineProperty(scrollContainer, "scrollHeight", { value: 1200 });
-    Object.defineProperty(scrollContainer, "scrollTo", { value: scrollTo });
-
     fireEvent.click(screen.getByTestId("comment-composer-shell"));
     const editor = await screen.findByPlaceholderText("Leave a comment...");
     fireEvent.change(editor, { target: { value: "A new update" } });
     const composer = editor.closest<HTMLElement>("[aria-busy], .relative.flex.flex-col.rounded-lg")!;
+    Object.defineProperty(composer, "scrollIntoView", { value: scrollIntoView });
     fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: "smooth" });
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "nearest" });
     });
   });
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -921,7 +921,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(".sticky.bottom-0")).toBeNull();
   });
 
-  it("waits for Virtuoso to render before scrolling like the minimap", async () => {
+  it("realigns after Virtuoso measures the newly posted row", async () => {
     mockApiObj.createComment.mockResolvedValue({
       id: "comment-new",
       issue_id: "issue-1",
@@ -944,8 +944,10 @@ describe("IssueDetail (shared)", () => {
 
     expect(scrollToIndexSpy).not.toHaveBeenCalled();
     await waitFor(() => {
-      expect(scrollToIndexSpy).toHaveBeenCalledWith({ index: 2, align: "end" });
+      expect(scrollToIndexSpy).toHaveBeenCalledTimes(2);
     });
+    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(1, { index: 2, align: "end" });
+    expect(scrollToIndexSpy).toHaveBeenNthCalledWith(2, { index: 2, align: "end" });
     expect(scrollIntoViewSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, Label, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -917,6 +917,37 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(container.querySelector(".sticky.bottom-0")).toBeNull();
+  });
+
+  it("scrolls the issue timeline to the bottom after posting a comment", async () => {
+    mockApiObj.createComment.mockResolvedValue({
+      id: "comment-new",
+      issue_id: "issue-1",
+      content: "A new update",
+      author_type: "member",
+      author_id: "user-1",
+      parent_id: null,
+      type: "comment",
+      created_at: "2026-08-13T00:00:00Z",
+      updated_at: "2026-08-13T00:00:00Z",
+    });
+    const scrollTo = vi.fn();
+    const { container } = renderIssueDetail();
+
+    await screen.findByText("Implement authentication");
+    const scrollContainer = container.querySelector("[data-tab-scroll-root]") as HTMLDivElement;
+    Object.defineProperty(scrollContainer, "scrollHeight", { value: 1200 });
+    Object.defineProperty(scrollContainer, "scrollTo", { value: scrollTo });
+
+    fireEvent.click(screen.getByTestId("comment-composer-shell"));
+    const editor = await screen.findByPlaceholderText("Leave a comment...");
+    fireEvent.change(editor, { target: { value: "A new update" } });
+    const composer = editor.closest<HTMLElement>("[aria-busy], .relative.flex.flex-col.rounded-lg")!;
+    fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: "smooth" });
+    });
   });
 
   it("reserves the chat launcher's corner at the end of the mobile scroll", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -921,7 +921,7 @@ describe("IssueDetail (shared)", () => {
     expect(container.querySelector(".sticky.bottom-0")).toBeNull();
   });
 
-  it("scrolls the posted comment with the same Virtuoso path as the minimap", async () => {
+  it("waits for Virtuoso to render before scrolling like the minimap", async () => {
     mockApiObj.createComment.mockResolvedValue({
       id: "comment-new",
       issue_id: "issue-1",
@@ -942,6 +942,7 @@ describe("IssueDetail (shared)", () => {
     const composer = editor.closest<HTMLElement>("[aria-busy], .relative.flex.flex-col.rounded-lg")!;
     fireEvent.click(within(composer).getByRole("button", { name: "Send" }));
 
+    expect(scrollToIndexSpy).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(scrollToIndexSpy).toHaveBeenCalledWith({ index: 2, align: "end" });
     });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1548,31 +1548,18 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   useEffect(() => {
     if (!pendingPostedCommentId) return;
 
-    // A newly appended row can be outside Virtuoso's mounted window. First
-    // move the virtual list to the containing top-level row so it materializes
-    // (a reply lives inside its root CommentCard), then align the exact DOM
-    // anchor once measurement has completed. The minimap only observes these
-    // anchors; it does not own or block scrolling.
+    // Match the minimap's single-scroll behavior. A reply lives inside its
+    // root CommentCard, so scrolling the containing top-level row to the end
+    // both materializes it and keeps Virtuoso as the sole scroll controller.
+    // Following this with native scrollIntoView would interrupt Virtuoso's
+    // smooth scroll and can leave the card only partially visible.
     const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
     const index = items.findIndex((item) => item.id === rootId);
     if (index < 0) return;
     if (!isFlatTimeline) {
       virtuosoRef.current?.scrollToIndex({ index, align: "end" });
     }
-
-    let frame = 0;
-    let attempts = 0;
-    const alignExactComment = () => {
-      const target = document.getElementById(`comment-${pendingPostedCommentId}`);
-      if (target) {
-        target.scrollIntoView({ behavior: "smooth", block: "end" });
-        setPendingPostedCommentId(null);
-        return;
-      }
-      if (++attempts < 12) frame = requestAnimationFrame(alignExactComment);
-    };
-    frame = requestAnimationFrame(alignExactComment);
-    return () => cancelAnimationFrame(frame);
+    setPendingPostedCommentId(null);
   }, [pendingPostedCommentId, items, replyToRoot, isFlatTimeline]);
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1155,6 +1155,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso prop would never receive the element. Callback ref + state fixes
   // that: setState triggers the re-render that hands Virtuoso the element.
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  // Bottom comment composer. Measured when scrolling a freshly posted comment
+  // into view so its bottom lands above the composer rather than behind it.
+  const composerRef = useRef<HTMLDivElement | null>(null);
   // Pull-based scroll restoration (MUL-4741): the platform serves the offset
   // captured when this route was last left. The ref-attach assignment covers
   // the flat render modes (real heights at commit); the virtualized browsing
@@ -1545,27 +1548,32 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso instance — minimap jumps drive the scroll container directly.
   const isFlatTimeline = !!highlightCommentId || find.open;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  useEffect(() => {
-    if (!pendingPostedCommentId) return;
+  // Scroll a freshly posted comment into view, aligned so its bottom sits just
+  // above the sticky composer (never behind it). A reply lives inside its root
+  // CommentCard, so the containing top-level row is the scroll target. Flat and
+  // virtualized timelines need separate scroll drivers, so they split into two
+  // effects below — kept apart because only the flat one depends on
+  // `scrollContainerEl`, and adding that dep to the virtualized effect would
+  // let a container re-measure cancel its in-flight scroll mid-flight.
 
-    // Match the minimap's single-scroll behavior. A reply lives inside its
-    // root CommentCard, so scrolling the containing top-level row to the end
-    // both materializes it and keeps Virtuoso as the sole scroll controller.
-    // The first jump materializes the row using Virtuoso's estimated height.
-    // Once the mounted row has been measured, repeat the same jump so `end`
-    // alignment uses its real height instead of leaving it partially visible.
+  // Virtualized mode: Virtuoso owns the scroll. The first jump materializes the
+  // row at its estimated height; once measured, the repeat aligns using the
+  // real height. The extra `offset` lifts the row's bottom clear of the sticky
+  // composer.
+  useEffect(() => {
+    if (!pendingPostedCommentId || isFlatTimeline) return;
     const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
     const index = items.findIndex((item) => item.id === rootId);
     if (index < 0) return;
     let timer: number | undefined;
+    const scrollEnd = () => {
+      const composerHeight = composerRef.current?.getBoundingClientRect().height ?? 0;
+      virtuosoRef.current?.scrollToIndex({ index, align: "end", offset: composerHeight });
+    };
     const frame = requestAnimationFrame(() => {
-      if (!isFlatTimeline) {
-        virtuosoRef.current?.scrollToIndex({ index, align: "end" });
-      }
+      scrollEnd();
       timer = window.setTimeout(() => {
-        if (!isFlatTimeline) {
-          virtuosoRef.current?.scrollToIndex({ index, align: "end" });
-        }
+        scrollEnd();
         setPendingPostedCommentId(null);
       }, 100);
     });
@@ -1574,6 +1582,39 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       if (timer !== undefined) window.clearTimeout(timer);
     };
   }, [pendingPostedCommentId, items, replyToRoot, isFlatTimeline]);
+
+  // Flat mode (find bar / deep link) has no Virtuoso, so drive scrollTop by
+  // hand: align the row's bottom to the composer's top edge. The comment's
+  // async layout (markdown, code highlight, images) keeps shifting its height,
+  // so re-align each frame until it settles (within 1px) or ~0.5s elapses — the
+  // same rAF stabilization the deep-link landing uses.
+  useEffect(() => {
+    if (!pendingPostedCommentId || !isFlatTimeline) return;
+    const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
+    if (items.findIndex((item) => item.id === rootId) < 0) return;
+    let rafId = 0;
+    let frames = 0;
+    let last = -1;
+    const alignBottom = () => {
+      const el = document.getElementById(`comment-${rootId}`);
+      const container = scrollContainerEl;
+      if (el && container) {
+        const c = container.getBoundingClientRect();
+        const e = el.getBoundingClientRect();
+        const composerHeight = composerRef.current?.getBoundingClientRect().height ?? 0;
+        const target = Math.max(0, container.scrollTop + (e.bottom - c.bottom) + composerHeight);
+        container.scrollTop = target;
+        if (Math.abs(target - last) > 1 && ++frames < 30) {
+          last = target;
+          rafId = requestAnimationFrame(alignBottom);
+          return;
+        }
+      }
+      setPendingPostedCommentId(null);
+    };
+    rafId = requestAnimationFrame(alignBottom);
+    return () => cancelAnimationFrame(rafId);
+  }, [pendingPostedCommentId, items, replyToRoot, isFlatTimeline, scrollContainerEl]);
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(
     () => () => {
@@ -3121,6 +3162,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               off the viewport edge — with -mb-4 giving the padding back to
               the column's py-8 so the at-rest layout doesn't shift. */}
           <div
+            ref={composerRef}
             className={cn(
               "mt-4",
               stickyComposer &&

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1200,7 +1200,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     requestAnimationFrame(() => {
       document.getElementById(`comment-${commentId}`)?.scrollIntoView({
         behavior: "smooth",
-        block: "nearest",
+        block: "end",
       });
     });
   }, []);

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1192,17 +1192,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     },
     [restoreScrollRef],
   );
+  const [pendingPostedCommentId, setPendingPostedCommentId] = useState<string | null>(null);
   const scrollToTimelineBottom = useCallback((commentId: string) => {
-    // The create-comment mutation updates the timeline before resolving, but
-    // Virtuoso applies the new row's measured height on the next frame. The
-    // new comment/reply itself is the precise target; scrolling the composer
-    // below it can leave a tall message partly outside the viewport.
-    requestAnimationFrame(() => {
-      document.getElementById(`comment-${commentId}`)?.scrollIntoView({
-        behavior: "smooth",
-        block: "end",
-      });
-    });
+    setPendingPostedCommentId(commentId);
   }, []);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   // User preference: pin the bottom comment bar to the scroll viewport. Off
@@ -1553,6 +1545,35 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso instance — minimap jumps drive the scroll container directly.
   const isFlatTimeline = !!highlightCommentId || find.open;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  useEffect(() => {
+    if (!pendingPostedCommentId) return;
+
+    // A newly appended row can be outside Virtuoso's mounted window. First
+    // move the virtual list to the containing top-level row so it materializes
+    // (a reply lives inside its root CommentCard), then align the exact DOM
+    // anchor once measurement has completed. The minimap only observes these
+    // anchors; it does not own or block scrolling.
+    const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
+    const index = items.findIndex((item) => item.id === rootId);
+    if (index < 0) return;
+    if (!isFlatTimeline) {
+      virtuosoRef.current?.scrollToIndex({ index, align: "end" });
+    }
+
+    let frame = 0;
+    let attempts = 0;
+    const alignExactComment = () => {
+      const target = document.getElementById(`comment-${pendingPostedCommentId}`);
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "end" });
+        setPendingPostedCommentId(null);
+        return;
+      }
+      if (++attempts < 12) frame = requestAnimationFrame(alignExactComment);
+    };
+    frame = requestAnimationFrame(alignExactComment);
+    return () => cancelAnimationFrame(frame);
+  }, [pendingPostedCommentId, items, replyToRoot, isFlatTimeline]);
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(
     () => () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1551,19 +1551,23 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // Match the minimap's single-scroll behavior. A reply lives inside its
     // root CommentCard, so scrolling the containing top-level row to the end
     // both materializes it and keeps Virtuoso as the sole scroll controller.
-    // The items prop and Virtuoso's internal measurements do not settle in
-    // the same commit, so wait through the next paint before scrolling.
+    // The first jump materializes the row using Virtuoso's estimated height.
+    // Once the mounted row has been measured, repeat the same jump so `end`
+    // alignment uses its real height instead of leaving it partially visible.
     const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
     const index = items.findIndex((item) => item.id === rootId);
     if (index < 0) return;
     let timer: number | undefined;
     const frame = requestAnimationFrame(() => {
+      if (!isFlatTimeline) {
+        virtuosoRef.current?.scrollToIndex({ index, align: "end" });
+      }
       timer = window.setTimeout(() => {
         if (!isFlatTimeline) {
           virtuosoRef.current?.scrollToIndex({ index, align: "end" });
         }
         setPendingPostedCommentId(null);
-      }, 50);
+      }, 100);
     });
     return () => {
       cancelAnimationFrame(frame);

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1192,6 +1192,18 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     },
     [restoreScrollRef],
   );
+  const scrollToTimelineBottom = useCallback(() => {
+    // The create-comment mutation updates the timeline before resolving, but
+    // Virtuoso applies the new row's measured height on the next frame. Wait
+    // for that commit, then scroll only this issue's container (native
+    // scrollIntoView can also move the surrounding desktop shell).
+    requestAnimationFrame(() => {
+      scrollContainerEl?.scrollTo({
+        top: scrollContainerEl.scrollHeight,
+        behavior: "smooth",
+      });
+    });
+  }, [scrollContainerEl]);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   // User preference: pin the bottom comment bar to the scroll viewport. Off
   // below `md` regardless of the preference — see the hook.
@@ -3098,7 +3110,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 keeps the previous issue's in-memory content and the
                 next keystroke would flush it into the new issue's
                 draft key. */}
-            <CommentInput key={id} issueId={id} onSubmit={submitComment} />
+            <CommentInput
+              key={id}
+              issueId={id}
+              onSubmit={submitComment}
+              onAccepted={scrollToTimelineBottom}
+            />
           </div>
         </div>
         </div>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1192,14 +1192,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     },
     [restoreScrollRef],
   );
-  const scrollToTimelineBottom = useCallback((target: HTMLElement) => {
+  const scrollToTimelineBottom = useCallback((commentId: string) => {
     // The create-comment mutation updates the timeline before resolving, but
     // Virtuoso applies the new row's measured height on the next frame. The
-    // composer sits immediately after the newly posted comment/reply, so
-    // bringing it into view lands on the new message without forcing the
-    // whole document to its maximum scroll offset.
+    // new comment/reply itself is the precise target; scrolling the composer
+    // below it can leave a tall message partly outside the viewport.
     requestAnimationFrame(() => {
-      target.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      document.getElementById(`comment-${commentId}`)?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
     });
   }, []);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1551,15 +1551,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // Match the minimap's single-scroll behavior. A reply lives inside its
     // root CommentCard, so scrolling the containing top-level row to the end
     // both materializes it and keeps Virtuoso as the sole scroll controller.
-    // Following this with native scrollIntoView would interrupt Virtuoso's
-    // smooth scroll and can leave the card only partially visible.
+    // The items prop and Virtuoso's internal measurements do not settle in
+    // the same commit, so wait through the next paint before scrolling.
     const rootId = replyToRoot.get(pendingPostedCommentId) ?? pendingPostedCommentId;
     const index = items.findIndex((item) => item.id === rootId);
     if (index < 0) return;
-    if (!isFlatTimeline) {
-      virtuosoRef.current?.scrollToIndex({ index, align: "end" });
-    }
-    setPendingPostedCommentId(null);
+    let timer: number | undefined;
+    const frame = requestAnimationFrame(() => {
+      timer = window.setTimeout(() => {
+        if (!isFlatTimeline) {
+          virtuosoRef.current?.scrollToIndex({ index, align: "end" });
+        }
+        setPendingPostedCommentId(null);
+      }, 50);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [pendingPostedCommentId, items, replyToRoot, isFlatTimeline]);
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1192,18 +1192,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     },
     [restoreScrollRef],
   );
-  const scrollToTimelineBottom = useCallback(() => {
+  const scrollToTimelineBottom = useCallback((target: HTMLElement) => {
     // The create-comment mutation updates the timeline before resolving, but
-    // Virtuoso applies the new row's measured height on the next frame. Wait
-    // for that commit, then scroll only this issue's container (native
-    // scrollIntoView can also move the surrounding desktop shell).
+    // Virtuoso applies the new row's measured height on the next frame. The
+    // composer sits immediately after the newly posted comment/reply, so
+    // bringing it into view lands on the new message without forcing the
+    // whole document to its maximum scroll offset.
     requestAnimationFrame(() => {
-      scrollContainerEl?.scrollTo({
-        top: scrollContainerEl.scrollHeight,
-        behavior: "smooth",
-      });
+      target.scrollIntoView({ behavior: "smooth", block: "nearest" });
     });
-  }, [scrollContainerEl]);
+  }, []);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   // User preference: pin the bottom comment bar to the scroll viewport. Off
   // below `md` regardless of the preference — see the hook.
@@ -2432,6 +2430,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             currentUserId={user?.id}
             canModerate={canModerateComments}
             onReply={submitReply}
+            onReplyAccepted={scrollToTimelineBottom}
             onEdit={editComment}
             onDelete={deleteComment}
             onToggleReaction={handleToggleReaction}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -28,9 +28,9 @@ interface ReplyInputProps {
   avatarId: string;
   /** Resolves true on success, false on failure — the reply box keeps its text
    *  (locked + spinning) until then, clearing only on success. */
-  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<string | boolean>;
   /** Called after the server accepts the reply and the composer is cleared. */
-  onAccepted?: (target: HTMLElement) => void;
+  onAccepted?: (commentId: string) => void;
   size?: "sm" | "default";
   /** When set, hydrates/persists the in-progress reply via the draft store.
    *  Required for replies inside virtualized timeline threads, where the
@@ -150,6 +150,7 @@ function ReplyInput({
   // See CommentInput: bound to the branch that actually wiped the editor, so a
   // draft the stale-submit guard kept is never disturbed.
   const editorScrubbedRef = useRef(false);
+  const acceptedCommentIdRef = useRef<string | null>(null);
 
   const { submitting, submit } = useComposerSubmit({
     editorRef,
@@ -182,7 +183,10 @@ function ReplyInput({
         content,
         activeIds.length > 0 ? activeIds : undefined,
         suppressAgentIds.length > 0 ? suppressAgentIds : undefined,
-      );
+      ).then((commentId) => {
+        acceptedCommentIdRef.current = typeof commentId === "string" ? commentId : null;
+        return !!commentId;
+      });
     },
     onAccepted: () => {
       // Success may only consume the entry it submitted — see CommentInput.
@@ -203,7 +207,7 @@ function ReplyInput({
       setIsEmpty(true);
       setSuppressedAgentIds(new Set());
       editorScrubbedRef.current = true;
-      if (composerRef.current) onAccepted?.(composerRef.current);
+      if (acceptedCommentIdRef.current) onAccepted?.(acceptedCommentIdRef.current);
     },
   });
 

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -29,6 +29,8 @@ interface ReplyInputProps {
   /** Resolves true on success, false on failure — the reply box keeps its text
    *  (locked + spinning) until then, clearing only on success. */
   onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
+  /** Called after the server accepts the reply and the composer is cleared. */
+  onAccepted?: (target: HTMLElement) => void;
   size?: "sm" | "default";
   /** When set, hydrates/persists the in-progress reply via the draft store.
    *  Required for replies inside virtualized timeline threads, where the
@@ -47,6 +49,7 @@ function ReplyInput({
   avatarType,
   avatarId,
   onSubmit,
+  onAccepted,
   size = "default",
   draftKey,
 }: ReplyInputProps) {
@@ -200,6 +203,7 @@ function ReplyInput({
       setIsEmpty(true);
       setSuppressedAgentIds(new Set());
       editorScrubbedRef.current = true;
+      if (composerRef.current) onAccepted?.(composerRef.current);
     },
   });
 

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -302,12 +302,12 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   // on success — so a slow send no longer leaves the box full next to an
   // already-posted comment, and a failed send keeps the draft.
   const submitComment = useCallback(
-    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<boolean> => {
+    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<string | false> => {
       if (!content.trim() || !userId) return false;
       try {
         const comment = await createComment({ content, attachmentIds, suppressAgentIds });
         warnUnhandledTriggers(comment?.trigger_outcomes, comment?.content);
-        return true;
+        return comment.id;
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
@@ -321,7 +321,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   );
 
   const submitReply = useCallback(
-    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<boolean> => {
+    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<string | false> => {
       if (!content.trim() || !userId) return false;
       try {
         const comment = await createComment({
@@ -332,7 +332,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
           suppressAgentIds,
         });
         warnUnhandledTriggers(comment?.trigger_outcomes, comment?.content);
-        return true;
+        return comment.id;
       } catch (err) {
         toast.error(
           err instanceof Error && err.message


### PR DESCRIPTION
close #6983 

## Summary
- scroll the issue timeline container to its latest height after a top-level comment is accepted
- scope the behavior to the local send-success path so realtime updates do not interrupt reading
- cover the behavior with an issue-detail regression test

## Verification
- pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx
- pnpm --filter @multica/views typecheck
- git diff --check





https://github.com/user-attachments/assets/602d547b-67a7-4cb1-b214-912b56ff7eb6


https://github.com/user-attachments/assets/b50f4cb0-99dc-4651-86da-a584433e9fe0


https://github.com/user-attachments/assets/e9f3a259-2c49-465a-b2f8-4150513b1301


https://github.com/user-attachments/assets/d8cf57e6-7859-4ea4-96ba-256c2184b9a0



