### PR TITLE
fix(settings): prefer Kyiv timezone name

### DIFF
--- a/packages/views/common/timezone-select.test.ts
+++ b/packages/views/common/timezone-select.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  browserTimezone,
+  resetBrowserTimezoneCache,
+  timezoneOptions,
+} from "./timezone-select";
+
+type IntlWithSupportedValues = typeof Intl & {
+  supportedValuesOf?: (key: "timeZone") => string[];
+};
+
+const intlWithSupportedValues = Intl as IntlWithSupportedValues;
+const realSupportedValuesOf = intlWithSupportedValues.supportedValuesOf;
+
+beforeEach(() => {
+  resetBrowserTimezoneCache();
+});
+
+afterEach(() => {
+  intlWithSupportedValues.supportedValuesOf = realSupportedValuesOf;
+  vi.restoreAllMocks();
+  resetBrowserTimezoneCache();
+});
+
+describe("timezoneOptions", () => {
+  it("uses the canonical Kyiv identifier for legacy Kiev runtime values", () => {
+    intlWithSupportedValues.supportedValuesOf = () => [
+      "Europe/Kiev",
+      "Europe/Kyiv",
+      "Asia/Tokyo",
+    ];
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: "Europe/Kiev" }),
+        }) as Intl.DateTimeFormat,
+    );
+
+    const options = timezoneOptions("Asia/Shanghai");
+
+    expect(options).not.toContain("Europe/Kiev");
+    expect(options.filter((timezone) => timezone === "Europe/Kyiv")).toHaveLength(1);
+    expect(options).toContain("Asia/Tokyo");
+    expect(browserTimezone()).toBe("Europe/Kyiv");
+  });
+
+  it("keeps a legacy current value selectable without adding a duplicate alias", () => {
+    intlWithSupportedValues.supportedValuesOf = () => ["Europe/Kiev", "Europe/Kyiv"];
+
+    const options = timezoneOptions("Europe/Kiev");
+
+    expect(options[0]).toBe("Europe/Kiev");
+    expect(options).not.toContain("Europe/Kyiv");
+  });
+});

--- a/packages/views/common/timezone-select.tsx
+++ b/packages/views/common/timezone-select.tsx
@@ -33,11 +33,19 @@ export const COMMON_TIMEZONES = [
   "Pacific/Auckland",
 ];
 
+// Older ICU/tzdata releases still return this backward-compatible alias even
+// when the preferred IANA identifier is accepted as input.
+export function preferredTimezoneName(timezone: string): string {
+  return timezone === "Europe/Kiev" ? "Europe/Kyiv" : timezone;
+}
+
 let cachedBrowserTZ: string | null = null;
 export function browserTimezone(): string {
   if (cachedBrowserTZ !== null) return cachedBrowserTZ;
   try {
-    cachedBrowserTZ = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    cachedBrowserTZ = preferredTimezoneName(
+      Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    );
   } catch {
     cachedBrowserTZ = "UTC";
   }
@@ -71,9 +79,21 @@ function supportedTimezones(): string[] {
 
 export function timezoneOptions(current: string): string[] {
   const browser = browserTimezone();
-  return Array.from(
-    new Set([current, browser, ...COMMON_TIMEZONES, ...supportedTimezones()]),
-  ).filter(Boolean);
+  const candidates = [
+    current,
+    browser,
+    ...COMMON_TIMEZONES.map(preferredTimezoneName),
+    ...supportedTimezones().map(preferredTimezoneName),
+  ];
+  const seenPreferredNames = new Set<string>();
+
+  return candidates.filter((timezone) => {
+    if (!timezone) return false;
+    const preferred = preferredTimezoneName(timezone);
+    if (seenPreferredNames.has(preferred)) return false;
+    seenPreferredNames.add(preferred);
+    return true;
+  });
 }
 
 export function TimezoneSelect({
@@ -91,8 +111,10 @@ export function TimezoneSelect({
 }) {
   const browser = browserTimezone();
   const options = timezoneOptions(value);
-  const render = (tz: string) =>
-    tz === browser ? `${tz}${browserSuffix}` : tz;
+  const render = (tz: string) => {
+    const preferred = preferredTimezoneName(tz);
+    return preferred === browser ? `${preferred}${browserSuffix}` : preferred;
+  };
   const items = options.map((value) => ({ value, label: render(value) }));
 
   return (

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -260,6 +260,15 @@ describe("PreferencesTab — Timezone section", () => {
     ).toContain("Asia/Shanghai");
   });
 
+  it("renders a legacy stored Ukraine timezone with the canonical spelling", () => {
+    userRef.current = { id: "user-1", timezone: "Europe/Kiev" };
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    const trigger = screen.getByRole("combobox", { name: "Viewing Timezone" });
+    expect(trigger).toHaveTextContent("Europe/Kyiv");
+    expect(trigger).not.toHaveTextContent("Europe/Kiev");
+  });
+
   // handleChange PATCHes then updates the store asynchronously, so the
   // post-pick assertions must waitFor it to settle.
   it("saving a new timezone PATCHes /api/me and updates the auth store", async () => {

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -20,7 +20,11 @@ import { useLocaleAdapter } from "@multica/core/i18n/react";
 import { useAuthStore } from "@multica/core/auth";
 import { useCommentComposerStore } from "@multica/core/issues/stores";
 import { api } from "@multica/core/api";
-import { browserTimezone, timezoneOptions } from "../../common/timezone-select";
+import {
+  browserTimezone,
+  preferredTimezoneName,
+  timezoneOptions,
+} from "../../common/timezone-select";
 import { useT } from "../../i18n";
 import {
   SettingsCard,
@@ -235,7 +239,7 @@ function TimezoneRow() {
     if (tz === BROWSER_TZ_VALUE) {
       return `${browser}${t(($) => $.preferences.timezone.browser_suffix)}`;
     }
-    return tz;
+    return preferredTimezoneName(tz);
   };
 
   return (


### PR DESCRIPTION
Fixes #7158

## Problem

Some ICU/tzdata releases still enumerate `Europe/Kiev`, so the Viewing Timezone picker shows the obsolete spelling and can list both aliases.

## Change

Map the legacy alias to `Europe/Kyiv` for browser/runtime values and display labels. Deduplication uses the preferred name while preserving an already stored legacy value as the Select value, avoiding an implicit settings write.

## Verification

- Vitest: 377 files, 4375 tests passed
- TypeScript: `tsc --noEmit`
- ESLint: changed files
