### PR TITLE
fix(issues): offer both outcomes on a revision conflict (MUL-6250)

### DIFF
--- a/packages/views/issues/components/comment-card-edit-gate.test.tsx
+++ b/packages/views/issues/components/comment-card-edit-gate.test.tsx
@@ -90,6 +90,7 @@ vi.mock("../../editor", async () => ({
   ) {
     editorDefaultValues.values.push(defaultValue);
     const valueRef = useRef(defaultValue ?? "");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
     // Mirrors the real editor's `uploading` node attrs — see the sibling
     // composer suite for the same stand-in.
     const inFlightRef = useRef(0);
@@ -123,9 +124,16 @@ vi.mock("../../editor", async () => ({
       // Mocks track ids only — no document to draw into.
       insertUploadPlaceholder: () => true,
       settleUploadPlaceholder: () => false,
+      // The real handle applies content the `defaultValue` prop cannot land
+      // (mount-only) and does so without emitting an update.
+      adoptContent: (markdown: string) => {
+        valueRef.current = markdown;
+        if (textareaRef.current) textareaRef.current.value = markdown;
+      },
     }));
     return (
       <textarea
+        ref={textareaRef}
         data-testid="editor"
         defaultValue={defaultValue}
         placeholder={placeholder}
@@ -245,6 +253,38 @@ describe("comment edit — content conflict", () => {
     expect(
       useCommentDraftStore.getState().getDraft("edit:issue-1:comment-1"),
     ).toBe("My local edit");
+  });
+
+  it("loads the server version into the editor when the user takes theirs", async () => {
+    const onEdit = vi.fn().mockRejectedValue({
+      body: { code: "revision_conflict" },
+    });
+    renderCard(onEdit);
+    await startEditing();
+
+    fireEvent.change(screen.getByTestId("editor"), {
+      target: { value: "My local edit" },
+    });
+    fireEvent.click(getSaveButton());
+    expect(
+      await screen.findByText("The comment was changed concurrently. Compare both versions."),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use the latest version" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("The comment was changed concurrently. Compare both versions."),
+      ).not.toBeInTheDocument(),
+    );
+    // The draft is replaced by the server body, and the editor shows it — a
+    // dirty editor ignores prop-driven content, so this proves adoptContent ran.
+    expect((screen.getByTestId("editor") as HTMLTextAreaElement).value).toBe("Original body");
+    expect(
+      useCommentDraftStore.getState().getDraft("edit:issue-1:comment-1"),
+    ).toBe("Original body");
+    // Taking the server version is local-only: the server already holds it.
+    expect(onEdit).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -402,6 +402,21 @@ function useEditAttachmentState(
     resetState();
   };
 
+  /**
+   * Discard the local draft and continue from the version the server holds.
+   * Local-only — the server already stores this content, so nothing is written.
+   * The editor is dirty (that is why the conflict exists), so `adoptContent` is
+   * the only channel that lands: a plain `defaultValue` change is mount-only.
+   */
+  const adoptServerVersion = () => {
+    const serverContent = entry.content ?? "";
+    editorRef.current?.adoptContent(serverContent);
+    setContent(serverContent);
+    setDraft(draftKey, serverContent);
+    setInitialContentBase(serverContent);
+    setRevisionConflict(false);
+  };
+
   // Await-then-render save (MUL-5181): shared submit contract, with the edit-
   // only concerns folded into onSubmit — the cancel-race guard, the no-op
   // short-circuit, and the failure toast. The hook owns the empty guard,
@@ -514,15 +529,22 @@ function useEditAttachmentState(
     cancelEdit,
     saveEdit,
     revisionConflict,
+    adoptServerVersion,
   };
 }
 
 function CommentRevisionConflict({
   serverContent,
   localContent,
+  onKeepLocal,
+  onUseServer,
+  saving,
 }: {
   serverContent: string;
   localContent: string;
+  onKeepLocal: () => void;
+  onUseServer: () => void;
+  saving?: boolean;
 }) {
   const { t } = useT("issues");
   return (
@@ -533,7 +555,22 @@ function CommentRevisionConflict({
       localLabel={t(($) => $.revision.local_version)}
       serverValue={serverContent}
       localValue={localContent}
-      footer={t(($) => $.revision.save_again)}
+      actions={(
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={saving}
+            onClick={onKeepLocal}
+          >
+            {t(($) => $.revision.keep_local)}
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={onUseServer}>
+            {t(($) => $.revision.use_server)}
+          </Button>
+        </div>
+      )}
     />
   );
 }
@@ -704,6 +741,9 @@ function CommentRow({
             <CommentRevisionConflict
               serverContent={entry.content ?? ""}
               localContent={edit.content}
+              onKeepLocal={() => void edit.saveEdit()}
+              onUseServer={edit.adoptServerVersion}
+              saving={edit.saving}
             />
           ) : null}
           {edit.standaloneEditAttachments.length > 0 && (
@@ -1027,6 +1067,9 @@ function CommentCardImpl({
                   <CommentRevisionConflict
                     serverContent={entry.content ?? ""}
                     localContent={edit.content}
+                    onKeepLocal={() => void edit.saveEdit()}
+                    onUseServer={edit.adoptServerVersion}
+                    saving={edit.saving}
                   />
                 ) : null}
                 <div className="flex items-center justify-between mt-2">

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -182,20 +182,36 @@ vi.mock("../../editor", async () => ({
     const valueRef = useRef(initialValue);
     const baseRef = useRef(initialValue);
     const [editorValue, setEditorValue] = useState(initialValue);
+    // Mirrors the real editor's dirty guard: once the user has typed, an
+    // external `value` change is refused so it cannot clobber unsaved bytes.
+    // Only the imperative adoptContent channel lands after that point.
+    const dirtyRef = useRef(false);
     useEffect(() => {
       contentEditorMounts.count += 1;
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     useEffect(() => {
-      if (syncedValue === undefined) return;
+      if (syncedValue === undefined || dirtyRef.current) return;
       valueRef.current = syncedValue;
       baseRef.current = syncedValue;
       setEditorValue(syncedValue);
     }, [syncedValue]);
     useImperativeHandle(ref, () => ({
       getMarkdown: () => valueRef.current,
-      clearContent: () => { valueRef.current = ""; setEditorValue(""); },
+      clearContent: () => {
+        valueRef.current = "";
+        dirtyRef.current = false;
+        setEditorValue("");
+      },
+      // The real handle applies content the `value` prop cannot land (a dirty
+      // editor refuses external syncs) and does so without emitting an update.
+      adoptContent: (markdown: string) => {
+        valueRef.current = markdown;
+        baseRef.current = markdown;
+        dirtyRef.current = false;
+        setEditorValue(markdown);
+      },
       focus: () => {},
       focusAtCoords: () => {},
       // The top-level composer blurs after a posted comment (afterAccepted).
@@ -214,6 +230,7 @@ vi.mock("../../editor", async () => ({
         value={editorValue}
         onChange={(e) => {
           valueRef.current = e.target.value;
+          dirtyRef.current = true;
           setEditorValue(e.target.value);
           onUpdate?.(e.target.value, baseRef.current);
         }}
@@ -1667,6 +1684,35 @@ describe("IssueDetail (shared)", () => {
     expect(screen.getByDisplayValue("My local description")).toBeVisible();
   });
 
+  it("restores the server description when the user takes the latest version", async () => {
+    mockApiObj.updateIssue.mockRejectedValueOnce({
+      body: { code: "revision_conflict" },
+    });
+    renderIssueDetail();
+
+    const editor = await screen.findByDisplayValue("Add JWT auth to the backend");
+    fireEvent.focus(editor);
+    fireEvent.change(editor, { target: { value: "My local description" } });
+
+    expect(
+      await screen.findByText("The description was changed concurrently. Compare both versions."),
+    ).toBeVisible();
+    const callsBeforeDiscard = mockApiObj.updateIssue.mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Use the latest version" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("The description was changed concurrently. Compare both versions."),
+      ).not.toBeInTheDocument(),
+    );
+    // A dirty editor ignores prop-driven content, so seeing the server text
+    // back in the editor proves the imperative adopt path ran.
+    expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeVisible();
+    // Taking the server version is local-only: the server already holds it.
+    expect(mockApiObj.updateIssue).toHaveBeenCalledTimes(callsBeforeDiscard);
+  });
+
   it("serializes description saves and rebases the queued draft on submitted content", async () => {
     let resolveFirst!: (issue: Issue) => void;
     const firstSave = new Promise<Issue>((resolve) => {
@@ -1815,6 +1861,36 @@ describe("IssueDetail (shared)", () => {
     ).toBeVisible();
     expect(screen.getAllByText("My local title").length).toBeGreaterThan(0);
     expect(screen.getByDisplayValue("My local title")).toBeVisible();
+  });
+
+  it("restores the server title when the user takes the latest version", async () => {
+    mockApiObj.updateIssue.mockRejectedValueOnce({
+      body: { code: "revision_conflict" },
+    });
+    renderIssueDetail();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Implement authentication" }));
+    const editor = await screen.findByTestId("title-editor");
+    fireEvent.change(editor, { target: { value: "My local title" } });
+    fireEvent.blur(editor);
+
+    expect(
+      await screen.findByText("The title was changed concurrently. Compare both versions."),
+    ).toBeVisible();
+    const callsBeforeDiscard = mockApiObj.updateIssue.mock.calls.length;
+
+    fireEvent.click(screen.getByRole("button", { name: "Use the latest version" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("The title was changed concurrently. Compare both versions."),
+      ).not.toBeInTheDocument(),
+    );
+    // TitleEditor takes its text at mount, so the remount is what puts the
+    // server title back — see titleResetToken.
+    expect(await screen.findByDisplayValue("Implement authentication")).toBeVisible();
+    // Taking the server version is local-only: the server already holds it.
+    expect(mockApiObj.updateIssue).toHaveBeenCalledTimes(callsBeforeDiscard);
   });
 
   describe("sub-issues list", () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1973,6 +1973,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const titleEditorRef = useRef<TitleEditorRef>(null);
   const titleBaseRef = useRef<string | undefined>(issue?.title);
   const [titleConflictDraft, setTitleConflictDraft] = useState<string | null>(null);
+  // Bumped when a conflicting title draft is discarded. TitleEditor reads its
+  // text from `defaultValue` at mount and exposes no imperative setter, so
+  // remounting is the only way to put the server's title back in the editor.
+  const [titleResetToken, setTitleResetToken] = useState(0);
   useEffect(() => {
     setTitleConflictDraft(null);
     setDescriptionConflictDraft(null);
@@ -2848,7 +2852,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor
-                key={`title-${id}`}
+                key={`title-${id}-${titleResetToken}`}
                 ref={titleEditorRef}
                 defaultValue={titleConflictDraft ?? issue.title}
                 placeholder={t(($) => $.detail.title_placeholder)}
@@ -2908,26 +2912,43 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               serverValue={issue.title}
               localValue={titleConflictDraft}
               actions={(
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => {
-                    const draft = titleConflictDraft.trim();
-                    if (!draft) return;
-                    handleUpdateField(
-                      { title: draft, title_base: issue.title },
-                      {
-                        onSuccess: (serverIssue) => {
-                          setTitleConflictDraft(null);
-                          titleBaseRef.current = serverIssue.title;
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      const draft = titleConflictDraft.trim();
+                      if (!draft) return;
+                      handleUpdateField(
+                        { title: draft, title_base: issue.title },
+                        {
+                          onSuccess: (serverIssue) => {
+                            setTitleConflictDraft(null);
+                            titleBaseRef.current = serverIssue.title;
+                          },
                         },
-                      },
-                    );
-                  }}
-                >
-                  {t(($) => $.revision.keep_local)}
-                </Button>
+                      );
+                    }}
+                  >
+                    {t(($) => $.revision.keep_local)}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      // Local-only: the server already holds this title, so
+                      // discarding writes nothing. The remount is what puts it
+                      // back into the editor (see titleResetToken).
+                      setTitleConflictDraft(null);
+                      titleBaseRef.current = issue.title;
+                      setTitleResetToken((token) => token + 1);
+                    }}
+                  >
+                    {t(($) => $.revision.use_server)}
+                  </Button>
+                </div>
               )}
             />
           ) : null}
@@ -3026,30 +3047,51 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 serverValue={issue.description || ""}
                 localValue={descriptionConflictDraft}
                 actions={(
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      handleUpdateField(
-                        {
-                          description: descriptionConflictDraft,
-                          description_base: issue.description || "",
-                          attachment_ids:
-                            descriptionAttachmentIdsRef.current.length > 0
-                              ? descriptionAttachmentIdsRef.current
-                              : undefined,
-                        },
-                        {
-                          onSuccess: () => {
-                            setDescriptionConflictDraft(null);
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        handleUpdateField(
+                          {
+                            description: descriptionConflictDraft,
+                            description_base: issue.description || "",
+                            attachment_ids:
+                              descriptionAttachmentIdsRef.current.length > 0
+                                ? descriptionAttachmentIdsRef.current
+                                : undefined,
                           },
-                        },
-                      );
-                    }}
-                  >
-                    {t(($) => $.revision.keep_local)}
-                  </Button>
+                          {
+                            onSuccess: () => {
+                              setDescriptionConflictDraft(null);
+                            },
+                          },
+                        );
+                      }}
+                    >
+                      {t(($) => $.revision.keep_local)}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        // The editor is dirty — that is why this conflict
+                        // exists — so the `value` prop cannot land: ContentEditor
+                        // deliberately refuses to clobber unsaved bytes.
+                        // adoptContent is the explicit "take this content"
+                        // channel and applies without emitting an update, so
+                        // discarding never writes.
+                        descEditorRef.current?.adoptContent(issue.description || "");
+                        descriptionAttachmentIdsRef.current = [];
+                        pendingDescriptionSaveRef.current = null;
+                        setDescriptionConflictDraft(null);
+                      }}
+                    >
+                      {t(($) => $.revision.use_server)}
+                    </Button>
+                  </div>
                 )}
               />
             ) : null}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -11,8 +11,8 @@
     "compare_comment": "The comment was changed concurrently. Compare both versions.",
     "server_version": "Latest server version",
     "local_version": "Your local version",
-    "keep_local": "Use local version and save",
-    "save_again": "After reviewing both versions, click Save again to use your local version."
+    "keep_local": "Keep my version",
+    "use_server": "Use the latest version"
   },
   "page": {
     "breadcrumb_title": "Issues",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -11,8 +11,8 @@
     "compare_comment": "コメントが同時に変更されました。両方の内容を比較してください。",
     "server_version": "サーバー上の最新版",
     "local_version": "ローカル版",
-    "keep_local": "ローカル版を使用して保存",
-    "save_again": "両方の内容を確認した後、もう一度「保存」をクリックするとローカル版を使用できます。"
+    "keep_local": "自分の版を使用",
+    "use_server": "最新版を使用"
   },
   "page": {
     "breadcrumb_title": "タスク",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -11,8 +11,8 @@
     "compare_comment": "댓글이 동시에 변경되었습니다. 두 버전을 비교하세요.",
     "server_version": "서버의 최신 버전",
     "local_version": "내 로컬 버전",
-    "keep_local": "로컬 버전으로 저장",
-    "save_again": "두 버전을 확인한 후 저장을 다시 클릭하면 로컬 버전을 사용할 수 있습니다."
+    "keep_local": "내 버전 유지",
+    "use_server": "최신 버전 사용"
   },
   "page": {
     "breadcrumb_title": "태스크",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -11,8 +11,8 @@
     "compare_comment": "评论存在并发修改，请比较两个版本。",
     "server_version": "服务端最新版本",
     "local_version": "你的本地版本",
-    "keep_local": "采用本地版本并保存",
-    "save_again": "确认后再次点击“保存”即可采用本地版本。"
+    "keep_local": "保留我的版本",
+    "use_server": "使用最新版本"
   },
   "page": {
     "breadcrumb_title": "任务",


### PR DESCRIPTION
## What does this PR do?

Fixes a dead end in the revision-conflict UI that shipped with #7038.

The conflict banner only ever offered **"Use local version and save"**. That is one of the two outcomes a two-sided conflict has, so the only way out of the state was to overwrite the other writer. There was no affordance for taking their version, and no way to dismiss the banner — the conflict draft is cleared only on a successful save or when you navigate to a different issue.

The comment path was worse: `CommentRevisionConflict` passed no `actions` at all, only a line of footer text telling the user to press Save again.

This adds **"Use the latest version"** next to **"Keep my version"** on all three surfaces — issue title, issue description, and comment body — and relabels the existing action by its outcome instead of by what it does mechanically.

Discarding is local-only: the server already holds that value, so nothing is written. Each surface needs a different channel to get the server text back into the editor, for reasons that are load-bearing:

- **Title** — `TitleEditor` reads `defaultValue` at mount and exposes no imperative setter, so the editor is remounted via a reset token in its `key`.
- **Description / comment** — `ContentEditor` deliberately refuses external `value` syncs while the editor is dirty, which is exactly the conflict state. The imperative `adoptContent` is the explicit "take this content" channel, and it applies with `emitUpdate: false`, so discarding never triggers a save.

Scope is deliberately narrow: only the missing action. Attribution ("who changed it, when"), length-adaptive presentation for short fields, draft-loss protection on navigate-away, and a real three-way merge are all worth doing but are follow-ups, not this PR.

## Related Issue

Follow-up to #7033 / #7038.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx` — added the discard action to the title and description conflict banners; added `titleResetToken` so the title editor can be remounted with the server value.
- `packages/views/issues/components/comment-card.tsx` — `CommentRevisionConflict` now renders both actions instead of a footer hint; added `adoptServerVersion` to the edit-state hook, which reloads the server body, rebases `initialContentBase`, and clears the conflict.
- `packages/views/locales/{en,ja,ko,zh-Hans}/issues.json` — added `revision.use_server`, reworded `revision.keep_local` to name its outcome, removed the now-unused `revision.save_again`.
- Tests for all three surfaces, plus a mock-fidelity fix (below).

### One thing worth a reviewer's attention

The `ContentEditor` mock in `issue-detail.test.tsx` applied the `value` prop unconditionally, so the description test passed even with the `adoptContent` call deleted — the mock was papering over the real dirty guard. The mock now mirrors that guard: once the user types, only `adoptContent` lands. Verified by deleting the call and watching the new test go red.

## How to Test

1. Open the same issue in two browser windows (a normal window and a private one work).
2. Edit the title in both, save from A, then save from B. B gets the comparison banner.
3. Click **Use the latest version** — B's draft is discarded, the banner clears, and the title editor shows A's title. No request is sent, because the server already has that value.
4. Click **Keep my version** in the same situation instead — B's title wins, as before.
5. Repeat both for the description and for editing the same comment.

Automated: `pnpm --filter @multica/views test` — 4405 tests pass, including three new regressions (`restores the server title…`, `restores the server description…`, `loads the server version into the editor when the user takes theirs`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Chinese copy follows the button rule in `conventions.zh.mdx` (verb-first, short): `保留我的版本` / `使用最新版本`.

Verification run locally: `pnpm --filter @multica/views test` (4405 passed), `pnpm typecheck` (7/7), `pnpm --filter @multica/views lint` (0 errors; the 28 warnings are pre-existing and none are in the touched files).

## Screenshots (optional)

Not included — no local dev stack was brought up for this change. The before state is the single-button banner in the linked issue discussion; the after state adds a second button beside it. The rendered output is covered by the three regression tests.

## AI Disclosure

**AI tool used:** Claude Code (Multica Agent)

**Prompt / approach:**

Triaged from a tester report that the conflict state had only one exit. Traced the conflict-draft lifecycle in `issue-detail.tsx` and `comment-card.tsx` to confirm the state is only cleared on a successful save or an issue switch, then read `ContentEditor`'s external-sync guards to find the correct channel for restoring server content. Implemented the missing action, then verified the new tests actually fail without the fix — which is what surfaced the mock-fidelity problem described above.
