### PR TITLE
fix(agent): capture opencode reasoning events into result output

### DIFF
--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -345,6 +345,7 @@ type eventResult struct {
 // the accumulated result. This is the core scanner loop, extracted for testability.
 func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventResult {
 	var output strings.Builder
+	var reasoning strings.Builder
 	var sessionID string
 	var usage TokenUsage
 	finalStatus := "completed"
@@ -411,6 +412,8 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 			if event.Part.Text != "" {
 				stepProducedOutput = true
 			}
+		case "reasoning":
+			b.handleReasoningEvent(event, ch, &reasoning)
 		case "tool_use":
 			b.handleToolUseEvent(event, ch)
 			stepProducedOutput = true
@@ -483,10 +486,22 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 		}
 	}
 
+	// OpenCode reasoning models (e.g. hy3-free) stream their final answer as
+	// `reasoning` events and emit no `text` event. Capture those, and when a
+	// run produced no text output but did produce reasoning, promote the
+	// reasoning to the deliverable output so a completed run is not reported
+	// with an empty Result.Output.
+	finalOutput := strings.TrimSpace(output.String())
+	if finalOutput == "" {
+		if rb := strings.TrimSpace(reasoning.String()); rb != "" {
+			finalOutput = rb
+		}
+	}
+
 	return eventResult{
 		status:            finalStatus,
 		errMsg:            finalError,
-		output:            output.String(),
+		output:            finalOutput,
 		sessionID:         sessionID,
 		usage:             usage,
 		noTerminalSignal:  noTerminalSignal,
@@ -528,6 +543,22 @@ func (b *opencodeBackend) handleTextEvent(event opencodeEvent, ch chan<- Message
 	if text != "" {
 		output.WriteString(text)
 		trySend(ch, Message{Type: MessageText, Content: text})
+	}
+}
+
+// handleReasoningEvent captures `reasoning` events from opencode. Reasoning
+// models stream their thinking (and, for some backends, their entire answer)
+// here rather than in `text` events. We forward it as a thinking message for
+// live visibility and accumulate it so processEvents can promote it to the
+// deliverable output when no text is produced.
+func (b *opencodeBackend) handleReasoningEvent(event opencodeEvent, ch chan<- Message, reasoning *strings.Builder) {
+	text := event.Part.Text
+	if text == "" {
+		text = event.Part.Reasoning
+	}
+	if text != "" {
+		reasoning.WriteString(text)
+		trySend(ch, Message{Type: MessageThinking, Content: text})
 	}
 }
 
@@ -660,6 +691,7 @@ func extractToolOutput(output any) string {
 //
 //	"step_start"  — agent step begins
 //	"text"        — text output from agent (part.text)
+//	"reasoning"   — thinking/answer stream from reasoning models (part.text or part.reasoning)
 //	"tool_use"    — tool invocation with call and result (part.tool, part.callID, part.state)
 //	"error"       — error from opencode (error.name, error.data.message)
 //	"step_finish" — agent step completes (includes token usage)
@@ -680,6 +712,9 @@ type opencodeEventPart struct {
 
 	// Text events
 	Text string `json:"text,omitempty"`
+
+	// Reasoning events (reasoning models stream their thinking/answer here)
+	Reasoning string `json:"reasoning,omitempty"`
 
 	// Tool use events
 	Tool   string             `json:"tool,omitempty"`


### PR DESCRIPTION
## Summary

OpenCode reasoning models (e.g. `hy3-free`, which is `reasoning:true`) stream their final answer as `reasoning` events and emit **no** `text` event. The opencode adapter in `server/pkg/agent/opencode.go` only concatenated `text` events into `result.output`, so reasoning-only runs reported `completed` (usage > 0 proves the provider round-trip happened) with an **empty** `Result.Output`. This is the root cause of the "completed but empty" Mika chat runs seen on the Opencode ROG.

## Root cause

`processEvents` had no `case "reasoning"` handler. `handleTextEvent` is the only place `result.output` is populated, and it reads `part.text` from `text` events only. Reasoning content was therefore dropped by design, not by a transient bug.

## Fix

- Added `Reasoning string` to `opencodeEventPart` (`json:"reasoning"`).
- Added a `case "reasoning":` handler (`handleReasoningEvent`) that accumulates `part.text` / `part.reasoning` into a buffer and forwards it as a `MessageThinking` for live visibility.
- After the stream loop, if the text output is empty but reasoning was captured, the reasoning buffer is promoted to the deliverable `result.output`.

### Important constraint — does NOT weaken the #6522 dead-stream guard

`reasoning` events do **not** mark a step as productive (`stepProducedOutput`). Step liveness stays token-based via `stepReportedUsage`, which already counts `reasoning` tokens. So a final step that only emitted a reasoning event with an all-zero token block (the #6522 dead-stream case) still fails closed with the "empty step" classifier prefix.

## Test plan / results

- `go build ./pkg/agent` → ok
- `go vet ./pkg/agent` → ok
- `go test ./pkg/agent -run TestOpencodeProcessEvents` → ok
  - `TestOpencodeProcessEventsEmptyFinalStepFails` confirms a zero-token reasoning step still reports `failed` with the `opencode stream ended` prefix (no regression of #6522).

## Deploy note

This change only takes effect after the running daemon is rebuilt and redeployed. Affected agents (e.g. Mika) were previously moved to Codebuddy `hy3` as a stopgap and can be moved back once deployed.
