### PR TITLE
MUL-6348 fix(channel): log lease_gen instead of lease_token

### DIFF
--- a/server/internal/integrations/channel/engine/supervisor.go
+++ b/server/internal/integrations/channel/engine/supervisor.go
@@ -598,6 +598,14 @@ func (s *Supervisor) startSupervisor(parent context.Context, inst Installation) 
 // same installation (the rotation path) carry different tokens. That
 // distinction stops an old supervisor's post-cancel release from
 // CAS-matching and deleting the successor's just-acquired lease.
+//
+// The result is an internal CAS marker, NOT a credential: it is never sent
+// to any platform and on its own grants nothing (only a direct Redis / DB
+// writer could act on it). It is still kept out of log FIELDS — GH #7132
+// reported a plaintext `lease_token=` field as a leaked channel credential,
+// and disproving that costs a full investigation every time someone reads
+// the log. supervise() logs node_id + lease_gen instead, which carries the
+// same diagnostic information under a name that does not read as a secret.
 func leaseToken(nodeID string, gen uint64) string {
 	return nodeID + "-g" + strconv.FormatUint(gen, 10)
 }
@@ -625,7 +633,7 @@ func (s *Supervisor) supervise(ctx context.Context, inst Installation, id string
 		"installation_id", id,
 		"channel_type", string(inst.ChannelType),
 		"node_id", s.nodeID,
-		"lease_token", leaseTok,
+		"lease_gen", gen,
 	)
 	backoff := s.cfg.MinBackoff
 

--- a/server/internal/integrations/channel/engine/supervisor_test.go
+++ b/server/internal/integrations/channel/engine/supervisor_test.go
@@ -1,10 +1,12 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -234,6 +236,26 @@ func uuidFromString(t *testing.T, s string) pgtype.UUID {
 
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// syncBuffer is a mutex-guarded sink for capturing slog output. The
+// supervisor logs from several goroutines, so an unguarded bytes.Buffer
+// would race under -race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func fastConfig() Config {
@@ -937,4 +959,55 @@ func TestSupervisorRejectsUnsafeLeaseIntervals(t *testing.T) {
 		LeaseTTL: 30 * time.Second, LeaseRenewInterval: 20 * time.Second, PollInterval: 25 * time.Second,
 		LeaseErrorRetryInterval: time.Second, LeaseExpirySafetyMargin: time.Second,
 	})
+}
+
+// The connection-exit log must not carry a field named lease_token. The
+// lease token is an internal CAS marker rather than a credential, but a
+// plaintext `lease_token=` in the log reads as a leaked channel credential
+// to anyone tailing it — that misread is what GH #7132 reported. node_id
+// and lease_gen are the same information under a name that does not invite
+// the false positive, so this asserts the field NAME is gone and the
+// diagnostic fields survived, not that anything is secret.
+func TestSupervisorExitLogOmitsLeaseTokenField(t *testing.T) {
+	q := newFakeStore()
+	instID := uuidFromString(t, "cccccccc-cccc-cccc-cccc-cccccccccccc")
+	q.installations = []Installation{activeInst(instID, "fp1")}
+
+	// First Connect fails immediately, driving the exact "connection exited
+	// with error" branch the report quoted; later attempts park on ctx.
+	fc := &fakeChannel{
+		typ: channel.TypeFeishu,
+		script: []func(ctx context.Context) error{
+			func(ctx context.Context) error { return errors.New("read message: websocket: close 1006") },
+		},
+	}
+	var builds int32
+	reg := fakeRegistry(fc, &builds, nil)
+
+	var logs syncBuffer
+	cfg := fastConfig()
+	cfg.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	sup := NewSupervisor(q, q, reg, nil, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	if !waitFor(time.Second, func() bool {
+		return strings.Contains(logs.String(), "connection exited with error")
+	}) {
+		t.Fatalf("expected the exit-with-error log; got %q", logs.String())
+	}
+	cancel()
+	sup.Wait()
+
+	out := logs.String()
+	if strings.Contains(out, "lease_token") {
+		t.Errorf("supervisor logs must not carry a lease_token field; got %q", out)
+	}
+	for _, field := range []string{"installation_id=", "node_id=", "lease_gen="} {
+		if !strings.Contains(out, field) {
+			t.Errorf("supervisor logs lost diagnostic field %s; got %q", field, out)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Closes #7132.

The channel engine supervisor attached the raw lease token to its child logger (`supervisor.go`), so **every** supervisor log line — not just the connection-exit one — carried a plaintext `lease_token=` field. #7132 reported this as a leaked Feishu channel credential.

**It is not a credential, and nothing was exposed.** `leaseToken()` composes an internal CAS marker from the process-local `crypto/rand` nodeID and the supervisor gen:

- it is never sent to Feishu (or Slack / DingTalk / WeCom — the engine is shared, so all four emitted this field);
- no HTTP handler or frontend surface accepts or returns `ws_lease_token`;
- acting on the value requires direct Redis or Postgres write access, which already permits stealing the lease outright;
- the default `LeaseTTL` is 180s and the nodeID regenerates per process, so historical log values are inert.

No advisory or token rotation is warranted.

The field name is still worth removing. `lease_token=<hex>` in a log reads as a credential to everyone who tails it, and disproving that costs a full investigation each time — this issue is the proof. Note that redacting the value would have been theatre: `node_id` is on the same line and the token is exactly `node_id + "-g" + gen`, so the value stays trivially reconstructable. Renaming is the honest fix. `installation_id` + `node_id` + `lease_gen` carries the identical diagnostic information.

## Testing

- `TestSupervisorExitLogOmitsLeaseTokenField` — drives the exact "connection exited with error" branch the report quoted and asserts the `lease_token` field name is gone while the diagnostic fields survive. Verified it fails on the pre-fix code (reproducing the reported line verbatim) and passes after.
- `go test ./internal/integrations/channel/engine/ -run TestSupervisor -race -count=1` — pass.
- `go build` / `go vet` / `gofmt` on the package — clean.

## Not included

`lark/ws_connector.go:214` wraps dial failures as `dial ws: %w`. If Lark ever returns a malformed wss URL, `url.Parse` yields a `*url.Error` carrying the **full auth-bearing URL**, which would then land in this same log line. That is the one genuine credential path in this area — unlike `lease_token` — but it is a distinct change and is left for a follow-up.
