### PR TITLE
MUL-6376 fix(db): regenerate DingTalk sqlc output

### DIFF
--- a/server/pkg/db/generated/dingtalk.sql.go
+++ b/server/pkg/db/generated/dingtalk.sql.go
@@ -158,7 +158,6 @@ func (q *Queries) DingTalkGroupRouteMatchesAgent(ctx context.Context, arg DingTa
 }
 
 const discoverDingTalkGroupRoute = `-- name: DiscoverDingTalkGroupRoute :one
-
 WITH workspace_guard AS MATERIALIZED (
     SELECT w.id
     FROM workspace w
@@ -220,9 +219,6 @@ type DiscoverDingTalkGroupRouteRow struct {
 	AgentActive bool        `json:"agent_active"`
 }
 
-// DingTalk-specific installation identity operations. The underlying channel_*
-// tables are shared, but these replacement semantics belong to DingTalk's BYO
-// AppKey model and deliberately stay out of the shared channel query surface.
 // Persist a group only after the shared inbound router has accepted the @bot
 // message and validated the sender's identity/workspace membership. The INSERT
 // default is the installation's agent; a later admin reassignment survives
@@ -352,6 +348,7 @@ func (q *Queries) ListDingTalkGroupRoutesByWorkspace(ctx context.Context, worksp
 }
 
 const listDingTalkUserBindingsForMember = `-- name: ListDingTalkUserBindingsForMember :many
+
 SELECT installation_id, channel_user_id
 FROM channel_user_binding
 WHERE workspace_id = $1
@@ -370,6 +367,9 @@ type ListDingTalkUserBindingsForMemberRow struct {
 	ChannelUserID  string      `json:"channel_user_id"`
 }
 
+// DingTalk-specific installation identity operations. The underlying channel_*
+// tables are shared, but these replacement semantics belong to DingTalk's BYO
+// AppKey model and deliberately stay out of the shared channel query surface.
 // Returns only the requesting Multica member's DingTalk identities. The
 // installation list is member-visible, so returning every member's staff id
 // here would expose staff ID values more broadly than necessary.


### PR DESCRIPTION
## Summary

- regenerate `server/pkg/db/generated/dingtalk.sql.go` with the repository-pinned sqlc v1.31.1
- restore the invariant enforced by `sqlc-check`: regeneration leaves no tracked or untracked output changes
- keep the SQL queries, generated APIs, and database schema unchanged; this only normalizes generated comment placement and whitespace

## Root cause

PR #7138 added the DingTalk query and generated code, but its recorded checks predated the new `sqlc-check` job and did not include that guard. Once merged, the updated `main` workflow regenerated the file and detected the mismatch. PR #7171 did not touch SQL; its push simply repeated the already-failing `main` check.

## Verification

- `make sqlc`
- `git diff --exit-code -- server/pkg/db/generated`
- no untracked files under `server/pkg/db/generated`
- `cd server && go test ./pkg/db/...`
- `cd server && go test ./internal/handler -run DingTalk -count=1`

Related to MUL-6376.
