### PR TITLE
Fix Windows Codex sandbox access to Multica CLI (ZIC-171)

### DIFF
--- a/server/internal/daemon/agent_cli_path.go
+++ b/server/internal/daemon/agent_cli_path.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// MulticaCLIPathEnv is an optional launcher hint for the multica binary agents
+// should find on PATH. Desktop or another supervisor may set it when the
+// daemon's own executable path is not the right path to expose to tasks.
+const MulticaCLIPathEnv = "MULTICA_CLI_PATH"
+
+const codexSandboxUsersGroup = "CodexSandboxUsers"
+
+var grantWindowsCodexSandboxUsersRX = grantWindowsCodexSandboxUsersRXImpl
+var resolveAgentSelfExecutable = os.Executable
+
+func agentCLIDirForTask(provider, envRoot string, logger *slog.Logger) string {
+	return agentCLIDirForTaskForGOOS(provider, envRoot, runtime.GOOS, logger)
+}
+
+func agentCLIDirForTaskForGOOS(provider, envRoot, goos string, logger *slog.Logger) string {
+	source := resolveAgentCLIPath(logger)
+	if source == "" {
+		return ""
+	}
+	if provider == "codex" && goos == "windows" && envRoot != "" {
+		staged, err := stageTaskScopedAgentCLI(source, envRoot, goos, logger)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("agent CLI: task-scoped Windows copy failed; falling back to source path", "source", source, "error", err)
+			}
+			return filepath.Dir(source)
+		}
+		return filepath.Dir(staged)
+	}
+	return filepath.Dir(source)
+}
+
+func resolveAgentCLIPath(logger *slog.Logger) string {
+	if hint := strings.TrimSpace(os.Getenv(MulticaCLIPathEnv)); hint != "" {
+		if info, err := os.Stat(hint); err == nil && !info.IsDir() {
+			return hint
+		} else if logger != nil {
+			logger.Warn("agent CLI: ignoring invalid MULTICA_CLI_PATH", "path", hint, "error", err)
+		}
+	}
+	selfBin, err := resolveAgentSelfExecutable()
+	if err != nil {
+		if logger != nil {
+			logger.Warn("agent CLI: could not resolve daemon executable", "error", err)
+		}
+		return ""
+	}
+	return selfBin
+}
+
+func stageTaskScopedAgentCLI(source, envRoot, goos string, logger *slog.Logger) (string, error) {
+	if goos != "windows" {
+		return source, nil
+	}
+	destDir := filepath.Join(envRoot, "bin")
+	dest := filepath.Join(destDir, "multica.exe")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir task cli dir: %w", err)
+	}
+	tmp := filepath.Join(destDir, fmt.Sprintf(".multica.exe.tmp-%d", os.Getpid()))
+	if err := copyFile(source, tmp); err != nil {
+		return "", fmt.Errorf("copy task cli: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("chmod task cli: %w", err)
+	}
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("replace task cli: %w", err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("install task cli: %w", err)
+	}
+	// Codex's elevated Windows sandbox runs commands as users in this local
+	// group. Grant only Read & Execute to the task-local CLI directory and file;
+	// failures are non-fatal so ordinary Windows Codex runs without that group
+	// remain compatible.
+	if err := grantWindowsCodexSandboxUsersRX(destDir, true); err != nil && logger != nil {
+		logger.Warn("agent CLI: could not grant Codex sandbox group access to task cli dir", "path", destDir, "error", err)
+	}
+	if err := grantWindowsCodexSandboxUsersRX(dest, false); err != nil && logger != nil {
+		logger.Warn("agent CLI: could not grant Codex sandbox group access to task cli", "path", dest, "error", err)
+	}
+	return dest, nil
+}
+
+func copyFile(source, dest string) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func grantWindowsCodexSandboxUsersRXImpl(path string, inheritable bool) error {
+	grant := codexSandboxUsersGroup + ":(RX)"
+	if inheritable {
+		grant = codexSandboxUsersGroup + ":(OI)(CI)(RX)"
+	}
+	return exec.Command("icacls", path, "/grant", grant).Run()
+}

--- a/server/internal/daemon/agent_cli_path_test.go
+++ b/server/internal/daemon/agent_cli_path_test.go
@@ -1,0 +1,140 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withResolvedExecutable(t *testing.T, path string) {
+	t.Helper()
+	original := resolveAgentSelfExecutable
+	resolveAgentSelfExecutable = func() (string, error) { return path, nil }
+	t.Cleanup(func() { resolveAgentSelfExecutable = original })
+}
+
+func withACLGrantRecorder(t *testing.T, calls *[]string, err error) {
+	t.Helper()
+	original := grantWindowsCodexSandboxUsersRX
+	grantWindowsCodexSandboxUsersRX = func(path string, inheritable bool) error {
+		*calls = append(*calls, path)
+		if inheritable {
+			(*calls)[len(*calls)-1] += "|inherit"
+		}
+		return err
+	}
+	t.Cleanup(func() { grantWindowsCodexSandboxUsersRX = original })
+}
+
+func TestAgentCLIDirForTask_WindowsCodexStagesTaskScopedCLI(t *testing.T) {
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "multica.exe")
+	if err := os.WriteFile(source, []byte("fake windows cli"), 0o755); err != nil {
+		t.Fatalf("write source cli: %v", err)
+	}
+	withResolvedExecutable(t, source)
+	var aclCalls []string
+	withACLGrantRecorder(t, &aclCalls, nil)
+
+	envRoot := t.TempDir()
+	got := agentCLIDirForTaskForGOOS("codex", envRoot, "windows", nil)
+
+	wantDir := filepath.Join(envRoot, "bin")
+	if got != wantDir {
+		t.Fatalf("agent CLI dir = %q, want %q", got, wantDir)
+	}
+	dest := filepath.Join(wantDir, "multica.exe")
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read staged cli: %v", err)
+	}
+	if string(data) != "fake windows cli" {
+		t.Fatalf("staged cli content = %q", string(data))
+	}
+	wantCalls := []string{wantDir + "|inherit", dest}
+	if len(aclCalls) != len(wantCalls) {
+		t.Fatalf("ACL calls = %#v, want %#v", aclCalls, wantCalls)
+	}
+	for i := range wantCalls {
+		if aclCalls[i] != wantCalls[i] {
+			t.Fatalf("ACL calls = %#v, want %#v", aclCalls, wantCalls)
+		}
+	}
+}
+
+func TestAgentCLIDirForTask_WindowsCodexKeepsStagedCLIWhenACLGrantFails(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "multica.exe")
+	if err := os.WriteFile(source, []byte("fake windows cli"), 0o755); err != nil {
+		t.Fatalf("write source cli: %v", err)
+	}
+	withResolvedExecutable(t, source)
+	var aclCalls []string
+	withACLGrantRecorder(t, &aclCalls, errors.New("group missing"))
+
+	envRoot := t.TempDir()
+	got := agentCLIDirForTaskForGOOS("codex", envRoot, "windows", nil)
+
+	wantDir := filepath.Join(envRoot, "bin")
+	if got != wantDir {
+		t.Fatalf("agent CLI dir = %q, want %q", got, wantDir)
+	}
+	if _, err := os.Stat(filepath.Join(wantDir, "multica.exe")); err != nil {
+		t.Fatalf("staged CLI should remain usable after ACL grant failure: %v", err)
+	}
+	if len(aclCalls) != 2 {
+		t.Fatalf("ACL grant should have been attempted for dir and file, got %#v", aclCalls)
+	}
+}
+
+func TestAgentCLIDirForTask_NonWindowsUsesSelfExecutableDir(t *testing.T) {
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "multica")
+	if err := os.WriteFile(source, []byte("fake cli"), 0o755); err != nil {
+		t.Fatalf("write source cli: %v", err)
+	}
+	withResolvedExecutable(t, source)
+	var aclCalls []string
+	withACLGrantRecorder(t, &aclCalls, nil)
+
+	got := agentCLIDirForTaskForGOOS("codex", t.TempDir(), "linux", nil)
+
+	if got != sourceDir {
+		t.Fatalf("agent CLI dir = %q, want %q", got, sourceDir)
+	}
+	if len(aclCalls) != 0 {
+		t.Fatalf("non-windows path should not touch ACLs, got %#v", aclCalls)
+	}
+}
+
+func TestAgentCLIDirForTask_WindowsNonCodexUsesSelfExecutableDir(t *testing.T) {
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "multica.exe")
+	if err := os.WriteFile(source, []byte("fake cli"), 0o755); err != nil {
+		t.Fatalf("write source cli: %v", err)
+	}
+	withResolvedExecutable(t, source)
+
+	got := agentCLIDirForTaskForGOOS("claude", t.TempDir(), "windows", nil)
+
+	if got != sourceDir {
+		t.Fatalf("agent CLI dir = %q, want %q", got, sourceDir)
+	}
+}
+
+func TestAgentCLIDirForTask_HintWinsOverSelfExecutable(t *testing.T) {
+	selfDir := t.TempDir()
+	withResolvedExecutable(t, filepath.Join(selfDir, "multica"))
+	hintDir := t.TempDir()
+	hint := filepath.Join(hintDir, "multica")
+	if err := os.WriteFile(hint, []byte("hint cli"), 0o755); err != nil {
+		t.Fatalf("write hint cli: %v", err)
+	}
+	t.Setenv(MulticaCLIPathEnv, hint)
+
+	got := agentCLIDirForTaskForGOOS("claude", t.TempDir(), "linux", nil)
+
+	if got != hintDir {
+		t.Fatalf("agent CLI dir = %q, want hint dir %q", got, hintDir)
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3711,12 +3711,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			}
 		}
 	}
-	// Ensure the multica CLI is on PATH inside the agent's environment.
-	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
-	// inherit the daemon's PATH. Prepend the directory of the running
-	// multica binary so that `multica` commands in the agent always resolve.
-	if selfBin, err := os.Executable(); err == nil {
-		binDir := filepath.Dir(selfBin)
+	// Ensure the multica CLI is on PATH inside the agent's environment. On
+	// Windows Codex, a task-local copy avoids exposing Desktop's bundled CLI
+	// directory to the elevated sandbox identity.
+	if binDir := agentCLIDirForTask(provider, env.RootDir, d.logger); binDir != "" {
 		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	}
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes Windows Codex elevated sandbox tasks failing to resolve the Multica CLI from the Desktop bundled install directory.

For Windows Codex tasks, the daemon now copies the running `multica.exe` into the task environment under `envRoot/bin`, prepends that task-local directory to `PATH`, and attempts to grant the Codex sandbox users group Read & Execute access to only that directory and file. Other providers and non-Windows tasks keep the existing self-executable PATH behavior.

## Related Issue

Closes #6865

Multica issue: ZIC-171

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Added daemon helper logic in `server/internal/daemon/agent_cli_path.go` to choose the agent-visible Multica CLI path.
- Staged a task-scoped Windows Codex CLI copy and attempted RX-only ACL grants for `CodexSandboxUsers`.
- Replaced the inline task `PATH` prepend in `server/internal/daemon/daemon.go`.
- Added unit tests for Windows Codex staging, ACL grant attempts/failure tolerance, non-Windows fallback, non-Codex fallback, and `MULTICA_CLI_PATH` source selection.

## Current Branch Note

GitHub currently reports this PR as merge-conflicting. The fix was first validated on upstream `main`, but the available fork is behind upstream and cannot be synced by this OAuth identity because upstream history includes workflow changes that require the GitHub `workflow` scope. To get a branch pushed at all, I rebuilt it on the fork's current `main`; a maintainer may need to sync the fork, grant a token with `workflow` scope, or cherry-pick the commit onto upstream `main`.

## How to Test

1. `cd server && go test ./internal/daemon -run 'TestAgentCLIDirForTask|TestSanitizeAgentEnv'`
2. `cd server && go test ./internal/daemon`
3. `make check-worktree`

Validation notes:

- Both daemon test commands passed locally.
- `make check-worktree` exited 0, but this host reported Docker was unavailable while checking the PostgreSQL container: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.
- Windows ACL behavior is covered by unit tests with the ACL grant call injected; it was not manually validated on a Windows Desktop install in this run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented a focused daemon fix for GitHub #6865. I traced the existing task environment PATH injection, confirmed the issue comments' `CodexSandboxUsers` RX-only workaround, found the stale conflicting PR #2705, then implemented a task-scoped Windows Codex CLI staging path with focused daemon tests.

## Screenshots (optional)

N/A
