### PR TITLE
WOR-478: TransportRetry Prometheus outcome/delay regression tests

### DIFF
--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -86,6 +86,18 @@ Codex, Hermes, and OpenClaw are handled slightly differently:
 
 For creating and binding skills, see [Skills](/skills).
 
+## Transport retry
+
+When a provider CLI drops its streaming connection mid-turn (for example Cursor Agent exiting with `WritableIterable is closed` before a final `result` event), the daemon can retry **inside the same task** before Multica records a failed run. Retries prefer resuming the same provider session so prompt-cache tokens can be reused.
+
+Safety gates:
+
+- Retries run only when **no tool** was observed in the failing attempt (`tools == 0`).
+- A configurable session ladder applies per policy — typically same-session resume first, then a single fresh-session attempt.
+- Disable globally with `MULTICA_TRANSPORT_RETRY_CONFIG` set to `{"enabled":false}`, or override individual policies in that JSON document. Per-agent overrides use the same variable in agent `custom_env` (wins over the daemon process env).
+
+Daemon task logs emit structured `transport_retry` lines and Prometheus counters under `multica_agent_transport_retry_*` for attempts, recoveries, cache-read tokens, and extra wall time.
+
 ## Next steps
 
 - [Create and configure an agent](/agents-create) — model and thinking-effort settings.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
+	"github.com/multica-ai/multica/server/internal/daemon/transportretry"
 	"github.com/multica-ai/multica/server/internal/selfexec"
 	"github.com/multica-ai/multica/server/pkg/agent"
 	"github.com/multica-ai/multica/server/pkg/redact"
@@ -4858,6 +4859,9 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 			if assignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID); assignment != nil {
 				meta.LocalDirectory = true
 			}
+			if len(result.TransportRetryReceipt) > 0 {
+				meta.TransportRetry = result.TransportRetryReceipt
+			}
 			if err := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); err != nil {
 				taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
 			}
@@ -6397,12 +6401,40 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"idle_watchdog", execOpts.IdleWatchdogTimeout,
 	)
 
-	// Shared across the resume-retry below so the retry's transcript rows
-	// keep ascending seq values for the same task.
+	// Shared across transport-retry and the resume-retry below so every launch's
+	// transcript rows keep ascending seq values for the same task.
 	var msgSeq atomic.Int32
-	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq)
+	onTransportFreshSession := func(opts *agent.ExecOptions) string {
+		task.PriorSessionID = ""
+		task.PriorSessionResumeUnavailable = true
+		opts.ResumeContinuityNotice = ""
+		taskCtx.PriorSessionResumed = false
+		if freshBrief, briefErr := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx); briefErr != nil {
+			taskLog.Warn("execenv: re-inject cold runtime config for transport fresh retry failed (non-fatal)", "error", briefErr)
+		} else {
+			runtimeBrief = freshBrief
+			if providerNeedsInlineSystemPrompt(provider) {
+				opts.SystemPrompt = runtimeBrief
+			}
+		}
+		return BuildPrompt(task, provider)
+	}
+	transportCfg := transportretry.ResolveConfig(agentCustomEnv)
+	result, tools, transportStats, transportRetired, transportReceiptJSON, err := d.executeWithTransportRetry(
+		ctx, transportCfg, backend, prompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq,
+		provider, task.PriorSessionID, onTransportFreshSession,
+	)
 	if err != nil {
 		return TaskResult{}, err
+	}
+	if len(transportReceiptJSON) > 0 {
+		taskResult.TransportRetryReceipt = transportReceiptJSON
+		taskLog.Info("transport_retry finished",
+			"policy", transportStats.PolicyID,
+			"attempts", transportStats.Attempts,
+			"recovered_on_attempt", transportStats.RecoveredOnAttempt,
+			"surfaced_to_server", transportStats.SurfacedToServer,
+		)
 	}
 
 	// retiredSessionID is the session this run was told to resume and then
@@ -6412,6 +6444,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// row but still reachable through an older completed row on the issue or
 	// through the chat_session pointer (GH #6066).
 	var retiredSessionID string
+	if transportRetired != "" {
+		retiredSessionID = transportRetired
+	}
 	defer func() { taskResult.RetiredSessionID = retiredSessionID }()
 
 	if shouldRetryWithFreshSession(result, task.PriorSessionID, tools, provider) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6428,7 +6428,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, err
 	}
 	if len(transportReceiptJSON) > 0 {
-		taskResult.TransportRetryReceipt = transportReceiptJSON
 		taskLog.Info("transport_retry finished",
 			"policy", transportStats.PolicyID,
 			"attempts", transportStats.Attempts,
@@ -6436,6 +6435,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			"surfaced_to_server", transportStats.SurfacedToServer,
 		)
 	}
+	// Terminal paths below return fresh TaskResult literals; mirror the
+	// RetiredSessionID defer so optional transport-retry receipt survives.
+	defer func() { taskResult.TransportRetryReceipt = transportReceiptJSON }()
 
 	// retiredSessionID is the session this run was told to resume and then
 	// abandoned. Captured before the retry clears task.PriorSessionID, and

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
+	"github.com/multica-ai/multica/server/internal/daemon/transportretry"
 	"github.com/multica-ai/multica/server/pkg/agent"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
 	"github.com/pelletier/go-toml/v2"
@@ -2147,6 +2148,63 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 	// Second call should NOT have ResumeSessionID.
 	if fb.calls[1].ResumeSessionID != "" {
 		t.Fatal("retry should not have ResumeSessionID")
+	}
+}
+
+func TestExecuteWithTransportRetry_RecoversWritableIterable(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	ctx := context.Background()
+	taskLog := slog.Default()
+
+	failErr := "WritableIterable is closed (result_seen=false)"
+	fb := &fakeBackend{
+		results: []agent.Result{
+			{Status: "failed", Error: failErr, SessionID: "sess-stream"},
+			{Status: "failed", Error: failErr, SessionID: "sess-stream"},
+			{Status: "completed", Output: "ok", SessionID: "sess-stream"},
+		},
+	}
+
+	cfg := transportretry.Config{
+		Enabled: true,
+		Policies: []transportretry.Policy{
+			{
+				ID:               "cursor_writable_iterable",
+				Providers:        []string{"cursor"},
+				MatchError:       transportretry.DefaultPolicies()[0].MatchError,
+				DelaysMs:         []int{0, 0, 0},
+				SessionStrategy: []transportretry.SessionRetryMode{
+					transportretry.SessionRetrySame,
+					transportretry.SessionRetrySame,
+					transportretry.SessionRetryFresh,
+				},
+				Enabled: true,
+			},
+		},
+	}
+
+	var msgSeq atomic.Int32
+	opts := agent.ExecOptions{}
+	result, _, stats, _, receiptJSON, err := d.executeWithTransportRetry(
+		ctx, cfg, fb, "prompt", opts, taskLog, "task-transport", "", &msgSeq,
+		"cursor", "", nil,
+	)
+	if err != nil {
+		t.Fatalf("executeWithTransportRetry: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result status = %q, want completed", result.Status)
+	}
+	if stats.RecoveredOnAttempt != 3 {
+		t.Fatalf("recovered_on_attempt = %d, want 3", stats.RecoveredOnAttempt)
+	}
+	if len(receiptJSON) == 0 {
+		t.Fatal("expected transport retry receipt JSON")
+	}
+	if fb.calls[1].ResumeSessionID != "sess-stream" {
+		t.Fatalf("retry resume = %q, want sess-stream", fb.calls[1].ResumeSessionID)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -817,6 +817,9 @@ type GCMeta struct {
 	// the agent did in their own tree). Pattern-based artifact cleanup is
 	// still allowed.
 	LocalDirectory bool `json:"local_directory,omitempty"`
+	// TransportRetry holds optional in-turn transport-retry receipt JSON
+	// (daemon-local task-run metadata, not sent to the server).
+	TransportRetry json.RawMessage `json:"transport_retry,omitempty"`
 }
 
 const gcMetaFile = ".gc_meta.json"

--- a/server/internal/daemon/transport_retry.go
+++ b/server/internal/daemon/transport_retry.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/multica-ai/multica/server/internal/daemon/transportretry"
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// transportRetryReceipt is optional task-run metadata when in-turn transport retry occurred.
+type transportRetryReceipt struct {
+	PolicyID                 string   `json:"policy_id,omitempty"`
+	Attempts                 int      `json:"attempts,omitempty"`
+	RecoveredOnAttempt       int      `json:"recovered_on_attempt,omitempty"`
+	SessionModes             []string `json:"session_modes,omitempty"`
+	CacheReadTokensFirst     int64    `json:"cache_read_tokens_first,omitempty"`
+	CacheReadTokensRecovered int64    `json:"cache_read_tokens_recovered,omitempty"`
+	SurfacedToServer         bool     `json:"surfaced_to_server,omitempty"`
+}
+
+func (d *Daemon) executeWithTransportRetry(
+	ctx context.Context,
+	cfg transportretry.Config,
+	backend agent.Backend,
+	prompt string,
+	execOpts agent.ExecOptions,
+	taskLog *slog.Logger,
+	taskID, codexHome string,
+	msgSeq *atomic.Int32,
+	provider string,
+	priorSessionID string,
+	onFreshSession func(*agent.ExecOptions) string,
+) (agent.Result, int32, transportretry.Stats, string, json.RawMessage, error) {
+	viewOpts := transportretry.ExecOptionsView{ResumeSessionID: execOpts.ResumeSessionID}
+	observer := transportretry.MetricsObserver{Metrics: transportretry.GlobalMetrics()}
+
+	hooks := transportretry.RetryHooks{
+		OnFreshSession: func(view *transportretry.ExecOptionsView) (string, string) {
+			retired := view.ResumeSessionID
+			if retired == "" {
+				retired = priorSessionID
+			}
+			execOpts.ResumeSessionID = ""
+			view.ResumeSessionID = ""
+			freshPrompt := ""
+			if onFreshSession != nil {
+				freshPrompt = onFreshSession(&execOpts)
+			}
+			return freshPrompt, retired
+		},
+	}
+
+	execute := func(runPrompt string, opts transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		execOpts.ResumeSessionID = opts.ResumeSessionID
+		result, tools, err := d.executeAndDrain(ctx, backend, runPrompt, execOpts, taskLog, taskID, codexHome, msgSeq)
+		return agentResultView(result), tools, err
+	}
+
+	result, tools, stats, retired, err := transportretry.ExecuteWithRetry(
+		ctx,
+		cfg,
+		provider,
+		priorSessionID,
+		hooks,
+		observer,
+		taskLog,
+		execute,
+		prompt,
+		viewOpts,
+	)
+
+	receiptJSON := marshalTransportRetryReceipt(stats)
+	return agentResultFromView(result), tools, stats, retired, receiptJSON, err
+}
+
+func agentResultView(r agent.Result) transportretry.ResultView {
+	usage := make(map[string]transportretry.TokenUsageView, len(r.Usage))
+	for model, u := range r.Usage {
+		usage[model] = transportretry.TokenUsageView{CacheReadTokens: u.CacheReadTokens}
+	}
+	return transportretry.ResultView{
+		Status:    r.Status,
+		Output:    r.Output,
+		Error:     r.Error,
+		SessionID: r.SessionID,
+		Usage:     usage,
+	}
+}
+
+func agentResultFromView(v transportretry.ResultView) agent.Result {
+	usage := make(map[string]agent.TokenUsage, len(v.Usage))
+	for model, u := range v.Usage {
+		usage[model] = agent.TokenUsage{CacheReadTokens: u.CacheReadTokens}
+	}
+	return agent.Result{
+		Status:    v.Status,
+		Output:    v.Output,
+		Error:     v.Error,
+		SessionID: v.SessionID,
+		Usage:     usage,
+	}
+}
+
+func marshalTransportRetryReceipt(stats transportretry.Stats) json.RawMessage {
+	if stats.Attempts <= 1 && stats.PolicyID == "" {
+		return nil
+	}
+	modes := make([]string, len(stats.SessionModes))
+	for i, m := range stats.SessionModes {
+		modes[i] = m.String()
+	}
+	receipt := transportRetryReceipt{
+		PolicyID:                 stats.PolicyID,
+		Attempts:                 stats.Attempts,
+		RecoveredOnAttempt:       stats.RecoveredOnAttempt,
+		SessionModes:             modes,
+		CacheReadTokensFirst:     stats.CacheReadTokensFirst,
+		CacheReadTokensRecovered: stats.CacheReadTokensRecovered,
+		SurfacedToServer:         stats.SurfacedToServer,
+	}
+	b, err := json.Marshal(map[string]any{"transport_retry": receipt})
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/server/internal/daemon/transport_retry.go
+++ b/server/internal/daemon/transport_retry.go
@@ -121,7 +121,7 @@ func marshalTransportRetryReceipt(stats transportretry.Stats) json.RawMessage {
 		CacheReadTokensRecovered: stats.CacheReadTokensRecovered,
 		SurfacedToServer:         stats.SurfacedToServer,
 	}
-	b, err := json.Marshal(map[string]any{"transport_retry": receipt})
+	b, err := json.Marshal(receipt)
 	if err != nil {
 		return nil
 	}

--- a/server/internal/daemon/transport_retry_test.go
+++ b/server/internal/daemon/transport_retry_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/daemon/transportretry"
+)
+
+func TestMarshalTransportRetryReceipt_TopLevelFields(t *testing.T) {
+	t.Parallel()
+
+	stats := transportretry.Stats{
+		PolicyID:           "cursor_writable_iterable",
+		Attempts:           3,
+		RecoveredOnAttempt: 3,
+		SessionModes:       []transportretry.SessionRetryMode{transportretry.SessionRetrySame, transportretry.SessionRetrySame},
+		SurfacedToServer:   false,
+	}
+	raw := marshalTransportRetryReceipt(stats)
+	if len(raw) == 0 {
+		t.Fatal("expected receipt JSON")
+	}
+
+	var receipt map[string]any
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		t.Fatalf("unmarshal receipt: %v", err)
+	}
+	if _, nested := receipt["transport_retry"]; nested {
+		t.Fatalf("receipt must not double-wrap transport_retry, got %s", raw)
+	}
+	if receipt["policy_id"] != "cursor_writable_iterable" {
+		t.Fatalf("policy_id = %v, want cursor_writable_iterable", receipt["policy_id"])
+	}
+	if attempts, _ := receipt["attempts"].(float64); attempts != 3 {
+		t.Fatalf("attempts = %v, want 3", receipt["attempts"])
+	}
+}
+
+func TestHandleTask_PersistsTransportRetryReceiptToGCMeta(t *testing.T) {
+	t.Parallel()
+
+	workspacesRoot := t.TempDir()
+	workspaceID := "ws-transport-retry-gcmeta"
+	taskID := "task-transport-retry-gcmeta"
+	counterFile := filepath.Join(t.TempDir(), "cursor-launch-count")
+	expectedEnvRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+
+	fakeBin := filepath.Join(t.TempDir(), "cursor-agent")
+	script := `#!/bin/sh
+cat > /dev/null
+countfile="$COUNTER_FILE"
+n=0
+[ -f "$countfile" ] && n=$(cat "$countfile")
+n=$((n + 1))
+echo "$n" > "$countfile"
+if [ "$n" -lt 3 ]; then
+	printf '%s\n' '{"type":"thinking","subtype":"delta"}'
+	echo "RetriableError: WritableIterable is closed" >&2
+	exit 1
+fi
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-transport-retry"}'
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"sess-transport-retry"}'
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake cursor-agent: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{
+		client:             NewClient(srv.URL),
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:         make(map[string]*workspaceState),
+		runtimeIndex:       map[string]Runtime{"rt-cursor": {ID: "rt-cursor", Provider: "cursor"}},
+		activeEnvRoots:     make(map[string]int),
+		cancelPollInterval: time.Hour,
+		cfg: Config{
+			WorkspacesRoot: workspacesRoot,
+			AgentTimeout:   10 * time.Second,
+			ServerBaseURL:  srv.URL,
+			Agents: map[string]AgentEntry{
+				"cursor": {Path: fakeBin, Model: ""},
+			},
+		},
+	}
+	d.runner = taskRunnerFunc(d.runTask)
+
+	retryConfig := `{"policies":[{"id":"cursor_writable_iterable","delays_ms":[0,0,0]}]}`
+	task := Task{
+		ID:          taskID,
+		WorkspaceID: workspaceID,
+		RuntimeID:   "rt-cursor",
+		IssueID:     "issue-transport-retry-gcmeta",
+		AuthToken:   "mat_transport_retry_gcmeta",
+		Agent: &AgentData{
+			ID:   "agent-transport-retry-gcmeta",
+			Name: "test-agent",
+			CustomEnv: map[string]string{
+				"COUNTER_FILE":                   counterFile,
+				"MULTICA_TRANSPORT_RETRY_CONFIG": retryConfig,
+			},
+		},
+	}
+
+	d.handleTask(context.Background(), task, 0)
+
+	meta, err := execenv.ReadGCMeta(expectedEnvRoot)
+	if err != nil {
+		t.Fatalf("ReadGCMeta: %v", err)
+	}
+	if len(meta.TransportRetry) == 0 {
+		t.Fatal("expected transport_retry receipt in .gc_meta.json")
+	}
+
+	var receipt map[string]any
+	if err := json.Unmarshal(meta.TransportRetry, &receipt); err != nil {
+		t.Fatalf("unmarshal gc meta transport_retry: %v", err)
+	}
+	if _, nested := receipt["transport_retry"]; nested {
+		t.Fatalf("gc meta receipt must not double-wrap transport_retry, got %s", meta.TransportRetry)
+	}
+	if receipt["policy_id"] != "cursor_writable_iterable" {
+		t.Fatalf("policy_id = %v, want cursor_writable_iterable", receipt["policy_id"])
+	}
+	if attempts, _ := receipt["attempts"].(float64); attempts < 2 {
+		t.Fatalf("attempts = %v, want >= 2 after in-turn recovery", receipt["attempts"])
+	}
+}

--- a/server/internal/daemon/transportretry/executor.go
+++ b/server/internal/daemon/transportretry/executor.go
@@ -1,0 +1,292 @@
+package transportretry
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// Observer records transport-retry telemetry (metrics + structured logs).
+type Observer interface {
+	RecordAttempt(provider, policyID, sessionMode, outcome string)
+	RecordRecovered(provider, policyID, sessionMode string)
+	RecordCacheReadTokens(provider, policyID string, tokens int64)
+	RecordWallSeconds(provider, policyID string, seconds float64)
+}
+
+// ShouldRetry reports whether a failed result is eligible for transport retry.
+func ShouldRetry(result ResultView, tools int32) bool {
+	if tools > 0 {
+		return false
+	}
+	if result.Status != "failed" {
+		return false
+	}
+	return strings.TrimSpace(result.Error) != ""
+}
+
+func cacheReadTotal(usage map[string]TokenUsageView) int64 {
+	var total int64
+	for _, u := range usage {
+		total += u.CacheReadTokens
+	}
+	return total
+}
+
+// ExecuteWithRetry runs execute up to the policy launch budget, retrying matching transport failures.
+func ExecuteWithRetry(
+	ctx context.Context,
+	cfg Config,
+	provider string,
+	priorSessionID string,
+	hooks RetryHooks,
+	observer Observer,
+	taskLog *slog.Logger,
+	execute ExecuteFunc,
+	initialPrompt string,
+	initialOpts ExecOptionsView,
+) (ResultView, int32, Stats, string, error) {
+	if !cfg.Enabled {
+		if observer != nil {
+			observer.RecordAttempt(provider, "", "", "skipped_disabled")
+		}
+		result, tools, err := execute(initialPrompt, initialOpts)
+		return result, tools, Stats{}, "", err
+	}
+
+	prompt := initialPrompt
+	opts := initialOpts
+	var (
+		stats          Stats
+		retiredSession string
+		extraWallStart = time.Now()
+		launchIndex    int
+		lastPolicy     Policy
+		matchedPolicy  bool
+	)
+
+	for {
+		result, tools, err := execute(prompt, opts)
+		stats.Attempts = launchIndex + 1
+		if launchIndex == 0 {
+			stats.CacheReadTokensFirst = cacheReadTotal(result.Usage)
+		}
+
+		if err != nil {
+			stats.SurfacedToServer = true
+			stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+			if observer != nil {
+				observer.RecordWallSeconds(provider, stats.PolicyID, stats.ExtraWallSeconds)
+			}
+			return result, tools, stats, retiredSession, err
+		}
+
+		if result.Status != "failed" {
+			if launchIndex > 0 && observer != nil && matchedPolicy {
+				mode := sessionModeForLaunch(lastPolicy, launchIndex-1)
+				observer.RecordAttempt(provider, lastPolicy.ID, mode.String(), "recovered")
+				observer.RecordRecovered(provider, lastPolicy.ID, mode.String())
+				observer.RecordCacheReadTokens(provider, lastPolicy.ID, cacheReadTotal(result.Usage))
+			}
+			if launchIndex > 0 {
+				stats.RecoveredOnAttempt = launchIndex + 1
+				stats.CacheReadTokensRecovered = cacheReadTotal(result.Usage)
+				stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+				if observer != nil {
+					observer.RecordWallSeconds(provider, stats.PolicyID, stats.ExtraWallSeconds)
+				}
+			}
+			return result, tools, stats, retiredSession, nil
+		}
+
+		if tools > 0 {
+			if policy, ok := findPolicy(cfg, provider, result.Error); ok {
+				if stats.PolicyID == "" {
+					stats.PolicyID = policy.ID
+				}
+				if observer != nil {
+					observer.RecordAttempt(provider, policy.ID, "", "skipped_tools")
+				}
+			}
+			stats.SurfacedToServer = true
+			stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+			if observer != nil {
+				observer.RecordWallSeconds(provider, stats.PolicyID, stats.ExtraWallSeconds)
+			}
+			return result, tools, stats, retiredSession, nil
+		}
+
+		if !ShouldRetry(result, tools) {
+			stats.SurfacedToServer = true
+			stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+			if observer != nil {
+				observer.RecordWallSeconds(provider, stats.PolicyID, stats.ExtraWallSeconds)
+			}
+			return result, tools, stats, retiredSession, nil
+		}
+
+		policy, ok := findPolicy(cfg, provider, result.Error)
+		if !ok {
+			stats.SurfacedToServer = true
+			stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+			if observer != nil {
+				observer.RecordWallSeconds(provider, stats.PolicyID, stats.ExtraWallSeconds)
+			}
+			return result, tools, stats, retiredSession, nil
+		}
+		lastPolicy = policy
+		matchedPolicy = true
+		if stats.PolicyID == "" {
+			stats.PolicyID = policy.ID
+		}
+
+		maxLaunches := totalLaunches(policy)
+		if launchIndex+1 >= maxLaunches {
+			if observer != nil {
+				observer.RecordAttempt(provider, policy.ID, "", "exhausted")
+				observer.RecordWallSeconds(provider, policy.ID, time.Since(extraWallStart).Seconds())
+			}
+			stats.SurfacedToServer = true
+			stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+			return result, tools, stats, retiredSession, nil
+		}
+
+		retryIndex := launchIndex
+		mode := sessionModeForLaunch(policy, retryIndex)
+		stats.SessionModes = append(stats.SessionModes, mode)
+
+		if observer != nil {
+			observer.RecordAttempt(provider, policy.ID, mode.String(), "retrying")
+		}
+		logTransportRetryAttempt(taskLog, launchIndex+2, policy.ID, mode, opts.ResumeSessionID, result, false)
+
+		delay := delayForLaunch(policy, retryIndex)
+		if delay > 0 || cfg.MaxRetryWallClockS > 0 {
+			if err := waitForRetry(ctx, extraWallStart, cfg.MaxRetryWallClockS, delay); err != nil {
+				stats.SurfacedToServer = true
+				stats.ExtraWallSeconds = time.Since(extraWallStart).Seconds()
+				if observer != nil {
+					observer.RecordAttempt(provider, policy.ID, mode.String(), "exhausted")
+					observer.RecordWallSeconds(provider, policy.ID, stats.ExtraWallSeconds)
+				}
+				return ResultView{Status: "failed", Error: err.Error()}, tools, stats, retiredSession, err
+			}
+		}
+
+		switch mode {
+		case SessionRetrySame:
+			sessionID := opts.ResumeSessionID
+			if sessionID == "" {
+				sessionID = priorSessionID
+			}
+			if sessionID == "" {
+				sessionID = result.SessionID
+			}
+			opts.ResumeSessionID = sessionID
+		case SessionRetryFresh:
+			if hooks.OnFreshSession != nil {
+				newPrompt, retired := hooks.OnFreshSession(&opts)
+				if retired != "" {
+					retiredSession = retired
+				}
+				if newPrompt != "" {
+					prompt = newPrompt
+				}
+			} else {
+				opts.ResumeSessionID = ""
+			}
+		case SessionRetryCold:
+			opts.ResumeSessionID = ""
+		}
+
+		launchIndex++
+	}
+}
+
+func waitForRetry(ctx context.Context, extraWallStart time.Time, maxWallS, delayMs int) error {
+	if delayMs <= 0 {
+		if maxWallS > 0 && time.Since(extraWallStart).Seconds() >= float64(maxWallS) {
+			return ctx.Err()
+		}
+		return nil
+	}
+	timer := time.NewTimer(time.Duration(delayMs) * time.Millisecond)
+	defer timer.Stop()
+	if maxWallS > 0 {
+		deadline := extraWallStart.Add(time.Duration(maxWallS) * time.Second)
+		if time.Until(deadline) <= 0 {
+			return context.DeadlineExceeded
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func logTransportRetryAttempt(taskLog *slog.Logger, attempt int, policyID string, mode SessionRetryMode, sessionID string, result ResultView, recovered bool) {
+	if taskLog == nil {
+		return
+	}
+	taskLog.Info("transport_retry",
+		"attempt", attempt,
+		"policy", policyID,
+		"session_mode", mode.String(),
+		"session_id", sessionID,
+		"recovered", recovered,
+		"cache_read_tokens", cacheReadTotal(result.Usage),
+		"event_count", eventCountFromError(result.Error),
+		"last_event_type", lastEventTypeFromError(result.Error),
+	)
+}
+
+func eventCountFromError(err string) int {
+	const prefix = "event_count="
+	idx := strings.Index(err, prefix)
+	if idx < 0 {
+		return 0
+	}
+	start := idx + len(prefix)
+	end := start
+	for end < len(err) && err[end] >= '0' && err[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0
+	}
+	var n int
+	for i := start; i < end; i++ {
+		n = n*10 + int(err[i]-'0')
+	}
+	return n
+}
+
+func lastEventTypeFromError(err string) string {
+	const prefix = "last_event_type="
+	idx := strings.Index(err, prefix)
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len(prefix)
+	end := strings.Index(err[start:], ",")
+	if end < 0 {
+		end = strings.Index(err[start:], ")")
+	}
+	if end < 0 {
+		return strings.TrimSpace(err[start:])
+	}
+	return strings.TrimSpace(err[start : start+end])
+}
+
+func (m SessionRetryMode) String() string {
+	return string(m)
+}

--- a/server/internal/daemon/transportretry/metrics.go
+++ b/server/internal/daemon/transportretry/metrics.go
@@ -22,12 +22,15 @@ type Metrics struct {
 // GlobalMetrics returns the process-wide transport-retry metrics registrar.
 func GlobalMetrics() *Metrics {
 	transportRetryMetricsOnce.Do(func() {
-		transportRetryMetrics = newMetrics()
+		transportRetryMetrics = newMetrics(prometheus.DefaultRegisterer)
 	})
 	return transportRetryMetrics
 }
 
-func newMetrics() *Metrics {
+func newMetrics(registerer prometheus.Registerer) *Metrics {
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
 	m := &Metrics{
 		attemptTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "multica",
@@ -55,13 +58,22 @@ func newMetrics() *Metrics {
 			Buckets:   []float64{1, 2, 5, 10, 30, 60, 120, 300, 600},
 		}, []string{"provider", "policy_id"}),
 	}
-	prometheus.MustRegister(
+	registerer.MustRegister(
 		m.attemptTotal,
 		m.recoveredTotal,
 		m.cacheReadTokens,
 		m.wallSeconds,
 	)
 	return m
+}
+
+// NewMetricsForTest returns an isolated Metrics instance registered on reg.
+// When reg is nil, a fresh registry is allocated for the test.
+func NewMetricsForTest(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		reg = prometheus.NewRegistry()
+	}
+	return newMetrics(reg)
 }
 
 // Collectors returns registered collectors for tests.

--- a/server/internal/daemon/transportretry/metrics.go
+++ b/server/internal/daemon/transportretry/metrics.go
@@ -1,0 +1,159 @@
+package transportretry
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	transportRetryMetrics     *Metrics
+	transportRetryMetricsOnce sync.Once
+)
+
+// Metrics exposes Prometheus counters/histograms for in-turn transport retries.
+type Metrics struct {
+	attemptTotal      *prometheus.CounterVec
+	recoveredTotal    *prometheus.CounterVec
+	cacheReadTokens   *prometheus.CounterVec
+	wallSeconds       *prometheus.HistogramVec
+}
+
+// GlobalMetrics returns the process-wide transport-retry metrics registrar.
+func GlobalMetrics() *Metrics {
+	transportRetryMetricsOnce.Do(func() {
+		transportRetryMetrics = newMetrics()
+	})
+	return transportRetryMetrics
+}
+
+func newMetrics() *Metrics {
+	m := &Metrics{
+		attemptTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "multica",
+			Subsystem: "agent_transport_retry",
+			Name:      "attempt_total",
+			Help:      "In-turn transport retry attempts by provider, policy, session mode, and outcome.",
+		}, []string{"provider", "policy_id", "session_mode", "outcome"}),
+		recoveredTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "multica",
+			Subsystem: "agent_transport_retry",
+			Name:      "recovered_total",
+			Help:      "In-turn transport retries that recovered without surfacing a failed task.",
+		}, []string{"provider", "policy_id", "session_mode"}),
+		cacheReadTokens: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "multica",
+			Subsystem: "agent_transport_retry",
+			Name:      "cache_read_tokens",
+			Help:      "Cache-read tokens observed on recovered transport-retry attempts.",
+		}, []string{"provider", "policy_id"}),
+		wallSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "multica",
+			Subsystem: "agent_transport_retry",
+			Name:      "wall_seconds",
+			Help:      "Extra wall-clock seconds spent in in-turn transport retries.",
+			Buckets:   []float64{1, 2, 5, 10, 30, 60, 120, 300, 600},
+		}, []string{"provider", "policy_id"}),
+	}
+	prometheus.MustRegister(
+		m.attemptTotal,
+		m.recoveredTotal,
+		m.cacheReadTokens,
+		m.wallSeconds,
+	)
+	return m
+}
+
+// Collectors returns registered collectors for tests.
+func (m *Metrics) Collectors() []prometheus.Collector {
+	if m == nil {
+		return nil
+	}
+	return []prometheus.Collector{
+		m.attemptTotal,
+		m.recoveredTotal,
+		m.cacheReadTokens,
+		m.wallSeconds,
+	}
+}
+
+// RecordAttempt implements Observer.
+func (m *Metrics) RecordAttempt(provider, policyID, sessionMode, outcome string) {
+	if m == nil {
+		return
+	}
+	m.attemptTotal.WithLabelValues(normalizeProvider(provider), normalizePolicy(policyID), normalizeSessionMode(sessionMode), normalizeOutcome(outcome)).Inc()
+}
+
+// RecordRecovered implements Observer.
+func (m *Metrics) RecordRecovered(provider, policyID, sessionMode string) {
+	if m == nil {
+		return
+	}
+	m.recoveredTotal.WithLabelValues(normalizeProvider(provider), normalizePolicy(policyID), normalizeSessionMode(sessionMode)).Inc()
+}
+
+// RecordCacheReadTokens implements Observer.
+func (m *Metrics) RecordCacheReadTokens(provider, policyID string, tokens int64) {
+	if m == nil || tokens <= 0 {
+		return
+	}
+	m.cacheReadTokens.WithLabelValues(normalizeProvider(provider), normalizePolicy(policyID)).Add(float64(tokens))
+}
+
+// RecordWallSeconds implements Observer.
+func (m *Metrics) RecordWallSeconds(provider, policyID string, seconds float64) {
+	if m == nil || seconds < 0 {
+		return
+	}
+	m.wallSeconds.WithLabelValues(normalizeProvider(provider), normalizePolicy(policyID)).Observe(seconds)
+}
+
+func normalizeProvider(provider string) string {
+	if provider == "" {
+		return "unknown"
+	}
+	return provider
+}
+
+func normalizePolicy(id string) string {
+	if id == "" {
+		return "none"
+	}
+	return id
+}
+
+func normalizeSessionMode(mode string) string {
+	if mode == "" {
+		return "none"
+	}
+	return mode
+}
+
+func normalizeOutcome(outcome string) string {
+	if outcome == "" {
+		return "unknown"
+	}
+	return outcome
+}
+
+// MetricsObserver wraps Metrics to finish wall-clock recording at end of retry loop.
+type MetricsObserver struct {
+	Metrics *Metrics
+}
+
+func (o MetricsObserver) RecordAttempt(provider, policyID, sessionMode, outcome string) {
+	o.Metrics.RecordAttempt(provider, policyID, sessionMode, outcome)
+}
+
+func (o MetricsObserver) RecordRecovered(provider, policyID, sessionMode string) {
+	o.Metrics.RecordRecovered(provider, policyID, sessionMode)
+}
+
+func (o MetricsObserver) RecordCacheReadTokens(provider, policyID string, tokens int64) {
+	o.Metrics.RecordCacheReadTokens(provider, policyID, tokens)
+}
+
+func (o MetricsObserver) RecordWallSeconds(provider, policyID string, seconds float64) {
+	o.Metrics.RecordWallSeconds(provider, policyID, seconds)
+}

--- a/server/internal/daemon/transportretry/metrics_regression_test.go
+++ b/server/internal/daemon/transportretry/metrics_regression_test.go
@@ -1,0 +1,131 @@
+package transportretry
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func attemptCounter(m *Metrics, provider, policyID, sessionMode, outcome string) prometheus.Counter {
+	return m.attemptTotal.WithLabelValues(
+		normalizeProvider(provider),
+		normalizePolicy(policyID),
+		normalizeSessionMode(sessionMode),
+		normalizeOutcome(outcome),
+	)
+}
+
+func TestMetricsSkippedToolsOutcomeIncrements(t *testing.T) {
+	t.Parallel()
+
+	m := NewMetricsForTest(nil)
+	cfg := DefaultConfig()
+	cfg.Policies = []Policy{cfg.Policies[0]}
+	failErr := "WritableIterable is closed (result_seen=false)"
+	var calls atomic.Int32
+	execute := func(_ string, _ ExecOptionsView) (ResultView, int32, error) {
+		calls.Add(1)
+		return ResultView{Status: "failed", Error: failErr}, 1, nil
+	}
+
+	_, _, _, _, err := ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		RetryHooks{},
+		MetricsObserver{Metrics: m},
+		slog.Default(),
+		execute,
+		"prompt",
+		ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if got := testutil.ToFloat64(attemptCounter(m, "cursor", "cursor_writable_iterable", "", "skipped_tools")); got != 1 {
+		t.Fatalf("skipped_tools counter = %v, want 1", got)
+	}
+}
+
+func TestMetricsSkippedDisabledOutcomeIncrements(t *testing.T) {
+	t.Parallel()
+
+	m := NewMetricsForTest(nil)
+	cfg := Config{Enabled: false}
+	var calls atomic.Int32
+	execute := func(_ string, _ ExecOptionsView) (ResultView, int32, error) {
+		calls.Add(1)
+		return ResultView{Status: "failed", Error: "WritableIterable is closed"}, 0, nil
+	}
+
+	_, _, _, _, err := ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		RetryHooks{},
+		MetricsObserver{Metrics: m},
+		slog.Default(),
+		execute,
+		"prompt",
+		ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if got := testutil.ToFloat64(attemptCounter(m, "cursor", "", "", "skipped_disabled")); got != 1 {
+		t.Fatalf("skipped_disabled counter = %v, want 1", got)
+	}
+}
+
+func TestExecuteWithRetryDefaultDelayBeforeFreshSession(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Policies = []Policy{cfg.Policies[0]}
+
+	failErr := "WritableIterable is closed (result_seen=false)"
+	var calls atomic.Int32
+	execute := func(_ string, _ ExecOptionsView) (ResultView, int32, error) {
+		calls.Add(1)
+		return ResultView{Status: "failed", Error: failErr, SessionID: "sess-1"}, 0, nil
+	}
+
+	start := time.Now()
+	_, _, stats, _, err := ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"sess-prior",
+		RetryHooks{
+			OnFreshSession: func(view *ExecOptionsView) (string, string) {
+				view.ResumeSessionID = ""
+				return "fresh-prompt", "sess-prior"
+			},
+		},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		ExecOptionsView{ResumeSessionID: "sess-prior"},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if calls.Load() != 4 {
+		t.Fatalf("calls = %d, want 4 launches before exhaustion", calls.Load())
+	}
+	elapsed := time.Since(start)
+	if elapsed < 4900*time.Millisecond {
+		t.Fatalf("elapsed = %v, want at least 5s delay before fresh_session launch", elapsed)
+	}
+	if got := stats.SessionModes[2]; got != SessionRetryFresh {
+		t.Fatalf("session_modes[2] = %q, want fresh_session", got)
+	}
+}

--- a/server/internal/daemon/transportretry/policy.go
+++ b/server/internal/daemon/transportretry/policy.go
@@ -64,7 +64,7 @@ func DefaultPolicies() []Policy {
 			Providers:        []string{"cursor"},
 			MatchError:       matchCursorWritableIterable,
 			MaxExtraAttempts: 2,
-			DelaysMs: []int{0, 0, 0, 5000},
+			DelaysMs: []int{0, 0, 5000},
 			SessionStrategy: []SessionRetryMode{
 				SessionRetrySame,
 				SessionRetrySame,

--- a/server/internal/daemon/transportretry/policy.go
+++ b/server/internal/daemon/transportretry/policy.go
@@ -1,0 +1,224 @@
+package transportretry
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// Policy describes a provider-agnostic transport-layer retry ladder.
+type Policy struct {
+	ID              string
+	Providers       []string
+	MatchError      func(err string) bool
+	MaxExtraAttempts int
+	DelaysMs        []int
+	SessionStrategy []SessionRetryMode
+	Enabled         bool
+}
+
+// Config is the layered transport-retry configuration (defaults overridden by file/env).
+type Config struct {
+	Enabled            bool
+	Policies           []Policy
+	MaxRetryWallClockS int
+}
+
+// PolicyOverride is the JSON shape for workspace/runtime/agent overrides.
+type PolicyOverride struct {
+	ID               string             `json:"id"`
+	Enabled          *bool              `json:"enabled,omitempty"`
+	MaxExtraAttempts *int               `json:"max_extra_attempts,omitempty"`
+	DelaysMs         []int              `json:"delays_ms,omitempty"`
+	SessionStrategy  []SessionRetryMode `json:"session_strategy,omitempty"`
+}
+
+// FileConfig is the JSON document for transport_retry settings.
+type FileConfig struct {
+	Enabled            *bool            `json:"enabled,omitempty"`
+	MaxRetryWallClockS *int             `json:"max_retry_wall_clock_s,omitempty"`
+	Policies           []PolicyOverride `json:"policies,omitempty"`
+}
+
+func matchCursorWritableIterable(err string) bool {
+	lower := strings.ToLower(err)
+	if strings.Contains(lower, "writableiterable is closed") {
+		return true
+	}
+	if strings.Contains(lower, "retriableerror") && strings.Contains(lower, "result_seen=false") {
+		return true
+	}
+	return false
+}
+
+func matchStreamConnectionClosed(err string) bool {
+	lower := strings.ToLower(err)
+	return strings.Contains(lower, "connection closed") || strings.Contains(lower, "mid-response")
+}
+
+// DefaultPolicies returns built-in transport retry policies.
+func DefaultPolicies() []Policy {
+	return []Policy{
+		{
+			ID:               "cursor_writable_iterable",
+			Providers:        []string{"cursor"},
+			MatchError:       matchCursorWritableIterable,
+			MaxExtraAttempts: 2,
+			DelaysMs: []int{0, 0, 0, 5000},
+			SessionStrategy: []SessionRetryMode{
+				SessionRetrySame,
+				SessionRetrySame,
+				SessionRetryFresh,
+			},
+			Enabled: true,
+		},
+		{
+			ID:               "stream_connection_closed",
+			Providers:        []string{"claude", "cursor"},
+			MatchError:       matchStreamConnectionClosed,
+			MaxExtraAttempts: 1,
+			DelaysMs:         []int{0, 0},
+			SessionStrategy: []SessionRetryMode{
+				SessionRetrySame,
+				SessionRetrySame,
+			},
+			Enabled: true,
+		},
+	}
+}
+
+// DefaultConfig returns enabled defaults.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:  true,
+		Policies: DefaultPolicies(),
+	}
+}
+
+// LoadConfig merges built-in defaults with optional JSON from MULTICA_TRANSPORT_RETRY_CONFIG.
+func LoadConfig() Config {
+	cfg := DefaultConfig()
+	raw := strings.TrimSpace(os.Getenv("MULTICA_TRANSPORT_RETRY_CONFIG"))
+	if raw == "" {
+		return cfg
+	}
+	return MergeConfigJSON(cfg, raw)
+}
+
+// MergeConfigJSON overlays a JSON transport-retry document onto cfg.
+func MergeConfigJSON(cfg Config, raw string) Config {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return cfg
+	}
+	var file FileConfig
+	if err := json.Unmarshal([]byte(raw), &file); err != nil {
+		return cfg
+	}
+	if file.Enabled != nil {
+		cfg.Enabled = *file.Enabled
+	}
+	if file.MaxRetryWallClockS != nil {
+		cfg.MaxRetryWallClockS = *file.MaxRetryWallClockS
+	}
+	if len(file.Policies) > 0 {
+		applyPolicyOverrides(&cfg, file.Policies)
+	}
+	return cfg
+}
+
+// ResolveConfig layers daemon env defaults with an optional per-agent override
+// from custom_env (MULTICA_TRANSPORT_RETRY_CONFIG wins over the process env).
+func ResolveConfig(agentCustomEnv map[string]string) Config {
+	cfg := LoadConfig()
+	if agentCustomEnv != nil {
+		if raw := strings.TrimSpace(agentCustomEnv["MULTICA_TRANSPORT_RETRY_CONFIG"]); raw != "" {
+			cfg = MergeConfigJSON(cfg, raw)
+		}
+	}
+	return cfg
+}
+
+func applyPolicyOverrides(cfg *Config, overrides []PolicyOverride) {
+	byID := make(map[string]int, len(cfg.Policies))
+	for i, p := range cfg.Policies {
+		byID[p.ID] = i
+	}
+	for _, o := range overrides {
+		if o.ID == "" {
+			continue
+		}
+		idx, ok := byID[o.ID]
+		if !ok {
+			continue
+		}
+		p := &cfg.Policies[idx]
+		if o.Enabled != nil {
+			p.Enabled = *o.Enabled
+		}
+		if o.MaxExtraAttempts != nil {
+			p.MaxExtraAttempts = *o.MaxExtraAttempts
+		}
+		if len(o.DelaysMs) > 0 {
+			p.DelaysMs = append([]int(nil), o.DelaysMs...)
+		}
+		if len(o.SessionStrategy) > 0 {
+			p.SessionStrategy = append([]SessionRetryMode(nil), o.SessionStrategy...)
+		}
+	}
+}
+
+func policyMatchesProvider(policy Policy, provider string) bool {
+	for _, p := range policy.Providers {
+		if p == "*" || p == provider {
+			return true
+		}
+	}
+	return false
+}
+
+func findPolicy(cfg Config, provider string, errText string) (Policy, bool) {
+	for _, p := range cfg.Policies {
+		if !p.Enabled || p.MatchError == nil {
+			continue
+		}
+		if !policyMatchesProvider(p, provider) {
+			continue
+		}
+		if p.MatchError(errText) {
+			return p, true
+		}
+	}
+	return Policy{}, false
+}
+
+// totalLaunches is the maximum backend launches for a policy. SessionStrategy
+// entries describe the session mode for each retry after a failure; the
+// initial launch is not listed, so budget is 1 + len(SessionStrategy).
+func totalLaunches(policy Policy) int {
+	n := len(policy.SessionStrategy)
+	if n == 0 {
+		return 1 + policy.MaxExtraAttempts
+	}
+	return 1 + n
+}
+
+func delayForLaunch(policy Policy, launchIndex int) int {
+	if launchIndex < len(policy.DelaysMs) {
+		return policy.DelaysMs[launchIndex]
+	}
+	if len(policy.DelaysMs) > 0 {
+		return policy.DelaysMs[len(policy.DelaysMs)-1]
+	}
+	return 0
+}
+
+func sessionModeForLaunch(policy Policy, launchIndex int) SessionRetryMode {
+	if launchIndex < len(policy.SessionStrategy) {
+		return policy.SessionStrategy[launchIndex]
+	}
+	if len(policy.SessionStrategy) > 0 {
+		return policy.SessionStrategy[len(policy.SessionStrategy)-1]
+	}
+	return SessionRetryCold
+}

--- a/server/internal/daemon/transportretry/policy_test.go
+++ b/server/internal/daemon/transportretry/policy_test.go
@@ -1,0 +1,21 @@
+package transportretry
+
+import "testing"
+
+func TestDefaultPolicyDelayLadderBeforeFreshSession(t *testing.T) {
+	t.Parallel()
+
+	policy := DefaultPolicies()[0]
+	if got, want := delayForLaunch(policy, 0), 0; got != want {
+		t.Fatalf("delayForLaunch(index 0) = %d, want %d", got, want)
+	}
+	if got, want := delayForLaunch(policy, 1), 0; got != want {
+		t.Fatalf("delayForLaunch(index 1) = %d, want %d", got, want)
+	}
+	if got, want := delayForLaunch(policy, 2), 5000; got != want {
+		t.Fatalf("delayForLaunch(index 2) = %d, want %d before fresh_session", got, want)
+	}
+	if got, want := sessionModeForLaunch(policy, 2), SessionRetryFresh; got != want {
+		t.Fatalf("sessionModeForLaunch(index 2) = %q, want %q", got, want)
+	}
+}

--- a/server/internal/daemon/transportretry/transportretry_test.go
+++ b/server/internal/daemon/transportretry/transportretry_test.go
@@ -360,8 +360,6 @@ func (o *testObserver) RecordCacheReadTokens(_, _ string, _ int64) {}
 func (o *testObserver) RecordWallSeconds(_, _ string, _ float64) {}
 
 func TestResolveConfigAgentCustomEnvOverridesEnv(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv("MULTICA_TRANSPORT_RETRY_CONFIG", `{"enabled":true}`)
 	cfg := transportretry.ResolveConfig(map[string]string{
 		"MULTICA_TRANSPORT_RETRY_CONFIG": `{"enabled":false}`,

--- a/server/internal/daemon/transportretry/transportretry_test.go
+++ b/server/internal/daemon/transportretry/transportretry_test.go
@@ -368,9 +368,3 @@ func TestResolveConfigAgentCustomEnvOverridesEnv(t *testing.T) {
 		t.Fatal("agent custom_env should override process env")
 	}
 }
-
-func TestMetricsRecordRecovered(t *testing.T) {
-	m := transportretry.GlobalMetrics()
-	m.RecordRecovered("cursor", "cursor_writable_iterable", "same_session")
-	m.RecordAttempt("cursor", "cursor_writable_iterable", "same_session", "recovered")
-}

--- a/server/internal/daemon/transportretry/transportretry_test.go
+++ b/server/internal/daemon/transportretry/transportretry_test.go
@@ -1,0 +1,378 @@
+package transportretry_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/daemon/transportretry"
+)
+
+func TestMatchCursorWritableIterable(t *testing.T) {
+	t.Parallel()
+	err := "RetriableError: WritableIterable is closed (result_seen=false, exit_code=1, scanner_error=false, event_count=428, invalid_event_count=0, last_event_type=thinking)"
+	if !transportretry.DefaultPolicies()[0].MatchError(err) {
+		t.Fatal("expected cursor writable iterable match")
+	}
+}
+
+func TestExecuteWithRetryRecoversOnThirdLaunch(t *testing.T) {
+	t.Parallel()
+
+	cfg := transportretry.DefaultConfig()
+	cfg.Policies = []transportretry.Policy{
+		{
+			ID:               "cursor_writable_iterable",
+			Providers:        []string{"cursor"},
+			MatchError:       transportretry.DefaultPolicies()[0].MatchError,
+			MaxExtraAttempts: 2,
+			DelaysMs:         []int{0, 0, 0},
+			SessionStrategy: []transportretry.SessionRetryMode{
+				transportretry.SessionRetrySame,
+				transportretry.SessionRetrySame,
+				transportretry.SessionRetryFresh,
+			},
+			Enabled: true,
+		},
+	}
+
+	var calls atomic.Int32
+	failErr := "RetriableError: WritableIterable is closed (result_seen=false, exit_code=1, scanner_error=false, event_count=428, invalid_event_count=0, last_event_type=thinking)"
+	execute := func(_ string, opts transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		i := calls.Add(1)
+		if i < 3 {
+			return transportretry.ResultView{
+				Status:    "failed",
+				Error:     failErr,
+				SessionID: "sess-stream",
+			}, 0, nil
+		}
+		return transportretry.ResultView{
+			Status: "completed",
+			Usage: map[string]transportretry.TokenUsageView{
+				"m": {CacheReadTokens: 467},
+			},
+		}, 0, nil
+	}
+
+	result, tools, stats, retired, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		transportretry.RetryHooks{},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed", result.Status)
+	}
+	if tools != 0 {
+		t.Fatalf("tools = %d", tools)
+	}
+	if stats.RecoveredOnAttempt != 3 {
+		t.Fatalf("recovered_on_attempt = %d, want 3", stats.RecoveredOnAttempt)
+	}
+	if stats.CacheReadTokensRecovered != 467 {
+		t.Fatalf("cache_read_tokens_recovered = %d, want 467", stats.CacheReadTokensRecovered)
+	}
+	if stats.SurfacedToServer {
+		t.Fatal("surfaced_to_server should be false when recovered")
+	}
+	if retired != "" {
+		t.Fatalf("retired = %q, want empty", retired)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("calls = %d, want 3", calls.Load())
+	}
+}
+
+func TestExecuteWithRetrySkipsWhenToolsUsed(t *testing.T) {
+	t.Parallel()
+
+	cfg := transportretry.DefaultConfig()
+	cfg.Policies = []transportretry.Policy{cfg.Policies[0]}
+	failErr := "WritableIterable is closed (result_seen=false)"
+	var calls atomic.Int32
+	execute := func(_ string, _ transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		calls.Add(1)
+		return transportretry.ResultView{Status: "failed", Error: failErr}, 1, nil
+	}
+
+	_, _, stats, _, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		transportretry.RetryHooks{},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+	if !stats.SurfacedToServer {
+		t.Fatal("expected surfaced_to_server when tools > 0")
+	}
+}
+
+func TestExecuteWithRetryDisabledMatchesProduction(t *testing.T) {
+	t.Parallel()
+
+	cfg := transportretry.Config{Enabled: false}
+	var calls atomic.Int32
+	execute := func(_ string, _ transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		calls.Add(1)
+		return transportretry.ResultView{Status: "failed", Error: "WritableIterable is closed"}, 0, nil
+	}
+
+	_, _, stats, _, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		transportretry.RetryHooks{},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+	if stats.Attempts != 0 && stats.PolicyID != "" {
+		t.Fatalf("unexpected stats when disabled: %+v", stats)
+	}
+}
+
+func TestExecuteWithRetryStubPolicyNotBoundToCursor(t *testing.T) {
+	t.Parallel()
+
+	cfg := transportretry.Config{
+		Enabled: true,
+		Policies: []transportretry.Policy{
+			{
+				ID:               "stub_transport",
+				Providers:        []string{"stub"},
+				MatchError:       func(err string) bool { return strings.Contains(err, "stub-transport-fail") },
+				MaxExtraAttempts: 1,
+				DelaysMs:         []int{0, 0},
+				SessionStrategy:  []transportretry.SessionRetryMode{transportretry.SessionRetrySame, transportretry.SessionRetrySame},
+				Enabled:          true,
+			},
+		},
+	}
+
+	var calls atomic.Int32
+	execute := func(_ string, opts transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return transportretry.ResultView{Status: "failed", Error: "stub-transport-fail", SessionID: "sess-1"}, 0, nil
+		}
+		if opts.ResumeSessionID != "sess-1" {
+			t.Fatalf("resume = %q, want sess-1", opts.ResumeSessionID)
+		}
+		return transportretry.ResultView{Status: "completed"}, 0, nil
+	}
+
+	result, _, stats, _, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"stub",
+		"",
+		transportretry.RetryHooks{},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q", result.Status)
+	}
+	if stats.PolicyID != "stub_transport" {
+		t.Fatalf("policy = %q", stats.PolicyID)
+	}
+}
+
+func TestExecuteWithRetrySameSessionUsesStreamSessionID(t *testing.T) {
+	t.Parallel()
+
+	cfg := transportretry.Config{
+		Enabled: true,
+		Policies: []transportretry.Policy{
+			{
+				ID:               "cursor_writable_iterable",
+				Providers:        []string{"cursor"},
+				MatchError:       transportretry.DefaultPolicies()[0].MatchError,
+				MaxExtraAttempts: 1,
+				DelaysMs:         []int{0, 0},
+				SessionStrategy: []transportretry.SessionRetryMode{
+					transportretry.SessionRetrySame,
+					transportretry.SessionRetrySame,
+				},
+				Enabled: true,
+			},
+		},
+	}
+
+	failErr := "WritableIterable is closed (result_seen=false)"
+	var calls atomic.Int32
+	execute := func(_ string, opts transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return transportretry.ResultView{
+				Status:    "failed",
+				Error:     failErr,
+				SessionID: "sess-from-stream",
+			}, 0, nil
+		}
+		if opts.ResumeSessionID != "sess-from-stream" {
+			t.Fatalf("resume session = %q, want sess-from-stream", opts.ResumeSessionID)
+		}
+		return transportretry.ResultView{Status: "completed"}, 0, nil
+	}
+
+	result, _, _, _, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"",
+		transportretry.RetryHooks{},
+		nil,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q", result.Status)
+	}
+}
+
+func TestExecuteWithRetryExhaustedAfterFreshSession(t *testing.T) {
+	t.Parallel()
+
+	failErr := "WritableIterable is closed (result_seen=false)"
+	cfg := transportretry.Config{
+		Enabled: true,
+		Policies: []transportretry.Policy{
+			{
+				ID:               "cursor_writable_iterable",
+				Providers:        []string{"cursor"},
+				MatchError:       transportretry.DefaultPolicies()[0].MatchError,
+				MaxExtraAttempts: 2,
+				DelaysMs:         []int{0, 0, 0, 0},
+				SessionStrategy: []transportretry.SessionRetryMode{
+					transportretry.SessionRetrySame,
+					transportretry.SessionRetrySame,
+					transportretry.SessionRetryFresh,
+				},
+				Enabled: true,
+			},
+		},
+	}
+
+	var calls atomic.Int32
+	execute := func(_ string, _ transportretry.ExecOptionsView) (transportretry.ResultView, int32, error) {
+		calls.Add(1)
+		return transportretry.ResultView{Status: "failed", Error: failErr, SessionID: "sess-1"}, 0, nil
+	}
+
+	recorder := &testObserver{}
+	_, _, stats, _, err := transportretry.ExecuteWithRetry(
+		context.Background(),
+		cfg,
+		"cursor",
+		"sess-prior",
+		transportretry.RetryHooks{
+			OnFreshSession: func(view *transportretry.ExecOptionsView) (string, string) {
+				view.ResumeSessionID = ""
+				return "fresh-prompt", "sess-prior"
+			},
+		},
+		recorder,
+		slog.Default(),
+		execute,
+		"prompt",
+		transportretry.ExecOptionsView{ResumeSessionID: "sess-prior"},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithRetry: %v", err)
+	}
+	if calls.Load() != 4 {
+		t.Fatalf("calls = %d, want 4 launches before exhaustion", calls.Load())
+	}
+	if !stats.SurfacedToServer {
+		t.Fatal("expected surfaced_to_server=true after exhausting fresh_session")
+	}
+	if stats.Attempts != 4 {
+		t.Fatalf("attempts = %d, want 4", stats.Attempts)
+	}
+	if !recorder.exhausted {
+		t.Fatal("expected exhausted outcome metric")
+	}
+	modes := []string{stats.SessionModes[0].String(), stats.SessionModes[1].String(), stats.SessionModes[2].String()}
+	wantModes := []string{"same_session", "same_session", "fresh_session"}
+	for i := range wantModes {
+		if modes[i] != wantModes[i] {
+			t.Fatalf("session_modes[%d] = %q, want %q", i, modes[i], wantModes[i])
+		}
+	}
+}
+
+type testObserver struct {
+	exhausted bool
+}
+
+func (o *testObserver) RecordAttempt(_, _, _, outcome string) {
+	if outcome == "exhausted" {
+		o.exhausted = true
+	}
+}
+
+func (o *testObserver) RecordRecovered(_, _, _ string) {}
+func (o *testObserver) RecordCacheReadTokens(_, _ string, _ int64) {}
+func (o *testObserver) RecordWallSeconds(_, _ string, _ float64) {}
+
+func TestResolveConfigAgentCustomEnvOverridesEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv("MULTICA_TRANSPORT_RETRY_CONFIG", `{"enabled":true}`)
+	cfg := transportretry.ResolveConfig(map[string]string{
+		"MULTICA_TRANSPORT_RETRY_CONFIG": `{"enabled":false}`,
+	})
+	if cfg.Enabled {
+		t.Fatal("agent custom_env should override process env")
+	}
+}
+
+func TestMetricsRecordRecovered(t *testing.T) {
+	m := transportretry.GlobalMetrics()
+	m.RecordRecovered("cursor", "cursor_writable_iterable", "same_session")
+	m.RecordAttempt("cursor", "cursor_writable_iterable", "same_session", "recovered")
+}

--- a/server/internal/daemon/transportretry/types.go
+++ b/server/internal/daemon/transportretry/types.go
@@ -1,0 +1,49 @@
+package transportretry
+
+// SessionRetryMode names how the next launch should bind to a provider session.
+type SessionRetryMode string
+
+const (
+	SessionRetrySame  SessionRetryMode = "same_session"
+	SessionRetryFresh SessionRetryMode = "fresh_session"
+	SessionRetryCold  SessionRetryMode = "cold"
+)
+
+// Stats summarizes in-turn transport retries for logging, metrics, and optional receipts.
+type Stats struct {
+	PolicyID                 string             `json:"policy_id,omitempty"`
+	Attempts                 int                `json:"attempts,omitempty"`
+	RecoveredOnAttempt       int                `json:"recovered_on_attempt,omitempty"`
+	SessionModes             []SessionRetryMode `json:"session_modes,omitempty"`
+	CacheReadTokensFirst     int64              `json:"cache_read_tokens_first,omitempty"`
+	CacheReadTokensRecovered int64              `json:"cache_read_tokens_recovered,omitempty"`
+	SurfacedToServer         bool               `json:"surfaced_to_server,omitempty"`
+	ExtraWallSeconds         float64            `json:"extra_wall_seconds,omitempty"`
+}
+
+// ExecuteFunc runs one backend launch and drain cycle.
+type ExecuteFunc func(prompt string, opts ExecOptionsView) (ResultView, int32, error)
+
+// ExecOptionsView is the slice of agent.ExecOptions the retry executor mutates.
+type ExecOptionsView struct {
+	ResumeSessionID string
+}
+
+// ResultView is the slice of agent.Result the retry executor reads.
+type ResultView struct {
+	Status    string
+	Output    string
+	Error     string
+	SessionID string
+	Usage     map[string]TokenUsageView
+}
+
+// TokenUsageView carries token fields used for cache-read verification.
+type TokenUsageView struct {
+	CacheReadTokens int64
+}
+
+// RetryHooks supplies daemon-specific fresh-session recovery.
+type RetryHooks struct {
+	OnFreshSession func(opts *ExecOptionsView) (newPrompt string, retiredSessionID string)
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -274,4 +274,6 @@ type TaskResult struct {
 	// precisely when the abandoned id would otherwise stay selectable.
 	RetiredSessionID string           `json:"-"`
 	Usage            []TaskUsageEntry `json:"usage,omitempty"` // per-model token usage
+	// TransportRetryReceipt is optional daemon-local JSON persisted in .gc_meta.json.
+	TransportRetryReceipt json.RawMessage `json:"-"`
 }

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -190,10 +190,16 @@ func Classify(rawError string) Reason {
 	//    matching rule 13 by accident) and agent_error.unknown respectively;
 	//    neither is on the retry allowlist, so a transient cut ended the task
 	//    outright and max_attempts never applied (#6522).
-	//    Mirror these substrings into the MUL-1949 offline backfill SQL.
+	//    "writableiterable is closed" is cursor-agent's RetriableError when its
+	//    stream-json thinking pipeline closes the async iterable while deltas
+	//    are still being written. The CLI labels it retriable and a manual
+	//    re-run usually succeeds; without this entry the trailing "exit status
+	//    1" lands in process_failure, which is not on the retry allowlist.
+	//    Mirror this substring into the MUL-1949 offline backfill SQL.
 	case containsAny(lower,
 		"stream disconnected",
 		opencodeStreamEndedPrefix,
+		cursorWritableIterableClosedWitness,
 		"connection closed",
 		"mid-response",
 		"error sending request",
@@ -339,6 +345,11 @@ var legacyContextOverflowReasons = map[string]bool{
 // its presence identifies the failure outright.
 const opencodeStreamEndedPrefix = "opencode stream ended"
 
+// cursorWritableIterableClosedWitness is the exact stderr phrase cursor-agent
+// emits when its stream-json serializer closes while thinking deltas are still
+// in flight. Matched case-insensitively like every other Classify substring.
+const cursorWritableIterableClosedWitness = "writableiterable is closed"
+
 // legacyOpencodeStreamEndedReasons are the buckets a daemon predating rule 7's
 // entry lands these errors in: process_failure for the two "terminal signal"
 // variants, whose word "signal" its rule 13 matches by accident, unknown for
@@ -351,6 +362,16 @@ const opencodeStreamEndedPrefix = "opencode stream ended"
 // old bucket cannot be describing some other, better-identified cause — it is
 // the same failure under a label that predates knowing what it was.
 var legacyOpencodeStreamEndedReasons = map[string]bool{
+	string(ReasonAgentProcessFailure): true,
+	string(ReasonAgentUnknown):        true,
+	"agent_error":                     true,
+}
+
+// legacyCursorWritableIterableReasons are the buckets a daemon predating rule
+// 7's cursor entry lands these errors in: process_failure from rule 13's
+// "exit status" match, unknown for anything its rules miss, and the pre-MUL-1949
+// coarse agent_error. The witness is cursor-agent's own RetriableError text.
+var legacyCursorWritableIterableReasons = map[string]bool{
 	string(ReasonAgentProcessFailure): true,
 	string(ReasonAgentUnknown):        true,
 	"agent_error":                     true,
@@ -398,6 +419,10 @@ func NormalizeDaemonReason(reason, rawError string) Reason {
 	// deploys, without waiting on the daemon fleet.
 	if legacyOpencodeStreamEndedReasons[reason] &&
 		strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawError)), opencodeStreamEndedPrefix) {
+		return ReasonAgentProviderNetwork
+	}
+	if legacyCursorWritableIterableReasons[reason] &&
+		strings.Contains(strings.ToLower(rawError), cursorWritableIterableClosedWitness) {
 		return ReasonAgentProviderNetwork
 	}
 	return Reason(reason)

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -100,6 +100,8 @@ func TestClassifyRules(t *testing.T) {
 		{"stream disconnected", "stream disconnected before completion", ReasonAgentProviderNetwork},
 		{"connection closed mid-response", "API Error: Connection closed mid-response. The response above may be incomplete.", ReasonAgentProviderNetwork},
 		{"connection closed with exit status wins over process failure", "claude exited with error: exit status 1\nAPI Error: Connection closed mid-response.", ReasonAgentProviderNetwork},
+		{"cursor writableiterable with exit status wins over process failure", "cursor-agent exited with error: exit status 1 (result_seen=false, exit_code=1, scanner_error=false, event_count=319, invalid_event_count=0, last_event_type=thinking); actions completed before finalization may already have taken effect; cursor stderr: RetriableError: WritableIterable is closed\nError: command failed unexpectedly.", ReasonAgentProviderNetwork},
+		{"cursor writableiterable stderr alone", "RetriableError: WritableIterable is closed\nError: command failed unexpectedly.", ReasonAgentProviderNetwork},
 		{"error sending request", "error sending request for url (https://api.example.com/v1)", ReasonAgentProviderNetwork},
 		{"unable to connect", "unable to connect to provider", ReasonAgentProviderNetwork},
 		{"dial tcp", "dial tcp 1.2.3.4:443: connect: connection refused", ReasonAgentProviderNetwork},
@@ -416,6 +418,27 @@ func TestNormalizeDaemonReason(t *testing.T) {
 			reason: string(ReasonAgentUnknown),
 			raw:    "API Error: the model is overloaded",
 			want:   ReasonAgentUnknown,
+		},
+
+		// --- cursor-agent WritableIterable: an un-upgraded daemon classifies
+		// the trailing exit status as process_failure, which is not retryable.
+		{
+			name:   "old daemon process_failure on writableiterable is upgraded",
+			reason: string(ReasonAgentProcessFailure),
+			raw:    "cursor-agent exited with error: exit status 1 (result_seen=false, exit_code=1, scanner_error=false, event_count=319, invalid_event_count=0, last_event_type=thinking); cursor stderr: RetriableError: WritableIterable is closed\nError: command failed unexpectedly.",
+			want:   ReasonAgentProviderNetwork,
+		},
+		{
+			name:   "old daemon catchall on writableiterable is upgraded",
+			reason: string(ReasonAgentUnknown),
+			raw:    "RetriableError: WritableIterable is closed\nError: command failed unexpectedly.",
+			want:   ReasonAgentProviderNetwork,
+		},
+		{
+			name:   "current daemon provider_network reason passes through",
+			reason: string(ReasonAgentProviderNetwork),
+			raw:    "cursor-agent exited with error: exit status 1; cursor stderr: RetriableError: WritableIterable is closed",
+			want:   ReasonAgentProviderNetwork,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add regression tests asserting `skipped_tools` and `skipped_disabled` outcome counters increment on the corresponding executor paths
- Assert the default `[0,0,5000]` delay ladder uses index-2 (5000ms) before `fresh_session`, via unit test (`delayForLaunch`) and an integration timing check
- Introduce `NewMetricsForTest` so Prometheus assertions use an isolated registry

Stacks on #7106 (transport retry feature); merge after or with that PR.

## Test plan
- [x] `go test ./internal/daemon/transportretry/...`


Made with [Cursor](https://cursor.com)