### PR TITLE
perf(issues): resolve bare identifiers via point lookup instead of full-text search (MUL-6268)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -918,8 +918,20 @@ export class ApiClient {
     });
   }
 
-  async getIssue(id: string): Promise<Issue> {
-    return this.fetch(`/api/issues/${id}`);
+  /**
+   * Fetch one issue by UUID **or** by bare identifier ("MUL-123"): the server
+   * resolves `PREFIX-NUMBER` against the workspace's own prefix through the
+   * unique `(workspace_id, number)` index, and 404s on a wrong prefix or a
+   * missing number.
+   *
+   * `signal` is optional so cancel-on-unmount callers (identifier autolink
+   * resolution) can abort an in-flight lookup the same way search does.
+   */
+  async getIssue(id: string, options?: { signal?: AbortSignal }): Promise<Issue> {
+    return this.fetch(
+      `/api/issues/${encodeURIComponent(id)}`,
+      options?.signal ? { signal: options.signal } : undefined,
+    );
   }
 
   async createIssue(data: CreateIssueRequest): Promise<Issue> {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -277,6 +277,7 @@ import {
   UNREADABLE_CRON_PREVIEW_RESPONSE,
   ListIssuesResponseSchema,
   CreateIssueResponseSchema,
+  IssueSchema,
   ListWebhookDeliveriesResponseSchema,
   RuntimeHourlyActivityListSchema,
   RuntimeUsageByAgentListSchema,
@@ -926,12 +927,28 @@ export class ApiClient {
    *
    * `signal` is optional so cancel-on-unmount callers (identifier autolink
    * resolution) can abort an in-flight lookup the same way search does.
+   *
+   * The 2xx body is validated, not cast. A single issue is not a list: there
+   * is no safe-empty shape to degrade to, and the identifier-autolink caller
+   * caches this result for 5 minutes, so a field-missing or type-drifted 200
+   * must not become a truthy issue with an `undefined` id. Like createIssue,
+   * an unusable body fails the call — and it fails with a plain Error, never
+   * an ApiError 404, so `issueIdentifierOptions` propagates it instead of
+   * caching it as "no such issue".
    */
   async getIssue(id: string, options?: { signal?: AbortSignal }): Promise<Issue> {
-    return this.fetch(
+    const raw = await this.fetch<unknown>(
       `/api/issues/${encodeURIComponent(id)}`,
       options?.signal ? { signal: options.signal } : undefined,
     );
+    const issue = parseWithFallback<Issue | null>(raw, IssueSchema, null, {
+      endpoint: "GET /api/issues/:id",
+    });
+    if (!issue) {
+      // parseWithFallback already logged the zod issues + raw payload.
+      throw new Error("GET /api/issues/:id returned a malformed issue");
+    }
+    return issue;
   }
 
   async createIssue(data: CreateIssueRequest): Promise<Issue> {

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { ApiClient } from "./client";
+import { ApiClient, ApiError } from "./client";
 import { parseWithFallback } from "./schema";
 
 // Helper: stub fetch with a single JSON response. Status defaults to 200.
@@ -126,6 +126,73 @@ describe("ApiClient schema fallback", () => {
       const client = new ApiClient("https://api.example.test");
       const res = await client.listIssues();
       expect(res).toEqual({ issues: [], total: 0 });
+    });
+  });
+
+  describe("getIssue", () => {
+    // Unlike a list, a single issue has no safe-empty shape, and the bare
+    // identifier autolink caches this result for 5 minutes. A malformed 2xx
+    // must therefore fail the call instead of becoming a truthy issue with an
+    // `undefined` id — and it must fail with something OTHER than an
+    // ApiError 404, which `issueIdentifierOptions` maps to "no such issue".
+    const validIssue = {
+      id: "issue-1",
+      workspace_id: "ws-1",
+      number: 1,
+      identifier: "MUL-1",
+      title: "Existing",
+      description: null,
+      status: "todo",
+      priority: "none",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 0,
+      start_date: null,
+      due_date: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    it("resolves a well-formed issue, defaulting the fields older servers omit", async () => {
+      stubFetchJson({ ...validIssue, unknown_field: "kept" });
+      const client = new ApiClient("https://api.example.test");
+      const issue = await client.getIssue("MUL-1");
+      expect(issue.id).toBe("issue-1");
+      expect(issue.stage).toBeNull();
+      expect(issue.metadata).toEqual({});
+      expect(issue.properties).toEqual({});
+    });
+
+    it("rejects a 200 body that is not a usable issue (no truthy issue with an undefined id)", async () => {
+      stubFetchJson({ not: "an issue" });
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.getIssue("MUL-1")).rejects.toThrow();
+    });
+
+    it("rejects a 200 body whose required field drifted type", async () => {
+      stubFetchJson({ ...validIssue, number: "1" });
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.getIssue("MUL-1")).rejects.toThrow();
+    });
+
+    it("does not disguise a malformed body as a 404", async () => {
+      stubFetchJson({ id: "issue-1" });
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.getIssue("MUL-1")).rejects.not.toBeInstanceOf(
+        ApiError,
+      );
+    });
+
+    it("still surfaces a real 404 as an ApiError so autolink can resolve to null", async () => {
+      stubFetchJson({ error: "issue not found" }, 404);
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.getIssue("TES-1")).rejects.toMatchObject({
+        status: 404,
+      });
     });
   });
 

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -2,14 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 
 import { setApiInstance } from "../api";
-import type { ApiClient } from "../api/client";
+import { ApiError, type ApiClient } from "../api/client";
 import type {
   Issue,
   IssueTableRowsRequest,
   IssueTableRowsResponse,
   ListIssuesParams,
   ListIssuesResponse,
-  SearchIssuesResponse,
 } from "../types";
 import {
   CHILDREN_BY_PARENTS_CHUNK_SIZE,
@@ -72,14 +71,10 @@ function installFakeChildApi(
   setApiInstance({ listChildIssues } as unknown as ApiClient);
 }
 
-function installFakeSearchApi(
-  searchIssues: (params: { q: string }) => Promise<SearchIssuesResponse>,
+function installFakeIssueApi(
+  getIssue: (id: string, options?: { signal?: AbortSignal }) => Promise<Issue>,
 ) {
-  setApiInstance({ searchIssues } as unknown as ApiClient);
-}
-
-function makeSearchResult(idx: number, identifier: string) {
-  return { ...makeIssue(idx), identifier, match_source: "title" as const };
+  setApiInstance({ getIssue } as unknown as ApiClient);
 }
 
 describe("childIssuesOptions", () => {
@@ -509,47 +504,51 @@ describe("issueIdentifierOptions", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns the issue whose identifier exactly matches the query", async () => {
-    const searchIssues = vi
-      .fn<(params: { q: string }) => Promise<SearchIssuesResponse>>()
-      .mockResolvedValue({
-        issues: [makeSearchResult(7, "MUL-7")],
-        total: 1,
-      });
-    installFakeSearchApi(searchIssues);
+  it("resolves the identifier through the exact-lookup endpoint, not search", async () => {
+    const getIssue = vi
+      .fn<(id: string, options?: { signal?: AbortSignal }) => Promise<Issue>>()
+      .mockResolvedValue(makeIssue(7));
+    installFakeIssueApi(getIssue);
 
     const data = await qc.fetchQuery(issueIdentifierOptions(WS_ID, "MUL-7"));
 
     expect(data?.id).toBe("issue-7");
-    expect(searchIssues).toHaveBeenCalledWith(
-      expect.objectContaining({ q: "MUL-7" }),
-    );
+    expect(getIssue).toHaveBeenCalledTimes(1);
+    expect(getIssue.mock.calls[0]?.[0]).toBe("MUL-7");
   });
 
-  it("returns null when no result's identifier matches (wrong prefix / number-only hit)", async () => {
-    // Backend number-match returns MUL-7 for a TES-7 query; exact filter rejects it.
-    const searchIssues = vi
-      .fn<(params: { q: string }) => Promise<SearchIssuesResponse>>()
-      .mockResolvedValue({
-        issues: [makeSearchResult(7, "MUL-7")],
-        total: 1,
-      });
-    installFakeSearchApi(searchIssues);
+  it("returns null on 404 (unknown number or wrong workspace prefix)", async () => {
+    // The server enforces the prefix now: TES-7 in a MUL workspace 404s.
+    const getIssue = vi
+      .fn<(id: string) => Promise<Issue>>()
+      .mockRejectedValue(new ApiError("issue not found", 404, "Not Found"));
+    installFakeIssueApi(getIssue);
 
     const data = await qc.fetchQuery(issueIdentifierOptions(WS_ID, "TES-7"));
 
     expect(data).toBeNull();
   });
 
-  it("returns null on an empty (or malformed→empty) search response", async () => {
-    const searchIssues = vi
-      .fn<(params: { q: string }) => Promise<SearchIssuesResponse>>()
-      .mockResolvedValue({ issues: [], total: 0 });
-    installFakeSearchApi(searchIssues);
+  it("propagates non-404 failures instead of caching them as 'no such issue'", async () => {
+    const getIssue = vi
+      .fn<(id: string) => Promise<Issue>>()
+      .mockRejectedValue(new ApiError("boom", 500, "Internal Server Error"));
+    installFakeIssueApi(getIssue);
 
-    const data = await qc.fetchQuery(issueIdentifierOptions(WS_ID, "MUL-999"));
+    await expect(
+      qc.fetchQuery(issueIdentifierOptions(WS_ID, "MUL-9")),
+    ).rejects.toThrow("boom");
+  });
 
-    expect(data).toBeNull();
+  it("passes the query's abort signal down so unmount cancels the lookup", async () => {
+    const getIssue = vi
+      .fn<(id: string, options?: { signal?: AbortSignal }) => Promise<Issue>>()
+      .mockResolvedValue(makeIssue(7));
+    installFakeIssueApi(getIssue);
+
+    await qc.fetchQuery(issueIdentifierOptions(WS_ID, "MUL-7"));
+
+    expect(getIssue.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("keys the query by workspace and identifier", () => {

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -4,7 +4,7 @@ import {
   queryOptions,
   type QueryClient,
 } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import type {
   Issue,
   IssueAssigneeType,
@@ -413,11 +413,18 @@ export function issueDetailOptions(wsId: string, id: string) {
 /**
  * Resolve a bare issue identifier ("MUL-123") to its issue, or `null`.
  *
- * Backs the Linear-style autolink: the backend `q` search matches an
- * identifier on issue NUMBER only (prefix-agnostic — `MUL-123` and `TES-123`
- * both hit number 123), so the exact `identifier === value` filter here is
- * what enforces the workspace prefix. A non-existent or wrong-prefix
- * identifier resolves to `null` and renders as plain text.
+ * Backs the Linear-style autolink. This is an EXACT lookup, so it goes to
+ * `GET /api/issues/{identifier}` — the server parses `PREFIX-NUMBER`, checks
+ * the prefix against the workspace's own `issue_prefix`, and reads the issue
+ * through the unique `(workspace_id, number)` index. A non-existent or
+ * wrong-prefix identifier 404s, which maps to `null` here and renders as
+ * plain text — the same contract the previous implementation had.
+ *
+ * It deliberately does NOT use `/api/issues/search`: that endpoint runs the
+ * workspace-wide full-text query (title/description/comment `LIKE`, ranking,
+ * snippet subquery, `COUNT(*) OVER()`) which is orders of magnitude more
+ * expensive than a point read, and autolink resolution was the dominant
+ * caller of it (MUL-6268).
  *
  * Server state → TanStack Query; the key includes `wsId` and the identifier,
  * so identical identifiers across the app share one request. Caller gates
@@ -427,13 +434,15 @@ export function issueIdentifierOptions(wsId: string, identifier: string) {
   return queryOptions({
     queryKey: issueKeys.identifier(wsId, identifier),
     queryFn: async ({ signal }) => {
-      const res = await api.searchIssues({
-        q: identifier,
-        limit: 10,
-        include_closed: true,
-        signal,
-      });
-      return res.issues.find((i) => i.identifier === identifier) ?? null;
+      try {
+        return await api.getIssue(identifier, { signal });
+      } catch (err) {
+        // Unknown identifier / wrong workspace prefix → render as plain text.
+        // Any other failure (401/5xx/abort) must keep propagating so the query
+        // is retried or cancelled instead of being cached as "no such issue".
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
     },
     // Identifier→issue mapping is effectively immutable; avoid refetch churn
     // when the same key renders across many comments/messages.


### PR DESCRIPTION
Multica issue: MUL-6268 (`e2799d87-0ac3-4e60-81c4-5b002e9779aa`)

## Background

`GET /api/issues/search` runs the workspace-wide full-text query — `LOWER(title/description) LIKE`, comment `EXISTS`, ranking, snippet subquery, `COUNT(*) OVER()` — and is currently taking ~186k calls / 24h (2.16 req/s avg, 10.4 req/s 5-min peak, P95 1.49s, ~730 `503` statement timeouts/day, +86% week over week).

The investigation on MUL-6268 traced the bulk of that traffic to the Linear-style bare-identifier autolink, not to user-initiated search: `/api/projects/search`, which fires alongside Cmd+K global search, only saw 343 calls in the same window, and 82/83 queries in a recent cancelled-request sample were complete `PREFIX-NUMBER` tokens. So the most expensive read path in the app is being used as an exact-lookup endpoint.

## Change

`issueIdentifierOptions` now resolves through `GET /api/issues/{identifier}` instead of search. That endpoint already existed and already does the right thing: `resolveIssueByIdentifier` splits `PREFIX-NUMBER`, requires the prefix to match the workspace's own `issue_prefix`, and reads via the unique `(workspace_id, number)` index.

- `api.getIssue` gained an optional `AbortSignal` so cancel-on-unmount behaves as before.
- `404` → `null`, so an unknown number or wrong-prefix token still renders as plain text. The prefix rule that used to be enforced client-side by `issues.find(i => i.identifier === identifier)` is now enforced server-side by the same endpoint that backs `/{ws}/issues/{key}` URLs.
- Non-404 failures (401/5xx/abort) keep propagating instead of being cached for 5 minutes as "no such issue".
- Detection stays uppercase-only (`ISSUE_IDENTIFIER_PATTERN`), so the case-insensitive server resolution introduces no new autolinks.

No server, SQL, schema, migration or response-contract change. Frontend-only and independently revertible; old and new clients hit unchanged endpoints, so there is no deploy ordering requirement.

## Verification

- `pnpm vitest run issues/queries.test.ts` in `packages/core` — 17 passed. Tests rewritten for the new path: exact lookup is called with the identifier (and not search), 404 → `null`, 500 propagates, and the query's abort signal reaches the client.
- `pnpm turbo typecheck --filter=@multica/core --filter=@multica/views` — 3 successful (incl. `@multica/ui`).
- `pnpm turbo lint --filter=@multica/core` — clean. `git diff --check` clean.
- Autolink render paths: `packages/views` `rich-content/*`, `editor/readonly-content.test.tsx`, `common/rich-content-sanitize-contract.test.tsx` — 147 passed.
- Full `packages/core` suite: 1395 passed, 8 failed in `realtime/use-realtime-sync-ws-instance.test.tsx`, `projects/mutations.test.tsx`, `workspace/mutations.test.tsx`. Verified pre-existing — the same 8 fail on unmodified `origin/main` (`git stash` baseline run), and none touch this code path.

## Follow-ups (not in this PR)

1. `POST /api/issues/resolve-identifiers` batch resolve, to collapse the remaining HTTP N+1 when one document mentions many distinct identifiers.
2. Make search's `COUNT(*) OVER()` opt-in (`include_total=true`) after confirming no external caller depends on `total`.
3. Add a bounded `purpose` dimension to search callers, and record `context.Canceled` as client-cancel/499 instead of 500 — 13.8% of that endpoint's responses are currently 500s that are really client aborts.

## Post-deploy check

Compare 24h `/api/issues/search` call volume, `GET /api/issues/{id}` volume, DB load, P95/P99 and 503 count against the numbers above.
