### PR TITLE
fix(daemon): gate quick-create prompts by task kind

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3205,7 +3205,7 @@ func gcMetaForTask(task Task) (execenv.GCMeta, bool) {
 	case task.IssueID != "":
 		meta.Kind = execenv.GCKindIssue
 		meta.IssueID = task.IssueID
-	case task.QuickCreatePrompt != "":
+	case task.IsQuickCreateTask():
 		// Quick-create tasks reach WriteGCMeta before the server runs
 		// LinkTaskToIssue, so IssueID is always empty here. Persist the
 		// task ID instead and let the GC loop ask the server for terminal
@@ -3534,6 +3534,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		AutopilotSource:                  task.AutopilotSource,
 		AutopilotTriggerPayload:          strings.TrimSpace(string(task.AutopilotTriggerPayload)),
 		QuickCreatePrompt:                task.QuickCreatePrompt,
+		TaskKind:                         task.Kind,
 		HandoffNote:                      task.HandoffNote,
 		IsSquadLeader:                    strings.Contains(instructions, "## Squad Operating Protocol"),
 		RequestingUserName:               task.RequestingUserName,
@@ -3719,7 +3720,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// command stamps the new issue with origin_type=quick_create +
 	// origin_id=<task_id> so the completion handler can find it
 	// deterministically (see GetIssueByOrigin).
-	if task.QuickCreatePrompt != "" {
+	if task.IsQuickCreateTask() {
 		agentEnv["MULTICA_QUICK_CREATE_TASK_ID"] = task.ID
 		if len(task.QuickCreateAttachmentIDs) > 0 {
 			if raw, err := json.Marshal(task.QuickCreateAttachmentIDs); err == nil {

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -492,7 +492,7 @@ func renderIssueContext(provider string, ctx TaskContextForEnv) string {
 	if ctx.AutopilotRunID != "" {
 		return renderAutopilotContext(ctx)
 	}
-	if ctx.QuickCreatePrompt != "" {
+	if ctx.isQuickCreateTask() {
 		return renderQuickCreateContext(ctx)
 	}
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -86,6 +86,7 @@ type TaskContextForEnv struct {
 	AutopilotSource         string
 	AutopilotTriggerPayload string
 	QuickCreatePrompt       string // non-empty for quick-create tasks
+	TaskKind                string // server-side source discriminator when available
 	HandoffNote             string // assignment handoff instruction; rendered into issue_context.md (MUL-3375)
 	IsSquadLeader           bool   // true when the agent is acting as a squad leader (may exit silently on no_action)
 	// WorkspaceContext is the workspace-level system prompt (workspace.context

--- a/server/internal/daemon/execenv/handoff_context_test.go
+++ b/server/internal/daemon/execenv/handoff_context_test.go
@@ -31,3 +31,20 @@ func TestRenderIssueContext_NoHandoffNote(t *testing.T) {
 		t.Fatalf("unexpected Handoff Note section when no note set:\n%s", md)
 	}
 }
+
+func TestRenderIssueContext_IssueTaskIgnoresStaleQuickCreatePrompt(t *testing.T) {
+	md := renderIssueContext("cursor", TaskContextForEnv{
+		IssueID:           "issue-1",
+		TaskKind:          "direct",
+		QuickCreatePrompt: "create exactly one issue",
+	})
+	if strings.Contains(md, "# Quick Create Task") {
+		t.Fatalf("issue context inherited quick-create sidecar:\n%s", md)
+	}
+	if !strings.Contains(md, "# Task Assignment") {
+		t.Fatalf("issue context lost assignment sidecar:\n%s", md)
+	}
+	if !strings.Contains(md, "**Issue ID:** issue-1") {
+		t.Fatalf("issue context lost issue id:\n%s", md)
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -616,7 +616,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	// issue (comment-triggered or assignment-triggered). Chat / quick-create /
 	// run-only autopilot don't carry an issue id and would just generate a
 	// failed `metadata list` call on every entry.
-	hasIssueContext := ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == ""
+	hasIssueContext := ctx.ChatSessionID == "" && !ctx.isQuickCreateTask() && ctx.AutopilotRunID == ""
 	if hasIssueContext {
 		b.WriteString("## Issue Metadata\n\n")
 		b.WriteString("Each issue carries a small KV `metadata` bag — a high-signal scratchpad where agents pin the handful of facts that future runs on this same issue will look up over and over (the PR URL, the deploy URL, what we're blocked on). It is NOT a place to record every fact you discover — that's what comments and the description are for. Most runs write **zero** new keys; that's the expected case, not a failure.\n\n")
@@ -627,7 +627,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- **Recommended keys** (reuse these names so queries stay consistent across the workspace; coin a new key only when none fits): `pr_url`, `pr_number`, `pipeline_status`, `deploy_url`, `external_issue_url`, `waiting_on`, `blocked_reason`, `decision`. Use snake_case ASCII. The list is short on purpose — most issues only need 1-2 of these pinned, not the full set.\n\n")
 	}
 
-	isAssignmentTriggered := ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" && ctx.TriggerCommentID == ""
+	isAssignmentTriggered := ctx.ChatSessionID == "" && !ctx.isQuickCreateTask() && ctx.AutopilotRunID == "" && ctx.TriggerCommentID == ""
 	if isAssignmentTriggered {
 		b.WriteString("## Instruction Precedence\n\n")
 		b.WriteString("Agent Identity instructions have priority over the assignment workflow below. ")
@@ -647,7 +647,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- If asked to perform actions (create issues, update status, etc.), use the appropriate CLI commands\n")
 		b.WriteString("- If the task requires code changes, use `multica repo checkout <url>` to get the code first. Use `--ref <branch-or-sha>` when you need an exact revision\n")
 		b.WriteString("- Keep responses concise and direct\n\n")
-	} else if ctx.QuickCreatePrompt != "" {
+	} else if ctx.isQuickCreateTask() {
 		// Quick-create task: detailed field / output rules live in the
 		// per-turn prompt (BuildPrompt → buildQuickCreatePrompt) so they
 		// have a single source of truth. Quick-create is one-shot, so the
@@ -739,7 +739,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	// `done`, and the agent has nothing to do or avoid on that path.
 	// Section is skipped for chat, quick-create, and run-only autopilot
 	// runs (no parent/child semantics there).
-	if ctx.IssueID != "" && ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" {
+	if ctx.IssueID != "" && ctx.ChatSessionID == "" && !ctx.isQuickCreateTask() && ctx.AutopilotRunID == "" {
 		b.WriteString("## Sub-issue Creation\n\n")
 		b.WriteString("**Choosing `--status` when creating sub-issues.** `--status todo` = **start now** (the default — an agent assignee fires immediately). `--status backlog` = **wait** (assignee is set but no trigger fires; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
 		b.WriteString("**Ordering with stages.** When sub-issues run in phases or wait on each other, group them with `--stage <N>` (N ≥ 1) rather than hand-promoting the backlog chain above. Children sharing a stage run together; once a whole stage finishes (every child in it terminal — `done`/`cancelled`) you are woken once to review and promote the next stage. Create the first stage's children at `--status todo` and later stages at `--stage k --status backlog`; with no `--stage` the whole sibling set behaves as one implicit stage (woken once, when the last child finishes). Reach for stages whenever a plan has more than one step or a step must wait for a group — it is the intended way to express order, and it is cheaper than tracking the chain by hand. Run `multica issue children <id>` to see children grouped by stage before promoting.\n\n")
@@ -814,7 +814,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	switch {
 	case ctx.AutopilotRunID != "":
 		b.WriteString("This is a run-only autopilot task, so there may be no issue comment to post. Your final assistant output is captured automatically as the autopilot run result. Keep it concise and state the outcome.\n")
-	case ctx.QuickCreatePrompt != "":
+	case ctx.isQuickCreateTask():
 		b.WriteString("This is a quick-create task. There is NO existing issue to comment on. Your final stdout is captured automatically and the platform writes the user's success/failure inbox notification based on whether `multica issue create` succeeded.\n\n")
 		b.WriteString("- Do NOT call `multica issue comment add` — the issue you just created has no conversation context for this run.\n")
 		b.WriteString("- Print exactly one final line: `Created <identifier-or-id>: <title>` after a successful `multica issue create`. Use the created issue's `identifier` from JSON output when available; otherwise use its `id`. Do not assume any workspace issue prefix such as `MUL-`; workspaces can use custom prefixes.\n")

--- a/server/internal/daemon/execenv/runtime_config_kind.go
+++ b/server/internal/daemon/execenv/runtime_config_kind.go
@@ -30,23 +30,31 @@ const (
 )
 
 // classifyTask maps a TaskContextForEnv to the single taskKind the slim
-// brief should be assembled for. Precedence (documented for the tiebreak
-// case, although the daemon never sets two specific-kind flags at once):
-// chat → quick-create → autopilot run-only → comment-triggered →
-// assignment-triggered.
+// brief should be assembled for. Linked task sources win over a non-empty
+// QuickCreatePrompt because older claim payloads can retain quick-create
+// data after the task has been linked back to the issue it created.
 func classifyTask(ctx TaskContextForEnv) taskKind {
 	switch {
 	case ctx.ChatSessionID != "":
 		return kindChat
-	case ctx.QuickCreatePrompt != "":
-		return kindQuickCreate
 	case ctx.AutopilotRunID != "":
 		return kindAutopilotRunOnly
 	case ctx.TriggerCommentID != "":
 		return kindCommentTriggered
+	case ctx.IssueID != "":
+		return kindAssignmentTriggered
+	case ctx.isQuickCreateTask():
+		return kindQuickCreate
 	default:
 		return kindAssignmentTriggered
 	}
+}
+
+func (ctx TaskContextForEnv) isQuickCreateTask() bool {
+	if ctx.TaskKind != "" {
+		return ctx.TaskKind == "quick_create" && ctx.IssueID == "" && ctx.ChatSessionID == "" && ctx.AutopilotRunID == ""
+	}
+	return ctx.QuickCreatePrompt != "" && ctx.IssueID == "" && ctx.ChatSessionID == "" && ctx.AutopilotRunID == ""
 }
 
 // hasIssueContext returns true for the kinds that operate on a real Multica

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -25,7 +25,8 @@ func withSlimBrief(t *testing.T) {
 }
 
 // TestClassifyTask pins the precedence rule on classifyTask. All five
-// kinds plus tiebreak cases for safety.
+// kinds plus tiebreak cases for safety. Linked task sources win over stale
+// QuickCreatePrompt payloads.
 func TestClassifyTask(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -40,8 +41,12 @@ func TestClassifyTask(t *testing.T) {
 		{"assignment-triggered", TaskContextForEnv{IssueID: "i"}, kindAssignmentTriggered},
 		{"assignment-bare", TaskContextForEnv{}, kindAssignmentTriggered},
 		{"tiebreak-chat-vs-quick", TaskContextForEnv{ChatSessionID: "c", QuickCreatePrompt: "p"}, kindChat},
-		{"tiebreak-quick-vs-autopilot", TaskContextForEnv{QuickCreatePrompt: "p", AutopilotRunID: "r"}, kindQuickCreate},
+		{"tiebreak-autopilot-vs-quick", TaskContextForEnv{QuickCreatePrompt: "p", AutopilotRunID: "r"}, kindAutopilotRunOnly},
 		{"tiebreak-autopilot-vs-comment", TaskContextForEnv{AutopilotRunID: "r", IssueID: "i", TriggerCommentID: "c"}, kindAutopilotRunOnly},
+		{"tiebreak-issue-vs-quick", TaskContextForEnv{IssueID: "i", QuickCreatePrompt: "p"}, kindAssignmentTriggered},
+		{"tiebreak-comment-vs-quick", TaskContextForEnv{IssueID: "i", TriggerCommentID: "c", QuickCreatePrompt: "p"}, kindCommentTriggered},
+		{"explicit-kind-quick-create", TaskContextForEnv{TaskKind: "quick_create", QuickCreatePrompt: "p"}, kindQuickCreate},
+		{"explicit-kind-direct-vs-quick", TaskContextForEnv{TaskKind: "direct", IssueID: "i", QuickCreatePrompt: "p"}, kindAssignmentTriggered},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -581,6 +581,34 @@ func TestSubIssueCreationSectionSkippedForNonIssueModes(t *testing.T) {
 	}
 }
 
+func TestIssueBriefIgnoresStaleQuickCreatePrompt(t *testing.T) {
+	t.Parallel()
+	out := buildMetaSkillContent("cursor", TaskContextForEnv{
+		IssueID:           "issue-123",
+		TaskKind:          "direct",
+		QuickCreatePrompt: "create exactly one issue",
+	})
+	for _, banned := range []string{
+		"This task was triggered by quick-create",
+		"Run exactly one `multica issue create` invocation",
+		"Do NOT call `multica issue get`",
+		"Do NOT call `multica issue comment add`",
+	} {
+		if strings.Contains(out, banned) {
+			t.Fatalf("issue brief inherited quick-create guardrail %q\n---\n%s", banned, out)
+		}
+	}
+	for _, required := range []string{
+		"## Issue Metadata",
+		"## Sub-issue Creation",
+		"Final results MUST be delivered via `multica issue comment add`",
+	} {
+		if !strings.Contains(out, required) {
+			t.Fatalf("issue brief missing %q\n---\n%s", required, out)
+		}
+	}
+}
+
 // writeRuntimeConfigFile is the safe replacement for the previous
 // unconditional os.WriteFile of CLAUDE.md / AGENTS.md. The two
 // states it must handle correctly are: file missing, file present without

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1296,6 +1296,12 @@ func TestGCMetaForTask(t *testing.T) {
 			want: execenv.GCKindChat,
 			idOK: func(m execenv.GCMeta) bool { return m.ChatSessionID == "c1" && m.IssueID == "" },
 		},
+		{
+			name: "issue wins over stale quick-create prompt",
+			task: Task{ID: "t6", WorkspaceID: "ws", IssueID: "i1", Kind: "direct", QuickCreatePrompt: "do the thing"},
+			want: execenv.GCKindIssue,
+			idOK: func(m execenv.GCMeta) bool { return m.IssueID == "i1" && m.TaskID == "" },
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -24,7 +24,7 @@ func BuildPrompt(task Task, provider string) string {
 	if task.AutopilotRunID != "" {
 		return buildAutopilotPrompt(task)
 	}
-	if task.QuickCreatePrompt != "" {
+	if task.IsQuickCreateTask() {
 		return buildQuickCreatePrompt(task)
 	}
 	var b strings.Builder

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -203,6 +203,27 @@ func TestBuildQuickCreatePromptParentPinning(t *testing.T) {
 	}
 }
 
+func TestBuildPromptIssueTaskIgnoresStaleQuickCreatePrompt(t *testing.T) {
+	task := Task{
+		IssueID:           "issue-123",
+		Kind:              "direct",
+		QuickCreatePrompt: "create exactly one issue",
+	}
+	out := BuildPrompt(task, "cursor")
+	if strings.Contains(out, "quick-create assistant") {
+		t.Fatalf("issue-bound task must not use quick-create prompt:\n%s", out)
+	}
+	if strings.Contains(out, "single `multica issue create` command") {
+		t.Fatalf("issue-bound task inherited quick-create single-create rule:\n%s", out)
+	}
+	if !strings.Contains(out, "Your assigned issue ID is: issue-123") {
+		t.Fatalf("issue-bound task lost assignment prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "multica issue get issue-123 --output json") {
+		t.Fatalf("issue-bound task must still instruct issue read:\n%s", out)
+	}
+}
+
 // TestBuildPromptSquadLeaderNoActionForMemberTrigger verifies that the
 // squad leader no_action prohibition is injected in the per-turn prompt
 // regardless of whether the triggering comment was posted by an agent or

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -81,6 +81,7 @@ type Task struct {
 	QuickCreatePrompt        string                `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
 	QuickCreateAttachmentIDs []string              `json:"quick_create_attachment_ids,omitempty"` // attachments uploaded in the quick-create prompt and bound by issue create
 	HandoffNote              string                `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the opening prompt + issue_context.md
+	Kind                     string                `json:"kind,omitempty"`                        // server-side source discriminator: comment, autopilot, chat, quick_create, or direct
 
 	SquadID               string `json:"squad_id,omitempty"`                // when the picker was a squad, the squad's UUID; Agent is still the resolved leader
 	SquadName             string `json:"squad_name,omitempty"`              // display name for the picker squad, used in prompt text
@@ -115,6 +116,13 @@ type Task struct {
 	// Empty or non-task-scoped values are fatal for writable agent tasks; the
 	// daemon must not fall back to its own token. See MUL-3292.
 	AuthToken string `json:"auth_token,omitempty"`
+}
+
+func (t Task) IsQuickCreateTask() bool {
+	if t.Kind != "" {
+		return t.Kind == "quick_create" && t.IssueID == "" && t.ChatSessionID == "" && t.AutopilotRunID == ""
+	}
+	return t.QuickCreatePrompt != "" && t.IssueID == "" && t.ChatSessionID == "" && t.AutopilotRunID == ""
 }
 
 // ChatAttachmentMeta is the structured attachment metadata the daemon


### PR DESCRIPTION
## What does this PR do?

Fixes daemon-side task source detection so Quick Create prompt payloads cannot override normal issue-task instructions. The daemon now treats Quick Create as an explicit task kind with no linked issue/chat/autopilot source, then uses that discriminator for prompt selection, runtime brief generation, sidecar context rendering, GC metadata, and Quick Create environment markers.

This prevents Cursor-backed custom agents from receiving Quick Create-only rules such as single `multica issue create` constraints during normal issue runs.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #7000
Closes MUL-6213
Multica issue: ZIC-168

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added explicit daemon/execenv Quick Create task classification that requires no linked issue, chat session, or autopilot run.
- Threaded the server-provided task `kind` into daemon runtime context.
- Updated prompt, runtime brief, sidecar context, GC metadata, and Quick Create env marker gates to use the source discriminator instead of raw `QuickCreatePrompt`.
- Added regression coverage for issue tasks carrying stale Quick Create prompt payloads.

## How to Test

1. `cd server && go test -count=1 ./internal/daemon`
2. `cd server && go test -count=1 ./internal/daemon/execenv`
3. `make check-worktree` was attempted, but local Docker was unavailable while checking PostgreSQL (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`), so the script exited before the full pipeline.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

No UI, docs, runtime, or Chinese product copy changes are included, so those checklist items are not applicable.

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
I traced the Quick Create context path from task claim through daemon prompt/runtime brief construction, changed source checks to use an explicit task-kind boundary, and added focused regression tests for normal issue tasks that still carry stale Quick Create prompt payloads.

## Screenshots (optional)

N/A
