### PR TITLE
[MUL-6142] WS-10: clarify Codex config inheritance for agents

### DIFF
--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -51,6 +51,40 @@ Two distinct text fields, often confused:
   Persona, responsibilities, boundaries, output and escalation rules go here,
   not in `description`.
 
+## Native config inheritance per provider
+
+An agent definition and a provider's native home are different configuration
+layers. For Codex, the daemon creates an isolated, per-task `CODEX_HOME` and
+seeds only an explicit subset of the machine's shared Codex home. A setting
+visible in Codex Desktop is therefore inherited only when it lives in one of
+the seeded native files or directories and is not replaced by a daemon-managed
+policy.
+
+| Codex Desktop / native data | Multica task behavior | Use instead when not inherited |
+|---|---|---|
+| `config.toml`, `config.json`, `instructions.md` | Copied into the per-task home, so ordinary native config and feature flags inherit as an isolated snapshot. The daemon then strips `[[skills.config]]` and applies its own sandbox, native multi-agent, and memory policy. | Prefer the first-class agent fields below for settings they own; put durable agent behavior in `instructions`. |
+| `auth.json` | Linked from the shared home so refreshed login state remains available. It is machine-local credential state, not portable agent configuration. | Configure authentication on the runtime host; never put credentials in `instructions`, issue metadata, or a skill. |
+| User `skills/` and plugin cache | User skill directories are linked into the task home; workspace-assigned skills are written last and win name conflicts. The Desktop `[[skills.config]]` registry is intentionally removed. | Bind reusable capabilities as Multica workspace skills. |
+| Goals / goal databases | Desktop goals are not copied from the shared home. Any `goals_*` database present is task-local state, not an agent-creation input. | Put durable objectives and operating boundaries in agent `instructions`; track concrete work in Multica projects and issues. |
+| Plan mode / GUI plan preference | Not an agent field and not imported from Desktop UI state. | State when planning is required in `instructions`; use `thinking_level` for the model's reasoning effort, not as a claim that GUI plan mode was inherited. |
+| Native memories | Disabled by daemon-managed config by default because native memory can leak context across tasks or workspaces. Do not set or recommend `MULTICA_CODEX_MEMORY=1` as a persistence strategy. | Use issue descriptions/status/comments, short issue metadata, project context, and versioned repository context files. |
+| GUI/runtime state | The shared state database is not copied. State created inside a task home can survive reuse of that same task environment, but it is not Desktop state and is not portable agent configuration. | Record decisions and progress explicitly in Multica; re-read the issue, metadata, and relevant comment threads on each run. |
+| Sandbox selection | Not inherited as an ordinary Desktop preference. The daemon rewrites a managed policy based on platform and runtime capability; Linux and current macOS defaults may be `danger-full-access`, while Windows honors a valid native sandbox opt-in and otherwise follows the compatibility policy. | Treat the runtime/daemon isolation boundary as authoritative; do not promise a sandbox level from the Desktop toggle. |
+| Session history | The machine's whole `~/.codex/sessions` history is never exposed. Fresh tasks start with a scoped store; an explicit resume may expose only that conversation's rollout through a per-agent, per-issue-or-chat store. | Treat Multica issue/chat history as the durable record; session resume is continuity plumbing, not memory or agent configuration. |
+
+For Codex, set `model`, `thinking_level`, and `service_tier` on the agent when
+the choice must be stable and inspectable. Leaving them empty deliberately
+falls back to native Codex config, but that makes the effective value
+machine-local and can make exact model/effort validation impossible before the
+task reaches the daemon. Use agent `instructions` for durable behavior and
+workspace skill bindings for reusable capability. Use Multica projects,
+issues, comments, short metadata, and repository context files for explicit
+cross-run state; none of those should contain secrets.
+
+This matrix is Codex-specific. Other providers have their own home seeding and
+managed-policy code; never infer that a Desktop/CLI setting inherits merely
+because an equivalent setting exists in that provider's GUI.
+
 ## CLI / API entry points
 
 Minimum create call (`--name` and `--runtime-id` are both required):

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -13,6 +13,27 @@ go test ./internal/service -run TestCreatingAgentsSkillCoversAgentCreationContra
 go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 ```
 
+## Native config inheritance — `server/internal/daemon/execenv`
+
+| Contract | Source | Behavior |
+|---|---|---|
+| Per-task Codex home allowlists | `codex_home.go` `codexSymlinkedFiles`, `codexCopiedFiles`, `prepareCodexHomeWithOpts` | Only `auth.json` is linked; `config.json`, `config.toml`, and `instructions.md` are copied. This explicit list is why arbitrary Desktop state and databases do not become agent configuration. |
+| Copied config is isolated and daemon-managed | `codex_home.go` `prepareCodexHomeWithOpts` | After copying config, the daemon sanitizes the skill registry, follows only approved referenced files, then writes managed sandbox, multi-agent, and memory blocks. Ordinary config/feature flags survive unless one of those policies owns the key. |
+| Desktop skill registry removed | `codex_skill_strip.go` `stripSkillsConfigEntries` / `sanitizeCopiedCodexConfig` | Every `[[skills.config]]` block is removed; all other config lines are preserved. This avoids plugin-only entries that Codex CLI cannot parse. |
+| User skills plus workspace precedence | `codex_user_skills.go` `seedUserCodexSkills`; `execenv.go` `hydrateCodexSkills` | Eligible shared user skill directories are linked into the task home; names reserved by workspace-assigned skills are skipped, then workspace skills are written last. |
+| Plugin cache exposure | `codex_home.go` `exposeSharedCodexPluginCache` | The shared `plugins/cache` directory is exposed through a directory link, separate from the stripped Desktop skill registry. |
+| Auth inheritance | `codex_home.go` `codexSymlinkedFiles`; `ensureSymlink`; `logCodexAuthState` | `auth.json` tracks the runtime host's shared login state; config files remain copies, not shared mutable files. |
+| Goals/logs/memories/state databases are task-local | `codex_home.go` `codexSessionStateGlobs` / `resetCodexSessionState` | Session-derived `state_*` indexes can be rebuilt when a legacy shared-session link is removed. Sibling `goals_*`, `logs_*`, and `memories_*` databases are explicitly left intact inside that task home; none are seeded from the shared home allowlists. |
+| Machine-wide session history is excluded | `codex_home.go` `prepareCodexSessionsDir`, `linkCodexSessionsToStore`, `exposeResumeRollout` | A fresh task gets an empty local session directory or a scoped per-conversation store. Only an explicitly resumed rollout may be exposed; the whole shared `~/.codex/sessions` tree is never mounted. |
+| Native memory disabled by default | `codex_memory.go` `ensureCodexMemoryConfig`, `MulticaCodexMemoryEnv` | Managed config disables both `features.memories` and memory generation/consumption. `MULTICA_CODEX_MEMORY` is an explicit leak-risk escape hatch, not the durable-state recommendation. |
+| Sandbox is daemon-owned | `codex_sandbox.go` `codexSandboxPolicyFor`, `codexSandboxPolicyForConfig`; `codex_home.go` `ensureCodexSandboxConfig` call | Platform/runtime policy rewrites the task config. Linux uses `danger-full-access`; current macOS falls back likewise while the network sandbox bug remains; Windows keeps a valid native opt-in or applies its documented fail-closed/compatibility branch. |
+| Agent-level alternatives | `handler/agent.go` `CreateAgentRequest`; `handler/daemon.go` `TaskAgentData`; `runtime_config_sections.go` `writeProjectContext` / `writeIssueMetadata` | `instructions`, `model`, `thinking_level`, and `service_tier` are explicit agent fields delivered at claim time. Project context and issue metadata are explicit task context, independent of Codex Desktop UI state. |
+
+There is intentionally no Codex Desktop goal, plan-mode, GUI-state, sandbox,
+or session-history import field in `CreateAgentRequest` or `TaskAgentData`.
+Combined with the native-home allowlists above, that absence is the source
+boundary behind the non-inheritance rows in the skill matrix.
+
 ## CLI entry points — `server/cmd/multica/cmd_agent.go`
 
 | Contract | Line | Behavior | Safe check |

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -373,6 +373,18 @@ func TestCreatingAgentsSkillCoversAgentCreationContracts(t *testing.T) {
 		"not a parameter manual",
 		"`description` is a catalog summary",
 		"`instructions` is the runtime behavior contract",
+		"## Native config inheritance per provider",
+		"`config.toml`, `config.json`, `instructions.md`",
+		"`auth.json`",
+		"Goals / goal databases",
+		"Plan mode / GUI plan preference",
+		"Do not set or recommend `MULTICA_CODEX_MEMORY=1`",
+		"GUI/runtime state",
+		"Sandbox selection",
+		"Session history",
+		"workspace skill bindings",
+		"Use Multica projects,",
+		"short metadata, and repository context files",
 		"`avatar_url` → a random `emoji:<glyph>`",
 		"multica agent create --name <name> --runtime-id <runtime-id>",
 		"`model` is a first-class persisted column",
@@ -411,6 +423,27 @@ func TestCreatingAgentsSkillCoversAgentCreationContracts(t *testing.T) {
 
 	if !skillHasFile(skill, "references/creating-agents-source-map.md") {
 		t.Errorf("creating-agents skill missing supporting file references/creating-agents-source-map.md")
+	}
+
+	var sourceMap string
+	for _, f := range skill.Files {
+		if f.Path == "references/creating-agents-source-map.md" {
+			sourceMap = f.Content
+			break
+		}
+	}
+	for _, want := range []string{
+		"## Native config inheritance",
+		"`codexSymlinkedFiles`, `codexCopiedFiles`",
+		"`stripSkillsConfigEntries` / `sanitizeCopiedCodexConfig`",
+		"`prepareCodexSessionsDir`, `linkCodexSessionsToStore`, `exposeResumeRollout`",
+		"`ensureCodexMemoryConfig`, `MulticaCodexMemoryEnv`",
+		"`codexSandboxPolicyFor`, `codexSandboxPolicyForConfig`",
+		"There is intentionally no Codex Desktop goal, plan-mode, GUI-state, sandbox,",
+	} {
+		if !strings.Contains(sourceMap, want) {
+			t.Errorf("creating-agents source map missing native-inheritance evidence %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add the missing Codex native-config inheritance matrix to `multica-creating-agents`
- distinguish copied/linked native configuration from non-inherited GUI goals, plan preferences, state, sandbox settings, and global session history
- document first-class agent fields and Multica-owned durable state as the supported alternatives
- add source-traced evidence and contract-test coverage for the matrix

## Validation

- `go test ./internal/service -run 'TestCreatingAgentsSkillCoversAgentCreationContracts|TestBuiltinSkillsConformToTemplate|TestBuiltinSkillsFrontmatterIsStrictYAML'`
- `go test ./internal/daemon/execenv -run 'TestPrepareCodexHomeSeedsFromShared|TestPrepareCodexSessionsDir_FreshCreatesEmptyLocalDir|TestPrepareCodexSessionsDir_MigratesLegacySymlinkNoResume|TestPrepareCodexSessionsDir_MigrateWithResumeRoutesThroughStore|TestResetCodexSessionState_OnlyRemovesSessionDerived|TestEnsureCodexMemoryConfig|TestCodexSandboxPolicy'`
- `git diff --check`

Related WS-10
