### PR TITLE
MUL-6330: fix(editor): rank exact-prefix skill matches first in the / picker

### DIFF
--- a/packages/views/editor/extensions/slash-command-suggestion.test.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.test.tsx
@@ -152,6 +152,103 @@ describe("slash command suggestion items", () => {
     expect(items(qc, "pull").map((i) => i.id)).toEqual(["s2"]);
   });
 
+  it("ranks name prefix matches above description-only matches", () => {
+    chatState.selectedAgentId = "agent-1";
+    const qc = fakeQc({
+      members: [{ user_id: "u1", name: "Alice", role: "member" }],
+      agents: [
+        agent({
+          id: "agent-1",
+          skills: [
+            { id: "s1", name: "grilling", description: "Grill the user about a plan" },
+            { id: "s2", name: "prototype", description: "Build a throwaway prototype" },
+            { id: "s3", name: "wayfinder", description: "Plan a huge chunk of work" },
+          ],
+        }),
+      ],
+    });
+
+    expect(items(qc, "wa").map((i) => i.id)).toEqual(["s3", "s2"]);
+  });
+
+  it("ranks an exact name match ahead of a longer prefix match", () => {
+    chatState.selectedAgentId = "agent-1";
+    const qc = fakeQc({
+      members: [{ user_id: "u1", name: "Alice", role: "member" }],
+      agents: [
+        agent({
+          id: "agent-1",
+          skills: [
+            { id: "s1", name: "reviewer", description: "" },
+            { id: "s2", name: "review", description: "" },
+          ],
+        }),
+      ],
+    });
+
+    expect(items(qc, "review").map((i) => i.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("ranks a name prefix above a mid-name match", () => {
+    chatState.selectedAgentId = "agent-1";
+    const qc = fakeQc({
+      members: [{ user_id: "u1", name: "Alice", role: "member" }],
+      agents: [
+        agent({
+          id: "agent-1",
+          skills: [
+            { id: "s1", name: "pr-review", description: "" },
+            { id: "s2", name: "review", description: "" },
+          ],
+        }),
+      ],
+    });
+
+    expect(items(qc, "rev").map((i) => i.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("keeps the configured skill order within a match tier", () => {
+    chatState.selectedAgentId = "agent-1";
+    const qc = fakeQc({
+      members: [{ user_id: "u1", name: "Alice", role: "member" }],
+      agents: [
+        agent({
+          id: "agent-1",
+          skills: [
+            { id: "s1", name: "deploy-web", description: "" },
+            { id: "s2", name: "deploy-api", description: "" },
+          ],
+        }),
+      ],
+    });
+
+    expect(items(qc, "deploy").map((i) => i.id)).toEqual(["s1", "s2"]);
+  });
+
+  it("keeps a name match inside the 20-item cap when description hits fill it", () => {
+    chatState.selectedAgentId = "agent-1";
+    const qc = fakeQc({
+      members: [{ user_id: "u1", name: "Alice", role: "member" }],
+      agents: [
+        agent({
+          id: "agent-1",
+          skills: [
+            ...Array.from({ length: 25 }, (_, i) => ({
+              id: `d${i}`,
+              name: `skill-${i}`,
+              description: "Build a throwaway prototype",
+            })),
+            { id: "s-named", name: "wayfinder", description: "" },
+          ],
+        }),
+      ],
+    });
+
+    const result = items(qc, "wa");
+    expect(result).toHaveLength(20);
+    expect(result[0]?.id).toBe("s-named");
+  });
+
   it("tolerates skills with missing descriptions from cached API data", () => {
     chatState.selectedAgentId = "agent-1";
     const qc = fakeQc({

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -164,6 +164,49 @@ export const SlashCommandList = forwardRef<
   );
 });
 
+const NO_MATCH = 4;
+
+/**
+ * Relevance tier for one skill, best first:
+ *
+ *   0 exact name → 1 name prefix → 2 name substring → 3 description only
+ *
+ * The name is what the user types after `/`; a description hit is a fallback
+ * for "I forget what it's called". Without the tiers, typing `/wa` left
+ * `wayfinder` behind every skill whose description happens to contain "wa"
+ * ("throwaway", "software"), because the list kept the agent's configured
+ * order.
+ */
+function skillMatchRank(
+  skill: { name: string; description?: string },
+  q: string,
+): number {
+  const name = skill.name.toLowerCase();
+  if (name === q) return 0;
+  if (name.startsWith(q)) return 1;
+  if (name.includes(q)) return 2;
+  if ((skill.description ?? "").toLowerCase().includes(q)) return 3;
+  return NO_MATCH;
+}
+
+/**
+ * Matching skills, best tier first. Ranking runs BEFORE the MAX_ITEMS
+ * truncation so a name match gives up neither its position nor its slot to a
+ * description hit. Sorting is stable, so the agent's configured order still
+ * decides ties within a tier.
+ */
+function rankSkillMatches<T extends { name: string; description?: string }>(
+  skills: T[],
+  q: string,
+): T[] {
+  if (!q) return skills;
+  return skills
+    .map((skill) => ({ skill, rank: skillMatchRank(skill, q) }))
+    .filter((entry) => entry.rank !== NO_MATCH)
+    .sort((a, b) => a.rank - b.rank)
+    .map((entry) => entry.skill);
+}
+
 function buildItems(qc: QueryClient, query: string): SlashCommandItem[] {
   const wsId = getCurrentWsId();
   if (!wsId) return [];
@@ -188,13 +231,7 @@ function buildItems(qc: QueryClient, query: string): SlashCommandItem[] {
     null;
 
   const q = query.toLowerCase();
-  return (activeAgent?.skills ?? [])
-    .filter(
-      (s) =>
-        !q ||
-        s.name.toLowerCase().includes(q) ||
-        (s.description ?? "").toLowerCase().includes(q),
-    )
+  return rankSkillMatches(activeAgent?.skills ?? [], q)
     .slice(0, MAX_ITEMS)
     .map((s) => ({ id: s.id, label: s.name, description: s.description ?? "" }));
 }

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -166,17 +166,7 @@ export const SlashCommandList = forwardRef<
 
 const NO_MATCH = 4;
 
-/**
- * Relevance tier for one skill, best first:
- *
- *   0 exact name → 1 name prefix → 2 name substring → 3 description only
- *
- * The name is what the user types after `/`; a description hit is a fallback
- * for "I forget what it's called". Without the tiers, typing `/wa` left
- * `wayfinder` behind every skill whose description happens to contain "wa"
- * ("throwaway", "software"), because the list kept the agent's configured
- * order.
- */
+/** Returns the match tier: exact name, prefix, substring, then description. */
 function skillMatchRank(
   skill: { name: string; description?: string },
   q: string,
@@ -189,12 +179,7 @@ function skillMatchRank(
   return NO_MATCH;
 }
 
-/**
- * Matching skills, best tier first. Ranking runs BEFORE the MAX_ITEMS
- * truncation so a name match gives up neither its position nor its slot to a
- * description hit. Sorting is stable, so the agent's configured order still
- * decides ties within a tier.
- */
+/** Ranks matches by relevance while preserving configured order within each tier. */
 function rankSkillMatches<T extends { name: string; description?: string }>(
   skills: T[],
   q: string,


### PR DESCRIPTION
## Problem

The chat `/` skill picker kept the agent's configured skill order while matching both names and descriptions. A skill whose name matched the query could therefore appear behind description-only matches.

## Fix

Rank matches into stable tiers before applying the 20-item cap:

1. exact name
2. name prefix
3. name substring
4. description only

Configured order still breaks ties within each tier.

## Tests

- `pnpm -C packages/views exec vitest run editor/extensions/slash-command-suggestion.test.tsx` (30 passed)
- `pnpm -C packages/views typecheck`
- `pnpm -C packages/views exec eslint editor/extensions/slash-command-suggestion.tsx editor/extensions/slash-command-suggestion.test.tsx`
