### PR TITLE
fix(comments): reveal newly posted messages

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -434,6 +434,7 @@ vi.mock("@multica/core/issues/stores", async () => ({
 // background instead, which is mechanism-independent and observable without
 // layout.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
+const virtuosoScrollToIndexSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("react-virtuoso", () => ({
   Virtuoso: forwardRef(function MockVirtuoso(
@@ -445,7 +446,7 @@ vi.mock("react-virtuoso", () => ({
       // since the deep-link cold-path drives the container's scrollTop on the
       // real DOM node, not Virtuoso's imperative API.
       scrollIntoView: vi.fn(),
-      scrollToIndex: vi.fn(),
+      scrollToIndex: virtuosoScrollToIndexSpy,
     }));
     return (
       <div data-testid="virtuoso-mock">
@@ -1078,6 +1079,88 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
+  });
+
+  it("reveals a newly posted comment in the virtualized timeline", async () => {
+    mockApiObj.createComment.mockResolvedValue({
+      id: "comment-new",
+      issue_id: "issue-1",
+      author_type: "member",
+      author_id: "user-1",
+      content: "A newly posted comment",
+      type: "comment",
+      parent_id: null,
+      reactions: [],
+      attachments: [],
+      created_at: "2026-01-18T00:00:00Z",
+      updated_at: "2026-01-18T00:00:00Z",
+      resolved_at: null,
+      resolved_by_type: null,
+      resolved_by_id: null,
+    });
+
+    renderIssueDetail();
+    await screen.findByText("Started working on this");
+
+    fireEvent.click(screen.getByTestId("comment-composer-shell"));
+    const editor = await screen.findByPlaceholderText("Leave a comment...");
+    fireEvent.change(editor, { target: { value: "A newly posted comment" } });
+    const send = screen
+      .getAllByRole("button", { name: "Send" })
+      .find((button) => !(button as HTMLButtonElement).disabled);
+    expect(send).toBeDefined();
+    fireEvent.click(send!);
+
+    await screen.findByText("A newly posted comment");
+    await waitFor(() => {
+      expect(virtuosoScrollToIndexSpy).toHaveBeenCalledWith({
+        index: 2,
+        align: "start",
+        offset: -16,
+        behavior: "auto",
+      });
+    });
+  });
+
+  it("reveals a newly posted reply inside its thread", async () => {
+    mockApiObj.createComment.mockResolvedValue({
+      id: "reply-new",
+      issue_id: "issue-1",
+      author_type: "member",
+      author_id: "user-1",
+      content: "A newly posted reply",
+      type: "comment",
+      parent_id: "comment-1",
+      reactions: [],
+      attachments: [],
+      created_at: "2026-01-18T00:00:00Z",
+      updated_at: "2026-01-18T00:00:00Z",
+      resolved_at: null,
+      resolved_by_type: null,
+      resolved_by_id: null,
+    });
+
+    renderIssueDetail();
+    await screen.findByText("Started working on this");
+
+    fireEvent.click(screen.getAllByTestId("reply-composer-shell")[0]!);
+    const editor = (await screen.findAllByPlaceholderText("Leave a reply..."))[0]!;
+    fireEvent.change(editor, { target: { value: "A newly posted reply" } });
+    const send = screen
+      .getAllByRole("button", { name: "Send" })
+      .find((button) => !(button as HTMLButtonElement).disabled);
+    expect(send).toBeDefined();
+    fireEvent.click(send!);
+
+    await screen.findByText("A newly posted reply");
+    await waitFor(() => {
+      expect(virtuosoScrollToIndexSpy).toHaveBeenCalledWith({
+        index: 0,
+        align: "start",
+        offset: -16,
+        behavior: "auto",
+      });
+    });
   });
 
   it("reruns the source task from an agent failure comment", async () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1542,6 +1542,79 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso instance — minimap jumps drive the scroll container directly.
   const isFlatTimeline = !!highlightCommentId || find.open;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [postedCommentTarget, setPostedCommentTarget] = useState<{
+    commentId: string;
+    rootId: string;
+  } | null>(null);
+  useEffect(() => setPostedCommentTarget(null), [id]);
+
+  // Only an explicit local submit arms this target. Incoming WebSocket
+  // comments keep the reader's current position; their cache update alone
+  // must never yank the viewport away from what the user is reading.
+  const handleSubmitComment = useCallback(
+    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => {
+      const comment = await submitComment(content, attachmentIds, suppressAgentIds);
+      if (!comment) return false;
+      setPostedCommentTarget({ commentId: comment.id, rootId: comment.id });
+      return true;
+    },
+    [submitComment],
+  );
+  const handleSubmitReply = useCallback(
+    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => {
+      const comment = await submitReply(parentId, content, attachmentIds, suppressAgentIds);
+      if (!comment) return false;
+      setPostedCommentTarget({
+        commentId: comment.id,
+        rootId: comment.parent_id ?? parentId,
+      });
+      return true;
+    },
+    [submitReply],
+  );
+
+  // A successful mutation updates the React Query timeline before it resolves,
+  // but the new row may still be outside Virtuoso's mounted window. First ask
+  // Virtuoso to materialize the owning thread, then measure the real comment
+  // node and scroll only the issue-detail container. Native scrollIntoView is
+  // deliberately avoided because it can move the desktop shell as well.
+  useEffect(() => {
+    if (!postedCommentTarget || !scrollContainerEl) return;
+    const rootIndex = items.findIndex((item) => item.id === postedCommentTarget.rootId);
+    if (rootIndex < 0) return;
+
+    if (!isFlatTimeline) {
+      virtuosoRef.current?.scrollToIndex({
+        index: rootIndex,
+        align: "start",
+        offset: -16,
+        behavior: "auto",
+      });
+    }
+
+    let rafId = 0;
+    let attempts = 0;
+    const reveal = () => {
+      const el = document.getElementById(`comment-${postedCommentTarget.commentId}`);
+      if (el) {
+        const containerRect = scrollContainerEl.getBoundingClientRect();
+        const commentRect = el.getBoundingClientRect();
+        scrollContainerEl.scrollTop = Math.max(
+          0,
+          scrollContainerEl.scrollTop + (commentRect.top - containerRect.top) - 16,
+        );
+        setPostedCommentTarget((current) =>
+          current?.commentId === postedCommentTarget.commentId ? null : current,
+        );
+        return;
+      }
+      attempts += 1;
+      if (attempts < 30) rafId = requestAnimationFrame(reveal);
+    };
+    rafId = requestAnimationFrame(reveal);
+    return () => cancelAnimationFrame(rafId);
+  }, [isFlatTimeline, items, postedCommentTarget, scrollContainerEl]);
+
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(
     () => () => {
@@ -2420,7 +2493,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             replies={timelineView.threadReplies.get(item.id) ?? EMPTY_REPLIES}
             currentUserId={user?.id}
             canModerate={canModerateComments}
-            onReply={submitReply}
+            onReply={handleSubmitReply}
             onEdit={editComment}
             onDelete={deleteComment}
             onToggleReaction={handleToggleReaction}
@@ -3099,7 +3172,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 keeps the previous issue's in-memory content and the
                 next keystroke would flush it into the new issue's
                 draft key. */}
-            <CommentInput key={id} issueId={id} onSubmit={submitComment} />
+            <CommentInput key={id} issueId={id} onSubmit={handleSubmitComment} />
           </div>
         </div>
         </div>

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -297,32 +297,32 @@ export function useIssueTimeline(issueId: string, userId?: string) {
     [t],
   );
 
-  // Returns true on success, false on failure. The composer keeps the user's
-  // text (editor locked + button spinning) until this settles and clears only
-  // on success — so a slow send no longer leaves the box full next to an
-  // already-posted comment, and a failed send keeps the draft.
+  // Returns the created comment on success, null on failure. Callers use the
+  // result both as the composer's acceptance signal and for post-create UI
+  // work that needs the authoritative comment id (for example, revealing the
+  // newly posted row in a virtualized timeline).
   const submitComment = useCallback(
-    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<boolean> => {
-      if (!content.trim() || !userId) return false;
+    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<Comment | null> => {
+      if (!content.trim() || !userId) return null;
       try {
         const comment = await createComment({ content, attachmentIds, suppressAgentIds });
         warnUnhandledTriggers(comment?.trigger_outcomes, comment?.content);
-        return true;
+        return comment;
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
             ? err.message
             : t(($) => $.comment.send_failed),
         );
-        return false;
+        return null;
       }
     },
     [userId, createComment, warnUnhandledTriggers, t],
   );
 
   const submitReply = useCallback(
-    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<boolean> => {
-      if (!content.trim() || !userId) return false;
+    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<Comment | null> => {
+      if (!content.trim() || !userId) return null;
       try {
         const comment = await createComment({
           content,
@@ -332,14 +332,14 @@ export function useIssueTimeline(issueId: string, userId?: string) {
           suppressAgentIds,
         });
         warnUnhandledTriggers(comment?.trigger_outcomes, comment?.content);
-        return true;
+        return comment;
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
             ? err.message
             : t(($) => $.comment.send_reply_failed),
         );
-        return false;
+        return null;
       }
     },
     [userId, createComment, warnUnhandledTriggers, t],


### PR DESCRIPTION
## What does this PR do?

Fixes issue-detail timelines not revealing a comment or reply immediately after the current user posts it.

The timeline cache already contained the server response; the missing behavior was viewport intent. The browsing path is virtualized and intentionally does not use Virtuoso `followOutput`, so appending data alone neither mounts the new row nor moves the reader.

This change keeps the authoritative created-comment result, uses its ID to mount the owning Virtuoso thread, and then scrolls only the issue-detail container to the exact comment row. Realtime comments from other users do not arm this behavior, so they cannot interrupt the reader.

## Related Issue

Closes #6983

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Thinking Path

1. The create-comment mutation already inserts the server response into the React Query timeline cache and deduplicates the matching WebSocket event.
2. The issue-detail browsing path uses Virtuoso without `followOutput`, so a newly appended row may remain outside both the viewport and the mounted DOM window.
3. The submit helpers previously collapsed the authoritative server response to a boolean, discarding the ID needed for precise post-create behavior.
4. The fix returns the created comment, records scroll intent only for an explicit local submit, asks Virtuoso to mount the owning root thread, then measures and reveals the exact comment node.
5. Native `scrollIntoView` remains avoided because it can also move the desktop shell; only the issue-detail container's `scrollTop` changes.

## Changes Made

- `packages/views/issues/hooks/use-issue-timeline.ts`
  - Return `Comment | null` from successful comment and reply submissions.
  - Preserve existing failure handling and partial-trigger warnings.
- `packages/views/issues/components/issue-detail.tsx`
  - Track the authoritative posted comment ID and owning root-thread ID.
  - Mount virtualized targets with `scrollToIndex`.
  - Reveal the exact row after it enters the DOM.
  - Keep WebSocket-only updates viewport-neutral.
- `packages/views/issues/components/issue-detail.test.tsx`
  - Cover a newly posted top-level comment.
  - Cover a newly posted reply inside its root thread.

## How to Test

1. Open an issue with enough timeline entries to scroll.
2. Post a top-level comment while the newest timeline row is outside the viewport.
3. Confirm the newly posted row is revealed.
4. Post a reply in an expanded thread and confirm the exact reply is revealed.
5. Receive a realtime comment while reading elsewhere and confirm the viewport does not jump.

Automated verification:

- `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx issues/hooks/use-issue-timeline.test.tsx`
- `pnpm --filter @multica/views test` — 342 files / 4098 tests passed
- `pnpm --filter @multica/views typecheck`
- Targeted ESLint for the three changed files
- GitHub CI — 9/9 checks passed

## Playwright Before/After Verification

Captured against isolated databases with identical fixtures at a 1440×900 viewport.

| Build | Timeline state after POST | Result |
| --- | --- | --- |
| Before (`2c0912b6e`) | `scrollTop = 0`; created node not mounted | New comment is posted but remains out of view |
| After (`59e3949d7`) | `scrollTop = 4031`; created node mounted at 594–772px inside the 56–892px container viewport | New comment is immediately visible |

The before run also confirmed the visible comment count increased from 18 to 19, separating “POST failed” from “POST succeeded but viewport did not follow.”

## Risk Notes

- The scroll target is armed only by an explicit local submit, not by cache updates or WebSocket events.
- Replies scroll via their owning root thread because Virtuoso virtualizes thread roots, while the final adjustment targets the exact reply node.
- The target is cleared on issue changes and after a successful reveal.
- The mount wait is bounded and cleaned up through `requestAnimationFrame` cancellation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] Documentation is not affected
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect the issue timeline mutation and virtualization paths, identify the missing local-submit scroll intent, implement a scoped fix, add comment and reply regressions, run package and CI verification, and reproduce the behavior before and after with Playwright.

## Screenshots

Before/after screenshots were captured locally during the Playwright verification. GitHub attachment upload is still pending; the measured viewport evidence is recorded above so the behavioral result remains reviewable without relying on a static image alone.
