### PR TITLE
fix(agent tasks): sanitize failure diagnostics

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3945,6 +3945,10 @@ func (s *TaskService) observeChatOutputLocalPath(task db.AgentTaskQueue, body st
 	)
 }
 
+func normalizeTaskFailureDiagnostic(errMsg string) string {
+	return strings.ReplaceAll(strings.ToValidUTF8(errMsg, "\uFFFD"), "\x00", "")
+}
+
 // FailTask marks a task as failed.
 // Issue status is NOT changed here — the agent manages it via the CLI.
 //
@@ -3962,6 +3966,8 @@ func (s *TaskService) observeChatOutputLocalPath(task db.AgentTaskQueue, body st
 // (via classifyPoisonedError, the timeout / runtime classifier, etc.)
 // will have their value preserved untouched.
 func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID string) (*db.AgentTaskQueue, error) {
+	errMsg = normalizeTaskFailureDiagnostic(errMsg)
+
 	// MUL-2946: synthesise a refined reason from the error text whenever the
 	// caller didn't supply one. This is the last write-path guard against
 	// "agent_error" coarse rows ending up in agent_task_queue.failure_reason

--- a/server/internal/service/task_failure_diagnostic_test.go
+++ b/server/internal/service/task_failure_diagnostic_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestNormalizeTaskFailureDiagnostic(t *testing.T) {
+	tests := []struct {
+		name       string
+		diagnostic string
+		want       string
+	}{
+		{
+			name:       "valid UTF-8 is unchanged",
+			diagnostic: "worker 失败：诊断详情",
+			want:       "worker 失败：诊断详情",
+		},
+		{
+			name:       "embedded NUL is removed",
+			diagnostic: "worker failed\x00 diagnostic details",
+			want:       "worker failed diagnostic details",
+		},
+		{
+			name:       "invalid UTF-8 is replaced",
+			diagnostic: string([]byte{'b', 'a', 'd', 0xff, 't', 'e', 'x', 't'}),
+			want:       "bad\uFFFDtext",
+		},
+		{
+			name:       "only NUL becomes empty",
+			diagnostic: "\x00\x00",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeTaskFailureDiagnostic(tt.diagnostic); got != tt.want {
+				t.Fatalf("normalizeTaskFailureDiagnostic() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFailTaskSanitizesNULDiagnostic(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	ctx := context.Background()
+	_, _, agentID, _ := seedAttributionFixture(t, pool)
+
+	var runtimeID string
+	if err := pool.QueryRow(ctx, `SELECT runtime_id::text FROM agent WHERE id = $1`, agentID).Scan(&runtimeID); err != nil {
+		t.Fatalf("load agent runtime: %v", err)
+	}
+
+	var taskID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue
+			(agent_id, runtime_id, status, priority, attempt, max_attempts, started_at)
+		VALUES ($1, $2, 'running', 0, 1, 1, now())
+		RETURNING id`, agentID, runtimeID).Scan(&taskID); err != nil {
+		t.Fatalf("seed running task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+	})
+
+	svc := &TaskService{Queries: db.New(pool), TxStarter: pool, Bus: events.New()}
+	if _, err := svc.FailTask(ctx, util.MustParseUUID(taskID), "worker failed\x00 diagnostic details", "", "", "", "agent_error", false, ""); err != nil {
+		t.Fatalf("FailTask: %v", err)
+	}
+
+	var (
+		status      string
+		completedAt pgtype.Timestamptz
+		diagnostic  string
+	)
+	if err := pool.QueryRow(ctx, `
+		SELECT status, completed_at, error
+		FROM agent_task_queue
+		WHERE id = $1`, taskID).Scan(&status, &completedAt, &diagnostic); err != nil {
+		t.Fatalf("read failed task: %v", err)
+	}
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+	if !completedAt.Valid {
+		t.Fatal("completed_at is NULL, want terminal timestamp")
+	}
+	if diagnostic != "worker failed diagnostic details" {
+		t.Fatalf("error = %q, want %q", diagnostic, "worker failed diagnostic details")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Normalizes agent task failure diagnostics at the start of TaskService.FailTask so PostgreSQL never receives an embedded NUL or malformed UTF-8. NUL bytes are removed, other invalid UTF-8 is replaced with U+FFFD, and the same normalized string is then used for failure classification, persistence, logs, comments, chat output, notifications, and events.

Thinking path: JSON decoding reconstructs escaped NUL bytes, the handler forwards the value unchanged, and FailTask previously classified and persisted that raw value. PostgreSQL rejects the TEXT write with SQLSTATE 22021, rolling back the terminal transition. Normalizing once at the service persistence boundary fixes that transaction while keeping all downstream behavior consistent.

Risk is limited to malformed diagnostics at this failure boundary. No handler, query, migration, or other database text field is changed.

## Related Issue

Closes #7098

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- server/internal/service/task.go: normalize failure diagnostics before classification and the failure transaction.
- server/internal/service/task_failure_diagnostic_test.go: cover valid UTF-8, embedded NUL, malformed UTF-8, NUL-only input, and the PostgreSQL-backed running-to-failed regression.

## How to Test

1. Run: go test ./internal/service -run '^(TestNormalizeTaskFailureDiagnostic|TestFailTaskSanitizesNULDiagnostic)$' -count=1
2. Run: go test ./internal/service -skip 'Skill' -count=1
3. Run: go vet ./internal/service

The PostgreSQL-backed test skips locally when DATABASE_URL is unavailable and runs against the migrated PostgreSQL service in CI. The unfiltered service suite has unrelated CRLF-sensitive embedded-skill failures on this Windows checkout; the filtered service suite and all scoped checks pass locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (apps/web/features/landing/i18n/) and **relevant docs** (apps/docs/content/docs/)
- [x] If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (terminology, mixed-rule for task / issue / skill)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Used the tool to trace the existing callback/service/transaction data flow, drive RED-to-GREEN tests, implement the approved minimal service-boundary normalization, and review and verify the scoped diff.

## Screenshots (optional)

Not applicable; no UI changes.