### PR TITLE
MUL-6169 fix(views): left-align page titles and unify page gutters

### DIFF
--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -570,7 +570,7 @@ function DetailHeader({
 
 function BackHeader({ paths, title }: { paths: string; title: string }) {
   return (
-    <PageHeader className="px-5">
+    <PageHeader>
       <div className="flex flex-1 items-center gap-2">
         <AppLink
           href={paths}

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -570,8 +570,8 @@ function DetailHeader({
 
 function BackHeader({ paths, title }: { paths: string; title: string }) {
   return (
-    <PageHeader className="justify-between px-5">
-      <div className="flex items-center gap-2">
+    <PageHeader className="px-5">
+      <div className="flex flex-1 items-center gap-2">
         <AppLink
           href={paths}
           className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-caption text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -571,15 +571,13 @@ function DetailHeader({
 function BackHeader({ paths, title }: { paths: string; title: string }) {
   return (
     <PageHeader>
-      <div className="flex flex-1 items-center gap-2">
-        <AppLink
-          href={paths}
-          className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-caption text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          {title}
-        </AppLink>
-      </div>
+      <AppLink
+        href={paths}
+        className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-caption text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {title}
+      </AppLink>
     </PageHeader>
   );
 }

--- a/packages/views/agents/components/agent-list-toolbar.tsx
+++ b/packages/views/agents/components/agent-list-toolbar.tsx
@@ -53,6 +53,8 @@ import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { availabilityConfig } from "../presence";
 import { useT } from "../../i18n";
 import type { AgentListRow } from "./agents-page";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 
 const COLUMN_KEYS: AgentColumnKey[] = [
   "status",
@@ -202,7 +204,7 @@ export function AgentListToolbar({
   );
 
   return (
-    <div className="h-12 shrink-0 overflow-x-auto px-5 [-webkit-overflow-scrolling:touch]">
+    <div className={cn("h-12 shrink-0 overflow-x-auto [-webkit-overflow-scrolling:touch]", PAGE_GUTTER)}>
       <div className="flex h-full w-max min-w-full items-center justify-between gap-2">
         {/* Left: local search + scope buttons + result count. Scope mixes the
           ownership lens (mine/all) with the archived lifecycle stage. Button

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -69,7 +69,7 @@ import { WebhookPayloadPreview } from "./webhook-payload-preview";
 import { WebhookDeliveriesSection } from "./webhook-deliveries-section";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { useT } from "../../i18n";
-import { PAGE_GUTTER } from "../../layout/page-header";
+import { PageHeader } from "../../layout/page-header";
 
 // A run that already happened is an instant in the reader's day, so it reads in
 // the reader's zone (no timeZone passed). A run that is still to come belongs to
@@ -665,11 +665,11 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className={cn("flex h-12 shrink-0 items-center gap-2 border-b", PAGE_GUTTER)}>
+        <PageHeader>
           <Skeleton className="h-4 w-4" />
           <span className="text-muted-foreground">/</span>
           <Skeleton className="h-4 w-32" />
-        </div>
+        </PageHeader>
         <div className="flex-1 overflow-y-auto">
           <div className="max-w-4xl mx-auto p-6 space-y-8">
             <section className="space-y-4">

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -69,6 +69,7 @@ import { WebhookPayloadPreview } from "./webhook-payload-preview";
 import { WebhookDeliveriesSection } from "./webhook-deliveries-section";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { useT } from "../../i18n";
+import { PAGE_GUTTER } from "../../layout/page-header";
 
 // A run that already happened is an instant in the reader's day, so it reads in
 // the reader's zone (no timeZone passed). A run that is still to come belongs to
@@ -664,7 +665,7 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex h-12 shrink-0 items-center gap-2 border-b px-5">
+        <div className={cn("flex h-12 shrink-0 items-center gap-2 border-b", PAGE_GUTTER)}>
           <Skeleton className="h-4 w-4" />
           <span className="text-muted-foreground">/</span>
           <Skeleton className="h-4 w-32" />

--- a/packages/views/autopilots/components/autopilot-list-toolbar.tsx
+++ b/packages/views/autopilots/components/autopilot-list-toolbar.tsx
@@ -191,7 +191,7 @@ export function AutopilotListToolbar({
   );
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-5">
+    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
       {/* Left: scope buttons + result count. Scope is the promoted status
           dimension (it does NOT appear in the filter dropdown). No search
           box: scope buttons already partition the (small) set, so search

--- a/packages/views/autopilots/components/autopilot-list-toolbar.tsx
+++ b/packages/views/autopilots/components/autopilot-list-toolbar.tsx
@@ -43,6 +43,8 @@ import {
 import { ActorAvatar } from "../../common/actor-avatar";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { useT } from "../../i18n";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 
 // Composite "type:id" value for polymorphic actor filter dimensions, so the
 // string[] filter store can hold agent/squad/member references alike.
@@ -191,7 +193,7 @@ export function AutopilotListToolbar({
   );
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
+    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
       {/* Left: scope buttons + result count. Scope is the promoted status
           dimension (it does NOT appear in the filter dropdown). No search
           box: scope buttons already partition the (small) set, so search

--- a/packages/views/autopilots/components/autopilot-list-toolbar.tsx
+++ b/packages/views/autopilots/components/autopilot-list-toolbar.tsx
@@ -43,8 +43,7 @@ import {
 import { ActorAvatar } from "../../common/actor-avatar";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { useT } from "../../i18n";
-import { PAGE_GUTTER } from "../../layout/page-header";
-import { cn } from "@multica/ui/lib/utils";
+import { PAGE_TOOLBAR } from "../../layout/page-header";
 
 // Composite "type:id" value for polymorphic actor filter dimensions, so the
 // string[] filter store can hold agent/squad/member references alike.
@@ -193,7 +192,7 @@ export function AutopilotListToolbar({
   );
 
   return (
-    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
+    <div className={PAGE_TOOLBAR}>
       {/* Left: scope buttons + result count. Scope is the promoted status
           dimension (it does NOT appear in the filter dropdown). No search
           box: scope buttons already partition the (small) set, so search

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -217,9 +217,7 @@ export function ChatPage() {
 
   const listHeader = (
     <PageHeader>
-      <div className="flex flex-1 items-center gap-2">
-        <h1 className="text-body font-semibold">{t(($) => $.page.title)}</h1>
-      </div>
+      <h1 className="flex-1 text-body font-semibold">{t(($) => $.page.title)}</h1>
       {newChatButton}
     </PageHeader>
   );

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -216,8 +216,8 @@ export function ChatPage() {
   );
 
   const listHeader = (
-    <PageHeader className="justify-between">
-      <div className="flex items-center gap-2">
+    <PageHeader>
+      <div className="flex flex-1 items-center gap-2">
         <h1 className="text-body font-semibold">{t(($) => $.page.title)}</h1>
       </div>
       {newChatButton}

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -460,7 +460,7 @@ export function DashboardPage() {
       onValueChange={handleTabChange}
       className="flex h-full min-h-0 flex-col gap-0"
     >
-      <PageHeader className="gap-2 px-5">
+      <PageHeader className="gap-2">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
           <h1 className="text-body font-medium">{t(($) => $.title)}</h1>
@@ -495,7 +495,7 @@ export function DashboardPage() {
           switching on the left, page-scoped filters on the right. Both tabs
           share the range and project filter, which is why the filters live
           here and not inside a tab. */}
-      <div className="h-12 shrink-0 overflow-x-auto border-b px-5 [-webkit-overflow-scrolling:touch]">
+      <div className="h-12 shrink-0 overflow-x-auto border-b px-4 [-webkit-overflow-scrolling:touch]">
         <div className="flex h-full w-max min-w-full items-center justify-between gap-2">
           <TabsList variant="line" className="gap-0 p-0 group-data-horizontal/tabs:h-full">
             <TabsTrigger

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -26,7 +26,7 @@ import {
 } from "@multica/core/dashboard";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 import { useViewingTimezone } from "../../common/use-viewing-timezone";
-import { PageHeader } from "../../layout/page-header";
+import { PageHeader, PAGE_GUTTER } from "../../layout/page-header";
 import { KpiCard } from "../../runtimes/components/shared";
 import { useNavigation } from "../../navigation";
 import {
@@ -66,6 +66,7 @@ import { ProjectFilter, TimeRangeFilter } from "./dashboard-filters";
 import { UsageTrendCard } from "./usage-trend-card";
 import { Leaderboard } from "./leaderboard";
 import { ErrorsTab } from "./errors-tab";
+import { cn } from "@multica/ui/lib/utils";
 
 // Stable references — `data ?? []` would create a new empty array on
 // every render while the query is loading, which breaks useMemo's
@@ -495,7 +496,7 @@ export function DashboardPage() {
           switching on the left, page-scoped filters on the right. Both tabs
           share the range and project filter, which is why the filters live
           here and not inside a tab. */}
-      <div className="h-12 shrink-0 overflow-x-auto border-b px-4 [-webkit-overflow-scrolling:touch]">
+      <div className={cn("h-12 shrink-0 overflow-x-auto border-b [-webkit-overflow-scrolling:touch]", PAGE_GUTTER)}>
         <div className="flex h-full w-max min-w-full items-center justify-between gap-2">
           <TabsList variant="line" className="gap-0 p-0 group-data-horizontal/tabs:h-full">
             <TabsTrigger

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -26,7 +26,8 @@ import {
 } from "@multica/core/dashboard";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 import { useViewingTimezone } from "../../common/use-viewing-timezone";
-import { PageHeader, PAGE_GUTTER } from "../../layout/page-header";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { CollectionPageHeader } from "../../layout/collection-page";
 import { KpiCard } from "../../runtimes/components/shared";
 import { useNavigation } from "../../navigation";
 import {
@@ -461,36 +462,36 @@ export function DashboardPage() {
       onValueChange={handleTabChange}
       className="flex h-full min-h-0 flex-col gap-0"
     >
-      <PageHeader className="gap-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <h1 className="text-body font-medium">{t(($) => $.title)}</h1>
-        </div>
-        {/* Data freshness cluster: the timestamp and the action that advances
-            it stay together. Refresh re-pulls the same scope, so it lives here
-            with the page metadata rather than among the scope controls. */}
-        <div className="flex shrink-0 items-center gap-1">
-          {tzLabel ? (
-            <span className="hidden text-caption text-muted-foreground lg:inline">
-              {updatedLabel
-                ? t(($) => $.header.timezone_and_updated, {
-                    tz: tzLabel,
-                    time: updatedLabel,
-                  })
-                : tzLabel}
-            </span>
-          ) : null}
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label={t(($) => $.header.refresh)}
-            onClick={handleRefresh}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
-          </Button>
-        </div>
-      </PageHeader>
+      <CollectionPageHeader
+        icon={BarChart3}
+        title={t(($) => $.title)}
+        actions={
+          /* Data freshness cluster: the timestamp and the action that advances
+             it stay together. Refresh re-pulls the same scope, so it lives here
+             with the page metadata rather than among the scope controls. */
+          <div className="flex items-center gap-1">
+            {tzLabel ? (
+              <span className="hidden text-caption text-muted-foreground lg:inline">
+                {updatedLabel
+                  ? t(($) => $.header.timezone_and_updated, {
+                      tz: tzLabel,
+                      time: updatedLabel,
+                    })
+                  : tzLabel}
+              </span>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t(($) => $.header.refresh)}
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
+            </Button>
+          </div>
+        }
+      />
 
       {/* View toolbar, same grammar as the issues surface header: view
           switching on the left, page-scoped filters on the right. Both tabs

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -460,8 +460,8 @@ export function DashboardPage() {
       onValueChange={handleTabChange}
       className="flex h-full min-h-0 flex-col gap-0"
     >
-      <PageHeader className="justify-between gap-2 px-5">
-        <div className="flex min-w-0 items-center gap-2">
+      <PageHeader className="gap-2 px-5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
           <h1 className="text-body font-medium">{t(($) => $.title)}</h1>
         </div>

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -430,8 +430,8 @@ export function InboxPage() {
   // -- Shared sub-components --------------------------------------------------
 
   const listHeader = (
-    <PageHeader className="justify-between">
-      <div className="flex items-center gap-2">
+    <PageHeader>
+      <div className="flex flex-1 items-center gap-2">
         <h1 className="text-body font-semibold">{t(($) => $.page.title)}</h1>
         {unreadCount > 0 && (
           <NumberFlow

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -65,7 +65,8 @@ import {
   DropdownMenuSeparator,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useIsCompact } from "@multica/ui/hooks/use-mobile";
-import { PageHeader } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
+import { PAGE_GUTTER, PageHeader } from "../../layout/page-header";
 import { useTimeAgo } from "./inbox-list-item";
 import { InboxList } from "./inbox-list";
 import { InboxContextMenuProvider } from "./inbox-context-menu";
@@ -558,7 +559,9 @@ export function InboxPage() {
   ) : undefined;
 
   const compactBackBar = compactBackAction ? (
-    <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">{compactBackAction}</div>
+    <div className={cn("flex h-12 shrink-0 items-center gap-2 border-b", PAGE_GUTTER)}>
+      {compactBackAction}
+    </div>
   ) : null;
 
   const detailContent = selected?.issue_id ? (
@@ -673,7 +676,7 @@ export function InboxPage() {
     if (viewLoading) {
       return (
         <div className="flex flex-1 flex-col min-h-0">
-          <div className="flex h-12 shrink-0 items-center border-b px-4">
+          <div className={cn("flex h-12 shrink-0 items-center border-b", PAGE_GUTTER)}>
             <Skeleton className="h-5 w-16" />
           </div>
           <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">
@@ -729,7 +732,7 @@ export function InboxPage() {
       <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
         <ResizablePanel id="list" defaultSize={320} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
           <div className="flex flex-col border-r h-full">
-            <div className="flex h-12 shrink-0 items-center border-b px-4">
+            <div className={cn("flex h-12 shrink-0 items-center border-b", PAGE_GUTTER)}>
               <Skeleton className="h-5 w-16" />
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -117,6 +117,7 @@ import {
   useViewStateWriter,
 } from "../../platform";
 import { cn } from "@multica/ui/lib/utils";
+import { PAGE_GUTTER } from "../../layout/page-header";
 
 import { ProgressRing } from "./progress-ring";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
@@ -984,7 +985,7 @@ export function IssueNotFound({
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       {leading && (
-        <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">{leading}</div>
+        <div className={cn("flex h-12 shrink-0 items-center gap-2 border-b", PAGE_GUTTER)}>{leading}</div>
       )}
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-body text-muted-foreground">
         <p>{t(($) => $.detail.not_found)}</p>
@@ -1014,7 +1015,7 @@ export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
       {/* The way back is real from the first frame, not once the issue lands:
           a host that gave up its own bar for `leadingAction` has nothing else
           to offer while this skeleton owns the screen. */}
-      <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+      <div className={cn("flex h-12 shrink-0 items-center gap-2 border-b", PAGE_GUTTER)}>
         {leading ?? (
           <>
             <Skeleton className="h-4 w-16" />

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -112,6 +112,8 @@ import {
 } from "@multica/core/issues/stores/issues-scope-store";
 import { actorKindForViewVariant } from "@multica/core/issues/surface/scope";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import { cn } from "@multica/ui/lib/utils";
+import { PAGE_GUTTER } from "../../layout/page-header";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
@@ -994,7 +996,7 @@ export function IssuesHeader({
 
   return (
     <>
-    <div className="min-h-12 shrink-0 px-4 py-2 [-webkit-overflow-scrolling:touch]">
+    <div className={cn("min-h-12 shrink-0 py-2 [-webkit-overflow-scrolling:touch]", PAGE_GUTTER)}>
       <div className="flex w-full min-w-0 items-start justify-between gap-2">
         {/* Left: the view bar — built-in tabs and saved views as one flat,
             per-user ordered row; wraps instead of overflowing. */}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -52,7 +52,7 @@ export function IssuesPage() {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <PageHeader className="gap-2">
+      <PageHeader>
         <ListTodo className="h-4 w-4 text-muted-foreground" />
         <h1 className="text-body font-medium">{t(($) => $.page.breadcrumb_title)}</h1>
       </PageHeader>

--- a/packages/views/layout/breadcrumb-header.tsx
+++ b/packages/views/layout/breadcrumb-header.tsx
@@ -45,7 +45,7 @@ interface BreadcrumbHeaderProps {
  */
 export function BreadcrumbHeader({ segments, leaf, actions, leading, className }: BreadcrumbHeaderProps) {
   return (
-    <PageHeader leading={leading} className={cn("gap-2 bg-background text-body", className)}>
+    <PageHeader leading={leading} className={cn("bg-background text-body", className)}>
       <div className="flex flex-1 items-center gap-1.5 min-w-0">
         {segments.map((segment) => (
           <Fragment key={segment.href}>

--- a/packages/views/layout/collection-page.tsx
+++ b/packages/views/layout/collection-page.tsx
@@ -41,7 +41,7 @@ export function CollectionPageHeader({
   className,
 }: CollectionPageHeaderProps) {
   return (
-    <PageHeader className={cn("px-5", className)}>
+    <PageHeader className={className}>
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <Icon
           aria-hidden="true"

--- a/packages/views/layout/collection-page.tsx
+++ b/packages/views/layout/collection-page.tsx
@@ -41,7 +41,7 @@ export function CollectionPageHeader({
   className,
 }: CollectionPageHeaderProps) {
   return (
-    <PageHeader className={cn("gap-3 px-5", className)}>
+    <PageHeader className={cn("px-5", className)}>
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <Icon
           aria-hidden="true"

--- a/packages/views/layout/collection-page.tsx
+++ b/packages/views/layout/collection-page.tsx
@@ -41,8 +41,8 @@ export function CollectionPageHeader({
   className,
 }: CollectionPageHeaderProps) {
   return (
-    <PageHeader className={cn("justify-between gap-3 px-5", className)}>
-      <div className="flex min-w-0 items-center gap-2">
+    <PageHeader className={cn("gap-3 px-5", className)}>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <Icon
           aria-hidden="true"
           className="size-4 shrink-0 text-muted-foreground"

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -7,7 +7,7 @@ import {
   CollectionPageHeader,
   CollectionPageHeaderAction,
 } from "./collection-page";
-import { PageHeader } from "./page-header";
+import { PAGE_GUTTER, PageHeader } from "./page-header";
 
 /**
  * Below `xl` the collapsed-nav trigger renders, so a header that reads as two
@@ -113,54 +113,53 @@ describe("PageHeader leading spacing", () => {
     expect(container.querySelector("header")).toHaveClass("gap-2");
   });
 
-  it("leads the collection header on the same gutter as the issues header", () => {
-    const collection = renderWithI18n(
-      <SidebarProvider>
-        <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />
-      </SidebarProvider>,
+  // The collection header and the issues header have to resolve to the same
+  // leading edge and the same gap. Each `it` below is one axis of that, read
+  // off both renders at once rather than asserted per page — a per-page
+  // assertion is what let the Agents toolbar drift while its header moved.
+  it.each([
+    ["gutter", /^px-/, PAGE_GUTTER],
+    ["gap", /^gap-/, "gap-2"],
+  ])("resolves the same %s for collection and issues headers", (_axis, pattern, expected) => {
+    const headerClass = (ui: React.ReactElement) =>
+      Array.from(
+        renderWithI18n(<SidebarProvider>{ui}</SidebarProvider>)
+          .container.querySelector("header")!
+          .classList,
+      ).find((c) => pattern.test(c));
+
+    const collection = headerClass(
+      <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />,
     );
-    const issues = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader className="gap-2">
-          <ListTodo className="h-4 w-4" />
-          <h1>Issues</h1>
-        </PageHeader>
-      </SidebarProvider>,
+    const issues = headerClass(
+      <PageHeader className="gap-2">
+        <ListTodo className="h-4 w-4" />
+        <h1>Issues</h1>
+      </PageHeader>,
     );
 
-    // Whatever the base gutter is, a collection page must not override it —
-    // that 4px is what made the Autopilot title sit right of Issues at every
-    // width, including >= xl where the nav trigger is not even rendered.
-    const gutterOf = (r: { container: HTMLElement }) =>
-      Array.from(r.container.querySelector("header")!.classList).find((c) =>
-        /^px-/.test(c),
-      );
-
-    expect(gutterOf(collection)).toBe("px-4");
-    expect(gutterOf(collection)).toBe(gutterOf(issues));
+    expect(collection).toBe(expected);
+    expect(collection).toBe(issues);
   });
+});
 
-  it("leads the collection header on the same gap as the issues header", () => {
-    const collection = renderWithI18n(
+/**
+ * The gutter is a constant so a page cannot spell its own and drift; the
+ * toolbar under a header reads the same one. Asserting the header renders the
+ * constant is what makes importing it elsewhere meaningful — the earlier
+ * version of this test hardcoded `px-4` in both the component and the
+ * expectation, so it could only ever agree with itself.
+ */
+describe("PAGE_GUTTER", () => {
+  it("is what PageHeader renders", () => {
+    const { container } = renderWithI18n(
       <SidebarProvider>
-        <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />
-      </SidebarProvider>,
-    );
-    const issues = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader className="gap-2">
-          <ListTodo className="h-4 w-4" />
-          <h1>Issues</h1>
+        <PageHeader>
+          <h1>Inbox</h1>
         </PageHeader>
       </SidebarProvider>,
     );
 
-    const gapOf = (r: { container: HTMLElement }) =>
-      Array.from(r.container.querySelector("header")!.classList).find((c) =>
-        c.startsWith("gap-"),
-      );
-
-    expect(gapOf(collection)).toBe("gap-2");
-    expect(gapOf(collection)).toBe(gapOf(issues));
+    expect(container.querySelector("header")).toHaveClass(PAGE_GUTTER);
   });
 });

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -79,3 +79,61 @@ describe("PageHeader title alignment", () => {
     expect(trigger).toHaveClass("xl:hidden");
   });
 });
+
+/**
+ * The trigger is a flex item, so the header's own `gap` already separates it
+ * from the title. When the trigger carried a margin as well, every header that
+ * declared a gap paid both and its title started further right than the ones
+ * that declared none — at 390px the Autopilot title sat 8px right of Issues.
+ * One declared gap, one source.
+ */
+describe("PageHeader leading spacing", () => {
+  it("gives the nav trigger no margin of its own", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader>
+          <h1>Inbox</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const trigger = container.querySelector("[data-slot='sidebar-trigger']")!;
+    expect(trigger.className).not.toMatch(/(^|\s)-?m[rsxe]?-/);
+  });
+
+  it("spaces a header that declares no gap by the base gap", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader>
+          <h1>Inbox</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    expect(container.querySelector("header")).toHaveClass("gap-2");
+  });
+
+  it("leads the collection header on the same gap as the issues header", () => {
+    const collection = renderWithI18n(
+      <SidebarProvider>
+        <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />
+      </SidebarProvider>,
+    );
+    const issues = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader className="gap-2">
+          <ListTodo className="h-4 w-4" />
+          <h1>Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const gapOf = (r: { container: HTMLElement }) =>
+      Array.from(r.container.querySelector("header")!.classList).find((c) =>
+        c.startsWith("gap-"),
+      );
+
+    expect(gapOf(collection)).toBe("gap-2");
+    expect(gapOf(collection)).toBe(gapOf(issues));
+  });
+});

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -113,6 +113,33 @@ describe("PageHeader leading spacing", () => {
     expect(container.querySelector("header")).toHaveClass("gap-2");
   });
 
+  it("leads the collection header on the same gutter as the issues header", () => {
+    const collection = renderWithI18n(
+      <SidebarProvider>
+        <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />
+      </SidebarProvider>,
+    );
+    const issues = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader className="gap-2">
+          <ListTodo className="h-4 w-4" />
+          <h1>Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    // Whatever the base gutter is, a collection page must not override it —
+    // that 4px is what made the Autopilot title sit right of Issues at every
+    // width, including >= xl where the nav trigger is not even rendered.
+    const gutterOf = (r: { container: HTMLElement }) =>
+      Array.from(r.container.querySelector("header")!.classList).find((c) =>
+        /^px-/.test(c),
+      );
+
+    expect(gutterOf(collection)).toBe("px-4");
+    expect(gutterOf(collection)).toBe(gutterOf(issues));
+  });
+
   it("leads the collection header on the same gap as the issues header", () => {
     const collection = renderWithI18n(
       <SidebarProvider>

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -75,6 +75,17 @@ describe("PageHeader base chrome", () => {
     expect(header).toHaveClass("gap-2", PAGE_GUTTER);
   });
 
+  it("does not let a call site override the shared gutter", () => {
+    const header = renderHeader(
+      <PageHeader className="px-8">
+        <h1>Inbox</h1>
+      </PageHeader>,
+    );
+
+    expect(header).toHaveClass(PAGE_GUTTER);
+    expect(header).not.toHaveClass("px-8");
+  });
+
   // Collection and issues headers drifted apart when each declared its own
   // spacing; both must resolve to the base gap and gutter.
   it("resolves the same gutter and gap for collection and issues headers", () => {

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -1,4 +1,5 @@
 import { ListTodo, Plus, Zap } from "lucide-react";
+import { within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SidebarProvider } from "@multica/ui/components/ui/sidebar";
@@ -9,157 +10,86 @@ import {
 } from "./collection-page";
 import { PAGE_GUTTER, PageHeader } from "./page-header";
 
-/**
- * Below `xl` the collapsed-nav trigger renders, so a header that reads as two
- * zones in source ("title left, actions right") is really three flex items.
- * `justify-between` then splits the free space on BOTH sides of the title and
- * parks it mid-header instead of beside the trigger — the desktop window is
- * narrower than `xl`, so that is where it shows up.
- *
- * The header stays left-aligned only while nothing distributes that space:
- * the content group grows and absorbs all of it.
- */
+// The layout rules under test are documented on `PageHeader` itself; each
+// test here pins one of them against the rendered output.
+
+function renderHeader(ui: React.ReactElement) {
+  const { container } = renderWithI18n(<SidebarProvider>{ui}</SidebarProvider>);
+  return within(container).getByRole("banner");
+}
+
+// Below `xl` the collapsed-nav trigger renders as a third flex item, so the
+// title stays left only while nothing distributes the free space: the content
+// group grows and the header never uses `justify-between`.
 function expectTitleLeftOfFreeSpace(header: HTMLElement) {
   const trigger = header.querySelector("[data-slot='sidebar-trigger']");
-  const items = Array.from(header.children);
-
   expect(trigger).not.toBeNull();
-  expect(items[0]).toBe(trigger);
+  expect(header.firstElementChild).toBe(trigger);
   expect(header).not.toHaveClass("justify-between");
 }
 
 describe("PageHeader title alignment", () => {
   it("keeps a collection title beside the nav trigger instead of centering it", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <CollectionPageHeader
-          icon={Zap}
-          title="Autopilot"
-          count={2}
-          actions={
-            <CollectionPageHeaderAction icon={Plus} label="New autopilot" />
-          }
-        />
-      </SidebarProvider>,
+    const header = renderHeader(
+      <CollectionPageHeader
+        icon={Zap}
+        title="Autopilot"
+        count={2}
+        actions={
+          <CollectionPageHeaderAction icon={Plus} label="New autopilot" />
+        }
+      />,
     );
 
-    const header = container.querySelector<HTMLElement>("header")!;
     expectTitleLeftOfFreeSpace(header);
 
-    const heading = header.querySelector("h1")!;
+    const heading = within(header).getByRole("heading");
     expect(heading.textContent).toBe("Autopilot");
     expect(heading.parentElement).toHaveClass("flex-1");
   });
 
   it("keeps the issues-style inline title packed against the nav trigger", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader className="gap-2">
-          <ListTodo className="h-4 w-4 text-muted-foreground" />
-          <h1 className="text-body font-medium">Issues</h1>
-        </PageHeader>
-      </SidebarProvider>,
+    const header = renderHeader(
+      <PageHeader>
+        <ListTodo className="h-4 w-4 text-muted-foreground" />
+        <h1 className="text-body font-medium">Issues</h1>
+      </PageHeader>,
     );
 
-    const header = container.querySelector<HTMLElement>("header")!;
     expectTitleLeftOfFreeSpace(header);
     expect(header.children).toHaveLength(3);
   });
-
-  it("still reserves the leading slot for the nav trigger on compact widths", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader>
-          <h1>Issues</h1>
-        </PageHeader>
-      </SidebarProvider>,
-    );
-
-    const trigger = container.querySelector("[data-slot='sidebar-trigger']")!;
-    expect(trigger).toHaveClass("xl:hidden");
-  });
 });
 
-/**
- * The trigger is a flex item, so the header's own `gap` already separates it
- * from the title. When the trigger carried a margin as well, every header that
- * declared a gap paid both and its title started further right than the ones
- * that declared none — at 390px the Autopilot title sat 8px right of Issues.
- * One declared gap, one source.
- */
-describe("PageHeader leading spacing", () => {
-  it("gives the nav trigger no margin of its own", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader>
-          <h1>Inbox</h1>
-        </PageHeader>
-      </SidebarProvider>,
+describe("PageHeader base chrome", () => {
+  it("supplies the trigger, gap and gutter without per-page classes", () => {
+    const header = renderHeader(
+      <PageHeader>
+        <h1>Inbox</h1>
+      </PageHeader>,
     );
 
-    const trigger = container.querySelector("[data-slot='sidebar-trigger']")!;
+    const trigger = header.querySelector("[data-slot='sidebar-trigger']")!;
+    expect(trigger).toHaveClass("xl:hidden");
     expect(trigger.className).not.toMatch(/(^|\s)-?m[rsxe]?-/);
+    expect(header).toHaveClass("gap-2", PAGE_GUTTER);
   });
 
-  it("spaces a header that declares no gap by the base gap", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader>
-          <h1>Inbox</h1>
-        </PageHeader>
-      </SidebarProvider>,
-    );
-
-    expect(container.querySelector("header")).toHaveClass("gap-2");
-  });
-
-  // The collection header and the issues header have to resolve to the same
-  // leading edge and the same gap. Each `it` below is one axis of that, read
-  // off both renders at once rather than asserted per page — a per-page
-  // assertion is what let the Agents toolbar drift while its header moved.
-  it.each([
-    ["gutter", /^px-/, PAGE_GUTTER],
-    ["gap", /^gap-/, "gap-2"],
-  ])("resolves the same %s for collection and issues headers", (_axis, pattern, expected) => {
-    const headerClass = (ui: React.ReactElement) =>
-      Array.from(
-        renderWithI18n(<SidebarProvider>{ui}</SidebarProvider>)
-          .container.querySelector("header")!
-          .classList,
-      ).find((c) => pattern.test(c));
-
-    const collection = headerClass(
+  // Collection and issues headers drifted apart when each declared its own
+  // spacing; both must resolve to the base gap and gutter.
+  it("resolves the same gutter and gap for collection and issues headers", () => {
+    const collection = renderHeader(
       <CollectionPageHeader icon={Zap} title="Autopilot" count={2} />,
     );
-    const issues = headerClass(
-      <PageHeader className="gap-2">
+    const issues = renderHeader(
+      <PageHeader>
         <ListTodo className="h-4 w-4" />
         <h1>Issues</h1>
       </PageHeader>,
     );
 
-    expect(collection).toBe(expected);
-    expect(collection).toBe(issues);
-  });
-});
-
-/**
- * The gutter is a constant so a page cannot spell its own and drift; the
- * toolbar under a header reads the same one. Asserting the header renders the
- * constant is what makes importing it elsewhere meaningful — the earlier
- * version of this test hardcoded `px-4` in both the component and the
- * expectation, so it could only ever agree with itself.
- */
-describe("PAGE_GUTTER", () => {
-  it("is what PageHeader renders", () => {
-    const { container } = renderWithI18n(
-      <SidebarProvider>
-        <PageHeader>
-          <h1>Inbox</h1>
-        </PageHeader>
-      </SidebarProvider>,
-    );
-
-    expect(container.querySelector("header")).toHaveClass(PAGE_GUTTER);
+    for (const header of [collection, issues]) {
+      expect(header).toHaveClass("gap-2", PAGE_GUTTER);
+    }
   });
 });

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -1,0 +1,81 @@
+import { ListTodo, Plus, Zap } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { SidebarProvider } from "@multica/ui/components/ui/sidebar";
+import { renderWithI18n } from "../test/i18n";
+import {
+  CollectionPageHeader,
+  CollectionPageHeaderAction,
+} from "./collection-page";
+import { PageHeader } from "./page-header";
+
+/**
+ * Below `xl` the collapsed-nav trigger renders, so a header that reads as two
+ * zones in source ("title left, actions right") is really three flex items.
+ * `justify-between` then splits the free space on BOTH sides of the title and
+ * parks it mid-header instead of beside the trigger — the desktop window is
+ * narrower than `xl`, so that is where it shows up.
+ *
+ * The header stays left-aligned only while nothing distributes that space:
+ * the content group grows and absorbs all of it.
+ */
+function expectTitleLeftOfFreeSpace(header: HTMLElement) {
+  const trigger = header.querySelector("[data-slot='sidebar-trigger']");
+  const items = Array.from(header.children);
+
+  expect(trigger).not.toBeNull();
+  expect(items[0]).toBe(trigger);
+  expect(header).not.toHaveClass("justify-between");
+}
+
+describe("PageHeader title alignment", () => {
+  it("keeps a collection title beside the nav trigger instead of centering it", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <CollectionPageHeader
+          icon={Zap}
+          title="Autopilot"
+          count={2}
+          actions={
+            <CollectionPageHeaderAction icon={Plus} label="New autopilot" />
+          }
+        />
+      </SidebarProvider>,
+    );
+
+    const header = container.querySelector<HTMLElement>("header")!;
+    expectTitleLeftOfFreeSpace(header);
+
+    const heading = header.querySelector("h1")!;
+    expect(heading.textContent).toBe("Autopilot");
+    expect(heading.parentElement).toHaveClass("flex-1");
+  });
+
+  it("keeps the issues-style inline title packed against the nav trigger", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader className="gap-2">
+          <ListTodo className="h-4 w-4 text-muted-foreground" />
+          <h1 className="text-body font-medium">Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const header = container.querySelector<HTMLElement>("header")!;
+    expectTitleLeftOfFreeSpace(header);
+    expect(header.children).toHaveLength(3);
+  });
+
+  it("still reserves the leading slot for the nav trigger on compact widths", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider>
+        <PageHeader>
+          <h1>Issues</h1>
+        </PageHeader>
+      </SidebarProvider>,
+    );
+
+    const trigger = container.querySelector("[data-slot='sidebar-trigger']")!;
+    expect(trigger).toHaveClass("xl:hidden");
+  });
+});

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -33,6 +33,15 @@ interface PageHeaderProps {
   className?: string;
 }
 
+/**
+ * Push actions right with `flex-1` on the content group, never with
+ * `justify-between` on the header.
+ *
+ * The leading slot below is a flex item too, so a header that reads as two
+ * zones in source is three at runtime, and `justify-between` splits the free
+ * space on BOTH sides of the title — parking it mid-header. Desktop windows
+ * sit below `xl`, where the trigger renders, so that is where it surfaces.
+ */
 export function PageHeader({ children, leading, className }: PageHeaderProps) {
   return (
     <header className={cn("flex h-12 shrink-0 items-center border-b px-4", className)}>

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -15,7 +15,7 @@ import { SidebarTrigger, useSidebarSafe } from "@multica/ui/components/ui/sideba
 export function CollapsedNavTrigger() {
   const sidebar = useSidebarSafe();
   if (!sidebar) return null;
-  return <SidebarTrigger className="mr-2 xl:hidden" />;
+  return <SidebarTrigger className="xl:hidden" />;
 }
 
 interface PageHeaderProps {
@@ -41,10 +41,21 @@ interface PageHeaderProps {
  * zones in source is three at runtime, and `justify-between` splits the free
  * space on BOTH sides of the title — parking it mid-header. Desktop windows
  * sit below `xl`, where the trigger renders, so that is where it surfaces.
+ *
+ * `gap-2` is the base for the same reason: it makes the header's own gap the
+ * single source of the leading-slot spacing. When the trigger carried its own
+ * margin as well, every header that declared a gap paid both and its title
+ * started further right than the ones that declared none. Override the gap
+ * per header if the zones need more air; do not add margin to the trigger.
+ *
+ * `px-4` is only the default gutter — a page whose content sits at `px-5`
+ * should pass that through so the title lines up with the toolbar under it.
  */
 export function PageHeader({ children, leading, className }: PageHeaderProps) {
   return (
-    <header className={cn("flex h-12 shrink-0 items-center border-b px-4", className)}>
+    <header
+      className={cn("flex h-12 shrink-0 items-center gap-2 border-b px-4", className)}
+    >
       {leading ?? <CollapsedNavTrigger />}
       {children}
     </header>

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -78,8 +78,8 @@ export function PageHeader({ children, leading, className }: PageHeaderProps) {
     <header
       className={cn(
         "flex h-12 shrink-0 items-center gap-2 border-b",
-        PAGE_GUTTER,
         className,
+        PAGE_GUTTER,
       )}
     >
       {leading ?? <CollapsedNavTrigger />}

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -16,6 +16,16 @@ import { SidebarTrigger, useSidebarSafe } from "@multica/ui/components/ui/sideba
 export const PAGE_GUTTER = "px-4";
 
 /**
+ * The filter/actions row directly under a `PageHeader`: same height and
+ * gutter so the two read as one chrome block. Shared for the same reason as
+ * `PAGE_GUTTER` — the toolbars drifted when each page spelled its own row.
+ */
+export const PAGE_TOOLBAR = cn(
+  "flex h-12 shrink-0 items-center justify-between gap-2",
+  PAGE_GUTTER,
+);
+
+/**
  * The way back to the nav wherever it is not a permanent column: a sheet below
  * the compact breakpoint, auto-collapsed from there up to `xl`.
  *

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -4,6 +4,18 @@ import { cn } from "@multica/ui/lib/utils";
 import { SidebarTrigger, useSidebarSafe } from "@multica/ui/components/ui/sidebar";
 
 /**
+ * The left edge every page shares: the header, the toolbar under it, and any
+ * body row that has to line up with them.
+ *
+ * It is a constant rather than a per-page class because the pages drifted
+ * apart exactly when it was one — collection pages sat at `px-5` and the
+ * issues family at `px-4`, so switching tabs moved the title 4px. Import this
+ * anywhere that edge matters instead of writing the class again; a page that
+ * spells its own gutter is the bug coming back.
+ */
+export const PAGE_GUTTER = "px-4";
+
+/**
  * The way back to the nav wherever it is not a permanent column: a sheet below
  * the compact breakpoint, auto-collapsed from there up to `xl`.
  *
@@ -48,13 +60,17 @@ interface PageHeaderProps {
  * started further right than the ones that declared none. Override the gap
  * per header if the zones need more air; do not add margin to the trigger.
  *
- * `px-4` is only the default gutter — a page whose content sits at `px-5`
- * should pass that through so the title lines up with the toolbar under it.
+ * Do not pass a `px-*` through `className`. The gutter is `PAGE_GUTTER` for
+ * every page, and the toolbar beneath the header reads the same constant.
  */
 export function PageHeader({ children, leading, className }: PageHeaderProps) {
   return (
     <header
-      className={cn("flex h-12 shrink-0 items-center gap-2 border-b px-4", className)}
+      className={cn(
+        "flex h-12 shrink-0 items-center gap-2 border-b",
+        PAGE_GUTTER,
+        className,
+      )}
     >
       {leading ?? <CollapsedNavTrigger />}
       {children}

--- a/packages/views/members/member-detail-page.tsx
+++ b/packages/views/members/member-detail-page.tsx
@@ -119,7 +119,7 @@ function RoleBadge({ role }: { role: MemberRole }) {
 function MemberDetailSkeleton() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <PageHeader className="px-5">
+      <PageHeader>
         <Skeleton className="h-5 w-52" />
       </PageHeader>
       <div className="flex shrink-0 items-center gap-3 border-b px-6 py-4">

--- a/packages/views/my-issues/components/my-issues-header.tsx
+++ b/packages/views/my-issues/components/my-issues-header.tsx
@@ -24,6 +24,8 @@ import {
   IssueDisplayControls,
   ViewRefreshIndicator,
 } from "../../issues/components/issues-header";
+import { cn } from "@multica/ui/lib/utils";
+import { PAGE_GUTTER } from "../../layout/page-header";
 import { FilterChipsBar } from "../../issues/components/filter-chips-bar";
 import { toast } from "sonner";
 import { SaveViewDialog, type SaveViewScope } from "../../issues/components/save-view-dialog";
@@ -98,7 +100,7 @@ export function MyIssuesHeader({
 
   return (
     <>
-    <div className="min-h-12 shrink-0 px-4 py-2 [-webkit-overflow-scrolling:touch]">
+    <div className={cn("min-h-12 shrink-0 py-2 [-webkit-overflow-scrolling:touch]", PAGE_GUTTER)}>
       <div className="flex w-full min-w-0 items-start justify-between gap-2">
         <div className="hidden min-w-0 flex-1 md:block">
           <ViewBar

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -20,7 +20,7 @@ export function MyIssuesPage() {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <PageHeader className="gap-2">
+      <PageHeader>
         <ListTodo className="h-4 w-4 text-muted-foreground" />
         <h1 className="text-body font-medium">{t(($) => $.page.breadcrumb)}</h1>
       </PageHeader>

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -963,7 +963,7 @@ export function ProjectsPage() {
       ) : (
         <>
           {/* Toolbar */}
-          <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-5">
+          <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
             <div className="flex min-w-0 items-center gap-2">
               <div className="relative hidden md:block">
                 <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
@@ -1264,7 +1264,7 @@ export function ProjectsPage() {
               </ListGrid>
             </div>
           ) : (
-            <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-4">
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-4">
               <div
                 className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4"
                 style={{ paddingBottom: LIST_GRID_BOTTOM_CLEARANCE }}
@@ -1296,7 +1296,7 @@ export function ProjectsPage() {
 function LoadingState({ isCompact }: { isCompact: boolean }) {
   if (isCompact) {
     return (
-      <div className="min-h-0 flex-1 overflow-auto px-5 pt-4">
+      <div className="min-h-0 flex-1 overflow-auto px-4 pt-4">
         <div className="space-y-2">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="h-11 w-full rounded-md" />
@@ -1306,7 +1306,7 @@ function LoadingState({ isCompact }: { isCompact: boolean }) {
     );
   }
   return (
-    <div className="grid grid-cols-1 gap-3 px-5 pt-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-3 px-4 pt-4 sm:grid-cols-2 lg:grid-cols-4">
       {Array.from({ length: 8 }).map((_, i) => (
         <div key={i} className="flex flex-col gap-2 rounded-md border p-3">
           <div className="flex items-center gap-2">

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -109,6 +109,8 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useFormatRelativeDate } from "./labels";
 import { ProjectStatusBadge, ProjectPriorityBadge } from "./project-badge";
 import { ProjectLeadPicker } from "./project-lead-picker";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 
 // Sort order maps for the enum columns (header sort needs a total order).
 const PRIORITY_ORDER: Record<ProjectPriority, number> = {
@@ -963,7 +965,7 @@ export function ProjectsPage() {
       ) : (
         <>
           {/* Toolbar */}
-          <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
+          <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
             <div className="flex min-w-0 items-center gap-2">
               <div className="relative hidden md:block">
                 <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
@@ -1264,7 +1266,7 @@ export function ProjectsPage() {
               </ListGrid>
             </div>
           ) : (
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-4">
+            <div className={cn("min-h-0 flex-1 overflow-y-auto pt-4", PAGE_GUTTER)}>
               <div
                 className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4"
                 style={{ paddingBottom: LIST_GRID_BOTTOM_CLEARANCE }}
@@ -1296,7 +1298,7 @@ export function ProjectsPage() {
 function LoadingState({ isCompact }: { isCompact: boolean }) {
   if (isCompact) {
     return (
-      <div className="min-h-0 flex-1 overflow-auto px-4 pt-4">
+      <div className={cn("min-h-0 flex-1 overflow-auto pt-4", PAGE_GUTTER)}>
         <div className="space-y-2">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="h-11 w-full rounded-md" />
@@ -1306,7 +1308,7 @@ function LoadingState({ isCompact }: { isCompact: boolean }) {
     );
   }
   return (
-    <div className="grid grid-cols-1 gap-3 px-4 pt-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className={cn("grid grid-cols-1 gap-3 pt-4 sm:grid-cols-2 lg:grid-cols-4", PAGE_GUTTER)}>
       {Array.from({ length: 8 }).map((_, i) => (
         <div key={i} className="flex flex-col gap-2 rounded-md border p-3">
           <div className="flex items-center gap-2">

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -109,7 +109,7 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useFormatRelativeDate } from "./labels";
 import { ProjectStatusBadge, ProjectPriorityBadge } from "./project-badge";
 import { ProjectLeadPicker } from "./project-lead-picker";
-import { PAGE_GUTTER } from "../../layout/page-header";
+import { PAGE_GUTTER, PAGE_TOOLBAR } from "../../layout/page-header";
 import { cn } from "@multica/ui/lib/utils";
 
 // Sort order maps for the enum columns (header sort needs a total order).
@@ -965,7 +965,7 @@ export function ProjectsPage() {
       ) : (
         <>
           {/* Toolbar */}
-          <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
+          <div className={PAGE_TOOLBAR}>
             <div className="flex min-w-0 items-center gap-2">
               <div className="relative hidden md:block">
                 <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -572,7 +572,7 @@ function EmptyState({ onConnectRemote }: { onConnectRemote: () => void }) {
 function RuntimesPageSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <PageHeader className="justify-between px-5">
+      <PageHeader className="px-5">
         <Skeleton className="h-4 w-24" />
       </PageHeader>
       <div className="mx-auto w-full max-w-[1440px] p-6">

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -572,7 +572,7 @@ function EmptyState({ onConnectRemote }: { onConnectRemote: () => void }) {
 function RuntimesPageSkeleton() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <PageHeader className="px-5">
+      <PageHeader>
         <Skeleton className="h-4 w-24" />
       </PageHeader>
       <div className="mx-auto w-full max-w-[1440px] p-6">

--- a/packages/views/skills/components/skill-list-toolbar.tsx
+++ b/packages/views/skills/components/skill-list-toolbar.tsx
@@ -176,7 +176,7 @@ export function SkillListToolbar({
   );
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-5">
+    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
       {/* Left: name search + result count. The count only appears while
           search/filters narrow the list — in the idle state it would just
           duplicate the total already shown in the page header. Below md the

--- a/packages/views/skills/components/skill-list-toolbar.tsx
+++ b/packages/views/skills/components/skill-list-toolbar.tsx
@@ -48,8 +48,7 @@ import {
 } from "@multica/core/skills/stores";
 import { useT } from "../../i18n";
 import type { SkillRow } from "./skills-page";
-import { PAGE_GUTTER } from "../../layout/page-header";
-import { cn } from "@multica/ui/lib/utils";
+import { PAGE_TOOLBAR } from "../../layout/page-header";
 
 export type OriginType = SkillOriginType;
 
@@ -178,7 +177,7 @@ export function SkillListToolbar({
   );
 
   return (
-    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
+    <div className={PAGE_TOOLBAR}>
       {/* Left: name search + result count. The count only appears while
           search/filters narrow the list — in the idle state it would just
           duplicate the total already shown in the page header. Below md the

--- a/packages/views/skills/components/skill-list-toolbar.tsx
+++ b/packages/views/skills/components/skill-list-toolbar.tsx
@@ -48,6 +48,8 @@ import {
 } from "@multica/core/skills/stores";
 import { useT } from "../../i18n";
 import type { SkillRow } from "./skills-page";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 
 export type OriginType = SkillOriginType;
 
@@ -176,7 +178,7 @@ export function SkillListToolbar({
   );
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
+    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
       {/* Left: name search + result count. The count only appears while
           search/filters narrow the list — in the idle state it would just
           duplicate the total already shown in the page header. Below md the

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -742,7 +742,7 @@ function SquadDetailInspector({
   return (
     <aside className="flex w-full flex-col rounded-lg border bg-background md:h-full md:min-h-0 md:overflow-y-auto">
       {/* Identity */}
-      <div className="flex flex-col gap-3 border-b px-4 pb-5 pt-5">
+      <div className="flex flex-col gap-3 border-b px-5 pb-5 pt-5">
         {canManage ? (
           <>
             <AvatarUploadControl
@@ -780,7 +780,7 @@ function SquadDetailInspector({
       </div>
 
       {/* Details — read-only */}
-      <div className="border-b px-4 py-4">
+      <div className="border-b px-5 py-4">
         <div className="mb-1 -mx-2 px-2 text-micro font-medium uppercase tracking-wider text-muted-foreground">
           {t(($) => $.inspector.details_section)}
         </div>

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -300,7 +300,7 @@ export function SquadDetailPage() {
 function SquadDetailSkeleton() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <PageHeader className="px-5">
+      <PageHeader>
         <Skeleton className="h-5 w-48" />
       </PageHeader>
       <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto p-3 md:grid md:grid-cols-[280px_minmax(0,1fr)] md:gap-4 md:overflow-hidden md:p-6 lg:grid-cols-[320px_minmax(0,1fr)]">
@@ -742,7 +742,7 @@ function SquadDetailInspector({
   return (
     <aside className="flex w-full flex-col rounded-lg border bg-background md:h-full md:min-h-0 md:overflow-y-auto">
       {/* Identity */}
-      <div className="flex flex-col gap-3 border-b px-5 pb-5 pt-5">
+      <div className="flex flex-col gap-3 border-b px-4 pb-5 pt-5">
         {canManage ? (
           <>
             <AvatarUploadControl
@@ -780,7 +780,7 @@ function SquadDetailInspector({
       </div>
 
       {/* Details — read-only */}
-      <div className="border-b px-5 py-4">
+      <div className="border-b px-4 py-4">
         <div className="mb-1 -mx-2 px-2 text-micro font-medium uppercase tracking-wider text-muted-foreground">
           {t(($) => $.inspector.details_section)}
         </div>

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -90,6 +90,8 @@ import {
   CollectionPageState,
 } from "../../layout/collection-page";
 import { useT } from "../../i18n";
+import { PAGE_GUTTER } from "../../layout/page-header";
+import { cn } from "@multica/ui/lib/utils";
 
 // Column template — the simplest member of the ListGrid family (squads are
 // the fewest entity, 1-5 rows): subgrid template + var tracks + two-zone
@@ -499,7 +501,7 @@ function SquadListToolbar({
   const sortLabel = SORT_LABELS[sortField];
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
+    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
       <div className="flex min-w-0 items-center gap-2">
         <div className="hidden shrink-0 items-center gap-1 md:flex">
           {SQUAD_SCOPES.map((s) => (

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -499,7 +499,7 @@ function SquadListToolbar({
   const sortLabel = SORT_LABELS[sortField];
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-5">
+    <div className="flex h-12 shrink-0 items-center justify-between gap-2 px-4">
       <div className="flex min-w-0 items-center gap-2">
         <div className="hidden shrink-0 items-center gap-1 md:flex">
           {SQUAD_SCOPES.map((s) => (

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -90,8 +90,7 @@ import {
   CollectionPageState,
 } from "../../layout/collection-page";
 import { useT } from "../../i18n";
-import { PAGE_GUTTER } from "../../layout/page-header";
-import { cn } from "@multica/ui/lib/utils";
+import { PAGE_TOOLBAR } from "../../layout/page-header";
 
 // Column template — the simplest member of the ListGrid family (squads are
 // the fewest entity, 1-5 rows): subgrid template + var tracks + two-zone
@@ -501,7 +500,7 @@ function SquadListToolbar({
   const sortLabel = SORT_LABELS[sortField];
 
   return (
-    <div className={cn("flex h-12 shrink-0 items-center justify-between gap-2", PAGE_GUTTER)}>
+    <div className={PAGE_TOOLBAR}>
       <div className="flex min-w-0 items-center gap-2">
         <div className="hidden shrink-0 items-center gap-1 md:flex">
           {SQUAD_SCOPES.map((s) => (


### PR DESCRIPTION
## Summary

- Left-align page titles that rendered centered below `xl`. The collapsed nav trigger makes the header three flex items, so `justify-between` split the free space on both sides of the title; content groups now grow with `flex-1` instead.
- Make the header's base `gap-2` the single source of leading-slot spacing by dropping the trigger's own margin, which double-spaced every header that also declared a gap.
- Unify page gutters behind an exported `PAGE_GUTTER` constant. Collection pages sat at `px-5` while the issues family sat at `px-4`, so switching tabs moved the title 4px; headers, toolbars, skeletons and aligned body rows now read the same constant, and `PAGE_TOOLBAR` shares the full toolbar row recipe.
- Simplification pass on the above: the dashboard header folds onto `CollectionPageHeader`, the autopilot-detail skeleton onto `PageHeader`, dead one-child wrappers and no-op `gap-2` overrides are removed, and the header tests consolidate to one render per behavior with role-based queries.

## Testing

- `pnpm typecheck` (6/6), `pnpm lint` (0 errors), `pnpm test` (all packages green, 3789 views tests)
- Verified in a browser at 390px, 1000px and 1440px: title and toolbar leading edges are flush on every page, all widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
