### PR TITLE
test(agent): stabilize Pi and OMP subprocess tests

### DIFF
--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1182,7 +1182,11 @@ printf '%s\n' 'fallback fallback-model 128K 8K yes no'
 	writeTestExecutable(t, fakePath, []byte(script))
 
 	started := time.Now()
-	models, err := discoverPiModelsWithin(context.Background(), fakePath, 100*time.Millisecond, time.Second)
+	// Keep the RPC deadline short so the test exercises the fallback, while
+	// leaving enough headroom for the fallback process to be scheduled in a
+	// race-enabled full-suite run. The model assertion below proves that the
+	// table phase receives its own live context.
+	models, err := discoverPiModelsWithin(context.Background(), fakePath, 100*time.Millisecond, 5*time.Second)
 	elapsed := time.Since(started)
 	if err != nil {
 		t.Fatalf("discoverPiModels: %v", err)
@@ -1190,7 +1194,7 @@ printf '%s\n' 'fallback fallback-model 128K 8K yes no'
 	if len(models) != 1 || models[0].ID != "fallback/fallback-model" {
 		t.Fatalf("hung RPC must leave time for the table fallback, got %+v after %s", models, elapsed)
 	}
-	if elapsed >= 2*time.Second {
+	if elapsed >= 7*time.Second {
 		t.Fatalf("RPC phase consumed the table fallback budget: elapsed %s", elapsed)
 	}
 }

--- a/server/pkg/agent/omp_test.go
+++ b/server/pkg/agent/omp_test.go
@@ -190,7 +190,11 @@ func TestOmpExecuteCompletesFromEventStream(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: sessionPath,
+	})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -276,7 +276,11 @@ func TestPiExecuteRetainsOnlyLastTurnOutput(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: sessionPath,
+	})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}


### PR DESCRIPTION
## What changed

- give the hung Pi RPC fallback test enough scheduling headroom under race-enabled full-suite runs
- keep the short RPC deadline so the test still proves that a hung RPC cannot starve table discovery
- place Pi and OMP session files under each test's temporary directory instead of the user's `~/.multica/pi-sessions`

## Why

`TestDiscoverPiModelsHungRPCPreservesTableFallbackBudget` used a one-second deadline for launching and completing its fallback subprocess. On a loaded race-enabled run, that subprocess can miss the deadline even though the two discovery phases are correctly isolated, producing an empty model list and a flaky package failure.

Two other subprocess tests allowed the backend to create session files under the real user home. Besides leaving test artifacts behind, those tests fail in environments where the home directory is intentionally read-only. Passing a test-local session path makes them hermetic without changing runtime behavior.

## Impact

Test-only change. Production Pi/OMP discovery, execution, and timeout values are unchanged.

## Validation

- `go test -race ./pkg/agent -run '^(TestDiscoverPiModelsHungRPCPreservesTableFallbackBudget|TestPiExecuteRetainsOnlyLastTurnOutput|TestOmpExecuteCompletesFromEventStream)$' -count=1`
- full serialized race suite passed twice: 359.316s and 363.550s
