### PR TITLE
KAP-1605: isolate Figma MCP from scheduled Hermes tasks

### DIFF
--- a/docs/plans/2026-08-13-hermes-run-only-mcp-oauth.md
+++ b/docs/plans/2026-08-13-hermes-run-only-mcp-oauth.md
@@ -1,0 +1,81 @@
+# Hermes Scheduled Figma MCP Isolation Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Prevent scheduled run-only Hermes autopilots from initializing the host-configured Figma OAuth MCP while preserving Figma for issue, chat, manual, and webhook tasks.
+
+**Architecture:** Keep the host Hermes profile immutable. During task-local `HERMES_HOME` derivation, detect the exact scheduled run-only task kind (`AutopilotRunID != "" && AutopilotSource == "schedule"`) and set `enabled: false` only on the `mcp_servers.figma` entry. Every other task and MCP entry retains the source configuration unchanged.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3`, Go unit tests.
+
+---
+
+### Task 1: Pin the scheduled configuration contract
+
+**Objective:** Add a regression test proving only scheduled run-only tasks disable Figma.
+
+**Files:**
+- Modify: `server/internal/daemon/execenv/hermes_home_test.go`
+
+**Step 1: Write failing test**
+
+Create a source `config.yaml` with Figma plus an unrelated MCP. Prepare scheduled, manual run-only, and regular issue task environments. Assert only the scheduled derived config sets Figma `enabled: false`; assert every other MCP and task remains unchanged; assert source config stays byte-identical. Cover shared YAML anchors without mutating the unrelated alias target, malformed/non-mapping scheduled config fail-closed behavior, and scheduled↔manual reuse transitions.
+
+**Step 2: Run test to verify failure**
+
+Run: `cd server && go test ./internal/daemon/execenv -run TestPrepareHermesScheduledRunOnlyDisablesOnlyFigmaMCP -count=1 -v`
+
+Expected: FAIL because current derived config preserves enabled Figma for scheduled tasks.
+
+### Task 2: Implement scoped Figma isolation
+
+**Objective:** Make the smallest reversible production change matching the regression contract.
+
+**Files:**
+- Modify: `server/internal/daemon/execenv/hermes_home.go`
+- Modify: `server/internal/daemon/execenv/execenv.go`
+
+**Step 1: Add preparation option**
+
+Add an internal Hermes-home option for disabling Figma. Keep the existing helper as an explicitly documented no-policy compatibility wrapper for existing tests and callers.
+
+**Step 2: Derive option from exact task kind**
+
+Fresh and reused Hermes environments derive the option through one shared helper only when `TaskContextForEnv.AutopilotRunID` is non-empty and `AutopilotSource` equals `schedule`.
+
+**Step 3: Rewrite only Figma**
+
+In parsed derived YAML, find the case-insensitive `figma` entry under `mcp_servers` and set `enabled: false`. Materialize aliases before editing so a shared anchor used by another MCP remains unchanged. Preserve all other fields and entries. Fail closed for scheduled isolation when the config cannot be parsed or rewritten; retain legacy verbatim fallback for non-scheduled tasks. Do not read or log credential values.
+
+**Step 4: Run regression test to verify pass**
+
+Run: `cd server && go test ./internal/daemon/execenv -run TestPrepareHermesScheduledRunOnlyDisablesOnlyFigmaMCP -count=1 -v`
+
+Expected: PASS.
+
+### Task 3: Verify integration and review
+
+**Objective:** Prove existing Hermes overlay behavior still passes and deliver a reviewable PR.
+
+**Files:**
+- Review: `server/internal/daemon/execenv/hermes_home.go`
+- Review: `server/internal/daemon/execenv/execenv.go`
+- Review: `server/internal/daemon/execenv/hermes_home_test.go`
+
+**Step 1: Format and run scoped suite**
+
+Run: `gofmt -w server/internal/daemon/execenv/hermes_home.go server/internal/daemon/execenv/execenv.go server/internal/daemon/execenv/hermes_home_test.go`
+
+Run: `cd server && go test ./internal/daemon/execenv -count=1`
+
+Expected: PASS.
+
+**Step 2: Run broader daemon tests**
+
+Run: `cd server && go test ./internal/daemon/... -count=1`
+
+Expected: PASS.
+
+**Step 3: Review and commit**
+
+Inspect `git diff --check`, `git diff --stat`, and the full diff. Commit with `fix(daemon): isolate Figma MCP from scheduled Hermes tasks`, push the issue branch, and open a PR whose title contains `KAP-1605`.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -213,6 +213,12 @@ type TaskContextForEnv struct {
 	InitiatorEmail string
 }
 
+func hermesHomeOptionsForTask(task TaskContextForEnv) hermesHomeOptions {
+	return hermesHomeOptions{
+		disableFigmaMCP: task.AutopilotRunID != "" && task.AutopilotSource == "schedule",
+	}
+}
+
 // SkillContextForEnv represents a skill to be written into the execution environment.
 type SkillContextForEnv struct {
 	Name        string
@@ -490,7 +496,8 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// Emptying an agent's own skill list is NOT a way to opt out of the overlay.
 	if params.Provider == "hermes" && len(params.Task.AgentSkills) > 0 {
 		hermesHome := filepath.Join(envRoot, "hermes-home")
-		sessions, err := prepareHermesHome(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
+		opts := hermesHomeOptionsForTask(params.Task)
+		sessions, err := prepareHermesHomeWithOptions(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, opts, logger)
 		if err != nil {
 			return nil, fmt.Errorf("execenv: prepare hermes-home: %w", err)
 		}
@@ -769,7 +776,8 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if params.Provider == "hermes" && env.RootDir != "" {
 		hermesHome := filepath.Join(env.RootDir, "hermes-home")
 		if len(params.Task.AgentSkills) > 0 {
-			sessions, err := prepareHermesHome(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, logger)
+			opts := hermesHomeOptionsForTask(params.Task)
+			sessions, err := prepareHermesHomeWithOptions(hermesHome, params.HermesSourceHome, params.HermesSourceMustExist, params.Task.AgentSkills, params.HermesEnv, params.HermesMemoryStore, params.HermesSessionStore, opts, logger)
 			if err != nil {
 				// Fail closed: a half-built overlay must not run. Returning nil
 				// makes the daemon fall back to a fresh Prepare, whose error

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -714,11 +714,23 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 // server and every other field on the Figma entry remain unchanged.
 func disableHermesFigmaMCP(doc *yaml.Node) error {
 	top := yamlDocumentRoot(doc)
+	if top == nil {
+		return fmt.Errorf("scheduled Hermes config must be a mapping")
+	}
+	materializedTop, err := materializeHermesYAMLMapping(top)
+	if err != nil {
+		return fmt.Errorf("materialize scheduled Hermes config: %w", err)
+	}
+	if doc.Kind == yaml.DocumentNode {
+		doc.Content[0] = materializedTop
+	} else {
+		*doc = *materializedTop
+	}
+	top = materializedTop
 	servers := yamlMapValue(top, "mcp_servers")
 	if servers == nil {
 		return nil
 	}
-	var err error
 	servers, err = materializeHermesYAMLMapping(servers)
 	if err != nil {
 		return fmt.Errorf("materialize scheduled mcp_servers config: %w", err)

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -355,6 +355,10 @@ func hermesProfileDir(root, name string) (home string, mustExist bool, err error
 	return filepath.Join(root, "profiles", canon), true, nil
 }
 
+type hermesHomeOptions struct {
+	disableFigmaMCP bool
+}
+
 // prepareHermesHome builds the per-task HERMES_HOME compatibility overlay
 // described above. The daemon exports the given path as HERMES_HOME on the
 // hermes subprocess so the CLI discovers the bound skills natively.
@@ -379,7 +383,13 @@ func hermesProfileDir(root, name string) (home string, mustExist bool, err error
 // database task-local. The returned hermesSessionMount reports both what got
 // mounted and whether the store actually holds a transcript, so the caller never
 // tells a task it can resume history that is not there.
+// prepareHermesHome is the no-policy compatibility/test helper. Production
+// task paths use prepareHermesHomeWithOptions with policy derived from the task.
 func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, workspaceSkills []SkillContextForEnv, env map[string]string, memoryStore, sessionStore string, logger *slog.Logger) (sessions hermesSessionMount, err error) {
+	return prepareHermesHomeWithOptions(hermesHome, sourceHome, sourceMustExist, workspaceSkills, env, memoryStore, sessionStore, hermesHomeOptions{}, logger)
+}
+
+func prepareHermesHomeWithOptions(hermesHome, sourceHome string, sourceMustExist bool, workspaceSkills []SkillContextForEnv, env map[string]string, memoryStore, sessionStore string, opts hermesHomeOptions, logger *slog.Logger) (sessions hermesSessionMount, err error) {
 	sharedHome := strings.TrimSpace(sourceHome)
 	if sharedHome == "" {
 		sharedHome = platformDefaultHermesHome()
@@ -426,7 +436,7 @@ func prepareHermesHome(hermesHome, sourceHome string, sourceMustExist bool, work
 	if err := mirrorSharedHermesHome(sharedHome, hermesHome, logger); err != nil {
 		return hermesSessionMount{}, fmt.Errorf("mirror shared hermes home: %w", err)
 	}
-	if err := writeDerivedHermesConfig(sharedHome, hermesHome, env, logger); err != nil {
+	if err := writeDerivedHermesConfig(sharedHome, hermesHome, env, opts, logger); err != nil {
 		return hermesSessionMount{}, fmt.Errorf("derive hermes config: %w", err)
 	}
 	if err := writeDerivedHermesEnv(sharedHome, hermesHome); err != nil {
@@ -638,7 +648,7 @@ func linkSharedHermesEntry(src, dst string) error {
 // the point of the fix; only the user's global skills would be missing. The file
 // is written 0600 (it can hold inline api_key secrets) via atomic replace, so
 // reuse also repairs a prior file's permissions.
-func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]string, logger *slog.Logger) error {
+func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]string, opts hermesHomeOptions, logger *slog.Logger) error {
 	srcConfig := filepath.Join(sharedHome, "config.yaml")
 	dstConfig := filepath.Join(hermesHome, "config.yaml")
 
@@ -673,11 +683,17 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
+		if opts.disableFigmaMCP {
+			return fmt.Errorf("parse shared config for scheduled Figma isolation: %w", err)
+		}
 		logger.Warn("execenv: hermes-home config parse failed; copying verbatim", "error", err)
 		return writeFileAtomic(dstConfig, data, 0o600)
 	}
 	dirs := computeHermesExternalDirs(sharedHome, existingHermesExternalDirs(&doc), env)
 	if err := setHermesExternalDirs(&doc, dirs); err != nil {
+		if opts.disableFigmaMCP {
+			return fmt.Errorf("prepare shared config for scheduled Figma isolation: %w", err)
+		}
 		logger.Warn("execenv: hermes-home set external_dirs failed; copying verbatim", "error", err)
 		return writeFileAtomic(dstConfig, data, 0o600)
 	}
@@ -685,7 +701,172 @@ func writeDerivedHermesConfig(sharedHome, hermesHome string, env map[string]stri
 	// Supermemory/Hindsight/etc. bank isn't shared across managed tasks; the
 	// built-in per-task memories/ dir is already isolated above.
 	disableHermesMemoryProvider(&doc)
+	if opts.disableFigmaMCP {
+		if err := disableHermesFigmaMCP(&doc); err != nil {
+			return err
+		}
+	}
 	return marshalYAMLToFile(&doc, dstConfig)
+}
+
+// disableHermesFigmaMCP disables only a host-configured Figma MCP entry in the
+// task-local derived config. Server names are case-insensitive; every other
+// server and every other field on the Figma entry remain unchanged.
+func disableHermesFigmaMCP(doc *yaml.Node) error {
+	top := yamlDocumentRoot(doc)
+	servers := yamlMapValue(top, "mcp_servers")
+	if servers == nil {
+		return nil
+	}
+	var err error
+	servers, err = materializeHermesYAMLMapping(servers)
+	if err != nil {
+		return fmt.Errorf("materialize scheduled mcp_servers config: %w", err)
+	}
+	yamlSetMapValue(top, "mcp_servers", servers)
+	for i := 0; i+1 < len(servers.Content); i += 2 {
+		if !strings.EqualFold(servers.Content[i].Value, "figma") {
+			continue
+		}
+		server := servers.Content[i+1]
+		if server.Kind != yaml.MappingNode {
+			return fmt.Errorf("scheduled Figma MCP config must be a mapping")
+		}
+		yamlSetMapValue(server, "enabled", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "false"})
+	}
+	return nil
+}
+
+// materializeHermesYAMLMapping resolves every alias under node, validates that
+// the result is a mapping, and expands YAML merge keys into explicit pairs.
+func materializeHermesYAMLMapping(node *yaml.Node) (*yaml.Node, error) {
+	materialized, err := materializeHermesYAMLNode(node, make(map[*yaml.Node]bool))
+	if err != nil {
+		return nil, err
+	}
+	if materialized.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("expected mapping, got YAML kind %d", materialized.Kind)
+	}
+	return flattenHermesYAMLMerge(materialized)
+}
+
+// flattenHermesYAMLMerge applies YAML merge semantics to one already
+// alias-materialized mapping. Explicit keys override merged keys. For a merge
+// sequence, earlier mappings override later mappings, matching YAML's merge-key
+// precedence. The returned mapping contains no << key.
+func flattenHermesYAMLMerge(mapping *yaml.Node) (*yaml.Node, error) {
+	type yamlPair struct {
+		key *yaml.Node
+		val *yaml.Node
+	}
+	explicit := make([]yamlPair, 0, len(mapping.Content)/2)
+	merges := make([]*yaml.Node, 0, 1)
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key, val := mapping.Content[i], mapping.Content[i+1]
+		if key.Kind != yaml.ScalarNode {
+			return nil, fmt.Errorf("mapping key must be a scalar")
+		}
+		if key.Value == "<<" {
+			merges = append(merges, val)
+			continue
+		}
+		explicit = append(explicit, yamlPair{key: key, val: val})
+	}
+
+	out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Style: mapping.Style}
+	index := make(map[string]int, len(explicit))
+	addFirst := func(key, val *yaml.Node) error {
+		if key.Kind != yaml.ScalarNode {
+			return fmt.Errorf("merged mapping key must be a scalar")
+		}
+		if _, exists := index[key.Value]; exists {
+			return nil
+		}
+		index[key.Value] = len(out.Content)
+		out.Content = append(out.Content, key, val)
+		return nil
+	}
+	mergeMapping := func(source *yaml.Node) error {
+		if source.Kind != yaml.MappingNode {
+			return fmt.Errorf("merge source must be a mapping, got YAML kind %d", source.Kind)
+		}
+		flat, err := flattenHermesYAMLMerge(source)
+		if err != nil {
+			return err
+		}
+		for i := 0; i+1 < len(flat.Content); i += 2 {
+			if err := addFirst(flat.Content[i], flat.Content[i+1]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, merge := range merges {
+		switch merge.Kind {
+		case yaml.MappingNode:
+			if err := mergeMapping(merge); err != nil {
+				return nil, err
+			}
+		case yaml.SequenceNode:
+			for _, source := range merge.Content {
+				if err := mergeMapping(source); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			return nil, fmt.Errorf("merge value must be a mapping or sequence of mappings, got YAML kind %d", merge.Kind)
+		}
+	}
+	for _, pair := range explicit {
+		if pos, exists := index[pair.key.Value]; exists {
+			out.Content[pos], out.Content[pos+1] = pair.key, pair.val
+			continue
+		}
+		index[pair.key.Value] = len(out.Content)
+		out.Content = append(out.Content, pair.key, pair.val)
+	}
+	return out, nil
+}
+
+// materializeHermesYAMLNode deep-copies node while recursively replacing every
+// alias with an independent copy of its target. Anchors are stripped from the
+// result so changing the task-local Figma mapping cannot mutate or re-link any
+// unrelated source mapping. visiting tracks the current target path and turns a
+// cyclic alias into an actionable error instead of unbounded recursion.
+func materializeHermesYAMLNode(node *yaml.Node, visiting map[*yaml.Node]bool) (*yaml.Node, error) {
+	if node == nil {
+		return nil, fmt.Errorf("nil YAML node")
+	}
+	if node.Kind == yaml.AliasNode {
+		if node.Alias == nil {
+			return nil, fmt.Errorf("dangling YAML alias %q", node.Value)
+		}
+		if visiting[node.Alias] {
+			return nil, fmt.Errorf("cyclic YAML alias %q", node.Value)
+		}
+		return materializeHermesYAMLNode(node.Alias, visiting)
+	}
+	if visiting[node] {
+		return nil, fmt.Errorf("cyclic YAML node")
+	}
+	visiting[node] = true
+	defer delete(visiting, node)
+
+	clone := *node
+	clone.Anchor = ""
+	clone.Alias = nil
+	if len(node.Content) == 0 {
+		return &clone, nil
+	}
+	clone.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		materialized, err := materializeHermesYAMLNode(child, visiting)
+		if err != nil {
+			return nil, err
+		}
+		clone.Content[i] = materialized
+	}
+	return &clone, nil
 }
 
 // disableHermesMemoryProvider forces skills-adjacent `memory.provider` to empty

--- a/server/internal/daemon/execenv/hermes_home_test.go
+++ b/server/internal/daemon/execenv/hermes_home_test.go
@@ -382,6 +382,128 @@ mcp_servers:
 	}
 }
 
+func TestPrepareHermesScheduledRunOnlyMaterializesAliasesAcrossDocument(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `mcp_servers:
+  figma:
+    enabled: true
+    auth: &figmaauth oauth
+other:
+  copy: *figmaauth
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-cross-document-alias",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task: TaskContextForEnv{
+			AutopilotRunID:  "scheduled-run",
+			AutopilotSource: "schedule",
+			AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read derived config: %v", err)
+	}
+	var parsed struct {
+		MCPServers map[string]struct {
+			Enabled bool   `yaml:"enabled"`
+			Auth    string `yaml:"auth"`
+		} `yaml:"mcp_servers"`
+		Other struct {
+			Copy string `yaml:"copy"`
+		} `yaml:"other"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("derived config must remain valid YAML: %v\n%s", err, data)
+	}
+	if got := parsed.MCPServers["figma"]; got.Enabled || got.Auth != "oauth" {
+		t.Errorf("Figma = %+v, want enabled false with auth preserved", got)
+	}
+	if parsed.Other.Copy != "oauth" {
+		t.Errorf("other.copy = %q, want materialized alias value", parsed.Other.Copy)
+	}
+	if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(source) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyMaterializesTopLevelMerge(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `base: &base
+  mcp_servers:
+    figma:
+      enabled: true
+      marker: merged
+    unrelated:
+      enabled: true
+<<: *base
+model: hermes-4
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-top-level-merge",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task: TaskContextForEnv{
+			AutopilotRunID:  "scheduled-run",
+			AutopilotSource: "schedule",
+			AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read derived config: %v", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse derived config node: %v\n%s", err, data)
+	}
+	if yamlMapValue(yamlDocumentRoot(&doc), "<<") != nil {
+		t.Fatal("derived top-level config must be materialized without merge key")
+	}
+	var parsed struct {
+		Model      string `yaml:"model"`
+		MCPServers map[string]struct {
+			Enabled bool   `yaml:"enabled"`
+			Marker  string `yaml:"marker"`
+		} `yaml:"mcp_servers"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse derived config: %v", err)
+	}
+	if got := parsed.MCPServers["figma"]; got.Enabled || got.Marker != "merged" {
+		t.Errorf("Figma = %+v, want merged config with enabled false", got)
+	}
+	if !parsed.MCPServers["unrelated"].Enabled || parsed.Model != "hermes-4" {
+		t.Errorf("unrelated config changed: parsed=%+v", parsed)
+	}
+	if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(source) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
 func TestPrepareHermesScheduledRunOnlyFailsClosedOnNonMappingFigmaAlias(t *testing.T) {
 	t.Parallel()
 	sharedHome := t.TempDir()

--- a/server/internal/daemon/execenv/hermes_home_test.go
+++ b/server/internal/daemon/execenv/hermes_home_test.go
@@ -145,6 +145,789 @@ func TestHermesDisablesExternalMemoryProvider(t *testing.T) {
 	}
 }
 
+func TestPrepareHermesScheduledRunOnlyDisablesOnlyFigmaMCP(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `model: hermes-4
+mcp_servers:
+  FiGmA:
+    transport: http
+    url: https://mcp.figma.example
+    auth: oauth
+    enabled: true
+    custom_setting: keep-me
+  github:
+    command: github-mcp
+    args: ["serve"]
+    enabled: true
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+
+	type mcpServer struct {
+		Enabled       *bool    `yaml:"enabled"`
+		Transport     string   `yaml:"transport"`
+		URL           string   `yaml:"url"`
+		Auth          string   `yaml:"auth"`
+		CustomSetting string   `yaml:"custom_setting"`
+		Command       string   `yaml:"command"`
+		Args          []string `yaml:"args"`
+	}
+	readServers := func(configPath string) map[string]mcpServer {
+		t.Helper()
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read derived config: %v", err)
+		}
+		var parsed struct {
+			MCPServers map[string]mcpServer `yaml:"mcp_servers"`
+		}
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("parse derived config: %v", err)
+		}
+		return parsed.MCPServers
+	}
+
+	tests := []struct {
+		name             string
+		taskID           string
+		task             TaskContextForEnv
+		wantFigmaEnabled bool
+	}{
+		{
+			name:             "scheduled run-only",
+			taskID:           "aaaa1111-2222-3333-4444-555566667777",
+			task:             TaskContextForEnv{AutopilotRunID: "run-scheduled", AutopilotSource: "schedule"},
+			wantFigmaEnabled: false,
+		},
+		{
+			name:             "manual run-only",
+			taskID:           "bbbb1111-2222-3333-4444-555566667777",
+			task:             TaskContextForEnv{AutopilotRunID: "run-manual", AutopilotSource: "manual"},
+			wantFigmaEnabled: true,
+		},
+		{
+			name:             "webhook run-only",
+			taskID:           "cccc1111-2222-3333-4444-555566667777",
+			task:             TaskContextForEnv{AutopilotRunID: "run-webhook", AutopilotSource: "webhook"},
+			wantFigmaEnabled: true,
+		},
+		{
+			name:             "regular issue",
+			taskID:           "dddd1111-2222-3333-4444-555566667777",
+			task:             TaskContextForEnv{IssueID: "issue-1"},
+			wantFigmaEnabled: true,
+		},
+		{
+			name:             "regular chat",
+			taskID:           "eeee1111-2222-3333-4444-555566667777",
+			task:             TaskContextForEnv{ChatSessionID: "chat-1"},
+			wantFigmaEnabled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.task.AgentSkills = []SkillContextForEnv{{Name: "Review Helper", Content: "x"}}
+			env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-figma",
+				TaskID:           tt.taskID,
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             tt.task,
+			}, testLogger())
+			if err != nil {
+				t.Fatalf("Prepare failed: %v", err)
+			}
+			defer env.Cleanup(true)
+
+			servers := readServers(filepath.Join(env.HermesHome, "config.yaml"))
+			figma := servers["FiGmA"]
+			if figma.Enabled == nil || *figma.Enabled != tt.wantFigmaEnabled {
+				t.Errorf("Figma enabled = %v, want %t", figma.Enabled, tt.wantFigmaEnabled)
+			}
+			if figma.Transport != "http" || figma.URL != "https://mcp.figma.example" || figma.Auth != "oauth" || figma.CustomSetting != "keep-me" {
+				t.Errorf("Figma fields changed: %+v", figma)
+			}
+			github := servers["github"]
+			if github.Enabled == nil || !*github.Enabled || github.Command != "github-mcp" || strings.Join(github.Args, " ") != "serve" {
+				t.Errorf("unrelated MCP changed: %+v", github)
+			}
+		})
+	}
+
+	if data, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read host config after prepare: %v", err)
+	} else if string(data) != hostConfig {
+		t.Error("host config was modified")
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyFailsClosedOnInvalidConfig(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{name: "malformed YAML", config: "mcp_servers:\n  figma: [\n"},
+		{name: "non-mapping root", config: "- mcp_servers\n- figma\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sharedHome := t.TempDir()
+			mustWrite(t, filepath.Join(sharedHome, "config.yaml"), tt.config)
+			task := TaskContextForEnv{
+				AutopilotRunID:  "scheduled-run",
+				AutopilotSource: "schedule",
+				AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+			}
+			if env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-invalid",
+				TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             task,
+			}, testLogger()); err == nil {
+				env.Cleanup(true)
+				t.Fatal("scheduled task must fail closed when Figma isolation cannot be applied")
+			}
+
+			// Preserve the legacy non-scheduled fallback: malformed/non-mapping
+			// source config is copied verbatim rather than blocking the task.
+			task.AutopilotRunID = ""
+			task.AutopilotSource = ""
+			task.IssueID = "issue-1"
+			env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-invalid",
+				TaskID:           "bbbb1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             task,
+			}, testLogger())
+			if err != nil {
+				t.Fatalf("regular task should retain legacy verbatim fallback: %v", err)
+			}
+			defer env.Cleanup(true)
+			if data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml")); err != nil {
+				t.Fatalf("read regular derived config: %v", err)
+			} else if string(data) != tt.config {
+				t.Errorf("regular derived config = %q, want verbatim source %q", data, tt.config)
+			}
+			if data, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+				t.Fatalf("read source config: %v", err)
+			} else if string(data) != tt.config {
+				t.Error("source config was modified")
+			}
+		})
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyMaterializesFigmaAlias(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `shared_mcp: &shared_mcp
+  transport: http
+  auth: oauth
+  enabled: true
+  custom_setting: keep-me
+mcp_servers:
+  figma: *shared_mcp
+  unrelated: *shared_mcp
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	task := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-alias",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             task,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read derived config: %v", err)
+	}
+	var parsed struct {
+		MCPServers map[string]struct {
+			Enabled       bool   `yaml:"enabled"`
+			Transport     string `yaml:"transport"`
+			Auth          string `yaml:"auth"`
+			CustomSetting string `yaml:"custom_setting"`
+		} `yaml:"mcp_servers"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse derived config: %v", err)
+	}
+	if got := parsed.MCPServers["figma"]; got.Enabled || got.Transport != "http" || got.Auth != "oauth" || got.CustomSetting != "keep-me" {
+		t.Errorf("materialized Figma = %+v, want preserved fields with enabled false", got)
+	}
+	if got := parsed.MCPServers["unrelated"]; !got.Enabled || got.Transport != "http" || got.Auth != "oauth" || got.CustomSetting != "keep-me" {
+		t.Errorf("unrelated anchored MCP changed: %+v", got)
+	}
+	if data, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(data) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyFailsClosedOnNonMappingFigmaAlias(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `shared_command: &shared_command figma-mcp
+mcp_servers:
+  figma: *shared_command
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	task := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	if env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-invalid-alias",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             task,
+	}, testLogger()); err == nil {
+		env.Cleanup(true)
+		t.Fatal("scheduled task must fail closed on non-mapping Figma alias")
+	}
+	if data, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(data) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyHandlesMCPServersShape(t *testing.T) {
+	t.Parallel()
+	scheduledTask := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	prepare := func(t *testing.T, hostConfig string) (*Environment, string) {
+		t.Helper()
+		sharedHome := t.TempDir()
+		mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+		env, err := Prepare(PrepareParams{
+			WorkspacesRoot:   t.TempDir(),
+			WorkspaceID:      "ws-hermes-servers-shape",
+			TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+			Provider:         "hermes",
+			HermesSourceHome: sharedHome,
+			Task:             scheduledTask,
+		}, testLogger())
+		if err != nil {
+			t.Fatalf("Prepare failed: %v", err)
+		}
+		t.Cleanup(func() { env.Cleanup(true) })
+		return env, sharedHome
+	}
+
+	t.Run("mapping alias is materialized", func(t *testing.T) {
+		hostConfig := `shared_servers: &shared_servers
+  figma:
+    enabled: true
+    custom_setting: keep-me
+  unrelated:
+    enabled: true
+mcp_servers: *shared_servers
+`
+		env, sharedHome := prepare(t, hostConfig)
+		data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read derived config: %v", err)
+		}
+		var parsed struct {
+			SharedServers map[string]struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"shared_servers"`
+			MCPServers map[string]struct {
+				Enabled       bool   `yaml:"enabled"`
+				CustomSetting string `yaml:"custom_setting"`
+			} `yaml:"mcp_servers"`
+		}
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("parse derived config: %v", err)
+		}
+		if got := parsed.MCPServers["figma"]; got.Enabled || got.CustomSetting != "keep-me" {
+			t.Errorf("materialized Figma = %+v, want enabled false with fields preserved", got)
+		}
+		if !parsed.MCPServers["unrelated"].Enabled {
+			t.Error("unrelated MCP was disabled")
+		}
+		if !parsed.SharedServers["figma"].Enabled || !parsed.SharedServers["unrelated"].Enabled {
+			t.Error("shared anchor was mutated")
+		}
+		if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+			t.Fatalf("read source config: %v", err)
+		} else if string(source) != hostConfig {
+			t.Error("source config was modified")
+		}
+	})
+
+	for _, tt := range []struct {
+		name   string
+		config string
+	}{
+		{name: "scalar", config: "mcp_servers: disabled\n"},
+		{name: "sequence", config: "mcp_servers: [figma]\n"},
+		{name: "non-mapping alias", config: "shared: &shared disabled\nmcp_servers: *shared\n"},
+	} {
+		t.Run(tt.name+" fails closed", func(t *testing.T) {
+			sharedHome := t.TempDir()
+			mustWrite(t, filepath.Join(sharedHome, "config.yaml"), tt.config)
+			if env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-servers-shape-invalid",
+				TaskID:           "bbbb1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             scheduledTask,
+			}, testLogger()); err == nil {
+				env.Cleanup(true)
+				t.Fatal("scheduled task must fail closed on present non-mapping mcp_servers")
+			}
+			if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+				t.Fatalf("read source config: %v", err)
+			} else if string(source) != tt.config {
+				t.Error("source config was modified")
+			}
+		})
+	}
+
+	t.Run("missing key is safe no-op", func(t *testing.T) {
+		hostConfig := "model: hermes-4\n"
+		env, sharedHome := prepare(t, hostConfig)
+		if _, err := os.Stat(filepath.Join(env.HermesHome, "config.yaml")); err != nil {
+			t.Fatalf("derived config missing: %v", err)
+		}
+		if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+			t.Fatalf("read source config: %v", err)
+		} else if string(source) != hostConfig {
+			t.Error("source config was modified")
+		}
+	})
+}
+
+func TestPrepareHermesScheduledRunOnlyMaterializesNestedAliases(t *testing.T) {
+	t.Parallel()
+	scheduledTask := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	tests := []struct {
+		name       string
+		hostConfig string
+	}{
+		{
+			name: "servers alias contains Figma entry alias",
+			hostConfig: `shared_entry: &shared_entry
+  enabled: true
+  transport: http
+  custom_setting: keep-me
+shared_servers: &shared_servers
+  figma: *shared_entry
+  unrelated: *shared_entry
+mcp_servers: *shared_servers
+`,
+		},
+		{
+			name: "Figma entry alias contains nested headers alias",
+			hostConfig: `shared_headers: &shared_headers
+  Authorization: Bearer-placeholder
+  X-Custom: keep-me
+shared_entry: &shared_entry
+  enabled: true
+  transport: http
+  headers: *shared_headers
+mcp_servers:
+  figma: *shared_entry
+  unrelated:
+    enabled: true
+    headers: *shared_headers
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sharedHome := t.TempDir()
+			mustWrite(t, filepath.Join(sharedHome, "config.yaml"), tt.hostConfig)
+			env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-nested-alias",
+				TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             scheduledTask,
+			}, testLogger())
+			if err != nil {
+				t.Fatalf("Prepare failed: %v", err)
+			}
+			defer env.Cleanup(true)
+
+			data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+			if err != nil {
+				t.Fatalf("read derived config: %v", err)
+			}
+			var parsed struct {
+				SharedEntry struct {
+					Enabled bool `yaml:"enabled"`
+				} `yaml:"shared_entry"`
+				SharedHeaders map[string]string `yaml:"shared_headers"`
+				MCPServers    map[string]struct {
+					Enabled       bool              `yaml:"enabled"`
+					Transport     string            `yaml:"transport"`
+					CustomSetting string            `yaml:"custom_setting"`
+					Headers       map[string]string `yaml:"headers"`
+				} `yaml:"mcp_servers"`
+			}
+			if err := yaml.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("parse derived config: %v\n%s", err, data)
+			}
+			figma := parsed.MCPServers["figma"]
+			if figma.Enabled || figma.Transport != "http" {
+				t.Errorf("materialized Figma = %+v, want enabled false with fields preserved", figma)
+			}
+			if strings.Contains(tt.name, "servers alias") {
+				if figma.CustomSetting != "keep-me" || !parsed.MCPServers["unrelated"].Enabled || parsed.MCPServers["unrelated"].CustomSetting != "keep-me" {
+					t.Errorf("shared entry fields changed: figma=%+v unrelated=%+v", figma, parsed.MCPServers["unrelated"])
+				}
+			} else {
+				wantHeaders := map[string]string{"Authorization": "Bearer-placeholder", "X-Custom": "keep-me"}
+				if figma.Headers["Authorization"] != wantHeaders["Authorization"] || figma.Headers["X-Custom"] != wantHeaders["X-Custom"] {
+					t.Errorf("nested Figma headers = %v, want %v", figma.Headers, wantHeaders)
+				}
+				if unrelated := parsed.MCPServers["unrelated"]; !unrelated.Enabled || unrelated.Headers["X-Custom"] != "keep-me" {
+					t.Errorf("unrelated shared headers changed: %+v", unrelated)
+				}
+				if parsed.SharedHeaders["Authorization"] != "Bearer-placeholder" || parsed.SharedHeaders["X-Custom"] != "keep-me" {
+					t.Errorf("shared headers anchor changed: %v", parsed.SharedHeaders)
+				}
+			}
+			if !parsed.SharedEntry.Enabled {
+				t.Error("shared entry anchor was mutated")
+			}
+			if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+				t.Fatalf("read source config: %v", err)
+			} else if string(source) != tt.hostConfig {
+				t.Error("source config was modified")
+			}
+		})
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyFailsClosedOnCyclicAlias(t *testing.T) {
+	t.Parallel()
+	sharedHome := t.TempDir()
+	hostConfig := `mcp_servers: &servers
+  figma: *servers
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	task := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	if env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-cyclic-alias",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             task,
+	}, testLogger()); err == nil {
+		env.Cleanup(true)
+		t.Fatal("scheduled task must fail closed on cyclic alias")
+	}
+	if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(source) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyMaterializesMCPServerMerges(t *testing.T) {
+	t.Parallel()
+	scheduledTask := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	tests := []struct {
+		name       string
+		hostConfig string
+		wantMarker string
+		wantLocal  string
+	}{
+		{
+			name: "single mapping merge",
+			hostConfig: `shared_servers: &shared_servers
+  figma:
+    enabled: true
+    marker: shared
+  unrelated:
+    enabled: true
+    marker: shared-unrelated
+mcp_servers:
+  <<: *shared_servers
+  local:
+    enabled: true
+    marker: explicit-local
+`,
+			wantMarker: "shared",
+			wantLocal:  "explicit-local",
+		},
+		{
+			name: "merge sequence earlier wins and explicit overrides",
+			hostConfig: `earlier: &earlier
+  figma:
+    enabled: true
+    marker: earlier
+  unrelated:
+    enabled: true
+    marker: earlier-unrelated
+later: &later
+  figma:
+    enabled: true
+    marker: later
+  unrelated:
+    enabled: false
+    marker: later-unrelated
+  later_only:
+    enabled: true
+    marker: from-later
+mcp_servers:
+  <<: [*earlier, *later]
+  local:
+    enabled: true
+    marker: explicit-local
+  unrelated:
+    enabled: true
+    marker: explicit-unrelated
+`,
+			wantMarker: "earlier",
+			wantLocal:  "explicit-local",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sharedHome := t.TempDir()
+			mustWrite(t, filepath.Join(sharedHome, "config.yaml"), tt.hostConfig)
+			env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-merge",
+				TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             scheduledTask,
+			}, testLogger())
+			if err != nil {
+				t.Fatalf("Prepare failed: %v", err)
+			}
+			defer env.Cleanup(true)
+
+			data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+			if err != nil {
+				t.Fatalf("read derived config: %v", err)
+			}
+			var doc yaml.Node
+			if err := yaml.Unmarshal(data, &doc); err != nil {
+				t.Fatalf("parse derived config node: %v", err)
+			}
+			serversNode := yamlMapValue(yamlDocumentRoot(&doc), "mcp_servers")
+			if yamlMapValue(serversNode, "<<") != nil {
+				t.Fatal("derived mcp_servers must be materialized without merge key")
+			}
+			var parsed struct {
+				MCPServers map[string]struct {
+					Enabled bool   `yaml:"enabled"`
+					Marker  string `yaml:"marker"`
+				} `yaml:"mcp_servers"`
+			}
+			if err := yaml.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("parse derived config: %v", err)
+			}
+			if got := parsed.MCPServers["figma"]; got.Enabled || got.Marker != tt.wantMarker {
+				t.Errorf("Figma = %+v, want enabled false marker %q", got, tt.wantMarker)
+			}
+			if got := parsed.MCPServers["local"]; !got.Enabled || got.Marker != tt.wantLocal {
+				t.Errorf("explicit local MCP changed: %+v", got)
+			}
+			if tt.name == "single mapping merge" {
+				if got := parsed.MCPServers["unrelated"]; !got.Enabled || got.Marker != "shared-unrelated" {
+					t.Errorf("merged unrelated MCP changed: %+v", got)
+				}
+			} else {
+				if got := parsed.MCPServers["unrelated"]; !got.Enabled || got.Marker != "explicit-unrelated" {
+					t.Errorf("explicit key did not override merged value: %+v", got)
+				}
+				if got := parsed.MCPServers["later_only"]; !got.Enabled || got.Marker != "from-later" {
+					t.Errorf("later-only merged key missing: %+v", got)
+				}
+			}
+			if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+				t.Fatalf("read source config: %v", err)
+			} else if string(source) != tt.hostConfig {
+				t.Error("source config was modified")
+			}
+		})
+	}
+}
+
+func TestPrepareHermesScheduledRunOnlyFailsClosedOnInvalidMCPServerMerge(t *testing.T) {
+	t.Parallel()
+	scheduledTask := TaskContextForEnv{
+		AutopilotRunID:  "scheduled-run",
+		AutopilotSource: "schedule",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	tests := []struct {
+		name       string
+		hostConfig string
+	}{
+		{name: "scalar merge", hostConfig: "mcp_servers:\n  <<: invalid\n"},
+		{name: "wrong-kind alias merge", hostConfig: "shared: &shared invalid\nmcp_servers:\n  <<: *shared\n"},
+		{name: "wrong-kind merge sequence item", hostConfig: "valid: &valid {figma: {enabled: true}}\ninvalid: &invalid nope\nmcp_servers:\n  <<: [*valid, *invalid]\n"},
+		{name: "cyclic merge", hostConfig: "mcp_servers: &servers\n  <<: *servers\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sharedHome := t.TempDir()
+			mustWrite(t, filepath.Join(sharedHome, "config.yaml"), tt.hostConfig)
+			if env, err := Prepare(PrepareParams{
+				WorkspacesRoot:   t.TempDir(),
+				WorkspaceID:      "ws-hermes-invalid-merge",
+				TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+				Provider:         "hermes",
+				HermesSourceHome: sharedHome,
+				Task:             scheduledTask,
+			}, testLogger()); err == nil {
+				env.Cleanup(true)
+				t.Fatal("scheduled task must fail closed on invalid mcp_servers merge")
+			}
+			if source, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+				t.Fatalf("read source config: %v", err)
+			} else if string(source) != tt.hostConfig {
+				t.Error("source config was modified")
+			}
+		})
+	}
+}
+
+func TestHermesHomeOptionsForTaskAndReuseTransitions(t *testing.T) {
+	t.Parallel()
+	if opts := hermesHomeOptionsForTask(TaskContextForEnv{AutopilotRunID: "run-1", AutopilotSource: "schedule"}); !opts.disableFigmaMCP {
+		t.Fatal("scheduled run-only task should disable Figma")
+	}
+	for _, task := range []TaskContextForEnv{
+		{AutopilotSource: "schedule"},
+		{AutopilotRunID: "run-1", AutopilotSource: "manual"},
+		{AutopilotRunID: "run-1", AutopilotSource: "Schedule"},
+		{IssueID: "issue-1"},
+	} {
+		if opts := hermesHomeOptionsForTask(task); opts.disableFigmaMCP {
+			t.Errorf("task %+v should preserve Figma", task)
+		}
+	}
+
+	sharedHome := t.TempDir()
+	hostConfig := `mcp_servers:
+  figma:
+    enabled: true
+    custom_setting: keep-me
+  unrelated:
+    enabled: true
+`
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), hostConfig)
+	manualTask := TaskContextForEnv{
+		AutopilotRunID:  "manual-run",
+		AutopilotSource: "manual",
+		AgentSkills:     []SkillContextForEnv{{Name: "Review Helper", Content: "x"}},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:   t.TempDir(),
+		WorkspaceID:      "ws-hermes-reuse-policy",
+		TaskID:           "aaaa1111-2222-3333-4444-555566667777",
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             manualTask,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare manual task failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	assertEnabled := func(wantFigma bool) {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(env.HermesHome, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read derived config: %v", err)
+		}
+		var parsed struct {
+			MCPServers map[string]struct {
+				Enabled       bool   `yaml:"enabled"`
+				CustomSetting string `yaml:"custom_setting"`
+			} `yaml:"mcp_servers"`
+		}
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			t.Fatalf("parse derived config: %v", err)
+		}
+		if got := parsed.MCPServers["figma"]; got.Enabled != wantFigma || got.CustomSetting != "keep-me" {
+			t.Errorf("Figma after reuse enabled=%t setting=%q, want enabled=%t setting=keep-me", got.Enabled, got.CustomSetting, wantFigma)
+		}
+		if !parsed.MCPServers["unrelated"].Enabled {
+			t.Error("unrelated MCP disabled during reuse transition")
+		}
+	}
+	assertEnabled(true)
+
+	scheduledTask := manualTask
+	scheduledTask.AutopilotRunID = "scheduled-run"
+	scheduledTask.AutopilotSource = "schedule"
+	if reused := Reuse(ReuseParams{
+		WorkDir:          env.WorkDir,
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             scheduledTask,
+	}, testLogger()); reused == nil {
+		t.Fatal("Reuse manual to scheduled returned nil")
+	}
+	assertEnabled(false)
+
+	if reused := Reuse(ReuseParams{
+		WorkDir:          env.WorkDir,
+		Provider:         "hermes",
+		HermesSourceHome: sharedHome,
+		Task:             manualTask,
+	}, testLogger()); reused == nil {
+		t.Fatal("Reuse scheduled to manual returned nil")
+	}
+	assertEnabled(true)
+
+	if data, err := os.ReadFile(filepath.Join(sharedHome, "config.yaml")); err != nil {
+		t.Fatalf("read source config: %v", err)
+	} else if string(data) != hostConfig {
+		t.Error("source config was modified")
+	}
+}
+
 // TestHermesDerivedConfigRebasesRelativeExternalDirs is the regression for the
 // silent-repoint bug: relative external_dirs must be rewritten to absolute paths
 // anchored at the shared home, absolute entries left intact, and the real skills


### PR DESCRIPTION
## What does this PR do?

Prevents scheduled Hermes autopilot tasks from eagerly initializing the host-configured Figma MCP and failing on OAuth in a non-interactive environment. The host profile remains immutable: only the derived task-local `HERMES_HOME/config.yaml` gets `mcp_servers.figma.enabled: false`.

The guard is intentionally limited to `AutopilotRunID != "" && AutopilotSource == "schedule"`. Manual, webhook, issue, chat, and other interactive paths retain Figma.

## Related Issue

KAP-1605

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Derive one scheduled-only Hermes-home option for both fresh and reused task environments.
- Disable only the case-insensitive Figma entry in the task-local MCP map.
- Materialize YAML aliases and merge keys before mutation so shared anchors and unrelated MCP entries remain unchanged.
- Fail closed for unsafe scheduled rewrites while retaining the legacy fallback for non-scheduled tasks.
- Cover source immutability, source discrimination, reuse transitions, malformed YAML, aliases, cycles, merge precedence, and absent MCP config.
- Add the implementation/thinking plan at `docs/plans/2026-08-13-hermes-run-only-mcp-oauth.md`.

## How to Test

1. `cd server && env -u MULTICA_TASK_CONFIG_ROOT go test ./internal/daemon/execenv -run 'TestPrepareHermesScheduledRunOnly|TestHermesHomeOptionsForTaskAndReuseTransitions' -count=1 -v`
2. `cd server && env -u MULTICA_TASK_CONFIG_ROOT go test ./internal/daemon/execenv -count=1`
3. `cd server && env -u MULTICA_TASK_CONFIG_ROOT go test ./internal/daemon/... -count=1`

## Risk and rollback

A scheduled autopilot that genuinely requires native Figma MCP will not receive it through this path. Manual, webhook, issue, and chat tasks are unchanged. Rollback is one commit revert; no host Hermes profile or OAuth cache is mutated.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex / Multica Agent

**Prompt / approach:** Traced the scheduled-run execution path and Hermes task-local profile derivation, compared reversible isolation options, implemented the narrow scheduled-source predicate with test-first regression coverage, then ran focused and full daemon suites plus independent spec and quality reviews.

## Screenshots (optional)

Not applicable; daemon-only change.
