### PR TITLE
fix(issue): show no-response task completions

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1080,6 +1080,26 @@ describe("IssueDetail (shared)", () => {
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
   });
 
+  it("renders an explicit activity when an issue task finishes without a text reply", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      {
+        type: "activity",
+        id: "activity-no-response",
+        actor_type: "agent",
+        actor_id: "agent-1",
+        action: "task_no_response",
+        details: { outcome: "no_response", task_id: "task-1" },
+        created_at: "2026-01-18T00:00:00Z",
+      },
+    ] as TimelineEntry[]);
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("finished without a text reply")).toBeInTheDocument();
+    });
+  });
+
   it("reruns the source task from an agent failure comment", async () => {
     mockApiObj.listTimeline.mockResolvedValue([
       ...mockTimeline,

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -313,6 +313,8 @@ function formatActivity(
       });
     case "description_updated":
       return t(($) => $.activity.description_updated);
+    case "task_no_response":
+      return t(($) => $.activity.task_no_response, { count: entry.coalesced_count ?? 1 });
     case "task_completed":
       return t(($) => $.activity.task_completed, { count: entry.coalesced_count ?? 1 });
     case "task_failed":
@@ -1400,7 +1402,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // - all other actions: within a 2-minute window
     // - squad_leader_evaluated: never coalesce; outcome/reason are audit data
     const COALESCE_MS = 2 * 60 * 1000;
-    const NO_TIME_LIMIT_ACTIONS = new Set(["task_completed", "task_failed"]);
+    const NO_TIME_LIMIT_ACTIONS = new Set(["task_completed", "task_failed", "task_no_response"]);
     const NEVER_COALESCE_ACTIONS = new Set(["squad_leader_evaluated"]);
     const coalesced: TimelineEntry[] = [];
     for (const entry of topLevel) {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -377,6 +377,8 @@
     "due_date_removed": "removed due date",
     "title_renamed": "renamed this issue from \"{{from}}\" to \"{{to}}\"",
     "description_updated": "updated the description",
+    "task_no_response_one": "finished without a text reply",
+    "task_no_response_other": "finished without a text reply ({{count}} times)",
     "task_completed_one": "completed the task",
     "task_completed_other": "completed the task ({{count}} times)",
     "task_failed_one": "task failed",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -372,6 +372,7 @@
     "due_date_removed": "期限を削除しました",
     "title_renamed": "このタスクのタイトルを \"{{from}}\" から \"{{to}}\" に変更しました",
     "description_updated": "説明を更新しました",
+    "task_no_response_other": "テキストの返信なしで作業を完了しました（{{count}} 回）",
     "task_completed_other": "作業を完了しました（{{count}} 回）",
     "task_failed_other": "作業が失敗しました（{{count}} 回）",
     "squad_leader_evaluated": "スクワッドのトリガーを評価しました",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -372,6 +372,7 @@
     "due_date_removed": "마감일을 제거했습니다",
     "title_renamed": "태스크 제목을 \"{{from}}\"에서 \"{{to}}\"로 바꿨습니다",
     "description_updated": "설명을 업데이트했습니다",
+    "task_no_response_other": "텍스트 답변 없이 작업을 완료했습니다({{count}}회)",
     "task_completed_other": "작업을 완료했습니다({{count}}회)",
     "task_failed_other": "작업이 실패했습니다({{count}}회)",
     "squad_leader_evaluated": "스쿼드 트리거를 평가했습니다",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -372,6 +372,7 @@
     "due_date_removed": "移除了截止日期",
     "title_renamed": "把这个任务从\"{{from}}\"重命名为\"{{to}}\"",
     "description_updated": "更新了描述",
+    "task_no_response_other": "本次 task 已结束，没有返回文字回复（{{count}} 次）",
     "task_completed_other": "完成了 task（{{count}} 次）",
     "task_failed_other": "task 失败（{{count}} 次）",
     "squad_leader_evaluated": "评估了小队触发",

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3107,6 +3107,64 @@ func TestCompleteTask_CommentTriggered_SuppressesTrivialDoneOutput(t *testing.T)
 	if count != 0 {
 		t.Fatalf("expected no synthesized agent comment for trivial Done output, got %d", count)
 	}
+
+	var activityCount int
+	var activityTaskID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*), COALESCE(max(details->>'task_id'), '')
+		FROM activity_log
+		WHERE issue_id = $1
+		  AND actor_type = 'agent'
+		  AND actor_id = $2
+		  AND action = 'task_no_response'
+	`, issueID, agentID).Scan(&activityCount, &activityTaskID); err != nil {
+		t.Fatalf("query no-response activity: %v", err)
+	}
+	if activityCount != 1 {
+		t.Fatalf("no-response activity count = %d, want 1", activityCount)
+	}
+	if activityTaskID != taskID {
+		t.Fatalf("no-response activity task_id = %q, want %q", activityTaskID, taskID)
+	}
+
+	// The same visible outcome is required when the runtime returns no text at
+	// all, which is the production shape reported in #7071.
+	var emptyTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id,
+			status, priority, started_at
+		)
+		VALUES ($1, $2, $3, $4, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerCommentID).Scan(&emptyTaskID); err != nil {
+		t.Fatalf("setup: create empty-output task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, emptyTaskID) })
+
+	w = httptest.NewRecorder()
+	req = newDaemonTokenRequest("POST", "/api/daemon/tasks/"+emptyTaskID+"/complete",
+		map[string]any{"output": "   "}, testWorkspaceID, "legit-daemon")
+	rctx = chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", emptyTaskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask empty output: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM activity_log
+		WHERE issue_id = $1
+		  AND action = 'task_no_response'
+		  AND details->>'task_id' = $2
+	`, issueID, emptyTaskID).Scan(&activityCount); err != nil {
+		t.Fatalf("query empty-output no-response activity: %v", err)
+	}
+	if activityCount != 1 {
+		t.Fatalf("empty-output no-response activity count = %d, want 1", activityCount)
+	}
 }
 
 func TestCompleteTask_AssignmentTriggered_DoesNotSuppressTrivialDoneOutput(t *testing.T) {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3753,24 +3753,25 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		if !suppressNoActionComment && !agentCommented {
 			var payload protocol.TaskCompletedPayload
 			if err := json.Unmarshal(result, &payload); err == nil {
-				if payload.Output != "" {
-					// Match the CLI's --content / --description behavior: agents that
-					// emit literal `\n` 4-char sequences (Python/JSON-style) get them
-					// decoded into real newlines before the comment hits the DB. See
-					// util.UnescapeBackslashEscapes for the exact contract.
-					body := util.UnescapeBackslashEscapes(payload.Output)
-					if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
-						slog.Warn("suppressing trivial comment-trigger fallback output",
-							"task_id", util.UUIDToString(task.ID),
-							"issue_id", util.UUIDToString(task.IssueID),
-							"agent_id", util.UUIDToString(task.AgentID),
-						)
-					} else {
-						// Redact first, then bound: a runaway raw-stream Output (GH #5455)
-						// must never reach the issue thread, even as a clipped excerpt.
-						content := truncateFallbackCommentBody(redact.Text(body), maxSynthesizedFallbackCommentRunes)
-						s.createAgentComment(ctx, task.IssueID, task.AgentID, content, "comment", task.TriggerCommentID, task.ID)
-					}
+				// Match the CLI's --content / --description behavior: agents that
+				// emit literal `\n` 4-char sequences (Python/JSON-style) get them
+				// decoded into real newlines before the comment hits the DB. See
+				// util.UnescapeBackslashEscapes for the exact contract.
+				body := util.UnescapeBackslashEscapes(payload.Output)
+				if strings.TrimSpace(body) == "" {
+					s.createTaskNoResponseActivity(ctx, task)
+				} else if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
+					slog.Warn("suppressing trivial comment-trigger fallback output",
+						"task_id", util.UUIDToString(task.ID),
+						"issue_id", util.UUIDToString(task.IssueID),
+						"agent_id", util.UUIDToString(task.AgentID),
+					)
+					s.createTaskNoResponseActivity(ctx, task)
+				} else {
+					// Redact first, then bound: a runaway raw-stream Output (GH #5455)
+					// must never reach the issue thread, even as a clipped excerpt.
+					content := truncateFallbackCommentBody(redact.Text(body), maxSynthesizedFallbackCommentRunes)
+					s.createAgentComment(ctx, task.IssueID, task.AgentID, content, "comment", task.TriggerCommentID, task.ID)
 				}
 			}
 		}
@@ -6095,6 +6096,61 @@ func (s *TaskService) getIssuePrefix(workspaceID pgtype.UUID) string {
 		return ""
 	}
 	return ws.IssuePrefix
+}
+
+// createTaskNoResponseActivity records the visible terminal outcome for an
+// issue task that completed without a comment or meaningful fallback text.
+// It stays an activity instead of impersonating an ordinary agent reply.
+func (s *TaskService) createTaskNoResponseActivity(ctx context.Context, task db.AgentTaskQueue) {
+	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
+	if err != nil {
+		slog.Warn("loading issue for no-response activity failed",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+			"error", err,
+		)
+		return
+	}
+
+	details, _ := json.Marshal(map[string]string{
+		"outcome": "no_response",
+		"task_id": util.UUIDToString(task.ID),
+	})
+	activity, err := s.Queries.CreateActivity(ctx, db.CreateActivityParams{
+		WorkspaceID: issue.WorkspaceID,
+		IssueID:     issue.ID,
+		ActorType:   pgtype.Text{String: "agent", Valid: true},
+		ActorID:     task.AgentID,
+		Action:      "task_no_response",
+		Details:     details,
+	})
+	if err != nil {
+		slog.Warn("creating no-response activity failed",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+			"error", err,
+		)
+		return
+	}
+
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventActivityCreated,
+		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
+		ActorType:   "agent",
+		ActorID:     util.UUIDToString(task.AgentID),
+		Payload: map[string]any{
+			"issue_id": util.UUIDToString(issue.ID),
+			"entry": map[string]any{
+				"type":       "activity",
+				"id":         util.UUIDToString(activity.ID),
+				"actor_type": "agent",
+				"actor_id":   util.UUIDToString(task.AgentID),
+				"action":     activity.Action,
+				"details":    json.RawMessage(details),
+				"created_at": util.TimestampToString(activity.CreatedAt),
+			},
+		},
+	})
 }
 
 func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID pgtype.UUID, content, commentType string, parentID, sourceTaskID pgtype.UUID) {


### PR DESCRIPTION
## What does this PR do?

Shows an explicit timeline activity when an issue task completes without a visible text reply.

Comment-triggered follow-ups can finish with blank output, while the existing trivial `Done.` suppression intentionally avoids posting a redundant agent comment. Both paths previously left the main issue feed unchanged even though the task completed successfully. This change records a `task_no_response` activity, publishes the existing `activity:created` event, and renders the result in the issue timeline without fabricating a normal comment.

The marker is only added when no real agent comment or existing squad-leader no-action activity already represents the outcome, avoiding duplicate timeline entries.

## Related Issue

Closes #7071

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / build system change

## Changes Made

- Record `task_no_response` for blank issue-task output and comment-triggered trivial completion output.
- Broadcast the activity through the existing realtime activity event.
- Render and coalesce the new outcome in the main issue timeline.
- Add English, Simplified Chinese, Japanese, and Korean copy.
- Add backend integration and frontend rendering regressions.

## How to Test

1. Run `cd server && DATABASE_URL=... go test -v ./internal/handler -run '^TestCompleteTask_CommentTriggered_SuppressesTrivialDoneOutput$' -count=1`.
2. Run `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`.
3. Run `pnpm --filter @multica/views typecheck`.

Regression proof:

- Before the fix, the backend assertion reports `no-response activity count = 0, want 1`, and the UI cannot find the no-response activity text.
- After the fix, the PostgreSQL-backed handler regression passes, the full issue-detail suite passes all 59 tests, and the views typecheck passes.

## Checklist

- [x] I followed the thinking path from user-facing symptom to data model, API/realtime delivery, and frontend rendering.
- [x] I tested the changes locally.
- [x] I added or updated tests that prove the fix.
- [x] I included screenshots for the visible UI change.
- [x] Documentation update is not applicable; no public API or configuration contract changed.
- [x] Landing/docs synchronization is not applicable.
- [x] Chinese copy follows the existing task and issue terminology.
- [x] I considered duplicate-event and backward-compatibility risks.
- [x] I will address reviewer comments.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Used Codex to trace the issue completion path from `TaskService.CompleteTask` through activity persistence and realtime delivery to the main issue timeline. Added failing backend and frontend regressions first  and validated both blank output and trivial-completion suppression paths.

## Screenshots (optional)

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/bfc9ec5a-e751-422c-b878-ccc26d3638ce" />