### PR TITLE
fix(agent): pass bare model id to agy instead of tab-joined id\label

### DIFF
--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -211,8 +211,8 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 	}
 	// agy 1.0.6 added a `--model` flag (MUL-3125), so Antigravity now takes a
 	// model env like every other backend. MULTICA_ANTIGRAVITY_MODEL seeds the
-	// daemon-wide default; its value is the exact `agy models` display string
-	// (e.g. "Claude Opus 4.6 (Thinking)"), not a provider/model slug.
+	// daemon-wide default; its value is the bare model id `agy models`
+	// advertises (e.g. "gemini-3.6-flash-medium"), not the display label.
 	if e, ok := probe("MULTICA_ANTIGRAVITY_PATH", "agy", "MULTICA_ANTIGRAVITY_MODEL"); ok {
 		agents["antigravity"] = e
 	}

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -49,6 +49,12 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 		return nil, fmt.Errorf("agy executable not found at %q: %w", execPath, err)
 	}
 
+	// Normalise a legacy agent.model value that was persisted as the full
+	// `id\tLabel` line the old parser stored (#6867). agy --model only accepts
+	// the bare id, so strip everything from the first tab onward. A value with
+	// no tab passes through unchanged.
+	opts.Model = antigravityNormaliseModel(opts.Model)
+
 	// Guard against agy's silent no-op on an unrecognised --model: it exits 0
 	// with empty output, which would otherwise surface as a "completed" but
 	// empty task. opts.Model is the single funnel for both agent.model and the
@@ -423,16 +429,16 @@ var antigravityBlockedArgs = map[string]blockedArgMode{
 // buildAntigravityArgs assembles the argv for a daemon-compatible one-shot agy
 // invocation.
 //
-//	agy -p <prompt> --dangerously-skip-permissions [--model <display name>]
+//	agy -p <prompt> --dangerously-skip-permissions [--model <model id>]
 //	    --print-timeout <duration> --log-file <tmp>
 //	    [--conversation <id>] [--add-dir <cwd>]
 //
 // agy 1.0.6 added a `--model` flag (MUL-3125), so opts.Model is now wired
-// through when set. The value is the exact human display string `agy models`
-// prints (e.g. "Claude Opus 4.6 (Thinking)"), NOT a provider/model slug —
-// it's passed verbatim as a single exec arg, so spaces and parens need no
-// shell quoting. agy still exposes no --system-prompt; runtime instructions
-// are delivered via AGENTS.md in the task workdir.
+// through when set. The value is the bare model id that `agy models`
+// advertises (e.g. "gemini-3.6-flash-medium"), NOT the display label —
+// it's passed verbatim as a single exec arg. agy still exposes no
+// --system-prompt; runtime instructions are delivered via AGENTS.md in
+// the task workdir.
 //
 // agy silently no-ops on a model string it doesn't recognise (empty output,
 // exit 0), so Execute validates opts.Model against the `agy models` catalog
@@ -467,13 +473,27 @@ func buildAntigravityArgs(prompt, logPath string, timeout time.Duration, opts Ex
 	return args
 }
 
+// antigravityNormaliseModel strips a tab-joined `id\tLabel` suffix from a
+// model value, returning the bare id that `agy --model` accepts. Values with
+// no tab pass through unchanged. This lets agents whose model was persisted
+// by the old parser (which stored the entire `agy models` line including the
+// tab and label) keep working without a manual re-set (#6867).
+func antigravityNormaliseModel(model string) string {
+	model = strings.TrimSpace(model)
+	if idx := strings.IndexByte(model, '\t'); idx >= 0 {
+		return strings.TrimSpace(model[:idx])
+	}
+	return model
+}
+
 // antigravityModelError returns an actionable error when `model` is non-empty
 // and definitively absent from `available` (the `agy models` catalog); it
 // returns nil otherwise. An empty `available` means discovery couldn't produce
 // a catalog (agy missing, transient failure) — we fail OPEN there and let agy
 // resolve the value, so a discovery hiccup never blocks a run. The match is
-// exact because agy's --model wants the precise display string; a near-miss
-// (extra space, dropped suffix) is correctly rejected since agy would silently
+// against the model ID (the bare value `agy --model` accepts) and, as a
+// fallback for legacy persisted values, the display Label. A near-miss (extra
+// space, dropped suffix) is correctly rejected since agy would silently
 // no-op on it anyway.
 func antigravityModelError(model string, available []Model) error {
 	if model == "" || len(available) == 0 {
@@ -481,7 +501,7 @@ func antigravityModelError(model string, available []Model) error {
 	}
 	ids := make([]string, 0, len(available))
 	for _, m := range available {
-		if m.ID == model {
+		if m.ID == model || m.Label == model {
 			return nil
 		}
 		ids = append(ids, m.ID)

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -49,12 +49,6 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 		return nil, fmt.Errorf("agy executable not found at %q: %w", execPath, err)
 	}
 
-	// Normalise a legacy agent.model value that was persisted as the full
-	// `id\tLabel` line the old parser stored (#6867). agy --model only accepts
-	// the bare id, so strip everything from the first tab onward. A value with
-	// no tab passes through unchanged.
-	opts.Model = antigravityNormaliseModel(opts.Model)
-
 	// Guard against agy's silent no-op on an unrecognised --model: it exits 0
 	// with empty output, which would otherwise surface as a "completed" but
 	// empty task. opts.Model is the single funnel for both agent.model and the
@@ -67,6 +61,18 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 	// hiccup (see antigravityModelError).
 	if opts.Model != "" {
 		catalog, _ := ListModels(ctx, "antigravity", execPath)
+
+		// Resolve the model to the bare id `agy --model` accepts. Two legacy
+		// shapes need normalising (#6867): a tab-joined `id\tLabel` line the
+		// old parser stored, and a pure display label set under the old docs.
+		// antigravityNormaliseModel strips the tab; antigravityResolveModelLabel
+		// maps a bare label to its id using the catalog. Both are read-time
+		// shims — the corrupted value stays persisted until the picker rewrites
+		// it via the new parser — but they keep existing agents running without
+		// a manual re-set.
+		opts.Model = antigravityNormaliseModel(opts.Model)
+		opts.Model = antigravityResolveModelLabel(opts.Model, catalog.Models)
+
 		if err := antigravityModelError(opts.Model, catalog.Models); err != nil {
 			return nil, err
 		}
@@ -478,10 +484,33 @@ func buildAntigravityArgs(prompt, logPath string, timeout time.Duration, opts Ex
 // no tab pass through unchanged. This lets agents whose model was persisted
 // by the old parser (which stored the entire `agy models` line including the
 // tab and label) keep working without a manual re-set (#6867).
+//
+// This is a read-time shim, not a data fix: the corrupted value stays
+// persisted until the picker rewrites it via the new parser.
 func antigravityNormaliseModel(model string) string {
 	model = strings.TrimSpace(model)
 	if idx := strings.IndexByte(model, '\t'); idx >= 0 {
 		return strings.TrimSpace(model[:idx])
+	}
+	return model
+}
+
+// antigravityResolveModelLabel maps a bare display label to its model id using
+// the `agy models` catalog. If `model` matches a catalog entry's Label (but
+// not its ID), it returns the matching ID so what reaches `agy --model` is a
+// value agy accepts; otherwise it returns `model` unchanged. When the catalog
+// is empty (discovery failed) the value passes through so agy resolves it.
+func antigravityResolveModelLabel(model string, available []Model) string {
+	if model == "" || len(available) == 0 {
+		return model
+	}
+	for _, m := range available {
+		if m.ID == model {
+			return model // already a bare id
+		}
+		if m.Label == model {
+			return m.ID
+		}
 	}
 	return model
 }
@@ -491,17 +520,17 @@ func antigravityNormaliseModel(model string) string {
 // returns nil otherwise. An empty `available` means discovery couldn't produce
 // a catalog (agy missing, transient failure) — we fail OPEN there and let agy
 // resolve the value, so a discovery hiccup never blocks a run. The match is
-// against the model ID (the bare value `agy --model` accepts) and, as a
-// fallback for legacy persisted values, the display Label. A near-miss (extra
-// space, dropped suffix) is correctly rejected since agy would silently
-// no-op on it anyway.
+// against the model ID — the bare value `agy --model` accepts. Callers should
+// resolve any label to its ID first (see antigravityResolveModelLabel). A
+// near-miss (extra space, dropped suffix) is correctly rejected since agy
+// would silently no-op on it anyway.
 func antigravityModelError(model string, available []Model) error {
 	if model == "" || len(available) == 0 {
 		return nil
 	}
 	ids := make([]string, 0, len(available))
 	for _, m := range available {
-		if m.ID == model || m.Label == model {
+		if m.ID == model {
 			return nil
 		}
 		ids = append(ids, m.ID)

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -42,21 +42,22 @@ func TestBuildAntigravityArgsBasic(t *testing.T) {
 func TestBuildAntigravityArgsModel(t *testing.T) {
 	t.Parallel()
 
-	// agy 1.0.6's --model takes the exact human display string (spaces +
-	// parens), not a slug. It must ride as a single argv element so no shell
-	// quoting is required, and it must sit before the user's custom args.
+	// agy 1.0.6's --model takes the bare model id (e.g.
+	// "claude-opus-4-6-thinking"), not the display label. It must ride as a
+	// single argv element so no shell quoting is required, and it must sit
+	// before the user's custom args.
 	args := buildAntigravityArgs(
 		"hello",
 		"/tmp/agy.log",
 		20*time.Minute,
-		ExecOptions{Cwd: "/work", Model: "Claude Opus 4.6 (Thinking)"},
+		ExecOptions{Cwd: "/work", Model: "claude-opus-4-6-thinking"},
 		quietAntigravityLogger(),
 	)
 
 	want := []string{
 		"-p", "hello",
 		"--dangerously-skip-permissions",
-		"--model", "Claude Opus 4.6 (Thinking)",
+		"--model", "claude-opus-4-6-thinking",
 		"--print-timeout", "20m0s",
 		"--log-file", "/tmp/agy.log",
 		"--add-dir", "/work",
@@ -468,13 +469,18 @@ func TestAntigravityModelError(t *testing.T) {
 	t.Parallel()
 
 	catalog := []Model{
-		{ID: "Gemini 3.5 Flash (Medium)", Label: "Gemini 3.5 Flash (Medium)", Provider: "antigravity"},
-		{ID: "Claude Opus 4.6 (Thinking)", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+		{ID: "gemini-3.5-flash-medium", Label: "Gemini 3.5 Flash (Medium)", Provider: "antigravity"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
 	}
 
-	// Exact catalog hit → accepted.
+	// Exact ID hit → accepted.
+	if err := antigravityModelError("claude-opus-4-6-thinking", catalog); err != nil {
+		t.Errorf("valid model id rejected: %v", err)
+	}
+
+	// Label hit → accepted (legacy value persisted as the display label).
 	if err := antigravityModelError("Claude Opus 4.6 (Thinking)", catalog); err != nil {
-		t.Errorf("valid model rejected: %v", err)
+		t.Errorf("valid model label rejected: %v", err)
 	}
 
 	// Empty model → accepted (flag omitted, agy resolves its own default).
@@ -502,13 +508,38 @@ func TestAntigravityModelError(t *testing.T) {
 		t.Errorf("error should point the user at `agy models`: %v", err)
 	}
 
-	// Near-miss (trailing space / dropped suffix) → still rejected, because agy
-	// needs the exact display string and would no-op on anything else.
-	if err := antigravityModelError("Claude Opus 4.6 (Thinking) ", catalog); err == nil {
+	// Near-miss (trailing space on the id) → still rejected, because agy
+	// needs the exact id and would no-op on anything else.
+	if err := antigravityModelError("claude-opus-4-6-thinking ", catalog); err == nil {
 		t.Error("near-miss model (trailing space) should be rejected")
 	}
-	if err := antigravityModelError("Claude Opus 4.6", catalog); err == nil {
+	if err := antigravityModelError("claude-opus", catalog); err == nil {
 		t.Error("near-miss model (dropped suffix) should be rejected")
+	}
+}
+
+// TestAntigravityNormaliseModel pins the legacy-value fix from #6867: a model
+// persisted as the full `id\tLabel` line (by the old parser) is stripped to
+// the bare id before being passed to `agy --model`. Values with no tab pass
+// through unchanged.
+func TestAntigravityNormaliseModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"gemini-3.6-flash-medium", "gemini-3.6-flash-medium"},
+		{"gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)", "gemini-3.6-flash-medium"},
+		{"  gemini-3.6-flash-medium  ", "gemini-3.6-flash-medium"},
+		{"  gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)  ", "gemini-3.6-flash-medium"},
+		{"Plain Display Name", "Plain Display Name"},
+	}
+	for _, tc := range tests {
+		if got := antigravityNormaliseModel(tc.input); got != tc.want {
+			t.Errorf("antigravityNormaliseModel(%q) = %q, want %q", tc.input, got, tc.want)
+		}
 	}
 }
 

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -464,7 +464,9 @@ func TestAntigravityBackendProviderErrorSurfacesAsFailed(t *testing.T) {
 // letting it run to a fake "completed + empty" success. This covers the same
 // validation regardless of whether opts.Model originated from agent.model, a
 // persisted/API value, or the daemon-wide MULTICA_ANTIGRAVITY_MODEL default —
-// they all collapse to opts.Model before Execute runs this check.
+// they all collapse to opts.Model before Execute runs this check. Callers
+// resolve any display label to its ID first (antigravityResolveModelLabel),
+// so validation is ID-only.
 func TestAntigravityModelError(t *testing.T) {
 	t.Parallel()
 
@@ -476,11 +478,6 @@ func TestAntigravityModelError(t *testing.T) {
 	// Exact ID hit → accepted.
 	if err := antigravityModelError("claude-opus-4-6-thinking", catalog); err != nil {
 		t.Errorf("valid model id rejected: %v", err)
-	}
-
-	// Label hit → accepted (legacy value persisted as the display label).
-	if err := antigravityModelError("Claude Opus 4.6 (Thinking)", catalog); err != nil {
-		t.Errorf("valid model label rejected: %v", err)
 	}
 
 	// Empty model → accepted (flag omitted, agy resolves its own default).
@@ -516,6 +513,13 @@ func TestAntigravityModelError(t *testing.T) {
 	if err := antigravityModelError("claude-opus", catalog); err == nil {
 		t.Error("near-miss model (dropped suffix) should be rejected")
 	}
+
+	// A bare display label must now be rejected here — callers are expected to
+	// resolve labels to ids via antigravityResolveModelLabel first. Letting a
+	// label through to agy would be the very no-op this guard exists to prevent.
+	if err := antigravityModelError("Claude Opus 4.6 (Thinking)", catalog); err == nil {
+		t.Error("bare display label should be rejected; callers must resolve it to the id first")
+	}
 }
 
 // TestAntigravityNormaliseModel pins the legacy-value fix from #6867: a model
@@ -540,6 +544,41 @@ func TestAntigravityNormaliseModel(t *testing.T) {
 		if got := antigravityNormaliseModel(tc.input); got != tc.want {
 			t.Errorf("antigravityNormaliseModel(%q) = %q, want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+// TestAntigravityResolveModelLabel pins the label→id resolution that keeps a
+// legacy display-label value (or a MULTICA_ANTIGRAVITY_MODEL default set under
+// the old docs) working: the label is mapped to its bare id so what reaches
+// `agy --model` is a value agy accepts (#6867 review).
+func TestAntigravityResolveModelLabel(t *testing.T) {
+	t.Parallel()
+
+	catalog := []Model{
+		{ID: "gemini-3.5-flash-medium", Label: "Gemini 3.5 Flash (Medium)", Provider: "antigravity"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+	}
+
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{"empty stays empty", "", ""},
+		{"bare id passes through", "gemini-3.5-flash-medium", "gemini-3.5-flash-medium"},
+		{"label resolves to id", "Gemini 3.5 Flash (Medium)", "gemini-3.5-flash-medium"},
+		{"label resolves to id (case 2)", "Claude Opus 4.6 (Thinking)", "claude-opus-4-6-thinking"},
+		{"unknown value passes through", "Totally Made Up Model", "Totally Made Up Model"},
+	}
+	for _, tc := range tests {
+		if got := antigravityResolveModelLabel(tc.model, catalog); got != tc.want {
+			t.Errorf("%s: antigravityResolveModelLabel(%q) = %q, want %q", tc.name, tc.model, got, tc.want)
+		}
+	}
+
+	// Empty catalog → pass-through (agy resolves the value itself).
+	if got := antigravityResolveModelLabel("Gemini 3.5 Flash (Medium)", nil); got != "Gemini 3.5 Flash (Medium)" {
+		t.Errorf("empty catalog should pass through, got %q", got)
 	}
 }
 

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -2054,13 +2054,14 @@ func acpModelLabel(name, modelID string) string {
 }
 
 // discoverAntigravityModels runs `agy models` and returns the catalog the
-// installed Antigravity CLI advertises (one display name per line).
+// installed Antigravity CLI advertises. Each output line is `id\tLabel`;
+// the bare id is what `agy --model` accepts and the label is the
+// human-readable display name.
 //
 // Unlike cursor / pi / opencode there is deliberately NO static fallback.
-// agy's `--model` takes the exact human display string (e.g.
-// "Claude Opus 4.6 (Thinking)") and silently no-ops on any value it doesn't
-// recognise — empty output, exit 0 — so a guessed static list would risk
-// offering a model the installed CLI can't honour, turning a typo into a
+// agy's `--model` silently no-ops on any value it doesn't recognise —
+// empty output, exit 0 — so a guessed static list would risk offering a
+// model the installed CLI can't honour, turning a typo into a
 // "successful" empty run. On any discovery failure we return an empty
 // catalog instead; agent.model stays unset and agy resolves its own
 // default. cachedDiscovery never caches empty results, so this retries on
@@ -2085,24 +2086,39 @@ func discoverAntigravityModels(ctx context.Context, executablePath string) ([]Mo
 	return parseAntigravityModels(string(out)), nil
 }
 
-// parseAntigravityModels turns `agy models` output — one model display name
-// per line — into Model entries. The display string IS the value `--model`
-// expects, so ID and Label are identical and the daemon ships opts.Model
-// verbatim. Blank and duplicate lines are skipped.
+// parseAntigravityModels turns `agy models` output into Model entries.
+//
+// `agy models` prints one model per line in the form `id\tLabel` (e.g.
+// "gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)"). The bare id (before
+// the tab) is what `agy --model` accepts; the label after the tab is the
+// human-readable display name. Older `agy` versions that printed just the
+// display name with no tab are handled too — the whole line becomes both ID
+// and Label. Blank and duplicate lines are skipped.
 func parseAntigravityModels(output string) []Model {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var models []Model
 	seen := map[string]bool{}
 	for scanner.Scan() {
-		name := strings.TrimSpace(scanner.Text())
-		if name == "" || seen[name] {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
 			continue
 		}
-		seen[name] = true
+		id, label := line, line
+		if idx := strings.IndexByte(line, '\t'); idx >= 0 {
+			id = strings.TrimSpace(line[:idx])
+			label = strings.TrimSpace(line[idx+1:])
+			if id == "" {
+				id = label
+			}
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
 		models = append(models, Model{
-			ID:       name,
-			Label:    name,
+			ID:       id,
+			Label:    label,
 			Provider: "antigravity",
 		})
 	}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1781,25 +1781,29 @@ func TestAntigravityModelSelectionSupported(t *testing.T) {
 	}
 }
 
-// TestParseAntigravityModels covers the `agy models` line-per-name format:
-// each non-blank line becomes a Model whose ID and Label are the verbatim
-// display string `--model` expects, duplicates collapse, and blanks drop.
+// TestParseAntigravityModels covers the `agy models` output format:
+// each non-blank line is `id\tLabel`; the bare id becomes the Model ID
+// (what `agy --model` accepts) and the label becomes the display Label.
+// Lines without a tab (older agy versions) collapse to id == label.
+// Duplicates (by id) collapse, and blanks drop.
 func TestParseAntigravityModels(t *testing.T) {
 	t.Parallel()
 
 	out := strings.Join([]string{
-		"Gemini 3.5 Flash (Medium)",
-		"Claude Opus 4.6 (Thinking)",
+		"gemini-3.5-flash-medium\tGemini 3.5 Flash (Medium)",
+		"claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)",
 		"", // blank line — skipped
-		"GPT-OSS 120B (Medium)",
-		"Claude Opus 4.6 (Thinking)", // duplicate — collapsed
+		"gpt-oss-120b-medium\tGPT-OSS 120B (Medium)",
+		"claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)", // duplicate id — collapsed
+		"Plain Display Name",                                   // no tab — id == label
 	}, "\n")
 
 	got := parseAntigravityModels(out)
 	want := []Model{
-		{ID: "Gemini 3.5 Flash (Medium)", Label: "Gemini 3.5 Flash (Medium)", Provider: "antigravity"},
-		{ID: "Claude Opus 4.6 (Thinking)", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
-		{ID: "GPT-OSS 120B (Medium)", Label: "GPT-OSS 120B (Medium)", Provider: "antigravity"},
+		{ID: "gemini-3.5-flash-medium", Label: "Gemini 3.5 Flash (Medium)", Provider: "antigravity"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+		{ID: "gpt-oss-120b-medium", Label: "GPT-OSS 120B (Medium)", Provider: "antigravity"},
+		{ID: "Plain Display Name", Label: "Plain Display Name", Provider: "antigravity"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("parseAntigravityModels len = %d, want %d (%+v)", len(got), len(want), got)


### PR DESCRIPTION
## What does this PR do?

Fixes #6867: the Multica daemon corrupted the `--model` value it passed to Google's Antigravity CLI (`agy`), concatenating the model's internal id and display label with a literal tab (`id\tLabel`). `agy` rejects this malformed value, so every agent configured to use an Antigravity/Gemini model failed on every run.

## Root cause

`agy models` outputs one model per line as `id\tLabel` (e.g. `gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)`). The parser `parseAntigravityModels` treated each entire line as both `ID` and `Label`, so the catalog entry's ID was the full `id\tLabel` string. When the UI model picker stored that as `agent.model`, the daemon passed it verbatim to `agy --model`, which only accepts the bare id.

## Changes

- **`parseAntigravityModels`** (`models.go`): splits each `agy models` line on the tab. The first field becomes the `Model.ID` (what `agy --model` accepts); the second becomes `Model.Label` (for display). Lines without a tab keep the old `id == label` behaviour for backward compatibility with older `agy` versions.
- **`antigravityNormaliseModel`** (`antigravity.go`): strips a tab-joined `id\tLabel` suffix from `opts.Model` at `Execute` time, so agents that already have the corrupted value persisted keep working without a manual re-set.
- **`antigravityModelError`** (`antigravity.go`): accepts a `Label` match too, so a legacy value stored as the display label is not falsely rejected by the up-front validation.
- Comments updated to reflect that `agy --model` takes the bare model id, not the display string.

## Related Issue

Closes #6867

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Install `agy` and run `agy models` — observe the tab-separated `id\tLabel` format.
2. Set an agent's model to a bare id: `multica agent update <id> --model "gemini-3.6-flash-medium"`.
3. Run the agent — it should execute successfully instead of failing with `exit status 1`.
4. For a legacy agent whose model was persisted as `gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)` (by the old parser): the normalisation step strips the tab-suffix at run time, so the agent works without a manual re-set.

Unit tests:
- `TestParseAntigravityModels` — covers tab-separated `id\tLabel`, no-tab lines, duplicates, blanks.
- `TestAntigravityModelError` — covers ID match, Label match (legacy), empty, nil catalog, near-miss rejection.
- `TestAntigravityNormaliseModel` — covers `id\tLabel` stripping, no-tab passthrough, whitespace trimming.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
