### PR TITLE
feat: add ntfy Android notification mirror

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,6 +246,25 @@ MULTICA_WECOM_SECRET_KEY=
 MULTICA_WECOM_MEDIA_ALLOW_CIDRS=
 MULTICA_WECOM_TRACE=
 
+# ntfy Android notification mirror. Disabled unless NTFY_ENABLED=true and all
+# required values are present. The public ntfy.sh service treats an unreserved
+# topic as a password: generate a fresh high-entropy value and never commit it
+# or print it in logs. Only notifications for NTFY_RECIPIENT_ID are mirrored.
+#
+# Generate a 64-character topic with: openssl rand -hex 32
+# Find your Multica user UUID with: multica user me --output json
+NTFY_ENABLED=false
+NTFY_BASE_URL=https://ntfy.sh
+NTFY_TOPIC=
+NTFY_RECIPIENT_ID=
+# Optional publisher token for an authenticated ntfy server.
+NTFY_TOKEN=
+# Optional HTTPS app URL for notification click-through. Falls back to
+# MULTICA_APP_URL, then FRONTEND_ORIGIN.
+NTFY_APP_URL=
+# End-to-end database lookup + publish deadline. Valid range: 100ms-10s.
+NTFY_TIMEOUT=3s
+
 # S3 / CloudFront
 # S3_BUCKET — bucket NAME only (e.g. "my-bucket"). Do NOT include the
 # ".s3.<region>.amazonaws.com" suffix; the server builds the public URL

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -171,10 +171,54 @@ allowlist の正確な判定順序は[ログインとサインアップ](/auth-s
 | Composio | `COMPOSIO_STATE_SECRET` | OAuth state の署名シークレット。`JWT_SECRET` から派生可能 |
 | セルフホスト Git | `MULTICA_VCS_INTEGRATION_ENABLED` | Forgejo/Gitea/GitLab 連携のスイッチ。compose ではデフォルトで有効 |
 | セルフホスト Git | `MULTICA_VCS_SECRET_KEY` | base64 エンコードされた 32 バイトの暗号化キー（`openssl rand -base64 32`）。未設定の場合、この機能全体が利用できません |
+| ntfy | `NTFY_ENABLED` | Android 通知ミラーの明示的なスイッチ。デフォルトは `false` |
+| ntfy | `NTFY_BASE_URL` | ntfy サーバーの HTTPS origin。公開サービスは `https://ntfy.sh` |
+| ntfy | `NTFY_TOPIC` | 32〜64 文字のランダムな topic。シークレットとして扱い、ログには出力しません |
+| ntfy | `NTFY_RECIPIENT_ID` | 通知をミラーする Multica メンバーの UUID |
+| ntfy | `NTFY_TOKEN` | 認証済み ntfy サーバー用の任意の Bearer token |
+| ntfy | `NTFY_APP_URL` | 通知タップ時に開く任意の Multica HTTPS URL。`MULTICA_APP_URL`、`FRONTEND_ORIGIN` の順にフォールバック |
+| ntfy | `NTFY_TIMEOUT` | データベース照会と送信の合計タイムアウト。`100ms`〜`10s`、デフォルトは `3s` |
 
 `GITHUB_APP_ID` と秘密鍵を設定しなくても、PR の関連付け・ミラー・マージによる done への遷移は通常どおり動きますが、カードに CI とマージ可否のステータスが表示されず、「GitHub から選択」のリポジトリ入口も無効になります。
 
 設定手順は [GitHub 連携](/github-integration#セルフホスト設定)、[Lark Bot](/lark-bot-integration#セルフホスト設定)、[Slack Bot](/slack-bot-integration#セルフホスト設定)を参照してください。
+
+### ntfy Android 通知ミラー
+
+ntfy アダプターはベストエフォートのミラーであり、アプリ内の受信トレイを置き換えたり変更したりしません。メンバーへのメンション、タスクの割り当て、エージェント実行の最終的な完了または失敗、タスクが `blocked` に入るイベントを対象にします。完了または失敗は、設定したメンバーがそのタスクを引き続きフォローし、`agent_activity` をミュートしていない場合だけ送信されます。自動再試行中の失敗は送信しません。
+
+通知文には業務本文を含めず、固定のイベント要約だけを使用します。HTTPS app URL が設定されている場合は、Multica の受信トレイへのリンクも付けます。タスクのタイトル、コメント、添付ファイル、エラー本文、資格情報、topic、token は通知のタイトル・本文やログに出ません。topic は ntfy のルーティングフィールドとしてだけ使用します。配信は上限付きメモリキュー、短いタイムアウト、再試行なしで動くため、タイムアウト、`429`、ntfy 障害、キュー満杯が Multica のリクエストをブロックすることはありません。
+
+<Callout type="warning">
+公開 ntfy サービスでは、予約されていない topic は実質的にパスワードであり、メッセージがサービスにキャッシュされる場合があります。新しいランダムな topic を生成し、保護された経路だけで共有してください。タスク、コミット、スクリーンショット、ログには貼り付けないでください。
+</Callout>
+
+topic を生成し、受信メンバーの UUID を確認します。結果はソース管理に入れないでください。
+
+```bash
+openssl rand -hex 32
+multica user me --output json
+```
+
+値はバックエンドのデプロイ環境だけに設定します。
+
+```dotenv
+NTFY_ENABLED=true
+NTFY_BASE_URL=https://ntfy.sh
+NTFY_TOPIC=<64-character-random-value>
+NTFY_RECIPIENT_ID=<multica-user-uuid>
+NTFY_TIMEOUT=3s
+```
+
+認証済み ntfy サーバーでは `NTFY_TOKEN` を任意で設定できます。`MULTICA_APP_URL` または `FRONTEND_ORIGIN` がメンバーから到達できる HTTPS app URL なら、`NTFY_APP_URL` は不要です。`.env` を編集した後はバックエンドを再作成してください。通常の Compose restart では設定を再読込しません。
+
+```bash
+docker compose -f docker-compose.selfhost.yml up -d --force-recreate backend
+```
+
+ntfy Android App で購読を追加し、サーバーに `https://ntfy.sh` を選び、保護された経路から topic を貼り付けます。端末上の表示名は「Multica」などに設定できます。公開 topic のリスクをデプロイ責任者が確認するまでは、手動テストメッセージを送信しないでください。承認後、対象の Multica イベントを 1 件だけ発生させ、固定要約とアプリ内リンクを確認します。
+
+ローテーションでは、新しい topic を生成して `NTFY_TOPIC` を置き換え、バックエンドを再作成し、Android で新しい topic を購読します。承認済みイベントを 1 件確認してから古い topic の購読を解除します。コードやデータベースの変更は不要です。ロールバックでは `NTFY_ENABLED=false` にしてバックエンドを再作成します。アプリ内通知はそのまま動作します。不要になった topic と token はデプロイのシークレットストアから削除してください。
 
 ## サーバーサイド LLM
 

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -171,10 +171,54 @@ reverse proxy 뒤에 배포한다면 실제 proxy 네트워크를 입력해야 �
 | Composio | `COMPOSIO_STATE_SECRET` | OAuth state 서명 키. `JWT_SECRET`에서 파생 가능 |
 | 자체 호스팅 Git | `MULTICA_VCS_INTEGRATION_ENABLED` | Forgejo/Gitea/GitLab 연동 스위치. compose에서는 기본 활성화 |
 | 자체 호스팅 Git | `MULTICA_VCS_SECRET_KEY` | base64로 인코딩한 32바이트 암호화 키(`openssl rand -base64 32`). 없으면 전체 기능을 사용할 수 없음 |
+| ntfy | `NTFY_ENABLED` | Android 알림 미러의 명시적 스위치. 기본값은 `false` |
+| ntfy | `NTFY_BASE_URL` | ntfy 서버의 HTTPS origin. 공개 서비스는 `https://ntfy.sh` 사용 |
+| ntfy | `NTFY_TOPIC` | 32~64자의 무작위 topic. secret으로 취급하며 로그에 기록하지 않음 |
+| ntfy | `NTFY_RECIPIENT_ID` | 알림을 미러링할 Multica 멤버 UUID |
+| ntfy | `NTFY_TOKEN` | 인증된 ntfy 서버에서 사용하는 선택적 Bearer token |
+| ntfy | `NTFY_APP_URL` | 알림 탭 시 열기 위한 선택적 Multica HTTPS URL. `MULTICA_APP_URL`, `FRONTEND_ORIGIN` 순으로 fallback |
+| ntfy | `NTFY_TIMEOUT` | 데이터베이스 조회와 전송의 총 timeout. `100ms`~`10s`, 기본값 `3s` |
 
 `GITHUB_APP_ID`와 private key를 설정하지 않아도 PR 연결, 미러링, merge 시 done 전환은 정상적으로 작동합니다. 다만 카드에 CI와 merge 가능 상태가 표시되지 않고 "GitHub에서 선택" 저장소 메뉴도 비활성화됩니다.
 
 설정 단계는 [GitHub 연동](/github-integration#자체-호스팅-설정), [Feishu Bot](/lark-bot-integration#자체-호스팅-설정), [Slack Bot](/slack-bot-integration#자체-호스팅-설정)을 참고하세요.
+
+### ntfy Android 알림 미러
+
+ntfy 어댑터는 best-effort 미러이며 앱 내 받은 편지함을 대체하거나 변경하지 않습니다. 멤버 멘션, 태스크 할당, 에이전트 실행의 최종 완료 또는 실패, 태스크가 `blocked`로 바뀌는 이벤트를 다룹니다. 완료 또는 실패는 설정한 멤버가 해당 태스크를 계속 구독하고 `agent_activity`를 음소거하지 않은 경우에만 전송하며, 자동 재시도 중인 실패는 보내지 않습니다.
+
+알림 문구에는 업무 본문을 넣지 않고 고정 이벤트 요약만 사용합니다. HTTPS app URL이 설정되어 있으면 Multica 받은 편지함 링크도 추가합니다. 태스크 제목, 댓글, 첨부 파일, 오류 본문, 자격 증명, topic, token은 알림 제목·본문이나 로그에 나타나지 않으며 topic은 ntfy 라우팅 필드로만 사용합니다. 전송은 크기가 제한된 메모리 큐, 짧은 timeout, 재시도 없음으로 동작하므로 timeout, `429`, ntfy 장애, 큐 가득 참이 Multica 요청을 차단하지 않습니다.
+
+<Callout type="warning">
+공개 ntfy 서비스에서 예약되지 않은 topic은 사실상 비밀번호이며 메시지가 서비스에 cache될 수 있습니다. 새 무작위 topic을 생성하고 보호된 채널로만 공유하세요. 태스크, commit, screenshot, 로그에는 붙여 넣지 마세요.
+</Callout>
+
+topic을 생성하고 수신 멤버 UUID를 확인합니다. 결과를 소스 관리에 넣지 마세요.
+
+```bash
+openssl rand -hex 32
+multica user me --output json
+```
+
+값은 backend 배포 환경에만 설정합니다.
+
+```dotenv
+NTFY_ENABLED=true
+NTFY_BASE_URL=https://ntfy.sh
+NTFY_TOPIC=<64-character-random-value>
+NTFY_RECIPIENT_ID=<multica-user-uuid>
+NTFY_TIMEOUT=3s
+```
+
+인증된 ntfy 서버에서는 `NTFY_TOKEN`을 선택적으로 설정할 수 있습니다. `MULTICA_APP_URL` 또는 `FRONTEND_ORIGIN`이 멤버가 접근할 수 있는 HTTPS app URL이면 `NTFY_APP_URL`은 필요하지 않습니다. `.env`를 수정한 뒤 backend를 다시 생성하세요. 일반 Compose restart는 설정을 다시 읽지 않습니다.
+
+```bash
+docker compose -f docker-compose.selfhost.yml up -d --force-recreate backend
+```
+
+ntfy Android App에서 구독을 추가하고 서버로 `https://ntfy.sh`를 선택한 다음 보호된 채널의 topic을 붙여 넣습니다. 로컬 표시 이름은 "Multica"처럼 지정할 수 있습니다. 배포 책임자가 공개 topic 위험을 검토하기 전에는 수동 테스트 메시지를 보내지 마세요. 승인 후 지원 범위의 Multica 이벤트 하나를 발생시켜 고정 요약과 앱 내 링크를 확인합니다.
+
+교체할 때는 새 topic을 생성하고 `NTFY_TOPIC`을 바꾼 뒤 backend를 다시 생성합니다. Android에서 새 topic을 구독하고 승인된 이벤트 하나를 확인한 후 이전 topic 구독을 해제하세요. 코드나 데이터베이스 변경은 필요하지 않습니다. 롤백할 때는 `NTFY_ENABLED=false`로 설정하고 backend를 다시 생성합니다. 앱 내 알림은 그대로 유지됩니다. 더 이상 필요 없는 topic과 token은 배포 secret store에서 삭제하세요.
 
 ## 서버 측 LLM
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -171,10 +171,54 @@ The auth rate limits require `REDIS_URL`; without it, the startup log notes that
 | Composio | `COMPOSIO_STATE_SECRET` | OAuth state signing secret; can be derived from `JWT_SECRET` |
 | Self-hosted Git | `MULTICA_VCS_INTEGRATION_ENABLED` | Forgejo/Gitea/GitLab integration switch; enabled by default in compose |
 | Self-hosted Git | `MULTICA_VCS_SECRET_KEY` | Base64-encoded 32-byte encryption key (`openssl rand -base64 32`); the feature is entirely unavailable without it |
+| ntfy | `NTFY_ENABLED` | Explicit switch for the Android notification mirror; defaults to `false` |
+| ntfy | `NTFY_BASE_URL` | HTTPS ntfy server origin; use `https://ntfy.sh` for the public service |
+| ntfy | `NTFY_TOPIC` | 32-64 character random topic; treated as a secret and never logged |
+| ntfy | `NTFY_RECIPIENT_ID` | Multica member UUID whose notifications are mirrored |
+| ntfy | `NTFY_TOKEN` | Optional Bearer token for authenticated ntfy servers |
+| ntfy | `NTFY_APP_URL` | Optional HTTPS Multica URL used for click-through; falls back to `MULTICA_APP_URL`, then `FRONTEND_ORIGIN` |
+| ntfy | `NTFY_TIMEOUT` | Database lookup and publish deadline, from `100ms` to `10s`; defaults to `3s` |
 
 Without `GITHUB_APP_ID` and the private key, PRs still link, mirror, and trigger merge-to-done normally, but cards show no CI or mergeability status, and the "pick from GitHub" repository entry is disabled.
 
 For setup steps, see [GitHub integration](/github-integration#self-hosting-setup), [Lark bot](/lark-bot-integration#self-hosting-setup), and [Slack bot](/slack-bot-integration#self-hosting-setup).
+
+### ntfy Android notification mirror
+
+The ntfy adapter is a best-effort mirror: it never replaces or changes the in-app inbox. It covers direct member mentions, assignments, final agent-run completion or failure, and issues entering `blocked`. A completion or failure is sent only when the configured member still follows that issue and has not muted `agent_activity`; retrying failures are suppressed.
+
+Push text is deliberately content-free. It contains a fixed event summary and, when an HTTPS app URL is configured, a link to the Multica inbox. Issue titles, comments, attachments, error text, credentials, topics, and tokens never appear in the notification title/body or logs; the topic is used only as the ntfy routing field. Delivery runs through a bounded in-memory queue with a short timeout and no retries, so a timeout, `429`, outage, or full queue cannot block Multica requests.
+
+<Callout type="warning">
+On a public ntfy server, an unreserved topic is effectively a password and messages may be cached by the service. Generate a new random topic, share it only through a protected channel, and never paste it into an issue, commit, screenshot, or log.
+</Callout>
+
+Generate the topic and find the recipient UUID without putting either value in source control:
+
+```bash
+openssl rand -hex 32
+multica user me --output json
+```
+
+Set the values only in the backend deployment environment:
+
+```dotenv
+NTFY_ENABLED=true
+NTFY_BASE_URL=https://ntfy.sh
+NTFY_TOPIC=<64-character-random-value>
+NTFY_RECIPIENT_ID=<multica-user-uuid>
+NTFY_TIMEOUT=3s
+```
+
+`NTFY_TOKEN` is optional for an authenticated server. `NTFY_APP_URL` is optional when `MULTICA_APP_URL` or `FRONTEND_ORIGIN` already contains the user-reachable HTTPS app URL. Recreate the backend after editing `.env`; a plain Compose restart does not reload it:
+
+```bash
+docker compose -f docker-compose.selfhost.yml up -d --force-recreate backend
+```
+
+In the ntfy Android app, add a subscription, choose `https://ntfy.sh` as the server, and paste the topic from the protected channel. Give it a local display name such as "Multica". Do not publish a manual test until the deployment owner has reviewed the public-topic risk; when approved, trigger one covered Multica event and confirm the fixed summary and click-through link.
+
+To rotate, generate a new topic, replace `NTFY_TOPIC`, recreate the backend, subscribe to the new topic on Android, verify one approved event, then unsubscribe from the old topic. Rotation needs no code or database change. To roll back, set `NTFY_ENABLED=false` and recreate the backend; in-app notifications continue unchanged. After rollback, remove the topic and token from the deployment secret store if they are no longer needed.
 
 ## Server-side LLM
 

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -171,10 +171,54 @@ MULTICA_PUBLIC_URL=https://api.multica.example.com
 | Composio | `COMPOSIO_STATE_SECRET` | OAuth state 签名密钥；可从 `JWT_SECRET` 派生 |
 | 自托管 Git | `MULTICA_VCS_INTEGRATION_ENABLED` | Forgejo/Gitea/GitLab 集成开关，compose 默认开启 |
 | 自托管 Git | `MULTICA_VCS_SECRET_KEY` | base64 编码的 32 字节加密密钥（`openssl rand -base64 32`）；未配置时该功能整体不可用 |
+| ntfy | `NTFY_ENABLED` | Android 通知镜像的显式开关，默认 `false` |
+| ntfy | `NTFY_BASE_URL` | ntfy 服务的 HTTPS origin；公共服务使用 `https://ntfy.sh` |
+| ntfy | `NTFY_TOPIC` | 32-64 字符的随机 topic；按密钥保护且不写入日志 |
+| ntfy | `NTFY_RECIPIENT_ID` | 要镜像通知的 Multica 成员 UUID |
+| ntfy | `NTFY_TOKEN` | 鉴权 ntfy 服务使用的可选 Bearer token |
+| ntfy | `NTFY_APP_URL` | 通知点击后打开的可选 Multica HTTPS 地址；依次回退到 `MULTICA_APP_URL`、`FRONTEND_ORIGIN` |
+| ntfy | `NTFY_TIMEOUT` | 数据库查询与发布的总超时，范围 `100ms` 到 `10s`，默认 `3s` |
 
 不配置 `GITHUB_APP_ID` 和私钥时，PR 仍会正常关联、镜像和触发合并转 done，但卡片上不显示 CI 与可合并状态，"从 GitHub 选择"仓库入口也会禁用。
 
 配置步骤见 [GitHub 集成](/github-integration#自托管配置)、[飞书 Bot](/lark-bot-integration#自托管配置)和 [Slack Bot](/slack-bot-integration#自托管配置)。
+
+### ntfy Android 通知镜像
+
+ntfy 适配器只做尽力而为的镜像，不会替换或改变站内收件箱。首版覆盖成员被提及、任务分配、智能体 task 最终完成或失败，以及任务进入 `blocked`。只有配置的成员仍在关注该任务，并且没有静音 `agent_activity` 时，才推送 task 完成或失败；自动重试中的失败不会推送。
+
+推送文案不携带业务正文，只包含固定的事件摘要；配置了 HTTPS app 地址时，再附带 Multica 收件箱链接。任务标题、评论、附件、错误文本、凭据、topic 和 token 都不会进入通知标题、正文或日志；topic 只作为 ntfy 路由字段使用。投递使用有界内存队列、短超时且不重试，因此超时、`429`、ntfy 故障或队列满都不会阻塞 Multica 请求。
+
+<Callout type="warning">
+公共 ntfy 服务上未预留的 topic 实际上就是密码，消息也可能由服务缓存。请生成新的随机 topic，只通过受保护渠道传递，不要粘贴到任务、提交、截图或日志中。
+</Callout>
+
+用下面的命令生成 topic 并查询接收成员 UUID，不要把结果写入源码：
+
+```bash
+openssl rand -hex 32
+multica user me --output json
+```
+
+只在后端部署环境中填写：
+
+```dotenv
+NTFY_ENABLED=true
+NTFY_BASE_URL=https://ntfy.sh
+NTFY_TOPIC=<64-character-random-value>
+NTFY_RECIPIENT_ID=<multica-user-uuid>
+NTFY_TIMEOUT=3s
+```
+
+鉴权 ntfy 服务可选填 `NTFY_TOKEN`。如果 `MULTICA_APP_URL` 或 `FRONTEND_ORIGIN` 已经是成员可访问的 HTTPS app 地址，就不需要单独设置 `NTFY_APP_URL`。修改 `.env` 后要重建后端；普通 Compose restart 不会重新读取配置：
+
+```bash
+docker compose -f docker-compose.selfhost.yml up -d --force-recreate backend
+```
+
+在 ntfy Android App 中新增订阅，服务端选择 `https://ntfy.sh`，再粘贴受保护渠道中的 topic；显示名称可以在手机本地设为 "Multica"。部署负责人审阅公共 topic 风险前，不要发布手工测试消息；确认后触发一项覆盖范围内的 Multica 事件，检查固定摘要和站内跳转链接。
+
+轮换时生成新 topic，替换 `NTFY_TOPIC`，重建后端，在 Android 上订阅新 topic，确认一个获批事件后再取消旧订阅。轮换不需要改代码或数据库。回滚时设为 `NTFY_ENABLED=false` 并重建后端，站内通知不受影响；如果不再使用，再从部署密钥存储中删除 topic 和 token。
 
 ## 服务端 LLM
 

--- a/deploy/helm/multica/templates/configmap.yaml
+++ b/deploy/helm/multica/templates/configmap.yaml
@@ -18,6 +18,10 @@ data:
   ALLOWED_EMAIL_DOMAINS: {{ .Values.backend.config.allowedEmailDomains | quote }}
   DISABLE_WORKSPACE_CREATION: {{ .Values.backend.config.disableWorkspaceCreation | quote }}
   MULTICA_VCS_INTEGRATION_ENABLED: {{ .Values.backend.config.vcsIntegrationEnabled | quote }}
+  NTFY_ENABLED: {{ .Values.backend.config.ntfyEnabled | quote }}
+  NTFY_BASE_URL: {{ .Values.backend.config.ntfyBaseUrl | quote }}
+  NTFY_APP_URL: {{ .Values.backend.config.ntfyAppUrl | quote }}
+  NTFY_TIMEOUT: {{ .Values.backend.config.ntfyTimeout | quote }}
   GOOGLE_CLIENT_ID: {{ .Values.backend.config.googleClientId | quote }}
   GOOGLE_REDIRECT_URI: {{ .Values.backend.config.googleRedirectUri | quote }}
   S3_BUCKET: {{ .Values.backend.config.s3Bucket | quote }}

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -28,6 +28,9 @@ images:
 #     --from-literal=RESEND_API_KEY="" \
 #     --from-literal=GOOGLE_CLIENT_SECRET="" \
 #     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+#     --from-literal=NTFY_TOPIC="" \
+#     --from-literal=NTFY_RECIPIENT_ID="" \
+#     --from-literal=NTFY_TOKEN="" \
 #     --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 #
 # External postgres (postgres.external.enabled=true):
@@ -38,6 +41,9 @@ images:
 #     --from-literal=RESEND_API_KEY="" \
 #     --from-literal=GOOGLE_CLIENT_SECRET="" \
 #     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+#     --from-literal=NTFY_TOPIC="" \
+#     --from-literal=NTFY_RECIPIENT_ID="" \
+#     --from-literal=NTFY_TOKEN="" \
 #     --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 #
 # The chart references this Secret by name; it does not template it, so real
@@ -129,6 +135,12 @@ backend:
     # MULTICA_VCS_SECRET_KEY through existingSecret before connections work.
     # Set false to hide and reject the integration for this deployment.
     vcsIntegrationEnabled: true
+    # Best-effort Android push mirror. Keep topic, recipient ID, and optional
+    # publisher token in existingSecret; only non-secret controls live here.
+    ntfyEnabled: false
+    ntfyBaseUrl: https://ntfy.sh
+    ntfyAppUrl: ""
+    ntfyTimeout: 3s
     googleClientId: ""
     googleRedirectUri: http://multica.dev.lan/auth/callback
     s3Bucket: ""

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -158,6 +158,15 @@ services:
       # for a debugging session and unset it when that session ends, because
       # what it records is user message content.
       MULTICA_WECOM_TRACE: ${MULTICA_WECOM_TRACE:-}
+      # Best-effort Android push mirror. Topic/token/recipient values stay in
+      # the operator's .env and are never baked into the image.
+      NTFY_ENABLED: ${NTFY_ENABLED:-false}
+      NTFY_BASE_URL: ${NTFY_BASE_URL:-https://ntfy.sh}
+      NTFY_TOPIC: ${NTFY_TOPIC:-}
+      NTFY_RECIPIENT_ID: ${NTFY_RECIPIENT_ID:-}
+      NTFY_TOKEN: ${NTFY_TOKEN:-}
+      NTFY_APP_URL: ${NTFY_APP_URL:-}
+      NTFY_TIMEOUT: ${NTFY_TIMEOUT:-3s}
     restart: unless-stopped
 
   frontend:

--- a/scripts/helm-config.test.sh
+++ b/scripts/helm-config.test.sh
@@ -22,6 +22,9 @@ default_config="$(
     --show-only templates/configmap.yaml
 )"
 require_rendered_value "$default_config" 'MULTICA_VCS_INTEGRATION_ENABLED: "true"'
+require_rendered_value "$default_config" 'NTFY_ENABLED: "false"'
+require_rendered_value "$default_config" 'NTFY_BASE_URL: "https://ntfy.sh"'
+require_rendered_value "$default_config" 'NTFY_TIMEOUT: "3s"'
 
 disabled_config="$(
   helm template multica "$CHART_DIR" \
@@ -29,5 +32,16 @@ disabled_config="$(
     --set backend.config.vcsIntegrationEnabled=false
 )"
 require_rendered_value "$disabled_config" 'MULTICA_VCS_INTEGRATION_ENABLED: "false"'
+
+ntfy_config="$(
+  helm template multica "$CHART_DIR" \
+    --show-only templates/configmap.yaml \
+    --set backend.config.ntfyEnabled=true \
+    --set backend.config.ntfyBaseUrl=https://ntfy.example \
+    --set backend.config.ntfyTimeout=750ms
+)"
+require_rendered_value "$ntfy_config" 'NTFY_ENABLED: "true"'
+require_rendered_value "$ntfy_config" 'NTFY_BASE_URL: "https://ntfy.example"'
+require_rendered_value "$ntfy_config" 'NTFY_TIMEOUT: "750ms"'
 
 echo "helm config rendering ok"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
+	ntfyintegration "github.com/multica-ai/multica/server/internal/integrations/ntfy"
 	"github.com/multica-ai/multica/server/internal/logger"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/realtime"
@@ -369,6 +370,18 @@ func main() {
 	registerSubscriberListeners(bus, pool)
 	registerActivityListeners(bus, queries)
 	registerNotificationListeners(bus, queries)
+	var ntfyMirror *ntfyintegration.Mirror
+	if ntfyConfig, err := ntfyintegration.ConfigFromEnv(); err != nil {
+		slog.Warn("ntfy mirror disabled: invalid configuration", "error", err)
+	} else if ntfyConfig != nil {
+		ntfyMirror = ntfyintegration.New(*ntfyConfig, queries, slog.Default(), nil)
+		ntfyMirror.Register(bus)
+		slog.Info("ntfy mirror enabled",
+			"recipient_scoped", true,
+			"timeout", ntfyConfig.Timeout.String(),
+			"queue_capacity", ntfyConfig.QueueCapacity,
+		)
+	}
 
 	metricsConfig := obsmetrics.ConfigFromEnv()
 	var metricsServer *http.Server
@@ -574,6 +587,13 @@ func main() {
 	// final batch of queued heartbeat bumps.
 	sweepCancel()
 	heartbeatScheduler.Stop()
+	if ntfyMirror != nil {
+		ntfyStopCtx, ntfyStopCancel := context.WithTimeout(context.Background(), time.Second)
+		if !ntfyMirror.Stop(ntfyStopCtx) {
+			slog.Warn("ntfy mirror did not exit within shutdown timeout")
+		}
+		ntfyStopCancel()
+	}
 	if h.WebhookDeliveryWorker != nil && !h.WebhookDeliveryWorker.WaitWithTimeout(5*time.Second) {
 		slog.Warn("webhook delivery worker did not exit within shutdown timeout")
 	}

--- a/server/internal/integrations/ntfy/config.go
+++ b/server/internal/integrations/ntfy/config.go
@@ -1,0 +1,143 @@
+package ntfy
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultTimeout       = 3 * time.Second
+	defaultQueueCapacity = 64
+	minTopicLength       = 32
+	maxTopicLength       = 64
+	minTopicUniqueChars  = 8
+)
+
+var topicPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// Config contains the deployment-wide ntfy mirror configuration. A single
+// high-entropy topic is scoped to one Multica member so a shared deployment
+// cannot copy other members' notifications to the operator's phone.
+type Config struct {
+	BaseURL       string
+	Topic         string
+	Token         string
+	RecipientID   string
+	AppURL        string
+	Timeout       time.Duration
+	QueueCapacity int
+}
+
+// ConfigFromEnv returns nil when the mirror is disabled. Enabling it is an
+// explicit opt-in and requires every privacy-sensitive routing value.
+func ConfigFromEnv() (*Config, error) {
+	rawEnabled := strings.TrimSpace(os.Getenv("NTFY_ENABLED"))
+	if rawEnabled == "" {
+		return nil, nil
+	}
+	enabled, err := strconv.ParseBool(rawEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("NTFY_ENABLED must be a boolean")
+	}
+	if !enabled {
+		return nil, nil
+	}
+
+	baseURL, err := httpsURL("NTFY_BASE_URL", os.Getenv("NTFY_BASE_URL"), true, true)
+	if err != nil {
+		return nil, err
+	}
+
+	topic := strings.TrimSpace(os.Getenv("NTFY_TOPIC"))
+	if topic == "" {
+		return nil, fmt.Errorf("NTFY_TOPIC is required when NTFY_ENABLED=true")
+	}
+	if len(topic) < minTopicLength || len(topic) > maxTopicLength ||
+		!topicPattern.MatchString(topic) || uniqueCharacters(topic) < minTopicUniqueChars {
+		return nil, fmt.Errorf("NTFY_TOPIC must be a random %d-%d character value using letters, digits, underscore, or hyphen", minTopicLength, maxTopicLength)
+	}
+
+	recipientID := strings.TrimSpace(os.Getenv("NTFY_RECIPIENT_ID"))
+	if recipientID == "" {
+		return nil, fmt.Errorf("NTFY_RECIPIENT_ID is required when NTFY_ENABLED=true")
+	}
+	recipientUUID, err := uuid.Parse(recipientID)
+	if err != nil {
+		return nil, fmt.Errorf("NTFY_RECIPIENT_ID must be a UUID")
+	}
+	recipientID = recipientUUID.String()
+
+	appURL := ""
+	if raw := strings.TrimSpace(os.Getenv("NTFY_APP_URL")); raw != "" {
+		appURL, err = httpsURL("NTFY_APP_URL", raw, false, false)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Existing local deployments commonly expose only an HTTP app URL.
+		// That must not disable publishing; it merely cannot be copied into a
+		// notification traveling through a public service.
+		for _, name := range []string{"MULTICA_APP_URL", "FRONTEND_ORIGIN"} {
+			raw := strings.TrimSpace(os.Getenv(name))
+			if raw == "" {
+				continue
+			}
+			if candidate, candidateErr := httpsURL(name, raw, false, false); candidateErr == nil {
+				appURL = candidate
+				break
+			}
+		}
+	}
+
+	timeout := defaultTimeout
+	if raw := strings.TrimSpace(os.Getenv("NTFY_TIMEOUT")); raw != "" {
+		timeout, err = time.ParseDuration(raw)
+		if err != nil || timeout < 100*time.Millisecond || timeout > 10*time.Second {
+			return nil, fmt.Errorf("NTFY_TIMEOUT must be between 100ms and 10s")
+		}
+	}
+
+	return &Config{
+		BaseURL:       baseURL,
+		Topic:         topic,
+		Token:         strings.TrimSpace(os.Getenv("NTFY_TOKEN")),
+		RecipientID:   recipientID,
+		AppURL:        appURL,
+		Timeout:       timeout,
+		QueueCapacity: defaultQueueCapacity,
+	}, nil
+}
+
+func uniqueCharacters(value string) int {
+	seen := make(map[rune]struct{})
+	for _, char := range value {
+		seen[char] = struct{}{}
+	}
+	return len(seen)
+}
+
+func httpsURL(name, raw string, required, originOnly bool) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if required {
+			return "", fmt.Errorf("%s is required when NTFY_ENABLED=true", name)
+		}
+		return "", nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("%s must be an HTTPS URL without credentials, query, or fragment", name)
+	}
+	if originOnly && u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("%s must be an HTTPS origin without a path", name)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}

--- a/server/internal/integrations/ntfy/config_test.go
+++ b/server/internal/integrations/ntfy/config_test.go
@@ -1,0 +1,136 @@
+package ntfy
+
+import (
+	"strings"
+	"testing"
+)
+
+func clearNtfyEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"NTFY_ENABLED", "NTFY_BASE_URL", "NTFY_TOPIC", "NTFY_TOKEN",
+		"NTFY_RECIPIENT_ID", "NTFY_APP_URL", "NTFY_TIMEOUT",
+		"MULTICA_APP_URL", "FRONTEND_ORIGIN",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestConfigFromEnvDisabled(t *testing.T) {
+	clearNtfyEnv(t)
+
+	config, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if config != nil {
+		t.Fatalf("ConfigFromEnv() = %+v, want nil while disabled", config)
+	}
+
+	t.Setenv("NTFY_ENABLED", "false")
+	config, err = ConfigFromEnv()
+	if err != nil || config != nil {
+		t.Fatalf("explicitly disabled config = %+v, err = %v; want nil, nil", config, err)
+	}
+}
+
+func TestConfigFromEnvRequiresCompleteSafeConfiguration(t *testing.T) {
+	clearNtfyEnv(t)
+	t.Setenv("NTFY_ENABLED", "true")
+
+	if _, err := ConfigFromEnv(); err == nil || !strings.Contains(err.Error(), "NTFY_BASE_URL") {
+		t.Fatalf("missing base URL error = %v", err)
+	}
+
+	t.Setenv("NTFY_BASE_URL", "http://ntfy.example")
+	if _, err := ConfigFromEnv(); err == nil || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("insecure base URL error = %v", err)
+	}
+
+	t.Setenv("NTFY_BASE_URL", "https://ntfy.example")
+	t.Setenv("NTFY_TOPIC", "guessable-topic")
+	_, err := ConfigFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "NTFY_TOPIC") {
+		t.Fatalf("short topic error = %v", err)
+	}
+	if strings.Contains(err.Error(), "guessable-topic") {
+		t.Fatalf("configuration error leaked the topic: %v", err)
+	}
+
+	repetitiveTopic := strings.Repeat("x", 40)
+	t.Setenv("NTFY_TOPIC", repetitiveTopic)
+	_, err = ConfigFromEnv()
+	if err == nil || strings.Contains(err.Error(), repetitiveTopic) {
+		t.Fatalf("low-variety topic error = %v", err)
+	}
+}
+
+func TestConfigFromEnvLoadsValidConfiguration(t *testing.T) {
+	clearNtfyEnv(t)
+	topic := strings.Repeat("a1b2c3d4", 6)
+	t.Setenv("NTFY_ENABLED", "true")
+	t.Setenv("NTFY_BASE_URL", "https://ntfy.sh/")
+	t.Setenv("NTFY_TOPIC", topic)
+	t.Setenv("NTFY_TOKEN", "publisher-token")
+	t.Setenv("NTFY_RECIPIENT_ID", "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA")
+	t.Setenv("MULTICA_APP_URL", "https://multica.example/app/")
+	t.Setenv("NTFY_TIMEOUT", "750ms")
+
+	config, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if config == nil {
+		t.Fatal("ConfigFromEnv() returned nil")
+	}
+	if config.BaseURL != "https://ntfy.sh" {
+		t.Fatalf("BaseURL = %q", config.BaseURL)
+	}
+	if config.Topic != topic || config.Token != "publisher-token" {
+		t.Fatalf("topic/token were not loaded")
+	}
+	if config.RecipientID != "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" {
+		t.Fatalf("RecipientID was not canonicalized: %q", config.RecipientID)
+	}
+	if config.AppURL != "https://multica.example/app" {
+		t.Fatalf("AppURL = %q", config.AppURL)
+	}
+	if config.Timeout.String() != "750ms" || config.QueueCapacity != defaultQueueCapacity {
+		t.Fatalf("timeout/queue = %s/%d", config.Timeout, config.QueueCapacity)
+	}
+}
+
+func TestConfigFromEnvDropsInsecureFallbackAppURL(t *testing.T) {
+	clearNtfyEnv(t)
+	t.Setenv("NTFY_ENABLED", "true")
+	t.Setenv("NTFY_BASE_URL", "https://ntfy.example")
+	t.Setenv("NTFY_TOPIC", strings.Repeat("a1b2c3d4", 5))
+	t.Setenv("NTFY_RECIPIENT_ID", "11111111-1111-4111-8111-111111111111")
+	t.Setenv("MULTICA_APP_URL", "http://multica.internal")
+
+	config, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+	if config.AppURL != "" {
+		t.Fatalf("insecure fallback AppURL = %q, want empty", config.AppURL)
+	}
+}
+
+func TestConfigFromEnvRejectsInvalidRecipientAndTimeout(t *testing.T) {
+	clearNtfyEnv(t)
+	t.Setenv("NTFY_ENABLED", "true")
+	t.Setenv("NTFY_BASE_URL", "https://ntfy.example")
+	t.Setenv("NTFY_TOPIC", strings.Repeat("a1b2c3d4", 5))
+	t.Setenv("NTFY_RECIPIENT_ID", "not-a-uuid")
+
+	if _, err := ConfigFromEnv(); err == nil || !strings.Contains(err.Error(), "NTFY_RECIPIENT_ID") {
+		t.Fatalf("invalid recipient error = %v", err)
+	}
+
+	t.Setenv("NTFY_RECIPIENT_ID", "11111111-1111-4111-8111-111111111111")
+	t.Setenv("NTFY_TIMEOUT", "1m")
+	if _, err := ConfigFromEnv(); err == nil || !strings.Contains(err.Error(), "NTFY_TIMEOUT") {
+		t.Fatalf("invalid timeout error = %v", err)
+	}
+}

--- a/server/internal/integrations/ntfy/mirror.go
+++ b/server/internal/integrations/ntfy/mirror.go
@@ -1,0 +1,435 @@
+package ntfy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	kindMention      = "mentioned"
+	kindAssignment   = "issue_assigned"
+	kindTaskComplete = "task_completed"
+	kindTaskFailed   = "task_failed"
+	kindIssueBlocked = "issue_blocked"
+
+	logInterval = time.Minute
+)
+
+type notificationQueries interface {
+	IsIssueSubscriber(context.Context, db.IsIssueSubscriberParams) (bool, error)
+	GetNotificationPreference(context.Context, db.GetNotificationPreferenceParams) (db.NotificationPreference, error)
+}
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type job struct {
+	kind        string
+	workspaceID string
+	issueID     string
+	requireSub  bool
+}
+
+type message struct {
+	title    string
+	body     string
+	priority int
+	tags     []string
+	click    string
+}
+
+type publishPayload struct {
+	Topic    string   `json:"topic"`
+	Message  string   `json:"message"`
+	Title    string   `json:"title"`
+	Priority int      `json:"priority"`
+	Tags     []string `json:"tags,omitempty"`
+	Click    string   `json:"click,omitempty"`
+}
+
+type throttledLog struct {
+	mu      sync.Mutex
+	last    time.Time
+	pending int64
+}
+
+// Mirror copies a privacy-minimized subset of Multica notifications to one
+// member's ntfy topic. Event handlers only enqueue fixed-size metadata; the
+// worker owns all database and network I/O.
+type Mirror struct {
+	config      Config
+	queries     notificationQueries
+	client      httpDoer
+	logger      *slog.Logger
+	recipientID pgtype.UUID
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	jobs   chan job
+	done   chan struct{}
+	stop   atomic.Bool
+
+	dropLog    throttledLog
+	failureLog throttledLog
+}
+
+// New creates and starts an ntfy mirror. Config must come from ConfigFromEnv
+// (or be equivalently validated by a test).
+func New(config Config, queries notificationQueries, logger *slog.Logger, client httpDoer) *Mirror {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = defaultTimeout
+	}
+	if config.QueueCapacity <= 0 {
+		config.QueueCapacity = defaultQueueCapacity
+	}
+	if client == nil {
+		client = &http.Client{Timeout: config.Timeout}
+	}
+	recipientID, err := util.ParseUUID(config.RecipientID)
+	if err != nil {
+		panic("ntfy: New called with an invalid recipient UUID")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &Mirror{
+		config:      config,
+		queries:     queries,
+		client:      client,
+		logger:      logger,
+		recipientID: recipientID,
+		ctx:         ctx,
+		cancel:      cancel,
+		jobs:        make(chan job, config.QueueCapacity),
+		done:        make(chan struct{}),
+	}
+	go m.run()
+	return m
+}
+
+// Register subscribes the mirror to the in-app notification stream for direct
+// member notifications and to task terminal events for completion/failure.
+func (m *Mirror) Register(bus *events.Bus) {
+	bus.Subscribe(protocol.EventInboxNew, m.handleInboxNew)
+	bus.Subscribe(protocol.EventTaskCompleted, func(e events.Event) {
+		m.handleTaskEvent(e, kindTaskComplete)
+	})
+	bus.Subscribe(protocol.EventTaskFailed, func(e events.Event) {
+		m.handleTaskEvent(e, kindTaskFailed)
+	})
+}
+
+// Stop cancels any in-flight delivery and drops queued work. Shutdown is
+// intentionally bounded; ntfy is a best-effort mirror, not durable state.
+func (m *Mirror) Stop(ctx context.Context) bool {
+	if m.stop.CompareAndSwap(false, true) {
+		m.cancel()
+	}
+	select {
+	case <-m.done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (m *Mirror) handleInboxNew(e events.Event) {
+	payload, ok := e.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+	item, ok := payload["item"].(map[string]any)
+	if !ok {
+		return
+	}
+	if stringValue(item["recipient_type"]) != "member" || stringValue(item["recipient_id"]) != m.config.RecipientID {
+		return
+	}
+
+	kind := ""
+	switch stringValue(item["type"]) {
+	case kindMention:
+		kind = kindMention
+	case kindAssignment:
+		kind = kindAssignment
+	case "status_changed":
+		if stringValue(item["issue_status"]) == "blocked" {
+			kind = kindIssueBlocked
+		}
+	}
+	if kind == "" {
+		return
+	}
+
+	workspaceID := stringValue(item["workspace_id"])
+	if workspaceID == "" {
+		workspaceID = e.WorkspaceID
+	}
+	m.enqueue(job{
+		kind:        kind,
+		workspaceID: workspaceID,
+		issueID:     stringValue(item["issue_id"]),
+	})
+}
+
+func (m *Mirror) handleTaskEvent(e events.Event, kind string) {
+	payload, ok := e.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+	if kind == kindTaskFailed {
+		if retryPending, _ := payload["retry_pending"].(bool); retryPending {
+			return
+		}
+	}
+	issueID := stringValue(payload["issue_id"])
+	if issueID == "" || e.WorkspaceID == "" {
+		return
+	}
+	m.enqueue(job{
+		kind:        kind,
+		workspaceID: e.WorkspaceID,
+		issueID:     issueID,
+		requireSub:  true,
+	})
+}
+
+func (m *Mirror) enqueue(j job) {
+	if m.stop.Load() {
+		return
+	}
+	select {
+	case m.jobs <- j:
+	default:
+		m.warnThrottled(&m.dropLog, "ntfy mirror: queue full; notification dropped",
+			"event_kind", j.kind)
+	}
+}
+
+func (m *Mirror) run() {
+	defer close(m.done)
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case j := <-m.jobs:
+			ctx, cancel := context.WithTimeout(m.ctx, m.config.Timeout)
+			msg, ok := m.resolve(ctx, j)
+			if ok {
+				m.deliver(ctx, j.kind, msg)
+			}
+			cancel()
+		}
+	}
+}
+
+func (m *Mirror) resolve(ctx context.Context, j job) (message, bool) {
+	if _, err := util.ParseUUID(j.workspaceID); err != nil {
+		return message{}, false
+	}
+	issueID, err := util.ParseUUID(j.issueID)
+	if err != nil {
+		return message{}, false
+	}
+	if j.requireSub {
+		if m.queries == nil {
+			return message{}, false
+		}
+		subscribed, err := m.queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
+			IssueID:  issueID,
+			UserType: "member",
+			UserID:   m.recipientID,
+		})
+		if err != nil {
+			m.warnThrottled(&m.failureLog, "ntfy mirror: recipient lookup failed",
+				"event_kind", j.kind)
+			return message{}, false
+		}
+		if !subscribed || m.agentActivityMuted(ctx, j.workspaceID) {
+			return message{}, false
+		}
+	}
+
+	msg, ok := messageForKind(j.kind)
+	if !ok {
+		return message{}, false
+	}
+	msg.click = m.issueLink(j.workspaceID, j.issueID)
+	return msg, true
+}
+
+func (m *Mirror) agentActivityMuted(ctx context.Context, workspaceID string) bool {
+	workspaceUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return true
+	}
+	pref, err := m.queries.GetNotificationPreference(ctx, db.GetNotificationPreferenceParams{
+		WorkspaceID: workspaceUUID,
+		UserID:      m.recipientID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false
+	}
+	if err != nil {
+		m.warnThrottled(&m.failureLog, "ntfy mirror: notification preference lookup failed")
+		return true
+	}
+	var prefs map[string]string
+	if err := json.Unmarshal(pref.Preferences, &prefs); err != nil {
+		m.warnThrottled(&m.failureLog, "ntfy mirror: notification preference decode failed")
+		return true
+	}
+	return prefs["agent_activity"] == "muted"
+}
+
+func messageForKind(kind string) (message, bool) {
+	switch kind {
+	case kindMention:
+		return message{
+			title:    "Multica: Mention",
+			body:     "You were mentioned on an issue. Open Multica to review it.",
+			priority: 3,
+			tags:     []string{"speech_balloon"},
+		}, true
+	case kindAssignment:
+		return message{
+			title:    "Multica: Assignment",
+			body:     "An issue was assigned to you. Open Multica to review it.",
+			priority: 3,
+			tags:     []string{"clipboard"},
+		}, true
+	case kindTaskComplete:
+		return message{
+			title:    "Multica: Agent run completed",
+			body:     "An agent run completed for an issue. Open Multica for details.",
+			priority: 3,
+			tags:     []string{"white_check_mark"},
+		}, true
+	case kindTaskFailed:
+		return message{
+			title:    "Multica: Agent run failed",
+			body:     "An agent run failed for an issue. Open Multica for details.",
+			priority: 4,
+			tags:     []string{"warning"},
+		}, true
+	case kindIssueBlocked:
+		return message{
+			title:    "Multica: Issue blocked",
+			body:     "An issue you follow entered blocked. Open Multica for details.",
+			priority: 4,
+			tags:     []string{"warning"},
+		}, true
+	default:
+		return message{}, false
+	}
+}
+
+func (m *Mirror) issueLink(workspaceID, issueID string) string {
+	if m.config.AppURL == "" {
+		return ""
+	}
+	u, err := url.Parse(m.config.AppURL)
+	if err != nil {
+		return ""
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + url.PathEscape(workspaceID) + "/inbox"
+	q := u.Query()
+	q.Set("issue", issueID)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (m *Mirror) deliver(ctx context.Context, kind string, msg message) {
+	body, err := json.Marshal(publishPayload{
+		Topic:    m.config.Topic,
+		Message:  msg.body,
+		Title:    msg.title,
+		Priority: msg.priority,
+		Tags:     msg.tags,
+		Click:    msg.click,
+	})
+	if err != nil {
+		m.warnThrottled(&m.failureLog, "ntfy mirror: request encoding failed",
+			"event_kind", kind)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.config.BaseURL+"/", bytes.NewReader(body))
+	if err != nil {
+		m.warnThrottled(&m.failureLog, "ntfy mirror: request creation failed",
+			"event_kind", kind)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if m.config.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+m.config.Token)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		reason := "transport"
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			reason = "timeout"
+		}
+		m.warnThrottled(&m.failureLog, "ntfy mirror: delivery failed",
+			"event_kind", kind, "reason", reason)
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		m.warnThrottled(&m.failureLog, "ntfy mirror: delivery rejected",
+			"event_kind", kind, "status", resp.StatusCode)
+		return
+	}
+	m.logger.Debug("ntfy mirror: notification delivered",
+		"event_kind", kind, "status", resp.StatusCode)
+}
+
+func (m *Mirror) warnThrottled(state *throttledLog, message string, attrs ...any) {
+	now := time.Now()
+	state.mu.Lock()
+	state.pending++
+	if !state.last.IsZero() && now.Sub(state.last) < logInterval {
+		state.mu.Unlock()
+		return
+	}
+	count := state.pending
+	state.pending = 0
+	state.last = now
+	state.mu.Unlock()
+
+	attrs = append(attrs, "occurrences", count)
+	m.logger.Warn(message, attrs...)
+}
+
+func stringValue(v any) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case *string:
+		if value != nil {
+			return *value
+		}
+	}
+	return ""
+}

--- a/server/internal/integrations/ntfy/mirror_test.go
+++ b/server/internal/integrations/ntfy/mirror_test.go
@@ -1,0 +1,316 @@
+package ntfy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	testRecipientID = "11111111-1111-4111-8111-111111111111"
+	testWorkspaceID = "22222222-2222-4222-8222-222222222222"
+	testIssueID     = "33333333-3333-4333-8333-333333333333"
+)
+
+type fakeQueries struct {
+	subscribed bool
+	subErr     error
+	prefs      []byte
+	prefErr    error
+}
+
+func (f *fakeQueries) IsIssueSubscriber(context.Context, db.IsIssueSubscriberParams) (bool, error) {
+	return f.subscribed, f.subErr
+}
+
+func (f *fakeQueries) GetNotificationPreference(context.Context, db.GetNotificationPreferenceParams) (db.NotificationPreference, error) {
+	if f.prefErr != nil {
+		return db.NotificationPreference{}, f.prefErr
+	}
+	if f.prefs == nil {
+		return db.NotificationPreference{}, pgx.ErrNoRows
+	}
+	return db.NotificationPreference{Preferences: f.prefs}, nil
+}
+
+type capturedRequest struct {
+	payload publishPayload
+	raw     string
+	auth    string
+}
+
+type doerFunc func(*http.Request) (*http.Response, error)
+
+func (f doerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testMirrorConfig(baseURL string) Config {
+	return Config{
+		BaseURL:       baseURL,
+		Topic:         strings.Repeat("random", 8),
+		Token:         "publisher-token",
+		RecipientID:   testRecipientID,
+		AppURL:        "https://multica.example",
+		Timeout:       500 * time.Millisecond,
+		QueueCapacity: 8,
+	}
+}
+
+func inboxEvent(notificationType, status, recipientID string) events.Event {
+	return events.Event{
+		Type:        protocol.EventInboxNew,
+		WorkspaceID: testWorkspaceID,
+		Payload: map[string]any{"item": map[string]any{
+			"recipient_type": "member",
+			"recipient_id":   recipientID,
+			"workspace_id":   testWorkspaceID,
+			"issue_id":       testIssueID,
+			"issue_status":   status,
+			"type":           notificationType,
+			"title":          "private issue title",
+			"body":           "private full comment body",
+		}},
+	}
+}
+
+func taskEvent(eventType string, retryPending bool) events.Event {
+	return events.Event{
+		Type:        eventType,
+		WorkspaceID: testWorkspaceID,
+		Payload: map[string]any{
+			"issue_id":      testIssueID,
+			"retry_pending": retryPending,
+			"error":         "provider error containing a credential",
+		},
+	}
+}
+
+func stopMirror(t *testing.T, mirror *Mirror) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if !mirror.Stop(ctx) {
+		t.Fatal("mirror did not stop")
+	}
+}
+
+func TestMirrorMapsRequiredEventsWithoutUserContent(t *testing.T) {
+	requests := make(chan capturedRequest, 8)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var payload publishPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Errorf("decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- capturedRequest{payload: payload, raw: string(raw), auth: r.Header.Get("Authorization")}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := testMirrorConfig(server.URL)
+	mirror := New(config, &fakeQueries{subscribed: true}, slog.New(slog.NewTextHandler(io.Discard, nil)), server.Client())
+	defer stopMirror(t, mirror)
+	bus := events.New()
+	mirror.Register(bus)
+
+	tests := []struct {
+		event events.Event
+		title string
+		prio  int
+	}{
+		{inboxEvent("mentioned", "in_progress", testRecipientID), "Multica: Mention", 3},
+		{inboxEvent("issue_assigned", "todo", testRecipientID), "Multica: Assignment", 3},
+		{inboxEvent("status_changed", "blocked", testRecipientID), "Multica: Issue blocked", 4},
+		{taskEvent(protocol.EventTaskCompleted, false), "Multica: Agent run completed", 3},
+		{taskEvent(protocol.EventTaskFailed, false), "Multica: Agent run failed", 4},
+	}
+
+	for _, test := range tests {
+		bus.Publish(test.event)
+		select {
+		case request := <-requests:
+			if request.payload.Title != test.title || request.payload.Priority != test.prio {
+				t.Errorf("payload title/priority = %q/%d, want %q/%d", request.payload.Title, request.payload.Priority, test.title, test.prio)
+			}
+			if request.payload.Topic != config.Topic {
+				t.Errorf("topic was not sent to ntfy")
+			}
+			if request.auth != "Bearer publisher-token" {
+				t.Errorf("Authorization = %q", request.auth)
+			}
+			if request.payload.Click != "https://multica.example/"+testWorkspaceID+"/inbox?issue="+testIssueID {
+				t.Errorf("click = %q", request.payload.Click)
+			}
+			for _, secret := range []string{"private issue title", "private full comment body", "provider error containing a credential", "publisher-token"} {
+				if strings.Contains(request.raw, secret) {
+					t.Errorf("request body leaked %q: %s", secret, request.raw)
+				}
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("no request for %s", test.title)
+		}
+	}
+}
+
+func TestMirrorFiltersUnrelatedMutedAndRetryEvents(t *testing.T) {
+	requests := make(chan struct{}, 8)
+	doer := doerFunc(func(*http.Request) (*http.Response, error) {
+		requests <- struct{}{}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})
+
+	config := testMirrorConfig("https://ntfy.example")
+	mirror := New(config, &fakeQueries{subscribed: false}, slog.New(slog.NewTextHandler(io.Discard, nil)), doer)
+	bus := events.New()
+	mirror.Register(bus)
+	bus.Publish(inboxEvent("mentioned", "in_progress", "44444444-4444-4444-8444-444444444444"))
+	bus.Publish(inboxEvent("new_comment", "in_progress", testRecipientID))
+	bus.Publish(inboxEvent("status_changed", "in_review", testRecipientID))
+	bus.Publish(taskEvent(protocol.EventTaskFailed, true))
+	bus.Publish(taskEvent(protocol.EventTaskCompleted, false))
+
+	select {
+	case <-requests:
+		t.Fatal("an unrelated, retrying, or unsubscribed event was delivered")
+	case <-time.After(100 * time.Millisecond):
+	}
+	stopMirror(t, mirror)
+
+	muted := New(config, &fakeQueries{subscribed: true, prefs: []byte(`{"agent_activity":"muted"}`)}, slog.New(slog.NewTextHandler(io.Discard, nil)), doer)
+	mutedBus := events.New()
+	muted.Register(mutedBus)
+	mutedBus.Publish(taskEvent(protocol.EventTaskCompleted, false))
+	select {
+	case <-requests:
+		t.Fatal("muted agent activity was delivered")
+	case <-time.After(100 * time.Millisecond):
+	}
+	stopMirror(t, muted)
+}
+
+func TestMirrorDeliveryFailureNeverBlocksPublisherOrRetries(t *testing.T) {
+	started := make(chan struct{}, 1)
+	var calls atomic.Int64
+	doer := doerFunc(func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	config := testMirrorConfig("https://ntfy.example")
+	config.Timeout = 40 * time.Millisecond
+	mirror := New(config, &fakeQueries{subscribed: true}, slog.New(slog.NewTextHandler(io.Discard, nil)), doer)
+	defer stopMirror(t, mirror)
+	bus := events.New()
+	mirror.Register(bus)
+
+	start := time.Now()
+	bus.Publish(inboxEvent("mentioned", "in_progress", testRecipientID))
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Fatalf("event publish blocked for %s", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("delivery did not start")
+	}
+	time.Sleep(120 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("delivery attempts = %d, want exactly 1 (no retries)", got)
+	}
+}
+
+func TestMirrorQueueOverflowIsNonBlockingAndLogsNoSecrets(t *testing.T) {
+	var logs bytes.Buffer
+	started := make(chan struct{}, 1)
+	doer := doerFunc(func(req *http.Request) (*http.Response, error) {
+		started <- struct{}{}
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	config := testMirrorConfig("https://private-ntfy.example")
+	config.Topic = strings.Repeat("secret-topic-", 4)
+	config.Token = "secret-token"
+	config.QueueCapacity = 1
+	config.Timeout = 500 * time.Millisecond
+	mirror := New(config, &fakeQueries{subscribed: true}, slog.New(slog.NewTextHandler(&logs, nil)), doer)
+	bus := events.New()
+	mirror.Register(bus)
+	bus.Publish(inboxEvent("mentioned", "in_progress", testRecipientID))
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first delivery did not start")
+	}
+
+	start := time.Now()
+	bus.Publish(inboxEvent("mentioned", "in_progress", testRecipientID))
+	bus.Publish(inboxEvent("mentioned", "in_progress", testRecipientID))
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Fatalf("full queue blocked publisher for %s", elapsed)
+	}
+	stopMirror(t, mirror)
+
+	output := logs.String()
+	if !strings.Contains(output, "queue full") {
+		t.Fatalf("missing diagnostic queue-full log: %q", output)
+	}
+	for _, secret := range []string{config.Topic, config.Token, "private full comment body", "private-ntfy.example"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("logs leaked %q: %s", secret, output)
+		}
+	}
+}
+
+func TestMirrorRejectedDeliveryLogsStatusWithoutTopicOrBody(t *testing.T) {
+	var logs bytes.Buffer
+	called := make(chan struct{}, 1)
+	doer := doerFunc(func(*http.Request) (*http.Response, error) {
+		called <- struct{}{}
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("server response may contain the topic"))}, nil
+	})
+	config := testMirrorConfig("https://private-ntfy.example")
+	config.Topic = strings.Repeat("private", 6)
+	config.Token = "secret-token"
+	mirror := New(config, &fakeQueries{subscribed: true}, slog.New(slog.NewTextHandler(&logs, nil)), doer)
+	bus := events.New()
+	mirror.Register(bus)
+	bus.Publish(inboxEvent("mentioned", "in_progress", testRecipientID))
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("delivery did not run")
+	}
+	stopMirror(t, mirror)
+
+	output := logs.String()
+	if !strings.Contains(output, "status=429") {
+		t.Fatalf("missing safe status diagnostic: %q", output)
+	}
+	for _, secret := range []string{config.Topic, config.Token, "private full comment body", "private-ntfy.example", "server response may contain the topic"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("logs leaked %q: %s", secret, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add an opt-in, recipient-scoped ntfy mirror for member mentions, issue assignments, blocked issues, and terminal agent-run completion/failure events
- publish fixed, redacted summaries through a bounded asynchronous queue with HTTPS-only configuration, short deadlines, no retries, and rate-limited safe diagnostics
- expose environment, Docker Compose, and Helm configuration and document Android setup, topic rotation, rollback, and the approval gate for a real public test

Tracks Multica issue LUMI-9.

## Security and operational impact

The public ntfy topic is treated as a secret routing credential: configuration requires a 32–64 character high-entropy value and never logs the topic, token, response body, notification content, or full endpoint. Notifications contain no issue title, comment, attachment, credential, or provider error. Optional click-through URLs contain workspace and issue identifiers.

The integration is disabled by default and does not change the existing in-app notification path. Queue overflow, timeouts, rate limits, and delivery failures are best-effort drops and cannot block the main request flow. No deployment or real public ntfy message was performed.

## Validation

- `go test ./internal/integrations/ntfy`
- `go test -race ./internal/integrations/ntfy -count=1`
- `go vet ./internal/integrations/ntfy`
- `go test ./cmd/server -count=1`
- `pnpm --filter @multica/docs typecheck`
- `bash scripts/helm-config.test.sh`
- `git diff --check`

A full `go test ./...` was also attempted in a task-isolated copy. The changed ntfy and server packages passed there; unrelated daemon/agent tests remain environment-dependent under the root task user, and fixture tests require repository-root files not included in that copy.
