### PR TITLE
MUL-6265 Support forwarded Slack message content

### DIFF
--- a/server/internal/integrations/slack/inbound.go
+++ b/server/internal/integrations/slack/inbound.go
@@ -175,6 +175,12 @@ func buildInbound(e slackevents.EventsAPIEvent, p buildInboundParams, mentionRe 
 		reply = &channel.ReplyCtx{MessageID: p.threadTS, RootID: p.threadTS}
 	}
 	text := cleanText(p.text, mentionRe)
+	if forwarded := forwardedMessageText(e); forwarded != "" {
+		if text != "" {
+			text += "\n\n"
+		}
+		text += "Forwarded message:\n" + forwarded
+	}
 	return channel.InboundMessage{
 		EventID:        p.ts,
 		MessageID:      p.ts,
@@ -192,6 +198,41 @@ func buildInbound(e slackevents.EventsAPIEvent, p buildInboundParams, mentionRe 
 		},
 		Raw: raw,
 	}
+}
+
+type forwardedAttachment struct {
+	slack.Attachment
+	IsMessageUnfurl bool `json:"is_msg_unfurl"`
+}
+
+// forwardedMessageText extracts only message unfurls from Slack's raw event;
+// slack.Attachment does not expose the is_msg_unfurl discriminator.
+func forwardedMessageText(e slackevents.EventsAPIEvent) string {
+	callback, ok := e.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok || callback.InnerEvent == nil {
+		return ""
+	}
+	var event struct {
+		Attachments []forwardedAttachment `json:"attachments"`
+	}
+	if err := json.Unmarshal(*callback.InnerEvent, &event); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(event.Attachments))
+	for _, attachment := range event.Attachments {
+		if !attachment.IsMessageUnfurl {
+			continue
+		}
+		text := attachmentText(attachment.Attachment)
+		if text == "" {
+			continue
+		}
+		if author := strings.TrimSpace(attachment.AuthorName); author != "" {
+			text = author + ":\n" + text
+		}
+		parts = append(parts, text)
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // cleanText strips a leading/embedded bot mention token and trims surrounding

--- a/server/internal/integrations/slack/inbound_test.go
+++ b/server/internal/integrations/slack/inbound_test.go
@@ -97,6 +97,58 @@ func TestInboundFromMessage_ChannelMention(t *testing.T) {
 	}
 }
 
+func TestInboundFromMessage_SeparatesForwardsFromOrdinaryAttachments(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type": "event_callback",
+		"event": {
+			"type": "message",
+			"user": "UALICE",
+			"text": "compare these",
+			"channel": "D123",
+			"channel_type": "im",
+			"ts": "1700000000.000260",
+			"attachments": [
+				{
+					"is_msg_unfurl": true,
+					"author_name": "Bob",
+					"text": "Deploy at 3pm.",
+					"files": [{"id": "F1", "url_private": "https://files.slack.com/files-pri/T1-F1/report.pdf"}]
+				},
+				{
+					"original_url": "https://example.com",
+					"text": "This ordinary attachment must stay out."
+				},
+				{
+					"is_msg_unfurl": true,
+					"author_name": "Carol",
+					"text": "Rollback if checks fail."
+				}
+			]
+		}
+	}`)
+	e, err := slackevents.ParseEvent(raw, slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("parse forwarded message event: %v", err)
+	}
+	m, ok := e.InnerEvent.Data.(*slackevents.MessageEvent)
+	if !ok {
+		t.Fatalf("inner event = %T, want *slackevents.MessageEvent", e.InnerEvent.Data)
+	}
+
+	msg, ingestable := translateMessage("UBOT", e, m)
+	if !ingestable {
+		t.Fatal("forwarded message should be ingestable")
+	}
+	const want = "compare these\n\nForwarded message:\nBob:\nDeploy at 3pm.\n\nCarol:\nRollback if checks fail."
+	if msg.Text != want || msg.CommandText != want {
+		t.Errorf("Text/CommandText = %q/%q, want %q", msg.Text, msg.CommandText, want)
+	}
+	resolver := NewMediaResolver(nil, newFakeMediaStorage(), &fakeMediaLedger{}, nil)
+	if resolver.HasMedia(msg) {
+		t.Error("forwarded attachment must not be treated as ordinary Slack file media")
+	}
+}
+
 func TestInboundFromMessage_ChannelNoMention(t *testing.T) {
 	msg, ok := translateMessage("UBOT", eventsAPI(nil), &slackevents.MessageEvent{
 		User:        "UALICE",


### PR DESCRIPTION
## Summary

- extract forwarded Slack message unfurls from the original Events API payload
- append forwarded content with author attribution while excluding ordinary attachment previews
- keep files nested in forwarded attachments out of normal media ingestion

## Validation

- `go test ./internal/integrations/slack -run '^TestInboundFromMessage_(SeparatesForwardsFromOrdinaryAttachments|DM|ChannelMention)$' -count=1`
- `go test ./internal/integrations/slack -count=1`
- `go vet ./...`
- `go build ./...`

Closes TIM-27
