### PR TITLE
fix(lark): ingest standalone file and audio messages (MUL-6198)

### DIFF
--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -257,7 +257,7 @@ func TestFeishuMediaResolver_HasMedia(t *testing.T) {
 		{"text", InboundMessage{MessageID: "om_t", MessageType: "text", Body: "hello", Content: `{"text":"hello"}`}, false},
 		{"image", InboundMessage{MessageID: "om_i", MessageType: "image", Body: "[Image]", Content: `{"image_key":"img_k"}`}, true},
 		{"video", InboundMessage{MessageID: "om_v", MessageType: "media", Body: "[Video]", Content: `{"file_key":"file_k"}`}, true},
-		{"file", InboundMessage{MessageID: "om_f", MessageType: "file", Body: "[File: spec.html]", Content: `{"file_key":"file_k","file_name":"spec.html"}`}, true},
+		{"file", InboundMessage{MessageID: "om_f", MessageType: "file", Body: "[File]", Content: `{"file_key":"file_k","file_name":"spec.html"}`}, true},
 		{"audio", InboundMessage{MessageID: "om_a", MessageType: "audio", Body: "[Audio]", Content: `{"file_key":"audio_k"}`}, true},
 		{"post with image", InboundMessage{MessageID: "om_p", MessageType: "post",
 			Content: `{"content":[[{"tag":"img","image_key":"img_post"}]]}`}, true},
@@ -276,44 +276,63 @@ func TestFeishuMediaResolver_HasMedia(t *testing.T) {
 
 func TestFeishuMediaResolver_AttachesStandaloneFileAndAudioMediaRefs(t *testing.T) {
 	tests := []struct {
-		name        string
-		messageType string
-		body        string
-		content     string
-		contentType string
-		filename    string
-		wantType    channel.MsgType
-		wantKey     string
+		name             string
+		messageType      string
+		body             string
+		content          string
+		contentType      string
+		downloadFilename string
+		wantFilename     string
+		wantContentType  string
+		wantType         channel.MsgType
+		wantKey          string
 	}{
 		{
-			name:        "html file",
-			messageType: "file",
-			body:        "[File: integration.html]",
-			content:     `{"file_key":"file_standalone","file_name":"integration.html","mime_type":"text/html"}`,
-			contentType: "text/html",
-			filename:    "integration.html",
-			wantType:    channel.MsgTypeFile,
-			wantKey:     "file_standalone",
+			name:             "html file",
+			messageType:      "file",
+			body:             "[File]",
+			content:          `{"file_key":"file_standalone","file_name":"integration.html"}`,
+			contentType:      "text/html",
+			downloadFilename: "integration.html",
+			wantFilename:     "integration.html",
+			wantContentType:  "text/html",
+			wantType:         channel.MsgTypeFile,
+			wantKey:          "file_standalone",
 		},
 		{
-			name:        "zip file",
-			messageType: "file",
-			body:        "[File: integration.zip]",
-			content:     `{"file_key":"zip_standalone","file_name":"integration.zip","mime_type":"application/zip"}`,
-			contentType: "application/zip",
-			filename:    "integration.zip",
-			wantType:    channel.MsgTypeFile,
-			wantKey:     "zip_standalone",
+			name:             "zip file",
+			messageType:      "file",
+			body:             "[File]",
+			content:          `{"file_key":"zip_standalone","file_name":"integration.zip"}`,
+			contentType:      "application/zip",
+			downloadFilename: "integration.zip",
+			wantFilename:     "integration.zip",
+			wantContentType:  "application/zip",
+			wantType:         channel.MsgTypeFile,
+			wantKey:          "zip_standalone",
 		},
 		{
-			name:        "audio",
-			messageType: "audio",
-			body:        "[Audio]",
-			content:     `{"file_key":"audio_standalone"}`,
-			contentType: "audio/ogg",
-			filename:    "voice.ogg",
-			wantType:    channel.MsgTypeAudio,
-			wantKey:     "audio_standalone",
+			name:            "audio without response filename",
+			messageType:     "audio",
+			body:            "[Audio]",
+			content:         `{"file_key":"audio_standalone"}`,
+			contentType:     "audio/opus",
+			wantFilename:    "feishu-audio-om_audio_without_response_filename.opus",
+			wantContentType: "audio/opus",
+			wantType:        channel.MsgTypeAudio,
+			wantKey:         "audio_standalone",
+		},
+		{
+			name:             "audio with extensionless response filename",
+			messageType:      "audio",
+			body:             "[Audio]",
+			content:          `{"file_key":"audio_extensionless"}`,
+			contentType:      "audio/octet-stream",
+			downloadFilename: "3CET6CGRY9",
+			wantFilename:     "3CET6CGRY9.opus",
+			wantContentType:  "audio/opus",
+			wantType:         channel.MsgTypeAudio,
+			wantKey:          "audio_extensionless",
 		},
 	}
 
@@ -322,7 +341,7 @@ func TestFeishuMediaResolver_AttachesStandaloneFileAndAudioMediaRefs(t *testing.
 			sender := &fakeSender{downloaded: DownloadedResource{
 				Data:        []byte("payload"),
 				ContentType: tc.contentType,
-				Filename:    tc.filename,
+				Filename:    tc.downloadFilename,
 				SizeBytes:   7,
 			}}
 			storage := &fakeMediaStorage{}
@@ -351,8 +370,11 @@ func TestFeishuMediaResolver_AttachesStandaloneFileAndAudioMediaRefs(t *testing.
 				t.Fatalf("media refs = %+v, want 1", got.MediaRefs)
 			}
 			ref := got.MediaRefs[0]
-			if ref.Type != tc.wantType || ref.Filename != tc.filename || ref.MimeType != tc.contentType || ref.SizeBytes != 7 {
+			if ref.Type != tc.wantType || ref.Filename != tc.wantFilename || ref.MimeType != tc.wantContentType || ref.SizeBytes != 7 {
 				t.Fatalf("media ref wrong: %+v", ref)
+			}
+			if upload := storage.uploads[0]; upload.filename != tc.wantFilename || upload.contentType != tc.wantContentType {
+				t.Fatalf("upload metadata wrong: %+v", upload)
 			}
 		})
 	}

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -257,6 +257,8 @@ func TestFeishuMediaResolver_HasMedia(t *testing.T) {
 		{"text", InboundMessage{MessageID: "om_t", MessageType: "text", Body: "hello", Content: `{"text":"hello"}`}, false},
 		{"image", InboundMessage{MessageID: "om_i", MessageType: "image", Body: "[Image]", Content: `{"image_key":"img_k"}`}, true},
 		{"video", InboundMessage{MessageID: "om_v", MessageType: "media", Body: "[Video]", Content: `{"file_key":"file_k"}`}, true},
+		{"file", InboundMessage{MessageID: "om_f", MessageType: "file", Body: "[File: spec.html]", Content: `{"file_key":"file_k","file_name":"spec.html"}`}, true},
+		{"audio", InboundMessage{MessageID: "om_a", MessageType: "audio", Body: "[Audio]", Content: `{"file_key":"audio_k"}`}, true},
 		{"post with image", InboundMessage{MessageID: "om_p", MessageType: "post",
 			Content: `{"content":[[{"tag":"img","image_key":"img_post"}]]}`}, true},
 		{"post text only", InboundMessage{MessageID: "om_pt", MessageType: "post",
@@ -267,6 +269,90 @@ func TestFeishuMediaResolver_HasMedia(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := resolver.HasMedia(channelMessageFromLark(tc.lm)); got != tc.want {
 				t.Fatalf("HasMedia = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFeishuMediaResolver_AttachesStandaloneFileAndAudioMediaRefs(t *testing.T) {
+	tests := []struct {
+		name        string
+		messageType string
+		body        string
+		content     string
+		contentType string
+		filename    string
+		wantType    channel.MsgType
+		wantKey     string
+	}{
+		{
+			name:        "html file",
+			messageType: "file",
+			body:        "[File: integration.html]",
+			content:     `{"file_key":"file_standalone","file_name":"integration.html","mime_type":"text/html"}`,
+			contentType: "text/html",
+			filename:    "integration.html",
+			wantType:    channel.MsgTypeFile,
+			wantKey:     "file_standalone",
+		},
+		{
+			name:        "zip file",
+			messageType: "file",
+			body:        "[File: integration.zip]",
+			content:     `{"file_key":"zip_standalone","file_name":"integration.zip","mime_type":"application/zip"}`,
+			contentType: "application/zip",
+			filename:    "integration.zip",
+			wantType:    channel.MsgTypeFile,
+			wantKey:     "zip_standalone",
+		},
+		{
+			name:        "audio",
+			messageType: "audio",
+			body:        "[Audio]",
+			content:     `{"file_key":"audio_standalone"}`,
+			contentType: "audio/ogg",
+			filename:    "voice.ogg",
+			wantType:    channel.MsgTypeAudio,
+			wantKey:     "audio_standalone",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeSender{downloaded: DownloadedResource{
+				Data:        []byte("payload"),
+				ContentType: tc.contentType,
+				Filename:    tc.filename,
+				SizeBytes:   7,
+			}}
+			storage := &fakeMediaStorage{}
+			resolver := NewFeishuMediaResolver(sender, fakeCreds{secret: "plain"}, storage, &fakeMediaLedger{}, newDiscardLogger())
+			lm := InboundMessage{
+				MessageID:   "om_" + tc.name,
+				MessageType: tc.messageType,
+				Body:        tc.body,
+				Content:     tc.content,
+			}
+
+			got := resolver.ResolveMedia(context.Background(), testMediaInstallation(t), engine.ResolvedIdentity{},
+				uuidFromString(t, "22222222-2222-2222-2222-222222222222"), uuidFromString(t, "33333333-3333-4333-8333-333333333333"), channelMessageFromLark(lm))
+
+			if len(sender.downloadCalls) != 1 {
+				t.Fatalf("download calls = %d, want 1", len(sender.downloadCalls))
+			}
+			call := sender.downloadCalls[0]
+			if call.MessageID != lm.MessageID || call.FileKey != tc.wantKey || call.Type != "file" {
+				t.Fatalf("download params wrong: %+v", call)
+			}
+			if len(storage.uploads) != 1 {
+				t.Fatalf("uploads = %d, want 1", len(storage.uploads))
+			}
+			if len(got.MediaRefs) != 1 {
+				t.Fatalf("media refs = %+v, want 1", got.MediaRefs)
+			}
+			ref := got.MediaRefs[0]
+			if ref.Type != tc.wantType || ref.Filename != tc.filename || ref.MimeType != tc.contentType || ref.SizeBytes != 7 {
+				t.Fatalf("media ref wrong: %+v", ref)
 			}
 		})
 	}

--- a/server/internal/integrations/lark/media_filename_test.go
+++ b/server/internal/integrations/lark/media_filename_test.go
@@ -40,6 +40,19 @@ func TestMediaExtensionKnowsPDF(t *testing.T) {
 	}
 }
 
+func TestMediaExtensionKnowsCommonAudioTypes(t *testing.T) {
+	for contentType, want := range map[string]string{
+		"audio/opus": ".opus",
+		"audio/ogg":  ".ogg",
+		"audio/amr":  ".amr",
+		"audio/mpeg": ".mp3",
+	} {
+		if got := mediaExtension(contentType); got != want {
+			t.Errorf("mediaExtension(%q) = %q, want %q", contentType, got, want)
+		}
+	}
+}
+
 // Every resource on one message shares a MessageID, so without the index
 // three photos in one send produce three objects with the same name.
 func TestGeneratedMediaFilenamesAreDistinctWithinAMessage(t *testing.T) {
@@ -62,5 +75,14 @@ func TestProvidedFilenameStillWins(t *testing.T) {
 	res := larkMediaResource{kind: channel.MsgTypeFile, filename: "quarterly.pdf"}
 	if got := mediaFilename(lm, res, DownloadedResourceStream{}, "application/pdf", 2); got != "quarterly.pdf" {
 		t.Errorf("mediaFilename = %q, want the platform's own name", got)
+	}
+}
+
+func TestProvidedAudioFilenameKeepsExistingExtension(t *testing.T) {
+	lm := InboundMessage{MessageID: "om_audio"}
+	res := larkMediaResource{kind: channel.MsgTypeAudio}
+	downloaded := DownloadedResourceStream{Filename: "voice.ogg"}
+	if got := mediaFilename(lm, res, downloaded, "audio/opus", 0); got != "voice.ogg" {
+		t.Errorf("mediaFilename = %q, want the platform's existing extension preserved", got)
 	}
 }

--- a/server/internal/integrations/lark/media_ingest.go
+++ b/server/internal/integrations/lark/media_ingest.go
@@ -51,8 +51,9 @@ func NewFeishuMediaResolver(api APIClient, creds CredentialsResolver, storage me
 }
 
 // HasMedia reports whether the message carries downloadable Feishu resources
-// (standalone image/video or post-embedded img/media spans). Pure in-memory
-// decode of the already-received payload — it runs on the connector ACK path.
+// (standalone image/video/file/audio or post-embedded img/media spans). Pure
+// in-memory decode of the already-received payload — it runs on the connector
+// ACK path.
 func (r *feishuMediaResolver) HasMedia(msg channel.InboundMessage) bool {
 	lm, err := larkMsgFromRaw(msg)
 	if err != nil {
@@ -118,13 +119,7 @@ func (r *feishuMediaResolver) ResolveMedia(ctx context.Context, inst engine.Reso
 			r.logMediaWarn("lark media download failed", lm, err)
 			continue
 		}
-		contentType := got.ContentType
-		if contentType == "" {
-			contentType = res.mimeType
-		}
-		if contentType == "" {
-			contentType = "application/octet-stream"
-		}
+		contentType := mediaContentType(res, got)
 		filename := mediaFilename(lm, res, got, contentType, resIndex)
 		uploadedBytes, err := r.uploadResource(ctx, key, got.Body, got.SizeBytes, contentType, filename)
 		if err != nil {
@@ -365,7 +360,7 @@ func mediaResourcesFromPost(lm InboundMessage) []larkMediaResource {
 func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResourceStream, contentType string, index int) string {
 	for _, candidate := range []string{got.Filename, res.filename} {
 		if name := cleanFilename(candidate); name != "" {
-			return name
+			return ensureAudioFilenameExtension(name, res.kind, contentType)
 		}
 	}
 	prefix := "feishu-file"
@@ -380,6 +375,45 @@ func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResou
 	name := prefix + "-" + safePathSegment(lm.MessageID)
 	if index > 0 {
 		name += "-" + strconv.Itoa(index+1)
+	}
+	return name + mediaExtension(contentType)
+}
+
+func mediaContentType(res larkMediaResource, got DownloadedResourceStream) string {
+	contentType := strings.TrimSpace(got.ContentType)
+	if res.kind == channel.MsgTypeAudio && isGenericBinaryContentType(contentType) {
+		if hinted := strings.TrimSpace(res.mimeType); !isGenericBinaryContentType(hinted) {
+			return hinted
+		}
+		// Feishu audio messages are Opus. Its resource endpoint can return an
+		// extensionless Content-Disposition filename together with the generic
+		// audio/octet-stream type, so preserve the protocol-level format here.
+		return "audio/opus"
+	}
+	if contentType == "" {
+		contentType = strings.TrimSpace(res.mimeType)
+	}
+	if contentType == "" {
+		return "application/octet-stream"
+	}
+	return contentType
+}
+
+func isGenericBinaryContentType(contentType string) bool {
+	if semi := strings.IndexByte(contentType, ';'); semi >= 0 {
+		contentType = contentType[:semi]
+	}
+	switch strings.ToLower(strings.TrimSpace(contentType)) {
+	case "", "application/octet-stream", "audio/octet-stream":
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureAudioFilenameExtension(name string, kind channel.MsgType, contentType string) string {
+	if kind != channel.MsgTypeAudio || path.Ext(name) != "" {
+		return name
 	}
 	return name + mediaExtension(contentType)
 }
@@ -415,6 +449,14 @@ func mediaExtension(contentType string) string {
 		return ".webp"
 	case "video/mp4":
 		return ".mp4"
+	case "audio/opus":
+		return ".opus"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/amr":
+		return ".amr"
+	case "audio/mpeg":
+		return ".mp3"
 	case "application/pdf":
 		// mime.ExtensionsByType returns ExtensionsByType(".pdf") on most
 		// systems, but it reads /etc/mime.types — which a slim container

--- a/server/internal/integrations/lark/media_ingest.go
+++ b/server/internal/integrations/lark/media_ingest.go
@@ -285,6 +285,23 @@ func mediaResourcesFromMessage(lm InboundMessage) []larkMediaResource {
 			sizeBytes: sizeBytes,
 			messageID: lm.MessageID,
 		}}
+	case "file", "audio":
+		if payload.FileKey == "" {
+			return nil
+		}
+		kind := channel.MsgTypeFile
+		if lm.MessageType == "audio" {
+			kind = channel.MsgTypeAudio
+		}
+		return []larkMediaResource{{
+			key:       payload.FileKey,
+			kind:      kind,
+			fetchType: "file",
+			filename:  filename,
+			mimeType:  mimeType,
+			sizeBytes: sizeBytes,
+			messageID: lm.MessageID,
+		}}
 	default:
 		return nil
 	}
@@ -357,6 +374,8 @@ func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResou
 		prefix = "feishu-image"
 	case channel.MsgTypeVideo:
 		prefix = "feishu-video"
+	case channel.MsgTypeAudio:
+		prefix = "feishu-audio"
 	}
 	name := prefix + "-" + safePathSegment(lm.MessageID)
 	if index > 0 {


### PR DESCRIPTION
## What does this PR do?

Feishu can deliver files and audio as standalone message types. Multica previously normalized those messages to `[File]` / `[Audio]`, but did not extract their message resources. As a result, a bound agent could receive the user's instruction while the actual business document or archive never reached the task attachment pipeline.

This is especially visible in Feishu-first workflows such as sales and marketplace integration support: users naturally send HTML specifications, ZIP archives, or audio directly to the Bot in a P2P chat instead of uploading them again through Multica Web Chat.

The change routes standalone `file` and `audio` messages through the existing `extractMediaResources` pipeline. That keeps downloading, metadata handling, storage, and task attachment behavior consistent with media embedded in other supported Feishu message types.

Risk and scope:

- No authentication, authorization, UI, or database behavior changes.
- Existing media download and attachment ingestion code is reused rather than introducing a second file path.
- This PR covers standalone file/audio message resources in direct (P2P) chats. Standalone file/audio messages in group chats carry no @ mention and are dropped by the existing group-mention filter before media ingestion, so group ZIP workflows remain outside this PR. Attachments discovered only through referenced or replied-to messages also remain outside this PR; #5887 should stay open.

## Related Issue

Related to #5887

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `server/internal/integrations/lark/media_ingest.go` to extract resources from standalone Feishu file and audio messages.
- Add focused coverage in `server/internal/integrations/lark/feishu_channel_test.go` for HTML files, ZIP archives, and audio resources.
- Verify that normalized message text and attachment metadata are both preserved.

## How to Test

1. Run `go test ./internal/integrations/lark -count=1` from `server/`.
2. Send a standalone HTML file or ZIP archive in a direct (P2P) Feishu chat with the bound agent.
3. Verify that the task contains a real attachment with the original filename instead of only the `[File]` placeholder.

Local verification completed:

- Affected Go integration package passed.
- The broader affected Go package set (`channel/engine`, `lark`, `handler`, and `service`) passed.
- A real standalone Feishu HTML file was downloaded, stored as a task attachment, and read by the agent end to end.
- `git diff --check` passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: no UI change)
- [x] I have updated relevant documentation to reflect my changes (not applicable: existing attachment behavior is restored)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Codex was used to trace the Feishu event-to-task attachment flow, compare standalone file/audio handling with the existing media resource pipeline, implement the smallest compatible change, add focused regression tests, and review the final diff for scope and security regressions. The behavior was also verified through a real Feishu file message before submission.

## Screenshots (optional)

Not applicable; this change has no UI surface.
