### PR TITLE
MUL-6175: Make unavailable price previews recoverable

### DIFF
--- a/packages/core/billing/workspace-subscription-queries.test.ts
+++ b/packages/core/billing/workspace-subscription-queries.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  workspaceSubscriptionPricesOptions,
+  workspaceSubscriptionPricesStaleTime,
+} from "./workspace-subscription-queries";
+
+describe("workspace subscription price query", () => {
+  it("keeps missing price responses stale so the UI can recover", () => {
+    expect(workspaceSubscriptionPricesStaleTime(undefined)).toBe(0);
+    expect(workspaceSubscriptionPricesStaleTime(null)).toBe(0);
+    expect(
+      workspaceSubscriptionPricesStaleTime({
+        month: {
+          currency: "usd",
+          unitAmount: 1_000,
+          interval: "month",
+          intervalCount: 1,
+        },
+        year: {
+          currency: "usd",
+          unitAmount: 9_600,
+          interval: "year",
+          intervalCount: 1,
+        },
+      }),
+    ).toBe(10 * 60 * 1_000);
+  });
+
+  it("revalidates stale prices when the Billing window regains focus", () => {
+    const options = workspaceSubscriptionPricesOptions("workspace-1");
+
+    expect(options.refetchOnWindowFocus).toBe(true);
+    expect(options.retry).toBe(false);
+  });
+});

--- a/packages/core/billing/workspace-subscription-queries.test.ts
+++ b/packages/core/billing/workspace-subscription-queries.test.ts
@@ -4,31 +4,39 @@ import {
   workspaceSubscriptionPricesStaleTime,
 } from "./workspace-subscription-queries";
 
+const validPrices = {
+  month: {
+    currency: "usd",
+    unitAmount: 1_000,
+    interval: "month",
+    intervalCount: 1,
+  },
+  year: {
+    currency: "usd",
+    unitAmount: 9_600,
+    interval: "year",
+    intervalCount: 1,
+  },
+} as const;
+
 describe("workspace subscription price query", () => {
   it("keeps missing price responses stale so the UI can recover", () => {
     expect(workspaceSubscriptionPricesStaleTime(undefined)).toBe(0);
     expect(workspaceSubscriptionPricesStaleTime(null)).toBe(0);
-    expect(
-      workspaceSubscriptionPricesStaleTime({
-        month: {
-          currency: "usd",
-          unitAmount: 1_000,
-          interval: "month",
-          intervalCount: 1,
-        },
-        year: {
-          currency: "usd",
-          unitAmount: 9_600,
-          interval: "year",
-          intervalCount: 1,
-        },
-      }),
-    ).toBe(10 * 60 * 1_000);
+    expect(workspaceSubscriptionPricesStaleTime(validPrices)).toBe(
+      10 * 60 * 1_000,
+    );
   });
 
-  it("revalidates stale prices when the Billing window regains focus", () => {
+  it("wires the data-aware stale time into focus revalidation", () => {
     const options = workspaceSubscriptionPricesOptions("workspace-1");
+    const staleTime = options.staleTime as (query: {
+      state: { data: typeof validPrices | null };
+    }) => number;
 
+    expect(typeof staleTime).toBe("function");
+    expect(staleTime({ state: { data: null } })).toBe(0);
+    expect(staleTime({ state: { data: validPrices } })).toBe(10 * 60 * 1_000);
     expect(options.refetchOnWindowFocus).toBe(true);
     expect(options.retry).toBe(false);
   });

--- a/packages/core/billing/workspace-subscription-queries.ts
+++ b/packages/core/billing/workspace-subscription-queries.ts
@@ -1,5 +1,8 @@
 import { queryOptions } from "@tanstack/react-query";
+import type { WorkspaceSubscriptionPrices } from "../types";
 import { api } from "../api";
+
+const WORKSPACE_SUBSCRIPTION_PRICES_STALE_TIME_MS = 10 * 60 * 1000;
 
 /**
  * Workspace subscription reads.
@@ -47,22 +50,36 @@ export function workspaceSubscriptionSummaryOptions(wsId: string) {
 }
 
 /**
+ * A validated price snapshot is stable deployment configuration, but a null
+ * parse fallback is not a snapshot. Keeping null fresh made one transient
+ * contract/deployment failure suppress prices for ten minutes with no way to
+ * recover from the Billing tab.
+ */
+export function workspaceSubscriptionPricesStaleTime(
+  prices: WorkspaceSubscriptionPrices | null | undefined,
+): number {
+  return prices ? WORKSPACE_SUBSCRIPTION_PRICES_STALE_TIME_MS : 0;
+}
+
+/**
  * Prices are deployment configuration, not workspace state: they change only
- * when an operator repoints a Stripe Price. Cache them for much longer than the
- * summary and do not refetch on focus — cloud already caches them and each miss
- * costs a Stripe round trip.
+ * when an operator repoints a Stripe Price. Cache validated values for much
+ * longer than the summary. Missing/malformed values stay stale so a remount or
+ * window focus can recover after a backend rollout or transient dependency
+ * failure; cloud already caches Stripe reads, so revalidation is inexpensive.
  *
  * Retry is disabled because the failure mode here is a misconfigured or
- * unvalidatable Price, which retrying cannot fix; the caller shows "price
- * confirmed at Checkout" instead.
+ * unvalidatable Price, which immediate retries cannot fix. The caller keeps
+ * Checkout available and exposes an explicit price-only retry instead.
  */
 export function workspaceSubscriptionPricesOptions(wsId: string) {
   return queryOptions({
     queryKey: workspaceSubscriptionKeys.prices(wsId),
     queryFn: () => api.getWorkspaceSubscriptionPrices(),
     enabled: wsId.length > 0,
-    staleTime: 10 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: (query) =>
+      workspaceSubscriptionPricesStaleTime(query.state.data),
+    refetchOnWindowFocus: true,
     retry: false,
   });
 }

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   portal: vi.fn(),
   reconcile: vi.fn(),
   refetch: vi.fn(),
+  refetchPrices: vi.fn(),
   openExternal: vi.fn(),
   role: "owner" as "owner" | "admin" | "member",
   workspaceId: "workspace-1",
@@ -30,6 +31,7 @@ const mocks = vi.hoisted(() => ({
     };
   } | null,
   pricesLoading: false,
+  pricesFetching: false,
   pricesError: false,
   entitlements: {
     workspaceId: "workspace-1",
@@ -121,6 +123,7 @@ describe("BillingTab", () => {
       },
     };
     mocks.pricesLoading = false;
+    mocks.pricesFetching = false;
     mocks.pricesError = false;
     Object.assign(mocks.entitlements, {
       plan: "free",
@@ -138,7 +141,9 @@ describe("BillingTab", () => {
         return {
           data: mocks.prices,
           isLoading: mocks.pricesLoading,
+          isFetching: mocks.pricesFetching,
           isError: mocks.pricesError,
+          refetch: mocks.refetchPrices,
         };
       }
       return {
@@ -250,6 +255,9 @@ describe("BillingTab", () => {
         ),
       ).toBeInTheDocument();
       expect(screen.queryByText(/\$0/)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Retry" }));
+      expect(mocks.refetchPrices).toHaveBeenCalledOnce();
 
       await user.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
       await user.click(

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -207,6 +207,9 @@ describe("BillingTab", () => {
     expect(
       screen.queryByText("Estimated monthly total: $30.00"),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
   });
 
   it("formats Stripe minor units for decimal, zero-decimal, and special currencies", () => {
@@ -229,6 +232,21 @@ describe("BillingTab", () => {
 
     renderWithI18n(<BillingTab />);
 
+    expect(
+      screen.getByRole("status", { name: "Loading subscription prices" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Upgrade to Pro" }),
+    ).toBeEnabled();
+  });
+
+  it("announces a price-only retry without blocking Checkout", () => {
+    mocks.prices = null;
+    mocks.pricesFetching = true;
+
+    renderWithI18n(<BillingTab />);
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeDisabled();
     expect(
       screen.getByRole("status", { name: "Loading subscription prices" }),
     ).toBeInTheDocument();
@@ -300,6 +318,9 @@ describe("BillingTab", () => {
     expect(
       screen.getByText(/Stripe Checkout shows the authoritative per-seat price/),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
   });
 
   it("creates Checkout with a client idempotency key and opens Stripe externally", async () => {

--- a/packages/views/settings/components/billing-tab.tsx
+++ b/packages/views/settings/components/billing-tab.tsx
@@ -517,8 +517,7 @@ function BillingTabContent() {
     selectedPrice?.intervalCount === 1 && formattedUnitPrice !== null;
   const hasDisplayableEstimatedTotal =
     hasDisplayableUnitPrice && formattedEstimatedTotal !== null;
-  const isPriceUnavailable =
-    !pricesQuery.isLoading && !hasDisplayableUnitPrice;
+  const canRetryPrice = !pricesQuery.isLoading && selectedPrice === null;
 
   return (
     <SettingsTab
@@ -703,21 +702,35 @@ function BillingTabContent() {
                 <p className="max-w-[65ch] text-caption leading-5 text-muted-foreground">
                   {t(($) => $.workspace.upgrade.price_at_checkout)}
                 </p>
-                {isPriceUnavailable ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={pricesQuery.isFetching}
-                    onClick={() => void pricesQuery.refetch()}
-                  >
+                {canRetryPrice ? (
+                  <>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      aria-busy={pricesQuery.isFetching}
+                      disabled={pricesQuery.isFetching}
+                      onClick={() => void pricesQuery.refetch()}
+                    >
+                      {pricesQuery.isFetching ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <RefreshCw />
+                      )}
+                      {t(($) => $.workspace.actions.retry)}
+                    </Button>
                     {pricesQuery.isFetching ? (
-                      <Loader2 className="animate-spin" />
-                    ) : (
-                      <RefreshCw />
-                    )}
-                    {t(($) => $.workspace.actions.retry)}
-                  </Button>
+                      <span
+                        className="sr-only"
+                        role="status"
+                        aria-label={t(
+                          ($) => $.workspace.upgrade.price_loading,
+                        )}
+                      >
+                        {t(($) => $.workspace.upgrade.price_loading)}
+                      </span>
+                    ) : null}
+                  </>
                 ) : null}
               </div>
               {canManage ? (

--- a/packages/views/settings/components/billing-tab.tsx
+++ b/packages/views/settings/components/billing-tab.tsx
@@ -517,6 +517,8 @@ function BillingTabContent() {
     selectedPrice?.intervalCount === 1 && formattedUnitPrice !== null;
   const hasDisplayableEstimatedTotal =
     hasDisplayableUnitPrice && formattedEstimatedTotal !== null;
+  const isPriceUnavailable =
+    !pricesQuery.isLoading && !hasDisplayableUnitPrice;
 
   return (
     <SettingsTab
@@ -701,6 +703,22 @@ function BillingTabContent() {
                 <p className="max-w-[65ch] text-caption leading-5 text-muted-foreground">
                   {t(($) => $.workspace.upgrade.price_at_checkout)}
                 </p>
+                {isPriceUnavailable ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={pricesQuery.isFetching}
+                    onClick={() => void pricesQuery.refetch()}
+                  >
+                    {pricesQuery.isFetching ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <RefreshCw />
+                    )}
+                    {t(($) => $.workspace.actions.retry)}
+                  </Button>
+                ) : null}
               </div>
               {canManage ? (
                 <Button

--- a/server/internal/integrations/wecom/inbound_media_bind_db_test.go
+++ b/server/internal/integrations/wecom/inbound_media_bind_db_test.go
@@ -272,12 +272,12 @@ func TestInboundImageBecomesAnAttachmentOnTheChatMessage(t *testing.T) {
 	var attachments int
 	for {
 		if err := pool.QueryRow(ctx, `
-			SELECT cm.id, cm.chat_session_id, cm.content, cm.channel_media_pending_until
+			SELECT cm.id, cm.chat_session_id, cm.content
 			FROM chat_message cm
 			JOIN chat_session cs ON cs.id = cm.chat_session_id
 			WHERE cs.workspace_id = $1 AND cm.role = 'user'
 			ORDER BY cm.created_at DESC LIMIT 1`,
-			fixture.workspaceID).Scan(&chatMessageID, &sessionID, &body, &pendingUntil); err != nil {
+			fixture.workspaceID).Scan(&chatMessageID, &sessionID, &body); err != nil {
 			if time.Now().After(deadline) {
 				t.Fatalf("no durable chat_message was ever written: %v", err)
 			}
@@ -355,6 +355,14 @@ func TestInboundImageBecomesAnAttachmentOnTheChatMessage(t *testing.T) {
 	}
 
 	// 4. The pending marker is cleared, which is what releases the agent run.
+	// Read it after observing the attachment and promotion. The polling query
+	// can race with the bind transaction and otherwise leave a stale pre-bind
+	// value in pendingUntil even though the database row has been cleared.
+	if err := pool.QueryRow(ctx,
+		`SELECT channel_media_pending_until FROM chat_message WHERE id = $1`, chatMessageID).
+		Scan(&pendingUntil); err != nil {
+		t.Fatalf("load media pending marker: %v", err)
+	}
 	if pendingUntil.Valid {
 		t.Errorf("channel_media_pending_until = %v, want NULL after binding", pendingUntil.Time)
 	}


### PR DESCRIPTION
## Problem

This follow-up does not establish why the staging prices request is unavailable. It fixes the separate recovery gap after a price read fails or returns an unreadable response.

Previously, React Query treated the schema fallback value `null` as successful data and cached it for ten minutes. The query also disabled refetching on window focus, and the UI provided no price-specific retry action. After one 404/503, transient Stripe failure, or unreadable response, Billing could remain on the Checkout notice without another in-page recovery attempt.

## Fix

- Keep the ten-minute client cache only for validated price snapshots; treat null or missing results as immediately stale.
- Refetch stale prices when the Billing window regains focus.
- Show a dedicated Retry action only when the selected price is absent, avoiding a no-op retry for present but non-displayable data.
- Announce price-only retry progress to assistive technology while keeping Checkout available.
- Keep amounts, Price IDs, currency, and seat quantity server-authoritative. Failed reads still never fabricate `$0`.
- Stabilize the unrelated WeCom backend regression assertion by re-reading its media marker after attachment binding and task promotion instead of asserting against a stale polling snapshot.

## Validation

- Billing component tests: 21/21
- Price query policy tests: 2/2, including direct coverage of the `options.staleTime` wiring
- WeCom media-bind regression: 100 repeated passes with the race detector
- `packages/views` and `packages/core` typecheck
- Targeted ESLint checks
- `@multica/web` production build
- `git diff --check`

## Remaining staging diagnosis

The original missing-price report still requires the actual `/api/cloud-subscriptions/prices` response status. A 404 indicates that the manually deployed main backend or multica-cloud prices route is not present; a 503 requires checking Stripe Price configuration and validation logs; a valid 200 response that still renders no price points back to the client contract.

This PR intentionally does not close MUL-6175. Keep the issue open until the staging upstream response is identified and the page/Checkout amounts are confirmed with the Sandbox E2E.
