### PR TITLE
fix(desktop): stop the tab flares biting into a neighbour's hover pill (MUL-6160)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.test.tsx
@@ -284,6 +284,32 @@ describe("TabBar merged-tab chrome", () => {
     }
   });
 
+  // A flare overhangs the neighbouring tab by 9px, so the backing above may only
+  // cover the arc and the canvas fill: left over the notch it prints a square of
+  // strip colour on top of whatever the neighbour draws there, which is how the
+  // hover pill lost its corner to a dark bite (MUL-6160). The notch is therefore
+  // masked out of the flare entirely, and the mask has to close before the arc's
+  // anti-aliasing starts (r - 1.2) or the arc loses the backing it needs.
+  it("punches the notch out rather than filling it with strip colour", () => {
+    const { getByLabelText } = render(<TabBar />);
+    const flares = getByLabelText("Issues")
+      .closest("[data-tab-frame]")
+      ?.querySelectorAll<HTMLElement>('[style*="radial-gradient"]');
+
+    expect(flares).toHaveLength(2);
+    for (const flare of flares ?? []) {
+      const corner = /circle at top (left|right), transparent 8\.8px/.exec(
+        flare.style.backgroundImage,
+      )?.[1];
+      const mask = flare.style.maskImage;
+
+      expect(corner).toBeDefined();
+      expect(mask).toContain(`radial-gradient(circle at top ${corner}, transparent 8.4px`);
+      expect(mask).toMatch(/ 8\.8px\)$/);
+      expect(flare.style.getPropertyValue("-webkit-mask-image")).toBe(mask);
+    }
+  });
+
   it("draws the merged cap only on the active tab", () => {
     const { getByLabelText } = render(<TabBar />);
     expect(

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -50,10 +50,10 @@ const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 // Chrome-style merged tab: the active tab shares the content surface's fill and
 // flares into it through concave bottom corners. Each flare is a small square
 // whose radial gradient carves a quarter-circle notch (transparent, so the
-// flare's own background-color shows through and the notch reads as the strip),
-// strokes a 1px arc that continues the tab's side border into the content card's
-// top ring, and fills the rest with the surface colour. The 0.4px spread on
-// either side of the --surface-border pair anti-aliases that arc.
+// strip behind the flare shows through), strokes a 1px arc that continues the
+// tab's side border into the content card's top ring, and fills the rest with
+// the surface colour. The 0.4px spread on either side of the --surface-border
+// pair anti-aliases that arc.
 //
 // That background-color is load-bearing, not decoration: the flare's bottom row
 // overlaps the content card's top ring, and in dark mode --surface-border is
@@ -63,10 +63,37 @@ const TAB_ENTRY_EASE = [0.22, 1, 0.36, 1] as const;
 // the curve. It therefore has to be the strip's real backdrop — the sidebar
 // wrapper's fill, which is conditional and not this file's to re-derive.
 // SIDEBAR_WRAPPER_FILL_CLASS reads it off the wrapper itself.
+//
+// The backing may only reach as far as it is needed, though. A flare hangs 9px
+// past the tab's edge, over the neighbouring tab, so an opaque square there
+// prints over whatever that neighbour draws: its hover pill lost the whole
+// corner it shares with the flare and read as a dark bite (MUL-6160). Masking
+// the notch away removes the backing exactly where the gradient is transparent
+// anyway, so the notch is a hole rather than a painted-on copy of the strip and
+// shows whatever is actually behind it — bare strip usually, the neighbour's
+// pill where it reaches in. The mask is opaque again by the radius where the
+// arc's anti-aliasing starts, so every pixel the arc and the canvas fill cover
+// keeps its backing.
 const TAB_FLARE_RADIUS = 10;
 const tabFlareGradient = (side: "left" | "right") => {
   const r = TAB_FLARE_RADIUS;
   return `radial-gradient(circle at top ${side}, transparent ${r - 1.2}px, var(--surface-border) ${r - 0.8}px, var(--surface-border) ${r - 0.2}px, var(--page-canvas) ${r + 0.2}px)`;
+};
+const tabFlareNotchMask = (side: "left" | "right") => {
+  const r = TAB_FLARE_RADIUS;
+  return `radial-gradient(circle at top ${side}, transparent ${r - 1.6}px, black ${r - 1.2}px)`;
+};
+// The flares are mirror images: the offset overlaps the tab edge by 1px so arc
+// and side border meet, and gradient and mask share the corner the offset picks.
+const tabFlareStyle = (side: "left" | "right"): React.CSSProperties => {
+  const overhang = -TAB_FLARE_RADIUS + 1;
+  const mask = tabFlareNotchMask(side);
+  return {
+    ...(side === "left" ? { left: overhang } : { right: overhang }),
+    backgroundImage: tabFlareGradient(side),
+    maskImage: mask,
+    WebkitMaskImage: mask,
+  };
 };
 
 type TabSnapshot = {
@@ -355,11 +382,11 @@ function SortableTabItem({
             <span className="absolute inset-x-0 bottom-0 h-2.5 bg-page-canvas" />
             <span
               className={cn("absolute bottom-0 size-2.5", SIDEBAR_WRAPPER_FILL_CLASS)}
-              style={{ left: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("left") }}
+              style={tabFlareStyle("left")}
             />
             <span
               className={cn("absolute bottom-0 size-2.5", SIDEBAR_WRAPPER_FILL_CLASS)}
-              style={{ right: -TAB_FLARE_RADIUS + 1, backgroundImage: tabFlareGradient("right") }}
+              style={tabFlareStyle("right")}
             />
           </span>
         ) : (


### PR DESCRIPTION
## What

Hovering either tab next to the active one printed a dark square notch into the hover pill's bottom corner — the corner nearest the active tab (MUL-6160).

Each flare hangs 9px past the active tab's edge, over the neighbouring tab, and carried an opaque backing across its whole 10×10 square. That backing is the strip's own fill, so it is invisible over bare strip — but not over anything the neighbour draws there. The pill's bottom corner sat under the square and came out squared off.

## Fix

The backing only has to reach the arc and the canvas fill, where the flare overlaps the content card's top ring and a translucent `--surface-border` would otherwise stack two keylines (#6918). The notch needs nothing: it is meant to read as the strip, which is exactly what shows through when it is empty.

So the notch is now masked out of the flare — a hole rather than a painted-on copy of the strip. It shows bare strip in the common case, and the neighbour's pill where the pill reaches in. The mask closes at `r - 1.2`, the radius where the arc's anti-aliasing starts, so every pixel the arc and the fill cover keeps the backing #6918 gave it.

## Verification

- `pnpm test` / `pnpm typecheck` / `pnpm lint` — all green.
- New unit test in `tab-bar.test.tsx` asserting the notch is masked out and that the mask closes before the arc's anti-aliasing; it fails without the change.
- Rendered the real strip markup against the repo's compiled Tailwind CSS at 2× with a real pointer hover, dark and light:
  - no tab hovered → the junction is unchanged to within 1/255, so the #6918 keyline fix stands;
  - neighbour hovered → the two renders differ only across the notch rows, where the pill's own rounded corner is restored.
