### PR TITLE
fix(views): make quick capture usable on mobile web (MUL-6236)

### DIFF
--- a/packages/views/modals/create-issue-dialog.test.tsx
+++ b/packages/views/modals/create-issue-dialog.test.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockSetLastMode = vi.hoisted(() => vi.fn());
+
+const mockCreateModeStore = {
+  lastMode: "agent" as "agent" | "manual",
+  setLastMode: mockSetLastMode,
+};
+
+vi.mock("@multica/core/issues/stores/create-mode-store", () => ({
+  useCreateModeStore: Object.assign(
+    (selector: (s: typeof mockCreateModeStore) => unknown) =>
+      selector(mockCreateModeStore),
+    { getState: () => mockCreateModeStore },
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({
+    className,
+    children,
+  }: {
+    className?: string;
+    children: ReactNode;
+  }) => (
+    <div data-testid="dialog-content" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./quick-create-issue", () => ({
+  AgentCreatePanel: () => <div>agent panel</div>,
+}));
+
+vi.mock("./create-issue", () => ({
+  ManualCreatePanel: () => <div>manual panel</div>,
+  manualDialogContentClass: () => "manual-dialog-class",
+}));
+
+// `cn` is deliberately NOT mocked here: the whole point of these assertions is
+// that tailwind-merge keeps the phone cap and the `sm:` width as two separate
+// groups instead of collapsing them into one max-width.
+import { CreateIssueDialog } from "./create-issue-dialog";
+
+function contentClass() {
+  return screen.getByTestId("dialog-content").className;
+}
+
+describe("CreateIssueDialog sizing", () => {
+  // MUL-6236: every width the shell sets is `!important` so it can beat
+  // DialogContent's own sizing — which also beat DialogContent's
+  // `max-w-[calc(100%-2rem)]` gutter, so the card ran the full width of a
+  // phone screen with no margin on either side.
+  it("caps the agent dialog inside the viewport on phones", () => {
+    render(<CreateIssueDialog onClose={vi.fn()} initialMode="agent" />);
+
+    expect(contentClass()).toContain("!max-w-[calc(100vw-1.5rem)]");
+    expect(contentClass()).toContain("sm:!max-w-xl");
+  });
+
+  it("uses dvh so mobile browser chrome cannot hide the agent footer", () => {
+    render(<CreateIssueDialog onClose={vi.fn()} initialMode="agent" />);
+
+    expect(contentClass()).toContain("!max-h-[80dvh]");
+    expect(contentClass()).not.toContain("!max-h-[80vh]");
+  });
+
+  it("hands manual mode its own sizing", () => {
+    render(<CreateIssueDialog onClose={vi.fn()} initialMode="manual" />);
+
+    expect(contentClass()).toBe("manual-dialog-class");
+  });
+});

--- a/packages/views/modals/create-issue-dialog.tsx
+++ b/packages/views/modals/create-issue-dialog.tsx
@@ -58,14 +58,22 @@ export function CreateIssueDialog({
           // Smooth size transition when switching modes — the manual mode
           // uses the same easing.
           "!transition-all !duration-300 !ease-out",
+          // Phone gutter. The widths below are `!important` so they beat
+          // DialogContent's own sizing — which also made them beat its
+          // `max-w-[calc(100%-2rem)]` safety margin, leaving the card flush
+          // against both screen edges on a 430px viewport (MUL-6236). Restore
+          // the margin here and let the `sm:` widths take over above 640px.
+          "!w-full !max-w-[calc(100vw-1.5rem)]",
           // Expanded matches manual's expanded footprint so toggling expand
           // mid-flow (or after a mode switch) lands the user on the same
           // visual size. Collapsed keeps the slim, content-driven default
           // — pasted screenshots still scroll inside instead of pushing the
-          // dialog past the viewport.
+          // dialog past the viewport. `dvh`, not `vh`: mobile Safari resolves
+          // `vh` against the URL-bar-hidden viewport, so 80vh can leave the
+          // footer under the browser chrome.
           isExpanded
-            ? "!max-w-4xl !w-full !h-5/6"
-            : "!max-w-xl !w-full !max-h-[80vh]",
+            ? "!h-5/6 sm:!max-w-4xl"
+            : "!max-h-[80dvh] sm:!max-w-xl",
         )
       : manualDialogContentClass(isExpanded);
 

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -557,7 +557,11 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { CreateIssueModal, ManualCreatePanel } from "./create-issue";
+import {
+  CreateIssueModal,
+  ManualCreatePanel,
+  manualDialogContentClass,
+} from "./create-issue";
 
 function renderModal(element: React.ReactElement) {
   const qc = new QueryClient({
@@ -1660,6 +1664,37 @@ describe("CreateIssueModal", () => {
       expect(createButton.className).toContain("aria-disabled:cursor-not-allowed");
       expect(createButton.className).toContain("aria-disabled:active:translate-y-0");
       expect(createButton.className).not.toContain("aria-disabled:pointer-events-none");
+    });
+  });
+
+  // MUL-6236 — the manual panel shares the agent panel's phone treatment; it
+  // is one tap away behind "Switch to Manual", so it hit the same bugs.
+  describe("phone layout", () => {
+    it("caps the dialog inside the viewport on phones", () => {
+      for (const isExpanded of [false, true]) {
+        const className = manualDialogContentClass(isExpanded);
+
+        // Without this the `!important` widths below also override
+        // DialogContent's own `max-w-[calc(100%-2rem)]` and the card runs
+        // edge to edge on a phone.
+        expect(className).toContain("!max-w-[calc(100vw-1.5rem)]");
+        expect(className).toContain(isExpanded ? "sm:!max-w-4xl" : "sm:!max-w-2xl");
+      }
+    });
+
+    it("keeps every footer control a direct child of the grid container", () => {
+      renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+      const switchToAgent = screen.getByRole("button", { name: /Switch to Agent/i });
+      const create = screen.getByRole("button", { name: "Create Issue" });
+
+      // Grid placement only sees direct children — re-wrapping either control
+      // collapses the 2x2 phone footer back to one jammed row.
+      const footer = switchToAgent.parentElement;
+      expect(footer?.className).toContain("grid-cols-[auto_1fr]");
+      expect(footer?.className).toContain("sm:flex");
+      expect(create.parentElement).toBe(footer);
+      expect(create.className).toContain("justify-self-end");
     });
   });
 });

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -771,7 +771,7 @@ export function ManualCreatePanel({
       // would otherwise stay a fully lit, pressable-looking primary button.
       // Deliberately no `pointer-events-none`: this control still has to hover
       // its tooltip and take the click that focuses the title.
-      className="aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:active:translate-y-0"
+      className="justify-self-end aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:active:translate-y-0"
     >
       {submitState === "submitting" ? (
         t(($) => $.create_issue.submitting)
@@ -781,12 +781,14 @@ export function ManualCreatePanel({
         <>
           {t(($) => $.create_issue.submit)}
           {/* Decorative: the accessible name must stay "Create Issue", not
-              "Create Issue Command Enter". Absent when `send` is unbound. */}
+              "Create Issue Command Enter". Absent when `send` is unbound.
+              Hidden on phones — no ⌘ key there, and the footer row is at its
+              tightest. */}
           {sendShortcut ? (
             <ShortcutKeycaps
               shortcut={sendShortcut}
               decorative
-              className="ml-1"
+              className="ml-1 max-sm:hidden"
               keyClassName="border-background/30 bg-background/15 text-primary-foreground shadow-none"
             />
           ) : null}
@@ -1248,49 +1250,51 @@ export function ManualCreatePanel({
               }}
             />
 
-            {/* Footer */}
-            <div className="flex flex-col gap-2 border-t px-4 py-3 shrink-0 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex min-h-7 items-center gap-2">
+            {/* Footer — same 2x2-grid-on-phones / single-row-from-`sm` shape
+                as the agent panel; see the note on AgentCreatePanel's footer
+                for why (MUL-6236). TooltipProvider/Tooltip render no DOM and
+                TooltipContent is portaled, so the Create button stays a direct
+                grid child in both branches below. */}
+            <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-2.5 border-t px-4 py-3 shrink-0 sm:flex sm:flex-wrap">
+              <div className="flex min-h-7 items-center gap-2 sm:mr-auto">
                 <FileUploadButton
                   multiple
                   onSelect={(file) => descEditorRef.current?.uploadFile(file)}
                 />
               </div>
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={switchToAgent}
-                  disabled={gate.uploading}
-                  aria-disabled={gate.uploading || undefined}
-                  aria-busy={gate.uploading || undefined}
-                  title={t(($) => $.create_issue.switch_to_agent_tooltip)}
-                  className="border-beam group flex shrink-0 items-center gap-1.5 text-caption px-2 py-1 rounded-sm text-muted-foreground bg-brand/5 hover:bg-brand/10 hover:text-foreground transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  <ArrowLeftRight className="size-3.5 text-brand transition-transform duration-300 group-hover:rotate-180" />
-                  {t(($) => $.create_issue.switch_to_agent)}
-                </button>
-                <label className="flex shrink-0 items-center gap-1.5 text-caption text-muted-foreground cursor-pointer select-none">
-                  <Switch
-                    size="sm"
-                    checked={keepOpen}
-                    onCheckedChange={setKeepOpen}
-                  />
-                  {t(($) => $.create_issue.create_another)}
-                </label>
-                {submitState === "missing_title" ? (
-                  <TooltipProvider delay={200}>
-                    <Tooltip>
-                      {/* No `<span>` wrapper needed now: aria-disabled leaves the
-                          button focusable and hoverable, so it can anchor its own
-                          tooltip. */}
-                      <TooltipTrigger render={createButton} />
-                      <TooltipContent side="top">{t(($) => $.create_issue.title_required)}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
-                  createButton
-                )}
-              </div>
+              <button
+                type="button"
+                onClick={switchToAgent}
+                disabled={gate.uploading}
+                aria-disabled={gate.uploading || undefined}
+                aria-busy={gate.uploading || undefined}
+                title={t(($) => $.create_issue.switch_to_agent_tooltip)}
+                className="border-beam group flex shrink-0 items-center gap-1.5 justify-self-end text-caption px-2 py-1 rounded-sm text-muted-foreground bg-brand/5 hover:bg-brand/10 hover:text-foreground transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <ArrowLeftRight className="size-3.5 text-brand transition-transform duration-300 group-hover:rotate-180" />
+                {t(($) => $.create_issue.switch_to_agent)}
+              </button>
+              <label className="flex shrink-0 items-center gap-1.5 text-caption text-muted-foreground cursor-pointer select-none">
+                <Switch
+                  size="sm"
+                  checked={keepOpen}
+                  onCheckedChange={setKeepOpen}
+                />
+                {t(($) => $.create_issue.create_another)}
+              </label>
+              {submitState === "missing_title" ? (
+                <TooltipProvider delay={200}>
+                  <Tooltip>
+                    {/* No `<span>` wrapper needed now: aria-disabled leaves the
+                        button focusable and hoverable, so it can anchor its own
+                        tooltip. */}
+                    <TooltipTrigger render={createButton} />
+                    <TooltipContent side="top">{t(($) => $.create_issue.title_required)}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                createButton
+              )}
             </div>
     </>
   );
@@ -1304,9 +1308,15 @@ export function manualDialogContentClass(isExpanded: boolean) {
     "p-0 gap-0 flex flex-col overflow-hidden",
     "!top-1/2 !left-1/2 !-translate-x-1/2",
     "!transition-all !duration-300 !ease-out",
+    // Phone gutter — see the matching note in create-issue-dialog.tsx: the
+    // `!important` widths below also override DialogContent's
+    // `max-w-[calc(100%-2rem)]`, leaving the card edge to edge on a phone
+    // (MUL-6236). `!h-96` stays a hard height; it already fits the shortest
+    // phone we support.
+    "!w-full !max-w-[calc(100vw-1.5rem)]",
     isExpanded
-      ? "!max-w-4xl !w-full !h-5/6 !-translate-y-1/2"
-      : "!max-w-2xl !w-full !h-96 !-translate-y-1/2",
+      ? "!h-5/6 !-translate-y-1/2 sm:!max-w-4xl"
+      : "!h-96 !-translate-y-1/2 sm:!max-w-2xl",
   );
 }
 

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -1046,4 +1046,42 @@ describe("AgentCreatePanel", () => {
       expect(mockQuickCreateIssue).toHaveBeenCalledTimes(1);
     });
   });
+
+  // MUL-6236 — the footer reflows to a 2x2 grid on phones. jsdom has no
+  // layout, so these pin the two structural preconditions the grid depends
+  // on rather than the rendered geometry.
+  describe("phone footer layout", () => {
+    beforeEach(() => {
+      renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+    });
+
+    it("keeps every footer control a direct child of the grid container", () => {
+      const switchToManual = screen.getByRole("button", { name: /Switch to Manual/i });
+      const create = screen.getByRole("button", { name: /^Create$/i });
+      const keepOpen = screen.getByRole("checkbox");
+      const attach = screen.getByRole("button", { name: "Upload file" });
+
+      const footer = switchToManual.parentElement;
+      expect(footer?.className).toContain("grid-cols-[auto_1fr]");
+      // From `sm` up the same children lay out as the original single row.
+      expect(footer?.className).toContain("sm:flex");
+
+      // Grid placement only sees direct children: re-wrapping any of these in
+      // a <div> collapses the 2x2 back to the jammed single row the bug
+      // report showed. The attach button keeps its own wrapper because it can
+      // gain a "N sent" badge — that wrapper is itself the first grid cell.
+      expect(create.parentElement).toBe(footer);
+      expect(keepOpen.parentElement?.parentElement).toBe(footer);
+      expect(attach.parentElement?.parentElement).toBe(footer);
+    });
+
+    it("hides the send keycaps below the sm breakpoint", () => {
+      const keycaps = document.querySelector('[data-slot="shortcut-keycaps"]');
+
+      // Present for pointer devices, display:none on a touch phone that has
+      // no ⌘ key and the least room in the footer row.
+      expect(keycaps).not.toBeNull();
+      expect(keycaps?.className).toContain("max-sm:hidden");
+    });
+  });
 });

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -25,6 +25,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { Button } from "@multica/ui/components/ui/button";
 import { Switch } from "@multica/ui/components/ui/switch";
+import { cn } from "@multica/ui/lib/utils";
 import { api, ApiError } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
@@ -761,9 +762,18 @@ export function AgentCreatePanel({
           )}
         </div>
 
-        {/* Footer */}
-        <div className="flex flex-col gap-2 border-t px-4 py-3 shrink-0 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-h-7 items-center gap-2">
+        {/* Footer. Two layouts, one flat child list:
+            - Phones get a 2x2 grid — attach / switch on the top row, keep-open
+              toggle / Create on the bottom one. Laid out as a single row the
+              four controls need ~383px of the 398px a 430px phone has left
+              after padding, which reads as jammed and wraps outright below
+              ~410px (MUL-6236).
+            - From `sm` up it is the original single flex row: `mr-auto` on the
+              attach group reproduces what `justify-between` did when the
+              children were two wrapper divs, and `justify-self-end` goes
+              inert on flex items. */}
+        <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-2.5 border-t px-4 py-3 shrink-0 sm:flex sm:flex-wrap">
+          <div className="flex min-h-7 items-center gap-2 sm:mr-auto">
             {/* Deliberately NOT disabled while uploading: each file is its
                 own queue entry, so queueing a second one is safe and waiting
                 for the first to land just to attach the next is busywork. */}
@@ -778,58 +788,62 @@ export function AgentCreatePanel({
               </span>
             )}
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <button
-              type="button"
-              onClick={switchToManual}
-              disabled={gate.uploading}
-              aria-disabled={gate.uploading || undefined}
-              aria-busy={gate.uploading || undefined}
-              title={t(($) => $.create_issue.switch_to_manual_tooltip)}
-              className="flex shrink-0 items-center gap-1.5 text-caption px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <ArrowLeftRight className="size-3.5" />
-              {t(($) => $.create_issue.switch_to_manual)}
-            </button>
-            <label className="flex shrink-0 items-center gap-1.5 text-caption text-muted-foreground cursor-pointer select-none">
-              <Switch
-                size="sm"
-                checked={keepOpen}
-                onCheckedChange={setKeepOpen}
-              />
-              {t(($) => $.create_issue.create_another)}
-            </label>
-            <Button
+          <button
+            type="button"
+            onClick={switchToManual}
+            disabled={gate.uploading}
+            aria-disabled={gate.uploading || undefined}
+            aria-busy={gate.uploading || undefined}
+            title={t(($) => $.create_issue.switch_to_manual_tooltip)}
+            className="flex shrink-0 items-center gap-1.5 justify-self-end text-caption px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <ArrowLeftRight className="size-3.5" />
+            {t(($) => $.create_issue.switch_to_manual)}
+          </button>
+          <label className="flex shrink-0 items-center gap-1.5 text-caption text-muted-foreground cursor-pointer select-none">
+            <Switch
               size="sm"
-              onClick={submit}
-              disabled={!hasContent || !actor || submitting || versionBlocked || gate.uploading}
-              aria-disabled={gate.uploading || undefined}
-              // Sending is a busy state too, not just uploading.
-              aria-busy={gate.uploading || submitting || undefined}
-              title={
-                versionBlocked
-                  ? t(($) => $.create_issue.agent.version_blocked_tooltip, { min: versionCheck.min })
-                  : undefined
-              }
-              className={justSent ? "min-w-28 !bg-emerald-600 !text-white" : "min-w-28"}
-            >
-              {submitting ? t(($) => $.create_issue.agent.sending) : gate.uploading ? t(($) => $.create_issue.agent.uploading) : justSent ? (
-                <span className="flex items-center gap-1"><Check className="size-3.5" />{t(($) => $.create_issue.agent.sent_label)}</span>
-              ) : (
-                <>
-                  {t(($) => $.create_issue.agent.submit)}
-                  {sendShortcut ? (
-                    <ShortcutKeycaps
-                      shortcut={sendShortcut}
-                      decorative
-                      className="ml-1"
-                      keyClassName="border-background/30 bg-background/15 text-primary-foreground shadow-none"
-                    />
-                  ) : null}
-                </>
-              )}
-            </Button>
-          </div>
+              checked={keepOpen}
+              onCheckedChange={setKeepOpen}
+            />
+            {t(($) => $.create_issue.create_another)}
+          </label>
+          <Button
+            size="sm"
+            onClick={submit}
+            disabled={!hasContent || !actor || submitting || versionBlocked || gate.uploading}
+            aria-disabled={gate.uploading || undefined}
+            // Sending is a busy state too, not just uploading.
+            aria-busy={gate.uploading || submitting || undefined}
+            title={
+              versionBlocked
+                ? t(($) => $.create_issue.agent.version_blocked_tooltip, { min: versionCheck.min })
+                : undefined
+            }
+            className={cn(
+              "justify-self-end min-w-28",
+              justSent && "!bg-emerald-600 !text-white",
+            )}
+          >
+            {submitting ? t(($) => $.create_issue.agent.sending) : gate.uploading ? t(($) => $.create_issue.agent.uploading) : justSent ? (
+              <span className="flex items-center gap-1"><Check className="size-3.5" />{t(($) => $.create_issue.agent.sent_label)}</span>
+            ) : (
+              <>
+                {t(($) => $.create_issue.agent.submit)}
+                {sendShortcut ? (
+                  // Touch phones have no ⌘ key and the narrowest footer row
+                  // to spare — drop the hint at the same breakpoint the
+                  // footer reflows at.
+                  <ShortcutKeycaps
+                    shortcut={sendShortcut}
+                    decorative
+                    className="ml-1 max-sm:hidden"
+                    keyClassName="border-background/30 bg-background/15 text-primary-foreground shadow-none"
+                  />
+                ) : null}
+              </>
+            )}
+          </Button>
         </div>
     </>
   );


### PR DESCRIPTION
Fixes MUL-6236.

The agent create dialog ("quick capture") was laid out for desktop only. On the reported 430px phone the card rendered edge to edge with no margin, the footer spent a whole row on a lone attach button, and the remaining three controls were jammed into ~383px of the 398px available. Below ~410px that row wrapped outright, giving three ragged footer rows.

## Changes

- **Phone gutter** — cap the dialog at `calc(100vw - 1.5rem)` below `sm`. Every width the shell sets is `!important` so it can beat `DialogContent`'s own sizing; that also made it beat `DialogContent`'s `max-w-[calc(100%-2rem)]` safety margin, which is why the card was full-bleed.
- **2×2 footer on phones** — attach / switch on the top row, keep-open toggle / Create below; back to the original single flex row from `sm` up. The four controls are now flat children so grid can place them, and `mr-auto` on the attach group reproduces what `justify-between` did with the two old wrapper divs.
- **No `⌘↵` keycaps below `sm`** — there is no such key on a touch phone, and that row has the least room to spare.
- **`80dvh` instead of `80vh`** — mobile Safari resolves `vh` against the URL-bar-hidden viewport, so `80vh` can leave the footer under the browser chrome.

The manual panel is one tap away behind "Switch to Manual" and shared the same footer markup and dialog sizing, so it gets the same treatment.

## Measurements

| viewport | dialog width | side gutters | footer height |
| --- | --- | --- | --- |
| iPhone 430×932 | 430px → **406px** | 0px → **12px** | 89px → 91px (2 tidy rows instead of 1 empty + 1 jammed) |
| iPhone 375×812 | 375px → **351px** | 0px → **12px** | 121px → **91px** |
| Desktop 1280 | 576px (unchanged) | unchanged | 53px (unchanged) |

## Verification

- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm --filter @multica/views test` — 346 files, only the pre-existing `layout/sidebar-resize.test.tsx` failure, which also fails on a clean checkout of this branch point.
- 7 new tests across `create-issue-dialog.test.tsx`, `quick-create-issue.test.tsx`, and `create-issue.test.tsx`. jsdom has no layout, so they pin the two things that would silently regress this: the phone width cap surviving tailwind-merge, and the footer controls staying flat children of the grid.
- Reverted the source (tests only) to confirm all 6 behavioural assertions fail without the fix.
- Rendered a replica built from the repo's real tokens, `base.css`, and Inter in headless Chromium at 430 / 375 / 1280px. **Desktop at 1280px is pixel-identical before vs after** (image diff bbox `None`).

## Not covered

Soft-keyboard occlusion. The dialog stays vertically centred, so once the keyboard opens on a phone the footer can end up behind it. `packages/views/chat/components/use-visual-viewport-keyboard.ts` already solves this for chat and would be the basis for a follow-up; it is a bigger change than this layout pass and the reported screenshot is the pre-keyboard state (iOS does not open the keyboard for the panel's programmatic autofocus).
