### PR TITLE
AERIS-207: repair PR link promotion and snapshot alerts

### DIFF
--- a/deploy/helm/multica/templates/prometheusrule.yaml
+++ b/deploy/helm/multica/templates/prometheusrule.yaml
@@ -40,4 +40,33 @@ spec:
           annotations:
             summary: "Business sampler query p95 is high"
             description: "Business sampler query {{ "{{ $labels.name }}" }} p95 is above 300ms, leaving little headroom before the 500ms statement_timeout."
+    - name: multica-github-pr
+      rules:
+        - alert: MulticaGitHubPRLinkWriteFailures
+          expr: increase(multica_github_pr_link_write_failures_total[10m]) > 0
+          for: {{ .Values.monitoring.prometheusRule.githubPRLinkFailuresFor | quote }}
+          labels:
+            severity: {{ .Values.monitoring.prometheusRule.severity | quote }}
+          annotations:
+            summary: "GitHub PR issue-link writes are failing"
+            description: "At least one GitHub PR could not be linked to its issue. Use the structured github: link failed log to identify the workspace, issue, repository, and PR."
+        - alert: MulticaGitHubPRSnapshotPipelineDisabled
+          expr: increase(multica_github_pr_snapshot_disabled_triggers_total[10m]) > 0
+          for: {{ .Values.monitoring.prometheusRule.githubPRSnapshotDisabledFor | quote }}
+          labels:
+            severity: {{ .Values.monitoring.prometheusRule.severity | quote }}
+          annotations:
+            summary: "GitHub PR snapshot refreshes are disabled"
+            description: "PR snapshot refresh triggers are being ignored because GITHUB_APP_ID or GITHUB_APP_PRIVATE_KEY is unavailable. PR links still work, but checks and API mergeability stay unavailable."
+        - alert: MulticaGitHubPRSnapshotRefreshFailures
+          expr: |
+            rate(multica_github_pr_snapshot_fetch_failures_total[10m])
+            + rate(multica_github_pr_snapshot_write_failures_total[10m])
+            + rate(multica_github_pr_snapshot_queue_drops_total[10m]) > 0
+          for: {{ .Values.monitoring.prometheusRule.githubPRSnapshotFailuresFor | quote }}
+          labels:
+            severity: {{ .Values.monitoring.prometheusRule.severity | quote }}
+          annotations:
+            summary: "GitHub PR snapshot refreshes are failing"
+            description: "GitHub API fetches, snapshot database writes, or refresh queue capacity are failing. Inspect ghsnapshot structured logs for the repository and PR."
 {{- end }}

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -208,4 +208,7 @@ monitoring:
     additionalLabels: {}
     samplerQueryErrorsFor: 5m
     samplerQueryLatencyFor: 10m
+    githubPRLinkFailuresFor: 5m
+    githubPRSnapshotDisabledFor: 5m
+    githubPRSnapshotFailuresFor: 5m
     severity: warning

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -378,6 +378,7 @@ func main() {
 	var channelMediaMetrics *obsmetrics.ChannelMediaReconcilerMetrics
 	var channelLeaseMetrics *obsmetrics.ChannelLeaseMetrics
 	var wecomMetrics *obsmetrics.WecomMetrics
+	var githubPRMetrics *obsmetrics.GitHubPRMetrics
 	if metricsConfig.Enabled() {
 		// Build a dedicated tiny pool for the BusinessSamplerCollector
 		// so a stalled scrape can never starve business traffic. If the
@@ -408,6 +409,7 @@ func main() {
 		channelMediaMetrics = metricsRegistry.ChannelMedia
 		channelLeaseMetrics = metricsRegistry.ChannelLease
 		wecomMetrics = metricsRegistry.Wecom
+		githubPRMetrics = metricsRegistry.GitHubPR
 		// Forward inbound daemon WS frames into the per-kind counter so
 		// dashboards can split heartbeat / unknown / invalid traffic.
 		if daemonHub != nil {
@@ -437,6 +439,7 @@ func main() {
 		ChannelLeaseMetrics: channelLeaseMetrics,
 		ChannelLeaseRedis:   channelLeaseRedis,
 		WecomMetrics:        wecomMetrics,
+		GitHubPRMetrics:     githubPRMetrics,
 		DaemonHub:           daemonHub,
 		DaemonWakeup:        daemonWakeup,
 		FeatureFlags:        flags,

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -183,9 +183,12 @@ type RouterOptions struct {
 	// WecomMetrics is the WeCom adapter's health sink. Nil discards every
 	// counter, which is what a deployment with /metrics turned off gets.
 	WecomMetrics *obsmetrics.WecomMetrics
-	DaemonHub    *daemonws.Hub
-	DaemonWakeup service.TaskWakeupNotifier
-	FeatureFlags *featureflag.Service
+	// GitHubPRMetrics receives PR-link and snapshot-pipeline failures. Nil when
+	// /metrics is disabled.
+	GitHubPRMetrics *obsmetrics.GitHubPRMetrics
+	DaemonHub       *daemonws.Hub
+	DaemonWakeup    service.TaskWakeupNotifier
+	FeatureFlags    *featureflag.Service
 	// HeartbeatScheduler, when non-nil, replaces the default synchronous
 	// passthrough scheduler on the constructed Handler. main.go injects a
 	// BatchedHeartbeatScheduler here so the caller can also drive Run/Stop;
@@ -354,6 +357,10 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	h.TaskService.FeatureFlags = opts.FeatureFlags
 	h.TaskService.Metrics = opts.BusinessMetrics
 	h.IssueService.Metrics = opts.BusinessMetrics
+	h.GitHubPRMetrics = opts.GitHubPRMetrics
+	if opts.GitHubPRMetrics != nil {
+		h.PRRefresh.SetMetrics(opts.GitHubPRMetrics)
+	}
 	if opts.BusinessMetrics != nil {
 		// Wire the BusinessMetrics receiver into the cloud runtime client
 		// so every outbound Fleet/Gateway request feeds the

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1646,7 +1646,17 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 				LinkedByType:        strToText("system"),
 				LinkedByID:          pgtype.UUID{},
 			}); err != nil {
-				slog.Warn("github: link failed", "err", err)
+				if h.GitHubPRMetrics != nil {
+					h.GitHubPRMetrics.RecordLinkWriteFailure()
+				}
+				slog.Warn("github: link failed",
+					"err", err,
+					"workspace_id", workspaceID,
+					"issue_id", uuidToString(issue.ID),
+					"repo_owner", p.Repository.Owner.Login,
+					"repo_name", p.Repository.Name,
+					"pr_number", p.PullRequest.Number,
+				)
 				continue
 			}
 			linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -1496,6 +1496,84 @@ func TestWebhook_BareBodyMentionHiddenFromPRList(t *testing.T) {
 	}
 }
 
+// TestWebhook_MergedBareBodyMentionCanBePromotedButNotHidden guards the
+// historical-backfill path: a PR that merged with only a bare body mention may
+// later gain a title/branch identifier and become a visible working link. Once
+// visible, post-terminal edits must not hide it again.
+func TestWebhook_MergedBareBodyMentionCanBePromotedButNotHidden(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "merged-reference-promotion-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "historical merged PR backfill",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	const installationID int64 = 30264007
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "merged-reference-promotion-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	body := "Context for reviewers: see " + created.Identifier
+	firePRWebhook(t, secret, installationID, 1, "Unrelated cleanup", body, "feat/cleanup", "opened")
+	firePRWebhook(t, secret, installationID, 1, "Unrelated cleanup", body, "feat/cleanup", "merged")
+
+	listLen := func() int {
+		t.Helper()
+		rows, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+		if err != nil {
+			t.Fatalf("ListPullRequestsByIssue: %v", err)
+		}
+		return len(rows)
+	}
+	if n := listLen(); n != 0 {
+		t.Fatalf("merged bare body mention should start hidden, got %d rows", n)
+	}
+
+	firePRWebhook(t, secret, installationID, 1, created.Identifier+": historical cleanup", body, "feat/cleanup", "edited_merged")
+	if n := listLen(); n != 1 {
+		t.Fatalf("post-merge title identifier should promote the link, got %d rows", n)
+	}
+	var closeIntent bool
+	if err := testPool.QueryRow(ctx,
+		`SELECT close_intent FROM issue_pull_request WHERE issue_id = $1`,
+		created.ID).Scan(&closeIntent); err != nil {
+		t.Fatalf("select close_intent: %v", err)
+	}
+	if closeIntent {
+		t.Fatal("post-merge visibility promotion must not add close intent")
+	}
+
+	firePRWebhook(t, secret, installationID, 1, "Unrelated cleanup", body, "feat/cleanup", "edited_merged")
+	if n := listLen(); n != 1 {
+		t.Fatalf("post-terminal edit must not hide a promoted link, got %d rows", n)
+	}
+}
+
 // TestWebhook_HiddenBodyMentionDoesNotBlockAutoAdvance guards the P1 the code
 // review flagged on PR #4611: a reference_only link (a PR that only mentions the
 // issue in its body) is hidden from the PR list, so it must not silently gate

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -333,7 +333,10 @@ type Handler struct {
 	// so the feature degrades cleanly on deployments without a private key.
 	// Wired in cmd/server/router.go after New.
 	PRRefresh *ghsnapshot.Manager
-	cfg       Config
+	// GitHubPRMetrics records PR-link and snapshot-pipeline failures. Nil when
+	// the metrics listener is disabled.
+	GitHubPRMetrics *obsmetrics.GitHubPRMetrics
+	cfg             Config
 }
 
 func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *events.Bus, emailService *service.EmailService, store storage.Storage, cfSigner *auth.CloudFrontSigner, analyticsClient analytics.Client, cfg Config, daemonHubs ...*daemonws.Hub) *Handler {

--- a/server/internal/handler/vcs_webhook_test.go
+++ b/server/internal/handler/vcs_webhook_test.go
@@ -223,6 +223,62 @@ func TestVCSWebhook_ReferenceOnlyExcludedAndNonBlocking(t *testing.T) {
 	}
 }
 
+func TestVCSWebhook_MergedBareBodyMentionCanBePromotedButNotHidden(t *testing.T) {
+	ctx := context.Background()
+	box := withVCSBox(t)
+	connID := seedVCSConnection(t, ctx, box, "forgejo", "https://forgejo.test")
+	issue := newVCSIssue(t, "Historical merged PR backfill")
+	t.Cleanup(func() { cleanupVCS(ctx, issue.ID) })
+
+	fire := func(action, title, updatedAt string) {
+		raw, _ := json.Marshal(map[string]any{
+			"action": action,
+			"pull_request": map[string]any{
+				"number": 17, "html_url": "https://forgejo.test/acme/widget/pulls/17",
+				"title": title, "body": "Related " + issue.Identifier,
+				"state": "closed", "merged": true,
+				"merged_at": "2026-04-29T00:00:00Z", "closed_at": "2026-04-29T00:00:00Z",
+				"created_at": "2026-04-28T00:00:00Z", "updated_at": updatedAt,
+				"head": map[string]any{"ref": "cleanup", "sha": "promote17"},
+				"user": map[string]any{"username": "octo"},
+			},
+			"repository": map[string]any{"name": "widget", "owner": map[string]any{"username": "acme"}},
+		})
+		w := httptest.NewRecorder()
+		testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+			"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
+		}, raw))
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("%s event: %d %s", action, w.Code, w.Body.String())
+		}
+	}
+
+	link := func() (referenceOnly, closeIntent bool) {
+		t.Helper()
+		if err := testPool.QueryRow(ctx,
+			`SELECT reference_only, close_intent FROM issue_vcs_pull_request WHERE issue_id = $1`,
+			issue.ID).Scan(&referenceOnly, &closeIntent); err != nil {
+			t.Fatalf("select link: %v", err)
+		}
+		return referenceOnly, closeIntent
+	}
+
+	fire("closed", "Unrelated cleanup", "2026-04-29T00:00:00Z")
+	if referenceOnly, closeIntent := link(); !referenceOnly || closeIntent {
+		t.Fatalf("initial link = reference_only=%v close_intent=%v, want true/false", referenceOnly, closeIntent)
+	}
+
+	fire("edited", issue.Identifier+": historical cleanup", "2026-04-30T00:00:00Z")
+	if referenceOnly, closeIntent := link(); referenceOnly || closeIntent {
+		t.Fatalf("promoted link = reference_only=%v close_intent=%v, want false/false", referenceOnly, closeIntent)
+	}
+
+	fire("edited", "Unrelated cleanup", "2026-05-01T00:00:00Z")
+	if referenceOnly, closeIntent := link(); referenceOnly || closeIntent {
+		t.Fatalf("later edit rewrote link = reference_only=%v close_intent=%v, want false/false", referenceOnly, closeIntent)
+	}
+}
+
 // The close gate must span providers: an issue with an OPEN GitHub PR and a
 // MERGED close-intent VCS PR must report open_count > 0, so neither webhook
 // auto-advances it out from under the still-open GitHub work (and vice versa).

--- a/server/internal/integrations/ghsnapshot/refresh.go
+++ b/server/internal/integrations/ghsnapshot/refresh.go
@@ -18,6 +18,15 @@ type TxBeginner interface {
 	Begin(ctx context.Context) (pgx.Tx, error)
 }
 
+// Metrics records bounded, operator-actionable failure classes without
+// importing the production metrics package into the integration.
+type Metrics interface {
+	RecordSnapshotDisabledTrigger()
+	RecordSnapshotFetchFailure()
+	RecordSnapshotWriteFailure()
+	RecordSnapshotQueueDrop()
+}
+
 // address is the refresh unit and the dedup / single-in-flight key
 // (acceptance criterion 3): one (installation, owner, repo, number) tuple, which
 // may fan out to multiple github_pull_request rows across workspaces.
@@ -53,6 +62,7 @@ type Manager struct {
 	queries   *db.Queries
 	pool      TxBeginner
 	onApplied func(ctx context.Context, prID pgtype.UUID)
+	metrics   Metrics
 
 	concurrency   int
 	viewTTL       time.Duration
@@ -115,6 +125,9 @@ func NewManager(client *Client, queries *db.Queries, pool TxBeginner, onApplied 
 // Enabled reports whether the pipeline will actually do anything.
 func (m *Manager) Enabled() bool { return m != nil && m.client.Enabled() }
 
+// SetMetrics installs the optional production metrics sink.
+func (m *Manager) SetMetrics(metrics Metrics) { m.metrics = metrics }
+
 // Start launches the worker pool and the TTL sweeper under ctx. No-op (and
 // safe) when the manager is disabled.
 func (m *Manager) Start(ctx context.Context) {
@@ -145,6 +158,7 @@ func (m *Manager) Start(ctx context.Context) {
 // retained. Never blocks the caller.
 func (m *Manager) Enqueue(installationID int64, owner, repo string, number int32) {
 	if !m.Enabled() {
+		m.recordDisabledTrigger()
 		return
 	}
 	addr := address{InstallationID: installationID, Owner: owner, Repo: repo, Number: number}
@@ -170,6 +184,7 @@ func (m *Manager) Enqueue(installationID int64, owner, repo string, number int32
 		delete(m.trailing, addr)
 		m.mu.Unlock()
 		slog.Warn("ghsnapshot: refresh queue full, dropping enqueue")
+		m.recordQueueDrop()
 	}
 }
 
@@ -178,6 +193,7 @@ func (m *Manager) Enqueue(installationID int64, owner, repo string, number int32
 // fresh data costs nothing.
 func (m *Manager) MaybeEnqueueOnView(installationID int64, owner, repo string, number int32, fetchedAt time.Time, hasFetched bool) {
 	if !m.Enabled() {
+		m.recordDisabledTrigger()
 		return
 	}
 	if hasFetched && m.now().Sub(fetchedAt) < m.viewTTL {
@@ -230,7 +246,8 @@ func (m *Manager) process(ctx context.Context, addr address) {
 		// Transient/GitHub failure: keep the last-known snapshot (the row is
 		// untouched, so the card shows stale data, never wrong data). No secret
 		// is ever logged. The next trigger or the TTL sweep retries.
-		slog.Warn("ghsnapshot: fetch failed", "owner", addr.Owner, "repo", addr.Repo, "number", addr.Number, "err", err.Error())
+		slog.Warn("ghsnapshot: fetch failed", "installation_id", addr.InstallationID, "owner", addr.Owner, "repo", addr.Repo, "number", addr.Number, "err", err.Error())
+		m.recordFetchFailure()
 		return
 	}
 
@@ -241,7 +258,8 @@ func (m *Manager) process(ctx context.Context, addr address) {
 		PrNumber:       addr.Number,
 	})
 	if err != nil {
-		slog.Warn("ghsnapshot: list rows failed", "err", err.Error())
+		slog.Warn("ghsnapshot: list rows failed", "installation_id", addr.InstallationID, "owner", addr.Owner, "repo", addr.Repo, "number", addr.Number, "err", err.Error())
+		m.recordWriteFailure()
 		return
 	}
 
@@ -250,7 +268,8 @@ func (m *Manager) process(ctx context.Context, addr address) {
 	for _, row := range rows {
 		applied, err := m.applySnapshot(ctx, row.ID, snap)
 		if err != nil {
-			slog.Warn("ghsnapshot: apply snapshot failed", "err", err.Error())
+			slog.Warn("ghsnapshot: apply snapshot failed", "installation_id", addr.InstallationID, "owner", addr.Owner, "repo", addr.Repo, "number", addr.Number, "err", err.Error())
+			m.recordWriteFailure()
 			continue
 		}
 		if !applied {
@@ -316,6 +335,7 @@ func (m *Manager) deferActive(ctx context.Context, addr address, delay time.Dura
 		default:
 			m.release(addr)
 			slog.Warn("ghsnapshot: refresh queue full, dropping rate-limited enqueue")
+			m.recordQueueDrop()
 		}
 	})
 }
@@ -354,6 +374,31 @@ func (m *Manager) finish(addr address) {
 		delete(m.trailing, addr)
 		m.mu.Unlock()
 		slog.Warn("ghsnapshot: refresh queue full, dropping trailing enqueue")
+		m.recordQueueDrop()
+	}
+}
+
+func (m *Manager) recordDisabledTrigger() {
+	if m != nil && m.metrics != nil {
+		m.metrics.RecordSnapshotDisabledTrigger()
+	}
+}
+
+func (m *Manager) recordFetchFailure() {
+	if m.metrics != nil {
+		m.metrics.RecordSnapshotFetchFailure()
+	}
+}
+
+func (m *Manager) recordWriteFailure() {
+	if m.metrics != nil {
+		m.metrics.RecordSnapshotWriteFailure()
+	}
+}
+
+func (m *Manager) recordQueueDrop() {
+	if m.metrics != nil {
+		m.metrics.RecordSnapshotQueueDrop()
 	}
 }
 

--- a/server/internal/integrations/ghsnapshot/refresh_db_test.go
+++ b/server/internal/integrations/ghsnapshot/refresh_db_test.go
@@ -100,7 +100,7 @@ func checkRunCount(t *testing.T, pool *pgxpool.Pool, prID pgtype.UUID) int {
 
 func TestListStaleUndecidedGitHubPRsExcludesDecidedAndRotatesCursor(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_010_000, 0)
@@ -201,7 +201,7 @@ func TestListStaleUndecidedGitHubPRsExcludesDecidedAndRotatesCursor(t *testing.T
 // response for an old head must never overwrite a newer head's snapshot.
 func TestApplySnapshotHeadSHAGuard(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_000_100, 0)
@@ -277,7 +277,7 @@ func TestApplySnapshotHeadSHAGuard(t *testing.T) {
 // trailing edge must still fetch and apply B immediately.
 func TestInFlightOldHeadKeepsTrailingRefresh(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	q := db.New(pool)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -368,7 +368,7 @@ func TestInFlightOldHeadKeepsTrailingRefresh(t *testing.T) {
 // replace, not an accumulation.
 func TestApplySnapshotReplacesRuns(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_000_200, 0)

--- a/server/internal/integrations/ghsnapshot/refresh_test.go
+++ b/server/internal/integrations/ghsnapshot/refresh_test.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+type recordingSnapshotMetrics struct {
+	disabled   int
+	fetch      int
+	write      int
+	queueDrops int
+}
+
+func (m *recordingSnapshotMetrics) RecordSnapshotDisabledTrigger() { m.disabled++ }
+func (m *recordingSnapshotMetrics) RecordSnapshotFetchFailure()    { m.fetch++ }
+func (m *recordingSnapshotMetrics) RecordSnapshotWriteFailure()    { m.write++ }
+func (m *recordingSnapshotMetrics) RecordSnapshotQueueDrop()       { m.queueDrops++ }
+
 func enabledClient(t *testing.T) *Client {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -22,16 +34,36 @@ func enabledClient(t *testing.T) *Client {
 // criterion 4): with no App key the manager touches nothing.
 func TestManagerDisabledNoOps(t *testing.T) {
 	m := NewManager(nil, nil, nil, nil)
+	metrics := &recordingSnapshotMetrics{}
+	m.SetMetrics(metrics)
 	if m.Enabled() {
 		t.Fatal("nil-client manager must be disabled")
 	}
 	m.Enqueue(1, "o", "r", 2)
 	m.MaybeEnqueueOnView(1, "o", "r", 2, time.Time{}, false)
+	if metrics.disabled != 2 {
+		t.Fatalf("disabled triggers = %d, want 2", metrics.disabled)
+	}
 	if len(m.queue) != 0 {
 		t.Fatalf("disabled manager enqueued %d items, want 0", len(m.queue))
 	}
 	// Start must be a safe no-op (no workers, no panic).
 	m.Start(context.Background())
+}
+
+func TestFetchFailureIsObservable(t *testing.T) {
+	m := NewManager(enabledClient(t), nil, nil, nil)
+	metrics := &recordingSnapshotMetrics{}
+	m.SetMetrics(metrics)
+	m.jitter = func() time.Duration { return 0 }
+	m.fetch = func(context.Context, *Client, int64, string, string, int32) (*PRSnapshot, error) {
+		return nil, errors.New("github unavailable")
+	}
+
+	m.process(context.Background(), address{InstallationID: 1, Owner: "o", Repo: "r", Number: 1})
+	if metrics.fetch != 1 {
+		t.Fatalf("fetch failures = %d, want 1", metrics.fetch)
+	}
 }
 
 // TestEnqueueCoalesces proves the dedup / single-in-flight key (acceptance

--- a/server/internal/metrics/github_pr.go
+++ b/server/internal/metrics/github_pr.go
@@ -1,0 +1,54 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// GitHubPRMetrics exposes the failure modes that otherwise leave PR links or
+// API snapshots silently absent. Counters intentionally carry no workspace,
+// installation, repository, or PR labels; those identifiers are unbounded and
+// belong in the adjacent structured logs.
+type GitHubPRMetrics struct {
+	linkWriteFailures        prometheus.Counter
+	snapshotDisabledTriggers prometheus.Counter
+	snapshotFetchFailures    prometheus.Counter
+	snapshotWriteFailures    prometheus.Counter
+	snapshotQueueDrops       prometheus.Counter
+}
+
+func NewGitHubPRMetrics() *GitHubPRMetrics {
+	counter := func(name, help string) prometheus.Counter {
+		return prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "multica",
+			Subsystem: "github_pr",
+			Name:      name,
+			Help:      help,
+		})
+	}
+	return &GitHubPRMetrics{
+		linkWriteFailures: counter("link_write_failures_total",
+			"GitHub pull request issue-link upserts that failed."),
+		snapshotDisabledTriggers: counter("snapshot_disabled_triggers_total",
+			"GitHub pull request snapshot refresh triggers ignored because GitHub App API credentials are unavailable."),
+		snapshotFetchFailures: counter("snapshot_fetch_failures_total",
+			"GitHub pull request snapshot API fetches that failed, excluding rate limits."),
+		snapshotWriteFailures: counter("snapshot_write_failures_total",
+			"GitHub pull request snapshot database reads or writes that failed."),
+		snapshotQueueDrops: counter("snapshot_queue_drops_total",
+			"GitHub pull request snapshot refreshes dropped because the in-memory queue was full."),
+	}
+}
+
+func (m *GitHubPRMetrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.linkWriteFailures,
+		m.snapshotDisabledTriggers,
+		m.snapshotFetchFailures,
+		m.snapshotWriteFailures,
+		m.snapshotQueueDrops,
+	}
+}
+
+func (m *GitHubPRMetrics) RecordLinkWriteFailure()        { m.linkWriteFailures.Inc() }
+func (m *GitHubPRMetrics) RecordSnapshotDisabledTrigger() { m.snapshotDisabledTriggers.Inc() }
+func (m *GitHubPRMetrics) RecordSnapshotFetchFailure()    { m.snapshotFetchFailures.Inc() }
+func (m *GitHubPRMetrics) RecordSnapshotWriteFailure()    { m.snapshotWriteFailures.Inc() }
+func (m *GitHubPRMetrics) RecordSnapshotQueueDrop()       { m.snapshotQueueDrops.Inc() }

--- a/server/internal/metrics/github_pr_test.go
+++ b/server/internal/metrics/github_pr_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestEveryGitHubPRFailureCounterActuallyCounts(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewGitHubPRMetrics()
+	for _, c := range m.Collectors() {
+		if err := reg.Register(c); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+
+	m.RecordLinkWriteFailure()
+	m.RecordSnapshotDisabledTrigger()
+	m.RecordSnapshotFetchFailure()
+	m.RecordSnapshotWriteFailure()
+	m.RecordSnapshotQueueDrop()
+
+	seen := gatherWecomValues(t, reg)
+	for _, want := range []string{
+		"multica_github_pr_link_write_failures_total",
+		"multica_github_pr_snapshot_disabled_triggers_total",
+		"multica_github_pr_snapshot_fetch_failures_total",
+		"multica_github_pr_snapshot_write_failures_total",
+		"multica_github_pr_snapshot_queue_drops_total",
+	} {
+		if seen[want] != 1 {
+			t.Errorf("%s = %v, want 1", want, seen[want])
+		}
+	}
+}
+
+func TestTheRegistryExposesGitHubPRCounters(t *testing.T) {
+	r := NewRegistry(RegistryOptions{})
+	if r.GitHubPR == nil {
+		t.Fatal("Registry.GitHubPR is nil; nothing can report through it")
+	}
+	r.GitHubPR.RecordSnapshotDisabledTrigger()
+
+	families, err := r.Gatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() == "multica_github_pr_snapshot_disabled_triggers_total" {
+			return
+		}
+	}
+	t.Fatal("multica_github_pr_snapshot_disabled_triggers_total is not exposed")
+}

--- a/server/internal/metrics/registry.go
+++ b/server/internal/metrics/registry.go
@@ -33,6 +33,7 @@ type Registry struct {
 	ChannelMedia *ChannelMediaReconcilerMetrics
 	ChannelLease *ChannelLeaseMetrics
 	Wecom        *WecomMetrics
+	GitHubPR     *GitHubPRMetrics
 	// Sampler is non-nil only when RegistryOptions.BusinessSampler was
 	// supplied with a valid Pool. Exposed so the cmd/server entrypoint
 	// can plumb the same instance into health checks if it ever wants to.
@@ -66,6 +67,9 @@ func NewRegistry(opts RegistryOptions) *Registry {
 	wecomMetrics := NewWecomMetrics()
 	reg.MustRegister(wecomMetrics.Collectors()...)
 
+	githubPRMetrics := NewGitHubPRMetrics()
+	reg.MustRegister(githubPRMetrics.Collectors()...)
+
 	if opts.Pool != nil {
 		reg.MustRegister(NewDBCollector(opts.Pool))
 	}
@@ -88,6 +92,7 @@ func NewRegistry(opts RegistryOptions) *Registry {
 		ChannelMedia: channelMedia,
 		ChannelLease: channelLease,
 		Wecom:        wecomMetrics,
+		GitHubPR:     githubPRMetrics,
 		Sampler:      sampler,
 	}
 }

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -64,6 +64,11 @@ Closes MUL-2759 in the body                        # links and shown
 Related to MUL-2759 in the body (no title/branch)  # links but reference_only → hidden
 ```
 
+For a merged or closed PR, a later edit that adds the issue key to the title or
+branch promotes an existing reference-only row into a visible working link.
+That promotion is one-way: later terminal edits cannot hide the link again, and
+they still cannot add close intent retroactively.
+
 ### Default for code-changing issue work
 
 When an issue run changes code in a checked-out GitHub repo, the default handoff

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -90,8 +90,12 @@ row is written with `reference_only = true`. Both `ListPullRequestsByIssue` and
 reference-only links are hidden from the CLI / UI PR list **and** excluded from
 the auto-advance gate (an open body-only mention must not silently block the
 issue from reaching `done` while invisible in the list). The row still exists for
-edit-time close-intent tracking. `reference_only` follows the same
-`preserve_close_intent` terminal gate as `close_intent`.
+edit-time close-intent tracking. At the terminal preserve gate, close intent
+stays frozen while reference-only visibility can move from hidden to visible but
+never back to hidden. The one-way expression lives in
+`server/pkg/db/queries/github.sql` (`LinkIssueToPullRequest`); migration
+`344_promote_terminal_pr_references` applies the same promotion to historical
+rows whose mirrored PR title or branch now contains the issue identifier.
 
 Drifted from the prior skill's `github.go:727` citation, which pointed at the old
 call-site location for the link logic.

--- a/server/migrations/344_promote_terminal_pr_references.down.sql
+++ b/server/migrations/344_promote_terminal_pr_references.down.sql
@@ -1,0 +1,3 @@
+-- Visibility promotion is an irreversible data correction. Re-hiding rows on
+-- rollback would remove legitimate working PRs from issue views.
+SELECT 1;

--- a/server/migrations/344_promote_terminal_pr_references.up.sql
+++ b/server/migrations/344_promote_terminal_pr_references.up.sql
@@ -1,0 +1,25 @@
+-- Repair historical links that were created from a bare PR body mention and
+-- therefore hidden as reference_only, then later gained a routable issue key
+-- in the mirrored title or branch after the PR was already terminal.
+--
+-- The webhook upsert now performs the same one-way promotion for future
+-- deliveries. This migration makes the rollout repair existing rows without a
+-- GitHub replay and is idempotent because it only changes TRUE to FALSE.
+UPDATE issue_pull_request AS ipr
+SET reference_only = FALSE
+FROM issue AS i, workspace AS w, github_pull_request AS pr
+WHERE ipr.reference_only
+  AND ipr.issue_id = i.id
+  AND w.id = i.workspace_id
+  AND pr.id = ipr.pull_request_id
+  AND pr.workspace_id = i.workspace_id
+  AND (
+      lower(pr.title) ~ (
+          '(^|[^a-z0-9])' || lower(w.issue_prefix || '-' || i.number::text) ||
+          '([^a-z0-9]|$)'
+      )
+      OR lower(COALESCE(pr.branch, '')) ~ (
+          '(^|[^a-z0-9])' || lower(w.issue_prefix || '-' || i.number::text) ||
+          '([^a-z0-9]|$)'
+      )
+  );

--- a/server/pkg/db/generated/github.sql.go
+++ b/server/pkg/db/generated/github.sql.go
@@ -297,7 +297,8 @@ ON CONFLICT (issue_id, pull_request_id) DO UPDATE SET
         ELSE EXCLUDED.close_intent
     END,
     reference_only = CASE
-        WHEN $7 THEN issue_pull_request.reference_only
+        WHEN $7
+            THEN issue_pull_request.reference_only AND EXCLUDED.reference_only
         ELSE EXCLUDED.reference_only
     END
 `
@@ -322,9 +323,10 @@ type LinkIssueToPullRequestParams struct {
 // keeping the merge-time decision stable.
 //
 // reference_only marks a link justified ONLY by a bare body mention (no closing
-// keyword, no title/branch reference). It follows the same preserve gate as
-// close_intent so a post-terminal edit can't retroactively hide a PR that did
-// the work. The issue's PR list filters these out (see ListPullRequestsByIssue).
+// keyword, no title/branch reference). After the PR becomes terminal it may
+// still be promoted from hidden to visible by adding a title/branch identifier,
+// but it can never be demoted back to hidden. The issue's PR list filters these
+// out (see ListPullRequestsByIssue).
 func (q *Queries) LinkIssueToPullRequest(ctx context.Context, arg LinkIssueToPullRequestParams) error {
 	_, err := q.db.Exec(ctx, linkIssueToPullRequest,
 		arg.IssueID,

--- a/server/pkg/db/generated/vcs.sql.go
+++ b/server/pkg/db/generated/vcs.sql.go
@@ -122,7 +122,8 @@ ON CONFLICT (issue_id, pull_request_id) DO UPDATE SET
         ELSE EXCLUDED.close_intent
     END,
     reference_only = CASE
-        WHEN $7 THEN issue_vcs_pull_request.reference_only
+        WHEN $7
+            THEN issue_vcs_pull_request.reference_only AND EXCLUDED.reference_only
         ELSE EXCLUDED.reference_only
     END
 `
@@ -142,8 +143,8 @@ type LinkIssueToVCSPullRequestParams struct {
 // =====================
 // reference_only marks a link justified ONLY by a bare body mention (no closing
 // keyword and no title/branch reference), mirroring the GitHub link upsert.
-// preserve_close_intent freezes both close_intent and reference_only once a
-// terminal merge/close event has been recorded.
+// preserve_close_intent freezes close_intent after a terminal event; visibility
+// may still be promoted from reference-only to working, but never demoted.
 func (q *Queries) LinkIssueToVCSPullRequest(ctx context.Context, arg LinkIssueToVCSPullRequestParams) error {
 	_, err := q.db.Exec(ctx, linkIssueToVCSPullRequest,
 		arg.IssueID,

--- a/server/pkg/db/queries/github.sql
+++ b/server/pkg/db/queries/github.sql
@@ -259,9 +259,10 @@ WHERE ipr.issue_id = $1 AND NOT ipr.reference_only;
 -- keeping the merge-time decision stable.
 --
 -- reference_only marks a link justified ONLY by a bare body mention (no closing
--- keyword, no title/branch reference). It follows the same preserve gate as
--- close_intent so a post-terminal edit can't retroactively hide a PR that did
--- the work. The issue's PR list filters these out (see ListPullRequestsByIssue).
+-- keyword, no title/branch reference). After the PR becomes terminal it may
+-- still be promoted from hidden to visible by adding a title/branch identifier,
+-- but it can never be demoted back to hidden. The issue's PR list filters these
+-- out (see ListPullRequestsByIssue).
 INSERT INTO issue_pull_request (
     issue_id, pull_request_id, linked_by_type, linked_by_id, close_intent, reference_only
 ) VALUES (
@@ -273,7 +274,8 @@ ON CONFLICT (issue_id, pull_request_id) DO UPDATE SET
         ELSE EXCLUDED.close_intent
     END,
     reference_only = CASE
-        WHEN sqlc.arg('preserve_close_intent') THEN issue_pull_request.reference_only
+        WHEN sqlc.arg('preserve_close_intent')
+            THEN issue_pull_request.reference_only AND EXCLUDED.reference_only
         ELSE EXCLUDED.reference_only
     END;
 

--- a/server/pkg/db/queries/vcs.sql
+++ b/server/pkg/db/queries/vcs.sql
@@ -197,8 +197,8 @@ WHERE pr.connection_id = $1 AND pr.head_sha = $2 AND pr.head_sha <> '';
 -- name: LinkIssueToVCSPullRequest :exec
 -- reference_only marks a link justified ONLY by a bare body mention (no closing
 -- keyword and no title/branch reference), mirroring the GitHub link upsert.
--- preserve_close_intent freezes both close_intent and reference_only once a
--- terminal merge/close event has been recorded.
+-- preserve_close_intent freezes close_intent after a terminal event; visibility
+-- may still be promoted from reference-only to working, but never demoted.
 INSERT INTO issue_vcs_pull_request (
     issue_id, pull_request_id, linked_by_type, linked_by_id, close_intent, reference_only
 ) VALUES (
@@ -210,6 +210,7 @@ ON CONFLICT (issue_id, pull_request_id) DO UPDATE SET
         ELSE EXCLUDED.close_intent
     END,
     reference_only = CASE
-        WHEN sqlc.arg('preserve_close_intent') THEN issue_vcs_pull_request.reference_only
+        WHEN sqlc.arg('preserve_close_intent')
+            THEN issue_vcs_pull_request.reference_only AND EXCLUDED.reference_only
         ELSE EXCLUDED.reference_only
     END;


### PR DESCRIPTION
## What does this PR do?

Repairs two independent failure modes behind AERIS-207:

1. A PR first linked by a bare body mention stayed permanently hidden after it was merged/closed, even if a later edit added the issue identifier to the title or branch. The terminal upsert froze `reference_only` together with `close_intent`.
2. GitHub API snapshot failures could leave checks and mergeability unavailable without a metric or alert explaining whether credentials, fetches, writes, or queue capacity were responsible.

The link fix makes visibility promotion one-way after a terminal event (`hidden -> visible`, never `visible -> hidden`) while continuing to freeze close intent. A migration applies the same idempotent promotion to historical GitHub rows whose mirrored title or branch now qualifies.

## Related Issue

AERIS-207 (Multica workspace)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Make terminal GitHub and generic VCS link upserts promote `reference_only` with monotonic boolean semantics while preserving close intent.
- Add migration 344 to repair existing hidden GitHub links from current mirrored title/branch data; the update is idempotent and does not alter close intent.
- Add GitHub and VCS regression tests for post-merge promotion, no retroactive close intent, and no later demotion.
- Add bounded Prometheus counters and Helm alerts for link-write failures, disabled snapshot credentials, snapshot fetch/write failures, and queue drops; add correlation fields to structured logs.
- Fix snapshot DB test cleanup ordering so row cleanup runs before the pool closes.
- Update the built-in issue/PR skill and its source map with the one-way promotion contract.

## How to Test

1. Run `DATABASE_URL=... bash scripts/test-go.sh --race` against a migrated PostgreSQL database.
2. Run `helm lint deploy/helm/multica --set monitoring.prometheusRule.enabled=true`.
3. Deliver a merged/closed PR first with only a bare issue mention, then edit its title or branch to contain the issue identifier; verify it becomes visible exactly once and never gains close intent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked terminology conventions (not applicable)
- [x] I have considered and documented risks below
- [x] I will address all reviewer comments before requesting merge

Risk is limited to link visibility and observability. The terminal close decision remains frozen; migration 344 only changes `reference_only` from true to false when the current mirrored title or branch has a boundary-safe identifier match. The down migration intentionally does not re-hide legitimate links.

## AI Disclosure

**AI tool used:** Multica Mika / Codex

**Prompt / approach:** Reproduced the hidden-link transition against PostgreSQL, confirmed the terminal preservation gate as root cause, added red/green regression coverage, applied the same monotonic rule to GitHub and generic VCS links, added an idempotent historical repair, then instrumented the snapshot failure classes and ran the full race suite in an isolated task-free environment.

## Screenshots (optional)

Not applicable; no UI change.
