### PR TITLE
MUL-6132 fix: stop stranding daemon task markers in user directories

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -259,11 +259,10 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 		// MULTICA_TASK_ID / MULTICA_DAEMON_PORT), the likeliest cause outside a
 		// real task is a leftover marker from a crashed daemon task in a
 		// local_directory. Name the exact file so a normal user can recover
-		// instead of hitting an opaque "requires mat_ token" error.
-		if !inAgentExecutionContext() && os.Getenv("MULTICA_DAEMON_PORT") == "" {
-			if markerPath := daemonTaskContextMarkerPath(); markerPath != "" {
-				return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", markerPath)
-			}
+		// instead of hitting an opaque "requires mat_ token" error. Shares its
+		// wording with requireHumanLocalCommand: same cause, same remedy.
+		if markerPath := leftoverDaemonTaskMarkerPath(); markerPath != "" {
+			return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token%s", leftoverMarkerSuffix(markerPath))
 		}
 		return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token%s", daemonPortOnlyContextHint())
 	}
@@ -428,31 +427,9 @@ func requireHumanLocalCommand(command string) error {
 	// the bare message below sends the user to the source to find out which
 	// file to remove. Mirrors newAPIClient's leftover-marker handling.
 	if markerPath := leftoverDaemonTaskMarkerPath(); markerPath != "" {
-		if healStaleDaemonTaskMarker(markerPath) {
-			fmt.Fprintf(os.Stderr, "multica: removed a stale daemon task marker at %s (no daemon-managed task is running)\n", markerPath)
-			return nil
-		}
-		return fmt.Errorf("%s is not available inside a daemon-managed task; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", command, markerPath)
+		return fmt.Errorf("%s is not available inside a daemon-managed task%s", command, leftoverMarkerSuffix(markerPath))
 	}
 	return fmt.Errorf("%s is not available inside a daemon-managed task", command)
-}
-
-// leftoverDaemonTaskMarkerPath returns the workdir marker path when a marker is
-// the ONLY reason the CLI considers itself inside a daemon-managed task, and ""
-// otherwise.
-//
-// Any MULTICA_* task identity in the environment means the daemon really did
-// launch this process, so the marker is doing its job and neither the message
-// nor the self-heal below applies. MULTICA_DAEMON_PORT is treated the same way
-// even though it is not sufficient on its own for identity: it still says a
-// daemon environment is present, which is not a leftover's fingerprint.
-func leftoverDaemonTaskMarkerPath() string {
-	if inAgentExecutionContext() ||
-		strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) != "" ||
-		strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) != "" {
-		return ""
-	}
-	return daemonTaskContextMarkerPath()
 }
 
 func hasDaemonTaskContextMarker() bool {

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -416,10 +416,43 @@ func requireTaskLocalConfigRoot() error {
 // set up, or operate the human-owned local daemon/profile. Task API commands
 // remain available with the injected mat_ token; these local commands do not.
 func requireHumanLocalCommand(command string) error {
-	if inDaemonTaskIdentityContext() {
-		return fmt.Errorf("%s is not available inside a daemon-managed task", command)
+	if !inDaemonTaskIdentityContext() {
+		return nil
 	}
-	return nil
+	// A workdir marker with no task identity in the environment is the one
+	// signal that can outlive the task that wrote it: a local_directory run
+	// that never cleaned up leaves it in the user's own repository, where it
+	// disables every command below this function for that whole directory tree
+	// until someone deletes the file by hand (MUL-6132). Try to retire it
+	// automatically, and when that cannot be proven safe, at least name it —
+	// the bare message below sends the user to the source to find out which
+	// file to remove. Mirrors newAPIClient's leftover-marker handling.
+	if markerPath := leftoverDaemonTaskMarkerPath(); markerPath != "" {
+		if healStaleDaemonTaskMarker(markerPath) {
+			fmt.Fprintf(os.Stderr, "multica: removed a stale daemon task marker at %s (no daemon-managed task is running)\n", markerPath)
+			return nil
+		}
+		return fmt.Errorf("%s is not available inside a daemon-managed task; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", command, markerPath)
+	}
+	return fmt.Errorf("%s is not available inside a daemon-managed task", command)
+}
+
+// leftoverDaemonTaskMarkerPath returns the workdir marker path when a marker is
+// the ONLY reason the CLI considers itself inside a daemon-managed task, and ""
+// otherwise.
+//
+// Any MULTICA_* task identity in the environment means the daemon really did
+// launch this process, so the marker is doing its job and neither the message
+// nor the self-heal below applies. MULTICA_DAEMON_PORT is treated the same way
+// even though it is not sufficient on its own for identity: it still says a
+// daemon environment is present, which is not a leftover's fingerprint.
+func leftoverDaemonTaskMarkerPath() string {
+	if inAgentExecutionContext() ||
+		strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) != "" ||
+		strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) != "" {
+		return ""
+	}
+	return daemonTaskContextMarkerPath()
 }
 
 func hasDaemonTaskContextMarker() bool {

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -406,6 +406,14 @@ func requireTaskLocalConfigRoot() error {
 		return nil
 	}
 	if strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) == "" {
+		// The third refusal path a leftover marker can trigger, alongside
+		// newAPIClient and requireHumanLocalCommand. It has to name the file
+		// too: a user hitting this one through `config show` or `auth status`
+		// is as stuck as one hitting the others, and "which command did you
+		// happen to run first" must not decide whether the error is actionable.
+		if markerPath := leftoverDaemonTaskMarkerPath(); markerPath != "" {
+			return fmt.Errorf("daemon-managed task requires a task-local Multica config root in %s%s", cli.TaskConfigRootEnv, leftoverMarkerSuffix(markerPath))
+		}
 		return fmt.Errorf("daemon-managed task requires a task-local Multica config root in %s%s", cli.TaskConfigRootEnv, daemonPortOnlyContextHint())
 	}
 	return nil
@@ -418,14 +426,13 @@ func requireHumanLocalCommand(command string) error {
 	if !inDaemonTaskIdentityContext() {
 		return nil
 	}
-	// A workdir marker with no task identity in the environment is the one
-	// signal that can outlive the task that wrote it: a local_directory run
-	// that never cleaned up leaves it in the user's own repository, where it
+	// A task-scoped workdir marker with no task identity in the environment is
+	// the one signal that can outlive the task that wrote it: a local_directory
+	// run that never cleaned up leaves it in the user's own repository, where it
 	// disables every command below this function for that whole directory tree
-	// until someone deletes the file by hand (MUL-6132). Try to retire it
-	// automatically, and when that cannot be proven safe, at least name it —
-	// the bare message below sends the user to the source to find out which
-	// file to remove. Mirrors newAPIClient's leftover-marker handling.
+	// until someone deletes the file by hand (MUL-6132). Name it, so the user
+	// knows which file that is; the bare message below sends them to the source
+	// instead. Mirrors newAPIClient's leftover-marker handling.
 	if markerPath := leftoverDaemonTaskMarkerPath(); markerPath != "" {
 		return fmt.Errorf("%s is not available inside a daemon-managed task%s", command, leftoverMarkerSuffix(markerPath))
 	}

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -41,7 +41,12 @@ func chdirWithDaemonTaskMarker(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
 		t.Fatalf("create marker dir: %v", err)
 	}
-	data := []byte(`{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `"}`)
+	// Task-scoped: a real workdir marker always carries the identity of the
+	// task that wrote it, and that identity is what separates a leftover from
+	// the permanent workspaces root marker, which has managed_by and nothing
+	// else (MUL-6132). Writing the bare form here would model the root marker
+	// rather than the workdir marker these tests are about.
+	data := []byte(`{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`)
 	if err := os.WriteFile(markerPath, data, 0o644); err != nil {
 		t.Fatalf("write marker: %v", err)
 	}

--- a/server/cmd/multica/stale_marker.go
+++ b/server/cmd/multica/stale_marker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -9,21 +10,61 @@ import (
 )
 
 // leftoverDaemonTaskMarkerPath returns the workdir marker path when a marker is
-// the ONLY reason the CLI considers itself inside a daemon-managed task, and ""
-// otherwise.
+// the ONLY reason the CLI considers itself inside a daemon-managed task AND
+// that marker could actually be a leftover. It returns "" otherwise.
+//
+// Two things disqualify a marker from the leftover treatment:
 //
 // Any MULTICA_* task identity in the environment means the daemon really did
-// launch this process, so the marker is doing its job and none of the
-// leftover-specific handling applies. MULTICA_DAEMON_PORT is treated the same
-// way even though it is not sufficient on its own for identity: it still says a
-// daemon environment is present, which is not a leftover's fingerprint.
+// launch this process, so the marker is doing its job. MULTICA_DAEMON_PORT
+// counts here even though it is not sufficient on its own for identity: it
+// still says a daemon environment is present, which is not a leftover's
+// fingerprint.
+//
+// A marker that is not task-scoped is the permanent workspaces root marker,
+// which never expires and must never be described as removable.
 func leftoverDaemonTaskMarkerPath() string {
 	if inAgentExecutionContext() ||
 		strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) != "" ||
 		strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) != "" {
 		return ""
 	}
-	return daemonTaskContextMarkerPath()
+	markerPath := daemonTaskContextMarkerPath()
+	if markerPath == "" || !markerIsTaskScoped(markerPath) {
+		return ""
+	}
+	return markerPath
+}
+
+// markerIsTaskScoped reports whether the marker at path belongs to one specific
+// task, as opposed to being the workspaces root marker.
+//
+// Two different markers share this filename, and daemonTaskContextMarkerPath
+// tells them apart by nothing but managed_by. The per-task marker carries the
+// identity of the task that wrote it and dies with that task. The workspaces
+// root marker carries no identity at all: the daemon re-creates it on every
+// start as a permanent, node-wide guard so a subprocess that escapes above its
+// workdir still fails closed. Telling anyone to delete THAT — a user, or an
+// agent subprocess that lost its environment and is reading the error — closes
+// the hole it exists to cover, so it gets the plain refusal instead.
+//
+// Identity means agent_id OR issue_id, not both: a chat task has no issue, and
+// requiring one would misfile its marker as the root marker and lose the hint
+// exactly where a leftover is possible. The root marker has neither field, so
+// either one present is enough to separate them.
+func markerIsTaskScoped(markerPath string) bool {
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		return false
+	}
+	var marker struct {
+		AgentID string `json:"agent_id"`
+		IssueID string `json:"issue_id"`
+	}
+	if json.Unmarshal(data, &marker) != nil {
+		return false
+	}
+	return strings.TrimSpace(marker.AgentID) != "" || strings.TrimSpace(marker.IssueID) != ""
 }
 
 // leftoverMarkerSuffix renders the shared tail both refusal paths append when a

--- a/server/cmd/multica/stale_marker.go
+++ b/server/cmd/multica/stale_marker.go
@@ -1,165 +1,47 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
-	"time"
+	"strings"
 
-	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/cli"
 )
 
-// staleMarkerMinAge is how long a daemon task marker must have been on disk
-// before the CLI will consider removing it.
+// leftoverDaemonTaskMarkerPath returns the workdir marker path when a marker is
+// the ONLY reason the CLI considers itself inside a daemon-managed task, and ""
+// otherwise.
 //
-// The probe below can only observe the daemon's task count at one instant. A
-// daemon that reports zero may be claiming a task right now and about to write
-// this very marker, and deleting it in that window would strip the guard off a
-// task that is genuinely starting. Nothing orders those two events, so the age
-// gate substitutes a bound the race cannot cross: a marker older than this was
-// written long before the probe and cannot belong to a task the probe missed.
-//
-// The cost is that a user who hits a fresh leftover waits, which is acceptable
-// because the leftovers this heals are hours to weeks old — the reported one
-// sat for five weeks.
-const staleMarkerMinAge = time.Hour
-
-// daemonProbeTimeout bounds the whole multi-profile probe. checkDaemonHealthOnPort
-// already applies its own 2s per-request timeout; this keeps a machine with many
-// profiles from turning a refused command into a long stall.
-const daemonProbeTimeout = 10 * time.Second
-
-// daemonHealthProbe is the health lookup the self-heal path uses. It is a
-// variable so tests can drive every branch of the decision — reachable and
-// idle, reachable and busy, unreachable, too old to report a count — without
-// binding real daemon ports, which on a developer machine are already taken by
-// the daemons this probe is meant to consult.
-var daemonHealthProbe = checkDaemonHealthOnPort
-
-// healStaleDaemonTaskMarker removes the daemon task marker at markerPath when,
-// and only when, the CLI can positively prove no daemon-managed task is live on
-// this machine. It reports whether the marker was removed.
-//
-// The marker makes the CLI fail closed: it is the last guard standing between
-// an agent subprocess that lost every MULTICA_* env var and a fallback to the
-// user's personal token. Removing it is therefore gated on positive evidence
-// only — "confirmed absent", never "not found". Every uncertain outcome
-// (unreachable daemon, unparseable health payload, a daemon too old to report a
-// task count) leaves the marker alone and keeps the command refused, because a
-// daemon that cannot be reached is exactly what a crashed daemon looks like,
-// and a task orphaned by that crash keeps running: task processes are only
-// placed in their own process group (see execenv isolation), never tied to the
-// daemon's lifetime.
-//
-// Callers must only reach this when the marker is the sole daemon signal — any
-// MULTICA_* task identity in the environment means the process really is inside
-// a task, and no file on disk can override that.
-func healStaleDaemonTaskMarker(markerPath string) bool {
-	if markerPath == "" {
-		return false
+// Any MULTICA_* task identity in the environment means the daemon really did
+// launch this process, so the marker is doing its job and none of the
+// leftover-specific handling applies. MULTICA_DAEMON_PORT is treated the same
+// way even though it is not sufficient on its own for identity: it still says a
+// daemon environment is present, which is not a leftover's fingerprint.
+func leftoverDaemonTaskMarkerPath() string {
+	if inAgentExecutionContext() ||
+		strings.TrimSpace(os.Getenv(cli.TaskConfigRootEnv)) != "" ||
+		strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) != "" {
+		return ""
 	}
-	if !markerIsTaskScoped(markerPath) {
-		return false
-	}
-	info, err := os.Stat(markerPath)
-	if err != nil || time.Since(info.ModTime()) < staleMarkerMinAge {
-		return false
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), daemonProbeTimeout)
-	defer cancel()
-	if !noDaemonManagedTaskIsLive(ctx) {
-		return false
-	}
-
-	if err := os.Remove(markerPath); err != nil {
-		return false
-	}
-	// The daemon creates .multica/ for the marker alone. Remove it when the
-	// marker was its only content so an in-place task leaves nothing behind;
-	// a non-empty directory (the user's own files, or .multica/project/ from
-	// another leftover) fails ENOTEMPTY and is left exactly as it was.
-	_ = os.Remove(filepath.Dir(markerPath))
-	return true
+	return daemonTaskContextMarkerPath()
 }
 
-// markerIsTaskScoped reports whether the marker describes one specific task.
+// leftoverMarkerSuffix renders the shared tail both refusal paths append when a
+// workdir marker is the only daemon signal: newAPIClient for API commands and
+// requireHumanLocalCommand for the local daemon/profile commands.
 //
-// Two different markers share this filename. The per-task marker carries the
-// agent and issue the task runs for, and dies with that task. The workspaces
-// root marker carries neither: it is a permanent, node-wide guard the daemon
-// re-creates on every start so a subprocess that escapes above its workdir
-// still fails closed. Only the first is ever a leftover; deleting the second
-// would silently disarm that guard for the whole tree, so anything without both
-// identifiers is out of scope here regardless of what the daemon probe says.
-func markerIsTaskScoped(markerPath string) bool {
-	data, err := os.ReadFile(markerPath)
-	if err != nil {
-		return false
-	}
-	var marker struct {
-		ManagedBy string `json:"managed_by"`
-		AgentID   string `json:"agent_id"`
-		IssueID   string `json:"issue_id"`
-	}
-	if json.Unmarshal(data, &marker) != nil {
-		return false
-	}
-	return marker.ManagedBy == execenv.TaskContextMarkerManagedBy &&
-		marker.AgentID != "" && marker.IssueID != ""
-}
-
-// noDaemonManagedTaskIsLive reports whether EVERY profile's daemon on this
-// machine answered and reported zero active tasks.
+// Both refusals have the same cause and the same remedy, so they say the same
+// thing. Keeping the wording in one place is what stops the two paths from
+// drifting again — before MUL-6132 only the API path named the file, so whether
+// a user could act on the error depended on which command they happened to run
+// first (MUL-6132 review).
 //
-// A profile whose daemon does not answer is not evidence of absence: that is
-// also what a daemon crashed mid-task looks like, and its orphaned task keeps
-// running with the marker as its only remaining guard. So a single silent or
-// unparseable profile makes the whole answer "unknown", and the caller must
-// keep failing closed. This is deliberately stricter than "the daemon I would
-// have talked to says zero" — a task claimed under one profile can be running
-// in a directory a command resolved to another profile touches.
-func noDaemonManagedTaskIsLive(ctx context.Context) bool {
-	named, err := knownProfiles()
-	if err != nil {
-		// The profile list is how we know which ports to probe. Without it we
-		// cannot claim to have checked them all.
-		return false
-	}
-	// The empty string is the default profile, which knownProfiles omits.
-	for _, profile := range append([]string{""}, named...) {
-		count, ok := probeDaemonActiveTasks(ctx, healthPortForProfile(profile))
-		if !ok || count != 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// probeDaemonActiveTasks returns the active task count reported by the daemon
-// on port, and whether that number could be established at all.
-//
-// active_task_count is the only count valid here. It spans the whole claimed
-// lifecycle including preparation, which is precisely when a marker exists but
-// no provider has launched; running_task_count omits that window and the daemon
-// documents it as unusable for safety barriers.
-//
-// The second return is why this exists alongside daemonActiveTaskCount, which
-// reports a missing field as 0. That reading is right for its caller — a
-// restart barrier that errs toward "go ahead" — and wrong here, where "the
-// daemon never told us" must not be read as "there is nothing running".
-func probeDaemonActiveTasks(ctx context.Context, port int) (int64, bool) {
-	health := daemonHealthProbe(ctx, port)
-	if !daemonAlive(health) {
-		return 0, false
-	}
-	// checkDaemonHealthOnPort decodes into map[string]any, so JSON numbers
-	// arrive as float64. A daemon predating the field reports nothing, which is
-	// unknown rather than zero.
-	raw, ok := health["active_task_count"].(float64)
-	if !ok {
-		return 0, false
-	}
-	return int64(raw), true
+// The CLI deliberately stops at naming the file rather than deleting it.
+// Removing the marker is removing a fail-closed guard, and no check the CLI can
+// run proves it is safe to: the daemon increments its active task count only
+// after a claim returns, so a probe can read zero for a task that is already
+// claimed and about to write this very marker. Retirement therefore belongs to
+// the daemon, which can serialize it against its own claim path.
+func leftoverMarkerSuffix(markerPath string) string {
+	return fmt.Sprintf("; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", markerPath)
 }

--- a/server/cmd/multica/stale_marker.go
+++ b/server/cmd/multica/stale_marker.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// staleMarkerMinAge is how long a daemon task marker must have been on disk
+// before the CLI will consider removing it.
+//
+// The probe below can only observe the daemon's task count at one instant. A
+// daemon that reports zero may be claiming a task right now and about to write
+// this very marker, and deleting it in that window would strip the guard off a
+// task that is genuinely starting. Nothing orders those two events, so the age
+// gate substitutes a bound the race cannot cross: a marker older than this was
+// written long before the probe and cannot belong to a task the probe missed.
+//
+// The cost is that a user who hits a fresh leftover waits, which is acceptable
+// because the leftovers this heals are hours to weeks old — the reported one
+// sat for five weeks.
+const staleMarkerMinAge = time.Hour
+
+// daemonProbeTimeout bounds the whole multi-profile probe. checkDaemonHealthOnPort
+// already applies its own 2s per-request timeout; this keeps a machine with many
+// profiles from turning a refused command into a long stall.
+const daemonProbeTimeout = 10 * time.Second
+
+// daemonHealthProbe is the health lookup the self-heal path uses. It is a
+// variable so tests can drive every branch of the decision — reachable and
+// idle, reachable and busy, unreachable, too old to report a count — without
+// binding real daemon ports, which on a developer machine are already taken by
+// the daemons this probe is meant to consult.
+var daemonHealthProbe = checkDaemonHealthOnPort
+
+// healStaleDaemonTaskMarker removes the daemon task marker at markerPath when,
+// and only when, the CLI can positively prove no daemon-managed task is live on
+// this machine. It reports whether the marker was removed.
+//
+// The marker makes the CLI fail closed: it is the last guard standing between
+// an agent subprocess that lost every MULTICA_* env var and a fallback to the
+// user's personal token. Removing it is therefore gated on positive evidence
+// only — "confirmed absent", never "not found". Every uncertain outcome
+// (unreachable daemon, unparseable health payload, a daemon too old to report a
+// task count) leaves the marker alone and keeps the command refused, because a
+// daemon that cannot be reached is exactly what a crashed daemon looks like,
+// and a task orphaned by that crash keeps running: task processes are only
+// placed in their own process group (see execenv isolation), never tied to the
+// daemon's lifetime.
+//
+// Callers must only reach this when the marker is the sole daemon signal — any
+// MULTICA_* task identity in the environment means the process really is inside
+// a task, and no file on disk can override that.
+func healStaleDaemonTaskMarker(markerPath string) bool {
+	if markerPath == "" {
+		return false
+	}
+	if !markerIsTaskScoped(markerPath) {
+		return false
+	}
+	info, err := os.Stat(markerPath)
+	if err != nil || time.Since(info.ModTime()) < staleMarkerMinAge {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), daemonProbeTimeout)
+	defer cancel()
+	if !noDaemonManagedTaskIsLive(ctx) {
+		return false
+	}
+
+	if err := os.Remove(markerPath); err != nil {
+		return false
+	}
+	// The daemon creates .multica/ for the marker alone. Remove it when the
+	// marker was its only content so an in-place task leaves nothing behind;
+	// a non-empty directory (the user's own files, or .multica/project/ from
+	// another leftover) fails ENOTEMPTY and is left exactly as it was.
+	_ = os.Remove(filepath.Dir(markerPath))
+	return true
+}
+
+// markerIsTaskScoped reports whether the marker describes one specific task.
+//
+// Two different markers share this filename. The per-task marker carries the
+// agent and issue the task runs for, and dies with that task. The workspaces
+// root marker carries neither: it is a permanent, node-wide guard the daemon
+// re-creates on every start so a subprocess that escapes above its workdir
+// still fails closed. Only the first is ever a leftover; deleting the second
+// would silently disarm that guard for the whole tree, so anything without both
+// identifiers is out of scope here regardless of what the daemon probe says.
+func markerIsTaskScoped(markerPath string) bool {
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		return false
+	}
+	var marker struct {
+		ManagedBy string `json:"managed_by"`
+		AgentID   string `json:"agent_id"`
+		IssueID   string `json:"issue_id"`
+	}
+	if json.Unmarshal(data, &marker) != nil {
+		return false
+	}
+	return marker.ManagedBy == execenv.TaskContextMarkerManagedBy &&
+		marker.AgentID != "" && marker.IssueID != ""
+}
+
+// noDaemonManagedTaskIsLive reports whether EVERY profile's daemon on this
+// machine answered and reported zero active tasks.
+//
+// A profile whose daemon does not answer is not evidence of absence: that is
+// also what a daemon crashed mid-task looks like, and its orphaned task keeps
+// running with the marker as its only remaining guard. So a single silent or
+// unparseable profile makes the whole answer "unknown", and the caller must
+// keep failing closed. This is deliberately stricter than "the daemon I would
+// have talked to says zero" — a task claimed under one profile can be running
+// in a directory a command resolved to another profile touches.
+func noDaemonManagedTaskIsLive(ctx context.Context) bool {
+	named, err := knownProfiles()
+	if err != nil {
+		// The profile list is how we know which ports to probe. Without it we
+		// cannot claim to have checked them all.
+		return false
+	}
+	// The empty string is the default profile, which knownProfiles omits.
+	for _, profile := range append([]string{""}, named...) {
+		count, ok := probeDaemonActiveTasks(ctx, healthPortForProfile(profile))
+		if !ok || count != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// probeDaemonActiveTasks returns the active task count reported by the daemon
+// on port, and whether that number could be established at all.
+//
+// active_task_count is the only count valid here. It spans the whole claimed
+// lifecycle including preparation, which is precisely when a marker exists but
+// no provider has launched; running_task_count omits that window and the daemon
+// documents it as unusable for safety barriers.
+//
+// The second return is why this exists alongside daemonActiveTaskCount, which
+// reports a missing field as 0. That reading is right for its caller — a
+// restart barrier that errs toward "go ahead" — and wrong here, where "the
+// daemon never told us" must not be read as "there is nothing running".
+func probeDaemonActiveTasks(ctx context.Context, port int) (int64, bool) {
+	health := daemonHealthProbe(ctx, port)
+	if !daemonAlive(health) {
+		return 0, false
+	}
+	// checkDaemonHealthOnPort decodes into map[string]any, so JSON numbers
+	// arrive as float64. A daemon predating the field reports nothing, which is
+	// unknown rather than zero.
+	raw, ok := health["active_task_count"].(float64)
+	if !ok {
+		return 0, false
+	}
+	return int64(raw), true
+}

--- a/server/cmd/multica/stale_marker.go
+++ b/server/cmd/multica/stale_marker.go
@@ -67,15 +67,18 @@ func markerIsTaskScoped(markerPath string) bool {
 	return strings.TrimSpace(marker.AgentID) != "" || strings.TrimSpace(marker.IssueID) != ""
 }
 
-// leftoverMarkerSuffix renders the shared tail both refusal paths append when a
-// workdir marker is the only daemon signal: newAPIClient for API commands and
-// requireHumanLocalCommand for the local daemon/profile commands.
+// leftoverMarkerSuffix renders the shared tail every refusal path appends when
+// a task-scoped workdir marker is the only daemon signal:
 //
-// Both refusals have the same cause and the same remedy, so they say the same
-// thing. Keeping the wording in one place is what stops the two paths from
-// drifting again — before MUL-6132 only the API path named the file, so whether
-// a user could act on the error depended on which command they happened to run
-// first (MUL-6132 review).
+//   - newAPIClient, for API commands
+//   - requireHumanLocalCommand, for the local daemon/profile commands
+//   - requireTaskLocalConfigRoot, for config show/set and auth status
+//
+// All three refusals have the same cause and the same remedy, so they say the
+// same thing. Keeping the wording in one place is what stops them from drifting
+// again — before MUL-6132 only the API path named the file, so whether a user
+// could act on the error depended on which command they happened to run first
+// (MUL-6132 review).
 //
 // The CLI deliberately stops at naming the file rather than deleting it.
 // Removing the marker is removing a fail-closed guard, and no check the CLI can

--- a/server/cmd/multica/stale_marker_test.go
+++ b/server/cmd/multica/stale_marker_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// seedDaemonTaskMarker writes a task-scoped daemon marker into a fresh temp
+// directory, backdates it past staleMarkerMinAge, chdirs into a nested
+// subdirectory so the CLI's upward walk has to find it, and returns the marker
+// path.
+func seedDaemonTaskMarker(t *testing.T, body string, age time.Duration) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	markerPath := filepath.Join(workDir, execenv.TaskContextMarkerRelPath)
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		t.Fatalf("create marker dir: %v", err)
+	}
+	if err := os.WriteFile(markerPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	backdated := time.Now().Add(-age)
+	if err := os.Chtimes(markerPath, backdated, backdated); err != nil {
+		t.Fatalf("backdate marker: %v", err)
+	}
+	nested := filepath.Join(workDir, "repo", "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested cwd: %v", err)
+	}
+	t.Chdir(nested)
+	return markerPath
+}
+
+func taskScopedMarkerBody() string {
+	return `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`
+}
+
+// stubDaemonHealth points the self-heal probe at a fixed health payload for
+// every port, and isolates HOME so knownProfiles() sees only the profiles this
+// test creates rather than the developer's real ones.
+func stubDaemonHealth(t *testing.T, health map[string]any) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	prev := daemonHealthProbe
+	daemonHealthProbe = func(context.Context, int) map[string]any { return health }
+	t.Cleanup(func() { daemonHealthProbe = prev })
+}
+
+func clearDaemonEnvSignals(t *testing.T) {
+	t.Helper()
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	t.Setenv(cli.TaskConfigRootEnv, "")
+}
+
+func idleDaemon() map[string]any {
+	return map[string]any{"status": "running", "active_task_count": float64(0)}
+}
+
+// TestHealStaleMarkerRemovesWhenEveryDaemonReportsIdle is the happy path of
+// MUL-6132: a leftover marker in the user's own directory is retired without the
+// user doing anything, so the command they ran just works.
+func TestHealStaleMarkerRemovesWhenEveryDaemonReportsIdle(t *testing.T) {
+	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+	stubDaemonHealth(t, idleDaemon())
+
+	if !healStaleDaemonTaskMarker(markerPath) {
+		t.Fatal("healStaleDaemonTaskMarker() = false; want true with every daemon idle")
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("marker still present after heal (stat err: %v)", err)
+	}
+	// The .multica directory existed only to hold the marker.
+	if _, err := os.Stat(filepath.Dir(markerPath)); !os.IsNotExist(err) {
+		t.Fatalf("empty .multica dir left behind (stat err: %v)", err)
+	}
+}
+
+// TestHealStaleMarkerRefusesOnUncertainEvidence covers the security rule the
+// whole feature turns on: the marker may only be deleted on positive evidence
+// that nothing is running. Every other outcome — including a daemon we simply
+// cannot reach — must leave it alone, because an unreachable daemon is exactly
+// what a crashed one looks like, and a task orphaned by that crash keeps
+// running with this marker as its only remaining guard.
+func TestHealStaleMarkerRefusesOnUncertainEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		health map[string]any
+	}{
+		{
+			name:   "daemon unreachable",
+			health: map[string]any{"status": "stopped"},
+		},
+		{
+			name:   "daemon busy",
+			health: map[string]any{"status": "running", "active_task_count": float64(1)},
+		},
+		{
+			name:   "daemon starting and busy",
+			health: map[string]any{"status": "starting", "active_task_count": float64(2)},
+		},
+		{
+			name:   "daemon too old to report a task count",
+			health: map[string]any{"status": "running"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+			stubDaemonHealth(t, tc.health)
+
+			if healStaleDaemonTaskMarker(markerPath) {
+				t.Fatal("healStaleDaemonTaskMarker() = true; want false on uncertain evidence")
+			}
+			if _, err := os.Stat(markerPath); err != nil {
+				t.Fatalf("marker was removed despite uncertain evidence: %v", err)
+			}
+		})
+	}
+}
+
+// TestHealStaleMarkerRefusesFreshMarker keeps the self-heal off the window
+// where a daemon reporting zero is claiming a task and about to write this very
+// marker.
+func TestHealStaleMarkerRefusesFreshMarker(t *testing.T) {
+	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), time.Minute)
+	stubDaemonHealth(t, idleDaemon())
+
+	if healStaleDaemonTaskMarker(markerPath) {
+		t.Fatal("healStaleDaemonTaskMarker() = true; want false for a marker younger than staleMarkerMinAge")
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("fresh marker was removed: %v", err)
+	}
+}
+
+// TestHealStaleMarkerRefusesWorkspacesRootMarker protects the node-wide guard.
+// The workspaces root marker shares this filename but carries no agent or issue
+// — it is permanent by design, and deleting it would silently disarm the
+// fail-closed guard for the entire daemon-owned tree.
+func TestHealStaleMarkerRefusesWorkspacesRootMarker(t *testing.T) {
+	rootMarker := `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `"}`
+	markerPath := seedDaemonTaskMarker(t, rootMarker, 2*time.Hour)
+	stubDaemonHealth(t, idleDaemon())
+
+	if healStaleDaemonTaskMarker(markerPath) {
+		t.Fatal("healStaleDaemonTaskMarker() = true; want false for the workspaces root marker")
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("workspaces root marker was removed: %v", err)
+	}
+}
+
+// TestRequireHumanLocalCommandHealsLeftoverMarker is the user-visible outcome:
+// the command that used to be permanently refused in this directory now runs.
+func TestRequireHumanLocalCommandHealsLeftoverMarker(t *testing.T) {
+	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+	clearDaemonEnvSignals(t)
+	stubDaemonHealth(t, idleDaemon())
+
+	if err := requireHumanLocalCommand("daemon stop"); err != nil {
+		t.Fatalf("requireHumanLocalCommand() = %v; want nil after healing the leftover marker", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("marker still present (stat err: %v)", err)
+	}
+}
+
+// TestRequireHumanLocalCommandNamesMarkerWhenItCannotHeal is the fallback that
+// replaces the old bare message. When the marker cannot be proven stale the
+// command stays refused — but the user is told which file to look at instead of
+// having to read the source to find out.
+func TestRequireHumanLocalCommandNamesMarkerWhenItCannotHeal(t *testing.T) {
+	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+	clearDaemonEnvSignals(t)
+	stubDaemonHealth(t, map[string]any{"status": "stopped"})
+
+	err := requireHumanLocalCommand("daemon stop")
+	if err == nil {
+		t.Fatal("requireHumanLocalCommand() = nil; want refusal when staleness cannot be proven")
+	}
+	if !strings.Contains(err.Error(), markerPath) {
+		t.Fatalf("error should name the marker path %q; got %q", markerPath, err.Error())
+	}
+	if !strings.Contains(err.Error(), "leftover") {
+		t.Fatalf("error should hint it may be a leftover; got %q", err.Error())
+	}
+	if _, statErr := os.Stat(markerPath); statErr != nil {
+		t.Fatalf("marker was removed on the refusal path: %v", statErr)
+	}
+}
+
+// TestRequireHumanLocalCommandKeepsEnvIdentityUnhealed guards the boundary of
+// the self-heal: a real daemon-managed task announces itself through the
+// environment, and no file on disk may talk the CLI out of that. These
+// invocations keep the original bare refusal and must never trigger a probe or
+// a delete.
+func TestRequireHumanLocalCommandKeepsEnvIdentityUnhealed(t *testing.T) {
+	for _, tc := range []struct{ name, env, value string }{
+		{name: "agent id", env: "MULTICA_AGENT_ID", value: "agent-1"},
+		{name: "task id", env: "MULTICA_TASK_ID", value: "task-1"},
+		{name: "task config root", env: cli.TaskConfigRootEnv, value: "/tmp/task-multica"},
+		{name: "daemon port", env: "MULTICA_DAEMON_PORT", value: "20032"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+			clearDaemonEnvSignals(t)
+			t.Setenv(tc.env, tc.value)
+			stubDaemonHealth(t, idleDaemon())
+
+			err := requireHumanLocalCommand("daemon stop")
+			if err == nil {
+				t.Fatal("requireHumanLocalCommand() = nil; want refusal inside a real daemon-managed task")
+			}
+			if strings.Contains(err.Error(), "leftover") {
+				t.Fatalf("env-signalled task context must not be reported as a leftover; got %q", err.Error())
+			}
+			if _, statErr := os.Stat(markerPath); statErr != nil {
+				t.Fatalf("marker was removed inside a real daemon-managed task: %v", statErr)
+			}
+		})
+	}
+}
+
+// TestNoDaemonManagedTaskIsLiveRequiresEveryProfile pins the strict rule: a
+// single profile whose daemon does not answer makes the whole verdict unknown,
+// even when another profile answers idle. A task claimed under one profile can
+// be running in a directory a command resolved to a different profile touches.
+func TestNoDaemonManagedTaskIsLiveRequiresEveryProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Two named profiles plus the implicit default.
+	for _, name := range []string{"alpha", "beta"} {
+		dir := filepath.Join(home, ".multica", "profiles", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create profile %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write profile config %s: %v", name, err)
+		}
+	}
+
+	prev := daemonHealthProbe
+	t.Cleanup(func() { daemonHealthProbe = prev })
+
+	// Every port answers idle -> provable.
+	daemonHealthProbe = func(context.Context, int) map[string]any { return idleDaemon() }
+	if !noDaemonManagedTaskIsLive(context.Background()) {
+		t.Fatal("noDaemonManagedTaskIsLive() = false; want true when every profile answers idle")
+	}
+
+	// Exactly one port goes silent -> unknown, no deletion allowed.
+	silent := healthPortForProfile("beta")
+	daemonHealthProbe = func(_ context.Context, port int) map[string]any {
+		if port == silent {
+			return map[string]any{"status": "stopped"}
+		}
+		return idleDaemon()
+	}
+	if noDaemonManagedTaskIsLive(context.Background()) {
+		t.Fatal("noDaemonManagedTaskIsLive() = true; want false when a profile's daemon is unreachable")
+	}
+}

--- a/server/cmd/multica/stale_marker_test.go
+++ b/server/cmd/multica/stale_marker_test.go
@@ -1,22 +1,20 @@
 package main
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
 // seedDaemonTaskMarker writes a task-scoped daemon marker into a fresh temp
-// directory, backdates it past staleMarkerMinAge, chdirs into a nested
-// subdirectory so the CLI's upward walk has to find it, and returns the marker
+// directory and chdirs into a nested subdirectory, so the CLI's upward walk has
+// to find it the same way it would in a user's repository. Returns the marker
 // path.
-func seedDaemonTaskMarker(t *testing.T, body string, age time.Duration) string {
+func seedDaemonTaskMarker(t *testing.T) string {
 	t.Helper()
 
 	workDir := t.TempDir()
@@ -24,12 +22,9 @@ func seedDaemonTaskMarker(t *testing.T, body string, age time.Duration) string {
 	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
 		t.Fatalf("create marker dir: %v", err)
 	}
+	body := `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`
 	if err := os.WriteFile(markerPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write marker: %v", err)
-	}
-	backdated := time.Now().Add(-age)
-	if err := os.Chtimes(markerPath, backdated, backdated); err != nil {
-		t.Fatalf("backdate marker: %v", err)
 	}
 	nested := filepath.Join(workDir, "repo", "pkg")
 	if err := os.MkdirAll(nested, 0o755); err != nil {
@@ -37,21 +32,6 @@ func seedDaemonTaskMarker(t *testing.T, body string, age time.Duration) string {
 	}
 	t.Chdir(nested)
 	return markerPath
-}
-
-func taskScopedMarkerBody() string {
-	return `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`
-}
-
-// stubDaemonHealth points the self-heal probe at a fixed health payload for
-// every port, and isolates HOME so knownProfiles() sees only the profiles this
-// test creates rather than the developer's real ones.
-func stubDaemonHealth(t *testing.T, health map[string]any) {
-	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	prev := daemonHealthProbe
-	daemonHealthProbe = func(context.Context, int) map[string]any { return health }
-	t.Cleanup(func() { daemonHealthProbe = prev })
 }
 
 func clearDaemonEnvSignals(t *testing.T) {
@@ -62,148 +42,48 @@ func clearDaemonEnvSignals(t *testing.T) {
 	t.Setenv(cli.TaskConfigRootEnv, "")
 }
 
-func idleDaemon() map[string]any {
-	return map[string]any{"status": "running", "active_task_count": float64(0)}
-}
-
-// TestHealStaleMarkerRemovesWhenEveryDaemonReportsIdle is the happy path of
-// MUL-6132: a leftover marker in the user's own directory is retired without the
-// user doing anything, so the command they ran just works.
-func TestHealStaleMarkerRemovesWhenEveryDaemonReportsIdle(t *testing.T) {
-	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
-	stubDaemonHealth(t, idleDaemon())
-
-	if !healStaleDaemonTaskMarker(markerPath) {
-		t.Fatal("healStaleDaemonTaskMarker() = false; want true with every daemon idle")
-	}
-	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
-		t.Fatalf("marker still present after heal (stat err: %v)", err)
-	}
-	// The .multica directory existed only to hold the marker.
-	if _, err := os.Stat(filepath.Dir(markerPath)); !os.IsNotExist(err) {
-		t.Fatalf("empty .multica dir left behind (stat err: %v)", err)
-	}
-}
-
-// TestHealStaleMarkerRefusesOnUncertainEvidence covers the security rule the
-// whole feature turns on: the marker may only be deleted on positive evidence
-// that nothing is running. Every other outcome — including a daemon we simply
-// cannot reach — must leave it alone, because an unreachable daemon is exactly
-// what a crashed one looks like, and a task orphaned by that crash keeps
-// running with this marker as its only remaining guard.
-func TestHealStaleMarkerRefusesOnUncertainEvidence(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		health map[string]any
-	}{
-		{
-			name:   "daemon unreachable",
-			health: map[string]any{"status": "stopped"},
-		},
-		{
-			name:   "daemon busy",
-			health: map[string]any{"status": "running", "active_task_count": float64(1)},
-		},
-		{
-			name:   "daemon starting and busy",
-			health: map[string]any{"status": "starting", "active_task_count": float64(2)},
-		},
-		{
-			name:   "daemon too old to report a task count",
-			health: map[string]any{"status": "running"},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
-			stubDaemonHealth(t, tc.health)
-
-			if healStaleDaemonTaskMarker(markerPath) {
-				t.Fatal("healStaleDaemonTaskMarker() = true; want false on uncertain evidence")
-			}
-			if _, err := os.Stat(markerPath); err != nil {
-				t.Fatalf("marker was removed despite uncertain evidence: %v", err)
-			}
-		})
-	}
-}
-
-// TestHealStaleMarkerRefusesFreshMarker keeps the self-heal off the window
-// where a daemon reporting zero is claiming a task and about to write this very
-// marker.
-func TestHealStaleMarkerRefusesFreshMarker(t *testing.T) {
-	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), time.Minute)
-	stubDaemonHealth(t, idleDaemon())
-
-	if healStaleDaemonTaskMarker(markerPath) {
-		t.Fatal("healStaleDaemonTaskMarker() = true; want false for a marker younger than staleMarkerMinAge")
-	}
-	if _, err := os.Stat(markerPath); err != nil {
-		t.Fatalf("fresh marker was removed: %v", err)
-	}
-}
-
-// TestHealStaleMarkerRefusesWorkspacesRootMarker protects the node-wide guard.
-// The workspaces root marker shares this filename but carries no agent or issue
-// — it is permanent by design, and deleting it would silently disarm the
-// fail-closed guard for the entire daemon-owned tree.
-func TestHealStaleMarkerRefusesWorkspacesRootMarker(t *testing.T) {
-	rootMarker := `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `"}`
-	markerPath := seedDaemonTaskMarker(t, rootMarker, 2*time.Hour)
-	stubDaemonHealth(t, idleDaemon())
-
-	if healStaleDaemonTaskMarker(markerPath) {
-		t.Fatal("healStaleDaemonTaskMarker() = true; want false for the workspaces root marker")
-	}
-	if _, err := os.Stat(markerPath); err != nil {
-		t.Fatalf("workspaces root marker was removed: %v", err)
-	}
-}
-
-// TestRequireHumanLocalCommandHealsLeftoverMarker is the user-visible outcome:
-// the command that used to be permanently refused in this directory now runs.
-func TestRequireHumanLocalCommandHealsLeftoverMarker(t *testing.T) {
-	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+// TestLeftoverMarkerReportedIdenticallyOnBothRefusalPaths is the regression test
+// for the split the MUL-6132 review found: only the API path named the marker
+// file, so whether a user could act on the refusal depended on which command
+// they happened to run first. Both paths must now point at the same file with
+// the same remedy.
+func TestLeftoverMarkerReportedIdenticallyOnBothRefusalPaths(t *testing.T) {
+	markerPath := seedDaemonTaskMarker(t)
 	clearDaemonEnvSignals(t)
-	stubDaemonHealth(t, idleDaemon())
+	t.Setenv("MULTICA_TOKEN", "")
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
 
-	if err := requireHumanLocalCommand("daemon stop"); err != nil {
-		t.Fatalf("requireHumanLocalCommand() = %v; want nil after healing the leftover marker", err)
+	humanErr := requireHumanLocalCommand("daemon stop")
+	if humanErr == nil {
+		t.Fatal("requireHumanLocalCommand() = nil; want refusal on a leftover marker")
 	}
-	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
-		t.Fatalf("marker still present (stat err: %v)", err)
+	_, apiErr := newAPIClient(testCmd())
+	if apiErr == nil {
+		t.Fatal("newAPIClient() = nil error; want refusal on a leftover marker")
 	}
-}
 
-// TestRequireHumanLocalCommandNamesMarkerWhenItCannotHeal is the fallback that
-// replaces the old bare message. When the marker cannot be proven stale the
-// command stays refused — but the user is told which file to look at instead of
-// having to read the source to find out.
-func TestRequireHumanLocalCommandNamesMarkerWhenItCannotHeal(t *testing.T) {
-	markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
-	clearDaemonEnvSignals(t)
-	stubDaemonHealth(t, map[string]any{"status": "stopped"})
+	for name, err := range map[string]error{"human-local": humanErr, "api": apiErr} {
+		if !strings.Contains(err.Error(), markerPath) {
+			t.Fatalf("%s error should name the marker path %q; got %q", name, markerPath, err.Error())
+		}
+		if !strings.Contains(err.Error(), "leftover") {
+			t.Fatalf("%s error should hint it may be a leftover; got %q", name, err.Error())
+		}
+	}
 
-	err := requireHumanLocalCommand("daemon stop")
-	if err == nil {
-		t.Fatal("requireHumanLocalCommand() = nil; want refusal when staleness cannot be proven")
-	}
-	if !strings.Contains(err.Error(), markerPath) {
-		t.Fatalf("error should name the marker path %q; got %q", markerPath, err.Error())
-	}
-	if !strings.Contains(err.Error(), "leftover") {
-		t.Fatalf("error should hint it may be a leftover; got %q", err.Error())
-	}
+	// The CLI never removes the marker: taking down a fail-closed guard needs a
+	// proof the CLI cannot produce, because the daemon's active task count only
+	// rises after a claim returns.
 	if _, statErr := os.Stat(markerPath); statErr != nil {
-		t.Fatalf("marker was removed on the refusal path: %v", statErr)
+		t.Fatalf("CLI must not delete the marker: %v", statErr)
 	}
 }
 
-// TestRequireHumanLocalCommandKeepsEnvIdentityUnhealed guards the boundary of
-// the self-heal: a real daemon-managed task announces itself through the
-// environment, and no file on disk may talk the CLI out of that. These
-// invocations keep the original bare refusal and must never trigger a probe or
-// a delete.
-func TestRequireHumanLocalCommandKeepsEnvIdentityUnhealed(t *testing.T) {
+// TestLeftoverMarkerNotReportedUnderRealTaskIdentity guards the boundary of the
+// leftover treatment. A real daemon-managed task announces itself through the
+// environment; those refusals are correct and must not be described to the user
+// as a stale file to delete.
+func TestLeftoverMarkerNotReportedUnderRealTaskIdentity(t *testing.T) {
 	for _, tc := range []struct{ name, env, value string }{
 		{name: "agent id", env: "MULTICA_AGENT_ID", value: "agent-1"},
 		{name: "task id", env: "MULTICA_TASK_ID", value: "task-1"},
@@ -211,61 +91,24 @@ func TestRequireHumanLocalCommandKeepsEnvIdentityUnhealed(t *testing.T) {
 		{name: "daemon port", env: "MULTICA_DAEMON_PORT", value: "20032"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			markerPath := seedDaemonTaskMarker(t, taskScopedMarkerBody(), 2*time.Hour)
+			markerPath := seedDaemonTaskMarker(t)
 			clearDaemonEnvSignals(t)
 			t.Setenv(tc.env, tc.value)
-			stubDaemonHealth(t, idleDaemon())
 
-			err := requireHumanLocalCommand("daemon stop")
-			if err == nil {
-				t.Fatal("requireHumanLocalCommand() = nil; want refusal inside a real daemon-managed task")
+			if got := leftoverDaemonTaskMarkerPath(); got != "" {
+				t.Fatalf("leftoverDaemonTaskMarkerPath() = %q; want \"\" under real task identity", got)
 			}
-			if strings.Contains(err.Error(), "leftover") {
-				t.Fatalf("env-signalled task context must not be reported as a leftover; got %q", err.Error())
+			// MULTICA_DAEMON_PORT alone is not task identity, so it does not by
+			// itself make a human-local command fail; the others do, and when
+			// they do the message must stay the plain one.
+			if err := requireHumanLocalCommand("daemon stop"); err != nil {
+				if strings.Contains(err.Error(), "leftover") {
+					t.Fatalf("env-signalled task context must not be reported as a leftover; got %q", err.Error())
+				}
 			}
 			if _, statErr := os.Stat(markerPath); statErr != nil {
-				t.Fatalf("marker was removed inside a real daemon-managed task: %v", statErr)
+				t.Fatalf("marker must survive: %v", statErr)
 			}
 		})
-	}
-}
-
-// TestNoDaemonManagedTaskIsLiveRequiresEveryProfile pins the strict rule: a
-// single profile whose daemon does not answer makes the whole verdict unknown,
-// even when another profile answers idle. A task claimed under one profile can
-// be running in a directory a command resolved to a different profile touches.
-func TestNoDaemonManagedTaskIsLiveRequiresEveryProfile(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	// Two named profiles plus the implicit default.
-	for _, name := range []string{"alpha", "beta"} {
-		dir := filepath.Join(home, ".multica", "profiles", name)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("create profile %s: %v", name, err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o644); err != nil {
-			t.Fatalf("write profile config %s: %v", name, err)
-		}
-	}
-
-	prev := daemonHealthProbe
-	t.Cleanup(func() { daemonHealthProbe = prev })
-
-	// Every port answers idle -> provable.
-	daemonHealthProbe = func(context.Context, int) map[string]any { return idleDaemon() }
-	if !noDaemonManagedTaskIsLive(context.Background()) {
-		t.Fatal("noDaemonManagedTaskIsLive() = false; want true when every profile answers idle")
-	}
-
-	// Exactly one port goes silent -> unknown, no deletion allowed.
-	silent := healthPortForProfile("beta")
-	daemonHealthProbe = func(_ context.Context, port int) map[string]any {
-		if port == silent {
-			return map[string]any{"status": "stopped"}
-		}
-		return idleDaemon()
-	}
-	if noDaemonManagedTaskIsLive(context.Background()) {
-		t.Fatal("noDaemonManagedTaskIsLive() = true; want false when a profile's daemon is unreachable")
 	}
 }

--- a/server/cmd/multica/stale_marker_test.go
+++ b/server/cmd/multica/stale_marker_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
-// seedDaemonTaskMarker writes a task-scoped daemon marker into a fresh temp
+// seedMarker writes a daemon marker with the given body into a fresh temp
 // directory and chdirs into a nested subdirectory, so the CLI's upward walk has
 // to find it the same way it would in a user's repository. Returns the marker
 // path.
-func seedDaemonTaskMarker(t *testing.T) string {
+func seedMarker(t *testing.T, body string) string {
 	t.Helper()
 
 	workDir := t.TempDir()
@@ -22,7 +22,6 @@ func seedDaemonTaskMarker(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
 		t.Fatalf("create marker dir: %v", err)
 	}
-	body := `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`
 	if err := os.WriteFile(markerPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write marker: %v", err)
 	}
@@ -32,6 +31,42 @@ func seedDaemonTaskMarker(t *testing.T) string {
 	}
 	t.Chdir(nested)
 	return markerPath
+}
+
+// issueTaskMarker is the marker an issue task writes: agent and issue both set.
+func issueTaskMarker() string {
+	return `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1","issue_id":"issue-1"}`
+}
+
+// chatTaskMarker is the marker a chat task writes. It has no issue, which is
+// why task identity cannot be defined as "agent_id AND issue_id".
+func chatTaskMarker() string {
+	return `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `","agent_id":"agent-1"}`
+}
+
+// workspacesRootMarker is the permanent node-wide guard: managed_by and nothing
+// else. EnsureWorkspacesRootMarker writes exactly this.
+func workspacesRootMarker() string {
+	return `{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `"}`
+}
+
+func seedDaemonTaskMarker(t *testing.T) string {
+	t.Helper()
+	return seedMarker(t, issueTaskMarker())
+}
+
+// refusalPaths returns every CLI entry point that can refuse because of a
+// leftover marker, so a new one cannot be added without deciding whether it
+// reports the file.
+func refusalPaths() map[string]func() error {
+	return map[string]func() error{
+		"human-local": func() error { return requireHumanLocalCommand("daemon stop") },
+		"api": func() error {
+			_, err := newAPIClient(testCmd())
+			return err
+		},
+		"task-local-config": requireTaskLocalConfigRoot,
+	}
 }
 
 func clearDaemonEnvSignals(t *testing.T) {
@@ -47,35 +82,67 @@ func clearDaemonEnvSignals(t *testing.T) {
 // file, so whether a user could act on the refusal depended on which command
 // they happened to run first. Both paths must now point at the same file with
 // the same remedy.
-func TestLeftoverMarkerReportedIdenticallyOnBothRefusalPaths(t *testing.T) {
-	markerPath := seedDaemonTaskMarker(t)
+func TestLeftoverMarkerReportedIdenticallyOnEveryRefusalPath(t *testing.T) {
+	for _, marker := range []struct{ name, body string }{
+		{name: "issue task", body: issueTaskMarker()},
+		{name: "chat task", body: chatTaskMarker()},
+	} {
+		t.Run(marker.name, func(t *testing.T) {
+			markerPath := seedMarker(t, marker.body)
+			clearDaemonEnvSignals(t)
+			t.Setenv("MULTICA_TOKEN", "")
+			t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+
+			for name, refuse := range refusalPaths() {
+				err := refuse()
+				if err == nil {
+					t.Fatalf("%s: got nil error; want refusal on a leftover marker", name)
+				}
+				if !strings.Contains(err.Error(), markerPath) {
+					t.Fatalf("%s error should name the marker path %q; got %q", name, markerPath, err.Error())
+				}
+				if !strings.Contains(err.Error(), "leftover") {
+					t.Fatalf("%s error should hint it may be a leftover; got %q", name, err.Error())
+				}
+			}
+
+			// The CLI never removes the marker: taking down a fail-closed guard
+			// needs a proof the CLI cannot produce, because the daemon's active
+			// task count only rises after a claim returns.
+			if _, statErr := os.Stat(markerPath); statErr != nil {
+				t.Fatalf("CLI must not delete the marker: %v", statErr)
+			}
+		})
+	}
+}
+
+// TestWorkspacesRootMarkerNeverReportedAsLeftover is the regression test for the
+// permanent node-wide guard. It shares a filename with the per-task marker but
+// is re-created by the daemon on every start and must never expire. Telling
+// anyone to delete it — a user, or an agent subprocess that lost its
+// environment and is reading this error — closes the hole it exists to cover.
+func TestWorkspacesRootMarkerNeverReportedAsLeftover(t *testing.T) {
+	markerPath := seedMarker(t, workspacesRootMarker())
 	clearDaemonEnvSignals(t)
 	t.Setenv("MULTICA_TOKEN", "")
 	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
 
-	humanErr := requireHumanLocalCommand("daemon stop")
-	if humanErr == nil {
-		t.Fatal("requireHumanLocalCommand() = nil; want refusal on a leftover marker")
-	}
-	_, apiErr := newAPIClient(testCmd())
-	if apiErr == nil {
-		t.Fatal("newAPIClient() = nil error; want refusal on a leftover marker")
+	if got := leftoverDaemonTaskMarkerPath(); got != "" {
+		t.Fatalf("leftoverDaemonTaskMarkerPath() = %q; want \"\" for the workspaces root marker", got)
 	}
 
-	for name, err := range map[string]error{"human-local": humanErr, "api": apiErr} {
-		if !strings.Contains(err.Error(), markerPath) {
-			t.Fatalf("%s error should name the marker path %q; got %q", name, markerPath, err.Error())
+	for name, refuse := range refusalPaths() {
+		err := refuse()
+		if err == nil {
+			t.Fatalf("%s: got nil error; want the plain refusal to stay in place", name)
 		}
-		if !strings.Contains(err.Error(), "leftover") {
-			t.Fatalf("%s error should hint it may be a leftover; got %q", name, err.Error())
+		if strings.Contains(err.Error(), "leftover") || strings.Contains(err.Error(), "remove it") {
+			t.Fatalf("%s must not describe the workspaces root marker as removable; got %q", name, err.Error())
 		}
 	}
 
-	// The CLI never removes the marker: taking down a fail-closed guard needs a
-	// proof the CLI cannot produce, because the daemon's active task count only
-	// rises after a claim returns.
 	if _, statErr := os.Stat(markerPath); statErr != nil {
-		t.Fatalf("CLI must not delete the marker: %v", statErr)
+		t.Fatalf("workspaces root marker must survive: %v", statErr)
 	}
 }
 

--- a/server/cmd/multica/stale_marker_test.go
+++ b/server/cmd/multica/stale_marker_test.go
@@ -77,11 +77,12 @@ func clearDaemonEnvSignals(t *testing.T) {
 	t.Setenv(cli.TaskConfigRootEnv, "")
 }
 
-// TestLeftoverMarkerReportedIdenticallyOnBothRefusalPaths is the regression test
-// for the split the MUL-6132 review found: only the API path named the marker
-// file, so whether a user could act on the refusal depended on which command
-// they happened to run first. Both paths must now point at the same file with
-// the same remedy.
+// TestLeftoverMarkerReportedIdenticallyOnEveryRefusalPath is the regression test
+// for the split the MUL-6132 reviews found: at first only the API path named the
+// marker file, and after that requireTaskLocalConfigRoot was still left out, so
+// whether a user could act on the refusal depended on which command they
+// happened to run first. All three paths must point at the same file with the
+// same remedy.
 func TestLeftoverMarkerReportedIdenticallyOnEveryRefusalPath(t *testing.T) {
 	for _, marker := range []struct{ name, body string }{
 		{name: "issue task", body: issueTaskMarker()},

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -433,16 +433,20 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// and avoids a conditional that would silently disable cleanup if the
 	// local_directory detection logic ever drifts.
 	manifest := &sidecarManifest{}
-	if err := writeContextFiles(workDir, params.Provider, params.Task, manifest); err != nil {
-		return nil, fmt.Errorf("execenv: write context files: %w", err)
-	}
 
-	// From here on the sidecar tree — including the daemon task marker — is on
-	// disk, but the manifest that records it is not written until the end of
-	// Prepare. Roll back from the in-memory manifest on every failure in
-	// between: the caller gets no Environment on those paths, so the teardown
-	// defers that normally undo this tree are never registered, and the files
-	// would stay behind with no record of what to remove (MUL-6132).
+	// Arm the rollback BEFORE the first write, not after writeContextFiles
+	// returns. writeContextFiles puts the daemon task marker down as its very
+	// first act and can then fail on any later step — .agent_context, skill
+	// files, project resources — so a defer registered after it returns would
+	// miss exactly the failures that strand a marker with nothing else around
+	// it. Rolling back an empty manifest is a no-op, which is what makes it
+	// safe to arm this early.
+	//
+	// The manifest that records these writes is not persisted until the end of
+	// Prepare, and the caller receives no Environment on any failure path, so
+	// none of the teardown defers that normally undo this tree are ever
+	// registered. Without this rollback the files stay on disk with no record
+	// of what to remove (MUL-6132).
 	//
 	// In place only. Worktree mode discards the whole worktree on failure just
 	// above, and a cloud envRoot is wiped wholesale by the GC — only the
@@ -458,6 +462,10 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 				logger.Warn("execenv: roll back sidecars after failed prepare", "work_dir", workDir, "error", err)
 			}
 		}()
+	}
+
+	if err := writeContextFiles(workDir, params.Provider, params.Task, manifest); err != nil {
+		return nil, fmt.Errorf("execenv: write context files: %w", err)
 	}
 
 	// Persist managed-env provenance for non-local issue envs at Prepare time

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -437,6 +437,29 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		return nil, fmt.Errorf("execenv: write context files: %w", err)
 	}
 
+	// From here on the sidecar tree — including the daemon task marker — is on
+	// disk, but the manifest that records it is not written until the end of
+	// Prepare. Roll back from the in-memory manifest on every failure in
+	// between: the caller gets no Environment on those paths, so the teardown
+	// defers that normally undo this tree are never registered, and the files
+	// would stay behind with no record of what to remove (MUL-6132).
+	//
+	// In place only. Worktree mode discards the whole worktree on failure just
+	// above, and a cloud envRoot is wiped wholesale by the GC — only the
+	// local_directory flow writes into a directory that outlives the task and
+	// belongs to the user, where a leftover marker disables every multica
+	// command in that directory tree until someone removes it by hand.
+	if params.LocalWorkDir != "" {
+		defer func() {
+			if prepareSucceeded {
+				return
+			}
+			if err := rollBackPreparedSidecars(*manifest); err != nil && logger != nil {
+				logger.Warn("execenv: roll back sidecars after failed prepare", "work_dir", workDir, "error", err)
+			}
+		}()
+	}
+
 	// Persist managed-env provenance for non-local issue envs at Prepare time
 	// (not on completion, where .gc_meta.json is written). A same-issue
 	// follow-up can be claimed the instant the prior task completes — before
@@ -531,6 +554,16 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	}
 
 	if err := writeSidecarManifest(envRoot, manifest); err != nil {
+		// In place the manifest is the ONLY record of what we wrote into the
+		// user's own directory, so losing it strands the sidecar tree there
+		// permanently — no crash required, a disk or permission hiccup is
+		// enough (MUL-6132). Fail so the rollback registered above removes the
+		// tree now, while we still hold the in-memory manifest. Elsewhere the
+		// manifest is a convenience the GC can do without, so a warning stays
+		// the right response.
+		if params.LocalWorkDir != "" {
+			return nil, fmt.Errorf("execenv: write sidecar manifest: %w", err)
+		}
 		logger.Warn("execenv: write sidecar manifest failed (non-fatal)", "error", err)
 	}
 

--- a/server/internal/daemon/execenv/prepare_rollback_test.go
+++ b/server/internal/daemon/execenv/prepare_rollback_test.go
@@ -1,0 +1,115 @@
+package execenv
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace is the regression test for
+// MUL-6132: a local_directory Prepare that fails partway must not leave the
+// daemon task marker (or any other sidecar) in the user's own repository.
+//
+// Before the fix, Prepare wrote the marker early and persisted the manifest that
+// records it last, and the caller receives no Environment on a failure — so a
+// failed Prepare left a marker no code path knew how to remove, which disabled
+// every human-local multica command in that directory tree until someone deleted
+// the file by hand.
+//
+// The induced failure is a pre-existing .cursor/mcp.json, which the managed
+// cursor MCP path refuses to overwrite. It is a pure filesystem failure that
+// needs no agent CLI on the machine, and it lands after the marker is written.
+func TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	userDir := t.TempDir()
+
+	// The user's own content: the file that makes Prepare fail, plus a plain
+	// file that must survive the rollback untouched.
+	cursorDir := filepath.Join(userDir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o755); err != nil {
+		t.Fatalf("create .cursor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cursorDir, "mcp.json"), []byte(`{"mine":true}`), 0o644); err != nil {
+		t.Fatalf("seed user mcp.json: %v", err)
+	}
+	userFile := filepath.Join(userDir, "README.md")
+	if err := os.WriteFile(userFile, []byte("user content"), 0o644); err != nil {
+		t.Fatalf("seed user file: %v", err)
+	}
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-rollback-001",
+		TaskID:         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		AgentName:      "Test Agent",
+		Provider:       "cursor",
+		LocalWorkDir:   userDir,
+		McpConfig:      json.RawMessage(`{"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}`),
+		Task: TaskContextForEnv{
+			IssueID: "11111111-2222-3333-4444-555555555555",
+			AgentID: "99999999-8888-7777-6666-555555555555",
+		},
+	}, testLogger())
+	if err == nil {
+		t.Fatal("Prepare succeeded; expected the pre-existing .cursor/mcp.json to fail it")
+	}
+
+	markerPath := filepath.Join(userDir, TaskContextMarkerRelPath)
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("daemon task marker survived a failed Prepare at %s (stat err: %v)", markerPath, statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(userDir, ".agent_context")); !os.IsNotExist(statErr) {
+		t.Fatalf(".agent_context survived a failed Prepare (stat err: %v)", statErr)
+	}
+
+	// The rollback must be scoped to what Prepare created: the user's own
+	// files, including the one that caused the failure, stay exactly as they
+	// were.
+	if data, readErr := os.ReadFile(userFile); readErr != nil || string(data) != "user content" {
+		t.Fatalf("rollback touched user content: data=%q err=%v", string(data), readErr)
+	}
+	if data, readErr := os.ReadFile(filepath.Join(cursorDir, "mcp.json")); readErr != nil || string(data) != `{"mine":true}` {
+		t.Fatalf("rollback touched the user's mcp.json: data=%q err=%v", string(data), readErr)
+	}
+}
+
+// TestPrepareSucceedsInPlaceAndLeavesMarker guards the other half of the
+// contract: the rollback fires only on failure. A Prepare that completes must
+// still leave the marker in place — it is the guard that makes a CLI invocation
+// from inside the task fail closed — and must persist the manifest that the
+// task teardown later uses to remove it.
+func TestPrepareSucceedsInPlaceAndLeavesMarker(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	userDir := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-rollback-002",
+		TaskID:         "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		AgentName:      "Test Agent",
+		LocalWorkDir:   userDir,
+		Task: TaskContextForEnv{
+			IssueID: "22222222-3333-4444-5555-666666666666",
+			AgentID: "88888888-7777-6666-5555-444444444444",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(userDir, TaskContextMarkerRelPath)); statErr != nil {
+		t.Fatalf("successful Prepare did not leave the daemon task marker: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.RootDir, sidecarManifestFile)); statErr != nil {
+		t.Fatalf("successful Prepare did not persist the sidecar manifest: %v", statErr)
+	}
+
+	// And the recorded manifest is what makes the marker removable later.
+	if err := CleanupSidecars(env.RootDir); err != nil {
+		t.Fatalf("CleanupSidecars: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(userDir, TaskContextMarkerRelPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("marker survived CleanupSidecars (stat err: %v)", statErr)
+	}
+}

--- a/server/internal/daemon/execenv/prepare_rollback_test.go
+++ b/server/internal/daemon/execenv/prepare_rollback_test.go
@@ -74,6 +74,50 @@ func TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace(t *testing.T) {
 	}
 }
 
+// TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker covers the earliest
+// failure window there is: writeContextFiles lays the marker down as its very
+// first act, then creates .agent_context, writes skills and writes project
+// resources — any of which can fail with the marker already on disk.
+//
+// The first version of the MUL-6132 fix armed the rollback only after
+// writeContextFiles returned, so exactly these failures still stranded a marker
+// in the user's repository with nothing else beside it (MUL-6132 review). The
+// induced failure is a plain file where .agent_context must be a directory.
+func TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	userDir := t.TempDir()
+
+	// A regular file at the path writeContextFiles needs as a directory, one
+	// step after it writes the marker.
+	blocker := filepath.Join(userDir, ".agent_context")
+	if err := os.WriteFile(blocker, []byte("user file"), 0o644); err != nil {
+		t.Fatalf("seed .agent_context blocker: %v", err)
+	}
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-rollback-003",
+		TaskID:         "cccccccc-dddd-eeee-ffff-000000000000",
+		AgentName:      "Test Agent",
+		LocalWorkDir:   userDir,
+		Task: TaskContextForEnv{
+			IssueID: "33333333-4444-5555-6666-777777777777",
+			AgentID: "77777777-6666-5555-4444-333333333333",
+		},
+	}, testLogger())
+	if err == nil {
+		t.Fatal("Prepare succeeded; expected the .agent_context blocker to fail it")
+	}
+
+	markerPath := filepath.Join(userDir, TaskContextMarkerRelPath)
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("daemon task marker survived a failure inside writeContextFiles at %s (stat err: %v)", markerPath, statErr)
+	}
+	if data, readErr := os.ReadFile(blocker); readErr != nil || string(data) != "user file" {
+		t.Fatalf("rollback touched the user's own file: data=%q err=%v", string(data), readErr)
+	}
+}
+
 // TestPrepareSucceedsInPlaceAndLeavesMarker guards the other half of the
 // contract: the rollback fires only on failure. A Prepare that completes must
 // still leave the marker in place — it is the guard that makes a CLI invocation

--- a/server/internal/daemon/execenv/sidecar_manifest.go
+++ b/server/internal/daemon/execenv/sidecar_manifest.go
@@ -284,6 +284,20 @@ func CleanupSidecars(envRoot string) error {
 		return fmt.Errorf("parse sidecar manifest %s: %w", manifestPath, err)
 	}
 
+	return rollBackManifest(m, manifestPath)
+}
+
+// rollBackManifest removes everything m records, then removes manifestPath
+// itself when it is non-empty. It is the shared body of CleanupSidecars (which
+// reads m back from disk after the task ran) and rollBackPreparedSidecars
+// (which passes the in-memory manifest of a Prepare that never finished, and
+// has no manifest file to delete because Prepare failed before writing one).
+//
+// Splitting it this way is what lets the failed-Prepare path reuse the exact
+// deletion semantics documented on CleanupSidecars — ENOENT and non-empty
+// directories tolerated, real I/O errors surfaced — instead of growing a second,
+// subtly different rollback that would drift from it.
+func rollBackManifest(m sidecarManifest, manifestPath string) error {
 	var firstErr error
 	captureErr := func(err error) {
 		if firstErr == nil {
@@ -334,11 +348,31 @@ func CleanupSidecars(envRoot string) error {
 		}
 	}
 
-	if err := os.Remove(manifestPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		captureErr(fmt.Errorf("remove manifest %s: %w", manifestPath, err))
+	if manifestPath != "" {
+		if err := os.Remove(manifestPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			captureErr(fmt.Errorf("remove manifest %s: %w", manifestPath, err))
+		}
 	}
 
 	return firstErr
+}
+
+// rollBackPreparedSidecars undoes the sidecar writes of a Prepare that failed
+// before it could persist the manifest, using the in-memory manifest Prepare
+// was still filling in.
+//
+// This is the only rollback available on that path. Prepare writes the daemon
+// task marker and the rest of the sidecar tree into the workdir early, but only
+// persists the manifest at the very end; every error return in between leaves
+// that tree on disk with no on-disk record of it, and the caller never receives
+// an Environment, so no teardown defer downstream knows there is anything to
+// clean (MUL-6132). For a local_directory task the workdir is the user's own
+// repository, so "left on disk" means a marker that disables every multica
+// command in that directory tree until someone deletes it by hand.
+//
+// There is no manifest file to remove, so manifestPath is empty.
+func rollBackPreparedSidecars(m sidecarManifest) error {
+	return rollBackManifest(m, "")
 }
 
 // removeReusedManagedSkillDirs force-removes the skill directories the prior

--- a/server/internal/daemon/execenv/sidecar_manifest.go
+++ b/server/internal/daemon/execenv/sidecar_manifest.go
@@ -209,10 +209,14 @@ func skillSlugCandidate(baseSlug string, attempt int) string {
 // writeSidecarManifest persists m to {envRoot}/{sidecarManifestFile}.
 // Empty manifests are still written so a later Cleanup that finds the
 // file knows tracking was attempted (vs. an old build that predates this
-// mechanism, where the file is absent and Cleanup must no-op). Failures
-// are returned to the caller; the caller treats them as non-fatal because
-// a missed manifest only degrades local_directory cleanup, not task
-// execution.
+// mechanism, where the file is absent and Cleanup must no-op).
+//
+// Failures are returned to the caller, and how much they matter depends on
+// where the sidecars landed. For a cloud envRoot the manifest is a convenience
+// the GC can do without, so Prepare logs and continues. For an in-place
+// local_directory run it is the only record of what was written into the user's
+// own repository, so Prepare treats the failure as fatal and rolls back while
+// it still holds the in-memory manifest (MUL-6132).
 func writeSidecarManifest(envRoot string, m *sidecarManifest) error {
 	if envRoot == "" {
 		return nil


### PR DESCRIPTION
A leftover `.multica/daemon_task_context.json` in a user's own directory disables every `multica` command in that whole directory tree — silently, permanently, and with an error that names neither the file nor a way out. The reported instance sat undetected for five weeks. This PR closes the failure paths that create those leftovers during `Prepare`, and makes every refusal name the file when one is hit. It does **not** recover residue left by a crash or `kill -9` — that needs the daemon-side sweep in the follow-ups below, so MUL-6132 is not fully closed until that lands.

## What was actually broken

**1. A failed `Prepare` guarantees residue — no crash required.**

`writeContextFiles` puts the marker down as its very first act, and the manifest that records it is only persisted at the end of `Prepare`. Every error return in between — inside `writeContextFiles` itself (`.agent_context`, skills, project resources) or after it (provider homes, MCP config) — leaves the tree on disk with nothing recording it, and the caller gets no `Environment`, so the teardown defers that normally undo it are never registered. `writeSidecarManifest` failing was also only a warning, so a disk or permission hiccup produced the same permanent residue.

For a `local_directory` task the workdir is the user's own repo, so this is a directory the user works in every day going permanently bad.

**2. The refusal was a dead end, on one path only.**

`requireHumanLocalCommand` said only `daemon stop is not available inside a daemon-managed task`. The API path has named the marker file since MUL-3922 (`cmd_agent.go:265`) — so whether a user could act on the refusal depended on which command they happened to run first.

## What this changes

**`fix(daemon)`** — arm an in-place rollback from the in-memory manifest before the first sidecar write, and make a manifest write failure fatal in place so the rollback runs while the record still exists. Rolling back an empty manifest is a no-op, which is what makes arming it that early safe. Worktree and cloud envs are untouched: the former discards the whole worktree, the latter is wiped by the GC.

**`fix(cli)`** — both refusal paths now resolve the leftover through one helper and report it identically, naming the file and the remedy.

## What this deliberately does NOT do

An earlier revision of this PR had the CLI retire a stale marker automatically after probing every profile's daemon for zero active tasks. That is removed. Two defects, both inherent to doing it from outside the daemon:

- **The probe cannot be sound.** `activeTasks` is incremented only *after* `ClaimTasksWSFirst` returns (`daemon.go:4555` → `daemon.go:4584`), so a probe can read zero for a task that is already claimed and about to write the marker at this very path. The marker's age says nothing about a file written after the probe, and serial probing across profiles widens the window.
- **"Every profile answered" did not hold.** Profiles were matched by health port, and that port is a hash that can collide, so one idle daemon could be counted as two profiles while a crashed one kept an orphan task running. `knownProfiles()` also skips unreadable subtrees silently — fine for suggesting names, not for proving a machine-wide absence.

Removing a fail-closed guard needs synchronization with the claim path, which only the daemon has. Retirement therefore moves to the daemon-side sweep (follow-up below), and the CLI keeps the half it can do soundly.

## Verification

```
go build ./...                                    ok
go vet ./cmd/multica/ ./internal/daemon/execenv/  ok
git diff --check                                  ok
```

Both rollback tests are verified regression tests — each fails without its fix and passes with it:

- `TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker` — failure *inside* `writeContextFiles`, one step after the marker is written (a plain file where `.agent_context` must be a directory). Fails on the previous commit with `daemon task marker survived a failure inside writeContextFiles`.
- `TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace` — failure after `writeContextFiles` (a pre-existing `.cursor/mcp.json`). Fails on pristine HEAD with `daemon task marker survived a failed Prepare`.

Both induce real failures through the filesystem only — no agent CLI on the machine is involved. Both also assert the user's own files, including the one that caused the failure, are left byte-identical.

Other tests:

- `TestPrepareSucceedsInPlaceAndLeavesMarker` — the rollback fires only on failure; a successful Prepare still leaves the marker and a manifest `CleanupSidecars` can act on.
- `TestLeftoverMarkerReportedIdenticallyOnBothRefusalPaths` — both paths name the file, and neither deletes it.
- `TestLeftoverMarkerNotReportedUnderRealTaskIdentity` — agent id / task id / task config root / daemon port are never described as a leftover.

Full-package runs: `cmd/multica` is clean (0 failures) when its test binary runs from a marker-free cwd. `internal/daemon/execenv` has 4 pre-existing Hermes failures, identical on pristine HEAD — confirmed by stashing the change and re-running.

## Follow-ups, not in this PR

- **Daemon-side marker retirement and startup sweep.** This is where automatic recovery belongs: the daemon can serialize deletion against its own claim path, and its sidecar manifests record exactly which marker paths it wrote, so ownership is proven rather than guessed from a port hash. It should also clear `.agent_context/issue_context.md` — a stale task assignment carrying a weeks-old issue id, with no guard at all, so a manual `claude` run in that directory can act on it.
- **Test-suite cwd pollution** — MUL-6138. 105 cases in `server/cmd/multica` fail whenever the package runs below any marker, because tests asserting the human-CLI path set `HOME` but never `t.Chdir`. CI is green only because it has no marker; every Multica agent runtime does.

