### PR TITLE
MUL-6188: docs: link the Multica CLI skill from the README and CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Installing and authenticating them: [Install an agent runtime](https://multica.a
 | Connect Git and chat tools | [GitHub](https://multica.ai/docs/github-integration) · [Self-hosted Git](https://multica.ai/docs/vcs-integration) · [Channels](https://multica.ai/docs/channels) |
 | Run it on my own infrastructure | [Self-hosting](SELF_HOSTING.md) · [Security model](https://multica.ai/docs/security-model) · [Environment variables](https://multica.ai/docs/environment-variables) |
 | Script it | [CLI reference](https://multica.ai/docs/cli) · [CLI and daemon guide](CLI_AND_DAEMON.md) · [Auth tokens](https://multica.ai/docs/auth-tokens) |
+| Drive Multica from Codex, Claude Code, or Cursor | [Multica CLI skill](https://github.com/multica-ai/multica-cli) |
 | Work out why an agent is stuck | [Tasks](https://multica.ai/docs/tasks) · [Troubleshooting](https://multica.ai/docs/troubleshooting) |
 
 ---

--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -297,8 +297,23 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 | `update` | — | CLI を最新バージョンに更新 | |
 | `version` | — | バージョン情報を表示 | `--output`（`text` または `json`） |
 
+## 別のコーディングエージェントから Multica を操作する
+
+作業の多くを Codex、Claude Code、Cursor の中で進めているなら、ターミナルに切り替えず
+そこから Multica を操作できます。[Multica CLI skill](https://github.com/multica-ai/multica-cli)
+は、このページのコマンドを安全に扱う方法をそれらのエージェントに教えます。イシューと
+コメントスレッドをトークンを浪費せずに読み、コメントはファイル経由で書き、メンション・
+ステータス変更・アサインが伴う副作用を正しく扱います。
+
+認証済みの CLI を通してのみ動作し、それ自体は何の権限も与えません。権限は引き続き
+ログイン、選択中のプロファイル、ワークスペースに由来します。CLI は v0.4.26 以降が必要です。
+Claude Code のプラグインマーケットプレイス、Codex の skill インストーラー、Cursor、
+その他 Markdown の指示を読み込むツールへのインストール方法は、リポジトリの README を
+参照してください。
+
 ## 次のステップ
 
+- [Multica CLI skill](https://github.com/multica-ai/multica-cli) — Codex、Claude Code、Cursor から Multica を操作する。
 - [認証とトークン](/auth-tokens) — PAT の作成、更新、失効。
 - [トラブルシューティング](/troubleshooting) — コマンドのエラーと、いつまでも開始しないタスクの診断。
 - [エージェントの作成と設定](/agents-create) — `agent create` 各フィールドの完全な意味。

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -297,8 +297,23 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 | `update` | — | CLI를 최신 버전으로 업데이트 | |
 | `version` | — | 버전 정보 확인 | `--output`(`text` 또는 `json`) |
 
+## 다른 코딩 에이전트에서 Multica 조작하기
+
+작업 대부분이 Codex, Claude Code, Cursor 안에서 이루어진다면 터미널로 전환하지 않고
+그곳에서 바로 Multica를 조작할 수 있습니다.
+[Multica CLI skill](https://github.com/multica-ai/multica-cli)은 이 페이지의 명령을
+안전하게 다루는 방법을 해당 에이전트에게 가르칩니다. 토큰을 낭비하지 않고 이슈와 댓글
+스레드를 읽고, 댓글은 파일을 통해 작성하며, 멘션·상태 변경·할당이 유발하는 부수 효과를
+올바르게 처리합니다.
+
+인증된 CLI를 통해서만 동작하며 그 자체로는 어떤 접근 권한도 부여하지 않습니다. 권한은
+여전히 로그인, 선택한 profile, workspace에서 나옵니다. CLI v0.4.26 이상이 필요합니다.
+Claude Code 플러그인 마켓플레이스, Codex skill 설치 도구, Cursor를 비롯해 Markdown
+지침을 읽어들이는 다른 도구의 설치 방법은 저장소 README를 참고하세요.
+
 ## 다음 단계
 
+- [Multica CLI skill](https://github.com/multica-ai/multica-cli) — Codex, Claude Code, Cursor에서 Multica를 조작합니다.
 - [인증과 토큰](/auth-tokens) — PAT 생성, 갱신, 취소를 알아봅니다.
 - [문제 해결](/troubleshooting) — 명령 오류와 태스크가 시작되지 않는 문제를 해결합니다.
 - [에이전트 생성 및 설정](/agents-create) — `agent create` 각 필드의 전체 의미를 알아봅니다.

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -318,8 +318,24 @@ The tables below cover every current top-level command, grouped the way the CLI 
 | `update` | — | Update the CLI to the latest version | |
 | `version` | — | Print version information | `--output` (`text` or `json`) |
 
+## Driving Multica from another coding agent
+
+If most of your work already happens inside Codex, Claude Code, or Cursor, you can
+operate Multica from there instead of switching to a terminal. The
+[Multica CLI skill](https://github.com/multica-ai/multica-cli) teaches those agents
+to drive the commands on this page safely: reading issues and comment threads
+without burning tokens, writing comments through a file, and handling the side
+effects that mentions, status changes, and assignments carry.
+
+It runs entirely through your authenticated CLI and grants no access of its own —
+permissions still come from your login, selected profile, and workspace. It requires
+CLI v0.4.26 or newer. The repository README covers installation for the Claude Code
+plugin marketplace, the Codex skill installer, Cursor, and any other tool that loads
+Markdown instructions.
+
 ## Next steps
 
+- [Multica CLI skill](https://github.com/multica-ai/multica-cli) — operate Multica from Codex, Claude Code, or Cursor.
 - [Authentication and tokens](/auth-tokens) — creating, renewing, and revoking PATs.
 - [Troubleshooting](/troubleshooting) — diagnosing command errors and tasks that never start.
 - [Create and configure an agent](/agents-create) — the full semantics of every `agent create` field.

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -297,8 +297,21 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 | `update` | — | 更新 CLI 到最新版本 | |
 | `version` | — | 查看版本信息 | `--output`（`text` 或 `json`） |
 
+## 在其他编码智能体里操作 Multica
+
+如果你的工作大多发生在 Codex、Claude Code 或 Cursor 里，可以直接在那里操作 Multica，
+不必切回终端。[Multica CLI skill](https://github.com/multica-ai/multica-cli)
+会教这些智能体安全地使用本页的命令：低成本地读 issue 和评论线程、通过文件写评论，
+以及正确处理 mention、状态变更和指派带来的副作用。
+
+它完全通过你已认证的 CLI 运行，本身不授予任何权限 —— 权限仍然只来自你的登录、
+所选 profile 和 workspace。要求 CLI 版本不低于 v0.4.26。该仓库的 README 说明了
+Claude Code 插件市场、Codex skill 安装器、Cursor 以及其他任何加载 Markdown 指令的
+工具的安装方式。
+
 ## 接下来
 
+- [Multica CLI skill](https://github.com/multica-ai/multica-cli) — 在 Codex、Claude Code 或 Cursor 里操作 Multica。
 - [认证与令牌](/auth-tokens) — PAT 的创建、续期和吊销。
 - [故障排查](/troubleshooting) — 命令报错和任务不开始的排查路径。
 - [创建和配置智能体](/agents-create) — `agent create` 各字段的完整语义。


### PR DESCRIPTION
The skill that teaches Codex, Claude Code, and Cursor to operate Multica through the authenticated CLI lives at [multica-ai/multica-cli](https://github.com/multica-ai/multica-cli) — but nothing in this repository points at it. A code search for the repo name returns only release-asset filenames (`multica-cli-<version>-<os>-<arch>.tar.gz`), never the repo.

The cost is visible in the issue tracker: users keep filing feature requests for a skill that already exists.

- #6968 — "Add an official Multica Operator Skill for natural-language workflows" (closed; the reporter had not found the existing repo)
- #4681 — "Proposal: Multica skills for Codex / Claude workflows" (open; a community member built their own CLI-backed skill pack five days after the official one was published)

That's a discoverability problem, not a missing feature.

## Changes

- **`README.md`** — one row in the documentation table: "Drive Multica from Codex, Claude Code, or Cursor".
- **`apps/docs/content/docs/cli.{mdx,zh,ja,ko}`** — a short section before *Next steps* explaining what the skill does and what it does not grant, plus a *Next steps* entry. All four languages updated together.

The section is placed on the CLI page rather than the Skills page on purpose: `skills.mdx` documents workspace skills attached to Multica agents, which is a different concept from a portable skill that drives the CLI from an external host. Putting it there would blur the two.

The copy states the v0.4.26 minimum and makes the permission boundary explicit — the skill runs entirely through the user's authenticated CLI and grants no access of its own.

## Verification

- Confirmed the link target returns HTTP 200.
- Confirmed each of the four language files gained exactly one section (12→13 for `cli.mdx`, 11→12 for the three translations). The pre-existing one-section gap between English and the translations is unrelated to this change and was left alone.
- Additions are plain Markdown prose and links — no JSX, expressions, or components.
- **No build or tests were run**: this is a docs-only change and the checkout has no `node_modules`.
