### PR TITLE
MUL-6180: allow billing idempotency CORS header

### DIFF
--- a/server/cmd/server/cors_headers_test.go
+++ b/server/cmd/server/cors_headers_test.go
@@ -23,6 +23,15 @@ func TestCORSAllowedHeaders_IncludeClientCapabilities(t *testing.T) {
 	}
 }
 
+// Workspace subscription checkout and portal requests use Idempotency-Key to
+// make retries safe. Browsers preflight that custom request header, so omitting
+// it from AllowedHeaders prevents the billing request from reaching the server.
+func TestCORSAllowedHeaders_IncludeIdempotencyKey(t *testing.T) {
+	if !slices.Contains(corsAllowedHeaders, "Idempotency-Key") {
+		t.Fatalf("Idempotency-Key missing from CORS allowed headers: %v", corsAllowedHeaders)
+	}
+}
+
 // Timeline and comment-list endpoints report defensive hard-cap clamps with
 // custom response headers.
 // Custom response headers are not readable from browser JS unless the server

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -59,6 +59,7 @@ var corsAllowedHeaders = []string{
 	"Accept",
 	"Authorization",
 	"Content-Type",
+	"Idempotency-Key",
 	"X-Workspace-ID",
 	"X-Workspace-Slug",
 	"X-Request-ID",


### PR DESCRIPTION
## Summary

- allow browser preflights carrying `Idempotency-Key`
- add a regression test covering workspace subscription checkout and portal requests

## Testing

- `go test ./cmd/server -run '^TestCORSAllowedHeaders_Include(IdempotencyKey|ClientCapabilities)$' -count=1`
- `git diff --check`

Full `go test ./cmd/server -count=1` is currently blocked locally by a stale shared test database missing unrelated columns (`properties`, `pause_reason`, and `unsubscribed_at`).

Closes MUL-6180
