### PR TITLE
feat(issues): add sub-issue priority sorting

### DIFF
--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -71,7 +71,10 @@ export { useSubIssuesCollapseStore } from "./sub-issues-collapse-store";
 export {
   useSubIssueDisplayStore,
   SUB_ISSUE_ROW_PROPERTY_KEYS,
+  SUB_ISSUE_SORT_FIELDS,
   DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
   type SubIssueRowProperties,
   type SubIssueRowPropertyKey,
+  type SubIssueSortField,
+  type SubIssueSortDirection,
 } from "./sub-issue-display-store";

--- a/packages/core/issues/stores/sub-issue-display-store.test.ts
+++ b/packages/core/issues/stores/sub-issue-display-store.test.ts
@@ -29,6 +29,8 @@ describe("sub-issue display store", () => {
     useSubIssueDisplayStore.setState({
       rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
       rowPropertyIds: [],
+      sortBy: "created",
+      sortDirection: "asc",
     });
   });
 
@@ -42,6 +44,8 @@ describe("sub-issue display store", () => {
       assignee: true,
     });
     expect(s.rowPropertyIds).toEqual([]);
+    expect(s.sortBy).toBe("created");
+    expect(s.sortDirection).toBe("asc");
   });
 
   it("toggleRowProperty flips a single field without touching the rest", () => {
@@ -67,5 +71,16 @@ describe("sub-issue display store", () => {
 
     useSubIssueDisplayStore.getState().toggleRowPropertyId("prop-1");
     expect(useSubIssueDisplayStore.getState().rowPropertyIds).toEqual(["prop-2"]);
+  });
+
+  it("updates sub-issue ordering independently from row properties", () => {
+    useSubIssueDisplayStore.getState().setSortBy("priority");
+    useSubIssueDisplayStore.getState().setSortDirection("desc");
+
+    const s = useSubIssueDisplayStore.getState();
+    expect(s.sortBy).toBe("priority");
+    expect(s.sortDirection).toBe("desc");
+    expect(s.rowProperties).toEqual(DEFAULT_SUB_ISSUE_ROW_PROPERTIES);
+    expect(s.rowPropertyIds).toEqual([]);
   });
 });

--- a/packages/core/issues/stores/sub-issue-display-store.ts
+++ b/packages/core/issues/stores/sub-issue-display-store.ts
@@ -3,13 +3,14 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { defaultStorage } from "../../platform/storage";
 
 /**
- * Which properties the issue-detail sub-issues rows display.
+ * Which properties the issue-detail sub-issue rows display and how the rows
+ * are ordered.
  *
  * This is a personal reading preference (like the comment composer's sticky
  * toggle), not a per-view setting: every issue's sub-issues panel shares the
  * one configuration, persisted globally via `defaultStorage`. Defaults match
- * the panel's built-in row layout so the preference is invisible until the
- * user changes it.
+ * the panel's built-in row layout and stable creation order, so the preference
+ * is invisible until the user changes it.
  *
  * `rowPropertyIds` holds workspace custom property definition ids. The list
  * is global while property ids are workspace-scoped — renderers resolve ids
@@ -28,6 +29,10 @@ export type SubIssueRowPropertyKey =
   (typeof SUB_ISSUE_ROW_PROPERTY_KEYS)[number];
 export type SubIssueRowProperties = Record<SubIssueRowPropertyKey, boolean>;
 
+export const SUB_ISSUE_SORT_FIELDS = ["created", "priority"] as const;
+export type SubIssueSortField = (typeof SUB_ISSUE_SORT_FIELDS)[number];
+export type SubIssueSortDirection = "asc" | "desc";
+
 export const DEFAULT_SUB_ISSUE_ROW_PROPERTIES: SubIssueRowProperties = {
   priority: true,
   labels: true,
@@ -39,8 +44,12 @@ export const DEFAULT_SUB_ISSUE_ROW_PROPERTIES: SubIssueRowProperties = {
 interface SubIssueDisplayStore {
   rowProperties: SubIssueRowProperties;
   rowPropertyIds: string[];
+  sortBy: SubIssueSortField;
+  sortDirection: SubIssueSortDirection;
   toggleRowProperty: (key: SubIssueRowPropertyKey) => void;
   toggleRowPropertyId: (propertyId: string) => void;
+  setSortBy: (field: SubIssueSortField) => void;
+  setSortDirection: (direction: SubIssueSortDirection) => void;
 }
 
 export const useSubIssueDisplayStore = create<SubIssueDisplayStore>()(
@@ -48,6 +57,8 @@ export const useSubIssueDisplayStore = create<SubIssueDisplayStore>()(
     (set) => ({
       rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
       rowPropertyIds: [],
+      sortBy: "created",
+      sortDirection: "asc",
       toggleRowProperty: (key) =>
         set((s) => ({
           rowProperties: { ...s.rowProperties, [key]: !s.rowProperties[key] },
@@ -58,6 +69,8 @@ export const useSubIssueDisplayStore = create<SubIssueDisplayStore>()(
             ? s.rowPropertyIds.filter((id) => id !== propertyId)
             : [...s.rowPropertyIds, propertyId],
         })),
+      setSortBy: (sortBy) => set({ sortBy }),
+      setSortDirection: (sortDirection) => set({ sortDirection }),
     }),
     {
       name: "multica_sub_issue_display",
@@ -74,6 +87,14 @@ export const useSubIssueDisplayStore = create<SubIssueDisplayStore>()(
             ...current.rowProperties,
             ...(p.rowProperties ?? {}),
           },
+          sortBy:
+            p.sortBy === "created" || p.sortBy === "priority"
+              ? p.sortBy
+              : current.sortBy,
+          sortDirection:
+            p.sortDirection === "asc" || p.sortDirection === "desc"
+              ? p.sortDirection
+              : current.sortDirection,
         };
       },
     },

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, Label, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -1705,7 +1704,6 @@ describe("IssueDetail (shared)", () => {
     });
 
     it("exposes persistent ordering controls in display settings", async () => {
-      const user = userEvent.setup();
       mockApiObj.listChildIssues.mockResolvedValue({
         issues: [
           subIssue({
@@ -1720,17 +1718,19 @@ describe("IssueDetail (shared)", () => {
       renderIssueDetail();
 
       await screen.findByText("Fix login flow");
-      await user.click(screen.getByRole("button", { name: "Display settings" }));
+      fireEvent.click(screen.getByRole("button", { name: "Display settings" }));
       const ordering = await screen.findByRole("combobox", { name: "Ordering" });
       expect(ordering).toHaveTextContent("Created date");
-      await user.click(ordering);
-      await user.click(await screen.findByRole("option", { name: "Priority" }));
+      fireEvent.click(ordering);
+      const priorityOption = await screen.findByRole("option", { name: "Priority" });
+      fireEvent.mouseMove(priorityOption);
+      fireEvent.click(priorityOption);
       expect(useSubIssueDisplayStore.getState().sortBy).toBe("priority");
       expect(screen.getByRole("combobox", { name: "Ordering" })).toHaveTextContent(
         "Priority",
       );
       const direction = screen.getByRole("button", { name: "Ascending" });
-      await user.click(direction);
+      fireEvent.click(direction);
       expect(useSubIssueDisplayStore.getState().sortDirection).toBe("desc");
       expect(screen.getByRole("button", { name: "Descending" })).toBeInTheDocument();
     });

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, Label, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -565,7 +566,7 @@ const mockTimeline: TimelineEntry[] = [
 // Import component under test (after mocks)
 // ---------------------------------------------------------------------------
 
-import { IssueDetail, groupSubIssuesByStage } from "./issue-detail";
+import { IssueDetail, groupSubIssuesByStage, sortSubIssues } from "./issue-detail";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1609,6 +1610,8 @@ describe("IssueDetail (shared)", () => {
       useSubIssueDisplayStore.setState({
         rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
         rowPropertyIds: [],
+        sortBy: "created",
+        sortDirection: "asc",
       });
     });
 
@@ -1701,6 +1704,37 @@ describe("IssueDetail (shared)", () => {
       expect(screen.queryByText("Jan 1")).not.toBeInTheDocument();
     });
 
+    it("exposes persistent ordering controls in display settings", async () => {
+      const user = userEvent.setup();
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-1",
+            number: 11,
+            identifier: "TES-11",
+            title: "Fix login flow",
+          }),
+        ],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Fix login flow");
+      await user.click(screen.getByRole("button", { name: "Display settings" }));
+      const ordering = await screen.findByRole("combobox", { name: "Ordering" });
+      expect(ordering).toHaveTextContent("Created date");
+      await user.click(ordering);
+      await user.click(await screen.findByRole("option", { name: "Priority" }));
+      expect(useSubIssueDisplayStore.getState().sortBy).toBe("priority");
+      expect(screen.getByRole("combobox", { name: "Ordering" })).toHaveTextContent(
+        "Priority",
+      );
+      const direction = screen.getByRole("button", { name: "Ascending" });
+      await user.click(direction);
+      expect(useSubIssueDisplayStore.getState().sortDirection).toBe("desc");
+      expect(screen.getByRole("button", { name: "Descending" })).toBeInTheDocument();
+    });
+
     it("renders opted-in custom property chips on rows that carry a value", async () => {
       const estimate = {
         id: "prop-1",
@@ -1764,6 +1798,52 @@ describe("IssueDetail (shared)", () => {
       const due = screen.getByText("Jan 1");
       expect(due.closest("span")?.className).not.toContain("text-destructive");
       expect(due.closest("span")?.className).toContain("text-muted-foreground");
+    });
+
+    it("orders sub-issues by priority with issue number as a stable tie-breaker", async () => {
+      useSubIssueDisplayStore.setState({ sortBy: "priority", sortDirection: "asc" });
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-14",
+            number: 14,
+            identifier: "TES-14",
+            title: "Later high priority",
+            priority: "high",
+          }),
+          subIssue({
+            id: "child-11",
+            number: 11,
+            identifier: "TES-11",
+            title: "No priority",
+            priority: "none",
+          }),
+          subIssue({
+            id: "child-13",
+            number: 13,
+            identifier: "TES-13",
+            title: "Urgent work",
+            priority: "urgent",
+          }),
+          subIssue({
+            id: "child-12",
+            number: 12,
+            identifier: "TES-12",
+            title: "Earlier high priority",
+            priority: "high",
+          }),
+        ],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Urgent work");
+      const rowOrder = screen
+        .getAllByRole("link")
+        .map((link) => link.textContent ?? "")
+        .filter((text) => /TES-(11|12|13|14)/.test(text))
+        .map((text) => text.match(/TES-\d+/)?.[0]);
+      expect(rowOrder).toEqual(["TES-13", "TES-12", "TES-14", "TES-11"]);
     });
   });
 
@@ -2095,11 +2175,18 @@ describe("IssueDetail (shared)", () => {
 });
 
 describe("groupSubIssuesByStage", () => {
-  const child = (id: string, stage: number | null): Issue => ({
+  const child = (
+    id: string,
+    stage: number | null,
+    priority: Issue["priority"] = "none",
+    number = 1,
+  ): Issue => ({
     ...mockIssue,
     id,
     parent_issue_id: "parent-1",
     stage,
+    priority,
+    number,
   });
 
   it("returns a single null-stage group when nothing is staged", () => {
@@ -2124,5 +2211,29 @@ describe("groupSubIssuesByStage", () => {
   it("omits the unstaged group when every child is staged", () => {
     const groups = groupSubIssuesByStage([child("s1", 1), child("s2", 2)]);
     expect(groups.map((g) => g.stage)).toEqual([1, 2]);
+  });
+
+  it("keeps stage order while priority-sorting within each stage", () => {
+    const sorted = sortSubIssues(
+      [
+        child("stage-2-urgent", 2, "urgent", 14),
+        child("stage-1-low", 1, "low", 11),
+        child("stage-1-high-later", 1, "high", 13),
+        child("stage-1-high-earlier", 1, "high", 12),
+      ],
+      "priority",
+      "asc",
+    );
+
+    const groups = groupSubIssuesByStage(sorted);
+    expect(groups.map((group) => group.stage)).toEqual([1, 2]);
+    expect(groups[0]?.items.map((issue) => issue.id)).toEqual([
+      "stage-1-high-earlier",
+      "stage-1-high-later",
+      "stage-1-low",
+    ]);
+    expect(groups[1]?.items.map((issue) => issue.id)).toEqual([
+      "stage-2-urgent",
+    ]);
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -6,6 +6,8 @@ import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink, useBackOrReplace } from "../../navigation";
 import {
   Archive,
+  ArrowDown,
+  ArrowUp,
   Calendar,
   CalendarClock,
   CalendarDays,
@@ -45,6 +47,14 @@ import {
   DropdownMenuItem,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { Popover, PopoverTrigger, PopoverContent } from "@multica/ui/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@multica/ui/components/ui/dialog";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@multica/ui/components/ui/command";
@@ -54,7 +64,7 @@ import { PropRow } from "../../common/prop-row";
 import { PropertyIcon } from "../../common/property-icon";
 import type { Attachment, Issue, IssueProperty, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
-import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
+import { STATUS_CONFIG, PRIORITY_CONFIG, PRIORITY_ORDER } from "@multica/core/issues/config";
 import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { toast } from "sonner";
@@ -100,8 +110,11 @@ import {
   useSubIssuesCollapseStore,
   useSubIssueDisplayStore,
   SUB_ISSUE_ROW_PROPERTY_KEYS,
+  SUB_ISSUE_SORT_FIELDS,
   type SubIssueRowProperties,
   type SubIssueRowPropertyKey,
+  type SubIssueSortField,
+  type SubIssueSortDirection,
 } from "@multica/core/issues/stores";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BatchActionToolbar } from "./batch-action-toolbar";
@@ -414,6 +427,25 @@ export function groupSubIssuesByStage(
     .map((s) => ({ stage: s, items: byStage.get(s) as Issue[] }));
   if (unstaged.length > 0) groups.push({ stage: null, items: unstaged });
   return groups;
+}
+
+/**
+ * Orders sub-issues for the detail panel without mutating the query cache.
+ * Priority follows the same high-to-low rank as the main issue surfaces;
+ * issue number is the deterministic sibling tie-breaker in either direction.
+ */
+export function sortSubIssues(
+  children: Issue[],
+  field: SubIssueSortField,
+  direction: SubIssueSortDirection,
+): Issue[] {
+  const directionFactor = direction === "asc" ? 1 : -1;
+  return children.toSorted((a, b) => {
+    const fieldOrder = field === "priority"
+      ? PRIORITY_ORDER.indexOf(a.priority) - PRIORITY_ORDER.indexOf(b.priority)
+      : a.number - b.number;
+    return fieldOrder === 0 ? a.number - b.number : fieldOrder * directionFactor;
+  });
 }
 
 // Shallow array equality by element identity. Used to reuse the previous
@@ -851,6 +883,14 @@ const SUB_ISSUE_ROW_PROPERTY_LABEL_KEY: Record<
   assignee: "card_assignee",
 };
 
+const SUB_ISSUE_SORT_LABEL_KEY: Record<
+  SubIssueSortField,
+  "sort_created" | "sort_priority"
+> = {
+  created: "sort_created",
+  priority: "sort_priority",
+};
+
 function SubIssueDisplayPopover({
   workspaceProperties,
 }: {
@@ -859,8 +899,17 @@ function SubIssueDisplayPopover({
   const { t } = useT("issues");
   const rowProperties = useSubIssueDisplayStore((s) => s.rowProperties);
   const rowPropertyIds = useSubIssueDisplayStore((s) => s.rowPropertyIds);
+  const sortBy = useSubIssueDisplayStore((s) => s.sortBy);
+  const sortDirection = useSubIssueDisplayStore((s) => s.sortDirection);
   const toggleRowProperty = useSubIssueDisplayStore((s) => s.toggleRowProperty);
   const toggleRowPropertyId = useSubIssueDisplayStore((s) => s.toggleRowPropertyId);
+  const setSortBy = useSubIssueDisplayStore((s) => s.setSortBy);
+  const setSortDirection = useSubIssueDisplayStore((s) => s.setSortDirection);
+  const sortItems: { value: SubIssueSortField; label: string }[] = SUB_ISSUE_SORT_FIELDS.map((value) => ({
+    value,
+    label: t(($) => $.display[SUB_ISSUE_SORT_LABEL_KEY[value]]),
+  }));
+  const sortLabel = t(($) => $.display[SUB_ISSUE_SORT_LABEL_KEY[sortBy]]);
 
   return (
     <Popover>
@@ -883,6 +932,55 @@ function SubIssueDisplayPopover({
         <TooltipContent side="bottom">{t(($) => $.display.tooltip)}</TooltipContent>
       </Tooltip>
       <PopoverContent align="end" className="w-56 p-0">
+        <div className="flex items-center justify-between gap-3 border-b px-3 py-2.5">
+          <span className="text-caption font-medium text-muted-foreground">
+            {t(($) => $.display.ordering_section)}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <Select<SubIssueSortField>
+              items={sortItems}
+              value={sortBy}
+              onValueChange={(value) => {
+                if (value) setSortBy(value);
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-24"
+                aria-label={t(($) => $.display.ordering_section)}
+              >
+                <SelectValue>{sortLabel}</SelectValue>
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectGroup>
+                  {sortItems.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() =>
+                setSortDirection(sortDirection === "asc" ? "desc" : "asc")
+              }
+              aria-label={
+                sortDirection === "asc"
+                  ? t(($) => $.display.ascending_title)
+                  : t(($) => $.display.descending_title)
+              }
+            >
+              {sortDirection === "asc" ? (
+                <ArrowUp className="size-3.5" />
+              ) : (
+                <ArrowDown className="size-3.5" />
+              )}
+            </Button>
+          </div>
+        </div>
         <div className="px-3 py-2.5">
           <div className="space-y-2">
             {SUB_ISSUE_ROW_PROPERTY_KEYS.map((key) => (
@@ -1688,6 +1786,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // definitions — ids from other workspaces or archived properties drop out.
   const subIssueRowProps = useSubIssueDisplayStore((s) => s.rowProperties);
   const subIssueRowPropertyIds = useSubIssueDisplayStore((s) => s.rowPropertyIds);
+  const subIssueSortBy = useSubIssueDisplayStore((s) => s.sortBy);
+  const subIssueSortDirection = useSubIssueDisplayStore((s) => s.sortDirection);
+  const sortedChildIssues = useMemo(
+    () => sortSubIssues(childIssues, subIssueSortBy, subIssueSortDirection),
+    [childIssues, subIssueSortBy, subIssueSortDirection],
+  );
   // Store-backed (not useState) so the collapsed state survives leaving the
   // issue and navigating back within the session.
   const subIssuesCollapsed = useSubIssuesCollapseStore((s) =>
@@ -2840,7 +2944,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
                 {/* List */}
                 {!subIssuesCollapsed && (() => {
-                  const groups = groupSubIssuesByStage(childIssues);
+                  const groups = groupSubIssuesByStage(sortedChildIssues);
                   const staged = childIssues.some((c) => c.stage != null);
                   return (
                     <div className="overflow-hidden rounded-lg border bg-card/30 divide-y divide-border/60">


### PR DESCRIPTION
## What does this PR do?

The issue detail sub-issue panel currently inherits the API stable issue-number order. Priority is visible on each row, but the panel has no ordering control, so urgent and high-priority work remains scattered through large child lists.

This PR adds a persisted **Ordering** control to the existing sub-issue display settings. Users can keep the existing created order or sort by priority, then switch between ascending and descending order.

The implementation keeps the server response stable and treats ordering as a personal presentation preference. Priority uses the canonical application rank: urgent, high, medium, low, then no priority. Stage grouping remains authoritative: stages stay in ascending order and priority sorting applies only within each stage. Equal-priority siblings fall back to issue number for deterministic realtime updates.

## Related Issue

No exact open issue or PR was found after searching the tracker. Related historical context: #4232 established stable issue-number ordering for sub-issues.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/stores/sub-issue-display-store.ts`: persist a typed sub-issue sort field and direction, with validated fallback for old or invalid stored values.
- `packages/views/issues/components/issue-detail.tsx`: add ordering controls and immutable client-side sorting before stage grouping.
- Store and issue-detail tests cover defaults, persistence controls, canonical priority order, stable tie-breaking, and stage semantics.

## How to Test

1. Open an issue with child issues across multiple priorities.
2. Open the sub-issue **Display settings**, set **Ordering** to **Priority**, and verify urgent and high-priority children move to the top.
3. Toggle the direction button and verify the order reverses; reload and verify the preference persists.
4. Add stages and verify stage groups remain ordered while children are priority-sorted inside each stage.

Automated verification:

- `pnpm typecheck`: 6/6 workspace tasks passed.
- `pnpm test`: 5/5 workspace tasks passed under the repository Node 22 toolchain.
- Targeted tests: 65/65 passed.
- `@multica/core` and `@multica/views` lint: 0 errors. The 24 reported warnings are pre-existing and outside the changed files.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

The request was to make a large sub-issue list sortable by priority. Codex traced the backend list order through React Query into the issue-detail renderer, searched existing issues and PRs for overlap, added regression coverage first, then implemented a persisted view preference and stage-aware client sorting. It ran targeted tests, full workspace tests, type checks, and lint before submission.

## Screenshots (optional)

The supplied before-state screenshot shows priorities interleaved in a 30-item sub-issue list. An isolated local browser stack could not be completed because the shared Docker daemon was occupied by unrelated builds; automated UI interaction tests cover the new display controls and rendered row order.