### PR TITLE
fix(views): left-align page titles pushed to the header centre

### DIFF
--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -93,6 +93,12 @@ describe("keyboard shortcut definitions", () => {
     expect(action.allowInEditable).toBe(true);
   });
 
+  it("keeps the inbox archive key out of editable controls", () => {
+    const action = SHORTCUT_ACTION_BY_ID.archiveInboxItem;
+    expect(action.defaultShortcut).toEqual(createShortcutChord("E"));
+    expect(action.allowInEditable).toBe(false);
+  });
+
   it("strictly distinguishes Command and Control on macOS", () => {
     const commandF = createShortcutChord("F", { primary: true });
     const controlF = createShortcutChord("F", { control: true });

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -12,6 +12,7 @@ export type ShortcutActionId =
   | "toggleChat"
   | "findInIssue"
   | "openThreadNav"
+  | "archiveInboxItem"
   | "send"
   | "goInbox"
   | "goChat"
@@ -99,6 +100,12 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
     category: "general",
     defaultShortcut: createShortcutChord("O", { primary: true, shift: true }),
     allowInEditable: true,
+  },
+  {
+    id: "archiveInboxItem",
+    category: "general",
+    defaultShortcut: createShortcutChord("E"),
+    allowInEditable: false,
   },
   { id: "send", category: "general", defaultShortcut: primary("Enter"), allowInEditable: true },
   { id: "goInbox", category: "navigation", defaultShortcut: null, allowInEditable: false },

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -569,8 +569,8 @@ function DetailHeader({
 
 function BackHeader({ paths, title }: { paths: string; title: string }) {
   return (
-    <PageHeader className="justify-between px-5">
-      <div className="flex items-center gap-2">
+    <PageHeader className="px-5">
+      <div className="flex flex-1 items-center gap-2">
         <AppLink
           href={paths}
           className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-caption text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -216,8 +216,8 @@ export function ChatPage() {
   );
 
   const listHeader = (
-    <PageHeader className="justify-between">
-      <div className="flex items-center gap-2">
+    <PageHeader>
+      <div className="flex flex-1 items-center gap-2">
         <h1 className="text-body font-semibold">{t(($) => $.page.title)}</h1>
       </div>
       {newChatButton}

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -460,8 +460,8 @@ export function DashboardPage() {
       onValueChange={handleTabChange}
       className="flex h-full min-h-0 flex-col gap-0"
     >
-      <PageHeader className="justify-between gap-2 px-5">
-        <div className="flex min-w-0 items-center gap-2">
+      <PageHeader className="gap-2 px-5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
           <h1 className="text-body font-medium">{t(($) => $.title)}</h1>
         </div>

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -34,8 +34,12 @@ vi.mock("@multica/core/paths", () => ({
   }),
 }));
 
+const modalState: { modal: string | null; open: ReturnType<typeof vi.fn> } = {
+  modal: null,
+  open: vi.fn(),
+};
 vi.mock("@multica/core/modals", () => ({
-  useModalStore: { getState: () => ({ open: vi.fn() }) },
+  useModalStore: { getState: () => modalState },
 }));
 
 vi.mock("@multica/core/issues/stores/draft-store", () => ({
@@ -54,14 +58,16 @@ vi.mock("@multica/core/inbox/queries", () => ({
 // fresh `vi.fn()` per render would make the effect's deps churn.
 const markReadMutate = vi.fn();
 const markUnreadMutate = vi.fn();
+const archiveMutate = vi.fn();
+const unarchiveMutate = vi.fn();
 
 vi.mock("@multica/core/inbox/mutations", () => {
   const mutation = () => ({ mutate: vi.fn() });
   return {
     useMarkInboxRead: () => ({ mutate: markReadMutate }),
     useMarkInboxUnread: () => ({ mutate: markUnreadMutate }),
-    useArchiveInbox: mutation,
-    useUnarchiveInbox: mutation,
+    useArchiveInbox: () => ({ mutate: archiveMutate }),
+    useUnarchiveInbox: () => ({ mutate: unarchiveMutate }),
     useMarkAllInboxRead: mutation,
     useArchiveAllInbox: mutation,
     useArchiveAllReadInbox: mutation,
@@ -186,6 +192,9 @@ function reset() {
   replace.mockClear();
   markReadMutate.mockClear();
   markUnreadMutate.mockClear();
+  archiveMutate.mockClear();
+  unarchiveMutate.mockClear();
+  modalState.modal = null;
   rowActions = null;
   issueDetailProps.length = 0;
   layout.width = PHONE;
@@ -405,6 +414,132 @@ describe("InboxPage", () => {
     fireEvent.click(screen.getByTestId("row"));
 
     expect(screen.queryByTestId("list")).not.toBeNull();
+  });
+
+  describe("archive shortcut", () => {
+    function pressArchiveKey(target: Element | Document = document) {
+      fireEvent.keyDown(target, { key: "e" });
+    }
+
+    function typeArchiveKeyInto(element: Element) {
+      document.body.appendChild(element);
+      pressArchiveKey(element);
+      element.remove();
+    }
+
+    it("archives the open notification", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      pressArchiveKey();
+
+      expect(archiveMutate).toHaveBeenCalledWith("inbox-a", expect.anything());
+    });
+
+    it("restores the open notification while reading the archive", () => {
+      reset();
+      layout.width = DESKTOP;
+      searchParams = new URLSearchParams("view=archived");
+      listData.archived = [
+        item({ id: "archived-1", issue_id: "issue-9", archived: true }),
+      ];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      pressArchiveKey();
+
+      expect(unarchiveMutate).toHaveBeenCalledWith("archived-1", expect.anything());
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("leaves the selection on the next notification", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [
+        item({ id: "inbox-a", issue_id: "issue-a" }),
+        item({ id: "inbox-b", issue_id: "issue-b" }),
+      ];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getAllByTestId("row")[0]!);
+      replace.mockClear();
+      pressArchiveKey();
+
+      expect(replace).toHaveBeenCalledWith("/acme/inbox?issue=issue-b");
+    });
+
+    it("does not fire while typing in an editable control", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+
+      typeArchiveKeyInto(document.createElement("input"));
+      typeArchiveKeyInto(document.createElement("textarea"));
+      const richText = document.createElement("div");
+      richText.setAttribute("contenteditable", "true");
+      typeArchiveKeyInto(richText);
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("stands down while a dialog is open", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      modalState.modal = "create-issue";
+      pressArchiveKey();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("ignores an auto-repeated key", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+      fireEvent.keyDown(document, { key: "e", repeat: true });
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("ignores a press a nearer handler already consumed", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      fireEvent.click(screen.getByTestId("row"));
+
+      const consumer = document.createElement("button");
+      consumer.addEventListener("keydown", (event) => event.preventDefault());
+      document.body.appendChild(consumer);
+      pressArchiveKey(consumer);
+      consumer.remove();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no notification is open", () => {
+      reset();
+      layout.width = DESKTOP;
+      listData.active = [item({ id: "inbox-a", issue_id: "issue-a" })];
+
+      render(<InboxPage />);
+      pressArchiveKey();
+
+      expect(archiveMutate).not.toHaveBeenCalled();
+    });
   });
 
   it("does not swallow a deep link to an issue that is not in the archive", () => {

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -423,8 +423,8 @@ export function InboxPage() {
   // -- Shared sub-components --------------------------------------------------
 
   const listHeader = (
-    <PageHeader className="justify-between">
-      <div className="flex items-center gap-2">
+    <PageHeader>
+      <div className="flex flex-1 items-center gap-2">
         <h1 className="text-body font-semibold">{t(($) => $.page.title)}</h1>
         {unreadCount > 0 && (
           <NumberFlow

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -6,6 +6,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
+import {
+  getShortcut,
+  isEditableShortcutTarget,
+  shortcutMatchesEvent,
+} from "@multica/core/shortcuts";
+import { isImeComposing } from "@multica/core/utils";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import {
   inboxListOptions,
@@ -343,6 +349,27 @@ export function InboxPage() {
         ),
     });
   };
+
+  // Keep the listener stable while using the latest selected-item action.
+  const actionOnSelectedRef = useRef<(() => void) | null>(null);
+  actionOnSelectedRef.current = selected
+    ? () => (isArchivedView ? handleUnarchive(selected.id) : handleArchive(selected.id))
+    : null;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
+      if (isEditableShortcutTarget(event.target)) return;
+      if (useModalStore.getState().modal) return;
+      if (!shortcutMatchesEvent(getShortcut("archiveInboxItem"), event)) return;
+      const run = actionOnSelectedRef.current;
+      if (!run) return;
+      event.preventDefault();
+      run();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   // Batch operations
   const handleMarkAllRead = () => {

--- a/packages/views/layout/collection-page.tsx
+++ b/packages/views/layout/collection-page.tsx
@@ -41,8 +41,8 @@ export function CollectionPageHeader({
   className,
 }: CollectionPageHeaderProps) {
   return (
-    <PageHeader className={cn("justify-between gap-3 px-5", className)}>
-      <div className="flex min-w-0 items-center gap-2">
+    <PageHeader className={cn("gap-3 px-5", className)}>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <Icon
           aria-hidden="true"
           className="size-4 shrink-0 text-muted-foreground"

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -1,0 +1,81 @@
+import { ListTodo, Plus, Zap } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { SidebarProvider } from "@multica/ui/components/ui/sidebar";
+import { renderWithI18n } from "../test/i18n";
+import {
+  CollectionPageHeader,
+  CollectionPageHeaderAction,
+} from "./collection-page";
+import { PageHeader } from "./page-header";
+
+/**
+ * Below `xl` the collapsed-nav trigger renders, so a header that reads as two
+ * zones in source ("title left, actions right") is really three flex items.
+ * `justify-between` then splits the free space on BOTH sides of the title and
+ * parks it mid-header instead of beside the trigger — the desktop window is
+ * narrower than `xl`, so that is where it shows up.
+ *
+ * The header stays left-aligned only while nothing distributes that space:
+ * the content group grows and absorbs all of it.
+ */
+function expectTitleLeftOfFreeSpace(header: HTMLElement) {
+  const trigger = header.querySelector("[data-slot='sidebar-trigger']");
+  const items = Array.from(header.children);
+
+  expect(trigger).not.toBeNull();
+  expect(items[0]).toBe(trigger);
+  expect(header).not.toHaveClass("justify-between");
+}
+
+describe("PageHeader title alignment", () => {
+  it("keeps a collection title beside the nav trigger instead of centering it", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <CollectionPageHeader
+          icon={Zap}
+          title="Autopilot"
+          count={2}
+          actions={
+            <CollectionPageHeaderAction icon={Plus} label="New autopilot" />
+          }
+        />
+      </SidebarProvider>,
+    );
+
+    const header = container.querySelector<HTMLElement>("header")!;
+    expectTitleLeftOfFreeSpace(header);
+
+    const heading = header.querySelector("h1")!;
+    expect(heading.textContent).toBe("Autopilot");
+    expect(heading.parentElement).toHaveClass("flex-1");
+  });
+
+  it("keeps the issues-style inline title packed against the nav trigger", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader className="gap-2">
+          <ListTodo className="h-4 w-4 text-muted-foreground" />
+          <h1 className="text-body font-medium">Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const header = container.querySelector<HTMLElement>("header")!;
+    expectTitleLeftOfFreeSpace(header);
+    expect(header.children).toHaveLength(3);
+  });
+
+  it("still reserves the leading slot for the nav trigger on compact widths", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader>
+          <h1>Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const trigger = container.querySelector("[data-slot='sidebar-trigger']")!;
+    expect(trigger).toHaveClass("xl:hidden");
+  });
+});

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -33,6 +33,15 @@ interface PageHeaderProps {
   className?: string;
 }
 
+/**
+ * Push actions right with `flex-1` on the content group, never with
+ * `justify-between` on the header.
+ *
+ * The leading slot below is a flex item too, so a header that reads as two
+ * zones in source is three at runtime, and `justify-between` splits the free
+ * space on BOTH sides of the title — parking it mid-header. Desktop windows
+ * sit below `xl`, where the trigger renders, so that is where it surfaces.
+ */
 export function PageHeader({ children, leading, className }: PageHeaderProps) {
   return (
     <header className={cn("flex h-12 shrink-0 items-center border-b px-4", className)}>

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "Toggle chat window", "description": "Open or close the floating chat window. Opening it focuses the message input." },
       "findInIssue": { "label": "Find in issue", "description": "Search within the open issue detail." },
       "openThreadNav": { "label": "Open thread navigator", "description": "List, search, and jump between the comment threads of the open issue." },
+      "archiveInboxItem": { "label": "Archive notification", "description": "Archive the open inbox notification, or restore it while reading the archive." },
       "send": { "label": "Send", "description": "Send chat messages, comments, replies, feedback, and prompts, and create issues in the create dialog." },
       "goInbox": { "label": "Go to Inbox", "description": "Open the workspace inbox." },
       "goChat": { "label": "Go to Chat", "description": "Open workspace chat." },

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "チャットウィンドウを切り替え", "description": "フローティングチャットを開閉します。開いたときは入力欄にフォーカスします。" },
       "findInIssue": { "label": "タスク内を検索", "description": "開いているタスクの詳細を検索します。" },
       "openThreadNav": { "label": "スレッドナビゲーターを開く", "description": "開いているタスクのコメントスレッドを一覧・検索して移動します。" },
+      "archiveInboxItem": { "label": "通知をアーカイブ", "description": "開いているインボックス通知をアーカイブします。アーカイブ表示中はアーカイブを解除します。" },
       "send": { "label": "送信", "description": "チャット、コメント、返信、フィードバック、プロンプトを送信し、作成ダイアログでタスクを作成します。" },
       "goInbox": { "label": "受信トレイへ移動", "description": "ワークスペースの受信トレイを開きます。" },
       "goChat": { "label": "チャットへ移動", "description": "ワークスペースのチャットを開きます。" },

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "채팅 창 전환", "description": "플로팅 채팅 창을 열거나 닫습니다. 열면 메시지 입력란에 포커스합니다." },
       "findInIssue": { "label": "태스크에서 찾기", "description": "열린 태스크 상세 내용에서 검색합니다." },
       "openThreadNav": { "label": "스레드 내비게이터 열기", "description": "열린 태스크의 댓글 스레드를 나열하고 검색해 이동합니다." },
+      "archiveInboxItem": { "label": "알림 보관", "description": "열린 인박스 알림을 보관합니다. 보관함을 보는 중에는 보관을 해제합니다." },
       "send": { "label": "보내기", "description": "채팅, 댓글, 답글, 피드백 및 프롬프트를 보내고, 생성 대화상자에서 태스크를 만듭니다." },
       "goInbox": { "label": "받은 편지함으로 이동", "description": "워크스페이스 받은 편지함을 엽니다." },
       "goChat": { "label": "채팅으로 이동", "description": "워크스페이스 채팅을 엽니다." },

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -115,6 +115,7 @@
       "toggleChat": { "label": "显示或隐藏聊天窗", "description": "打开或关闭悬浮聊天窗，打开时自动聚焦输入框。" },
       "findInIssue": { "label": "在任务中查找", "description": "搜索当前打开的任务详情。" },
       "openThreadNav": { "label": "打开讨论导航", "description": "列出、搜索并跳转当前任务的评论讨论。" },
+      "archiveInboxItem": { "label": "归档通知", "description": "归档当前打开的收件箱通知；在归档列表中则取消归档。" },
       "send": { "label": "发送", "description": "发送聊天消息、评论、回复、反馈和提示词，并在创建弹窗中创建任务。" },
       "goInbox": { "label": "前往收件箱", "description": "打开工作区收件箱。" },
       "goChat": { "label": "前往聊天", "description": "打开工作区聊天。" },

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -572,7 +572,7 @@ function EmptyState({ onConnectRemote }: { onConnectRemote: () => void }) {
 function RuntimesPageSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <PageHeader className="justify-between px-5">
+      <PageHeader className="px-5">
         <Skeleton className="h-4 w-24" />
       </PageHeader>
       <div className="mx-auto w-full max-w-[1440px] p-6">


### PR DESCRIPTION
## Problem

`PageHeader` renders the collapsed-nav trigger in its leading slot, and that trigger is a flex item like any other. So a header written as two zones — title left, actions right — is actually **three** flex items at runtime. `justify-between` then splits the free space on *both* sides of the title and parks it in the middle of the header.

The trigger is `xl:hidden`, and desktop windows sit below `xl`, which is why this only showed up on desktop. Measured on the Autopilot header at a 1000px viewport: the title started at x=425 against a header centre of x=500.

## Fix

Let the content group absorb the free space with `flex-1` instead of distributing it with `justify-between`. This is the pattern `breadcrumb-header.tsx` already used, which is why breadcrumbs were never affected.

Fixed headers:

- `CollectionPageHeader` — covers autopilots, projects, squads, skills, agents and runtimes
- dashboard, inbox, chat
- agent-detail back header, which had a single child and was pushed fully right
- the runtimes loading skeleton, same single-child case

The Issues and My Issues headers never used `justify-between`, so they were already correct and are unchanged.

The rule is now recorded on `PageHeader` itself so the next header does not repeat it.

## Verification

Rendered both attached header variants in a real browser at 390px, 1000px and 1440px:

| | before | after |
| --- | --- | --- |
| Autopilot title x | 425 (header centre 500) | 125 |
| Issues title x | 117 | 117 |

Narrow widths are unchanged: the title still truncates, the count stays pinned, and the action collapses to its icon-only form. Above `xl` the trigger is hidden and nothing moves.

New regression test at `packages/views/layout/page-header.test.tsx` covers both variants and fails against the previous markup.

`pnpm typecheck`, `pnpm lint` (0 errors) and `pnpm test` (3788 tests) all pass.
