### PR TITLE
MUL-6272: generate the command palette's Pages group from the nav registry

### DIFF
--- a/packages/views/locales/en/search.json
+++ b/packages/views/locales/en/search.json
@@ -11,16 +11,6 @@
     "cancelled": "Cancelled",
     "recent": "Recent"
   },
-  "pages": {
-    "inbox": "Inbox",
-    "my_issues": "My Issues",
-    "issues": "Issues",
-    "projects": "Projects",
-    "agents": "Agents",
-    "runtimes": "Runtimes",
-    "skills": "Skills",
-    "settings": "Settings"
-  },
   "commands": {
     "current_theme_aria": "Current theme",
     "new_issue": "New Issue",

--- a/packages/views/locales/ja/search.json
+++ b/packages/views/locales/ja/search.json
@@ -11,16 +11,6 @@
     "cancelled": "キャンセル済み",
     "recent": "最近の項目"
   },
-  "pages": {
-    "inbox": "インボックス",
-    "my_issues": "マイタスク",
-    "issues": "タスク",
-    "projects": "プロジェクト",
-    "agents": "エージェント",
-    "runtimes": "ランタイム",
-    "skills": "スキル",
-    "settings": "設定"
-  },
   "commands": {
     "current_theme_aria": "現在のテーマ",
     "new_issue": "新規タスク",

--- a/packages/views/locales/ko/search.json
+++ b/packages/views/locales/ko/search.json
@@ -11,16 +11,6 @@
     "cancelled": "취소됨",
     "recent": "최근 항목"
   },
-  "pages": {
-    "inbox": "인박스",
-    "my_issues": "내 태스크",
-    "issues": "태스크",
-    "projects": "프로젝트",
-    "agents": "에이전트",
-    "runtimes": "런타임",
-    "skills": "스킬",
-    "settings": "설정"
-  },
   "commands": {
     "current_theme_aria": "현재 테마",
     "new_issue": "새 태스크",

--- a/packages/views/locales/zh-Hans/search.json
+++ b/packages/views/locales/zh-Hans/search.json
@@ -11,16 +11,6 @@
     "cancelled": "已取消",
     "recent": "最近"
   },
-  "pages": {
-    "inbox": "收件箱",
-    "my_issues": "我的任务",
-    "issues": "任务",
-    "projects": "项目",
-    "agents": "智能体",
-    "runtimes": "运行时",
-    "skills": "Skills",
-    "settings": "设置"
-  },
   "commands": {
     "current_theme_aria": "当前主题",
     "new_issue": "新建任务",

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -3,15 +3,25 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
+import { WORKSPACE_PAGES } from "@multica/core/paths";
 import { SearchCommand } from "./search-command";
 import { useSearchStore } from "./search-store";
 import enCommon from "../locales/en/common.json";
 import enAuth from "../locales/en/auth.json";
 import enSettings from "../locales/en/settings.json";
 import enSearch from "../locales/en/search.json";
+// The palette labels its Pages group from the sidebar's own nav strings, so
+// the layout namespace is part of its contract, not incidental setup.
+import enLayout from "../locales/en/layout.json";
 
 const TEST_RESOURCES = {
-  en: { common: enCommon, auth: enAuth, settings: enSettings, search: enSearch },
+  en: {
+    common: enCommon,
+    auth: enAuth,
+    settings: enSettings,
+    search: enSearch,
+    layout: enLayout,
+  },
 };
 
 function I18nWrapper({ children }: { children: ReactNode }) {
@@ -166,10 +176,14 @@ vi.mock("@multica/core/paths", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@multica/core/paths")>()),
   useWorkspacePaths: () => ({
     inbox: () => "/ws-test/inbox",
+    chat: () => "/ws-test/chat",
     myIssues: () => "/ws-test/my-issues",
     issues: () => "/ws-test/issues",
     projects: () => "/ws-test/projects",
+    autopilots: () => "/ws-test/autopilots",
     agents: () => "/ws-test/agents",
+    squads: () => "/ws-test/squads",
+    usage: () => "/ws-test/usage",
     runtimes: () => "/ws-test/runtimes",
     skills: () => "/ws-test/skills",
     settings: () => "/ws-test/settings",
@@ -336,6 +350,60 @@ describe("SearchCommand", () => {
       expect(screen.getByText((_, el) => el?.textContent === "Settings" && el?.tagName === "SPAN")).toBeInTheDocument();
     });
     expect(screen.queryByText("Inbox")).not.toBeInTheDocument();
+  });
+
+  it("offers every workspace nav page, not a hand-maintained subset", async () => {
+    const user = userEvent.setup();
+    renderSearch();
+    const input = screen.getByPlaceholderText("Type a command or search...");
+
+    // The Pages group is generated from WORKSPACE_PAGES — the same registry
+    // the sidebar and the desktop tab bar read — so searching a page by the
+    // exact name the sidebar shows must always reach it. The hand-written
+    // list this replaced had gone stale by four pages (MUL-6272).
+    for (const page of Object.values(WORKSPACE_PAGES)) {
+      const label = enLayout.nav[page.navKey];
+      await user.clear(input);
+      await user.type(input, label);
+      expect(
+        await screen.findByText(
+          (_, el) => el?.textContent === label && el?.tagName === "SPAN",
+        ),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("does not surface a page on an incidental substring of a hidden keyword", async () => {
+    const user = userEvent.setup();
+    renderSearch();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "s");
+
+    // Inbox carries the hidden keyword "notifications". Matching keywords by
+    // substring made a bare "s" pull Inbox into the list with nothing on the
+    // row to explain why; keywords match by prefix instead.
+    await waitFor(() => {
+      expect(
+        screen.getByText((_, el) => el?.textContent === "Settings" && el?.tagName === "SPAN"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Inbox")).not.toBeInTheDocument();
+  });
+
+  it("navigates to a page whose label differs from its route segment", async () => {
+    const user = userEvent.setup();
+    renderSearch();
+
+    // Analytics lives at /usage: proof the row resolves its destination from
+    // the page key rather than from the words on screen.
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "analytics");
+
+    await user.click(await screen.findByText("Analytics"));
+
+    expect(mockPush).toHaveBeenCalledWith("/ws-test/usage");
+    expect(useSearchStore.getState().open).toBe(false);
   });
 
   it("navigates to page on selection", async () => {

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -1161,4 +1161,93 @@ describe("SearchCommand", () => {
       expect(renderedHeadings()).not.toContain("Cancelled");
     });
   });
+
+  // Rows from the previous query stay on screen while the next request is in
+  // flight (that is what keeps the list from strobing on every keystroke), so
+  // they have to stop being *reachable*. cmdk re-selects the first valid item
+  // on every input change, so a live stale row means Enter opens a result the
+  // user is no longer searching for.
+  describe("stale results while the next query is in flight", () => {
+    const alphaIssue = {
+      id: "issue-alpha",
+      workspace_id: "ws-test",
+      number: 100,
+      identifier: "MUL-100",
+      title: "Alpha result",
+      description: null,
+      status: "todo",
+      priority: "none",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 0,
+      start_date: null,
+      due_date: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      match_source: "title",
+    };
+
+    /** HighlightText splits the title into <mark> + text, so match the span. */
+    const alphaRowTitle = () =>
+      screen.getByText(
+        (_, el) => el?.textContent === "Alpha result" && el?.tagName === "SPAN",
+      );
+
+    /** Resolve the first query; hang on everything after it. */
+    const answerOnlyAlpha = () => {
+      mockSearchIssues.mockImplementation(({ q }: { q: string }) =>
+        q === "alpha"
+          ? Promise.resolve({ issues: [alphaIssue], total: 1 })
+          : new Promise(() => {}),
+      );
+      mockSearchProjects.mockImplementation(({ q }: { q: string }) =>
+        q === "alpha"
+          ? Promise.resolve({ projects: [], total: 0 })
+          : new Promise(() => {}),
+      );
+    };
+
+    const typeAlphaThenChange = async (
+      user: ReturnType<typeof userEvent.setup>,
+    ) => {
+      answerOnlyAlpha();
+      renderSearch();
+      const input = screen.getByPlaceholderText("Type a command or search...");
+      await user.type(input, "alpha");
+      await waitFor(
+        () => {
+          expect(alphaRowTitle()).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+      // Query changes; the response for it never arrives.
+      await user.type(input, "zzz");
+      return input;
+    };
+
+    it("does not open the previous query's result on Enter", async () => {
+      const user = userEvent.setup();
+      const input = await typeAlphaThenChange(user);
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(useSearchStore.getState().open).toBe(true);
+    });
+
+    it("does not open the previous query's result on click", async () => {
+      const user = userEvent.setup();
+      await typeAlphaThenChange(user);
+
+      // Still painted (that is the point), but inert.
+      fireEvent.click(alphaRowTitle());
+
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(useSearchStore.getState().open).toBe(true);
+    });
+  });
 });

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -37,8 +37,8 @@ import {
 } from "@multica/core/issues/stores";
 import { issueDetailOptions, issueTimelineOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core";
-import { useWorkspacePaths } from "@multica/core/paths";
-import type { WorkspacePaths } from "@multica/core/paths";
+import { useWorkspacePaths, WORKSPACE_PAGES } from "@multica/core/paths";
+import type { WorkspacePageKey, WorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { createShortcutChord } from "@multica/core/shortcuts";
 import { memberListOptions } from "@multica/core/workspace/queries";
@@ -72,24 +72,42 @@ import { matchesPinyin } from "../editor/extensions/pinyin-match";
 import { HighlightText } from "./highlight-text";
 import { useSearchStore } from "./search-store";
 
-// Nav items reference WorkspacePaths method names so they can be resolved
-// against the current workspace slug at render time (see SearchCommand body).
-// Only parameterless paths are valid nav destinations.
-type NavKey =
-  | "inbox"
-  | "myIssues"
-  | "issues"
-  | "projects"
-  | "agents"
-  | "runtimes"
-  | "skills"
-  | "settings";
+// The palette's Pages group is generated from WORKSPACE_PAGES, the same
+// registry the sidebar nav and the desktop tab bar read. It used to be a
+// hand-written list, which silently went stale every time a page was added:
+// Chat, Autopilot, Squads and Analytics shipped in the sidebar but were
+// unreachable from the palette (MUL-6272). Deriving the list means a new
+// workspace page is in the palette the moment it is in the registry.
+//
+// Page keys double as WorkspacePaths method names, so `p[key]()` resolves the
+// destination against the current workspace slug at render time. Every
+// WorkspacePageKey must therefore stay a parameterless path builder.
+
+// Extra query aliases per page, on top of the localized label. Declared as a
+// total Record so adding a workspace page is a compile error until its
+// keywords are filled in.
+const PAGE_KEYWORDS: Record<WorkspacePageKey, string[]> = {
+  inbox: ["inbox", "notifications", "收件箱", "通知"],
+  chat: ["chat", "messages", "conversation", "聊天", "消息", "对话"],
+  myIssues: ["my", "issues", "assigned", "mine", "我的", "任务"],
+  issues: ["issues", "tasks", "bugs", "任务"],
+  projects: ["projects", "kanban", "项目"],
+  autopilots: ["autopilot", "autopilots", "automation", "schedule", "cron", "webhook", "自动化", "定时"],
+  agents: ["agents", "bots", "ai", "智能体"],
+  squads: ["squads", "teams", "小队", "团队"],
+  usage: ["usage", "analytics", "stats", "metrics", "统计", "分析", "用量"],
+  runtimes: ["runtimes", "environments", "machines", "运行时"],
+  skills: ["skills", "library", "技能"],
+  settings: ["settings", "config", "preferences", "设置", "配置"],
+};
+
+const NAV_PAGE_KEYS = Object.keys(WORKSPACE_PAGES) as WorkspacePageKey[];
 
 // No `icon` field: like the sidebar nav, a page's icon is derived from its
 // destination path via routeIconForPath, so all navigation surfaces show the
 // same icon for the same route.
 interface NavPage {
-  key: NavKey;
+  key: WorkspacePageKey;
   label: string;
   keywords: string[];
 }
@@ -103,6 +121,24 @@ function memberInitials(name: string) {
     .join("")
     .toUpperCase()
     .slice(0, 2);
+}
+
+// Row matcher shared by the Pages and Commands groups.
+//
+// Keywords match by prefix, not substring. They are invisible synonyms, so a
+// substring hit reads as a bug from the outside: "s" used to surface Inbox
+// (via "notifications") and "i" surfaced nearly every page. The visible label
+// still matches anywhere, because there the user can see what they hit.
+//
+// Pinyin is included for the same reason member search has it: under a Chinese
+// UI the localized label is the only thing the user can aim at, so typing
+// "renwu" has to reach "任务".
+function matchesRow(label: string, keywords: string[], query: string) {
+  return (
+    label.toLowerCase().includes(query) ||
+    keywords.some((kw) => kw.startsWith(query)) ||
+    matchesPinyin(label, query)
+  );
 }
 
 function matchesMember(member: MemberWithUser, query: string) {
@@ -240,18 +276,28 @@ interface SearchResults {
   projects: SearchProjectResult[];
 }
 
+// One heading treatment for every group. Headings go through cmdk's `heading`
+// prop rather than a hand-rolled div: cmdk renders it into a
+// [cmdk-group-heading] node and points the group's aria-labelledby at it, so a
+// screen reader announces which group a row belongs to.
+const GROUP_CLASS =
+  "p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground";
+
 export function SearchCommand() {
   const { t } = useT("search");
-  const navPages: NavPage[] = [
-    { key: "inbox", label: t(($) => $.pages.inbox), keywords: ["inbox", "notifications", "收件箱"] },
-    { key: "myIssues", label: t(($) => $.pages.my_issues), keywords: ["my", "issues", "assigned", "我的"] },
-    { key: "issues", label: t(($) => $.pages.issues), keywords: ["issues", "tasks", "bugs"] },
-    { key: "projects", label: t(($) => $.pages.projects), keywords: ["projects", "kanban", "项目"] },
-    { key: "agents", label: t(($) => $.pages.agents), keywords: ["agents", "bots", "ai"] },
-    { key: "runtimes", label: t(($) => $.pages.runtimes), keywords: ["runtimes", "environments"] },
-    { key: "skills", label: t(($) => $.pages.skills), keywords: ["skills", "library"] },
-    { key: "settings", label: t(($) => $.pages.settings), keywords: ["settings", "config", "preferences", "设置"] },
-  ];
+  // Page names come from the sidebar's own namespace rather than a private
+  // copy under `search.pages`: one translated string per page, so the palette
+  // can never disagree with the sidebar about what a page is called.
+  const { t: tNav } = useT("layout");
+  const navPages = useMemo<NavPage[]>(
+    () =>
+      NAV_PAGE_KEYS.map((key) => ({
+        key,
+        label: tNav(($) => $.nav[WORKSPACE_PAGES[key].navKey]),
+        keywords: PAGE_KEYWORDS[key],
+      })),
+    [tNav],
+  );
   const { pathname, getShareableUrl } = useNavigation();
   const intentNavigate = useIntentNavigate();
   const open = useSearchStore((s) => s.open);
@@ -283,8 +329,13 @@ export function SearchCommand() {
   // typically already in the detail cache because the user has opened them;
   // if not, this triggers a lookup per id so Recent never depends on whether
   // the issue falls inside the paginated list cache.
+  //
+  // Gated on `open`: the palette is mounted for the whole session, and the
+  // store keeps up to 20 recent ids, so an ungated list fired up to 20 issue
+  // detail requests on every cold app load for a surface the user may never
+  // open.
   const recentDetailQueries = useQueries({
-    queries: recentItems.map((item) => issueDetailOptions(wsId, item.id)),
+    queries: open ? recentItems.map((item) => issueDetailOptions(wsId, item.id)) : [],
   });
   const recentIssues = useMemo(
     () =>
@@ -301,12 +352,8 @@ export function SearchCommand() {
   const filteredPages = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
-    return navPages.filter(
-      (page) =>
-        page.label.toLowerCase().includes(q) ||
-        page.keywords.some((kw) => kw.includes(q)),
-    );
-  }, [query]);
+    return navPages.filter((page) => matchesRow(page.label, page.keywords, q));
+  }, [navPages, query]);
 
   // Detect if current route is an issue detail page — /{slug}/issues/{id}.
   // Falls back to null on any other route; used to gate issue-specific commands.
@@ -468,11 +515,7 @@ export function SearchCommand() {
     // (theme switches, copy actions, New Project) are revealed as the user
     // types, leaving the empty-state space to Recent.
     if (!q) return commands.filter((c) => c.key === "new-issue");
-    return commands.filter(
-      (c) =>
-        c.label.toLowerCase().includes(q) ||
-        c.keywords.some((kw) => kw.includes(q)),
-    );
+    return commands.filter((c) => matchesRow(c.label, c.keywords, q));
   }, [commands, query]);
 
   const filteredMembers = useMemo(() => {
@@ -603,7 +646,7 @@ export function SearchCommand() {
   );
 
   const handlePageSelect = useCallback(
-    (key: NavKey) => {
+    (key: WorkspacePageKey) => {
       setOpen(false);
       intentNavigate(p[key](), consumeIntent());
     },
@@ -673,10 +716,10 @@ export function SearchCommand() {
           <CommandPrimitive.List className="max-h-[min(400px,50vh)] overflow-y-auto overflow-x-hidden">
             {/* Pages section — only shown when query matches */}
             {filteredPages.length > 0 && (
-              <CommandPrimitive.Group className="p-2">
-                <div className="px-3 py-1.5 text-caption font-medium text-muted-foreground">
-                  {t(($) => $.groups.pages)}
-                </div>
+              <CommandPrimitive.Group
+                heading={t(($) => $.groups.pages)}
+                className={GROUP_CLASS}
+              >
                 {filteredPages.map((page) => {
                   const PageIcon = routeIconForPath(p[page.key]());
                   return (
@@ -698,10 +741,10 @@ export function SearchCommand() {
 
             {/* Commands section — New Issue / New Project / Copy link / Theme, only shown when query matches */}
             {filteredCommands.length > 0 && (
-              <CommandPrimitive.Group className="p-2">
-                <div className="px-3 py-1.5 text-caption font-medium text-muted-foreground">
-                  {t(($) => $.groups.commands)}
-                </div>
+              <CommandPrimitive.Group
+                heading={t(($) => $.groups.commands)}
+                className={GROUP_CLASS}
+              >
                 {filteredCommands.map((cmd) => (
                   <CommandPrimitive.Item
                     key={cmd.key}
@@ -720,10 +763,10 @@ export function SearchCommand() {
             )}
 
             {filteredMembers.length > 0 && (
-              <CommandPrimitive.Group className="p-2">
-                <div className="px-3 py-1.5 text-caption font-medium text-muted-foreground">
-                  {t(($) => $.groups.members)}
-                </div>
+              <CommandPrimitive.Group
+                heading={t(($) => $.groups.members)}
+                className={GROUP_CLASS}
+              >
                 {filteredMembers.map((member) => (
                   <CommandPrimitive.Item
                     key={member.user_id}
@@ -750,7 +793,15 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {isLoading && (
+            {/*
+              Spinner only while there is nothing to look at. isLoading flips
+              on the keystroke, before the 300ms debounce even fires, so
+              swapping the whole result list for a spinner on every character
+              made the list strobe while typing. Keeping the previous query's
+              rows until the next response lands is the standard trade: they
+              are one keystroke stale for a moment, instead of gone.
+            */}
+            {isLoading && !hasResults && (
               <div className="flex items-center justify-center py-10">
                 <Loader2 className="size-5 animate-spin text-muted-foreground" />
               </div>
@@ -778,10 +829,10 @@ export function SearchCommand() {
               type can precede a live row of the other. Direct hits stay in
               their live section (see partitionAggregatedSearchResults).
             */}
-            {!isLoading && partitionedResults.liveProjects.length > 0 && (
+            {partitionedResults.liveProjects.length > 0 && (
               <CommandPrimitive.Group
                 heading={t(($) => $.groups.projects)}
-                className="p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+                className={GROUP_CLASS}
               >
                 {partitionedResults.liveProjects.map((project) => (
                   <ProjectResultRow
@@ -794,10 +845,10 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {!isLoading && partitionedResults.liveIssues.length > 0 && (
+            {partitionedResults.liveIssues.length > 0 && (
               <CommandPrimitive.Group
                 heading={t(($) => $.groups.issues)}
-                className="p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+                className={GROUP_CLASS}
               >
                 {partitionedResults.liveIssues.map((issue) => (
                   <IssueResultRow
@@ -810,10 +861,10 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {!isLoading && partitionedResults.hasCancelled && (
+            {partitionedResults.hasCancelled && (
               <CommandPrimitive.Group
                 heading={t(($) => $.groups.cancelled)}
-                className="p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+                className={GROUP_CLASS}
               >
                 {partitionedResults.cancelledProjects.map((project) => (
                   <ProjectResultRow
@@ -834,12 +885,16 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {!isLoading && !query.trim() && recentIssues.length > 0 && (
-              <CommandPrimitive.Group className="p-2">
-                <div className="flex items-center gap-2 px-3 py-1.5 text-caption font-medium text-muted-foreground">
-                  <Clock className="size-3" />
-                  <span>{t(($) => $.groups.recent)}</span>
-                </div>
+            {!query.trim() && recentIssues.length > 0 && (
+              <CommandPrimitive.Group
+                heading={
+                  <>
+                    <Clock className="size-3" />
+                    <span>{t(($) => $.groups.recent)}</span>
+                  </>
+                }
+                className={`${GROUP_CLASS} [&_[cmdk-group-heading]]:flex [&_[cmdk-group-heading]]:items-center [&_[cmdk-group-heading]]:gap-2`}
+              >
                 {recentIssues.map((item) => (
                   <CommandPrimitive.Item
                     key={item.id}

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -175,16 +175,19 @@ function IssueAssigneeAvatar({
 function ProjectResultRow({
   project,
   query,
+  disabled,
   onSelect,
 }: {
   project: SearchProjectResult;
   query: string;
+  disabled?: boolean;
   onSelect: (value: string) => void;
 }) {
   return (
     <CommandPrimitive.Item
       key={`project:${project.id}`}
       value={`project:${project.id}`}
+      disabled={disabled}
       onSelect={onSelect}
       className="flex cursor-default select-none flex-col gap-1 rounded-lg px-3 py-2.5 text-body outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-accent"
     >
@@ -213,16 +216,19 @@ function ProjectResultRow({
 function IssueResultRow({
   issue,
   query,
+  disabled,
   onSelect,
 }: {
   issue: SearchIssueResult;
   query: string;
+  disabled?: boolean;
   onSelect: (value: string) => void;
 }) {
   return (
     <CommandPrimitive.Item
       key={issue.id}
       value={issue.id}
+      disabled={disabled}
       onSelect={onSelect}
       className="flex cursor-default select-none flex-col gap-1 rounded-lg px-3 py-2.5 text-body outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-accent"
     >
@@ -272,9 +278,18 @@ interface CommandItem {
 }
 
 interface SearchResults {
+  /**
+   * The trimmed query these rows answer. Rows outlive the query that fetched
+   * them — they stay painted while the next request is in flight — so every
+   * result set carries the question it is the answer to, and anything that can
+   * act on a row checks that it still matches what the user typed.
+   */
+  query: string;
   issues: SearchIssueResult[];
   projects: SearchProjectResult[];
 }
+
+const NO_RESULTS: SearchResults = { query: "", issues: [], projects: [] };
 
 // One heading treatment for every group. Headings go through cmdk's `heading`
 // prop rather than a hand-rolled div: cmdk renders it into a
@@ -344,7 +359,7 @@ export function SearchCommand() {
   );
 
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResults>({ issues: [], projects: [] });
+  const [results, setResults] = useState<SearchResults>(NO_RESULTS);
   const [isLoading, setIsLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -537,6 +552,13 @@ export function SearchCommand() {
     results.projects.length > 0 ||
     filteredMembers.length > 0;
 
+  // Rows answering an earlier query are still painted while the next request
+  // is in flight — that is what keeps the list from strobing on every
+  // keystroke — but they must not be actionable: cmdk re-selects the first
+  // valid item whenever the input changes, so a live stale row turns the next
+  // Enter into a jump to a result the user has already typed past.
+  const resultsAreStale = results.query !== query.trim();
+
   // Cross-type cancelled demotion (MUL-5824). The two searches are ranked
   // independently server-side, so the partition has to happen here, where they
   // are aggregated for display. See the render note on the results list.
@@ -545,9 +567,11 @@ export function SearchCommand() {
       partitionAggregatedSearchResults({
         issues: results.issues,
         projects: results.projects,
-        query,
+        // The partition describes these rows, so it keys off the query they
+        // answer — not what the user has typed since.
+        query: results.query,
       }),
-    [results, query],
+    [results],
   );
 
   // Close on single ESC — capture phase fires before base-ui Dialog's handlers
@@ -576,7 +600,7 @@ export function SearchCommand() {
   useEffect(() => {
     if (!open) {
       setQuery("");
-      setResults({ issues: [], projects: [] });
+      setResults(NO_RESULTS);
       setIsLoading(false);
     }
   }, [open]);
@@ -586,7 +610,7 @@ export function SearchCommand() {
     if (abortRef.current) abortRef.current.abort();
 
     if (!q.trim()) {
-      setResults({ issues: [], projects: [] });
+      setResults(NO_RESULTS);
       setIsLoading(false);
       return;
     }
@@ -612,6 +636,7 @@ export function SearchCommand() {
         ]);
         if (!controller.signal.aborted) {
           setResults({
+            query: q.trim(),
             issues: issueRes.issues,
             projects: projectRes.projects,
           });
@@ -619,6 +644,10 @@ export function SearchCommand() {
         }
       } catch {
         if (!controller.signal.aborted) {
+          // Drop the previous query's rows rather than leaving them on screen
+          // permanently greyed out: the request that would have replaced them
+          // is never coming. The list falls through to the empty state.
+          setResults({ query: q.trim(), issues: [], projects: [] });
           setIsLoading(false);
         }
       }
@@ -838,7 +867,8 @@ export function SearchCommand() {
                   <ProjectResultRow
                     key={`project:${project.id}`}
                     project={project}
-                    query={query}
+                    query={results.query}
+                    disabled={resultsAreStale}
                     onSelect={handleSelect}
                   />
                 ))}
@@ -854,7 +884,8 @@ export function SearchCommand() {
                   <IssueResultRow
                     key={issue.id}
                     issue={issue}
-                    query={query}
+                    query={results.query}
+                    disabled={resultsAreStale}
                     onSelect={handleSelect}
                   />
                 ))}
@@ -870,7 +901,8 @@ export function SearchCommand() {
                   <ProjectResultRow
                     key={`project:${project.id}`}
                     project={project}
-                    query={query}
+                    query={results.query}
+                    disabled={resultsAreStale}
                     onSelect={handleSelect}
                   />
                 ))}
@@ -878,7 +910,8 @@ export function SearchCommand() {
                   <IssueResultRow
                     key={issue.id}
                     issue={issue}
-                    query={query}
+                    query={results.query}
+                    disabled={resultsAreStale}
                     onSelect={handleSelect}
                   />
                 ))}


### PR DESCRIPTION
Closes MUL-6272

## What was wrong

The command palette kept its own hand-written list of navigation destinations, plus its own copy of the page names under `search.pages`. Both had gone stale: the sidebar has 12 workspace pages, the palette offered 8.

Missing: **Chat**, **Autopilot**, **Squads**, **Analytics**. All four have configurable `go*` shortcuts in `packages/core/shortcuts/definitions.ts` and sidebar rows — the palette was the only navigation surface that didn't know about them.

## The fix

Generate the Pages group from `WORKSPACE_PAGES`, the registry the sidebar nav and the desktop tab bar already read, and label it from `layout.nav`. A new workspace page is now in the palette the moment it is in the registry, and the palette can't disagree with the sidebar about what a page is called. Per-page query aliases stay local as a total `Record<WorkspacePageKey, string[]>`, so adding a page without keywords is a compile error.

## Also fixed while auditing the same file

| | |
| --- | --- |
| Keyword false positives | Keywords are invisible synonyms, so a substring hit reads as a bug: `s` surfaced Inbox via `notifications`, `i` surfaced nearly every page. They match by prefix now; visible labels still match anywhere. |
| No pinyin on pages/commands | Member rows already match by pinyin. Under a Chinese UI the localized label is the only thing a user can aim at, so `renwu` now reaches 任务. |
| Groups without accessible names | Four of seven groups used hand-rolled heading divs instead of cmdk's `heading` prop, which is what wires the group's `aria-labelledby`. |
| Result list strobing | `isLoading` flips on the keystroke, before the 300ms debounce fires, so every character swapped the whole list for a spinner. Previous rows now stay until the next response lands. |
| Cold-load request burst | The palette is mounted all session and the recent store holds 20 ids, so up to 20 issue-detail requests fired on every cold load for a surface that may never be opened. Gated on `open`. |

## Tests

Three added, including a registry-driven guard that every `WORKSPACE_PAGES` entry is reachable by the exact name the sidebar shows — the drift this PR fixes can't come back silently.

`pnpm typecheck` (6/6), `pnpm exec eslint`, and the `@multica/views` suite pass. One unrelated failure, `layout/sidebar-resize.test.tsx`, reproduces unchanged on `main` at 85a88b3.
