### PR TITLE
feat(agent): centralize provider capabilities

### DIFF
--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -84,6 +84,14 @@ Codex, Hermes, and OpenClaw are handled slightly differently:
 - Hermes uses a per-task `HERMES_HOME`. Existing local configuration is still readable, but bound skills and session data are isolated per task. This isolation kicks in only when the agent has skills bound; tasks without bound skills use the machine's original Hermes home.
 - OpenClaw uses `skills/` under the current task's working directory, and the per-run configuration sets that directory as the workspace.
 
+### OpenClaw compatibility
+
+Multica supports OpenClaw `2026.5.5` and newer. The daemon writes the runtime brief to the task workdir's `AGENTS.md`, pins the OpenClaw workspace to that workdir, and writes bound skills to `skills/<name>/SKILL.md`. Supported versions therefore use one file-based instruction path.
+
+Older OpenClaw releases keep the legacy inline instruction fallback because their workspace bootstrap is not reliable enough to guarantee that `AGENTS.md` is loaded. The fallback is explicitly version-gated and is not used for supported releases, preventing duplicate instructions and unnecessary prompt tokens.
+
+The executable source of truth for this contract, including MCP, sandbox/approval, skill/config paths, and compatibility metadata, is [`docs/provider-capabilities.md`](https://github.com/multica-ai/multica/blob/main/docs/provider-capabilities.md).
+
 For creating and binding skills, see [Skills](/skills).
 
 ## Next steps

--- a/docs/decisions/ADR-0001-provider-capability-matrix.md
+++ b/docs/decisions/ADR-0001-provider-capability-matrix.md
@@ -1,0 +1,33 @@
+# ADR-0001: Centralize provider capability and compatibility declarations
+
+- **Date:** 2026-08-18
+- **Status:** proposed
+
+## Context and Problem
+
+Provider behavior is represented by adapter factories, daemon conditionals, runtime context paths, MCP discovery, frontend capability tabs, and documentation. A provider change can therefore require synchronized edits across several layers. OpenClaw additionally has a native workspace instruction path and a legacy inline path, so an unconditional fallback duplicates the runtime brief for supported releases.
+
+## Decision
+
+`server/pkg/agent/provider_capabilities.go` is the executable source of truth for provider capability metadata. It declares supported provider families, MCP support and source locations, sandbox/approval behavior, runtime config files, workspace and user skill paths, instruction delivery, and compatibility requirements.
+
+- `SupportedTypes` is derived from the matrix.
+- Daemon runtime config and skill path resolution consume matrix rows.
+- MCP discovery uses the matrix support predicate and retains provider-specific parsing only where the CLI format differs.
+- The frontend MCP provider set is a generated mirror guarded by a Go canary.
+- `docs/provider-capabilities.md` is generated from the matrix and tested byte-for-byte.
+- OpenClaw versions below `2026.5.5` retain inline instruction delivery. Supported versions use the workspace-pinned `AGENTS.md` and `skills/` path only.
+
+## Consequences
+
+Adding a provider capability requires one matrix row plus the adapter implementation and any provider-specific executable behavior. Drift in the supported-type list, frontend MCP mirror, generated documentation, skill paths, or OpenClaw instruction boundary fails focused tests instead of relying on manual review.
+
+Provider-specific parsing remains in the daemon when the external CLI uses a unique config format. The matrix records that source and the tests verify the shared support contract; it does not pretend that all providers share one wire format.
+
+## Verification
+
+- `TestProviderCapabilityMatrixMatchesFactory`
+- `TestProviderCapabilityMatrixMatchesFrontendMCPMirror`
+- `TestProviderCapabilityMatrixDocumentationIsGenerated`
+- `TestOpenClawInstructionDeliveryIsVersionGated`
+- `TestVersionAtLeastParsesCLIOutput`

--- a/docs/provider-capabilities.md
+++ b/docs/provider-capabilities.md
@@ -1,0 +1,49 @@
+# Provider capability matrix
+
+This file is generated from `server/pkg/agent/provider_capabilities.go`. Do not edit it by hand.
+
+| Provider | MCP support/delivery | Sandbox/approval | Runtime config | Workspace skills | User skills | Instruction delivery | Compatibility |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Claude Code | yes: --mcp-config + --strict-mcp-config | bypassPermissions; daemon blocks approval prompts | `CLAUDE.md` | `.claude/skills` | `~/.claude/skills` | file | native CLAUDE.md and .claude/skills discovery |
+| CodeBuddy | yes: --mcp-config; native user/project/local scopes remain enabled | bypassPermissions; disallowed approval tools | `CODEBUDDY.md` | `.codebuddy/skills` | `~/.codebuddy/skills` | file | native CODEBUDDY.md and .codebuddy/skills discovery |
+| Codex | yes: task CODEX_HOME/config.toml | workspace-write; sandbox policy in config/args | `AGENTS.md` | `CODEX_HOME/skills` | `$CODEX_HOME/skills` | file | AGENTS.md is read from the task cwd; skills use task CODEX_HOME |
+| GitHub Copilot CLI | no: not supported by agent.mcp_config | yolo/interactive policy owned by Copilot CLI | `AGENTS.md` | `.github/skills` | `~/.copilot/skills` | file | AGENTS.md and .github/skills project discovery |
+| OpenCode | yes: OPENCODE_CONFIG_CONTENT | provider-native permission policy | `AGENTS.md` | `.opencode/skills` | `~/.config/opencode/skills` | file | --dir/PWD anchors AGENTS.md and .opencode/skills at the task workdir |
+| DevEco Code | no: not supported by agent.mcp_config | provider-native permission policy | `AGENTS.md` | `.deveco/skills` | `~/.config/deveco/skills` | file | OpenCode-compatible AGENTS.md and .deveco/skills discovery |
+| OpenClaw | yes: per-task openclaw-config.json wrapper | --local plus daemon-owned agent config | `AGENTS.md` | `skills` | `~/.openclaw/skills` | file+legacy-inline before 2026.5.5 | supported >= 2026.5.5: workspace-pinned AGENTS.md + skills/ only; older releases retain inline fallback |
+| Hermes Agent | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `HERMES_HOME/skills` | `~/.hermes/skills` | file | per-task HERMES_HOME is seeded and AGENTS.md is read from the ACP cwd |
+| Pi coding agent | no: not supported by agent.mcp_config | provider-native tool policy | `AGENTS.md` | `.pi/skills` | `~/.pi/agent/skills` | file | AGENTS.md and .pi/skills are loaded from the task cwd |
+| Cursor Agent | yes: task Cursor MCP config/auth sidecars | --yolo | `AGENTS.md` | `.cursor/skills` | `~/.cursor/skills` | file | AGENTS.md and .cursor/skills are anchored with --workspace |
+| Kimi CLI | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.kimi/skills` | `~/.kimi/skills` | inline | inline fallback remains required while Kimi cwd discovery is opaque |
+| Reasonix | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.reasonix/skills` | `$REASONIX_HOME/skills` | file | AGENTS.md and .reasonix/skills follow the effective REASONIX_HOME |
+| Kiro CLI | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.kiro/skills` | `~/.kiro/skills` | file | Kiro ACP smoke uses root AGENTS.md and .kiro/skills |
+| Antigravity | no: not supported by agent.mcp_config | provider-native permission policy | `AGENTS.md` | `.agents/skills` | `~/.gemini/antigravity-cli/skills` | file | AGENTS.md and .agents/skills use Antigravity workspace discovery |
+| Qoder CLI | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.qoder/skills` | `~/.qoder/skills` | file | Qoder project skills use .qoder/skills |
+| Qoder CLI CN | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.qoder/skills` | `~/.qoder-cn/skills` | file | Qoder CN project skills use .qoder/skills and a separate user root |
+| Trae CLI | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `.traecli/skills` | `~/.traecli/skills` | inline | Trae reads .trae/rules rather than AGENTS.md; inline delivery remains required |
+| Grok Build | yes: ACP session/new MCP parameters | --always-approve | `AGENTS.md` | `.grok/skills` | `$GROK_HOME/skills` | file | Grok Build reads AGENTS.md and .grok/skills from the task cwd |
+| Qwen Code | yes: Qwen native config/session parameters | provider-native permission policy | `QWEN.md` | `.qwen/skills` | `$QWEN_HOME/skills` | file | QWEN.md is the runtime context file; .qwen/skills is project-local |
+| QwenPaw | yes: ACP session/new MCP parameters | ACP permission policy | `AGENTS.md` | `skill_pool` | `$QWENPAW_WORKING_DIR/skill_pool` | inline | QwenPaw workspace skill_pool is isolated; inline delivery remains required |
+
+MCP config source details:
+
+- `claude`: `~/.claude.json:mcpServers`
+- `codebuddy`: `CodeBuddy native user/project/local scopes`
+- `codex`: `CODEX_HOME/config.toml:mcp_servers`
+- `copilot`: `native Copilot configuration`
+- `opencode`: `XDG_CONFIG_HOME/opencode/opencode.json:mcp`
+- `deveco`: `native DevEco configuration`
+- `openclaw`: `CLAWDBOT_CONFIG_PATH or OPENCLAW_STATE_DIR/openclaw.json:mcp.servers`
+- `hermes`: `HERMES_HOME native profile`
+- `pi`: `Pi native extensions/config`
+- `cursor`: `~/.cursor/mcp.json:mcpServers`
+- `kimi`: `Kimi native config`
+- `reasonix`: `REASONIX_HOME native config`
+- `kiro`: `Kiro native config`
+- `antigravity`: `Gemini/Antigravity native config`
+- `qoder`: `Qoder native config`
+- `qoderclicn`: `Qoder CN native config`
+- `traecli`: `Trae CLI native config`
+- `grok`: `GROK_HOME native config`
+- `qwen`: `QWEN_HOME native config`
+- `qwenpaw`: `QWENPAW_WORKING_DIR native skill/config store`

--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -1,3 +1,7 @@
+// This is a generated mirror of `server/pkg/agent/provider_capabilities.go`.
+// The Go provider-capability tests parse this list and fail on drift, because
+// the frontend package cannot import the server's Go table at runtime.
+//
 // The set of runtime providers whose backend reads `agent.mcp_config` and
 // forwards MCP servers to the underlying CLI. The MCP config tab is hidden
 // for every other provider so a user can't save a value the runtime will

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5217,30 +5217,19 @@ func providerDisplayName(name string) string {
 }
 
 // providerNeedsInlineSystemPrompt reports whether the runtime brief must ride
-// along in the turn itself (agent.ExecOptions.SystemPrompt) because the CLI
-// will not pick up the per-task context file execenv writes into the workdir.
-// This is the ONLY place that decides it, and it is the reason every other
-// backend sees an empty SystemPrompt.
+// along in the turn itself. The matrix owns both the provider policy and the
+// OpenClaw compatibility boundary, so adding a provider does not require a
+// second daemon-only switch.
 //
-// Adding a provider here is a real fix only when that CLI genuinely ignores its
-// context file — traecli was added because it reads .trae/rules/ and not
-// AGENTS.md, so its agents were silently missing the workflow section and left
-// issues stuck in `todo` with no comment and no error. Adding one that DOES
-// read the file just duplicates the brief on every turn.
-//
-// Confirmed to load their context file, so deliberately absent here. MUL-5392
-// probed each one over its real launch path with a canary in the context file
-// and no inline delivery: claude 2.1.220 (CLAUDE.md), codex 0.144.6 driving the
-// app-server (AGENTS.md), opencode 1.17.7 (AGENTS.md), pi 0.67.2 (AGENTS.md),
-// hermes 0.18.2 over ACP (AGENTS.md). kiro was confirmed earlier by a kiro-cli
-// 2.13.0 ACP smoke — see the call site. Still unprobed: grok, qoder, codebuddy.
-func providerNeedsInlineSystemPrompt(provider string) bool {
-	switch provider {
-	case "openclaw", "kimi", "traecli", "qwenpaw":
-		return true
-	default:
-		return false
+// An omitted version preserves the legacy fallback for callers/tests that do
+// not have a detected CLI version. Production task execution passes the
+// version paired with the resolved executable path.
+func providerNeedsInlineSystemPrompt(provider string, versions ...string) bool {
+	version := ""
+	if len(versions) > 0 {
+		version = versions[0]
 	}
+	return agent.InstructionNeedsInline(provider, version)
 }
 
 // gateResumeToReusedWorkdir clears the task's prior session unless the task
@@ -6365,7 +6354,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// as always included, and a real kiro-cli 2.13.0 ACP smoke confirms it.
 	// Prepending the full runtime brief into the ACP user prompt duplicates that
 	// context and bloats every turn.
-	if providerNeedsInlineSystemPrompt(provider) {
+	if providerNeedsInlineSystemPrompt(provider, resolvedVersion) {
 		execOpts.SystemPrompt = runtimeBrief
 	}
 
@@ -6448,7 +6437,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			taskLog.Warn("execenv: re-inject cold runtime config for fresh retry failed (non-fatal)", "error", briefErr)
 		} else {
 			runtimeBrief = freshBrief
-			if providerNeedsInlineSystemPrompt(provider) {
+			if providerNeedsInlineSystemPrompt(provider, resolvedVersion) {
 				execOpts.SystemPrompt = runtimeBrief
 			}
 		}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -672,32 +672,36 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
+		name     string
 		provider string
+		version  string
 		want     bool
 	}{
-		{provider: "openclaw", want: true},
+		{name: "openclaw_legacy", provider: "openclaw", version: "2026.5.4", want: true},
+		{name: "openclaw_supported_boundary", provider: "openclaw", version: agent.OpenClawMinimumSupportedVersion, want: false},
+		{name: "openclaw_supported_newer", provider: "openclaw", version: "2026.6.0", want: false},
 		// Hermes ACP starts in the task cwd and loads AGENTS.md / .agent_context
 		// directly. Inlining the full runtime brief duplicates that context and
 		// can trip upstream provider safety filters on otherwise harmless tasks.
-		{provider: "hermes", want: false},
+		{name: "hermes", provider: "hermes", want: false},
 		// Kiro CLI loads a root AGENTS.md in ACP sessions. Inlining the same
 		// runtime brief duplicates it at the start of every user turn.
-		{provider: "kiro", want: false},
-		{provider: "kimi", want: true},
+		{name: "kiro", provider: "kiro", want: false},
+		{name: "kimi", provider: "kimi", want: true},
 		// Reasonix loads AGENTS.md from the ACP session cwd.
-		{provider: "reasonix", want: false},
-		{provider: "traecli", want: true},
+		{name: "reasonix", provider: "reasonix", want: false},
+		{name: "traecli", provider: "traecli", want: true},
 		// Qwen Code loads the per-task QWEN.md file natively.
-		{provider: "qwen", want: false},
-		{provider: "codex", want: false},
-		{provider: "claude", want: false},
+		{name: "qwen", provider: "qwen", want: false},
+		{name: "codex", provider: "codex", want: false},
+		{name: "claude", provider: "claude", want: false},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.provider, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := providerNeedsInlineSystemPrompt(tc.provider); got != tc.want {
-				t.Fatalf("providerNeedsInlineSystemPrompt(%q) = %v, want %v", tc.provider, got, tc.want)
+			if got := providerNeedsInlineSystemPrompt(tc.provider, tc.version); got != tc.want {
+				t.Fatalf("providerNeedsInlineSystemPrompt(%q, %q) = %v, want %v", tc.provider, tc.version, got, tc.want)
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -339,6 +339,14 @@ func skillsDirPath(workDir, provider string) string {
 	if desc, ok := agent.BuiltinRuntimeByID(provider); ok {
 		return filepath.Join(workDir, desc.SkillsDir)
 	}
+	if capability, ok := agent.ProviderCapabilityFor(provider); ok {
+		// Codex and Hermes are written into their isolated homes by Prepare,
+		// so this helper is not called for those providers. All other known
+		// providers use the matrix path and bypass the legacy fallback switch.
+		if path := capability.WorkspaceSkillPath; path != "" && path != "CODEX_HOME/skills" && path != "HERMES_HOME/skills" {
+			return filepath.Join(workDir, filepath.FromSlash(path))
+		}
+	}
 	switch provider {
 	case "claude":
 		// Claude Code natively discovers skills from .claude/skills/ in the workdir.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -193,31 +193,16 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (strin
 // Cleanup in lockstep — both paths consult the same table so a new provider
 // added to one side cannot drift past the other.
 func runtimeConfigPath(workDir, provider string) string {
-	// Built-in runtime identities (e.g. "omp") inherit their config file
-	// from their protocol family — resolve the family from the descriptor
-	// and delegate to the family's switch case. This avoids hardcoding
-	// "AGENTS.md" for every descriptor; a compatible runtime on Claude,
-	// CodeBuddy, or Qwen would otherwise write the wrong file.
+	// Built-in runtime identities inherit their protocol family's file contract
+	// unless the descriptor owns a distinct native path.
 	if desc, ok := agent.BuiltinRuntimeByID(provider); ok {
 		return runtimeConfigPath(workDir, desc.ProtocolFamily)
 	}
-	switch provider {
-	case "claude":
-		return filepath.Join(workDir, "CLAUDE.md")
-	case "codebuddy":
-		// CodeBuddy Code's native memory file is CODEBUDDY.md, not
-		// CLAUDE.md — see https://www.codebuddy.ai/docs/cli/codebuddy-dir
-		// ("CODEBUDDY.md / .codebuddy/CODEBUDDY.md — Project-level memory
-		// file"). CodeBuddy only reads CLAUDE.md if the user manually
-		// migrates/symlinks it in.
-		return filepath.Join(workDir, "CODEBUDDY.md")
-	case "qwen":
-		return filepath.Join(workDir, "QWEN.md")
-	case "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwenpaw":
-		return filepath.Join(workDir, "AGENTS.md")
-	default:
+	capability, ok := agent.ProviderCapabilityFor(provider)
+	if !ok || capability.RuntimeConfigFile == "" {
 		return ""
 	}
+	return filepath.Join(workDir, capability.RuntimeConfigFile)
 }
 
 // writeRuntimeConfigFile writes the Multica runtime brief to path without

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -116,9 +116,10 @@ const (
 // location by Codex (https://developers.openai.com/codex/skills) and Gemini
 // CLI (https://geminicli.com/docs/cli/skills/), among others.
 //
-// Longer-term this mapping would be better colocated with the provider
-// definitions under server/pkg/agent so adding a new runtime can't silently
-// miss the local-skills surface.
+// The provider-specific roots above are declared in the canonical capability
+// matrix under server/pkg/agent. This function retains only discovery-order
+// and legacy compatibility behavior so a new runtime cannot silently miss the
+// local-skills surface.
 func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -126,108 +127,30 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 	}
 
 	var providerRoot string
-	// Built-in runtime identities (e.g. "omp") declare their user skills dir
-	// in the descriptor; resolve to providerRoot and fall through to the
-	// common construction below so universal roots, merging, and fallback
-	// import all still apply — same as every protocol-family provider.
+	// Built-in runtime identities declare their own user skill root in the
+	// runtime descriptor. Protocol families use the canonical matrix, including
+	// environment overrides such as CODEX_HOME and QWEN_HOME.
 	if desc, ok := agent.BuiltinRuntimeByID(provider); ok {
-		providerRoot = filepath.Join(home, desc.UserSkillsDir)
-	} else {
-		switch provider {
-		case "claude":
-			providerRoot = filepath.Join(home, ".claude", "skills")
-		case "codebuddy":
-			// CodeBuddy Code is a Claude Code fork but ships its own native
-			// config directory; it does NOT read ~/.claude/skills unless the
-			// user manually symlinks it in (the vendor's documented Claude
-			// Code migration path). See
-			// https://www.codebuddy.ai/docs/cli/codebuddy-dir ("Global
-			// directory ~/.codebuddy/") and
-			// https://www.codebuddy.ai/docs/cli/skills ("User-level Skills:
-			// ~/.codebuddy/skills/").
-			providerRoot = filepath.Join(home, ".codebuddy", "skills")
-		case "codex":
-			codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
-			if codexHome == "" {
-				codexHome = filepath.Join(home, ".codex")
+		providerRoot = filepath.Join(home, filepath.FromSlash(desc.UserSkillsDir))
+	} else if capability, ok := agent.ProviderCapabilityFor(provider); ok {
+		providerRoot = filepath.Join(home, filepath.FromSlash(capability.UserSkillHomeRelative))
+		if capability.UserSkillEnvVar != "" {
+			if override := strings.TrimSpace(os.Getenv(capability.UserSkillEnvVar)); override != "" {
+				providerRoot = filepath.Join(override, filepath.FromSlash(capability.UserSkillEnvRelative))
 			}
-			providerRoot = filepath.Join(codexHome, "skills")
-		case "copilot":
-			providerRoot = filepath.Join(home, ".copilot", "skills")
-		case "opencode":
-			providerRoot = filepath.Join(home, ".config", "opencode", "skills")
-		case "deveco":
-			providerRoot = filepath.Join(home, ".config", "deveco", "skills")
-		case "openclaw":
-			providerRoot = filepath.Join(home, ".openclaw", "skills")
-		case "pi":
-			providerRoot = filepath.Join(home, ".pi", "agent", "skills")
-		case "cursor":
-			providerRoot = filepath.Join(home, ".cursor", "skills")
-		case "hermes":
-			providerRoot = filepath.Join(home, ".hermes", "skills")
-		case "kimi":
-			providerRoot = filepath.Join(home, ".kimi", "skills")
-		case "reasonix":
-			reasonixHome := strings.TrimSpace(os.Getenv("REASONIX_HOME"))
-			if reasonixHome == "" {
-				reasonixHome = filepath.Join(home, ".reasonix")
-			}
-			providerRoot = filepath.Join(reasonixHome, "skills")
-		case "kiro":
-			providerRoot = filepath.Join(home, ".kiro", "skills")
-		case "qoder":
-			providerRoot = filepath.Join(home, ".qoder", "skills")
-		case "qoderclicn":
-			providerRoot = filepath.Join(home, ".qoder-cn", "skills")
-		case "traecli":
-			// Official TRAE CLI global skills live in ~/.traecli/skills.
-			// See https://docs.trae.cn/cli_skills
-			providerRoot = filepath.Join(home, ".traecli", "skills")
-		case "antigravity":
-			// agy inherits Gemini CLI's global skill root; see
-			// https://antigravity.google/docs/gcli-migration ("Global skills").
-			providerRoot = filepath.Join(home, ".gemini", "antigravity-cli", "skills")
-		case "grok":
-			// GROK_HOME replaces the default ~/.grok home for settings, sessions,
-			// and user-level skills.
-			grokHome := strings.TrimSpace(os.Getenv("GROK_HOME"))
-			if grokHome == "" {
-				grokHome = filepath.Join(home, ".grok")
-			}
-			providerRoot = filepath.Join(grokHome, "skills")
-		case "qwen":
-			// QWEN_HOME replaces Qwen Code's global ~/.qwen directory. It owns
-			// settings, sessions, credentials and personal skills; project
-			// .qwen/skills remains rooted in the task workdir.
-			qwenHome := strings.TrimSpace(os.Getenv("QWEN_HOME"))
-			if qwenHome == "" {
-				qwenHome = filepath.Join(home, ".qwen")
-			}
-			providerRoot = filepath.Join(qwenHome, "skills")
-		case "qwenpaw":
-			// QWENPAW_WORKING_DIR (or legacy COPAW_WORKING_DIR) overrides
-			// QwenPaw's global ~/.qwenpaw directory, which owns settings,
-			// sessions, credentials and personal skills. The runtime
-			// resolves its root from QWENPAW_WORKING_DIR → COPAW_WORKING_DIR
-			// → ~/.copaw (legacy) → ~/.qwenpaw (default).
-			// See constant.py in the QwenPaw source.
-			qwenpawHome := strings.TrimSpace(os.Getenv("QWENPAW_WORKING_DIR"))
-			if qwenpawHome == "" {
-				qwenpawHome = strings.TrimSpace(os.Getenv("COPAW_WORKING_DIR"))
-			}
-			if qwenpawHome == "" {
-				legacyCopaw := filepath.Join(home, ".copaw")
-				if _, err := os.Stat(legacyCopaw); err == nil {
-					qwenpawHome = legacyCopaw
-				} else {
-					qwenpawHome = filepath.Join(home, ".qwenpaw")
+		}
+		if provider == "qwenpaw" && strings.TrimSpace(os.Getenv("QWENPAW_WORKING_DIR")) == "" {
+			if legacy := strings.TrimSpace(os.Getenv("COPAW_WORKING_DIR")); legacy != "" {
+				providerRoot = filepath.Join(legacy, "skill_pool")
+			} else {
+				legacy := filepath.Join(home, ".copaw")
+				if _, statErr := os.Stat(legacy); statErr == nil {
+					providerRoot = filepath.Join(legacy, "skill_pool")
 				}
 			}
-			providerRoot = filepath.Join(qwenpawHome, "skill_pool")
-		default:
-			return nil, false, nil
 		}
+	} else {
+		return nil, false, nil
 	}
 
 	roots := []localSkillRoot{

--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/multica-ai/multica/server/pkg/agent"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -244,6 +245,9 @@ func stripJSONC(raw []byte) ([]byte, error) {
 // logs; the public capabilities endpoint continues to use the redacted summary
 // type above.
 func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) {
+	if !agent.ProviderSupportsMCPConfig(provider) {
+		return map[string]any{}, false, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, false, fmt.Errorf("resolve user home: %w", err)
@@ -369,6 +373,9 @@ func loadClaudePluginMcpServerConfigs(home string) map[string]any {
 }
 
 func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary, bool, error) {
+	if !agent.ProviderSupportsMCPConfig(provider) {
+		return []runtimeLocalMcpServerSummary{}, false, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, false, fmt.Errorf("resolve user home: %w", err)

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -271,28 +271,7 @@ type Config struct {
 // so the family picker rejected it (#4945). grok is the xAI Grok Build CLI
 // ACP backend (`grok agent --always-approve stdio`). qwen is Qwen Code's
 // native `qwen -p <prompt> --output-format stream-json` backend.
-var SupportedTypes = []string{
-	"claude",
-	"codebuddy",
-	"codex",
-	"copilot",
-	"opencode",
-	"deveco",
-	"openclaw",
-	"hermes",
-	"pi",
-	"cursor",
-	"kimi",
-	"reasonix",
-	"kiro",
-	"antigravity",
-	"qoder",
-	"qoderclicn",
-	"traecli",
-	"grok",
-	"qwen",
-	"qwenpaw",
-}
+var SupportedTypes = SupportedProviderTypes()
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.
 // Used to validate a custom runtime profile's protocol_family before it is

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -27,7 +27,7 @@ const openclawNoParseableOutput = "openclaw returned no parseable output"
 // to silently produce no output. The check in Execute fails fast with
 // a hardcoded upgrade hint so users see an actionable message instead
 // of "openclaw returned no parseable output".
-const minOpenclawVersion = "2026.5.5"
+const minOpenclawVersion = OpenClawMinimumSupportedVersion
 
 // openclawVersionPattern extracts a three-segment dotted version from
 // arbitrary `openclaw --version` output (e.g. "openclaw 2026.5.5",

--- a/server/pkg/agent/provider_capabilities.go
+++ b/server/pkg/agent/provider_capabilities.go
@@ -1,0 +1,507 @@
+package agent
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// InstructionDelivery describes how the daemon delivers its runtime brief.
+// File delivery is preferred because the provider reads the native context
+// file from the task workdir. Legacy inline delivery is retained only for a
+// provider/version pair whose native file path is not yet reliable.
+type InstructionDelivery string
+
+const (
+	InstructionFile                 InstructionDelivery = "file"
+	InstructionInline               InstructionDelivery = "inline"
+	InstructionFileWithLegacyInline InstructionDelivery = "file+legacy-inline"
+)
+
+// OpenClawMinimumSupportedVersion is the compatibility boundary for the
+// workspace-pinned OpenClaw config and native AGENTS.md/skills discovery.
+// Releases older than this keep the legacy inline instruction fallback.
+const OpenClawMinimumSupportedVersion = "2026.5.5"
+
+// ProviderCapability is the canonical provider capability contract. Runtime
+// conditionals and generated documentation should consume this table rather
+// than maintaining independent provider switch lists.
+//
+// Paths are relative to the task workdir unless they use an environment/home
+// field. UserSkillEnvRelative is the path below UserSkillEnvVar when that
+// variable is set.
+type ProviderCapability struct {
+	Type                  string
+	DisplayName           string
+	SupportsMCPConfig     bool
+	MCPDelivery           string
+	MCPConfigSource       string
+	NativeSkillCatalog    bool
+	RuntimeConfigFile     string
+	WorkspaceSkillPath    string
+	UserSkillHomeRelative string
+	UserSkillEnvVar       string
+	UserSkillEnvRelative  string
+	InstructionDelivery   InstructionDelivery
+	LegacyInlineBefore    string
+	SandboxApproval       string
+	Compatibility         string
+}
+
+// providerCapabilityTable is the single source of truth for the supported
+// protocol families. Keep entries ordered like SupportedTypes so generated
+// docs and validation failures are stable.
+var providerCapabilityTable = []ProviderCapability{
+	{
+		Type:                  "claude",
+		DisplayName:           "Claude Code",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "--mcp-config + --strict-mcp-config",
+		MCPConfigSource:       "~/.claude.json:mcpServers",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "CLAUDE.md",
+		WorkspaceSkillPath:    ".claude/skills",
+		UserSkillHomeRelative: ".claude/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "bypassPermissions; daemon blocks approval prompts",
+		Compatibility:         "native CLAUDE.md and .claude/skills discovery",
+	},
+	{
+		Type:                  "codebuddy",
+		DisplayName:           "CodeBuddy",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "--mcp-config; native user/project/local scopes remain enabled",
+		MCPConfigSource:       "CodeBuddy native user/project/local scopes",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "CODEBUDDY.md",
+		WorkspaceSkillPath:    ".codebuddy/skills",
+		UserSkillHomeRelative: ".codebuddy/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "bypassPermissions; disallowed approval tools",
+		Compatibility:         "native CODEBUDDY.md and .codebuddy/skills discovery",
+	},
+	{
+		Type:                  "codex",
+		DisplayName:           "Codex",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "task CODEX_HOME/config.toml",
+		MCPConfigSource:       "CODEX_HOME/config.toml:mcp_servers",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    "CODEX_HOME/skills",
+		UserSkillHomeRelative: ".codex/skills",
+		UserSkillEnvVar:       "CODEX_HOME",
+		UserSkillEnvRelative:  "skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "workspace-write; sandbox policy in config/args",
+		Compatibility:         "AGENTS.md is read from the task cwd; skills use task CODEX_HOME",
+	},
+	{
+		Type:                  "copilot",
+		DisplayName:           "GitHub Copilot CLI",
+		SupportsMCPConfig:     false,
+		MCPDelivery:           "not supported by agent.mcp_config",
+		MCPConfigSource:       "native Copilot configuration",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".github/skills",
+		UserSkillHomeRelative: ".copilot/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "yolo/interactive policy owned by Copilot CLI",
+		Compatibility:         "AGENTS.md and .github/skills project discovery",
+	},
+	{
+		Type:                  "opencode",
+		DisplayName:           "OpenCode",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "OPENCODE_CONFIG_CONTENT",
+		MCPConfigSource:       "XDG_CONFIG_HOME/opencode/opencode.json:mcp",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".opencode/skills",
+		UserSkillHomeRelative: ".config/opencode/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "provider-native permission policy",
+		Compatibility:         "--dir/PWD anchors AGENTS.md and .opencode/skills at the task workdir",
+	},
+	{
+		Type:                  "deveco",
+		DisplayName:           "DevEco Code",
+		SupportsMCPConfig:     false,
+		MCPDelivery:           "not supported by agent.mcp_config",
+		MCPConfigSource:       "native DevEco configuration",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".deveco/skills",
+		UserSkillHomeRelative: ".config/deveco/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "provider-native permission policy",
+		Compatibility:         "OpenCode-compatible AGENTS.md and .deveco/skills discovery",
+	},
+	{
+		Type:                  "openclaw",
+		DisplayName:           "OpenClaw",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "per-task openclaw-config.json wrapper",
+		MCPConfigSource:       "CLAWDBOT_CONFIG_PATH or OPENCLAW_STATE_DIR/openclaw.json:mcp.servers",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    "skills",
+		UserSkillHomeRelative: ".openclaw/skills",
+		InstructionDelivery:   InstructionFileWithLegacyInline,
+		LegacyInlineBefore:    OpenClawMinimumSupportedVersion,
+		SandboxApproval:       "--local plus daemon-owned agent config",
+		Compatibility:         "supported >= 2026.5.5: workspace-pinned AGENTS.md + skills/ only; older releases retain inline fallback",
+	},
+	{
+		Type:                  "hermes",
+		DisplayName:           "Hermes Agent",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "HERMES_HOME native profile",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    "HERMES_HOME/skills",
+		UserSkillHomeRelative: ".hermes/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "per-task HERMES_HOME is seeded and AGENTS.md is read from the ACP cwd",
+	},
+	{
+		Type:                  "pi",
+		DisplayName:           "Pi coding agent",
+		SupportsMCPConfig:     false,
+		MCPDelivery:           "not supported by agent.mcp_config",
+		MCPConfigSource:       "Pi native extensions/config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".pi/skills",
+		UserSkillHomeRelative: ".pi/agent/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "provider-native tool policy",
+		Compatibility:         "AGENTS.md and .pi/skills are loaded from the task cwd",
+	},
+	{
+		Type:                  "cursor",
+		DisplayName:           "Cursor Agent",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "task Cursor MCP config/auth sidecars",
+		MCPConfigSource:       "~/.cursor/mcp.json:mcpServers",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".cursor/skills",
+		UserSkillHomeRelative: ".cursor/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "--yolo",
+		Compatibility:         "AGENTS.md and .cursor/skills are anchored with --workspace",
+	},
+	{
+		Type:                  "kimi",
+		DisplayName:           "Kimi CLI",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "Kimi native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".kimi/skills",
+		UserSkillHomeRelative: ".kimi/skills",
+		InstructionDelivery:   InstructionInline,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "inline fallback remains required while Kimi cwd discovery is opaque",
+	},
+	{
+		Type:                  "reasonix",
+		DisplayName:           "Reasonix",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "REASONIX_HOME native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".reasonix/skills",
+		UserSkillHomeRelative: ".reasonix/skills",
+		UserSkillEnvVar:       "REASONIX_HOME",
+		UserSkillEnvRelative:  "skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "AGENTS.md and .reasonix/skills follow the effective REASONIX_HOME",
+	},
+	{
+		Type:                  "kiro",
+		DisplayName:           "Kiro CLI",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "Kiro native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".kiro/skills",
+		UserSkillHomeRelative: ".kiro/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "Kiro ACP smoke uses root AGENTS.md and .kiro/skills",
+	},
+	{
+		Type:                  "antigravity",
+		DisplayName:           "Antigravity",
+		SupportsMCPConfig:     false,
+		MCPDelivery:           "not supported by agent.mcp_config",
+		MCPConfigSource:       "Gemini/Antigravity native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".agents/skills",
+		UserSkillHomeRelative: ".gemini/antigravity-cli/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "provider-native permission policy",
+		Compatibility:         "AGENTS.md and .agents/skills use Antigravity workspace discovery",
+	},
+	{
+		Type:                  "qoder",
+		DisplayName:           "Qoder CLI",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "Qoder native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".qoder/skills",
+		UserSkillHomeRelative: ".qoder/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "Qoder project skills use .qoder/skills",
+	},
+	{
+		Type:                  "qoderclicn",
+		DisplayName:           "Qoder CLI CN",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "Qoder CN native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".qoder/skills",
+		UserSkillHomeRelative: ".qoder-cn/skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "Qoder CN project skills use .qoder/skills and a separate user root",
+	},
+	{
+		Type:                  "traecli",
+		DisplayName:           "Trae CLI",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "Trae CLI native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".traecli/skills",
+		UserSkillHomeRelative: ".traecli/skills",
+		InstructionDelivery:   InstructionInline,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "Trae reads .trae/rules rather than AGENTS.md; inline delivery remains required",
+	},
+	{
+		Type:                  "grok",
+		DisplayName:           "Grok Build",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "GROK_HOME native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    ".grok/skills",
+		UserSkillHomeRelative: ".grok/skills",
+		UserSkillEnvVar:       "GROK_HOME",
+		UserSkillEnvRelative:  "skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "--always-approve",
+		Compatibility:         "Grok Build reads AGENTS.md and .grok/skills from the task cwd",
+	},
+	{
+		Type:                  "qwen",
+		DisplayName:           "Qwen Code",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "Qwen native config/session parameters",
+		MCPConfigSource:       "QWEN_HOME native config",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "QWEN.md",
+		WorkspaceSkillPath:    ".qwen/skills",
+		UserSkillHomeRelative: ".qwen/skills",
+		UserSkillEnvVar:       "QWEN_HOME",
+		UserSkillEnvRelative:  "skills",
+		InstructionDelivery:   InstructionFile,
+		SandboxApproval:       "provider-native permission policy",
+		Compatibility:         "QWEN.md is the runtime context file; .qwen/skills is project-local",
+	},
+	{
+		Type:                  "qwenpaw",
+		DisplayName:           "QwenPaw",
+		SupportsMCPConfig:     true,
+		MCPDelivery:           "ACP session/new MCP parameters",
+		MCPConfigSource:       "QWENPAW_WORKING_DIR native skill/config store",
+		NativeSkillCatalog:    true,
+		RuntimeConfigFile:     "AGENTS.md",
+		WorkspaceSkillPath:    "skill_pool",
+		UserSkillHomeRelative: ".qwenpaw/skill_pool",
+		UserSkillEnvVar:       "QWENPAW_WORKING_DIR",
+		UserSkillEnvRelative:  "skill_pool",
+		InstructionDelivery:   InstructionInline,
+		SandboxApproval:       "ACP permission policy",
+		Compatibility:         "QwenPaw workspace skill_pool is isolated; inline delivery remains required",
+	},
+}
+
+// SupportedProviderTypes returns a fresh ordered list of protocol families.
+func SupportedProviderTypes() []string {
+	out := make([]string, 0, len(providerCapabilityTable))
+	for _, capability := range providerCapabilityTable {
+		out = append(out, capability.Type)
+	}
+	return out
+}
+
+// AllProviderCapabilities returns a copy of the canonical capability rows.
+func AllProviderCapabilities() []ProviderCapability {
+	return append([]ProviderCapability(nil), providerCapabilityTable...)
+}
+
+// ProviderCapabilityFor returns the capability row for a protocol family or a
+// built-in runtime identity such as omp. Built-in identities inherit the
+// protocol contract and override only their runtime-specific paths/label.
+func ProviderCapabilityFor(provider string) (ProviderCapability, bool) {
+	for _, capability := range providerCapabilityTable {
+		if capability.Type == provider {
+			return capability, true
+		}
+	}
+	if desc, ok := BuiltinRuntimeByID(provider); ok {
+		if capability, ok := ProviderCapabilityFor(desc.ProtocolFamily); ok {
+			capability.Type = provider
+			capability.DisplayName = desc.DisplayName
+			capability.WorkspaceSkillPath = desc.SkillsDir
+			capability.UserSkillHomeRelative = desc.UserSkillsDir
+			return capability, true
+		}
+	}
+	return ProviderCapability{}, false
+}
+
+// ProviderSupportsMCPConfig is the shared MCP capability predicate used by
+// server discovery and UI mirrors. Unknown providers fail closed.
+func ProviderSupportsMCPConfig(provider string) bool {
+	capability, ok := ProviderCapabilityFor(provider)
+	return ok && capability.SupportsMCPConfig
+}
+
+// InstructionNeedsInline reports whether the runtime brief must be included in
+// ExecOptions.SystemPrompt for the provider/version pair. An unknown version
+// keeps the legacy fallback enabled for compatibility rows.
+func InstructionNeedsInline(provider, version string) bool {
+	capability, ok := ProviderCapabilityFor(provider)
+	if !ok {
+		return false
+	}
+	switch capability.InstructionDelivery {
+	case InstructionInline:
+		return true
+	case InstructionFileWithLegacyInline:
+		return !VersionAtLeast(version, capability.LegacyInlineBefore)
+	default:
+		return false
+	}
+}
+
+// VersionAtLeast compares the first three numeric components of version and
+// minimum. It returns false when either value cannot be parsed, which keeps a
+// legacy fallback enabled instead of silently dropping instructions.
+func VersionAtLeast(version, minimum string) bool {
+	got, ok := numericVersion(version)
+	if !ok {
+		return false
+	}
+	want, ok := numericVersion(minimum)
+	if !ok {
+		return false
+	}
+	for i := range got {
+		if got[i] < want[i] {
+			return false
+		}
+		if got[i] > want[i] {
+			return true
+		}
+	}
+	return true
+}
+
+func numericVersion(raw string) ([3]int, bool) {
+	var out [3]int
+	raw = strings.TrimSpace(raw)
+	start := -1
+	for i := 0; i < len(raw); i++ {
+		if raw[i] >= '0' && raw[i] <= '9' {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return out, false
+	}
+	parts := strings.Split(raw[start:], ".")
+	if len(parts) < 3 {
+		return out, false
+	}
+	for i := 0; i < 3; i++ {
+		end := 0
+		for end < len(parts[i]) && parts[i][end] >= '0' && parts[i][end] <= '9' {
+			end++
+		}
+		if end == 0 {
+			return out, false
+		}
+		value, err := strconv.Atoi(parts[i][:end])
+		if err != nil {
+			return out, false
+		}
+		out[i] = value
+	}
+	return out, true
+}
+
+// ProviderCapabilityMatrixMarkdown renders the checked-in documentation
+// mirror. The package test compares this output with docs/provider-capabilities.md
+// so documentation drift is an executable failure rather than a review guess.
+func ProviderCapabilityMatrixMarkdown() string {
+	var b strings.Builder
+	b.WriteString("# Provider capability matrix\n\n")
+	b.WriteString("This file is generated from `server/pkg/agent/provider_capabilities.go`. Do not edit it by hand.\n\n")
+	b.WriteString("| Provider | MCP support/delivery | Sandbox/approval | Runtime config | Workspace skills | User skills | Instruction delivery | Compatibility |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, capability := range providerCapabilityTable {
+		mcp := "no: " + capability.MCPDelivery
+		if capability.SupportsMCPConfig {
+			mcp = "yes: " + capability.MCPDelivery
+		}
+		instructions := string(capability.InstructionDelivery)
+		if capability.LegacyInlineBefore != "" {
+			instructions += " before " + capability.LegacyInlineBefore
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | `%s` | `%s` | `%s` | %s | %s |\n",
+			capability.DisplayName,
+			mcp,
+			capability.SandboxApproval,
+			capability.RuntimeConfigFile,
+			capability.WorkspaceSkillPath,
+			userSkillPathLabel(capability),
+			instructions,
+			capability.Compatibility,
+		)
+	}
+	b.WriteString("\n")
+	b.WriteString("MCP config source details:\n\n")
+	for _, capability := range providerCapabilityTable {
+		fmt.Fprintf(&b, "- `%s`: `%s`\n", capability.Type, capability.MCPConfigSource)
+	}
+	return b.String()
+}
+
+func userSkillPathLabel(capability ProviderCapability) string {
+	if capability.UserSkillEnvVar != "" {
+		return "$" + capability.UserSkillEnvVar + "/" + capability.UserSkillEnvRelative
+	}
+	return "~/" + strings.TrimPrefix(capability.UserSkillHomeRelative, "./")
+}

--- a/server/pkg/agent/provider_capabilities_test.go
+++ b/server/pkg/agent/provider_capabilities_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProviderCapabilityMatrixMatchesFactory(t *testing.T) {
+	t.Parallel()
+
+	capabilities := AllProviderCapabilities()
+	if len(capabilities) != len(SupportedTypes) {
+		t.Fatalf("capability rows = %d, SupportedTypes = %d", len(capabilities), len(SupportedTypes))
+	}
+	seen := make(map[string]bool, len(capabilities))
+	for _, capability := range capabilities {
+		if capability.Type == "" || seen[capability.Type] {
+			t.Fatalf("duplicate or empty provider capability %q", capability.Type)
+		}
+		seen[capability.Type] = true
+		if !capability.NativeSkillCatalog {
+			t.Errorf("%s must declare a native skill catalog", capability.Type)
+		}
+		if capability.RuntimeConfigFile == "" || capability.WorkspaceSkillPath == "" {
+			t.Errorf("%s is missing a runtime or workspace skill path", capability.Type)
+		}
+		if capability.UserSkillHomeRelative == "" {
+			t.Errorf("%s is missing its user skill root", capability.Type)
+		}
+		if capability.SandboxApproval == "" || capability.Compatibility == "" {
+			t.Errorf("%s is missing sandbox/approval or compatibility metadata", capability.Type)
+		}
+		if capability.SupportsMCPConfig && capability.MCPConfigSource == "" {
+			t.Errorf("%s is missing its MCP config source", capability.Type)
+		}
+		if _, err := New(capability.Type, Config{}); err != nil {
+			t.Errorf("matrix provider %s is not constructible: %v", capability.Type, err)
+		}
+	}
+	for _, provider := range SupportedTypes {
+		if !seen[provider] {
+			t.Errorf("SupportedTypes contains %q without a capability row", provider)
+		}
+	}
+}
+
+func TestProviderCapabilityMatrixMatchesFrontendMCPMirror(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "..", "packages", "core", "agents", "mcp-support.ts")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read frontend MCP mirror: %v", err)
+	}
+	text := string(raw)
+	for _, capability := range providerCapabilityTable {
+		hasProvider := strings.Contains(text, fmt.Sprintf("  %q,", capability.Type))
+		if hasProvider != capability.SupportsMCPConfig {
+			t.Errorf("frontend MCP mirror for %s = %v, matrix = %v", capability.Type, hasProvider, capability.SupportsMCPConfig)
+		}
+	}
+}
+
+func TestProviderCapabilityMatrixDocumentationIsGenerated(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "..", "docs", "provider-capabilities.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated capability documentation: %v", err)
+	}
+	if got, want := string(raw), ProviderCapabilityMatrixMarkdown(); got != want {
+		t.Fatalf("generated capability documentation is stale")
+	}
+}
+
+func TestOpenClawInstructionDeliveryIsVersionGated(t *testing.T) {
+	t.Parallel()
+
+	if !InstructionNeedsInline("openclaw", "2026.5.4") {
+		t.Fatal("OpenClaw legacy versions must retain inline instructions")
+	}
+	for _, version := range []string{OpenClawMinimumSupportedVersion, "2026.6.0", "openclaw v2027.1.0"} {
+		if InstructionNeedsInline("openclaw", version) {
+			t.Fatalf("OpenClaw %s must use the single file-based path", version)
+		}
+	}
+	if !InstructionNeedsInline("openclaw", "") {
+		t.Fatal("unknown OpenClaw version must fail closed to the legacy inline path")
+	}
+}
+
+func TestVersionAtLeastParsesCLIOutput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		version string
+		minimum string
+		want    bool
+	}{
+		{"2026.5.5", "2026.5.5", true},
+		{"openclaw v2026.6.0 c37871e", "2026.5.5", true},
+		{"2026.5.4", "2026.5.5", false},
+		{"unknown", "2026.5.5", false},
+	}
+	for _, tc := range cases {
+		if got := VersionAtLeast(tc.version, tc.minimum); got != tc.want {
+			t.Errorf("VersionAtLeast(%q, %q) = %v, want %v", tc.version, tc.minimum, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- centralize provider MCP, sandbox, runtime-config, skill-path, and instruction-delivery capabilities in one Go matrix
- derive supported provider validation and daemon runtime paths from that matrix
- gate OpenClaw's legacy inline fallback below 2026.5.5, keeping supported releases on one file-based path
- add generated capability documentation, ADR, frontend MCP drift coverage, and compatibility tests

Related: #7159

## Validation

- `go test ./pkg/agent -count=1 -timeout=15m` passes
- `go test ./internal/daemon/execenv -count=1 -timeout=15m` passes
- focused daemon provider/context tests pass
- the full `internal/daemon` package still has failures in existing config, identity, and repo-cache/worktree tests outside this change
