### PR TITLE
MUL-6224: route thread replies by task coverage, not the mutable trigger pointer

### DIFF
--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -693,3 +693,63 @@ func TestCommentTriggerMentionAssigneeDoneIssue(t *testing.T) {
 		t.Errorf("expected 1 pending task after @mention of assignee on done issue, got %d", n)
 	}
 }
+
+// TestCommentTriggerThreadSurvivesTriggerReattribution is the MUL-6224
+// regression: conversation-continuation ownership must mean "a task COVERED the
+// thread root", not "the root is still some task's trigger_comment_id".
+//
+// The trigger pointer is mutable: when a second comment merges into the root's
+// still-queued task (MUL-4195 coalescing), MergeCommentIntoPendingTask
+// re-attributes trigger_comment_id to the new comment and demotes the root into
+// coalesced_comment_ids. Ownership matching keyed on the trigger pointer alone
+// therefore lost the thread the moment a busy-window merge stole it: every
+// later un-mentioned member reply in that thread routed NOWHERE — silently, at
+// create time and again in every completion reconcile (which re-runs the same
+// deterministic routing), so the instruction was permanently dropped. That is
+// exactly how two member instructions vanished on MUL-6139.
+func TestCommentTriggerThreadSurvivesTriggerReattribution(t *testing.T) {
+	agentID := getAgentID(t)
+	issueID := createIssueAssignedToAgent(t, "MUL-6224 re-attribution test", agentID)
+	t.Cleanup(func() {
+		clearTasks(t, issueID)
+		resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+		resp.Body.Close()
+	})
+	clearTasks(t, issueID) // drop the assignment task so we start clean
+
+	// Member starts a thread; the root triggers a task (trigger = root).
+	rootID := postComment(t, issueID, "The plugin capabilities also need work", nil)
+	// A second top-level comment lands while that task is still queued and
+	// merges into it: the trigger is re-attributed, the root is demoted.
+	otherID := postComment(t, issueID, "Also, the page does not refresh", nil)
+	if n := countPendingTasks(t, issueID); n != 1 {
+		t.Fatalf("expected the second comment to merge into the pending task, got %d tasks", n)
+	}
+	if got := latestTriggerCommentID(t, issueID); got != otherID {
+		t.Fatalf("merge should re-attribute trigger_comment_id to %s, got %s", otherID, got)
+	}
+	if coalesced := coalescedCommentIDs(t, issueID); !containsID(coalesced, rootID) {
+		t.Fatalf("expected root %s demoted into coalesced_comment_ids, got %v", rootID, coalesced)
+	}
+
+	// The merged batch run claims and starts — the incident window: the agent
+	// is busy, the root is covered by a RUNNING task that no longer points at
+	// it, and nothing is queued/dispatched.
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE agent_task_queue
+		SET status = 'running', started_at = now()
+		WHERE issue_id = $1 AND status = 'queued'
+	`, issueID); err != nil {
+		t.Fatalf("failed to mark batch task running: %v", err)
+	}
+
+	// Member replies under the ROOT without a mention ("ok, go ahead"). Before
+	// the fix this routed nowhere and no task was ever created for it.
+	replyID := postComment(t, issueID, "ok, please go ahead with that", strPtr(rootID))
+	if n := countPendingTasks(t, issueID); n != 1 {
+		t.Fatalf("expected 1 pending task (conversation continuation via coalesced root), got %d", n)
+	}
+	if got := latestTriggerCommentID(t, issueID); got != replyID {
+		t.Errorf("continuation task trigger_comment_id = %q, want reply id %q", got, replyID)
+	}
+}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -14,6 +14,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -1674,22 +1675,28 @@ func (h *Handler) PreviewCommentTriggers(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// taskCoversReplyParent reports whether parentID is a comment this task is
-// authorized to reply under. A comment-triggered task may reply to its trigger
-// comment OR to any earlier comment that was folded into the same run while it
-// was still queued (coalesced_comment_ids). A coalesced run answers each root
-// thread it covered inside that thread, so its replies legitimately target
-// those threads' comments — not just the trigger (MUL-4348 per-thread fan-out).
+// taskCoversComment reports whether commentID is part of this task's input
+// set: its current trigger comment, or an earlier comment folded into the same
+// run (coalesced_comment_ids). The trigger pointer alone under-reports what a
+// task covers — MergeCommentIntoPendingTask re-attributes trigger_comment_id
+// to the newest folded comment (MUL-4302), demoting earlier inputs (often
+// thread roots) into coalesced_comment_ids.
 //
-// Every other parent on the task's own issue is still rejected: this is the
-// defense against resumed-session --parent drift and cross-thread misplacement.
-// The allow-list is exactly the set the run was given to answer, so it cannot
-// reach arbitrary comments.
-func taskCoversReplyParent(task db.AgentTaskQueue, parentID pgtype.UUID) bool {
-	if !parentID.Valid {
+// Two consumers rely on this exact set:
+//   - Reply-parent authorization (CreateComment): a comment-triggered task may
+//     reply under its trigger OR any comment folded into the same run — a
+//     coalesced run answers each root thread it covered inside that thread
+//     (MUL-4348 per-thread fan-out). Every other parent on the task's own
+//     issue is still rejected: that is the defense against resumed-session
+//     --parent drift and cross-thread misplacement.
+//   - Conversation-continuation routing (routeConversationOwnersForRoot): a
+//     thread root this task covered marks the thread as the covering agent's
+//     conversation whether or not the root is still the trigger (MUL-6224).
+func taskCoversComment(task db.AgentTaskQueue, commentID pgtype.UUID) bool {
+	if !commentID.Valid {
 		return false
 	}
-	target := uuidToString(parentID)
+	target := uuidToString(commentID)
 	if task.TriggerCommentID.Valid && uuidToString(task.TriggerCommentID) == target {
 		return true
 	}
@@ -1802,7 +1809,7 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 				task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 					if task.TriggerCommentID.Valid {
-						if !taskCoversReplyParent(task, parentID) {
+						if !taskCoversComment(task, parentID) {
 							// Keep this error actionable for agents (MUL-4417 / GH #5266).
 							// The two rejections need different copy. A resumed
 							// session carrying a previous turn's --parent forward
@@ -2738,6 +2745,23 @@ func hasMemberMention(mentions []util.Mention) bool {
 	return false
 }
 
+// warnCommentRouteLookup logs an UNEXPECTED lookup failure inside an implicit
+// comment route. Implicit routes legitimately answer "no route" for policy
+// reasons (missing row, archived agent, invoke gate) and those stay silent —
+// but an infrastructure error must not be indistinguishable from them: it
+// means a member comment may be dropped with no other trace (MUL-6224).
+func warnCommentRouteLookup(route, step string, issue db.Issue, targetID pgtype.UUID, opts commentTriggerComputeOptions, err error) {
+	if err == nil || errors.Is(err, pgx.ErrNoRows) {
+		return
+	}
+	slog.Warn("comment routing: "+step+" failed",
+		"route", route,
+		"issue_id", uuidToString(issue.ID),
+		"target_id", uuidToString(targetID),
+		"comment_id", uuidToString(opts.ExcludeTriggerCommentID),
+		"error", err)
+}
+
 func (h *Handler) routeReplyToParentAuthor(ctx context.Context, issue db.Issue, parent *db.Comment, authorType, authorID string, opts commentTriggerComputeOptions) (commentAgentTrigger, bool) {
 	if parent == nil || parent.AuthorType != "agent" || !parent.AuthorID.Valid {
 		return commentAgentTrigger{}, false
@@ -2747,15 +2771,13 @@ func (h *Handler) routeReplyToParentAuthor(ctx context.Context, issue db.Issue, 
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+		warnCommentRouteLookup("thread-parent", "load parent agent", issue, parent.AuthorID, opts, err)
 		return commentAgentTrigger{}, false
 	}
 	if !h.canInvokeAgent(ctx, agent, authorType, authorID, opts.effectiveInvoker(), uuidToString(issue.WorkspaceID)) {
 		return commentAgentTrigger{}, false
 	}
-	hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, parent.AuthorID, opts)
-	if err != nil {
-		return commentAgentTrigger{}, false
-	}
+	hasPending := h.pendingDedupOrFailOpen(ctx, issue.ID, parent.AuthorID, opts, "thread-parent")
 	return commentAgentTrigger{Agent: agent, Source: commentTriggerSourceThreadParent, AlreadyPending: hasPending}, true
 }
 
@@ -2772,6 +2794,7 @@ func (h *Handler) routeThreadRootOwners(ctx context.Context, issue db.Issue, par
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil || !root.ID.Valid || root.AuthorType != "member" {
+		warnCommentRouteLookup("conversation", "load thread root", issue, parent.ID, opts, err)
 		return nil, false
 	}
 	return h.routeConversationOwnersForRoot(ctx, issue, root, memberID, opts)
@@ -2788,22 +2811,31 @@ func (h *Handler) routeConversationOwnersForRoot(ctx context.Context, issue db.I
 		return []commentAgentTrigger{trigger}, true
 	}
 
-	rootID := uuidToString(root.ID)
 	excludedID := uuidToString(opts.ExcludeTriggerCommentID)
 
 	tasks, err := h.Queries.ListTasksByIssue(ctx, issue.ID)
 	if err != nil {
+		// Without the task list there is no ownership evidence and the reply
+		// falls into the member-to-member no-route below — leave a trace, this
+		// is a drop, not a policy decision (MUL-6224).
+		slog.Warn("conversation routing: list issue tasks failed; reply gets no conversation route",
+			"issue_id", uuidToString(issue.ID), "comment_id", excludedID, "error", err)
 		return nil, false
 	}
 	routedAgents := make(map[string]conversationRoutedAgentInfo)
 	for _, task := range tasks {
-		if !task.TriggerCommentID.Valid || !task.AgentID.Valid {
+		if !task.AgentID.Valid {
 			continue
 		}
-		if excludedID != "" && uuidToString(task.TriggerCommentID) == excludedID {
+		if excludedID != "" && task.TriggerCommentID.Valid && uuidToString(task.TriggerCommentID) == excludedID {
 			continue
 		}
-		if uuidToString(task.TriggerCommentID) != rootID {
+		// Ownership means the task COVERED the root, not "the root is still the
+		// trigger pointer": a merge re-attributes trigger_comment_id to the
+		// newest folded comment, which used to make a busy-window root's whole
+		// thread permanently unroutable for un-mentioned member replies — at
+		// create time AND in every completion reconcile (MUL-6224).
+		if !taskCoversComment(task, root.ID) {
 			continue
 		}
 		agentID := uuidToString(task.AgentID)
@@ -2865,15 +2897,13 @@ func (h *Handler) routeConversationContinuationToAgent(ctx context.Context, issu
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+		warnCommentRouteLookup("conversation", "load conversation agent", issue, agentID, opts, err)
 		return commentAgentTrigger{}, false
 	}
 	if !h.canInvokeAgent(ctx, agent, "member", memberID, memberID, uuidToString(issue.WorkspaceID)) {
 		return commentAgentTrigger{}, false
 	}
-	hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, agentID, opts)
-	if err != nil {
-		return commentAgentTrigger{}, false
-	}
+	hasPending := h.pendingDedupOrFailOpen(ctx, issue.ID, agentID, opts, "conversation")
 	trigger := commentAgentTrigger{Agent: agent, Source: commentTriggerSourceConversation, AlreadyPending: hasPending}
 	if squadID.Valid {
 		if squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
@@ -2910,6 +2940,7 @@ func (h *Handler) routeAssignedSquadLeaderFallback(ctx context.Context, issue db
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil {
+		warnCommentRouteLookup("assigned-squad-leader", "load assigned squad", issue, issue.AssigneeID, opts, err)
 		return commentAgentTrigger{}, false
 	}
 	if authorType == "agent" && authorID == uuidToString(squad.LeaderID) &&
@@ -2921,16 +2952,37 @@ func (h *Handler) routeAssignedSquadLeaderFallback(ctx context.Context, issue db
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+		warnCommentRouteLookup("assigned-squad-leader", "load squad leader agent", issue, squad.LeaderID, opts, err)
 		return commentAgentTrigger{}, false
 	}
 	if !h.canInvokeAgent(ctx, agent, authorType, authorID, opts.effectiveInvoker(), uuidToString(issue.WorkspaceID)) {
 		return commentAgentTrigger{}, false
 	}
-	hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, squad.LeaderID, opts)
-	if err != nil {
-		return commentAgentTrigger{}, false
-	}
+	hasPending := h.pendingDedupOrFailOpen(ctx, issue.ID, squad.LeaderID, opts, "assigned-squad-leader")
 	return commentAgentTrigger{Agent: agent, Source: commentTriggerSourceIssueAssignee, Squad: &squad, AlreadyPending: hasPending}, true
+}
+
+// pendingDedupOrFailOpen resolves a route's AlreadyPending flag, FAILING OPEN
+// (no pending) when the check errors. The flag is a dedup optimization only:
+// enqueue correctness is already guaranteed by the
+// idx_one_pending_task_per_issue_agent_v2 partial unique index plus the
+// ErrDuplicatePendingTask merge/register retry loop in
+// resolveCommentTriggerEnqueue, so "false" at worst costs one extra insert
+// attempt that converges through that loop. Failing CLOSED here returned the
+// same signal as a policy rejection and silently discarded the member's
+// comment — with no log and no dispatch outcome (MUL-6224 defect 2).
+func (h *Handler) pendingDedupOrFailOpen(ctx context.Context, issueID, agentID pgtype.UUID, opts commentTriggerComputeOptions, route string) bool {
+	hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issueID, agentID, opts)
+	if err != nil {
+		slog.Warn("comment routing: pending-task dedup check failed; failing open",
+			"route", route,
+			"issue_id", uuidToString(issueID),
+			"agent_id", uuidToString(agentID),
+			"comment_id", uuidToString(opts.ExcludeTriggerCommentID),
+			"error", err)
+		return false
+	}
+	return hasPending
 }
 
 func (h *Handler) hasPendingTaskForIssueAndAgent(ctx context.Context, issueID, agentID pgtype.UUID, opts commentTriggerComputeOptions) (bool, error) {

--- a/server/internal/handler/comment_reply_authz_handler_test.go
+++ b/server/internal/handler/comment_reply_authz_handler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestCreateComment_TriggeredTaskRejectsTopLevelComment exercises the full
-// CreateComment handler path (not just taskCoversReplyParent) for the trap
+// CreateComment handler path (not just taskCoversComment) for the trap
 // reported in MUL-4417 / GH #5266: a comment-triggered task that posts a
 // parentless, top-level comment on its own issue is rejected with a 409 whose
 // message names the trigger comment and states that top-level comments are not

--- a/server/internal/handler/comment_reply_authz_test.go
+++ b/server/internal/handler/comment_reply_authz_test.go
@@ -40,8 +40,8 @@ func TestTaskCoversReplyParent(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := taskCoversReplyParent(task, tc.parent); got != tc.want {
-				t.Errorf("taskCoversReplyParent(%s) = %v, want %v", uuidToString(tc.parent), got, tc.want)
+			if got := taskCoversComment(task, tc.parent); got != tc.want {
+				t.Errorf("taskCoversComment(%s) = %v, want %v", uuidToString(tc.parent), got, tc.want)
 			}
 		})
 	}
@@ -49,7 +49,7 @@ func TestTaskCoversReplyParent(t *testing.T) {
 	// An assignment-triggered task (no trigger comment, no coalesced set) covers
 	// nothing here; the caller only consults this when TriggerCommentID is valid.
 	empty := db.AgentTaskQueue{}
-	if taskCoversReplyParent(empty, util.MustParseUUID(trigger)) {
+	if taskCoversComment(empty, util.MustParseUUID(trigger)) {
 		t.Errorf("a task with no trigger/coalesced comments must not authorize any parent")
 	}
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3626,6 +3626,17 @@ func (h *Handler) reconcileCommentsOnCompletion(ctx context.Context, task *db.Ag
 		// comments are unaffected: they keep their full routing.
 		if actorType != "member" {
 			triggers = keepExplicitMentionTriggers(triggers)
+		} else if len(triggers) == 0 {
+			// An undelivered MEMBER comment that routes to NO agent at all is
+			// beyond every safety net: this reconcile — and every later one —
+			// re-runs the same deterministic routing, so nothing will ever
+			// replay it (MUL-6224). It may be a legitimately agent-free side
+			// thread, but when it is a lost instruction this line is the only
+			// trace, so log it rather than skip in silence.
+			slog.Warn("reconcile comments on completion: undelivered member comment routes to no agent",
+				"issue_id", uuidToString(task.IssueID),
+				"completed_task_id", uuidToString(task.ID),
+				"comment_id", uuidToString(c.ID))
 		}
 		scoped := make([]commentAgentTrigger, 0, 1)
 		for _, trigger := range triggers {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3285,6 +3285,7 @@ func (h *Handler) assigneeFallbackAgent(ctx context.Context, issue db.Issue, act
 	}
 	agent, err := h.Queries.GetAgent(ctx, issue.AssigneeID)
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+		warnCommentRouteLookup("issue-assignee", "load assignee agent", issue, issue.AssigneeID, opts, err)
 		return db.Agent{}, false, false
 	}
 	if !h.canInvokeAgent(ctx, agent, actorType, actorID, opts.effectiveInvoker(), uuidToString(issue.WorkspaceID)) {
@@ -3292,10 +3293,9 @@ func (h *Handler) assigneeFallbackAgent(ctx context.Context, issue db.Issue, act
 	}
 	// Coalescing queue: pending is still a valid route target, but callers
 	// that actually enqueue tasks use this flag to avoid piling on duplicates.
-	hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, issue.AssigneeID, opts)
-	if err != nil {
-		return db.Agent{}, false, false
-	}
+	// The check fails OPEN: a DB error here must degrade to "no dedup", never
+	// to "no route" (MUL-6224).
+	hasPending := h.pendingDedupOrFailOpen(ctx, issue.ID, issue.AssigneeID, opts, "issue-assignee")
 	return agent, hasPending, true
 }
 


### PR DESCRIPTION
## Problem

Two member instructions on MUL-6139 were permanently lost with no task, no log, and no user-visible signal (analysis: MUL-6224). Root cause is deterministic, not a transient error:

1. Un-mentioned member replies under a member-authored thread root route only through conversation-continuation, which decided thread ownership by `task.trigger_comment_id == root_id`. On a miss the reply falls into the member-to-member dead end — the assignee fallback is never consulted.
2. `trigger_comment_id` is a mutable pointer: `MergeCommentIntoPendingTask` re-attributes it to the newest folded comment (by design, MUL-4302) and demotes the root into `coalesced_comment_ids`. Any root posted during a busy window loses its trigger identity to the merge batch.
3. Completion reconcile re-runs the same routing, so it deterministically reproduces the no-route and skips the comment in silence — the at-least-once net cannot catch this class.

On MUL-6139: roots `10b0b417` → `9f944f44` (11:24–11:32) coalesced into one task whose final trigger became `9f944f44`; root `d2b8bbd5` lost its identity, and the two un-mentioned replies under it (`eaf2b483` 11:50:53, `2b19e59f` 12:08:38 "ok 那你改一下吧") routed nowhere, at create time and at the 12:09:44 reconcile.

## Fix

- **Ownership = coverage.** `routeConversationOwnersForRoot` now matches a root against the task's input set (trigger OR `coalesced_comment_ids`) via `taskCoversComment` — the same predicate reply-parent authorization already used (renamed from `taskCoversReplyParent`; the two consumers deliberately share one definition of "task covers comment").
- **Dedup checks fail open.** A `hasPendingTaskForIssueAndAgent` error in the implicit routes (issue-assignee, thread-parent, conversation, assigned-squad-leader) degraded to "no route" and silently discarded the comment. The flag is a dedup optimization only — the `idx_one_pending_task_per_issue_agent_v2` partial unique index plus the `ErrDuplicatePendingTask` merge/register retry loop already guarantee no duplicate pending task — so the check now fails open and logs, with the comment id.
- **No more untraced drops.** Unexpected (non-`ErrNoRows`) lookup failures inside implicit routes are logged with `comment_id`/`issue_id`, and completion reconcile logs an undelivered member comment that routes to no agent at all instead of `continue`-ing in silence.

## Tests

- `TestCommentTriggerThreadSurvivesTriggerReattribution` reproduces the incident end-to-end: root triggers a task → second comment merges and steals the trigger → batch task running → un-mentioned reply under the root must still enqueue a continuation task. Fails with `got 0` pending tasks before the fix, passes after.
- Existing suites pass: `go test ./cmd/server` (includes `comment_at_least_once_test.go`, `comment_trigger_integration_test.go`) and `./internal/handler` (two pre-existing environment-only failures on my machine — `TestRenewPAT_ParallelRenewExtendsExactlyOnce`, `TestTaskWriteFence_LocksWorkspacesInIDOrder` — fail identically on the base commit, "too many clients" on local postgres).

## Out of scope (tracked on MUL-6224)

Durable obligation records (B4), reconcile watermark (B5), the comment→task conversion ledger/scan (B6/C7), and the "this comment triggered no run" UI signal (C8).
