### PR TITLE
fix(desktop): stop the tab flares printing dark squares under the active tab (MUL-6143)

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -238,7 +238,12 @@ export function DesktopShell() {
       <WorkspaceSlugProvider slug={slug}>
         <DesktopInboxBridge />
         <div className="flex h-screen bg-app-shell">
-          <SidebarProvider className="flex-1 bg-app-shell">
+          {/* bg-app-shell is the wrapper's non-inset fill, so it also owns the
+              non-inset half of --sidebar-wrapper-fill. sidebar.tsx supplies the
+              inset half of both. Anything that has to paint an opaque layer
+              over this wrapper (the tab flares) reads the variable rather than
+              re-deriving which of the two is in play. */}
+          <SidebarProvider className="flex-1 bg-app-shell [--sidebar-wrapper-fill:var(--app-shell)]">
             {slug && <GlobalShortcuts />}
             {slug && <WindowToolbar />}
             {slug && <AppSidebar topSlot={<SidebarTopSpacer />} searchSlot={<SearchTrigger />} />}

--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -261,7 +261,10 @@ describe("TabBar merged-tab chrome", () => {
     );
   });
 
-  // The opaque sidebar backing keeps the flare and card keylines from stacking.
+  // The opaque backing keeps the flare and card keylines from stacking, and
+  // must equal the strip's backdrop on both sides of the compact breakpoint:
+  // the wrapper paints bg-sidebar only while an inset sidebar is mounted, so
+  // the flare mirrors that condition instead of pinning one token.
   it("paints each flare on an opaque layer matching the strip backdrop", () => {
     const { getByLabelText } = render(<TabBar />);
     const flares = getByLabelText("Issues")
@@ -270,9 +273,14 @@ describe("TabBar merged-tab chrome", () => {
 
     expect(flares).toHaveLength(2);
     for (const flare of flares ?? []) {
-      expect(flare.getAttribute("style")).toContain(
-        "var(--page-canvas) 10.2px), var(--sidebar)",
+      expect(flare).toHaveClass(
+        "bg-app-shell",
+        "group-has-data-[variant=inset]/sidebar-wrapper:bg-sidebar",
       );
+      // The gradient itself carries no backing layer; the classes above own it.
+      expect(flare.getAttribute("style")).toContain("var(--page-canvas) 10.2px)");
+      expect(flare.getAttribute("style")).not.toContain("var(--sidebar)");
+      expect(flare.getAttribute("style")).not.toContain("var(--app-shell)");
     }
   });
 

--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -247,10 +247,7 @@ describe("TabBar active-tab title persistence", () => {
 });
 
 describe("TabBar merged-tab chrome", () => {
-  // Dark mode's --surface-border is translucent, so a fill painted under the
-  // cap's own border tints its keyline lighter than the flare arcs and the
-  // content card's ring, leaving a visible step where the tab meets the frame.
-  // bg-clip-padding keeps the fill inside the border box.
+  // Keep the fill inside the translucent keyline so the merged border is even.
   it("keeps the active tab's page-canvas fill out from under its keyline", () => {
     const { getByLabelText } = render(<TabBar />);
     const cap = getByLabelText("Issues")
@@ -264,17 +261,7 @@ describe("TabBar merged-tab chrome", () => {
     );
   });
 
-  // The flare's bottom row sits on top of the content card's top ring. Both
-  // draw --surface-border, so in dark mode the arc would composite over the
-  // ring rather than replace it and the two translucent keylines would stack
-  // into a markedly lighter line right at the straight-to-curve junction. An
-  // opaque layer under the gradient makes the flare replace whatever it
-  // covers.
-  //
-  // That layer must be --sidebar, the tab strip's real backdrop (the sidebar
-  // wrapper paints bg-sidebar while the inset-variant app sidebar is
-  // mounted). --app-shell is markedly darker in dark mode and printed a
-  // visible dark square under each bottom corner of the active tab.
+  // The opaque sidebar backing keeps the flare and card keylines from stacking.
   it("paints each flare on an opaque layer matching the strip backdrop", () => {
     const { getByLabelText } = render(<TabBar />);
     const flares = getByLabelText("Issues")

--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -267,10 +267,15 @@ describe("TabBar merged-tab chrome", () => {
   // The flare's bottom row sits on top of the content card's top ring. Both
   // draw --surface-border, so in dark mode the arc would composite over the
   // ring rather than replace it and the two translucent keylines would stack
-  // into a markedly lighter line right at the straight-to-curve junction. The
-  // opaque --app-shell layer under the gradient makes the flare replace
-  // whatever it covers.
-  it("paints each flare on an opaque shell layer", () => {
+  // into a markedly lighter line right at the straight-to-curve junction. An
+  // opaque layer under the gradient makes the flare replace whatever it
+  // covers.
+  //
+  // That layer must be --sidebar, the tab strip's real backdrop (the sidebar
+  // wrapper paints bg-sidebar while the inset-variant app sidebar is
+  // mounted). --app-shell is markedly darker in dark mode and printed a
+  // visible dark square under each bottom corner of the active tab.
+  it("paints each flare on an opaque layer matching the strip backdrop", () => {
     const { getByLabelText } = render(<TabBar />);
     const flares = getByLabelText("Issues")
       .closest("[data-tab-frame]")
@@ -279,7 +284,7 @@ describe("TabBar merged-tab chrome", () => {
     expect(flares).toHaveLength(2);
     for (const flare of flares ?? []) {
       expect(flare.getAttribute("style")).toContain(
-        "var(--page-canvas) 10.2px), var(--app-shell)",
+        "var(--page-canvas) 10.2px), var(--sidebar)",
       );
     }
   });

--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
+import { SIDEBAR_WRAPPER_FILL_CLASS } from "@multica/ui/components/ui/sidebar";
 
 type MockTab = {
   id: string;
@@ -261,11 +262,12 @@ describe("TabBar merged-tab chrome", () => {
     );
   });
 
-  // The opaque backing keeps the flare and card keylines from stacking, and
-  // must equal the strip's backdrop on both sides of the compact breakpoint:
-  // the wrapper paints bg-sidebar only while an inset sidebar is mounted, so
-  // the flare mirrors that condition instead of pinning one token.
-  it("paints each flare on an opaque layer matching the strip backdrop", () => {
+  // The opaque backing keeps the flare and card keylines from stacking, and has
+  // to equal the strip's backdrop at every width. It reads that colour off the
+  // sidebar wrapper's published fill rather than naming a token, so no token may
+  // appear here or in the gradient — a pinned one is exactly the regression this
+  // covers. The wrapper's end of the contract is covered in packages/views.
+  it("paints each flare on the sidebar wrapper's own fill", () => {
     const { getByLabelText } = render(<TabBar />);
     const flares = getByLabelText("Issues")
       .closest("[data-tab-frame]")
@@ -273,14 +275,12 @@ describe("TabBar merged-tab chrome", () => {
 
     expect(flares).toHaveLength(2);
     for (const flare of flares ?? []) {
-      expect(flare).toHaveClass(
-        "bg-app-shell",
-        "group-has-data-[variant=inset]/sidebar-wrapper:bg-sidebar",
-      );
-      // The gradient itself carries no backing layer; the classes above own it.
+      expect(flare).toHaveClass(SIDEBAR_WRAPPER_FILL_CLASS);
       expect(flare.getAttribute("style")).toContain("var(--page-canvas) 10.2px)");
       expect(flare.getAttribute("style")).not.toContain("var(--sidebar)");
       expect(flare.getAttribute("style")).not.toContain("var(--app-shell)");
+      expect(flare.className).not.toContain("bg-app-shell");
+      expect(flare.className).not.toContain("bg-sidebar");
     }
   });
 

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -47,12 +47,18 @@ const TAB_SCROLL_FADE_SIZE = 24;
 const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 
 // The active tab flares into the content surface through concave corners.
-// An opaque sidebar backing prevents its translucent arc from stacking with
-// the content card's top ring.
+// An opaque backing (the flare's background-color) prevents its translucent
+// arc from stacking with the content card's top ring. The backing must equal
+// the strip's backdrop, which is the sidebar wrapper's fill: bg-sidebar while
+// an inset sidebar is mounted, bg-app-shell otherwise (compact widths render
+// the sidebar as a sheet). TAB_FLARE_BACKDROP mirrors the wrapper's own
+// has-data-[variant=inset]:bg-sidebar condition so the two cannot drift.
 const TAB_FLARE_RADIUS = 10;
-const tabFlareBackground = (side: "left" | "right") => {
+const TAB_FLARE_BACKDROP =
+  "bg-app-shell group-has-data-[variant=inset]/sidebar-wrapper:bg-sidebar";
+const tabFlareGradient = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
-  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px), var(--sidebar)`;
+  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px)`;
 };
 
 type TabSnapshot = {
@@ -340,12 +346,12 @@ function SortableTabItem({
             <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas bg-clip-padding" />
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span
-              className="absolute bottom-0 size-2.5"
-              style={{ left: -TAB_FLARE_RADIUS + 1, background: tabFlareBackground("left") }}
+              className={cn("absolute bottom-0 size-2.5", TAB_FLARE_BACKDROP)}
+              style={{ left: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("left") }}
             />
             <span
-              className="absolute bottom-0 size-2.5"
-              style={{ right: -TAB_FLARE_RADIUS + 1, background: tabFlareBackground("right") }}
+              className={cn("absolute bottom-0 size-2.5", TAB_FLARE_BACKDROP)}
+              style={{ right: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("right") }}
             />
           </span>
         ) : (

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -48,23 +48,30 @@ const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 
 // Chrome-style merged tab: the active tab shares the content surface's fill
 // and flares into it through concave bottom corners. Each flare is a small
-// square whose radial gradient carves a quarter-circle notch (the shell fill
-// below), strokes a 1px arc that continues the tab's side border into the
-// content card's top ring, and fills the rest with the surface color. The
-// 0.4px stop spread anti-aliases the arc.
+// square whose radial gradient carves a quarter-circle notch (the backdrop
+// fill below), strokes a 1px arc that continues the tab's side border into
+// the content card's top ring, and fills the rest with the surface color.
+// The 0.4px stop spread anti-aliases the arc.
 //
-// The gradient sits on an opaque --app-shell layer rather than letting the
-// shell show through, because the flare's bottom row overlaps the content
+// The gradient sits on an opaque backdrop layer rather than letting the
+// strip show through, because the flare's bottom row overlaps the content
 // card's top ring. In dark mode --surface-border is translucent
 // (oklch(1 0 0 / 10%)), so the arc would composite over the ring instead of
 // replacing it and the two keylines would stack into a markedly lighter line
-// right where the straight ring meets the curve. The shell layer makes the
-// flare opaque over everything it covers, so the arc reads the same tone
-// whether it crosses the ring or the bare shell.
+// right where the straight ring meets the curve. The backdrop layer makes
+// the flare opaque over everything it covers, so the arc reads the same tone
+// whether it crosses the ring or the bare strip.
+//
+// That layer must be --sidebar, not --app-shell: the tab strip sits on the
+// sidebar wrapper, which paints bg-sidebar whenever the inset-variant app
+// sidebar is mounted (sidebar.tsx's has-data-[variant=inset]:bg-sidebar).
+// In dark mode --app-shell is markedly darker than --sidebar, so using it
+// here printed a visible dark square under each bottom corner of the active
+// tab. In light mode the two tokens share one value.
 const TAB_FLARE_RADIUS = 10;
 const tabFlareBackground = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
-  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px), var(--app-shell)`;
+  return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px), var(--sidebar)`;
 };
 
 type TabSnapshot = {
@@ -351,8 +358,9 @@ function SortableTabItem({
                 1px border. In dark mode --surface-border is translucent
                 (oklch(1 0 0 / 10%)), so a fill behind it would tint this
                 keyline lighter than the flare arcs and the content card's
-                ring, which both composite over --app-shell. That leaves a
-                visible step exactly where the tab merges into the frame. */}
+                ring, which both composite over the sidebar wrapper's fill.
+                That leaves a visible step exactly where the tab merges into
+                the frame. */}
             <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas bg-clip-padding" />
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -34,6 +34,7 @@ import {
   ContextMenuTrigger,
 } from "@multica/ui/components/ui/context-menu";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
+import { SIDEBAR_WRAPPER_FILL_CLASS } from "@multica/ui/components/ui/sidebar";
 import { cn } from "@multica/ui/lib/utils";
 import { useTabStore, useActiveGroup, type Tab } from "@/stores/tab-store";
 import { paths } from "@multica/core/paths";
@@ -46,16 +47,23 @@ import { parseIssueWindowPath } from "../../../shared/issue-window";
 const TAB_SCROLL_FADE_SIZE = 24;
 const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 
-// The active tab flares into the content surface through concave corners.
-// An opaque backing (the flare's background-color) prevents its translucent
-// arc from stacking with the content card's top ring. The backing must equal
-// the strip's backdrop, which is the sidebar wrapper's fill: bg-sidebar while
-// an inset sidebar is mounted, bg-app-shell otherwise (compact widths render
-// the sidebar as a sheet). TAB_FLARE_BACKDROP mirrors the wrapper's own
-// has-data-[variant=inset]:bg-sidebar condition so the two cannot drift.
+// Chrome-style merged tab: the active tab shares the content surface's fill and
+// flares into it through concave bottom corners. Each flare is a small square
+// whose radial gradient carves a quarter-circle notch (transparent, so the
+// flare's own background-color shows through and the notch reads as the strip),
+// strokes a 1px arc that continues the tab's side border into the content card's
+// top ring, and fills the rest with the surface colour. The 0.4px spread on
+// either side of the --surface-border pair anti-aliases that arc.
+//
+// That background-color is load-bearing, not decoration: the flare's bottom row
+// overlaps the content card's top ring, and in dark mode --surface-border is
+// translucent (oklch(1 0 0 / 10%)), so without an opaque layer beneath it the
+// arc would composite over the ring instead of replacing it and the two keylines
+// would stack into a markedly lighter line right where the straight ring meets
+// the curve. It therefore has to be the strip's real backdrop — the sidebar
+// wrapper's fill, which is conditional and not this file's to re-derive.
+// SIDEBAR_WRAPPER_FILL_CLASS reads it off the wrapper itself.
 const TAB_FLARE_RADIUS = 10;
-const TAB_FLARE_BACKDROP =
-  "bg-app-shell group-has-data-[variant=inset]/sidebar-wrapper:bg-sidebar";
 const tabFlareGradient = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
   return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px)`;
@@ -346,11 +354,11 @@ function SortableTabItem({
             <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas bg-clip-padding" />
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span
-              className={cn("absolute bottom-0 size-2.5", TAB_FLARE_BACKDROP)}
+              className={cn("absolute bottom-0 size-2.5", SIDEBAR_WRAPPER_FILL_CLASS)}
               style={{ left: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("left") }}
             />
             <span
-              className={cn("absolute bottom-0 size-2.5", TAB_FLARE_BACKDROP)}
+              className={cn("absolute bottom-0 size-2.5", SIDEBAR_WRAPPER_FILL_CLASS)}
               style={{ right: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("right") }}
             />
           </span>

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -46,28 +46,9 @@ import { parseIssueWindowPath } from "../../../shared/issue-window";
 const TAB_SCROLL_FADE_SIZE = 24;
 const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 
-// Chrome-style merged tab: the active tab shares the content surface's fill
-// and flares into it through concave bottom corners. Each flare is a small
-// square whose radial gradient carves a quarter-circle notch (the backdrop
-// fill below), strokes a 1px arc that continues the tab's side border into
-// the content card's top ring, and fills the rest with the surface color.
-// The 0.4px stop spread anti-aliases the arc.
-//
-// The gradient sits on an opaque backdrop layer rather than letting the
-// strip show through, because the flare's bottom row overlaps the content
-// card's top ring. In dark mode --surface-border is translucent
-// (oklch(1 0 0 / 10%)), so the arc would composite over the ring instead of
-// replacing it and the two keylines would stack into a markedly lighter line
-// right where the straight ring meets the curve. The backdrop layer makes
-// the flare opaque over everything it covers, so the arc reads the same tone
-// whether it crosses the ring or the bare strip.
-//
-// That layer must be --sidebar, not --app-shell: the tab strip sits on the
-// sidebar wrapper, which paints bg-sidebar whenever the inset-variant app
-// sidebar is mounted (sidebar.tsx's has-data-[variant=inset]:bg-sidebar).
-// In dark mode --app-shell is markedly darker than --sidebar, so using it
-// here printed a visible dark square under each bottom corner of the active
-// tab. In light mode the two tokens share one value.
+// The active tab flares into the content surface through concave corners.
+// An opaque sidebar backing prevents its translucent arc from stacking with
+// the content card's top ring.
 const TAB_FLARE_RADIUS = 10;
 const tabFlareBackground = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
@@ -354,13 +335,8 @@ function SortableTabItem({
               isDragging && "opacity-60",
             )}
           >
-            {/* bg-clip-padding keeps the page-canvas fill out from under the
-                1px border. In dark mode --surface-border is translucent
-                (oklch(1 0 0 / 10%)), so a fill behind it would tint this
-                keyline lighter than the flare arcs and the content card's
-                ring, which both composite over the sidebar wrapper's fill.
-                That leaves a visible step exactly where the tab merges into
-                the frame. */}
+            {/* Keep the fill inside the translucent keyline so it matches the
+                flare arcs and content card ring. */}
             <span className="absolute inset-x-0 top-0 bottom-2.5 rounded-t-lg border border-b-0 border-surface-border bg-page-canvas bg-clip-padding" />
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span

--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -38,6 +38,22 @@ const SIDEBAR_DRAG_THRESHOLD = 2
 // header's trigger brings it back.
 const SIDEBAR_AUTO_COLLAPSE_QUERY = "(min-width: 1024px) and (max-width: 1279px)"
 
+/**
+ * Paints an element with whatever the sidebar wrapper is currently filled with.
+ *
+ * A descendant that has to lay down an opaque layer over the wrapper — rather
+ * than over its own parent — must match the wrapper's fill exactly, and that
+ * fill is conditional: `bg-sidebar` while an inset-variant sidebar is mounted,
+ * the consumer's own background otherwise. Naming a token at the descendant
+ * reproduces that condition in a second place, which then drifts (#6874). Use
+ * this class instead: the wrapper publishes its fill as `--sidebar-wrapper-fill`
+ * under the same `:has()` condition that paints it, so the two cannot disagree.
+ *
+ * Consumers that give the wrapper a background must declare the matching
+ * non-inset half, e.g. `bg-app-shell [--sidebar-wrapper-fill:var(--app-shell)]`.
+ */
+const SIDEBAR_WRAPPER_FILL_CLASS = "bg-(--sidebar-wrapper-fill)"
+
 function clampSidebarWidth(width: number) {
   return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, width))
 }
@@ -218,7 +234,14 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            "group/sidebar-wrapper flex min-h-svh w-full",
+            // Both halves of the inset branch carry the identical :has()
+            // condition, so SIDEBAR_WRAPPER_FILL_CLASS can never name a colour
+            // this element is not actually painted with. The non-inset fill is
+            // the consumer's (this component paints nothing then), so the
+            // consumer declares that half of the variable next to its own
+            // background class.
+            "has-data-[variant=inset]:bg-sidebar has-data-[variant=inset]:[--sidebar-wrapper-fill:var(--sidebar)]",
             className
           )}
           {...props}
@@ -908,6 +931,7 @@ function SidebarMenuSubButton({
 }
 
 export {
+  SIDEBAR_WRAPPER_FILL_CLASS,
   Sidebar,
   SidebarContent,
   SidebarFooter,

--- a/packages/views/layout/sidebar-wrapper-fill.test.tsx
+++ b/packages/views/layout/sidebar-wrapper-fill.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SIDEBAR_WRAPPER_FILL_CLASS,
+  SidebarProvider,
+} from "@multica/ui/components/ui/sidebar";
+import { renderWithI18n } from "../test/i18n";
+
+// The wrapper's fill is conditional, and descendants that paint an opaque layer
+// over it have to match it exactly (the desktop tab flares do — #6874 shipped a
+// dark square under the active tab when they didn't). SIDEBAR_WRAPPER_FILL_CLASS
+// is the contract that keeps them in step. None of it is observable in jsdom, so
+// these assertions cover what a rename or a class-merge conflict would silently
+// break; the compiled selectors themselves are Tailwind's business.
+describe("sidebar wrapper fill contract", () => {
+  const variable = /^bg-\((--[a-z-]+)\)$/.exec(SIDEBAR_WRAPPER_FILL_CLASS)?.[1];
+
+  function wrapperOf(className?: string) {
+    const { container } = renderWithI18n(<SidebarProvider className={className} />);
+    return container.querySelector<HTMLElement>("[data-slot='sidebar-wrapper']")!;
+  }
+
+  it("publishes the variable that SIDEBAR_WRAPPER_FILL_CLASS reads", () => {
+    expect(variable).toBeDefined();
+    expect(wrapperOf().className).toContain(`${variable}:var(--sidebar)`);
+  });
+
+  // Paint and variable must carry the identical condition. If one branch grows a
+  // condition the other lacks, the variable starts naming a color the wrapper is
+  // not painted with, which is the original bug in a new place.
+  it("gates the inset fill and the inset variable on the same condition", () => {
+    const classes = wrapperOf().className.split(/\s+/);
+    const insetBranch = classes.filter((c) => c.startsWith("has-data-[variant=inset]:"));
+
+    expect(insetBranch).toContain("has-data-[variant=inset]:bg-sidebar");
+    expect(insetBranch).toContain(`has-data-[variant=inset]:[${variable}:var(--sidebar)]`);
+  });
+
+  // tailwind-merge drops same-group utilities, and the consumer's non-inset pair
+  // arrives through the same cn() call as the inset pair above. All four have to
+  // survive: lose the variable and the flares fall back to transparent, lose the
+  // background and the wrapper does.
+  it("keeps a consumer's non-inset fill alongside the inset branch", () => {
+    const classes = wrapperOf(
+      `flex-1 bg-app-shell [${variable}:var(--app-shell)]`,
+    ).className.split(/\s+/);
+
+    expect(classes).toEqual(
+      expect.arrayContaining([
+        "bg-app-shell",
+        `[${variable}:var(--app-shell)]`,
+        "has-data-[variant=inset]:bg-sidebar",
+        `has-data-[variant=inset]:[${variable}:var(--sidebar)]`,
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
On desktop in dark mode, a solid dark square appeared under each bottom corner of the active tab after the keyline-unification fix (MUL-6106 / #6874).

## Cause

That fix backed the flare gradient with an opaque `var(--app-shell)` layer, on the assumption that the tab strip sits on `bg-app-shell`. The strip actually sits on the `SidebarProvider` wrapper, whose fill is conditional (`packages/ui/components/ui/sidebar.tsx`): `has-data-[variant=inset]:bg-sidebar` while the inset-variant app sidebar is mounted (≥ `lg`), and the layout's `bg-app-shell` otherwise — below `lg` the sidebar renders as a sheet, so no `[data-variant=inset]` element exists. In dark mode `--app-shell` (≈ rgb 12) is markedly darker than `--sidebar` (≈ rgb 24), so a backing pinned to either token prints a visible square on the other side of the breakpoint.

## Fix

Take the backing out of the gradient, and off any token. The wrapper publishes its own fill as a custom property under the same `:has()` condition that paints it, and exports the class that reads it:

```
// sidebar.tsx — wrapper: paint and variable, one condition
has-data-[variant=inset]:bg-sidebar has-data-[variant=inset]:[--sidebar-wrapper-fill:var(--sidebar)]

// desktop-layout.tsx — consumer owns the non-inset half, next to the class that produces it
bg-app-shell [--sidebar-wrapper-fill:var(--app-shell)]

// tab-bar.tsx — flare
SIDEBAR_WRAPPER_FILL_CLASS   // "bg-(--sidebar-wrapper-fill)"
```

The gradient stays inline as `background-image`; the class layer supplies the opaque backing. The flare now always composites over the colour actually behind it, so the notch is invisible and the arc reads the same tone as the cap border and the content card's ring at every width. The keyline-stacking problem MUL-6106 solved stays solved, since the backing is still opaque. And because the condition lives only on the wrapper, nothing downstream can drift from it — an earlier revision of this PR mirrored the condition at the flare instead, which would have re-broken silently on any rename in `sidebar.tsx`.

## Verification

A harness rendered the strip, tab chrome, and content card from the gradient template and token values read out of `tab-bar.tsx` and `tokens.css`, replicating the wrapper's `:has()` cascade, across {dark, light} × {inset sidebar mounted, compact/sheet}. Sampled pixels (single channel), after the fix:

| scenario | flare notch | backdrop | arc | ring |
| --- | --- | --- | --- | --- |
| dark, large | 24 | 24 | 47 | 46 |
| dark, compact | 12 | 12 | 36 | 35 |
| light, both | matches | matches | 228 | 228 |

Against `main`, the case this changes is **dark at large widths** — `main` pins the backing to `--app-shell` (12) while the wrapper there is painted `--sidebar` (24), which is the square in the bug report. Dark compact was already correct on `main` (backing and backdrop are both `--app-shell`), and light mode never had the bug at all, since `--app-shell` and `--sidebar` share one value there. Both of those render byte-identical to `main` (max channel diff 0).

The compiled selectors come from the real `globals.css` theme: the inset declaration out-specifies the consumer's, 0,2,0 vs 0,1,0 — the same mechanism the wrapper's own `bg-sidebar` uses to beat the consumer's background class.

`pnpm --filter @multica/desktop test`, `pnpm --filter @multica/views test`, `typecheck` and `lint` pass. The contract is covered from both ends: the desktop test asserts the flares name no token and that the gradient carries no pinned colour layer, and `packages/views/layout/sidebar-wrapper-fill.test.tsx` asserts the wrapper keeps paint and variable gated on one condition, and that `tailwind-merge` leaves the consumer's pair intact.

---

Maintainer follow-up (`de64a7d`) applied the review points from MUL-6143: moved the backdrop knowledge into the wrapper as above, restored the gradient-geometry rationale dropped in `3aafa0e7` (the 1.2/0.8/0.2px stop offsets and the 0.4px anti-aliasing spread had no other explanation in the file), and rewrote this Verification section against `main` — it previously read as relative to an intermediate commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
