### PR TITLE
MUL-6303: fix(desktop): keep the workspace singleton across a same-workspace tab swap

### DIFF
--- a/apps/desktop/src/renderer/src/components/workspace-route-layout.test.tsx
+++ b/apps/desktop/src/renderer/src/components/workspace-route-layout.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -16,6 +17,7 @@ const state = vi.hoisted(() => ({
   modalAriaLabel: "source-backfill-modal-marker",
   currentSlug: null as string | null,
   pendingDeletes: new Set<string>(),
+  childQuerySlugs: [] as (string | null)[],
 }));
 
 vi.mock("@multica/core/auth", () => {
@@ -30,8 +32,14 @@ vi.mock("@multica/core/auth", () => {
 // A real-enough stand-in for the platform singleton: the layout both writes
 // and reads it (the clear paths check `getCurrentSlug()` before wiping), so a
 // bare vi.fn() would make every guard trivially true.
+// The slug-equality early return mirrors the real singleton
+// (packages/core/platform/workspace-storage.ts). It is load-bearing for the
+// tab-swap case below: the incoming layout of a same-workspace swap writes the
+// slug that is already there, so its write is a no-op and cannot be what stops
+// the outgoing cleanup from clearing it.
 vi.mock("@multica/core/platform", () => ({
   setCurrentWorkspace: vi.fn((slug: string | null) => {
+    if (state.currentSlug === slug) return;
     state.currentSlug = slug;
   }),
   getCurrentSlug: () => state.currentSlug,
@@ -149,6 +157,7 @@ beforeEach(() => {
   state.modalRenders = 0;
   state.currentSlug = null;
   state.pendingDeletes = new Set<string>();
+  state.childQuerySlugs = [];
 });
 
 describe("WorkspaceRouteLayout", () => {
@@ -242,5 +251,90 @@ describe("WorkspaceRouteLayout workspace singleton lifecycle", () => {
     unmount();
 
     expect(state.currentSlug).toBe("other");
+  });
+});
+
+/**
+ * MUL-6303 / #7086. Desktop mounts exactly one tab at a time and keys the host
+ * on the active tab id (tab-content.tsx), so opening or switching a tab
+ * unmounts the whole router subtree and builds a new one beside it. React
+ * renders the incoming tree first and only then runs the outgoing tree's
+ * effect cleanups — so the release path above has to survive a successor that
+ * has already taken over.
+ *
+ * The guard it shipped with (slug equality) could not see that successor when
+ * both tabs belonged to the SAME workspace: the "+" button opens
+ * /<slug>/issues in the active workspace, so the incoming layout carried the
+ * same slug, its write deduped to a no-op, and the outgoing cleanup cleared
+ * the singleton out from under it. Every request the new tab fired then went
+ * out without X-Workspace-Slug and came back 400, and the shell dropped its
+ * sidebar — until the app was relaunched.
+ */
+describe("WorkspaceRouteLayout across a tab swap", () => {
+  // Records the singleton as a child sees it. Real workspace-scoped queries
+  // fire from effects exactly like this one, which is why the ordering matters:
+  // an outgoing cleanup that clears the singleton still lands BEFORE the
+  // incoming tab's first request goes out.
+  function ChildQuery() {
+    useEffect(() => {
+      state.childQuerySlugs.push(state.currentSlug);
+    }, []);
+    return <div data-testid="outlet" />;
+  }
+
+  // Mirrors ActiveTabHost: one tab mounted at a time, keyed by tab id.
+  function TabHost({ slug }: { slug: string }) {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    qc.setQueryData(["workspace-by-slug"], state.workspace);
+    qc.setQueryData(["workspace-list"], state.wsList);
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={[`/${slug}/issues`]}>
+          <Routes>
+            <Route path=":workspaceSlug/*" element={<WorkspaceRouteLayout />}>
+              <Route path="*" element={<ChildQuery />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it("keeps the workspace when the incoming tab is in the SAME workspace", () => {
+    const { rerender } = render(<TabHost key="tab-1" slug="acme" />);
+    expect(state.currentSlug).toBe("acme");
+
+    rerender(<TabHost key="tab-2" slug="acme" />);
+
+    expect(state.currentSlug).toBe("acme");
+    // Both tabs' first requests carried a workspace. The second entry is the
+    // one that used to be null, which is what produced the 400s.
+    expect(state.childQuerySlugs).toEqual(["acme", "acme"]);
+  });
+
+  it("adopts the incoming workspace when the tab is in a DIFFERENT workspace", () => {
+    state.wsList = [
+      { id: "ws-1", slug: "acme" },
+      { id: "ws-2", slug: "globex" },
+    ];
+    const { rerender } = render(<TabHost key="tab-1" slug="acme" />);
+    expect(state.currentSlug).toBe("acme");
+
+    state.workspace = { id: "ws-2", slug: "globex" };
+    rerender(<TabHost key="tab-2" slug="globex" />);
+
+    expect(state.currentSlug).toBe("globex");
+    expect(state.childQuerySlugs).toEqual(["acme", "globex"]);
+  });
+
+  it("still releases the workspace when the last tab goes away", () => {
+    const { unmount } = render(<TabHost key="tab-1" slug="acme" />);
+    expect(state.currentSlug).toBe("acme");
+
+    unmount();
+
+    expect(state.currentSlug).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/components/workspace-route-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/workspace-route-layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { WorkspaceSlugProvider } from "@multica/core/paths";
@@ -15,6 +15,19 @@ import { WorkspacePresencePrefetch } from "@multica/views/layout";
 import { SourceBackfillModal } from "@multica/views/onboarding";
 import { useTabStore } from "@/stores/tab-store";
 import { useWindowOverlayStore } from "@/stores/window-overlay-store";
+
+/**
+ * Which mounted layout instance currently owns the platform workspace
+ * singleton. Claimed during render (next to the setCurrentWorkspace write it
+ * guards) and read by the unmount cleanup, which must not release a singleton
+ * a successor has already taken over (MUL-6303 / #7086).
+ *
+ * Module scope rather than context: the two instances that have to agree here
+ * never share a React tree. Desktop mounts exactly one tab at a time and keys
+ * the host on the active tab id (tab-content.tsx), so switching or opening a
+ * tab tears the whole router subtree down and builds a new one beside it.
+ */
+let singletonOwner: symbol | null = null;
 
 /**
  * Desktop equivalent of apps/web/app/[workspaceSlug]/layout.tsx.
@@ -35,6 +48,11 @@ import { useWindowOverlayStore } from "@/stores/window-overlay-store";
  */
 export function WorkspaceRouteLayout() {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+  // Identity for this mounted instance. A Symbol so two layouts can never
+  // compare equal — including the incoming and outgoing layout of a
+  // same-workspace tab swap, which carry the same slug and workspace id and
+  // are therefore indistinguishable by value.
+  const [instanceId] = useState(() => Symbol("workspace-route-layout"));
   const user = useAuthStore((s) => s.user);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
   // While a WindowOverlay is open (onboarding, accept-invite, new-workspace),
@@ -81,7 +99,13 @@ export function WorkspaceRouteLayout() {
   // while the deleted workspace is STILL in the list cache (the invalidation
   // refetch is a network round-trip). Without the guard we write the dead slug
   // straight back over the cleanup.
+  //
+  // Claiming ownership here — in the same render pass, before any cleanup can
+  // run — is what makes the unmount release below safe. React renders the
+  // incoming tree before it runs the outgoing tree's effect cleanups, so by
+  // the time the old layout tries to release, the new one already owns.
   if (workspace && workspaceSlug && !isWorkspaceDeletePending(workspace.id)) {
+    singletonOwner = instanceId;
     setCurrentWorkspace(workspaceSlug, workspace.id);
   }
 
@@ -121,12 +145,29 @@ export function WorkspaceRouteLayout() {
     setCurrentWorkspace(null, null);
   }, [listReady, workspace, workspaceSlug]);
 
+  // The ownership check is what keeps a same-workspace tab swap from wiping
+  // the workspace context (MUL-6303 / #7086). The slug check alone cannot see
+  // that swap: the "+" button opens /<slug>/issues in the ACTIVE workspace
+  // (tab-bar.tsx), so the incoming layout carries the SAME slug, its render
+  // write dedupes to a no-op inside setCurrentWorkspace, and the outgoing
+  // cleanup then found getCurrentSlug() still equal to its own slug and
+  // cleared it. Every workspace-scoped request the new tab fired went out
+  // without X-Workspace-Slug and came back 400, and the shell — which gates
+  // its chrome on the same singleton — dropped the sidebar with it. Nothing
+  // re-ran the render write afterwards, so it stayed broken until relaunch.
+  //
+  // Both checks still earn their place: ownership covers a successor that
+  // shares this slug, and the slug check covers this same instance being
+  // re-run for a new slug (the effect's own dependency change), where the
+  // singleton has already moved on and must not be clobbered.
   useEffect(() => {
     return () => {
+      if (singletonOwner !== instanceId) return;
       if (getCurrentSlug() !== workspaceSlug) return;
+      singletonOwner = null;
       setCurrentWorkspace(null, null);
     };
-  }, [workspaceSlug]);
+  }, [workspaceSlug, instanceId]);
 
   if (isAuthLoading) return null;
   if (!user) return null;


### PR DESCRIPTION
Fixes #7086.

## What was broken

On 0.4.27 Desktop, opening a new tab or switching tabs **inside one workspace** left the client with no active workspace. The sidebar disappeared, every workspace-scoped request went out without `X-Workspace-Slug` and came back 400 (so the Issues board showed "Loading more failed — Retry" with 0 in every column), and nothing recovered it short of relaunching the app — at which point the next tab switch broke it again.

All platforms, not just macOS — this is renderer logic. Switching tabs across *different* workspaces was unaffected, which is why it reproduced for some people and not others.

## Why

Desktop mounts exactly one tab at a time and keys the host on the active tab id (`tab-content.tsx`), so a tab swap unmounts the whole router subtree and builds a new one beside it. React renders the incoming tree before running the outgoing tree's effect cleanups.

The release path added in #7064 guarded only on slug equality:

```ts
if (getCurrentSlug() !== workspaceSlug) return;
setCurrentWorkspace(null, null);
```

That guard catches a workspace *switch*, but not a swap within one workspace. The "+" button opens `/<slug>/issues` in the **active** workspace (`tab-bar.tsx`), so the incoming layout carries the **same** slug, its render-phase write dedupes to a no-op inside `setCurrentWorkspace` (`workspace-storage.ts` returns early on slug equality), and the outgoing cleanup then finds `getCurrentSlug()` still equal to its own slug and clears it.

The incoming tab's queries fire from effects, which run *after* that cleanup — so its very first requests are the ones that go out unscoped. And because the route element identity never changes, React bails out of re-rendering the layout afterwards, so the render-phase write never runs again and the singleton stays null until relaunch.

## The fix

Give each mounted layout an instance identity and have it claim the singleton in the same render pass that writes it. The unmount release bails when a successor already owns it.

The slug check stays alongside the new ownership check — it still covers the *same* instance re-running for a new slug (the effect's own dependency change), where the singleton has already moved on.

The MUL-6231 behaviour this path exists for is preserved: releasing on genuine unmount, releasing when the workspace stops resolving, and not clobbering an incoming workspace on a switch.

## Testing

`apps/desktop/src/renderer/src/components/workspace-route-layout.test.tsx` — three new cases mounting the real keyed-host swap rather than calling `unmount()` by hand, since the bug is entirely about React's commit ordering:

- same-workspace swap keeps the workspace (**fails on `main`**, passes here)
- cross-workspace swap adopts the incoming workspace (control — was already correct)
- last tab going away still releases the workspace

They assert on the slug a child query observes at effect time, because that value is exactly what became the 400s. The platform mock now mirrors the real slug-equality early return — without it the incoming layout's write would look like it could have been what saved the singleton.

Verified locally:

- `pnpm -C apps/desktop test` — 52 files, 499 tests passing
- `pnpm -C apps/desktop run typecheck` — clean
- `pnpm -C apps/desktop run lint` — clean (one pre-existing warning in `tab-content.tsx`, untouched here)

Not verified by hand on a packaged build — the reproduction and the fix are both established through the test above.

Given the app is effectively unusable for anyone who works in more than one tab, this is worth a patch release rather than waiting for the normal cadence.
