### PR TITLE
MUL-6218: fix(desktop) stop page headers stacking a second sidebar toggle

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.test.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.test.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import { useSidebar } from "@multica/ui/components/ui/sidebar";
+import { RESOURCES } from "@multica/views/locales";
+
+// The shell is the only thing under test here, so everything it mounts around
+// the sidebar is stubbed out. What survives is the pair that has to agree:
+// `WindowToolbar`'s own trigger, and the `hasExternalTrigger` the provider
+// publishes to every page header inside the canvas.
+vi.mock("@/hooks/use-tab-history", () => ({
+  useTabHistory: () => ({
+    canGoBack: false,
+    canGoForward: false,
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+  }),
+  useNavigationInputBindings: () => {},
+}));
+
+vi.mock("@/platform/navigation", () => ({
+  DesktopNavigationProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  routeContentLinkPath: vi.fn(),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  WorkspaceSlugProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  paths: { workspace: () => ({ inbox: () => "/acme/inbox" }) },
+  useCurrentWorkspace: () => null,
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
+  subscribeToCurrentSlug: () => () => {},
+}));
+
+vi.mock("@multica/views/navigation", () => ({
+  useNavigation: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@multica/views/platform", () => ({
+  useDesktopUnreadBadge: () => {},
+}));
+
+vi.mock("@multica/views/layout", () => ({
+  AppSidebar: () => null,
+  GlobalShortcuts: () => null,
+}));
+
+vi.mock("@multica/views/modals/registry", () => ({ ModalRegistry: () => null }));
+vi.mock("@multica/views/search", () => ({
+  SearchCommand: () => null,
+  SearchTrigger: () => null,
+}));
+vi.mock("@multica/views/chat", () => ({ FloatingChat: () => null }));
+vi.mock("./tab-bar", () => ({ TabBar: () => null }));
+vi.mock("./window-overlay", () => ({ WindowOverlay: () => null }));
+
+// Stands in for whatever page the active tab is showing. Reports the one fact
+// a `PageHeader` reads before deciding to render its own fallback trigger.
+vi.mock("./tab-content", () => ({
+  TabContent: () => {
+    const { hasExternalTrigger } = useSidebar();
+    return (
+      <div data-testid="page-content" data-external-trigger={hasExternalTrigger} />
+    );
+  },
+}));
+
+const { DesktopShell } = await import("./desktop-layout");
+
+function renderShell() {
+  (
+    window as unknown as { desktopAPI: Record<string, unknown> }
+  ).desktopAPI = {
+    onNavigationGesture: () => () => {},
+    onInboxOpen: () => () => {},
+  };
+
+  return render(
+    <I18nProvider locale="en" resources={RESOURCES}>
+      <DesktopShell />
+    </I18nProvider>,
+  );
+}
+
+describe("DesktopShell sidebar trigger", () => {
+  // The window toolbar parks a trigger beside the traffic lights that never
+  // scrolls away, so nothing inside the canvas may add a second one. Desktop
+  // windows sit below `xl`, exactly the band where `PageHeader`'s fallback
+  // trigger renders, so every page used to stack an identical icon 50px under
+  // this one — and a third when a list/detail surface brought its own header
+  // along (MUL-6218).
+  it("keeps exactly one trigger and tells page headers not to add another", () => {
+    const { container, getByTestId } = renderShell();
+
+    expect(container.querySelectorAll("[data-slot='sidebar-trigger']")).toHaveLength(1);
+    expect(getByTestId("page-content")).toHaveAttribute(
+      "data-external-trigger",
+      "true",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -243,7 +243,16 @@ export function DesktopShell() {
               inset half of both. Anything that has to paint an opaque layer
               over this wrapper (the tab flares) reads the variable rather than
               re-deriving which of the two is in play. */}
-          <SidebarProvider className="flex-1 bg-app-shell [--sidebar-wrapper-fill:var(--app-shell)]">
+          {/* hasExternalTrigger: WindowToolbar below parks a SidebarTrigger
+              beside the traffic lights, where it is always reachable. Page
+              headers inside the canvas must not add their own fallback one on
+              top of it — desktop windows sit below `xl`, exactly where that
+              fallback renders, so every page showed a second identical icon
+              50px under this one (MUL-6218). */}
+          <SidebarProvider
+            hasExternalTrigger
+            className="flex-1 bg-app-shell [--sidebar-wrapper-fill:var(--app-shell)]"
+          >
             {slug && <GlobalShortcuts />}
             {slug && <WindowToolbar />}
             {slug && <AppSidebar topSlot={<SidebarTopSpacer />} searchSlot={<SearchTrigger />} />}

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -36,3 +36,20 @@ if (!localStorageIsUsable) {
     value: storage,
   });
 }
+
+// jsdom doesn't provide matchMedia; the sidebar's compact breakpoint and
+// auto-collapse band both read it. Nothing matches, so a shell mounted here
+// renders at its full desktop width. Mirrors packages/views/test/setup.ts.
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}

--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -71,6 +71,17 @@ type SidebarContextProps = {
    */
   isCompact: boolean
   toggleSidebar: () => void
+  /**
+   * The app shell keeps a `SidebarTrigger` of its own on screen, outside the
+   * page chrome — the desktop window toolbar does, beside the traffic lights.
+   *
+   * Surfaces that would otherwise supply a fallback trigger read this and
+   * supply nothing: the shell's own is always reachable, so a second one is
+   * duplicate chrome rather than a way back to a nav that had none (MUL-6218).
+   * It describes the shell, not the current viewport, so it does not track
+   * whether that trigger happens to be mounted this render.
+   */
+  hasExternalTrigger: boolean
 }
 
 type SidebarResizeContextProps = {
@@ -108,6 +119,7 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  hasExternalTrigger = false,
   className,
   style,
   children,
@@ -116,6 +128,15 @@ function SidebarProvider({
   defaultOpen?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  /**
+   * Declare that this shell keeps its own always-reachable `SidebarTrigger`
+   * outside the page chrome. See `SidebarContextProps.hasExternalTrigger`.
+   *
+   * Defaults to false, and the default is the safe one: a shell that forgets
+   * to opt out shows one redundant icon, while a shell that has to opt in and
+   * forgets leaves a collapsed nav with no way back.
+   */
+  hasExternalTrigger?: boolean
 }) {
   const isCompact = useIsCompact()
   const [openMobile, setOpenMobile] = React.useState(false)
@@ -211,8 +232,18 @@ function SidebarProvider({
       openMobile,
       setOpenMobile,
       toggleSidebar,
+      hasExternalTrigger,
     }),
-    [state, open, setOpen, isCompact, openMobile, setOpenMobile, toggleSidebar]
+    [
+      state,
+      open,
+      setOpen,
+      isCompact,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      hasExternalTrigger,
+    ]
   )
   const resizeContextValue = React.useMemo<SidebarResizeContextProps>(
     () => ({

--- a/packages/views/layout/page-header.test.tsx
+++ b/packages/views/layout/page-header.test.tsx
@@ -8,13 +8,18 @@ import {
   CollectionPageHeader,
   CollectionPageHeaderAction,
 } from "./collection-page";
-import { PAGE_GUTTER, PageHeader } from "./page-header";
+import { CollapsedNavTrigger, PAGE_GUTTER, PageHeader } from "./page-header";
 
 // The layout rules under test are documented on `PageHeader` itself; each
 // test here pins one of them against the rendered output.
 
-function renderHeader(ui: React.ReactElement) {
-  const { container } = renderWithI18n(<SidebarProvider>{ui}</SidebarProvider>);
+function renderHeader(
+  ui: React.ReactElement,
+  providerProps?: { hasExternalTrigger?: boolean },
+) {
+  const { container } = renderWithI18n(
+    <SidebarProvider {...providerProps}>{ui}</SidebarProvider>,
+  );
   return within(container).getByRole("banner");
 }
 
@@ -84,6 +89,40 @@ describe("PageHeader base chrome", () => {
 
     expect(header).toHaveClass(PAGE_GUTTER);
     expect(header).not.toHaveClass("px-8");
+  });
+
+  // A shell that keeps its own trigger on screen (the desktop window toolbar)
+  // gets no fallback one: the header's copy is the same icon 50px below the
+  // shell's, and a list/detail surface stacked a third alongside it (MUL-6218).
+  it("drops its trigger under a shell that keeps its own on screen", () => {
+    const header = renderHeader(
+      <PageHeader>
+        <h1>Inbox</h1>
+      </PageHeader>,
+      { hasExternalTrigger: true },
+    );
+
+    expect(header.querySelector("[data-slot='sidebar-trigger']")).toBeNull();
+    expect(within(header).getByRole("heading")).toBe(header.firstElementChild);
+  });
+
+  // The pages that build their own chrome (settings) reach for the trigger
+  // directly, so the rule has to live in the trigger and not in `PageHeader`.
+  it("drops a directly rendered trigger under that shell too", () => {
+    const { container } = renderWithI18n(
+      <SidebarProvider hasExternalTrigger>
+        <CollapsedNavTrigger />
+      </SidebarProvider>,
+    );
+
+    expect(container.querySelector("[data-slot='sidebar-trigger']")).toBeNull();
+  });
+
+  // Outside a `SidebarProvider` there is no nav to reopen at all.
+  it("renders nothing when no sidebar is mounted", () => {
+    const { container } = renderWithI18n(<CollapsedNavTrigger />);
+
+    expect(container.querySelector("[data-slot='sidebar-trigger']")).toBeNull();
   });
 
   // Collection and issues headers drifted apart when each declared its own

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -29,14 +29,21 @@ export const PAGE_TOOLBAR = cn(
  * The way back to the nav wherever it is not a permanent column: a sheet below
  * the compact breakpoint, auto-collapsed from there up to `xl`.
  *
- * Every surface below `xl` needs one of these. `PageHeader` supplies it for
- * free, so this is exported for the pages that build their own chrome instead
- * — without it a touch user has no way to reopen the nav at all. Renders
- * nothing outside a `SidebarProvider` so such a page still stands alone.
+ * Every surface below `xl` needs one of these — unless the shell around it
+ * already keeps one on screen. `PageHeader` supplies it for free, so this is
+ * exported for the pages that build their own chrome instead; without it a
+ * touch user has no way to reopen the nav at all.
+ *
+ * Renders nothing in the two cases where it would not be the way back:
+ * outside a `SidebarProvider` (a page that stands alone, with no nav to
+ * reopen), and under a shell that declares `hasExternalTrigger` — the desktop
+ * window toolbar's trigger never scrolls away or hides, so a second copy in
+ * every page header stacked two identical icons 50px apart, and a third
+ * whenever a detail pane brought its own header along (MUL-6218).
  */
 export function CollapsedNavTrigger() {
   const sidebar = useSidebarSafe();
-  if (!sidebar) return null;
+  if (!sidebar || sidebar.hasExternalTrigger) return null;
   return <SidebarTrigger className="xl:hidden" />;
 }
 


### PR DESCRIPTION
Closes MUL-6218

## What was wrong

The desktop window toolbar parks a `SidebarTrigger` beside the traffic lights, and `PageHeader` supplies its own `xl:hidden` fallback trigger for every page. Desktop windows sit below `xl` — exactly the band where that fallback renders — so both were on screen at once, two identical panel icons about 50px apart. A list/detail surface added a third: the inbox reported here shows the window toolbar's, the inbox list header's, and the issue detail header's simultaneously.

Web was never affected: `DashboardLayout` has no chrome outside the page headers, so its trigger is the only one.

## The fix

`SidebarProvider` takes a `hasExternalTrigger` prop for shells that keep a trigger of their own permanently on screen. `CollapsedNavTrigger` reads it from the sidebar context and renders nothing when it is set, so the desktop keeps only the window toolbar's trigger.

The default is `false` on purpose, and it is the safe direction: a shell that forgets to opt out shows one redundant icon, while a shell that had to opt in and forgot would strand a user with a collapsed nav and no way back.

## Tests

- `packages/views/layout/page-header.test.tsx` — `PageHeader` and a directly rendered `CollapsedNavTrigger` both drop the trigger under a shell that declares `hasExternalTrigger`; unchanged behaviour without it, and outside a `SidebarProvider`.
- `apps/desktop/.../desktop-layout.test.tsx` (new) — the shell renders exactly one trigger and publishes `hasExternalTrigger` to the page content. Both new tests fail against `main`.
- `apps/desktop/test/setup.ts` gains the `matchMedia` stub the views setup already has; the sidebar's breakpoint hooks need it to mount under jsdom.

`pnpm typecheck` and `pnpm lint` clean. Full `pnpm test` is green apart from pre-existing failures in `packages/core` and `layout/sidebar-resize.test.tsx`, which fail identically on `main` — this sandbox's Node ships a native `localStorage` the test setups' guard does not replace, so the `setItem` spies never fire.

Not verified in a running desktop build — no local stack was started for this change.
