### PR TITLE
MUL-6395: fix(inbox): give the inbox row's status glyph the custom status's identity

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -1,27 +1,42 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { WorkspaceSlugProvider } from "@multica/core/paths";
-import type { InboxItem } from "@multica/core/types";
+import { buildIssueStatusCatalog } from "@multica/core/issue-statuses";
+import type { InboxItem, IssueStatusEntry } from "@multica/core/types";
 import { NavigationProvider } from "../../navigation";
 import type { NavigationAdapter } from "../../navigation";
 import { InboxListItem } from "./inbox-list-item";
 
+// The catalog is server state; these suites render leaves without a
+// QueryClientProvider, so it is stubbed like the other data hooks. The real
+// `buildIssueStatusCatalog` is used rather than a hand-rolled object so the
+// resolver semantics under test (category, entry, is_system) are the shipped
+// ones. `undefined` is the cold-catalog case every test but the status suite
+// exercises.
+let catalogEntries: IssueStatusEntry[] | undefined;
+
 vi.mock("@multica/core/issue-statuses/hooks", () => ({
-  // The catalog is server state; these suites render leaves without a
-  // QueryClientProvider, so it is stubbed like the other data hooks. Built-in
-  // keys are their own category, which is what this fixture asserts on.
-  useIssueStatuses: () => ({
-    statuses: [],
-    activeStatuses: [],
-    categoryOf: (key: string) => key,
-    labelOf: (key: string) => key,
-    entryOf: () => undefined,
-    inCategory: () => [],
-    isLoaded: true,
-  }),
+  useIssueStatuses: () => buildIssueStatusCatalog(catalogEntries),
 }));
 
-vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
+vi.mock("../../issues/components", () => ({
+  StatusIcon: ({
+    status,
+    category,
+    color,
+  }: {
+    status: string;
+    category?: string;
+    color?: string | null;
+  }) => (
+    <span
+      data-testid="status-icon"
+      data-status={status}
+      data-category={category ?? ""}
+      data-color={color ?? ""}
+    />
+  ),
+}));
 vi.mock("../../issues/components/issue-agent-activity-indicator", () => ({
   IssueAgentActivityIndicator: ({
     issueId,
@@ -309,5 +324,93 @@ describe("InboxListItem link semantics", () => {
     });
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(openInNewTab).not.toHaveBeenCalled();
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// MUL-6395 — the row's only status affordance is one glyph, and the glyph set
+// is per CATEGORY. Without the status's own colour, switching an issue between
+// two statuses that share a category (built-in "In Review" → custom "Human
+// Review") repainted the row identically, so the inbox looked like it had
+// simply not picked the change up.
+// ---------------------------------------------------------------------------
+
+const IN_REVIEW_BUILT_IN: IssueStatusEntry = {
+  id: "in_review",
+  workspace_id: "workspace-1",
+  key: "in_review",
+  name: "In Review",
+  description: "",
+  category: "in_review",
+  color: "#8b5cf6",
+  is_system: true,
+  position: 0,
+  archived_at: null,
+  created_at: "",
+  updated_at: "",
+};
+
+const HUMAN_REVIEW: IssueStatusEntry = {
+  ...IN_REVIEW_BUILT_IN,
+  id: "human_review",
+  key: "human_review",
+  name: "Human Review",
+  color: "#ff0000",
+  is_system: false,
+  position: 1,
+};
+
+describe("InboxListItem status glyph", () => {
+  it("paints a custom status in its own colour", () => {
+    catalogEntries = [IN_REVIEW_BUILT_IN, HUMAN_REVIEW];
+
+    const { getByTestId } = renderRow({
+      item: item({ issue_status: "human_review" }),
+      view: "inbox",
+    });
+
+    const icon = getByTestId("status-icon");
+    expect(icon.getAttribute("data-category")).toBe("in_review");
+    expect(icon.getAttribute("data-color")).toBe("#ff0000");
+  });
+
+  it("leaves a built-in status on its semantic token colour", () => {
+    // The catalog seeds a colour for the built-ins too, but those are theme
+    // tokens in the UI — passing the seeded hex would hard-code one theme.
+    catalogEntries = [IN_REVIEW_BUILT_IN, HUMAN_REVIEW];
+
+    const { getByTestId } = renderRow({
+      item: item({ issue_status: "in_review" }),
+      view: "inbox",
+    });
+
+    expect(getByTestId("status-icon").getAttribute("data-color")).toBe("");
+  });
+
+  it("names the status, so two statuses in one category stay distinguishable", () => {
+    catalogEntries = [IN_REVIEW_BUILT_IN, HUMAN_REVIEW];
+
+    const { container } = renderRow({
+      item: item({ issue_status: "human_review" }),
+      view: "inbox",
+    });
+
+    expect(container.querySelector('[title="Human Review"]')).not.toBeNull();
+  });
+
+  it("still renders a custom status before the catalog lands", () => {
+    // categoryOf falls back to `todo` for an unresolved key; the row must show
+    // the glyph anyway rather than dropping the status entirely.
+    catalogEntries = undefined;
+
+    const { getByTestId } = renderRow({
+      item: item({ issue_status: "human_review" }),
+      view: "inbox",
+    });
+
+    const icon = getByTestId("status-icon");
+    expect(icon.getAttribute("data-status")).toBe("human_review");
+    expect(icon.getAttribute("data-color")).toBe("");
   });
 });

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -12,6 +12,7 @@ import type { InboxView } from "./inbox-view";
 import { InboxDetailLabel } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
 import { useInboxContextMenu } from "./inbox-context-menu";
+import { useStatusLabel } from "../../issues/utils/status-label";
 import { InboxRowMenu } from "./inbox-row-menu";
 import { handleRowActivationKey } from "../../common/row-actions-menu";
 import { useT } from "../../i18n";
@@ -54,7 +55,9 @@ export function InboxListItem({
   const timeAgo = useTimeAgo();
   // Inbox is a cross-workspace surface, so the catalog is read against the
   // item's OWN workspace rather than the route's. (MUL-6243)
-  const { categoryOf: statusCategoryOf } = useIssueStatuses(item.workspace_id);
+  const { categoryOf: statusCategoryOf, entryOf: statusEntryOf } =
+    useIssueStatuses(item.workspace_id);
+  const statusLabelOf = useStatusLabel(item.workspace_id);
   const openContextMenu = useInboxContextMenu();
   // Null-safe slug (not useWorkspacePaths, which throws): the row renders in
   // tests and could render outside a workspace route; without a slug the
@@ -76,6 +79,16 @@ export function InboxListItem({
     ? t(($) => $.list.unarchive_tooltip)
     : t(($) => $.list.archive_tooltip);
   const actorType = item.actor_type ?? item.recipient_type;
+  // The glyph is per CATEGORY, so it alone cannot tell "In Review" from a
+  // custom "Human Review" — moving between two statuses of the same category
+  // left this row pixel-identical and read as "the inbox never updated"
+  // (MUL-6395). Colour is what carries a custom status's own identity, exactly
+  // as the status-changed detail label already renders it. Built-ins pass null
+  // so they keep their semantic token colour rather than the catalog's seed.
+  const statusEntry = item.issue_status
+    ? statusEntryOf(item.issue_status)
+    : undefined;
+  const statusColor = statusEntry?.is_system === true ? null : statusEntry?.color;
 
   return (
     // A div, not a <button>: the row carries its own controls (the action
@@ -152,11 +165,21 @@ export function InboxListItem({
             </button>
             <InboxRowMenu item={item} view={view} />
             {item.issue_status && (
-              <StatusIcon
-                status={item.issue_status}
-                category={statusCategoryOf(item.issue_status)}
-                className="h-3.5 w-3.5 shrink-0"
-              />
+              // Icon-only, like every other issue row — but a colour is not a
+              // name, and this row has no space for the CustomStatusChip the
+              // board card and list row carry. `title` is that name, and it is
+              // the same affordance the archive button above already uses.
+              <span
+                title={statusLabelOf(item.issue_status)}
+                className="flex shrink-0 items-center"
+              >
+                <StatusIcon
+                  status={item.issue_status}
+                  category={statusCategoryOf(item.issue_status)}
+                  color={statusColor}
+                  className="h-3.5 w-3.5 shrink-0"
+                />
+              </span>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Reported on the Inbox page: changing an issue's status from the detail sidebar syncs the status glyph on the matching inbox row for the 7 built-in statuses, but switching to a **custom** status appears to do nothing.

The cache is not the problem. Every write path — `useUpdateIssue`'s optimistic `applyIssueChange`, its server reconcile, and the `issue:updated` realtime handler — patches `InboxItem.issue_status` without looking at the status key, so `item.issue_status` does become `human_review`. (Verified with a throwaway coordinator test against a custom key before touching anything.)

The problem is that the row cannot *show* it. The row's only status affordance is one `StatusIcon`, and the glyph set is per **category** (MUL-6243): a custom status renders with its category's icon and that category's semantic token colour, and MUL-6243 wired the row's `category` but not its `color`. Two statuses in the same category therefore render pixel-identically — and sharing a category with a built-in is precisely what a custom status does. `in_review` → a custom "Human Review" repaints nothing, which reads as "the inbox list never updated".

## Changes

`packages/views/inbox/components/inbox-list-item.tsx`:

- Resolve the catalog **entry** alongside the category and pass its `color` to `StatusIcon`, mirroring what `inbox-detail-label.tsx` (the `status_changed` label, one file over) already does. Built-ins pass `null` so they keep their theme token instead of the catalog's server-seeded colour.
- Carry the resolved status name as a `title`. The board card and list row solve "which status inside this category?" with `CustomStatusChip`; this row has no room for a name chip, and `title` is the affordance its own archive button already uses. Built-in names still resolve through i18n via `useStatusLabel`, not the catalog's English seed.

## Verification

- `packages/views/inbox/components/inbox-list-item.test.tsx` — 4 new cases: custom status paints its own colour, built-in stays on its token, the name is exposed, and an unresolved key before the catalog lands still renders. Two of them fail on `main` and pass with the change.
- `pnpm -C packages/views vitest run inbox` — 80 passed.
- `pnpm -C packages/views tsc --noEmit`, `eslint` on both changed files — clean.
- Full `packages/views` suite: 4412/4413. The single failure is `autopilots/components/autopilot-dialog.validation.test.tsx`, which passes on its own and fails only under full-suite load — pre-existing flake, unrelated to this change.

## Not in scope

`apps/mobile/components/inbox/inbox-row.tsx` has a worse version of the same bug — it passes no `category` at all, so every custom status renders as the Todo glyph. Mobile has no issue-status catalog yet, so that is a port of MUL-6243 rather than a fix here.

MUL-6395
