### PR TITLE
MUL-6291: stop paying for jsdom in pure-logic frontend suites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,8 @@ Tests follow the code:
 Rules:
 
 - Never test shared component behavior in an app test file.
+- Give each product behavior ONE canonical layer. Pure parsing, state transitions and boundary matrices belong in a `.test.ts` beside the helper; the component suite keeps the happy path, the wiring, accessibility and named regressions, and points at the canonical file in a comment. Do not re-run a helper's matrix through a DOM mount.
+- A `.test.ts` that needs no DOM must start with `// @vitest-environment node`. jsdom costs ~0.8s of setup per file and buys such a suite nothing. Do not add it to a test whose code under test branches on `typeof window`/`document` — under node it would silently take the SSR path and still pass.
 - `packages/views/` tests must not mock `next/*` or `react-router-dom`.
 - Mock `@multica/core` stores with the Zustand callable-store shape (`selectorFn` plus `getState`).
 - Mock `@multica/core/api` for API calls.

--- a/apps/desktop/src/main/auth-session-coordinator.test.ts
+++ b/apps/desktop/src/main/auth-session-coordinator.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   AuthSessionCoordinator,

--- a/apps/desktop/src/main/cli-release-asset.test.ts
+++ b/apps/desktop/src/main/cli-release-asset.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { selectPlatformReleaseAssetName } from "./cli-release-asset";

--- a/apps/desktop/src/main/context-menu.test.ts
+++ b/apps/desktop/src/main/context-menu.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Capture every MenuItem the SUT constructs so each test can assert

--- a/apps/desktop/src/main/daemon-auth-probe.test.ts
+++ b/apps/desktop/src/main/daemon-auth-probe.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { classifyAuthProbe, isAuthStatusError } from "./daemon-auth-probe";

--- a/apps/desktop/src/main/daemon-os.test.ts
+++ b/apps/desktop/src/main/daemon-os.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 
 import {

--- a/apps/desktop/src/main/daemon-profile.test.ts
+++ b/apps/desktop/src/main/daemon-profile.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { homedir } from "os";
 import { join } from "path";
 import { describe, expect, it } from "vitest";

--- a/apps/desktop/src/main/dev-log.test.ts
+++ b/apps/desktop/src/main/dev-log.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { createBestEffortDevLog } from "./dev-log";

--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("electron", () => ({

--- a/apps/desktop/src/main/freeze-breadcrumb.test.ts
+++ b/apps/desktop/src/main/freeze-breadcrumb.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/apps/desktop/src/main/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import { handleAppShortcut, type ShortcutInput } from "./keyboard-shortcuts";
 

--- a/apps/desktop/src/main/navigation-gestures.test.ts
+++ b/apps/desktop/src/main/navigation-gestures.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import type { BrowserWindow } from "electron";
 import { describe, expect, it, vi } from "vitest";
 import { NAVIGATION_GESTURE_CHANNEL } from "../shared/navigation-gestures";

--- a/apps/desktop/src/main/navigation-guard.test.ts
+++ b/apps/desktop/src/main/navigation-guard.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   describeBlockedNavigation,

--- a/apps/desktop/src/main/notification-gate.test.ts
+++ b/apps/desktop/src/main/notification-gate.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   NotificationGate,

--- a/apps/desktop/src/main/renderer-recovery.test.ts
+++ b/apps/desktop/src/main/renderer-recovery.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createElectronReloadPrompt, installRendererRecoveryHandlers } from "./renderer-recovery";
 

--- a/apps/desktop/src/main/runtime-config-loader.test.ts
+++ b/apps/desktop/src/main/runtime-config-loader.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { mkdtemp, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";

--- a/apps/desktop/src/main/updater-preferences.test.ts
+++ b/apps/desktop/src/main/updater-preferences.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it } from "vitest";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserWindow, WebContents } from "electron";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";

--- a/apps/desktop/src/main/version-decision.test.ts
+++ b/apps/desktop/src/main/version-decision.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { decideVersionAction } from "./version-decision";
 

--- a/apps/desktop/src/main/window-state.test.ts
+++ b/apps/desktop/src/main/window-state.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/apps/desktop/src/renderer/src/components/parse-daemon-log.test.ts
+++ b/apps/desktop/src/renderer/src/components/parse-daemon-log.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { parseLogLine } from "./parse-daemon-log";
 

--- a/apps/desktop/src/renderer/src/font-fallback-order.test.ts
+++ b/apps/desktop/src/renderer/src/font-fallback-order.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/apps/desktop/src/renderer/src/freeze-flush.test.ts
+++ b/apps/desktop/src/renderer/src/freeze-flush.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 /**
  * Two regressions are pinned here, both found in review of MUL-5345.
  *

--- a/apps/desktop/src/renderer/src/platform/daemon-login-sync.test.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-login-sync.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/apps/desktop/src/shared/daemon-types.test.ts
+++ b/apps/desktop/src/shared/daemon-types.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { daemonStatusAlive } from "./daemon-types";
 

--- a/apps/desktop/src/shared/issue-window.test.ts
+++ b/apps/desktop/src/shared/issue-window.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   encodeIssueWindowArgument,

--- a/apps/desktop/src/shared/main-renderer-messages.test.ts
+++ b/apps/desktop/src/shared/main-renderer-messages.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   MainRendererMessageQueue,

--- a/apps/desktop/src/shared/navigation-gestures.test.ts
+++ b/apps/desktop/src/shared/navigation-gestures.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   isNavigationGesture,

--- a/apps/desktop/src/shared/renderer-route-context.test.ts
+++ b/apps/desktop/src/shared/renderer-route-context.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 /**
  * This context is attached to freeze/crash reports, which leave the machine.
  * The sanitizer is the last checkpoint before a renderer-supplied payload is

--- a/apps/desktop/src/shared/runtime-config.test.ts
+++ b/apps/desktop/src/shared/runtime-config.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_RUNTIME_CONFIG,

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -19,37 +19,42 @@ function createMemoryStorage(): Storage {
   };
 }
 
-const localStorageIsUsable =
-  typeof globalThis.localStorage?.getItem === "function" &&
-  typeof globalThis.localStorage?.setItem === "function" &&
-  typeof globalThis.localStorage?.removeItem === "function" &&
-  typeof globalThis.localStorage?.clear === "function";
+// Everything below patches gaps in jsdom. Pure-logic suites opt out of jsdom
+// with `// @vitest-environment node` and share this file, so there is no DOM to
+// patch there — bail out rather than guard each stub.
+if (typeof window !== "undefined") {
+  const localStorageIsUsable =
+    typeof globalThis.localStorage?.getItem === "function" &&
+    typeof globalThis.localStorage?.setItem === "function" &&
+    typeof globalThis.localStorage?.removeItem === "function" &&
+    typeof globalThis.localStorage?.clear === "function";
 
-if (!localStorageIsUsable) {
-  const storage = createMemoryStorage();
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
-}
+  if (!localStorageIsUsable) {
+    const storage = createMemoryStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+  }
 
-// jsdom doesn't provide matchMedia; the sidebar's compact breakpoint and
-// auto-collapse band both read it. Nothing matches, so a shell mounted here
-// renders at its full desktop width. Mirrors packages/views/test/setup.ts.
-if (typeof window.matchMedia !== "function") {
-  window.matchMedia = (query: string) =>
-    ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    }) as MediaQueryList;
+  // jsdom doesn't provide matchMedia; the sidebar's compact breakpoint and
+  // auto-collapse band both read it. Nothing matches, so a shell mounted here
+  // renders at its full desktop width. Mirrors packages/views/test/setup.ts.
+  if (typeof window.matchMedia !== "function") {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+  }
 }

--- a/apps/web/app/brand-variant-cascade.test.ts
+++ b/apps/web/app/brand-variant-cascade.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import postcss from "postcss";

--- a/apps/web/app/font-fallback-order.test.ts
+++ b/apps/web/app/font-fallback-order.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/apps/web/app/text-contrast.test.ts
+++ b/apps/web/app/text-contrast.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/apps/web/app/type-scale.test.ts
+++ b/apps/web/app/type-scale.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve, join, relative } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/apps/web/config/runtime-urls.test.ts
+++ b/apps/web/config/runtime-urls.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import {

--- a/apps/web/features/landing/utils/github-release.test.ts
+++ b/apps/web/features/landing/utils/github-release.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchLatestRelease } from "./github-release";
 

--- a/apps/web/features/landing/utils/parse-release-assets.test.ts
+++ b/apps/web/features/landing/utils/parse-release-assets.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { parseReleaseAssets } from "./parse-release-assets";
 

--- a/apps/web/features/landing/utils/use-github-stars.test.ts
+++ b/apps/web/features/landing/utils/use-github-stars.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { formatStarCount } from "./use-github-stars";
 

--- a/apps/web/lib/docs-href.test.ts
+++ b/apps/web/lib/docs-href.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { docsHrefForLocale } from "./docs-href";
 

--- a/apps/web/lib/public-host.test.ts
+++ b/apps/web/lib/public-host.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { isOfficialMarketingHost } from "./public-host";

--- a/apps/web/lib/use-case-locale-fallback.test.ts
+++ b/apps/web/lib/use-case-locale-fallback.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockUseCasesSource = vi.hoisted(() => ({

--- a/apps/web/platform/client-os.test.ts
+++ b/apps/web/platform/client-os.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { detectWebOS } from "./client-os";
 

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,48 +1,53 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
-// jsdom doesn't provide ResizeObserver; stub it so components that rely on it
-// (e.g. input-otp) can render in tests.
-if (typeof globalThis.ResizeObserver === "undefined") {
-  globalThis.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as unknown as typeof ResizeObserver;
-}
+// Everything below patches gaps in jsdom. Pure-logic suites opt out of jsdom
+// with `// @vitest-environment node` and share this file, so there is no DOM to
+// patch there — bail out rather than guard each stub.
+if (typeof window !== "undefined") {
+  // jsdom doesn't provide ResizeObserver; stub it so components that rely on it
+  // (e.g. input-otp) can render in tests.
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
 
-// jsdom doesn't implement elementFromPoint; input-otp uses it internally.
-if (typeof document.elementFromPoint !== "function") {
-  document.elementFromPoint = () => null;
-}
+  // jsdom doesn't implement elementFromPoint; input-otp uses it internally.
+  if (typeof document.elementFromPoint !== "function") {
+    document.elementFromPoint = () => null;
+  }
 
-// jsdom 29 / Node.js 22+ may not provide a proper Web Storage API.
-// Create a proper localStorage mock if methods are missing.
-if (
-  typeof globalThis.localStorage === "undefined" ||
-  typeof globalThis.localStorage.getItem !== "function"
-) {
-  const store: Record<string, string> = {};
-  const localStorageMock = {
-    getItem: vi.fn((key: string) => store[key] ?? null),
-    setItem: vi.fn((key: string, value: string) => {
-      store[key] = value;
-    }),
-    removeItem: vi.fn((key: string) => {
-      delete store[key];
-    }),
-    clear: vi.fn(() => {
-      for (const key of Object.keys(store)) {
+  // jsdom 29 / Node.js 22+ may not provide a proper Web Storage API.
+  // Create a proper localStorage mock if methods are missing.
+  if (
+    typeof globalThis.localStorage === "undefined" ||
+    typeof globalThis.localStorage.getItem !== "function"
+  ) {
+    const store: Record<string, string> = {};
+    const localStorageMock = {
+      getItem: vi.fn((key: string) => store[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
         delete store[key];
-      }
-    }),
-    get length() {
-      return Object.keys(store).length;
-    },
-    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
-  };
-  Object.defineProperty(globalThis, "localStorage", {
-    value: localStorageMock,
-    writable: true,
-  });
+      }),
+      clear: vi.fn(() => {
+        for (const key of Object.keys(store)) {
+          delete store[key];
+        }
+      }),
+      get length() {
+        return Object.keys(store).length;
+      },
+      key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorageMock,
+      writable: true,
+    });
+  }
 }

--- a/packages/views/agents/agents-i18n-parity.test.ts
+++ b/packages/views/agents/agents-i18n-parity.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import en from "../locales/en/agents.json";
 import zhHans from "../locales/zh-Hans/agents.json";

--- a/packages/views/agents/components/inspector/model-capability.test.ts
+++ b/packages/views/agents/components/inspector/model-capability.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { RuntimeModel } from "@multica/core/types";
 import {

--- a/packages/views/agents/components/inspector/model-change-cleanup.test.ts
+++ b/packages/views/agents/components/inspector/model-change-cleanup.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { RuntimeModel } from "@multica/core/types";
 import { buildModelChangeUpdate } from "./model-change-cleanup";

--- a/packages/views/agents/components/tabs/env-file.test.ts
+++ b/packages/views/agents/components/tabs/env-file.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import type { EnvAssignment } from "./env-file";

--- a/packages/views/agents/components/tabs/mcp-config-model.test.ts
+++ b/packages/views/agents/components/tabs/mcp-config-model.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   listManagedMcpServers,

--- a/packages/views/agents/components/tabs/task-failure.test.ts
+++ b/packages/views/agents/components/tabs/task-failure.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { cancelReasonLabel, failureReasonLabel } from "./task-failure";

--- a/packages/views/autopilots/components/autopilots-page.test.ts
+++ b/packages/views/autopilots/components/autopilots-page.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 

--- a/packages/views/autopilots/components/run-now-toast.test.ts
+++ b/packages/views/autopilots/components/run-now-toast.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { runNowToastKind, runNowBlockedKey } from "./run-now-toast";
 

--- a/packages/views/autopilots/components/schedule-editor/cron-grammar.test.ts
+++ b/packages/views/autopilots/components/schedule-editor/cron-grammar.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
 import { cronFields, parseCron, toCron } from "./cron-mapping";
 

--- a/packages/views/autopilots/components/schedule-editor/cron-mapping.test.ts
+++ b/packages/views/autopilots/components/schedule-editor/cron-mapping.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { cronFields, parseCron, toCron } from "./cron-mapping";
 import type { ScheduleConfig } from "./model";

--- a/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
+++ b/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
@@ -463,21 +463,6 @@ describe("ScheduleEditor", () => {
     expect(screen.getByTestId("cron-out").textContent).toBe("30 14 * * *");
   });
 
-  it("keeps the minute across a fixed time → minute-step window → fixed time trip", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("30 14 * * *"));
-    await user.click(screen.getByRole("button", { name: "At an interval" }));
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    await user.click(screen.getByLabelText("Window start hour"));
-    await user.keyboard("14");
-    await user.click(screen.getByRole("button", { name: "At a time" }));
-    // A minute-step window is hour-granular, so its bounds read :00 — but the
-    // model still holds the 30 the user typed. Reading the anchor back off the
-    // window would silently fire the schedule half an hour early.
-    expect(screen.getByTestId("cron-out").textContent).toBe("30 14 * * *");
-  });
-
   it("focuses the interval when the time switches to an interval", async () => {
     const user = userEvent.setup();
     renderEditor(cron("0 9 * * *"));
@@ -707,18 +692,6 @@ describe("ScheduleEditor", () => {
     expect(cronOut()).toBe("0 9-23/3 * * *");
   });
 
-  it("takes a window widened back to the whole day as all day again", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-21/3 * * *"));
-    await user.click(screen.getByLabelText("Window start hour"));
-    await user.keyboard("00");
-    await user.click(screen.getByLabelText("Window end hour"));
-    await user.keyboard("23");
-    // A window that spans the day IS all day: the schedule has one form, and
-    // "0-23/3" is not a second one.
-    expect(cronOut()).toBe("0 */3 * * *");
-  });
-
   it("clears the window end to the end of the day, not onto its start", async () => {
     const user = userEvent.setup();
     renderEditor(cron("0 9-15 * * *"));
@@ -738,15 +711,6 @@ describe("ScheduleEditor", () => {
     expect(cronOut()).toBe("0 * * * *");
   });
 
-  it("raises the window end when the start is moved past it", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-12 * * *"));
-    const startHour = screen.getByLabelText("Window start hour");
-    await user.click(startHour!);
-    await user.keyboard("18");
-    expect(cronOut()).toBe("0 18-18 * * *");
-  });
-
   it("moves the shared firing minute when the window end's minute is edited", async () => {
     const user = userEvent.setup();
     renderEditor(cron("0 9-21 * * *"));
@@ -757,16 +721,9 @@ describe("ScheduleEditor", () => {
     expect(cronOut()).toBe("30 9-21 * * *");
   });
 
-  it("keeps the firing minute across an interval unit round-trip", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("30 */2 * * *"));
-    await user.click(screen.getAllByRole("combobox")[0]!);
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    await user.click(screen.getAllByRole("combobox")[0]!);
-    await user.click(await screen.findByRole("option", { name: "hours" }));
-    expect(cronOut()).toBe("30 */2 * * *");
-  });
-
+  // The all-day variant of this round-trip is the same wiring with a strictly
+  // weaker assertion; clampWindow's own unit round-trip matrix is in
+  // transitions.test.ts.
   it("keeps the firing minute across a unit round-trip with a time window", async () => {
     const user = userEvent.setup();
     renderEditor(cron("30 9-21/2 * * *"));

--- a/packages/views/autopilots/components/schedule-editor/schedule-editor.tsx
+++ b/packages/views/autopilots/components/schedule-editor/schedule-editor.tsx
@@ -49,6 +49,17 @@ import {
 } from "./cron-mapping";
 import { classifyScheduleRejection } from "./validate";
 import { useDescribeSchedule } from "./describe";
+import {
+  clampWindow,
+  defaultAtTime,
+  defaultEveryTime,
+  displayWindow,
+  isFullDay,
+  timeAnchorOf,
+  toggleDay,
+  type EveryPattern,
+  type ScheduleWindow,
+} from "./transitions";
 
 export interface ScheduleEditorProps {
   value: ScheduleConfig;
@@ -62,9 +73,6 @@ export interface ScheduleEditorProps {
 }
 
 const PREVIEW_DEBOUNCE_MS = 300;
-
-type EveryPattern = Extract<TimePattern, { kind: "every" }>;
-type ScheduleWindow = { from: string; to: string };
 
 function useNowTicker(intervalMs = 30_000): Date {
   const [now, setNow] = useState(() => new Date());
@@ -96,113 +104,6 @@ function useFormatCountdown() {
       });
     return t(($) => $.schedule_editor.countdown.minutes, { minutes });
   };
-}
-
-// The window is a dimension of the schedule, not a mode of the editor: all day is
-// the window that spans the day, and the model spells that one way — `window:
-// null`. Every window the editor commits goes through here, so the two never drift
-// into two representations of the same schedule.
-//
-// The bounds are read as hours. A minute-step window is hour-granular (its ends
-// read :00 and :59), and an hours-step window carries the firing minute at both
-// ends — neither minute has a say in whether the window spans the day.
-function isFullDay(window: ScheduleWindow): boolean {
-  return timeParts(window.from).hour === 0 && timeParts(window.to).hour === 23;
-}
-
-/** The window as the controls show it. All day has no window of its own, and the
- *  fields still have to render something: the bounds it stands for. */
-function displayWindow(time: EveryPattern): ScheduleWindow {
-  if (time.window !== null) return time.window;
-  return time.unit === "hours"
-    ? { from: `00:${pad2(time.minute)}`, to: `23:${pad2(time.minute)}` }
-    : { from: "00:00", to: "23:59" };
-}
-
-// An "every N hours, all day" pattern has nowhere to keep an hour, so the last
-// hour:minute the user actually expressed is carried outside the model. Without
-// it, at 14:30 → interval → at silently comes back as 09:30.
-//
-// The hour comes from the window, the minute from `minute` — never from the
-// window's own text. A minute-step window is hour-granular, so its bounds read
-// :00; taking the minute from there would drop the 30 of a 14:30 the user typed
-// before switching, which the model still holds.
-//
-// All day has no hour to give: the 00:00 its fields show is the absence of a
-// bound, not a time the user picked, and carrying it over would rewrite their
-// 14:30 to 00:30 on the way back to a fixed time.
-function timeAnchorOf(time: TimePattern): string | null {
-  if (time.kind === "at") return time.time;
-  if (time.window === null) return null;
-  return `${pad2(timeParts(time.window.from).hour)}:${pad2(time.minute)}`;
-}
-
-function defaultAtTime(prev: TimePattern, anchor: string): string {
-  return (
-    timeAnchorOf(prev) ??
-    `${pad2(timeParts(anchor).hour)}:${pad2(prev.kind === "every" ? prev.minute : 0)}`
-  );
-}
-
-// Switching to a fixed time can only carry one HH:MM, so the step, the unit and
-// the window would be gone on the way back — "every 3h, 9:00–21:00" would return
-// as "every hour, all day". They are remembered outside the model and restored,
-// rebased on whatever time the user is now switching away from.
-function defaultEveryTime(prev: TimePattern, anchor: EveryPattern | null): EveryPattern {
-  if (prev.kind === "every") return prev;
-  const { hour, minute } = timeParts(prev.time);
-  const base: EveryPattern = anchor ?? {
-    kind: "every",
-    interval: 1,
-    unit: "hours",
-    window: null,
-    minute,
-  };
-  const time: EveryPattern = { ...base, minute };
-  if (time.window === null) return time;
-  // The window restarts at the time the user is switching away from — but only
-  // where that still leaves a window. Rebasing "09:00–15:00" onto a 22:00 fixed
-  // time would drag the end up to 22 and hand back the single hour 22:00–22:00,
-  // destroying the very window this anchor exists to keep.
-  // Strictly earlier: a start rebased onto the end hour itself leaves the single
-  // hour 15:00–15:00, which is the same collapse by another name.
-  const rebased =
-    hour < timeParts(time.window.to).hour
-      ? { from: `${pad2(hour)}:${pad2(minute)}`, to: time.window.to }
-      : time.window;
-  // Rebasing a window that ends at 23 onto a midnight fixed time spans the whole
-  // day, and a window that spans the day is not one — the model holds that as all
-  // day, and nothing else may hand back a second form of it.
-  const window = clampWindow(rebased, time.unit, minute);
-  return { ...time, window: isFullDay(window) ? null : window };
-}
-
-// Keep windows canonical: `minute` — not the window's own current text — is the
-// single source of truth for the firing minute, so a hours → minutes → hours
-// unit round-trip restores it instead of leaving the zeroed value behind. Minute
-// intervals are hour-granular, and `to` is never earlier than `from`.
-function clampWindow(
-  window: ScheduleWindow,
-  unit: EveryPattern["unit"],
-  minute: number,
-): ScheduleWindow {
-  const from = timeParts(window.from);
-  const to = timeParts(window.to);
-  const edgeMinute = unit === "hours" ? minute : 0;
-  const endMinute = unit === "hours" ? minute : 59;
-  const endHour = Math.max(to.hour, from.hour);
-  return {
-    from: `${pad2(from.hour)}:${pad2(edgeMinute)}`,
-    to: `${pad2(endHour)}:${pad2(endMinute)}`,
-  };
-}
-
-function toggleDay(days: number[], day: number): number[] {
-  if (days.includes(day)) {
-    if (days.length === 1) return days;
-    return days.filter((d) => d !== day);
-  }
-  return [...days, day].toSorted((a, b) => a - b);
 }
 
 /** One dimension of the schedule. A fieldset, not a styled div: a greyed-out

--- a/packages/views/autopilots/components/schedule-editor/transitions.test.ts
+++ b/packages/views/autopilots/components/schedule-editor/transitions.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { TimePattern } from "./model";
+import {
+  clampWindow,
+  defaultAtTime,
+  defaultEveryTime,
+  displayWindow,
+  isFullDay,
+  timeAnchorOf,
+  toggleDay,
+  type EveryPattern,
+} from "./transitions";
+
+// The canonical matrix for the editor's schedule state transitions. These ran
+// as full DOM mounts in schedule-editor.test.tsx, one userEvent chain per
+// combination; the component suite now keeps the wiring and focus cases and
+// defers the combination space to the table below.
+
+const every = (over: Partial<EveryPattern> = {}): EveryPattern => ({
+  kind: "every",
+  interval: 1,
+  unit: "hours",
+  window: null,
+  minute: 0,
+  ...over,
+});
+
+describe("isFullDay", () => {
+  it.each([
+    ["00:00", "23:59", true],
+    ["00:30", "23:30", true],
+    ["00:00", "23:00", true],
+    ["09:00", "21:00", false],
+    ["00:00", "22:59", false],
+    ["01:00", "23:59", false],
+    ["22:00", "22:00", false],
+  ])("%s–%s spans the day: %s", (from, to, expected) => {
+    expect(isFullDay({ from, to })).toBe(expected);
+  });
+
+  // Only the hours decide. An hours-step window carries the firing minute at
+  // both ends, and a minute-step window reads :00/:59 — neither may turn a
+  // day-spanning window into something the model would hold as a real window.
+  it("ignores the minutes at both bounds", () => {
+    expect(isFullDay({ from: "00:59", to: "23:00" })).toBe(true);
+  });
+});
+
+describe("displayWindow", () => {
+  it("passes a real window through untouched", () => {
+    const window = { from: "09:00", to: "21:00" };
+    expect(displayWindow(every({ window }))).toEqual(window);
+  });
+
+  // All day has no window of its own, but the fields still render something:
+  // the bounds it stands for, at the granularity of the unit.
+  it("renders all day as the bounds it stands for, per unit", () => {
+    expect(displayWindow(every({ unit: "hours", minute: 30 }))).toEqual({
+      from: "00:30",
+      to: "23:30",
+    });
+    expect(displayWindow(every({ unit: "minutes", minute: 30 }))).toEqual({
+      from: "00:00",
+      to: "23:59",
+    });
+  });
+});
+
+describe("timeAnchorOf", () => {
+  it("takes a fixed time verbatim", () => {
+    expect(timeAnchorOf({ kind: "at", time: "14:30" })).toBe("14:30");
+  });
+
+  // The hour comes from the window, the minute from `minute` — never from the
+  // window's own text. A minute-step window is hour-granular, so its bounds
+  // read :00; reading the minute off them would fire a 14:30 schedule at 14:00.
+  it("takes the hour from the window and the minute from the model", () => {
+    expect(
+      timeAnchorOf(
+        every({ unit: "minutes", minute: 30, window: { from: "14:00", to: "14:59" } }),
+      ),
+    ).toBe("14:30");
+    expect(
+      timeAnchorOf(
+        every({ unit: "hours", minute: 30, window: { from: "14:30", to: "21:30" } }),
+      ),
+    ).toBe("14:30");
+  });
+
+  // All day has no hour to give: the 00:00 its fields show is the absence of a
+  // bound, not a time the user picked. Carrying it over would rewrite a 14:30.
+  it("has no anchor for an all-day interval", () => {
+    expect(timeAnchorOf(every({ minute: 30 }))).toBeNull();
+  });
+});
+
+describe("defaultAtTime", () => {
+  it("carries the anchor the current pattern can give", () => {
+    expect(defaultAtTime({ kind: "at", time: "14:30" }, "09:00")).toBe("14:30");
+    expect(
+      defaultAtTime(every({ minute: 30, window: { from: "14:30", to: "21:30" } }), "09:00"),
+    ).toBe("14:30");
+  });
+
+  // Falling back to the remembered anchor keeps the hour, but the minute is the
+  // schedule's own and outranks the anchor's.
+  it("falls back to the remembered hour with the pattern's minute", () => {
+    expect(defaultAtTime(every({ minute: 45 }), "08:15")).toBe("08:45");
+    expect(defaultAtTime({ kind: "at", time: "00:00" }, "08:15")).toBe("00:00");
+  });
+});
+
+describe("defaultEveryTime", () => {
+  it("leaves an interval pattern alone", () => {
+    const time = every({ interval: 3, window: { from: "09:00", to: "21:00" } });
+    expect(defaultEveryTime(time, null)).toBe(time);
+  });
+
+  // Step, unit and window are as much user input as the hour is; rebuilding
+  // from defaults would turn "every 3h, 9–21" into "every hour, all day".
+  it("restores the remembered step, unit and window", () => {
+    const anchor = every({ interval: 3, window: { from: "09:00", to: "21:00" } });
+    expect(defaultEveryTime({ kind: "at", time: "10:00" }, anchor)).toMatchObject({
+      interval: 3,
+      unit: "hours",
+      window: { from: "10:00", to: "21:00" },
+    });
+  });
+
+  it("falls back to hourly all day with no anchor", () => {
+    expect(defaultEveryTime({ kind: "at", time: "10:15" }, null)).toEqual(
+      every({ interval: 1, unit: "hours", window: null, minute: 15 }),
+    );
+  });
+
+  // Rebasing "09:00–15:00" onto a 22:00 fixed time would drag the end up and
+  // hand back the single hour 22:00–22:00, destroying the very window the
+  // anchor exists to keep. Rebasing onto the end hour itself is the same
+  // collapse by another name, so the guard is strictly-earlier.
+  it.each([
+    ["22:00", { from: "09:00", to: "15:00" }],
+    ["15:00", { from: "09:00", to: "15:00" }],
+  ])("keeps the window when %s would collapse it", (time, window) => {
+    expect(
+      defaultEveryTime({ kind: "at", time }, every({ interval: 3, window })),
+    ).toMatchObject({ window });
+  });
+
+  // A window rebased across the whole day is not a window — the model spells
+  // that one way, and nothing else may hand back a second form of it.
+  it("collapses a rebased day-spanning window to all day", () => {
+    expect(
+      defaultEveryTime(
+        { kind: "at", time: "00:00" },
+        every({ interval: 3, window: { from: "09:00", to: "23:00" } }),
+      ),
+    ).toMatchObject({ window: null });
+  });
+});
+
+describe("clampWindow", () => {
+  // `minute` — not the window's own current text — is the single source of
+  // truth for the firing minute, so an hours → minutes → hours round-trip
+  // restores it instead of leaving the zeroed value behind.
+  it.each([
+    ["hours", 30, { from: "09:00", to: "21:00" }, { from: "09:30", to: "21:30" }],
+    ["minutes", 30, { from: "09:30", to: "21:30" }, { from: "09:00", to: "21:59" }],
+    ["hours", 0, { from: "09:30", to: "21:30" }, { from: "09:00", to: "21:00" }],
+  ] as const)("%s at :%s canonicalises the bounds", (unit, minute, input, expected) => {
+    expect(clampWindow(input, unit, minute)).toEqual(expected);
+  });
+
+  // The end is never earlier than the start: moving the start past the end
+  // raises the end to meet it rather than inverting the range.
+  it.each([
+    [{ from: "18:00", to: "12:00" }, { from: "18:00", to: "18:00" }],
+    [{ from: "09:00", to: "09:00" }, { from: "09:00", to: "09:00" }],
+    [{ from: "00:00", to: "23:00" }, { from: "00:00", to: "23:00" }],
+  ])("raises an overrun end to the start", (input, expected) => {
+    expect(clampWindow(input, "hours", 0)).toEqual(expected);
+  });
+
+  it("survives a unit round-trip with the firing minute intact", () => {
+    const start = { from: "09:30", to: "21:30" };
+    const toMinutes = clampWindow(start, "minutes", 30);
+    expect(clampWindow(toMinutes, "hours", 30)).toEqual(start);
+  });
+});
+
+describe("toggleDay", () => {
+  it("adds a day in ascending order", () => {
+    expect(toggleDay([1, 5], 3)).toEqual([1, 3, 5]);
+    expect(toggleDay([3], 0)).toEqual([0, 3]);
+  });
+
+  it("removes a day that is already selected", () => {
+    expect(toggleDay([1, 3, 5], 3)).toEqual([1, 5]);
+  });
+
+  // A weekly schedule with no days never fires; the last one is not removable.
+  it("keeps the last remaining day", () => {
+    expect(toggleDay([3], 3)).toEqual([3]);
+  });
+});
+
+// A fixed time survives a trip out to an interval and back. The component
+// suite keeps one round-trip case for the wiring; the pattern-level guarantee
+// it rests on is here.
+describe("fixed time → interval → fixed time", () => {
+  it.each([
+    ["14:30", every({ interval: 3, window: { from: "09:00", to: "21:00" } })],
+    ["14:30", null],
+    ["00:15", null],
+  ])("returns %s unchanged", (time, anchor) => {
+    const at: TimePattern = { kind: "at", time };
+    const interval = defaultEveryTime(at, anchor);
+    expect(defaultAtTime(interval, time)).toBe(time);
+  });
+});

--- a/packages/views/autopilots/components/schedule-editor/transitions.ts
+++ b/packages/views/autopilots/components/schedule-editor/transitions.ts
@@ -1,0 +1,115 @@
+import type { TimePattern } from "./model";
+import { pad2, timeParts } from "./model";
+
+export type EveryPattern = Extract<TimePattern, { kind: "every" }>;
+export type ScheduleWindow = { from: string; to: string };
+
+// The window is a dimension of the schedule, not a mode of the editor: all day is
+// the window that spans the day, and the model spells that one way — `window:
+// null`. Every window the editor commits goes through here, so the two never drift
+// into two representations of the same schedule.
+//
+// The bounds are read as hours. A minute-step window is hour-granular (its ends
+// read :00 and :59), and an hours-step window carries the firing minute at both
+// ends — neither minute has a say in whether the window spans the day.
+export function isFullDay(window: ScheduleWindow): boolean {
+  return timeParts(window.from).hour === 0 && timeParts(window.to).hour === 23;
+}
+
+/** The window as the controls show it. All day has no window of its own, and the
+ *  fields still have to render something: the bounds it stands for. */
+export function displayWindow(time: EveryPattern): ScheduleWindow {
+  if (time.window !== null) return time.window;
+  return time.unit === "hours"
+    ? { from: `00:${pad2(time.minute)}`, to: `23:${pad2(time.minute)}` }
+    : { from: "00:00", to: "23:59" };
+}
+
+// An "every N hours, all day" pattern has nowhere to keep an hour, so the last
+// hour:minute the user actually expressed is carried outside the model. Without
+// it, at 14:30 → interval → at silently comes back as 09:30.
+//
+// The hour comes from the window, the minute from `minute` — never from the
+// window's own text. A minute-step window is hour-granular, so its bounds read
+// :00; taking the minute from there would drop the 30 of a 14:30 the user typed
+// before switching, which the model still holds.
+//
+// All day has no hour to give: the 00:00 its fields show is the absence of a
+// bound, not a time the user picked, and carrying it over would rewrite their
+// 14:30 to 00:30 on the way back to a fixed time.
+export function timeAnchorOf(time: TimePattern): string | null {
+  if (time.kind === "at") return time.time;
+  if (time.window === null) return null;
+  return `${pad2(timeParts(time.window.from).hour)}:${pad2(time.minute)}`;
+}
+
+export function defaultAtTime(prev: TimePattern, anchor: string): string {
+  return (
+    timeAnchorOf(prev) ??
+    `${pad2(timeParts(anchor).hour)}:${pad2(prev.kind === "every" ? prev.minute : 0)}`
+  );
+}
+
+// Switching to a fixed time can only carry one HH:MM, so the step, the unit and
+// the window would be gone on the way back — "every 3h, 9:00–21:00" would return
+// as "every hour, all day". They are remembered outside the model and restored,
+// rebased on whatever time the user is now switching away from.
+export function defaultEveryTime(
+  prev: TimePattern,
+  anchor: EveryPattern | null,
+): EveryPattern {
+  if (prev.kind === "every") return prev;
+  const { hour, minute } = timeParts(prev.time);
+  const base: EveryPattern = anchor ?? {
+    kind: "every",
+    interval: 1,
+    unit: "hours",
+    window: null,
+    minute,
+  };
+  const time: EveryPattern = { ...base, minute };
+  if (time.window === null) return time;
+  // The window restarts at the time the user is switching away from — but only
+  // where that still leaves a window. Rebasing "09:00–15:00" onto a 22:00 fixed
+  // time would drag the end up to 22 and hand back the single hour 22:00–22:00,
+  // destroying the very window this anchor exists to keep.
+  // Strictly earlier: a start rebased onto the end hour itself leaves the single
+  // hour 15:00–15:00, which is the same collapse by another name.
+  const rebased =
+    hour < timeParts(time.window.to).hour
+      ? { from: `${pad2(hour)}:${pad2(minute)}`, to: time.window.to }
+      : time.window;
+  // Rebasing a window that ends at 23 onto a midnight fixed time spans the whole
+  // day, and a window that spans the day is not one — the model holds that as all
+  // day, and nothing else may hand back a second form of it.
+  const window = clampWindow(rebased, time.unit, minute);
+  return { ...time, window: isFullDay(window) ? null : window };
+}
+
+// Keep windows canonical: `minute` — not the window's own current text — is the
+// single source of truth for the firing minute, so a hours → minutes → hours
+// unit round-trip restores it instead of leaving the zeroed value behind. Minute
+// intervals are hour-granular, and `to` is never earlier than `from`.
+export function clampWindow(
+  window: ScheduleWindow,
+  unit: EveryPattern["unit"],
+  minute: number,
+): ScheduleWindow {
+  const from = timeParts(window.from);
+  const to = timeParts(window.to);
+  const edgeMinute = unit === "hours" ? minute : 0;
+  const endMinute = unit === "hours" ? minute : 59;
+  const endHour = Math.max(to.hour, from.hour);
+  return {
+    from: `${pad2(from.hour)}:${pad2(edgeMinute)}`,
+    to: `${pad2(endHour)}:${pad2(endMinute)}`,
+  };
+}
+
+export function toggleDay(days: number[], day: number): number[] {
+  if (days.includes(day)) {
+    if (days.length === 1) return days;
+    return days.filter((d) => d !== day);
+  }
+  return [...days, day].toSorted((a, b) => a - b);
+}

--- a/packages/views/chat/components/task-status-pill.test.ts
+++ b/packages/views/chat/components/task-status-pill.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { effectiveTaskStatus, pickStageKeys } from "./task-status-pill";
 

--- a/packages/views/chat/floating-chat-visibility.test.ts
+++ b/packages/views/chat/floating-chat-visibility.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { isFloatingChatRouteSuppressed } from "./floating-chat-visibility";
 

--- a/packages/views/chat/lib/copy-text.test.ts
+++ b/packages/views/chat/lib/copy-text.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import type { ChatMessage } from "@multica/core/types";
 import type { ChatTimelineItem } from "@multica/core/chat";

--- a/packages/views/chat/lib/quick-actions.test.ts
+++ b/packages/views/chat/lib/quick-actions.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { stripChatQuickActionsProtocol } from "./quick-actions";
 

--- a/packages/views/common/avatar-crop.test.ts
+++ b/packages/views/common/avatar-crop.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { blobToAvatarFile } from "./avatar-crop";
 

--- a/packages/views/common/color-utils.test.ts
+++ b/packages/views/common/color-utils.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   hexToHsv,

--- a/packages/views/common/format-in-time-zone.test.ts
+++ b/packages/views/common/format-in-time-zone.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { formatInTimeZone } from "./format-in-time-zone";
 

--- a/packages/views/common/github-url.test.ts
+++ b/packages/views/common/github-url.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { githubShortLabel, midTruncate } from "./github-url";
 

--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   buildLanes,

--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { TaskMessagePayload } from "@multica/core/types/events";
 import { appendTimelineItem, buildTimeline, coalesceTimelineItems, type TimelineItem } from "./build-timeline";

--- a/packages/views/common/task-transcript/redact.test.ts
+++ b/packages/views/common/task-transcript/redact.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { redactSecrets } from "./redact";
 

--- a/packages/views/common/task-transcript/run-outcome.test.ts
+++ b/packages/views/common/task-transcript/run-outcome.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { buildRunOutcome } from "./run-outcome";
 import { buildSteps } from "./build-steps";

--- a/packages/views/common/task-transcript/trace-event-presenter.test.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   collapseDiffContext,

--- a/packages/views/common/task-transcript/transcript-follow.test.ts
+++ b/packages/views/common/task-transcript/transcript-follow.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { createNewestFirstFollow, FOLLOW_EDGE_THRESHOLD } from "./transcript-follow";
 

--- a/packages/views/common/type-scale-merge.test.ts
+++ b/packages/views/common/type-scale-merge.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { cn } from "@multica/ui/lib/utils";
 

--- a/packages/views/editor/extensions/pinyin-match.test.ts
+++ b/packages/views/editor/extensions/pinyin-match.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { matchesPinyin } from "./pinyin-match";
 

--- a/packages/views/editor/extensions/slash-command-extension.test.ts
+++ b/packages/views/editor/extensions/slash-command-extension.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { SlashCommandExtension } from "./slash-command-extension";
 

--- a/packages/views/editor/syntax-highlight.test.ts
+++ b/packages/views/editor/syntax-highlight.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { codeLowlight, highlightCode } from "./syntax-highlight";
 

--- a/packages/views/editor/utils/escape-markdown-label.test.ts
+++ b/packages/views/editor/utils/escape-markdown-label.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { escapeMarkdownLabel } from "./escape-markdown-label";
 

--- a/packages/views/editor/utils/hash-string.test.ts
+++ b/packages/views/editor/utils/hash-string.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { hashString } from "./hash-string";
 

--- a/packages/views/editor/utils/highlight-markdown.test.ts
+++ b/packages/views/editor/utils/highlight-markdown.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { highlightToHtml } from "./highlight-markdown";
 

--- a/packages/views/editor/utils/highlight-match.test.ts
+++ b/packages/views/editor/utils/highlight-match.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { matchHighlightAt, findLiteralRanges } from "./highlight-match";
 

--- a/packages/views/editor/utils/parse-markdown-chunked.test.ts
+++ b/packages/views/editor/utils/parse-markdown-chunked.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   MARKDOWN_CHUNK_THRESHOLD,

--- a/packages/views/editor/utils/preprocess-links.test.ts
+++ b/packages/views/editor/utils/preprocess-links.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { preprocessLinks } from "@multica/ui/markdown/linkify";
 

--- a/packages/views/editor/utils/preview.test.ts
+++ b/packages/views/editor/utils/preview.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   extensionToLanguage,

--- a/packages/views/editor/utils/zoom-transform.test.ts
+++ b/packages/views/editor/utils/zoom-transform.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   MAX_SCALE,

--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { InboxItem } from "@multica/core/types";
 import {

--- a/packages/views/issues/blocked-trigger-copy.test.ts
+++ b/packages/views/issues/blocked-trigger-copy.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { blockedReasonLabel, blockedShortReasonLabel } from "./blocked-trigger-copy";

--- a/packages/views/issues/components/description-preview.test.ts
+++ b/packages/views/issues/components/description-preview.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 
 import { descriptionPreview } from "./description-preview";

--- a/packages/views/issues/components/thread-utils.test.ts
+++ b/packages/views/issues/components/thread-utils.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { TimelineEntry } from "@multica/core/types";
 import {

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import type { Issue, IssueAssigneeGroup } from "@multica/core/types";
 import {

--- a/packages/views/issues/utils/strip-mention-markdown.test.ts
+++ b/packages/views/issues/utils/strip-mention-markdown.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import { stripMentionMarkdown } from "./strip-mention-markdown";
 

--- a/packages/views/locales/parity.test.ts
+++ b/packages/views/locales/parity.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";

--- a/packages/views/onboarding/source-backfill-merge.test.ts
+++ b/packages/views/onboarding/source-backfill-merge.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { mergedQuestionnairePatch } from "./source-backfill-merge";
 

--- a/packages/views/onboarding/source-backfill-modal.test.tsx
+++ b/packages/views/onboarding/source-backfill-modal.test.tsx
@@ -137,13 +137,12 @@ function renderModal() {
 }
 
 describe("SourceBackfillModal", () => {
-  it("does not render when there is no user", () => {
-    renderModal();
-    expect(
-      screen.queryByText(/How did you hear about Multica/i),
-    ).not.toBeInTheDocument();
-  });
-
+  // Which users need the backfill is needsSourceBackfill's contract — no user,
+  // not yet onboarded, empty/missing/legacy-string/malformed source, the skip
+  // flag and the dismiss cap all have their matrix in
+  // @multica/core/onboarding/needs-backfill.test.ts. What belongs here is the
+  // modal's own reaction to the verdict, so one settled user stands for the
+  // whole "predicate says no" family.
   it("does not render when the user already recorded a source", () => {
     setUser({
       id: "u1",
@@ -273,18 +272,6 @@ describe("SourceBackfillModal", () => {
     expect(sent.source_skipped).toBe(true);
     expect(sent.role).toBe("founder");
     expect(sent.use_case).toEqual(["manage_team"]);
-  });
-
-  it("treats a legacy single-string source as already answered", () => {
-    setUser({
-      id: "u1",
-      onboarded_at: "2026-01-01T00:00:00Z",
-      onboarding_questionnaire: { source: "search" },
-    });
-    renderModal();
-    expect(
-      screen.queryByText(/How did you hear about Multica/i),
-    ).not.toBeInTheDocument();
   });
 
   it("picking a second option replaces the first (single-select primary source)", async () => {

--- a/packages/views/projects/components/project-issue-metrics.test.ts
+++ b/packages/views/projects/components/project-issue-metrics.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { getProjectIssueMetrics } from "./project-issue-metrics";
 

--- a/packages/views/rich-content/package-exports.test.ts
+++ b/packages/views/rich-content/package-exports.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 /**
  * Package export-target guard.
  *

--- a/packages/views/rich-content/rich-content-boundary.test.ts
+++ b/packages/views/rich-content/rich-content-boundary.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 /**
  * Import boundary guard (MUL-4922, Howard's contract #3).
  *

--- a/packages/views/rich-content/streaming-fence.test.ts
+++ b/packages/views/rich-content/streaming-fence.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { computeClosedFenceOffsets } from "./streaming-fence";
 

--- a/packages/views/runtimes/components/pending-runtime.test.ts
+++ b/packages/views/runtimes/components/pending-runtime.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { AgentRuntime, RuntimeProfile } from "@multica/core/types";
 import {

--- a/packages/views/runtimes/components/runtime-docs.test.ts
+++ b/packages/views/runtimes/components/runtime-docs.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   customRuntimeDocsHref,

--- a/packages/views/runtimes/components/runtime-profile-catalog.test.ts
+++ b/packages/views/runtimes/components/runtime-profile-catalog.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { RuntimeProfile } from "@multica/core/types";
 import {

--- a/packages/views/skills/components/refresh-skill-dialog.test.tsx
+++ b/packages/views/skills/components/refresh-skill-dialog.test.tsx
@@ -73,23 +73,14 @@ describe("RefreshSkillDialog source URL", () => {
     expect((link.textContent ?? "").length).toBeLessThanOrEqual(60);
   });
 
-  it("renders no link when the origin has no source_url", () => {
-    renderDialog({ type: "manual" });
-    expect(screen.queryByRole("link")).toBeNull();
-  });
-
-  // config.origin is persisted verbatim through the skill update API, so an
-  // injected source_url must never surface as a live anchor in the dialog.
-  it("renders no link when a non-import origin carries an injected source_url", () => {
+  // Which source_urls are linkable is originSourceUrl's contract, and its full
+  // matrix — host mismatch, lookalike hosts, non-http schemes, malformed and
+  // missing values, non-import origins — lives in ../lib/origin.test.ts. This
+  // case pins the wiring instead: when the helper refuses, the dialog renders
+  // no anchor at all. config.origin is persisted verbatim through the skill
+  // update API, so an injected source_url is the rejection that matters most.
+  it("renders no link when the helper refuses the source_url", () => {
     renderDialog({ type: "manual", source_url: SOURCE_URL });
-    expect(screen.queryByRole("link")).toBeNull();
-  });
-
-  it("renders no link when the source_url host does not match the origin type", () => {
-    renderDialog({
-      type: "github",
-      source_url: "https://evil.example/anthropics/skills",
-    });
     expect(screen.queryByRole("link")).toBeNull();
   });
 });

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -451,19 +451,11 @@ describe("SkillDetailPage origin link", () => {
     ).toBeNull();
   });
 
-  it("does not link an imported origin whose source_url is missing", async () => {
-    skillRef.current = {
-      ...baseSkill,
-      config: { origin: { type: "github" } },
-    };
-    renderPage();
-    expect(await screen.findByText("Imported · GitHub")).toBeTruthy();
-    expect(
-      screen.queryByRole("link", { name: "Imported · GitHub" }),
-    ).toBeNull();
-  });
-
-  it("does not link a source_url whose host does not match the origin type", async () => {
+  // Which source_urls are linkable is originSourceUrl's contract; its full
+  // matrix lives in ../lib/origin.test.ts. What belongs here is the chip's
+  // behaviour when the helper refuses: it degrades to plain text, still
+  // naming the origin, rather than dropping the label along with the href.
+  it("degrades a refused source_url to plain text, keeping the chip", async () => {
     skillRef.current = {
       ...baseSkill,
       config: {

--- a/packages/views/skills/lib/origin.test.ts
+++ b/packages/views/skills/lib/origin.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { originSourceUrl, type OriginInfo } from "./origin";
 

--- a/packages/views/test/setup.ts
+++ b/packages/views/test/setup.ts
@@ -19,50 +19,55 @@ function createMemoryStorage(): Storage {
   };
 }
 
-if (typeof globalThis.localStorage?.clear !== "function") {
-  const storage = createMemoryStorage();
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: storage,
-  });
-}
+// Everything below patches gaps in jsdom. Pure-logic suites opt out of jsdom
+// with `// @vitest-environment node` and share this file, so there is no DOM to
+// patch there — bail out rather than guard each stub.
+if (typeof window !== "undefined") {
+  if (typeof globalThis.localStorage?.clear !== "function") {
+    const storage = createMemoryStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+  }
 
-// jsdom doesn't provide matchMedia; useIsMobile() relies on it.
-if (typeof window.matchMedia !== "function") {
-  window.matchMedia = (query: string) =>
-    ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    }) as MediaQueryList;
-}
+  // jsdom doesn't provide matchMedia; useIsMobile() relies on it.
+  if (typeof window.matchMedia !== "function") {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+  }
 
-// jsdom doesn't provide ResizeObserver; stub it so components that rely on it
-// (e.g. input-otp) can render in tests.
-if (typeof globalThis.ResizeObserver === "undefined") {
-  globalThis.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as unknown as typeof ResizeObserver;
-}
+  // jsdom doesn't provide ResizeObserver; stub it so components that rely on it
+  // (e.g. input-otp) can render in tests.
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
 
-// jsdom doesn't implement elementFromPoint; input-otp uses it internally.
-if (typeof document.elementFromPoint !== "function") {
-  document.elementFromPoint = () => null;
-}
+  // jsdom doesn't implement elementFromPoint; input-otp uses it internally.
+  if (typeof document.elementFromPoint !== "function") {
+    document.elementFromPoint = () => null;
+  }
 
-// jsdom has no layout, so it doesn't implement scrollIntoView; list components
-// that keep a keyboard cursor in view (e.g. the thread navigator) call it.
-if (typeof Element.prototype.scrollIntoView !== "function") {
-  Element.prototype.scrollIntoView = () => {};
+  // jsdom has no layout, so it doesn't implement scrollIntoView; list components
+  // that keep a keyboard cursor in view (e.g. the thread navigator) call it.
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = () => {};
+  }
 }

--- a/packages/views/workspace/slug.test.ts
+++ b/packages/views/workspace/slug.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect } from "vitest";
 import {
   nameToWorkspaceSlug,


### PR DESCRIPTION
## What this changes

MUL-6291, **first increment**. This is the test-governance half of MUL-6283: the runner split (MUL-6290) buys back wall time by adding CPU; this buys it back by not spending it. It does not close MUL-6291 — see *Scope* at the bottom.

Vitest's own breakdown for `@multica/views` is where the shape of the problem shows up:

```
Duration 219.26s (transform 72.61s, setup 66.77s, import 644.34s, tests 508.20s, environment 632.98s)
```

Only **26%** of the work is running assertions. Two thirds goes on constructing a jsdom for every one of the 358 test files and importing its module graph. So the first-order win is not deleting cases — it is not paying for a DOM in suites that never touch one.

### 1. Pure-logic suites opt out of jsdom

94 `.test.ts` files across views / web / desktop now start with `// @vitest-environment node`. The three jsdom setup files bail out when there is no DOM so a node-env suite can share them.

Candidates were **not** picked by grepping for `window` — the first pass at that flagged `cron-grammar`, `runtimes/utils` and `dashboard/utils`, whose "window" is a *time* window and a *context* window. They were picked by walking each test's module graph (skipping `import type`, which is erased and never loads the module) and rejecting anything that reaches production code branching on `typeof window`/`document`. That guard matters: under node such a test takes the SSR path and **still passes**, which is worse than being slow. The survivors were then verified empirically and reverted where they failed — 27 files stayed on jsdom for this reason and are listed in the issue.

### 2. schedule-editor state transitions sink to a table

The editor's seven pure transitions (`isFullDay`, `displayWindow`, `timeAnchorOf`, `defaultAtTime`, `defaultEveryTime`, `clampWindow`, `toggleDay`) move out of `schedule-editor.tsx` into `transitions.ts` — a pure move, no behaviour change. `transitions.test.ts` covers the full combination space table-driven: **34 cases in 3ms**, against a component suite where the same ground cost a full `renderEditor()` and a userEvent chain each.

Four component cases came out, each superseded by a strictly stronger sibling or by the new matrix. The anchor/focus/aria cases stay — that bookkeeping lives in component state, not in the transitions, and sinking it would have lost real coverage.

### 3. Cross-layer duplicates, where a canonical layer already exists

- `originSourceUrl`'s rejection matrix is canonical in `skills/lib/origin.test.ts`; it was being re-run through `refresh-skill-dialog` (3 mounts) and `skill-detail-page` (2 mounts). Each keeps one wiring case, and the detail page's now asserts the thing only it can: the chip **degrades to plain text** rather than vanishing with the href.
- `needsSourceBackfill` is canonical in `core/onboarding/needs-backfill.test.ts`; `source-backfill-modal` re-ran two of its branches, one with a byte-identical title. The surviving case is the one that also asserts a settled user never pays for the count query.

Every removal names its canonical file in a comment, so the next person doesn't re-add it.

## Measurements

### What is verified

Interleaved A/B on one machine, same SHA, alternating before/after to cancel drift. **The 45 converted views files**, 3 rounds:

| | wall | environment (CPU) | tests |
|---|---|---|---|
| jsdom | 13.63 / 8.88 / **8.72s** | 91.80 / 54.50 / **53.15s** | ~1s |
| node | 2.17 / 2.51 / **2.03s** | 8 / 6 / **4ms** | ~0.8s |

jsdom was costing 53s of CPU to run 0.9s of assertions. This is the tightest measurement in the PR and the one I stand behind.

### What is NOT verified: whole-job wall time

Two CI runs of **equivalent base code** bracket this PR:

| `frontend-test` | base A `9d6c0c81` (merge-base) | base B `4696eab2` | this PR `794bfbca` |
|---|---:|---:|---:|
| job wall | **508s** | **359s** | **391s** |
| views | 468.44s | 306.65s | 349.67s |
| desktop | 111.08s | 72.04s | 52.80s |
| web | 67.33s | 43.22s | 33.22s |

The two baselines differ from each other by **149s (41%)** on the same job and **162s (53%)** on views. **Runner variance is larger than the effect being measured.** Against base A this PR is 117s faster; against base B it is 32s slower. Neither number means anything on its own, and I am not quoting either as a result.

`environment` — the CPU this PR actually targets — is the more stable column, and there web and desktop are unambiguous across both baselines:

| environment (CPU) | base A | base B | this PR |
|---|---:|---:|---:|
| desktop | 158.35s | 97.66s | **46.59s** |
| web | 115.92s | 72.90s | **42.05s** |
| views | 408.60s | 254.65s | 285.66s |

views does not resolve: only 53 of its 359 files converted, so the remaining 306 jsdom builds still dominate and swamp the delta.

One caveat on reading these logs: `core` reports byte-identical timings (`60.66s`, transform `10.74s`, import `45.77s`, …) in base B and in this PR. That is a **Turbo cache replay, not a measurement** — core is untouched here, so its task hash was unchanged. Any workspace-level comparison across runs has to check for that first.

**So: the ~25–35s of cold wall time I estimated earlier is an extrapolation from CPU removed, not a measured result.** Treat it as a hypothesis to confirm over several post-merge runs, not as a delivered number.

### Inventory

| | before | after |
|---|---|---|
| test files | 562 | 563 |
| test LOC | 127,576 | 127,818 |
| DOM mounts | 2,569 | 2,560 |
| node-env files | 0 | 95 |

Test LOC went **up** by 242, and DOM mounts fell by only 9 (0.35%). That is the honest trade: the table-driven matrix is more thorough than the four DOM mounts it replaced and runs in 3ms. This change was never going to win on LOC or on mount count — the win is the 95 jsdom constructions that no longer happen per run.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (25 pre-existing warnings, none in touched files)
- All four suites green: views 359 files / 4256 tests, core 126 / 1418, desktop 52 / 505, web 28 / 229
- CI green on `794bfbca` (12/12 checks)

## Not done, deliberately

- **slack / dingtalk / wecom tabs** share 5 case titles across 3 suites, but they are three separate 600–800 line implementations. Deleting any would leave that implementation unguarded; the real fix is extracting a shared channel tab, which is a production refactor, not a test sweep.
- **`highlight-markdown.test.ts` vs `highlight.test.ts`** share 3 titles but enforce the same `==` grammar across two independent implementations (renderer vs tiptap extension). The duplication is the point.
- **`skills-page.source-link.test.tsx`** was named in the audit as 218 lines for 3 behaviours. Read closely it is a middle-click/auxclick bubbling regression rig with a vacuity guard — the mock weight is the cost of the page's surface area, not waste. Kept.

## Scope

This handles **4 hot suites**, not the 10–12 MUL-6291 asks for, and the 30–60s cold-run target is not demonstrated. Deliberately **not** using `Closes` — MUL-6291 stays open. Remaining hot suites are a different problem (expensive per-mount, not duplicated cases) and are listed on the issue with the full 563-file inventory:

| suite | baseline | cases |
|---|---:|---:|
| `auth/login-page.test.tsx` | 8.9s | 34 |
| `issues/components/issue-detail.test.tsx` | 6.5s | 60 |
| `editor/mermaid-viewer.test.tsx` | 5.9s | 25 |
| `agents/.../thinking-picker.test.tsx` | 5.3s | 7 |
| `agents/.../custom-args-tab.test.tsx` | 4.2s | 4 |

**Follow-up worth filing:** nothing but `CLAUDE.md` currently stops a future `// @vitest-environment node` test from importing code that branches on `typeof window` and silently taking the SSR path. That check should be automated.

Refs MUL-6291.
