### PR TITLE
fix(web): show the newest fully-uploaded release on /download (MUL-6313)

### DIFF
--- a/apps/web/features/landing/components/download/all-platforms.tsx
+++ b/apps/web/features/landing/components/download/all-platforms.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
 import { useLocale } from "../../i18n";
-import type { DownloadAssets } from "../../utils/parse-release-assets";
+import {
+  hasCompleteAssetSet,
+  type DownloadAssets,
+} from "../../utils/parse-release-assets";
 import { AppleIcon, LinuxIcon, WindowsIcon } from "./os-icons";
 
 interface Props {
@@ -126,7 +129,9 @@ export function AllPlatforms({
           />
         </div>
 
-        {isFallbackNeeded(assets) ? (
+        {/* Some row is missing its link — surface the GitHub fallback so
+            users on an orphaned row still have a way out. */}
+        {!hasCompleteAssetSet(assets) ? (
           <p className="mt-6 text-label text-[#0a0d12]/60">
             <Link
               href={fallbackHref}
@@ -193,13 +198,4 @@ function Row({ icon, label, formats, unavailable, isLast }: RowProps) {
       </div>
     </div>
   );
-}
-
-// Twelve desktop artifacts are expected per release (four Mac,
-// two Windows, six Linux). If any are missing, surface the GitHub
-// fallback link so users on an orphaned row have a way out.
-const EXPECTED_ASSET_COUNT = 12;
-
-function isFallbackNeeded(assets: DownloadAssets): boolean {
-  return Object.values(assets).filter(Boolean).length < EXPECTED_ASSET_COUNT;
 }

--- a/apps/web/features/landing/utils/github-release.test.ts
+++ b/apps/web/features/landing/utils/github-release.test.ts
@@ -1,36 +1,46 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchLatestRelease } from "./github-release";
 
-const SAMPLE_LATEST_ASSET = {
-  name: "multica-desktop-0.2.14-mac-arm64.dmg",
-  browser_download_url:
-    "https://github.com/multica-ai/multica/releases/download/v0.2.14/multica-desktop-0.2.14-mac-arm64.dmg",
-};
+/** The twelve desktop artifacts a finished release carries. */
+function completeAssets(version: string) {
+  return [
+    `multica-desktop-${version}-mac-arm64.dmg`,
+    `multica-desktop-${version}-mac-arm64.zip`,
+    `multica-desktop-${version}-mac-x64.dmg`,
+    `multica-desktop-${version}-mac-x64.zip`,
+    `multica-desktop-${version}-windows-x64.exe`,
+    `multica-desktop-${version}-windows-arm64.exe`,
+    `multica-desktop-${version}-linux-x86_64.AppImage`,
+    `multica-desktop-${version}-linux-amd64.deb`,
+    `multica-desktop-${version}-linux-x86_64.rpm`,
+    `multica-desktop-${version}-linux-arm64.AppImage`,
+    `multica-desktop-${version}-linux-arm64.deb`,
+    `multica-desktop-${version}-linux-aarch64.rpm`,
+  ].map((name) => ({
+    name,
+    browser_download_url: `https://github.test/download/v${version}/${name}`,
+  }));
+}
 
-const SAMPLE_PREV_ASSET = {
-  name: "multica-desktop-0.2.13-mac-arm64.dmg",
-  browser_download_url:
-    "https://github.com/multica-ai/multica/releases/download/v0.2.13/multica-desktop-0.2.13-mac-arm64.dmg",
-};
+/** What a release looks like before the Windows/Linux jobs upload. */
+function macOnlyAssets(version: string) {
+  return completeAssets(version).filter((a) => a.name.includes("-mac-"));
+}
 
 function releasePayload(overrides: {
   tag: string;
-  publishedMinutesAgo?: number;
-  asset?: { name: string; browser_download_url: string };
+  assets?: { name: string; browser_download_url: string }[];
   prerelease?: boolean;
   draft?: boolean;
 }) {
-  const published = new Date(
-    Date.now() - (overrides.publishedMinutesAgo ?? 0) * 60_000,
-  ).toISOString();
   return {
     tag_name: overrides.tag,
-    published_at: published,
+    published_at: "2026-08-17T10:00:00Z",
     html_url: `https://github.com/multica-ai/multica/releases/tag/${overrides.tag}`,
     prerelease: overrides.prerelease ?? false,
     draft: overrides.draft ?? false,
-    assets: overrides.asset ? [overrides.asset] : [],
+    assets: overrides.assets ?? [],
   };
 }
 
@@ -47,72 +57,88 @@ function mockFetchWithReleases(releases: unknown[]) {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("fetchLatestRelease", () => {
-  it("uses previous release when latest was published within the fresh window", async () => {
+  it("uses the latest release when its desktop assets are complete", async () => {
     mockFetchWithReleases([
-      releasePayload({
-        tag: "v0.2.14",
-        publishedMinutesAgo: 10,
-        asset: SAMPLE_LATEST_ASSET,
-      }),
-      releasePayload({
-        tag: "v0.2.13",
-        publishedMinutesAgo: 60 * 24,
-        asset: SAMPLE_PREV_ASSET,
-      }),
-    ]);
-
-    const result = await fetchLatestRelease();
-    expect(result.version).toBe("v0.2.13");
-    expect(result.assets.macArm64Dmg).toBe(SAMPLE_PREV_ASSET.browser_download_url);
-  });
-
-  it("uses latest release once it is older than the fresh window", async () => {
-    mockFetchWithReleases([
-      releasePayload({
-        tag: "v0.2.14",
-        publishedMinutesAgo: 120,
-        asset: SAMPLE_LATEST_ASSET,
-      }),
-      releasePayload({
-        tag: "v0.2.13",
-        publishedMinutesAgo: 60 * 24,
-        asset: SAMPLE_PREV_ASSET,
-      }),
+      releasePayload({ tag: "v0.2.14", assets: completeAssets("0.2.14") }),
+      releasePayload({ tag: "v0.2.13", assets: completeAssets("0.2.13") }),
     ]);
 
     const result = await fetchLatestRelease();
     expect(result.version).toBe("v0.2.14");
-    expect(result.assets.macArm64Dmg).toBe(SAMPLE_LATEST_ASSET.browser_download_url);
+    expect(result.assets.winX64Exe).toContain("0.2.14");
   });
 
-  it("falls back to latest when there is no previous release", async () => {
+  // MUL-6313: v0.4.28's Windows packaging job failed and its Linux job
+  // never finished, so the newest release carried Mac builds only and
+  // /download rendered every Windows and Linux button as disabled.
+  it("steps back to the newest complete release when the latest is missing platforms", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     mockFetchWithReleases([
-      releasePayload({
-        tag: "v0.0.1",
-        publishedMinutesAgo: 5,
-        asset: SAMPLE_LATEST_ASSET,
-      }),
+      releasePayload({ tag: "v0.4.28", assets: macOnlyAssets("0.4.28") }),
+      releasePayload({ tag: "v0.4.27", assets: completeAssets("0.4.27") }),
     ]);
 
     const result = await fetchLatestRelease();
-    expect(result.version).toBe("v0.0.1");
+    expect(result.version).toBe("v0.4.27");
+    expect(result.htmlUrl).toContain("v0.4.27");
+    expect(result.assets.winX64Exe).toContain("0.4.27");
+    expect(result.assets.linuxArm64Rpm).toContain("0.4.27");
+  });
+
+  // The old implementation only stepped back for the first hour after
+  // publish, so a permanently broken release started showing dead
+  // buttons once that window elapsed. Completeness carries no clock.
+  it("keeps stepping back regardless of how old the incomplete release is", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockFetchWithReleases([
+      {
+        ...releasePayload({
+          tag: "v0.4.28",
+          assets: macOnlyAssets("0.4.28"),
+        }),
+        published_at: "2020-01-01T00:00:00Z",
+      },
+      releasePayload({ tag: "v0.4.27", assets: completeAssets("0.4.27") }),
+    ]);
+
+    const result = await fetchLatestRelease();
+    expect(result.version).toBe("v0.4.27");
+  });
+
+  it("searches past several incomplete releases", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockFetchWithReleases([
+      releasePayload({ tag: "v0.5.2", assets: macOnlyAssets("0.5.2") }),
+      releasePayload({ tag: "v0.5.1", assets: [] }),
+      releasePayload({ tag: "v0.5.0", assets: macOnlyAssets("0.5.0") }),
+      releasePayload({ tag: "v0.4.9", assets: completeAssets("0.4.9") }),
+    ]);
+
+    const result = await fetchLatestRelease();
+    expect(result.version).toBe("v0.4.9");
+  });
+
+  it("falls back to the latest release when no candidate is complete", async () => {
+    mockFetchWithReleases([
+      releasePayload({ tag: "v0.4.28", assets: macOnlyAssets("0.4.28") }),
+      releasePayload({ tag: "v0.4.27", assets: macOnlyAssets("0.4.27") }),
+    ]);
+
+    const result = await fetchLatestRelease();
+    expect(result.version).toBe("v0.4.28");
+    expect(result.assets.macArm64Dmg).toContain("0.4.28");
+    expect(result.assets.winX64Exe).toBeUndefined();
   });
 
   it("skips prereleases and drafts in the candidate list", async () => {
     mockFetchWithReleases([
-      releasePayload({
-        tag: "v0.2.15-rc.1",
-        publishedMinutesAgo: 30,
-        prerelease: true,
-      }),
-      releasePayload({
-        tag: "v0.2.14",
-        publishedMinutesAgo: 120,
-        asset: SAMPLE_LATEST_ASSET,
-      }),
+      releasePayload({ tag: "v0.2.15-rc.1", prerelease: true }),
+      releasePayload({ tag: "v0.2.14-draft", draft: true }),
+      releasePayload({ tag: "v0.2.14", assets: completeAssets("0.2.14") }),
     ]);
 
     const result = await fetchLatestRelease();
@@ -134,7 +160,6 @@ describe("fetchLatestRelease", () => {
       assets: {},
     });
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   it("returns an empty release shape when all candidates are filtered out", async () => {

--- a/apps/web/features/landing/utils/github-release.ts
+++ b/apps/web/features/landing/utils/github-release.ts
@@ -1,22 +1,24 @@
 import {
+  hasCompleteAssetSet,
   parseReleaseAssets,
   type DownloadAssets,
 } from "./parse-release-assets";
 
 /**
- * Server-side fetcher for the latest Multica release, designed to
- * run inside a Next.js server component. Response is cached by the
- * Next.js fetch cache for 5 minutes (Vercel ISR) so hitting /download
- * costs at most one GitHub API call per region per 5 minutes.
+ * Server-side fetcher for the latest downloadable Multica release,
+ * designed to run inside a Next.js server component. Response is cached
+ * by the Next.js fetch cache for 5 minutes (Vercel ISR) so hitting
+ * /download costs at most one GitHub API call per region per 5 minutes.
  *
- * Desktop assets don't all land at the same time: CI uploads Linux
- * and Windows within a minute of each other, but macOS is packaged
- * manually (notarization credentials aren't wired into CI yet) and
- * lands tens of minutes later. To avoid showing the half-filled
- * mid-flight state on /download, the fetcher pulls the two most
- * recent releases and falls back to the previous one for the first
- * hour after publish. Empirically full desktop uploads complete in
- * ~20 min; 1 h gives 3x buffer for commonly-variable manual steps.
+ * Desktop assets don't all land at the same time: CI uploads Linux and
+ * Windows within a minute of each other, but macOS is packaged manually
+ * (notarization credentials aren't wired into CI yet) and lands tens of
+ * minutes later. A packaging job can also fail outright and leave a
+ * release permanently short of some platforms. Either way the newest
+ * release is not always the newest *downloadable* one, so we pull a
+ * short window of recent releases and show the newest whose desktop
+ * asset set is complete — every button on the page then resolves to a
+ * real file.
  *
  * On any failure (network, rate limit, malformed payload) returns a
  * `null`-shaped result and logs — the page degrades to a "version
@@ -30,12 +32,14 @@ export interface LatestRelease {
   assets: DownloadAssets;
 }
 
+// Five candidates tolerates four consecutive incomplete releases before
+// the page has to fall back to showing the newest one as-is. Releases
+// ship roughly daily, so that is days of head room — while staying one
+// cheap request.
 const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/multica-ai/multica/releases?per_page=2";
+  "https://api.github.com/repos/multica-ai/multica/releases?per_page=5";
 
 const REVALIDATE_SECONDS = 300;
-
-const FRESH_RELEASE_WINDOW_MS = 60 * 60 * 1000;
 
 interface GitHubReleasePayload {
   tag_name?: string;
@@ -77,19 +81,16 @@ export async function fetchLatestRelease(): Promise<LatestRelease> {
     // prerelease shadowing a stable version on /download would be a
     // regression.
     const stable = data.filter((r) => !r.prerelease && !r.draft);
-    const latest = stable[0];
-    if (!latest) {
+    const chosen = pickRelease(stable);
+    if (!chosen) {
       return emptyRelease();
     }
-    const previous = stable[1];
-    const chosen =
-      previous && isWithinFreshWindow(latest) ? previous : latest;
 
     return {
-      version: chosen.tag_name ?? null,
-      publishedAt: chosen.published_at ?? null,
-      htmlUrl: chosen.html_url ?? null,
-      assets: parseReleaseAssets(chosen.assets ?? []),
+      version: chosen.release.tag_name ?? null,
+      publishedAt: chosen.release.published_at ?? null,
+      htmlUrl: chosen.release.html_url ?? null,
+      assets: chosen.assets,
     };
   } catch (err) {
     console.warn("[download] fetchLatestRelease failed:", err);
@@ -97,11 +98,38 @@ export async function fetchLatestRelease(): Promise<LatestRelease> {
   }
 }
 
-function isWithinFreshWindow(release: GitHubReleasePayload): boolean {
-  if (!release.published_at) return false;
-  const publishedAt = Date.parse(release.published_at);
-  if (Number.isNaN(publishedAt)) return false;
-  return Date.now() - publishedAt < FRESH_RELEASE_WINDOW_MS;
+interface PickedRelease {
+  release: GitHubReleasePayload;
+  assets: DownloadAssets;
+}
+
+/**
+ * Newest release whose desktop assets are all present. Falls back to the
+ * newest release overall when no candidate is complete — the page then
+ * shows what does exist plus its "all releases" escape hatch, which
+ * still beats reporting no version at all.
+ */
+function pickRelease(
+  candidates: GitHubReleasePayload[],
+): PickedRelease | undefined {
+  const parsed = candidates.map((release) => ({
+    release,
+    assets: parseReleaseAssets(release.assets ?? []),
+  }));
+
+  const complete = parsed.find((c) => hasCompleteAssetSet(c.assets));
+  if (complete) {
+    if (complete !== parsed[0]) {
+      // Worth a line in the logs: a release that never completes its
+      // asset set is invisible on /download until someone notices.
+      console.warn(
+        `[download] skipping ${parsed[0]?.release.tag_name ?? "latest release"}` +
+          ` — incomplete desktop assets; showing ${complete.release.tag_name}`,
+      );
+    }
+    return complete;
+  }
+  return parsed[0];
 }
 
 function emptyRelease(): LatestRelease {

--- a/apps/web/features/landing/utils/parse-release-assets.test.ts
+++ b/apps/web/features/landing/utils/parse-release-assets.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { parseReleaseAssets } from "./parse-release-assets";
+import { hasCompleteAssetSet, parseReleaseAssets } from "./parse-release-assets";
 
 function asset(name: string) {
   return {
@@ -30,5 +30,43 @@ describe("parseReleaseAssets", () => {
       macX64Zip:
         "https://github.test/releases/multica-desktop-0.4.2-mac-x64.zip",
     });
+  });
+});
+
+/** Every artifact name a finished release publishes, in real-world form —
+ *  note Linux arch varies by format (x86_64 for AppImage/rpm, amd64 for
+ *  deb; aarch64 for rpm, arm64 for the rest). */
+const ALL_ARTIFACT_NAMES = [
+  "multica-desktop-0.4.27-mac-arm64.dmg",
+  "multica-desktop-0.4.27-mac-arm64.zip",
+  "multica-desktop-0.4.27-mac-x64.dmg",
+  "multica-desktop-0.4.27-mac-x64.zip",
+  "multica-desktop-0.4.27-windows-x64.exe",
+  "multica-desktop-0.4.27-windows-arm64.exe",
+  "multica-desktop-0.4.27-linux-x86_64.AppImage",
+  "multica-desktop-0.4.27-linux-amd64.deb",
+  "multica-desktop-0.4.27-linux-x86_64.rpm",
+  "multica-desktop-0.4.27-linux-arm64.AppImage",
+  "multica-desktop-0.4.27-linux-arm64.deb",
+  "multica-desktop-0.4.27-linux-aarch64.rpm",
+];
+
+describe("hasCompleteAssetSet", () => {
+  it("accepts a release carrying all twelve desktop artifacts", () => {
+    const assets = parseReleaseAssets(ALL_ARTIFACT_NAMES.map(asset));
+    expect(hasCompleteAssetSet(assets)).toBe(true);
+  });
+
+  it("rejects a release missing any single artifact", () => {
+    for (const dropped of ALL_ARTIFACT_NAMES) {
+      const assets = parseReleaseAssets(
+        ALL_ARTIFACT_NAMES.filter((n) => n !== dropped).map(asset),
+      );
+      expect(hasCompleteAssetSet(assets), `missing ${dropped}`).toBe(false);
+    }
+  });
+
+  it("rejects an empty asset set", () => {
+    expect(hasCompleteAssetSet({})).toBe(false);
   });
 });

--- a/apps/web/features/landing/utils/parse-release-assets.ts
+++ b/apps/web/features/landing/utils/parse-release-assets.ts
@@ -98,3 +98,36 @@ export function parseReleaseAssets(raw: GitHubAsset[]): DownloadAssets {
 export function hasAnyAsset(assets: DownloadAssets): boolean {
   return Object.values(assets).some((v) => typeof v === "string");
 }
+
+/**
+ * The twelve desktop artifacts a finished release carries: four Mac,
+ * two Windows, six Linux. Listed explicitly rather than counted, so
+ * adding an optional key to `DownloadAssets` later (a universal Mac
+ * build, say) can't silently redefine what "complete" means.
+ */
+const REQUIRED_ASSET_KEYS: (keyof DownloadAssets)[] = [
+  "macArm64Dmg",
+  "macArm64Zip",
+  "macX64Dmg",
+  "macX64Zip",
+  "winX64Exe",
+  "winArm64Exe",
+  "linuxAmd64AppImage",
+  "linuxAmd64Deb",
+  "linuxAmd64Rpm",
+  "linuxArm64AppImage",
+  "linuxArm64Deb",
+  "linuxArm64Rpm",
+];
+
+/**
+ * Whether every platform/arch/format the /download page offers resolved
+ * to a URL. A release that fails this is either mid-flight (CI has
+ * uploaded Linux + Windows but the manually notarized Mac builds haven't
+ * landed) or permanently broken (a packaging job failed and was never
+ * re-run) — both render dead buttons, so both are worth stepping back
+ * from. See `pickRelease` in `github-release.ts`.
+ */
+export function hasCompleteAssetSet(assets: DownloadAssets): boolean {
+  return REQUIRED_ASSET_KEYS.every((key) => typeof assets[key] === "string");
+}


### PR DESCRIPTION
## Problem

Every Windows and Linux button on `/download` renders disabled.

Two things stack up:

1. **The immediate trigger.** v0.4.28's release run had `desktop (windows-latest, win)` **fail** and `desktop (ubuntu-latest, linux)` never finish, so the GitHub Release carries Mac builds only — no `.exe`, no `.AppImage` / `.deb` / `.rpm`. (v0.4.27 has the full set.)
2. **The reason the page can't absorb that.** `/download` shows whatever the newest release is, and a missing asset renders as a disabled chip.

Release selection did guard against a partial release, but with a time proxy: fall back to the previous release for the first hour after publish, assuming a gap means uploads are still in flight. That only covers the mid-flight case. A release whose packaging job failed never completes, so once the hour elapsed the page pinned itself to a release it couldn't fully serve — indefinitely.

## Change

Select on the actual signal rather than the clock: parse each recent release and show the newest whose desktop asset set is complete, so every button resolves to a real file.

- `hasCompleteAssetSet` in `parse-release-assets.ts` — one definition of "complete", listing the twelve required keys explicitly so adding an optional key later can't silently redefine it.
- `pickRelease` in `github-release.ts` — newest complete release, falling back to newest overall when no candidate qualifies (page then degrades as before, via disabled rows plus the "all releases" link).
- Candidate window 2 → 5, and a `console.warn` when the newest release is skipped — a release that never completes its uploads is otherwise invisible until someone reports dead buttons.
- `all-platforms.tsx` drops its inline asset count in favour of the shared helper.

This also covers the original mid-flight case more durably: Mac is packaged manually and lands tens of minutes after CI, and the page now steps back for exactly as long as that takes rather than for a fixed hour.

## Verification

- `vitest run features/landing` — 8 files / 29 tests pass.
- The three new regression tests fail against the previous implementation and pass with this change (confirmed by stashing the source change and re-running).
- Live check against the real GitHub API: v0.4.28 is skipped and v0.4.27 is chosen with all twelve artifacts; `curl` on the resolved Windows `.exe` returns HTTP 206.
- `tsc --noEmit` and `eslint` clean on the touched files.

## Not addressed here

- **The failed Windows packaging job on v0.4.28** is a separate CI problem. Its logs weren't retrievable while the run still showed in-progress. This PR stops it from breaking the download page, but the release itself is still missing artifacts and the job needs a re-run/fix.
- **The hero CTA** renders *no* button at all (rather than a disabled one) when the visitor's platform asset is missing and the API call itself succeeded. This change makes that state rare, but it's still a gap worth closing separately.
