### PR TITLE
feat(desktop): add tab cycling shortcuts

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-navigation-input-bindings.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-navigation-input-bindings.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { render } from "@testing-library/react";
+import { configureShortcutPlatform } from "@multica/core/shortcuts";
 import { useTabStore } from "@/stores/tab-store";
+import { useWindowOverlayStore } from "@/stores/window-overlay-store";
 import { useNavigationInputBindings } from "./use-tab-history";
 
 function Probe() {
@@ -36,16 +38,61 @@ function seedHistory() {
   });
 }
 
+function seedTabs() {
+  seedHistory();
+  useTabStore.setState((state) => ({
+    byWorkspace: {
+      acme: {
+        ...state.byWorkspace.acme,
+        tabs: [
+          state.byWorkspace.acme.tabs[0],
+          {
+            ...state.byWorkspace.acme.tabs[0],
+            id: "t2",
+            url: "/acme/projects",
+            resourceKey: "/acme/projects",
+          },
+          {
+            ...state.byWorkspace.acme.tabs[0],
+            id: "t3",
+            url: "/acme/skills",
+            resourceKey: "/acme/skills",
+          },
+        ],
+      },
+    },
+  }));
+}
+
+function activeTabId(): string {
+  return useTabStore.getState().byWorkspace.acme.activeTabId;
+}
+
+function stubWindowContext(kind: "main" | "issue") {
+  (window as unknown as { desktopAPI: Record<string, unknown> }).desktopAPI = {
+    windowContext:
+      kind === "main"
+        ? { kind: "main" }
+        : { kind: "issue", path: "/acme/issues/abc", workspaceSlug: "acme" },
+  };
+}
+
 function activeHistoryIndex(): number {
   return useTabStore.getState().byWorkspace.acme.tabs[0].history.index;
 }
 
-function keydown(init: KeyboardEventInit, target: EventTarget = window) {
+function keydown(
+  init: KeyboardEventInit & { keyCode?: number },
+  target: EventTarget = window,
+) {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
     cancelable: true,
     ...init,
   });
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, "keyCode", { value: init.keyCode });
+  }
   target.dispatchEvent(event);
   return event;
 }
@@ -53,6 +100,13 @@ function keydown(init: KeyboardEventInit, target: EventTarget = window) {
 describe("useNavigationInputBindings", () => {
   beforeEach(() => {
     seedHistory();
+    configureShortcutPlatform("macos");
+    useWindowOverlayStore.setState({ overlay: null });
+    stubWindowContext("main");
+  });
+
+  afterEach(() => {
+    configureShortcutPlatform(null);
   });
 
   it("goes back on Cmd+Left", () => {
@@ -84,6 +138,132 @@ describe("useNavigationInputBindings", () => {
     const before = activeHistoryIndex();
     const event = keydown({ key, metaKey: true });
     expect(activeHistoryIndex()).toBe(before);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it.each(["macos", "windows", "linux"] as const)(
+    "cycles tabs with Control+Tab on %s",
+    (platform) => {
+      seedTabs();
+      configureShortcutPlatform(platform);
+      render(<Probe />);
+
+      const event = keydown({ key: "Tab", ctrlKey: true });
+
+      expect(activeTabId()).toBe("t2");
+      expect(event.defaultPrevented).toBe(true);
+    },
+  );
+
+  it.each(["macos", "windows", "linux"] as const)(
+    "cycles to the previous tab with Control+Shift+Tab on %s",
+    (platform) => {
+      seedTabs();
+      configureShortcutPlatform(platform);
+      render(<Probe />);
+
+      keydown({ key: "Tab", ctrlKey: true, shiftKey: true });
+
+      expect(activeTabId()).toBe("t3");
+    },
+  );
+
+  it.each([
+    ["[", "t3"],
+    ["{", "t3"],
+    ["]", "t2"],
+    ["}", "t2"],
+  ])("accepts the macOS shifted bracket alias %s", (key, expectedId) => {
+    seedTabs();
+    render(<Probe />);
+
+    const event = keydown({ key, metaKey: true, shiftKey: true });
+
+    expect(activeTabId()).toBe(expectedId);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it.each(["windows", "linux"] as const)(
+    "does not handle bracket aliases on %s",
+    (platform) => {
+      seedTabs();
+      configureShortcutPlatform(platform);
+      render(<Probe />);
+
+      const event = keydown({ key: "]", ctrlKey: true, shiftKey: true });
+
+      expect(activeTabId()).toBe("t1");
+      expect(event.defaultPrevented).toBe(false);
+    },
+  );
+
+  it.each([
+    [{ key: "Tab", ctrlKey: true, repeat: true }, "repeat"],
+    [{ key: "Tab", ctrlKey: true, isComposing: true }, "IME composition"],
+    [{ key: "Tab", ctrlKey: true, keyCode: 229 }, "IME keyCode 229"],
+    [{ key: "Tab", metaKey: true }, "missing Control"],
+    [{ key: "Tab", ctrlKey: true, metaKey: true }, "extra Meta"],
+    [{ key: "Tab", ctrlKey: true, altKey: true }, "extra Alt"],
+  ])("ignores tab cycling with %s", (init, _reason) => {
+    seedTabs();
+    render(<Probe />);
+
+    const event = keydown(init);
+
+    expect(activeTabId()).toBe("t1");
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("respects an earlier handler that prevents tab cycling", () => {
+    seedTabs();
+    render(<Probe />);
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault();
+
+    window.dispatchEvent(event);
+
+    expect(activeTabId()).toBe("t1");
+  });
+
+  it("ignores tab cycling in editable targets and editable ancestors", () => {
+    seedTabs();
+    render(<Probe />);
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    const target = document.createElement("span");
+    editor.appendChild(target);
+    document.body.appendChild(editor);
+
+    const event = keydown({ key: "Tab", ctrlKey: true }, target);
+
+    expect(activeTabId()).toBe("t1");
+    expect(event.defaultPrevented).toBe(false);
+    editor.remove();
+  });
+
+  it("ignores tab cycling while a full-window overlay is active", () => {
+    seedTabs();
+    useWindowOverlayStore.setState({ overlay: { type: "onboarding" } });
+    render(<Probe />);
+
+    keydown({ key: "Tab", ctrlKey: true });
+
+    expect(activeTabId()).toBe("t1");
+  });
+
+  it("does not subscribe in a dedicated issue window", () => {
+    seedTabs();
+    stubWindowContext("issue");
+    render(<Probe />);
+
+    const event = keydown({ key: "Tab", ctrlKey: true });
+
+    expect(activeTabId()).toBe("t1");
     expect(event.defaultPrevented).toBe(false);
   });
 

--- a/apps/desktop/src/renderer/src/hooks/use-tab-history.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-history.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect } from "react";
+import {
+  getShortcutPlatform,
+  isEditableShortcutTarget,
+} from "@multica/core/shortcuts";
+import { isImeComposing } from "@multica/core/utils";
 import { useTabStore, useActiveTabHistory } from "@/stores/tab-store";
+import { useWindowOverlayStore } from "@/stores/window-overlay-store";
 
 /**
  * Shell back/forward for the active tab (MUL-4741 session architecture).
@@ -27,18 +33,12 @@ export function useTabHistory() {
   return { canGoBack, canGoForward, goBack, goForward };
 }
 
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  if (target.isContentEditable) return true;
-  const tag = target.tagName;
-  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
-}
-
 /**
- * Keyboard and mouse back/forward for the active tab's history:
- * Cmd/Ctrl+←/→ (browser convention), plus mouse side buttons 3/4. The
- * Cmd/Ctrl+[ / ] chords are handled by the shared shortcut registry
- * (packages/core/shortcuts via <GlobalShortcuts>) instead, so they stay
+ * Desktop tab cycling plus keyboard and mouse back/forward for the active
+ * tab's history. Ctrl+Tab cycles tabs on every desktop OS; macOS also accepts
+ * Cmd+Shift+[ / ]. Cmd/Ctrl+←/→ and mouse side buttons 3/4 navigate history.
+ * Unshifted Cmd/Ctrl+[ / ] stays in the shared shortcut registry
+ * (packages/core/shortcuts via <GlobalShortcuts>) so it stays
  * rebindable and identical on web and desktop. The renderer's mouseup is the
  * ONE cross-platform source for side buttons — the main process deliberately
  * does not forward `app-command` (Windows/Linux emit both, which would
@@ -48,7 +48,34 @@ export function useNavigationInputBindings() {
   const { goBack, goForward } = useTabHistory();
 
   useEffect(() => {
+    if (window.desktopAPI.windowContext?.kind === "issue") return undefined;
+
     const onKeyDown = (e: KeyboardEvent) => {
+      const controlTab =
+        e.ctrlKey && !e.metaKey && !e.altKey && e.key === "Tab";
+      const macosTabAlias =
+        getShortcutPlatform() === "macos" &&
+        e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        e.shiftKey &&
+        (e.key === "[" || e.key === "{" || e.key === "]" || e.key === "}");
+      if (controlTab || macosTabAlias) {
+        if (
+          e.defaultPrevented ||
+          e.repeat ||
+          isImeComposing(e) ||
+          isEditableShortcutTarget(e.target) ||
+          useWindowOverlayStore.getState().overlay
+        ) {
+          return;
+        }
+        e.preventDefault();
+        const previous = controlTab ? e.shiftKey : e.key === "[" || e.key === "{";
+        useTabStore.getState().cycleActiveTab(previous ? -1 : 1);
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
       if (!mod || e.altKey || e.shiftKey) return;
       // Cmd/Ctrl+[ and +] are intentionally NOT handled here: they are
@@ -63,7 +90,7 @@ export function useNavigationInputBindings() {
       if (!back && !forward) return;
       // In editable contexts these chords belong to the text field:
       // cmd+arrow moves the caret to the line edge, cmd+bracket indents.
-      if (isEditableTarget(e.target)) return;
+      if (isEditableShortcutTarget(e.target)) return;
       e.preventDefault();
       if (back) goBack();
       else goForward();

--- a/apps/desktop/src/renderer/src/stores/tab-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.test.ts
@@ -392,6 +392,68 @@ describe("useTabStore actions", () => {
     store.setActiveTab(acmeTabId);
     expect(useTabStore.getState().activeWorkspaceSlug).toBe("acme");
   });
+
+  it("cycles tabs in visual order with wraparound while preserving history and MRU", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const firstId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    store.navigateActiveSession("/acme/issues/abc");
+    const secondId = store.addTab("/acme/projects", "Projects");
+    const thirdId = store.addTab("/acme/skills", "Skills");
+    const before = useTabStore.getState().byWorkspace.acme.tabs.map((tab) => tab.history);
+
+    store.cycleActiveTab(1);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(secondId);
+    expect(useTabStore.getState().byWorkspace.acme.recentTabIds[0]).toBe(firstId);
+    store.cycleActiveTab(1);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(thirdId);
+    store.cycleActiveTab(1);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(firstId);
+    store.cycleActiveTab(-1);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(thirdId);
+    expect(useTabStore.getState().byWorkspace.acme.tabs.map((tab) => tab.history)).toEqual(before);
+  });
+
+  it("cycles through reordered tab-strip positions", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const secondId = store.addTab("/acme/projects", "Projects");
+    const thirdId = store.addTab("/acme/skills", "Skills");
+
+    store.moveTab(2, 1);
+    store.cycleActiveTab(1);
+
+    expect(useTabStore.getState().byWorkspace.acme.tabs.map((tab) => tab.id)).toEqual([
+      expect.any(String),
+      thirdId,
+      secondId,
+    ]);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(thirdId);
+  });
+
+  it("does not cycle without at least two valid tabs", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const before = useTabStore.getState().byWorkspace.acme;
+
+    store.cycleActiveTab(1);
+    expect(useTabStore.getState().byWorkspace.acme).toBe(before);
+
+    useTabStore.setState({
+      byWorkspace: {
+        acme: {
+          ...before,
+          tabs: [...before.tabs, { ...before.tabs[0], id: "t2" }],
+          activeTabId: "missing",
+        },
+      },
+    });
+    const invalid = useTabStore.getState().byWorkspace.acme;
+
+    store.cycleActiveTab(1);
+
+    expect(useTabStore.getState().byWorkspace.acme).toBe(invalid);
+  });
 });
 
 describe("navigateActiveSession", () => {

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -196,6 +196,8 @@ interface TabStore {
    * path that "jumps" to a tab belonging to a non-active workspace.
    */
   setActiveTab: (tabId: string) => void;
+  /** Cycle through the active workspace's tabs in visual order. */
+  cycleActiveTab: (direction: -1 | 1) => void;
   /** Patch display metadata of a tab (title-sync). Finds across groups. */
   updateTab: (tabId: string, patch: Partial<Pick<TabSession, "title">>) => void;
   /**
@@ -690,6 +692,29 @@ export const useTabStore = create<TabStore>()(
           byWorkspace: {
             ...byWorkspace,
             [slug]: reconcileGroup(group, group.tabs, tabId),
+          },
+        });
+      },
+
+      cycleActiveTab(direction) {
+        const { activeWorkspaceSlug, byWorkspace } = get();
+        if (!activeWorkspaceSlug) return;
+        const group = byWorkspace[activeWorkspaceSlug];
+        if (!group || group.tabs.length < 2) return;
+        const activeIndex = group.tabs.findIndex(
+          (tab) => tab.id === group.activeTabId,
+        );
+        if (activeIndex < 0) return;
+        const nextIndex =
+          (activeIndex + direction + group.tabs.length) % group.tabs.length;
+        set({
+          byWorkspace: {
+            ...byWorkspace,
+            [activeWorkspaceSlug]: reconcileGroup(
+              group,
+              group.tabs,
+              group.tabs[nextIndex].id,
+            ),
           },
         });
       },

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -259,6 +259,8 @@
       "close_tab": "Close active tab",
       "select_tab_1_to_8": "Select tab 1–8",
       "select_last_tab": "Select last tab",
+      "previous_tab": "Previous tab",
+      "next_tab": "Next tab",
       "zoom_in": "Zoom in",
       "zoom_out": "Zoom out",
       "reset_zoom": "Reset zoom",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -259,6 +259,8 @@
       "close_tab": "アクティブなタブを閉じる",
       "select_tab_1_to_8": "1〜8番目のタブを選択",
       "select_last_tab": "最後のタブを選択",
+      "previous_tab": "前のタブ",
+      "next_tab": "次のタブ",
       "zoom_in": "拡大",
       "zoom_out": "縮小",
       "reset_zoom": "ズームをリセット",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -259,6 +259,8 @@
       "close_tab": "활성 탭 닫기",
       "select_tab_1_to_8": "1~8번째 탭 선택",
       "select_last_tab": "마지막 탭 선택",
+      "previous_tab": "이전 탭",
+      "next_tab": "다음 탭",
       "zoom_in": "확대",
       "zoom_out": "축소",
       "reset_zoom": "확대/축소 재설정",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -259,6 +259,8 @@
       "close_tab": "关闭当前标签页",
       "select_tab_1_to_8": "选择第 1–8 个标签页",
       "select_last_tab": "选择最后一个标签页",
+      "previous_tab": "上一个标签页",
+      "next_tab": "下一个标签页",
       "zoom_in": "放大",
       "zoom_out": "缩小",
       "reset_zoom": "重置缩放",

--- a/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
+++ b/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
@@ -13,6 +13,7 @@ import { KeyboardShortcutsTab } from "./keyboard-shortcuts-tab";
 describe("KeyboardShortcutsTab", () => {
   beforeEach(() => {
     configureShortcutPlatform("windows");
+    configureShortcutRuntime("web");
     useShortcutStore.getState().resetAll();
   });
 
@@ -49,6 +50,49 @@ describe("KeyboardShortcutsTab", () => {
       screen.getByRole("img", { name: "Ctrl+1–8" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("img", { name: "Ctrl+9" })).toBeInTheDocument();
+  });
+
+  it("shows only Control+Tab shortcuts on Windows and Linux desktop", () => {
+    configureShortcutRuntime("desktop");
+    renderWithI18n(<KeyboardShortcutsTab />);
+
+    expect(screen.getByText("Previous tab")).toBeInTheDocument();
+    expect(screen.getByText("Next tab")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Ctrl+Shift+Tab" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Ctrl+Tab" })).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Ctrl+Shift+[" })).not.toBeInTheDocument();
+
+    cleanup();
+    configureShortcutPlatform("linux");
+    renderWithI18n(<KeyboardShortcutsTab />);
+
+    expect(screen.getByRole("img", { name: "Ctrl+Shift+Tab" })).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Super+Shift+[" })).not.toBeInTheDocument();
+  });
+
+  it("shows macOS Control+Tab shortcuts with Command+Shift bracket aliases", () => {
+    configureShortcutPlatform("macos");
+    configureShortcutRuntime("desktop");
+    renderWithI18n(<KeyboardShortcutsTab />);
+
+    expect(screen.getByRole("img", { name: "⌃⇧Tab" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "⌃Tab" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "⌘⇧[" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "⌘⇧]" })).toBeInTheDocument();
+    const separators = screen
+      .getAllByText("/")
+      .filter((element) => element.tagName === "SPAN");
+    expect(separators).toHaveLength(2);
+    separators.forEach((separator) => {
+      expect(separator).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  it("omits tab cycling shortcuts on web", () => {
+    renderWithI18n(<KeyboardShortcutsTab />);
+
+    expect(screen.queryByText("Previous tab")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next tab")).not.toBeInTheDocument();
   });
 
   it("records a shortcut and applies it immediately", () => {

--- a/packages/views/settings/components/keyboard-shortcuts-tab.tsx
+++ b/packages/views/settings/components/keyboard-shortcuts-tab.tsx
@@ -18,6 +18,8 @@ import { cn } from "@multica/ui/lib/utils";
 import {
   findShortcutConflict,
   createShortcutChord,
+  getShortcutPlatform,
+  getShortcutRuntime,
   isReservedShortcut,
   isShortcutAllowedForAction,
   isPlainShortcut,
@@ -73,6 +75,9 @@ export function KeyboardShortcutsTab() {
   }, [query, t]);
 
   const groups: readonly ShortcutCategory[] = ["general", "navigation"];
+  const tabCyclingShortcuts = getShortcutRuntime() === "desktop";
+  const macos = getShortcutPlatform() === "macos";
+  const controlTabModifiers = macos ? { control: true } : { primary: true };
 
   const capture = (actionId: ShortcutActionId, event: React.KeyboardEvent) => {
     event.preventDefault();
@@ -199,6 +204,23 @@ export function KeyboardShortcutsTab() {
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.close_tab)} shortcut={createShortcutChord("W", { primary: true })} />
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.select_tab_1_to_8)} shortcut={createShortcutChord("1–8", { primary: true })} />
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.select_last_tab)} shortcut={createShortcutChord("9", { primary: true })} />
+          {tabCyclingShortcuts ? (
+            <>
+              <FixedShortcutRow
+                label={t(($) => $.shortcuts.fixed.previous_tab)}
+                shortcut={createShortcutChord("Tab", {
+                  ...controlTabModifiers,
+                  shift: true,
+                })}
+                alias={macos ? createShortcutChord("[", { primary: true, shift: true }) : undefined}
+              />
+              <FixedShortcutRow
+                label={t(($) => $.shortcuts.fixed.next_tab)}
+                shortcut={createShortcutChord("Tab", controlTabModifiers)}
+                alias={macos ? createShortcutChord("]", { primary: true, shift: true }) : undefined}
+              />
+            </>
+          ) : null}
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.zoom_in)} shortcut={createShortcutChord("Plus", { primary: true })} />
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.zoom_out)} shortcut={createShortcutChord("Minus", { primary: true })} />
           <FixedShortcutRow label={t(($) => $.shortcuts.fixed.reset_zoom)} shortcut={createShortcutChord("0", { primary: true })} />
@@ -357,10 +379,22 @@ function ShortcutRow({
   );
 }
 
-function FixedShortcutRow({ label, shortcut }: { label: string; shortcut: ShortcutChord }) {
+function FixedShortcutRow({
+  label,
+  shortcut,
+  alias,
+}: {
+  label: string;
+  shortcut: ShortcutChord;
+  alias?: ShortcutChord;
+}) {
   return (
     <SettingsRow label={label}>
-      <ShortcutKeycaps shortcut={shortcut} size="md" className="justify-end" />
+      <div className="flex items-center justify-end gap-2">
+        <ShortcutKeycaps shortcut={shortcut} size="md" />
+        {alias ? <span aria-hidden="true">/</span> : null}
+        {alias ? <ShortcutKeycaps shortcut={alias} size="md" /> : null}
+      </div>
     </SettingsRow>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Adds desktop-only tab cycling with the conventional Control+Tab bindings while preserving macOS bracket aliases:

- Next tab on macOS, Windows, and Linux: `Control+Tab`
- Previous tab on macOS, Windows, and Linux: `Control+Shift+Tab`
- macOS next-tab alias: `Shift+Command+]`
- macOS previous-tab alias: `Shift+Command+[` 

Cycling follows the visible tab-strip order, wraps at both ends, updates the existing recent-tab history used when closing tabs, and leaves each tab's navigation history unchanged. The bindings are fixed desktop renderer shortcuts, so the web runtime and shared rebindable shortcut registry remain unchanged.

This PR is intentionally left in draft for Robert's review.

## Related Issue

Closes #6938

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added visual-order tab cycling with wraparound to `apps/desktop/src/renderer/src/stores/tab-store.ts`.
- Added exact desktop bindings and guards in `apps/desktop/src/renderer/src/hooks/use-tab-history.ts`.
- Preserved dedicated issue-window, overlay, editable-target, repeat, prevented-event, and IME guards.
- Kept existing unshifted Command/Ctrl bracket navigation-history shortcuts unchanged.
- Added platform-specific fixed shortcut rows to Keyboard Shortcuts settings.
- Preserved the numbered-tab shortcut rows added to upstream while resolving the September 4 refresh conflicts.
- Added Previous tab and Next tab labels in English, Simplified Chinese, Japanese, and Korean.
- Added focused store, keyboard, settings, and locale tests.
- Rebased the single feature commit onto current upstream `main` at `ca47495fc`; no unrelated surface-bridge changes are present.

## How to Test

```bash
corepack pnpm --filter @multica/desktop exec vitest run \
  src/renderer/src/stores/tab-store.test.ts \
  src/renderer/src/hooks/use-navigation-input-bindings.test.tsx

corepack pnpm --filter @multica/views exec vitest run \
  settings/components/keyboard-shortcuts-tab.test.tsx \
  locales/parity.test.ts

corepack pnpm --filter @multica/desktop typecheck
corepack pnpm --filter @multica/views typecheck

(cd apps/desktop && corepack pnpm exec eslint \
  src/renderer/src/hooks/use-navigation-input-bindings.test.tsx \
  src/renderer/src/hooks/use-tab-history.ts \
  src/renderer/src/stores/tab-store.test.ts \
  src/renderer/src/stores/tab-store.ts \
  --max-warnings 0)

(cd packages/views && corepack pnpm exec eslint \
  settings/components/keyboard-shortcuts-tab.test.tsx \
  settings/components/keyboard-shortcuts-tab.tsx \
  --max-warnings 0)

git diff --check upstream/main...HEAD
```

Results from the September 4 refresh:

- Desktop focused tests: 2 files, 114 tests passed.
- Views settings and locale tests: 2 files, 173 tests passed.
- Desktop and views typechecks passed.
- Changed-file desktop and views ESLint passed with zero warnings.
- `git diff --check upstream/main...HEAD` passed.
- The branch is one commit directly on current upstream `main`, and the changed-file set is limited to the expected 10 feature files.
- Final read-only review found no defects.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions
- [x] I have considered and documented risks below
- [x] I will address all reviewer comments before requesting merge

## Risk

Unit and component tests verify matching and state transitions, but the refreshed bindings have not been manually exercised in packaged Electron on every target OS and keyboard layout. In particular, Chromium/Electron delivery of `Control+Tab` should receive a final macOS, Windows, and Linux smoke test.

## AI Disclosure

**AI tool used:** Multica agent using OpenCode (GPT-5.6 Sol / high)

**Approach:** Rebased the existing single feature commit onto the September 4 upstream `main`, resolved settings conflicts additively, preserved the accepted desktop-only behavior, ran focused verification, and completed a read-only final review.

## Fresh CI

The September 4 GitHub CI run completed successfully: all required checks passed, with `image-budget` skipped by the workflow.

## Screenshot
### Before
<img width="725" height="331" alt="image" src="https://github.com/user-attachments/assets/320a167a-2492-46c1-b9c7-e0ddb0af1a35" />

### After
<img width="733" height="457" alt="image" src="https://github.com/user-attachments/assets/3d436bb0-ddc6-46e7-8fdc-34124fff3b48" />