### PR TITLE
MUL-6333 fix(transcript): state the run's agent once, not on every prose row

### DIFF
--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -309,6 +309,30 @@ describe("AgentTranscriptDialog", () => {
     expect(screen.getByText(/"command": "pnpm test"/)).toBeInTheDocument();
   });
 
+  // Regression, #7125: a run of short prose steps under a long agent name put
+  // the same semibold name above every one-line body, so the row's heaviest
+  // element was the one value that never changes. Identity belongs to the run,
+  // and the header already carries it.
+  it("states the agent once in the header, not on every prose row", () => {
+    renderWithI18n(
+      <AgentTranscriptDialog
+        open
+        onOpenChange={vi.fn()}
+        task={{ ...baseTask, agent_id: "agent-1" }}
+        items={[
+          { seq: 1, type: "text", content: "Cleanup done. Starting tests:" },
+          { seq: 2, type: "text", content: "Now adding the Feishu row:" },
+          { seq: 3, type: "text", content: "Now the version bump:" },
+        ]}
+        agentName="【Chores|Opus5】Multica Helper"
+      />,
+    );
+
+    expect(screen.getAllByTestId("rich-content")).toHaveLength(3);
+    expect(screen.getAllByText("【Chores|Opus5】Multica Helper")).toHaveLength(1);
+    expect(screen.getAllByTestId("actor-avatar")).toHaveLength(1);
+  });
+
   it("folds a call and its result into one step instead of two rows", () => {
     renderDialog([
       { seq: 1, type: "tool_use", tool: "Bash", input: { command: "ls" } },

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -333,6 +333,33 @@ describe("AgentTranscriptDialog", () => {
     expect(screen.getAllByTestId("actor-avatar")).toHaveLength(1);
   });
 
+  // A facet is only readable if you can see what it selects. Tool facets always
+  // could — their rows print the tool name — but prose rows carried no kind
+  // mark at all, so "Agent" in the menu pointed at nothing.
+  it("anchors each filter facet to the glyph its rows carry", () => {
+    renderDialog([
+      { seq: 1, type: "text", content: "Committing now:" },
+      { seq: 2, type: "tool_use", tool: "Bash", input: { command: "git commit" } },
+    ]);
+
+    const agentFacet = screen.getByRole("menuitemcheckbox", { name: "Agent" });
+    expect(agentFacet.querySelector(".lucide-bot")).not.toBeNull();
+
+    const proseRow = screen.getByTestId("rich-content").closest(".group");
+    expect(proseRow?.querySelector(".lucide-bot")).not.toBeNull();
+  });
+
+  it("names a tool facet the way its rows do, keeping the prefix in the key", () => {
+    renderDialog([{ seq: 1, type: "tool_use", tool: "Bash", input: { command: "ls" } }]);
+
+    expect(screen.getByRole("menuitemcheckbox", { name: "Bash" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitemcheckbox", { name: "tool:Bash" })).toBeNull();
+
+    // The label changed; the persisted facet key did not.
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Bash" }));
+    expect(useTranscriptViewStore.getState().selectedFilterKeys).toEqual(["tool:Bash"]);
+  });
+
   it("folds a call and its result into one step instead of two rows", () => {
     renderDialog([
       { seq: 1, type: "tool_use", tool: "Bash", input: { command: "ls" } },

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -418,20 +418,25 @@ export function AgentTranscriptDialog({
   // why the pairing is positional.
   const steps = useMemo(() => buildSteps(items), [items]);
 
+  // A facet reads as what its rows look like: the glyph the rows carry, and the
+  // name the rows print. The first step of a kind stands in for the glyph. The
+  // `tool:` prefix stays in the key (it is what gets persisted) but never
+  // reaches the menu — the rows say `Bash`, so the facet says `Bash` too.
   const filterOptions = useMemo(() => {
-    const options = new Map<string, string>();
+    const options = new Map<string, { label: string; step: TraceStep }>();
     for (const step of steps) {
       const key = stepFilterKey(step);
       if (options.has(key)) continue;
-      options.set(
-        key,
-        step.kind === "call"
-          ? key
-          : traceEventLabel({ type: step.item.type, tool: step.item.tool }),
-      );
+      options.set(key, {
+        label:
+          step.kind === "call"
+            ? step.tool || t(($) => $.transcript.kind_tool)
+            : traceEventLabel({ type: step.item.type, tool: step.item.tool }),
+        step,
+      });
     }
-    return Array.from(options.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-  }, [steps]);
+    return Array.from(options.entries()).sort((a, b) => a[1].label.localeCompare(b[1].label));
+  }, [steps, t]);
 
   const filterOptionKeys = useMemo(
     () => new Set(filterOptions.map(([value]) => value)),
@@ -1036,13 +1041,19 @@ export function AgentTranscriptDialog({
                 )}
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-auto">
-                {filterOptions.map(([value, label]) => (
+                {filterOptions.map(([value, option]) => (
                   <DropdownMenuCheckboxItem
                     key={value}
                     checked={selectedFilterKeys.includes(value)}
                     onCheckedChange={() => toggleFilterKey(value)}
                   >
-                    {label}
+                    <span className="flex items-center gap-1.5">
+                      <StepIcon
+                        step={option.step}
+                        className="h-3 w-3 shrink-0 text-muted-foreground"
+                      />
+                      {option.label}
+                    </span>
                   </DropdownMenuCheckboxItem>
                 ))}
                 {selectedFilterKeys.length > 0 && (
@@ -1318,14 +1329,19 @@ function DurationCell({ ms, pending }: { ms?: number; pending?: boolean }) {
  * row would be the same two values repeated for every step, and the header
  * already states them. Repeating them cost a semibold 12px line above 12px
  * body text, which on a run of short steps made the row's heaviest element its
- * least informative one. The green rule is what marks prose as the agent
- * speaking; it says the same thing in 2px.
+ * least informative one.
+ *
+ * What the row does keep is its kind: the same `StepIcon` column every other
+ * row carries, so "Agent" in the filter has something to point at. Kind, not
+ * identity — the glyph says "the agent's own words", which is what the facet
+ * selects, and it says it in 12px without a repeated string.
  */
 function ProseRow({ row, runStartMs }: TranscriptRowProps & { row: TraceMessageStep }) {
   return (
     <div className="group flex items-start gap-2 px-4 py-2.5">
       <OffsetCell startedAt={row.startedAt} runStartMs={runStartMs} />
       <span aria-hidden className="mt-1 w-0.5 self-stretch rounded-full bg-success" />
+      <StepIcon step={row} className="mt-1 h-3 w-3 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1 pr-2">
         <RichContent
           content={row.item.content ?? ""}

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -1147,8 +1147,6 @@ export function AgentTranscriptDialog({
                 itemContent={(_, row) => (
                   <TranscriptRow
                     row={row}
-                    agentName={agentName || agentInfo?.name || ""}
-                    agentId={task.agent_id}
                     runStartMs={runStartMs}
                     isLive={isLive}
                     selectedSeq={selectedSeq}
@@ -1261,8 +1259,6 @@ function RunOutcomeRow({
 
 interface TranscriptRowProps {
   row: TraceRow;
-  agentName: string;
-  agentId?: string;
   runStartMs?: number;
   isLive: boolean;
   selectedSeq: number | null;
@@ -1316,30 +1312,21 @@ function DurationCell({ ms, pending }: { ms?: number; pending?: boolean }) {
  * This is the layer inversion the redesign turns on: the report used to look
  * exactly like a `Read`, so the one thing worth reading was the hardest thing
  * to find. Prose is content and stays open; tool calls are evidence and fold.
+ *
+ * Identity is deliberately absent here. A transcript is one run by one agent —
+ * `TraceMessageStep` carries no per-step actor, so an avatar and name on the
+ * row would be the same two values repeated for every step, and the header
+ * already states them. Repeating them cost a semibold 12px line above 12px
+ * body text, which on a run of short steps made the row's heaviest element its
+ * least informative one. The green rule is what marks prose as the agent
+ * speaking; it says the same thing in 2px.
  */
-function ProseRow({
-  row,
-  agentName,
-  agentId,
-  runStartMs,
-}: TranscriptRowProps & { row: TraceMessageStep }) {
+function ProseRow({ row, runStartMs }: TranscriptRowProps & { row: TraceMessageStep }) {
   return (
     <div className="group flex items-start gap-2 px-4 py-2.5">
       <OffsetCell startedAt={row.startedAt} runStartMs={runStartMs} />
       <span aria-hidden className="mt-1 w-0.5 self-stretch rounded-full bg-success" />
-      <div className="mt-0.5 shrink-0">
-        {agentId ? (
-          <ActorAvatar actorType="agent" actorId={agentId} size="sm" />
-        ) : (
-          <div className="flex h-5 w-5 items-center justify-center rounded-full bg-info/10 text-info">
-            <Bot className="h-3 w-3" />
-          </div>
-        )}
-      </div>
       <div className="min-w-0 flex-1 pr-2">
-        {agentName && (
-          <div className="mb-0.5 text-caption font-semibold">{agentName}</div>
-        )}
         <RichContent
           content={row.item.content ?? ""}
           density="compact"


### PR DESCRIPTION
Fixes #7125.

## What's wrong

#7011 gave each agent prose row an avatar and a semibold agent name, to promote prose over tool calls. But a transcript is **one run by one agent**: `agentName` and `agentId={task.agent_id}` are passed the same values to every row, and `TraceMessageStep` carries no per-step actor. So that block is a constant repeated once per step — its information content is zero, and the dialog header ~40px above already states both.

It also inverts the type hierarchy. The name renders at `text-caption font-semibold`; `.transcript-prose` body renders at `var(--text-caption)` weight 400. Both are 12px — **same size, name heavier**. On a run of short steps the heaviest element in each row is the one value that never changes.

Two things amplify it: `groupSteps` only coalesces consecutive same-tool calls, so `kind: "text"` steps are always one row each under `divide-y`; and the reporter's screenshot has the "Agent" facet active, where `stepFilterKey` returns `step.kind` for non-calls — so 100% of visible rows are that single agent's prose. The view that least needs the identity repeats it hardest.

This only shows up at one end of the range: a 20-character agent name over one-line steps (reporter) versus a 1-character name over long markdown bodies (maintainer, in the issue thread). Same layout, opposite extremes.

## The change

Drop the avatar and name from `ProseRow`. The existing `bg-success` rule is what marks prose as the agent speaking — same signal in 2px instead of 48px. Prose promotion is untouched: it comes from `RichContent` at reading measure staying expanded, not from the avatar. `agentName`/`agentId` were only ever read by `ProseRow`, so the props come off `TranscriptRowProps` and the call site too.

A one-line prose row goes from ~58px to ~40px (content 34% → 50%), and ~28px of horizontal gutter comes back before the text starts.

This restores the pre-#7011 identity behaviour — header only, which is what the reporter remembers as "非常清爽" — while keeping everything else that redesign introduced (steps, lanes, outcome, inspector).

### Why not "show it at identity change points"

That's what the issue asks for, but there is no change point to detect: the identity is structurally constant within a dialog. A `prevAgentId !== agentId` predicate would be provably always-false today — dead code, and the kind of speculative fallback `CLAUDE.md` rules out. If sub-agent or squad transcripts ever land, they'll need a per-step actor on `TraceMessageStep` first, and grouping can be built on that real signal then.

### Deliberately not in this PR

Suppressing the `divide-y` between consecutive prose rows and tightening continuation padding, so a run of short steps reads as one block rather than N cards. That's a separate visual-rhythm judgement and worth eyeballing after this lands — the identity repetition is the reported problem and this keeps the diff to one function.

## Verification

- `pnpm --filter @multica/views exec vitest run common/task-transcript/` — 152 passed (8 files).
- `pnpm typecheck` — 6/6 successful.
- `eslint` on both changed files — clean.
- New regression test covers the exact reported shape (long agent name + three consecutive short prose steps). Verified it actually catches the bug: reverting the source change fails it with `expected [...] to have a length of 1 but got 4`.


---

## Follow-up: the `Agent` facet had nothing to point at

Review feedback on the first commit: with the avatar and name gone, prose became the only step kind carrying **no mark at all**. Tool rows print their tool name, thinking and error rows print their kind, prose printed nothing — so `Agent` in the filter named a set of rows you couldn't pick out of the list without selecting it first.

`StepIcon` already returned a `Bot` glyph for the `text` kind. Nothing ever rendered it, because `ProseRow` skipped the icon column. So this is finishing an existing design rather than adding one:

- **`ProseRow` renders `StepIcon`.** That's the *kind* mark, not identity — it says "the agent's own words", which is exactly what the facet selects, in 12px with no repeated string. It fills a column every other row already fills, so prose bodies now align with tool labels instead of hanging left of them.
- **Filter items carry the same glyph**, so a facet looks like its rows. This helps every facet, not just `Agent`.
- **Tool facets are labelled `Bash`, not `tool:Bash`.** The rows say `Bash`; the menu leaked the internal key. The key itself is untouched — it's what persists — only the label changed. This one predates the rebuild (back to #4884), fixed here because it's the same "the filter doesn't say what it selects" defect.

### Verification (both commits)

- `pnpm --filter @multica/views exec vitest run common/task-transcript/` — 154 passed (8 files).
- `pnpm typecheck` — 6/6 successful. `eslint` on both changed files — clean.
- Two new tests, both confirmed to fail without this commit (`expected null not to be null`, and `Unable to find ... name "Bash"`): one asserts the prose row and the `Agent` menu item carry the same glyph, one asserts the tool facet is labelled `Bash` while `selectedFilterKeys` still records `tool:Bash`.
