### PR TITLE
MUL-5982: fix(chat): keep following rapid live output

### DIFF
--- a/packages/views/chat/components/chat-message-list.test.tsx
+++ b/packages/views/chat/components/chat-message-list.test.tsx
@@ -20,16 +20,21 @@ vi.mock("react-virtuoso", () => ({
     computeItemKey,
     components,
     context,
+    followOutput,
   }: {
     data: unknown[];
     itemContent: (i: number, item: unknown) => ReactElement;
     computeItemKey: (i: number, item: unknown) => string;
     components?: { Footer?: (p: { context?: unknown }) => ReactElement | null };
     context?: unknown;
+    followOutput?: (atBottom: boolean) => "smooth" | "auto" | false;
   }) => {
     const Footer = components?.Footer;
     return (
-      <div>
+      <div
+        data-follow-at-bottom={String(followOutput?.(true))}
+        data-follow-away-from-bottom={String(followOutput?.(false))}
+      >
         {data.map((item, i) => (
           <div key={computeItemKey(i, item)} data-row-key={computeItemKey(i, item)}>
             {itemContent(i, item)}
@@ -87,6 +92,46 @@ function pushTaskMessage(qc: QueryClient, msg: TaskMessagePayload) {
     );
   });
 }
+
+describe("ChatMessageList live follow (#6697)", () => {
+  it("follows appended output immediately only while Virtuoso is at the live end", () => {
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={new QueryClient()}>
+          <ChatMessageList
+            messages={[]}
+            pendingTask={null}
+            availability="online"
+          />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+
+    const list = container.querySelector("[data-follow-at-bottom]");
+    expect(list).toHaveAttribute("data-follow-at-bottom", "auto");
+    expect(list).toHaveAttribute("data-follow-away-from-bottom", "false");
+  });
+
+  it("does not follow while older history is being prepended", () => {
+    const { container } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={new QueryClient()}>
+          <ChatMessageList
+            messages={[]}
+            pendingTask={null}
+            availability="online"
+            isFetchingOlderMessages
+          />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+
+    expect(container.querySelector("[data-follow-at-bottom]")).toHaveAttribute(
+      "data-follow-at-bottom",
+      "false",
+    );
+  });
+});
 
 describe("ChatMessageList live timeline (MUL-3960 regression)", () => {
   // The live footer is passed to Virtuoso through `components`. If that prop

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -185,7 +185,6 @@ export function ChatMessageList({
 }: ChatMessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
-  const [isNearBottom, setIsNearBottom] = useState(true);
   const setScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
     scrollRef.current = node;
     setScrollContainerEl(node);
@@ -329,8 +328,13 @@ export function ChatMessageList({
         initialTopMostItemIndex={{ index: "LAST", align: "end" }}
         increaseViewportBy={{ top: 400, bottom: 600 }}
         atBottomThreshold={120}
-        atBottomStateChange={setIsNearBottom}
-        followOutput={() => (!isFetchingOlderMessages && isNearBottom ? "smooth" : false)}
+        // Follow rapid streamed output only while Virtuoso says the reader is
+        // at the live end. An in-flight smooth animation temporarily reports
+        // "not at bottom" on the next append and permanently drops the follow
+        // (#6697), so live growth must use an immediate scroll.
+        followOutput={(atBottom) =>
+          !isFetchingOlderMessages && atBottom ? "auto" : false
+        }
         startReached={() => {
           if (hasOlderMessages && !isFetchingOlderMessages) {
             onLoadOlderMessages?.();


### PR DESCRIPTION
## What does this PR do?

Fixes Chat live output stopping its automatic follow while an agent is still streaming rapidly.

Thinking path:

- Chat already delegates list positioning to React Virtuoso.
- The existing `followOutput` callback ignored the current `atBottom` argument and instead read React state updated by `atBottomStateChange`.
- It also requested `smooth` scrolling for every append. While one animation is still in flight, the next append can observe the viewport away from the bottom and permanently disengage following. The transcript fix in #5932 documents the same Virtuoso behavior.
- This change uses the current Virtuoso callback value directly and requests `auto` for live growth. Manual scrolling away still returns `false`, and history prepends remain guarded by `isFetchingOlderMessages`.

## Related Issue

Closes #6697

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/chat/components/chat-message-list.tsx`: derive following from the current Virtuoso `atBottom` value and use immediate scrolling for rapid appends.
- `packages/views/chat/components/chat-message-list.test.tsx`: cover following at the live end, preserving reader-controlled scroll-away, and suppressing follow during older-history prepends.

## How to Test

1. Open Chat with enough history to fill the viewport.
2. Start an agent response that emits output rapidly.
3. Keep the viewport at the live end and verify every new chunk remains visible.
4. Scroll upward and verify new chunks do not pull the reader back down.
5. Return to the bottom and verify following resumes.

Automated verification:

- `pnpm --filter @multica/views test` — 345 files / 4151 tests passed.
- `pnpm --filter @multica/views typecheck` — passed.
- `pnpm --filter @multica/views lint` — passed with pre-existing warnings only.
- CI frontend build/typecheck/lint command — 12/12 tasks passed.
- The two repository-wide scan tests that exceeded their 5-second timeout under local parallel package load passed 36/36 when rerun directly.

Real-Virtuoso Playwright harness, 5 runs of 80 rows appended every 24 ms:

| Strategy | Final bottom gap |
| --- | ---: |
| Previous smooth/state callback | 6352–6526 px |
| Current immediate/callback-argument strategy | 1 px in all 5 runs |

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] Documentation update is not required for this behavior-only bug fix
- [x] Landing copy and docs sync is not applicable
- [x] Chinese product copy is not changed
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: live output now moves immediately instead of animating. This matches the existing Transcript live-follow fix and avoids treating an in-flight animation as reader intent. Readers who scroll away remain undisturbed.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Inspected unclaimed issues, traced #6697 through Chat and the prior Transcript fix, wrote a failing Virtuoso-contract regression test, changed the minimum callback behavior, and validated both strategies with a real React Virtuoso Playwright harness under rapid appends.

## Screenshots

A side-by-side Playwright capture was produced locally; it can be attached in review because GitHub CLI cannot upload local image attachments.