### PR TITLE
docs(mobile): document EXPO_APPLE_TEAM_ID for multi-team signing (MUL-6375)

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -32,3 +32,13 @@ EXPO_PUBLIC_API_URL=https://<api-host>
 # never overridable (variants must stay on their canonical ids so the same
 # device can hold all three side-by-side).
 # EXPO_BUNDLE_IDENTIFIER_DEV=com.yourname.multica.dev
+
+# Optional. Apple Developer Team ID used to sign local iOS builds. Only needed
+# if your Apple ID belongs to more than one team (a personal team plus an
+# employer's, say) — with a single team the build picks it automatically. Find
+# the id in the Apple Developer Portal under Membership.
+#
+# Unlike the bundle id overrides this is variant-independent: the same team
+# signs dev / staging / production, so setting it once is enough. Leave it unset
+# to keep Expo's own signing-identity detection.
+# EXPO_APPLE_TEAM_ID=ABCDE12345

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -23,6 +23,13 @@ export EXPO_BUNDLE_IDENTIFIER_PROD=com.yourname.multica
 pnpm ios:mobile:device:prod:release
 ```
 
+**If your Apple ID belongs to more than one Apple Developer team** — a personal team plus an employer's, say — the build signs with the first identity it finds, which may not be the team you meant, and it keeps reusing that choice on every later build. Pin the right one (find the id in the Apple Developer Portal under Membership):
+
+```bash
+export EXPO_APPLE_TEAM_ID=ABCDE12345
+pnpm ios:mobile:device:prod:release
+```
+
 **7-day signing limit**: a free Apple ID signs builds for 7 days. After that, plug back into the Mac and re-run the command to re-sign. An Apple Developer Program account ($99/yr) extends this to 1 year.
 
 Everything below is for app developers — you can ignore the rest if you only wanted a personal install.
@@ -57,6 +64,8 @@ cp apps/mobile/.env.example apps/mobile/.env.development.local
 ```
 
 If your Apple ID isn't on the Multica Apple Developer team yet, also uncomment and set `EXPO_BUNDLE_IDENTIFIER_DEV` to a reverse-domain you own (e.g. `com.yourname.multica.dev`). This **only** overrides the dev variant — staging / production bundle ids are intentionally not overridable so variants can coexist.
+
+If your Apple ID belongs to more than one Apple Developer team, also set `EXPO_APPLE_TEAM_ID` to the team that should sign your builds. Unlike the bundle id overrides it applies to every variant, and it is re-applied on each run — so it also fixes a checkout that has already latched onto the wrong team.
 
 ## Build it onto your iPhone
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -32,6 +32,16 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     icon: "./assets/icon.png",
     ios: {
       supportsTablet: false,
+      // Pins DEVELOPMENT_TEAM on every prebuild. Leaving it unset is the normal
+      // path — `expo run:ios` then resolves a signing identity from the Keychain
+      // itself, which is right when the Apple ID owns exactly one team. With
+      // several (a personal team plus an employer's) it takes the *first*
+      // identity found whenever the terminal is non-interactive, writes that
+      // choice into the generated ios/, and never clears it again: prebuild only
+      // writes DEVELOPMENT_TEAM when a value is present, so a project pinned to
+      // the wrong team stays wrong until ios/ is deleted. Setting this re-applies
+      // the intended team on every `scripts/ios-run.sh` run, which also repairs
+      // an already-mispinned checkout.
       appleTeamId: process.env.EXPO_APPLE_TEAM_ID,
       // Per-variant bundle id overrides exist for one reason: an Apple ID
       // can only sign bundle prefixes it owns, so contributors not on the


### PR DESCRIPTION
## Summary

Follow-up to #7173, which added `ios.appleTeamId: process.env.EXPO_APPLE_TEAM_ID` to `apps/mobile/app.config.ts`. The mapping was correct but undocumented, so the people it helps — self-builders whose Apple ID belongs to more than one Apple Developer team — would have to read `app.config.ts` to discover it, while they are actually stuck on a code-signing error.

This documents it the same three ways its sibling `EXPO_BUNDLE_IDENTIFIER_*` overrides already are:

- `apps/mobile/README.md` — a troubleshooting entry next to the existing "No matching provisioning profiles" one, plus a line in **First-time setup**.
- `apps/mobile/.env.example` — a commented-out entry explaining when it is needed and that it applies to every variant (unlike the bundle id overrides, which are per-variant).
- `apps/mobile/app.config.ts` — a why-comment at the call site, matching the file's existing style.

No behaviour change: comments and Markdown only.

## Why it matters beyond "first build picks the right team"

Worth spelling out because it is the non-obvious part: `@expo/config-plugins`' `withDevelopmentTeam` only writes `DEVELOPMENT_TEAM` when a value is present, and `expo run:ios` writes its own auto-resolved choice into the generated `ios/` on first build. So a developer who once got signed with the wrong team stays on it for every subsequent build until `ios/` is deleted. Because `apps/mobile/scripts/ios-run.sh` re-runs `expo prebuild` on every invocation, setting `EXPO_APPLE_TEAM_ID` re-applies the intended team each run and repairs an already-mispinned checkout. That is the part most worth documenting.

## Verification

- `pnpm exec turbo typecheck lint test --filter=@multica/mobile` — 4/4 tasks pass, 0 errors (the 7 lint warnings are pre-existing and in files this PR does not touch).
- No iOS build was run; the change contains no executable code.
