### PR TITLE
MUL-6399: fix(issues): drop category headings from the status list

### DIFF
--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -105,7 +105,7 @@ export function IssueActionsMenuItems({
 }: IssueActionsMenuItemsProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
-  const { options: statusOptions } = useStatusOptions(wsId);
+  const statusOptions = useStatusOptions(wsId);
   const { categoryOf, entryOf } = useIssueStatuses(wsId);
   const {
     isPinned,
@@ -167,9 +167,8 @@ export function IssueActionsMenuItems({
         <P.SubContent>
           {/* Catalog-driven, like the picker and the filter: every entry point
               that can change a status must offer the same set, or a custom
-              status is unreachable from the board's right-click menu. Flat
-              rather than grouped — these primitives have no label item — but
-              already in canonical category order. (MUL-6243) */}
+              status is unreachable from the board's right-click menu. One flat
+              list in canonical category order. (MUL-6243) */}
           {statusOptions.map((option) => (
             <P.Item
               key={option.key}
@@ -177,7 +176,7 @@ export function IssueActionsMenuItems({
             >
               <StatusIcon
                 status={option.key}
-                category={categoryOf(option.key)}
+                category={option.category}
                 color={option.color}
                 className="h-3.5 w-3.5"
               />

--- a/packages/views/issues/components/issues-header.status-filter.test.tsx
+++ b/packages/views/issues/components/issues-header.status-filter.test.tsx
@@ -1,19 +1,22 @@
 // @vitest-environment jsdom
 
 /**
- * The status filter's category headings, against the REAL Base UI menu
- * primitives (MUL-6393).
+ * The status filter's list, against the REAL Base UI menu primitives.
  *
- * `DropdownMenuLabel` renders Base UI's `Menu.GroupLabel`, whose
- * `useMenuGroupRootContext()` THROWS when it has no `Menu.Group` ancestor.
- * The heading only renders once a workspace holds a custom status, so the
- * missing group stayed invisible until the first one was created — and then
- * opening the filter menu took the whole app down, because no error boundary
- * sits above the issues surface. Same failure as MUL-4819, one menu over.
+ * The filter lists every offerable status flat, in canonical category order,
+ * with no category heading — the icon already carries the category, and a
+ * heading per category doubled the menu's height (MUL-6399).
+ *
+ * That is also what keeps the menu from crashing. `DropdownMenuLabel` renders
+ * Base UI's `Menu.GroupLabel`, whose `useMenuGroupRootContext()` THROWS
+ * without a `Menu.Group` ancestor; the heading only rendered once a workspace
+ * held a custom status, so the missing group stayed invisible until the first
+ * one was created — and then opening the filter took the whole app down, since
+ * no error boundary sits above the issues surface (MUL-6393, MUL-4819).
  *
  * These tests therefore must NOT mock `@multica/ui/components/ui/dropdown-menu`:
  * a flattened mock renders a heading outside a group perfectly happily, which
- * is exactly how the bug shipped.
+ * is exactly how that bug shipped.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -111,29 +114,33 @@ afterEach(() => {
 });
 
 describe("IssueFilterMenu status section", () => {
-  it("opens with a custom status in the catalog instead of crashing on the category heading", async () => {
+  it("lists a custom status inline, with no category heading", async () => {
     renderFilterMenu([...BUILT_INS, HUMAN_REVIEW]);
 
-    // Reaching this at all is the regression: the heading below used to throw
-    // out of Base UI's Menu.GroupLabel and unmount the app.
+    // Opening at all is the MUL-6393 regression: the heading this list no
+    // longer renders used to throw out of Base UI's Menu.GroupLabel and
+    // unmount the app.
     await openStatusSubmenu();
 
+    expect(document.querySelector("[data-slot='dropdown-menu-label']")).toBeNull();
+    // The custom status sits directly after the built-in of the category it
+    // behaves as — one flat list, top to bottom.
+    // Built-ins are named by i18n, the custom one by the catalog.
     expect(
-      screen.getByRole("menuitemcheckbox", { name: /Human Review/ }),
-    ).toBeInTheDocument();
-    // The heading is present AND owns a group — Base UI wires it up as the
-    // group's accessible name, which is only possible inside Menu.Group.
-    const heading = screen.getByText("In Review", {
-      selector: "[data-slot='dropdown-menu-label']",
-    });
-    const group = heading.closest("[data-slot='dropdown-menu-group']");
-    expect(group).not.toBeNull();
-    expect(group?.getAttribute("aria-labelledby")).toBe(heading.id);
-    // Both In Review statuses sit under that one heading.
-    expect(group?.querySelectorAll("[role='menuitemcheckbox']")).toHaveLength(2);
+      screen.getAllByRole("menuitemcheckbox").map((el) => el.textContent?.trim()),
+    ).toEqual([
+      "Backlog",
+      "Todo",
+      "In Progress",
+      "In Review",
+      "Human Review",
+      "Done",
+      "Blocked",
+      "Cancelled",
+    ]);
   });
 
-  it("keeps the flat, heading-free list for a workspace with no custom statuses", async () => {
+  it("lists the 7 built-ins for a workspace with no custom statuses", async () => {
     renderFilterMenu(BUILT_INS);
 
     await openStatusSubmenu();

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cloneElement, Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cloneElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
@@ -1212,7 +1212,7 @@ export function IssueFilterMenu({
   const viewStoreApi = useViewStoreApi();
   const act = viewStoreApi.getState();
   const wsId = useWorkspaceId();
-  const { groups: statusGroups, hasCustom: showStatusGroupLabels } = useStatusOptions(wsId);
+  const statusOptions = useStatusOptions(wsId);
   const { data: workspaceProperties = [] } = useQuery(propertyListOptions(wsId));
   const filterableProperties = useMemo(
     () =>
@@ -1309,56 +1309,37 @@ export function IssueFilterMenu({
               <DropdownMenuSubContent className="w-auto min-w-48">
                 {/* Options come from the workspace catalog, so a custom status
                     is filterable — otherwise an issue moved onto one could not
-                    be narrowed to. Grouped by category, and headings appear
-                    only once a category holds more than one status, so a
-                    workspace that never customized anything sees the same flat
-                    7-row list. (MUL-6243) */}
-                {statusGroups.map((group) => {
-                  const items = group.options.map((option) => {
-                    const checked = statusFilters.includes(option.key);
-                    const count = counts.status.get(option.key) ?? 0;
-                    const fixed = viewBaseline?.status.has(option.key) === true;
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={option.key}
-                        checked={checked}
-                        disabled={fixed}
-                        title={fixed ? fixedTitle : undefined}
-                        onCheckedChange={() => act.toggleStatusFilter(option.key)}
-                        className={FILTER_ITEM_CLASS}
-                      >
-                        <HoverCheck checked={checked} />
-                        <StatusIcon
-                          status={option.key}
-                          category={group.category}
-                          color={option.color}
-                          className="h-3.5 w-3.5"
-                        />
-                        {option.label}
-                        {count > 0 && (
-                          <span className="ml-auto text-caption text-muted-foreground">
-                            {t(($) => $.filters.issue_count, { count })}
-                          </span>
-                        )}
-                      </DropdownMenuCheckboxItem>
-                    );
-                  });
-                  // A heading MUST be wrapped in DropdownMenuGroup: it renders
-                  // Base UI's Menu.GroupLabel, which reads a Menu.Group context
-                  // and THROWS without one, taking the whole app down — no error
-                  // boundary sits above the issues surface (MUL-4819, MUL-6393).
-                  // Without a heading the group would only add an unnamed
-                  // role="group" around a single row, so the un-customized
-                  // workspace keeps the flat 7-row list it always had.
-                  return showStatusGroupLabels ? (
-                    <DropdownMenuGroup key={group.category}>
-                      <DropdownMenuLabel className="text-caption text-muted-foreground">
-                        {t(($) => $.status[group.category])}
-                      </DropdownMenuLabel>
-                      {items}
-                    </DropdownMenuGroup>
-                  ) : (
-                    <Fragment key={group.category}>{items}</Fragment>
+                    be narrowed to. One flat list in category order: the icon
+                    already carries the category, and a heading per category
+                    doubled the menu's height for no added information
+                    (MUL-6243, MUL-6399). */}
+                {statusOptions.map((option) => {
+                  const checked = statusFilters.includes(option.key);
+                  const count = counts.status.get(option.key) ?? 0;
+                  const fixed = viewBaseline?.status.has(option.key) === true;
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={option.key}
+                      checked={checked}
+                      disabled={fixed}
+                      title={fixed ? fixedTitle : undefined}
+                      onCheckedChange={() => act.toggleStatusFilter(option.key)}
+                      className={FILTER_ITEM_CLASS}
+                    >
+                      <HoverCheck checked={checked} />
+                      <StatusIcon
+                        status={option.key}
+                        category={option.category}
+                        color={option.color}
+                        className="h-3.5 w-3.5"
+                      />
+                      {option.label}
+                      {count > 0 && (
+                        <span className="ml-auto text-caption text-muted-foreground">
+                          {t(($) => $.filters.issue_count, { count })}
+                        </span>
+                      )}
+                    </DropdownMenuCheckboxItem>
                   );
                 })}
               </DropdownMenuSubContent>

--- a/packages/views/issues/components/pickers/property-picker.tsx
+++ b/packages/views/issues/components/pickers/property-picker.tsx
@@ -229,19 +229,6 @@ export function PropertyPicker({
 // PickerItem — single selectable row
 // ---------------------------------------------------------------------------
 
-/**
- * Non-interactive section heading inside a picker list. Rendered as a plain
- * element, not a button, so `ITEM_SELECTOR` skips it and arrow-key navigation
- * moves between real options only.
- */
-export function PickerGroupLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="px-2 pb-1 pt-2 text-caption font-medium text-muted-foreground first:pt-1">
-      {children}
-    </div>
-  );
-}
-
 export function PickerItem({
   selected,
   disabled,

--- a/packages/views/issues/components/pickers/status-picker.tsx
+++ b/packages/views/issues/components/pickers/status-picker.tsx
@@ -6,7 +6,7 @@ import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { StatusIcon } from "../status-icon";
-import { PropertyPicker, PickerItem, PickerGroupLabel } from "./property-picker";
+import { PropertyPicker, PickerItem } from "./property-picker";
 import { useT } from "../../../i18n";
 import { useStatusLabel } from "../../utils/status-label";
 import { useStatusOptions } from "../../utils/status-options";
@@ -50,30 +50,21 @@ export function StatusPicker({
   const labelOf = useStatusLabel(wsId);
 
   /**
-   * Offerable statuses grouped by category, in canonical category order.
+   * Offerable statuses as one flat list, in canonical category order.
    *
    * Archived statuses are excluded: archiving retires a status from future
    * assignment while leaving the issues already on it untouched. Falls back to
    * the 7 built-ins until the catalog lands, so a cold render offers exactly
    * what it always did instead of an empty popover. (MUL-6243)
    */
-  const { groups: allGroups, options: allOptions, hasCustom } = useStatusOptions(wsId);
+  const allOptions = useStatusOptions(wsId);
 
-  const groups = useMemo(() => {
+  const options = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return allGroups;
-    return allGroups
-      .map((g) => ({
-        ...g,
-        options: g.options.filter((o) => o.label.toLowerCase().includes(q)),
-      }))
-      .filter((g) => g.options.length > 0);
-  }, [allGroups, query]);
+    if (!q) return allOptions;
+    return allOptions.filter((o) => o.label.toLowerCase().includes(q));
+  }, [allOptions, query]);
 
-  // Category headings only earn their space once a category holds more than
-  // one status. A workspace that never customized anything sees the same flat
-  // 7-row list as before.
-  const showGroupLabels = hasCustom;
   const searchable = allOptions.length > SEARCH_THRESHOLD;
 
   return (
@@ -104,32 +95,25 @@ export function StatusPicker({
         ) : null)
       }
     >
-      {groups.map((group) => (
-        <div key={group.category}>
-          {showGroupLabels && (
-            <PickerGroupLabel>{t(($) => $.status[group.category])}</PickerGroupLabel>
-          )}
-          {group.options.map((option) => (
-            <PickerItem
-              key={option.key}
-              selected={option.key === status}
-              hoverClassName={STATUS_CONFIG[group.category].hoverBg}
-              onClick={() => {
-                onUpdate({ status: option.key });
-                setOpen(false);
-                setQuery("");
-              }}
-            >
-              <StatusIcon
-                status={option.key}
-                category={group.category}
-                color={option.color}
-                className="h-3.5 w-3.5"
-              />
-              <span className="truncate">{option.label}</span>
-            </PickerItem>
-          ))}
-        </div>
+      {options.map((option) => (
+        <PickerItem
+          key={option.key}
+          selected={option.key === status}
+          hoverClassName={STATUS_CONFIG[option.category].hoverBg}
+          onClick={() => {
+            onUpdate({ status: option.key });
+            setOpen(false);
+            setQuery("");
+          }}
+        >
+          <StatusIcon
+            status={option.key}
+            category={option.category}
+            color={option.color}
+            className="h-3.5 w-3.5"
+          />
+          <span className="truncate">{option.label}</span>
+        </PickerItem>
       ))}
     </PropertyPicker>
   );

--- a/packages/views/issues/utils/status-options.test.tsx
+++ b/packages/views/issues/utils/status-options.test.tsx
@@ -67,7 +67,7 @@ describe("useStatusOptions", () => {
     catalogEntries = undefined;
     const { result } = renderHook(() => useStatusOptions("workspace-1"));
 
-    expect(result.current.options.map((o) => o.key)).toEqual([
+    expect(result.current.map((o) => o.key)).toEqual([
       "backlog",
       "todo",
       "in_progress",
@@ -76,18 +76,34 @@ describe("useStatusOptions", () => {
       "blocked",
       "cancelled",
     ]);
-    expect(result.current.hasCustom).toBe(false);
   });
 
-  it("groups a custom status under the category it behaves as", () => {
+  // One flat list, never nested by category (MUL-6399): a custom status sits
+  // directly after the built-in of the category it behaves as, so the whole
+  // catalog reads top to bottom in canonical order.
+  it("places a custom status inline, after the built-in of its category", () => {
     catalogEntries = [...BUILT_INS, entry({ key: "qa", name: "QA", category: "in_review" })];
     const { result } = renderHook(() => useStatusOptions("workspace-1"));
 
-    const inReview = result.current.groups.find((g) => g.category === "in_review");
-    expect(inReview?.options.map((o) => o.key)).toEqual(["in_review", "qa"]);
-    // Still 7 groups: a custom status must never create an eighth board column.
-    expect(result.current.groups).toHaveLength(7);
-    expect(result.current.hasCustom).toBe(true);
+    expect(result.current.map((o) => o.key)).toEqual([
+      "backlog",
+      "todo",
+      "in_progress",
+      "in_review",
+      "qa",
+      "done",
+      "blocked",
+      "cancelled",
+    ]);
+  });
+
+  // The category is what the row's icon and hover color are drawn from, so it
+  // travels with the option now that no heading states it.
+  it("carries the category a custom status behaves as", () => {
+    catalogEntries = [...BUILT_INS, entry({ key: "qa", name: "QA", category: "in_review" })];
+    const { result } = renderHook(() => useStatusOptions("workspace-1"));
+
+    expect(result.current.find((o) => o.key === "qa")?.category).toBe("in_review");
   });
 
   // Archiving retires a status from FUTURE assignment. Offering it here would
@@ -99,7 +115,7 @@ describe("useStatusOptions", () => {
     ];
     const { result } = renderHook(() => useStatusOptions("workspace-1"));
 
-    expect(result.current.options.map((o) => o.key)).not.toContain("qa");
+    expect(result.current.map((o) => o.key)).not.toContain("qa");
   });
 
   // Built-ins keep their semantic token color; a hex here would override it.
@@ -107,7 +123,7 @@ describe("useStatusOptions", () => {
     catalogEntries = [...BUILT_INS, entry({ key: "qa", name: "QA", color: "#ff0000" })];
     const { result } = renderHook(() => useStatusOptions("workspace-1"));
 
-    const byKey = new Map(result.current.options.map((o) => [o.key, o.color]));
+    const byKey = new Map(result.current.map((o) => [o.key, o.color]));
     expect(byKey.get("qa")).toBe("#ff0000");
     expect(byKey.get("in_review")).toBeNull();
   });

--- a/packages/views/issues/utils/status-options.ts
+++ b/packages/views/issues/utils/status-options.ts
@@ -8,19 +8,20 @@ import { useStatusLabel } from "./status-label";
 
 export interface StatusOption {
   key: IssueStatus;
+  /** The category this status behaves as — drives its icon and hover color. */
+  category: IssueStatusCategory;
   label: string;
   /** `#rrggbb` for a custom status; null for a built-in, which keeps its token color. */
   color: string | null;
 }
 
-export interface StatusOptionGroup {
-  category: IssueStatusCategory;
-  options: StatusOption[];
-}
-
 /**
- * The statuses a user can pick or filter by, grouped by category in canonical
- * category order (MUL-6243).
+ * The statuses a user can pick or filter by, as one flat list in canonical
+ * category order (MUL-6243, MUL-6399).
+ *
+ * Category is carried per option rather than expressed as a heading: it is the
+ * behavior a status inherits, which the icon and hover color already say, and
+ * a heading per category turned a 7-row list into 14 rows of half whitespace.
  *
  * Shared by the status picker and the status filter so the two can never drift
  * — a status offered in one and missing from the other is exactly how an issue
@@ -30,37 +31,27 @@ export interface StatusOptionGroup {
  * assignment. Issues already on one keep it, and `useStatusLabel` still names
  * it, because the catalog query keeps archived rows.
  */
-export function useStatusOptions(wsId: string): {
-  groups: StatusOptionGroup[];
-  /** Flat list in the same order, for surfaces without grouping. */
-  options: StatusOption[];
-  /** True once any category holds more than one status — i.e. group headings earn their space. */
-  hasCustom: boolean;
-} {
+export function useStatusOptions(wsId: string): StatusOption[] {
   const { activeStatuses } = useIssueStatuses(wsId);
   const labelOf = useStatusLabel(wsId);
 
-  return useMemo(() => {
-    const groups = ALL_STATUSES.map((category) => {
-      const entries = activeStatuses.filter((e) => e.category === category);
-      const options: StatusOption[] =
-        entries.length > 0
-          ? entries.map((e) => ({
-              key: e.key as IssueStatus,
-              label: labelOf(e.key),
-              color: e.is_system ? null : e.color,
-            }))
-          : // No catalog row for this category: the fetch is still in flight,
-            // or this workspace predates the seed. Offer the built-in, whose
-            // key IS the category, so a lifecycle step is never missing.
-            [{ key: category as IssueStatus, label: labelOf(category), color: null }];
-      return { category, options };
-    });
-
-    return {
-      groups,
-      options: groups.flatMap((g) => g.options),
-      hasCustom: groups.some((g) => g.options.length > 1),
-    };
-  }, [activeStatuses, labelOf]);
+  return useMemo(
+    () =>
+      ALL_STATUSES.flatMap((category) => {
+        const entries = activeStatuses.filter((e) => e.category === category);
+        // No catalog row for this category: the fetch is still in flight, or
+        // this workspace predates the seed. Offer the built-in, whose key IS
+        // the category, so a lifecycle step is never missing.
+        if (entries.length === 0) {
+          return [{ key: category as IssueStatus, category, label: labelOf(category), color: null }];
+        }
+        return entries.map((e) => ({
+          key: e.key as IssueStatus,
+          category,
+          label: labelOf(e.key),
+          color: e.is_system ? null : e.color,
+        }));
+      }),
+    [activeStatuses, labelOf],
+  );
 }


### PR DESCRIPTION
The status picker's category headings cost more space than they earned: once a workspace held a single custom status, the popover stacked 7 headings above 8 rows and doubled in height to say what each row's own icon and color already said.

Statuses are now one flat list in canonical category order, with a custom status sitting directly after the built-in of the category it behaves as. The category travels on the option instead of the heading, so the icon and hover color still come from it.

All three surfaces that offer a status share one `useStatusOptions`, so they went flat together: picker, filter menu, and the row context menu. That also removes the `DropdownMenuLabel` that crashed the filter menu in MUL-6393 — no heading, no `Menu.GroupLabel` outside a `Menu.Group`. `PickerGroupLabel` had no remaining caller and is gone.

## Verification

- `pnpm typecheck` passes across all 7 packages
- `status-options.test.tsx` and `issues-header.status-filter.test.tsx` pass (assertions rewritten for the flat list)
- Everything else is left to CI
