### PR TITLE
fix(mobile): configure Apple team from environment (MUL-6375)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -32,6 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     icon: "./assets/icon.png",
     ios: {
       supportsTablet: false,
+      appleTeamId: process.env.EXPO_APPLE_TEAM_ID,
       // Per-variant bundle id overrides exist for one reason: an Apple ID
       // can only sign bundle prefixes it owns, so contributors not on the
       // Multica Apple Developer team (and external users self-building a


### PR DESCRIPTION
## Summary
- map `EXPO_APPLE_TEAM_ID` to Expo's supported `ios.appleTeamId` configuration field
- allow self-builders with multiple Apple Developer teams to select the correct signing team during Expo prebuild
- preserve Expo's normal behavior when the variable is unset

## Verification
- `pnpm --filter @multica/mobile typecheck`
- `git diff --check`

Closes #7172