### PR TITLE
MUL-6156: fix(editor): add accessible names to bubble menu controls

### DIFF
--- a/packages/views/editor/bubble-menu.test.tsx
+++ b/packages/views/editor/bubble-menu.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Editor } from "@tiptap/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@floating-ui/dom", () => ({
+  autoUpdate: vi.fn(() => vi.fn()),
+  computePosition: vi.fn(() =>
+    Promise.resolve({
+      x: 0,
+      y: 0,
+      middlewareData: {},
+    }),
+  ),
+  flip: vi.fn(),
+  hide: vi.fn(),
+  offset: vi.fn(),
+  shift: vi.fn(),
+}));
+
+vi.mock("@tiptap/react", () => ({
+  useEditorState: () => ({
+    bold: false,
+    italic: false,
+    strike: false,
+    code: false,
+    highlight: false,
+    link: false,
+    blockquote: false,
+    bulletList: false,
+    orderedList: false,
+    taskList: false,
+    headingLevel: undefined,
+  }),
+}));
+
+vi.mock("@multica/core/issues/mutations", () => ({
+  useCreateIssue: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("../i18n", async () => {
+  const editor = (await import("../locales/en/editor.json")).default;
+  return {
+    useT: () => ({
+      t: (selector: (resources: typeof editor) => string) => selector(editor),
+    }),
+  };
+});
+
+import { EditorBubbleMenu } from "./bubble-menu";
+
+function createEditor(): Editor {
+  const chain = {
+    focus: vi.fn(),
+    toggleBold: vi.fn(),
+    toggleItalic: vi.fn(),
+    toggleStrike: vi.fn(),
+    toggleCode: vi.fn(),
+    toggleHighlight: vi.fn(),
+    extendMarkRange: vi.fn(),
+    unsetLink: vi.fn(),
+    setLink: vi.fn(),
+    toggleHeading: vi.fn(),
+    setParagraph: vi.fn(),
+    toggleBulletList: vi.fn(),
+    toggleOrderedList: vi.fn(),
+    toggleTaskList: vi.fn(),
+    toggleBlockquote: vi.fn(),
+    insertContentAt: vi.fn(),
+    run: vi.fn(),
+  };
+  for (const method of Object.keys(chain)) {
+    if (method !== "run") {
+      chain[method as keyof typeof chain] = vi.fn(() => chain) as never;
+    }
+  }
+
+  return {
+    isEditable: true,
+    isDestroyed: false,
+    isInitialized: false,
+    state: {
+      selection: { empty: false, from: 1, to: 2 },
+      doc: {
+        textBetween: () => "selected text",
+        resolve: () => ({ parent: { type: { name: "paragraph" } } }),
+      },
+    },
+    view: {
+      dom: document.createElement("div"),
+      hasFocus: () => false,
+    },
+    commands: {
+      focus: vi.fn(),
+    },
+    chain: () => chain,
+    getAttributes: () => ({ href: "https://example.com" }),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as Editor;
+}
+
+describe("EditorBubbleMenu accessibility", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("gives every icon-only formatting control an accessible name", () => {
+    render(
+      <EditorBubbleMenu editor={createEditor()} currentIssueId="issue-parent" />,
+    );
+
+    for (const name of [
+      "Bold",
+      "Italic",
+      "Strikethrough",
+      "Code",
+      "Highlight",
+      "Link",
+      "List",
+      "Task list",
+      "Quote",
+      "Create sub-issue from selection",
+    ]) {
+      expect(
+        screen.getByLabelText(name, { selector: "button" }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("gives every icon-only link editing control an accessible name", () => {
+    render(<EditorBubbleMenu editor={createEditor()} />);
+
+    fireEvent.click(screen.getByLabelText("Link", { selector: "button" }));
+
+    expect(
+      screen.getByLabelText("Apply link", { selector: "button" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Remove link", { selector: "button" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Close link editor", { selector: "button" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -126,6 +126,7 @@ function MarkButton({
         render={
           <Toggle
             size="sm"
+            aria-label={label}
             pressed={isActive}
             onPressedChange={() => toggleMarkActions[mark](editor)}
             onMouseDown={(e) => e.preventDefault()}
@@ -222,15 +223,33 @@ function LinkEditBar({
           if (e.key === "Escape") { e.preventDefault(); onClose(); editor.commands.focus(); }
         }}
       />
-      <Button size="icon-xs" variant="ghost" onClick={apply} onMouseDown={(e) => e.preventDefault()}>
+      <Button
+        size="icon-xs"
+        variant="ghost"
+        aria-label={t(($) => $.bubble_menu.link_edit.apply)}
+        onClick={apply}
+        onMouseDown={(e) => e.preventDefault()}
+      >
         <Check className="size-3.5" />
       </Button>
       {existingHref && (
-        <Button size="icon-xs" variant="ghost" onClick={remove} onMouseDown={(e) => e.preventDefault()}>
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          aria-label={t(($) => $.bubble_menu.link_edit.remove)}
+          onClick={remove}
+          onMouseDown={(e) => e.preventDefault()}
+        >
           <Unlink className="size-3.5" />
         </Button>
       )}
-      <Button size="icon-xs" variant="ghost" onClick={() => { onClose(); editor.commands.focus(); }} onMouseDown={(e) => e.preventDefault()}>
+      <Button
+        size="icon-xs"
+        variant="ghost"
+        aria-label={t(($) => $.bubble_menu.link_edit.close)}
+        onClick={() => { onClose(); editor.commands.focus(); }}
+        onMouseDown={(e) => e.preventDefault()}
+      >
         <X className="size-3.5" />
       </Button>
     </div>
@@ -312,7 +331,12 @@ function ListDropdown({ editor, onOpenChange, isBullet, isOrdered, isTask }: { e
     <Popover modal={false} open={open} onOpenChange={handleOpenChange}>
       <Tooltip>
         <TooltipTrigger render={
-          <PopoverTrigger className="inline-flex h-7 items-center gap-0.5 rounded-md px-1.5 text-caption font-medium hover:bg-muted aria-pressed:bg-muted" aria-pressed={isBullet || isOrdered || isTask} onMouseDown={(e) => e.preventDefault()} />
+          <PopoverTrigger
+            className="inline-flex h-7 items-center gap-0.5 rounded-md px-1.5 text-caption font-medium hover:bg-muted aria-pressed:bg-muted"
+            aria-label={t(($) => $.bubble_menu.list)}
+            aria-pressed={isBullet || isOrdered || isTask}
+            onMouseDown={(e) => e.preventDefault()}
+          />
         }>
           <List className="size-3.5" />
           <ChevronDown className="size-3" />
@@ -442,6 +466,7 @@ function CreateSubIssueButton({
         render={
           <Toggle
             size="sm"
+            aria-label={t(($) => $.bubble_menu.sub_issue.tooltip)}
             pressed={false}
             disabled={pending}
             onPressedChange={handleClick}
@@ -617,7 +642,13 @@ function EditorBubbleMenu({
             <Separator orientation="vertical" className="mx-0.5 h-5" />
             <Tooltip>
               <TooltipTrigger render={
-                <Toggle size="sm" pressed={fmt.link} onPressedChange={() => setMode("link-edit")} onMouseDown={(e) => e.preventDefault()} />
+                <Toggle
+                  size="sm"
+                  aria-label={t(($) => $.bubble_menu.link)}
+                  pressed={fmt.link}
+                  onPressedChange={() => setMode("link-edit")}
+                  onMouseDown={(e) => e.preventDefault()}
+                />
               }>
                 <Link2 className="size-3.5" />
               </TooltipTrigger>
@@ -633,7 +664,13 @@ function EditorBubbleMenu({
                 away instead of two. */}
             <Tooltip>
               <TooltipTrigger render={
-                <Toggle size="sm" pressed={fmt.taskList} onPressedChange={() => editor.chain().focus().toggleTaskList().run()} onMouseDown={(e) => e.preventDefault()} />
+                <Toggle
+                  size="sm"
+                  aria-label={t(($) => $.bubble_menu.task_list)}
+                  pressed={fmt.taskList}
+                  onPressedChange={() => editor.chain().focus().toggleTaskList().run()}
+                  onMouseDown={(e) => e.preventDefault()}
+                />
               }>
                 <ListTodo className="size-3.5" />
               </TooltipTrigger>
@@ -641,7 +678,13 @@ function EditorBubbleMenu({
             </Tooltip>
             <Tooltip>
               <TooltipTrigger render={
-                <Toggle size="sm" pressed={fmt.blockquote} onPressedChange={() => editor.chain().focus().toggleBlockquote().run()} onMouseDown={(e) => e.preventDefault()} />
+                <Toggle
+                  size="sm"
+                  aria-label={t(($) => $.bubble_menu.quote)}
+                  pressed={fmt.blockquote}
+                  onPressedChange={() => editor.chain().focus().toggleBlockquote().run()}
+                  onMouseDown={(e) => e.preventDefault()}
+                />
               }>
                 <Quote className="size-3.5" />
               </TooltipTrigger>

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -10,6 +10,11 @@
     "task_list": "Task list",
     "quote": "Quote",
     "url_aria_label": "URL",
+    "link_edit": {
+      "apply": "Apply link",
+      "remove": "Remove link",
+      "close": "Close link editor"
+    },
     "heading_dropdown": {
       "text": "Text",
       "normal_text": "Normal Text",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -10,6 +10,11 @@
     "task_list": "チェックリスト",
     "quote": "引用",
     "url_aria_label": "URL",
+    "link_edit": {
+      "apply": "リンクを適用",
+      "remove": "リンクを削除",
+      "close": "リンク編集を閉じる"
+    },
     "heading_dropdown": {
       "text": "テキスト",
       "normal_text": "標準テキスト",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -10,6 +10,11 @@
     "task_list": "체크리스트",
     "quote": "인용",
     "url_aria_label": "URL",
+    "link_edit": {
+      "apply": "링크 적용",
+      "remove": "링크 제거",
+      "close": "링크 편집기 닫기"
+    },
     "heading_dropdown": {
       "text": "텍스트",
       "normal_text": "일반 텍스트",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -10,6 +10,11 @@
     "task_list": "待办列表",
     "quote": "引用",
     "url_aria_label": "URL",
+    "link_edit": {
+      "apply": "应用链接",
+      "remove": "移除链接",
+      "close": "关闭链接编辑器"
+    },
     "heading_dropdown": {
       "text": "正文",
       "normal_text": "正文",


### PR DESCRIPTION
## What does this PR do?

Adds accessible names to the icon-only controls in the editor Bubble Menu.

Previously, these controls relied on visual icons and tooltips, which did not provide reliable accessible names for assistive technologies. This change adds localized `aria-label` attributes while reusing existing Bubble Menu copy where possible.

Link editing actions receive dedicated localized labels for applying, removing, and closing the link editor. Tests verify that every icon-only formatting and link-editing control is discoverable by its accessible label.

This approach does not change the visual UI or editor behavior.

### Thinking path

1. The Bubble Menu is shared by web and desktop through `packages/views`.
2. Icon-only controls require accessible names independent of their tooltips.
3. Existing translated tooltip text is reused where it accurately describes the action.
4. Dedicated translations are added only for link-editing actions that had no existing labels.
5. Component tests assert the accessible labels, while locale parity tests ensure all supported languages remain synchronized.

### Risks

Low risk. The change only adds accessibility attributes, translations, and tests. It does not alter formatting commands, editor state, or visual layout.

Full package type checking was attempted but is currently blocked by the unrelated missing module `remark-cjk-friendly/parseOnly` in `packages/views/rich-content/rich-content.tsx`.

## Related Issue

No tracking issue currently exists for this change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added localized accessible names to formatting controls in `packages/views/editor/bubble-menu.tsx`.
- Added accessible names to the link, list, task-list, quote, and create-sub-issue controls.
- Added accessible names to the apply, remove, and close actions in the link editor.
- Added link-editing translations to:
  - `packages/views/locales/en/editor.json`
  - `packages/views/locales/zh-Hans/editor.json`
  - `packages/views/locales/ja/editor.json`
  - `packages/views/locales/ko/editor.json`
- Added accessibility coverage in `packages/views/editor/bubble-menu.test.tsx`.

## How to Test

1. Use Node.js 22 and run:

   ```bash
   pnpm --filter @multica/views exec vitest run editor/bubble-menu.test.tsx locales/parity.test.ts
   ```

2. Verify that both test files pass, including all Bubble Menu accessible-name assertions and locale parity checks.

3. Run ESLint:

   ```bash
   pnpm --filter @multica/views exec eslint editor/bubble-menu.tsx editor/bubble-menu.test.tsx
   ```

4. Optionally inspect the Bubble Menu with browser accessibility tools and confirm that each icon-only button has a localized accessible name.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] UI screenshots are not applicable because this change has no visual effect
- [x] Documentation updates are not required for this accessibility-only change
- [x] Landing copy and product docs are not applicable because no runtime, coding tool, or UI tab was added
- [x] I checked the Chinese product copy against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented the risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

I asked Cursor to inspect the latest upstream `main`, identify a small accessibility contribution, create a dedicated branch, and add accessible names to the editor Bubble Menu controls.

The implementation reused existing accessibility and i18n patterns in `packages/views`, added dedicated four-language labels for link-editing actions, added focused component tests, and ran the relevant Vitest, locale parity, and ESLint checks.

## Screenshots (optional)

Not applicable. This change does not alter the visual UI.