### PR TITLE
fix(daemon): stop concurrent tasks evicting each other's OpenClaw discovery cache

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config_cache.go
+++ b/server/internal/daemon/execenv/openclaw_config_cache.go
@@ -51,6 +51,22 @@ const (
 	// config file. The TTL is the backstop that keeps those visible, at the
 	// cost of re-running discovery at most once a minute.
 	openclawDiscoveryCacheTTL = time.Minute
+
+	// openclawDiscoveryCacheFutureSkew is how far ahead of the reader's clock
+	// sample an entry may be dated and still count as fresh.
+	//
+	// Without it, tasks starting together on one daemon evict each other's
+	// work. Every caller samples time.Now() once and passes it down, so a peer
+	// that sampled later but committed its rename first leaves an entry dated
+	// microseconds "in the future" — and the reader, whose own store just
+	// succeeded, throws it away and re-runs discovery for nothing. The same
+	// interleaving is what made TestOpenclawDiscoveryCacheConcurrentPreparations
+	// flake in CI.
+	//
+	// One second is far above that window and far below what the guard below
+	// exists to catch. It also bounds the cost of being wrong: an entry dated
+	// into the future outlives its TTL by at most this much.
+	openclawDiscoveryCacheFutureSkew = time.Second
 )
 
 // openclawDiscoveryFingerprint is the "is this entry still true?" evidence
@@ -208,10 +224,13 @@ func loadOpenclawDiscoveryCache(cachePath, bin string, now time.Time) (openclawD
 		return openclawDiscoveryCacheEntry{}, false
 	}
 	age := now.Sub(time.Unix(0, entry.CachedAtNano))
-	// A negative age means the entry was written in the future — a clock jump
-	// or a hand-edited file. Treat it as a miss rather than trusting it for a
-	// TTL that may never expire.
-	if age < 0 || age > openclawDiscoveryCacheTTL {
+	// An age well below zero means the entry was written in the future — a
+	// clock jump or a hand-edited file. Treat it as a miss rather than trusting
+	// it for a TTL that may never expire. Sub-second future dating is not that:
+	// it is the ordinary result of a concurrent writer on this same daemon
+	// (see openclawDiscoveryCacheFutureSkew), and rejecting it only buys an
+	// unnecessary discovery run.
+	if age < -openclawDiscoveryCacheFutureSkew || age > openclawDiscoveryCacheTTL {
 		return openclawDiscoveryCacheEntry{}, false
 	}
 	current, err := buildOpenclawDiscoveryFingerprint(bin, entry.ActiveConfigPath)

--- a/server/internal/daemon/execenv/openclaw_config_cache_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_cache_test.go
@@ -291,6 +291,38 @@ func TestOpenclawDiscoveryCacheSkipsFailedDiscovery(t *testing.T) {
 	}
 }
 
+// TestOpenclawDiscoveryCacheFutureDatedEntry pins both edges of the
+// future-dating rule.
+//
+// Callers sample time.Now() once and pass it down, so on a daemon running
+// several tasks at once a peer routinely commits an entry stamped after the
+// reader's sample. That entry is completely valid — rejecting it just costs an
+// extra discovery run, and it is what made the concurrency test below flake.
+// A real clock jump still has to be caught, since an entry dated far ahead
+// would otherwise never age out of its TTL.
+func TestOpenclawDiscoveryCacheFutureDatedEntry(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		ahead time.Duration
+		want  bool
+	}{
+		{"concurrent writer, microseconds ahead", 500 * time.Microsecond, true},
+		{"just inside the tolerance", openclawDiscoveryCacheFutureSkew - time.Millisecond, true},
+		{"clock jump, well past the tolerance", openclawDiscoveryCacheFutureSkew + time.Minute, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOpenclawCacheFixture(t)
+			readerNow := time.Now()
+			if err := storeOpenclawDiscoveryCache(f.cachePath(), f.bin, f.configPath, []any{map[string]any{"id": "scout"}}, false, readerNow.Add(tc.ahead)); err != nil {
+				t.Fatalf("store: %v", err)
+			}
+			if _, ok := loadOpenclawDiscoveryCache(f.cachePath(), f.bin, readerNow); ok != tc.want {
+				t.Fatalf("entry dated %v ahead of the reader: hit = %t, want %t", tc.ahead, ok, tc.want)
+			}
+		})
+	}
+}
+
 // TestOpenclawDiscoveryCacheConcurrentPreparations covers several tasks
 // starting at once on the same daemon: the writes are atomic, so every task
 // either sees a complete old entry or a complete new one, and none of them


### PR DESCRIPTION
## Summary

`TestOpenclawDiscoveryCacheConcurrentPreparations` fails intermittently on CI ([example run](https://github.com/multica-ai/multica/actions/runs/32224149368/job/95980329806) — `cache load failed under concurrency`). It is not a test-only problem: the flake is a real, if benign, production behaviour.

`loadOpenclawDiscoveryCache` treated *any* entry stamped later than the reader's clock sample as a clock jump and returned a miss:

```go
age := now.Sub(time.Unix(0, entry.CachedAtNano))
if age < 0 || age > openclawDiscoveryCacheTTL { // miss
```

Callers sample `time.Now()` once and pass it down. So when a daemon starts several tasks at once, a peer that sampled *later* but committed its rename *first* leaves an entry dated microseconds "in the future" — and the reader, whose own store just succeeded, discards a perfectly valid entry and re-runs discovery for nothing. In production that costs an extra CLI round; in the test it is an assertion failure.

Deterministic repro of the underlying rule, independent of any goroutine scheduling:

```go
writerNow := time.Now()
storeOpenclawDiscoveryCache(cachePath, bin, configPath, agents, false, writerNow)
// a peer that sampled 500µs earlier
loadOpenclawDiscoveryCache(cachePath, bin, writerNow.Add(-500*time.Microsecond)) // ok == false
```

## Fix

Tolerate a bounded skew rather than rejecting all future dating:

```go
if age < -openclawDiscoveryCacheFutureSkew || age > openclawDiscoveryCacheTTL {
```

`openclawDiscoveryCacheFutureSkew` is 1s — orders of magnitude above the interleaving window, and far below the clock jump the guard exists to catch. It also bounds the cost of being wrong: an entry dated ahead outlives its TTL by at most the tolerance (TTL is 1 minute).

`TestOpenclawDiscoveryCacheFutureDatedEntry` pins both edges so the constant cannot drift in either direction: a concurrent writer's entry is a hit (at 500µs and just inside the tolerance), a jumped clock is still a miss.

## Verification

- The new test fails on the old guard (both in-tolerance cases return `false`) and passes on the new one.
- `TestOpenclawDiscoveryCacheConcurrentPreparations`: 1800 runs at `-cpu=8` with no failure. Before the fix it reproduced within a few hundred.
- `go test ./internal/daemon/execenv/ -count=1` passes; `-race -count=20` on the OpenClaw tests passes; `go build ./...`, `go vet`, `gofmt -l` clean.

Found while investigating red CI on #7199, which touches nothing in this package — kept separate so it can be reviewed and reverted on its own.
