### PR TITLE
MUL-6299: retire expired compatibility fallbacks

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -961,15 +961,9 @@ export class ApiClient {
   }
 
   async createIssue(data: CreateIssueRequest): Promise<Issue> {
-    // Parse through a schema (not a raw cast): the create modal keys its
-    // label-attach compatibility fallback off `labels` being absent vs a
-    // validated Label[], so an unvalidated wrong shape must not slip through.
     // Unlike list endpoints, a create that returns an unusable body is a
-    // FAILED mutation, not a safe-empty read: fall back to null and reject so
-    // the modal keeps the draft and shows a failure toast instead of a blank
-    // "created" card pointing at an empty issue id. parseWithFallback already
-    // logged the schema issues + raw payload; the empty message lets the modal
-    // render its localized "failed to create" toast.
+    // failed mutation, not a safe-empty read. Reject so the modal keeps the
+    // draft instead of rendering a blank "created" card.
     const raw = await this.fetch<unknown>("/api/issues", {
       method: "POST",
       body: JSON.stringify(data),

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -197,12 +197,8 @@ describe("ApiClient schema fallback", () => {
   });
 
   describe("createIssue", () => {
-    // The create modal decides whether to run its label-attach fallback by
-    // reading `labels` off the parsed response, and treats a rejection as a
-    // failed create (keep the draft, failure toast). So: a valid issue with
-    // any labels shape resolves (labels absent → undefined, valid → Label[],
-    // malformed → undefined), but a body that isn't a usable issue rejects
-    // rather than fabricating a blank "success".
+    // The create response must acknowledge the authoritative labels snapshot.
+    // Any unusable body rejects rather than fabricating a blank "success".
     const validIssue = {
       id: "issue-1",
       workspace_id: "ws-1",
@@ -224,6 +220,7 @@ describe("ApiClient schema fallback", () => {
       due_date: null,
       metadata: {},
       properties: {},
+      labels: [],
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-01T00:00:00Z",
     };
@@ -236,12 +233,11 @@ describe("ApiClient schema fallback", () => {
       updated_at: "2025-01-01T00:00:00Z",
     };
 
-    it("keeps labels undefined when the backend omits the field (older backend)", async () => {
-      stubFetchJson(validIssue, 201);
+    it("rejects when the backend omits the authoritative labels field", async () => {
+      const { labels: _, ...withoutLabels } = validIssue;
+      stubFetchJson(withoutLabels, 201);
       const client = new ApiClient("https://api.example.test");
-      const issue = await client.createIssue({ title: "Created" });
-      expect(issue.id).toBe("issue-1");
-      expect(issue.labels).toBeUndefined();
+      await expect(client.createIssue({ title: "Created" })).rejects.toThrow();
     });
 
     it("validates a well-formed labels array", async () => {
@@ -251,21 +247,16 @@ describe("ApiClient schema fallback", () => {
       expect(issue.labels?.map((l) => l.id)).toEqual(["label-1"]);
     });
 
-    it("degrades a null labels field to undefined so the client falls back", async () => {
+    it("rejects a null labels field", async () => {
       stubFetchJson({ ...validIssue, labels: null }, 201);
       const client = new ApiClient("https://api.example.test");
-      const issue = await client.createIssue({ title: "Created" });
-      // The issue itself still parses; only the malformed labels degrade.
-      expect(issue.id).toBe("issue-1");
-      expect(issue.labels).toBeUndefined();
+      await expect(client.createIssue({ title: "Created" })).rejects.toThrow();
     });
 
-    it("degrades a labels array of the wrong element shape to undefined", async () => {
+    it("rejects a labels array of the wrong element shape", async () => {
       stubFetchJson({ ...validIssue, labels: [{ nope: true }] }, 201);
       const client = new ApiClient("https://api.example.test");
-      const issue = await client.createIssue({ title: "Created" });
-      expect(issue.id).toBe("issue-1");
-      expect(issue.labels).toBeUndefined();
+      await expect(client.createIssue({ title: "Created" })).rejects.toThrow();
     });
 
     it("rejects when the whole response body is not a usable issue (no fake success)", async () => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -969,23 +969,12 @@ export const ListIssuesResponseSchema = z.object({
   total: z.number().default(0),
 }).loose();
 
-// Response schema for POST /api/issues. Two tightenings over IssueSchema:
-//
-//   - `id` must be non-empty. A created issue always carries a real id, so an
-//     empty/absent id means the create effectively failed. createIssue turns a
-//     schema failure into a rejection (not a fabricated success), so tightening
-//     id here routes an id-less body to that same failure path.
-//   - `labels` is the backend-compatibility signal the create modal reads to
-//     decide whether the backend attached labels in the create transaction
-//     (present) or predates that (absent → fall back to per-label attach).
-//     Validate it strictly as Label[] and degrade a malformed value to
-//     `undefined` — the same as an absent field — so a wrong shape (null,
-//     object, a garbage array) can never masquerade as "handled" and suppress
-//     the fallback. Unlike the loose IssueSchema.labels (z.array(z.unknown())),
-//     the elements are fully validated. See packages/views/modals/create-issue.tsx.
+// A successful create always returns a real id and the authoritative label
+// snapshot attached in the same transaction. Treat either field being absent
+// or malformed as a failed mutation so the modal keeps the user's draft.
 export const CreateIssueResponseSchema = IssueSchema.extend({
   id: z.string().min(1),
-  labels: z.array(LabelSchema).optional().catch(undefined),
+  labels: z.array(LabelSchema),
 }).loose();
 
 export const EMPTY_LIST_ISSUES_RESPONSE: ListIssuesResponse = {

--- a/packages/core/labels/index.ts
+++ b/packages/core/labels/index.ts
@@ -4,7 +4,6 @@ export {
   useUpdateLabel,
   useDeleteLabel,
   useAttachLabel,
-  useAttachLabelToIssue,
   useDetachLabel,
   useAttachResourceLabel,
   useDetachResourceLabel,

--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -215,30 +215,6 @@ export function useAttachLabel(issueId: string) {
   });
 }
 
-/**
- * Attach a label to an issue identified by mutation variables rather than a
- * closed-over `issueId`. `useAttachLabel` binds one issueId at hook-call time
- * for the optimistic issue-detail flow; this variant defers the id to call
- * time so a caller can attach labels to an issue that doesn't exist yet at
- * render — e.g. labels chosen in the create-issue dialog, attached right after
- * the issue is created. No optimistic patch: the create flow closes the dialog
- * and relies on the settle-time invalidation to surface the new labels.
- */
-export function useAttachLabelToIssue() {
-  const qc = useQueryClient();
-  const wsId = useWorkspaceId();
-  return useMutation({
-    mutationFn: ({ issueId, labelId }: { issueId: string; labelId: string }) =>
-      api.attachLabel(issueId, labelId),
-    onSettled: (_data, _err, { issueId }) => {
-      qc.invalidateQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
-      // Issues embed a denormalized labels snapshot, so refresh the issues
-      // caches that hold it (list / board / detail) once the attach settles.
-      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
-    },
-  });
-}
-
 export function useDetachLabel(issueId: string) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();

--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -158,7 +158,6 @@
     "toast_duplicate_view": "View existing issue",
     "toast_link_subissues_all_failed": "Failed to link sub-issues",
     "toast_link_subissues_partial": "Failed to link {{failed}} of {{total}} sub-issues",
-    "toast_link_labels_failed": "Failed to attach labels",
     "toast_set_properties_failed": "Could not set {{count}} custom property values",
     "switch_to_agent": "Switch to Agent",
     "switch_to_agent_tooltip": "Switch to create with agent — describe in one line and let the agent file it",

--- a/packages/views/locales/ja/modals.json
+++ b/packages/views/locales/ja/modals.json
@@ -156,7 +156,6 @@
     "toast_duplicate_view": "既存のタスクを表示",
     "toast_link_subissues_all_failed": "サブタスクをリンクできませんでした",
     "toast_link_subissues_partial": "サブタスク {{total}} 件中 {{failed}} 件をリンクできませんでした",
-    "toast_link_labels_failed": "ラベルを付けられませんでした",
     "toast_set_properties_failed": "{{count}} 件のカスタムプロパティを設定できませんでした",
     "switch_to_agent": "エージェントに切り替え",
     "switch_to_agent_tooltip": "エージェントで作成に切り替えます。一行で説明すれば、エージェントがタスクを作成します",

--- a/packages/views/locales/ko/modals.json
+++ b/packages/views/locales/ko/modals.json
@@ -156,7 +156,6 @@
     "toast_duplicate_view": "기존 태스크 보기",
     "toast_link_subissues_all_failed": "하위 태스크를 연결하지 못했습니다",
     "toast_link_subissues_partial": "하위 태스크 {{total}}개 중 {{failed}}개를 연결하지 못했습니다",
-    "toast_link_labels_failed": "라벨을 연결하지 못했습니다",
     "toast_set_properties_failed": "사용자 지정 속성 값 {{count}}개를 설정하지 못했습니다",
     "switch_to_agent": "에이전트로 전환",
     "switch_to_agent_tooltip": "에이전트로 만들기로 전환합니다. 한 줄로 설명하면 에이전트가 태스크를 작성합니다.",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -156,7 +156,6 @@
     "toast_duplicate_view": "查看已有任务",
     "toast_link_subissues_all_failed": "关联子任务失败",
     "toast_link_subissues_partial": "{{total}} 个子任务中有 {{failed}} 个关联失败",
-    "toast_link_labels_failed": "关联标签失败",
     "toast_set_properties_failed": "有 {{count}} 个自定义属性设置失败",
     "switch_to_agent": "切换到智能体",
     "switch_to_agent_tooltip": "切换到通过智能体创建——一句话描述，让它替你建",

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -31,7 +31,6 @@ function I18nWrapper({ children }: { children: ReactNode }) {
 
 const mockPush = vi.hoisted(() => vi.fn());
 const mockCreateIssue = vi.hoisted(() => vi.fn());
-const mockAttachLabel = vi.hoisted(() => vi.fn());
 const mockListProperties = vi.hoisted(() => vi.fn());
 const mockSetIssueProperty = vi.hoisted(() => vi.fn());
 const mockSetShared = vi.hoisted(() => vi.fn());
@@ -221,10 +220,6 @@ vi.mock("@multica/core/issues/stores/issue-create-settings-store", () => ({
 vi.mock("@multica/core/issues/mutations", () => ({
   useCreateIssue: () => ({ mutateAsync: mockCreateIssue }),
   useUpdateIssue: () => ({ mutate: vi.fn() }),
-}));
-
-vi.mock("@multica/core/labels", () => ({
-  useAttachLabelToIssue: () => ({ mutateAsync: mockAttachLabel }),
 }));
 
 vi.mock("@multica/core/properties", async (importOriginal) => {
@@ -622,12 +617,8 @@ describe("CreateIssueModal", () => {
       identifier: "TES-123",
       title: "Ship create issue regression coverage",
       status: "todo",
-      // Current backend echoes the attached labels, so the create flow skips
-      // the legacy per-label attach fallback. Empty is enough — what matters
-      // is that the field is present (not undefined).
       labels: [],
     });
-    mockAttachLabel.mockResolvedValue({ labels: [] });
     mockListProperties.mockResolvedValue({
       properties: [
         {
@@ -724,44 +715,6 @@ describe("CreateIssueModal", () => {
           ],
         }),
       );
-    });
-    // Backend echoed `labels`, so the atomic path handled it — no legacy
-    // per-label attach fallback should run.
-    expect(mockAttachLabel).not.toHaveBeenCalled();
-  });
-
-  it("falls back to per-label attach when an older backend omits labels from the create response", async () => {
-    const user = userEvent.setup();
-    // Older backend: ignores label_ids and returns an issue with no `labels`
-    // field (the rolling-deploy window where web is ahead of the backend).
-    mockCreateIssue.mockResolvedValueOnce({
-      id: "issue-123",
-      identifier: "TES-123",
-      title: "Labeled issue",
-      status: "todo",
-    });
-    mockDraftStore.draft.manual.labelIds = [
-      "aaaaaaaa-1111-2222-3333-444444444444",
-      "bbbbbbbb-1111-2222-3333-444444444444",
-    ];
-
-    renderModal(<CreateIssueModal onClose={vi.fn()} />);
-
-    fireEvent.change(screen.getByPlaceholderText("Issue title"), {
-      target: { value: "Labeled issue" },
-    });
-    await user.click(screen.getByRole("button", { name: "Create Issue" }));
-
-    await waitFor(() => {
-      expect(mockAttachLabel).toHaveBeenCalledTimes(2);
-    });
-    expect(mockAttachLabel).toHaveBeenCalledWith({
-      issueId: "issue-123",
-      labelId: "aaaaaaaa-1111-2222-3333-444444444444",
-    });
-    expect(mockAttachLabel).toHaveBeenCalledWith({
-      issueId: "issue-123",
-      labelId: "bbbbbbbb-1111-2222-3333-444444444444",
     });
   });
 

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -69,7 +69,6 @@ import {
 } from "@multica/core/issues/stores/issue-create-settings-store";
 import { issueDetailOptions, childIssuesOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
-import { useAttachLabelToIssue } from "@multica/core/labels";
 import {
   propertyListOptions,
   useSetIssueProperty,
@@ -386,7 +385,6 @@ export function ManualCreatePanel({
 
   const createIssueMutation = useCreateIssue();
   const updateIssueMutation = useUpdateIssue();
-  const attachLabelMutation = useAttachLabelToIssue();
   const setIssuePropertyMutation = useSetIssueProperty();
   const resetForNextIssue = () => {
     setTitle("");
@@ -470,9 +468,7 @@ export function ManualCreatePanel({
         attachment_ids: activeAttachmentIds.length > 0 ? activeAttachmentIds : undefined,
         // The server attaches these in the same transaction as the create and
         // echoes them back as `issue.labels`, so a stale selection fails the
-        // create instead of leaving a committed-but-unlabeled issue. A legacy
-        // backend that predates this ignores the field — handled by the
-        // compatibility fallback below.
+        // create instead of leaving a committed-but-unlabeled issue.
         label_ids: labelIds.length > 0 ? labelIds : undefined,
         parent_issue_id: parentIssueId,
         // Stage is only meaningful for a sub-issue (relative to its siblings).
@@ -539,32 +535,6 @@ export function ManualCreatePanel({
                   total: childIssues.length,
                 }),
           );
-        }
-      }
-
-      // Backend-compatibility fallback for the rolling deploy window: the web
-      // app auto-deploys on merge but the backend deploys manually, so a newer
-      // web build can briefly talk to a backend that predates atomic label
-      // creation. That backend silently ignores `label_ids` and returns an
-      // issue with no `labels` field. Only then do we fall back to the legacy
-      // per-label attach so the user's labels aren't silently dropped. When
-      // `labels` is present (current backend) the atomic path already ran, so
-      // we skip this — no double-write, no per-label fan-out.
-      if (labelIds.length > 0 && issue.labels === undefined) {
-        const results = await Promise.allSettled(
-          labelIds.map((labelId) =>
-            attachLabelMutation.mutateAsync({ issueId: issue.id, labelId }),
-          ),
-        );
-        let labelsFailed = 0;
-        for (const result of results) {
-          if (result.status === "rejected") {
-            labelsFailed += 1;
-            console.error("[create-issue] label attach fallback failed", result.reason);
-          }
-        }
-        if (labelsFailed > 0) {
-          toast.error(t(($) => $.create_issue.toast_link_labels_failed));
         }
       }
 
@@ -924,9 +894,7 @@ export function ManualCreatePanel({
               )}
 
               {/* Labels — occupies the slot that used to hold Due date so the
-                  add-label entry is exposed directly on the dialog. Draft mode:
-                  selection is local until the issue is created (handleSubmit
-                  attaches the labels afterward). */}
+                  add-label entry is exposed directly on the dialog. */}
               {showField.labels && (
                 <LabelPicker
                   selectedIds={labelIds}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2702,9 +2702,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 
 	resp := issueToResponse(issue, prefix)
 	resp.Attachments = buildAttachmentResponses(res.Attachments)
-	// Echo the authoritative labels attached in the create transaction. Always
-	// non-nil (empty slice when none) so a newer client can tell the backend
-	// understood label_ids and skip its legacy post-create attach fallback.
+	// Echo the authoritative labels attached in the create transaction.
 	labelResponses := labelsToResponse(res.Labels)
 	resp.Labels = &labelResponses
 	writeJSON(w, http.StatusCreated, resp)

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -163,8 +163,7 @@ type IssueCreateResult struct {
 	// Labels is the authoritative set of labels attached to the new issue in
 	// the create transaction (empty when none were requested). Callers echo it
 	// on the create response + issue:created event so every client renders the
-	// new issue already labeled and a new client can detect that the backend
-	// understood label_ids (see the create handler's compatibility contract).
+	// new issue already labeled.
 	Labels         []db.IssueLabel
 	DuplicateIssue *db.Issue
 }

--- a/server/pkg/composio/tools.go
+++ b/server/pkg/composio/tools.go
@@ -33,13 +33,6 @@ type ExecuteToolRequest struct {
 	// version; setting this avoids unintended drift when Composio promotes
 	// a new latest.
 	Version string `json:"version,omitempty"`
-
-	// AllowTracing is the upstream-deprecated debug-tracing flag.
-	//
-	// Deprecated: marked deprecated on the Composio side (v3.1) — kept here
-	// only for backward compatibility with existing callers. Will be removed
-	// once Composio drops the field.
-	AllowTracing bool `json:"allow_tracing,omitempty"`
 }
 
 // ExecuteToolResponse is the typed result. The upstream wire shape varies by


### PR DESCRIPTION
## Summary

- remove the expired rolling-deploy fallback that re-attached issue labels after creation
- require the atomic create response to include a validated authoritative label snapshot
- remove the fallback-only mutation helper, tests, and localized error copy
- remove the unused deprecated Composio `allow_tracing` request field

## Why

Issue labels have been attached atomically since MUL-4832. Keeping the temporary post-create path meant the same operation still had two implementations, extra fan-out requests, and a malformed response could silently select legacy behavior. The current server contract is now explicit and failures preserve the user's draft.

The Composio flag had no callers and was already deprecated upstream.

## Impact

This removes 165 lines and adds 21 lines, leaving one create-label path and one response contract. Installed-client compatibility protections and runtime/daemon fallbacks remain unchanged.

## Verification

- `pnpm exec vitest run api/schema.test.ts labels/mutations.test.tsx` — 75 passed
- `pnpm exec vitest run modals/create-issue.test.tsx` — 42 passed
- changed-file ESLint in `packages/core` and `packages/views`
- `pnpm typecheck`
- `go test ./internal/handler ./internal/service ./pkg/composio`
- `git diff --check`

Closes MUL-6299
