### PR TITLE
MUL-6282 fix(agent): fail a Pi task when Pi ends the turn on an error without retrying

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -299,6 +299,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		var output strings.Builder
 		finalStatus := "completed"
 		var finalError string
+		var lastTurnError string
 		usage := make(map[string]TokenUsage)
 
 		// Pi message_update events can be large (they embed the full message
@@ -323,6 +324,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			case "turn_start":
 				output.Reset()
 				textBuffer.Reset()
+				lastTurnError = ""
 
 			case "message_update":
 				if evt.AssistantMessageEvent == nil {
@@ -360,7 +362,11 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				})
 
 			case "turn_end":
-				if msg := decodePiMessage(evt.Message); msg != nil && msg.Usage != nil {
+				msg := decodePiMessage(evt.Message)
+				if msg == nil {
+					continue
+				}
+				if msg.Usage != nil {
 					model := msg.Model
 					if model == "" {
 						model = opts.Model
@@ -374,6 +380,16 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 					u.CacheReadTokens += msg.Usage.CacheRead
 					u.CacheWriteTokens += msg.Usage.CacheWrite
 					usage[model] = u
+				}
+				// A turn Pi ends on an error is only terminal when nothing
+				// follows it. Pi emits the same stopReason before an automatic
+				// retry, and turn_start clears this, so a later successful turn
+				// leaves nothing behind.
+				if msg.StopReason == "error" {
+					lastTurnError = msg.ErrorMessage
+					if lastTurnError == "" {
+						lastTurnError = label + " ended the turn with an error"
+					}
 				}
 
 			case "error":
@@ -419,6 +435,12 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		} else if writeErr != nil && finalStatus == "completed" {
 			finalStatus = "failed"
 			finalError = fmt.Sprintf("%s prompt write failed: %v", label, writeErr)
+		} else if lastTurnError != "" && finalStatus == "completed" {
+			// Pi exits 0 after a turn it could not complete and did not retry,
+			// and emits neither an `error` event nor `auto_retry_end`. Without
+			// this the run reports success with no output.
+			finalStatus = "failed"
+			finalError = lastTurnError
 		}
 
 		b.cfg.Logger.Info(label+" finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
@@ -472,6 +494,12 @@ type piMessage struct {
 	Role  string   `json:"role,omitempty"`
 	Model string   `json:"model,omitempty"`
 	Usage *piUsage `json:"usage,omitempty"`
+
+	// turn_end carries the terminal state of the turn. Pi sets StopReason to
+	// "error" for a provider call it could not complete, whether or not it
+	// goes on to retry, and puts the provider's message in ErrorMessage.
+	StopReason   string `json:"stopReason,omitempty"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
 type piUsage struct {

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -298,6 +298,104 @@ func TestPiExecuteRetainsOnlyLastTurnOutput(t *testing.T) {
 	}
 }
 
+func TestPiExecuteFailsOnUnretriedTurnError(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Pi ends the turn with stopReason=error and declines to retry (401, 429
+	// and friends). It emits no `error` event and no auto_retry_end, and exits
+	// 0, so the terminal state lives only on turn_end.
+	events := []string{
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"turn_end","message":{"role":"assistant","content":[],"model":"test","usage":{"input":0,"output":0},"stopReason":"error","errorMessage":"OpenAI API error (401): invalid token"}}`,
+		`{"type":"agent_end","messages":[],"willRetry":false}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "invalid token") {
+			t.Fatalf("Error: got %q, want it to carry the provider message", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestPiExecuteSucceedsWhenRetryFollowsTurnError(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// The same stopReason=error precedes an automatic retry. The retry
+	// succeeds, so the run must not inherit the first turn's failure.
+	events := []string{
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"turn_end","message":{"role":"assistant","content":[],"model":"test","usage":{"input":0,"output":0},"stopReason":"error","errorMessage":"OpenAI API error (503): no available channel"}}`,
+		`{"type":"agent_end","messages":[],"willRetry":true}`,
+		`{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":1}`,
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"recovered"}}`,
+		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":2,"output":2}}}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "recovered" {
+			t.Fatalf("Output: got %q, want %q", result.Output, "recovered")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func TestStripPiToolCallMarkup(t *testing.T) {
 	tests := map[string]string{
 		`before call:bash{command:<|"|>cd repo/path && ls -F<|"|>}<tool_call|> after`:                           "before  after",


### PR DESCRIPTION
When Pi ends a turn with `stopReason: "error"` and decides not to retry, the daemon records the task as `completed` with empty output and empty `agent_error`. It is never marked failed and never retried — the user sees a successful run that produced nothing. This hit us in production: a task closed in 6 seconds while the provider was returning 429 for quota exhaustion.

Pi reports the failure correctly; the signal was dropped on the Multica side.

## What Pi emits

`pi -p "say ok" --mode json --provider <custom> --model <model> --api-key sk-invalid --no-session --no-tools`, abridged:

```json
{"type":"turn_end","message":{"role":"assistant","content":[],
  "stopReason":"error",
  "errorMessage":"OpenAI API error (401): {\"message\":\"invalid token\",...}"},
  "toolResults":[]}
{"type":"agent_end","messages":[...],"willRetry":false}
```

`stopReason` and `errorMessage` are both present and `willRetry` is `false`. There is no standalone `error` event and no `auto_retry_end`, because Pi never retried.

A 503 produces the same `turn_end` but with `willRetry: true` and a trailing `auto_retry_end(success: false)` — that path was already reported as `failed`. Only the no-retry path leaked.

## Where it was dropped

`piMessage` declared only `Role`, `Model` and `Usage`, so `stopReason` / `errorMessage` were discarded at decode time. The `turn_end` arm used that message for token accounting only, and failure was recognized in just two places: the standalone `error` event, and `auto_retry_end` with `success: false`. Neither fires here, so `finalStatus` stayed `completed`.

## The fix

Decode both fields and remember the error of the turn that just ended. Because Pi emits the same `stopReason` *before* an automatic retry, treating it as terminal on sight would fail runs that go on to recover — so it is cleared on `turn_start`, and only a trailing failed turn survives to fail the run.

## Tests

- `TestPiExecuteFailsOnUnretriedTurnError` — 401 with no retry must fail the run and carry the provider message.
- `TestPiExecuteSucceedsWhenRetryFollowsTurnError` — the same `stopReason` followed by a successful retry must still complete, with the recovered output intact.

Reverting only `pi.go` and keeping the tests reproduces the original symptom exactly: `expected status=failed, got "completed" (error="")`.

`go build ./...`, `go test ./pkg/agent`, and `go test ./internal/daemon` all pass.
