### PR TITLE
perf(ci): path-filter the backend jobs to skip irrelevant PRs (MUL-6389)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the heavy frontend validation jobs and sqlc verification
-  # have anything to do.
+  # Decides whether the heavy frontend validation jobs, the backend Go jobs
+  # and sqlc verification have anything to do.
   # The frontend jobs validate the web/desktop apps, the shared packages,
   # the install graph, and the selfhost / reserved-slugs scripts it runs;
   # a pure backend-only or docs-only PR touches none of those and gains
-  # nothing from a full web build. The outputs are consumed by the focused
-  # jobs below.
+  # nothing from a full web build. Symmetrically, the backend jobs compile
+  # and test server/, so a frontend-only or docs-only PR gains nothing from
+  # a `go test -race` run. The outputs are consumed by the focused jobs
+  # below.
   changes:
     runs-on: ubuntu-latest
     permissions:
@@ -25,6 +27,7 @@ jobs:
       pull-requests: read
     outputs:
       frontend: ${{ steps.decide.outputs.frontend }}
+      backend: ${{ steps.decide.outputs.backend }}
       sqlc: ${{ steps.decide.outputs.sqlc }}
     steps:
       - name: Checkout
@@ -72,6 +75,23 @@ jobs:
               - 'docker-compose.selfhost.yml'
               - 'docker-compose.selfhost.build.yml'
               - 'Makefile'
+            # Everything the backend jobs (backend-tests,
+            # go-vulnerability-scan, windows-execenv) read. The Go test
+            # binaries resolve every fixture they load from runtime.Caller,
+            # so nothing outside server/ reaches them; the extra entries are
+            # the shell entry points those jobs run and the Helm chart
+            # scripts/helm-config.test.sh renders. Same bias as the frontend
+            # filter: over-match rather than silently skip validation.
+            backend:
+              - 'server/**'
+              - 'deploy/helm/**'
+              - 'scripts/helm-config.test.sh'
+              - 'scripts/test-go.sh'
+              - 'scripts/test-go.test.sh'
+              - 'scripts/go-test-with-agent-cli-guard.sh'
+              - 'scripts/agent-cli-command-names.txt'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
             sqlc:
               - 'server/pkg/db/queries/**'
               - 'server/pkg/db/generated/**'
@@ -82,21 +102,30 @@ jobs:
 
       - name: Decide
         id: decide
-        # Always run the frontend job on push to main (full validation);
-        # on pull_request, run only when frontend-relevant paths changed.
-        # The frontend job itself always runs and reports success — its
-        # steps are gated on this output rather than the job being skipped
-        # — so the required "frontend" status check is satisfied with a
-        # genuine green instead of being left pending on filtered PRs.
+        # Always run everything on push to main (full validation); on
+        # pull_request, run only the areas whose paths changed.
+        # The gated jobs themselves always run and report success — their
+        # steps are gated on these outputs rather than the job being skipped
+        # — so the required "frontend" / "backend" status checks are
+        # satisfied with a genuine green instead of being left pending on
+        # filtered PRs. It also keeps the aggregate gates strict: a job that
+        # goes missing for any OTHER reason (a failed `changes`, a cancelled
+        # run) still reports non-success and fails the gate.
         env:
           EVENT_NAME: ${{ github.event_name }}
           FRONTEND_CHANGED: ${{ steps.filter.outputs.frontend }}
+          BACKEND_CHANGED: ${{ steps.filter.outputs.backend }}
           SQLC_CHANGED: ${{ steps.filter.outputs.sqlc }}
         run: |
           if [ "$EVENT_NAME" != "pull_request" ] || [ "$FRONTEND_CHANGED" = "true" ]; then
             echo "frontend=true" >> "$GITHUB_OUTPUT"
           else
             echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$BACKEND_CHANGED" = "true" ]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=false" >> "$GITHUB_OUTPUT"
           fi
           if [ "$EVENT_NAME" != "pull_request" ] || [ "$SQLC_CHANGED" = "true" ]; then
             echo "sqlc=true" >> "$GITHUB_OUTPUT"
@@ -384,7 +413,14 @@ jobs:
           fi
 
   backend-tests:
+    needs: changes
     runs-on: ubuntu-latest
+    # `services` cannot be conditional, so the Postgres and Redis containers
+    # still start on a filtered PR. That is ~1 minute of runner time against
+    # the several minutes the gated steps below cost; job-level `if` would
+    # save it but report `skipped` to the aggregate gate, which then has to
+    # accept `skipped` as success and stops catching jobs that go missing for
+    # reasons other than the path filter.
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -417,9 +453,11 @@ jobs:
       REDIS_TEST_URL: redis://localhost:6379/1
     steps:
       - name: Checkout
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Go
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/setup-go@v5
         with:
           # Deliberately independent from the minimum patch in server/go.mod:
@@ -429,32 +467,41 @@ jobs:
           cache-dependency-path: server/go.sum
 
       - name: Setup Helm
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: azure/setup-helm@v4
 
       - name: Test Helm chart
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         run: bash scripts/helm-config.test.sh
 
       - name: Build
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         run: cd server && go build ./...
 
       - name: Run migrations
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         run: cd server && go run ./cmd/migrate up
 
       - name: Verify Go test wrapper
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         run: bash scripts/test-go.test.sh
 
       - name: Test
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         run: bash scripts/test-go.sh --race
 
   # Keep the live vulnerability database from hiding build and test results.
   # The aggregate backend job below still treats both jobs as one merge gate.
   go-vulnerability-scan:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Go
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/setup-go@v5
         with:
           # Deliberately independent from the minimum patch in server/go.mod:
@@ -464,6 +511,7 @@ jobs:
           cache-dependency-path: server/go.sum
 
       - name: Scan Go vulnerabilities
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         run: go tool govulncheck ./...
 
@@ -492,12 +540,18 @@ jobs:
     # The environment-preparation deadline owns a process tree, not just a Go
     # process. This Windows runtime test verifies Job Object cancellation kills
     # a delayed descendant before an immediate retry can reuse the same root.
+    # Every step here is a Go test under server/, so it rides the same path
+    # filter as the backend jobs; steps are gated rather than the job so the
+    # check still reports green on a filtered PR.
+    needs: changes
     runs-on: windows-latest
     steps:
       - name: Checkout
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Go
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/setup-go@v5
         with:
           # Deliberately independent from the minimum patch in server/go.mod:
@@ -507,6 +561,7 @@ jobs:
           cache-dependency-path: server/go.sum
 
       - name: Test Windows execution-environment isolation
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # Keep this job scoped to the runtime regression it exists to prove.
         # The package's legacy OpenClaw HOME tests are not Windows-safe and are
@@ -514,6 +569,7 @@ jobs:
         run: go test ./internal/daemon/execenv -run '^TestPrepareIsolated_WindowsKillsDescendantBeforeRetry$' -count=1 -timeout=5m
 
       - name: Test Windows agent launcher argv/stdin handling
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # Agent prompts must never reach a Windows launcher through argv: the
         # official cursor-agent.ps1 and pi.ps1 launch native children with
@@ -530,6 +586,7 @@ jobs:
         run: go test ./pkg/agent -v -run '^(TestCursorExecutePromptSurvivesPowerShellShim|TestPiExecutePromptSurvivesPowerShellShim|TestPlatformCursorInvocation|TestPlatformCopilotInvocation|TestPlatformPiInvocation)' -count=1 -timeout=5m
 
       - name: Test Windows OpenCode oversized prompt reaches stdin
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # #6538: the daemon inlined the whole task prompt as an argv element,
         # so every OpenCode task whose prompt cleared CreateProcess's 32,767
@@ -546,6 +603,7 @@ jobs:
         run: go test ./pkg/agent -v -run '^TestOpencodeExecuteOversizedPromptStartsOnWindows$' -count=1 -timeout=5m
 
       - name: Test Windows agent process-tree ownership
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # A Job Object is the only way to prove whole-tree termination on
         # Windows, and only a real Windows runner can exercise it: that a
@@ -556,6 +614,7 @@ jobs:
         run: go test ./pkg/agent -v -run '^(TestStartOwnedProcessTreeCapturesImmediateDescendants|TestStartOwnedProcessTreeLeavesNoSuspendedChild|TestWaitProcessGroupGoneWithoutOwnershipReportsUnconfirmed|TestCodexInitializeRetrySupportedWithOwnedProcessTree|TestCodexWindowsDescendantsDieWithTheOwnedProcessTree)$' -count=1 -timeout=5m
 
       - name: Test Windows OpenClaw npm shim interpreter resolution
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # #6061: every OpenClaw task failed execenv prep on a Windows host with
         # a bare `exit status 1` and no stderr. A batch shim resolves and runs
@@ -577,6 +636,7 @@ jobs:
         run: go test ./internal/daemon/execenv -v -run '^TestWindowsOpenclawShim' -count=1 -timeout=5m
 
       - name: Test Windows isolated repo checkout is committable
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # #6449: on Windows the daemon now hands Codex tasks a checkout whose
         # .git lives inside the task workdir, because a linked worktree's
@@ -598,6 +658,7 @@ jobs:
         run: go test ./internal/daemon/repocache -v -run '^(TestIsolatedCheckoutIsCommittableOnWindows|TestIsolatedCheckoutAcrossVolumesOnWindows)$' -count=1 -timeout=5m
 
       - name: Test Windows directory-junction link safety
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # MUL-6000: the per-task codex-home links the user's real skills into
         # the task directory instead of copying them. On Windows that link is a
@@ -617,6 +678,7 @@ jobs:
           go test ./internal/daemon -v -run '^(TestCleanTaskArtifacts_DoesNotFollowDirectoryJunction|TestTaskSize_DoesNotCountDirectoryJunction)$' -count=1 -timeout=5m
 
       - name: Test Windows agent executable junction resolution
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         # The standalone Codex installer exposes bin as a directory junction.
         # filepath.EvalSymlinks cannot traverse that reparse-point shape, so
@@ -627,6 +689,7 @@ jobs:
         run: go test ./internal/daemon -v -run '^(TestCanonicalExecutablePath|TestTrimExtendedLengthPrefix|TestResolveAgentExecutablePathKeeps|TestResolveAgentEntry(FollowsRetargetedInstallerJunction|CanonicalizesRediscoveredJunction|ForLaunchKeepsCmdShimLaunchable|ForLaunchRejectsUnverifiedInitialJunctionTarget|ForLaunchRejectsRediscoveredJunctionWhenFinalPathResolutionFails|DoesNotSharePreRetargetSingleflightResult|ForLaunchFailsWhenJunctionKeepsRetargeting)|TestHandleTaskReportsWindowsCodexProcessStartFailure)' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server
         run: go build ./cmd/multica
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,28 @@ jobs:
               - 'docker-compose.selfhost.build.yml'
               - 'Makefile'
             # Everything the backend jobs (backend-tests,
-            # go-vulnerability-scan, windows-execenv) read. The Go test
-            # binaries resolve every fixture they load from runtime.Caller,
-            # so nothing outside server/ reaches them; the extra entries are
-            # the shell entry points those jobs run and the Helm chart
-            # scripts/helm-config.test.sh renders. Same bias as the frontend
+            # go-vulnerability-scan, windows-execenv) read, which is NOT the
+            # same thing as server/**: three Go tests reach out of the module
+            # to pin a contract against a file the other side owns, and each
+            # one has to be listed here or the PR that breaks the contract is
+            # exactly the PR that skips the test. Same bias as the frontend
             # filter: over-match rather than silently skip validation.
             backend:
               - 'server/**'
               - 'deploy/helm/**'
+              # pkg/agent/worktree_capability_contract_test.go reads this file
+              # and compares LOCAL_WORKTREE_CAPABILITY against the daemon's
+              # protocol constant. A typo on either side disables worktree
+              # mode for everyone with no error anywhere, so a change to the
+              # frontend half must run the backend suite.
+              - 'packages/core/runtimes/cli-version.ts'
+              # internal/daemon/agent_command_names_test.go reads both of
+              # these; they are also the entry points scripts/test-go.sh runs.
+              - 'scripts/agent-cli-command-names.txt'
+              - 'scripts/go-test-with-agent-cli-guard.sh'
               - 'scripts/helm-config.test.sh'
               - 'scripts/test-go.sh'
               - 'scripts/test-go.test.sh'
-              - 'scripts/go-test-with-agent-cli-guard.sh'
-              - 'scripts/agent-cli-command-names.txt'
               - 'Makefile'
               - '.github/workflows/ci.yml'
             sqlc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,12 @@ jobs:
               - 'Makefile'
             # Everything the backend jobs (backend-tests,
             # go-vulnerability-scan, windows-execenv) read, which is NOT the
-            # same thing as server/**: three Go tests reach out of the module
-            # to pin a contract against a file the other side owns, and each
-            # one has to be listed here or the PR that breaks the contract is
-            # exactly the PR that skips the test. Same bias as the frontend
-            # filter: over-match rather than silently skip validation.
+            # same thing as server/**: four Go tests reach out of the module
+            # to pin a contract against a file the other side owns, across
+            # three cross-module file dependencies. Each of those files has
+            # to be listed here or the PR that breaks the contract is exactly
+            # the PR that skips the test. Same bias as the frontend filter:
+            # over-match rather than silently skip validation.
             backend:
               - 'server/**'
               - 'deploy/helm/**'
@@ -92,7 +93,9 @@ jobs:
               # frontend half must run the backend suite.
               - 'packages/core/runtimes/cli-version.ts'
               # internal/daemon/agent_command_names_test.go reads both of
-              # these; they are also the entry points scripts/test-go.sh runs.
+              # these as test inputs; the guard script is additionally the
+              # entry point scripts/test-go.sh runs, and the names file is
+              # the data that guard consumes.
               - 'scripts/agent-cli-command-names.txt'
               - 'scripts/go-test-with-agent-cli-guard.sh'
               - 'scripts/helm-config.test.sh'

--- a/server/pkg/agent/worktree_capability_contract_test.go
+++ b/server/pkg/agent/worktree_capability_contract_test.go
@@ -22,6 +22,11 @@ import (
 // looks for it. A typo on either side silently disables worktree mode for
 // everyone, with no error anywhere — which is precisely the failure this whole
 // area keeps producing.
+// This test reads OUT of the Go module, so CI's backend path filter has to
+// list the frontend file explicitly (`backend` in .github/workflows/ci.yml).
+// Without it, a PR that only edits the frontend token skips the very test
+// that would catch the mismatch. Move or rename the path below and the
+// filter must move with it.
 func TestWorktreeCapabilityTokenMatchesFrontend(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "packages", "core", "runtimes", "cli-version.ts")
 	src, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Frontend CI already skips its work when a PR touches nothing it validates. The backend side did not: `backend-tests` (Postgres + Redis + Helm + `go build` + migrations + `go test -race`), `go-vulnerability-scan` and `windows-execenv` ran on every PR, including ones that never touch `server/`.

This adds a `backend` path filter alongside the existing `frontend` and `sqlc` filters in the `changes` job and gates those three jobs on it.

### Filter scope

```
server/**
deploy/helm/**
packages/core/runtimes/cli-version.ts
scripts/agent-cli-command-names.txt
scripts/go-test-with-agent-cli-guard.sh
scripts/helm-config.test.sh
scripts/test-go.sh
scripts/test-go.test.sh
Makefile
.github/workflows/ci.yml
```

`server/**` is deliberately **not** the whole set. Four Go tests reach out of the module to pin a contract against a file the other side owns, across three cross-module file dependencies — and each of those files has to be listed, because the PR that breaks such a contract is exactly the PR that would otherwise skip the test:

| Test | Reads |
| --- | --- |
| `pkg/agent/worktree_capability_contract_test.go` → `TestWorktreeCapabilityTokenMatchesFrontend` | `packages/core/runtimes/cli-version.ts` |
| `internal/daemon/agent_command_names_test.go` → `TestAgentCLIGuardCoversDefaultCommands` | `scripts/agent-cli-command-names.txt` |
| `internal/daemon/agent_command_names_test.go` → `TestAgentCLIGuardDetectsSwallowedFailure`, `TestAgentCLIGuardFailsClosedWhenSetupFails` | `scripts/go-test-with-agent-cli-guard.sh` |

The worktree capability one matters most: the daemon advertises that token, the server stores it, the UI looks for it, and a typo on either side silently disables worktree mode for everyone with no error anywhere. Everything else the Go tests read resolves from `runtime.Caller` and stays inside `server/`, and all three `go:embed` directives point inside `server/` too. The remaining filter entries are the shell entry points the jobs execute and the Helm chart `scripts/helm-config.test.sh` renders. Same bias as the frontend filter: over-match rather than silently skip validation.

The reverse direction is clean — no TS test reads out of `server/`; the frontend filter's `reserved_slugs.json` entry is there for the generator script, not a test.

### Why steps are gated, not jobs

Matching the existing `frontend` / `sqlc-check` pattern:

- The aggregate `backend` check reports a genuine green on a filtered PR instead of staying pending.
- The aggregate keeps requiring `success`, so a job that goes missing for a reason *other* than the path filter (failed `changes`, cancelled run) still fails the gate. Job-level `if` would force the aggregate to accept `skipped` and lose that.

Trade-off: `services` cannot be conditional, so `backend-tests` still starts its Postgres and Redis containers on a filtered PR — roughly a minute, against the several minutes the gated steps cost.

### Effect

- Frontend-only PR: skips `go test -race`, govulncheck, and the Windows runner.
- Root docs-only PR: skips backend as well as frontend.
- Push to `main`: unchanged — full validation always runs.
- This PR touches `.github/workflows/ci.yml`, which is in the filter, so its own run exercises the full backend suite.

`installer` still runs unconditionally on three OSes; it is shell-only and out of scope here.

## Testing

`dorny/paths-filter` matches with picomatch, so the filter lists are parsed straight out of `ci.yml` (not a copy) and matched against candidate change sets:

```
PASS  frontend=true  backend=true   only packages/core/runtimes/cli-version.ts
PASS  frontend=false backend=true   only scripts/agent-cli-command-names.txt
PASS  frontend=false backend=true   only scripts/go-test-with-agent-cli-guard.sh
PASS  frontend=false backend=true   only server/pkg/agent/codex.go
PASS  frontend=false backend=true   only server/go.sum
PASS  frontend=false backend=true   only deploy/helm/multica/values.yaml
PASS  frontend=true  backend=false  only packages/views/issue/issue-row.tsx
PASS  frontend=true  backend=false  only packages/core/runtimes/models.ts
PASS  frontend=true  backend=false  only apps/web/app/page.tsx
PASS  frontend=false backend=false  only root docs
PASS  frontend=false backend=false  only apps/mobile
```

Also:

- `actionlint .github/workflows/ci.yml` — clean (parses the YAML and validates every `needs.changes.outputs.*` expression).
- `go test ./pkg/agent -run '^TestWorktreeCapabilityTokenMatchesFrontend$' -count=1` — pass.
- `go test ./internal/daemon -run '^TestAgentCLIGuard' -count=1` — pass.
- `bash scripts/test-go.test.sh` — pass.
- `gofmt` / `go vet` — clean.
- Simulated the `Decide` script across `push` / `pull_request` × each filter outcome; `push` yields `true` for all three outputs, `pull_request` yields exactly the changed areas.
- Gate coverage: 8/8 steps in `backend-tests`, 3/3 in `go-vulnerability-scan`, 11/11 in `windows-execenv`; the aggregate `backend` step stays ungated.

No application code changed — the only non-workflow edit is a comment in the contract test pointing back at the filter it depends on.
