### PR TITLE
MUL-6300: fix(daemon): let reply turns own the status arc for their own issue

### DIFF
--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -218,7 +218,7 @@ func TestInjectRuntimeConfigKeepsTriggerCommentOutOfBrief(t *testing.T) {
 		"No mode line → Reply mode",
 		// The fallback is only safe because Reply mode's own status rule is
 		// conditional: no work, no status write (MUL-6300).
-		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
+		"Purely conversational turns (question, discussion, acknowledgement) never touch status",
 		"`Turn mode: Reply.`",
 		"`Turn mode: Ownership.`",
 		"Use the `--parent` value the per-turn user message gives you for this turn",

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -216,7 +216,9 @@ func TestInjectRuntimeConfigKeepsTriggerCommentOutOfBrief(t *testing.T) {
 		// "Reply mode" pinned separately could both pass while the text
 		// says "No mode line → Ownership mode" (final-review catch).
 		"No mode line → Reply mode",
-		"do not change the issue status",
+		// The fallback is only safe because Reply mode's own status rule is
+		// conditional: no work, no status write (MUL-6300).
+		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
 		"`Turn mode: Reply.`",
 		"`Turn mode: Ownership.`",
 		"Use the `--parent` value the per-turn user message gives you for this turn",

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -559,8 +559,8 @@ func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
 // modes (MUL-6300) — a comment asking for rework is the same work as an
 // assignment, so gating the arc on trigger type left delivered-then-reworked
 // issues stale until a human moved the card. What stays out of the arc is
-// what never carried work: conversational turns, and turns on an issue
-// assigned to someone else.
+// what never carried work: conversational turns, and turns on an issue not
+// assigned to this agent (someone else's, or unassigned).
 //
 // Squad leaders share the opening in_progress step so the parent leaves todo
 // as soon as coordination starts, but their first assignment turn is only a
@@ -619,7 +619,7 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 		// The leader's arc is not the ordinary one: dispatch is not delivery,
 		// so the parent stays in_progress until a later re-trigger confirms
 		// the goal is met.
-		b.WriteString("- Issue status: a section in your instructions may explicitly grant you ownership of this issue's status (the Squad Operating Protocol's \"Own the parent issue status\" responsibility). That section only appears when this issue is assigned to your squad; when it is there, treat it as a standing instruction — keep the parent `in_progress` while members work, and move it to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. Dispatching members is not completion. When it is absent, this issue belongs to another assignee: never run `multica issue status` on it. A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.\n\n")
+		b.WriteString("- Issue status: your instructions may grant you ownership of this issue's status (the Squad Operating Protocol's \"Own the parent issue status\" responsibility — it only appears when this issue is assigned to your squad). When present, treat it as standing: keep the parent `in_progress` while members work, and move it to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. Dispatching members is not completion. When absent, this issue is not yours: never run `multica issue status` on it. Purely conversational turns (question, discussion, acknowledgement) never touch status.\n\n")
 	} else {
 		// MUL-6300 replaces the original "do NOT change the issue status
 		// unless the comment explicitly asks for it" (PR #205) with the arc
@@ -631,11 +631,14 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 		//
 		// Two invariants survive verbatim from #205 / #2918, and the guard
 		// tests pin both: a conversational turn never writes status, and a
-		// run that is a guest on someone else's issue (@mention pull-in)
-		// never writes status either. Whether this agent is the assignee is
-		// answerable on every turn: step 1 already reads `assignee_id`, and
-		// `## Agent Identity` carries this agent's own id.
-		b.WriteString("- Issue status: when this issue is assigned to you and this turn does substantive work on it, own the status the same way Ownership mode does — set `in_progress` when you start that work, and when your turn completes move the issue to the status the work is now in (delivered and awaiting acceptance is `in_review`; leave `done` to a human). A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched. When the issue is assigned to someone else and you were pulled in by an @mention, its status belongs to that assignee: never run `multica issue status` on it.\n\n")
+		// turn on an issue not assigned to this agent never writes status
+		// either. The second is deliberately "not assigned to you", not
+		// "assigned to someone else": an @mention can also land the agent on
+		// an UNASSIGNED issue (triage), and that case must stay no-write too.
+		// Whether this agent is the assignee is answerable on every turn:
+		// step 1 already reads `assignee_id`, and `## Agent Identity` carries
+		// this agent's own id.
+		b.WriteString("- Issue status: when this issue is assigned to you and this turn does substantive work on it, own the status arc as Ownership mode does — set `in_progress` when you start, and at turn end set the status the work has reached (delivered and awaiting acceptance = `in_review`; `done` stays human). Purely conversational turns (question, discussion, acknowledgement) never touch status; neither does any turn on an issue not assigned to you.\n\n")
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -533,8 +533,10 @@ func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
 //
 // The two modes are expressed as a router rather than two concatenated step
 // lists: the mode-specific status rules live INSIDE their own mode block so
-// "own the status arc" and "do not touch the status" can never be read as
-// peer instructions with no arbitration.
+// the unconditional arc and the conditional one can never be read as peer
+// instructions with no arbitration. Ownership mode opens the arc on every
+// turn (the trigger itself is the intent); Reply mode opens it only when the
+// turn does substantive work on an issue assigned to this agent.
 //
 // Step 3 asks for a roots scan first, not `--recent 10` (MUL-5372). `--recent N`
 // caps THREADS, not comments: each returned thread carries its root plus every
@@ -553,19 +555,26 @@ func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
 // step is what made this one bloat in the first place.
 //
 // Ordinary agents own the full status arc for their issue: open with
-// in_progress, deliver with in_review. Squad leaders share the opening
-// in_progress step so the parent leaves todo as soon as coordination
-// starts, but their first assignment turn is only a dispatch — flipping
-// the parent to in_review there would mark unfinished multi-stage work
-// as ready for review. Leaders move the parent to in_review later, when
-// a re-trigger (member update / stage barrier) confirms the overall goal
-// is met; see the Squad Operating Protocol and child-done system comments.
+// in_progress, deliver with in_review. That arc is the agent's on BOTH
+// modes (MUL-6300) — a comment asking for rework is the same work as an
+// assignment, so gating the arc on trigger type left delivered-then-reworked
+// issues stale until a human moved the card. What stays out of the arc is
+// what never carried work: conversational turns, and turns on an issue
+// assigned to someone else.
+//
+// Squad leaders share the opening in_progress step so the parent leaves todo
+// as soon as coordination starts, but their first assignment turn is only a
+// dispatch — flipping the parent to in_review there would mark unfinished
+// multi-stage work as ready for review. Leaders move the parent to in_review
+// later, when a re-trigger (member update / stage barrier) confirms the
+// overall goal is met; see the Squad Operating Protocol and child-done system
+// comments.
 //
 // ctx.IsSquadLeader is a PER-TASK role, not agent configuration: branching on
 // it here does move brief bytes when the same agent runs leader one turn and
 // worker the next. Owner-accepted tradeoff; decision recorded in MUL-5811.
 func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
-	b.WriteString("**Turn mode.** The per-turn user message names this run's mode on a line of its own: `Turn mode: Reply.` (respond to the comment that message carries — it brings the triggering comment's id and your `--parent` value) or `Turn mode: Ownership.` (an assignment or status change started this run). Steps 1–5 are shared; then **apply exactly one mode block, the one the user message named** — they differ on issue status. No mode line → Reply mode, do not change the issue status.\n\n")
+	b.WriteString("**Turn mode.** The per-turn user message names this run's mode on a line of its own: `Turn mode: Reply.` (respond to the comment that message carries — it brings the triggering comment's id and your `--parent` value) or `Turn mode: Ownership.` (an assignment or status change started this run). Steps 1–5 are shared; then **apply exactly one mode block, the one the user message named** — they differ on issue status. No mode line → Reply mode.\n\n")
 
 	b.WriteString("**Steps 1–5 — both modes** (the per-turn user message carries this issue's real id and ready-to-run context-read commands; assemble other calls from `## Available Commands`)\n\n")
 	b.WriteString("1. Read the issue (`multica issue get`) to understand the context — its JSON already carries the issue's `metadata` bag (empty `{}` is normal), so no separate metadata read is needed. What to look for: `## Issue Metadata`.\n")
@@ -599,21 +608,34 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 		b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
 	}
 	if ctx.IsSquadLeader {
-		// The default rule below and the Squad Operating Protocol's
-		// "Own the parent issue status" responsibility would otherwise
-		// contradict each other on the squad's most common shape:
-		// @mention dispatch with no child issues, where the member's
-		// delivery comment never "explicitly asks" for a status change and
-		// no child-done system comment exists to carry that ask. Naming the
-		// protocol section as the exception resolves it in one direction.
+		// A leader's authority over the parent's status comes from the Squad
+		// Operating Protocol's "Own the parent issue status" responsibility,
+		// which the server injects ONLY when the issue is assigned to this
+		// squad (see buildSquadLeaderBriefing). Naming that section is what
+		// keeps this bullet correct on both leader paths: a guest leader —
+		// @squad-mentioned on an issue owned by someone else — never receives
+		// the grant, so the no-status-writes half below governs.
 		//
-		// The exception is safe to state unconditionally here because the
-		// grant only exists in the instructions when the server determined
-		// this issue is assigned to this squad (see buildSquadLeaderBriefing);
-		// a guest leader gets the opposite text and this stays a no-op.
-		b.WriteString("- Do NOT change the issue status unless the comment explicitly asks for it — **or** a section in your instructions explicitly grants you ownership of this issue's status (the Squad Operating Protocol's \"Own the parent issue status\" responsibility). That section only appears when this issue is assigned to your squad; when it is there, treat it as a standing instruction and move the parent to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. When it is absent, the rule above is absolute. **The Ownership-mode status steps above do not apply in Reply mode.**\n\n")
+		// The leader's arc is not the ordinary one: dispatch is not delivery,
+		// so the parent stays in_progress until a later re-trigger confirms
+		// the goal is met.
+		b.WriteString("- Issue status: a section in your instructions may explicitly grant you ownership of this issue's status (the Squad Operating Protocol's \"Own the parent issue status\" responsibility). That section only appears when this issue is assigned to your squad; when it is there, treat it as a standing instruction — keep the parent `in_progress` while members work, and move it to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. Dispatching members is not completion. When it is absent, this issue belongs to another assignee: never run `multica issue status` on it. A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.\n\n")
 	} else {
-		b.WriteString("- Do NOT change the issue status unless the comment explicitly asks for it. **The Ownership-mode status steps above do not apply in Reply mode.**\n\n")
+		// MUL-6300 replaces the original "do NOT change the issue status
+		// unless the comment explicitly asks for it" (PR #205) with the arc
+		// this rule always meant to protect. That prohibition was written to
+		// stop conversational turns from churning the board, but it also
+		// covered the most common real trigger — a comment asking for rework
+		// on a delivered issue — so the status sat stale until a human moved
+		// the card by hand.
+		//
+		// Two invariants survive verbatim from #205 / #2918, and the guard
+		// tests pin both: a conversational turn never writes status, and a
+		// run that is a guest on someone else's issue (@mention pull-in)
+		// never writes status either. Whether this agent is the assignee is
+		// answerable on every turn: step 1 already reads `assignee_id`, and
+		// `## Agent Identity` carries this agent's own id.
+		b.WriteString("- Issue status: when this issue is assigned to you and this turn does substantive work on it, own the status the same way Ownership mode does — set `in_progress` when you start that work, and when your turn completes move the issue to the status the work is now in (delivered and awaiting acceptance is `in_review`; leave `done` to a human). A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched. When the issue is assigned to someone else and you were pulled in by an @mention, its status belongs to that assignee: never run `multica issue status` on it.\n\n")
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -145,7 +145,8 @@ func TestBriefHasNoParentNotificationGuidance(t *testing.T) {
 // PR #2918) survive it and are pinned here:
 //
 //   - a purely conversational turn never writes status;
-//   - a run that is a guest on someone else's issue never writes status.
+//   - a turn on an issue not assigned to this agent never writes status
+//     (someone else's issue, or an unassigned one reached via @mention).
 //
 // The brief must also still carry no unconditional placeholder flip: a bare
 // `multica issue status <this-issue-id> in_review` command would fire on every
@@ -165,12 +166,14 @@ func TestReplyModeStatusRuleIsScopedToOwnedWorkTurns(t *testing.T) {
 	for _, want := range []string{
 		// The arc itself: both ends, and the ceiling that keeps `done` human.
 		"when this issue is assigned to you and this turn does substantive work on it",
-		"set `in_progress` when you start that work",
-		"delivered and awaiting acceptance is `in_review`; leave `done` to a human",
+		"set `in_progress` when you start",
+		"delivered and awaiting acceptance = `in_review`; `done` stays human",
 		// Invariant 1: conversation does not move the board.
-		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
-		// Invariant 2: no status writes on an issue owned by someone else.
-		"When the issue is assigned to someone else and you were pulled in by an @mention, its status belongs to that assignee: never run `multica issue status` on it.",
+		"Purely conversational turns (question, discussion, acknowledgement) never touch status",
+		// Invariant 2: no status writes on an issue not assigned to this agent —
+		// "not assigned to you" on purpose, so the unassigned @mention path is
+		// covered, not just issues owned by someone else.
+		"neither does any turn on an issue not assigned to you",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("reply-mode status rule missing %q\n---\n%s", want, out)
@@ -205,8 +208,8 @@ func TestCommentTriggeredSquadLeaderDefersToStatusOwnershipGrant(t *testing.T) {
 		// the parent on the turn it hands work to members.
 		"Dispatching members is not completion.",
 		// No grant → no status writes, the guest-leader path (MUL-3724).
-		"When it is absent, this issue belongs to another assignee: never run `multica issue status` on it.",
-		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
+		"When absent, this issue is not yours: never run `multica issue status` on it.",
+		"Purely conversational turns (question, discussion, acknowledgement) never touch status",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("squad-leader comment brief missing %q\n---\n%s", want, out)

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -139,13 +139,18 @@ func TestBriefHasNoParentNotificationGuidance(t *testing.T) {
 	}
 }
 
-// Comment-triggered briefs must NOT carry any unconditional status-flip
-// command targeting the current issue. Previous revisions had a
-// dedicated protocol step that wrote `multica issue status <this-issue-id> in_review`;
-// the comment-triggered workflow rule "Do NOT change the issue status
-// unless the comment explicitly asks for it" must remain the source of
-// truth (Elon's blocking review on PR #2918).
-func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
+// Reply mode owns the same status arc as Ownership mode, but only for turns
+// that carry work on this agent's own issue (MUL-6300). Two invariants from
+// the original prohibition (PR #205, reinforced by Elon's blocking review on
+// PR #2918) survive it and are pinned here:
+//
+//   - a purely conversational turn never writes status;
+//   - a run that is a guest on someone else's issue never writes status.
+//
+// The brief must also still carry no unconditional placeholder flip: a bare
+// `multica issue status <this-issue-id> in_review` command would fire on every
+// reply turn regardless of whether the turn delivered anything.
+func TestReplyModeStatusRuleIsScopedToOwnedWorkTurns(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
 		IssueID:          "55555555-6666-7777-8888-999999999999",
@@ -154,27 +159,36 @@ func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	out := buildMetaSkillContent("claude", ctx)
 
 	if strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
-		t.Errorf("comment-triggered brief must not contain a placeholder `<this-issue-id> in_review` flip — that conflicts with the comment-triggered \"do not change status unless asked\" rule")
+		t.Errorf("reply brief must not contain a placeholder `<this-issue-id> in_review` flip — the arc is conditional on the turn having delivered work")
 	}
 
-	const guardrail = "Do NOT change the issue status unless the comment explicitly asks for it"
-	if !strings.Contains(out, guardrail) {
-		t.Errorf("expected the comment-triggered workflow guardrail %q to be present", guardrail)
+	for _, want := range []string{
+		// The arc itself: both ends, and the ceiling that keeps `done` human.
+		"when this issue is assigned to you and this turn does substantive work on it",
+		"set `in_progress` when you start that work",
+		"delivered and awaiting acceptance is `in_review`; leave `done` to a human",
+		// Invariant 1: conversation does not move the board.
+		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
+		// Invariant 2: no status writes on an issue owned by someone else.
+		"When the issue is assigned to someone else and you were pulled in by an @mention, its status belongs to that assignee: never run `multica issue status` on it.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("reply-mode status rule missing %q\n---\n%s", want, out)
+		}
 	}
 
-	// For an ordinary agent the guardrail is absolute — the squad-leader
-	// carve-out below must not leak into this path.
+	// The squad-leader carve-out below must not leak into the ordinary path.
 	if strings.Contains(out, "Own the parent issue status") {
 		t.Errorf("ordinary-agent comment brief must not reference the squad status grant:\n%s", out)
 	}
 }
 
-// A squad leader on a comment-triggered turn gets the same guardrail plus a
-// named exception. Without it the guardrail and the Squad Operating Protocol's
-// "Own the parent issue status" responsibility contradict each other on the
-// @mention-dispatch shape, where the member's delivery comment never asks for
-// a status change and no child-done system comment exists to ask on its
-// behalf — so the parent would sit in in_progress forever.
+// A squad leader's authority over the parent's status is granted by the Squad
+// Operating Protocol, not by this brief: the server injects "Own the parent
+// issue status" only when the issue is assigned to THIS squad. The reply-mode
+// bullet therefore routes on that section by name, so the same text is correct
+// for an owning leader (dispatch, wait, then in_review) and for a guest leader
+// @squad-mentioned on someone else's issue (no status writes at all).
 func TestCommentTriggeredSquadLeaderDefersToStatusOwnershipGrant(t *testing.T) {
 	t.Parallel()
 	out := buildMetaSkillContent("claude", TaskContextForEnv{
@@ -184,21 +198,25 @@ func TestCommentTriggeredSquadLeaderDefersToStatusOwnershipGrant(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		"Do NOT change the issue status unless the comment explicitly asks for it",
 		`Squad Operating Protocol's "Own the parent issue status"`,
 		"only appears when this issue is assigned to your squad",
 		"without waiting to be asked",
-		"When it is absent, the rule above is absolute.",
+		// Dispatch is not delivery: without this the leader would close out
+		// the parent on the turn it hands work to members.
+		"Dispatching members is not completion.",
+		// No grant → no status writes, the guest-leader path (MUL-3724).
+		"When it is absent, this issue belongs to another assignee: never run `multica issue status` on it.",
+		"A purely conversational turn — question, discussion, acknowledgement — leaves the status untouched.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("squad-leader comment brief missing %q\n---\n%s", want, out)
 		}
 	}
 
-	// The unqualified sentence must be gone: its presence alongside the grant
-	// is the contradiction this branch exists to remove.
-	if strings.Contains(out, "explicitly asks for it\n") {
-		t.Errorf("squad-leader comment brief still ends the guardrail unqualified\n---\n%s", out)
+	// The leader must NOT inherit the ordinary agent's arc: it keys off
+	// assignment to the agent itself, which is never true for a squad parent.
+	if strings.Contains(out, "when this issue is assigned to you and this turn does substantive work on it") {
+		t.Errorf("squad-leader comment brief must not carry the ordinary-agent status arc\n---\n%s", out)
 	}
 }
 

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -53,9 +53,11 @@ func backendResumeContinuityNotice(task Task) string {
 // emitted unconditionally from the same branches BuildPrompt uses to pick a
 // path, so the two can never disagree.
 //
-// Reply mode = respond to the triggering comment, do not touch issue status.
-// Ownership mode = an assignment/status change started this run; own the
-// status arc. Applying the wrong one silently changes issue status.
+// Reply mode = respond to the triggering comment; the status arc opens only
+// when the turn does substantive work on an issue assigned to this agent
+// (MUL-6300). Ownership mode = an assignment/status change started this run;
+// own the status arc unconditionally. Applying the wrong one changes when
+// issue status moves.
 const (
 	turnModeReply     = "**Turn mode: Reply.** Follow the Reply-mode block in your runtime workflow file for this turn; the Ownership-mode status steps do not apply.\n\n"
 	turnModeOwnership = "**Turn mode: Ownership.** Follow the Ownership-mode block in your runtime workflow file for this turn; the Reply-mode rules do not apply.\n\n"

--- a/server/internal/handler/issue_child_done_stage_test.go
+++ b/server/internal/handler/issue_child_done_stage_test.go
@@ -171,8 +171,9 @@ func TestStageAdvanceInstruction(t *testing.T) {
 		}
 		// It must make clear that finishing the stage != the whole issue is
 		// done, and hand both paths (wrap up / create the next stage) to the
-		// leader. When wrapping up, the explicit ask is in_review so the
-		// comment-triggered "only change status when asked" rule permits it.
+		// leader. The explicit in_review command marks the wrap-up moment;
+		// the write itself is authorized by the standing status-ownership
+		// grant (MUL-6300), not by this ask.
 		if !strings.Contains(got, "does not mean the whole issue is done") {
 			t.Fatalf("expected stage-done != issue-done framing, got %q", got)
 		}

--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -74,13 +74,15 @@ Your responsibilities, in order:
 // leader was woken on is assigned to THIS squad. Only then does the leader own
 // the parent's status arc.
 //
-// The "even when no comment asked you to" clause is load-bearing: the comment
-// workflow's default rule is "do not change status unless the comment asks",
-// and a member's delivery comment never asks. Without an explicit standing
-// grant here, the @mention-dispatch squad shape (no child issues, so no
-// child-done system comment carrying an explicit ask) would leave the parent
-// stuck in in_progress forever. The comment workflow defers to this section by
-// name — keep the heading text in sync with writeWorkflowComment.
+// This grant is what the reply-mode leader bullet routes on, by section name:
+// present → the leader owns the parent's arc, absent → no status writes at
+// all (MUL-6300). The ordinary assignee-scoped arc never applies to a leader,
+// because the parent is assigned to the squad, not to the leader agent — so
+// without this section a leader could never wrap the parent up, and the
+// @mention-dispatch shape (no child issues, so no child-done system comment)
+// would leave it stuck in in_progress forever. The "even when no comment
+// asked you to" clause makes the standing nature explicit — keep the heading
+// text in sync with writeWorkflowIssue.
 const squadParentStatusOwned = `6. **Own the parent issue status.** This issue is assigned to your squad,
    so its status is yours to manage (unless Agent Identity forbids status
    changes). On the first assignment turn, move the parent to

--- a/server/internal/handler/squad_parent_status_contract_test.go
+++ b/server/internal/handler/squad_parent_status_contract_test.go
@@ -59,11 +59,10 @@ func TestSquadAssignedLeaderCanWrapUpOnCommentTurn(t *testing.T) {
 		t.Fatalf("squad-assigned briefing must grant status ownership:\n%s", briefing)
 	}
 
-	// The runtime brief must not restate the prohibition in its absolute form,
-	// which is what contradicted the grant. The absolute sentence ends right
-	// after "explicitly asks for it"; the leader variant continues past it.
-	if strings.Contains(brief, "explicitly asks for it\n") {
-		t.Error("leader runtime brief still carries the unqualified no-status-change rule, " +
+	// The runtime brief must not carry a blanket no-status-change rule: any
+	// unqualified form of it contradicts the grant this leader just received.
+	if strings.Contains(brief, "Do NOT change the issue status") {
+		t.Error("leader runtime brief still carries an unqualified no-status-change rule, " +
 			"which contradicts the Own-the-parent-issue-status grant")
 	}
 	for _, want := range []string{
@@ -112,8 +111,8 @@ func TestGuestLeaderCannotChangeStatusOnCommentTurn(t *testing.T) {
 		}
 	}
 
-	// But the grant is absent, so the runtime brief's carve-out has nothing to
-	// activate and the default prohibition governs.
+	// But the grant is absent, so the runtime brief's grant branch has nothing
+	// to activate and its no-status-writes branch governs.
 	if strings.Contains(briefing, "Own the parent issue status") {
 		t.Errorf("guest leader must not receive the status-ownership grant:\n%s", briefing)
 	}

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -142,15 +142,16 @@ Contracts:
   enqueue-time via `canEnqueueSquadLeader` (squad.go:1037);
 - archived squad / archived leader rejected at assign-time (issue.go:2622-2627);
 - pending task dedup is applied (squad.go:1042-1048);
-- parent status is agent-managed: assignment brief (`writeWorkflowAssignment` with
-  `IsSquadLeader`) requires `in_progress` on the first turn and forbids
+- parent status is agent-managed: the Ownership-mode block (`writeWorkflowIssue`
+  with `IsSquadLeader`) requires `in_progress` on the first turn and forbids
   unconditional `in_review` on that dispatch turn; Squad Operating Protocol
   (`squad_briefing.go`) owns the ongoing `in_progress` → later `in_review`
-  contract. `StartTask` / `CompleteTask` do not write issue status. On
-  comment-triggered leader turns `writeWorkflowComment` names that protocol
-  responsibility as the one exception to "do not change status unless the
-  comment asks" — without it the @mention-dispatch shape (no child issues, so
-  no child-done ask) would strand the parent in `in_progress`.
+  contract. `StartTask` / `CompleteTask` do not write issue status. On reply
+  turns the leader's status bullet routes on that protocol responsibility by
+  name: present (issue assigned to this squad) → wrap up with `in_review` when
+  the goal is met, absent (guest leader) → no status writes at all. Ordinary
+  agents get the assignee-scoped arc instead, which never fires for a squad
+  parent because the parent is assigned to the squad, not to the leader agent.
 
 ## Comment / Mention
 

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -232,9 +232,11 @@ Contracts:
   ungated path; any future invocation gate must be added to BOTH together.
 - parent status is not auto-advanced by the barrier: the system comment asks the
   leader to continue or — when the overall goal is met — run
-  `multica issue status <parent-id> in_review`. That explicit ask is what lets a
-  comment-triggered leader turn change status (the comment workflow otherwise
-  forbids status flips unless asked). `done` remains human / integration owned.
+  `multica issue status <parent-id> in_review`. The write is authorized by the
+  Squad Operating Protocol's standing "Own the parent issue status" grant
+  (present exactly when the issue is assigned to this squad); the system
+  comment marks the wrap-up moment, it is not the permission. `done` remains
+  human / integration owned.
 
 ## Private Leader Access
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -182,10 +182,14 @@ on it. These are the contracts, not advice:
 - **`backlog`** parks an agent-assigned issue: the assignee is set but no task
   fires. Moving `backlog → todo` (or any non-done/non-cancelled status) enqueues
   the assigned agent then.
-- **`in_progress` / `in_review` on assignment runs** are agent-managed CLI
-  mutations, not `StartTask` / `CompleteTask` side effects. The assignment
-  runtime brief asks ordinary agents for `todo`/`backlog` → `in_progress` then
-  `in_review` when they have delivered. Squad leaders share the opening
+- **`in_progress` / `in_review`** are agent-managed CLI mutations, not
+  `StartTask` / `CompleteTask` side effects. The runtime brief asks ordinary
+  agents for `todo`/`backlog` → `in_progress` then `in_review` when they have
+  delivered. Ownership turns open that arc unconditionally; reply turns own the
+  same arc, but only when the issue is assigned to you AND the turn does
+  substantive work — a question, a discussion, or an acknowledgement never
+  moves the status, and neither does a turn on an issue assigned to someone
+  else (you were pulled in by an @mention). Squad leaders share the opening
   `in_progress` step on the first assignment turn, keep the parent there while
   members work, and only move to `in_review` when a later re-trigger confirms
   the overall goal is met.

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -188,8 +188,9 @@ on it. These are the contracts, not advice:
   delivered. Ownership turns open that arc unconditionally; reply turns own the
   same arc, but only when the issue is assigned to you AND the turn does
   substantive work — a question, a discussion, or an acknowledgement never
-  moves the status, and neither does a turn on an issue assigned to someone
-  else (you were pulled in by an @mention). Squad leaders share the opening
+  moves the status, and neither does a turn on an issue not assigned to you
+  (someone else's, or unassigned — you were pulled in by an @mention either
+  way). Squad leaders share the opening
   `in_progress` step on the first assignment turn, keep the parent there while
   members work, and only move to `in_review` when a later re-trigger confirms
   the overall goal is met.

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -130,7 +130,7 @@ and is hidden from the PR list.
 | Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
 | Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
-| Assignment brief: ordinary agent `in_progress` then `in_review`; squad leader `in_progress` only on first dispatch | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowAssignment`) | new citation |
+| Runtime brief: ordinary agent `in_progress` then `in_review` (Ownership mode unconditionally, Reply mode only for work turns on its own issue); squad leader `in_progress` only on first dispatch | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowIssue`) | new citation |
 | Failed task may roll `in_progress` → `todo` when no active task remains | `server/internal/service/task.go` (`HandleFailedTasks`) | new citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
@@ -174,8 +174,9 @@ Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee. Promoting the next stage's `backlog` sub-issues to
 `todo` is the woken agent's decision, not a server side effect. When the woken
 assignee (often a squad leader) decides the parent is complete, the system
-comment explicitly asks for `multica issue status <parent-id> in_review` —
-comment-triggered runs otherwise must not change status unless asked.
+comment explicitly asks for `multica issue status <parent-id> in_review`. A
+reply turn may move the status on its own too, but only when the issue is
+assigned to that agent and the turn actually delivered work.
 
 ## Metadata CLI
 


### PR DESCRIPTION
## Problem (MUL-6300)

Reply-mode (comment-triggered) turns were forbidden from changing issue status at all — "Do NOT change the issue status unless the comment explicitly asks for it" (PR #205). That prohibition was written to stop conversational turns from churning the board, but it also covered the most common real trigger: a comment asking for rework on a delivered issue. The status sat stale until a human moved the card by hand (MUL-5165). This PR replaces #5781, whose target text was rewritten by MUL-5377 and can no longer be rebased.

## Fix

Replace the blanket ban with the conditional arc it always meant to protect. The reply-mode status rule is now:

> Issue status: when this issue is assigned to you and this turn does substantive work on it, own the status arc as Ownership mode does — set `in_progress` when you start, and at turn end set the status the work has reached (delivered and awaiting acceptance = `in_review`; `done` stays human). Purely conversational turns (question, discussion, acknowledgement) never touch status; neither does any turn on an issue not assigned to you.

Two invariants survive verbatim from #205 / #2918 and are pinned by guard tests:

- a purely conversational turn never writes status;
- a turn on an issue **not assigned to this agent** never writes status — deliberately "not assigned to you" rather than "assigned to someone else", so an @mention onto an *unassigned* issue (triage) stays no-write too.

Squad leaders keep routing on the Squad Operating Protocol's "Own the parent issue status" grant: present (issue assigned to this squad) → dispatch, wait, wrap up with `in_review`; absent (guest leader, MUL-3724) → no status writes. The ordinary assignee-scoped arc never fires for a squad parent because the parent is assigned to the squad, not the leader agent.

No server-side enqueue changes are needed: status-triggered runs only fire on `backlog` → non-terminal, and `IsSelfLoop` / `hasPendingRun` already suppress self-retriggering from inside a run.

## Scope

- `runtime_config_sections.go`: both reply-mode status bullets rewritten (ordinary 103 → 70 words, squad leader 110 → 92; conversational sentence identical in both branches). Turn-mode router intro drops its stale ban tail.
- Guard tests re-pinned to the new invariants (`TestReplyModeStatusRuleIsScopedToOwnedWorkTurns`, squad-leader variant, fallback pin in `reply_instructions_test.go`); handler squad contract broadened to reject any blanket "Do NOT change the issue status" form.
- Decision-ledger surfaces purged of the old rule stated as current behavior: `prompt.go` turn-mode comment, `squad_briefing.go` grant rationale, `issue_child_done_stage_test.go` comment, and the agent-readable `multica-squads` source map (the wrap-up write is authorized by the standing grant, not the system comment's ask).
- Built-in skill docs (`multica-working-on-issues`, `multica-squads` source maps) updated in the same PR per repo rule.

## Verification

- `go test ./internal/daemon/execenv/ -run ByteIdentical` — MUL-5377 byte-identical brief invariant holds (rule text is static; mode routing stays per-turn via `BuildPrompt`).
- Guard tests, daemon prompt marker tests, handler squad owner/guest contract tests, child-done stage tests, builtin-skill tests: green.
- Full `execenv` package shows only the four pre-existing Hermes environment failures; the same set fails on `origin/main`.
- `gofmt` / `go vet` clean on touched files.

Prompt-level rule fidelity still depends on each runtime's model; the deterministic outcome-reporting design remains tracked as MUL-5165 P2.
