### PR TITLE
MUL-6178: fix(skills): re-verify permission and staleness inside the refresh transaction

### DIFF
--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -102,6 +103,23 @@ var (
 	errSkillOverwriteForbidden    = errors.New("not permitted to overwrite target skill")
 	errSkillOverwriteNameMismatch = errors.New("target skill name does not match the imported skill")
 	errSkillOverwriteNameConflict = errors.New("another skill in the workspace already has the imported name")
+	errSkillOverwriteStale        = errors.New("target skill changed since it was read")
+)
+
+// skillOverwriteAuthz names the permission rule overwriteSkillWithFiles applies
+// inside its transaction. It is a policy, not a decision: the tx evaluates it
+// against state it reads itself, so a caller that did slow work (a network
+// fetch) between its own check and this write cannot carry a stale verdict in.
+type skillOverwriteAuthz int
+
+const (
+	// overwriteAuthzCreatorOnly is the default. Only the skill's current
+	// creator may overwrite it — see canOverwriteSkillByLocalImport.
+	overwriteAuthzCreatorOnly skillOverwriteAuthz = iota
+	// overwriteAuthzCreatorOrManager mirrors canManageSkill: the caller must
+	// still be a workspace member, and must be an owner/admin or the skill's
+	// current creator. Membership and role are re-read inside the tx.
+	overwriteAuthzCreatorOrManager
 )
 
 type skillOverwriteInput struct {
@@ -117,21 +135,64 @@ type skillOverwriteInput struct {
 	// A collision with another skill in the workspace (UNIQUE(workspace_id,
 	// name)) fails the whole overwrite with errSkillOverwriteNameConflict.
 	NewName string
-	// AllowOverwrite overrides the in-tx permission recheck. Nil keeps the
-	// default creator-only policy (canOverwriteSkillByLocalImport).
-	AllowOverwrite func(userID string, skill db.Skill) bool
-	Description    string
-	Content        string
-	Config         any
-	Files          []CreateSkillFileRequest
+	// Authz selects the permission rule re-applied inside the tx.
+	Authz skillOverwriteAuthz
+	// ExpectedUpdatedAt, when valid, must equal the target's current updated_at.
+	// Otherwise the overwrite fails with errSkillOverwriteStale. Callers that
+	// read the skill, do slow work, then overwrite pass what they read.
+	ExpectedUpdatedAt pgtype.Timestamptz
+	Description       string
+	Content           string
+	Config            any
+	Files             []CreateSkillFileRequest
+}
+
+// authorizeSkillOverwrite applies input.Authz to the locked target row. Under
+// overwriteAuthzCreatorOrManager it re-reads the caller's membership, so a
+// caller removed from the workspace or demoted since the request-time check is
+// rejected here rather than landing the write.
+func authorizeSkillOverwrite(ctx context.Context, qtx *db.Queries, input skillOverwriteInput, existing db.Skill) error {
+	isCreator := canOverwriteSkillByLocalImport(input.UserID, existing)
+	if input.Authz == overwriteAuthzCreatorOnly {
+		if !isCreator {
+			return errSkillOverwriteForbidden
+		}
+		return nil
+	}
+
+	userUUID, err := util.ParseUUID(input.UserID)
+	if err != nil {
+		return errSkillOverwriteForbidden
+	}
+	member, err := qtx.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+		UserID:      userUUID,
+		WorkspaceID: input.WorkspaceID,
+	})
+	if err != nil {
+		// No membership row: the caller left or was removed since the
+		// request-time check.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return errSkillOverwriteForbidden
+		}
+		return err
+	}
+	if !roleAllowed(member.Role, "owner", "admin", "member") {
+		return errSkillOverwriteForbidden
+	}
+	if !roleAllowed(member.Role, "owner", "admin") && !isCreator {
+		return errSkillOverwriteForbidden
+	}
+	return nil
 }
 
 // overwriteSkillWithFiles re-imports a bundle onto an existing skill in a single
-// transaction. It re-verifies, inside that tx, that the target still exists in
-// the workspace and that UserID may overwrite it (creator-only — see
-// canOverwriteSkillByLocalImport). A target deleted or a creator change between
-// the user's confirm and this write fails cleanly via errSkillOverwriteNotFound
-// / errSkillOverwriteForbidden rather than falling back to create.
+// transaction. It locks the target row and re-verifies three things in that tx:
+// the target still exists in the workspace, UserID may overwrite it under
+// input.Authz (see authorizeSkillOverwrite), and it has not changed since
+// input.ExpectedUpdatedAt. A deleted target, a creator change, a role change, or
+// a concurrent edit fails cleanly via errSkillOverwriteNotFound,
+// errSkillOverwriteForbidden or errSkillOverwriteStale rather than falling back
+// to create.
 //
 // Preserved: id, created_by, created_at, name, and agent_skill bindings (the
 // row identity and the binding table are never touched). Replaced: description,
@@ -155,7 +216,10 @@ func (h *Handler) overwriteSkillWithFiles(ctx context.Context, input skillOverwr
 
 	qtx := h.Queries.WithTx(tx)
 
-	existing, err := qtx.GetSkillInWorkspace(ctx, db.GetSkillInWorkspaceParams{
+	// FOR UPDATE locks the row for the rest of the tx, so the checks below
+	// (permission, updated_at, name) still hold at the UPDATE. Under READ
+	// COMMITTED a plain read would let a concurrent edit commit in between.
+	existing, err := qtx.GetSkillInWorkspaceForUpdate(ctx, db.GetSkillInWorkspaceForUpdateParams{
 		ID:          input.TargetSkillID,
 		WorkspaceID: input.WorkspaceID,
 	})
@@ -165,12 +229,16 @@ func (h *Handler) overwriteSkillWithFiles(ctx context.Context, input skillOverwr
 		}
 		return SkillWithFilesResponse{}, err
 	}
-	allowOverwrite := input.AllowOverwrite
-	if allowOverwrite == nil {
-		allowOverwrite = canOverwriteSkillByLocalImport
+	if err := authorizeSkillOverwrite(ctx, qtx, input, existing); err != nil {
+		return SkillWithFilesResponse{}, err
 	}
-	if !allowOverwrite(input.UserID, existing) {
-		return SkillWithFilesResponse{}, errSkillOverwriteForbidden
+	// Compare-and-set against the row the caller read before its slow work.
+	// UpdateSkill replaces name, description, content and config outright.
+	// Without this check an edit made in that window disappears with no signal
+	// — including a change to the source URL in config.origin.
+	if input.ExpectedUpdatedAt.Valid &&
+		!existing.UpdatedAt.Time.Equal(input.ExpectedUpdatedAt.Time) {
+		return SkillWithFilesResponse{}, errSkillOverwriteStale
 	}
 	// The overwrite is keyed on target_skill_id, but the conflict the user
 	// confirmed was a same-name collision; reject if the target's name no longer

--- a/server/internal/handler/skill_refresh.go
+++ b/server/internal/handler/skill_refresh.go
@@ -12,8 +12,6 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/multica-ai/multica/server/pkg/protocol"
-
-	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // errSkillNotRefreshable marks a skill whose stored provenance cannot be
@@ -128,8 +126,9 @@ func (h *Handler) RefreshSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Permission before any upstream fetch, so a forbidden caller cannot burn
-	// the 45s fetch budget. Mirrors canManageSkill, keeping the member row to
-	// re-check permission inside the overwrite transaction.
+	// the 45s fetch budget. This is only the early reject: the overwrite tx
+	// re-reads membership and applies the same rule itself, because the fetch
+	// in between runs for up to importFetchTimeout.
 	workspaceID := uuidToString(skill.WorkspaceID)
 	member, ok := h.requireWorkspaceRole(w, r, workspaceID, "skill not found", "owner", "admin", "member")
 	if !ok {
@@ -174,13 +173,15 @@ func (h *Handler) RefreshSkill(w http.ResponseWriter, r *http.Request) {
 		TargetSkillID: skill.ID,
 		UserID:        userID,
 		NewName:       newName,
-		AllowOverwrite: func(uid string, s db.Skill) bool {
-			return isAdmin || (s.CreatedBy.Valid && uuidToString(s.CreatedBy) == uid)
-		},
-		Description: imported.description,
-		Content:     imported.content,
-		Config:      mergeSkillConfigOrigin(skill.Config, imported.origin),
-		Files:       importedSkillFileRequests(imported),
+		Authz:         overwriteAuthzCreatorOrManager,
+		// Second hazard in the same window: an edit made while the fetch runs
+		// would be replaced without warning. Return 409 so the user re-confirms
+		// against what the skill now says.
+		ExpectedUpdatedAt: skill.UpdatedAt,
+		Description:       imported.description,
+		Content:           imported.content,
+		Config:            mergeSkillConfigOrigin(skill.Config, imported.origin),
+		Files:             importedSkillFileRequests(imported),
 	})
 	if err != nil {
 		switch {
@@ -190,6 +191,8 @@ func (h *Handler) RefreshSkill(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusForbidden, "only the skill creator or a workspace admin can update this skill from its source")
 		case errors.Is(err, errSkillOverwriteNameConflict):
 			writeError(w, http.StatusConflict, "a skill named \""+newName+"\" already exists in this workspace")
+		case errors.Is(err, errSkillOverwriteStale):
+			writeError(w, http.StatusConflict, "this skill was edited while the update was downloading; review the changes and try again")
 		default:
 			writeError(w, http.StatusInternalServerError, "failed to update skill from source: "+err.Error())
 		}

--- a/server/internal/handler/skill_refresh_test.go
+++ b/server/internal/handler/skill_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -45,8 +46,37 @@ func createImportTargetSkillWithConfig(t *testing.T, name, ownerID, configJSON s
 func installClawHubFixture(t *testing.T, slug, displayName, summary string, files map[string]string) *int {
 	t.Helper()
 
+	return installClawHubFixtureGated(t, slug, displayName, summary, files, nil)
+}
+
+// installGatedClawHubFixture is installClawHubFixture with a barrier. The first
+// upstream request closes fetching and then blocks until the test closes
+// release, which is what lets a test mutate the database while the refresh is
+// parked mid-fetch — the window the in-tx permission and staleness re-checks
+// exist to cover.
+func installGatedClawHubFixture(t *testing.T, slug, displayName, summary string, files map[string]string) (fetching <-chan struct{}, release chan<- struct{}) {
+	t.Helper()
+
+	started := make(chan struct{})
+	gate := make(chan struct{})
+	var once sync.Once
+	installClawHubFixtureGated(t, slug, displayName, summary, files, func() {
+		once.Do(func() {
+			close(started)
+			<-gate
+		})
+	})
+	return started, gate
+}
+
+func installClawHubFixtureGated(t *testing.T, slug, displayName, summary string, files map[string]string, gate func()) *int {
+	t.Helper()
+
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gate != nil {
+			gate()
+		}
 		requests++
 		switch {
 		case r.URL.Path == "/api/v1/skills/"+slug:
@@ -275,6 +305,93 @@ func TestRefreshSkill_PlainMemberNonCreatorForbidden(t *testing.T) {
 	// Permission is checked before the fetch: the upstream must never be hit.
 	if *requests != 0 {
 		t.Fatalf("forbidden refresh must not contact the upstream, got %d requests", *requests)
+	}
+}
+
+// The request-time permission check happens before a fetch that may run for
+// importFetchTimeout. A caller demoted or removed during that window must not
+// land the overwrite, so the write tx re-reads membership and rejects here.
+func TestRefreshSkill_RoleRevokedDuringFetchForbidden(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	// The skill belongs to the workspace owner. The caller is a separate
+	// admin, so their role is the only thing authorizing them.
+	adminID := createRuntimeLocalSkillTestMember(t, "admin")
+	slug := fmt.Sprintf("refresh-revoked-%d", time.Now().UnixNano())
+	skillID := createImportTargetSkillWithConfig(t, slug, testUserID, clawhubOriginConfig(slug), nil)
+
+	fetching, release := installGatedClawHubFixture(t, slug, slug, "incoming", map[string]string{"SKILL.md": "# incoming"})
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- doRefreshSkill(t, adminID, skillID) }()
+
+	select {
+	case <-fetching:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream fetch never started")
+	}
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM member WHERE workspace_id = $1 AND user_id = $2`, testWorkspaceID, adminID); err != nil {
+		t.Fatalf("revoke membership: %v", err)
+	}
+	close(release)
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh never returned")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 after membership was revoked mid-fetch, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, desc, _, _ := getSkillRow(t, skillID); desc != "original description" {
+		t.Fatalf("revoked refresh must not mutate the skill, description = %q", desc)
+	}
+}
+
+// An edit that lands while the upstream fetch is in flight must survive. The
+// write tx compares updated_at against the row the request read, so the
+// overwrite fails with 409 and the edit stays.
+func TestRefreshSkill_ConcurrentEditConflicts(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	slug := fmt.Sprintf("refresh-raced-%d", time.Now().UnixNano())
+	skillID := createImportTargetSkillWithConfig(t, slug, testUserID, clawhubOriginConfig(slug), nil)
+
+	fetching, release := installGatedClawHubFixture(t, slug, slug, "incoming", map[string]string{"SKILL.md": "# incoming"})
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- doRefreshSkill(t, testUserID, skillID) }()
+
+	select {
+	case <-fetching:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream fetch never started")
+	}
+	// Another member edits the body without renaming the skill.
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE skill SET content = $2, updated_at = now() WHERE id = $1`,
+		skillID, "# someone else's edit"); err != nil {
+		t.Fatalf("concurrent edit: %v", err)
+	}
+	close(release)
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh never returned")
+	}
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 after a concurrent edit, got %d: %s", w.Code, w.Body.String())
+	}
+	if _, _, content, _ := getSkillRow(t, skillID); content != "# someone else's edit" {
+		t.Fatalf("concurrent edit must survive, content = %q", content)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
@@ -261,9 +261,11 @@ instead of retrying in a loop:
 
 - `422`: the skill has no refreshable provenance (created manually, imported
   from a local archive, or copied from a local runtime). Re-import instead.
-- `409`: the upstream renamed the skill and another workspace skill already
-  uses that name; nothing was changed.
-- `403`: caller is neither the creator nor a workspace admin.
+- `409`: either the upstream renamed the skill and another workspace skill
+  already uses that name, or someone edited the skill while the download was in
+  flight. Nothing was changed; re-read the skill before retrying.
+- `403`: caller is neither the creator nor a workspace admin, or lost that
+  standing while the download was in flight.
 - `502` / `503` / `504` / `413`: upstream fetch failed (gone, unavailable,
   timed out, or now exceeds import caps); the skill is left untouched.
 

--- a/server/internal/service/builtin_skills/multica-skill-importing/references/skill-importing-source-map.md
+++ b/server/internal/service/builtin_skills/multica-skill-importing/references/skill-importing-source-map.md
@@ -124,16 +124,18 @@ that omit `on_conflict` still receive a bare `SkillWithFilesResponse`.
 
 | Behavior | File:line |
 |---|---|
-| `RefreshSkill` handler | `server/internal/handler/skill_refresh.go:120` |
+| `RefreshSkill` handler | `server/internal/handler/skill_refresh.go:118` |
 | Route `r.Post("/refresh", h.RefreshSkill)` | `server/cmd/server/router.go:1594` |
 | Reads stored provenance `config.origin.{type,source_url}` | `parseSkillOrigin`, `server/internal/handler/skill_refresh.go:32` |
 | Refreshable origins are `github` / `skills_sh` / `clawhub` only | `refreshableOriginSource`, `server/internal/handler/skill_refresh.go:57` |
 | Re-runs the matching import fetcher from the stored `source_url` | `fetchImportedSkillFromOrigin`, `server/internal/handler/skill_refresh.go:75` |
 | Non-refreshable origin → 422 | `errSkillNotRefreshable`, `server/internal/handler/skill_refresh.go:22` |
-| Permission: creator or workspace owner/admin, checked before the fetch | `server/internal/handler/skill_refresh.go:120` (body) — broader than import-overwrite's creator-only rule |
-| Merges only `config.origin`, preserving other config keys | `mergeSkillConfigOrigin`, `server/internal/handler/skill_refresh.go:99` |
-| In-place overwrite preserving id/creator/bindings, adopting upstream rename | `overwriteSkillWithFiles` with `NewName` + `AllowOverwrite`, `server/internal/handler/skill_create.go:119-122`, tx helper `:133` |
-| Upstream rename colliding with another skill → 409 | `errSkillOverwriteNameConflict`, `server/internal/handler/skill_create.go:104` |
+| Permission: creator or workspace owner/admin, checked before the fetch | `server/internal/handler/skill_refresh.go:118` (body) — broader than import-overwrite's creator-only rule |
+| Permission re-read inside the write tx, so a demotion during the fetch → 403 | `authorizeSkillOverwrite`, `server/internal/handler/skill_create.go:154` |
+| Merges only `config.origin`, preserving other config keys | `mergeSkillConfigOrigin`, `server/internal/handler/skill_refresh.go:97` |
+| In-place overwrite preserving id/creator/bindings, adopting upstream rename | `overwriteSkillWithFiles` with `NewName` + `Authz`, `server/internal/handler/skill_create.go:134-139`, tx helper `:202` |
+| Upstream rename colliding with another skill → 409 | `errSkillOverwriteNameConflict`, `server/internal/handler/skill_create.go:105` |
+| An edit landing during the fetch → 409, the edit is kept | `ExpectedUpdatedAt` compare-and-set, `server/internal/handler/skill_create.go:143` |
 | Fetch failures map like import (413/502/503/504) | `importFetchErrorResponse` (grep in `server/internal/handler/skill.go`) |
 | CLI `skill refresh <id>` def / runner | `server/cmd/multica/cmd_skill.go:66`, `runSkillRefresh` at `:425` |
 | Handler tests | `server/internal/handler/skill_refresh_test.go` |

--- a/server/pkg/db/generated/skill.sql.go
+++ b/server/pkg/db/generated/skill.sql.go
@@ -196,6 +196,38 @@ func (q *Queries) GetSkillInWorkspace(ctx context.Context, arg GetSkillInWorkspa
 	return i, err
 }
 
+const getSkillInWorkspaceForUpdate = `-- name: GetSkillInWorkspaceForUpdate :one
+SELECT id, workspace_id, name, description, content, config, created_by, created_at, updated_at FROM skill
+WHERE id = $1 AND workspace_id = $2
+FOR UPDATE
+`
+
+type GetSkillInWorkspaceForUpdateParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Row-locking read for the overwrite path. The lock holds for the rest of the
+// transaction, which turns the caller's updated_at comparison into a real
+// compare-and-set. Without it, under READ COMMITTED, a concurrent edit can
+// commit between the read and the UPDATE and be discarded unnoticed.
+func (q *Queries) GetSkillInWorkspaceForUpdate(ctx context.Context, arg GetSkillInWorkspaceForUpdateParams) (Skill, error) {
+	row := q.db.QueryRow(ctx, getSkillInWorkspaceForUpdate, arg.ID, arg.WorkspaceID)
+	var i Skill
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Description,
+		&i.Content,
+		&i.Config,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listAgentSkillNamesByAgentIDs = `-- name: ListAgentSkillNamesByAgentIDs :many
 SELECT ask.agent_id, s.name
 FROM agent_skill ask

--- a/server/pkg/db/queries/skill.sql
+++ b/server/pkg/db/queries/skill.sql
@@ -23,6 +23,15 @@ WHERE id = $1;
 SELECT * FROM skill
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetSkillInWorkspaceForUpdate :one
+-- Row-locking read for the overwrite path. The lock holds for the rest of the
+-- transaction, which turns the caller's updated_at comparison into a real
+-- compare-and-set. Without it, under READ COMMITTED, a concurrent edit can
+-- commit between the read and the UPDATE and be discarded unnoticed.
+SELECT * FROM skill
+WHERE id = $1 AND workspace_id = $2
+FOR UPDATE;
+
 -- name: GetSkillByWorkspaceAndName :one
 -- Used by skill import and runtime-local skill discovery to reuse a workspace
 -- skill by name rather than violating UNIQUE(workspace_id, name).


### PR DESCRIPTION
## What

`POST /api/skills/{id}/refresh` (added in #6847) checks `canManageSkill`, then fetches the bundle from the upstream for up to `importFetchTimeout` (45s), then overwrites. Two things can change during that window, and neither was re-checked at the write.

**Permission.** The `AllowOverwrite` closure captured `isAdmin` from the request-time check, so a caller removed from the workspace or demoted mid-fetch still landed the overwrite. Only `isCreator` was re-evaluated in the transaction. Replaced with an `Authz` policy the transaction applies to a membership row it reads itself.

**Staleness.** `UpdateSkill` replaces name, description, content and config outright, and the only in-tx guard was the name comparison. An edit made during the fetch disappeared with no signal — including a change to `config.origin`'s source URL. The request now carries the `updated_at` it read into the transaction as a compare-and-set, returning `409`.

The target read becomes `FOR UPDATE`, so both checks still hold at the `UPDATE`. Under READ COMMITTED a plain read lets a concurrent edit commit in between.

## Tests

Both regression tests park the refresh mid-fetch on a gated ClawHub fixture, mutate the database, then release:

- `TestRefreshSkill_RoleRevokedDuringFetchForbidden` — admin's membership is deleted mid-fetch → `403`, skill unchanged.
- `TestRefreshSkill_ConcurrentEditConflicts` — another member edits the body mid-fetch → `409`, the edit survives.

Each was confirmed to fail against the current behavior before the fix: emulating the pre-fetch verdict makes the first return `200`, and dropping `ExpectedUpdatedAt` makes the second return `200` with the edit overwritten.

## Verification

- `go test ./internal/handler` — full package, against a migrated Postgres
- `go test ./cmd/multica`
- `go vet ./...`
- `sqlc generate` for the new `GetSkillInWorkspaceForUpdate` query

## Notes

Behavior change for API clients: refresh can now return `409` for a reason other than a rename collision. The built-in skill docs (`SKILL.md` and the source map) are updated in the same PR per CLAUDE.md.

The import-overwrite path is untouched — it keeps the creator-only default, now spelled `overwriteAuthzCreatorOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)