### PR TITLE
MUL-6363: feat(issues): support filtering custom properties by "no value"

### DIFF
--- a/packages/views/issues/components/filter-chips-bar.tsx
+++ b/packages/views/issues/components/filter-chips-bar.tsx
@@ -2,6 +2,7 @@
 
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { useStatusLabel } from "../utils/status-label";
+import { NO_PROPERTY_VALUE } from "../utils/filter";
 import { useMemo, type ReactNode } from "react";
 import {
   CalendarDays,
@@ -457,6 +458,9 @@ function useFilterChips(
     const actorProperty = isActorPropertyType(definition.type);
     const actorValues = actorProperty ? actorFilterValues(selected) : [];
     const optionName = (optionId: string): string | undefined => {
+      if (optionId === NO_PROPERTY_VALUE) {
+        return t(($) => $.pickers.custom_property.no_value_label);
+      }
       if (actorProperty) {
         const ref = parseActorRef(optionId);
         return ref ? actorName({ type: ref.kind, id: ref.id }) : undefined;

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -116,6 +116,7 @@ import { cn } from "@multica/ui/lib/utils";
 import { PAGE_GUTTER } from "../../layout/page-header";
 import { useT } from "../../i18n";
 import { useStatusOptions } from "../utils/status-options";
+import { NO_PROPERTY_VALUE } from "../utils/filter";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { WorkspaceAgentWorkingChip } from "./workspace-agent-working-chip";
@@ -704,26 +705,38 @@ function PropertyFilterOptions({
       }));
   }, [actorProperty, actorMembers, currentUserId]);
 
-  const options = actorProperty
-    ? actorOptions.map((option) => ({
-        id: option.id,
-        name: option.name,
-        color: undefined as string | undefined,
-        actorType: option.actorType as string | undefined,
-        actorId: option.actorId as string | undefined,
-      }))
-    : property.type === "checkbox"
-      ? [
-          { id: "true", name: t(($) => $.pickers.custom_property.true_label), color: undefined, actorType: undefined, actorId: undefined },
-          { id: "false", name: t(($) => $.pickers.custom_property.false_label), color: undefined, actorType: undefined, actorId: undefined },
-        ]
-      : (property.config.options ?? []).map((option) => ({
+  // "No value" is offered for every property type: it selects issues where the
+  // property is unset, the inverse of picking one of the options below.
+  const noValueOption = {
+    id: NO_PROPERTY_VALUE,
+    name: t(($) => $.pickers.custom_property.no_value_label),
+    color: undefined as string | undefined,
+    actorType: undefined as string | undefined,
+    actorId: undefined as string | undefined,
+  };
+  const options = [
+    ...(actorProperty
+      ? actorOptions.map((option) => ({
           id: option.id,
           name: option.name,
-          color: option.color as string | undefined,
-          actorType: undefined as string | undefined,
-          actorId: undefined as string | undefined,
-        }));
+          color: undefined as string | undefined,
+          actorType: option.actorType as string | undefined,
+          actorId: option.actorId as string | undefined,
+        }))
+      : property.type === "checkbox"
+        ? [
+            { id: "true", name: t(($) => $.pickers.custom_property.true_label), color: undefined, actorType: undefined, actorId: undefined },
+            { id: "false", name: t(($) => $.pickers.custom_property.false_label), color: undefined, actorType: undefined, actorId: undefined },
+          ]
+        : (property.config.options ?? []).map((option) => ({
+            id: option.id,
+            name: option.name,
+            color: option.color as string | undefined,
+            actorType: undefined as string | undefined,
+            actorId: undefined as string | undefined,
+          }))),
+    noValueOption,
+  ];
 
   return (
     <>

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -5,6 +5,7 @@ import {
   applyIssueFilters,
   filterAssigneeGroups,
   filterIssues,
+  NO_PROPERTY_VALUE,
   type IssueFilters,
 } from "./filter";
 
@@ -433,6 +434,32 @@ describe("property filters", () => {
       propertyFilters: { [doneId]: ["true"] },
     });
     expect(result.map((i) => i.id)).toEqual(["P4"]);
+  });
+
+  it("no-value matches issues where the property is unset", () => {
+    // P1/P2/P3 have no `doneId` at all; P4 has it set to true.
+    const result = filterIssues([critical, minor, unset, checked], {
+      ...NO_FILTER,
+      propertyFilters: { [doneId]: [NO_PROPERTY_VALUE] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P1", "P2", "P3"]);
+  });
+
+  it("no-value ORs with a value within the definition", () => {
+    const result = filterIssues([critical, minor, unset, checked], {
+      ...NO_FILTER,
+      propertyFilters: { [doneId]: ["true", NO_PROPERTY_VALUE] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P1", "P2", "P3", "P4"]);
+  });
+
+  it("no-value ANDs across definitions", () => {
+    // Only P2 carries `sevId=opt-minor` and leaves `doneId` unset.
+    const result = filterIssues([critical, minor, unset, checked], {
+      ...NO_FILTER,
+      propertyFilters: { [sevId]: ["opt-minor"], [doneId]: [NO_PROPERTY_VALUE] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P2"]);
   });
 
   it("ANDs across definitions", () => {

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -53,10 +53,19 @@ export interface IssueFilterContext {
 }
 
 /**
+ * Filter value that selects issues where a custom property is UNSET ("No
+ * value"). Mirrors the backend sentinel in `parsePropertiesFilterParam`
+ * (`server/internal/handler/property.go`); cannot collide with a real option id
+ * (select options are UUIDs, checkbox uses "true"/"false").
+ */
+export const NO_PROPERTY_VALUE = "__none__";
+
+/**
  * Match one issue against the property filters. Select values are single
  * option-id strings, multi_select values are option-id arrays, checkbox
  * values are booleans compared against the "true"/"false" pseudo-options.
- * An issue with no value for a filtered definition never matches it.
+ * An issue with no value for a filtered definition matches only when the
+ * "No value" (NO_PROPERTY_VALUE) pseudo-option is selected for it.
  */
 export function issueMatchesPropertyFilters(
   issue: Issue,
@@ -66,7 +75,10 @@ export function issueMatchesPropertyFilters(
   for (const [propertyId, selected] of Object.entries(propertyFilters)) {
     if (selected.length === 0) continue;
     const value = issue.properties?.[propertyId];
-    if (value === undefined) return false;
+    if (value === undefined) {
+      if (selected.includes(NO_PROPERTY_VALUE)) continue;
+      return false;
+    }
     if (typeof value === "string") {
       if (!selected.includes(value)) return false;
     } else if (Array.isArray(value)) {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -650,6 +650,7 @@
       "none": "No value",
       "true_label": "Yes",
       "false_label": "No",
+      "no_value_label": "No value",
       "value_placeholder": "Enter value…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -620,6 +620,7 @@
       "none": "値なし",
       "true_label": "はい",
       "false_label": "いいえ",
+      "no_value_label": "値なし",
       "value_placeholder": "値を入力…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -620,6 +620,7 @@
       "none": "값 없음",
       "true_label": "예",
       "false_label": "아니요",
+      "no_value_label": "값 없음",
       "value_placeholder": "값 입력…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -619,6 +619,7 @@
       "empty": "空",
       "true_label": "是",
       "false_label": "否",
+      "no_value_label": "未设置",
       "value_placeholder": "输入值…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/server/internal/handler/issue_table_facets.go
+++ b/server/internal/handler/issue_table_facets.go
@@ -247,11 +247,13 @@ GROUP BY a.id`, compiled.where)
 		propertyKey := "'" + util.UUIDToString(property.ID) + "'"
 		switch property.Type {
 		case "select", "actor":
-			query = fmt.Sprintf(`SELECT i.properties ->> %s, COUNT(*)::bigint FROM issue i WHERE %s AND jsonb_typeof(i.properties -> %s) = 'string' GROUP BY 1`, propertyKey, compiled.where, propertyKey)
+			// Unset issues count under the "__none__" bucket so the filter menu's
+			// "No value" option carries a real count (issues without the key).
+			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'string' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
 		case "multi_select", "multi_actor":
-			query = fmt.Sprintf(`SELECT property_value.value, COUNT(DISTINCT i.id)::bigint FROM issue i JOIN LATERAL jsonb_array_elements_text(CASE WHEN jsonb_typeof(i.properties -> %s) = 'array' THEN i.properties -> %s ELSE '[]'::jsonb END) AS property_value(value) ON TRUE WHERE %s GROUP BY property_value.value`, propertyKey, propertyKey, compiled.where)
+			query = fmt.Sprintf(`SELECT COALESCE(property_value.value, '__none__'), COUNT(DISTINCT i.id)::bigint FROM issue i JOIN LATERAL (SELECT jsonb_array_elements_text(CASE WHEN jsonb_typeof(i.properties -> %s) = 'array' THEN i.properties -> %s ELSE '[]'::jsonb END) AS value UNION ALL SELECT NULL WHERE NOT (i.properties ? %s)) property_value(value) ON TRUE WHERE %s GROUP BY 1`, propertyKey, propertyKey, propertyKey, compiled.where)
 		case "checkbox":
-			query = fmt.Sprintf(`SELECT i.properties ->> %s, COUNT(*)::bigint FROM issue i WHERE %s AND jsonb_typeof(i.properties -> %s) = 'boolean' GROUP BY 1`, propertyKey, compiled.where, propertyKey)
+			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'boolean' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
 		default:
 			writeIssueTableUnsupportedGroup(w, "property_type_unsupported", "This property type cannot be used as a filter facet.")
 			return response, false

--- a/server/internal/handler/property.go
+++ b/server/internal/handler/property.go
@@ -1070,6 +1070,11 @@ func (h *Handler) withPropertyLock(r *http.Request, lockKeys []string, fn func(q
 const (
 	maxPropertiesFilterDefinitions = 20
 	maxPropertiesFilterValues      = 50
+	// noPropertyValue is the filter value that means "unset" — it compiles to a
+	// key-absence predicate instead of a jsonb containment pattern. The string
+	// cannot collide with a real option id (select option ids are UUIDs and
+	// checkbox uses "true"/"false").
+	noPropertyValue = "__none__"
 )
 
 // parsePropertiesFilterParam reads the `properties` query parameter — a JSON
@@ -1080,6 +1085,10 @@ const (
 // checkbox. The stored value shape differs per type (string, array element,
 // boolean), so each value expands to every containment form it could match;
 // forms that can't match are simply never satisfied.
+//
+// The special value noPropertyValue ("__none__") means "unset": it emits the
+// marker object {"__none__": "<definitionId>"} that parseNoPropertyValuePattern
+// and the static ListOpenIssues unroll both recognize as a key-absence check.
 //
 // Returns (nil, true) when the parameter is empty.
 func parsePropertiesFilterParam(w http.ResponseWriter, raw string) ([][]json.RawMessage, bool) {
@@ -1119,10 +1128,24 @@ func parsePropertiesFilterParam(w http.ResponseWriter, raw string) ([][]json.Raw
 			alternatives = append(alternatives, buf)
 			return true
 		}
+		hasNoValue := false
 		for _, value := range values {
 			if value == "" {
 				writeError(w, http.StatusBadRequest, "properties filter values cannot be empty")
 				return nil, false
+			}
+			if value == noPropertyValue {
+				if hasNoValue {
+					continue
+				}
+				marker, err := json.Marshal(map[string]string{noPropertyValue: definitionID})
+				if err != nil {
+					writeError(w, http.StatusBadRequest, "properties filter is invalid")
+					return nil, false
+				}
+				alternatives = append(alternatives, marker)
+				hasNoValue = true
+				continue
 			}
 			if !appendAlt(value) || !appendAlt([]string{value}) { // select string / multi_select element
 				return nil, false
@@ -1148,16 +1171,36 @@ func parsePropertiesFilterParam(w http.ResponseWriter, raw string) ([][]json.Raw
 	return groups, true
 }
 
+// parseNoPropertyValuePattern reports whether an alternative is the synthesized
+// "no value" marker — the jsonb object {"__none__": "<definitionId>"} — and
+// returns the definition id whose key-absence the predicate must test.
+func parseNoPropertyValuePattern(alt json.RawMessage) (string, bool) {
+	var marker map[string]string
+	if err := json.Unmarshal(alt, &marker); err != nil {
+		return "", false
+	}
+	defID, ok := marker[noPropertyValue]
+	return defID, ok
+}
+
 // propertiesFilterPredicate renders the AND-of-ORs containment check for a
 // compiled filter as plain `i.properties @> $n` disjunctions with one bind
 // parameter per alternative. Constant containment operands are what lets the
 // planner drive the jsonb_path_ops GIN index (a correlated
 // jsonb_array_elements form defeats it — verified via EXPLAIN in review).
+//
+// A "no value" marker alternative renders as a key-absence disjunction —
+// `NOT (i.properties ? $m)` — which cannot use the GIN index but is exact for
+// the unset state (property values are never null; DELETE unsets).
 func propertiesFilterPredicate(groups [][]json.RawMessage, addArg func(any) string) string {
 	groupSQL := make([]string, 0, len(groups))
 	for _, alternatives := range groups {
 		ors := make([]string, 0, len(alternatives))
 		for _, alt := range alternatives {
+			if defID, ok := parseNoPropertyValuePattern(alt); ok {
+				ors = append(ors, fmt.Sprintf("NOT (i.properties ? %s)", addArg(defID)))
+				continue
+			}
 			ors = append(ors, fmt.Sprintf("i.properties @> %s::jsonb", addArg(string(alt))))
 		}
 		groupSQL = append(groupSQL, "("+strings.Join(ors, " OR ")+")")

--- a/server/internal/handler/property_test.go
+++ b/server/internal/handler/property_test.go
@@ -580,6 +580,105 @@ func TestListIssuesPropertyFilterAndSort(t *testing.T) {
 	if got := listIssues("?limit=5&sort=property:" + uuid.NewString()); len(got) == 0 {
 		t.Fatalf("unknown-definition sort should fall back to position order, got empty")
 	}
+
+	// "No value" filter (the "__none__" sentinel): issues without the property
+	// match, the one explicitly set to `true` does not. limit=200 so the ~55
+	// matching issues (54 pad + numLow/numHigh, all without the checkbox) fit
+	// on one page — the 50-row default would hide numLow behind windowing.
+	noValueQuery := func(values ...string) string {
+		buf, _ := json.Marshal(map[string][]string{box.ID: values})
+		return "?limit=200&properties=" + url.QueryEscape(string(buf))
+	}
+	noneGot := ids(listIssues(noValueQuery("__none__")))
+	if _, present := noneGot[target]; present {
+		t.Fatalf("no-value filter included the issue with the property set")
+	}
+	if _, present := noneGot[numLow]; !present {
+		t.Fatalf("no-value filter missed an issue without the property")
+	}
+
+	// OR within a definition: "true" plus "no value" covers set and unset.
+	both := ids(listIssues(noValueQuery("true", "__none__")))
+	if _, present := both[target]; !present {
+		t.Fatalf("OR no-value filter missed the set issue")
+	}
+	if _, present := both[numLow]; !present {
+		t.Fatalf("OR no-value filter missed the unset issue")
+	}
+
+	// AND across definitions: matching select + no-value checkbox must exclude
+	// the target (it has the checkbox set, so it cannot match the unset branch).
+	andBuf, _ := json.Marshal(map[string][]string{sel.ID: {hitID}, box.ID: {"__none__"}})
+	andGot := ids(listIssues("?limit=50&properties=" + url.QueryEscape(string(andBuf))))
+	if _, present := andGot[target]; present {
+		t.Fatalf("AND no-value semantics failed: target matched contradictory filter")
+	}
+
+	// The open_only branch unrolls the same compiled filter through the static
+	// ListOpenIssues query, so the marker must be honored there too.
+	openNone := ids(listIssues(filterQuery(box.ID, "__none__") + "&open_only=true"))
+	if _, present := openNone[target]; present {
+		t.Fatalf("open_only no-value filter included the set issue")
+	}
+	if len(openNone) == 0 {
+		t.Fatalf("open_only no-value filter returned nothing")
+	}
+}
+
+func TestParsePropertiesFilterNoValueUnit(t *testing.T) {
+	defID := uuid.NewString()
+	w := httptest.NewRecorder()
+	var args []any
+	addArg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	// "__none__" compiles to the marker object, and the predicate turns that
+	// marker into a key-absence check rather than a containment pattern.
+	groups, ok := parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["__none__"]}`, defID))
+	if !ok {
+		t.Fatalf("no-value parse failed: %s", w.Body.String())
+	}
+	if len(groups) != 1 || len(groups[0]) != 1 {
+		t.Fatalf("expected one group with one alternative, got %d / %d", len(groups), len(groups[0]))
+	}
+	if parsed, isMarker := parseNoPropertyValuePattern(groups[0][0]); !isMarker || parsed != defID {
+		t.Fatalf("expected no-value marker for %s, got %q isMarker=%v", defID, parsed, isMarker)
+	}
+	sql := propertiesFilterPredicate(groups, addArg)
+	if !strings.Contains(sql, "NOT (i.properties ? $1)") {
+		t.Fatalf("no-value predicate wrong: %s", sql)
+	}
+
+	// A normal containment alternative is never mistaken for the marker.
+	groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["true"]}`, defID))
+	if !ok {
+		t.Fatalf("containment parse failed: %s", w.Body.String())
+	}
+	if _, isMarker := parseNoPropertyValuePattern(groups[0][0]); isMarker {
+		t.Fatalf("checkbox true alternative misdetected as the marker")
+	}
+
+	// Mixed true + no value: containment OR key-absence.
+	groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["true","__none__"]}`, defID))
+	if !ok {
+		t.Fatalf("mixed parse failed: %s", w.Body.String())
+	}
+	args = nil
+	sql = propertiesFilterPredicate(groups, addArg)
+	if !strings.Contains(sql, "@> $1") || !strings.Contains(sql, "NOT (i.properties ? ") {
+		t.Fatalf("mixed predicate wrong: %s", sql)
+	}
+
+	// Duplicate sentinels collapse to a single marker.
+	groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["__none__","__none__"]}`, defID))
+	if !ok {
+		t.Fatalf("duplicate parse failed: %s", w.Body.String())
+	}
+	if len(groups[0]) != 1 {
+		t.Fatalf("duplicate sentinel produced %d alternatives, want 1", len(groups[0]))
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -978,6 +1077,59 @@ func TestIssueActorPropertyFacets(t *testing.T) {
 	memberCounts := facetKeys(plainMemberID)
 	if memberCounts[memberRef] != 1 || memberCounts[otherRef] != 1 {
 		t.Fatalf("plain member sees different facet keys than the owner: %v", memberCounts)
+	}
+}
+
+// TestIssuePropertyFacetNoValue verifies the checkbox facet reports an unset
+// "__none__" bucket alongside "true"/"false", so the filter menu's "No value"
+// option carries a real count. A brand-new select marker narrows the facet to
+// exactly the two issues created here, keeping the counts deterministic in the
+// shared fixture workspace.
+func TestIssuePropertyFacetNoValue(t *testing.T) {
+	marker := createTestProperty(t, map[string]any{
+		"name": "FM" + uuid.NewString()[:8], "type": "select",
+		"config": map[string]any{"options": []map[string]any{{"name": "Only", "color": "#3b82f6"}}},
+	})
+	markerOpt := marker.Config.Options[0].ID
+	hold := createTestProperty(t, map[string]any{"name": "FH" + uuid.NewString()[:8], "type": "checkbox"})
+
+	setID := createPropertyTestIssue(t, "hold facet set")
+	unsetID := createPropertyTestIssue(t, "hold facet unset")
+	for _, id := range []string{setID, unsetID} {
+		if w := setIssuePropertyRaw(t, id, marker.ID, markerOpt); w.Code != http.StatusOK {
+			t.Fatalf("seed marker: %d %s", w.Code, w.Body.String())
+		}
+	}
+	if w := setIssuePropertyRaw(t, setID, hold.ID, true); w.Code != http.StatusOK {
+		t.Fatalf("set hold: %d %s", w.Code, w.Body.String())
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPost, "/api/issues/table/facets", map[string]any{
+		"query": map[string]any{
+			"scope":   map[string]any{"kind": "workspace"},
+			"filters": map[string]any{"properties": map[string][]string{marker.ID: {markerOpt}}},
+			"sort":    map[string]any{"field": "position", "direction": "asc"},
+		},
+		"facets":        []map[string]any{{"kind": "property", "property_id": hold.ID}},
+		"include_total": false,
+	})
+	testHandler.ListIssueTableFacets(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssueTableFacets: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp issueTableFacetsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode facets: %v", err)
+	}
+	counts := map[string]int64{}
+	for _, facet := range resp.Facets {
+		for _, value := range facet.Values {
+			counts[value.Key] = value.Count
+		}
+	}
+	if counts["true"] != 1 || counts["__none__"] != 1 {
+		t.Fatalf("hold facet counts wrong: %v", counts)
 	}
 }
 

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -1084,9 +1084,11 @@ WHERE i.workspace_id = $1
   AND ($7::jsonb IS NULL OR i.metadata @> $7::jsonb)
   -- properties_filter is a jsonb array of groups, each group an array of
   -- containment patterns (built by parsePropertiesFilterParam): the issue
-  -- must match at least one pattern from EVERY group (AND of ORs). The
-  -- correlated form skips the GIN index, which is fine here: open_only is
-  -- an unpaginated workspace scan already narrowed by status.
+  -- must match at least one pattern from EVERY group (AND of ORs). A pattern
+  -- of the shape {"__none__": "<definitionId>"} is the "no value" marker and
+  -- matches when the issue's properties are missing that key. The correlated
+  -- form skips the GIN index, which is fine here: open_only is an
+  -- unpaginated workspace scan already narrowed by status.
   AND (
     $8::jsonb IS NULL
     OR NOT EXISTS (
@@ -1095,7 +1097,8 @@ WHERE i.workspace_id = $1
       WHERE NOT EXISTS (
         SELECT 1
         FROM jsonb_array_elements(pf.alternatives) AS alt(pattern)
-        WHERE i.properties @> alt.pattern
+        WHERE (alt.pattern ? '__none__' AND NOT (i.properties ? (alt.pattern ->> '__none__')))
+           OR (NOT (alt.pattern ? '__none__') AND i.properties @> alt.pattern)
       )
     )
   )

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -250,9 +250,11 @@ WHERE i.workspace_id = $1
   AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR i.metadata @> sqlc.narg('metadata_filter')::jsonb)
   -- properties_filter is a jsonb array of groups, each group an array of
   -- containment patterns (built by parsePropertiesFilterParam): the issue
-  -- must match at least one pattern from EVERY group (AND of ORs). The
-  -- correlated form skips the GIN index, which is fine here: open_only is
-  -- an unpaginated workspace scan already narrowed by status.
+  -- must match at least one pattern from EVERY group (AND of ORs). A pattern
+  -- of the shape {"__none__": "<definitionId>"} is the "no value" marker and
+  -- matches when the issue's properties are missing that key. The correlated
+  -- form skips the GIN index, which is fine here: open_only is an
+  -- unpaginated workspace scan already narrowed by status.
   AND (
     sqlc.narg('properties_filter')::jsonb IS NULL
     OR NOT EXISTS (
@@ -261,7 +263,8 @@ WHERE i.workspace_id = $1
       WHERE NOT EXISTS (
         SELECT 1
         FROM jsonb_array_elements(pf.alternatives) AS alt(pattern)
-        WHERE i.properties @> alt.pattern
+        WHERE (alt.pattern ? '__none__' AND NOT (i.properties ? (alt.pattern ->> '__none__')))
+           OR (NOT (alt.pattern ? '__none__') AND i.properties @> alt.pattern)
       )
     )
   )


### PR DESCRIPTION
Closes #7153

## Summary

Adds a **"No value"** option to the custom-property filter. Selecting it matches
issues where the property is unset — the inverse of picking a value — so teams
can express "everything that is NOT X" without a negative operator.

Example: a team uses a `挂起` (Hold) checkbox to park issues while keeping their
status untouched. `挂起 = No value` now returns every non-parked issue, which
`挂起 = false` could not (that only matched issues *explicitly* stored as
`false`, hiding all unset issues — and a workspace with zero explicit `false`
values returned nothing).

## What changed

**Backend**
- `parsePropertiesFilterParam` (`server/internal/handler/property.go`) compiles
  the `__none__` sentinel into a `{"__none__": "<defId>"}` marker instead of a
  jsonb containment pattern.
- `propertiesFilterPredicate` renders the marker as a key-absence disjunction
  (`NOT (i.properties ? $n)`), OR-ed with any real values in the same
  definition and AND-ed across definitions.
- The static `ListOpenIssues` unroll recognizes the same marker, so the
  `open_only` path honors the filter too.
- Property table facets report an unset `__none__` bucket, so the "No value"
  option carries a real count in the filter menu.

**Frontend**
- `issueMatchesPropertyFilters` matches unset issues when `__none__` is
  selected (`packages/views/issues/utils/filter.ts`).
- `PropertyFilterOptions` offers a "No value" option for every property type;
  the filter chips bar renders it via the new `no_value_label` i18n key
  (added for en / zh-Hans / ja / ko).

## Verification

- Backend: new handler + unit tests for the `__none__` sentinel (list,
  `open_only`, OR/AND semantics, facet bucket); full `internal/handler` suite
  passes.
- Frontend: new `issueMatchesPropertyFilters` cases; full `@multica/views`
  issues suite (76 files / 746 tests) passes; `tsc --noEmit` clean.

## Notes

The `__none__` sentinel cannot collide with a real option id: select option ids
are UUIDs and checkbox uses `"true"`/`"false"`.
