### PR TITLE
FLU-65: retry interrupted CLI requests safely

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -896,10 +896,10 @@ layer.) The underlying detail is still available on demand (see `--debug`).
 ### What you see
 
 - **Friendly, single-line message.** Transport failures (timeout, DNS,
-  connection refused, TLS) and HTTP status failures (401/403/404/409/400·422/
-  429/5xx) are each rendered as one clear sentence with a next step — for
-  example a timeout suggests checking the network or raising
-  `MULTICA_HTTP_TIMEOUT`, and a 401 tells you to run `multica login`.
+  connection refused, TLS, interrupted connections) and HTTP status failures
+  (401/403/404/409/400·422/429/5xx) are each rendered as one clear sentence
+  with a next step — for example a timeout suggests checking the network or
+  raising `MULTICA_HTTP_TIMEOUT`, and a 401 tells you to run `multica login`.
 - **Server-provided validation messages are preserved.** For a 400/422 that
   carries a message from the server, that message is shown verbatim
   (`Invalid request: <server message>`); only when there is none do you get the
@@ -926,7 +926,7 @@ The process exit code is tiered so scripts can branch on the failure class:
 | --- | --- |
 | `0` | success |
 | `1` | generic / unclassified error |
-| `2` | network error (timeout, DNS, connection refused, TLS, offline) |
+| `2` | network error (timeout, DNS, connection refused, TLS, interrupted, offline) |
 | `3` | authentication / authorization (HTTP 401, 403) |
 | `4` | not found (HTTP 404) |
 | `5` | validation (HTTP 400, 422) |
@@ -957,4 +957,19 @@ always at least this value, so raising it takes effect across all commands.
 
 ```bash
 MULTICA_HTTP_TIMEOUT=60s multica issue list
+```
+
+### Automatic retries
+
+The CLI retries brief transport interruptions and HTTP 502/503/504 responses
+for idempotent requests. It waits 200 ms and 600 ms between the default two
+retries. A request that fails while dialing can be retried for any method
+because it never reached the server. Once a write may have reached the server,
+POST and PATCH requests are not replayed; check whether the change took effect
+before running such a command again.
+
+Set `MULTICA_HTTP_RETRIES` to the number of retries, or to `0` to disable them:
+
+```bash
+MULTICA_HTTP_RETRIES=0 multica issue list
 ```

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -157,7 +157,12 @@ func NewAPIClient(baseURL, workspaceID, token string) *APIClient {
 		BaseURL:     strings.TrimRight(baseURL, "/"),
 		WorkspaceID: workspaceID,
 		Token:       token,
-		HTTPClient:  &http.Client{Timeout: httpTimeout()},
+		HTTPClient: &http.Client{
+			Timeout: httpTimeout(),
+			// Retries live in the transport so every call site below gets
+			// them without having to opt in (FLU-65).
+			Transport: newRetryTransport(nil),
+		},
 	}
 }
 

--- a/server/internal/cli/errors.go
+++ b/server/internal/cli/errors.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -25,11 +26,12 @@ type ErrorKind int
 
 const (
 	// Network / transport layer (errors returned by http.Client.Do).
-	KindNetworkTimeout ErrorKind = iota // context deadline exceeded / i/o timeout
-	KindNetworkDNS                      // no such host
-	KindNetworkRefused                  // connection refused
-	KindNetworkTLS                      // x509 / tls handshake failures
-	KindNetworkOffline                  // catch-all: host unreachable, reset, etc.
+	KindNetworkTimeout     ErrorKind = iota // context deadline exceeded / i/o timeout
+	KindNetworkDNS                          // no such host
+	KindNetworkRefused                      // connection refused
+	KindNetworkTLS                          // x509 / tls handshake failures
+	KindNetworkInterrupted                  // connection established, then broke: reset, EOF, GOAWAY
+	KindNetworkOffline                      // catch-all: host/network unreachable
 
 	// HTTP status layer.
 	KindAuthRequired // 401
@@ -56,7 +58,8 @@ const (
 // IsNetwork reports whether the kind is a transport-layer failure.
 func (k ErrorKind) IsNetwork() bool {
 	switch k {
-	case KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS, KindNetworkOffline:
+	case KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS,
+		KindNetworkInterrupted, KindNetworkOffline:
 		return true
 	default:
 		return false
@@ -76,6 +79,8 @@ func (k ErrorKind) String() string {
 		return "network_refused"
 	case KindNetworkTLS:
 		return "network_tls"
+	case KindNetworkInterrupted:
+		return "network_interrupted"
 	case KindNetworkOffline:
 		return "network_offline"
 	case KindAuthRequired:
@@ -221,6 +226,22 @@ func classifyNetworkError(err error) ErrorKind {
 		return KindNetworkRefused
 	}
 
+	// The connection was established and then broke mid-flight. These are the
+	// errors a lossy link produces once TCP is already up, and they are the
+	// ones a retry actually fixes — keeping them out of the "offline"
+	// catch-all is what stops the CLI telling users to check a network that
+	// is, in fact, working (FLU-65).
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return KindNetworkInterrupted
+	}
+
+	// Genuinely unreachable: the packet had nowhere to go.
+	if errors.Is(err, syscall.ENETUNREACH) || errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETDOWN) {
+		return KindNetworkOffline
+	}
+
 	// String fallbacks for anything not surfaced as a typed error.
 	msg := strings.ToLower(err.Error())
 	switch {
@@ -232,6 +253,18 @@ func classifyNetworkError(err error) ErrorKind {
 		return KindNetworkRefused
 	case strings.Contains(msg, "x509"), strings.Contains(msg, "certificate"), strings.Contains(msg, "tls"):
 		return KindNetworkTLS
+	case strings.Contains(msg, "network is unreachable"), strings.Contains(msg, "no route to host"),
+		strings.Contains(msg, "network is down"):
+		return KindNetworkOffline
+	// HTTP/2 and connection-reuse failures never surface as a typed syscall
+	// error, so they have to be matched on text. "malformed http status code"
+	// is the desync we actually observed on this deployment when a reused
+	// keep-alive connection was torn down between the request and its reply.
+	case strings.Contains(msg, "connection reset by peer"), strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "unexpected eof"), strings.Contains(msg, "eof"),
+		strings.Contains(msg, "goaway"), strings.Contains(msg, "malformed http"),
+		strings.Contains(msg, "client connection lost"), strings.Contains(msg, "connection was forcibly closed"):
+		return KindNetworkInterrupted
 	}
 	return KindNetworkOffline
 }
@@ -298,6 +331,14 @@ var kindMessages = map[ErrorKind][2]string{
 	KindNetworkTLS: {
 		"Could not establish a secure connection to the Multica server (TLS/certificate error). Check your system clock and CA certificates.",
 		"无法与 Multica 服务器建立安全连接（TLS/证书错误）。请检查系统时间和 CA 证书。",
+	},
+	// Deliberately does not claim the CLI already retried: a non-idempotent
+	// request that reached the wire is never replayed (see retry.go), so that
+	// promise would be false exactly when it matters most — and it is also
+	// why the message warns about checking before re-running a write.
+	KindNetworkInterrupted: {
+		"The connection to the Multica server was interrupted before the response arrived — usually a transient network drop. Run the command again; if it creates or changes something, check first whether it already took effect. Re-run with --debug for the underlying transport error.",
+		"与 Multica 服务器的连接在收到响应前被中断——通常是网络瞬时抖动。请重新运行该命令；若该命令会创建或修改数据，请先确认上一次是否已经生效。可加 --debug 查看底层传输错误。",
 	},
 	KindNetworkOffline: {
 		"Could not reach the Multica server. Check your network connection.",

--- a/server/internal/cli/errors_test.go
+++ b/server/internal/cli/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"syscall"
@@ -36,7 +37,19 @@ func TestClassifyNetworkError(t *testing.T) {
 		{"dns string fallback", errors.New("dial tcp: lookup api.multica.ai: no such host"), KindNetworkDNS},
 		{"refused string fallback", errors.New("dial tcp 127.0.0.1:443: connect: connection refused"), KindNetworkRefused},
 		{"tls string fallback", errors.New("x509: certificate signed by unknown authority"), KindNetworkTLS},
-		{"offline catch-all", errors.New("write: connection reset by peer"), KindNetworkOffline},
+		// A reset means the connection was up and then broke. It used to fall
+		// into the offline catch-all, which told users to check a network
+		// that was working; it is now its own retryable kind (FLU-65).
+		{"reset is interrupted", errors.New("write: connection reset by peer"), KindNetworkInterrupted},
+		{"reset typed is interrupted", syscall.ECONNRESET, KindNetworkInterrupted},
+		{"broken pipe is interrupted", errors.New("write tcp 10.0.0.1:443: write: broken pipe"), KindNetworkInterrupted},
+		{"eof is interrupted", io.EOF, KindNetworkInterrupted},
+		{"unexpected eof is interrupted", errors.New("Post \"https://x\": unexpected EOF"), KindNetworkInterrupted},
+		{"goaway is interrupted", errors.New("http2: server sent GOAWAY and closed the connection"), KindNetworkInterrupted},
+		{"malformed status is interrupted", errors.New("malformed HTTP status code \"Server\""), KindNetworkInterrupted},
+		{"unreachable is offline", errors.New("dial tcp 10.0.0.1:443: connect: network is unreachable"), KindNetworkOffline},
+		{"no route is offline", syscall.EHOSTUNREACH, KindNetworkOffline},
+		{"offline catch-all", errors.New("something we have never seen"), KindNetworkOffline},
 		{"nil", nil, KindUnknown},
 	}
 	for _, tc := range cases {
@@ -80,7 +93,8 @@ func TestHTTPErrorKind(t *testing.T) {
 func TestFormatErrorAllKinds(t *testing.T) {
 	withLang(t, "") // default English
 	allKinds := []ErrorKind{
-		KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS, KindNetworkOffline,
+		KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS,
+		KindNetworkInterrupted, KindNetworkOffline,
 		KindAuthRequired, KindForbidden, KindNotFound, KindConflict, KindValidation,
 		KindRateLimited, KindServerError, KindUnknown,
 	}
@@ -375,19 +389,20 @@ func withLang(t *testing.T, lang string) {
 
 func TestErrorKindString(t *testing.T) {
 	cases := map[ErrorKind]string{
-		KindNetworkTimeout: "network_timeout",
-		KindNetworkDNS:     "network_dns",
-		KindNetworkRefused: "network_refused",
-		KindNetworkTLS:     "network_tls",
-		KindNetworkOffline: "network_offline",
-		KindAuthRequired:   "auth_required",
-		KindForbidden:      "forbidden",
-		KindNotFound:       "not_found",
-		KindConflict:       "conflict",
-		KindValidation:     "validation",
-		KindRateLimited:    "rate_limited",
-		KindServerError:    "server_error",
-		KindUnknown:        "unknown",
+		KindNetworkTimeout:     "network_timeout",
+		KindNetworkDNS:         "network_dns",
+		KindNetworkRefused:     "network_refused",
+		KindNetworkTLS:         "network_tls",
+		KindNetworkInterrupted: "network_interrupted",
+		KindNetworkOffline:     "network_offline",
+		KindAuthRequired:       "auth_required",
+		KindForbidden:          "forbidden",
+		KindNotFound:           "not_found",
+		KindConflict:           "conflict",
+		KindValidation:         "validation",
+		KindRateLimited:        "rate_limited",
+		KindServerError:        "server_error",
+		KindUnknown:            "unknown",
 	}
 	seen := map[string]ErrorKind{}
 	for k, want := range cases {

--- a/server/internal/cli/retry.go
+++ b/server/internal/cli/retry.go
@@ -1,0 +1,251 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// The CLI runs one process per command, so a single transport blip is a hard
+// failure with no second chance: the agent or user sees an error and the work
+// stops. That is what made a lossy link between a runtime and a self-hosted
+// server look like constant outages (FLU-65) even while the server itself was
+// healthy. retryTransport absorbs those blips underneath every APIClient call
+// site at once, so no individual command has to remember to retry.
+//
+// Transport-layer failures and transient gateway responses are retried here.
+// Gateway retries are limited to idempotent methods: replaying a 5xx POST
+// could duplicate a side effect the server had in fact applied.
+
+// defaultRetrySchedule is the backoff between attempts. N entries → N+1
+// attempts in the worst case (one immediate + N retries). Kept short on
+// purpose: the whole schedule has to fit inside the client's 30s timeout
+// (see httpTimeout) alongside the attempts themselves, and a link that is
+// still dropping packets after ~1s of backoff is an outage rather than a
+// blip.
+var defaultRetrySchedule = []time.Duration{
+	200 * time.Millisecond,
+	600 * time.Millisecond,
+}
+
+// retrySleep is the sleep between attempts. It is a package variable so tests
+// can swap in an instant sleep without rewriting the schedule.
+var retrySleep = func(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// retrySchedule returns the backoff schedule, honoring MULTICA_HTTP_RETRIES.
+// The value is the number of RETRIES (not attempts); 0 disables retrying
+// entirely, which is the escape hatch for anyone who needs a command to fail
+// fast. Invalid or negative values fall back to the default.
+func retrySchedule() []time.Duration {
+	v := strings.TrimSpace(os.Getenv("MULTICA_HTTP_RETRIES"))
+	if v == "" {
+		return defaultRetrySchedule
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return defaultRetrySchedule
+	}
+	if n == 0 {
+		return nil
+	}
+	schedule := make([]time.Duration, 0, n)
+	delay := defaultRetrySchedule[0]
+	for i := 0; i < n; i++ {
+		schedule = append(schedule, delay)
+		delay *= 3
+	}
+	return schedule
+}
+
+// retryTransport wraps a RoundTripper with bounded retries for transport
+// errors. A nil base means http.DefaultTransport.
+type retryTransport struct {
+	base     http.RoundTripper
+	schedule []time.Duration
+}
+
+// newRetryTransport builds the CLI's retrying transport over base.
+func newRetryTransport(base http.RoundTripper) *retryTransport {
+	return &retryTransport{base: base, schedule: retrySchedule()}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	attemptReq := req
+	for attempt := 0; ; attempt++ {
+		resp, err := base.RoundTrip(attemptReq)
+		if err == nil {
+			if attempt >= len(t.schedule) || !shouldRetryStatus(attemptReq, resp) {
+				return resp, nil
+			}
+			// Rewind before draining: if the body cannot be replayed we have
+			// to hand this response back intact rather than an emptied one.
+			next, rewindErr := rewindRequest(req)
+			if rewindErr != nil {
+				return resp, nil
+			}
+			// Drain so the connection goes back to the pool instead of being
+			// torn down between attempts.
+			drainAndClose(resp)
+			if sleepErr := retrySleep(req.Context(), t.schedule[attempt]); sleepErr != nil {
+				return nil, sleepErr
+			}
+			attemptReq = next
+			continue
+		}
+		if attempt >= len(t.schedule) || !shouldRetry(attemptReq, err) {
+			return nil, err
+		}
+		// A body we cannot rewind means the next attempt would send a
+		// truncated request, which is worse than the error we already have.
+		next, rewindErr := rewindRequest(req)
+		if rewindErr != nil {
+			return nil, err
+		}
+		if sleepErr := retrySleep(req.Context(), t.schedule[attempt]); sleepErr != nil {
+			return nil, sleepErr
+		}
+		attemptReq = next
+	}
+}
+
+// gatewayStatuses are the responses that mean "the edge is up but the
+// application behind it is not" — exactly what a client sees while the stack
+// is still coming up. On this deployment a 70-second cold start after a host
+// reboot produced ~1000 of them (FLU-65), roughly half on plain GETs that
+// were safe to repeat.
+//
+// 500 is deliberately absent: an application error is not a blip, and
+// retrying it only delays a real failure. 429 is absent too — retrying a
+// rate-limited request is what caused the limit.
+var gatewayStatuses = map[int]bool{
+	http.StatusBadGateway:         true,
+	http.StatusServiceUnavailable: true,
+	http.StatusGatewayTimeout:     true,
+}
+
+// shouldRetryStatus reports whether a successfully-received response should be
+// thrown away and re-requested. Only idempotent methods qualify: a 502 says
+// nothing about whether the request behind it was applied, so replaying a POST
+// could still duplicate a write.
+func shouldRetryStatus(req *http.Request, resp *http.Response) bool {
+	if resp == nil || !gatewayStatuses[resp.StatusCode] {
+		return false
+	}
+	if req.Context().Err() != nil {
+		return false
+	}
+	return isIdempotentMethod(req.Method)
+}
+
+// drainAndClose consumes a bounded amount of the response body so the
+// underlying connection can be reused, then closes it.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	_ = resp.Body.Close()
+}
+
+// shouldRetry reports whether err is worth another attempt for this request.
+//
+// The safety question is whether replaying could duplicate a side effect. If
+// the dial itself failed the server never saw the request, so any method can
+// be replayed. Once bytes are on the wire we cannot tell "never processed"
+// from "processed, response lost", so only methods the HTTP spec defines as
+// idempotent are replayed — a dropped `issue comment add` reply is better
+// than posting it twice.
+func shouldRetry(req *http.Request, err error) bool {
+	if err == nil {
+		return false
+	}
+	// The caller's deadline is already blown (this is also how the client's
+	// own Timeout surfaces); another attempt would only fail again.
+	if req.Context().Err() != nil {
+		return false
+	}
+	if !isRetryableTransportError(err) {
+		return false
+	}
+	if isDialError(err) {
+		return true
+	}
+	return isIdempotentMethod(req.Method)
+}
+
+// isRetryableTransportError filters out transport failures that a retry
+// cannot fix: a bad certificate or an unresolvable name will fail identically
+// on the next attempt, and burning the schedule on them only delays the error
+// the user needs to see.
+func isRetryableTransportError(err error) bool {
+	switch classifyNetworkError(err) {
+	case KindNetworkTLS, KindNetworkDNS:
+		return false
+	default:
+		return true
+	}
+}
+
+// isDialError reports whether the failure happened while establishing the
+// connection, which proves the request never reached the server.
+func isDialError(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return true
+	}
+	return false
+}
+
+func isIdempotentMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+// rewindRequest clones req with a fresh, unread body so it can be sent again.
+// It reports an error when the body has already been consumed and cannot be
+// replayed (GetBody is nil), which net/http only leaves unset for streaming
+// bodies the CLI does not construct.
+func rewindRequest(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.Body == nil || req.Body == http.NoBody {
+		return clone, nil
+	}
+	if req.GetBody == nil {
+		return nil, errors.New("request body cannot be replayed")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	return clone, nil
+}

--- a/server/internal/cli/retry_test.go
+++ b/server/internal/cli/retry_test.go
@@ -1,0 +1,344 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// instantRetrySleep removes the backoff wait so tests exercise the retry loop
+// without burning the schedule's wall-clock time.
+func instantRetrySleep(t *testing.T) {
+	t.Helper()
+	prev := retrySleep
+	retrySleep = func(ctx context.Context, _ time.Duration) error { return ctx.Err() }
+	t.Cleanup(func() { retrySleep = prev })
+}
+
+// fakeRoundTripper fails its first failures calls, then succeeds.
+type fakeRoundTripper struct {
+	failures int
+	err      error
+	attempts int
+	bodies   []string
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.attempts++
+	if req.Body != nil && req.Body != http.NoBody {
+		data, _ := io.ReadAll(req.Body)
+		f.bodies = append(f.bodies, string(data))
+	}
+	if f.attempts <= f.failures {
+		return nil, f.err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Request:    req,
+	}, nil
+}
+
+func newTestRetryTransport(base http.RoundTripper) *retryTransport {
+	return &retryTransport{base: base, schedule: defaultRetrySchedule}
+}
+
+func TestRetryTransportRetriesInterruptedGET(t *testing.T) {
+	instantRetrySleep(t)
+	base := &fakeRoundTripper{failures: 2, err: syscall.ECONNRESET}
+	rt := newTestRetryTransport(base)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/api/issues", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer resp.Body.Close()
+	if base.attempts != 3 {
+		t.Errorf("attempts = %d, want 3 (1 initial + 2 retries)", base.attempts)
+	}
+}
+
+func TestRetryTransportGivesUpAfterSchedule(t *testing.T) {
+	instantRetrySleep(t)
+	base := &fakeRoundTripper{failures: 99, err: syscall.ECONNRESET}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/issues", nil)
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("expected error once the schedule is exhausted")
+	}
+	if want := len(defaultRetrySchedule) + 1; base.attempts != want {
+		t.Errorf("attempts = %d, want %d", base.attempts, want)
+	}
+}
+
+// A POST that already reached the wire must not be replayed: the server may
+// have applied it and only the response was lost. Posting a comment twice is
+// worse than surfacing the error.
+func TestRetryTransportDoesNotReplayPOSTAfterWrite(t *testing.T) {
+	instantRetrySleep(t)
+	base := &fakeRoundTripper{failures: 1, err: syscall.ECONNRESET}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://example.invalid/api/comments", strings.NewReader(`{"a":1}`))
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("expected the POST error to surface, not a replay")
+	}
+	if base.attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (POST must not be replayed)", base.attempts)
+	}
+}
+
+// A dial failure proves the request never reached the server, so even a POST
+// is safe to replay.
+func TestRetryTransportReplaysPOSTOnDialFailure(t *testing.T) {
+	instantRetrySleep(t)
+	dialErr := &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}
+	base := &fakeRoundTripper{failures: 1, err: dialErr}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://example.invalid/api/comments", strings.NewReader(`{"a":1}`))
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected replay to succeed, got %v", err)
+	}
+	defer resp.Body.Close()
+	if base.attempts != 2 {
+		t.Errorf("attempts = %d, want 2", base.attempts)
+	}
+	// Both attempts must carry the full body, not a truncated remnant.
+	for i, b := range base.bodies {
+		if b != `{"a":1}` {
+			t.Errorf("attempt %d body = %q, want the full payload", i+1, b)
+		}
+	}
+}
+
+// TLS and DNS failures fail identically on the next attempt; retrying only
+// delays the error the user needs.
+func TestRetryTransportDoesNotRetryPermanentFailures(t *testing.T) {
+	instantRetrySleep(t)
+	for name, err := range map[string]error{
+		"tls": errors.New("x509: certificate signed by unknown authority"),
+		"dns": &net.DNSError{Err: "no such host", Name: "x", IsNotFound: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := &fakeRoundTripper{failures: 99, err: err}
+			rt := newTestRetryTransport(base)
+			req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/issues", nil)
+			if _, rtErr := rt.RoundTrip(req); rtErr == nil {
+				t.Fatal("expected error")
+			}
+			if base.attempts != 1 {
+				t.Errorf("attempts = %d, want 1", base.attempts)
+			}
+		})
+	}
+}
+
+func TestRetryTransportStopsOnCanceledContext(t *testing.T) {
+	instantRetrySleep(t)
+	base := &fakeRoundTripper{failures: 99, err: syscall.ECONNRESET}
+	rt := newTestRetryTransport(base)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.invalid/api/issues", nil)
+	if _, err := rt.RoundTrip(req); err == nil {
+		t.Fatal("expected error")
+	}
+	if base.attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (canceled context must not retry)", base.attempts)
+	}
+}
+
+func TestRetryTransportReturnsCancellationDuringBackoff(t *testing.T) {
+	previousSleep := retrySleep
+	retrySleep = func(ctx context.Context, _ time.Duration) error {
+		return context.Canceled
+	}
+	t.Cleanup(func() { retrySleep = previousSleep })
+
+	base := &fakeRoundTripper{failures: 99, err: syscall.ECONNRESET}
+	rt := newTestRetryTransport(base)
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/issues", nil)
+
+	_, err := rt.RoundTrip(req)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled from the interrupted backoff", err)
+	}
+	if base.attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (canceled backoff must stop retries)", base.attempts)
+	}
+}
+
+// statusRoundTripper serves the given statuses in order, then 200.
+type statusRoundTripper struct {
+	statuses []int
+	attempts int
+	methods  []string
+}
+
+func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.methods = append(s.methods, req.Method)
+	code := http.StatusOK
+	if s.attempts < len(s.statuses) {
+		code = s.statuses[s.attempts]
+	}
+	s.attempts++
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader("body")),
+		Request:    req,
+	}, nil
+}
+
+// A cold-starting stack answers 502 through the proxy until the app is up.
+// An idempotent GET should ride that out instead of failing the command.
+func TestRetryTransportRetriesGatewayStatusForGET(t *testing.T) {
+	instantRetrySleep(t)
+	base := &statusRoundTripper{statuses: []int{http.StatusBadGateway, http.StatusServiceUnavailable}}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/inbox", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after riding out the gateway errors", resp.StatusCode)
+	}
+	if base.attempts != 3 {
+		t.Errorf("attempts = %d, want 3", base.attempts)
+	}
+}
+
+// A 502 says nothing about whether the write behind it was applied, so a POST
+// must surface it rather than replay.
+func TestRetryTransportDoesNotRetryGatewayStatusForPOST(t *testing.T) {
+	instantRetrySleep(t)
+	base := &statusRoundTripper{statuses: []int{http.StatusBadGateway, http.StatusBadGateway}}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodPost, "https://example.invalid/api/inbox/x/read", strings.NewReader("{}"))
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want the 502 surfaced", resp.StatusCode)
+	}
+	if base.attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (POST must not be replayed on 502)", base.attempts)
+	}
+}
+
+// 500 is an application error, not a blip; retrying only delays the failure.
+func TestRetryTransportDoesNotRetry500(t *testing.T) {
+	instantRetrySleep(t)
+	base := &statusRoundTripper{statuses: []int{http.StatusInternalServerError, http.StatusInternalServerError}}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/issues", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 surfaced", resp.StatusCode)
+	}
+	if base.attempts != 1 {
+		t.Errorf("attempts = %d, want 1", base.attempts)
+	}
+}
+
+// The response handed back must still have a readable body — the retry path
+// drains intermediate responses, and draining the final one would give the
+// caller an empty payload.
+func TestRetryTransportFinalResponseBodyIsIntact(t *testing.T) {
+	instantRetrySleep(t)
+	base := &statusRoundTripper{statuses: []int{http.StatusBadGateway}}
+	rt := newTestRetryTransport(base)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://example.invalid/api/inbox", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(data) != "body" {
+		t.Errorf("body = %q, want %q", string(data), "body")
+	}
+}
+
+func TestRetryScheduleHonorsEnv(t *testing.T) {
+	t.Setenv("MULTICA_HTTP_RETRIES", "0")
+	if got := retrySchedule(); len(got) != 0 {
+		t.Errorf("MULTICA_HTTP_RETRIES=0 should disable retries, got %v", got)
+	}
+	t.Setenv("MULTICA_HTTP_RETRIES", "4")
+	if got := retrySchedule(); len(got) != 4 {
+		t.Errorf("MULTICA_HTTP_RETRIES=4 should yield 4 retries, got %d", len(got))
+	}
+	t.Setenv("MULTICA_HTTP_RETRIES", "nonsense")
+	if got := retrySchedule(); len(got) != len(defaultRetrySchedule) {
+		t.Errorf("invalid value should fall back to the default, got %d", len(got))
+	}
+}
+
+// End-to-end through a real http.Client: the first response is killed
+// mid-flight, and the CLI's client must still return the retried success
+// without the caller knowing anything happened.
+func TestAPIClientRetriesThroughRealServer(t *testing.T) {
+	instantRetrySleep(t)
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if hits == 1 {
+			// Hijack and drop the connection so the client sees a transport
+			// error rather than an HTTP status.
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(srv.URL, "ws", "token")
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := c.GetJSON(context.Background(), "/api/issues/abc", &out); err != nil {
+		t.Fatalf("expected the retry to hide the dropped connection, got %v", err)
+	}
+	if out.ID != "abc" {
+		t.Errorf("id = %q, want abc", out.ID)
+	}
+	if hits < 2 {
+		t.Errorf("server hits = %d, want at least 2", hits)
+	}
+}


### PR DESCRIPTION
## Summary

- add a shared retrying `RoundTripper` under every CLI `APIClient` call
- retry retryable transport failures plus 502/503/504 for idempotent methods
- never replay POST/PATCH after a request may have reached the server; only pre-dial failures are safe for every method
- classify reset/EOF/GOAWAY/connection-desync failures as interrupted connections instead of reporting the server as offline
- document retry behavior and the `MULTICA_HTTP_RETRIES` escape hatch

## Why

FLU-65 traced repeated “Could not reach the Multica server” reports to lossy runtime-to-server links and an overly broad network-error fallback. A single transient interruption currently fails the whole CLI process even when the server is healthy.

## Verification

- `go test -count=1 ./internal/cli ./cmd/multica`
- `go test -race -count=1 ./internal/cli`
- `go vet ./internal/cli ./cmd/multica`
- `go build -buildvcs=false -o /tmp/multica ./cmd/multica`
- `gofmt -d` on all changed Go files

All checks ran with Go 1.26.6. This PR does not create a release; rollout should happen from a patch tag after merge.
