### PR TITLE
MUL-5879: fix(agent): surface every in-flight built-in Hermes tool call

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -377,10 +377,11 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	activity := make(chan struct{}, 1)
 
 	c := &hermesClient{
-		cfg:          b.cfg,
-		stdin:        stdin,
-		pending:      make(map[int]*pendingRPC),
-		pendingTools: make(map[string]*pendingToolCall),
+		cfg:                        b.cfg,
+		stdin:                      stdin,
+		pending:                    make(map[int]*pendingRPC),
+		pendingTools:               make(map[string]*pendingToolCall),
+		toolStartCarriesFinalInput: true,
 		acceptNotification: func(string) bool {
 			return streamingCurrentTurn.Load()
 		},
@@ -892,6 +893,19 @@ type hermesClient struct {
 	// acceptNotification can drop ACP session updates before dispatching to
 	// handlers that mutate client state such as usage or pending tool calls.
 	acceptNotification func(updateType string) bool
+	// toolStartCarriesFinalInput marks a dialect whose tool_call start frame is
+	// the only place a call's input ever appears, so MessageToolUse can be
+	// emitted as soon as the call starts instead of being held until it
+	// completes. Hermes sets it: it attaches rawInput on the start frame for
+	// ordinary tools, deliberately omits it for its "polished" tool set, and
+	// never sends rawInput on an update (acp_adapter/tools.py — build_tool_call
+	// passes `raw_input=None if tool_name in _POLISHED_TOOLS else arguments`,
+	// and build_tool_complete passes none at all). Waiting therefore cannot
+	// yield more input, and only costs the run its in-flight visibility.
+	//
+	// Other backends leave it false and keep deferring — Kimi streams its args
+	// across updates, so for it the start frame is genuinely incomplete.
+	toolStartCarriesFinalInput bool
 
 	// pendingTools buffers the args for tool calls whose input streams in
 	// across multiple ACP tool_call_update messages (kimi does this —
@@ -1573,12 +1587,21 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 	// AgentToolWatchdog and is judged by the much shorter AgentIdleWatchdog
 	// instead, so a legitimately long tool call is force-stopped early.
 	//
-	// It is only safe where the content demonstrably IS the invocation, which
-	// ACP does not promise in general — see acpToolCallStartCarriesInvocation.
-	if acpToolCallStartCarriesInvocation(toolName, argsText) {
+	// Only a dialect that will never send input later can do this without
+	// losing the input — see toolStartCarriesFinalInput.
+	if c.toolStartCarriesFinalInput {
+		// The content blocks are display output, not input, so they are used as
+		// Input only for the one shape that demonstrably IS the invocation.
+		// Everything else reports no input rather than passing a rendering
+		// ("Preparing write to <path>") off as the call's arguments.
+		var input map[string]any
+		if acpToolCallStartCarriesInvocation(toolName, argsText) {
+			input = parseToolArgsJSON(argsText)
+		}
 		c.trackTool(msg.ToolCallID, &pendingToolCall{
 			toolName: toolName,
 			argsText: argsText,
+			input:    input,
 			emitted:  true,
 		})
 		if c.onMessage != nil {
@@ -1586,7 +1609,7 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 				Type:   MessageToolUse,
 				Tool:   toolName,
 				CallID: msg.ToolCallID,
-				Input:  parseToolArgsJSON(argsText),
+				Input:  input,
 			})
 		}
 		return
@@ -1604,23 +1627,17 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 }
 
 // acpToolCallStartCarriesInvocation reports whether a tool_call start frame's
-// content can be treated as the call's input, which is the only case where
-// MessageToolUse may be emitted before the call completes.
+// content can be reported as the call's input rather than as display output.
 //
 // It deliberately recognises exactly one shape: a `terminal` call whose content
 // is the `$ <command>` line. In ACP, `content` is display output produced by the
-// tool call and `rawInput` is the input, and a later update may still supply the
-// real rawInput — so treating arbitrary content as input would both mis-record
-// the invocation and freeze the wrong value before the real one arrives. Hermes
-// suppresses rawInput for its whole "polished" tool set and renders each one
-// differently: `terminal` renders `$ <command>` (the invocation), but
-// `write_file` and `patch` render prose like "Preparing write to <path>", and
-// the browser/web/media tools render their own summaries. Only the terminal
-// rendering is the command itself.
-//
-// Nine ACP backends share this client, so everything else — including Kimi's
-// token-streamed args and any backend whose start frame carries a status line —
-// keeps deferring exactly as before.
+// tool call and `rawInput` is the input, so treating arbitrary content as input
+// mis-records the invocation. Hermes suppresses rawInput for its whole
+// "polished" tool set and renders each one differently: `terminal` renders
+// `$ <command>` (the invocation), but `write_file` and `patch` render prose like
+// "Preparing write to <path>", and the browser/web/media tools render their own
+// summaries. Only the terminal rendering is the command itself; the rest report
+// no input at all.
 func acpToolCallStartCarriesInvocation(toolName, argsText string) bool {
 	if toolName != "terminal" {
 		return false

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -381,7 +381,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		stdin:                      stdin,
 		pending:                    make(map[int]*pendingRPC),
 		pendingTools:               make(map[string]*pendingToolCall),
-		toolStartCarriesFinalInput: true,
+		toolStartCarriesFinalInput: b.cfg.BuiltinRuntime,
 		acceptNotification: func(string) bool {
 			return streamingCurrentTurn.Load()
 		},
@@ -896,15 +896,22 @@ type hermesClient struct {
 	// toolStartCarriesFinalInput marks a dialect whose tool_call start frame is
 	// the only place a call's input ever appears, so MessageToolUse can be
 	// emitted as soon as the call starts instead of being held until it
-	// completes. Hermes sets it: it attaches rawInput on the start frame for
-	// ordinary tools, deliberately omits it for its "polished" tool set, and
-	// never sends rawInput on an update (acp_adapter/tools.py — build_tool_call
-	// passes `raw_input=None if tool_name in _POLISHED_TOOLS else arguments`,
-	// and build_tool_complete passes none at all). Waiting therefore cannot
-	// yield more input, and only costs the run its in-flight visibility.
+	// completes. Waiting cannot yield more input for such a dialect, and only
+	// costs the run its in-flight visibility.
 	//
-	// Other backends leave it false and keep deferring — Kimi streams its args
-	// across updates, so for it the start frame is genuinely incomplete.
+	// It is a vendor-verified compatibility exception, so the hermes backend
+	// scopes it to Config.BuiltinRuntime the same way
+	// acpToleratesOmittedMcpCapabilities does: `protocol_family: hermes` with
+	// `command_name: jcode` reaches this backend as "hermes" while being an
+	// unrelated implementation, and only the real Hermes Agent binary is known
+	// to behave this way — acp_adapter/tools.py's build_tool_call passes
+	// `raw_input=None if tool_name in _POLISHED_TOOLS else arguments`, and
+	// build_tool_complete passes none at all. Unset means deferring, so a
+	// custom hermes-family runtime that supplies rawInput on a later update
+	// still has it recorded.
+	//
+	// Other backends leave it false too — Kimi streams its args across updates,
+	// so for it the start frame is genuinely incomplete.
 	toolStartCarriesFinalInput bool
 
 	// pendingTools buffers the args for tool calls whose input streams in

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1562,20 +1562,20 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 		return
 	}
 
-	// No rawInput: the args, if any, live in the content blocks. Whether we
-	// can emit now depends on whether those args are already complete.
+	// No rawInput: whatever the start frame carries is in the content blocks.
 	argsText := extractACPToolCallText(msg.Content)
 
-	// Hermes puts the whole invocation in the start frame's content (its
-	// terminal tool sends `$ <command>` and never streams more), so deferring
-	// buys nothing and costs the run its only evidence that a tool is running:
-	// nothing at all is emitted until tool_call_update completes. A tool that
-	// stalls then renders as a blank run with no visible tool call — the
+	// Emitting at the start frame is what makes an in-flight tool visible at
+	// all: nothing is otherwise emitted until tool_call_update completes, so a
+	// tool that stalls renders as a blank run with no visible tool call — the
 	// symptom in GH#6583 — and, because the daemon's in-flight tool counter
 	// only advances on MessageToolUse, such a call never gets charged to
 	// AgentToolWatchdog and is judged by the much shorter AgentIdleWatchdog
 	// instead, so a legitimately long tool call is force-stopped early.
-	if acpToolCallArgsSettled(argsText) {
+	//
+	// It is only safe where the content demonstrably IS the invocation, which
+	// ACP does not promise in general — see acpToolCallStartCarriesInvocation.
+	if acpToolCallStartCarriesInvocation(toolName, argsText) {
 		c.trackTool(msg.ToolCallID, &pendingToolCall{
 			toolName: toolName,
 			argsText: argsText,
@@ -1603,31 +1603,29 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 	})
 }
 
-// acpToolCallArgsSettled reports whether a tool_call start frame's content
-// already carries the complete tool arguments, so MessageToolUse can be emitted
-// immediately instead of being held until the call completes.
+// acpToolCallStartCarriesInvocation reports whether a tool_call start frame's
+// content can be treated as the call's input, which is the only case where
+// MessageToolUse may be emitted before the call completes.
 //
-// The discriminator is the shape of the text, not the backend, because all nine
-// ACP backends share this client and each may change independently. Kimi streams
-// its args as a JSON object built up token by token, so a mid-stream fragment is
-// always an *unterminated* JSON object or array (`{"comm`). Everything else is
-// as complete as it will ever be: a whole JSON object, or plain text like
-// Hermes' `$ ls -la`. Empty content carries nothing to show and stays deferred.
+// It deliberately recognises exactly one shape: a `terminal` call whose content
+// is the `$ <command>` line. In ACP, `content` is display output produced by the
+// tool call and `rawInput` is the input, and a later update may still supply the
+// real rawInput — so treating arbitrary content as input would both mis-record
+// the invocation and freeze the wrong value before the real one arrives. Hermes
+// suppresses rawInput for its whole "polished" tool set and renders each one
+// differently: `terminal` renders `$ <command>` (the invocation), but
+// `write_file` and `patch` render prose like "Preparing write to <path>", and
+// the browser/web/media tools render their own summaries. Only the terminal
+// rendering is the command itself.
 //
-// Emitting early does not change what the UI renders — parseToolArgsJSON turns
-// the same text into the same Input map the deferred path would have produced at
-// completion time — it only changes when it appears.
-func acpToolCallArgsSettled(argsText string) bool {
-	trimmed := strings.TrimSpace(argsText)
-	if trimmed == "" {
+// Nine ACP backends share this client, so everything else — including Kimi's
+// token-streamed args and any backend whose start frame carries a status line —
+// keeps deferring exactly as before.
+func acpToolCallStartCarriesInvocation(toolName, argsText string) bool {
+	if toolName != "terminal" {
 		return false
 	}
-	// Only a JSON object/array can be a partially-streamed fragment; treat it
-	// as settled once it parses as a complete value.
-	if trimmed[0] == '{' || trimmed[0] == '[' {
-		return json.Valid([]byte(trimmed))
-	}
-	return true
+	return strings.HasPrefix(strings.TrimSpace(argsText), "$ ")
 }
 
 func (c *hermesClient) handleToolCallUpdate(data json.RawMessage) {
@@ -1757,7 +1755,16 @@ func (c *hermesClient) emitDeferredToolUse(
 		input = p.input
 	case p != nil:
 		toolName = p.toolName
-		input = parseToolArgsJSON(p.argsText)
+		// A rawInput on the update is the call's actual input, so it wins over
+		// whatever the start frame rendered into content. ACP lets a start
+		// frame carry only display text ("Preparing write to <path>") and
+		// supply rawInput later; without this the display text would be
+		// recorded as the invocation and the real input silently dropped.
+		if updateRawInput != nil {
+			input = updateRawInput
+		} else {
+			input = parseToolArgsJSON(p.argsText)
+		}
 	default:
 		// No record of the start frame — fall back to the update's own
 		// title/kind/rawInput so the UI at least sees the tool name.

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1562,15 +1562,72 @@ func (c *hermesClient) handleToolCallStart(data json.RawMessage) {
 		return
 	}
 
+	// No rawInput: the args, if any, live in the content blocks. Whether we
+	// can emit now depends on whether those args are already complete.
+	argsText := extractACPToolCallText(msg.Content)
+
+	// Hermes puts the whole invocation in the start frame's content (its
+	// terminal tool sends `$ <command>` and never streams more), so deferring
+	// buys nothing and costs the run its only evidence that a tool is running:
+	// nothing at all is emitted until tool_call_update completes. A tool that
+	// stalls then renders as a blank run with no visible tool call — the
+	// symptom in GH#6583 — and, because the daemon's in-flight tool counter
+	// only advances on MessageToolUse, such a call never gets charged to
+	// AgentToolWatchdog and is judged by the much shorter AgentIdleWatchdog
+	// instead, so a legitimately long tool call is force-stopped early.
+	if acpToolCallArgsSettled(argsText) {
+		c.trackTool(msg.ToolCallID, &pendingToolCall{
+			toolName: toolName,
+			argsText: argsText,
+			emitted:  true,
+		})
+		if c.onMessage != nil {
+			c.onMessage(Message{
+				Type:   MessageToolUse,
+				Tool:   toolName,
+				CallID: msg.ToolCallID,
+				Input:  parseToolArgsJSON(argsText),
+			})
+		}
+		return
+	}
+
 	// Kimi streams args token-by-token across tool_call_update messages;
 	// the initial tool_call often carries an empty content block. Buffer
 	// the tool and defer MessageToolUse emission to avoid the UI seeing
 	// a command with `{""` as its input.
 	c.trackTool(msg.ToolCallID, &pendingToolCall{
 		toolName: toolName,
-		argsText: extractACPToolCallText(msg.Content),
+		argsText: argsText,
 		emitted:  false,
 	})
+}
+
+// acpToolCallArgsSettled reports whether a tool_call start frame's content
+// already carries the complete tool arguments, so MessageToolUse can be emitted
+// immediately instead of being held until the call completes.
+//
+// The discriminator is the shape of the text, not the backend, because all nine
+// ACP backends share this client and each may change independently. Kimi streams
+// its args as a JSON object built up token by token, so a mid-stream fragment is
+// always an *unterminated* JSON object or array (`{"comm`). Everything else is
+// as complete as it will ever be: a whole JSON object, or plain text like
+// Hermes' `$ ls -la`. Empty content carries nothing to show and stays deferred.
+//
+// Emitting early does not change what the UI renders — parseToolArgsJSON turns
+// the same text into the same Input map the deferred path would have produced at
+// completion time — it only changes when it appears.
+func acpToolCallArgsSettled(argsText string) bool {
+	trimmed := strings.TrimSpace(argsText)
+	if trimmed == "" {
+		return false
+	}
+	// Only a JSON object/array can be a partially-streamed fragment; treat it
+	// as settled once it parses as a complete value.
+	if trimmed[0] == '{' || trimmed[0] == '[' {
+		return json.Valid([]byte(trimmed))
+	}
+	return true
 }
 
 func (c *hermesClient) handleToolCallUpdate(data json.RawMessage) {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -4064,29 +4064,98 @@ func TestHermesClientDefersToolUseForPartialStreamedArgs(t *testing.T) {
 	}
 }
 
-func TestACPToolCallArgsSettled(t *testing.T) {
+func TestACPToolCallStartCarriesInvocation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
+		toolName string
 		argsText string
 		want     bool
 	}{
-		{"empty", "", false},
-		{"whitespace only", "   \n ", false},
-		{"partial json object", `{"comm`, false},
-		{"partial json array", `[{"a":1}`, false},
-		{"complete json object", `{"command":"echo hi"}`, true},
-		{"complete json array", `[1,2]`, true},
-		{"hermes shell text", "$ ls -la", true},
-		{"plain text", "not-json", true},
+		{"hermes terminal command", "terminal", "$ ls -la", true},
+		{"hermes terminal with leading space", "terminal", "  $ go build ./...", true},
+		{"terminal but not a command line", "terminal", "Running the command...", false},
+		{"write_file prose", "write_file", "Preparing write to /tmp/a.txt. Approval prompt shows the diff.", false},
+		{"patch prose", "patch", "Preparing replace edit for /tmp/a.txt. Approval prompt shows the diff.", false},
+		{"web_search summary", "web_search", "Searching the web for golang acp", false},
+		{"kimi streamed json", "Shell", `{"command":"echo hi"}`, false},
+		{"kimi partial json", "Shell", `{"comm`, false},
+		{"empty", "terminal", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := acpToolCallArgsSettled(tt.argsText); got != tt.want {
-				t.Errorf("acpToolCallArgsSettled(%q) = %v, want %v", tt.argsText, got, tt.want)
+			if got := acpToolCallStartCarriesInvocation(tt.toolName, tt.argsText); got != tt.want {
+				t.Errorf("acpToolCallStartCarriesInvocation(%q, %q) = %v, want %v",
+					tt.toolName, tt.argsText, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestHermesClientDoesNotFreezeDisplayTextAsInput is the protocol-level guard.
+//
+// ACP defines `content` as display output produced by the tool call and
+// `rawInput` as the input, and a later update may still supply the real
+// rawInput. Hermes itself does this: write_file's start frame renders
+// "Preparing write to <path>..." with no rawInput. That text must never be
+// recorded as the invocation, and a rawInput arriving later must win.
+func TestHermesClientDoesNotFreezeDisplayTextAsInput(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:   make(map[int]*pendingRPC),
+		onMessage: func(msg Message) { got = append(got, msg) },
+	}
+
+	// Start frame: display prose only, no rawInput (verbatim Hermes shape).
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"Preparing write to /tmp/hello.txt. Approval prompt shows the diff.","type":"text"},"type":"content"}],"kind":"edit","locations":[{"path":"/tmp/hello.txt"}],"title":"write: /tmp/hello.txt","toolCallId":"tc-w1","sessionUpdate":"tool_call"}}}`)
+
+	if len(got) != 0 {
+		t.Fatalf("display-only start frame must not emit a tool use, got %+v", got)
+	}
+
+	// Completion carries the real input.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-w1","status":"completed","title":"write: /tmp/hello.txt","kind":"edit","rawInput":{"path":"/tmp/hello.txt","content":"hi"},"content":[{"type":"content","content":{"type":"text","text":"wrote 2 bytes"}}]}}}`)
+
+	if len(got) != 2 || got[0].Type != MessageToolUse || got[1].Type != MessageToolResult {
+		t.Fatalf("expected [ToolUse, ToolResult], got %+v", got)
+	}
+	if path, _ := got[0].Input["path"].(string); path != "/tmp/hello.txt" {
+		t.Errorf("real rawInput must win over display text; Input = %v", got[0].Input)
+	}
+	if text, ok := got[0].Input["text"].(string); ok && strings.Contains(text, "Preparing write") {
+		t.Errorf("display text was frozen as the invocation: %q", text)
+	}
+}
+
+// TestHermesClientDefersNonCommandStartContent: a start frame whose content is
+// not a `$ <command>` line stays deferred even when the text is complete and
+// non-JSON, so a backend that renders a status line cannot have it mistaken for
+// the invocation.
+func TestHermesClientDefersNonCommandStartContent(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:   make(map[int]*pendingRPC),
+		onMessage: func(msg Message) { got = append(got, msg) },
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call","toolCallId":"tc","title":"Shell","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"not-json"}}]}}}`)
+
+	if len(got) != 0 {
+		t.Fatalf("non-command start content must stay deferred, got %+v", got)
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc","status":"completed","content":[{"type":"content","content":{"type":"text","text":"output"}}]}}}`)
+
+	if len(got) != 2 || got[0].Type != MessageToolUse {
+		t.Fatalf("expected [ToolUse, ToolResult], got %+v", got)
+	}
+	if text, _ := got[0].Input["text"].(string); text != "not-json" {
+		t.Errorf("deferred fallback Input.text: got %v", got[0].Input)
 	}
 }

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -3985,3 +3985,108 @@ func TestHermesBackendIgnoresRefusalOnFreshSession(t *testing.T) {
 		t.Error("ResumeRejected = true, want false on a fresh session")
 	}
 }
+
+// TestHermesClientEmitsToolUseWhenStartFrameCarriesCommand pins GH#6583.
+//
+// The tool_call line is a verbatim capture from `hermes acp` (Hermes Agent
+// v0.20.0) driven with this client's own handshake: it carries the full
+// invocation in `content` but no rawInput. Before the fix that combination hit
+// the kimi deferral path, so nothing was emitted until the call completed —
+// an in-flight Hermes tool was invisible in run-messages, and the daemon's
+// in-flight tool counter (which only advances on MessageToolUse) never saw it.
+func TestHermesClientEmitsToolUseWhenStartFrameCarriesCommand(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:   make(map[int]*pendingRPC),
+		onMessage: func(msg Message) { got = append(got, msg) },
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"$ multica issue get 7473e16c --output json","type":"text"},"type":"content"}],"kind":"execute","locations":[],"title":"terminal: multica issue get 7473e16c --output json","toolCallId":"tc-305462f5d67d","sessionUpdate":"tool_call"}}}`)
+
+	if len(got) != 1 {
+		t.Fatalf("expected MessageToolUse on the start frame, got %d: %+v", len(got), got)
+	}
+	if got[0].Type != MessageToolUse {
+		t.Fatalf("type: got %v, want MessageToolUse", got[0].Type)
+	}
+	if got[0].Tool != "terminal" {
+		t.Errorf("tool: got %q, want %q", got[0].Tool, "terminal")
+	}
+	if got[0].CallID != "tc-305462f5d67d" {
+		t.Errorf("callID: got %q", got[0].CallID)
+	}
+	if text, _ := got[0].Input["text"].(string); text != "$ multica issue get 7473e16c --output json" {
+		t.Errorf("input.text: got %v", got[0].Input["text"])
+	}
+
+	// Completion must add only the result — never a second MessageToolUse.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"terminal result\n- **exit_code:** 0","type":"text"},"type":"content"}],"kind":"execute","status":"completed","toolCallId":"tc-305462f5d67d","sessionUpdate":"tool_call_update"}}}`)
+
+	if len(got) != 2 {
+		t.Fatalf("expected [ToolUse, ToolResult], got %d: %+v", len(got), got)
+	}
+	if got[1].Type != MessageToolResult {
+		t.Errorf("second message: got %v, want MessageToolResult", got[1].Type)
+	}
+	if got[1].Status != "completed" {
+		t.Errorf("result status: got %q", got[1].Status)
+	}
+}
+
+// TestHermesClientDefersToolUseForPartialStreamedArgs guards the kimi path the
+// fix above must not regress: a start frame carrying an unterminated JSON
+// fragment is still buffered, so the UI never sees a half-streamed command.
+func TestHermesClientDefersToolUseForPartialStreamedArgs(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:   make(map[int]*pendingRPC),
+		onMessage: func(msg Message) { got = append(got, msg) },
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-kimi","title":"Shell","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"{\"comm"}}]}}}`)
+
+	if len(got) != 0 {
+		t.Fatalf("expected partial args to stay deferred, got %+v", got)
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-kimi","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"{\"command\":\"echo hi\"}"}}]}}}`)
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-kimi","status":"completed","content":[{"type":"content","content":{"type":"text","text":"hi\n"}}]}}}`)
+
+	if len(got) != 2 || got[0].Type != MessageToolUse || got[1].Type != MessageToolResult {
+		t.Fatalf("expected [ToolUse, ToolResult], got %+v", got)
+	}
+	if cmd, _ := got[0].Input["command"].(string); cmd != "echo hi" {
+		t.Errorf("streamed args should be parsed at completion: got %v", got[0].Input)
+	}
+}
+
+func TestACPToolCallArgsSettled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		argsText string
+		want     bool
+	}{
+		{"empty", "", false},
+		{"whitespace only", "   \n ", false},
+		{"partial json object", `{"comm`, false},
+		{"partial json array", `[{"a":1}`, false},
+		{"complete json object", `{"command":"echo hi"}`, true},
+		{"complete json array", `[1,2]`, true},
+		{"hermes shell text", "$ ls -la", true},
+		{"plain text", "not-json", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := acpToolCallArgsSettled(tt.argsText); got != tt.want {
+				t.Errorf("acpToolCallArgsSettled(%q) = %v, want %v", tt.argsText, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -3999,8 +3999,9 @@ func TestHermesClientEmitsToolUseWhenStartFrameCarriesCommand(t *testing.T) {
 
 	var got []Message
 	c := &hermesClient{
-		pending:   make(map[int]*pendingRPC),
-		onMessage: func(msg Message) { got = append(got, msg) },
+		pending:                    make(map[int]*pendingRPC),
+		toolStartCarriesFinalInput: true,
+		onMessage:                  func(msg Message) { got = append(got, msg) },
 	}
 
 	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"$ multica issue get 7473e16c --output json","type":"text"},"type":"content"}],"kind":"execute","locations":[],"title":"terminal: multica issue get 7473e16c --output json","toolCallId":"tc-305462f5d67d","sessionUpdate":"tool_call"}}}`)
@@ -4157,5 +4158,94 @@ func TestHermesClientDefersNonCommandStartContent(t *testing.T) {
 	}
 	if text, _ := got[0].Input["text"].(string); text != "not-json" {
 		t.Errorf("deferred fallback Input.text: got %v", got[0].Input)
+	}
+}
+
+// TestHermesClientEmitsToolUseForPolishedToolWithoutInput covers the rest of
+// GH#6583's defect: Hermes omits rawInput for its whole polished tool set, so
+// write / patch / web / browser / execute_code calls were invisible while
+// running and never advanced the daemon's in-flight tool counter, leaving them
+// on the short idle budget instead of the tool budget.
+//
+// They must now surface at the start frame like terminal does — but with no
+// Input, because their content is a rendering ("Preparing write to <path>"),
+// not the call's arguments.
+func TestHermesClientEmitsToolUseForPolishedToolWithoutInput(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:                    make(map[int]*pendingRPC),
+		toolStartCarriesFinalInput: true,
+		onMessage:                  func(msg Message) { got = append(got, msg) },
+	}
+
+	// Verbatim Hermes write_file start frame: prose content, no rawInput.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"Preparing write to /tmp/hello.txt. Approval prompt shows the diff.","type":"text"},"type":"content"}],"kind":"edit","locations":[{"path":"/tmp/hello.txt"}],"title":"write: /tmp/hello.txt","toolCallId":"tc-w9","sessionUpdate":"tool_call"}}}`)
+
+	if len(got) != 1 || got[0].Type != MessageToolUse {
+		t.Fatalf("expected MessageToolUse at the start frame, got %+v", got)
+	}
+	if got[0].Tool != "write_file" {
+		t.Errorf("tool: got %q, want %q", got[0].Tool, "write_file")
+	}
+	if got[0].CallID != "tc-w9" {
+		t.Errorf("callID: got %q", got[0].CallID)
+	}
+	if got[0].Input != nil {
+		t.Errorf("display prose must not be reported as input, got Input = %v", got[0].Input)
+	}
+
+	// Completion adds only the result — no second MessageToolUse.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-w9","status":"completed","kind":"edit","content":[{"type":"content","content":{"type":"text","text":"wrote 2 bytes"}}]}}}`)
+
+	if len(got) != 2 || got[1].Type != MessageToolResult {
+		t.Fatalf("expected [ToolUse, ToolResult], got %+v", got)
+	}
+	if got[1].Output != "wrote 2 bytes" {
+		t.Errorf("result output: got %q", got[1].Output)
+	}
+}
+
+// TestHermesClientReadFileStartWithNoContentStillVisible: read_file sends a
+// start frame with no content at all. It must still register as an in-flight
+// tool so the run shows it and the daemon counts it.
+func TestHermesClientReadFileStartWithNoContentStillVisible(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:                    make(map[int]*pendingRPC),
+		toolStartCarriesFinalInput: true,
+		onMessage:                  func(msg Message) { got = append(got, msg) },
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"kind":"read","locations":[{"path":"/tmp/a.go"}],"title":"read: /tmp/a.go","toolCallId":"tc-r1","sessionUpdate":"tool_call"}}}`)
+
+	if len(got) != 1 || got[0].Type != MessageToolUse || got[0].Tool != "read_file" {
+		t.Fatalf("expected a read_file MessageToolUse at start, got %+v", got)
+	}
+	if got[0].Input != nil {
+		t.Errorf("expected no fabricated input, got %v", got[0].Input)
+	}
+}
+
+// TestHermesClientOtherDialectsStillDefer: the flag is opt-in, so a backend
+// that has not set it (kimi, kiro, qoder, grok, mcode, qwenpaw, reasonix,
+// traecli) keeps the previous deferred behaviour even for a terminal-shaped
+// frame.
+func TestHermesClientOtherDialectsStillDefer(t *testing.T) {
+	t.Parallel()
+
+	var got []Message
+	c := &hermesClient{
+		pending:   make(map[int]*pendingRPC),
+		onMessage: func(msg Message) { got = append(got, msg) },
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"content":[{"content":{"text":"$ ls -la","type":"text"},"type":"content"}],"kind":"execute","title":"terminal: ls -la","toolCallId":"tc-x","sessionUpdate":"tool_call"}}}`)
+
+	if len(got) != 0 {
+		t.Fatalf("dialects without toolStartCarriesFinalInput must still defer, got %+v", got)
 	}
 }

--- a/server/pkg/agent/hermes_tool_visibility_execute_unix_test.go
+++ b/server/pkg/agent/hermes_tool_visibility_execute_unix_test.go
@@ -1,0 +1,134 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The `hermes` provider covers two kinds of binary: the real Hermes Agent, and
+// any custom runtime profile declaring `protocol_family: hermes` (jcode is the
+// documented example). Only the former is known to put a call's whole input on
+// the tool_call start frame, so toolStartCarriesFinalInput must be scoped to
+// Config.BuiltinRuntime rather than switched on for every hermes-family
+// implementation.
+//
+// These tests drive hermesBackend.Execute — the real construction path — rather
+// than a hand-built client, because the scope leak lives in how the client is
+// constructed, not in how it handles frames.
+
+// hermesToolVisibilityStub answers one turn that runs a single tool whose start
+// frame carries display text and no rawInput, and whose completion frame
+// carries the real rawInput. That is the shape where deferring matters: a
+// dialect wrongly marked "final input at start" records Input=nil and drops the
+// real input when the completion frame arrives.
+const hermesToolVisibilityStub = `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_tv"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_tv","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"write: /tmp/a.txt","kind":"edit","content":[{"type":"content","content":{"type":"text","text":"Preparing write to /tmp/a.txt. Approval prompt shows the diff."}}]}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_tv","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","status":"completed","title":"write: /tmp/a.txt","kind":"edit","rawInput":{"path":"/tmp/a.txt","content":"hi"},"content":[{"type":"content","content":{"type":"text","text":"wrote 2 bytes"}}]}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+
+func runHermesToolVisibilityTurn(t *testing.T, builtin bool) []Message {
+	t.Helper()
+
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "hermes")
+	writeTestExecutable(t, fakePath, []byte(hermesToolVisibilityStub))
+
+	backend, err := New("hermes", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		BuiltinRuntime: builtin,
+	})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "ping", ExecOptions{Timeout: 15 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var tools []Message
+	for msg := range session.Messages {
+		switch msg.Type {
+		case MessageToolUse, MessageToolResult:
+			tools = append(tools, msg)
+		}
+	}
+	if result := <-session.Result; result.Status != "completed" {
+		t.Fatalf("result = %+v, want a completed turn", result)
+	}
+	return tools
+}
+
+// A custom hermes-family runtime (BuiltinRuntime=false) must keep deferring, so
+// the rawInput its completion frame carries is what gets recorded.
+func TestHermesCustomRuntimeDefersToolUseAndKeepsRealInput(t *testing.T) {
+	t.Parallel()
+
+	tools := runHermesToolVisibilityTurn(t, false)
+
+	if len(tools) != 2 {
+		t.Fatalf("expected [ToolUse, ToolResult], got %d: %+v", len(tools), tools)
+	}
+	if tools[0].Type != MessageToolUse || tools[1].Type != MessageToolResult {
+		t.Fatalf("unexpected message order: %+v", tools)
+	}
+	// Emitted from the completion frame, so it carries the real input.
+	if path, _ := tools[0].Input["path"].(string); path != "/tmp/a.txt" {
+		t.Errorf("custom runtime must keep the completion frame's rawInput, got Input = %v", tools[0].Input)
+	}
+	if text, ok := tools[0].Input["text"].(string); ok {
+		t.Errorf("display text must not be recorded as input, got %q", text)
+	}
+}
+
+// The built-in Hermes binary emits at the start frame, so the call is visible
+// (and counted in flight) while it runs. Its display text is still not treated
+// as input.
+func TestHermesBuiltinRuntimeEmitsToolUseAtStart(t *testing.T) {
+	t.Parallel()
+
+	tools := runHermesToolVisibilityTurn(t, true)
+
+	if len(tools) != 2 {
+		t.Fatalf("expected [ToolUse, ToolResult], got %d: %+v", len(tools), tools)
+	}
+	if tools[0].Type != MessageToolUse || tools[1].Type != MessageToolResult {
+		t.Fatalf("unexpected message order: %+v", tools)
+	}
+	if tools[0].Tool != "write_file" {
+		t.Errorf("tool: got %q, want %q", tools[0].Tool, "write_file")
+	}
+	// Emitted from the start frame, which has no rawInput — and its display
+	// prose must not be substituted for one.
+	if tools[0].Input != nil {
+		t.Errorf("start-frame emit must report no input, got %v", tools[0].Input)
+	}
+	if tools[1].Output != "wrote 2 bytes" {
+		t.Errorf("result output: got %q", tools[1].Output)
+	}
+}


### PR DESCRIPTION
## Summary

On the Hermes runtime an in-flight tool call was invisible: nothing was emitted until the call completed.

Hermes' ACP `tool_call` start frame carries no `rawInput` for its "polished" tool set (~40 tools — `terminal`, `write_file`, `patch`, `read_file`, `execute_code`, `web_*`, `browser_*`, …). `handleToolCallStart` only emitted `MessageToolUse` when `rawInput` was present, so those calls fell through to the deferral path that exists for Kimi — which streams its args token by token — and the tool-use message was held until `tool_call_update` arrived.

Two consequences:

- A tool that stalls renders as a completely blank run: only the agent's thinking, no visible tool call, no indication anything is running. This is what made GH#6583 impossible to self-diagnose.
- The daemon's in-flight tool counter only advances on `MessageToolUse`, so Hermes tool calls were never charged to `AgentToolWatchdog` (2h) and were judged by `AgentIdleWatchdog` (30min) instead — a legitimately long `browser_*` or `execute_code` call gets force-stopped early, and the longer budget never applied.

## Approach

Emit `MessageToolUse` at the start frame, gated on a **dialect flag** (`toolStartCarriesFinalInput`) rather than on the frame's content.

The flag says "this dialect's start frame is the only place a call's input ever appears", which is verified for the real Hermes Agent binary in `acp_adapter/tools.py`:

- `build_tool_call` passes `raw_input=None if tool_name in _POLISHED_TOOLS else arguments`
- `build_tool_complete` never passes `raw_input` at all

so waiting cannot yield more input; it only costs the run its visibility.

**The flag is scoped to `Config.BuiltinRuntime`.** This backend also serves custom runtime profiles declaring `protocol_family: hermes` (jcode is the documented example), which arrive as "hermes" while being unrelated implementations. Only the vendor binary was verified, so the exception is fenced by the same signal `acpToleratesOmittedMcpCapabilities` already uses, and an unset caller fails closed onto the deferred path. The other eight backends sharing `hermesClient` leave the flag false as well — Kimi genuinely streams its args across updates.

**Display content is not passed off as input.** In ACP, `content` is display output produced by the tool call and `rawInput` is the input. Hermes renders each polished tool differently: `terminal` renders `$ <command>` (the invocation), while `write_file`/`patch` render prose like "Preparing write to `<path>`" and the browser/web/media tools render their own summaries. Only the terminal rendering becomes `Input`; every other polished tool reports no input rather than recording a rendering as arguments.

Additionally, a `rawInput` arriving on the update now wins over buffered start-frame text on the deferred path, so the generic path records the real input rather than the rendering.

## Verification

`hermes acp` (Hermes Agent v0.20.0) was driven locally with this client's exact handshake to capture the real frames; the tests use them verbatim.

- `go test ./pkg/agent -run 'Hermes|Kimi|ACP|Kiro|Qoder|Grok|Mcode|Qwenpaw|Reasonix|Trae' -count=1` — pass
- `go test ./internal/daemon -run 'Watchdog|Idle|Tool' -count=1` — pass
- `gofmt` clean, `go vet ./pkg/agent` clean, `git diff --check` clean

Construction-layer regressions (drive `hermesBackend.Execute` against an ACP stub whose start frame carries display text only and whose completion frame carries the real `rawInput`):

- `TestHermesCustomRuntimeDefersToolUseAndKeepsRealInput` — `BuiltinRuntime=false` keeps deferring and records the real input. Verified to fail if the flag is switched on unconditionally.
- `TestHermesBuiltinRuntimeEmitsToolUseAtStart` — `BuiltinRuntime=true` emits at the start frame with no fabricated input.

Frame-handling regressions:

- `TestHermesClientEmitsToolUseWhenStartFrameCarriesCommand` — captured v0.20.0 terminal frame emits immediately; completion adds only the result.
- `TestHermesClientEmitsToolUseForPolishedToolWithoutInput` — captured `write_file` frame emits immediately with **no** Input.
- `TestHermesClientReadFileStartWithNoContentStillVisible` — a start frame with no content at all still registers as in-flight.
- `TestHermesClientOtherDialectsStillDefer` — a dialect without the flag keeps the previous deferred behaviour even for a terminal-shaped frame.
- `TestHermesClientDoesNotFreezeDisplayTextAsInput` — display-only start frame plus a later real `rawInput` must record the real input.
- `TestHermesClientDefersNonCommandStartContent` — nothing is emitted before completion on the generic path.
- `TestACPToolCallStartCarriesInvocation` — shape matrix across terminal / write_file / patch / web_search / Kimi JSON.

Pre-existing Kimi guards (`TestHermesClientKimiStreamingToolCall`, `TestHermesClientKimiMalformedArgsFallback`) are unchanged and still pass.

## Known gap (not introduced here)

Mid-stream `tool_call_update` frames buffer only `content`, not `rawInput`. A backend that supplies `rawInput` exactly once on a non-terminal update and not on the completion frame would still lose it. That is a pre-existing limit of the shared state machine, not a regression from this PR, and no captured Hermes frame does it.
