### PR TITLE
MUL-6279: De-emphasize share-link URLs

### DIFF
--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -265,10 +265,15 @@ function ShareLinkRow({
         <Link className="h-4 w-4 text-muted-foreground" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="text-body font-medium truncate">{joinUrl}</div>
-        <div className="flex items-center gap-1 text-caption text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-x-1 text-body font-medium">
           <span>{t(($) => $.members.share_link_uses, { used: link.use_count, max: link.max_uses ?? "∞" })}</span>
           {link.expires_at && <span>· {t(($) => $.members.share_link_expires, { date: new Date(link.expires_at).toLocaleDateString() })}</span>}
+        </div>
+        <div
+          className="truncate font-mono text-caption text-muted-foreground/70"
+          title={joinUrl}
+        >
+          {joinUrl}
         </div>
       </div>
       <Button

--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -270,7 +270,7 @@ function ShareLinkRow({
           {link.expires_at && <span>· {t(($) => $.members.share_link_expires, { date: new Date(link.expires_at).toLocaleDateString() })}</span>}
         </div>
         <div
-          className="truncate font-mono text-caption text-muted-foreground/70"
+          className="truncate font-mono text-caption text-muted-foreground"
           title={joinUrl}
         >
           {joinUrl}


### PR DESCRIPTION
## Summary

- promote share-link usage and expiry into the readable primary line
- render the generated URL as a subdued monospace caption while preserving its full value on hover
- allow the readable summary to wrap cleanly at narrower widths

## Verification

- `pnpm --filter @multica/views lint` (passes with 25 pre-existing warnings)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views test` (356 files, 4219 tests)
- local backend health check and frontend `/login` smoke check

Closes MUL-6279
