### PR TITLE
MUL-6302: Link update prompt to changelog

### DIFF
--- a/apps/desktop/src/renderer/src/components/update-notification.test.tsx
+++ b/apps/desktop/src/renderer/src/components/update-notification.test.tsx
@@ -1,0 +1,59 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UpdateNotification } from "./update-notification";
+
+const mocks = vi.hoisted(() => ({
+  installUpdate: vi.fn(),
+  openExternal: vi.fn(),
+}));
+
+type UpdateDownloadedListener = (info: {
+  version: string;
+  releaseNotes?: string;
+}) => void;
+
+describe("UpdateNotification", () => {
+  let updateDownloaded: UpdateDownloadedListener;
+
+  beforeEach(() => {
+    mocks.installUpdate.mockReset().mockResolvedValue(undefined);
+    mocks.openExternal.mockReset().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "desktopAPI", {
+      configurable: true,
+      value: { openExternal: mocks.openExternal },
+    });
+    Object.defineProperty(window, "updater", {
+      configurable: true,
+      value: {
+        onUpdateDownloaded: (listener: UpdateDownloadedListener) => {
+          updateDownloaded = listener;
+          return vi.fn();
+        },
+        installUpdate: mocks.installUpdate,
+      },
+    });
+  });
+
+  it("opens the downloaded version's changelog from the update prompt", () => {
+    render(<UpdateNotification />);
+    act(() => updateDownloaded({ version: "0.4.27" }));
+
+    expect(screen.queryByRole("button", { name: "Later" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "See changelog" }));
+
+    expect(mocks.openExternal).toHaveBeenCalledWith(
+      "https://multica.ai/changelog#release-0-4-27",
+    );
+  });
+
+  it("still installs the update immediately from the primary action", () => {
+    render(<UpdateNotification />);
+    act(() => updateDownloaded({ version: "0.4.27" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+
+    expect(mocks.installUpdate).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/renderer/src/components/update-notification.tsx
+++ b/apps/desktop/src/renderer/src/components/update-notification.tsx
@@ -8,6 +8,10 @@ type UpdateState =
   | { status: "idle" }
   | { status: "ready"; version: string };
 
+function changelogUrl(version: string): string {
+  return `https://multica.ai/changelog#release-${version.replace(/\./g, "-")}`;
+}
+
 export function UpdateNotification() {
   const [state, setState] = useState<UpdateState>({ status: "idle" });
   const [dismissed, setDismissed] = useState(false);
@@ -45,10 +49,12 @@ export function UpdateNotification() {
           <div className="mt-2 flex items-center gap-1.5">
             <button
               type="button"
-              onClick={() => setDismissed(true)}
+              onClick={() =>
+                window.desktopAPI.openExternal(changelogUrl(state.version))
+              }
               className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-caption font-medium text-foreground hover:bg-accent transition-colors"
             >
-              Later
+              See changelog
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary

- replace the desktop update prompt’s “Later” action with “See changelog”
- open the downloaded version’s matching changelog anchor in the default browser
- preserve the close control and “Restart now” behavior
- add regression coverage for both update prompt actions

## Why

The previous secondary action only dismissed the update prompt, so users could not inspect the release notes before deciding to restart. The new action links directly to the downloaded version’s changelog entry.

## Validation

- `pnpm --filter @multica/desktop test` — 52 files, 496 tests passed
- `pnpm --filter @multica/desktop typecheck:web`
- ESLint on the changed source and test
- `git diff --check`
