### PR TITLE
MUL-6225: fix Gmail SMTP verification delivery

### DIFF
--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -290,7 +290,6 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 	// non-ASCII workspace/inviter names crossing strict or older SMTP hops.
 	has8Bit, _ := c.Extension("8BITMIME")
 	encodedSubject := mime.QEncoding.Encode("utf-8", subject)
-	msgID := fmt.Sprintf("<%d@%s>", time.Now().UnixNano(), s.smtpHost)
 
 	var bodyBytes []byte
 	var cte string
@@ -319,8 +318,6 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 	headers := "From: " + s.fromEmail + "\r\n" +
 		"To: " + to + "\r\n" +
 		"Subject: " + encodedSubject + "\r\n" +
-		"Date: " + time.Now().UTC().Format(time.RFC1123Z) + "\r\n" +
-		"Message-ID: " + msgID + "\r\n" +
 		"MIME-Version: 1.0\r\n" +
 		"Content-Type: text/html; charset=UTF-8\r\n" +
 		"Content-Transfer-Encoding: " + cte + "\r\n" +

--- a/server/internal/service/email_test.go
+++ b/server/internal/service/email_test.go
@@ -502,6 +502,8 @@ func TestSendSMTP_OpenClientFailureNoPanic(t *testing.T) {
 type testSMTPServer struct {
 	Listener net.Listener
 	Addr     string
+	// ReceivedData captures complete DATA payloads for message-level assertions.
+	ReceivedData chan string
 
 	// Auth mechs advertised in EHLO response (e.g. "LOGIN" or "PLAIN LOGIN")
 	AuthMechs string
@@ -521,6 +523,9 @@ func startTestSMTPServer(t *testing.T, cfg testSMTPServer) (*testSMTPServer, fun
 	}
 	cfg.Listener = l
 	cfg.Addr = l.Addr().String()
+	if cfg.ReceivedData == nil {
+		cfg.ReceivedData = make(chan string, 4)
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -616,12 +621,15 @@ func (s *testSMTPServer) handleConn(conn net.Conn) {
 		case upper == "DATA":
 			writeLine("354 Start mail input; end with <CRLF>.<CRLF>")
 			// Read until line containing only "."
+			var dataLines []string
 			for {
 				dataLine := readLine()
 				if dataLine == "." {
 					break
 				}
+				dataLines = append(dataLines, dataLine)
 			}
+			s.ReceivedData <- strings.Join(dataLines, "\r\n")
 			writeLine("250 OK")
 
 		case strings.HasPrefix(upper, "STARTTLS"):
@@ -685,6 +693,28 @@ func TestSendSMTP_PlainAuthSucceedsWithoutFallback(t *testing.T) {
 	err := s.sendSMTP("to@example.com", "Test Subject", "<p>Hello</p>")
 	if err != nil {
 		t.Fatalf("sendSMTP failed: %v", err)
+	}
+}
+
+func TestSendSMTP_OmitsProviderManagedHeaders(t *testing.T) {
+	srv, cleanup := startTestSMTPServer(t, testSMTPServer{})
+	defer cleanup()
+	host, port, _ := net.SplitHostPort(srv.Addr)
+
+	s := &EmailService{
+		fromEmail: "sender@gmail.com",
+		smtpHost:  host,
+		smtpPort:  port,
+	}
+	if err := s.sendSMTP("to@example.com", "Test Subject", "<p>Hello</p>"); err != nil {
+		t.Fatalf("sendSMTP failed: %v", err)
+	}
+
+	payload := strings.ToLower(<-srv.ReceivedData)
+	for _, header := range []string{"date:", "message-id:"} {
+		if strings.Contains(payload, "\r\n"+header) || strings.HasPrefix(payload, header) {
+			t.Fatalf("SMTP payload must let the provider assign %s; got:\n%s", header, payload)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Gmail SMTP accepted Multica verification messages with a `250` response but silently omitted them from recipient inboxes. Controlled cross-tests against a working Go SMTP application isolated the failure to Multica supplying `Date` and provider-domain `Message-ID` headers alongside its MIME transfer metadata. SMTP delivery now leaves `Date` and `Message-ID` assignment to the provider while preserving the existing TLS, authentication, HTML, and transfer-encoding behavior.

## Validation

- `go test ./internal/service`
- Rebuilt and deployed the self-host backend, then confirmed a real `/auth/send-code` request reached a Gmail inbox.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
