### PR TITLE
MUL-6387: guard chat rename during IME composition

### DIFF
--- a/packages/views/chat/components/chat-session-header.test.tsx
+++ b/packages/views/chat/components/chat-session-header.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { ChatSession } from "@multica/core/types";
+import enChat from "../../locales/en/chat.json";
+
+const updateMutate = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({ agentDetail: (id: string) => `/agents/${id}` }),
+}));
+
+vi.mock("@multica/core/chat/mutations", () => ({
+  useUpdateChatSession: () => ({ mutate: updateMutate }),
+  useDeleteChatSession: () => ({ mutate: vi.fn() }),
+  useSetChatSessionArchived: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/chat", () => ({
+  useChatStore: (selector: (state: { setActiveSession: () => void }) => unknown) =>
+    selector({ setActiveSession: vi.fn() }),
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => null,
+}));
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+import { ChatSessionHeader } from "./chat-session-header";
+
+const TEST_RESOURCES = { en: { chat: enChat } };
+const RENAME_LABEL = enChat.header.rename;
+
+const session: ChatSession = {
+  id: "session-1",
+  workspace_id: "ws-1",
+  agent_id: "agent-1",
+  creator_id: "user-1",
+  title: "Original title",
+  status: "active",
+  has_unread: false,
+  unread_count: 0,
+  last_message: null,
+  pinned: false,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+function startRename(): HTMLInputElement {
+  render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <ChatSessionHeader session={session} agent={null} />
+    </I18nProvider>,
+  );
+  fireEvent.click(screen.getByTitle(RENAME_LABEL));
+  return screen.getByRole("textbox", { name: RENAME_LABEL });
+}
+
+describe("ChatSessionHeader rename keyboard behavior", () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+  });
+
+  it.each([
+    ["standard composition signal", { isComposing: true, keyCode: 13 }],
+    ["Safari composition signal", { isComposing: false, keyCode: 229 }],
+  ])("keeps editing when Enter carries the %s", (_name, eventInit) => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+
+    fireEvent.keyDown(input, { key: "Enter", ...eventInit });
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("yanjiu");
+  });
+
+  it("submits once on a normal Enter", () => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "Renamed chat" } });
+
+    fireEvent.keyDown(input, { key: "Enter", isComposing: false, keyCode: 13 });
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      title: "Renamed chat",
+    });
+    expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
+  });
+
+  it("still cancels the edit on Escape", () => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "Discard me" } });
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
+    expect(screen.getByText("Original title")).toBeInTheDocument();
+  });
+});

--- a/packages/views/chat/components/chat-session-header.test.tsx
+++ b/packages/views/chat/components/chat-session-header.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import type { ChatSession } from "@multica/core/types";
 import enChat from "../../locales/en/chat.json";
@@ -33,6 +33,7 @@ import { ChatSessionHeader } from "./chat-session-header";
 
 const TEST_RESOURCES = { en: { chat: enChat } };
 const RENAME_LABEL = enChat.header.rename;
+const OUTSIDE_LABEL = "Outside control";
 
 const session: ChatSession = {
   id: "session-1",
@@ -51,9 +52,12 @@ const session: ChatSession = {
 
 function startRename(): HTMLInputElement {
   render(
-    <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <ChatSessionHeader session={session} agent={null} />
-    </I18nProvider>,
+    <>
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <ChatSessionHeader session={session} agent={null} />
+      </I18nProvider>
+      <button type="button">{OUTSIDE_LABEL}</button>
+    </>,
   );
   fireEvent.click(screen.getByTitle(RENAME_LABEL));
   return screen.getByRole("textbox", { name: RENAME_LABEL });
@@ -94,13 +98,15 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
 
   it("defers blur submission until an active composition ends", () => {
     const input = startRename();
+    const outside = screen.getByRole("button", { name: OUTSIDE_LABEL });
     fireEvent.change(input, { target: { value: "yanjiu" } });
     fireEvent.compositionStart(input);
 
-    fireEvent.blur(input);
+    outside.focus();
 
     expect(updateMutate).not.toHaveBeenCalled();
     expect(input).toBeInTheDocument();
+    expect(outside).toHaveFocus();
 
     fireEvent.change(input, { target: { value: "研究" } });
     fireEvent.compositionEnd(input);
@@ -113,17 +119,51 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
     expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
   });
 
-  it("still submits the current value on an ordinary blur", () => {
+  it("falls back to the current value when compositionend does not arrive", async () => {
     const input = startRename();
+    const outside = screen.getByRole("button", { name: OUTSIDE_LABEL });
+    fireEvent.change(input, { target: { value: "研究" } });
+    fireEvent.compositionStart(input);
+
+    outside.focus();
+
+    await waitFor(() => {
+      expect(updateMutate).toHaveBeenCalledTimes(1);
+    });
+    expect(updateMutate).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      title: "研究",
+    });
+    expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
+  });
+
+  it("still submits the current value when focus moves outside", () => {
+    const input = startRename();
+    const outside = screen.getByRole("button", { name: OUTSIDE_LABEL });
     fireEvent.change(input, { target: { value: "Blurred title" } });
 
-    fireEvent.blur(input);
+    outside.focus();
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
     expect(updateMutate).toHaveBeenCalledWith({
       sessionId: "session-1",
       title: "Blurred title",
     });
+    expect(outside).toHaveFocus();
+  });
+
+  it.each([
+    ["standard composition signal", { isComposing: true, keyCode: 27 }],
+    ["Safari composition signal", { isComposing: false, keyCode: 229 }],
+  ])("keeps editing when Escape carries the %s", (_name, eventInit) => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+
+    fireEvent.keyDown(input, { key: "Escape", ...eventInit });
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("yanjiu");
   });
 
   it("still cancels the edit on Escape", () => {

--- a/packages/views/chat/components/chat-session-header.test.tsx
+++ b/packages/views/chat/components/chat-session-header.test.tsx
@@ -92,6 +92,40 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
     expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
   });
 
+  it("defers blur submission until an active composition ends", () => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+    fireEvent.compositionStart(input);
+
+    fireEvent.blur(input);
+
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "研究" } });
+    fireEvent.compositionEnd(input);
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      title: "研究",
+    });
+    expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
+  });
+
+  it("still submits the current value on an ordinary blur", () => {
+    const input = startRename();
+    fireEvent.change(input, { target: { value: "Blurred title" } });
+
+    fireEvent.blur(input);
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      title: "Blurred title",
+    });
+  });
+
   it("still cancels the edit on Escape", () => {
     const input = startRename();
     fireEvent.change(input, { target: { value: "Discard me" } });

--- a/packages/views/chat/components/chat-session-header.test.tsx
+++ b/packages/views/chat/components/chat-session-header.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import type { ChatSession } from "@multica/core/types";
 import enChat from "../../locales/en/chat.json";
@@ -102,7 +102,9 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
     fireEvent.change(input, { target: { value: "yanjiu" } });
     fireEvent.compositionStart(input);
 
-    outside.focus();
+    act(() => {
+      outside.focus();
+    });
 
     expect(updateMutate).not.toHaveBeenCalled();
     expect(input).toBeInTheDocument();
@@ -119,22 +121,21 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
     expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
   });
 
-  it("falls back to the current value when compositionend does not arrive", async () => {
+  it("closes without saving a partial value when compositionend does not arrive", async () => {
     const input = startRename();
     const outside = screen.getByRole("button", { name: OUTSIDE_LABEL });
-    fireEvent.change(input, { target: { value: "研究" } });
+    fireEvent.change(input, { target: { value: "yanjiu" } });
     fireEvent.compositionStart(input);
 
-    outside.focus();
+    act(() => {
+      outside.focus();
+    });
 
     await waitFor(() => {
-      expect(updateMutate).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
     });
-    expect(updateMutate).toHaveBeenCalledWith({
-      sessionId: "session-1",
-      title: "研究",
-    });
-    expect(screen.queryByRole("textbox", { name: RENAME_LABEL })).not.toBeInTheDocument();
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(screen.getByText("Original title")).toBeInTheDocument();
   });
 
   it("still submits the current value when focus moves outside", () => {
@@ -142,7 +143,9 @@ describe("ChatSessionHeader rename keyboard behavior", () => {
     const outside = screen.getByRole("button", { name: OUTSIDE_LABEL });
     fireEvent.change(input, { target: { value: "Blurred title" } });
 
-    outside.focus();
+    act(() => {
+      outside.focus();
+    });
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
     expect(updateMutate).toHaveBeenCalledWith({

--- a/packages/views/chat/components/chat-session-header.tsx
+++ b/packages/views/chat/components/chat-session-header.tsx
@@ -68,6 +68,7 @@ export function ChatSessionHeader({
   // A browser can blur the input before it emits compositionend. Remember
   // that intent so the final composed value is committed, not the draft.
   const commitAfterCompositionRef = useRef(false);
+  const blurCommitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const title = session.title?.trim() || t(($) => $.window.untitled);
 
@@ -78,7 +79,23 @@ export function ChatSessionHeader({
     }
   }, [editing]);
 
+  useEffect(
+    () => () => {
+      if (blurCommitTimeoutRef.current !== null) {
+        clearTimeout(blurCommitTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const clearPendingBlurCommit = () => {
+    if (blurCommitTimeoutRef.current === null) return;
+    clearTimeout(blurCommitTimeoutRef.current);
+    blurCommitTimeoutRef.current = null;
+  };
+
   const startRename = () => {
+    clearPendingBlurCommit();
     isComposingRef.current = false;
     commitAfterCompositionRef.current = false;
     setDraft(session.title ?? "");
@@ -86,6 +103,7 @@ export function ChatSessionHeader({
   };
 
   const commitRename = (raw = draft) => {
+    clearPendingBlurCommit();
     isComposingRef.current = false;
     commitAfterCompositionRef.current = false;
     setEditing(false);
@@ -133,17 +151,27 @@ export function ChatSessionHeader({
             onBlur={(e) => {
               if (isComposingRef.current) {
                 commitAfterCompositionRef.current = true;
+                const input = e.currentTarget;
+                // Let a compositionend queued by the same focus change win.
+                // If it never arrives, commit on the next task instead of
+                // leaving an unfocused editor open indefinitely.
+                clearPendingBlurCommit();
+                blurCommitTimeoutRef.current = setTimeout(() => {
+                  if (!commitAfterCompositionRef.current) return;
+                  commitRename(input.value);
+                }, 0);
                 return;
               }
               commitRename(e.currentTarget.value);
             }}
             onKeyDown={(e) => {
+              if (isImeComposing(e)) return;
               if (e.key === "Enter") {
-                if (isImeComposing(e)) return;
                 e.preventDefault();
                 commitRename();
               } else if (e.key === "Escape") {
                 e.preventDefault();
+                clearPendingBlurCommit();
                 isComposingRef.current = false;
                 commitAfterCompositionRef.current = false;
                 setEditing(false);

--- a/packages/views/chat/components/chat-session-header.tsx
+++ b/packages/views/chat/components/chat-session-header.tsx
@@ -28,6 +28,7 @@ import {
 } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
 import type { Agent, ChatSession } from "@multica/core/types";
+import { isImeComposing } from "@multica/core/utils";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AppLink } from "../../navigation";
 import { useT } from "../../i18n";
@@ -116,6 +117,7 @@ export function ChatSessionHeader({
             onBlur={commitRename}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
+                if (isImeComposing(e)) return;
                 e.preventDefault();
                 commitRename();
               } else if (e.key === "Escape") {

--- a/packages/views/chat/components/chat-session-header.tsx
+++ b/packages/views/chat/components/chat-session-header.tsx
@@ -64,6 +64,10 @@ export function ChatSessionHeader({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [draft, setDraft] = useState(session.title ?? "");
   const inputRef = useRef<HTMLInputElement>(null);
+  const isComposingRef = useRef(false);
+  // A browser can blur the input before it emits compositionend. Remember
+  // that intent so the final composed value is committed, not the draft.
+  const commitAfterCompositionRef = useRef(false);
 
   const title = session.title?.trim() || t(($) => $.window.untitled);
 
@@ -75,13 +79,17 @@ export function ChatSessionHeader({
   }, [editing]);
 
   const startRename = () => {
+    isComposingRef.current = false;
+    commitAfterCompositionRef.current = false;
     setDraft(session.title ?? "");
     setEditing(true);
   };
 
-  const commitRename = () => {
+  const commitRename = (raw = draft) => {
+    isComposingRef.current = false;
+    commitAfterCompositionRef.current = false;
     setEditing(false);
-    const trimmed = draft.trim();
+    const trimmed = raw.trim();
     if (!trimmed || trimmed === session.title) return;
     updateSession.mutate({ sessionId: session.id, title: trimmed });
   };
@@ -114,7 +122,21 @@ export function ChatSessionHeader({
             maxLength={200}
             aria-label={t(($) => $.header.rename)}
             onChange={(e) => setDraft(e.target.value)}
-            onBlur={commitRename}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+            }}
+            onCompositionEnd={(e) => {
+              isComposingRef.current = false;
+              if (!commitAfterCompositionRef.current) return;
+              commitRename(e.currentTarget.value);
+            }}
+            onBlur={(e) => {
+              if (isComposingRef.current) {
+                commitAfterCompositionRef.current = true;
+                return;
+              }
+              commitRename(e.currentTarget.value);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 if (isImeComposing(e)) return;
@@ -122,6 +144,8 @@ export function ChatSessionHeader({
                 commitRename();
               } else if (e.key === "Escape") {
                 e.preventDefault();
+                isComposingRef.current = false;
+                commitAfterCompositionRef.current = false;
                 setEditing(false);
               }
             }}

--- a/packages/views/chat/components/chat-session-header.tsx
+++ b/packages/views/chat/components/chat-session-header.tsx
@@ -158,6 +158,16 @@ export function ChatSessionHeader({
                 clearPendingBlurCommit();
                 blurCommitTimeoutRef.current = setTimeout(() => {
                   if (!commitAfterCompositionRef.current) return;
+                  // Without compositionend, the current DOM value is not
+                  // known to be final. Close without persisting a partial
+                  // composition instead of recreating the original bug.
+                  if (isComposingRef.current) {
+                    clearPendingBlurCommit();
+                    isComposingRef.current = false;
+                    commitAfterCompositionRef.current = false;
+                    setEditing(false);
+                    return;
+                  }
                   commitRename(input.value);
                 }, 0);
                 return;

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -15,6 +15,7 @@ import {
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useAuthStore } from "@multica/core/auth";
+import { isImeComposing } from "@multica/core/utils";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { canAssignAgent } from "@multica/views/issues/components";
@@ -1641,6 +1642,7 @@ function SessionRenameInput({
         // selection keyboard handler consume them.
         e.stopPropagation();
         if (e.key === "Enter") {
+          if (isImeComposing(e)) return;
           e.preventDefault();
           onSubmit(value);
         } else if (e.key === "Escape") {

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -15,7 +15,6 @@ import {
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useAuthStore } from "@multica/core/auth";
-import { isImeComposing } from "@multica/core/utils";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { canAssignAgent } from "@multica/views/issues/components";
@@ -72,6 +71,7 @@ import { useChatInputFocus } from "./use-chat-input-focus";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import { ChatQueue } from "./chat-queue";
+import { SessionRenameInput } from "./session-rename-input";
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatContextItems } from "./use-chat-context-items";
 import { useChatResize } from "./use-chat-resize";
@@ -1167,6 +1167,9 @@ function SessionDropdown({
   // session id (not the full session) so a stale closure can't overwrite a
   // newer rename pulled in via WS.
   const [renamingId, setRenamingId] = useState<string | null>(null);
+  // Keep the controlled popover open even if its outside-press listener runs
+  // before SessionRenameInput's document listener for the same pointerdown.
+  const renameComposingRef = useRef(false);
   const setArchived = useSetChatSessionArchived();
   const updateSession = useUpdateChatSession();
   const setActiveSession = useChatStore((s) => s.setActiveSession);
@@ -1261,6 +1264,7 @@ function SessionDropdown({
   };
 
   const handleSubmitRename = (sessionId: string, raw: string) => {
+    renameComposingRef.current = false;
     const trimmed = raw.trim();
     const current = sessions.find((s) => s.id === sessionId);
     setRenamingId(null);
@@ -1355,7 +1359,10 @@ function SessionDropdown({
             key: "rename",
             icon: <Pencil className="size-3.5" />,
             label: t(($) => $.session_history.row_rename_aria),
-            onSelect: () => setRenamingId(session.id),
+            onSelect: () => {
+              renameComposingRef.current = false;
+              setRenamingId(session.id);
+            },
           },
           {
             key: "archive",
@@ -1401,7 +1408,13 @@ function SessionDropdown({
             <SessionRenameInput
               initialValue={session.title ?? ""}
               onSubmit={(value) => handleSubmitRename(session.id, value)}
-              onCancel={() => setRenamingId(null)}
+              onCancel={() => {
+                renameComposingRef.current = false;
+                setRenamingId(null);
+              }}
+              onCompositionChange={(isComposing) => {
+                renameComposingRef.current = isComposing;
+              }}
             />
           ) : isConfirmingStop ? (
             <div className="truncate text-body font-medium text-destructive">
@@ -1513,7 +1526,13 @@ function SessionDropdown({
 
   return (
     <>
-      <Popover open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+      <Popover
+        open={isHistoryOpen}
+        onOpenChange={(open) => {
+          if (!open && renameComposingRef.current) return;
+          setIsHistoryOpen(open);
+        }}
+      >
         <div className="flex min-w-0 items-center gap-1">
           <PopoverTrigger className="flex max-w-96 min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-accent data-[popup-open]:bg-accent data-open:bg-accent">
             {triggerAgent && (
@@ -1574,84 +1593,6 @@ function SessionDropdown({
         </PopoverContent>
       </Popover>
     </>
-  );
-}
-
-/**
- * Inline editor for a session title. Mounts focused with the existing
- * title pre-selected so the user can either replace it outright or arrow
- * into the existing text. Enter commits, Escape cancels, a real click
- * outside the input also commits.
- *
- * We do NOT commit on the input's `blur` event: the history popover can
- * move focus to sibling rows and nested actions while the user is still
- * interacting with the panel. Instead a document-level `pointerdown`
- * listener commits only when the user actually clicks outside the input.
- */
-function SessionRenameInput({
-  initialValue,
-  onSubmit,
-  onCancel,
-}: {
-  initialValue: string;
-  onSubmit: (value: string) => void;
-  onCancel: () => void;
-}) {
-  const { t } = useT("chat");
-  const [value, setValue] = useState(initialValue);
-  const inputRef = useRef<HTMLInputElement>(null);
-  // Hold the latest value + callback in refs so the mount-only effect's
-  // listener always sees fresh state without re-subscribing on every
-  // keystroke (which would briefly leave a window where pointerdown isn't
-  // observed).
-  const valueRef = useRef(value);
-  valueRef.current = value;
-  const onSubmitRef = useRef(onSubmit);
-  onSubmitRef.current = onSubmit;
-
-  useEffect(() => {
-    inputRef.current?.focus();
-    inputRef.current?.select();
-
-    const handlePointerDown = (e: PointerEvent) => {
-      const input = inputRef.current;
-      if (!input) return;
-      if (input.contains(e.target as Node)) return;
-      onSubmitRef.current(valueRef.current);
-    };
-    // Capture phase — commit before outside-click handling can close the
-    // popover and unmount this component.
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown, true);
-    };
-  }, []);
-
-  return (
-    <input
-      ref={inputRef}
-      type="text"
-      value={value}
-      maxLength={200}
-      aria-label={t(($) => $.session_history.row_rename_aria)}
-      onChange={(e) => setValue(e.target.value)}
-      onClick={(e) => e.stopPropagation()}
-      onPointerDown={(e) => e.stopPropagation()}
-      onKeyDown={(e) => {
-        // Keep editing keys inside the input instead of letting the row
-        // selection keyboard handler consume them.
-        e.stopPropagation();
-        if (e.key === "Enter") {
-          if (isImeComposing(e)) return;
-          e.preventDefault();
-          onSubmit(value);
-        } else if (e.key === "Escape") {
-          e.preventDefault();
-          onCancel();
-        }
-      }}
-      className="w-full rounded-sm bg-background px-1 py-0.5 text-body outline-none ring-1 ring-border focus-visible:ring-brand"
-    />
   );
 }
 

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1167,9 +1167,6 @@ function SessionDropdown({
   // session id (not the full session) so a stale closure can't overwrite a
   // newer rename pulled in via WS.
   const [renamingId, setRenamingId] = useState<string | null>(null);
-  // Keep the controlled popover open even if its outside-press listener runs
-  // before SessionRenameInput's document listener for the same pointerdown.
-  const renameComposingRef = useRef(false);
   const setArchived = useSetChatSessionArchived();
   const updateSession = useUpdateChatSession();
   const setActiveSession = useChatStore((s) => s.setActiveSession);
@@ -1264,7 +1261,6 @@ function SessionDropdown({
   };
 
   const handleSubmitRename = (sessionId: string, raw: string) => {
-    renameComposingRef.current = false;
     const trimmed = raw.trim();
     const current = sessions.find((s) => s.id === sessionId);
     setRenamingId(null);
@@ -1359,10 +1355,7 @@ function SessionDropdown({
             key: "rename",
             icon: <Pencil className="size-3.5" />,
             label: t(($) => $.session_history.row_rename_aria),
-            onSelect: () => {
-              renameComposingRef.current = false;
-              setRenamingId(session.id);
-            },
+            onSelect: () => setRenamingId(session.id),
           },
           {
             key: "archive",
@@ -1408,13 +1401,7 @@ function SessionDropdown({
             <SessionRenameInput
               initialValue={session.title ?? ""}
               onSubmit={(value) => handleSubmitRename(session.id, value)}
-              onCancel={() => {
-                renameComposingRef.current = false;
-                setRenamingId(null);
-              }}
-              onCompositionChange={(isComposing) => {
-                renameComposingRef.current = isComposing;
-              }}
+              onCancel={() => setRenamingId(null)}
             />
           ) : isConfirmingStop ? (
             <div className="truncate text-body font-medium text-destructive">
@@ -1526,13 +1513,7 @@ function SessionDropdown({
 
   return (
     <>
-      <Popover
-        open={isHistoryOpen}
-        onOpenChange={(open) => {
-          if (!open && renameComposingRef.current) return;
-          setIsHistoryOpen(open);
-        }}
-      >
+      <Popover open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
         <div className="flex min-w-0 items-center gap-1">
           <PopoverTrigger className="flex max-w-96 min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-accent data-[popup-open]:bg-accent data-open:bg-accent">
             {triggerAgent && (

--- a/packages/views/chat/components/session-rename-input.test.tsx
+++ b/packages/views/chat/components/session-rename-input.test.tsx
@@ -8,7 +8,6 @@ const TEST_RESOURCES = { en: { chat: enChat } };
 const RENAME_LABEL = enChat.session_history.row_rename_aria;
 const onSubmit = vi.fn();
 const onCancel = vi.fn();
-const onCompositionChange = vi.fn();
 
 function renderInput(): HTMLInputElement {
   render(
@@ -17,7 +16,6 @@ function renderInput(): HTMLInputElement {
         initialValue="Original title"
         onSubmit={onSubmit}
         onCancel={onCancel}
-        onCompositionChange={onCompositionChange}
       />
     </I18nProvider>,
   );
@@ -28,7 +26,6 @@ describe("SessionRenameInput", () => {
   beforeEach(() => {
     onSubmit.mockReset();
     onCancel.mockReset();
-    onCompositionChange.mockReset();
   });
 
   it.each([
@@ -44,20 +41,11 @@ describe("SessionRenameInput", () => {
     expect(input).toHaveValue("yanjiu");
   });
 
-  it("blocks outside pointerdown until composition ends, then submits", () => {
+  it("submits the latest value on outside pointerdown", () => {
     const input = renderInput();
-    fireEvent.change(input, { target: { value: "yanjiu" } });
-    fireEvent.compositionStart(input);
-
-    expect(fireEvent.pointerDown(document.body)).toBe(false);
-    expect(onSubmit).not.toHaveBeenCalled();
-    expect(onCompositionChange).toHaveBeenLastCalledWith(true);
-
     fireEvent.change(input, { target: { value: "研究" } });
-    fireEvent.compositionEnd(input);
     fireEvent.pointerDown(document.body);
 
-    expect(onCompositionChange).toHaveBeenLastCalledWith(false);
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith("研究");
   });

--- a/packages/views/chat/components/session-rename-input.test.tsx
+++ b/packages/views/chat/components/session-rename-input.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enChat from "../../locales/en/chat.json";
+import { SessionRenameInput } from "./session-rename-input";
+
+const TEST_RESOURCES = { en: { chat: enChat } };
+const RENAME_LABEL = enChat.session_history.row_rename_aria;
+const onSubmit = vi.fn();
+const onCancel = vi.fn();
+const onCompositionChange = vi.fn();
+
+function renderInput(): HTMLInputElement {
+  render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <SessionRenameInput
+        initialValue="Original title"
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+        onCompositionChange={onCompositionChange}
+      />
+    </I18nProvider>,
+  );
+  return screen.getByRole("textbox", { name: RENAME_LABEL });
+}
+
+describe("SessionRenameInput", () => {
+  beforeEach(() => {
+    onSubmit.mockReset();
+    onCancel.mockReset();
+    onCompositionChange.mockReset();
+  });
+
+  it.each([
+    ["standard composition signal", { isComposing: true, keyCode: 13 }],
+    ["Safari composition signal", { isComposing: false, keyCode: 229 }],
+  ])("does not submit Enter with the %s", (_name, eventInit) => {
+    const input = renderInput();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+
+    fireEvent.keyDown(input, { key: "Enter", ...eventInit });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(input).toHaveValue("yanjiu");
+  });
+
+  it("blocks outside pointerdown until composition ends, then submits", () => {
+    const input = renderInput();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+    fireEvent.compositionStart(input);
+
+    expect(fireEvent.pointerDown(document.body)).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCompositionChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.change(input, { target: { value: "研究" } });
+    fireEvent.compositionEnd(input);
+    fireEvent.pointerDown(document.body);
+
+    expect(onCompositionChange).toHaveBeenLastCalledWith(false);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("研究");
+  });
+
+  it("keeps normal Enter and Escape behavior", () => {
+    const input = renderInput();
+    fireEvent.change(input, { target: { value: "Renamed chat" } });
+
+    fireEvent.keyDown(input, { key: "Enter", isComposing: false, keyCode: 13 });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("Renamed chat");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/views/chat/components/session-rename-input.test.tsx
+++ b/packages/views/chat/components/session-rename-input.test.tsx
@@ -50,6 +50,20 @@ describe("SessionRenameInput", () => {
     expect(onSubmit).toHaveBeenCalledWith("研究");
   });
 
+  it.each([
+    ["standard composition signal", { isComposing: true, keyCode: 27 }],
+    ["Safari composition signal", { isComposing: false, keyCode: 229 }],
+  ])("does not cancel Escape with the %s", (_name, eventInit) => {
+    const input = renderInput();
+    fireEvent.change(input, { target: { value: "yanjiu" } });
+
+    fireEvent.keyDown(input, { key: "Escape", ...eventInit });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(input).toHaveValue("yanjiu");
+  });
+
   it("keeps normal Enter and Escape behavior", () => {
     const input = renderInput();
     fireEvent.change(input, { target: { value: "Renamed chat" } });

--- a/packages/views/chat/components/session-rename-input.tsx
+++ b/packages/views/chat/components/session-rename-input.tsx
@@ -68,8 +68,8 @@ export function SessionRenameInput({
         // Keep editing keys inside the input instead of letting the row
         // selection keyboard handler consume them.
         e.stopPropagation();
+        if (isImeComposing(e)) return;
         if (e.key === "Enter") {
-          if (isImeComposing(e)) return;
           e.preventDefault();
           onSubmit(value);
         } else if (e.key === "Escape") {

--- a/packages/views/chat/components/session-rename-input.tsx
+++ b/packages/views/chat/components/session-rename-input.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { isImeComposing } from "@multica/core/utils";
+import { useT } from "../../i18n";
+
+/**
+ * Inline editor for a session title. Mounts focused with the existing
+ * title pre-selected so the user can either replace it outright or arrow
+ * into the existing text. Enter commits, Escape cancels, a real click
+ * outside the input also commits.
+ *
+ * We do NOT commit on the input's `blur` event: the history popover can
+ * move focus to sibling rows and nested actions while the user is still
+ * interacting with the panel. Instead a document-level `pointerdown`
+ * listener commits only when the user actually clicks outside the input.
+ */
+export function SessionRenameInput({
+  initialValue,
+  onSubmit,
+  onCancel,
+  onCompositionChange,
+}: {
+  initialValue: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+  onCompositionChange?: (isComposing: boolean) => void;
+}) {
+  const { t } = useT("chat");
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isComposingRef = useRef(false);
+  // Hold the latest value + callback in refs so the mount-only effect's
+  // listener always sees fresh state without re-subscribing on every
+  // keystroke (which would briefly leave a window where pointerdown isn't
+  // observed).
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+
+    const handlePointerDown = (e: PointerEvent) => {
+      const input = inputRef.current;
+      if (!input) return;
+      if (input.contains(e.target as Node)) return;
+      if (isComposingRef.current) {
+        // Do not let the same pointerdown dismiss the controlled popover and
+        // discard the draft while the IME still owns the input.
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
+      onSubmitRef.current(valueRef.current);
+    };
+    // Capture phase — commit before outside-click handling can close the
+    // popover and unmount this component.
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      maxLength={200}
+      aria-label={t(($) => $.session_history.row_rename_aria)}
+      onChange={(e) => setValue(e.target.value)}
+      onCompositionStart={() => {
+        isComposingRef.current = true;
+        onCompositionChange?.(true);
+      }}
+      onCompositionEnd={() => {
+        isComposingRef.current = false;
+        onCompositionChange?.(false);
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        // Keep editing keys inside the input instead of letting the row
+        // selection keyboard handler consume them.
+        e.stopPropagation();
+        if (e.key === "Enter") {
+          if (isImeComposing(e)) return;
+          e.preventDefault();
+          onSubmit(value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+      className="w-full rounded-sm bg-background px-1 py-0.5 text-body outline-none ring-1 ring-border focus-visible:ring-brand"
+    />
+  );
+}

--- a/packages/views/chat/components/session-rename-input.tsx
+++ b/packages/views/chat/components/session-rename-input.tsx
@@ -19,17 +19,14 @@ export function SessionRenameInput({
   initialValue,
   onSubmit,
   onCancel,
-  onCompositionChange,
 }: {
   initialValue: string;
   onSubmit: (value: string) => void;
   onCancel: () => void;
-  onCompositionChange?: (isComposing: boolean) => void;
 }) {
   const { t } = useT("chat");
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement>(null);
-  const isComposingRef = useRef(false);
   // Hold the latest value + callback in refs so the mount-only effect's
   // listener always sees fresh state without re-subscribing on every
   // keystroke (which would briefly leave a window where pointerdown isn't
@@ -47,13 +44,6 @@ export function SessionRenameInput({
       const input = inputRef.current;
       if (!input) return;
       if (input.contains(e.target as Node)) return;
-      if (isComposingRef.current) {
-        // Do not let the same pointerdown dismiss the controlled popover and
-        // discard the draft while the IME still owns the input.
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        return;
-      }
       onSubmitRef.current(valueRef.current);
     };
     // Capture phase — commit before outside-click handling can close the
@@ -72,14 +62,6 @@ export function SessionRenameInput({
       maxLength={200}
       aria-label={t(($) => $.session_history.row_rename_aria)}
       onChange={(e) => setValue(e.target.value)}
-      onCompositionStart={() => {
-        isComposingRef.current = true;
-        onCompositionChange?.(true);
-      }}
-      onCompositionEnd={() => {
-        isComposingRef.current = false;
-        onCompositionChange?.(false);
-      }}
       onClick={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

- keep chat rename inputs open when Enter or Escape is consumed by an active CJK IME composition
- apply the existing cross-browser `isImeComposing` guard to both the Chat page header and floating Chat history
- defer header blur submission until composition ends; if `compositionend` is missing or late, close without persisting a partial composition
- preserve the floating editor's existing outside-click submit and dismiss behavior
- cover real focus movement, missing `compositionend`, Escape, outside pointerdown, and Safari's `keyCode === 229` fallback

## Validation

- `pnpm --filter @multica/views exec vitest run chat/` (20 files, 226 tests passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint chat/components/chat-session-header.tsx chat/components/chat-session-header.test.tsx chat/components/session-rename-input.tsx chat/components/session-rename-input.test.tsx`
- `git diff --check`

Fixes #7191
Closes MUL-6387
