### PR TITLE
MUL-6228: resolve full-UUID issue refs locally instead of a resolver GET

### DIFF
--- a/server/cmd/multica/cmd_id_resolver.go
+++ b/server/cmd/multica/cmd_id_resolver.go
@@ -16,7 +16,9 @@ const minShortIDPrefixLen = 4
 const resolverListPageLimit = 50
 
 type resolvedID struct {
-	ID      string
+	ID string
+	// Display is a best-effort label for human-facing messages. It may equal
+	// ID when resolution does not fetch display metadata from the server.
 	Display string
 }
 
@@ -154,12 +156,11 @@ func resolveIssueRef(ctx context.Context, client *cli.APIClient, input string) (
 		// A full UUID is self-identifying: the resolver GET added a round
 		// trip and no information, and agents pay it several times per run
 		// during bootstrap (GH #7017). Lowercased to the canonical form the
-		// server emits. Two consequences, both accepted there: messages
-		// built from Display show the UUID rather than the issue key for
-		// full-UUID invocations, and a nonexistent UUID now 404s on the
-		// command's own request instead of the resolver's — every write
-		// path re-validates server-side (e.g. parent_issue_id on create),
-		// so nothing is stored on the strength of the ref alone.
+		// server emits. Messages without an issue response may show this UUID
+		// rather than the issue key, and failures now come from the command's
+		// next issue-aware endpoint. Every write path re-validates server-side
+		// (e.g. parent_issue_id on create), so nothing is stored on the strength
+		// of the ref alone.
 		id := strings.ToLower(trimmed)
 		return resolvedID{ID: id, Display: id}, nil
 	}

--- a/server/cmd/multica/cmd_id_resolver.go
+++ b/server/cmd/multica/cmd_id_resolver.go
@@ -151,7 +151,17 @@ func resolveIssueRef(ctx context.Context, client *cli.APIClient, input string) (
 		return fetchIssueRef(ctx, client, trimmed)
 	}
 	if uuidRegexp.MatchString(trimmed) {
-		return fetchIssueRef(ctx, client, trimmed)
+		// A full UUID is self-identifying: the resolver GET added a round
+		// trip and no information, and agents pay it several times per run
+		// during bootstrap (GH #7017). Lowercased to the canonical form the
+		// server emits. Two consequences, both accepted there: messages
+		// built from Display show the UUID rather than the issue key for
+		// full-UUID invocations, and a nonexistent UUID now 404s on the
+		// command's own request instead of the resolver's — every write
+		// path re-validates server-side (e.g. parent_issue_id on create),
+		// so nothing is stored on the strength of the ref alone.
+		id := strings.ToLower(trimmed)
+		return resolvedID{ID: id, Display: id}, nil
 	}
 
 	// Detect the common "I copied a truncated UUID" case and give a

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -1609,9 +1609,10 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("get issue: %w", err)
 	}
+	targetDisplay := issueDisplayKey(target)
 	status := strVal(target, "status")
 	if status == "" {
-		return fmt.Errorf("issue %s has no status, cannot determine its column", issueRef.Display)
+		return fmt.Errorf("issue %s has no status, cannot determine its column", targetDisplay)
 	}
 
 	// Resolve the relative target up front, before any no-op shortcut, so a bad
@@ -1629,7 +1630,7 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("resolve target issue: %w", err)
 		}
 		if otherRef.ID == issueRef.ID {
-			return fmt.Errorf("cannot reorder issue %s relative to itself", issueRef.Display)
+			return fmt.Errorf("cannot reorder issue %s relative to itself", targetDisplay)
 		}
 	}
 
@@ -1661,9 +1662,9 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 		// succeed here (its target is necessarily in another column), so report
 		// that rather than a misleading "nothing to reorder".
 		if relative {
-			return reorderTargetNotInColumnError(ctx, client, otherRef, issueRef, status)
+			return reorderTargetNotInColumnError(ctx, client, otherRef, targetDisplay, status)
 		}
-		fmt.Fprintf(os.Stderr, "Issue %s is the only issue in the %s column; nothing to reorder.\n", issueRef.Display, status)
+		fmt.Fprintf(os.Stderr, "Issue %s is the only issue in the %s column; nothing to reorder.\n", targetDisplay, status)
 		return issueReorderOutput(cmd, target)
 	}
 
@@ -1676,7 +1677,7 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 	default:
 		idx := indexOfString(ordered, otherRef.ID)
 		if idx == -1 {
-			return reorderTargetNotInColumnError(ctx, client, otherRef, issueRef, status)
+			return reorderTargetNotInColumnError(ctx, client, otherRef, targetDisplay, status)
 		}
 		if before != "" {
 			insertIdx = idx
@@ -1693,7 +1694,7 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 	currentPos := positions[issueRef.ID]
 	newPos := computeReorderPosition(reordered, issueRef.ID, positions, currentPos)
 	if newPos == currentPos {
-		fmt.Fprintf(os.Stderr, "Issue %s is already in that position.\n", issueRef.Display)
+		fmt.Fprintf(os.Stderr, "Issue %s is already in that position.\n", targetDisplay)
 		return issueReorderOutput(cmd, target)
 	}
 
@@ -1727,13 +1728,15 @@ func issueReorderOutput(cmd *cobra.Command, issue map[string]any) error {
 // not be used. It fetches the target only to report its actual column in the
 // message, so the common mistake (target lives in a different column) gets a
 // precise, actionable error instead of a bare "not found".
-func reorderTargetNotInColumnError(ctx context.Context, client *cli.APIClient, otherRef, issueRef resolvedID, status string) error {
+func reorderTargetNotInColumnError(ctx context.Context, client *cli.APIClient, otherRef resolvedID, issueDisplay, status string) error {
+	otherDisplay := otherRef.Display
 	if other, err := fetchIssue(ctx, client, otherRef.ID); err == nil {
+		otherDisplay = issueDisplayKey(other)
 		if otherStatus := strVal(other, "status"); otherStatus != "" && otherStatus != status {
-			return fmt.Errorf("issue %s is in the %q column but %s is in %q; move one with `multica issue status` first, or pick a target in the same column", otherRef.Display, otherStatus, issueRef.Display, status)
+			return fmt.Errorf("issue %s is in the %q column but %s is in %q; move one with `multica issue status` first, or pick a target in the same column", otherDisplay, otherStatus, issueDisplay, status)
 		}
 	}
-	return fmt.Errorf("issue %s was not found in the %q column", otherRef.Display, status)
+	return fmt.Errorf("issue %s was not found in the %q column", otherDisplay, status)
 }
 
 // fetchIssue retrieves a single issue by canonical ID.

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -906,6 +906,33 @@ func TestResolveIssueRef(t *testing.T) {
 		}
 	})
 
+	t.Run("full UUID resolves locally with zero HTTP requests", func(t *testing.T) {
+		// A full UUID is self-identifying — the resolver used to GET
+		// /api/issues/<uuid> just to learn the id it already had, and
+		// agents pay that per `multica issue …` call during run
+		// bootstrap (GH #7017). Any HTTP call here means the local
+		// resolve regressed.
+		var hits []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits = append(hits, r.Method+" "+r.URL.Path)
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+
+		client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+		got, err := resolveIssueRef(context.Background(), client, "1881A167-4BB6-4602-944B-F40CE4192FE6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Canonical lowercase, whatever case the user pasted.
+		if got.ID != "1881a167-4bb6-4602-944b-f40ce4192fe6" || got.Display != got.ID {
+			t.Fatalf("got %#v", got)
+		}
+		if len(hits) != 0 {
+			t.Fatalf("full UUID must not perform any HTTP call; got %#v", hits)
+		}
+	})
+
 	t.Run("short UUID prefix is rejected without any HTTP call", func(t *testing.T) {
 		// Until commit 9a3a99c this called fetchIssueCandidates and paged
 		// /api/issues client-side, which timed out on large workspaces
@@ -998,31 +1025,6 @@ func TestResolveIssueRef(t *testing.T) {
 		}
 	})
 
-	t.Run("full UUID still resolves via single GET", func(t *testing.T) {
-		// Sanity check: the canonical reference forms must still work.
-		var hits []string
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			hits = append(hits, r.Method+" "+r.URL.Path)
-			if r.URL.Path == "/api/issues/"+issue["id"].(string) {
-				json.NewEncoder(w).Encode(issue)
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		defer srv.Close()
-
-		client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
-		got, err := resolveIssueRef(context.Background(), client, issue["id"].(string))
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got.ID != issue["id"] || got.Display != "MUL-1852" {
-			t.Fatalf("got %#v", got)
-		}
-		if len(hits) != 1 {
-			t.Fatalf("full UUID must resolve via a single request; got %#v", hits)
-		}
-	})
 }
 
 func TestFetchAutopilotCandidatesPaginates(t *testing.T) {

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -3507,6 +3507,37 @@ func TestRunIssueReorderRejectsCrossColumnTarget(t *testing.T) {
 	}
 }
 
+func TestReorderTargetNotInColumnErrorUsesFetchedIssueKey(t *testing.T) {
+	otherID := "33333333-3333-3333-3333-333333333333"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/issues/"+otherID {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         otherID,
+			"identifier": "MUL-3",
+			"status":     "in_progress",
+		})
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	err := reorderTargetNotInColumnError(
+		context.Background(),
+		client,
+		resolvedID{ID: otherID, Display: otherID},
+		"MUL-9",
+		"todo",
+	)
+	if msg := err.Error(); !strings.Contains(msg, "issue MUL-3") || !strings.Contains(msg, "MUL-9") {
+		t.Fatalf("error = %q, want fetched issue keys for both issues", msg)
+	}
+	if strings.Contains(err.Error(), otherID) {
+		t.Fatalf("error = %q, should not expose the UUID after fetching the issue key", err)
+	}
+}
+
 func mkIssue(id, key, status string, pos float64) map[string]any {
 	return map[string]any{"id": id, "identifier": key, "status": status, "position": pos}
 }


### PR DESCRIPTION
Closes #7017, along the shape proposed there.

`resolveIssueRef` sent a full UUID through `GET /api/issues/<uuid>` just to learn the id it already had. Agents fire several `multica issue …` calls back-to-back during run bootstrap — we count 10+ CLI calls in a typical run's transcript on our self-hosted deployment — so the round-trip is paid several times per run.

Full-UUID refs now short-circuit to a lowercased `resolvedID` with **zero** HTTP requests, pinned by test the same way the short-prefix rejection already is. Identifier refs (`MUL-123`) keep the fetch — that mapping genuinely needs the server.

Accepted consequences and error-surface details:

- Messages built only from `Display` show the UUID rather than the issue key for full-UUID invocations. Commands that render the issue from their own response (`issue get`) are unaffected. `issue reorder` also keeps the issue key in its messages because it already fetches the relevant issues as part of the operation.
- Resource validation moves from the resolver GET to the command's next issue-aware endpoint. Most nonexistent UUIDs therefore 404 on the command's own request, with two narrower differences:
  - `issue create --parent <uuid>` returns the create endpoint's 400 validation error (`ExitValidation`, 5) instead of the resolver's 404 (`ExitNotFound`, 4). The create handler re-validates `parent_issue_id` with `GetIssueInWorkspace` before storing anything.
  - `issue comment add <uuid> --attachment <path>` reaches the attachment endpoint first, which returns 403 `invalid issue_id` (`ExitAuth`, 3) instead of the resolver's 404. The upload handler performs that validation before `Storage.Upload`, so a missing or foreign issue still produces zero uploaded/orphaned files.

Every write path continues to validate the issue server-side; the local shortcut only removes a redundant lookup and does not grant access or persist state on the strength of the UUID alone.

The previous "full UUID still resolves via single GET" test asserted the old contract and is superseded by the zero-request test.
