### PR TITLE
MUL-6278 fix(views): settle the run timeline's scrollbars so hovering a bar cannot shake it

### DIFF
--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -3,6 +3,7 @@ import {
   buildLanes,
   buildSteps,
   groupSteps,
+  laneSegmentPosition,
   rowCalls,
   shouldShowTimeline,
   timelineTicks,
@@ -234,6 +235,40 @@ describe("timelineTicks", () => {
 
   it("returns nothing for a run with no length", () => {
     expect(timelineTicks(0)).toEqual([]);
+  });
+});
+
+describe("laneSegmentPosition", () => {
+  const total = 39 * 60_000;
+
+  it("gives a sub-pixel call a visible, clickable minimum width", () => {
+    // 40ms of a 39-minute run is well under a pixel at any sane track width,
+    // so the floor is what the reader actually sees.
+    const { width } = laneSegmentPosition({ startMs: 0, durationMs: 40, kind: "tool" }, total);
+    const [, truePct] = width.match(/^max\(3px, ([\d.e-]+)%\)$/) ?? [];
+    expect(Number(truePct)).toBeCloseTo(0.0017, 4);
+  });
+
+  it("keeps a widened sliver inside the axis instead of past its end", () => {
+    // The last thing a run does ends at the run's end, so the final segment is
+    // routinely a sliver at ~100%. Left unclamped, its 3px minimum lands beyond
+    // the track, and those 3px of scrollable overflow are what gave the
+    // timeline a scrollbar it could not settle on (#6278). Capping the offset
+    // by the bar's own width is what keeps `left + width` on the axis.
+    const last = laneSegmentPosition(
+      { startMs: total - 300, durationMs: 300, kind: "think" },
+      total,
+    );
+    expect(last.left).toBe(`min(${((total - 300) / total) * 100}%, 100% - ${last.width})`);
+  });
+
+  it("leaves a segment wider than the minimum where it belongs", () => {
+    // min() picks the raw offset here: 25% + 50% is comfortably inside 100%.
+    const mid = laneSegmentPosition(
+      { startMs: total / 4, durationMs: total / 2, kind: "tool" },
+      total,
+    );
+    expect(mid).toEqual({ left: "min(25%, 100% - max(3px, 50%))", width: "max(3px, 50%)" });
   });
 });
 

--- a/packages/views/common/task-transcript/build-steps.ts
+++ b/packages/views/common/task-transcript/build-steps.ts
@@ -358,6 +358,27 @@ export function timelineTicks(totalMs: number, maxTicks = 6): number[] {
   return ticks;
 }
 
+/** A bar thinner than this would vanish; a fast call has to stay clickable. */
+const SEGMENT_MIN_PX = 3;
+
+/**
+ * Where one segment sits on its lane, as CSS.
+ *
+ * The width floor is what makes this more than two percentages: a 40ms call in
+ * a 40-minute run rounds to a fraction of a pixel, so every bar is given a
+ * visible minimum and zooming is what makes its width truthful. That floor is
+ * also why `left` is clamped — a sliver starting at 99.99% would otherwise
+ * paint its 3px past the end of the axis, and those 3px of scrollable overflow
+ * hand the track a horizontal scrollbar it has nothing to scroll with (#6278).
+ */
+export function laneSegmentPosition(
+  segment: LaneSegment,
+  totalMs: number,
+): { left: string; width: string } {
+  const width = `max(${SEGMENT_MIN_PX}px, ${(segment.durationMs / totalMs) * 100}%)`;
+  return { left: `min(${(segment.startMs / totalMs) * 100}%, 100% - ${width})`, width };
+}
+
 /**
  * How the tool lane's time splits by what the calls were doing.
  *

--- a/packages/views/common/task-transcript/run-timeline.tsx
+++ b/packages/views/common/task-transcript/run-timeline.tsx
@@ -3,7 +3,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Minus, Plus } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
-import { timelineTicks, type LaneSegment, type TraceLanes, type ToolKindTotals } from "./build-steps";
+import {
+  laneSegmentPosition,
+  timelineTicks,
+  type LaneSegment,
+  type TraceLanes,
+  type ToolKindTotals,
+} from "./build-steps";
 import { useT } from "../../i18n";
 
 /**
@@ -94,13 +100,7 @@ function LaneTrack({
             "absolute inset-y-0 rounded-[3px] transition-opacity hover:opacity-80",
             SEGMENT_TONE[segment.kind],
           )}
-          style={{
-            left: `${(segment.startMs / totalMs) * 100}%`,
-            // Sub-pixel bars would vanish; a visible minimum keeps a fast call
-            // clickable. Zooming in is what makes the width truthful — which is
-            // the whole reason the track scrolls.
-            width: `max(3px, ${(segment.durationMs / totalMs) * 100}%)`,
-          }}
+          style={laneSegmentPosition(segment, totalMs)}
         />
       ))}
     </div>
@@ -190,9 +190,17 @@ export function RunTimeline({
           </div>
         </div>
 
+        {/* Zoom scrolls this track sideways; nothing ever scrolls it down.
+            Saying so matters: `overflow-x: auto` alone computes `overflow-y`
+            to `auto` as well, so a stray pixel of paint below the lanes buys a
+            vertical scrollbar, and that scrollbar narrows the track, which
+            re-decides whether the horizontal one is needed. Two lanes 15px
+            tall have no fixed point to settle on, and any `:hover` inside
+            re-runs the decision every frame — the timeline shakes for as long
+            as the pointer rests on a bar (#6278). */}
         <div
           ref={scrollerRef}
-          className="min-w-0 flex-1 overflow-x-auto overscroll-x-contain"
+          className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain"
         >
           <div className="relative" style={{ width: `${zoom * 100}%` }}>
             <div className="relative h-3">
@@ -230,7 +238,9 @@ export function RunTimeline({
             {selectedOffsetMs !== undefined && (
               <div
                 aria-hidden
-                className="pointer-events-none absolute bottom-[-2px] top-2.5 w-0.5 rounded-full bg-brand"
+                // Ends on the lanes, not below them: the track clips its own
+                // vertical overflow now, so an overhang would only be cropped.
+                className="pointer-events-none absolute bottom-0 top-2.5 w-0.5 rounded-full bg-brand"
                 style={{
                   left: `${
                     (Math.min(Math.max(selectedOffsetMs, 0), lanes.totalMs) / lanes.totalMs) * 100


### PR DESCRIPTION
## What

Hovering any bar in a long run's transcript timeline made the whole strip shake, forever.

The strip handed itself two slivers of scrollable overflow:

- **3px horizontally** — a segment's width has a `max(3px, …)` floor so a fast call stays visible and clickable. A run ends on its last tool call, so the trailing model gap is routinely a sliver at ~99.99%, and widening it to 3px paints it past the end of the axis.
- **2px vertically** — the playhead's `bottom-[-2px]` overhang. `overflow-x: auto` computes `overflow-y` to `auto` as well, so that overhang is enough to buy a vertical scrollbar.

Six-to-eleven pixels of scrollbar is a lot on 50px of track: the vertical one narrows the track, which re-decides whether the horizontal one is needed, which changes the height, which re-decides the vertical one. The layout has two answers and settles on neither, and any `:hover` inside re-runs the decision — so the strip flips between 69px and 80px tall for as long as the pointer rests on a bar. Short runs escape it because their trailing segment is wide enough not to need the floor.

## Change

- `laneSegmentPosition()` in `build-steps.ts` now owns a segment's CSS geometry and clamps the offset by the bar's own width (`left: min(x%, 100% - width)`), so a widened sliver stays on the axis. The 3px floor is unchanged — the bar shifts left by up to 3px instead of hanging off the end.
- The track pins `overflow-y: hidden`. Zoom scrolls it sideways; nothing ever scrolls it down, and saying so removes the feedback path entirely.
- The playhead ends on the lanes (`bottom-0`) rather than 2px below, since that overhang could now only be cropped.

## Verification

Measured the component's real rendered markup against the app's compiled CSS in Chromium, sampling the strip's geometry every frame while hovering:

| | before | after |
| --- | --- | --- |
| scrollable overflow | 3px x, 2px y | 0, 0 |
| scrollbars on the strip | both (11px each) | none |
| bars that flip the layout on hover | 82 / 103 | 0 / 103 |
| sustained shaking, widths 700–1100px | every width, ~27 flips/42 frames | none at any width |

Zoom still works: at 2x the track scrolls sideways (774px of scrollable width, horizontal scrollbar only, no vertical one).

- `pnpm typecheck` — passes
- `pnpm exec vitest run` in `packages/views` — 356 files / 4222 tests pass
- `eslint` on the changed files — clean
- New unit tests cover the width floor, the clamped sliver, and the unclamped ordinary segment

Closes MUL-6278.
