### PR TITLE
feat(daemon): pass task initiator info to agent process as env vars

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -133,8 +133,14 @@ func taskScopedAuthToken(task Task) (string, error) {
 	return token, nil
 }
 
+// taskMulticaEnvironment builds the Multica-owned environment variables for
+// the spawned agent process. Values here are available to every agent CLI
+// (Hermes, Claude Code, Codex, …) and any MCP tool it runs, complementing
+// the `## Task Initiator` block the prompt already carries. Only non-empty
+// initiator fields are emitted, so task kinds with no attributable human
+// initiator (on-assign, autopilot, quick-create) do not receive empty vars.
 func taskMulticaEnvironment(task Task, agentName, token, configRoot, workspacesRoot, serverURL string, healthPort, slot int, tempDir string) map[string]string {
-	return map[string]string{
+	env := map[string]string{
 		"MULTICA_TOKEN":        token,
 		cli.TaskConfigRootEnv:  configRoot,
 		TaskWorkspacesRootEnv:  workspacesRoot,
@@ -149,6 +155,19 @@ func taskMulticaEnvironment(task Task, agentName, token, configRoot, workspacesR
 		"TMP":                  tempDir,
 		"TEMP":                 tempDir,
 	}
+	if v := strings.TrimSpace(task.InitiatorType); v != "" {
+		env["MULTICA_INITIATOR_TYPE"] = v
+	}
+	if v := strings.TrimSpace(task.InitiatorID); v != "" {
+		env["MULTICA_INITIATOR_ID"] = v
+	}
+	if v := strings.TrimSpace(task.InitiatorName); v != "" {
+		env["MULTICA_INITIATOR_NAME"] = v
+	}
+	if v := strings.TrimSpace(task.InitiatorEmail); v != "" {
+		env["MULTICA_INITIATOR_EMAIL"] = v
+	}
+	return env
 }
 
 // taskRunner executes a single agent task and returns the result.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -584,6 +584,67 @@ func TestTaskMulticaEnvironmentIncludesPrivateConfigRoot(t *testing.T) {
 	}
 }
 
+// TestTaskMulticaEnvironmentIncludesInitiator verifies that the task
+// initiator's identity is exposed to the spawned agent process as
+// MULTICA_INITIATOR_* environment variables, so agent CLIs (Hermes, Claude
+// Code, …) and MCP tools can read who triggered the task without parsing
+// the `## Task Initiator` block out of the prompt text. Empty initiator
+// fields are omitted rather than emitted as empty strings, so task kinds
+// with no attributable human initiator (on-assign, autopilot, quick-create)
+// do not receive the vars at all.
+func TestTaskMulticaEnvironmentIncludesInitiator(t *testing.T) {
+	t.Parallel()
+
+	task := Task{
+		ID:             "task-init",
+		AgentID:        "agent-init",
+		WorkspaceID:    "ws-init",
+		InitiatorType:  "member",
+		InitiatorID:    "u-initiator",
+		InitiatorName:  "Bohan",
+		InitiatorEmail: "bohan@example.com",
+	}
+	env := taskMulticaEnvironment(task, "agent-name", "mat_sentinel", "/cfg", "/ws", "https://task.example", 19514, 1, "/tmp")
+
+	if got := env["MULTICA_INITIATOR_TYPE"]; got != "member" {
+		t.Fatalf("MULTICA_INITIATOR_TYPE = %q, want %q", got, "member")
+	}
+	if got := env["MULTICA_INITIATOR_ID"]; got != "u-initiator" {
+		t.Fatalf("MULTICA_INITIATOR_ID = %q, want %q", got, "u-initiator")
+	}
+	if got := env["MULTICA_INITIATOR_NAME"]; got != "Bohan" {
+		t.Fatalf("MULTICA_INITIATOR_NAME = %q, want %q", got, "Bohan")
+	}
+	if got := env["MULTICA_INITIATOR_EMAIL"]; got != "bohan@example.com" {
+		t.Fatalf("MULTICA_INITIATOR_EMAIL = %q, want %q", got, "bohan@example.com")
+	}
+}
+
+// TestTaskMulticaEnvironmentOmitsEmptyInitiator verifies that when a task
+// has no initiator (e.g. autopilot or on-assign tasks), no
+// MULTICA_INITIATOR_* variables are emitted at all — not even empty ones.
+func TestTaskMulticaEnvironmentOmitsEmptyInitiator(t *testing.T) {
+	t.Parallel()
+
+	task := Task{
+		ID:          "task-no-init",
+		AgentID:     "agent-no-init",
+		WorkspaceID: "ws-no-init",
+	}
+	env := taskMulticaEnvironment(task, "agent-name", "mat_sentinel", "/cfg", "/ws", "https://task.example", 19514, 1, "/tmp")
+
+	for _, key := range []string{
+		"MULTICA_INITIATOR_TYPE",
+		"MULTICA_INITIATOR_ID",
+		"MULTICA_INITIATOR_NAME",
+		"MULTICA_INITIATOR_EMAIL",
+	} {
+		if _, ok := env[key]; ok {
+			t.Fatalf("unexpected %q in env for initiator-less task", key)
+		}
+	}
+}
+
 // When `brew --prefix` is unavailable but the executable path is under a
 // known Cellar root, triggerRestart must recover the prefix from the
 // known-prefix list and target <prefix>/bin/multica.


### PR DESCRIPTION
## Summary

When the daemon spawns an agent CLI (Hermes, Claude Code, Codex, …), the task initiator's identity is currently only available as text in the prompt — the `## Task Initiator` block rendered by `perTurnContextBlocks` in `server/internal/daemon/prompt.go`. Agent CLIs and MCP tools that want to read **who triggered the task** programmatically have no structured channel; they must scrape it out of the prompt.

This change exposes the same four initiator fields as environment variables on the spawned agent process, so any agent CLI or MCP tool can read them without parsing prompt text.

## Changes

`server/internal/daemon/daemon.go` — `taskMulticaEnvironment` now emits four new env vars when the corresponding task fields are non-empty:

- `MULTICA_INITIATOR_TYPE` (`member` / `agent`)
- `MULTICA_INITIATOR_ID`
- `MULTICA_INITIATOR_NAME`
- `MULTICA_INITIATOR_EMAIL`

Empty fields are omitted rather than emitted as empty strings, so task kinds with no attributable human initiator (on-assign, autopilot, quick-create) do not receive the vars at all. This complements (does not replace) the existing `## Task Initiator` prompt block.

`server/internal/daemon/daemon_test.go` — two new tests:
- `TestTaskMulticaEnvironmentIncludesInitiator` — verifies all four vars are set for a member-initiated task.
- `TestTaskMulticaEnvironmentOmitsEmptyInitiator` — verifies no initiator vars are emitted for an initiator-less task (autopilot/on-assign).

## Test plan

- [ ] `go test ./internal/daemon/ -run TestTaskMulticaEnvironment` passes
- [ ] `gofmt -l server/internal/daemon/daemon.go server/internal/daemon/daemon_test.go` returns empty
- [ ] Existing `TestTaskMulticaEnvironmentIncludesPrivateConfigRoot` still passes (task has no initiator → no new vars)
