### PR TITLE
MUL-6141: feat(runtimes): price Qwen/Kimi/Ark models and strip ':' provider prefixes

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -347,8 +347,8 @@ describe("estimateCost", () => {
       cache_read_tokens: 1_000_000,
       cache_write_tokens: 1_000_000,
     });
-    // 1M × $2 + 1M × $6 + 1M × $0.25 + 1M × $2.50 = $10.75.
-    expect(cost).toBeCloseTo(10.75, 5);
+    // 1M × $2 + 1M × $6 + 1M × $0.17 + 1M × $2.50 = $10.67.
+    expect(cost).toBeCloseTo(10.67, 5);
     // `ark-code-latest` is a rolling Volcengine alias, not a stable model
     // identity, so it is deliberately unmapped after the prefix strip.
     expect(isModelPriced("custom:ark-code-latest", "hermes")).toBe(false);

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -334,6 +334,73 @@ describe("estimateCost", () => {
     ).toBe(0);
   });
 
+  it("strips `provider:model` routing prefixes (Hermes custom providers) before resolving", () => {
+    // Regression: canonicalCandidates only stripped `/` prefixes, so Hermes
+    // ids like `alibaba-coding-plan:qwen3.8-max` and `custom:ark-code-latest`
+    // never resolved and stayed uncosted. `:` must be stripped like `/`.
+    const cost = estimateCost({
+      ...zeroUsage,
+      provider: "hermes",
+      model: "alibaba-coding-plan:qwen3.8-max",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_read_tokens: 1_000_000,
+      cache_write_tokens: 1_000_000,
+    });
+    // 1M × $2 + 1M × $6 + 1M × $0.25 + 1M × $2.50 = $10.75.
+    expect(cost).toBeCloseTo(10.75, 5);
+    expect(isModelPriced("custom:ark-code-latest", "hermes")).toBe(true);
+    expect(isModelPriced("kimi-coding:kimi-k3", "hermes")).toBe(true);
+  });
+
+  it("prices the Qwen / Kimi / Ark models added from models.dev", () => {
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "qwen3.7-plus",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(3.5, 5); // $0.50 + $3.00
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "kimi-code/k3",
+        provider: "kimi",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(18, 5); // kimi/k3 → $3 + $15
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "ark-code-latest",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(5.04, 5); // $0.84 + $4.20
+  });
+
+  it("keeps subscription-only and preview SKUs distinct from their GA siblings", () => {
+    // qwen3.8-max-preview is subscription-priced at 0; it must NOT inherit
+    // qwen3.8-max's $2/$6 tier, and `qwen3.8-max-preview[1m]` must resolve
+    // to the preview row after the context-tag strip.
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "qwen3.8-max-preview[1m]",
+        input_tokens: 1_000_000,
+      }),
+    ).toBe(0);
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "qwen3.8-max",
+        input_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(2, 5);
+  });
+
   it("returns 0 for a genuinely unknown model so the UI can flag it", () => {
     expect(
       estimateCost({

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -349,11 +349,13 @@ describe("estimateCost", () => {
     });
     // 1M × $2 + 1M × $6 + 1M × $0.25 + 1M × $2.50 = $10.75.
     expect(cost).toBeCloseTo(10.75, 5);
-    expect(isModelPriced("custom:ark-code-latest", "hermes")).toBe(true);
+    // `ark-code-latest` is a rolling Volcengine alias, not a stable model
+    // identity, so it is deliberately unmapped after the prefix strip.
+    expect(isModelPriced("custom:ark-code-latest", "hermes")).toBe(false);
     expect(isModelPriced("kimi-coding:kimi-k3", "hermes")).toBe(true);
   });
 
-  it("prices the Qwen / Kimi / Ark models added from models.dev", () => {
+  it("prices the Qwen / Kimi models added from models.dev", () => {
     expect(
       estimateCost({
         ...zeroUsage,
@@ -361,7 +363,7 @@ describe("estimateCost", () => {
         input_tokens: 1_000_000,
         output_tokens: 1_000_000,
       }),
-    ).toBeCloseTo(3.5, 5); // $0.50 + $3.00
+    ).toBeCloseTo(2.0, 5); // $0.40 + $1.60 (International ≤256K tier)
     expect(
       estimateCost({
         ...zeroUsage,
@@ -374,11 +376,15 @@ describe("estimateCost", () => {
     expect(
       estimateCost({
         ...zeroUsage,
-        model: "ark-code-latest",
+        model: "qwen3.6-flash",
         input_tokens: 1_000_000,
         output_tokens: 1_000_000,
       }),
-    ).toBeCloseTo(5.04, 5); // $0.84 + $4.20
+    ).toBeCloseTo(1.75, 5); // $0.25 + $1.50 (International ≤256K tier)
+    // `ark-code-latest` is a rolling Volcengine alias (target switched in
+    // the console, possibly across model families), not a stable model
+    // identity — it stays unmapped like grok-composer-*.
+    expect(isModelPriced("ark-code-latest")).toBe(false);
   });
 
   it("keeps subscription-only and preview SKUs distinct from their GA siblings", () => {
@@ -399,6 +405,33 @@ describe("estimateCost", () => {
         input_tokens: 1_000_000,
       }),
     ).toBeCloseTo(2, 5);
+  });
+
+  it("iteratively strips nested routing prefixes (custom:anthropic/claude-opus-4.7)", () => {
+    // Regression for the review blocker: stripProvider used to peel a single
+    // `/` or `:` layer, so a Hermes-style `custom:anthropic/claude-opus-4.7`
+    // stopped at `anthropic/claude-opus-4.7` and missed the table while the
+    // backend substring rules matched it. Iterative peeling must resolve it
+    // to the Opus tier: 1M × $5 + 1M × $25 = $30.
+    const cost = estimateCost({
+      ...zeroUsage,
+      provider: "hermes",
+      model: "custom:anthropic/claude-opus-4.7",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(30, 5);
+    expect(isModelPriced("custom:anthropic/claude-opus-4.7", "hermes")).toBe(true);
+  });
+
+  it("keeps unknown suffixed Qwen variants unmapped (anchored aliases)", () => {
+    // Regression for the review blocker: the backend alias regexes were
+    // unanchored substrings, so `qwen3.7-plus-extra` / `qwen3.8-max-preview-extra`
+    // silently borrowed a tier. The frontend exact matcher must agree and
+    // leave them unmapped so both sides surface the same diagnostics.
+    expect(isModelPriced("qwen3.7-plus-extra")).toBe(false);
+    expect(isModelPriced("qwen3.6-flash-extra")).toBe(false);
+    expect(isModelPriced("qwen3.8-max-preview-extra")).toBe(false);
   });
 
   it("returns 0 for a genuinely unknown model so the UI can flag it", () => {

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -267,6 +267,13 @@ const MODEL_PRICING: Record<
   //    Only K2.6 is on the official price sheet today; earlier K2 variants
   //    are intentionally omitted until Moonshot publishes their rates. --
   "kimi-k2.6":          { input: 0.95, output: 4.00, cacheRead: 0.16,   cacheWrite: 0.95 },
+  // Kimi K3 (platform.kimi.ai/docs/pricing/chat-k3 via models.dev
+  // providers/moonshotai/models/kimi-k3.toml). Moonshot bills no separate
+  // cache write, so cacheWrite mirrors input (same convention as kimi-k2.6).
+  "kimi-k3":            { input: 3.0,  output: 15.0,  cacheRead: 0.30,   cacheWrite: 3.0 },
+  // Kimi Code CLI reports the same model as `kimi-code/k3`; provider-qualified
+  // because `k3` is a generic id (see the provider-qualified keys note above).
+  "kimi/k3":            { input: 3.0,  output: 15.0,  cacheRead: 0.30,   cacheWrite: 3.0 },
 
   // -- Zhipu z.ai (docs.z.ai/guides/overview/pricing). Free flash tiers
   //    are priced at 0 so they resolve cleanly instead of falling through
@@ -283,6 +290,30 @@ const MODEL_PRICING: Record<
   "glm-4.5-air":        { input: 0.2,  output: 1.1,  cacheRead: 0.03,   cacheWrite: 0.2 },
   "glm-4.5-airx":       { input: 1.1,  output: 4.5,  cacheRead: 0.22,   cacheWrite: 1.1 },
   "glm-4.5-flash":      { input: 0,    output: 0,    cacheRead: 0,      cacheWrite: 0 },
+
+  // -- Alibaba Qwen (models.dev providers/alibaba, accessed 2026-08-13;
+  //    sourced from alibabacloud.com model-studio pricing). qwen3.8-max is
+  //    priced at the published pay-as-you-go rate so the dashboard shows the
+  //    absolute cost even though the runtime reaches it through an Alibaba
+  //    Token/Coding Plan subscription. qwen3.8-max-preview stays at 0:
+  //    it is only served through the subscription (token-plan.cn-beijing.
+  //    maas.aliyuncs.com), which does not bill per token — 0 resolves
+  //    cleanly instead of tripping the unmapped diagnostic (same convention
+  //    as the free GLM flash tiers below). qwen3.6-flash carries no
+  //    published cache-read discount, so cacheRead stays 0. --
+  "qwen3.7-plus":       { input: 0.50,  output: 3.00,  cacheRead: 0.05,   cacheWrite: 0.625 },
+  "qwen3.6-flash":      { input: 0.1875, output: 1.125, cacheRead: 0,      cacheWrite: 0.234375 },
+  "qwen3.8-max":        { input: 2.00,  output: 6.00,  cacheRead: 0.25,   cacheWrite: 2.5 },
+  "qwen3.8-max-preview":{ input: 0,      output: 0,     cacheRead: 0,      cacheWrite: 0 },
+
+  // -- Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is the
+  //    rolling alias for Volcengine's current coding model
+  //    (doubao-seed-evolving as of 2026-08-13). Official price sheet
+  //    (docs.volcengine.com/docs/82379/1099320, updated 2026-08-12) lists
+  //    CNY per MTok: 6.00 in / 30.00 out / 1.20 cached; converted at
+  //    7.15 CNY/USD. Volcengine bills no separate cache write, so cacheWrite
+  //    mirrors input (same convention as DeepSeek/Moonshot). --
+  "ark-code-latest":    { input: 0.84,   output: 4.20,  cacheRead: 0.17,   cacheWrite: 0.84 },
 
   // -- xAI Grok (docs.x.ai/developers/pricing). Rates below are the
   //    short-context tier, and are now only a FALLBACK for Grok: xAI reports
@@ -461,8 +492,15 @@ function canonicalCandidates(model: string): string[] {
   const stripDate = (s: string) =>
     s.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
   const stripProvider = (s: string) => {
+    // Routing prefixes come in two flavours: `vendor/model` (opencode-style)
+    // and `provider:model` (Hermes custom providers). Take whichever
+    // separator comes first so mixed forms still resolve.
     const i = s.indexOf("/");
-    return i > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, i)) ? s.slice(i + 1) : s;
+    const j = s.indexOf(":");
+    const sep = i === -1 ? j : j === -1 ? i : Math.min(i, j);
+    return sep > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, sep))
+      ? s.slice(sep + 1)
+      : s;
   };
   // Only Anthropic IDs are dot↔dash equivalent. OpenAI separators are
   // semantic, so we leave `gpt-5.4` etc. alone.

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -298,19 +298,19 @@ const MODEL_PRICING: Record<
   //    $0.25 / output $1.50. Cache prices: Explicit Cache Creation = 1.25×
   //    input (qwen3.7-plus $0.50, qwen3.6-flash $0.3125); Explicit Cache
   //    Read = 10% of input (qwen3.7-plus $0.04, qwen3.6-flash $0.025).
-  //    qwen3.8-max is priced at the published pay-as-you-go rate
-  //    (qwencloud.com/models/qwen3.8-max: Input $2, Output $6, Implicit
-  //    Cache $0.25, Creation $2.5, Read $0.17; also listed on
-  //    alibabacloud.com/help model-pricing) so the dashboard shows the
-  //    absolute cost even though the runtime reaches it through an Alibaba
-  //    Token/Coding Plan subscription. qwen3.8-max-preview stays at 0:
+  // qwen3.8-max is priced at the published pay-as-you-go rate
+  // (qwencloud.com/models/qwen3.8-max: Input $2, Output $6, Implicit
+  // Cache $0.25, Creation $2.5, Explicit Cache Read $0.17; also listed on
+  // alibabacloud.com/help model-pricing) so the dashboard shows the
+  // absolute cost even though the runtime reaches it through an Alibaba
+  // Token/Coding Plan subscription. qwen3.8-max-preview stays at 0:
   //    it is only served through the subscription (token-plan.cn-beijing.
   //    maas.aliyuncs.com), which does not bill per token — 0 resolves
   //    cleanly instead of tripping the unmapped diagnostic (same convention
   //    as the free GLM flash tiers below). --
   "qwen3.7-plus":       { input: 0.40,  output: 1.60,  cacheRead: 0.04,   cacheWrite: 0.50 },
   "qwen3.6-flash":      { input: 0.25,  output: 1.50,  cacheRead: 0.025,  cacheWrite: 0.3125 },
-  "qwen3.8-max":        { input: 2.00,  output: 6.00,  cacheRead: 0.25,   cacheWrite: 2.5 },
+  "qwen3.8-max":        { input: 2.00,  output: 6.00,  cacheRead: 0.17,   cacheWrite: 2.5 },
   "qwen3.8-max-preview":{ input: 0,      output: 0,     cacheRead: 0,      cacheWrite: 0 },
 
   // -- Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is a

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -291,29 +291,35 @@ const MODEL_PRICING: Record<
   "glm-4.5-airx":       { input: 1.1,  output: 4.5,  cacheRead: 0.22,   cacheWrite: 1.1 },
   "glm-4.5-flash":      { input: 0,    output: 0,    cacheRead: 0,      cacheWrite: 0 },
 
-  // -- Alibaba Qwen (models.dev providers/alibaba, accessed 2026-08-13;
-  //    sourced from alibabacloud.com model-studio pricing). qwen3.8-max is
-  //    priced at the published pay-as-you-go rate so the dashboard shows the
+  // -- Alibaba Qwen (International ≤256K tier; official sources:
+  //    alibabacloud.com/help/model-studio pricing sheet and
+  //    qwencloud.com/models/<model> pages, accessed 2026-08-12).
+  //    qwen3.7-plus: input $0.40 / output $1.60; qwen3.6-flash: input
+  //    $0.25 / output $1.50. Cache prices: Explicit Cache Creation = 1.25×
+  //    input (qwen3.7-plus $0.50, qwen3.6-flash $0.3125); Explicit Cache
+  //    Read = 10% of input (qwen3.7-plus $0.04, qwen3.6-flash $0.025).
+  //    qwen3.8-max is priced at the published pay-as-you-go rate
+  //    (qwencloud.com/models/qwen3.8-max: Input $2, Output $6, Implicit
+  //    Cache $0.25, Creation $2.5, Read $0.17; also listed on
+  //    alibabacloud.com/help model-pricing) so the dashboard shows the
   //    absolute cost even though the runtime reaches it through an Alibaba
   //    Token/Coding Plan subscription. qwen3.8-max-preview stays at 0:
   //    it is only served through the subscription (token-plan.cn-beijing.
   //    maas.aliyuncs.com), which does not bill per token — 0 resolves
   //    cleanly instead of tripping the unmapped diagnostic (same convention
-  //    as the free GLM flash tiers below). qwen3.6-flash carries no
-  //    published cache-read discount, so cacheRead stays 0. --
-  "qwen3.7-plus":       { input: 0.50,  output: 3.00,  cacheRead: 0.05,   cacheWrite: 0.625 },
-  "qwen3.6-flash":      { input: 0.1875, output: 1.125, cacheRead: 0,      cacheWrite: 0.234375 },
+  //    as the free GLM flash tiers below). --
+  "qwen3.7-plus":       { input: 0.40,  output: 1.60,  cacheRead: 0.04,   cacheWrite: 0.50 },
+  "qwen3.6-flash":      { input: 0.25,  output: 1.50,  cacheRead: 0.025,  cacheWrite: 0.3125 },
   "qwen3.8-max":        { input: 2.00,  output: 6.00,  cacheRead: 0.25,   cacheWrite: 2.5 },
   "qwen3.8-max-preview":{ input: 0,      output: 0,     cacheRead: 0,      cacheWrite: 0 },
 
-  // -- Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is the
-  //    rolling alias for Volcengine's current coding model
-  //    (doubao-seed-evolving as of 2026-08-13). Official price sheet
-  //    (docs.volcengine.com/docs/82379/1099320, updated 2026-08-12) lists
-  //    CNY per MTok: 6.00 in / 30.00 out / 1.20 cached; converted at
-  //    7.15 CNY/USD. Volcengine bills no separate cache write, so cacheWrite
-  //    mirrors input (same convention as DeepSeek/Moonshot). --
-  "ark-code-latest":    { input: 0.84,   output: 4.20,  cacheRead: 0.17,   cacheWrite: 0.84 },
+  // -- Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is a
+  //    rolling alias whose target the Volcengine console can switch between
+  //    model families, so it is not a stable model identity. Daemons report
+  //    the alias itself, not the resolved model, so there is no reliable
+  //    rate to attach — it deliberately stays unmapped (same philosophy as
+  //    xAI's `grok-composer-*`, see below), surfacing in the pricing dialog
+  //    instead of inheriting a guessed rate. --
 
   // -- xAI Grok (docs.x.ai/developers/pricing). Rates below are the
   //    short-context tier, and are now only a FALLBACK for Grok: xAI reports
@@ -493,14 +499,24 @@ function canonicalCandidates(model: string): string[] {
     s.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
   const stripProvider = (s: string) => {
     // Routing prefixes come in two flavours: `vendor/model` (opencode-style)
-    // and `provider:model` (Hermes custom providers). Take whichever
-    // separator comes first so mixed forms still resolve.
-    const i = s.indexOf("/");
-    const j = s.indexOf(":");
-    const sep = i === -1 ? j : j === -1 ? i : Math.min(i, j);
-    return sep > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, sep))
-      ? s.slice(sep + 1)
-      : s;
+    // and `provider:model` (Hermes custom providers), and can nest
+    // (`custom:anthropic/claude-opus-4.7` is a provider-prefixed id whose
+    // model segment is itself provider-prefixed). Iteratively strip the
+    // earliest `/` or `:` separator while the preceding segment looks like a
+    // routing layer (`^[a-z][a-z0-9_-]*$`), until nothing valid remains to
+    // strip. The raw string is always the first candidate (see `push(raw)`
+    // below), so provider-qualified table keys like `cursor/composer-2.5`
+    // still resolve before any stripping happens — iterative peeling only
+    // ever adds previously-missed nested forms.
+    let out = s;
+    for (;;) {
+      const i = out.indexOf("/");
+      const j = out.indexOf(":");
+      const sep = i === -1 ? j : j === -1 ? i : Math.min(i, j);
+      if (sep <= 0 || !/^[a-z][a-z0-9_-]*$/i.test(out.slice(0, sep))) break;
+      out = out.slice(sep + 1);
+    }
+    return out;
   };
   // Only Anthropic IDs are dot↔dash equivalent. OpenAI separators are
   // semantic, so we leave `gpt-5.4` etc. alone.

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -75,28 +75,31 @@ var modelPrices = map[string]ModelPrice{
 	"xai:grok-4.20-0309-reasoning":     {Provider: "xai", Model: "grok-4.20-0309-reasoning", InputPerM: 1.25, CacheReadPerM: 0.20, CacheWritePerM: 1.25, OutputPerM: 2.50},
 	"xai:grok-4.20-0309-non-reasoning": {Provider: "xai", Model: "grok-4.20-0309-non-reasoning", InputPerM: 1.25, CacheReadPerM: 0.20, CacheWritePerM: 1.25, OutputPerM: 2.50},
 	// Alibaba Qwen (models.dev providers/alibaba, accessed 2026-08-13;
-	// sourced from alibabacloud.com model-studio pricing). qwen3.8-max is
-	// priced at the published pay-as-you-go rate; qwen3.8-max-preview is
-	// served through the Alibaba Token Plan subscription, which does not bill
-	// per token, so it stays at 0 (same convention as the free GLM flash
-	// tiers). qwen3.6-flash carries no published cache-read discount, so
-	// CacheReadPerM stays 0. Mirror packages/views/runtimes/utils.ts.
-	"alibaba:qwen3.7-plus":        {Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
-	"alibaba:qwen3.6-flash":       {Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.1875, CacheReadPerM: 0, CacheWritePerM: 0.234375, OutputPerM: 1.125},
+	// sourced from alibabacloud.com model-pricing — International ≤256K
+	// input tier — and the qwencloud.com model pages). qwen3.7-plus and
+	// qwen3.6-flash carry the published International ≤256K rates;
+	// CacheWritePerM is the Explicit Cache Creation rate (1.25x input) and
+	// CacheReadPerM the Explicit Cache Read rate (0.1x input). qwen3.8-max
+	// is priced at the published pay-as-you-go rate from its
+	// qwencloud.com/models/qwen3.8-max page (the source models.dev cites);
+	// qwen3.8-max-preview is served through the Alibaba Token Plan
+	// subscription, which does not bill per token, so it stays at 0 (same
+	// convention as the free GLM flash tiers). Mirror
+	// packages/views/runtimes/utils.ts.
+	"alibaba:qwen3.7-plus":        {Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.40, CacheReadPerM: 0.04, CacheWritePerM: 0.50, OutputPerM: 1.60},
+	"alibaba:qwen3.6-flash":       {Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.25, CacheReadPerM: 0.025, CacheWritePerM: 0.3125, OutputPerM: 1.50},
 	"alibaba:qwen3.8-max":         {Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.25, CacheWritePerM: 2.50, OutputPerM: 6.00},
 	"alibaba:qwen3.8-max-preview": {Provider: "alibaba", Model: "qwen3.8-max-preview", InputPerM: 0, CacheReadPerM: 0, CacheWritePerM: 0, OutputPerM: 0},
 	// Moonshot Kimi K3 (platform.kimi.ai/docs/pricing/chat-k3 via models.dev
 	// providers/moonshotai/models/kimi-k3.toml). Moonshot bills no separate
 	// cache write, so CacheWritePerM mirrors Input.
 	"moonshotai:kimi-k3": {Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
-	// Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is the
-	// rolling alias for Volcengine's current coding model
-	// (doubao-seed-evolving as of 2026-08-13). Official price sheet
-	// (docs.volcengine.com/docs/82379/1099320, updated 2026-08-12) lists
-	// CNY per MTok: 6.00 in / 30.00 out / 1.20 cached; converted at
-	// 7.15 CNY/USD. Volcengine bills no separate cache write, so
-	// CacheWritePerM mirrors Input.
-	"volcengine:ark-code-latest": {Provider: "volcengine", Model: "ark-code-latest", InputPerM: 0.84, CacheReadPerM: 0.17, CacheWritePerM: 0.84, OutputPerM: 4.20},
+	// Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is a
+	// rolling alias whose target can be switched in the Volcengine console
+	// (across model families), so it is not a stable model identity; the
+	// daemon reports the alias itself, never the resolved model. No rate is
+	// published for the alias, so it stays unmapped rather than inheriting
+	// a guessed rate (same convention as xAI's `grok-composer-*`).
 }
 
 var modelAliasRules = []struct {
@@ -146,19 +149,23 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-multi-agent-0309$`), "xai:grok-4.20-multi-agent-0309"},
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-reasoning$`), "xai:grok-4.20-0309-reasoning"},
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-non-reasoning$`), "xai:grok-4.20-0309-non-reasoning"},
-	// Alibaba Qwen. qwen3.8-max is anchored so `qwen3.8-max-preview` (and its
-	// `[1m]` variant) never borrows the GA tier; the preview rule is a plain
-	// substring so `qwen3.8-max-preview[1m]` still resolves.
-	{regexp.MustCompile(`qwen3[.-]7-plus`), "alibaba:qwen3.7-plus"},
-	{regexp.MustCompile(`qwen3[.-]6-flash`), "alibaba:qwen3.6-flash"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max$`), "alibaba:qwen3.8-max"},
-	{regexp.MustCompile(`qwen3[.-]8-max-preview`), "alibaba:qwen3.8-max-preview"},
+	// Alibaba Qwen. All rules are anchored so unknown suffixed variants
+	// (`qwen3.7-plus-extra`, `qwen3.8-max-preview-extra`) stay unmapped;
+	// `($|\[)` admits the bracketed `[1m]` context suffix, matching the
+	// frontend's behavior of stripping the context tag. qwen3.8-max stays
+	// anchored so `qwen3.8-max-preview` (and its `[1m]` variant) never
+	// borrows the GA tier.
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]7-plus$`), "alibaba:qwen3.7-plus"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]6-flash$`), "alibaba:qwen3.6-flash"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max($|\[)`), "alibaba:qwen3.8-max"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max-preview($|\[)`), "alibaba:qwen3.8-max-preview"},
 	// Kimi K3. Anchored so the distinct CodeBuddy SKU `kimi-k3-1` stays
 	// unmapped; `kimi-code/k3` (Kimi Code CLI) resolves via the `/k3$` form.
 	{regexp.MustCompile(`(^|/|:)kimi-k3$`), "moonshotai:kimi-k3"},
 	{regexp.MustCompile(`(^|/|:)k3$`), "moonshotai:kimi-k3"},
-	// Volcengine Ark coding model (rolling alias).
-	{regexp.MustCompile(`ark-code-latest`), "volcengine:ark-code-latest"},
+	// Volcengine Ark `ark-code-latest` is deliberately absent: it is a
+	// console-switchable rolling alias across model families, not a stable
+	// model identity, so it stays unmapped.
 }
 
 func PriceForModelAlias(model string) (ModelPrice, bool) {

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -151,14 +151,16 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-non-reasoning$`), "xai:grok-4.20-0309-non-reasoning"},
 	// Alibaba Qwen. All rules are anchored so unknown suffixed variants
 	// (`qwen3.7-plus-extra`, `qwen3.8-max-preview-extra`) stay unmapped;
-	// an optional complete bracket tag `[…]` at the end is admitted to
-	// match the frontend's behavior of stripping the context tag. qwen3.8-max
-	// stays anchored so `qwen3.8-max-preview` (and its `[1m]` variant) never
-	// borrows the GA tier.
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]7-plus(\[[^\]]*\])?$`), "alibaba:qwen3.7-plus"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]6-flash(\[[^\]]*\])?$`), "alibaba:qwen3.6-flash"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max(\[[^\]]*\])?$`), "alibaba:qwen3.8-max"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max-preview(\[[^\]]*\])?$`), "alibaba:qwen3.8-max-preview"},
+	// an optional complete bracket tag `[…]` with at least one character
+	// inside is admitted to match the frontend's behavior of stripping the
+	// context tag (`\[[^\]]+\]$` in packages/views/runtimes/utils.ts), so
+	// empty tags like `qwen3.7-plus[]` stay unmapped on both sides.
+	// qwen3.8-max stays anchored so `qwen3.8-max-preview` (and its `[1m]`
+	// variant) never borrows the GA tier.
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]7-plus(\[[^\]]+\])?$`), "alibaba:qwen3.7-plus"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]6-flash(\[[^\]]+\])?$`), "alibaba:qwen3.6-flash"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max(\[[^\]]+\])?$`), "alibaba:qwen3.8-max"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max-preview(\[[^\]]+\])?$`), "alibaba:qwen3.8-max-preview"},
 	// Kimi K3. Anchored so the distinct CodeBuddy SKU `kimi-k3-1` stays
 	// unmapped; `kimi-code/k3` (Kimi Code CLI) resolves via the `/k3$` form.
 	{regexp.MustCompile(`(^|/|:)kimi-k3$`), "moonshotai:kimi-k3"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -74,6 +74,29 @@ var modelPrices = map[string]ModelPrice{
 	"xai:grok-4.20-multi-agent-0309":   {Provider: "xai", Model: "grok-4.20-multi-agent-0309", InputPerM: 1.25, CacheReadPerM: 0.20, CacheWritePerM: 1.25, OutputPerM: 2.50},
 	"xai:grok-4.20-0309-reasoning":     {Provider: "xai", Model: "grok-4.20-0309-reasoning", InputPerM: 1.25, CacheReadPerM: 0.20, CacheWritePerM: 1.25, OutputPerM: 2.50},
 	"xai:grok-4.20-0309-non-reasoning": {Provider: "xai", Model: "grok-4.20-0309-non-reasoning", InputPerM: 1.25, CacheReadPerM: 0.20, CacheWritePerM: 1.25, OutputPerM: 2.50},
+	// Alibaba Qwen (models.dev providers/alibaba, accessed 2026-08-13;
+	// sourced from alibabacloud.com model-studio pricing). qwen3.8-max is
+	// priced at the published pay-as-you-go rate; qwen3.8-max-preview is
+	// served through the Alibaba Token Plan subscription, which does not bill
+	// per token, so it stays at 0 (same convention as the free GLM flash
+	// tiers). qwen3.6-flash carries no published cache-read discount, so
+	// CacheReadPerM stays 0. Mirror packages/views/runtimes/utils.ts.
+	"alibaba:qwen3.7-plus":        {Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
+	"alibaba:qwen3.6-flash":       {Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.1875, CacheReadPerM: 0, CacheWritePerM: 0.234375, OutputPerM: 1.125},
+	"alibaba:qwen3.8-max":         {Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.25, CacheWritePerM: 2.50, OutputPerM: 6.00},
+	"alibaba:qwen3.8-max-preview": {Provider: "alibaba", Model: "qwen3.8-max-preview", InputPerM: 0, CacheReadPerM: 0, CacheWritePerM: 0, OutputPerM: 0},
+	// Moonshot Kimi K3 (platform.kimi.ai/docs/pricing/chat-k3 via models.dev
+	// providers/moonshotai/models/kimi-k3.toml). Moonshot bills no separate
+	// cache write, so CacheWritePerM mirrors Input.
+	"moonshotai:kimi-k3": {Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
+	// Volcengine Ark (ark.cn-beijing.volces.com). `ark-code-latest` is the
+	// rolling alias for Volcengine's current coding model
+	// (doubao-seed-evolving as of 2026-08-13). Official price sheet
+	// (docs.volcengine.com/docs/82379/1099320, updated 2026-08-12) lists
+	// CNY per MTok: 6.00 in / 30.00 out / 1.20 cached; converted at
+	// 7.15 CNY/USD. Volcengine bills no separate cache write, so
+	// CacheWritePerM mirrors Input.
+	"volcengine:ark-code-latest": {Provider: "volcengine", Model: "ark-code-latest", InputPerM: 0.84, CacheReadPerM: 0.17, CacheWritePerM: 0.84, OutputPerM: 4.20},
 }
 
 var modelAliasRules = []struct {
@@ -123,6 +146,19 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-multi-agent-0309$`), "xai:grok-4.20-multi-agent-0309"},
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-reasoning$`), "xai:grok-4.20-0309-reasoning"},
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-non-reasoning$`), "xai:grok-4.20-0309-non-reasoning"},
+	// Alibaba Qwen. qwen3.8-max is anchored so `qwen3.8-max-preview` (and its
+	// `[1m]` variant) never borrows the GA tier; the preview rule is a plain
+	// substring so `qwen3.8-max-preview[1m]` still resolves.
+	{regexp.MustCompile(`qwen3[.-]7-plus`), "alibaba:qwen3.7-plus"},
+	{regexp.MustCompile(`qwen3[.-]6-flash`), "alibaba:qwen3.6-flash"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max$`), "alibaba:qwen3.8-max"},
+	{regexp.MustCompile(`qwen3[.-]8-max-preview`), "alibaba:qwen3.8-max-preview"},
+	// Kimi K3. Anchored so the distinct CodeBuddy SKU `kimi-k3-1` stays
+	// unmapped; `kimi-code/k3` (Kimi Code CLI) resolves via the `/k3$` form.
+	{regexp.MustCompile(`(^|/|:)kimi-k3$`), "moonshotai:kimi-k3"},
+	{regexp.MustCompile(`(^|/|:)k3$`), "moonshotai:kimi-k3"},
+	// Volcengine Ark coding model (rolling alias).
+	{regexp.MustCompile(`ark-code-latest`), "volcengine:ark-code-latest"},
 }
 
 func PriceForModelAlias(model string) (ModelPrice, bool) {

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -88,7 +88,7 @@ var modelPrices = map[string]ModelPrice{
 	// packages/views/runtimes/utils.ts.
 	"alibaba:qwen3.7-plus":        {Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.40, CacheReadPerM: 0.04, CacheWritePerM: 0.50, OutputPerM: 1.60},
 	"alibaba:qwen3.6-flash":       {Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.25, CacheReadPerM: 0.025, CacheWritePerM: 0.3125, OutputPerM: 1.50},
-	"alibaba:qwen3.8-max":         {Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.25, CacheWritePerM: 2.50, OutputPerM: 6.00},
+	"alibaba:qwen3.8-max":         {Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.17, CacheWritePerM: 2.50, OutputPerM: 6.00},
 	"alibaba:qwen3.8-max-preview": {Provider: "alibaba", Model: "qwen3.8-max-preview", InputPerM: 0, CacheReadPerM: 0, CacheWritePerM: 0, OutputPerM: 0},
 	// Moonshot Kimi K3 (platform.kimi.ai/docs/pricing/chat-k3 via models.dev
 	// providers/moonshotai/models/kimi-k3.toml). Moonshot bills no separate
@@ -151,14 +151,14 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)grok-4\.20-0309-non-reasoning$`), "xai:grok-4.20-0309-non-reasoning"},
 	// Alibaba Qwen. All rules are anchored so unknown suffixed variants
 	// (`qwen3.7-plus-extra`, `qwen3.8-max-preview-extra`) stay unmapped;
-	// `($|\[)` admits the bracketed `[1m]` context suffix, matching the
-	// frontend's behavior of stripping the context tag. qwen3.8-max stays
-	// anchored so `qwen3.8-max-preview` (and its `[1m]` variant) never
+	// an optional complete bracket tag `[…]` at the end is admitted to
+	// match the frontend's behavior of stripping the context tag. qwen3.8-max
+	// stays anchored so `qwen3.8-max-preview` (and its `[1m]` variant) never
 	// borrows the GA tier.
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]7-plus$`), "alibaba:qwen3.7-plus"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]6-flash$`), "alibaba:qwen3.6-flash"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max($|\[)`), "alibaba:qwen3.8-max"},
-	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max-preview($|\[)`), "alibaba:qwen3.8-max-preview"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]7-plus(\[[^\]]*\])?$`), "alibaba:qwen3.7-plus"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]6-flash(\[[^\]]*\])?$`), "alibaba:qwen3.6-flash"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max(\[[^\]]*\])?$`), "alibaba:qwen3.8-max"},
+	{regexp.MustCompile(`(^|/|:)qwen3[.-]8-max-preview(\[[^\]]*\])?$`), "alibaba:qwen3.8-max-preview"},
 	// Kimi K3. Anchored so the distinct CodeBuddy SKU `kimi-k3-1` stays
 	// unmapped; `kimi-code/k3` (Kimi Code CLI) resolves via the `/k3$` form.
 	{regexp.MustCompile(`(^|/|:)kimi-k3$`), "moonshotai:kimi-k3"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -212,10 +212,11 @@ func TestGrokPricingMatchesRecordedTurn(t *testing.T) {
 }
 
 // TestPriceForModelAliasAlibabaMoonshotVolcengine pins the pay-as-you-go
-// rates for the Chinese-model runtimes (Qwen / Kimi / Volcengine Ark) added
-// from models.dev, and the transport spellings that reach them:
-// `provider:model` (Hermes custom providers), `provider/model` (opencode),
-// and bare ids.
+// rates for the Chinese-model runtimes (Qwen / Kimi) added from models.dev,
+// and the transport spellings that reach them: `provider:model` (Hermes
+// custom providers), `provider/model` (opencode), and bare ids. Volcengine's
+// `ark-code-latest` rolling alias is covered as unmapped in
+// TestPriceForModelAliasNoFalseBorrowing.
 func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 	cases := []struct {
 		model string
@@ -223,15 +224,15 @@ func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 	}{
 		{
 			model: "qwen3.7-plus",
-			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.40, CacheReadPerM: 0.04, CacheWritePerM: 0.50, OutputPerM: 1.60},
 		},
 		{
 			model: "alibaba-coding-plan:qwen3.7-plus",
-			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.40, CacheReadPerM: 0.04, CacheWritePerM: 0.50, OutputPerM: 1.60},
 		},
 		{
 			model: "qwen3.6-flash",
-			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.1875, CacheReadPerM: 0, CacheWritePerM: 0.234375, OutputPerM: 1.125},
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.25, CacheReadPerM: 0.025, CacheWritePerM: 0.3125, OutputPerM: 1.50},
 		},
 		{
 			model: "alibaba-coding-plan:qwen3.8-max",
@@ -251,8 +252,12 @@ func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 			want:  ModelPrice{Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
 		},
 		{
-			model: "custom:ark-code-latest",
-			want:  ModelPrice{Provider: "volcengine", Model: "ark-code-latest", InputPerM: 0.84, CacheReadPerM: 0.17, CacheWritePerM: 0.84, OutputPerM: 4.20},
+			// `custom:anthropic/claude-opus-4.7` (provider prefix + nested
+			// slash path) must still resolve to the anthropic Opus tier via
+			// substring matching, mirroring the frontend stripProvider
+			// regression case.
+			model: "custom:anthropic/claude-opus-4.7",
+			want:  ModelPrice{Provider: "anthropic", Model: "claude-opus-4.7", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
 		},
 	}
 
@@ -269,7 +274,8 @@ func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 
 // TestPriceForModelAliasNoFalseBorrowing guards the anchored rules: a preview
 // SKU must not inherit the GA tier, a distinct CodeBuddy SKU must not inherit
-// Kimi K3, and an unknown variant must stay unmapped.
+// Kimi K3, unknown suffixed variants must stay unmapped, and the Volcengine
+// `ark-code-latest` rolling alias must stay unmapped.
 func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 	for _, model := range []string{
 		"qwen3.8-max-preview",
@@ -291,7 +297,14 @@ func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 		t.Fatalf("qwen3.8-max-preview[1m] = %+v (ok=%v); want the preview row", got, ok)
 	}
 
-	for _, model := range []string{"qwen3.8-max-extra", "kimi-k3-1"} {
+	for _, model := range []string{
+		"qwen3.8-max-extra",
+		"kimi-k3-1",
+		"qwen3.7-plus-extra",
+		"qwen3.6-flash-extra",
+		"qwen3.8-max-preview-extra",
+		"custom:ark-code-latest",
+	} {
 		if _, ok := PriceForModelAlias(model); ok {
 			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved", model)
 		}

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -236,7 +236,7 @@ func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 		},
 		{
 			model: "alibaba-coding-plan:qwen3.8-max",
-			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.25, CacheWritePerM: 2.50, OutputPerM: 6.00},
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.17, CacheWritePerM: 2.50, OutputPerM: 6.00},
 		},
 		{
 			model: "custom:qwen3.8-max-preview[1m]",
@@ -282,6 +282,9 @@ func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 		"qwen3.8-max-preview[1m]",
 		"kimi-k3-1",
 		"qwen3.8-max-extra",
+		"qwen3.8-max[",
+		"qwen3.8-max[1m]-extra",
+		"qwen3.8-max-preview[1m]-extra",
 	} {
 		got, ok := PriceForModelAlias(model)
 		if !ok {
@@ -293,8 +296,18 @@ func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 	}
 
 	// A distinct SKU that borrows nothing must resolve to its own row.
-	if got, ok := PriceForModelAlias("qwen3.8-max-preview[1m]"); !ok || got.Model != "qwen3.8-max-preview" {
-		t.Fatalf("qwen3.8-max-preview[1m] = %+v (ok=%v); want the preview row", got, ok)
+	for _, tc := range []struct {
+		model     string
+		wantModel string
+	}{
+		{"qwen3.8-max-preview[1m]", "qwen3.8-max-preview"},
+		{"qwen3.8-max-preview[context]", "qwen3.8-max-preview"},
+		{"qwen3.8-max[1m]", "qwen3.8-max"},
+	} {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok || got.Model != tc.wantModel {
+			t.Fatalf("PriceForModelAlias(%q) = %+v (ok=%v); want %s", tc.model, got, ok, tc.wantModel)
+		}
 	}
 
 	for _, model := range []string{

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -210,3 +210,90 @@ func TestGrokPricingMatchesRecordedTurn(t *testing.T) {
 		t.Fatalf("recomputed cost = %.10f, want %.10f (xAI costUsdTicks)", got, wantUSD)
 	}
 }
+
+// TestPriceForModelAliasAlibabaMoonshotVolcengine pins the pay-as-you-go
+// rates for the Chinese-model runtimes (Qwen / Kimi / Volcengine Ark) added
+// from models.dev, and the transport spellings that reach them:
+// `provider:model` (Hermes custom providers), `provider/model` (opencode),
+// and bare ids.
+func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{
+			model: "qwen3.7-plus",
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
+		},
+		{
+			model: "alibaba-coding-plan:qwen3.7-plus",
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.7-plus", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.625, OutputPerM: 3.00},
+		},
+		{
+			model: "qwen3.6-flash",
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.6-flash", InputPerM: 0.1875, CacheReadPerM: 0, CacheWritePerM: 0.234375, OutputPerM: 1.125},
+		},
+		{
+			model: "alibaba-coding-plan:qwen3.8-max",
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.8-max", InputPerM: 2.00, CacheReadPerM: 0.25, CacheWritePerM: 2.50, OutputPerM: 6.00},
+		},
+		{
+			model: "custom:qwen3.8-max-preview[1m]",
+			want:  ModelPrice{Provider: "alibaba", Model: "qwen3.8-max-preview", InputPerM: 0, CacheReadPerM: 0, CacheWritePerM: 0, OutputPerM: 0},
+		},
+		{
+			model: "kimi-coding:kimi-k3",
+			want:  ModelPrice{Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
+		},
+		{
+			// Kimi Code CLI reports `kimi-code/k3`.
+			model: "kimi-code/k3",
+			want:  ModelPrice{Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
+		},
+		{
+			model: "custom:ark-code-latest",
+			want:  ModelPrice{Provider: "volcengine", Model: "ark-code-latest", InputPerM: 0.84, CacheReadPerM: 0.17, CacheWritePerM: 0.84, OutputPerM: 4.20},
+		},
+	}
+
+	for _, tc := range cases {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", tc.model)
+		}
+		if got != tc.want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+}
+
+// TestPriceForModelAliasNoFalseBorrowing guards the anchored rules: a preview
+// SKU must not inherit the GA tier, a distinct CodeBuddy SKU must not inherit
+// Kimi K3, and an unknown variant must stay unmapped.
+func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
+	for _, model := range []string{
+		"qwen3.8-max-preview",
+		"qwen3.8-max-preview[1m]",
+		"kimi-k3-1",
+		"qwen3.8-max-extra",
+	} {
+		got, ok := PriceForModelAlias(model)
+		if !ok {
+			continue
+		}
+		if got.Model == "qwen3.8-max" || got.Model == "kimi-k3" {
+			t.Fatalf("PriceForModelAlias(%q) borrowed %s; want the SKU's own tier or unmapped", model, got.Model)
+		}
+	}
+
+	// A distinct SKU that borrows nothing must resolve to its own row.
+	if got, ok := PriceForModelAlias("qwen3.8-max-preview[1m]"); !ok || got.Model != "qwen3.8-max-preview" {
+		t.Fatalf("qwen3.8-max-preview[1m] = %+v (ok=%v); want the preview row", got, ok)
+	}
+
+	for _, model := range []string{"qwen3.8-max-extra", "kimi-k3-1"} {
+		if _, ok := PriceForModelAlias(model); ok {
+			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved", model)
+		}
+	}
+}

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -274,8 +274,10 @@ func TestPriceForModelAliasAlibabaMoonshotVolcengine(t *testing.T) {
 
 // TestPriceForModelAliasNoFalseBorrowing guards the anchored rules: a preview
 // SKU must not inherit the GA tier, a distinct CodeBuddy SKU must not inherit
-// Kimi K3, unknown suffixed variants must stay unmapped, and the Volcengine
-// `ark-code-latest` rolling alias must stay unmapped.
+// Kimi K3, unknown suffixed variants must stay unmapped, empty bracket tags
+// (`qwen3.7-plus[]` etc.) must stay unmapped to match the frontend's
+// `\[[^\]]+\]$` tag stripping, and the Volcengine `ark-code-latest` rolling
+// alias must stay unmapped.
 func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 	for _, model := range []string{
 		"qwen3.8-max-preview",
@@ -317,6 +319,12 @@ func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 		"qwen3.6-flash-extra",
 		"qwen3.8-max-preview-extra",
 		"custom:ark-code-latest",
+		// Empty bracket tags: the frontend's `\[[^\]]+\]$` tag stripper
+		// leaves these unmapped, so the backend must too.
+		"qwen3.7-plus[]",
+		"qwen3.6-flash[]",
+		"qwen3.8-max[]",
+		"qwen3.8-max-preview[]",
 	} {
 		if _, ok := PriceForModelAlias(model); ok {
 			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved", model)


### PR DESCRIPTION
## What

Local BYO runtimes (Claude Code, Codex, Hermes, Kimi, Qwen Code, opencode) report token usage but never a provider-reported cost, so the dashboard prices them from the rate tables. Two gaps kept those costs at $0 for the Qwen / Kimi models:

1. **Missing rows** in both pricing tables (`packages/views/runtimes/utils.ts` and the server registry `server/internal/metrics/pricing.go`) for Qwen 3.6/3.7/3.8 and Kimi K3.
2. **A resolver bug**: `canonicalCandidates` stripped only `/` routing prefixes, so Hermes-style `provider:model` ids (`alibaba-coding-plan:qwen3.8-max`, `custom:ark-code-latest`, `kimi-coding:kimi-k3`, `opencode-go:deepseek-v4-flash`) never resolved and stayed uncosted — `opencode-go:deepseek-v4-flash` was silently uncosted despite having a row. The server-side alias regexes already handled `:`; only the frontend resolver was broken.

## Changes

- **`packages/views/runtimes/utils.ts`** — add USD per-MTok rows for `qwen3.6-flash`, `qwen3.7-plus`, `qwen3.8-max` (pay-as-you-go), `qwen3.8-max-preview` (Alibaba Token/Coding Plan subscription, priced 0 like the free GLM tiers), and `kimi-k3` / `kimi/k3`. Fix `stripProvider` to strip `:` prefixes too and resolve nested routing prefixes (`custom:anthropic/claude-opus-4.7`) iteratively, with a comment.
- **`server/internal/metrics/pricing.go`** — mirror the same rows in the server registry (the file's own comment requires the two tables to stay in sync). All Qwen/Kimi alias rules are anchored: `qwen3.8-max-preview` / `kimi-k3-1` never borrow the GA tier; an optional complete bracket tag `[…]` (at least one character inside, matching the frontend's `\[[^\]]+\]$` tag stripping) is admitted so `qwen3.8-max-preview[1m]` still resolves while empty tags (`qwen3.7-plus[]`) and unknown suffixes stay unmapped on both sides; `kimi-code/k3` resolves via the `/k3$` form. `ark-code-latest` is deliberately left unmapped — it is a Volcengine console-switchable rolling alias across model families, not a stable model identity, and the daemon reports the alias, never the resolved concrete model.
- **Tests** — Go cases pinning the new rows plus no-false-borrowing guards (unknown suffixes, malformed/empty bracket tags, `ark-code-latest` all stay unmapped); frontend regression tests for `provider:model` stripping, nested routing prefixes, and the new rows.

## Sources

- Qwen: alibabacloud.com model-pricing sheet, International tier, `0<Token≤256K` (`$1.20/$4.80` above 256K), accessed 2026-08-17. Cache rates: Explicit Cache Creation 1.25× input, Explicit Cache Read 10% of input (`qwen3.7-plus`: `$0.50` / `$0.04`; `qwen3.6-flash`: `$0.3125` / `$0.025`) from the qwencloud.com model pages.
- `qwen3.8-max`: qwencloud.com/models/qwen3.8-max — Input `$2`, Output `$6`, Implicit Cache `$0.25`, Explicit Cache Creation `$2.50`, Explicit Cache Read `$0.17` (same source models.dev cites).
- Kimi K3: models.dev `providers/moonshotai`, accessed 2026-08-13.

## Testing

- `go test ./internal/metrics/... -count=1` — pass (alias tests + no-false-borrowing guards incl. empty-tag negatives)
- `vitest run packages/views/runtimes/utils.test.ts` — 88 pass
- `git diff --check` — clean

## Notes

- `qwen3.8-max` is priced at the published pay-as-you-go rate ($2/$6) even though the reporting runtime reaches it through a subscription, so the dashboard shows absolute cost.
- `ark-code-latest` is a rolling Volcengine alias (users can switch its target in the console, including across model families), so it stays unmapped on both sides — same convention as other unstable identities.
