### PR TITLE
fix(agent): fail open on untrusted Antigravity catalogs

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // antigravityBackend implements Backend by spawning Google's Antigravity CLI
@@ -469,14 +471,15 @@ func buildAntigravityArgs(prompt, logPath string, timeout time.Duration, opts Ex
 
 // antigravityModelError returns an actionable error when `model` is non-empty
 // and definitively absent from `available` (the `agy models` catalog); it
-// returns nil otherwise. An empty `available` means discovery couldn't produce
-// a catalog (agy missing, transient failure) — we fail OPEN there and let agy
-// resolve the value, so a discovery hiccup never blocks a run. The match is
+// returns nil otherwise. An empty or structurally untrustworthy `available`
+// means discovery couldn't produce a reliable catalog (agy missing, transient
+// failure, or output format drift) — we fail OPEN there and let agy resolve the
+// value, so a discovery hiccup never blocks a run. The match is
 // exact because agy's --model wants the precise display string; a near-miss
 // (extra space, dropped suffix) is correctly rejected since agy would silently
 // no-op on it anyway.
 func antigravityModelError(model string, available []Model) error {
-	if model == "" || len(available) == 0 {
+	if model == "" || !antigravityModelCatalogTrusted(available) {
 		return nil
 	}
 	ids := make([]string, 0, len(available))
@@ -490,6 +493,26 @@ func antigravityModelError(model string, available []Model) error {
 		"antigravity model %q is not available from `agy models`; pick one of: %s",
 		model, strings.Join(ids, ", "),
 	)
+}
+
+// antigravityModelCatalogTrusted reports whether every discovered model has an
+// ID shape that is safe to treat as authoritative. Labels are intentionally
+// ignored: they are display text and may contain spaces.
+func antigravityModelCatalogTrusted(available []Model) bool {
+	if len(available) == 0 {
+		return false
+	}
+	for _, model := range available {
+		if model.ID == "" || !utf8.ValidString(model.ID) {
+			return false
+		}
+		for _, r := range model.ID {
+			if unicode.IsControl(r) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // antigravityNoCapPrintTimeout is the --print-timeout value used when the daemon

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -512,6 +512,58 @@ func TestAntigravityModelError(t *testing.T) {
 	}
 }
 
+// TestAntigravityModelErrorCatalogTrust catches catalog format drift turning
+// model validation into a total outage. Only catalogs made entirely of
+// non-empty, valid UTF-8 IDs without control characters are authoritative.
+func TestAntigravityModelErrorCatalogTrust(t *testing.T) {
+	t.Parallel()
+
+	trusted := []Model{
+		{ID: "gemini-3.7-flash-high", Label: "Gemini 3.7 Flash (High)", Provider: "antigravity"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+	}
+
+	if err := antigravityModelError("gemini-3.7-flash-high", trusted); err != nil {
+		t.Fatalf("trusted catalog rejected an exact ID hit: %v", err)
+	}
+	err := antigravityModelError("not-a-real-model", trusted)
+	if err == nil {
+		t.Fatal("trusted catalog should reject an unknown model")
+	}
+	if !strings.Contains(err.Error(), "gemini-3.7-flash-high") {
+		t.Errorf("error should list model IDs: %v", err)
+	}
+	if strings.Contains(err.Error(), "Gemini 3.7 Flash (High)") {
+		t.Errorf("error should not present display labels as submit-ready IDs: %v", err)
+	}
+
+	untrusted := map[string][]Model{
+		"empty ID": {
+			{ID: "", Label: "Gemini 3.7 Flash (High)", Provider: "antigravity"},
+		},
+		"tab-joined legacy row": {
+			{ID: "gemini-3.7-flash-high\tGemini 3.7 Flash (High)", Label: "Gemini 3.7 Flash (High)", Provider: "antigravity"},
+		},
+		"control character": {
+			{ID: "gemini-3.7-flash-high\x00", Label: "Gemini 3.7 Flash (High)", Provider: "antigravity"},
+		},
+		"invalid UTF-8": {
+			{ID: string([]byte{0xff}), Label: "invalid", Provider: "antigravity"},
+		},
+		"mixed trusted and malformed rows": {
+			trusted[0],
+			{ID: "claude-opus-4-6-thinking\nClaude Opus 4.6 (Thinking)", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+		},
+	}
+	for name, catalog := range untrusted {
+		t.Run(name, func(t *testing.T) {
+			if err := antigravityModelError("not-a-real-model", catalog); err != nil {
+				t.Errorf("untrusted catalog should fail open, got: %v", err)
+			}
+		})
+	}
+}
+
 // seedAntigravityTranscript writes a transcript.jsonl under appDataDir for the
 // given conversation id, at the real path agy uses
 // (<appDataDir>/brain/<cid>/.system_generated/logs/transcript.jsonl).


### PR DESCRIPTION
## What does this PR do?

Antigravity model validation currently treats every non-empty `agy models` result as authoritative. When catalog output drifts and a row is parsed into a malformed ID, preflight rejects otherwise valid model selections before `agy` can handle them.

This change adds a narrow catalog-trust check:

- empty or structurally untrustworthy catalogs fail open and defer model handling to `agy`;
- trustworthy catalogs still reject unknown model IDs;
- validation errors list submit-ready IDs rather than display labels;
- regression tests cover trusted, empty, tab-joined, control-character, invalid UTF-8, and mixed catalogs.

This intentionally does not duplicate the parser and legacy normalization work in #6654 and #6953.

## Related Issue

Addresses #6979

Closes TRUE-9

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `antigravityModelCatalogTrusted` to distinguish authoritative catalogs from malformed discovery output.
- Changed preflight model validation to fail open only when catalog evidence is untrustworthy.
- Kept hard rejection for unknown models in trustworthy catalogs.
- Added focused regression coverage for catalog trust behavior and error output.

## How to Test

1. Run the focused Antigravity agent tests.
2. Run `go vet ./pkg/agent` from `server`.
3. Confirm a trusted catalog rejects an unknown model, while malformed catalogs defer validation to `agy`.

Local verification completed:

- focused Antigravity tests passed;
- `go vet ./pkg/agent` passed;
- `git diff --check` passed.

## Risks

Malformed catalogs now defer validation to `agy`, so errors in that case may occur during runtime instead of preflight. Trustworthy catalogs retain the existing unknown-model rejection behavior.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: backend-only change)
- [x] I have updated relevant documentation to reflect my changes (not applicable: no public behavior or configuration change)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Investigated #6979 and the existing Antigravity parser PRs, isolated the remaining catalog-trust failure mode, implemented a narrowly scoped fail-open guard, and added focused regression tests. The resulting diff and test output were reviewed before submission.

## Screenshots (optional)

Not applicable; this is a backend-only change.
