### PR TITLE
MUL-6379: fix CLI updates on restricted Redis

### DIFF
--- a/server/internal/handler/runtime_local_skills_redis_store.go
+++ b/server/internal/handler/runtime_local_skills_redis_store.go
@@ -94,17 +94,24 @@ func (s *RedisLocalSkillListStore) Create(ctx context.Context, runtimeID string)
 		return nil, fmt.Errorf("marshal list request: %w", err)
 	}
 
-	pipe := s.rdb.TxPipeline()
-	pipe.Set(ctx, localSkillListKey(req.ID), data, runtimeLocalSkillStoreRetention)
-	pipe.ZAdd(ctx, localSkillListPendingKey(runtimeID), redis.Z{
+	requestKey := localSkillListKey(req.ID)
+	pendingKey := localSkillListPendingKey(runtimeID)
+	// Creation does not require a Redis transaction: the request is not
+	// observable by dispatchers until it is added to the pending set. A plain
+	// pipeline also works on managed Redis deployments that deny MULTI.
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, requestKey, data, runtimeLocalSkillStoreRetention)
+	pipe.ZAdd(ctx, pendingKey, redis.Z{
 		Score:  float64(now.UnixNano()),
 		Member: req.ID,
 	})
 	// Keep the pending ZSET alive a bit longer than the individual request
 	// so stale members still in the zset can be swept lazily on PopPending
 	// without blocking the create path on deletion.
-	pipe.Expire(ctx, localSkillListPendingKey(runtimeID), runtimeLocalSkillStoreRetention*2)
+	pipe.Expire(ctx, pendingKey, runtimeLocalSkillStoreRetention*2)
 	if _, err := pipe.Exec(ctx); err != nil {
+		_ = s.rdb.Del(ctx, requestKey).Err()
+		_ = s.rdb.ZRem(ctx, pendingKey, req.ID).Err()
 		return nil, fmt.Errorf("persist list request: %w", err)
 	}
 	return req, nil
@@ -287,14 +294,20 @@ func (s *RedisLocalSkillImportStore) Create(ctx context.Context, input LocalSkil
 		return nil, err
 	}
 
-	pipe := s.rdb.TxPipeline()
-	pipe.Set(ctx, localSkillImportKey(req.ID), data, runtimeLocalSkillStoreRetention)
-	pipe.ZAdd(ctx, localSkillImportPendingKey(input.RuntimeID), redis.Z{
+	requestKey := localSkillImportKey(req.ID)
+	pendingKey := localSkillImportPendingKey(input.RuntimeID)
+	// Match the other request stores: creation only needs ordered batching, and
+	// avoiding MULTI keeps this path compatible with restricted managed Redis.
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, requestKey, data, runtimeLocalSkillStoreRetention)
+	pipe.ZAdd(ctx, pendingKey, redis.Z{
 		Score:  float64(now.UnixNano()),
 		Member: req.ID,
 	})
-	pipe.Expire(ctx, localSkillImportPendingKey(input.RuntimeID), runtimeLocalSkillStoreRetention*2)
+	pipe.Expire(ctx, pendingKey, runtimeLocalSkillStoreRetention*2)
 	if _, err := pipe.Exec(ctx); err != nil {
+		_ = s.rdb.Del(ctx, requestKey).Err()
+		_ = s.rdb.ZRem(ctx, pendingKey, req.ID).Err()
 		return nil, fmt.Errorf("persist import request: %w", err)
 	}
 	return req, nil

--- a/server/internal/handler/runtime_local_skills_redis_store_test.go
+++ b/server/internal/handler/runtime_local_skills_redis_store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 )
 
 const redisTestDB = 14
+
+var redisACLTestUserSequence atomic.Uint64
 
 // newRedisTestClient connects to the Redis instance indicated by REDIS_TEST_URL
 // and flushes this package's logical test DB so each test starts from a clean
@@ -42,6 +45,37 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 		rdb.Close()
 	})
 	return rdb
+}
+
+func newRedisTestClientWithoutMulti(t *testing.T) *redis.Client {
+	t.Helper()
+	admin := newRedisTestClient(t)
+	ctx := context.Background()
+	username := fmt.Sprintf("runtime-no-multi-%d", redisACLTestUserSequence.Add(1))
+	const password = "runtime-no-multi-test-password"
+
+	if err := admin.Do(
+		ctx,
+		"ACL", "SETUSER", username,
+		"reset", "on", ">"+password, "~*", "+@all", "-multi", "-exec",
+	).Err(); err != nil {
+		t.Fatalf("create restricted Redis user: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := admin.Do(context.Background(), "ACL", "DELUSER", username).Err(); err != nil {
+			t.Errorf("delete restricted Redis user: %v", err)
+		}
+	})
+
+	opts := *admin.Options()
+	opts.Username = username
+	opts.Password = password
+	restricted := redis.NewClient(&opts)
+	t.Cleanup(func() { _ = restricted.Close() })
+	if err := restricted.Ping(ctx).Err(); err != nil {
+		t.Fatalf("connect as restricted Redis user: %v", err)
+	}
+	return restricted
 }
 
 func TestRedisLocalSkillListStore_CreateGetComplete(t *testing.T) {
@@ -94,6 +128,31 @@ func TestRedisLocalSkillListStore_CreateGetComplete(t *testing.T) {
 	}
 	if !got.McpSupported || len(got.McpServers) != 1 || got.McpServers[0].Name != "fetch" {
 		t.Fatalf("MCP inventory not persisted: %+v", got.McpServers)
+	}
+}
+
+func TestRedisLocalSkillListStore_CreateWithoutMultiPermission(t *testing.T) {
+	rdb := newRedisTestClientWithoutMulti(t)
+	ctx := context.Background()
+	store := NewRedisLocalSkillListStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("create without MULTI permission: %v", err)
+	}
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get created request: %v", err)
+	}
+	if got == nil || got.ID != req.ID {
+		t.Fatalf("created request was not persisted: %+v", got)
+	}
+	pending, err := store.HasPending(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("check pending request: %v", err)
+	}
+	if !pending {
+		t.Fatal("created request was not queued")
 	}
 }
 
@@ -273,6 +332,35 @@ func TestRedisLocalSkillImportStore_PreservesCreatorID(t *testing.T) {
 	}
 	if got.TargetSkillID != "target-skill-99" {
 		t.Fatalf("target_skill_id lost round trip: %q", got.TargetSkillID)
+	}
+}
+
+func TestRedisLocalSkillImportStore_CreateWithoutMultiPermission(t *testing.T) {
+	rdb := newRedisTestClientWithoutMulti(t)
+	ctx := context.Background()
+	store := NewRedisLocalSkillImportStore(rdb)
+
+	req, err := store.Create(ctx, LocalSkillImportRequestInput{
+		RuntimeID: "runtime-no-multi",
+		CreatorID: "user-1",
+		SkillKey:  "review-helper",
+	})
+	if err != nil {
+		t.Fatalf("create without MULTI permission: %v", err)
+	}
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get created request: %v", err)
+	}
+	if got == nil || got.ID != req.ID {
+		t.Fatalf("created request was not persisted: %+v", got)
+	}
+	pending, err := store.HasPending(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("check pending request: %v", err)
+	}
+	if !pending {
+		t.Fatal("created request was not queued")
 	}
 }
 

--- a/server/internal/handler/runtime_models_redis_store.go
+++ b/server/internal/handler/runtime_models_redis_store.go
@@ -64,16 +64,23 @@ func (s *RedisModelListStore) Create(ctx context.Context, runtimeID string) (*Mo
 		return nil, err
 	}
 
-	pipe := s.rdb.TxPipeline()
-	pipe.Set(ctx, modelListKey(req.ID), data, modelListStoreRetention)
-	pipe.ZAdd(ctx, modelListPendingKey(runtimeID), redis.Z{
+	requestKey := modelListKey(req.ID)
+	pendingKey := modelListPendingKey(runtimeID)
+	// Creation does not require a Redis transaction: the request is not
+	// observable by dispatchers until it is added to the pending set. A plain
+	// pipeline also works on managed Redis deployments that deny MULTI.
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, requestKey, data, modelListStoreRetention)
+	pipe.ZAdd(ctx, pendingKey, redis.Z{
 		Score:  float64(now.UnixNano()),
 		Member: req.ID,
 	})
 	// Keep the pending zset alive past the per-record retention so stale
 	// members can be lazily swept on PopPending.
-	pipe.Expire(ctx, modelListPendingKey(runtimeID), modelListStoreRetention*2)
+	pipe.Expire(ctx, pendingKey, modelListStoreRetention*2)
 	if _, err := pipe.Exec(ctx); err != nil {
+		_ = s.rdb.Del(ctx, requestKey).Err()
+		_ = s.rdb.ZRem(ctx, pendingKey, req.ID).Err()
 		return nil, fmt.Errorf("persist model list request: %w", err)
 	}
 	return req, nil

--- a/server/internal/handler/runtime_models_redis_store_test.go
+++ b/server/internal/handler/runtime_models_redis_store_test.go
@@ -98,6 +98,31 @@ func TestRedisModelListStore_CreateGetComplete(t *testing.T) {
 	}
 }
 
+func TestRedisModelListStore_CreateWithoutMultiPermission(t *testing.T) {
+	rdb := newRedisTestClientWithoutMulti(t)
+	ctx := context.Background()
+	store := NewRedisModelListStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("create without MULTI permission: %v", err)
+	}
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get created request: %v", err)
+	}
+	if got == nil || got.ID != req.ID {
+		t.Fatalf("created request was not persisted: %+v", got)
+	}
+	pending, err := store.HasPending(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("check pending request: %v", err)
+	}
+	if !pending {
+		t.Fatal("created request was not queued")
+	}
+}
+
 // TestRedisModelListStore_PopPendingAcrossInstances is the regression test
 // for the exact bug this PR fixes: two API replicas share one Redis, one
 // receives the POST that creates the request, the other receives the daemon

--- a/server/internal/handler/runtime_update_redis_store.go
+++ b/server/internal/handler/runtime_update_redis_store.go
@@ -68,7 +68,12 @@ func (s *RedisUpdateStore) Create(ctx context.Context, runtimeID, targetVersion,
 		return nil, errUpdateInProgress
 	}
 
-	pipe := s.rdb.TxPipeline()
+	// The active reservation above provides the concurrency guarantee this
+	// write needs. Use a plain pipeline so managed Redis deployments that allow
+	// SET/ZADD but deny MULTI can still create update requests. Exec failures
+	// remain safe because the compensation below removes every partially
+	// written key and releases the reservation.
+	pipe := s.rdb.Pipeline()
 	pipe.Set(ctx, updateKey(req.ID), data, updateStoreRetention)
 	pipe.ZAdd(ctx, updatePendingKey(runtimeID), redis.Z{
 		Score:  float64(now.UnixNano()),

--- a/server/internal/handler/runtime_update_redis_store_test.go
+++ b/server/internal/handler/runtime_update_redis_store_test.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/redis/go-redis/v9"
 )
 
 func TestRedisUpdateStore_EnvelopePersistsRunStartedAt(t *testing.T) {
@@ -83,36 +81,9 @@ func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
 }
 
 func TestRedisUpdateStore_CreateWithoutMultiPermission(t *testing.T) {
-	rdb := newRedisTestClient(t)
+	rdb := newRedisTestClientWithoutMulti(t)
 	ctx := context.Background()
-
-	const (
-		username = "runtime-update-no-multi"
-		password = "runtime-update-test-password"
-	)
-	if err := rdb.Do(
-		ctx,
-		"ACL", "SETUSER", username,
-		"reset", "on", ">"+password, "~*", "+@all", "-multi", "-exec",
-	).Err(); err != nil {
-		t.Fatalf("create restricted Redis user: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := rdb.Do(context.Background(), "ACL", "DELUSER", username).Err(); err != nil {
-			t.Errorf("delete restricted Redis user: %v", err)
-		}
-	})
-
-	opts := *rdb.Options()
-	opts.Username = username
-	opts.Password = password
-	restricted := redis.NewClient(&opts)
-	t.Cleanup(func() { _ = restricted.Close() })
-	if err := restricted.Ping(ctx).Err(); err != nil {
-		t.Fatalf("connect as restricted Redis user: %v", err)
-	}
-
-	store := NewRedisUpdateStore(restricted)
+	store := NewRedisUpdateStore(rdb)
 	req, err := store.Create(ctx, "runtime-no-multi", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create without MULTI permission: %v", err)
@@ -127,6 +98,13 @@ func TestRedisUpdateStore_CreateWithoutMultiPermission(t *testing.T) {
 	}
 	if got == nil || got.ID != req.ID {
 		t.Fatalf("created request was not persisted: %+v", got)
+	}
+	pending, err := store.HasPending(ctx, "runtime-no-multi")
+	if err != nil {
+		t.Fatalf("check pending request: %v", err)
+	}
+	if !pending {
+		t.Fatal("created request was not queued")
 	}
 }
 

--- a/server/internal/handler/runtime_update_redis_store_test.go
+++ b/server/internal/handler/runtime_update_redis_store_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 func TestRedisUpdateStore_EnvelopePersistsRunStartedAt(t *testing.T) {
@@ -77,6 +79,54 @@ func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
 
 	if _, err := store.Create(ctx, "runtime-1", "v1.2.4", "user-1"); err != nil {
 		t.Fatalf("create after complete should be allowed: %v", err)
+	}
+}
+
+func TestRedisUpdateStore_CreateWithoutMultiPermission(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+
+	const (
+		username = "runtime-update-no-multi"
+		password = "runtime-update-test-password"
+	)
+	if err := rdb.Do(
+		ctx,
+		"ACL", "SETUSER", username,
+		"reset", "on", ">"+password, "~*", "+@all", "-multi", "-exec",
+	).Err(); err != nil {
+		t.Fatalf("create restricted Redis user: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rdb.Do(context.Background(), "ACL", "DELUSER", username).Err(); err != nil {
+			t.Errorf("delete restricted Redis user: %v", err)
+		}
+	})
+
+	opts := *rdb.Options()
+	opts.Username = username
+	opts.Password = password
+	restricted := redis.NewClient(&opts)
+	t.Cleanup(func() { _ = restricted.Close() })
+	if err := restricted.Ping(ctx).Err(); err != nil {
+		t.Fatalf("connect as restricted Redis user: %v", err)
+	}
+
+	store := NewRedisUpdateStore(restricted)
+	req, err := store.Create(ctx, "runtime-no-multi", "v1.2.3", "user-1")
+	if err != nil {
+		t.Fatalf("create without MULTI permission: %v", err)
+	}
+	if req.Status != UpdatePending {
+		t.Fatalf("initial status = %s, want %s", req.Status, UpdatePending)
+	}
+
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get created request: %v", err)
+	}
+	if got == nil || got.ID != req.ID {
+		t.Fatalf("created request was not persisted: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- create update, model-list, local-skill-list, and local-skill-import requests with plain Redis pipelines so managed deployments that deny `MULTI` can use every affected flow
- preserve the update store's active-request reservation and add best-effort cleanup to the other request stores if a pipelined write fails
- cover all four stores with a shared Redis ACL test client that allows the data commands but denies `MULTI`/`EXEC`; each regression test verifies both the persisted record and pending queue

## Testing

- `REDIS_TEST_URL=redis://127.0.0.1:6397/1 go test -race ./internal/handler -run '^TestRedis(Update|ModelList|LocalSkillList|LocalSkillImport)Store_' -count=1`
- `git diff --check`

The restricted-ACL tests reproduce `NOPERM ... no permissions to run the 'multi' command` before the three follow-up store changes and pass after them. Direct production API log access was not available in this environment, so the production error attribution is not presented as independently confirmed here.

Broader handler/router tests were previously attempted, but the checkout's existing local test database is behind the current schema (`comment.via_plugin_id` is missing) and has unrelated fixture collisions.

Refs MUL-6379 — keep the issue open until the deployed API path is verified.
