### PR TITLE
YUX-18: Support exact agent invocation allowlist

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -589,7 +589,7 @@ export const EMPTY_MEMBER_LIST: MemberWithUser[] = [];
 
 const AgentInvocationTargetSchema: z.ZodType<AgentInvocationTarget> = z
   .object({
-    target_type: z.enum(["workspace", "member", "team"]).catch("team"),
+    target_type: z.enum(["workspace", "member", "team", "agent"]).catch("team"),
     target_id: z
       .string()
       .nullable()

--- a/apps/mobile/lib/agent-schema.test.ts
+++ b/apps/mobile/lib/agent-schema.test.ts
@@ -16,6 +16,7 @@ describe("AgentSchema invocation permissions", () => {
       invocation_targets: [
         { target_type: "workspace" },
         { target_type: "member", target_id: "member-1" },
+        { target_type: "agent", target_id: "agent-1" },
       ],
     });
 
@@ -23,6 +24,7 @@ describe("AgentSchema invocation permissions", () => {
     expect(parsed.invocation_targets).toEqual([
       { target_type: "workspace", target_id: null },
       { target_type: "member", target_id: "member-1" },
+      { target_type: "agent", target_id: "agent-1" },
     ]);
   });
 

--- a/packages/core/agents/effective-access.test.ts
+++ b/packages/core/agents/effective-access.test.ts
@@ -15,6 +15,9 @@ function member(id: string): AgentInvocationTarget {
 function team(id: string): AgentInvocationTarget {
   return { target_type: "team", target_id: id };
 }
+function agent(id: string): AgentInvocationTarget {
+  return { target_type: "agent", target_id: id };
+}
 
 describe("effectiveAccessScope", () => {
   it("maps private to owner-only", () => {
@@ -31,6 +34,10 @@ describe("effectiveAccessScope", () => {
 
   it("maps public_to + team target only to specific-people", () => {
     expect(effectiveAccessScope("public_to", [team("t-1")])).toBe("specific-people");
+  });
+
+  it("maps public_to + agent target only to specific-people", () => {
+    expect(effectiveAccessScope("public_to", [agent("a-1")])).toBe("specific-people");
   });
 
   it("maps public_to with no targets to specific-people", () => {

--- a/packages/core/agents/effective-access.ts
+++ b/packages/core/agents/effective-access.ts
@@ -12,7 +12,8 @@ import type { AgentInvocationTarget, AgentPermissionMode } from "../types";
  * (`server/internal/handler/agent_access.go`):
  *   - owner-only      = `private` (only the owner may invoke)
  *   - workspace       = `public_to` with a workspace target (any member/agent/system)
- *   - specific-people = `public_to` without a workspace target (member/team targets)
+ *   - specific-people = `public_to` without a workspace target
+ *     (member/team/agent targets)
  */
 export type AccessScope = "workspace" | "specific-people" | "owner-only";
 

--- a/packages/core/permissions/rules.test.ts
+++ b/packages/core/permissions/rules.test.ts
@@ -249,6 +249,18 @@ describe("canAssignAgentToIssue", () => {
     ).toBe(true);
   });
 
+  it("does not treat an agent target as a human invocation grant", () => {
+    const a = makeAgent({
+      visibility: "private",
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "agent", target_id: "agent-1" }],
+      owner_id: ALICE,
+    });
+    const d = canAssignAgentToIssue(a, { userId: BOB, role: "admin" });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe("private_visibility");
+  });
+
   it("denies logged-out users", () => {
     const a = makeAgent({
       visibility: "workspace",

--- a/packages/core/permissions/rules.ts
+++ b/packages/core/permissions/rules.ts
@@ -52,6 +52,7 @@ export function canEditAgent(agent: Agent, ctx: PermissionContext): Decision {
  *     change — workspace admins NO LONGER bypass a private agent.
  *   - permission_mode "public_to" + workspace target: any workspace member
  *   - permission_mode "public_to" + member target: only the matching user
+ *   - agent target: server-only A2A grant; never grants the current human
  *   - team target: reserved, INERT in v1 (never grants)
  */
 export function canAssignAgentToIssue(
@@ -86,8 +87,9 @@ export function canAssignAgentToIssue(
     return ALLOW;
   }
 
-  // A member grant opens invocation to exactly the targeted user. Team
-  // targets are reserved and INERT in v1 — they never grant.
+  // A member grant opens invocation to exactly the targeted user. Agent
+  // targets apply only to authenticated agent actors on the server; team
+  // targets are reserved and INERT in v1. Neither grants this human caller.
   if (
     targets.some(
       (t) => t.target_type === "member" && t.target_id === ctx.userId,

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -13,7 +13,7 @@ export type AgentVisibility = "workspace" | "private";
 // may TRIGGER / assign / @mention / chat an agent. The legacy `visibility`
 // field REMAINS but is now DERIVED on the backend from these two: a
 // `public_to` agent WITH a workspace target maps to `visibility: "workspace"`;
-// everything else (private, or public_to scoped only to member/team targets)
+// everything else (private, or public_to scoped only to member/team/agent targets)
 // maps to `visibility: "private"`.
 //
 // Invocation semantics:
@@ -22,6 +22,8 @@ export type AgentVisibility = "workspace" | "private";
 //     bypass — the key behavior change vs the old visibility model)
 //   - permission_mode "public_to" + workspace target: any workspace member
 //   - permission_mode "public_to" + member target: only the matching user
+//   - permission_mode "public_to" + agent target: only the exact active
+//     same-workspace agent actor; direct and non-transitive
 //   - team target: reserved, INERT in v1 (never grants)
 // ---------------------------------------------------------------------------
 
@@ -30,20 +32,20 @@ export type AgentPermissionMode = "private" | "public_to";
 /**
  * A single invocation grant on an agent. `target_id` is `null` for the
  * workspace target (the grant covers every workspace member); it carries the
- * member / team id for the scoped grants.
+ * member / team / agent id for the scoped grants.
  */
 export interface AgentInvocationTarget {
-  target_type: "workspace" | "member" | "team";
+  target_type: "workspace" | "member" | "team" | "agent";
   target_id: string | null;
 }
 
 /**
  * Wire shape for invocation targets on CREATE / UPDATE requests. For a
  * workspace target the client may omit `target_id` (the backend fills the
- * workspace id); member / team targets REQUIRE it.
+ * workspace id); member / team / agent targets REQUIRE it.
  */
 export interface AgentInvocationTargetInput {
-  target_type: "workspace" | "member" | "team";
+  target_type: "workspace" | "member" | "team" | "agent";
   target_id?: string;
 }
 

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -176,6 +176,7 @@ func init() {
 	agentCreateCmd.Flags().String("permission-mode", "", "Invocation permission mode: private (owner only) or public_to (allow-list via --public-to-*). Authoritative over --visibility when set.")
 	agentCreateCmd.Flags().Bool("public-to-workspace", false, "public_to: allow every workspace member to invoke this agent.")
 	agentCreateCmd.Flags().StringSlice("public-to-member", nil, "public_to: allow the given member user id(s) to invoke this agent. Repeatable.")
+	agentCreateCmd.Flags().StringSlice("public-to-agent", nil, "public_to: allow the given same-workspace agent id(s) to invoke this agent. Repeatable.")
 	agentCreateCmd.Flags().Int32("max-concurrent-tasks", 6, "Maximum concurrent tasks (1-50)")
 	agentCreateCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -205,6 +206,7 @@ func init() {
 	agentUpdateCmd.Flags().String("permission-mode", "", "New invocation permission mode: private or public_to. Authoritative over --visibility. Owner-only.")
 	agentUpdateCmd.Flags().Bool("public-to-workspace", false, "public_to: allow every workspace member to invoke this agent.")
 	agentUpdateCmd.Flags().StringSlice("public-to-member", nil, "public_to: allow the given member user id(s) to invoke this agent. Repeatable.")
+	agentUpdateCmd.Flags().StringSlice("public-to-agent", nil, "public_to: allow the given same-workspace agent id(s) to invoke this agent. Repeatable.")
 	agentUpdateCmd.Flags().String("status", "", "New status")
 	agentUpdateCmd.Flags().Int32("max-concurrent-tasks", 0, "New max concurrent tasks (1-50)")
 	agentUpdateCmd.Flags().String("output", "json", "Output format: table or json")
@@ -597,7 +599,8 @@ func runAgentGet(cmd *cobra.Command, args []string) error {
 }
 
 // applyAgentPermissionFlags translates the invocation-permission flags
-// (--permission-mode / --public-to-workspace / --public-to-member) into the
+// (--permission-mode / --public-to-workspace / --public-to-member /
+// --public-to-agent) into the
 // permission_mode + invocation_targets request fields (MUL-3963). When none of
 // the flags are set it is a no-op, so the legacy --visibility handling still
 // drives the request. When any public-to-* flag is present without an explicit
@@ -606,7 +609,8 @@ func applyAgentPermissionFlags(cmd *cobra.Command, body map[string]any) {
 	hasMode := cmd.Flags().Changed("permission-mode")
 	hasWorkspace := cmd.Flags().Changed("public-to-workspace")
 	hasMembers := cmd.Flags().Changed("public-to-member")
-	if !hasMode && !hasWorkspace && !hasMembers {
+	hasAgents := cmd.Flags().Changed("public-to-agent")
+	if !hasMode && !hasWorkspace && !hasMembers && !hasAgents {
 		return
 	}
 
@@ -623,6 +627,11 @@ func applyAgentPermissionFlags(cmd *cobra.Command, body map[string]any) {
 	if members, _ := cmd.Flags().GetStringSlice("public-to-member"); len(members) > 0 {
 		for _, m := range members {
 			targets = append(targets, map[string]any{"target_type": "member", "target_id": m})
+		}
+	}
+	if agents, _ := cmd.Flags().GetStringSlice("public-to-agent"); len(agents) > 0 {
+		for _, agentID := range agents {
+			targets = append(targets, map[string]any{"target_type": "agent", "target_id": agentID})
 		}
 	}
 	body["invocation_targets"] = targets
@@ -802,7 +811,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --thinking-level, --service-tier, --custom-args, --mcp-config, --visibility, --permission-mode, --public-to-workspace, --public-to-member, --public-to-agent, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/cmd/multica/cmd_agent_copy.go
+++ b/server/cmd/multica/cmd_agent_copy.go
@@ -67,6 +67,7 @@ func registerAgentCopyFlags(cmd *cobra.Command) {
 	cmd.Flags().String("permission-mode", "", "Override invocation permission mode: private or public_to. Authoritative over --visibility.")
 	cmd.Flags().Bool("public-to-workspace", false, "public_to: allow every workspace member to invoke the copy.")
 	cmd.Flags().StringSlice("public-to-member", nil, "public_to: allow the given member user id(s) to invoke the copy. Repeatable.")
+	cmd.Flags().StringSlice("public-to-agent", nil, "public_to: allow the given same-workspace agent id(s) to invoke the copy. Repeatable.")
 	cmd.Flags().Bool("no-skills", false, "Do not copy the source agent's workspace skill assignments.")
 	// Secret / machine-local fields are never copied from the source; these
 	// flags provide fresh values for the copy, mirroring 'agent create'.
@@ -217,6 +218,7 @@ func runAgentCopy(cmd *cobra.Command, args []string) error {
 	permOverride := cmd.Flags().Changed("permission-mode") ||
 		cmd.Flags().Changed("public-to-workspace") ||
 		cmd.Flags().Changed("public-to-member") ||
+		cmd.Flags().Changed("public-to-agent") ||
 		cmd.Flags().Changed("visibility")
 	if permOverride {
 		if cmd.Flags().Changed("visibility") {

--- a/server/cmd/multica/cmd_agent_copy_test.go
+++ b/server/cmd/multica/cmd_agent_copy_test.go
@@ -38,7 +38,10 @@ func fullSourceAgent() map[string]any {
 		"thinking_level":       "high",
 		"service_tier":         "priority",
 		"permission_mode":      "public_to",
-		"invocation_targets":   []any{map[string]any{"target_type": "workspace"}},
+		"invocation_targets": []any{
+			map[string]any{"target_type": "workspace"},
+			map[string]any{"target_type": "agent", "target_id": "agent-source"},
+		},
 		"skills": []any{
 			map[string]any{"id": "skill-1", "name": "One"},
 			map[string]any{"id": "skill-2", "name": "Two"},
@@ -133,7 +136,10 @@ func TestAgentCopySameRuntimeCopiesPortableFields(t *testing.T) {
 	if gotBody["permission_mode"] != "public_to" {
 		t.Errorf("permission_mode = %v", gotBody["permission_mode"])
 	}
-	if !reflect.DeepEqual(gotBody["invocation_targets"], []any{map[string]any{"target_type": "workspace"}}) {
+	if !reflect.DeepEqual(gotBody["invocation_targets"], []any{
+		map[string]any{"target_type": "workspace"},
+		map[string]any{"target_type": "agent", "target_id": "agent-source"},
+	}) {
 		t.Errorf("invocation_targets = %v", gotBody["invocation_targets"])
 	}
 	// Skills bind in the same create request.
@@ -322,6 +328,27 @@ func TestAgentCopyPermissionOverrideReplacesSource(t *testing.T) {
 	// workspace target must be gone.
 	if got, ok := gotBody["invocation_targets"].([]any); !ok || len(got) != 0 {
 		t.Errorf("invocation_targets = %v, want empty list", gotBody["invocation_targets"])
+	}
+}
+
+func TestAgentCopyPublicToAgentOverrideReplacesSource(t *testing.T) {
+	var gotBody map[string]any
+	srv := copyMockServer(t, fullSourceAgent(), &gotBody)
+	defer srv.Close()
+	setCopyTestEnv(t, srv.URL)
+
+	cmd := newAgentCopyTestCmd()
+	_ = cmd.Flags().Set("public-to-agent", "agent-allowed")
+
+	if err := runAgentCopy(cmd, []string{"agent-src"}); err != nil {
+		t.Fatalf("runAgentCopy: %v", err)
+	}
+	if gotBody["permission_mode"] != "public_to" {
+		t.Errorf("permission_mode = %v, want public_to", gotBody["permission_mode"])
+	}
+	want := []any{map[string]any{"target_type": "agent", "target_id": "agent-allowed"}}
+	if !reflect.DeepEqual(gotBody["invocation_targets"], want) {
+		t.Errorf("invocation_targets = %#v, want %#v", gotBody["invocation_targets"], want)
 	}
 }
 

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -33,6 +33,48 @@ func freshAgentEnvSetCmd() *cobra.Command {
 	return c
 }
 
+func freshAgentPermissionCmd() *cobra.Command {
+	c := &cobra.Command{Use: "agent-permission"}
+	c.Flags().String("permission-mode", "", "")
+	c.Flags().Bool("public-to-workspace", false, "")
+	c.Flags().StringSlice("public-to-member", nil, "")
+	c.Flags().StringSlice("public-to-agent", nil, "")
+	return c
+}
+
+func TestApplyAgentPermissionFlagsIncludesExactAgentTargets(t *testing.T) {
+	cmd := freshAgentPermissionCmd()
+	if err := cmd.Flags().Set("public-to-member", "member-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("public-to-agent", "agent-1,agent-2"); err != nil {
+		t.Fatal(err)
+	}
+
+	body := map[string]any{}
+	applyAgentPermissionFlags(cmd, body)
+
+	if body["permission_mode"] != "public_to" {
+		t.Fatalf("permission_mode = %v, want public_to", body["permission_mode"])
+	}
+	want := []map[string]any{
+		{"target_type": "member", "target_id": "member-1"},
+		{"target_type": "agent", "target_id": "agent-1"},
+		{"target_type": "agent", "target_id": "agent-2"},
+	}
+	if !reflect.DeepEqual(body["invocation_targets"], want) {
+		t.Fatalf("invocation_targets = %#v, want %#v", body["invocation_targets"], want)
+	}
+}
+
+func TestAgentPermissionCommandsExposePublicToAgent(t *testing.T) {
+	for _, cmd := range []*cobra.Command{agentCreateCmd, agentUpdateCmd, agentCopyCmd} {
+		if cmd.Flag("public-to-agent") == nil {
+			t.Errorf("%s is missing --public-to-agent", cmd.CommandPath())
+		}
+	}
+}
+
 func chdirWithDaemonTaskMarker(t *testing.T) {
 	t.Helper()
 

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1034,8 +1034,9 @@ type CreateAgentRequest struct {
 	// PermissionMode + InvocationTargets are the new invocation-permission
 	// inputs (MUL-3963). When permission_mode is present it is authoritative
 	// and Visibility is ignored; when absent, legacy Visibility is mapped
-	// (private -> private, workspace -> public_to+workspace target). On create
-	// only the caller can be the owner, so targets are accepted unconditionally.
+	// (private -> private, workspace -> public_to+workspace target). Invocation
+	// permission writes require a human owner; an agent actor cannot create an
+	// allow-list on its owner's behalf.
 	PermissionMode     *string                    `json:"permission_mode"`
 	InvocationTargets  []AgentInvocationTargetDTO `json:"invocation_targets"`
 	MaxConcurrentTasks int32                      `json:"max_concurrent_tasks"`
@@ -1125,13 +1126,27 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve invocation permission (MUL-3963). permission_mode is
 	// authoritative when present; otherwise the legacy visibility value is
-	// mapped. On create the caller is always the owner, so targets are
-	// accepted unconditionally.
+	// mapped. A task-scoped agent actor may create an otherwise-private agent,
+	// but cannot author an invocation allow-list on its backing user's behalf.
+	_, hasPermissionMode := rawFields["permission_mode"]
 	_, hasTargets := rawFields["invocation_targets"]
+	_, hasVisibility := rawFields["visibility"]
+	permissionTouched := hasPermissionMode || hasTargets || hasVisibility
 	legacyVis := req.Visibility
-	perm, _, permErr := parsePermissionInput(wsUUID, req.PermissionMode, req.InvocationTargets, req.PermissionMode != nil, hasTargets, &legacyVis)
+	perm, _, permErr := parsePermissionInput(wsUUID, req.PermissionMode, req.InvocationTargets, hasPermissionMode, hasTargets, &legacyVis)
 	if permErr != nil {
 		writeError(w, http.StatusBadRequest, permErr.Error())
+		return
+	}
+	if permissionTouched {
+		actorType, _ := h.resolveActor(r, ownerID, workspaceID)
+		if actorType == "agent" {
+			writeError(w, http.StatusForbidden, "agents may not configure invocation permissions")
+			return
+		}
+	}
+	if err := validateInvocationAgentTargets(r.Context(), h.Queries, wsUUID, perm.targets); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{
@@ -1288,6 +1303,16 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to save agent access")
 		return
 	}
+	if permissionTouched {
+		if err := createAgentInvocationPermissionActivity(
+			r.Context(), qtx, wsUUID, created.ID, parseUUID(ownerID), "create", perm,
+		); err != nil {
+			slog.Error("create agent invocation permission audit failed; rolling back create",
+				append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(created.ID))...)
+			writeError(w, http.StatusInternalServerError, "audit log write failed; agent create rolled back")
+			return
+		}
+	}
 	for _, skillID := range skillUUIDs {
 		if err := qtx.AddAgentSkill(r.Context(), db.AddAgentSkillParams{
 			AgentID: created.ID,
@@ -1356,10 +1381,10 @@ type UpdateAgentRequest struct {
 	McpConfig  *json.RawMessage `json:"mcp_config"`
 	Visibility *string          `json:"visibility"`
 	// PermissionMode + InvocationTargets are the invocation-permission inputs
-	// (MUL-3963). Owner-only writes (like composio_toolkit_allowlist): a
-	// non-owner admin passing them is silently ignored, because the invoke
-	// gate is owner/allow-list based and an admin-authored allow-list would
-	// confuse the owner about who can run their agent. permission_mode is
+	// (MUL-3963). Human-owner-only writes: a real change from a non-owner is
+	// rejected, while unchanged fields echoed by PATCH-as-PUT clients are
+	// ignored. Agent actors are not allowed to write them even when their
+	// backing user owns the target. permission_mode is
 	// authoritative when present; otherwise legacy visibility is mapped.
 	PermissionMode     *string                     `json:"permission_mode"`
 	InvocationTargets  *[]AgentInvocationTargetDTO `json:"invocation_targets"`
@@ -1683,14 +1708,19 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	replacePermissionTargets := false
 	var resolvedPerm resolvedPermission
 	if permissionTouched {
-		isAgentOwner := uuidToString(existing.OwnerID) == requestUserID(r)
-		if !isAgentOwner {
+		actorType, _ := h.resolveActor(r, requestUserID(r), uuidToString(existing.WorkspaceID))
+		isHumanAgentOwner := actorType != "agent" && uuidToString(existing.OwnerID) == requestUserID(r)
+		if !isHumanAgentOwner {
 			changed, permErr := h.permissionInputChangesAgent(r.Context(), existing, req, hasPermissionMode, hasTargets)
 			if permErr != nil {
 				writeError(w, http.StatusInternalServerError, "failed to evaluate invocation permission change")
 				return
 			}
 			if changed {
+				if actorType == "agent" {
+					writeError(w, http.StatusForbidden, "agents may not configure invocation permissions")
+					return
+				}
 				writeError(w, http.StatusForbidden, "only the agent owner can change access (permission_mode / invocation_targets)")
 				return
 			}
@@ -1704,6 +1734,10 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			perm, _, permErr := parsePermissionInput(existing.WorkspaceID, req.PermissionMode, targetsDTO, hasPermissionMode, hasTargets, req.Visibility)
 			if permErr != nil {
 				writeError(w, http.StatusBadRequest, permErr.Error())
+				return
+			}
+			if err := validateInvocationAgentTargets(r.Context(), h.Queries, existing.WorkspaceID, perm.targets); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			resolvedPerm = perm
@@ -1882,7 +1916,18 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	updated, err := h.Queries.UpdateAgent(r.Context(), params)
+	// Persist the agent row, its invocation targets, and the permission audit
+	// in one transaction. A failed target or audit write must not leave a mode
+	// flip committed with the old allow-list (or vice versa).
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start agent update transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	updated, err := qtx.UpdateAgent(r.Context(), params)
 	if err != nil {
 		// Unique constraint on (workspace_id, name) — mirror CreateAgent and
 		// return a clear conflict instead of a 500 that leaks the raw
@@ -1908,7 +1953,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// clear the field. COALESCE in UpdateAgent cannot set a column to NULL, so
 	// mcp_config, thinking_level, and service_tier use dedicated clear queries.
 	if shouldClearMcpConfig {
-		updated, err = h.Queries.ClearAgentMcpConfig(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentMcpConfig(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent mcp_config failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear mcp_config: "+err.Error())
@@ -1916,7 +1961,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearThinkingLevel {
-		updated, err = h.Queries.ClearAgentThinkingLevel(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentThinkingLevel(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent thinking_level failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear thinking_level: "+err.Error())
@@ -1924,7 +1969,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearServiceTier {
-		updated, err = h.Queries.ClearAgentServiceTier(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentServiceTier(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent service_tier failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear service_tier: "+err.Error())
@@ -1932,7 +1977,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearComposioAllowlist {
-		updated, err = h.Queries.ClearAgentComposioToolkitAllowlist(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentComposioToolkitAllowlist(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent composio_toolkit_allowlist failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear composio_toolkit_allowlist: "+err.Error())
@@ -1944,11 +1989,25 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// permission. Done after the row update so a permission_mode flip and its
 	// targets land together.
 	if replacePermissionTargets {
-		if err := h.replaceInvocationTargets(r.Context(), updated.ID, parseUUID(requestUserID(r)), resolvedPerm.targets); err != nil {
+		if err := replaceInvocationTargetsWithQueries(r.Context(), qtx, updated.ID, parseUUID(requestUserID(r)), resolvedPerm.targets); err != nil {
 			slog.Warn("update agent: persist invocation targets failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to update invocation targets: "+err.Error())
 			return
 		}
+		if err := createAgentInvocationPermissionActivity(
+			r.Context(), qtx, updated.WorkspaceID, updated.ID, parseUUID(requestUserID(r)), "update", resolvedPerm,
+		); err != nil {
+			slog.Error("update agent invocation permission audit failed; rolling back update",
+				append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+			writeError(w, http.StatusInternalServerError, "audit log write failed; agent update rolled back")
+			return
+		}
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Warn("commit agent update failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+		writeError(w, http.StatusInternalServerError, "failed to commit agent update")
+		return
 	}
 
 	resp := h.agentToResponse(updated)
@@ -2295,11 +2354,13 @@ func (h *Handler) ListAgentTasks(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	// Run history is part of the private-agent gate ("查看历史会话"). Same
-	// 403 semantics as GetAgent.
+	// Run history is private agent data. Invocation authority (including an
+	// exact agent allow-list edge) never grants this read; an agent principal
+	// may inspect only its own history.
 	workspaceID := uuidToString(agent.WorkspaceID)
 	actorType, actorID := h.resolveActor(r, requestUserID(r), workspaceID)
-	if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
+	if !agentActorMayInspectPrivateData(actorType, actorID, agent) ||
+		!h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
 		writeError(w, http.StatusForbidden, "you do not have access to this agent")
 		return
 	}

--- a/server/internal/handler/agent_access.go
+++ b/server/internal/handler/agent_access.go
@@ -28,11 +28,13 @@ import (
 //         agent/system principals) may invoke.
 //       * member target    -> only the specific user may invoke.
 //       * team target       -> reserved, inert in V1.
+//       * agent target      -> only that exact, active same-workspace agent
+//         actor may invoke.
 //
-// A2A is judged by the top-of-chain human originator, never by the immediate
-// agent actor: if user U triggers agent A and A @-mentions agent B, B is only
-// invocable when U (the originator) is in B's allow-list. This prevents agents
-// from forming a channel that bypasses the owner's white-list.
+// Member/owner grants in an A2A chain are judged by the top-of-chain human
+// originator. Agent grants are deliberately different: they match only the
+// immediate, server-authenticated agent actor. Grants are never traversed, so
+// A -> B and B -> C does not imply A -> C.
 
 // canInvokeAgent reports whether a run may be enqueued for `agent` on behalf of
 // the given actor. Judgement is by the *effective invoking user*:
@@ -102,6 +104,26 @@ func (h *Handler) canInvokeAgent(ctx context.Context, agent db.Agent, actorType,
 		case "team":
 			// Reserved: team membership does not exist yet in V1, so team
 			// targets never admit anyone (also fail-closed for system/agent).
+		case "agent":
+			// Match only the immediate agent principal, never the human
+			// originator and never another allow-list edge. Re-resolve it in
+			// the target agent's workspace on every invocation so archived,
+			// deleted, system, and cross-workspace source agents fail closed
+			// even when a stale target row remains.
+			if actorType != "agent" || actorID == "" {
+				continue
+			}
+			sourceID, err := util.ParseUUID(actorID)
+			if err != nil || uuidToString(t.TargetID) != uuidToString(sourceID) {
+				continue
+			}
+			source, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+				ID:          sourceID,
+				WorkspaceID: agent.WorkspaceID,
+			})
+			if err == nil && !source.ArchivedAt.Valid {
+				return true
+			}
 		}
 	}
 	return false
@@ -112,7 +134,9 @@ func (h *Handler) canInvokeAgent(ctx context.Context, agent db.Agent, actorType,
 // see canInvokeAgent for that.
 //
 // Rules:
-//   - agent actors always pass (A2A collaboration + inspection preserved).
+//   - agent actors always pass this metadata/view gate so A2A routing can
+//     resolve agents; private-data endpoints must additionally call
+//     agentActorMayInspectPrivateData.
 //   - the agent owner always passes.
 //   - workspace owner/admin pass (governance / inventory visibility retained).
 //   - a regular member passes for a public_to agent only when they hit a
@@ -175,6 +199,15 @@ func memberAllowedToViewAgent(agent db.Agent, targets []db.AgentInvocationTarget
 		return false
 	}
 	return memberHitsInvocationTargets(targets, userID)
+}
+
+// agentActorMayInspectPrivateData keeps invocation authority separate from
+// private-data access. A running agent may inspect its own chats, run history,
+// and activity, but an allow-list edge to another agent never grants those
+// reads. Agent metadata remains available through ListAgents / GetAgent with
+// secret fields redacted so A2A routing can still resolve names and ids.
+func agentActorMayInspectPrivateData(actorType, actorID string, target db.Agent) bool {
+	return actorType != "agent" || (actorID != "" && actorID == uuidToString(target.ID))
 }
 
 // invokeOriginatorFromRequest resolves the top-of-chain human user id for an
@@ -332,11 +365,10 @@ func (h *Handler) taskFromRequestHeader(r *http.Request) (db.AgentTaskQueue, boo
 	return task, true
 }
 
-// accessibleAgentIDs returns the set of agent IDs in the workspace the actor
-// is allowed to see, for use by workspace-wide aggregation endpoints
-// (run counts, activity histograms, task snapshots) that need to filter out
-// private / non-allow-listed agents the member can't access. Returns nil and
-// false on error.
+// accessibleAgentIDs returns the set of agent IDs whose private aggregate data
+// the actor may inspect. Agent principals are limited to themselves regardless
+// of invocation grants; members retain the existing owner/admin/allow-list
+// view rules. Returns nil and false on error.
 func (h *Handler) accessibleAgentIDs(ctx context.Context, workspaceID, actorType, actorID, role string) (map[string]struct{}, bool) {
 	wsUUID, err := util.ParseUUID(workspaceID)
 	if err != nil {
@@ -352,6 +384,9 @@ func (h *Handler) accessibleAgentIDs(ctx context.Context, workspaceID, actorType
 	}
 	allowed := make(map[string]struct{}, len(agents))
 	for _, a := range agents {
+		if actorType == "agent" && actorID != uuidToString(a.ID) {
+			continue
+		}
 		if actorType == "member" {
 			if !memberAllowedToViewAgent(a, targetsByAgent[uuidToString(a.ID)], actorID, role) {
 				continue

--- a/server/internal/handler/agent_permission.go
+++ b/server/internal/handler/agent_permission.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -11,9 +12,9 @@ import (
 )
 
 // AgentInvocationTargetDTO is the wire shape of one invocation allow-list
-// entry (MUL-3963). target_id is null for team placeholders that a client
-// omitted, but is always present for workspace (the workspace id) and member
-// (the user id) rows persisted by the backend.
+// entry (MUL-3963). target_id is always present on rows persisted by the
+// backend: workspace rows carry the workspace id, and member / team / agent
+// rows carry the referenced principal id.
 type AgentInvocationTargetDTO struct {
 	TargetType string  `json:"target_type"`
 	TargetID   *string `json:"target_id"`
@@ -26,6 +27,9 @@ const (
 	invocationTargetWorkspace = "workspace"
 	invocationTargetMember    = "member"
 	invocationTargetTeam      = "team"
+	invocationTargetAgent     = "agent"
+
+	agentInvocationPermissionActivity = "agent_invocation_permission_updated"
 )
 
 // deriveLegacyVisibility maps the permission model back onto the legacy
@@ -91,8 +95,8 @@ func (p resolvedPermission) legacyVisibility() string {
 //   - permissionMode == nil && visibility == nil  -> caller default (returns ok=false, nil)
 //   - permissionMode provided                     -> authoritative
 //   - only legacy visibility provided             -> mapped:
-//       "private"   -> private
-//       "workspace" -> public_to + workspace target
+//     "private"   -> private
+//     "workspace" -> public_to + workspace target
 //
 // workspaceID seeds workspace targets (stored as the workspace id). The
 // returned error is a client-facing 400 message.
@@ -150,7 +154,7 @@ func parsePermissionInput(workspaceID pgtype.UUID, permissionMode *string, targe
 				if err != nil {
 					return resolvedPermission{}, false, fmt.Errorf("member invocation target_id is not a valid uuid")
 				}
-				key := "member:" + *t.TargetID
+				key := "member:" + uuidToString(uid)
 				if _, dup := seen[key]; dup {
 					continue
 				}
@@ -164,14 +168,28 @@ func parsePermissionInput(workspaceID pgtype.UUID, permissionMode *string, targe
 				if err != nil {
 					return resolvedPermission{}, false, fmt.Errorf("team invocation target_id is not a valid uuid")
 				}
-				key := "team:" + *t.TargetID
+				key := "team:" + uuidToString(tid)
 				if _, dup := seen[key]; dup {
 					continue
 				}
 				seen[key] = struct{}{}
 				res.targets = append(res.targets, targetSpec{targetType: invocationTargetTeam, targetID: tid})
+			case invocationTargetAgent:
+				if t.TargetID == nil || *t.TargetID == "" {
+					return resolvedPermission{}, false, fmt.Errorf("agent invocation target requires target_id")
+				}
+				aid, err := util.ParseUUID(*t.TargetID)
+				if err != nil {
+					return resolvedPermission{}, false, fmt.Errorf("agent invocation target_id is not a valid uuid")
+				}
+				key := "agent:" + uuidToString(aid)
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+				res.targets = append(res.targets, targetSpec{targetType: invocationTargetAgent, targetID: aid})
 			default:
-				return resolvedPermission{}, false, fmt.Errorf("invocation target_type must be 'workspace', 'member', or 'team'")
+				return resolvedPermission{}, false, fmt.Errorf("invocation target_type must be 'workspace', 'member', 'team', or 'agent'")
 			}
 		}
 	}
@@ -186,10 +204,69 @@ func parsePermissionInput(workspaceID pgtype.UUID, permissionMode *string, targe
 	return res, true, nil
 }
 
-// replaceInvocationTargets rewrites an agent's invocation allow-list wholesale:
-// clear then re-insert. Called inside create/update after the agent row exists.
-func (h *Handler) replaceInvocationTargets(ctx context.Context, agentID pgtype.UUID, createdBy pgtype.UUID, targets []targetSpec) error {
-	return replaceInvocationTargetsWithQueries(ctx, h.Queries, agentID, createdBy, targets)
+// validateInvocationAgentTargets resolves every agent principal before an
+// allow-list is persisted. Agent grants are deliberately narrower than member
+// grants: the source must be a non-archived user agent in the exact same
+// workspace as the target agent. Unknown, archived, system, and cross-workspace
+// ids share one client-facing error so the write surface cannot be used to
+// enumerate private agents in another workspace.
+func validateInvocationAgentTargets(ctx context.Context, q *db.Queries, workspaceID pgtype.UUID, targets []targetSpec) error {
+	for _, target := range targets {
+		if target.targetType != invocationTargetAgent {
+			continue
+		}
+		source, err := q.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          target.targetID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil || source.ArchivedAt.Valid {
+			return fmt.Errorf("agent invocation target_id does not refer to an active agent in this workspace")
+		}
+	}
+	return nil
+}
+
+// createAgentInvocationPermissionActivity writes a queryable, non-secret audit
+// record for an owner-authored allow-list mutation. It intentionally stores
+// only the target agent id, mode, operation, and principal type/id pairs; agent
+// names, configuration, task history, env, and MCP data never enter the log.
+// Callers execute it in the same transaction as the permission rows so an
+// unaudited permission mutation cannot commit.
+func createAgentInvocationPermissionActivity(
+	ctx context.Context,
+	q *db.Queries,
+	workspaceID pgtype.UUID,
+	agentID pgtype.UUID,
+	actorID pgtype.UUID,
+	operation string,
+	permission resolvedPermission,
+) error {
+	targets := make([]AgentInvocationTargetDTO, 0, len(permission.targets))
+	for _, target := range permission.targets {
+		id := uuidToString(target.targetID)
+		targets = append(targets, AgentInvocationTargetDTO{
+			TargetType: target.targetType,
+			TargetID:   &id,
+		})
+	}
+	details, err := json.Marshal(map[string]any{
+		"agent_id":           uuidToString(agentID),
+		"operation":          operation,
+		"permission_mode":    permission.mode,
+		"invocation_targets": targets,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = q.CreateActivity(ctx, db.CreateActivityParams{
+		WorkspaceID: workspaceID,
+		IssueID:     pgtype.UUID{},
+		ActorType:   pgtype.Text{String: "member", Valid: true},
+		ActorID:     actorID,
+		Action:      agentInvocationPermissionActivity,
+		Details:     details,
+	})
+	return err
 }
 
 // replaceInvocationTargetsWithQueries is the tx-friendly variant: callers that

--- a/server/internal/handler/agent_permission_test.go
+++ b/server/internal/handler/agent_permission_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // createPermissionTestMember inserts a fresh workspace member and returns its
@@ -227,7 +228,11 @@ func createPublicToAgentWithTargets(t *testing.T, name string, targets []map[str
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID) })
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM activity_log WHERE details->>'agent_id' = $1`, resp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM agent_invocation_target WHERE agent_id = $1`, resp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID)
+	})
 	return resp.ID
 }
 
@@ -251,6 +256,401 @@ func invocationTargetCount(t *testing.T, agentID string) int {
 		t.Fatalf("count targets: %v", err)
 	}
 	return n
+}
+
+func loadPermissionTestAgent(t *testing.T, agentID string) db.Agent {
+	t.Helper()
+	agent, err := testHandler.Queries.GetAgent(context.Background(), util.MustParseUUID(agentID))
+	if err != nil {
+		t.Fatalf("load agent %s: %v", agentID, err)
+	}
+	return agent
+}
+
+// TestCanInvokeAgent_PublicToAgentWhitelist locks the exact A2A semantics:
+// immediate actor id only, same workspace, active source, and no traversal of
+// other agents' grants.
+func TestCanInvokeAgent_PublicToAgentWhitelist(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	sourceA := createHandlerTestAgent(t, "agent-target-source-a", nil)
+	other := createHandlerTestAgent(t, "agent-target-source-other", nil)
+	middle := createPublicToAgentWithTargets(t, "agent-target-middle", []map[string]any{
+		{"target_type": "agent", "target_id": sourceA},
+	})
+	target := createPublicToAgentWithTargets(t, "agent-target-final", []map[string]any{
+		{"target_type": "agent", "target_id": middle},
+	})
+
+	if !testHandler.canInvokeAgent(ctx, loadPermissionTestAgent(t, middle), "agent", sourceA, "", testWorkspaceID) {
+		t.Fatal("the exact allow-listed source agent should invoke the middle agent")
+	}
+	if testHandler.canInvokeAgent(ctx, loadPermissionTestAgent(t, middle), "agent", other, "", testWorkspaceID) {
+		t.Fatal("an unlisted same-workspace agent must not invoke the middle agent")
+	}
+	if testHandler.canInvokeAgent(ctx, loadPermissionTestAgent(t, target), "agent", sourceA, "", testWorkspaceID) {
+		t.Fatal("A -> middle and middle -> target must not imply A -> target")
+	}
+	if !testHandler.canInvokeAgent(ctx, loadPermissionTestAgent(t, target), "agent", middle, "", testWorkspaceID) {
+		t.Fatal("the immediate middle agent should invoke its exact target")
+	}
+
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET archived_at = now() WHERE id = $1`, middle); err != nil {
+		t.Fatalf("archive source agent: %v", err)
+	}
+	if testHandler.canInvokeAgent(ctx, loadPermissionTestAgent(t, target), "agent", middle, "", testWorkspaceID) {
+		t.Fatal("an archived allow-listed source agent must fail closed immediately")
+	}
+}
+
+// TestCreateAgent_AgentInvocationTargetValidationAndAudit covers the write
+// contract: same-workspace active agent ids only, canonical de-duplication,
+// minimal read shape, and a non-secret activity record in the same create tx.
+func TestCreateAgent_AgentInvocationTargetValidationAndAudit(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	source := createHandlerTestAgent(t, "agent-target-valid-source", nil)
+	foreign := createForeignWorkspaceAgent(t)
+	archived := createHandlerTestAgent(t, "agent-target-archived-source", nil)
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET archived_at = now() WHERE id = $1`, archived); err != nil {
+		t.Fatalf("archive source: %v", err)
+	}
+
+	create := func(name string, targets []map[string]any) (int, AgentResponse) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		testHandler.CreateAgent(w, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+			"name":               name,
+			"runtime_id":         handlerTestRuntimeID(t),
+			"permission_mode":    "public_to",
+			"invocation_targets": targets,
+		}))
+		var resp AgentResponse
+		if w.Code == http.StatusCreated {
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode create response: %v", err)
+			}
+			t.Cleanup(func() {
+				testPool.Exec(context.Background(), `DELETE FROM activity_log WHERE details->>'agent_id' = $1`, resp.ID)
+				testPool.Exec(context.Background(), `DELETE FROM agent_invocation_target WHERE agent_id = $1`, resp.ID)
+				testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID)
+			})
+		}
+		return w.Code, resp
+	}
+
+	code, created := create("agent-target-valid-create", []map[string]any{
+		{"target_type": "agent", "target_id": source},
+		{"target_type": "agent", "target_id": source},
+	})
+	if code != http.StatusCreated {
+		t.Fatalf("valid agent target create: got %d, want 201", code)
+	}
+	if len(created.InvocationTargets) != 1 || created.InvocationTargets[0].TargetType != "agent" ||
+		created.InvocationTargets[0].TargetID == nil || *created.InvocationTargets[0].TargetID != source {
+		t.Fatalf("invocation_targets = %+v, want one minimal agent target", created.InvocationTargets)
+	}
+	if created.Visibility != "private" {
+		t.Fatalf("agent-scoped permission widened legacy visibility to %q, want private", created.Visibility)
+	}
+	if n := invocationTargetCount(t, created.ID); n != 1 {
+		t.Fatalf("duplicate agent targets persisted as %d rows, want 1", n)
+	}
+
+	var action, details string
+	if err := testPool.QueryRow(ctx, `
+		SELECT action, details::text FROM activity_log
+		WHERE workspace_id = $1 AND details->>'agent_id' = $2
+		ORDER BY created_at DESC LIMIT 1
+	`, testWorkspaceID, created.ID).Scan(&action, &details); err != nil {
+		t.Fatalf("load permission audit: %v", err)
+	}
+	if action != agentInvocationPermissionActivity {
+		t.Fatalf("audit action = %q, want %q", action, agentInvocationPermissionActivity)
+	}
+	var audit map[string]any
+	if err := json.Unmarshal([]byte(details), &audit); err != nil {
+		t.Fatalf("decode permission audit: %v", err)
+	}
+	for _, forbidden := range []string{"agent_name", "instructions", "custom_env", "mcp_config"} {
+		if _, exists := audit[forbidden]; exists {
+			t.Errorf("permission audit must not contain %q: %s", forbidden, details)
+		}
+	}
+
+	// A human owner can replace agent targets on update. The target rows and
+	// audit event move together, and a rejected update leaves both untouched.
+	replacement := createHandlerTestAgent(t, "agent-target-update-source", nil)
+	w := httptest.NewRecorder()
+	r := withURLParam(newRequest("PUT", "/api/agents/"+created.ID, map[string]any{
+		"permission_mode": "public_to",
+		"invocation_targets": []map[string]any{
+			{"target_type": "agent", "target_id": replacement},
+		},
+	}), "id", created.ID)
+	testHandler.UpdateAgent(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid agent target update: got %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var updated AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.InvocationTargets) != 1 || updated.InvocationTargets[0].TargetID == nil ||
+		*updated.InvocationTargets[0].TargetID != replacement {
+		t.Fatalf("updated invocation_targets = %+v, want replacement source", updated.InvocationTargets)
+	}
+	var operation string
+	if err := testPool.QueryRow(ctx, `
+		SELECT details->>'operation' FROM activity_log
+		WHERE workspace_id = $1 AND action = $2 AND details->>'agent_id' = $3
+		ORDER BY created_at DESC, id DESC LIMIT 1
+	`, testWorkspaceID, agentInvocationPermissionActivity, created.ID).Scan(&operation); err != nil {
+		t.Fatalf("load update permission audit: %v", err)
+	}
+	if operation != "update" {
+		t.Fatalf("latest permission audit operation = %q, want update", operation)
+	}
+
+	w = httptest.NewRecorder()
+	r = withURLParam(newRequest("PUT", "/api/agents/"+created.ID, map[string]any{
+		"permission_mode": "public_to",
+		"invocation_targets": []map[string]any{
+			{"target_type": "agent", "target_id": foreign},
+		},
+	}), "id", created.ID)
+	testHandler.UpdateAgent(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("foreign agent target update: got %d, want 400: %s", w.Code, w.Body.String())
+	}
+	var persistedTarget string
+	if err := testPool.QueryRow(ctx, `
+		SELECT target_id::text FROM agent_invocation_target
+		WHERE agent_id = $1 AND target_type = 'agent'
+	`, created.ID).Scan(&persistedTarget); err != nil {
+		t.Fatal(err)
+	}
+	if persistedTarget != replacement {
+		t.Fatalf("rejected update changed persisted target to %s, want %s", persistedTarget, replacement)
+	}
+
+	for name, targets := range map[string][]map[string]any{
+		"cross-workspace": {{"target_type": "agent", "target_id": foreign}},
+		"archived":        {{"target_type": "agent", "target_id": archived}},
+		"missing":         {{"target_type": "agent", "target_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}},
+		"malformed":       {{"target_type": "agent", "target_id": "not-a-uuid"}},
+		"unknown-type":    {{"target_type": "unknown", "target_id": source}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			code, _ := create("agent-target-invalid-"+name, targets)
+			if code != http.StatusBadRequest {
+				t.Fatalf("invalid agent target create: got %d, want 400", code)
+			}
+			var count int
+			if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent WHERE workspace_id = $1 AND name = $2`, testWorkspaceID, "agent-target-invalid-"+name).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 0 {
+				t.Fatalf("invalid target left %d partial agent rows", count)
+			}
+		})
+	}
+}
+
+func TestAgentInvocationTarget_IssueAssignmentAndBacklogPromotion(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	source := createHandlerTestAgent(t, "agent-target-issue-source", nil)
+	other := createHandlerTestAgent(t, "agent-target-issue-other", nil)
+	target := createPublicToAgentWithTargets(t, "agent-target-issue-target", []map[string]any{
+		{"target_type": "agent", "target_id": source},
+	})
+	sourceTask := createHandlerTestTaskForAgent(t, source)
+	otherTask := createHandlerTestTaskForAgent(t, other)
+
+	createAsAgent := func(actorID, taskID, title, status string) (int, IssueResponse) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+			"title":         title,
+			"status":        status,
+			"assignee_type": "agent",
+			"assignee_id":   target,
+		})
+		r.Header.Set("X-Agent-ID", actorID)
+		r.Header.Set("X-Task-ID", taskID)
+		testHandler.CreateIssue(w, r)
+		var resp IssueResponse
+		if w.Code == http.StatusCreated {
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, resp.ID)
+				testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, resp.ID)
+			})
+		}
+		return w.Code, resp
+	}
+
+	if code, _ := createAsAgent(other, otherTask, "agent-target-denied-create", "todo"); code != http.StatusForbidden {
+		t.Fatalf("unlisted source create assign: got %d, want 403", code)
+	}
+	var deniedRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM issue WHERE workspace_id = $1 AND title = 'agent-target-denied-create'`, testWorkspaceID).Scan(&deniedRows); err != nil {
+		t.Fatal(err)
+	}
+	if deniedRows != 0 {
+		t.Fatalf("denied assignment left %d partial issues", deniedRows)
+	}
+
+	code, backlog := createAsAgent(source, sourceTask, "agent-target-backlog-promote", "backlog")
+	if code != http.StatusCreated {
+		t.Fatalf("allow-listed source backlog create: got %d, want 201", code)
+	}
+	var before int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2`, backlog.ID, target).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if before != 0 {
+		t.Fatalf("backlog assignment enqueued %d tasks before promotion", before)
+	}
+
+	w := httptest.NewRecorder()
+	r := newRequest("PATCH", "/api/issues/"+backlog.ID, map[string]any{"status": "todo"})
+	r.Header.Set("X-Agent-ID", source)
+	r.Header.Set("X-Task-ID", sourceTask)
+	r = withURLParam(r, "id", backlog.ID)
+	testHandler.UpdateIssue(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("allow-listed backlog promotion: got %d: %s", w.Code, w.Body.String())
+	}
+	var after int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2`, backlog.ID, target).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != 1 {
+		t.Fatalf("backlog promotion enqueued %d tasks, want 1", after)
+	}
+}
+
+func TestAgentInvocationTarget_DoesNotGrantPermissionMutationOrPrivateData(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	source := createHandlerTestAgent(t, "agent-target-private-data-source", nil)
+	sourceTask := createHandlerTestTaskForAgent(t, source)
+	target := createPublicToAgentWithTargets(t, "agent-target-private-data-target", []map[string]any{
+		{"target_type": "agent", "target_id": source},
+	})
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET mcp_config = '{"token":"must-not-leak"}'::jsonb WHERE id = $1`, target); err != nil {
+		t.Fatalf("seed target mcp config: %v", err)
+	}
+
+	agentRequest := func(method, path string, body any) *http.Request {
+		r := newRequest(method, path, body)
+		r.Header.Set("X-Agent-ID", source)
+		r.Header.Set("X-Task-ID", sourceTask)
+		return r
+	}
+
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, agentRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":            "agent-authored-permission-create",
+		"runtime_id":      handlerTestRuntimeID(t),
+		"permission_mode": "public_to",
+		"invocation_targets": []map[string]any{
+			{"target_type": "agent", "target_id": source},
+		},
+	}))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("agent-authored permission create: got %d, want 403: %s", w.Code, w.Body.String())
+	}
+	var createdByAgent int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent WHERE workspace_id = $1 AND name = 'agent-authored-permission-create'`, testWorkspaceID).Scan(&createdByAgent); err != nil {
+		t.Fatal(err)
+	}
+	if createdByAgent != 0 {
+		t.Fatalf("rejected agent-authored permission create left %d rows", createdByAgent)
+	}
+
+	// The exact invocation grant does not let the source rewrite the target's
+	// allow-list, even though both agent tasks use the same backing owner PAT.
+	w = httptest.NewRecorder()
+	r := withURLParam(agentRequest("PUT", "/api/agents/"+target, map[string]any{
+		"permission_mode": "private",
+	}), "id", target)
+	testHandler.UpdateAgent(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("agent-authored permission update: got %d, want 403: %s", w.Code, w.Body.String())
+	}
+	if got := loadPermissionTestAgent(t, target).PermissionMode; got != "public_to" {
+		t.Fatalf("rejected permission update changed mode to %q", got)
+	}
+
+	// Agent metadata stays discoverable for routing, but MCP config is redacted.
+	w = httptest.NewRecorder()
+	r = withURLParam(agentRequest("GET", "/api/agents/"+target, nil), "id", target)
+	testHandler.GetAgent(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("agent metadata read: got %d: %s", w.Code, w.Body.String())
+	}
+	var detail AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.McpConfig != nil || !detail.McpConfigRedacted {
+		t.Fatalf("agent metadata leaked MCP config: config=%s redacted=%v", detail.McpConfig, detail.McpConfigRedacted)
+	}
+
+	// Plaintext env and another agent's run history remain unavailable.
+	for name, handler := range map[string]func(http.ResponseWriter, *http.Request){
+		"env":     testHandler.GetAgentEnv,
+		"history": testHandler.ListAgentTasks,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := withURLParam(agentRequest("GET", "/api/agents/"+target+"/"+name, nil), "id", target)
+			handler(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("allow-listed source read %s: got %d, want 403: %s", name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// A human chat owned by the backing user also stays private to its target
+	// agent; sharing invocation does not share the transcript.
+	var sessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status)
+		VALUES ($1, $2, $3, 'private target chat', 'active') RETURNING id
+	`, testWorkspaceID, target, testUserID).Scan(&sessionID); err != nil {
+		t.Fatalf("seed target chat: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO chat_message (chat_session_id, role, content)
+		VALUES ($1, 'user', 'private chat content')
+	`, sessionID); err != nil {
+		t.Fatalf("seed target chat message: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID) })
+
+	w = httptest.NewRecorder()
+	r = agentRequest("GET", "/api/chat/sessions/"+sessionID+"/messages", nil)
+	r = withChatTestWorkspaceCtx(t, r)
+	r = withURLParam(r, "sessionId", sessionID)
+	testHandler.ListChatMessages(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("allow-listed source read target chat: got %d, want 403: %s", w.Code, w.Body.String())
+	}
 }
 
 // TestCanInvokeAgent_MixedMemberAndTeamTargets verifies a public_to agent can

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -278,7 +278,8 @@ func (h *Handler) gateChatSessionForUser(w http.ResponseWriter, r *http.Request,
 		return db.ChatSession{}, false
 	}
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
-	if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
+	if !agentActorMayInspectPrivateData(actorType, actorID, agent) ||
+		!h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
 		writeError(w, http.StatusForbidden, "you do not have access to this agent")
 		return db.ChatSession{}, false
 	}
@@ -1812,7 +1813,8 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		actorType, actorID := h.resolveActor(r, userID, workspaceID)
-		if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
+		if !agentActorMayInspectPrivateData(actorType, actorID, agent) ||
+			!h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
 			writeError(w, http.StatusForbidden, "you do not have access to this agent")
 			return
 		}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3181,10 +3181,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 
 // validateAssigneePair verifies the (assignee_type, assignee_id) pair refers
 // to an existing entity in the workspace. For agent assignees it also rejects
-// archived agents and runs the private-agent gate via canAccessPrivateAgent
-// — assigning an issue is a task-producing surface, so it must use the same
-// predicate as chat / @-mention / history. Agent callers (X-Agent-ID) bypass
-// the gate so A2A flows can still hand work off to private agents.
+// archived agents and runs the centralized invocation gate. Assigning an
+// issue is a task-producing surface, so agent callers need an exact agent
+// allow-list edge (or an existing workspace-wide grant); such edges are not
+// transitive and do not grant any read access to the target agent's data.
 //
 // Returns (statusCode, errorMessage). statusCode == 0 means the pair is valid;
 // callers should treat any non-zero status as a rejection and surface it back

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -73,7 +73,48 @@ sent.
 The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 `instructions`, `avatar_url`, `runtime_id`, `runtime_config`, `custom_env`,
 `custom_args`, `model`, `thinking_level`, `service_tier`, `visibility`,
-`max_concurrent_tasks`, `mcp_config`, `skill_ids`.
+`permission_mode`, `invocation_targets`, `max_concurrent_tasks`, `mcp_config`,
+`skill_ids`.
+
+## Invocation permission
+
+`permission_mode` + `invocation_targets` are the authorization source for
+assigning, mentioning, chatting with, or otherwise starting an agent. The
+legacy `visibility` field is only a derived compatibility projection:
+
+- `private`: only the human owner may invoke.
+- `public_to` + `workspace`: any member or workspace-internal agent/system
+  principal may invoke.
+- `public_to` + `member`: only that exact human user may invoke.
+- `public_to` + `agent`: only that exact, active, same-workspace agent actor may
+  invoke. This edge is direct and non-transitive: A → B and B → C does not grant
+  A → C.
+- `team` is stored but inert until team membership has an authority source.
+
+The owner can set an exact agent edge from create, update, or copy:
+
+```bash
+multica agent create --name <name> --runtime-id <runtime-id> \
+  --public-to-agent <source-agent-id> --output json
+multica agent update <target-agent-id> \
+  --permission-mode public_to --public-to-agent <source-agent-id> --output json
+multica agent copy <source-agent-id> \
+  --public-to-agent <new-invoker-agent-id> --output json
+```
+
+`--public-to-agent` and `--public-to-member` are repeatable and may be combined.
+An agent target must be a non-archived user agent in the same workspace;
+malformed, missing, archived, system, and cross-workspace ids are rejected.
+Duplicate ids are canonicalized idempotently. Writes are human-owner-only:
+task-scoped agent actors cannot configure these grants even when their backing
+user owns the target. Every successful explicit permission write records a
+minimal `agent_invocation_permission_updated` activity row containing only the
+mode and target type/id pairs.
+
+Invocation permission grants task creation only. They never grant another agent
+access to the target's env, MCP config, human chat transcripts, run history, or
+unrelated workspace data. Agent metadata remains discoverable for routing, with
+secret fields redacted.
 
 ## Copying an agent
 
@@ -94,6 +135,9 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
   `" (copy)"`), `description`, `instructions`, avatar, `custom_args`,
   `max_concurrent_tasks`, invocation permission (`permission_mode` +
   allow-list), and assigned workspace skills.
+- Agent invocation targets are copied verbatim when the copy remains in the
+  same workspace. The server revalidates every target on create, so a stale,
+  archived, or foreign target fails closed instead of being silently widened.
 - A copied `max_concurrent_tasks` is included only when the source value is
   within 1–50. Historical out-of-range values are omitted so the new agent
   receives the server default (`6`); an explicit out-of-range
@@ -125,7 +169,8 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
 | `runtime_config` | `agent.runtime_config` (JSON) | JSON shape checked CLI-side; server stores as-is | runtime-specific config; defaults to `{}` |
 | `custom_env` | `agent.custom_env` (JSON object) | — | daemon (process env); see Env & secrets |
 | `mcp_config` | `agent.mcp_config` (raw JSON) | CLI checks it is a JSON object or `null`; server stores as-is. At create, literal `null` is dropped (no-op); at update, `null` clears the column | daemon → provider (provider-specific MCP handling); redacted on read |
-| `visibility` | `agent.visibility` | — | access control; defaults to `private`; gates who can read/route a private agent (e.g. a private squad leader) — NOT the runtime prompt |
+| `visibility` | `agent.visibility` | derived from invocation permission | legacy compatibility projection; `workspace` only for `public_to` + workspace target, otherwise `private` |
+| `permission_mode` + `invocation_targets` | `agent.permission_mode` + `agent_invocation_target` rows | owner-only; agent targets must be active same-workspace agents | authoritative invoke/assign/@mention/chat gate; agent targets match only the immediate actor and are non-transitive |
 | `max_concurrent_tasks` | `agent.max_concurrent_tasks` | integer from 1 through 50; out-of-range values return 400 | scheduler task cap; defaults to `6` |
 
 Defaults when omitted or explicitly `null`: `max_concurrent_tasks` → `6`.
@@ -304,6 +349,8 @@ State-changing (require an explicit instruction — do not run speculatively):
 - `multica agent create` — inserts a new agent row.
 - `multica agent copy` — inserts a new agent row (a fork of an existing agent);
   the source is left untouched.
+- `multica agent update --permission-mode/--public-to-*` — replaces the target
+  agent's invocation allow-list; only the human agent owner may do this.
 - `multica agent skills add` / `set` — mutate bindings (`set` is destructive:
   it drops bindings not in the new list).
 - `multica agent env set` — overwrites the full `custom_env` map and writes an
@@ -322,6 +369,10 @@ State-changing (require an explicit instruction — do not run speculatively):
   clear; only `custom_env` is gated behind the dedicated env endpoint.
 - "`agent get` shows env values." It shows only `has_custom_env` and
   `custom_env_key_count`.
+- "An agent allow-list edge shares the target's data." It does not: the edge
+  authorizes invocation only, not env, MCP, chat, run-history, or unrelated
+  resource reads.
+- "Agent allow-lists are transitive." They are direct actor-id checks only.
 - "An invalid `thinking_level`/`model` combo is caught at create." Only an
   unknown provider-level literal is — model-specific gaps fail at run time.
 - "`set` and `add` are interchangeable for skills." `set` replaces all

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -24,6 +24,7 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | MCP flags on `agent update` | 200–202 | Same three channels on update; `--mcp-config null` clears. Unlike `custom_env`, `mcp_config` IS settable via update | `multica agent update --help` |
 | `thinking-level` / `service-tier` flags on `agent update` | 189–190 | Thin pass-throughs; an explicit empty string clears the saved override and restores the runtime/local Codex default | `multica agent update --help` |
 | `max-concurrent-tasks` flags + validation | `cmd_agent.go` 179, 208; `cmd_agent_validation.go` 5–20 | Shared CLI helper enforces 1–50; create/update call it before their HTTP mutation and omitted create flags stay absent | `multica agent create --help`; `multica agent update --help` |
+| Exact agent invocation flags | `cmd_agent.go` `applyAgentPermissionFlags`; `cmd_agent_copy.go` `registerAgentCopyFlags` | `--public-to-agent` is repeatable on create/update/copy and emits `{target_type:"agent",target_id:<uuid>}`; any permission override replaces the whole copied allow-list | `multica agent create --help`; `multica agent update --help`; `multica agent copy --help` |
 | `runAgentCreate` builds body + `POST /api/agents` | 533–628 | Only sets a body key when the flag `Changed`; validates `max_concurrent_tasks` at 605–611, then posts to `/api/agents` (617) | read 533–628 |
 | Body assembly: description/instructions/runtime-config/custom-args/custom-env/mcp-config/model/thinking-level/service-tier | 548–611 | `model`, `thinking_level`, and `service_tier` are `Changed`-gated pass-throughs; omitted flags are not sent | read the `runAgentCreate` body assembly |
 | `runAgentUpdate` sends `thinking_level` / `service_tier` / `mcp_config` | 630–725 | Each override key is added only when its flag is `Changed`; `max_concurrent_tasks` is range-checked at 693–699; `custom_env` is intentionally not a flag here | read the `runAgentUpdate` body assembly |
@@ -44,6 +45,7 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | Concurrency copy compatibility | `runAgentCopy`, `copiedAgentMaxConcurrentTasks` | Explicit `--max-concurrent-tasks` is validated before any request; valid source values are copied, while historical values outside 1–50 are omitted so create defaults to 6 | read the concurrency body assembly |
 | Skills copied in the create transaction | 239 | Source skill ids sent as `skill_ids`, bound in the same `POST /api/agents` tx (267); `--no-skills` opts out | read `runAgentCopy` |
 | Secrets never copied | 240–266 | `custom_env`/`mcp_config`/`runtime_config` set only from explicit secret-safe flags, never read from the source | `multica agent copy --help` |
+| Invocation targets copied / revalidated | `runAgentCopy` permission block; `agent_permission.go` `validateInvocationAgentTargets` | A same-workspace copy preserves new agent target rows verbatim; the create API rejects stale, archived, system, or foreign sources | read `runAgentCopy`; `multica agent copy --help` |
 
 ## Create handler — `server/internal/handler/agent.go`
 
@@ -74,6 +76,18 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | `UpdateAgent` rejects `custom_env` | 910–913 | if `custom_env` present in body → 400 "use PUT /api/agents/{id}/env (or `multica agent env set`)" |
 | `UpdateAgent` persists / clears `mcp_config` | 944–948, 1060–1061 | Tri-state from the raw body: key omitted → no change; literal `null` → `ClearAgentMcpConfig`; object → replace. No 400 like `custom_env` — `mcp_config` IS updatable here |
 | `description` ≤ 255 on update too | 921–924 | same cap re-checked on update |
+| Agent target parse + canonical de-duplication | `agent_permission.go` `parsePermissionInput` | `target_type=agent` requires a UUID; duplicate UUID spellings collapse to one target; unknown types fail 400 |
+| Same-workspace active-source validation | `agent_permission.go` `validateInvocationAgentTargets` | Resolves through `GetAgentInWorkspace` and rejects archived, system, missing, and cross-workspace source ids without enumerating which case occurred |
+| Human-owner-only permission writes + audit | `agent.go` `CreateAgent` / `UpdateAgent`; `agent_permission.go` `createAgentInvocationPermissionActivity` | Agent actors cannot configure invocation permission. Explicit human-owner writes persist the mode, targets, and minimal `agent_invocation_permission_updated` activity row in one transaction |
+| Exact non-transitive invoke gate | `agent_access.go` `canInvokeAgent` | An agent target matches only `actorType=agent` + the immediate actor id, re-resolved as active in the target workspace on every invocation; it never follows another edge or the human originator |
+| Invocation is separate from private-data reads | `agent_access.go` `agentActorMayInspectPrivateData`; `agent.go` `ListAgentTasks`; `chat.go` `gateChatSessionForUser`; `agent_env.go` `authorizeAgentEnv` | A source may invoke an allow-listed target but cannot read its run history, human chat, env, or MCP secrets; metadata reads remain redacted |
+
+## Schema migration — `server/migrations/327_agent_invocation_target_agent.*.sql`
+
+| Contract | Evidence | Behavior |
+|---|---|---|
+| Additive target enum | up migration CHECK | Adds `agent` without changing existing workspace/member/team rows or indexes |
+| Fail-closed rollback | down migration | Deletes agent-target rows before restoring the old CHECK; never converts them into workspace grants |
 
 ## Runtime model/thinking discovery — `server/pkg/agent/{models,thinking}.go`
 

--- a/server/migrations/327_agent_invocation_target_agent.down.sql
+++ b/server/migrations/327_agent_invocation_target_agent.down.sql
@@ -1,0 +1,14 @@
+-- Old binaries do not understand agent principals. Remove those additive rows
+-- before restoring the previous CHECK so rollback remains fail-closed rather
+-- than widening an agent to workspace access.
+DELETE FROM agent_invocation_target WHERE target_type = 'agent';
+
+ALTER TABLE agent_invocation_target
+    DROP CONSTRAINT IF EXISTS agent_invocation_target_target_type_check;
+
+ALTER TABLE agent_invocation_target
+    ADD CONSTRAINT agent_invocation_target_target_type_check
+    CHECK (target_type IN ('workspace', 'member', 'team'));
+
+COMMENT ON TABLE agent_invocation_target IS
+    'Allow-list of who may invoke a public_to agent (MUL-3963). One row per (agent, target_type, target); targets stack and canInvokeAgent OR-matches. workspace rows store the agent workspace_id in target_id; member rows store the user id; team rows are reserved and inert in V1. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: agent_id / created_by / member target_id relationships are maintained in the application layer.';

--- a/server/migrations/327_agent_invocation_target_agent.up.sql
+++ b/server/migrations/327_agent_invocation_target_agent.up.sql
@@ -1,0 +1,12 @@
+-- Allow a public_to agent to name another same-workspace agent as an exact
+-- invocation principal. Same-workspace / active-agent validation stays in the
+-- application layer because this polymorphic table deliberately has no FKs.
+ALTER TABLE agent_invocation_target
+    DROP CONSTRAINT IF EXISTS agent_invocation_target_target_type_check;
+
+ALTER TABLE agent_invocation_target
+    ADD CONSTRAINT agent_invocation_target_target_type_check
+    CHECK (target_type IN ('workspace', 'member', 'team', 'agent'));
+
+COMMENT ON TABLE agent_invocation_target IS
+    'Allow-list of who may invoke a public_to agent. Agent targets grant only the exact active same-workspace source agent and are non-transitive; workspace/member/team retain their existing semantics. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: relationships are validated and cleaned up in the application layer.';

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -61,7 +61,7 @@ type AgentBuilderDraft struct {
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
 }
 
-// Allow-list of who may invoke a public_to agent (MUL-3963). One row per (agent, target_type, target); targets stack and canInvokeAgent OR-matches. workspace rows store the agent workspace_id in target_id; member rows store the user id; team rows are reserved and inert in V1. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: agent_id / created_by / member target_id relationships are maintained in the application layer (see migration comment).
+// Allow-list of who may invoke a public_to agent. Agent targets grant only the exact active same-workspace source agent and are non-transitive; workspace/member/team retain their existing semantics. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: relationships are validated and cleaned up in the application layer.
 type AgentInvocationTarget struct {
 	ID         pgtype.UUID        `json:"id"`
 	AgentID    pgtype.UUID        `json:"agent_id"`


### PR DESCRIPTION
## Summary

- add `target_type=agent` as an additive invocation principal with active, same-workspace validation and exact non-transitive matching
- make permission writes human-owner-only and persist the mode, targets, and minimal audit event atomically
- expose `--public-to-agent` on create, update, and copy while preserving/revalidating copied grants
- keep invocation authority separate from target env, MCP secrets, private chats, run history, and aggregate activity reads
- update shared/mobile types, built-in agent-creation guidance, migrations, and regression coverage

## Verification

- `go test ./cmd/multica` (targeted permission/copy tests)
- `go test ./internal/service -run 'TestCreatingAgentsSkillCoversAgentCreationContracts|TestBuiltinSkillsConformToTemplate'`
- `go test ./... -run '^$'` (all Go packages compile)
- `go vet ./internal/handler ./cmd/multica`
- `pnpm typecheck` and mobile typecheck
- targeted Vitest: 59 tests passed
- core/mobile lint: no errors (mobile reports 7 pre-existing warnings)
- full parallel frontend run hit two unrelated 5-second source-scan timeouts; both files passed separately (36 tests)

Database integration regressions are included for create/update validation, exact/non-transitive invocation, issue assignment/backlog promotion, audit, and private-data isolation. They could not execute locally because the Docker daemon is unavailable; CI should run them after migration 327.

Closes YUX-18
