### PR TITLE
MUL-6296 fix(daemon): garbage-collect workspace roots abandoned by a profile change

### DIFF
--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/processtree"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
@@ -82,38 +83,20 @@ type gcStats struct {
 
 // runGC performs a single GC scan across all workspace directories.
 func (d *Daemon) runGC(ctx context.Context) {
-	root := d.cfg.WorkspacesRoot
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return
-		}
-		d.logger.Warn("gc: read workspaces root failed", "error", err)
-		return
-	}
-
 	stats := &gcStats{byPattern: map[string]int{}}
-	for _, wsEntry := range entries {
-		// Skip every daemon-internal dot directory, not just .repos. A
-		// workspace directory is always a UUID, so a dot-prefixed entry is one
-		// of our own caches. Walking .skill-cache as if it were a workspace
-		// made its `v1` directory look like a task dir with no .gc_meta.json,
-		// so the orphan path would delete the entire bundle cache once its
-		// mtime went 72h without a new bundle. That reclaimed a few hundred KB
-		// and cost a full re-download.
-		if !wsEntry.IsDir() || strings.HasPrefix(wsEntry.Name(), ".") {
-			continue
-		}
-		wsDir := filepath.Join(root, wsEntry.Name())
-		d.gcWorkspace(ctx, wsDir, stats)
+	for _, gr := range d.gcWorkspaceRoots() {
+		d.gcRoot(ctx, gr.root, stats)
 	}
 
 	// Stable-root records are published before the physical env root so a
 	// re-dispatch cannot choose a different readable path. If preparation never
 	// reaches ClaimEnvRoot, no task directory exists for the normal GC walk to
 	// reclaim. Bound those records separately, but only after the orphan grace
-	// period and an authoritative terminal/not-found task check.
-	rootRecordsRemoved, rootRecordsErr := execenv.PruneTaskRootIndex(root, d.cfg.GCOrphanTTL, time.Now(), func(_ string, taskID string) bool {
+	// period and an authoritative terminal/not-found task check. This stays on
+	// the current profile's root: root-index records are the current daemon's
+	// own dispatch bookkeeping, and reclaimed profile roots are handled by the
+	// per-root gcRoot walk above instead.
+	rootRecordsRemoved, rootRecordsErr := execenv.PruneTaskRootIndex(d.cfg.WorkspacesRoot, d.cfg.GCOrphanTTL, time.Now(), func(_ string, taskID string) bool {
 		if ctx.Err() != nil || d.client == nil {
 			return false
 		}
@@ -127,12 +110,6 @@ func (d *Daemon) runGC(ctx context.Context) {
 		d.logger.Warn("gc: prune task root index failed", "error", rootRecordsErr)
 	}
 	stats.taskRootIndexEntriesReclaimed += rootRecordsRemoved
-
-	// Prune stale worktree references from all bare repo caches, then evict the
-	// caches nothing needs anymore. These live outside any workspace directory
-	// and are never reclaimed by the task walk above.
-	d.pruneRepoWorktreesContext(ctx, root, stats)
-
 	// Reclaim per-issue Codex session stores idle past their TTL. These live
 	// under the shared ~/.codex home (outside WorkspacesRoot) so resume survives
 	// the task GC, which means they need their own bounded lifecycle (MUL-4424).
@@ -192,8 +169,106 @@ func (d *Daemon) runGC(ctx context.Context) {
 	}
 }
 
+// gcRoot identifies a single workspace root to scan during a GC pass.
+type gcRoot struct {
+	profile string
+	root    string
+}
+
+// gcWorkspaceRoots returns the workspace roots a single GC pass should walk:
+// the current profile's root plus every root left behind by a previous profile
+// whose daemon is no longer running. Roots owned by a live daemon are skipped
+// because isActiveEnvRoot is in-process memory: a daemon sweeping another
+// profile's root would not see that profile's live tasks and would delete
+// workdirs a different daemon is actively using (see #6962).
+func (d *Daemon) gcWorkspaceRoots() []gcRoot {
+	roots := []gcRoot{{profile: d.cfg.Profile, root: d.cfg.WorkspacesRoot}}
+
+	profilesDir, err := cli.ProfileDir("")
+	if err != nil {
+		return roots
+	}
+	profilesDir = filepath.Join(profilesDir, "profiles")
+	entries, err := os.ReadDir(profilesDir)
+	if err != nil {
+		// No profiles directory: there are no other roots to scan.
+		return roots
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		profile := entry.Name()
+		if profile == d.cfg.Profile {
+			continue
+		}
+		if d.profileDaemonActive(profile) {
+			continue
+		}
+		root, err := ResolveWorkspacesRoot(profile, "")
+		if err != nil {
+			continue
+		}
+		if info, statErr := os.Stat(root); statErr != nil || !info.IsDir() {
+			continue
+		}
+		roots = append(roots, gcRoot{profile: profile, root: root})
+	}
+
+	return roots
+}
+
+// profileDaemonActive reports whether the daemon for the given profile appears
+// to be running, based on the presence of its daemon.pid file. A live daemon
+// removes that file on exit, so an absent file means the profile is not running
+// and its workspace root is safe to garbage-collect. This is intentionally
+// conservative: a stale pid file left by a crash only skips cleanup; it can
+// never cause a live daemon's workdirs to be deleted.
+func (d *Daemon) profileDaemonActive(profile string) bool {
+	profileDir, err := cli.ProfileDir(profile)
+	if err != nil {
+		return true
+	}
+	_, err = os.Stat(filepath.Join(profileDir, "daemon.pid"))
+	return err == nil
+}
+
+// gcRoot performs the per-root portion of a GC scan: walking workspace
+// directories and pruning repo worktree caches under a single root.
+func (d *Daemon) gcRoot(ctx context.Context, root string, stats *gcStats) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		d.logger.Warn("gc: read workspaces root failed", "error", err)
+		return
+	}
+
+	for _, wsEntry := range entries {
+		// Skip every daemon-internal dot directory, not just .repos. A
+		// workspace directory is always a UUID, so a dot-prefixed entry is one
+		// of our own caches. Walking .skill-cache as if it were a workspace
+		// made its `v1` directory look like a task dir with no .gc_meta.json,
+		// so the orphan path would delete the entire bundle cache once its
+		// mtime went 72h without a new bundle. That reclaimed a few hundred KB
+		// and cost a full re-download.
+		if !wsEntry.IsDir() || strings.HasPrefix(wsEntry.Name(), ".") {
+			continue
+		}
+		wsDir := filepath.Join(root, wsEntry.Name())
+		d.gcWorkspace(ctx, root, wsDir, stats)
+	}
+
+	// Prune stale worktree references from all bare repo caches, then evict the
+	// caches nothing needs anymore. These live outside any workspace directory
+	// and are never reclaimed by the task walk above.
+	d.pruneRepoWorktreesContext(ctx, root, stats)
+}
+
 // gcWorkspace scans task directories inside a single workspace directory.
-func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) {
+func (d *Daemon) gcWorkspace(ctx context.Context, root, wsDir string, stats *gcStats) {
 	taskEntries, err := os.ReadDir(wsDir)
 	if err != nil {
 		d.logger.Warn("gc: read workspace dir failed", "dir", wsDir, "error", err)
@@ -224,8 +299,8 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) 
 				continue
 			}
 		}
-		action := d.shouldCleanTaskDir(ctx, taskDir)
-		cleanedHere += d.applyGCAction(taskDir, action, stats)
+		action := d.shouldCleanTaskDir(ctx, root, taskDir)
+		cleanedHere += d.applyGCAction(root, taskDir, action, stats)
 	}
 	workspaceIDs := make([]string, 0, len(issueCandidatesByWorkspace))
 	for workspaceID := range issueCandidatesByWorkspace {
@@ -233,7 +308,7 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) 
 	}
 	sort.Strings(workspaceIDs)
 	for _, workspaceID := range workspaceIDs {
-		cleanedHere += d.gcWorkspaceIssues(ctx, workspaceID, issueCandidatesByWorkspace[workspaceID], stats)
+		cleanedHere += d.gcWorkspaceIssues(ctx, root, workspaceID, issueCandidatesByWorkspace[workspaceID], stats)
 	}
 
 	// Remove the workspace directory itself if it's now empty.
@@ -256,7 +331,7 @@ type issueGCCandidate struct {
 // of workspace-level requests. Multiple task dirs for the same issue share one
 // result. The client transparently falls back to the legacy per-issue endpoint
 // when it is connected to an older server.
-func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, candidates []issueGCCandidate, stats *gcStats) int {
+func (d *Daemon) gcWorkspaceIssues(ctx context.Context, root, workspaceID string, candidates []issueGCCandidate, stats *gcStats) int {
 	if len(candidates) == 0 {
 		return 0
 	}
@@ -305,13 +380,13 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 			// data stays. The regenerable Codex cache is still fair game —
 			// see applyManagedArtifactFallback.
 			action := d.applyManagedArtifactFallback(candidate.taskDir, candidate.meta, gcActionSkip)
-			cleaned += d.applyGCAction(candidate.taskDir, action, stats)
+			cleaned += d.applyGCAction(root, candidate.taskDir, action, stats)
 			continue
 		}
 		action := d.gcDecisionIssueResult(candidate.taskDir, candidate.meta, result)
 		action = d.applyLocalDirectoryGCOverride(candidate.meta, action)
 		action = d.applyManagedArtifactFallback(candidate.taskDir, candidate.meta, action)
-		cleaned += d.applyGCAction(candidate.taskDir, action, stats)
+		cleaned += d.applyGCAction(root, candidate.taskDir, action, stats)
 	}
 	return cleaned
 }
@@ -319,9 +394,9 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 // applyGCAction performs one decision and updates cycle stats. Each mutation
 // atomically reserves the env root because a task can start while the server
 // reconciliation request is in flight.
-func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) int {
+func (d *Daemon) applyGCAction(root, taskDir string, action gcAction, stats *gcStats) int {
 	if action != gcActionSkip {
-		if _, err := d.gcTaskDirOwner(taskDir); err != nil {
+		if _, err := d.gcTaskDirOwner(root, taskDir); err != nil {
 			d.logger.Warn("gc: refusing to mutate unowned task directory", "dir", taskDir, "error", err)
 			stats.skipped++
 			return 0
@@ -334,7 +409,7 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 		defer release()
 		// Re-read provenance after taking the exclusion lock so a concurrent
 		// reset cannot change ownership between validation and mutation.
-		if _, err := d.gcTaskDirOwner(taskDir); err != nil {
+		if _, err := d.gcTaskDirOwner(root, taskDir); err != nil {
 			d.logger.Warn("gc: refusing to mutate task directory after ownership changed", "dir", taskDir, "error", err)
 			stats.skipped++
 			return 0
@@ -342,7 +417,7 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 	}
 	switch action {
 	case gcActionClean:
-		bytes, removed := d.cleanTaskDir(taskDir)
+		bytes, removed := d.cleanTaskDir(root, taskDir)
 		if !removed {
 			stats.skipped++
 			return 0
@@ -351,7 +426,7 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 		stats.bytesReclaimed += bytes
 		return 1
 	case gcActionOrphan:
-		bytes, removed := d.cleanTaskDir(taskDir)
+		bytes, removed := d.cleanTaskDir(root, taskDir)
 		if !removed {
 			stats.skipped++
 			return 0
@@ -401,7 +476,7 @@ const (
 // shouldCleanTaskDir decides whether a task directory should be removed.
 // Dispatches on meta.Kind so chat / autopilot / quick-create tasks each
 // follow the parent record that actually governs their lifecycle.
-func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcAction {
+func (d *Daemon) shouldCleanTaskDir(ctx context.Context, root, taskDir string) gcAction {
 	// A task currently running on this env root must never be reclaimed —
 	// not even on the done/cancelled or orphan-404 paths. A re-dispatched or
 	// still-running task can reuse the prior workdir of an already-done issue
@@ -414,7 +489,7 @@ func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcActio
 
 	meta, err := execenv.ReadGCMeta(taskDir)
 	if err != nil {
-		if _, ownerErr := d.gcTaskDirOwner(taskDir); ownerErr != nil {
+		if _, ownerErr := d.gcTaskDirOwner(root, taskDir); ownerErr != nil {
 			d.logger.Warn("gc: skipping directory without valid task ownership", "dir", taskDir, "error", ownerErr)
 			return gcActionSkip
 		}
@@ -843,7 +918,7 @@ func isAgentTaskTerminal(status string) bool {
 // and its position under WorkspacesRoot agree. Missing GC metadata is not
 // ownership proof: partially prepared roots have .task_owner, while arbitrary
 // user directories do not.
-func (d *Daemon) gcTaskDirOwner(taskDir string) (*execenv.EnvRootOwner, error) {
+func (d *Daemon) gcTaskDirOwner(root, taskDir string) (*execenv.EnvRootOwner, error) {
 	owner, err := execenv.ReadEnvRootOwner(taskDir)
 	if err != nil {
 		return nil, fmt.Errorf("read task owner: %w", err)
@@ -862,7 +937,7 @@ func (d *Daemon) gcTaskDirOwner(taskDir string) (*execenv.EnvRootOwner, error) {
 		}
 		validated.WorkspaceID = strings.TrimSpace(meta.WorkspaceID)
 	}
-	if err := execenv.ValidateEnvRootOwnerPath(d.cfg.WorkspacesRoot, taskDir, validated); err != nil {
+	if err := execenv.ValidateEnvRootOwnerPath(root, taskDir, validated); err != nil {
 		return nil, err
 	}
 	return &validated, nil
@@ -871,14 +946,14 @@ func (d *Daemon) gcTaskDirOwner(taskDir string) (*execenv.EnvRootOwner, error) {
 // cleanTaskDir removes a proven daemon-owned task directory, logs the
 // reclaimed bytes, and returns that count for the cycle summary. A failed or
 // refused removal reports removed=false.
-func (d *Daemon) cleanTaskDir(taskDir string) (bytes int64, removed bool) {
+func (d *Daemon) cleanTaskDir(root, taskDir string) (bytes int64, removed bool) {
 	// Measure first, prove ownership second. dirSize walks the entire tree,
 	// which on a large task directory takes long enough for the validated
 	// directory to be replaced underneath us — checking before that walk would
 	// hand RemoveAll a path last proven ours tens of seconds earlier. This is
 	// the defense-in-depth check, so it sits immediately before the removal.
 	bytes = dirSize(taskDir)
-	owner, ownerErr := d.gcTaskDirOwner(taskDir)
+	owner, ownerErr := d.gcTaskDirOwner(root, taskDir)
 	if ownerErr != nil {
 		d.logger.Warn("gc: refusing to remove unowned task directory", "dir", taskDir, "error", ownerErr)
 		return 0, false
@@ -889,7 +964,7 @@ func (d *Daemon) cleanTaskDir(taskDir string) (bytes int64, removed bool) {
 	} else {
 		d.logger.Info("gc: removed", "dir", taskDir, "bytes_reclaimed", bytes)
 	}
-	if err := execenv.RemoveRootDirRecord(d.cfg.WorkspacesRoot, taskDir, *owner); err != nil {
+	if err := execenv.RemoveRootDirRecord(root, taskDir, *owner); err != nil {
 		d.logger.Warn("gc: remove stable task root record failed", "dir", taskDir, "error", err)
 	}
 	return bytes, true

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -203,6 +204,9 @@ func (d *Daemon) gcWorkspaceRoots() []gcRoot {
 		if profile == d.cfg.Profile {
 			continue
 		}
+		// Another daemon's active task set only exists in that daemon's
+		// process. Even though this daemon can see the root on disk, sweeping
+		// it would bypass isActiveEnvRoot and could delete in-flight workdirs.
 		if d.profileDaemonActive(profile) {
 			continue
 		}
@@ -220,18 +224,25 @@ func (d *Daemon) gcWorkspaceRoots() []gcRoot {
 }
 
 // profileDaemonActive reports whether the daemon for the given profile appears
-// to be running, based on the presence of its daemon.pid file. A live daemon
-// removes that file on exit, so an absent file means the profile is not running
-// and its workspace root is safe to garbage-collect. This is intentionally
-// conservative: a stale pid file left by a crash only skips cleanup; it can
-// never cause a live daemon's workdirs to be deleted.
+// to be running. The pid file is only a pointer to the process: SIGKILL, OOM,
+// and host power loss can leave it behind, so its presence alone is not proof
+// of liveness. Unreadable or malformed files and inconclusive process probes
+// fail safe to active. PID reuse can also produce a false positive, but that
+// only postpones cleanup instead of risking another daemon's workdirs.
 func (d *Daemon) profileDaemonActive(profile string) bool {
 	profileDir, err := cli.ProfileDir(profile)
 	if err != nil {
 		return true
 	}
-	_, err = os.Stat(filepath.Join(profileDir, "daemon.pid"))
-	return err == nil
+	pidBytes, err := os.ReadFile(filepath.Join(profileDir, "daemon.pid"))
+	if err != nil {
+		return !os.IsNotExist(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil || pid <= 0 {
+		return true
+	}
+	return processAlive(pid)
 }
 
 // gcRoot performs the per-root portion of a GC scan: walking workspace

--- a/server/internal/daemon/gc_managed_artifact_test.go
+++ b/server/internal/daemon/gc_managed_artifact_test.go
@@ -76,11 +76,11 @@ func TestManagedArtifact_IdleActiveChatReclaimsSandboxBin(t *testing.T) {
 	writeFile(t, filepath.Join(taskDir, "workdir/repo/.sandbox-bin/user-owned"), 32)
 
 	stats := &gcStats{byPattern: map[string]int{}}
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionCleanManagedArtifacts {
 		t.Fatalf("want gcActionCleanManagedArtifacts, got %d", action)
 	}
-	d.applyGCAction(taskDir, action, stats)
+	d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, action, stats)
 
 	assertGone(t, taskDir, sandboxBinRel)
 	assertKept(t, taskDir,
@@ -113,7 +113,7 @@ func TestManagedArtifact_FreshActiveChatKeepsSandboxBin(t *testing.T) {
 	})
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionSkip {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionSkip {
 		t.Fatalf("want gcActionSkip inside the TTL, got %d", got)
 	}
 	assertKept(t, taskDir, sandboxBinRel+"/codex")
@@ -135,7 +135,7 @@ func TestManagedArtifact_ArtifactTTLZeroDisablesFallback(t *testing.T) {
 	})
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionSkip {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionSkip {
 		t.Fatalf("want gcActionSkip with artifact TTL disabled, got %d", got)
 	}
 	assertKept(t, taskDir, sandboxBinRel+"/codex")
@@ -155,7 +155,7 @@ func TestManagedArtifact_ZeroCompletedAtIsLeftAlone(t *testing.T) {
 	})
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionSkip {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionSkip {
 		t.Fatalf("want gcActionSkip for zero completed_at, got %d", got)
 	}
 	assertKept(t, taskDir, sandboxBinRel+"/codex")
@@ -208,11 +208,11 @@ func TestManagedArtifact_NonTerminalAutopilotAndQuickCreate(t *testing.T) {
 		taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", tc.name, tc.meta)
 		writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
-		action := d.shouldCleanTaskDir(context.Background(), taskDir)
+		action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 		if action != gcActionCleanManagedArtifacts {
 			t.Fatalf("%s: want gcActionCleanManagedArtifacts, got %d", tc.name, action)
 		}
-		d.applyGCAction(taskDir, action, &gcStats{byPattern: map[string]int{}})
+		d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, action, &gcStats{byPattern: map[string]int{}})
 		assertGone(t, taskDir, sandboxBinRel)
 		assertKept(t, taskDir, ".gc_meta.json")
 	}
@@ -234,7 +234,7 @@ func TestManagedArtifact_ActiveEnvRootKeepsSandboxBin(t *testing.T) {
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
 	d.markActiveEnvRoot(taskDir)
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionSkip {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionSkip {
 		t.Fatalf("want gcActionSkip for an active env root, got %d", got)
 	}
 	assertKept(t, taskDir, sandboxBinRel+"/codex")
@@ -257,11 +257,11 @@ func TestManagedArtifact_LocalDirectoryChatReclaimsSandboxBin(t *testing.T) {
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 	writeFile(t, filepath.Join(taskDir, "logs/run.log"), 32)
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionCleanManagedArtifacts {
 		t.Fatalf("want gcActionCleanManagedArtifacts, got %d", action)
 	}
-	d.applyGCAction(taskDir, action, &gcStats{byPattern: map[string]int{}})
+	d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, action, &gcStats{byPattern: map[string]int{}})
 	assertGone(t, taskDir, sandboxBinRel)
 	assertKept(t, taskDir, "logs/run.log", ".gc_meta.json")
 }
@@ -283,22 +283,22 @@ func TestManagedArtifact_SecondCycleIsANoOp(t *testing.T) {
 	})
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
 
-	first := d.shouldCleanTaskDir(context.Background(), taskDir)
+	first := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if first != gcActionCleanManagedArtifacts {
 		t.Fatalf("first cycle: want gcActionCleanManagedArtifacts, got %d", first)
 	}
-	d.applyGCAction(taskDir, first, &gcStats{byPattern: map[string]int{}})
+	d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, first, &gcStats{byPattern: map[string]int{}})
 	assertGone(t, taskDir, sandboxBinRel)
 
 	for cycle := 2; cycle <= 3; cycle++ {
-		if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionSkip {
+		if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionSkip {
 			t.Fatalf("cycle %d: want gcActionSkip once the cache is gone, got %d", cycle, got)
 		}
 	}
 
 	// A later Codex run re-provisions the cache; the GC must notice it again.
 	writeFile(t, filepath.Join(taskDir, sandboxBinRel, "codex"), 4096)
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionCleanManagedArtifacts {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionCleanManagedArtifacts {
 		t.Fatalf("want reclaim after re-provision, got %d", got)
 	}
 }
@@ -391,7 +391,7 @@ func TestManagedArtifact_UnreachableIssueStillReclaimsCache(t *testing.T) {
 	writeFile(t, filepath.Join(taskDir, "output/result.md"), 32)
 
 	stats := &gcStats{byPattern: map[string]int{}}
-	d.gcWorkspaceIssues(context.Background(), "ws", []issueGCCandidate{{taskDir: taskDir, meta: meta}}, stats)
+	d.gcWorkspaceIssues(context.Background(), d.cfg.WorkspacesRoot, "ws", []issueGCCandidate{{taskDir: taskDir, meta: meta}}, stats)
 
 	assertGone(t, taskDir, sandboxBinRel)
 	assertKept(t, taskDir, "output/result.md", ".gc_meta.json")

--- a/server/internal/daemon/gc_multiroot_test.go
+++ b/server/internal/daemon/gc_multiroot_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGCWorkspaceRootsMultiProfile verifies that a single GC pass walks the
+// current profile's root plus roots abandoned by a previous profile whose
+// daemon is no longer running, while skipping roots owned by a live daemon.
+func TestGCWorkspaceRootsMultiProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+
+	// The current (default) profile's root comes straight from the config, not
+	// from $HOME resolution.
+	currentRoot := t.TempDir()
+
+	// An abandoned profile: its daemon exited (no daemon.pid), and its
+	// workspace root exists. It must be included so GC can reclaim it.
+	abandoned := "old-profile"
+	abandonedProfileDir := filepath.Join(home, ".multica", "profiles", abandoned)
+	if err := os.MkdirAll(abandonedProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abandonedRoot := filepath.Join(home, "multica_workspaces_"+abandoned)
+	if err := os.MkdirAll(abandonedRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A live profile: daemon.pid is present, so its root must be skipped. GC
+	// must never delete workdirs another daemon is actively using.
+	live := "live-profile"
+	liveProfileDir := filepath.Join(home, ".multica", "profiles", live)
+	if err := os.MkdirAll(liveProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(liveProfileDir, "daemon.pid"), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	liveRoot := filepath.Join(home, "multica_workspaces_"+live)
+	if err := os.MkdirAll(liveRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A profile whose state directory exists but whose workspace root was never
+	// created. There is nothing to scan, so it must be skipped.
+	neverUsed := "never-used"
+	neverUsedProfileDir := filepath.Join(home, ".multica", "profiles", neverUsed)
+	if err := os.MkdirAll(neverUsedProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New(Config{WorkspacesRoot: currentRoot}, slog.Default())
+	roots := d.gcWorkspaceRoots()
+
+	got := make(map[string]bool, len(roots))
+	for _, gr := range roots {
+		got[gr.root] = true
+	}
+
+	if !got[currentRoot] {
+		t.Errorf("current root %q missing from roots", currentRoot)
+	}
+	if !got[abandonedRoot] {
+		t.Errorf("abandoned root %q missing from roots (should be scanned)", abandonedRoot)
+	}
+	if got[liveRoot] {
+		t.Errorf("live root %q present in roots (should be skipped: daemon running)", liveRoot)
+	}
+	neverUsedRoot := filepath.Join(home, "multica_workspaces_"+neverUsed)
+	if got[neverUsedRoot] {
+		t.Errorf("never-used root %q present in roots (should be skipped: root does not exist)", neverUsedRoot)
+	}
+}
+
+// TestProfileDaemonActive verifies ownership detection is driven by the
+// presence of a profile's daemon.pid file.
+func TestProfileDaemonActive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	live := "live"
+	liveDir := filepath.Join(home, ".multica", "profiles", live)
+	if err := os.MkdirAll(liveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(liveDir, "daemon.pid"), []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dead := "dead"
+	deadDir := filepath.Join(home, ".multica", "profiles", dead)
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New(Config{}, slog.Default())
+
+	if !d.profileDaemonActive(live) {
+		t.Errorf("profile %q with daemon.pid should be active", live)
+	}
+	if d.profileDaemonActive(dead) {
+		t.Errorf("profile %q without daemon.pid should be inactive", dead)
+	}
+}

--- a/server/internal/daemon/gc_multiroot_test.go
+++ b/server/internal/daemon/gc_multiroot_test.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestGCWorkspaceRootsMultiProfile verifies that a single GC pass walks the
@@ -105,5 +108,61 @@ func TestProfileDaemonActive(t *testing.T) {
 	}
 	if d.profileDaemonActive(dead) {
 		t.Errorf("profile %q without daemon.pid should be inactive", dead)
+	}
+}
+
+// TestRunGCReclaimsAbandonedProfileRoot 是端到端验证：真实构造一个
+// 废弃 profile 的 workspace root（daemon 已退出、无 daemon.pid），里面留一个
+// 无 .gc_meta.json 且 mtime 超过 GCOrphanTTL 的孤儿 task 目录，然后真实调用
+// runGC，断言孤儿目录被删除、而 mtime 较新的活跃目录被保留。
+func TestRunGCReclaimsAbandonedProfileRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// 当前 profile (default) 的 workspace root（空）
+	currentRoot := filepath.Join(home, "multica_workspaces")
+	if err := os.MkdirAll(currentRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 废弃 profile：daemon 已退出，profiles 目录存在但无 daemon.pid
+	const abandoned = "old-profile"
+	abandonedProfileDir := filepath.Join(home, ".multica", "profiles", abandoned)
+	if err := os.MkdirAll(abandonedProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abandonedRoot := filepath.Join(home, "multica_workspaces_"+abandoned)
+
+	// 孤儿 task 目录：无 .gc_meta.json，mtime 73 小时前。它仍带有有效的
+	// .task_owner 标记（真实崩溃会留下该标记），因此所有权校验通过，仅由
+	// mtime 决定是否清理。
+	orphanTask := createTaskDir(t, abandonedRoot, "ws-abc", "task-orphan", nil)
+	if err := os.WriteFile(filepath.Join(orphanTask, "leftover.txt"), []byte("orphan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orphanMtime := time.Now().Add(-73 * time.Hour)
+	if err := os.Chtimes(orphanTask, orphanMtime, orphanMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	// 活跃 task 目录：mtime 较新，不应被删除。
+	activeTask := createTaskDir(t, abandonedRoot, "ws-abc", "task-active", nil)
+	if err := os.WriteFile(filepath.Join(activeTask, "recent.txt"), []byte("active"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New(Config{
+		Profile:        "",
+		WorkspacesRoot: currentRoot,
+		GCOrphanTTL:    72 * time.Hour,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	d.runGC(context.Background())
+
+	if _, err := os.Stat(orphanTask); !os.IsNotExist(err) {
+		t.Errorf("废弃 profile 的孤儿 task 目录未被 GC 删除: %v", err)
+	}
+	if _, err := os.Stat(activeTask); err != nil {
+		t.Errorf("活跃 task 目录不应被删除: %v", err)
 	}
 }

--- a/server/internal/daemon/gc_multiroot_test.go
+++ b/server/internal/daemon/gc_multiroot_test.go
@@ -6,9 +6,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
+
+const nonexistentTestPID = 2147483647
 
 // TestGCWorkspaceRootsMultiProfile verifies that a single GC pass walks the
 // current profile's root plus roots abandoned by a previous profile whose
@@ -34,18 +37,33 @@ func TestGCWorkspaceRootsMultiProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A live profile: daemon.pid is present, so its root must be skipped. GC
-	// must never delete workdirs another daemon is actively using.
+	// A live profile points at this test process, so its root must be skipped.
+	// GC must never delete workdirs another daemon is actively using.
 	live := "live-profile"
 	liveProfileDir := filepath.Join(home, ".multica", "profiles", live)
 	if err := os.MkdirAll(liveProfileDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(liveProfileDir, "daemon.pid"), []byte("12345"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(liveProfileDir, "daemon.pid"), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	liveRoot := filepath.Join(home, "multica_workspaces_"+live)
 	if err := os.MkdirAll(liveRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stale pid file left by a crashed daemon must not strand the profile's
+	// workspace root forever.
+	stale := "stale-profile"
+	staleProfileDir := filepath.Join(home, ".multica", "profiles", stale)
+	if err := os.MkdirAll(staleProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleProfileDir, "daemon.pid"), []byte(strconv.Itoa(nonexistentTestPID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleRoot := filepath.Join(home, "multica_workspaces_"+stale)
+	if err := os.MkdirAll(staleRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,61 +92,74 @@ func TestGCWorkspaceRootsMultiProfile(t *testing.T) {
 	if got[liveRoot] {
 		t.Errorf("live root %q present in roots (should be skipped: daemon running)", liveRoot)
 	}
+	if !got[staleRoot] {
+		t.Errorf("stale-pid root %q missing from roots (should be scanned)", staleRoot)
+	}
 	neverUsedRoot := filepath.Join(home, "multica_workspaces_"+neverUsed)
 	if got[neverUsedRoot] {
 		t.Errorf("never-used root %q present in roots (should be skipped: root does not exist)", neverUsedRoot)
 	}
 }
 
-// TestProfileDaemonActive verifies ownership detection is driven by the
-// presence of a profile's daemon.pid file.
+// TestProfileDaemonActive verifies that ownership detection distinguishes a
+// live process from a stale pid file while failing safe on malformed content.
 func TestProfileDaemonActive(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	live := "live"
-	liveDir := filepath.Join(home, ".multica", "profiles", live)
-	if err := os.MkdirAll(liveDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(liveDir, "daemon.pid"), []byte("1"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	dead := "dead"
-	deadDir := filepath.Join(home, ".multica", "profiles", dead)
-	if err := os.MkdirAll(deadDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
 	d := New(Config{}, slog.Default())
-
-	if !d.profileDaemonActive(live) {
-		t.Errorf("profile %q with daemon.pid should be active", live)
+	tests := []struct {
+		name     string
+		pid      string
+		want     bool
+		writePID bool
+	}{
+		{name: "missing", want: false},
+		{name: "live", pid: strconv.Itoa(os.Getpid()), want: true, writePID: true},
+		{name: "live-whitespace", pid: " \n" + strconv.Itoa(os.Getpid()) + "\t", want: true, writePID: true},
+		{name: "stale", pid: strconv.Itoa(nonexistentTestPID), want: false, writePID: true},
+		{name: "malformed", pid: "not-a-pid", want: true, writePID: true},
+		{name: "non-positive", pid: "0", want: true, writePID: true},
 	}
-	if d.profileDaemonActive(dead) {
-		t.Errorf("profile %q without daemon.pid should be inactive", dead)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profileDir := filepath.Join(home, ".multica", "profiles", tt.name)
+			if err := os.MkdirAll(profileDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tt.writePID {
+				if err := os.WriteFile(filepath.Join(profileDir, "daemon.pid"), []byte(tt.pid), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := d.profileDaemonActive(tt.name); got != tt.want {
+				t.Errorf("profileDaemonActive(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
 	}
 }
 
-// TestRunGCReclaimsAbandonedProfileRoot 是端到端验证：真实构造一个
-// 废弃 profile 的 workspace root（daemon 已退出、无 daemon.pid），里面留一个
-// 无 .gc_meta.json 且 mtime 超过 GCOrphanTTL 的孤儿 task 目录，然后真实调用
-// runGC，断言孤儿目录被删除、而 mtime 较新的活跃目录被保留。
+// TestRunGCReclaimsAbandonedProfileRoot exercises the real GC entry point
+// against a profile root whose crashed daemon left a stale pid file. An orphan
+// older than GCOrphanTTL is removed while a recent task directory is preserved.
 func TestRunGCReclaimsAbandonedProfileRoot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// 当前 profile (default) 的 workspace root（空）
+	// The current default profile's workspace root is empty.
 	currentRoot := filepath.Join(home, "multica_workspaces")
 	if err := os.MkdirAll(currentRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// 废弃 profile：daemon 已退出，profiles 目录存在但无 daemon.pid
+	// The abandoned profile has the stale pid file a crash would leave behind.
 	const abandoned = "old-profile"
 	abandonedProfileDir := filepath.Join(home, ".multica", "profiles", abandoned)
 	if err := os.MkdirAll(abandonedProfileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(abandonedProfileDir, "daemon.pid"), []byte(strconv.Itoa(nonexistentTestPID)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	abandonedRoot := filepath.Join(home, "multica_workspaces_"+abandoned)
@@ -160,9 +191,9 @@ func TestRunGCReclaimsAbandonedProfileRoot(t *testing.T) {
 	d.runGC(context.Background())
 
 	if _, err := os.Stat(orphanTask); !os.IsNotExist(err) {
-		t.Errorf("废弃 profile 的孤儿 task 目录未被 GC 删除: %v", err)
+		t.Errorf("abandoned profile's orphan task was not removed: %v", err)
 	}
 	if _, err := os.Stat(activeTask); err != nil {
-		t.Errorf("活跃 task 目录不应被删除: %v", err)
+		t.Errorf("recent task directory should be preserved: %v", err)
 	}
 }

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -331,7 +331,7 @@ func TestShouldCleanTaskDir_DoneIssueOverTTL(t *testing.T) {
 		CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionClean {
 		t.Fatalf("expected gcActionClean, got %d", action)
 	}
@@ -357,7 +357,7 @@ func TestShouldCleanTaskDir_CancelledIssueOverTTL(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionClean {
 		t.Fatalf("expected gcActionClean, got %d", action)
 	}
@@ -383,7 +383,7 @@ func TestShouldCleanTaskDir_OpenIssueSkipped(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip for open issue, got %d", action)
 	}
@@ -409,7 +409,7 @@ func TestShouldCleanTaskDir_DoneButRecentSkipped(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip for recently-done issue, got %d", action)
 	}
@@ -422,7 +422,7 @@ func TestShouldCleanTaskDir_NoMetaRecentSkipped(t *testing.T) {
 	// No meta, fresh directory — should skip.
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task5", nil)
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip for recent orphan, got %d", action)
 	}
@@ -435,7 +435,7 @@ func TestShouldCleanTaskDir_NoMetaOldOrphan(t *testing.T) {
 	d.cfg.GCOrphanTTL = 0 // treat all orphans as expired
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task6", nil)
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionOrphan {
 		t.Fatalf("expected gcActionOrphan, got %d", action)
 	}
@@ -458,7 +458,7 @@ func TestShouldCleanTaskDir_APIErrorSkipped(t *testing.T) {
 		CompletedAt: time.Now().Add(-2 * time.Hour),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on API error despite completed-task TTL, got %d", action)
 	}
@@ -482,7 +482,7 @@ func TestShouldCleanTaskDir_Issue404OldOrphan(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionOrphan {
 		t.Fatalf("expected gcActionOrphan for unreachable issue past TTL, got %d", action)
 	}
@@ -510,7 +510,7 @@ func TestShouldCleanTaskDir_Issue404RecentSkipped(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip for recent 404 (cross-workspace safety), got %d", action)
 	}
@@ -526,7 +526,7 @@ func TestCleanTaskDir_RemovesDirectory(t *testing.T) {
 		t.Fatal("task dir should exist before cleanup")
 	}
 
-	if bytes, removed := d.cleanTaskDir(taskDir); !removed || bytes < 64 {
+	if bytes, removed := d.cleanTaskDir(d.cfg.WorkspacesRoot, taskDir); !removed || bytes < 64 {
 		t.Fatalf("reclaimed bytes = %d, want at least payload size", bytes)
 	}
 
@@ -597,7 +597,7 @@ func TestApplyGCAction_RefusesEveryMutationWithoutOwner(t *testing.T) {
 			}
 
 			stats := &gcStats{byPattern: map[string]int{}}
-			if removed := d.applyGCAction(taskDir, tc.action, stats); removed != 0 {
+			if removed := d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, tc.action, stats); removed != 0 {
 				t.Fatalf("applyGCAction reported %d removals on an unowned directory", removed)
 			}
 			if stats.cleaned != 0 || stats.orphaned != 0 || stats.artifactDirs != 0 || stats.bytesReclaimed != 0 {
@@ -633,7 +633,7 @@ func TestCleanTaskDir_RefusesOwnerPathMismatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bytes, removed := d.cleanTaskDir(taskDir); removed || bytes != 0 {
+	if bytes, removed := d.cleanTaskDir(d.cfg.WorkspacesRoot, taskDir); removed || bytes != 0 {
 		t.Fatalf("cleanTaskDir removed owner/path mismatch: removed=%v bytes=%d", removed, bytes)
 	}
 	if _, err := os.Stat(survivor); err != nil {
@@ -663,7 +663,7 @@ func TestCleanTaskDir_AcceptsLegacyOwnerWithGCWorkspaceIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, removed := d.cleanTaskDir(taskDir); !removed {
+	if _, removed := d.cleanTaskDir(d.cfg.WorkspacesRoot, taskDir); !removed {
 		t.Fatal("legacy task owner with matching GC workspace identity was not removed")
 	}
 	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
@@ -689,7 +689,7 @@ func TestCleanTaskDir_RemovesStableRootRecord(t *testing.T) {
 	}
 	original := env.RootDir
 	d := &Daemon{cfg: Config{WorkspacesRoot: root}, logger: slog.Default()}
-	if bytes, removed := d.cleanTaskDir(original); !removed || bytes <= 0 {
+	if bytes, removed := d.cleanTaskDir(d.cfg.WorkspacesRoot, original); !removed || bytes <= 0 {
 		t.Fatalf("reclaimed bytes = %d, want owner metadata bytes", bytes)
 	}
 
@@ -729,7 +729,7 @@ func TestGcWorkspace_CleansEmptyWorkspaceDir(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	d.gcWorkspace(context.Background(), wsDir, &gcStats{byPattern: map[string]int{}})
+	d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, &gcStats{byPattern: map[string]int{}})
 
 	if _, err := os.Stat(wsDir); !os.IsNotExist(err) {
 		t.Fatal("empty workspace dir should be removed after all tasks cleaned")
@@ -779,7 +779,7 @@ func TestGCWorkspace_BatchesAndDeduplicatesIssueChecks(t *testing.T) {
 	})
 
 	stats := &gcStats{byPattern: map[string]int{}}
-	d.gcWorkspace(context.Background(), wsDir, stats)
+	d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, stats)
 
 	if batchRequests != 1 || legacyRequests != 0 {
 		t.Fatalf("requests: batch=%d legacy=%d, want batch=1 legacy=0", batchRequests, legacyRequests)
@@ -821,7 +821,7 @@ func TestGCWorkspace_CompletedTaskTTLRemovesOpenIssue(t *testing.T) {
 	writeFile(t, filepath.Join(taskDir, "workdir", "checkout.bin"), 128)
 
 	stats := &gcStats{byPattern: map[string]int{}}
-	d.gcWorkspace(context.Background(), wsDir, stats)
+	d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, stats)
 
 	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
 		t.Fatalf("completed open-issue task dir should be removed, stat error = %v", err)
@@ -857,7 +857,7 @@ func TestGCWorkspace_OldServerFallbackIsCached(t *testing.T) {
 		taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, tc.workspace, fmt.Sprintf("task-%d", i), &execenv.GCMeta{
 			IssueID: tc.issueID, WorkspaceID: tc.workspace, CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
 		})
-		d.gcWorkspace(context.Background(), wsDir, &gcStats{byPattern: map[string]int{}})
+		d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, &gcStats{byPattern: map[string]int{}})
 		if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
 			t.Fatalf("legacy fallback did not clean %s", taskDir)
 		}
@@ -894,7 +894,7 @@ func TestGCWorkspace_BatchFailureDoesNotFanOutOrClean(t *testing.T) {
 		IssueID: issueID, WorkspaceID: "ws-fail", CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
 	})
 	stats := &gcStats{byPattern: map[string]int{}}
-	d.gcWorkspace(context.Background(), wsDir, stats)
+	d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, stats)
 
 	if batchRequests != 1 || legacyRequests != 0 {
 		t.Fatalf("requests: batch=%d legacy=%d, want batch=1 legacy=0", batchRequests, legacyRequests)
@@ -946,7 +946,7 @@ func TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns(t *test
 	}
 
 	stats := &gcStats{byPattern: map[string]int{}}
-	d.gcWorkspace(context.Background(), wsDir, stats)
+	d.gcWorkspace(context.Background(), d.cfg.WorkspacesRoot, wsDir, stats)
 
 	if _, err := os.Stat(filepath.Join(taskDir, "codex-home/.sandbox-bin")); !os.IsNotExist(err) {
 		t.Fatalf("managed Codex sandbox should be removed, stat err=%v", err)
@@ -993,7 +993,7 @@ func TestShouldCleanTaskDir_OpenIssueArtifactCleanup(t *testing.T) {
 		CompletedAt: time.Now().Add(-24 * time.Hour),
 	})
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action != gcActionCleanArtifacts {
 		t.Fatalf("expected gcActionCleanArtifacts for old completed task on open issue, got %d", action)
 	}
@@ -1022,7 +1022,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLRemovesOpenIssue(t *testing.T) {
 		CompletedAt: time.Now().Add(-25 * time.Hour),
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionClean {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionClean {
 		t.Fatalf("expected completed-task TTL to clean open issue env, got %d", action)
 	}
 
@@ -1032,7 +1032,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLRemovesOpenIssue(t *testing.T) {
 		WorkspaceID: "ws1",
 		CompletedAt: time.Now().Add(-23 * time.Hour),
 	})
-	if action := d.shouldCleanTaskDir(context.Background(), recentTaskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, recentTaskDir); action != gcActionSkip {
 		t.Fatalf("expected completed-task TTL to preserve a recent open-issue env, got %d", action)
 	}
 }
@@ -1058,7 +1058,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLUnknownIssueStatusFailsClosed(t *tes
 		CompletedAt: time.Now().Add(-2 * time.Hour),
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected unknown issue status to fail closed, got %d", action)
 	}
 }
@@ -1080,7 +1080,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLRequiresCompletionTime(t *testing.T)
 		Kind: execenv.GCKindIssue, IssueID: issueID, WorkspaceID: "ws1",
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected task without completed_at to remain, got %d", action)
 	}
 }
@@ -1106,7 +1106,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLKeepsLocalDirectoryArtifactTTLSepara
 		LocalDirectory: true,
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected completed-task TTL not to accelerate local_directory artifact cleanup, got %d", action)
 	}
 
@@ -1117,7 +1117,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLKeepsLocalDirectoryArtifactTTLSepara
 		CompletedAt:    time.Now().Add(-13 * time.Hour),
 		LocalDirectory: true,
 	})
-	if action := d.shouldCleanTaskDir(context.Background(), artifactEligibleDir); action != gcActionCleanArtifacts {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, artifactEligibleDir); action != gcActionCleanArtifacts {
 		t.Fatalf("expected existing artifact TTL to remain effective for local_directory env, got %d", action)
 	}
 }
@@ -1142,7 +1142,7 @@ func TestShouldCleanTaskDir_CompletedTaskTTLPreservesActiveEnv(t *testing.T) {
 	d.markActiveEnvRoot(taskDir)
 	defer d.unmarkActiveEnvRoot(taskDir)
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected active env to remain despite completed-task TTL, got %d", action)
 	}
 }
@@ -1167,7 +1167,7 @@ func TestShouldCleanTaskDir_OpenIssueRecentTaskSkipped(t *testing.T) {
 		CompletedAt: time.Now().Add(-1 * time.Minute),
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip for fresh completed_at, got %d", action)
 	}
 }
@@ -1193,7 +1193,7 @@ func TestShouldCleanTaskDir_LegacyMetaUsesManagedOnlyFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionCleanManagedArtifacts {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionCleanManagedArtifacts {
 		t.Fatalf("expected managed-only fallback for stale legacy meta, got %d", action)
 	}
 
@@ -1205,7 +1205,7 @@ func TestShouldCleanTaskDir_LegacyMetaUsesManagedOnlyFallback(t *testing.T) {
 	if err := os.Chtimes(recentDir, old, old); err != nil {
 		t.Fatal(err)
 	}
-	if action := d.shouldCleanTaskDir(context.Background(), recentDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, recentDir); action != gcActionSkip {
 		t.Fatalf("expected recent legacy meta to remain untouched, got %d", action)
 	}
 }
@@ -1233,7 +1233,7 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsArtifactCleanup(t *testing.T) {
 	d.markActiveEnvRoot(taskDir)
 	defer d.unmarkActiveEnvRoot(taskDir)
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip while task is active, got %d", action)
 	}
 }
@@ -1266,7 +1266,7 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsFullCleanup(t *testing.T) {
 	d.markActiveEnvRoot(taskDir)
 	defer d.unmarkActiveEnvRoot(taskDir)
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with done+stale issue, got %d", action)
 	}
 }
@@ -1292,7 +1292,7 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsOrphan404(t *testing.T) {
 	d.markActiveEnvRoot(taskDir)
 	defer d.unmarkActiveEnvRoot(taskDir)
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with 404 issue, got %d", action)
 	}
 }
@@ -1307,7 +1307,7 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsNoMetaOrphan(t *testing.T) {
 	d.markActiveEnvRoot(taskDir)
 	defer d.unmarkActiveEnvRoot(taskDir)
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with no-meta orphan, got %d", action)
 	}
 }
@@ -1333,7 +1333,7 @@ func TestShouldCleanTaskDir_ArtifactTTLDisabled(t *testing.T) {
 		CompletedAt: time.Now().Add(-100 * 24 * time.Hour),
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip when artifact GC disabled, got %d", action)
 	}
 }
@@ -1354,7 +1354,7 @@ func TestShouldCleanTaskDir_ArtifactTTLDisabledSkipsLocalOrphanManagedCleanup(t 
 		Kind: execenv.GCKindIssue, IssueID: issueID, WorkspaceID: "ws1", LocalDirectory: true,
 	})
 
-	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
+	if action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); action != gcActionSkip {
 		t.Fatalf("expected artifact TTL zero to disable managed local orphan cleanup, got %d", action)
 	}
 }
@@ -2225,7 +2225,7 @@ func TestShouldCleanTaskDir_KindDispatch(t *testing.T) {
 			}
 			d := newGCTestDaemon(t, mux)
 			taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", tc.name, tc.meta)
-			got := d.shouldCleanTaskDir(context.Background(), taskDir)
+			got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 			if got != tc.want {
 				t.Fatalf("kind dispatch %q: want %d, got %d", tc.name, tc.want, got)
 			}
@@ -2278,7 +2278,7 @@ func TestShouldCleanTaskDir_EmptyParentIDFallsBackToOrphanMTime(t *testing.T) {
 			d.cfg.GCOrphanTTL = 365 * 24 * time.Hour
 			taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", tc.name, tc.meta)
 
-			got := d.shouldCleanTaskDir(context.Background(), taskDir)
+			got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 			if got != gcActionSkip {
 				t.Fatalf("empty parent id should skip while under orphan TTL, got %d", got)
 			}
@@ -2290,7 +2290,7 @@ func TestShouldCleanTaskDir_EmptyParentIDFallsBackToOrphanMTime(t *testing.T) {
 			if err := os.Chtimes(taskDir, old, old); err != nil {
 				t.Fatalf("chtimes: %v", err)
 			}
-			got = d.shouldCleanTaskDir(context.Background(), taskDir)
+			got = d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 			if got != gcActionOrphan {
 				t.Fatalf("empty parent id over orphan TTL should orphan, got %d", got)
 			}
@@ -2371,7 +2371,7 @@ func TestShouldCleanTaskDir_ChatHardDeletedFreshMtime(t *testing.T) {
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", "hard-deleted-chat", meta)
 	// taskDir mtime is now-ish — well within any sane GCOrphanTTL.
 
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionClean {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionClean {
 		t.Fatalf("hard-deleted chat with fresh mtime must clean immediately, got %d", got)
 	}
 }
@@ -2415,11 +2415,11 @@ func TestShouldCleanTaskDir_ChatActiveResistsOldMtime(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	action := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if action == gcActionClean || action == gcActionOrphan {
 		t.Fatalf("active chat session's directory must never be removed, got action %d", action)
 	}
-	d.applyGCAction(taskDir, action, &gcStats{byPattern: map[string]int{}})
+	d.applyGCAction(d.cfg.WorkspacesRoot, taskDir, action, &gcStats{byPattern: map[string]int{}})
 
 	for _, rel := range []string{".", "logs/run.log", "output/result.md", ".gc_meta.json"} {
 		if _, err := os.Stat(filepath.Join(taskDir, rel)); err != nil {
@@ -2527,7 +2527,7 @@ func TestShouldCleanTaskDir_LocalDirectoryNeverClean(t *testing.T) {
 		LocalDirectory: true,
 	})
 
-	got := d.shouldCleanTaskDir(context.Background(), taskDir)
+	got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if got == gcActionClean {
 		t.Fatalf("expected local_directory task to never return gcActionClean, got gcActionClean")
 	}
@@ -2559,7 +2559,7 @@ func TestShouldCleanTaskDir_LocalDirectoryOrphanUsesManagedOnly(t *testing.T) {
 		LocalDirectory: true,
 	})
 
-	got := d.shouldCleanTaskDir(context.Background(), taskDir)
+	got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir)
 	if got != gcActionCleanManagedArtifacts {
 		t.Fatalf("expected local_directory orphan to use managed-only cleanup, got %d", got)
 	}
@@ -2590,7 +2590,7 @@ func TestShouldCleanTaskDir_LocalDirectoryFalsePreservesNormalClean(t *testing.T
 		// LocalDirectory unset (false).
 	})
 
-	if got := d.shouldCleanTaskDir(context.Background(), taskDir); got != gcActionClean {
+	if got := d.shouldCleanTaskDir(context.Background(), d.cfg.WorkspacesRoot, taskDir); got != gcActionClean {
 		t.Fatalf("expected gcActionClean for normal task, got %d", got)
 	}
 }

--- a/server/internal/daemon/process_alive_unix.go
+++ b/server/internal/daemon/process_alive_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processAlive probes pid without sending a signal. ESRCH is the only result
+// that proves the process is gone; permission and other errors fail safe to
+// alive so GC cannot act on an inconclusive ownership check.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return !errors.Is(err, syscall.ESRCH)
+}

--- a/server/internal/daemon/process_alive_windows.go
+++ b/server/internal/daemon/process_alive_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// processAlive opens a synchronizable process handle and checks whether it has
+// exited without waiting. Access-denied and unexpected results fail safe to
+// alive; ERROR_INVALID_PARAMETER is how OpenProcess reports a vanished pid.
+func processAlive(pid int) bool {
+	process, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return !errors.Is(err, windows.ERROR_INVALID_PARAMETER)
+	}
+	defer windows.CloseHandle(process)
+
+	status, err := windows.WaitForSingleObject(process, 0)
+	if err != nil {
+		return true
+	}
+	return status != windows.WAIT_OBJECT_0
+}


### PR DESCRIPTION
## Summary

`multica daemon`'s garbage collector only ever scanned `d.cfg.WorkspacesRoot` — the current profile's workspace root. Once an install switched to a named profile, everything left behind in the old profile's root was stranded forever: GC never visited it, so it could grow unbounded. Disk-usage reporting already walked all roots, but reclamation did not.

## Fix

Teach GC to walk every profile's workspace root:

- `gcWorkspaceRoots()` now returns the current profile's root plus any other profile root whose owning daemon is not running.
- Ownership is checked per profile via its `daemon.pid` (a live daemon keeps its PID file), so GC never reclaims another live daemon's in-flight workdirs.
- Roots that have never been used (no workspace dir) are skipped, matching the previous single-root behavior.

## Testing

- `go build ./cmd/multica/` passes
- `go test ./internal/daemon/ -run "GC|Daemon"` passes
- Added `TestGCWorkspaceRootsMultiProfile` and `TestProfileDaemonActive` covering: abandoned profile root is reclaimed, live daemon's root is skipped, never-used root is skipped.

Closes #6962