### PR TITLE
MUL-6290: split views tests onto a dedicated runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the (heavy, ~6min) frontend job has anything to do.
-  # The frontend job validates the web/desktop apps, the shared packages,
+  # Decides whether the heavy frontend validation jobs have anything to do.
+  # The frontend jobs validate the web/desktop apps, the shared packages,
   # the install graph, and the selfhost / reserved-slugs scripts it runs;
   # a pure backend-only or docs-only PR touches none of those and gains
   # nothing from a full web build. This job emits a single `frontend`
-  # output consumed by the frontend job below.
+  # output consumed by the frontend jobs below.
   changes:
     runs-on: ubuntu-latest
     permissions:
@@ -85,18 +85,13 @@ jobs:
             echo "frontend=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # The frontend validation is split across two runners on purpose. Both
-  # `@multica/web:build` (a webpack production build) and `@multica/views:test`
-  # (259 jsdom files) are CPU-saturating, and a standard runner only has
-  # 4 vCPUs. Running them in one job made them starve each other: the views
-  # suite needs ~104s wall when it owns 4 cores but took ~500s sharing them,
-  # and the identical webpack compile went from ~26s to ~342s. Splitting buys
-  # a second 4-vCPU box rather than reducing the work; total runner-minutes go
-  # up slightly, wall-clock feedback time goes down.
-  #
-  # The split is weighted, not even: the test group is by far the heavier half
-  # (~575 CPU-seconds vs ~250 for build + typecheck + lint), so it gets a
-  # runner to itself and everything else shares the other one.
+  # The frontend validation is split across three runners on purpose. A prior
+  # split isolated build/typecheck/lint from the test suites; on a full test
+  # cache miss, however, web/core/desktop/views still competed for the four
+  # vCPUs on the test runner and stretched the job to ~8 minutes. Views is the
+  # longest suite, so it gets a runner to itself while the remaining suites
+  # continue in parallel on another runner. The extra setup increases total
+  # runner-minutes slightly but reduces wall-clock feedback time.
   frontend-build:
     needs: changes
     runs-on: ubuntu-latest
@@ -135,7 +130,7 @@ jobs:
 
       # Cache entries are immutable, so the key carries the commit SHA to make
       # every run publish a fresh one and `restore-keys` falls back to the most
-      # recent prefix match. The two frontend jobs run disjoint task sets, so
+      # recent prefix match. The three frontend jobs run disjoint task sets, so
       # they get their own prefixes rather than racing to save one key.
       # GitHub scopes caches by branch: a PR reads main's entries (so unchanged
       # tasks hit on the first push) and writes its own (so re-pushes hit too).
@@ -218,22 +213,71 @@ jobs:
           restore-keys: |
             turbo-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
 
-      - name: Test
+      - name: Test web, core, and desktop
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         # Same filter rationale as frontend-build. Type errors are not this
         # job's responsibility -- frontend-build owns the `typecheck` task.
         # `test` reaches dependency sources through the hash-only
         # `^cache-inputs` edge (see turbo.json), so no `tsc` runs here.
-        run: pnpm exec turbo test --filter='!@multica/docs' --filter='!@multica/mobile'
+        run: pnpm exec turbo test --filter='!@multica/docs' --filter='!@multica/mobile' --filter='!@multica/views'
+
+  # Keep views in a standalone job so it owns the runner's CPU. A future
+  # Vitest shard matrix can be added here without changing the aggregate
+  # gate's dependency: GitHub reports the matrix job's combined result.
+  frontend-views-test:
+    needs: changes
+    runs-on: ubuntu-latest
+    env:
+      TURBO_CACHE_DIR: .turbo/cache
+    steps:
+      - name: Checkout
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: pnpm install
+
+      - name: Resolve runtime for cache key
+        id: runtime
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: echo "node=$(node --version)" >> "$GITHUB_OUTPUT"
+
+      # Views has its own prefix so concurrent jobs never race to save the
+      # same immutable cache key. The task hash still includes all dependency
+      # sources through turbo.json's hash-only `^cache-inputs` edge.
+      - name: Restore turbo cache
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/cache@v6
+        with:
+          path: .turbo/cache
+          key: turbo-views-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-${{ github.sha }}
+          restore-keys: |
+            turbo-views-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
+
+      - name: Test views
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: pnpm exec turbo test --filter='@multica/views'
 
   # Aggregate gate. `frontend` is the status-check name the repository's
   # branch rules refer to, so it has to survive the split above: this job
-  # keeps reporting under that name and simply fails when either half fails.
+  # keeps reporting under that name and simply fails when any worker fails.
   # It also inherits the old contract that the check goes green (rather than
-  # staying pending) on PRs the path filter excluded — both halves succeed
+  # staying pending) on PRs the path filter excluded — all workers succeed
   # trivially in that case because every step is gated off.
   frontend:
-    needs: [frontend-build, frontend-test]
+    needs: [frontend-build, frontend-test, frontend-views-test]
     # `!cancelled()` rather than `always()`: a run superseded by a newer push
     # is cancelled by the concurrency group above, and there is no reason to
     # spend a runner reporting a verdict nobody will read.
@@ -244,10 +288,12 @@ jobs:
         env:
           BUILD_RESULT: ${{ needs.frontend-build.result }}
           TEST_RESULT: ${{ needs.frontend-test.result }}
+          VIEWS_TEST_RESULT: ${{ needs.frontend-views-test.result }}
         run: |
           echo "frontend-build: $BUILD_RESULT"
           echo "frontend-test:  $TEST_RESULT"
-          if [ "$BUILD_RESULT" != "success" ] || [ "$TEST_RESULT" != "success" ]; then
+          echo "frontend-views-test: $VIEWS_TEST_RESULT"
+          if [ "$BUILD_RESULT" != "success" ] || [ "$TEST_RESULT" != "success" ] || [ "$VIEWS_TEST_RESULT" != "success" ]; then
             echo "::error::frontend validation failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,14 @@ jobs:
             echo "frontend=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # The frontend validation is split across three runners on purpose. A prior
+  # The frontend validation is split across four runners on purpose. A prior
   # split isolated build/typecheck/lint from the test suites; on a full test
   # cache miss, however, web/core/desktop/views still competed for the four
-  # vCPUs on the test runner and stretched the job to ~8 minutes. Views is the
-  # longest suite, so it gets a runner to itself while the remaining suites
-  # continue in parallel on another runner. The extra setup increases total
-  # runner-minutes slightly but reduces wall-clock feedback time.
+  # vCPUs on the test runner and stretched the job to ~8 minutes. Giving views
+  # its own runner only reduced that to 7m23s because the suite itself remained
+  # the long pole, so two Vitest shards now split it across two runners while
+  # the remaining suites continue in parallel on another. The extra setup
+  # increases total runner-minutes but reduces wall-clock feedback time.
   frontend-build:
     needs: changes
     runs-on: ubuntu-latest
@@ -130,8 +131,8 @@ jobs:
 
       # Cache entries are immutable, so the key carries the commit SHA to make
       # every run publish a fresh one and `restore-keys` falls back to the most
-      # recent prefix match. The three frontend jobs run disjoint task sets, so
-      # they get their own prefixes rather than racing to save one key.
+      # recent prefix match. Each frontend worker runs a disjoint task set, so
+      # it gets its own prefix rather than racing to save one key.
       # GitHub scopes caches by branch: a PR reads main's entries (so unchanged
       # tasks hit on the first push) and writes its own (so re-pushes hit too).
       - name: Restore turbo cache
@@ -221,11 +222,19 @@ jobs:
         # `^cache-inputs` edge (see turbo.json), so no `tsc` runs here.
         run: pnpm exec turbo test --filter='!@multica/docs' --filter='!@multica/mobile' --filter='!@multica/views'
 
-  # Keep views in a standalone job so it owns the runner's CPU. A future
-  # Vitest shard matrix can be added here without changing the aggregate
-  # gate's dependency: GitHub reports the matrix job's combined result.
+  # Split views across two runners. GitHub reports the matrix job's combined
+  # result, so the aggregate gate can continue depending on this one job ID.
   frontend-views-test:
+    name: frontend-views-test (${{ matrix.index }}/${{ matrix.total }})
     needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - index: 1
+            total: 2
+          - index: 2
+            total: 2
     runs-on: ubuntu-latest
     env:
       TURBO_CACHE_DIR: .turbo/cache
@@ -254,21 +263,22 @@ jobs:
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: echo "node=$(node --version)" >> "$GITHUB_OUTPUT"
 
-      # Views has its own prefix so concurrent jobs never race to save the
-      # same immutable cache key. The task hash still includes all dependency
-      # sources through turbo.json's hash-only `^cache-inputs` edge.
+      # Each shard has its own prefix so concurrent jobs never race to save the
+      # same immutable cache key. Turbo also includes the passthrough `--shard`
+      # argument in the task hash, while dependency sources still flow through
+      # turbo.json's hash-only `^cache-inputs` edge.
       - name: Restore turbo cache
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: actions/cache@v6
         with:
           path: .turbo/cache
-          key: turbo-views-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-${{ github.sha }}
+          key: turbo-views-test-${{ matrix.index }}-of-${{ matrix.total }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-${{ github.sha }}
           restore-keys: |
-            turbo-views-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
+            turbo-views-test-${{ matrix.index }}-of-${{ matrix.total }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
 
-      - name: Test views
+      - name: Test views shard ${{ matrix.index }}/${{ matrix.total }}
         if: ${{ needs.changes.outputs.frontend == 'true' }}
-        run: pnpm exec turbo test --filter='@multica/views'
+        run: pnpm exec turbo test --filter='@multica/views' -- --shard=${{ matrix.index }}/${{ matrix.total }}
 
   # Aggregate gate. `frontend` is the status-check name the repository's
   # branch rules refer to, so it has to survive the split above: this job


### PR DESCRIPTION
## Summary

- move `@multica/views` tests out of `frontend-test` and into a dedicated matrix job
- split the views suite across two Vitest shards with `--shard=1/2` and `--shard=2/2`
- use shard-specific Actions cache keys; Turbo also hashes the shard argument, so neither shard can reuse the other's test output
- keep `fail-fast: false` and preserve the existing `frontend` aggregate gate across build, non-views tests, and both shards

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Turbo dry-runs produce distinct task hashes for shard 1/2 and shard 2/2
- each GitHub cold run passed 179 files in shard 1/2 and 179 files in shard 2/2 (358 total)
- all three forced-cold GitHub runs and the aggregate `frontend` gate passed

## CI measurements

Measured on commit `889f83ff2`. For each forced-cold run, the four exact cache entries for this PR merge ref and commit were removed first; caches for `main` and older commits were left intact.

| Run | Build | Non-views tests | Views 1/2 | Views 2/2 | Frontend wall time | Worker total |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Cold 1 | 4m50s | 1m49s | 2m32s | 3m44s | 4m50s | 12m55s |
| Cold 2 | 4m44s | 1m54s | 2m54s | 3m22s | 4m44s | 12m54s |
| Cold 3 | 4m57s | 1m45s | 3m40s | 3m59s | 4m57s | 14m21s |

The forced-cold frontend wall-time median is **4m50s** and the slowest run is **4m57s**, below the 6m00s median and 6m30s slowest-run targets. Compared with the recent pre-split `frontend-test` job at 8m08s, median feedback is 3m18s faster (about 41%). Compared with the one-runner views split at 7m23s, the second step removes another 2m33s from the median critical path.

Cold worker usage has a 12m55s median, equal to the recent pre-split build-plus-test total (4m47s + 8m08s). The three-run average is 13m23s, 28s higher because the third run was noisier.

Same-SHA warm-cache job reruns completed in 50s (build), 31s (non-views tests), 39s (views 1/2), and 35s (views 2/2): 50s wall time and 2m35s worker total. Relative to the unsharded version of this PR, that is a 12s warm-wall and 50s worker-time cost for the substantially shorter cold critical path.

Closes MUL-6290
