### PR TITLE
fix(views): release the drag lock on cancelled drags (MUL-6240)

### DIFF
--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -553,6 +553,16 @@ function BoardViewImpl({
     [groupedIssues, groups, grouping, groupingOptionIds, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue],
   );
 
+  // An aborted drag (pointercancel, window resize, tab hide, Escape) fires
+  // onDragCancel instead of onDragEnd. Releasing the drag lock here keeps the
+  // column mirror resyncing with the cache afterwards — see the same handler in
+  // list-view for the touch path that makes this routine (MUL-6240).
+  const handleDragCancel = useCallback(() => {
+    isDraggingRef.current = false;
+    setActiveIssue(null);
+    setColumns(buildColumns(groupedIssues, groups, grouping, groupingOptionIds));
+  }, [groupedIssues, groups, grouping, groupingOptionIds, setColumns, isDraggingRef]);
+
   return (
     <DndContext
       sensors={sensors}
@@ -560,6 +570,7 @@ function BoardViewImpl({
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div
         ref={pan.ref}

--- a/packages/views/issues/components/list-view.test.tsx
+++ b/packages/views/issues/components/list-view.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { Issue, IssueStatus } from "@multica/core/types";
+import { ListView } from "./list-view";
+import { IssueContextMenuProvider } from "../actions";
+import { ScrollRestorationProvider } from "../../platform";
+import type { IssueStatusPagination } from "../surface/use-issue-status-branches";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+const mockGetAgentTaskSnapshot = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+vi.mock("@multica/core/api", () => ({
+  api: { getAgentTaskSnapshot: mockGetAgentTaskSnapshot },
+  getApi: () => ({ getAgentTaskSnapshot: mockGetAgentTaskSnapshot }),
+  setApiInstance: vi.fn(),
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/paths")>("@multica/core/paths");
+  return {
+    ...actual,
+    useWorkspaceSlug: () => "acme",
+    useRequiredWorkspaceSlug: () => "acme",
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigation: () => ({ push: vi.fn(), pathname: "/issues" }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const mockAuthUser = { id: "user-1", email: "test@test.com", name: "Test User" };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => {
+      const state = { user: mockAuthUser, isAuthenticated: true };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ user: mockAuthUser, isAuthenticated: true }) },
+  ),
+  registerAuthStore: vi.fn(),
+  createAuthStore: vi.fn(),
+}));
+
+// View store. `listCollapsedStatuses` is mutable so `toggleListCollapsed`
+// models the real store: the accordion's expanded set is derived from it.
+const mockViewState: {
+  sortBy: string;
+  sortDirection: string;
+  cardProperties: Record<string, boolean>;
+  cardPropertyIds: string[];
+  listCollapsedStatuses: IssueStatus[];
+  toggleListCollapsed: (status: IssueStatus) => void;
+} = {
+  sortBy: "position",
+  sortDirection: "asc",
+  cardProperties: {},
+  cardPropertyIds: [],
+  listCollapsedStatuses: [],
+  toggleListCollapsed: vi.fn((status: IssueStatus) => {
+    mockViewState.listCollapsedStatuses =
+      mockViewState.listCollapsedStatuses.includes(status)
+        ? mockViewState.listCollapsedStatuses.filter((s) => s !== status)
+        : [...mockViewState.listCollapsedStatuses, status];
+  }),
+};
+
+vi.mock("@multica/core/issues/stores/view-store-context", () => ({
+  ViewStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  useViewStore: (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
+  useViewStoreApi: () => ({
+    getState: () => mockViewState,
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+  }),
+}));
+
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    () => ({ open: vi.fn() }),
+    { getState: () => ({ open: vi.fn() }) },
+  ),
+}));
+
+// Capture the DndContext callbacks so a test can drive dnd-kit's real
+// lifecycle — including the cancel path, which never calls onDragEnd.
+let lastOnDragStart: any = null;
+let lastOnDragCancel: any = null;
+const stableSetNodeRef = () => {};
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children, onDragStart, onDragCancel }: any) => {
+    lastOnDragStart = onDragStart;
+    lastOnDragCancel = onDragCancel;
+    return children;
+  },
+  DragOverlay: () => null,
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDroppable: () => ({ setNodeRef: stableSetNodeRef, isOver: false }),
+  pointerWithin: vi.fn(),
+  closestCenter: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: any) => children,
+  verticalListSortingStrategy: {},
+  arrayMove: <T,>(arr: T[]) => arr,
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+// jsdom has no layout, so the real Virtuoso measures a 0-height viewport and
+// renders nothing. Render rows inline so the panel's contents are assertable.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({ data, itemContent }: any) => (
+    <div data-testid="virtuoso-mock">
+      {(data ?? []).map((item: any, i: number) => (
+        <div key={i}>{itemContent(i, item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const ISSUES: Issue[] = [
+  {
+    id: "issue-1",
+    identifier: "MUL-1",
+    title: "First todo issue",
+    status: "todo",
+    priority: "none",
+    position: 1,
+    workspace_id: "ws-1",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as Issue,
+  {
+    id: "issue-2",
+    identifier: "MUL-2",
+    title: "Second todo issue",
+    status: "todo",
+    priority: "none",
+    position: 2,
+    workspace_id: "ws-1",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as Issue,
+];
+
+const PAGINATION = {
+  todo: {
+    hasMore: false,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    total: 2,
+    loadMore: vi.fn(),
+    retry: vi.fn(),
+  },
+} as unknown as IssueStatusPagination;
+
+function renderListView() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider resources={TEST_RESOURCES} locale="en">
+        <IssueContextMenuProvider>
+          <ScrollRestorationProvider adapter={{ get: () => undefined }}>
+            <ListView
+              issues={ISSUES}
+              visibleStatuses={["todo"]}
+              statusPagination={PAGINATION}
+              onMoveIssue={vi.fn()}
+            />
+          </ScrollRestorationProvider>
+        </IssueContextMenuProvider>
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ListView status header collapse", () => {
+  beforeEach(() => {
+    mockViewState.listCollapsedStatuses = [];
+    lastOnDragStart = null;
+    lastOnDragCancel = null;
+  });
+
+  it("collapses a status group when its header is clicked", async () => {
+    const user = userEvent.setup();
+    renderListView();
+
+    const trigger = screen.getByRole("button", { expanded: true });
+    await user.click(trigger);
+
+    expect(mockViewState.listCollapsedStatuses).toEqual(["todo"]);
+  });
+
+  it("still collapses after a drag is cancelled instead of dropped", async () => {
+    const user = userEvent.setup();
+    renderListView();
+
+    // dnd-kit fires onDragCancel — never onDragEnd — when the browser aborts
+    // an active pointer drag. On touch that happens on every scroll gesture
+    // that starts on a row: the drag activates past the 5px threshold, then
+    // the browser takes the gesture over and fires pointercancel. A cancel
+    // that leaves the drag lock engaged makes the header's collapse toggle a
+    // permanent no-op (MUL-6240).
+    expect(lastOnDragCancel).toBeTypeOf("function");
+    act(() => {
+      lastOnDragStart({ active: { id: "issue-1" } });
+      lastOnDragCancel();
+    });
+
+    const trigger = screen.getByRole("button", { expanded: true });
+    await user.click(trigger);
+
+    expect(mockViewState.listCollapsedStatuses).toEqual(["todo"]);
+  });
+});

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -313,6 +313,21 @@ function ListViewImpl({
     [issues, groups, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, setColumns, columnsRef, isDraggingRef],
   );
 
+  // dnd-kit fires onDragCancel — never onDragEnd — when an active drag is
+  // aborted: pointercancel, window resize, tab hide, or Escape. Touch browsers
+  // hit that path constantly, because a scroll gesture that starts on a row
+  // moves past the 5px activation distance and *then* the browser takes the
+  // gesture over for native scrolling and cancels the pointer. Without this
+  // handler `isDraggingRef` stayed true for the rest of the session, which
+  // froze the column mirror against cache updates and — because the accordion's
+  // onValueChange is guarded by the same ref — made tapping a status header a
+  // no-op, so groups could no longer be collapsed at all (MUL-6240).
+  const handleDragCancel = useCallback(() => {
+    isDraggingRef.current = false;
+    setActiveIssue(null);
+    setColumns(buildColumns(issues, groups, "status"));
+  }, [issues, groups, setColumns, isDraggingRef]);
+
   // The single scroll container is shared by every status panel's Virtuoso as
   // its customScrollParent, so a callback ref hands the element to the panels
   // once it mounts. Keeping one scroller (rather than one per panel) preserves
@@ -385,6 +400,7 @@ function ListViewImpl({
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div ref={attachScroller} data-tab-scroll-root="list" className="flex-1 min-h-0 overflow-y-auto p-2 pt-0">
         {content}

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -1339,6 +1339,16 @@ function SwimLaneViewImpl({
     ],
   );
 
+  // An aborted drag (pointercancel, window resize, tab hide, Escape) fires
+  // onDragCancel instead of onDragEnd. Releasing the drag lock here keeps
+  // localCells resyncing with the cache afterwards — see the same handler in
+  // list-view for the touch path that makes this routine (MUL-6240).
+  const handleDragCancel = useCallback(() => {
+    isDraggingRef.current = false;
+    setActiveIssue(null);
+    setLocalCells(cells);
+  }, [cells]);
+
   const computeLaneKey = (_index: number, lane: LaneGroup) => lane.key;
   const renderLane = (index: number, lane: LaneGroup) => (
     <div className={index === 0 ? undefined : "pt-4"}>
@@ -1368,6 +1378,7 @@ function SwimLaneViewImpl({
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div ref={attachScroller} data-tab-scroll-root="swimlane" className="flex flex-1 min-h-0 gap-4 overflow-auto p-4">
         <div className="flex shrink-0 flex-col" style={{ width: `${trackWidth}px` }}>


### PR DESCRIPTION
Closes MUL-6240

## Symptom

On mobile web, tapping a status bar in the issues **list view** does not collapse the group. It works on a freshly loaded page, then stops working permanently once you scroll the list — which on a phone is immediately.

## Cause

The list/board/swimlane surfaces track an in-flight drag with `isDraggingRef`, set in `onDragStart` and cleared in `onDragEnd`. dnd-kit does **not** call `onDragEnd` when a drag is aborted — it calls `onDragCancel`, which none of the three surfaces passed. `@dnd-kit/core` routes `pointercancel`, window `resize`, `visibilitychange`, and Escape through that path.

Touch hits it on essentially every scroll: a scroll gesture starting on a row moves past the `PointerSensor`'s 5px activation distance, so a drag starts; the browser then takes the gesture over for native scrolling and fires `pointercancel`. Confirmed in a mobile Chromium session — one `pointerdown`, one `pointercancel`, zero `pointerup`.

The stuck flag then freezes the column mirror against cache updates on all three surfaces, and in `list-view` it additionally short-circuits the accordion's `onValueChange`:

```tsx
onValueChange={(value: string[]) => {
  if (isDraggingRef.current) return;   // never false again → collapse is dead
```

## Fix

Wire `onDragCancel` on all three `DndContext`s to release the lock, clear the drag overlay, and resync from the cache — the same reset the no-drop branch of `onDragEnd` already performs.

## Verification

- New `packages/views/issues/components/list-view.test.tsx` drives the real cancel lifecycle (`onDragStart` → `onDragCancel`) and asserts the header still collapses. Confirmed failing without the fix.
- Reproduced and re-verified end to end in a mobile Chromium session (iPhone 13 emulation) against a local stack, using a synthesized touch scroll: collapse was dead before the fix, and collapse + expand both work after.
- `pnpm typecheck` clean; `pnpm lint` clean for the changed files; all 474 `packages/views/issues/components` tests pass.

Nine pre-existing failures elsewhere (8 in `@multica/core` workspace/project/realtime mutation tests, 1 in `layout/sidebar-resize`) reproduce identically on the unmodified baseline and are unrelated.

## Note, not fixed here

The underlying reason a drag activates at all during a touch scroll is that `PointerSensor` uses a bare `{ distance: 5 }` activation constraint, which touch gestures cross before the browser claims them. Splitting into `MouseSensor` + a delay-based `TouchSensor` would stop the spurious activation, but it changes desktop drag semantics too, so it is out of scope for this bug.
