### PR TITLE
feat(web): name browser tabs after the open workspace page (MUL-6222)

### DIFF
--- a/apps/web/app/[workspaceSlug]/(dashboard)/layout.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/layout.tsx
@@ -1,25 +1,35 @@
 "use client";
 
+import { Suspense } from "react";
 import { DashboardLayout } from "@multica/views/layout";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 import { SearchCommand, SearchTrigger } from "@multica/views/search";
 import { FloatingChat } from "@multica/views/chat";
 import { WebNotificationBridge } from "@/components/web-notification-bridge";
+import { WorkspaceDocumentTitle } from "@/platform/workspace-document-title";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <DashboardLayout
-      loadingIndicator={<MulticaIcon className="size-6" />}
-      searchSlot={<SearchTrigger />}
-      extra={
-        <>
-          <SearchCommand />
-          <WebNotificationBridge />
-          <FloatingChat />
-        </>
-      }
-    >
-      {children}
-    </DashboardLayout>
+    <>
+      {/* useSearchParams requires a Suspense boundary in the app router. Sits
+          outside DashboardLayout so the tab is named while the guard is still
+          resolving the workspace. */}
+      <Suspense fallback={null}>
+        <WorkspaceDocumentTitle />
+      </Suspense>
+      <DashboardLayout
+        loadingIndicator={<MulticaIcon className="size-6" />}
+        searchSlot={<SearchTrigger />}
+        extra={
+          <>
+            <SearchCommand />
+            <WebNotificationBridge />
+            <FloatingChat />
+          </>
+        }
+      >
+        {children}
+      </DashboardLayout>
+    </>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,6 +8,7 @@ import { WebProviders } from "@/components/web-providers";
 import type { SupportedLocale } from "@multica/core/i18n";
 import { RESOURCES } from "@multica/views/locales";
 import { getRequestLocale } from "@/lib/request-locale";
+import { SITE_TITLE, TITLE_TEMPLATE } from "@/platform/document-title";
 import {
   resolveBrowserApiBaseUrl,
   resolveBrowserWsUrl,
@@ -74,8 +75,8 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.multica.ai"),
   title: {
-    default: "Multica — Project Management for Human + Agent Teams",
-    template: "%s | Multica",
+    default: SITE_TITLE,
+    template: TITLE_TEMPLATE,
   },
   description:
     "Open-source platform that turns coding agents into real teammates. Assign tasks, track progress, compound skills.",

--- a/apps/web/platform/document-title.test.tsx
+++ b/apps/web/platform/document-title.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+/**
+ * MUL-6222 — the web half of the tab-title contract.
+ *
+ * What a URL is *named* is resolved by `@multica/core/paths` +
+ * `useTabPresentation` and tested there; mocked out here so these cover only
+ * the platform wiring web owns: the site suffix, the unknown-route and
+ * navigation behavior of `document.title`.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+const route = vi.hoisted(() => ({ pathname: "/acme/issues", search: "" }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => route.pathname,
+  useSearchParams: () => new URLSearchParams(route.search),
+}));
+
+const presentation = vi.hoisted(() => ({
+  title: "Issues",
+  urls: [] as string[],
+}));
+vi.mock("@multica/views/layout", () => ({
+  useTabPresentation: (url: string) => {
+    presentation.urls.push(url);
+    return { title: presentation.title, visual: { kind: "icon", icon: "ListTodo" } };
+  },
+}));
+
+import {
+  MAX_PAGE_TITLE_LENGTH,
+  SITE_TITLE,
+  formatDocumentTitle,
+} from "./document-title";
+import { WorkspaceDocumentTitle } from "./workspace-document-title";
+
+function open(pathname: string, search = "") {
+  route.pathname = pathname;
+  route.search = search;
+}
+
+beforeEach(() => {
+  presentation.urls = [];
+  presentation.title = "Issues";
+  document.title = SITE_TITLE;
+});
+
+describe("formatDocumentTitle", () => {
+  it("puts the page name in front of the product name", () => {
+    expect(formatDocumentTitle("MUL-123: Fix login")).toBe(
+      "MUL-123: Fix login | Multica",
+    );
+  });
+
+  it("falls back to the site title rather than a bare suffix", () => {
+    expect(formatDocumentTitle("")).toBe(SITE_TITLE);
+    expect(formatDocumentTitle("   ")).toBe(SITE_TITLE);
+    expect(formatDocumentTitle(null)).toBe(SITE_TITLE);
+    expect(formatDocumentTitle(undefined)).toBe(SITE_TITLE);
+  });
+
+  it("clips an over-long title and keeps the identifying prefix", () => {
+    const title = `MUL-123: ${"long ".repeat(60)}`;
+    const formatted = formatDocumentTitle(title);
+
+    expect(formatted.startsWith("MUL-123: long")).toBe(true);
+    expect(formatted.endsWith("… | Multica")).toBe(true);
+    // Ellipsis replaces the clipped remainder, and no trailing space survives.
+    expect(formatted).not.toContain(" … ");
+  });
+
+  it("clips on code points so an emoji is never cut in half", () => {
+    const formatted = formatDocumentTitle("🎯".repeat(MAX_PAGE_TITLE_LENGTH + 10));
+    const pageTitle = formatted.slice(0, formatted.indexOf(" | Multica"));
+
+    expect(Array.from(pageTitle)).toHaveLength(MAX_PAGE_TITLE_LENGTH + 1);
+    expect(pageTitle).not.toContain("�");
+    expect(pageTitle.endsWith("🎯…")).toBe(true);
+  });
+
+  it("leaves a title at the limit untouched", () => {
+    const exact = "x".repeat(MAX_PAGE_TITLE_LENGTH);
+    expect(formatDocumentTitle(exact)).toBe(`${exact} | Multica`);
+  });
+});
+
+describe("WorkspaceDocumentTitle", () => {
+  it("names the tab after the open issue", () => {
+    open("/acme/issues/MUL-123");
+    presentation.title = "MUL-123: Fix login";
+
+    render(<WorkspaceDocumentTitle />);
+
+    expect(document.title).toBe("MUL-123: Fix login | Multica");
+  });
+
+  it("resolves against the full URL so a container's selection titles the tab", () => {
+    open("/acme/inbox", "issue=abc&view=archived");
+    presentation.title = "MUL-9: Ping";
+
+    render(<WorkspaceDocumentTitle />);
+
+    expect(presentation.urls).toContain("/acme/inbox?issue=abc&view=archived");
+    expect(document.title).toBe("MUL-9: Ping | Multica");
+  });
+
+  it("keeps the site title on an unrecognized route", () => {
+    open("/acme/not-a-route");
+    presentation.title = "Unknown page";
+
+    render(<WorkspaceDocumentTitle />);
+
+    expect(document.title).toBe(SITE_TITLE);
+  });
+
+  it("restores the site title when the dashboard unmounts", () => {
+    open("/acme/projects/p1");
+    presentation.title = "Website redesign";
+
+    const view = render(<WorkspaceDocumentTitle />);
+    expect(document.title).toBe("Website redesign | Multica");
+
+    view.unmount();
+    expect(document.title).toBe(SITE_TITLE);
+  });
+
+  it("re-asserts the title when a navigation keeps the same page name", () => {
+    open("/acme/inbox");
+    presentation.title = "Inbox";
+    const view = render(<WorkspaceDocumentTitle />);
+    expect(document.title).toBe("Inbox | Multica");
+
+    // A route change re-renders the target's metadata, resetting the title to
+    // the root default before our effect gets to run again.
+    document.title = SITE_TITLE;
+    open("/acme/inbox", "view=archived");
+    view.rerender(<WorkspaceDocumentTitle />);
+
+    expect(document.title).toBe("Inbox | Multica");
+  });
+});

--- a/apps/web/platform/document-title.ts
+++ b/apps/web/platform/document-title.ts
@@ -1,0 +1,60 @@
+/**
+ * The browser tab title contract for the web app.
+ *
+ * Two writers produce titles and they must agree: Next.js metadata renders the
+ * `<title>` for statically known routes (landing, auth), and
+ * `WorkspaceDocumentTitle` sets `document.title` on workspace routes, whose
+ * names only exist in the query cache. Both go through the constants here so
+ * `Issues | Multica` and `Changelog | Multica` can never drift into two
+ * different separators.
+ *
+ * Pure and React-free on purpose: the root layout is a server component and
+ * imports `SITE_TITLE` / `TITLE_TEMPLATE` for its metadata export.
+ */
+
+/** Root fallback — the title of a page that has nothing more specific to say. */
+export const SITE_TITLE = "Multica — Project Management for Human + Agent Teams";
+
+/** Appended to every page-specific title. */
+export const TITLE_SUFFIX = " | Multica";
+
+/** Next.js `metadata.title.template`; see apps/web/app/layout.tsx. */
+export const TITLE_TEMPLATE = `%s${TITLE_SUFFIX}`;
+
+/**
+ * Longest page name we put in front of the suffix, counted in code points.
+ *
+ * Issue titles are unbounded server-side, and the whole string ends up in the
+ * window title, history entries and bookmarks, not just the tab — a 600-char
+ * title makes all three unreadable. Browsers truncate the tab itself far
+ * earlier than this, so the cap only exists to keep those secondary surfaces
+ * sane; the discriminating part of a title (the issue key) leads, so it always
+ * survives both truncations.
+ */
+export const MAX_PAGE_TITLE_LENGTH = 120;
+
+/**
+ * Clip to {@link MAX_PAGE_TITLE_LENGTH} code points.
+ *
+ * Iterating code points rather than slicing UTF-16 units keeps an emoji or any
+ * other astral character from being cut in half into a replacement glyph — a
+ * real case here, since issue titles routinely open with one.
+ */
+function clipTitle(title: string): string {
+  const codePoints = Array.from(title);
+  if (codePoints.length <= MAX_PAGE_TITLE_LENGTH) return title;
+  return `${codePoints.slice(0, MAX_PAGE_TITLE_LENGTH).join("").trimEnd()}…`;
+}
+
+/**
+ * Build the full document title for a page name, e.g.
+ * `MUL-123: Fix login` → `MUL-123: Fix login | Multica`.
+ *
+ * An empty or whitespace-only name falls back to {@link SITE_TITLE} rather than
+ * rendering a bare ` | Multica`.
+ */
+export function formatDocumentTitle(pageTitle: string | null | undefined): string {
+  const trimmed = pageTitle?.trim();
+  if (!trimmed) return SITE_TITLE;
+  return `${clipTitle(trimmed)}${TITLE_SUFFIX}`;
+}

--- a/apps/web/platform/workspace-document-title.tsx
+++ b/apps/web/platform/workspace-document-title.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { parseTabSubject } from "@multica/core/paths";
+import { useTabPresentation } from "@multica/views/layout";
+import { SITE_TITLE, formatDocumentTitle } from "./document-title";
+
+/**
+ * Names the browser tab after whatever the workspace route has open, e.g.
+ * `MUL-123: Fix login | Multica` (MUL-6222). Without it every open dashboard
+ * tab renders the root metadata title, so several issues side by side are
+ * indistinguishable until you click into each one.
+ *
+ * The URL → title resolution is not ours: it is the same pure subject parser
+ * plus cache-backed presentation hook that names desktop's tabs, so a browser
+ * tab and a desktop tab for one URL always read identically, in the user's
+ * locale, and a renamed project or a changed issue title re-titles the tab
+ * live. Every query behind it is cache-only, so this costs no extra request.
+ *
+ * Mounted once per dashboard layout — one writer for the whole tree. A page
+ * that wants a different title should teach `resolveTabPresentation` about its
+ * subject rather than setting `document.title` behind this component's back.
+ */
+export function WorkspaceDocumentTitle() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Inbox and Chat carry their selection in the query string, and the subject
+  // parser reads it, so the title has to be recomputed from the full URL.
+  const search = searchParams.toString();
+  const url = search ? `${pathname}?${search}` : pathname;
+
+  const subject = useMemo(() => parseTabSubject(url), [url]);
+  const { title } = useTabPresentation(url);
+
+  // An unrecognized URL gets the site title, never the "Unknown page" label a
+  // tab strip needs: a browser tab has no other place to show the product name.
+  const documentTitle =
+    subject.kind === "unknown" ? SITE_TITLE : formatDocumentTitle(title);
+
+  // `url` is a dependency even though `documentTitle` is what we write: an app
+  // router navigation re-renders the target route's metadata and resets
+  // document.title to the root default, so a move between two routes that
+  // happen to share a title (`/inbox` → `/inbox?view=archived`) has to
+  // re-assert it.
+  useEffect(() => {
+    document.title = documentTitle;
+  }, [documentTitle, url]);
+
+  // Leaving the dashboard entirely (logout, workspace switcher, landing) drops
+  // back to the site title so the stale issue name never outlives its page.
+  useEffect(() => {
+    return () => {
+      document.title = SITE_TITLE;
+    };
+  }, []);
+
+  return null;
+}

--- a/e2e/issues.spec.ts
+++ b/e2e/issues.spec.ts
@@ -178,6 +178,11 @@ test.describe("Issues", () => {
     await expect(
       page.locator("a", { hasText: "Issues" }).first(),
     ).toBeVisible();
+    // The browser tab must name the issue, so several open at once stay
+    // distinguishable without clicking into each (MUL-6222).
+    await expect(page).toHaveTitle(
+      `${issue.identifier}: ${issue.title} | Multica`,
+    );
   });
 
   test("can dismiss issue creation", async ({ page }) => {

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -13,14 +13,18 @@ test.describe("Navigation", () => {
     await page.getByRole("link", { name: "Inbox" }).click();
     await expect(page).toHaveURL(/\/inbox/, { timeout: ROUTE_CHANGE_TIMEOUT });
     await waitForPageText(page, "Inbox");
+    // Each destination renames the browser tab after itself (MUL-6222).
+    await expect(page).toHaveTitle("Inbox | Multica");
 
     await page.getByRole("link", { name: "Agents" }).click();
     await expect(page).toHaveURL(/\/agents/, { timeout: ROUTE_CHANGE_TIMEOUT });
     await waitForPageText(page, "Agents");
+    await expect(page).toHaveTitle("Agents | Multica");
 
     await page.getByRole("link", { name: "Issues", exact: true }).click();
     await expect(page).toHaveURL(/\/issues/, { timeout: ROUTE_CHANGE_TIMEOUT });
     await waitForPageText(page, "Issues");
+    await expect(page).toHaveTitle("Issues | Multica");
   });
 
   test("settings page loads via sidebar", async ({ page }) => {


### PR DESCRIPTION
Closes #7010 (MUL-6222).

## Problem

Every page under `/{slug}/...` rendered the root metadata title, so a browser
tab for `MUL-123` and one for `MUL-456` both read
`Multica — Project Management for Human + Agent Teams`. With several issues
open you had to click into each tab to find the one you wanted.

## What changed

`WorkspaceDocumentTitle` mounts once in the web dashboard layout and names the
tab after whatever the route has open:

| Route | Tab title |
| --- | --- |
| `/{slug}/issues/MUL-123` | `MUL-123: Fix login \| Multica` |
| `/{slug}/projects/{id}` | `Website redesign \| Multica` |
| `/{slug}/inbox?issue=…` | `MUL-9: Ping \| Multica` |
| `/{slug}/issues` | `Issues \| Multica` |
| unrecognized URL | site title |

The URL → title resolution is not new. It is the same pure subject parser
(`parseTabSubject`) plus the cache-backed presentation hook (`useTabPresentation`)
that already name desktop's tabs, so:

- a browser tab and a desktop tab for one URL read identically, in the user's locale;
- a renamed project or an edited issue title re-titles the open tab live;
- every query behind it is cache-only (`enabled: false`), so it costs no extra request;
- a page whose data has not loaded yet shows its type label (`Issue | Multica`), never a wrong identity.

One writer for the whole tree: a page that wants a different title should teach
`resolveTabPresentation` about its subject rather than setting `document.title`
behind the component's back.

Supporting details:

- `SITE_TITLE` and the `%s | Multica` template now live in
  `apps/web/platform/document-title.ts` and are imported by the root layout's
  metadata, so the statically rendered title and the client-set one cannot drift
  into two different separators.
- Page names are clipped at 120 code points (code points, not UTF-16 units, so a
  leading emoji is never cut in half). The cap is for the window title, history
  and bookmarks — the tab itself truncates far earlier, and the issue key leads,
  so it survives both truncations.
- An unrecognized URL falls back to the site title rather than the "Unknown page"
  label a tab strip needs; a browser tab has no other place to show the product name.
- Leaving the dashboard restores the site title, so a stale issue name never
  outlives its page.

Desktop is untouched.

## Tests

- `apps/web/platform/document-title.test.tsx` — new: suffix, blank/unknown-route
  fallbacks, code-point clipping, restore-on-unmount, and re-assertion after a
  navigation that keeps the same page name (the app router re-renders the target
  route's metadata and resets `document.title`).
- `e2e/issues.spec.ts` — the issue detail flow now asserts
  `{identifier}: {title} | Multica`.
- `e2e/navigation.spec.ts` — sidebar navigation asserts each destination's tab title.

Ran locally: `pnpm --filter @multica/web test` (209 passed), `typecheck`, `lint`
(clean; the one warning is pre-existing in `(auth)/login/page.tsx`). The Playwright
specs above were not executed locally — this machine's PostgreSQL is at its
connection limit, so the local stack could not migrate; they run in CI.
`pnpm --filter @multica/web build` fails on this checkout at
`/(auth)/workspaces/new` prerender, identically with and without this change
(verified against a stashed tree), so it is pre-existing.
