### PR TITLE
fix(daemon): pin agent tasks to runtime owner home

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6003,6 +6003,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"TMP":                  taskTempDir,
 		"TEMP":                 taskTempDir,
 	}
+	// Pin the daemon user's real HOME and XDG base directories explicitly on
+	// every agent child. Relying only on ambient inheritance is too fragile:
+	// provider wrappers and resumed environments created by older daemons have
+	// historically redirected HOME to <envRoot>/home, which makes host CLI
+	// logins (a1, gh, aws, kubectl, ...) appear missing inside the task. HOME is
+	// already blocked from agent custom_env below, so this is the authoritative
+	// runtime-owner identity boundary rather than a user-overridable setting.
+	if err := pinTaskUserHomeEnv(agentEnv); err != nil {
+		return TaskResult{}, fmt.Errorf("pin task user home: %w", err)
+	}
 	if checkoutMode := repoCheckoutModeFor(provider, runtime.GOOS); checkoutMode != "" {
 		agentEnv[repoCheckoutModeEnv] = checkoutMode
 	}
@@ -7518,6 +7528,37 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	return false
+}
+
+// pinTaskUserHomeEnv makes the daemon user's config roots explicit in the
+// child environment. XDG variables preserve daemon-level overrides when set;
+// otherwise they use the freedesktop defaults below HOME. Keeping this in the
+// launch layer applies the same credential-discovery contract to every agent
+// provider, including reused task environments.
+func pinTaskUserHomeEnv(agentEnv map[string]string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve daemon user home: %w", err)
+	}
+	home = strings.TrimSpace(home)
+	if home == "" {
+		return errors.New("daemon user home is empty")
+	}
+
+	agentEnv["HOME"] = home
+	for key, fallback := range map[string]string{
+		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(home, ".cache"),
+		"XDG_DATA_HOME":   filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME":  filepath.Join(home, ".local", "state"),
+	} {
+		value := strings.TrimSpace(os.Getenv(key))
+		if value == "" {
+			value = fallback
+		}
+		agentEnv[key] = value
+	}
+	return nil
 }
 
 // layerCustomEnvAndHermesHome applies the agent's custom_env onto the child env

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -437,6 +437,61 @@ func TestCodexTaskShellEnvInheritsRealHome(t *testing.T) {
 	}
 }
 
+func TestPinTaskUserHomeEnvUsesDaemonHomeAndXDGDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+
+	env := map[string]string{
+		"HOME":            "/stale/task/home",
+		"XDG_CONFIG_HOME": "/stale/task/home/.config",
+	}
+	if err := pinTaskUserHomeEnv(env); err != nil {
+		t.Fatalf("pinTaskUserHomeEnv: %v", err)
+	}
+
+	want := map[string]string{
+		"HOME":            home,
+		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(home, ".cache"),
+		"XDG_DATA_HOME":   filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME":  filepath.Join(home, ".local", "state"),
+	}
+	for key, value := range want {
+		if got := env[key]; got != value {
+			t.Errorf("%s = %q, want %q", key, got, value)
+		}
+	}
+}
+
+func TestPinTaskUserHomeEnvPreservesDaemonXDGOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "/daemon/config")
+	t.Setenv("XDG_CACHE_HOME", "/daemon/cache")
+	t.Setenv("XDG_DATA_HOME", "/daemon/data")
+	t.Setenv("XDG_STATE_HOME", "/daemon/state")
+
+	env := map[string]string{}
+	if err := pinTaskUserHomeEnv(env); err != nil {
+		t.Fatalf("pinTaskUserHomeEnv: %v", err)
+	}
+	for key, want := range map[string]string{
+		"HOME":            home,
+		"XDG_CONFIG_HOME": "/daemon/config",
+		"XDG_CACHE_HOME":  "/daemon/cache",
+		"XDG_DATA_HOME":   "/daemon/data",
+		"XDG_STATE_HOME":  "/daemon/state",
+	} {
+		if got := env[key]; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestCodexShellAuthorizedCustomEnvNamesUsesDaemonBlocklist(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- explicitly pin HOME and XDG base directories for every agent child process
- preserve daemon-level XDG overrides and use standard HOME defaults otherwise
- prevent resumed legacy task environments or provider wrappers from hiding host CLI logins such as a1

## Verification

- `go test ./internal/daemon -run "Test(PinTaskUserHomeEnv|CodexTaskShellEnvInheritsRealHome|PrepareCodexKeepsRealHome|ReuseCodexToleratesLegacyTaskHome)" -count=1`
- deployed on the daemon host and verified `a1 auth whoami` under the effective HOME/XDG environment