### PR TITLE
fix(migrations): fail closed on 341 rollback instead of deleting actor properties (MUL-6305)

### DIFF
--- a/server/internal/migrations/issue_property_actor_rollback_test.go
+++ b/server/internal/migrations/issue_property_actor_rollback_test.go
@@ -1,0 +1,106 @@
+package migrations
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestIssuePropertyActorRollbackFailsClosed pins the one behaviour a production
+// rollback depends on: 341 down must refuse to run while actor definitions
+// exist, rather than deleting them. A definition row is the field itself —
+// issues key their values by definition id — so a silent delete orphans every
+// value and the up migration cannot restore it.
+func TestIssuePropertyActorRollbackFailsClosed(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("integration test requires Postgres at DATABASE_URL")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Fatalf("connect to Postgres: %v", err)
+	}
+	defer pool.Close()
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire Postgres connection: %v", err)
+	}
+	defer conn.Release()
+
+	// Temp table shadows the real catalog for this session, so the migration
+	// files run unmodified against a disposable copy of the shape they target.
+	if _, err := conn.Exec(ctx, `
+		CREATE TEMP TABLE issue_property (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			workspace_id UUID NOT NULL,
+			name TEXT NOT NULL,
+			type TEXT NOT NULL,
+			archived_at TIMESTAMPTZ,
+			CONSTRAINT issue_property_type_check CHECK (
+				type IN ('text', 'number', 'select', 'multi_select', 'date', 'checkbox', 'url')
+			)
+		)
+	`); err != nil {
+		t.Fatalf("create temporary issue_property table: %v", err)
+	}
+
+	applyMigrationFile(t, ctx, conn.Conn(), "341_issue_property_actor_types.up.sql")
+
+	const workspaceID = "00000000-0000-0000-0000-000000000001"
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO issue_property (workspace_id, name, type)
+		VALUES ($1, 'Reviewer', 'actor'), ($1, 'Escalation', 'multi_actor')
+	`, workspaceID); err != nil {
+		t.Fatalf("insert actor property definitions: %v", err)
+	}
+	// Archived definitions still resolve historical values, so they must block
+	// the rollback exactly like active ones.
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO issue_property (workspace_id, name, type, archived_at)
+		VALUES ($1, 'Old reviewer', 'actor', now())
+	`, workspaceID); err != nil {
+		t.Fatalf("insert archived actor property definition: %v", err)
+	}
+
+	downSQL := readMigrationFile(t, "341_issue_property_actor_types.down.sql")
+	_, err = conn.Exec(ctx, downSQL)
+	if err == nil {
+		t.Fatal("down migration succeeded with actor definitions present; it must fail closed")
+	}
+	if !strings.Contains(err.Error(), "cannot roll back 341") {
+		t.Fatalf("down migration failed for the wrong reason: %v", err)
+	}
+
+	var remaining int
+	if err := conn.QueryRow(ctx, `
+		SELECT count(*) FROM issue_property WHERE type IN ('actor', 'multi_actor')
+	`).Scan(&remaining); err != nil {
+		t.Fatalf("count actor definitions after refused rollback: %v", err)
+	}
+	if remaining != 3 {
+		t.Fatalf("refused rollback destroyed definitions: %d of 3 left", remaining)
+	}
+
+	// After the operator migrates those definitions off the actor types, the
+	// rollback goes through and the pre-actor allowlist is back in force.
+	if _, err := conn.Exec(ctx, `
+		UPDATE issue_property SET type = 'text' WHERE type IN ('actor', 'multi_actor')
+	`); err != nil {
+		t.Fatalf("convert actor definitions to text: %v", err)
+	}
+
+	applyMigrationFile(t, ctx, conn.Conn(), "341_issue_property_actor_types.down.sql")
+
+	if _, err := conn.Exec(ctx, `
+		INSERT INTO issue_property (workspace_id, name, type)
+		VALUES ($1, 'Reviewer again', 'actor')
+	`, workspaceID); !isCheckViolation(err) {
+		t.Fatalf("insert actor definition after rollback: got %v, want check violation", err)
+	}
+}

--- a/server/migrations/341_issue_property_actor_types.down.sql
+++ b/server/migrations/341_issue_property_actor_types.down.sql
@@ -1,10 +1,34 @@
--- Restore the pre-actor type allowlist. Actor definitions have to go first or
--- the constraint cannot be re-added. Their values stay in each issue's
--- property bag, keyed by a definition id that no longer resolves — the same
--- shape the catalog already tolerates for a removed definition, and readers
--- skip those keys. Re-running the up migration does NOT bring the definitions
--- back, so this is a local-rollback tool, not a reversible production step.
-DELETE FROM issue_property WHERE type IN ('actor', 'multi_actor');
+-- Restore the pre-actor type allowlist.
+--
+-- Fails closed when any actor / multi_actor definition still exists, the same
+-- stance as 337: rewriting or deleting those rows to make the old constraint
+-- fit would destroy user data. A definition row IS the field — issues key their
+-- values by definition id, so deleting it orphans every value it holds and
+-- re-running the up migration brings nothing back. Archived definitions count
+-- too; their values stay resolvable, so they are just as costly to drop.
+--
+-- Rolling back a database that already carries actor fields therefore starts
+-- with an explicit, auditable data migration that converts those definitions
+-- (and the values issues hold for them) to a type the old allowlist accepts.
+-- Only then is this direction safe to run.
+--
+-- The guard aborts before any DDL runs; the restored constraint is a second
+-- line of defence that would reject the same rows on its own.
+DO $$
+DECLARE
+    actor_defs BIGINT;
+BEGIN
+    SELECT count(*) INTO actor_defs
+    FROM issue_property
+    WHERE type IN ('actor', 'multi_actor');
+
+    IF actor_defs > 0 THEN
+        RAISE EXCEPTION 'cannot roll back 341: % actor/multi_actor property definition(s) still exist', actor_defs
+            USING HINT = 'Convert those definitions and the issue values keyed to them to a pre-actor type first; this migration will not delete user data.';
+    END IF;
+END
+$$;
+
 ALTER TABLE issue_property DROP CONSTRAINT IF EXISTS issue_property_type_check;
 ALTER TABLE issue_property ADD CONSTRAINT issue_property_type_check
     CHECK (type IN ('text', 'number', 'select', 'multi_select', 'date', 'checkbox', 'url'));


### PR DESCRIPTION
## What

`341_issue_property_actor_types.down.sql` deleted every `actor` / `multi_actor` property definition so the pre-actor `CHECK` constraint would fit again. That is silent, unrecoverable data loss on a production schema rollback:

- a definition row **is** the field — issues key their values by definition id, so deleting it orphans every value it holds;
- re-running the up migration restores the type allowlist, not the definitions;
- unlike custom issue statuses, `actor` / `multi_actor` ship with no feature flag in front of them, so any workspace can create one the moment v0.4.28 is out.

Flagged as a release blocker in the v0.4.28 preflight check (MUL-6305).

## How

Refuse the rollback instead, the same stance `337_issue_status_open_check.down.sql` already takes: abort with an actionable message while any such definition still exists, and leave the operator to convert those definitions — and the issue values keyed to them — with an explicit, auditable data migration first. Archived definitions count too; their values stay resolvable.

The restored constraint would reject the same rows on its own, so the guard only turns an opaque check violation into a message that says what to do.

## Verification

Against a throwaway `pgvector/pgvector:pg17` instance:

- `go run ./cmd/migrate up` on an empty database — 341 applies clean.
- With one `actor` definition present, `go run ./cmd/migrate down` aborts on 341: `cannot roll back 341: 1 actor/multi_actor property definition(s) still exist`. The definition, the `schema_migrations` row and the widened constraint are all untouched — nothing half-applied.
- After converting that definition to `text`, `go run ./cmd/migrate down` rolls 341 back normally and the pre-actor allowlist is back in force.
- New `TestIssuePropertyActorRollbackFailsClosed` covers refusal, non-destruction, archived definitions, and the post-conversion happy path. Confirmed it fails against the old destructive down file.
- `go test ./internal/migrations/ ./cmd/migrate/` pass; `gofmt` / `go vet` clean.
