### PR TITLE
fix(web): send /favicon.ico to /favicon.svg with a relative Location

### DIFF
--- a/apps/web/app/favicon.ico/route.test.ts
+++ b/apps/web/app/favicon.ico/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("/favicon.ico", () => {
+  it("redirects with a RELATIVE Location, whatever origin served the request", () => {
+    // A standalone server behind a reverse proxy sees its own bind
+    // address as the request origin. An absolute Location built from it
+    // (http://0.0.0.0:3000/favicon.svg) is unreachable from any browser
+    // and leaks the internal bind address — GH #7116. Relative resolves
+    // against the origin the client actually used.
+    const res = GET();
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("/favicon.svg");
+  });
+});

--- a/apps/web/app/favicon.ico/route.ts
+++ b/apps/web/app/favicon.ico/route.ts
@@ -1,3 +1,16 @@
-export function GET(request: Request) {
-  return Response.redirect(new URL("/favicon.svg", request.url), 308);
+// Redirect the legacy /favicon.ico request to the real SVG icon.
+//
+// The Location is deliberately RELATIVE. Building an absolute URL from
+// request.url bakes in the standalone server's bind address — behind a
+// reverse proxy that emitted `Location: http://0.0.0.0:3000/favicon.svg`,
+// a dead end for every browser and a leak of the internal bind address
+// (GH #7116). A relative Location resolves against whatever origin the
+// client actually used, which is the only origin we can trust here:
+// self-hosted deployments sit behind arbitrary proxies and need no
+// public-URL configuration for this to hold.
+export function GET() {
+  return new Response(null, {
+    status: 308,
+    headers: { Location: "/favicon.svg" },
+  });
 }


### PR DESCRIPTION
Fixes #7116.

`app/favicon.ico/route.ts` built an absolute redirect from `request.url`, which on a standalone server is the *bind* address. Behind a reverse proxy that came out as:

```
$ curl -sSI http://<internal-host>/favicon.ico
HTTP/1.1 308 Permanent Redirect
location: http://localhost:3000/favicon.svg
```

— a dead end for every browser, and the internal bind address leaks to every client (we reproduced `localhost:3000` on our deployment; the reporter saw `0.0.0.0:3000` — same root, different bind host).

The Location is now relative. RFC 7231 §7.1.2 allows it, and every browser resolves it against the origin the client actually used — which is the only origin the server can trust here: self-hosted deployments sit behind arbitrary proxies, and this needs no public-URL configuration to be right. `Response.redirect()` refuses relative URLs, so the response is constructed directly.

Verified on a self-hosted deployment behind OpenResty:

```
$ curl -sSI -H "Host: <public-host>" http://127.0.0.1/favicon.ico
HTTP/1.1 308 Permanent Redirect
location: /favicon.svg

$ curl -sS -o /dev/null -w "%{http_code} %{content_type}" -L .../favicon.ico
200 image/svg+xml
```

The test pins the relative-Location contract so a future refactor doesn't quietly reintroduce the absolute form.
