### PR TITLE
fix(skills): skip binary supporting files in runtime-local skill sync

### DIFF
--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/skill"
 	"github.com/multica-ai/multica/server/pkg/agent"
@@ -376,15 +377,34 @@ func collectLocalSkillFiles(skillDir string, includeContent bool) ([]SkillFileDa
 		// A binary supporting file cannot survive SkillFileData.Content: the
 		// bytes go out as a Go string and encoding/json rewrites every invalid
 		// UTF-8 byte to U+FFFD, so writeSkillFiles later recreates a file that
-		// differs from the original and will not open. Skip it the way the
-		// archive/URL importer already does, and skip it regardless of
-		// includeContent so the discovery and sync passes agree on which files
-		// make up the bundle.
-		if skill.IsLikelyBinaryFilePath(rel) {
+		// differs from the original and will not open.
+		//
+		// IsLikelyBinaryFilePath is only a cheap first pass on the extension —
+		// the same heuristic the archive/URL importer uses. On its own it
+		// misses a binary file with an unlisted or missing extension (a
+		// .safetensors, a .parquet, a stray no-extension blob) and a text file
+		// in a non-UTF-8 encoding, both of which corrupt exactly the same way.
+		// The read below is the actual guarantee: skip whenever the bytes
+		// themselves are not valid UTF-8, regardless of what the extension
+		// suggested. This runs on both the includeContent=false (discovery)
+		// and includeContent=true (sync) passes so they agree on which files
+		// make up the bundle — skipping the read on the false pass would let
+		// a discovery listing promise a file that sync then silently drops.
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		likelyBinaryExt := skill.IsLikelyBinaryFilePath(rel)
+		if likelyBinaryExt || !utf8.Valid(content) {
+			reason := "invalid_utf8"
+			if likelyBinaryExt {
+				reason = "binary_extension"
+			}
 			slog.Info("local skill: skipping binary file",
 				"skill_dir", skillDir,
 				"path", filepath.ToSlash(rel),
 				"size", info.Size(),
+				"reason", reason,
 			)
 			return nil
 		}
@@ -398,10 +418,6 @@ func collectLocalSkillFiles(skillDir string, includeContent bool) ([]SkillFileDa
 
 		file := SkillFileData{Path: filepath.ToSlash(rel)}
 		if includeContent {
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return nil
-			}
 			file.Content = string(content)
 		}
 		files = append(files, file)

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -379,26 +380,43 @@ func collectLocalSkillFiles(skillDir string, includeContent bool) ([]SkillFileDa
 		// UTF-8 byte to U+FFFD, so writeSkillFiles later recreates a file that
 		// differs from the original and will not open.
 		//
-		// IsLikelyBinaryFilePath is only a cheap first pass on the extension —
-		// the same heuristic the archive/URL importer uses. On its own it
-		// misses a binary file with an unlisted or missing extension (a
-		// .safetensors, a .parquet, a stray no-extension blob) and a text file
-		// in a non-UTF-8 encoding, both of which corrupt exactly the same way.
+		// IsLikelyBinaryFilePath is the cheap first pass on the extension — the
+		// same heuristic the archive/URL importer uses — checked before any
+		// read so a known-binary file never pays the I/O. On its own it misses
+		// a binary file with an unlisted or missing extension (a .safetensors,
+		// a .parquet, a stray no-extension blob) and a text file in a
+		// non-UTF-8 encoding, both of which corrupt exactly the same way.
+		if skill.IsLikelyBinaryFilePath(rel) {
+			slog.Info("local skill: skipping binary file",
+				"skill_dir", skillDir,
+				"path", filepath.ToSlash(rel),
+				"size", info.Size(),
+				"reason", "binary_extension",
+			)
+			return nil
+		}
 		// The read below is the actual guarantee: skip whenever the bytes
-		// themselves are not valid UTF-8, regardless of what the extension
-		// suggested. This runs on both the includeContent=false (discovery)
-		// and includeContent=true (sync) passes so they agree on which files
-		// make up the bundle — skipping the read on the false pass would let
-		// a discovery listing promise a file that sync then silently drops.
+		// themselves are not safely round-trippable, regardless of what the
+		// extension suggested. This runs on both the includeContent=false
+		// (discovery) and includeContent=true (sync) passes so they agree on
+		// which files make up the bundle — skipping the read on the false pass
+		// would let a discovery listing promise a file that sync then silently
+		// drops.
+		//
+		// Valid UTF-8 alone is not enough: a NUL byte is legal UTF-8 but the
+		// server-side import path strips every 0x00 via sanitizeNullBytes
+		// (server/internal/handler/skill_create.go), so a file that is valid
+		// UTF-8 but contains NUL — UTF-16LE text made of ASCII characters is a
+		// realistic example — still comes back different from what went in.
+		// Require both: valid UTF-8 AND NUL-free.
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
-		likelyBinaryExt := skill.IsLikelyBinaryFilePath(rel)
-		if likelyBinaryExt || !utf8.Valid(content) {
+		if !utf8.Valid(content) || bytes.IndexByte(content, 0) >= 0 {
 			reason := "invalid_utf8"
-			if likelyBinaryExt {
-				reason = "binary_extension"
+			if utf8.Valid(content) {
+				reason = "embedded_nul"
 			}
 			slog.Info("local skill: skipping binary file",
 				"skill_dir", skillDir,

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -370,6 +371,21 @@ func collectLocalSkillFiles(skillDir string, includeContent bool) ([]SkillFileDa
 
 		info, err := entry.Info()
 		if err != nil || info.Size() > maxLocalSkillFileSize {
+			return nil
+		}
+		// A binary supporting file cannot survive SkillFileData.Content: the
+		// bytes go out as a Go string and encoding/json rewrites every invalid
+		// UTF-8 byte to U+FFFD, so writeSkillFiles later recreates a file that
+		// differs from the original and will not open. Skip it the way the
+		// archive/URL importer already does, and skip it regardless of
+		// includeContent so the discovery and sync passes agree on which files
+		// make up the bundle.
+		if skill.IsLikelyBinaryFilePath(rel) {
+			slog.Info("local skill: skipping binary file",
+				"skill_dir", skillDir,
+				"path", filepath.ToSlash(rel),
+				"size", info.Size(),
+			)
 			return nil
 		}
 		if len(files) >= maxLocalSkillFileCount {

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -1100,3 +1100,72 @@ func TestLoadRuntimeLocalSkillBundle_ProviderNonDirFallsThrough(t *testing.T) {
 	}
 
 }
+
+// invalidUTF8Docx is a .docx prefix (PK zip magic) followed by bytes that are
+// not valid UTF-8. Carrying this through SkillFileData.Content is exactly the
+// corruption in #7143: encoding/json rewrites each invalid byte to U+FFFD, so
+// the file written back into the task environment no longer opens.
+const invalidUTF8Docx = "PK\x03\x04\x14\x00\x06\x00\xff\xfe\x80\x81payload"
+
+func TestCollectLocalSkillFiles_SkipsBinarySupportingFiles(t *testing.T) {
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":               "---\nname: docs\n---\nbody\n",
+		"references/notes.md":    "# notes\n",
+		"references/report.docx": invalidUTF8Docx,
+		"assets/logo.png":        "\x89PNG\r\n\x1a\n\x00\x00\x00",
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("collected paths = %v, want %v", paths, want)
+	}
+
+	// The text file that survives must survive byte-for-byte.
+	if files[0].Content != "# notes\n" {
+		t.Errorf("text content = %q, want %q", files[0].Content, "# notes\n")
+	}
+}
+
+func TestCollectLocalSkillFiles_BinarySkipIsConsistentAcrossPasses(t *testing.T) {
+	// Discovery reports the bundle with includeContent=false and sync uploads
+	// it with includeContent=true. If only one pass skipped binary files the
+	// two would disagree on what the bundle contains, so the skip must not
+	// depend on includeContent.
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":               "---\nname: docs\n---\nbody\n",
+		"references/notes.md":    "# notes\n",
+		"references/report.docx": invalidUTF8Docx,
+	})
+
+	listed, err := collectLocalSkillFiles(skillDir, false)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles(includeContent=false): %v", err)
+	}
+	synced, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles(includeContent=true): %v", err)
+	}
+
+	listedPaths := make([]string, 0, len(listed))
+	for _, f := range listed {
+		listedPaths = append(listedPaths, f.Path)
+	}
+	syncedPaths := make([]string, 0, len(synced))
+	for _, f := range synced {
+		syncedPaths = append(syncedPaths, f.Path)
+	}
+	if !reflect.DeepEqual(listedPaths, syncedPaths) {
+		t.Fatalf("discovery pass = %v, sync pass = %v; passes must agree", listedPaths, syncedPaths)
+	}
+}

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -1233,6 +1233,64 @@ func TestCollectLocalSkillFiles_SkipsInvalidUTF8WithNoExtension(t *testing.T) {
 	}
 }
 
+// validUTF8WithNUL is UTF-16LE encoding of "Hello": every byte is a valid
+// single-byte UTF-8 sequence (printable ASCII or NUL), so utf8.Valid alone
+// would accept it — multica-eve's review on #7175 flagged this as a
+// realistic byte-integrity hole: the server-side import path
+// (server/internal/handler/skill_create.go's sanitizeNullBytes) strips every
+// 0x00, so a file like this still comes back different from what went in.
+const validUTF8WithNUL = "H\x00e\x00l\x00l\x00o\x00"
+
+// A file with an unlisted extension that is valid UTF-8 but contains an
+// embedded NUL must still be caught — utf8.Valid alone is not sufficient.
+func TestCollectLocalSkillFiles_SkipsUnlistedExtensionWithEmbeddedNUL(t *testing.T) {
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":            "---\nname: docs\n---\nbody\n",
+		"references/notes.md": "# notes\n",
+		"weights/model.dat":   validUTF8WithNUL,
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("collected paths = %v, want %v — valid UTF-8 with an embedded NUL must still be caught", paths, want)
+	}
+}
+
+// A no-extension file with the same valid-UTF-8-but-NUL-containing content
+// must be caught the same way.
+func TestCollectLocalSkillFiles_SkipsNoExtensionWithEmbeddedNUL(t *testing.T) {
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":             "---\nname: docs\n---\nbody\n",
+		"references/notes.md":  "# notes\n",
+		"references/UTF16NAME": validUTF8WithNUL,
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("collected paths = %v, want %v — a no-extension file with an embedded NUL must still be caught", paths, want)
+	}
+}
+
 // A valid-UTF-8 text file — including one with an extension the blacklist
 // doesn't recognize, and one with no extension at all — must still pass
 // through untouched. The content check must not over-trigger on ordinary

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -1139,13 +1139,16 @@ func TestCollectLocalSkillFiles_SkipsBinarySupportingFiles(t *testing.T) {
 func TestCollectLocalSkillFiles_BinarySkipIsConsistentAcrossPasses(t *testing.T) {
 	// Discovery reports the bundle with includeContent=false and sync uploads
 	// it with includeContent=true. If only one pass skipped binary files the
-	// two would disagree on what the bundle contains, so the skip must not
-	// depend on includeContent.
+	// two would disagree on what the bundle contains. This must hold both for
+	// a listed binary extension and for one caught only by the content-level
+	// UTF-8 check — the discovery pass has to actually read the file to make
+	// the same call the sync pass makes.
 	root := t.TempDir()
 	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
-		"SKILL.md":               "---\nname: docs\n---\nbody\n",
-		"references/notes.md":    "# notes\n",
-		"references/report.docx": invalidUTF8Docx,
+		"SKILL.md":                  "---\nname: docs\n---\nbody\n",
+		"references/notes.md":       "# notes\n",
+		"references/report.docx":    invalidUTF8Docx,
+		"weights/model.safetensors": invalidUTF8Bytes,
 	})
 
 	listed, err := collectLocalSkillFiles(skillDir, false)
@@ -1167,5 +1170,93 @@ func TestCollectLocalSkillFiles_BinarySkipIsConsistentAcrossPasses(t *testing.T)
 	}
 	if !reflect.DeepEqual(listedPaths, syncedPaths) {
 		t.Fatalf("discovery pass = %v, sync pass = %v; passes must agree", listedPaths, syncedPaths)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(listedPaths, want) {
+		t.Fatalf("collected paths = %v, want %v", listedPaths, want)
+	}
+}
+
+// invalidUTF8Bytes carries no listed binary extension's magic — it exists to
+// prove the content-level check, not the extension list, is what catches it.
+const invalidUTF8Bytes = "\xff\xfe\x00\x01payload\x80\x81"
+
+// Bohan-J's review on #7175: the extension blacklist alone doesn't close the
+// root cause. A binary file with an unlisted extension must still be caught
+// by the content-level utf8.Valid check.
+func TestCollectLocalSkillFiles_SkipsUnlistedBinaryExtension(t *testing.T) {
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":                  "---\nname: docs\n---\nbody\n",
+		"references/notes.md":       "# notes\n",
+		"weights/model.safetensors": invalidUTF8Bytes,
+		"data/table.parquet":        invalidUTF8Bytes,
+		"blob.bin":                  invalidUTF8Bytes,
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("collected paths = %v, want %v — an unlisted binary extension must still be caught by the content check", paths, want)
+	}
+}
+
+// A binary file with no extension at all must be caught the same way.
+func TestCollectLocalSkillFiles_SkipsInvalidUTF8WithNoExtension(t *testing.T) {
+	root := t.TempDir()
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":            "---\nname: docs\n---\nbody\n",
+		"references/notes.md": "# notes\n",
+		"references/README":   invalidUTF8Bytes,
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	want := []string{"references/notes.md"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("collected paths = %v, want %v — a no-extension binary file must still be caught by the content check", paths, want)
+	}
+}
+
+// A valid-UTF-8 text file — including one with an extension the blacklist
+// doesn't recognize, and one with no extension at all — must still pass
+// through untouched. The content check must not over-trigger on ordinary
+// text.
+func TestCollectLocalSkillFiles_ValidUTF8TextPassesThroughUntouched(t *testing.T) {
+	root := t.TempDir()
+	body := "# Notes\n\nContém acentos e emoji 🎉 — não é binário.\n"
+	skillDir := writeTestLocalSkill(t, root, "docs", map[string]string{
+		"SKILL.md":  "---\nname: docs\n---\nbody\n",
+		"notes.txt": body,
+		"data.csv":  "a,b,c\n1,2,3\n",
+		"config":    "key=value\n",
+	})
+
+	files, err := collectLocalSkillFiles(skillDir, true)
+	if err != nil {
+		t.Fatalf("collectLocalSkillFiles: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("expected all 3 valid-UTF-8 supporting files to pass through, got %d: %+v", len(files), files)
+	}
+	for _, f := range files {
+		if f.Path == "notes.txt" && f.Content != body {
+			t.Errorf("notes.txt content = %q, want %q", f.Content, body)
+		}
 	}
 }

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -644,7 +644,7 @@ func isCapError(err error) bool {
 // assets the agent never reads as text anyway. Logging the skip leaves a
 // breadcrumb if a user expected one of these to import.
 func (s *importedSkill) addFile(path, content string) error {
-	if isLikelyBinaryFilePath(path) {
+	if skillpkg.IsLikelyBinaryFilePath(path) {
 		slog.Info("skill import: skipping binary file", "path", path, "size", len(content))
 		return nil
 	}
@@ -657,34 +657,6 @@ func (s *importedSkill) addFile(path, content string) error {
 	s.bundleSize += len(content)
 	s.files = append(s.files, importedFile{path: path, content: content})
 	return nil
-}
-
-// isLikelyBinaryFilePath reports whether the file's extension indicates a
-// non-text payload. Conservative blacklist — extensions not on the list
-// are assumed text and pass through. `sanitizeNullBytes` (called at PG
-// insert time) is the second-line defence against any text file that
-// turns out to have stray invalid-UTF-8 bytes.
-func isLikelyBinaryFilePath(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	switch ext {
-	case
-		// images
-		".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".ico", ".heic",
-		// fonts
-		".ttf", ".otf", ".woff", ".woff2", ".eot",
-		// archives
-		".zip", ".gz", ".tar", ".bz2", ".7z", ".rar",
-		// documents (binary office)
-		".pdf", ".docx", ".xlsx", ".pptx", ".doc", ".xls", ".ppt",
-		// media
-		".mp3", ".mp4", ".wav", ".avi", ".mov", ".webm", ".m4a", ".flac",
-		// compiled / executable
-		".exe", ".dll", ".so", ".dylib", ".class", ".jar", ".wasm",
-		// db / cache
-		".db", ".sqlite", ".sqlite3", ".pyc":
-		return true
-	}
-	return false
 }
 
 // --- ClawHub types ---
@@ -1368,7 +1340,7 @@ func addSupportingFilesFromTree(ctx context.Context, httpClient *http.Client, re
 		if lowerBase == "skill.md" || lowerBase == "license" || lowerBase == "license.txt" || lowerBase == "license.md" {
 			continue
 		}
-		if isLikelyBinaryFilePath(relPath) {
+		if skillpkg.IsLikelyBinaryFilePath(relPath) {
 			continue
 		}
 		eligible = append(eligible, treeFile{repoPath: entry.Path, relPath: relPath, size: entry.size()})

--- a/server/internal/skill/binary.go
+++ b/server/internal/skill/binary.go
@@ -1,0 +1,40 @@
+package skill
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsLikelyBinaryFilePath reports whether the file's extension indicates a
+// non-text payload. Conservative blacklist — extensions not on the list are
+// assumed text and pass through.
+//
+// Both skill ingestion paths need this, for the same reason from two
+// directions: an archive/URL import cannot put these bytes in a PG TEXT
+// column (SQLSTATE 22021), and runtime-local sync cannot carry them through
+// SkillFileData.Content, because encoding/json rewrites every invalid UTF-8
+// byte to U+FFFD on the daemon/server hop. Either way the bytes that come
+// back out are not the bytes that went in, so both paths skip the file
+// instead of storing a payload they would later hand back corrupted.
+func IsLikelyBinaryFilePath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case
+		// images
+		".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".ico", ".heic",
+		// fonts
+		".ttf", ".otf", ".woff", ".woff2", ".eot",
+		// archives
+		".zip", ".gz", ".tar", ".bz2", ".7z", ".rar",
+		// documents (binary office)
+		".pdf", ".docx", ".xlsx", ".pptx", ".doc", ".xls", ".ppt",
+		// media
+		".mp3", ".mp4", ".wav", ".avi", ".mov", ".webm", ".m4a", ".flac",
+		// compiled / executable
+		".exe", ".dll", ".so", ".dylib", ".class", ".jar", ".wasm",
+		// db / cache
+		".db", ".sqlite", ".sqlite3", ".pyc":
+		return true
+	}
+	return false
+}

--- a/server/internal/skill/binary_test.go
+++ b/server/internal/skill/binary_test.go
@@ -1,0 +1,49 @@
+package skill
+
+import "testing"
+
+func TestIsLikelyBinaryFilePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// The Office formats runtime-local skill bundles actually carry.
+		{"references/report.docx", true},
+		{"references/data.xlsx", true},
+		{"deck.pptx", true},
+		{"legacy.doc", true},
+		{"spec.pdf", true},
+		// Other non-text payloads.
+		{"assets/logo.png", true},
+		{"fonts/Inter.woff2", true},
+		{"bundle.zip", true},
+		{"clip.mp4", true},
+		{"helper.so", true},
+		{"cache.sqlite3", true},
+		// Extension matching is case-insensitive: Windows skill dirs routinely
+		// carry upper-cased extensions.
+		{"references/REPORT.DOCX", true},
+		{"Assets/Logo.PNG", true},
+		// Text payloads must pass through — skipping these would silently drop
+		// the reference material a skill exists to provide.
+		{"SKILL.md", false},
+		{"references/notes.md", false},
+		{"scripts/run.sh", false},
+		{"config.json", false},
+		{"data.csv", false},
+		{"template.html", false},
+		{"main.py", false},
+		// No extension, and a dotfile whose name is not an extension.
+		{"Makefile", false},
+		{".gitignore", false},
+		{"", false},
+		// A directory-looking path with a binary extension is still binary.
+		{"nested/dir/archive.tar", true},
+	}
+
+	for _, tt := range tests {
+		if got := IsLikelyBinaryFilePath(tt.path); got != tt.want {
+			t.Errorf("IsLikelyBinaryFilePath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`collectLocalSkillFiles` (`server/internal/daemon/local_skills.go`) read every supporting file into `SkillFileData.Content` as a Go string. That string crosses the daemon/server hop as JSON, and `encoding/json` rewrites each invalid UTF-8 byte to U+FFFD — so `writeSkillFiles` (`server/internal/daemon/execenv/context.go`) recreated a file whose bytes differ from the original. A `.docx`, `.xlsx` or `.pdf` carried in a runtime-local skill bundle therefore arrived in the prepared task environment corrupt and would not open (#7143).

The archive/URL importer already refuses this class of file for the mirror-image reason — those bytes cannot go into a PG TEXT column (SQLSTATE 22021) — but runtime-local sync never got the same protection.

## Change

Give both ingestion paths one shared predicate, and apply it on the runtime-local path.

- `server/internal/skill/binary.go` (new): the importer's extension blacklist becomes `IsLikelyBinaryFilePath`. The package is already imported by both the handler (`skillpkg`) and the daemon, so this is a move, not a new abstraction — the list itself is unchanged.
- `server/internal/handler/skill.go`: drops its local copy and calls the shared predicate from both existing call sites. No behaviour change.
- `server/internal/daemon/local_skills.go`: `collectLocalSkillFiles` now skips binary supporting files, with a log breadcrumb matching the importer's.

The skip deliberately does **not** depend on `includeContent`: discovery reports the bundle with content omitted and sync uploads it with content included, so skipping in only one pass would leave the two disagreeing about which files make up the bundle. The skip also sits before the file-count and bundle-size accounting, so a large binary no longer consumes a bundle's byte budget on its way to being dropped.

Skipping rather than base64-encoding through the wire is the parity fix the issue asks for; it keeps the `SkillFileData` contract between installed daemons and the server untouched.

## Test plan

- `server/internal/skill/binary_test.go`: table test over the predicate — the Office formats from the report, other binary payloads, upper-cased extensions (Windows skill dirs commonly carry `.DOCX`), and the text payloads that must still pass through.
- `server/internal/daemon/local_skills_test.go`:
  - `TestCollectLocalSkillFiles_SkipsBinarySupportingFiles` — a `.docx` holding real invalid UTF-8 bytes plus a `.png` are dropped, the `.md` survives byte-for-byte. Verified it fails before the change (`collected paths = [assets/logo.png references/notes.md references/report.docx]`) and passes after, so it is a real regression guard.
  - `TestCollectLocalSkillFiles_BinarySkipIsConsistentAcrossPasses` — pins the `includeContent`-independence above.
- `go test ./internal/skill ./internal/daemon ./internal/daemon/execenv ./internal/handler` ✅ · `go vet` ✅ · `gofmt` clean · `go build ./...` ✅

Fixes #7143
