### PR TITLE
MUL-6344: Show billing summary and autopilot quota usage

### DIFF
--- a/packages/core/autopilots/index.ts
+++ b/packages/core/autopilots/index.ts
@@ -1,5 +1,6 @@
 export {
   autopilotKeys,
+  autopilotQuotaUsageOptions,
   autopilotListOptions,
   autopilotDetailOptions,
   autopilotRunsOptions,

--- a/packages/core/autopilots/queries.ts
+++ b/packages/core/autopilots/queries.ts
@@ -3,6 +3,7 @@ import { api } from "../api";
 
 export const autopilotKeys = {
   all: (wsId: string) => ["autopilots", wsId] as const,
+  usage: (wsId: string) => [...autopilotKeys.all(wsId), "usage"] as const,
   list: (wsId: string) => [...autopilotKeys.all(wsId), "list"] as const,
   detail: (wsId: string, id: string) =>
     [...autopilotKeys.all(wsId), "detail", id] as const,
@@ -17,6 +18,16 @@ export const autopilotKeys = {
   cronPreview: (wsId: string, expr: string, tz: string) =>
     [...autopilotKeys.all(wsId), "cron-preview", expr, tz] as const,
 };
+
+export function autopilotQuotaUsageOptions(wsId: string) {
+  return queryOptions({
+    queryKey: autopilotKeys.usage(wsId),
+    queryFn: () => api.getAutopilotQuotaUsage(),
+    enabled: wsId.length > 0,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
 
 export function autopilotListOptions(wsId: string) {
   return queryOptions({

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -134,9 +134,13 @@
       "title": "Subscription data may be out of date",
       "description": "The last trusted snapshot has expired. We are refreshing it; actions remain guarded by the server."
     },
+    "snapshot_unknown": {
+      "title": "Subscription data cannot be verified",
+      "description": "The snapshot expiration time is invalid. We are refreshing it; plan-dependent limits remain unavailable."
+    },
     "subscription_notice": {
       "canceling_title": "Cancellation is scheduled",
-      "canceling_description": "Pro remains available through {{date}}, then this workspace moves to Free.",
+      "canceling_description": "This subscription is scheduled to cancel on {{date}}. The plan badge above shows the access currently enforced.",
       "canceling_description_without_date": "This subscription is scheduled to cancel at the end of its current period.",
       "incomplete_title": "Subscription setup is incomplete",
       "incomplete_description": "Open billing management to finish or review the payment setup.",
@@ -195,6 +199,7 @@
       "autopilots": "Successful automations",
       "autopilots_description": "The Free allowance resets each UTC calendar month. Pro is unlimited.",
       "unlimited": "Unlimited",
+      "unavailable": "Unavailable",
       "per_month": "{{count}} / month",
       "usage_loading": "Loading automation usage",
       "usage_label": "Automation quota usage",

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -81,6 +81,11 @@
       "trialing": "Trialing",
       "past_due": "Past due",
       "canceled": "Canceled",
+      "incomplete": "Incomplete",
+      "incomplete_expired": "Setup expired",
+      "paused": "Paused",
+      "unpaid": "Unpaid",
+      "stale": "Snapshot stale",
       "unknown": "Unknown status"
     },
     "load_failed": {
@@ -89,6 +94,7 @@
     },
     "actions": {
       "retry": "Retry",
+      "retry_autopilots": "Retry automation usage",
       "upgrade": "Upgrade to Pro",
       "manage": "Manage billing",
       "refresh_seats": "Refresh seats",
@@ -121,7 +127,27 @@
     },
     "past_due": {
       "title": "Payment needs attention",
-      "description": "Open the Billing Portal to update your payment method and keep Pro access."
+      "description": "Open the Billing Portal to update your payment method and keep Pro access.",
+      "grace_description": "Update your payment method by {{date}} to keep Pro access."
+    },
+    "snapshot_stale": {
+      "title": "Subscription data may be out of date",
+      "description": "The last trusted snapshot has expired. We are refreshing it; actions remain guarded by the server."
+    },
+    "subscription_notice": {
+      "canceling_title": "Cancellation is scheduled",
+      "canceling_description": "Pro remains available through {{date}}, then this workspace moves to Free.",
+      "canceling_description_without_date": "This subscription is scheduled to cancel at the end of its current period.",
+      "incomplete_title": "Subscription setup is incomplete",
+      "incomplete_description": "Open billing management to finish or review the payment setup.",
+      "incomplete_expired_title": "Subscription setup expired",
+      "incomplete_expired_description": "The previous payment setup expired without activating Pro. Start a new upgrade when ready.",
+      "paused_title": "Subscription is paused",
+      "paused_description": "Open billing management to review the pause and available recovery options.",
+      "unpaid_title": "Subscription is unpaid",
+      "unpaid_description": "Open billing management to resolve the unpaid balance.",
+      "canceled_title": "Subscription is canceled",
+      "canceled_description": "The entitlement badge above shows the plan currently enforced for this workspace."
     },
     "read_only": {
       "title": "Read-only billing access",
@@ -135,6 +161,8 @@
       "members_description": "Agents and pending invitations are not counted as seats.",
       "member_count_one": "{{count}} member",
       "member_count_other": "{{count}} members",
+      "billing_interval": "Billing interval",
+      "billing_interval_description": "The interval stored for the active subscription.",
       "period_end": "Current period ends",
       "period_end_description": "The date reported by the current subscription snapshot."
     },
@@ -161,19 +189,41 @@
     },
     "limits": {
       "title": "Usage and limits",
-      "description": "Current limits are shown without inventing usage totals the server does not provide yet.",
+      "description": "Limits come from the current entitlement. Automation usage comes from server quota accounting.",
       "issues": "Recent tasks",
       "issues_description": "Free keeps the most recently active tasks available. Pro has no window limit.",
       "autopilots": "Successful automations",
       "autopilots_description": "The Free allowance resets each UTC calendar month. Pro is unlimited.",
       "unlimited": "Unlimited",
-      "per_month": "{{count}} / month"
+      "per_month": "{{count}} / month",
+      "usage_loading": "Loading automation usage",
+      "usage_label": "Automation quota usage",
+      "current_usage": "Current usage",
+      "reached": "Limit reached",
+      "usage_total": "{{total}} / {{limit}}",
+      "usage_breakdown": "{{used}} completed · {{reserved}} in progress",
+      "resets_at": "Resets {{date}}",
+      "usage_unavailable": "Usage is temporarily unavailable"
     },
     "seats": {
       "title": "Seats",
       "description": "Every current human member counts as a Pro seat. Agents and pending invitations do not.",
       "human_members": "Current human members",
       "human_members_description": "Refresh after membership changes to ask cloud billing to reconcile Stripe quantity.",
+      "billed": "Billed seats",
+      "billed_description": "The seat quantity currently persisted for Stripe billing.",
+      "pending": "Scheduled seat quantity",
+      "pending_description": "A lower quantity that cloud billing reports for the next period.",
+      "seat_count_one": "{{count}} seat",
+      "seat_count_other": "{{count}} seats",
+      "pending_with_date_one": "{{count}} seat from {{date}}",
+      "pending_with_date_other": "{{count}} seats from {{date}}",
+      "none_pending": "No scheduled change",
+      "not_subscribed": "No active subscription",
+      "unavailable": "Unavailable",
+      "summary_loading": "Loading subscription seat details",
+      "summary_unavailable_title": "Some seat details are unavailable",
+      "summary_unavailable_description": "The current plan is still shown, but billed and scheduled seat quantities could not be loaded.",
       "updated": "Seats refreshed",
       "reconciled": "Current members: {{actual}} · billed seats: {{billed}}"
     },

--- a/packages/views/locales/en/billing.json
+++ b/packages/views/locales/en/billing.json
@@ -85,7 +85,6 @@
       "incomplete_expired": "Setup expired",
       "paused": "Paused",
       "unpaid": "Unpaid",
-      "stale": "Snapshot stale",
       "unknown": "Unknown status"
     },
     "load_failed": {
@@ -127,16 +126,8 @@
     },
     "past_due": {
       "title": "Payment needs attention",
-      "description": "Open the Billing Portal to update your payment method and keep Pro access.",
+      "description": "Open the Billing Portal to update your payment method. The plan badge above shows the access currently available.",
       "grace_description": "Update your payment method by {{date}} to keep Pro access."
-    },
-    "snapshot_stale": {
-      "title": "Subscription data may be out of date",
-      "description": "The last trusted snapshot has expired. We are refreshing it; actions remain guarded by the server."
-    },
-    "snapshot_unknown": {
-      "title": "Subscription data cannot be verified",
-      "description": "The snapshot expiration time is invalid. We are refreshing it; plan-dependent limits remain unavailable."
     },
     "subscription_notice": {
       "canceling_title": "Cancellation is scheduled",

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -81,6 +81,11 @@
       "trialing": "トライアル中",
       "past_due": "支払い遅延",
       "canceled": "キャンセル済み",
+      "incomplete": "未完了",
+      "incomplete_expired": "設定期限切れ",
+      "paused": "一時停止中",
+      "unpaid": "未払い",
+      "stale": "スナップショット期限切れ",
       "unknown": "不明なステータス"
     },
     "load_failed": {
@@ -89,6 +94,7 @@
     },
     "actions": {
       "retry": "再試行",
+      "retry_autopilots": "自動化の使用量を再取得",
       "upgrade": "Pro にアップグレード",
       "manage": "請求を管理",
       "refresh_seats": "席数を更新",
@@ -121,7 +127,27 @@
     },
     "past_due": {
       "title": "お支払い方法の確認が必要です",
-      "description": "Pro を継続するには Billing Portal でお支払い方法を更新してください。"
+      "description": "Pro を継続するには Billing Portal でお支払い方法を更新してください。",
+      "grace_description": "Pro を継続するには {{date}} までにお支払い方法を更新してください。"
+    },
+    "snapshot_stale": {
+      "title": "サブスクリプション情報が古い可能性があります",
+      "description": "最後の信頼できるスナップショットは期限切れです。更新中も操作はサーバーで検証されます。"
+    },
+    "subscription_notice": {
+      "canceling_title": "キャンセルが予定されています",
+      "canceling_description": "{{date}} までは Pro を利用でき、その後このワークスペースは Free に移行します。",
+      "canceling_description_without_date": "このサブスクリプションは現在の期間終了時にキャンセルされる予定です。",
+      "incomplete_title": "サブスクリプション設定が未完了です",
+      "incomplete_description": "請求管理を開き、お支払い設定を完了または確認してください。",
+      "incomplete_expired_title": "サブスクリプション設定の期限が切れました",
+      "incomplete_expired_description": "以前のお支払い設定は Pro を有効化せず期限切れになりました。必要なときに再度アップグレードしてください。",
+      "paused_title": "サブスクリプションは一時停止中です",
+      "paused_description": "請求管理を開き、一時停止と再開方法を確認してください。",
+      "unpaid_title": "サブスクリプションは未払いです",
+      "unpaid_description": "請求管理を開き、未払い残高を解消してください。",
+      "canceled_title": "サブスクリプションはキャンセル済みです",
+      "canceled_description": "上のプランバッジは、このワークスペースに現在適用されているプランを示します。"
     },
     "read_only": {
       "title": "請求情報の閲覧のみ",
@@ -134,6 +160,8 @@
       "members": "ユーザー席",
       "members_description": "エージェントと保留中の招待は席数に含まれません。",
       "member_count_other": "{{count}}名",
+      "billing_interval": "請求期間",
+      "billing_interval_description": "有効なサブスクリプションに保存されている請求期間です。",
       "period_end": "現在の期間終了日",
       "period_end_description": "現在のサブスクリプション情報で報告された日付です。"
     },
@@ -159,19 +187,39 @@
     },
     "limits": {
       "title": "使用量と上限",
-      "description": "サーバーがまだ提供していない使用済み件数を 0 とせず、現在の上限のみ表示します。",
+      "description": "上限は現在の entitlement、自動化の使用量はサーバーのクォータ集計に基づきます。",
       "issues": "最近のタスク",
       "issues_description": "Free では最近アクティブなタスクを利用できます。Pro には件数制限がありません。",
       "autopilots": "成功した自動化",
       "autopilots_description": "Free の上限は UTC の暦月ごとにリセットされます。Pro は無制限です。",
       "unlimited": "無制限",
-      "per_month": "月 {{count}} 回"
+      "per_month": "月 {{count}} 回",
+      "usage_loading": "自動化の使用量を読み込み中",
+      "usage_label": "自動化クォータの使用量",
+      "current_usage": "現在の使用量",
+      "reached": "上限に達しました",
+      "usage_total": "{{total}} / {{limit}}",
+      "usage_breakdown": "完了 {{used}} · 実行中 {{reserved}}",
+      "resets_at": "{{date}} にリセット",
+      "usage_unavailable": "使用量は一時的に利用できません"
     },
     "seats": {
       "title": "席数",
       "description": "現在のユーザーメンバーはそれぞれ Pro の 1 席として数えられます。エージェントと保留中の招待は含まれません。",
       "human_members": "現在のユーザーメンバー",
       "human_members_description": "メンバー変更後に更新すると、Cloud Billing が Stripe の quantity を照合します。",
+      "billed": "請求席数",
+      "billed_description": "Stripe 請求に現在保存されている席数です。",
+      "pending": "変更予定の席数",
+      "pending_description": "Cloud Billing が次の期間に対して報告した、より少ない席数です。",
+      "seat_count_other": "{{count}}席",
+      "pending_with_date_other": "{{date}} から {{count}}席",
+      "none_pending": "予定された変更はありません",
+      "not_subscribed": "有効なサブスクリプションはありません",
+      "unavailable": "利用できません",
+      "summary_loading": "サブスクリプションの席数詳細を読み込み中",
+      "summary_unavailable_title": "一部の席数詳細を利用できません",
+      "summary_unavailable_description": "現在のプランは表示できますが、請求席数と変更予定の席数を読み込めませんでした。",
       "updated": "席数を更新しました",
       "reconciled": "現在のメンバー: {{actual}} · 請求席数: {{billed}}"
     },

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -85,7 +85,6 @@
       "incomplete_expired": "設定期限切れ",
       "paused": "一時停止中",
       "unpaid": "未払い",
-      "stale": "スナップショット期限切れ",
       "unknown": "不明なステータス"
     },
     "load_failed": {
@@ -127,16 +126,8 @@
     },
     "past_due": {
       "title": "お支払い方法の確認が必要です",
-      "description": "Pro を継続するには Billing Portal でお支払い方法を更新してください。",
+      "description": "Billing Portal でお支払い方法を更新してください。上のプランバッジには現在利用できるアクセス権が表示されます。",
       "grace_description": "Pro を継続するには {{date}} までにお支払い方法を更新してください。"
-    },
-    "snapshot_stale": {
-      "title": "サブスクリプション情報が古い可能性があります",
-      "description": "最後の信頼できるスナップショットは期限切れです。更新中も操作はサーバーで検証されます。"
-    },
-    "snapshot_unknown": {
-      "title": "サブスクリプション情報を確認できません",
-      "description": "スナップショットの有効期限が無効です。更新中のため、プランに依存する上限は利用できません。"
     },
     "subscription_notice": {
       "canceling_title": "キャンセルが予定されています",

--- a/packages/views/locales/ja/billing.json
+++ b/packages/views/locales/ja/billing.json
@@ -134,9 +134,13 @@
       "title": "サブスクリプション情報が古い可能性があります",
       "description": "最後の信頼できるスナップショットは期限切れです。更新中も操作はサーバーで検証されます。"
     },
+    "snapshot_unknown": {
+      "title": "サブスクリプション情報を確認できません",
+      "description": "スナップショットの有効期限が無効です。更新中のため、プランに依存する上限は利用できません。"
+    },
     "subscription_notice": {
       "canceling_title": "キャンセルが予定されています",
-      "canceling_description": "{{date}} までは Pro を利用でき、その後このワークスペースは Free に移行します。",
+      "canceling_description": "このサブスクリプションは {{date}} にキャンセルされる予定です。上のプランバッジには現在適用中のアクセス権が表示されます。",
       "canceling_description_without_date": "このサブスクリプションは現在の期間終了時にキャンセルされる予定です。",
       "incomplete_title": "サブスクリプション設定が未完了です",
       "incomplete_description": "請求管理を開き、お支払い設定を完了または確認してください。",
@@ -193,6 +197,7 @@
       "autopilots": "成功した自動化",
       "autopilots_description": "Free の上限は UTC の暦月ごとにリセットされます。Pro は無制限です。",
       "unlimited": "無制限",
+      "unavailable": "利用できません",
       "per_month": "月 {{count}} 回",
       "usage_loading": "自動化の使用量を読み込み中",
       "usage_label": "自動化クォータの使用量",

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -134,9 +134,13 @@
       "title": "구독 정보가 오래되었을 수 있습니다",
       "description": "마지막으로 신뢰할 수 있는 스냅샷이 만료되었습니다. 새로고침 중에도 작업은 서버에서 검증됩니다."
     },
+    "snapshot_unknown": {
+      "title": "구독 정보를 확인할 수 없습니다",
+      "description": "스냅샷 만료 시간이 올바르지 않습니다. 새로고침 중이며 플랜에 따른 한도는 사용할 수 없습니다."
+    },
     "subscription_notice": {
       "canceling_title": "구독 취소가 예정되어 있습니다",
-      "canceling_description": "{{date}}까지 Pro를 사용할 수 있으며 이후 이 워크스페이스는 Free로 전환됩니다.",
+      "canceling_description": "이 구독은 {{date}}에 취소될 예정입니다. 위의 플랜 배지는 현재 적용 중인 액세스를 표시합니다.",
       "canceling_description_without_date": "이 구독은 현재 결제 기간 종료 시 취소될 예정입니다.",
       "incomplete_title": "구독 설정이 완료되지 않았습니다",
       "incomplete_description": "결제 관리를 열어 결제 설정을 완료하거나 확인하세요.",
@@ -193,6 +197,7 @@
       "autopilots": "성공한 자동화",
       "autopilots_description": "Free 한도는 UTC 기준 매월 초기화됩니다. Pro는 무제한입니다.",
       "unlimited": "무제한",
+      "unavailable": "사용할 수 없음",
       "per_month": "월 {{count}}회",
       "usage_loading": "자동화 사용량 불러오는 중",
       "usage_label": "자동화 쿼터 사용량",

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -81,6 +81,11 @@
       "trialing": "체험 중",
       "past_due": "결제 연체",
       "canceled": "취소됨",
+      "incomplete": "미완료",
+      "incomplete_expired": "설정 만료",
+      "paused": "일시 중지됨",
+      "unpaid": "미결제",
+      "stale": "스냅샷 만료됨",
       "unknown": "알 수 없는 상태"
     },
     "load_failed": {
@@ -89,6 +94,7 @@
     },
     "actions": {
       "retry": "다시 시도",
+      "retry_autopilots": "자동화 사용량 다시 시도",
       "upgrade": "Pro로 업그레이드",
       "manage": "결제 관리",
       "refresh_seats": "좌석 새로고침",
@@ -121,7 +127,27 @@
     },
     "past_due": {
       "title": "결제 정보를 확인해야 합니다",
-      "description": "Pro 이용을 유지하려면 Billing Portal에서 결제 수단을 업데이트하세요."
+      "description": "Pro 이용을 유지하려면 Billing Portal에서 결제 수단을 업데이트하세요.",
+      "grace_description": "Pro 이용을 유지하려면 {{date}}까지 결제 수단을 업데이트하세요."
+    },
+    "snapshot_stale": {
+      "title": "구독 정보가 오래되었을 수 있습니다",
+      "description": "마지막으로 신뢰할 수 있는 스냅샷이 만료되었습니다. 새로고침 중에도 작업은 서버에서 검증됩니다."
+    },
+    "subscription_notice": {
+      "canceling_title": "구독 취소가 예정되어 있습니다",
+      "canceling_description": "{{date}}까지 Pro를 사용할 수 있으며 이후 이 워크스페이스는 Free로 전환됩니다.",
+      "canceling_description_without_date": "이 구독은 현재 결제 기간 종료 시 취소될 예정입니다.",
+      "incomplete_title": "구독 설정이 완료되지 않았습니다",
+      "incomplete_description": "결제 관리를 열어 결제 설정을 완료하거나 확인하세요.",
+      "incomplete_expired_title": "구독 설정이 만료되었습니다",
+      "incomplete_expired_description": "이전 결제 설정은 Pro를 활성화하지 못한 채 만료되었습니다. 필요할 때 다시 업그레이드하세요.",
+      "paused_title": "구독이 일시 중지되었습니다",
+      "paused_description": "결제 관리를 열어 일시 중지 상태와 복구 방법을 확인하세요.",
+      "unpaid_title": "구독이 미결제 상태입니다",
+      "unpaid_description": "결제 관리를 열어 미결제 잔액을 해결하세요.",
+      "canceled_title": "구독이 취소되었습니다",
+      "canceled_description": "위 요금제 배지는 이 워크스페이스에 현재 적용되는 요금제를 보여 줍니다."
     },
     "read_only": {
       "title": "결제 정보 읽기 전용",
@@ -134,6 +160,8 @@
       "members": "사용자 좌석",
       "members_description": "에이전트와 대기 중인 초대는 좌석에 포함되지 않습니다.",
       "member_count_other": "멤버 {{count}}명",
+      "billing_interval": "결제 주기",
+      "billing_interval_description": "활성 구독에 저장된 결제 주기입니다.",
       "period_end": "현재 결제 기간 종료일",
       "period_end_description": "현재 구독 정보에 보고된 날짜입니다."
     },
@@ -159,19 +187,39 @@
     },
     "limits": {
       "title": "사용량 및 한도",
-      "description": "서버가 아직 제공하지 않는 사용량을 0으로 표시하지 않고 현재 한도만 보여 줍니다.",
+      "description": "한도는 현재 entitlement에서, 자동화 사용량은 서버 쿼터 집계에서 가져옵니다.",
       "issues": "최근 태스크",
       "issues_description": "Free에서는 최근 활성 태스크를 이용할 수 있습니다. Pro에는 범위 제한이 없습니다.",
       "autopilots": "성공한 자동화",
       "autopilots_description": "Free 한도는 UTC 기준 매월 초기화됩니다. Pro는 무제한입니다.",
       "unlimited": "무제한",
-      "per_month": "월 {{count}}회"
+      "per_month": "월 {{count}}회",
+      "usage_loading": "자동화 사용량 불러오는 중",
+      "usage_label": "자동화 쿼터 사용량",
+      "current_usage": "현재 사용량",
+      "reached": "한도 도달",
+      "usage_total": "{{total}} / {{limit}}",
+      "usage_breakdown": "완료 {{used}} · 진행 중 {{reserved}}",
+      "resets_at": "{{date}}에 초기화",
+      "usage_unavailable": "사용량을 일시적으로 불러올 수 없습니다"
     },
     "seats": {
       "title": "좌석",
       "description": "현재 사용자 멤버 한 명당 Pro 좌석 하나로 계산됩니다. 에이전트와 대기 중인 초대는 포함되지 않습니다.",
       "human_members": "현재 사용자 멤버",
       "human_members_description": "멤버 변경 후 새로고침하면 Cloud Billing이 Stripe quantity를 조정합니다.",
+      "billed": "결제 좌석",
+      "billed_description": "Stripe 결제에 현재 저장된 좌석 수입니다.",
+      "pending": "예정 좌석 수",
+      "pending_description": "Cloud Billing이 다음 결제 기간에 대해 보고한 더 적은 좌석 수입니다.",
+      "seat_count_other": "좌석 {{count}}개",
+      "pending_with_date_other": "{{date}}부터 좌석 {{count}}개",
+      "none_pending": "예정된 변경 없음",
+      "not_subscribed": "활성 구독 없음",
+      "unavailable": "사용할 수 없음",
+      "summary_loading": "구독 좌석 상세 정보 불러오는 중",
+      "summary_unavailable_title": "일부 좌석 상세 정보를 불러올 수 없습니다",
+      "summary_unavailable_description": "현재 요금제는 계속 표시되지만 결제 좌석과 예정 좌석 수를 불러오지 못했습니다.",
       "updated": "좌석 새로고침됨",
       "reconciled": "현재 멤버: {{actual}} · 결제 좌석: {{billed}}"
     },

--- a/packages/views/locales/ko/billing.json
+++ b/packages/views/locales/ko/billing.json
@@ -85,7 +85,6 @@
       "incomplete_expired": "설정 만료",
       "paused": "일시 중지됨",
       "unpaid": "미결제",
-      "stale": "스냅샷 만료됨",
       "unknown": "알 수 없는 상태"
     },
     "load_failed": {
@@ -127,16 +126,8 @@
     },
     "past_due": {
       "title": "결제 정보를 확인해야 합니다",
-      "description": "Pro 이용을 유지하려면 Billing Portal에서 결제 수단을 업데이트하세요.",
+      "description": "Billing Portal에서 결제 수단을 업데이트하세요. 위의 요금제 배지는 현재 이용 가능한 액세스를 표시합니다.",
       "grace_description": "Pro 이용을 유지하려면 {{date}}까지 결제 수단을 업데이트하세요."
-    },
-    "snapshot_stale": {
-      "title": "구독 정보가 오래되었을 수 있습니다",
-      "description": "마지막으로 신뢰할 수 있는 스냅샷이 만료되었습니다. 새로고침 중에도 작업은 서버에서 검증됩니다."
-    },
-    "snapshot_unknown": {
-      "title": "구독 정보를 확인할 수 없습니다",
-      "description": "스냅샷 만료 시간이 올바르지 않습니다. 새로고침 중이며 플랜에 따른 한도는 사용할 수 없습니다."
     },
     "subscription_notice": {
       "canceling_title": "구독 취소가 예정되어 있습니다",

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -85,7 +85,6 @@
       "incomplete_expired": "开通已过期",
       "paused": "已暂停",
       "unpaid": "未付款",
-      "stale": "快照已过期",
       "unknown": "未知状态"
     },
     "load_failed": {
@@ -127,16 +126,8 @@
     },
     "past_due": {
       "title": "付款信息需要处理",
-      "description": "打开 Billing Portal 更新付款方式，以继续使用 Pro。",
+      "description": "打开 Billing Portal 更新付款方式。上方的套餐徽章显示当前可用权限。",
       "grace_description": "请在 {{date}} 前更新付款方式，以继续使用 Pro。"
-    },
-    "snapshot_stale": {
-      "title": "订阅数据可能已经过期",
-      "description": "上一次可信快照已经过期，系统正在刷新；所有操作仍由服务端校验。"
-    },
-    "snapshot_unknown": {
-      "title": "无法验证订阅数据",
-      "description": "快照到期时间无效。系统正在刷新；依赖套餐的限额暂不可用。"
     },
     "subscription_notice": {
       "canceling_title": "订阅已安排取消",

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -134,9 +134,13 @@
       "title": "订阅数据可能已经过期",
       "description": "上一次可信快照已经过期，系统正在刷新；所有操作仍由服务端校验。"
     },
+    "snapshot_unknown": {
+      "title": "无法验证订阅数据",
+      "description": "快照到期时间无效。系统正在刷新；依赖套餐的限额暂不可用。"
+    },
     "subscription_notice": {
       "canceling_title": "订阅已安排取消",
-      "canceling_description": "Pro 可使用至 {{date}}，之后这个工作区将转为 Free。",
+      "canceling_description": "此订阅计划于 {{date}} 取消。上方的套餐徽章显示当前实际生效的权限。",
       "canceling_description_without_date": "这个订阅将在当前周期结束时取消。",
       "incomplete_title": "订阅开通尚未完成",
       "incomplete_description": "打开账单管理，完成或检查付款设置。",
@@ -193,6 +197,7 @@
       "autopilots": "成功的自动化执行",
       "autopilots_description": "Free 限额按 UTC 自然月重置；Pro 不限次数。",
       "unlimited": "不限",
+      "unavailable": "暂不可用",
       "per_month": "每月 {{count}} 次",
       "usage_loading": "正在加载自动化用量",
       "usage_label": "自动化额度用量",

--- a/packages/views/locales/zh-Hans/billing.json
+++ b/packages/views/locales/zh-Hans/billing.json
@@ -81,6 +81,11 @@
       "trialing": "试用中",
       "past_due": "付款逾期",
       "canceled": "已取消",
+      "incomplete": "未完成",
+      "incomplete_expired": "开通已过期",
+      "paused": "已暂停",
+      "unpaid": "未付款",
+      "stale": "快照已过期",
       "unknown": "未知状态"
     },
     "load_failed": {
@@ -89,6 +94,7 @@
     },
     "actions": {
       "retry": "重试",
+      "retry_autopilots": "重试加载自动化用量",
       "upgrade": "升级到 Pro",
       "manage": "管理账单",
       "refresh_seats": "刷新席位",
@@ -121,7 +127,27 @@
     },
     "past_due": {
       "title": "付款信息需要处理",
-      "description": "打开 Billing Portal 更新付款方式，以继续使用 Pro。"
+      "description": "打开 Billing Portal 更新付款方式，以继续使用 Pro。",
+      "grace_description": "请在 {{date}} 前更新付款方式，以继续使用 Pro。"
+    },
+    "snapshot_stale": {
+      "title": "订阅数据可能已经过期",
+      "description": "上一次可信快照已经过期，系统正在刷新；所有操作仍由服务端校验。"
+    },
+    "subscription_notice": {
+      "canceling_title": "订阅已安排取消",
+      "canceling_description": "Pro 可使用至 {{date}}，之后这个工作区将转为 Free。",
+      "canceling_description_without_date": "这个订阅将在当前周期结束时取消。",
+      "incomplete_title": "订阅开通尚未完成",
+      "incomplete_description": "打开账单管理，完成或检查付款设置。",
+      "incomplete_expired_title": "订阅开通已过期",
+      "incomplete_expired_description": "上一次付款设置未能启用 Pro 且已过期，需要时请重新发起升级。",
+      "paused_title": "订阅已暂停",
+      "paused_description": "打开账单管理，查看暂停原因和可用的恢复方式。",
+      "unpaid_title": "订阅款项尚未支付",
+      "unpaid_description": "打开账单管理处理未支付款项。",
+      "canceled_title": "订阅已取消",
+      "canceled_description": "上方套餐徽标显示这个工作区当前实际生效的套餐。"
     },
     "read_only": {
       "title": "账单只读权限",
@@ -134,6 +160,8 @@
       "members": "成员席位",
       "members_description": "智能体和待接受的邀请不计入席位。",
       "member_count_other": "{{count}} 位成员",
+      "billing_interval": "付款周期",
+      "billing_interval_description": "当前订阅保存的付款周期。",
       "period_end": "当前周期结束时间",
       "period_end_description": "当前订阅快照报告的日期。"
     },
@@ -159,19 +187,39 @@
     },
     "limits": {
       "title": "用量与限额",
-      "description": "这里仅显示当前套餐限额，不会把服务端尚未提供的已用量伪装成 0。",
+      "description": "限额来自当前 entitlement，自动化用量来自服务端额度统计。",
       "issues": "最近活跃的任务",
       "issues_description": "Free 可访问最近活跃的任务；Pro 没有窗口限制。",
       "autopilots": "成功的自动化执行",
       "autopilots_description": "Free 限额按 UTC 自然月重置；Pro 不限次数。",
       "unlimited": "不限",
-      "per_month": "每月 {{count}} 次"
+      "per_month": "每月 {{count}} 次",
+      "usage_loading": "正在加载自动化用量",
+      "usage_label": "自动化额度用量",
+      "current_usage": "当前用量",
+      "reached": "已达到限额",
+      "usage_total": "{{total}} / {{limit}}",
+      "usage_breakdown": "已完成 {{used}} · 进行中 {{reserved}}",
+      "resets_at": "{{date}} 重置",
+      "usage_unavailable": "用量暂时不可用"
     },
     "seats": {
       "title": "席位",
       "description": "每位当前成员都会计为一个 Pro 席位，智能体和待接受的邀请不计。",
       "human_members": "当前成员",
       "human_members_description": "成员变化后刷新，通知 Cloud Billing 对账 Stripe quantity。",
+      "billed": "计费席位",
+      "billed_description": "Stripe 账单当前保存的席位数量。",
+      "pending": "待生效席位",
+      "pending_description": "Cloud Billing 报告的下一周期较低席位数量。",
+      "seat_count_other": "{{count}} 个席位",
+      "pending_with_date_other": "{{date}} 起 {{count}} 个席位",
+      "none_pending": "没有待生效变更",
+      "not_subscribed": "没有有效订阅",
+      "unavailable": "不可用",
+      "summary_loading": "正在加载订阅席位详情",
+      "summary_unavailable_title": "部分席位详情不可用",
+      "summary_unavailable_description": "当前套餐仍会显示，但暂时无法加载计费席位和待生效席位。",
       "updated": "席位已刷新",
       "reconciled": "当前成员：{{actual}} · 计费席位：{{billed}}"
     },

--- a/packages/views/settings/components/billing-state.test.ts
+++ b/packages/views/settings/components/billing-state.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AutopilotQuotaUsage,
+  WorkspaceSubscriptionEntitlements,
+  WorkspaceSubscriptionSummary,
+} from "@multica/core/types";
+import {
+  hasManagedWorkspaceSubscription,
+  isBillingSnapshotExpired,
+  resolveAutopilotUsage,
+} from "./billing-state";
+
+const freeEntitlements: WorkspaceSubscriptionEntitlements = {
+  workspaceId: "workspace-1",
+  plan: "free",
+  status: "inactive",
+  seats: 3,
+  issueWindow: 17,
+  autopilotRuns: 7,
+  currentPeriodEnd: null,
+  snapshotExpiresAt: null,
+  version: 1,
+};
+
+const quotaUsage: AutopilotQuotaUsage = {
+  action: "enforce",
+  used: 3,
+  reserved: 2,
+  limit: 7,
+  period_start: "2030-01-01T00:00:00Z",
+  period_end: "2030-02-01T00:00:00Z",
+  reset_at: "2030-02-01T00:00:00Z",
+  blocked_counts: {},
+};
+
+describe("resolveAutopilotUsage", () => {
+  it("counts reserved runs toward progress and the reached decision", () => {
+    expect(resolveAutopilotUsage(freeEntitlements, quotaUsage, false)).toEqual({
+      kind: "metered",
+      used: 3,
+      reserved: 2,
+      total: 5,
+      limit: 7,
+      progress: 500 / 7,
+      reached: false,
+      resetAt: "2030-02-01T00:00:00Z",
+    });
+
+    expect(
+      resolveAutopilotUsage(
+        freeEntitlements,
+        { ...quotaUsage, used: 5 },
+        false,
+      ),
+    ).toMatchObject({ total: 7, reached: true, progress: 100 });
+  });
+
+  it("shows Pro as unlimited from entitlement even when usage is unavailable", () => {
+    expect(
+      resolveAutopilotUsage(
+        { ...freeEntitlements, plan: "pro", autopilotRuns: null },
+        undefined,
+        true,
+      ),
+    ).toEqual({ kind: "unlimited" });
+  });
+
+  it("does not turn missing or disabled limited usage into zero or unlimited", () => {
+    expect(resolveAutopilotUsage(freeEntitlements, undefined, true)).toEqual({
+      kind: "unavailable",
+    });
+    expect(
+      resolveAutopilotUsage(
+        freeEntitlements,
+        {
+          ...quotaUsage,
+          action: "off",
+          used: null,
+          reserved: null,
+          limit: null,
+          reset_at: null,
+        },
+        false,
+      ),
+    ).toEqual({ kind: "unavailable" });
+  });
+});
+
+describe("billing subscription state", () => {
+  it("treats snapshot expiration as stale without rejecting invalid dates", () => {
+    expect(isBillingSnapshotExpired("2030-01-01T00:00:00Z", 1)).toBe(false);
+    expect(
+      isBillingSnapshotExpired("2030-01-01T00:00:00Z", 2_000_000_000_000),
+    ).toBe(true);
+    expect(isBillingSnapshotExpired("not-a-date", 2_000_000_000_000)).toBe(
+      false,
+    );
+  });
+
+  it("prefers subscription facts and keeps safe compatibility fallbacks", () => {
+    const summary = {
+      entitlement: freeEntitlements,
+      billingInterval: null,
+      actualSeats: 3,
+      billedSeats: null,
+      pendingSeatQuantity: null,
+      cancelAtPeriodEnd: false,
+      graceUntil: null,
+      hasStripeCustomer: true,
+    } satisfies WorkspaceSubscriptionSummary;
+
+    expect(hasManagedWorkspaceSubscription(freeEntitlements, summary)).toBe(
+      true,
+    );
+    expect(
+      hasManagedWorkspaceSubscription(
+        { ...freeEntitlements, status: "past_due" },
+        undefined,
+      ),
+    ).toBe(true);
+    expect(hasManagedWorkspaceSubscription(freeEntitlements, undefined)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/views/settings/components/billing-state.test.ts
+++ b/packages/views/settings/components/billing-state.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 import type {
   AutopilotQuotaUsage,
@@ -6,7 +8,7 @@ import type {
 } from "@multica/core/types";
 import {
   hasManagedWorkspaceSubscription,
-  isBillingSnapshotExpired,
+  resolveBillingSnapshotFreshness,
   resolveAutopilotUsage,
 } from "./billing-state";
 
@@ -35,7 +37,9 @@ const quotaUsage: AutopilotQuotaUsage = {
 
 describe("resolveAutopilotUsage", () => {
   it("counts reserved runs toward progress and the reached decision", () => {
-    expect(resolveAutopilotUsage(freeEntitlements, quotaUsage, false)).toEqual({
+    expect(
+      resolveAutopilotUsage(freeEntitlements, quotaUsage, false, "fresh"),
+    ).toEqual({
       kind: "metered",
       used: 3,
       reserved: 2,
@@ -51,6 +55,7 @@ describe("resolveAutopilotUsage", () => {
         freeEntitlements,
         { ...quotaUsage, used: 5 },
         false,
+        "fresh",
       ),
     ).toMatchObject({ total: 7, reached: true, progress: 100 });
   });
@@ -61,14 +66,15 @@ describe("resolveAutopilotUsage", () => {
         { ...freeEntitlements, plan: "pro", autopilotRuns: null },
         undefined,
         true,
+        "fresh",
       ),
     ).toEqual({ kind: "unlimited" });
   });
 
   it("does not turn missing or disabled limited usage into zero or unlimited", () => {
-    expect(resolveAutopilotUsage(freeEntitlements, undefined, true)).toEqual({
-      kind: "unavailable",
-    });
+    expect(
+      resolveAutopilotUsage(freeEntitlements, undefined, true, "fresh"),
+    ).toEqual({ kind: "unavailable" });
     expect(
       resolveAutopilotUsage(
         freeEntitlements,
@@ -81,20 +87,41 @@ describe("resolveAutopilotUsage", () => {
           reset_at: null,
         },
         false,
+        "fresh",
       ),
     ).toEqual({ kind: "unavailable" });
   });
+
+  it.each(["stale", "unknown"] as const)(
+    "does not derive unlimited or metered usage from a %s snapshot",
+    (snapshotFreshness) => {
+      expect(
+        resolveAutopilotUsage(
+          { ...freeEntitlements, plan: "pro", autopilotRuns: null },
+          quotaUsage,
+          false,
+          snapshotFreshness,
+        ),
+      ).toEqual({ kind: "unavailable" });
+    },
+  );
 });
 
 describe("billing subscription state", () => {
-  it("treats snapshot expiration as stale without rejecting invalid dates", () => {
-    expect(isBillingSnapshotExpired("2030-01-01T00:00:00Z", 1)).toBe(false);
+  it("distinguishes fresh, stale, and invalid snapshots", () => {
+    expect(resolveBillingSnapshotFreshness(null, 1)).toBe("fresh");
     expect(
-      isBillingSnapshotExpired("2030-01-01T00:00:00Z", 2_000_000_000_000),
-    ).toBe(true);
-    expect(isBillingSnapshotExpired("not-a-date", 2_000_000_000_000)).toBe(
-      false,
-    );
+      resolveBillingSnapshotFreshness("2030-01-01T00:00:00Z", 1),
+    ).toBe("fresh");
+    expect(
+      resolveBillingSnapshotFreshness(
+        "2030-01-01T00:00:00Z",
+        2_000_000_000_000,
+      ),
+    ).toBe("stale");
+    expect(
+      resolveBillingSnapshotFreshness("not-a-date", 2_000_000_000_000),
+    ).toBe("unknown");
   });
 
   it("prefers subscription facts and keeps safe compatibility fallbacks", () => {

--- a/packages/views/settings/components/billing-state.test.ts
+++ b/packages/views/settings/components/billing-state.test.ts
@@ -7,8 +7,8 @@ import type {
   WorkspaceSubscriptionSummary,
 } from "@multica/core/types";
 import {
+  canPurchaseWorkspaceSubscription,
   hasManagedWorkspaceSubscription,
-  resolveBillingSnapshotFreshness,
   resolveAutopilotUsage,
 } from "./billing-state";
 
@@ -38,7 +38,7 @@ const quotaUsage: AutopilotQuotaUsage = {
 describe("resolveAutopilotUsage", () => {
   it("counts reserved runs toward progress and the reached decision", () => {
     expect(
-      resolveAutopilotUsage(freeEntitlements, quotaUsage, false, "fresh"),
+      resolveAutopilotUsage(freeEntitlements, quotaUsage, false, false),
     ).toEqual({
       kind: "metered",
       used: 3,
@@ -55,7 +55,7 @@ describe("resolveAutopilotUsage", () => {
         freeEntitlements,
         { ...quotaUsage, used: 5 },
         false,
-        "fresh",
+        false,
       ),
     ).toMatchObject({ total: 7, reached: true, progress: 100 });
   });
@@ -66,14 +66,14 @@ describe("resolveAutopilotUsage", () => {
         { ...freeEntitlements, plan: "pro", autopilotRuns: null },
         undefined,
         true,
-        "fresh",
+        true,
       ),
     ).toEqual({ kind: "unlimited" });
   });
 
   it("does not turn missing or disabled limited usage into zero or unlimited", () => {
     expect(
-      resolveAutopilotUsage(freeEntitlements, undefined, true, "fresh"),
+      resolveAutopilotUsage(freeEntitlements, undefined, true, false),
     ).toEqual({ kind: "unavailable" });
     expect(
       resolveAutopilotUsage(
@@ -87,43 +87,35 @@ describe("resolveAutopilotUsage", () => {
           reset_at: null,
         },
         false,
-        "fresh",
+        false,
       ),
     ).toEqual({ kind: "unavailable" });
   });
 
-  it.each(["stale", "unknown"] as const)(
-    "does not derive unlimited or metered usage from a %s snapshot",
-    (snapshotFreshness) => {
-      expect(
-        resolveAutopilotUsage(
-          { ...freeEntitlements, plan: "pro", autopilotRuns: null },
-          quotaUsage,
-          false,
-          snapshotFreshness,
-        ),
-      ).toEqual({ kind: "unavailable" });
-    },
-  );
+  it("keeps authoritative metered usage independent of entitlement unlimited", () => {
+    expect(
+      resolveAutopilotUsage(
+        { ...freeEntitlements, plan: "pro", autopilotRuns: null },
+        quotaUsage,
+        false,
+        false,
+      ),
+    ).toMatchObject({ kind: "metered", total: 5, limit: 7 });
+  });
+
+  it("does not derive unlimited when the entitlement fact is not trusted", () => {
+    expect(
+      resolveAutopilotUsage(
+        { ...freeEntitlements, plan: "pro", autopilotRuns: null },
+        undefined,
+        true,
+        false,
+      ),
+    ).toEqual({ kind: "unavailable" });
+  });
 });
 
 describe("billing subscription state", () => {
-  it("distinguishes fresh, stale, and invalid snapshots", () => {
-    expect(resolveBillingSnapshotFreshness(null, 1)).toBe("fresh");
-    expect(
-      resolveBillingSnapshotFreshness("2030-01-01T00:00:00Z", 1),
-    ).toBe("fresh");
-    expect(
-      resolveBillingSnapshotFreshness(
-        "2030-01-01T00:00:00Z",
-        2_000_000_000_000,
-      ),
-    ).toBe("stale");
-    expect(
-      resolveBillingSnapshotFreshness("not-a-date", 2_000_000_000_000),
-    ).toBe("unknown");
-  });
-
   it("prefers subscription facts and keeps safe compatibility fallbacks", () => {
     const summary = {
       entitlement: freeEntitlements,
@@ -141,12 +133,42 @@ describe("billing subscription state", () => {
     );
     expect(
       hasManagedWorkspaceSubscription(
-        { ...freeEntitlements, status: "past_due" },
+        { ...freeEntitlements, status: "incomplete_expired" },
         undefined,
       ),
     ).toBe(true);
     expect(hasManagedWorkspaceSubscription(freeEntitlements, undefined)).toBe(
       false,
     );
+  });
+
+  it.each([
+    ["inactive", true],
+    ["canceled", true],
+    ["incomplete_expired", true],
+    ["active", false],
+    ["trialing", false],
+    ["past_due", false],
+    ["incomplete", false],
+    ["paused", false],
+    ["unpaid", false],
+    ["future_status", false],
+  ])("allows a Free workspace in %s to purchase: %s", (status, expected) => {
+    expect(
+      canPurchaseWorkspaceSubscription({
+        ...freeEntitlements,
+        status,
+      }),
+    ).toBe(expected);
+  });
+
+  it("never offers Checkout while Pro is currently enforced", () => {
+    expect(
+      canPurchaseWorkspaceSubscription({
+        ...freeEntitlements,
+        plan: "pro",
+        status: "active",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/views/settings/components/billing-state.ts
+++ b/packages/views/settings/components/billing-state.ts
@@ -18,6 +18,8 @@ export type AutopilotUsageView =
       resetAt: string;
     };
 
+export type BillingSnapshotFreshness = "fresh" | "stale" | "unknown";
+
 /**
  * Quota admission counts completed and reserved runs. Keep reserved work
  * visible so the progress bar matches the server's blocking decision.
@@ -26,7 +28,12 @@ export function resolveAutopilotUsage(
   entitlements: WorkspaceSubscriptionEntitlements,
   usage: AutopilotQuotaUsage | undefined,
   failed: boolean,
+  snapshotFreshness: BillingSnapshotFreshness,
 ): AutopilotUsageView {
+  if (snapshotFreshness !== "fresh") {
+    return { kind: "unavailable" };
+  }
+
   if (
     entitlements.plan === "pro" &&
     entitlements.autopilotRuns === null
@@ -71,13 +78,14 @@ export function resolveAutopilotUsage(
   };
 }
 
-export function isBillingSnapshotExpired(
+export function resolveBillingSnapshotFreshness(
   expiresAt: string | null,
   now: number = Date.now(),
-): boolean {
-  if (!expiresAt) return false;
+): BillingSnapshotFreshness {
+  if (!expiresAt) return "fresh";
   const expiresAtMs = new Date(expiresAt).getTime();
-  return Number.isFinite(expiresAtMs) && expiresAtMs <= now;
+  if (!Number.isFinite(expiresAtMs)) return "unknown";
+  return expiresAtMs <= now ? "stale" : "fresh";
 }
 
 const MANAGED_SUBSCRIPTION_STATUSES = new Set([

--- a/packages/views/settings/components/billing-state.ts
+++ b/packages/views/settings/components/billing-state.ts
@@ -18,74 +18,61 @@ export type AutopilotUsageView =
       resetAt: string;
     };
 
-export type BillingSnapshotFreshness = "fresh" | "stale" | "unknown";
-
 /**
  * Quota admission counts completed and reserved runs. Keep reserved work
- * visible so the progress bar matches the server's blocking decision.
+ * visible so the progress bar matches the server's blocking decision. A
+ * complete metered response is authoritative independently of entitlement
+ * state; only the unlimited fallback comes from the entitlement response.
  */
 export function resolveAutopilotUsage(
   entitlements: WorkspaceSubscriptionEntitlements,
   usage: AutopilotQuotaUsage | undefined,
   failed: boolean,
-  snapshotFreshness: BillingSnapshotFreshness,
+  allowEntitlementUnlimited: boolean,
 ): AutopilotUsageView {
-  if (snapshotFreshness !== "fresh") {
-    return { kind: "unavailable" };
+  if (!failed && usage !== undefined && usage.action !== "off") {
+    const { used, reserved, limit, reset_at: resetAt } = usage;
+    if (
+      used !== null &&
+      reserved !== null &&
+      limit !== null &&
+      resetAt !== null &&
+      used >= 0 &&
+      reserved >= 0 &&
+      limit >= 0 &&
+      Number.isFinite(used) &&
+      Number.isFinite(reserved) &&
+      Number.isFinite(limit)
+    ) {
+      const total = used + reserved;
+      const reached = total >= limit;
+      const progress =
+        limit === 0
+          ? 100
+          : Math.min(100, Math.max(0, (total / limit) * 100));
+
+      return {
+        kind: "metered",
+        used,
+        reserved,
+        total,
+        limit,
+        progress,
+        reached,
+        resetAt,
+      };
+    }
   }
 
   if (
+    allowEntitlementUnlimited &&
     entitlements.plan === "pro" &&
     entitlements.autopilotRuns === null
   ) {
     return { kind: "unlimited" };
   }
 
-  if (
-    failed ||
-    !usage ||
-    usage.action === "off" ||
-    usage.used === null ||
-    usage.reserved === null ||
-    usage.limit === null ||
-    usage.reset_at === null ||
-    usage.used < 0 ||
-    usage.reserved < 0 ||
-    usage.limit < 0 ||
-    !Number.isFinite(usage.used) ||
-    !Number.isFinite(usage.reserved) ||
-    !Number.isFinite(usage.limit)
-  ) {
-    return { kind: "unavailable" };
-  }
-
-  const total = usage.used + usage.reserved;
-  const reached = total >= usage.limit;
-  const progress =
-    usage.limit === 0
-      ? 100
-      : Math.min(100, Math.max(0, (total / usage.limit) * 100));
-
-  return {
-    kind: "metered",
-    used: usage.used,
-    reserved: usage.reserved,
-    total,
-    limit: usage.limit,
-    progress,
-    reached,
-    resetAt: usage.reset_at,
-  };
-}
-
-export function resolveBillingSnapshotFreshness(
-  expiresAt: string | null,
-  now: number = Date.now(),
-): BillingSnapshotFreshness {
-  if (!expiresAt) return "fresh";
-  const expiresAtMs = new Date(expiresAt).getTime();
-  if (!Number.isFinite(expiresAtMs)) return "unknown";
-  return expiresAtMs <= now ? "stale" : "fresh";
+  return { kind: "unavailable" };
 }
 
 const MANAGED_SUBSCRIPTION_STATUSES = new Set([
@@ -94,8 +81,15 @@ const MANAGED_SUBSCRIPTION_STATUSES = new Set([
   "past_due",
   "canceled",
   "incomplete",
+  "incomplete_expired",
   "paused",
   "unpaid",
+]);
+
+const PURCHASABLE_SUBSCRIPTION_STATUSES = new Set([
+  "inactive",
+  "canceled",
+  "incomplete_expired",
 ]);
 
 /**
@@ -111,5 +105,19 @@ export function hasManagedWorkspaceSubscription(
     summary?.billedSeats !== null && summary?.billedSeats !== undefined ||
     entitlements.plan === "pro" ||
     MANAGED_SUBSCRIPTION_STATUSES.has(entitlements.status)
+  );
+}
+
+/**
+ * Checkout creates a new subscription. Cloud accepts an existing record only
+ * after cancellation or incomplete setup expiry; every other known status may
+ * still represent a live or recoverable subscription and stays in Portal.
+ */
+export function canPurchaseWorkspaceSubscription(
+  entitlements: WorkspaceSubscriptionEntitlements,
+): boolean {
+  return (
+    entitlements.plan === "free" &&
+    PURCHASABLE_SUBSCRIPTION_STATUSES.has(entitlements.status)
   );
 }

--- a/packages/views/settings/components/billing-state.ts
+++ b/packages/views/settings/components/billing-state.ts
@@ -1,0 +1,107 @@
+import type {
+  AutopilotQuotaUsage,
+  WorkspaceSubscriptionEntitlements,
+  WorkspaceSubscriptionSummary,
+} from "@multica/core/types";
+
+export type AutopilotUsageView =
+  | { kind: "unlimited" }
+  | { kind: "unavailable" }
+  | {
+      kind: "metered";
+      used: number;
+      reserved: number;
+      total: number;
+      limit: number;
+      progress: number;
+      reached: boolean;
+      resetAt: string;
+    };
+
+/**
+ * Quota admission counts completed and reserved runs. Keep reserved work
+ * visible so the progress bar matches the server's blocking decision.
+ */
+export function resolveAutopilotUsage(
+  entitlements: WorkspaceSubscriptionEntitlements,
+  usage: AutopilotQuotaUsage | undefined,
+  failed: boolean,
+): AutopilotUsageView {
+  if (
+    entitlements.plan === "pro" &&
+    entitlements.autopilotRuns === null
+  ) {
+    return { kind: "unlimited" };
+  }
+
+  if (
+    failed ||
+    !usage ||
+    usage.action === "off" ||
+    usage.used === null ||
+    usage.reserved === null ||
+    usage.limit === null ||
+    usage.reset_at === null ||
+    usage.used < 0 ||
+    usage.reserved < 0 ||
+    usage.limit < 0 ||
+    !Number.isFinite(usage.used) ||
+    !Number.isFinite(usage.reserved) ||
+    !Number.isFinite(usage.limit)
+  ) {
+    return { kind: "unavailable" };
+  }
+
+  const total = usage.used + usage.reserved;
+  const reached = total >= usage.limit;
+  const progress =
+    usage.limit === 0
+      ? 100
+      : Math.min(100, Math.max(0, (total / usage.limit) * 100));
+
+  return {
+    kind: "metered",
+    used: usage.used,
+    reserved: usage.reserved,
+    total,
+    limit: usage.limit,
+    progress,
+    reached,
+    resetAt: usage.reset_at,
+  };
+}
+
+export function isBillingSnapshotExpired(
+  expiresAt: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (!expiresAt) return false;
+  const expiresAtMs = new Date(expiresAt).getTime();
+  return Number.isFinite(expiresAtMs) && expiresAtMs <= now;
+}
+
+const MANAGED_SUBSCRIPTION_STATUSES = new Set([
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+  "incomplete",
+  "paused",
+  "unpaid",
+]);
+
+/**
+ * Summary facts are primary. Plan and status are compatibility fallbacks so
+ * an older or temporarily unavailable summary does not hide the recovery UI.
+ */
+export function hasManagedWorkspaceSubscription(
+  entitlements: WorkspaceSubscriptionEntitlements,
+  summary: WorkspaceSubscriptionSummary | null | undefined,
+): boolean {
+  return (
+    summary?.hasStripeCustomer === true ||
+    summary?.billedSeats !== null && summary?.billedSeats !== undefined ||
+    entitlements.plan === "pro" ||
+    MANAGED_SUBSCRIPTION_STATUSES.has(entitlements.status)
+  );
+}

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -556,6 +556,33 @@ describe("BillingTab", () => {
     }
   });
 
+  it("keeps Checkout syncing when a stale Pro snapshot cannot confirm activation", () => {
+    vi.useFakeTimers();
+    navigationState.search = "tab=billing&result=success&session_id=cs_test_1";
+    Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "active",
+      issueWindow: null,
+      autopilotRuns: null,
+      snapshotExpiresAt: "2000-01-01T00:00:00Z",
+    });
+    try {
+      renderWithI18n(<BillingTab />);
+
+      expect(
+        screen.getByText("Activating your subscription"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Pro is active")).not.toBeInTheDocument();
+      expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
+      expect(screen.getByText("Snapshot stale")).toBeInTheDocument();
+      expect(mocks.useQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ refetchInterval: 2_000 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps plan facts visible but hides subscription mutations from members", () => {
     mocks.role = "member";
 
@@ -670,6 +697,37 @@ describe("BillingTab", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Snapshot stale")).toBeInTheDocument();
     expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
+    expect(screen.queryByText("17")).not.toBeInTheDocument();
+    expect(screen.queryByText("5 / 7")).not.toBeInTheDocument();
+    expect(screen.queryByText("7 / month")).not.toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("Usage is temporarily unavailable"),
+    ).toBeInTheDocument();
+  });
+
+  it("treats an invalid snapshot expiration as unknown and hides Pro limits", () => {
+    Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "active",
+      issueWindow: null,
+      autopilotRuns: null,
+      snapshotExpiresAt: "not-a-date",
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(
+      screen.getByText("Subscription data cannot be verified"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unknown status")).toBeInTheDocument();
+    expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("Usage is temporarily unavailable"),
+    ).toBeInTheDocument();
+    expect(mocks.refetch).toHaveBeenCalledOnce();
+    expect(mocks.refetchSummary).toHaveBeenCalledOnce();
   });
 
   it("shows grace and scheduled-cancellation dates from subscription facts", () => {
@@ -690,7 +748,37 @@ describe("BillingTab", () => {
       screen.getByText(/Update your payment method by Feb 15, 2030/),
     ).toBeInTheDocument();
     expect(screen.getByText("Cancellation is scheduled")).toBeInTheDocument();
-    expect(screen.getByText(/Pro remains available through Mar 1, 2030/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/subscription is scheduled to cancel on Mar 1, 2030/),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps cancellation and pending-seat dates on one summary snapshot", () => {
+    Object.assign(mocks.entitlements, {
+      plan: "free",
+      currentPeriodEnd: "2030-03-01T00:00:00Z",
+    });
+    Object.assign(mocks.summary, {
+      entitlement: {
+        ...mocks.entitlements,
+        currentPeriodEnd: "2030-04-01T00:00:00Z",
+      },
+      pendingSeatQuantity: 4,
+      cancelAtPeriodEnd: true,
+      hasStripeCustomer: true,
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(
+      screen.getByText(/subscription is scheduled to cancel on Apr 1, 2030/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/4 seats from Apr 1, 2030/)).toBeInTheDocument();
+    expect(screen.getByText("Mar 1, 2030")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/subscription is scheduled to cancel on Mar 1, 2030/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Pro remains available/)).not.toBeInTheDocument();
   });
 
   it("shows Pro management and unlimited limits without a second Checkout", () => {

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -42,6 +42,8 @@ const mocks = vi.hoisted(() => ({
   usagePending: false,
   usageFetching: false,
   usageError: false,
+  entitlementsDataUpdatedAt: 0,
+  entitlementsFetchedAfterMount: false,
   entitlements: {
     workspaceId: "workspace-1",
     plan: "free",
@@ -170,6 +172,8 @@ describe("BillingTab", () => {
     mocks.usagePending = false;
     mocks.usageFetching = false;
     mocks.usageError = false;
+    mocks.entitlementsDataUpdatedAt = 0;
+    mocks.entitlementsFetchedAfterMount = false;
     Object.assign(mocks.entitlements, {
       plan: "free",
       status: "inactive",
@@ -235,6 +239,8 @@ describe("BillingTab", () => {
       }
       return {
         data: mocks.entitlements,
+        dataUpdatedAt: mocks.entitlementsDataUpdatedAt,
+        isFetchedAfterMount: mocks.entitlementsFetchedAfterMount,
         isPending: false,
         isError: false,
         refetch: mocks.refetch,
@@ -556,16 +562,18 @@ describe("BillingTab", () => {
     }
   });
 
-  it("keeps Checkout syncing when a stale Pro snapshot cannot confirm activation", () => {
+  it("keeps Checkout syncing until Pro is fetched after the return callback", () => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
     navigationState.search = "tab=billing&result=success&session_id=cs_test_1";
     Object.assign(mocks.entitlements, {
       plan: "pro",
       status: "active",
       issueWindow: null,
       autopilotRuns: null,
-      snapshotExpiresAt: "2000-01-01T00:00:00Z",
     });
+    mocks.entitlementsDataUpdatedAt = Date.now() - 1;
+    mocks.entitlementsFetchedAfterMount = true;
     try {
       renderWithI18n(<BillingTab />);
 
@@ -574,10 +582,40 @@ describe("BillingTab", () => {
       ).toBeInTheDocument();
       expect(screen.queryByText("Pro is active")).not.toBeInTheDocument();
       expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
-      expect(screen.getByText("Snapshot stale")).toBeInTheDocument();
+      expect(screen.getByText("Unavailable")).toBeInTheDocument();
+      expect(screen.getByText("5 / 7")).toBeInTheDocument();
       expect(mocks.useQuery).toHaveBeenCalledWith(
         expect.objectContaining({ refetchInterval: 2_000 }),
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("confirms Pro after an entitlement fetch newer than the return callback", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
+    navigationState.search = "tab=billing&result=success&session_id=cs_test_1";
+    Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "active",
+      issueWindow: null,
+      autopilotRuns: null,
+    });
+    Object.assign(mocks.usage, {
+      action: "off",
+      used: null,
+      reserved: null,
+      limit: null,
+      reset_at: null,
+    });
+    mocks.entitlementsDataUpdatedAt = Date.now() + 1;
+    mocks.entitlementsFetchedAfterMount = true;
+    try {
+      renderWithI18n(<BillingTab />);
+
+      expect(screen.getByText("Pro is active")).toBeInTheDocument();
+      expect(screen.getAllByText("Unlimited")).toHaveLength(2);
     } finally {
       vi.useRealTimers();
     }
@@ -601,7 +639,18 @@ describe("BillingTab", () => {
 
   it("renders authoritative subscription seat facts", () => {
     Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "active",
+      issueWindow: null,
+      autopilotRuns: null,
       currentPeriodEnd: "2030-02-01T00:00:00Z",
+    });
+    Object.assign(mocks.usage, {
+      action: "off",
+      used: null,
+      reserved: null,
+      limit: null,
+      reset_at: null,
     });
     Object.assign(mocks.summary, {
       billingInterval: "month",
@@ -687,54 +736,12 @@ describe("BillingTab", () => {
     expect(screen.getByText(title)).toBeInTheDocument();
   });
 
-  it("warns when the trusted entitlement snapshot has expired", () => {
-    mocks.entitlements.snapshotExpiresAt = "2000-01-01T00:00:00Z";
-
-    renderWithI18n(<BillingTab />);
-
-    expect(
-      screen.getByText("Subscription data may be out of date"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Snapshot stale")).toBeInTheDocument();
-    expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
-    expect(screen.queryByText("17")).not.toBeInTheDocument();
-    expect(screen.queryByText("5 / 7")).not.toBeInTheDocument();
-    expect(screen.queryByText("7 / month")).not.toBeInTheDocument();
-    expect(screen.getByText("Unavailable")).toBeInTheDocument();
-    expect(
-      screen.getByText("Usage is temporarily unavailable"),
-    ).toBeInTheDocument();
-  });
-
-  it("treats an invalid snapshot expiration as unknown and hides Pro limits", () => {
-    Object.assign(mocks.entitlements, {
-      plan: "pro",
-      status: "active",
-      issueWindow: null,
-      autopilotRuns: null,
-      snapshotExpiresAt: "not-a-date",
-    });
-
-    renderWithI18n(<BillingTab />);
-
-    expect(
-      screen.getByText("Subscription data cannot be verified"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Unknown status")).toBeInTheDocument();
-    expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
-    expect(screen.getByText("Unavailable")).toBeInTheDocument();
-    expect(
-      screen.getByText("Usage is temporarily unavailable"),
-    ).toBeInTheDocument();
-    expect(mocks.refetch).toHaveBeenCalledOnce();
-    expect(mocks.refetchSummary).toHaveBeenCalledOnce();
-  });
-
   it("shows grace and scheduled-cancellation dates from subscription facts", () => {
     Object.assign(mocks.entitlements, {
       plan: "pro",
       status: "past_due",
       currentPeriodEnd: "2030-03-01T00:00:00Z",
+      snapshotExpiresAt: "2030-02-15T00:00:00Z",
     });
     Object.assign(mocks.summary, {
       graceUntil: "2030-02-15T00:00:00Z",
@@ -751,6 +758,34 @@ describe("BillingTab", () => {
     expect(
       screen.getByText(/subscription is scheduled to cancel on Mar 1, 2030/),
     ).toBeInTheDocument();
+  });
+
+  it("stops deriving Pro access after the summary grace deadline", () => {
+    Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "past_due",
+      issueWindow: null,
+      autopilotRuns: null,
+    });
+    mocks.summary.graceUntil = "2000-01-01T00:00:00Z";
+    Object.assign(mocks.usage, {
+      action: "off",
+      used: null,
+      reserved: null,
+      limit: null,
+      reset_at: null,
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Open the Billing Portal to update your payment method. The plan badge above shows the access currently available.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/keep Pro access/)).not.toBeInTheDocument();
   });
 
   it("keeps cancellation and pending-seat dates on one summary snapshot", () => {
@@ -774,7 +809,8 @@ describe("BillingTab", () => {
       screen.getByText(/subscription is scheduled to cancel on Apr 1, 2030/),
     ).toBeInTheDocument();
     expect(screen.getByText(/4 seats from Apr 1, 2030/)).toBeInTheDocument();
-    expect(screen.getByText("Mar 1, 2030")).toBeInTheDocument();
+    expect(screen.getByText("Apr 1, 2030")).toBeInTheDocument();
+    expect(screen.queryByText("Mar 1, 2030")).not.toBeInTheDocument();
     expect(
       screen.queryByText(/subscription is scheduled to cancel on Mar 1, 2030/),
     ).not.toBeInTheDocument();
@@ -789,6 +825,13 @@ describe("BillingTab", () => {
       autopilotRuns: null,
       currentPeriodEnd: "2026-09-13T00:00:00Z",
       version: 3,
+    });
+    Object.assign(mocks.usage, {
+      action: "off",
+      used: null,
+      reserved: null,
+      limit: null,
+      reset_at: null,
     });
 
     renderWithI18n(<BillingTab />);
@@ -808,33 +851,55 @@ describe("BillingTab", () => {
     );
   });
 
-  it("keeps the billing portal available for a canceled Pro period", () => {
-    Object.assign(mocks.entitlements, {
-      plan: "pro",
-      status: "canceled",
-      currentPeriodEnd: "2026-09-13T00:00:00Z",
-      version: 4,
-    });
+  it.each(["canceled", "incomplete_expired"])(
+    "keeps management and self-service repurchase available for %s Free",
+    (status) => {
+      Object.assign(mocks.entitlements, {
+        plan: "free",
+        status,
+        currentPeriodEnd: "2026-09-13T00:00:00Z",
+        version: 4,
+      });
+      Object.assign(mocks.summary, {
+        billedSeats: 3,
+        hasStripeCustomer: true,
+      });
 
-    renderWithI18n(<BillingTab />);
+      renderWithI18n(<BillingTab />);
 
-    expect(
-      screen.getByRole("button", { name: "Manage billing" }),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole("button", { name: "Manage billing" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Upgrade to Pro" }),
+      ).toBeInTheDocument();
+      expect(mocks.useQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["workspace-subscriptions", "workspace-1", "prices"],
+          enabled: true,
+        }),
+      );
+    },
+  );
 
   it("keeps payment recovery available when past-due grace has resolved to Free", () => {
     Object.assign(mocks.entitlements, {
       plan: "free",
       status: "past_due",
-      snapshotExpiresAt: "2026-09-01T00:00:00Z",
+      snapshotExpiresAt: null,
       version: 4,
     });
+    mocks.summary.graceUntil = "2000-01-01T00:00:00Z";
 
     renderWithI18n(<BillingTab />);
 
     expect(screen.getByText("Payment needs attention")).toBeInTheDocument();
-    expect(screen.queryByText("Sep 1, 2026")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Open the Billing Portal to update your payment method. The plan badge above shows the access currently available.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/keep Pro access/)).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Manage billing" }),
     ).toBeInTheDocument();

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   portal: vi.fn(),
   reconcile: vi.fn(),
   refetch: vi.fn(),
+  refetchSummary: vi.fn(),
+  refetchUsage: vi.fn(),
   refetchPrices: vi.fn(),
   openExternal: vi.fn(),
   role: "owner" as "owner" | "admin" | "member",
@@ -33,16 +35,43 @@ const mocks = vi.hoisted(() => ({
   pricesLoading: false,
   pricesFetching: false,
   pricesError: false,
+  summaryPending: false,
+  summaryFetching: false,
+  summaryError: false,
+  summaryMalformed: false,
+  usagePending: false,
+  usageFetching: false,
+  usageError: false,
   entitlements: {
     workspaceId: "workspace-1",
     plan: "free",
     status: "inactive",
     seats: 3,
-    issueWindow: 1000,
-    autopilotRuns: 100,
+    issueWindow: 17,
+    autopilotRuns: 7,
     currentPeriodEnd: null as string | null,
     snapshotExpiresAt: null as string | null,
     version: 0,
+  },
+  summary: {
+    entitlement: null as never,
+    billingInterval: null as "month" | "year" | null,
+    actualSeats: 3,
+    billedSeats: null as number | null,
+    pendingSeatQuantity: null as number | null,
+    cancelAtPeriodEnd: false,
+    graceUntil: null as string | null,
+    hasStripeCustomer: false,
+  },
+  usage: {
+    action: "enforce" as "off" | "observe" | "enforce",
+    used: 3 as number | null,
+    reserved: 2 as number | null,
+    limit: 7 as number | null,
+    period_start: "2030-01-01T00:00:00Z" as string | null,
+    period_end: "2030-02-01T00:00:00Z" as string | null,
+    reset_at: "2030-02-01T00:00:00Z" as string | null,
+    blocked_counts: {} as Record<string, number> | null,
   },
 }));
 
@@ -57,6 +86,9 @@ vi.mock("@multica/core/billing", () => ({
   workspaceSubscriptionPricesOptions: (wsId: string) => ({
     queryKey: ["workspace-subscriptions", wsId, "prices"],
   }),
+  workspaceSubscriptionSummaryOptions: (wsId: string) => ({
+    queryKey: ["workspace-subscriptions", wsId, "summary"],
+  }),
   useCreateWorkspaceSubscriptionCheckout: () => ({
     mutateAsync: mocks.checkout,
     isPending: false,
@@ -68,6 +100,12 @@ vi.mock("@multica/core/billing", () => ({
   useReconcileWorkspaceSubscriptionSeats: () => ({
     mutateAsync: mocks.reconcile,
     isPending: false,
+  }),
+}));
+
+vi.mock("@multica/core/autopilots", () => ({
+  autopilotQuotaUsageOptions: (wsId: string) => ({
+    queryKey: ["autopilots", wsId, "usage"],
   }),
 }));
 
@@ -125,15 +163,42 @@ describe("BillingTab", () => {
     mocks.pricesLoading = false;
     mocks.pricesFetching = false;
     mocks.pricesError = false;
+    mocks.summaryPending = false;
+    mocks.summaryFetching = false;
+    mocks.summaryError = false;
+    mocks.summaryMalformed = false;
+    mocks.usagePending = false;
+    mocks.usageFetching = false;
+    mocks.usageError = false;
     Object.assign(mocks.entitlements, {
       plan: "free",
       status: "inactive",
       seats: 3,
-      issueWindow: 1000,
-      autopilotRuns: 100,
+      issueWindow: 17,
+      autopilotRuns: 7,
       currentPeriodEnd: null,
       snapshotExpiresAt: null,
       version: 0,
+    });
+    Object.assign(mocks.summary, {
+      entitlement: mocks.entitlements,
+      billingInterval: null,
+      actualSeats: 3,
+      billedSeats: null,
+      pendingSeatQuantity: null,
+      cancelAtPeriodEnd: false,
+      graceUntil: null,
+      hasStripeCustomer: false,
+    });
+    Object.assign(mocks.usage, {
+      action: "enforce",
+      used: 3,
+      reserved: 2,
+      limit: 7,
+      period_start: "2030-01-01T00:00:00Z",
+      period_end: "2030-02-01T00:00:00Z",
+      reset_at: "2030-02-01T00:00:00Z",
+      blocked_counts: {},
     });
     mocks.useQuery.mockImplementation((options: unknown) => {
       const queryKey = (options as { queryKey?: readonly unknown[] }).queryKey;
@@ -144,6 +209,28 @@ describe("BillingTab", () => {
           isFetching: mocks.pricesFetching,
           isError: mocks.pricesError,
           refetch: mocks.refetchPrices,
+        };
+      }
+      if (queryKey?.[queryKey.length - 1] === "summary") {
+        return {
+          data: mocks.summaryError
+            ? undefined
+            : mocks.summaryMalformed
+              ? null
+              : mocks.summary,
+          isPending: mocks.summaryPending,
+          isFetching: mocks.summaryFetching,
+          isError: mocks.summaryError,
+          refetch: mocks.refetchSummary,
+        };
+      }
+      if (queryKey?.[queryKey.length - 1] === "usage") {
+        return {
+          data: mocks.usageError ? undefined : mocks.usage,
+          isPending: mocks.usagePending,
+          isFetching: mocks.usageFetching,
+          isError: mocks.usageError,
+          refetch: mocks.refetchUsage,
         };
       }
       return {
@@ -186,8 +273,9 @@ describe("BillingTab", () => {
     renderWithI18n(<BillingTab />);
 
     expect(screen.getByRole("heading", { name: "Billing" })).toBeInTheDocument();
-    expect(screen.getByText("1,000")).toBeInTheDocument();
-    expect(screen.getByText("100 / month")).toBeInTheDocument();
+    expect(screen.getByText("17")).toBeInTheDocument();
+    expect(screen.getByText("5 / 7")).toBeInTheDocument();
+    expect(screen.getByText("3 completed · 2 in progress")).toBeInTheDocument();
     expect(screen.getByText("$10.00 per human seat")).toBeInTheDocument();
     expect(
       screen.getByText("Estimated monthly total: $30.00"),
@@ -297,10 +385,21 @@ describe("BillingTab", () => {
         queryKey: ["workspace-subscriptions", "workspace-2", "prices"],
       }),
     );
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["workspace-subscriptions", "workspace-2", "summary"],
+      }),
+    );
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["autopilots", "workspace-2", "usage"],
+      }),
+    );
   });
 
   it("shows the unit price without a zero estimated total when seats are unavailable", () => {
     mocks.entitlements.seats = 0;
+    mocks.summary.actualSeats = 0;
 
     renderWithI18n(<BillingTab />);
 
@@ -471,6 +570,127 @@ describe("BillingTab", () => {
     expect(
       screen.queryByRole("button", { name: "Refresh seats" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders authoritative subscription seat facts", () => {
+    Object.assign(mocks.entitlements, {
+      currentPeriodEnd: "2030-02-01T00:00:00Z",
+    });
+    Object.assign(mocks.summary, {
+      billingInterval: "month",
+      actualSeats: 4,
+      billedSeats: 5,
+      pendingSeatQuantity: 4,
+      hasStripeCustomer: true,
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(screen.getByText("Monthly")).toBeInTheDocument();
+    expect(screen.getByText("5 seats")).toBeInTheDocument();
+    expect(screen.getByText(/4 seats from Feb 1, 2030/)).toBeInTheDocument();
+    expect(screen.getAllByText("4 members")).toHaveLength(2);
+  });
+
+  it("uses completed and reserved runs for the quota decision", () => {
+    Object.assign(mocks.usage, { used: 5, reserved: 2, limit: 7 });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(screen.getByText("Limit reached")).toBeInTheDocument();
+    expect(screen.getByText("7 / 7")).toBeInTheDocument();
+    expect(screen.getByText("5 completed · 2 in progress")).toBeInTheDocument();
+  });
+
+  it("does not render missing limited usage as zero or unlimited", async () => {
+    const user = userEvent.setup();
+    Object.assign(mocks.usage, {
+      action: "off",
+      used: null,
+      reserved: null,
+      limit: null,
+      reset_at: null,
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(
+      screen.getByText("Usage is temporarily unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("7 / month")).toBeInTheDocument();
+    expect(screen.queryByText("Unlimited")).not.toBeInTheDocument();
+    expect(screen.queryByText(/0 \/ 7/)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Retry automation usage" }),
+    );
+    expect(mocks.refetchUsage).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["request fails", true, false],
+    ["response is malformed", false, true],
+  ])(
+    "keeps plan facts visible when the subscription summary %s",
+    (_case, isError, isMalformed) => {
+      mocks.summaryError = isError;
+      mocks.summaryMalformed = isMalformed;
+
+      renderWithI18n(<BillingTab />);
+
+      expect(screen.getByText("Free")).toBeInTheDocument();
+      expect(
+        screen.getByText("Some seat details are unavailable"),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Unavailable")).toHaveLength(2);
+    },
+  );
+
+  it.each([
+    ["incomplete", "Subscription setup is incomplete"],
+    ["incomplete_expired", "Subscription setup expired"],
+    ["paused", "Subscription is paused"],
+    ["unpaid", "Subscription is unpaid"],
+    ["canceled", "Subscription is canceled"],
+  ])("renders a recovery notice for %s", (status, title) => {
+    mocks.entitlements.status = status;
+
+    renderWithI18n(<BillingTab />);
+
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+
+  it("warns when the trusted entitlement snapshot has expired", () => {
+    mocks.entitlements.snapshotExpiresAt = "2000-01-01T00:00:00Z";
+
+    renderWithI18n(<BillingTab />);
+
+    expect(
+      screen.getByText("Subscription data may be out of date"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Snapshot stale")).toBeInTheDocument();
+    expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
+  });
+
+  it("shows grace and scheduled-cancellation dates from subscription facts", () => {
+    Object.assign(mocks.entitlements, {
+      plan: "pro",
+      status: "past_due",
+      currentPeriodEnd: "2030-03-01T00:00:00Z",
+    });
+    Object.assign(mocks.summary, {
+      graceUntil: "2030-02-15T00:00:00Z",
+      cancelAtPeriodEnd: true,
+      hasStripeCustomer: true,
+    });
+
+    renderWithI18n(<BillingTab />);
+
+    expect(
+      screen.getByText(/Update your payment method by Feb 15, 2030/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cancellation is scheduled")).toBeInTheDocument();
+    expect(screen.getByText(/Pro remains available through Mar 1, 2030/)).toBeInTheDocument();
   });
 
   it("shows Pro management and unlimited limits without a second Checkout", () => {

--- a/packages/views/settings/components/billing-tab.tsx
+++ b/packages/views/settings/components/billing-tab.tsx
@@ -59,8 +59,8 @@ import {
   SettingsTab,
 } from "./settings-layout";
 import {
+  canPurchaseWorkspaceSubscription,
   hasManagedWorkspaceSubscription,
-  resolveBillingSnapshotFreshness,
   resolveAutopilotUsage,
 } from "./billing-state";
 
@@ -235,11 +235,18 @@ function BillingTabContent() {
   const [returnState, setReturnState] = useState<{
     workspaceId: string | null;
     result: WorkspaceBillingReturnResult | null;
-  }>({ workspaceId: wsId || null, result: returnResultParam });
-  const returnResult =
-    returnState.workspaceId === null || returnState.workspaceId === wsId
-      ? returnState.result
-      : null;
+    observedAt: number | null;
+  }>(() => ({
+    workspaceId: wsId || null,
+    result: returnResultParam,
+    observedAt: returnResultParam === "success" ? Date.now() : null,
+  }));
+  const returnStateMatchesWorkspace =
+    returnState.workspaceId === null || returnState.workspaceId === wsId;
+  const returnResult = returnStateMatchesWorkspace ? returnState.result : null;
+  const returnObservedAt = returnStateMatchesWorkspace
+    ? returnState.observedAt
+    : null;
   const [interval, setInterval] =
     useState<WorkspaceSubscriptionInterval>("month");
   const [checkoutConfirmOpen, setCheckoutConfirmOpen] = useState(false);
@@ -272,7 +279,11 @@ function BillingTabContent() {
   useEffect(() => {
     if (!callbackKey || consumedCallbackKeyRef.current === callbackKey) return;
     consumedCallbackKeyRef.current = callbackKey;
-    setReturnState({ workspaceId: wsId || null, result: returnResultParam });
+    setReturnState({
+      workspaceId: wsId || null,
+      result: returnResultParam,
+      observedAt: returnResultParam === "success" ? Date.now() : null,
+    });
     if (returnResultParam === "cancel") checkoutIntentRef.current = null;
 
     const params = new URLSearchParams(navigation.searchParams);
@@ -304,11 +315,12 @@ function BillingTabContent() {
     refetchInterval: isSyncingCheckout ? 2_000 : false,
   });
   const entitlements = entitlementQuery.data;
-  const snapshotFreshness = entitlements
-    ? resolveBillingSnapshotFreshness(entitlements.snapshotExpiresAt)
-    : "unknown";
-  const isFreshPro =
-    entitlements?.plan === "pro" && snapshotFreshness === "fresh";
+  const isCheckoutProConfirmed =
+    returnResult === "success" &&
+    returnObservedAt !== null &&
+    entitlements?.plan === "pro" &&
+    entitlementQuery.isFetchedAfterMount &&
+    entitlementQuery.dataUpdatedAt >= returnObservedAt;
   const summaryQuery = useQuery({
     ...workspaceSubscriptionSummaryOptions(wsId),
     refetchInterval: isSyncingCheckout ? 2_000 : false,
@@ -320,8 +332,9 @@ function BillingTabContent() {
   const hasManagedSubscription = entitlements
     ? hasManagedWorkspaceSubscription(entitlements, summaryQuery.data)
     : false;
-  const canUpgrade =
-    entitlements?.plan === "free" && !hasManagedSubscription;
+  const canUpgrade = entitlements
+    ? canPurchaseWorkspaceSubscription(entitlements)
+    : false;
   const pricesQuery = useQuery({
     ...workspaceSubscriptionPricesOptions(wsId),
     enabled: wsId.length > 0 && canUpgrade,
@@ -333,29 +346,25 @@ function BillingTabContent() {
   const refetchSummary = summaryQuery.refetch;
 
   useEffect(() => {
-    if (isSyncingCheckout && isFreshPro) {
+    if (isSyncingCheckout && isCheckoutProConfirmed) {
       setIsSyncingCheckout(false);
       setSyncTimedOut(false);
       checkoutIntentRef.current = null;
     }
-  }, [isFreshPro, isSyncingCheckout]);
+  }, [isCheckoutProConfirmed, isSyncingCheckout]);
 
   useEffect(() => {
-    const expiresAt = entitlements?.snapshotExpiresAt;
-    if (!expiresAt) return;
-    const expiresAtMs = new Date(expiresAt).getTime();
-    if (Number.isNaN(expiresAtMs)) {
-      void refetchEntitlements();
-      void refetchSummary();
-      return;
-    }
-    const delay = Math.max(0, expiresAtMs - Date.now()) + 100;
+    const graceUntil = summaryQuery.data?.graceUntil;
+    if (!graceUntil) return;
+    const graceUntilMs = new Date(graceUntil).getTime();
+    if (Number.isNaN(graceUntilMs)) return;
+    const delay = Math.max(0, graceUntilMs - Date.now()) + 100;
     const timeout = window.setTimeout(() => {
       void refetchEntitlements();
       void refetchSummary();
     }, Math.min(delay, 2_147_000_000));
     return () => window.clearTimeout(timeout);
-  }, [entitlements?.snapshotExpiresAt, refetchEntitlements, refetchSummary]);
+  }, [refetchEntitlements, refetchSummary, summaryQuery.data?.graceUntil]);
 
   const planLabel = (plan: string) => {
     switch (plan) {
@@ -540,12 +549,24 @@ function BillingTabContent() {
     );
   }
 
-  const periodEnd = formatDate(entitlements.currentPeriodEnd, locale);
   const summaryPeriodEnd = formatDate(
     summaryQuery.data?.entitlement.currentPeriodEnd ?? null,
     locale,
   );
-  const graceUntil = formatDate(summaryQuery.data?.graceUntil ?? null, locale);
+  const graceUntilValue = summaryQuery.data?.graceUntil ?? null;
+  const graceUntil = formatDate(graceUntilValue, locale);
+  const graceUntilMs = graceUntilValue
+    ? new Date(graceUntilValue).getTime()
+    : Number.NaN;
+  const hasActiveProGrace =
+    entitlements.plan === "pro" &&
+    entitlements.status === "past_due" &&
+    Number.isFinite(graceUntilMs) &&
+    graceUntilMs > Date.now();
+  const canUseEntitlementUnlimited =
+    entitlements.plan === "pro" &&
+    (entitlements.status !== "past_due" || hasActiveProGrace) &&
+    (returnResult !== "success" || isCheckoutProConfirmed);
   const actualSeats = summaryQuery.data?.actualSeats ?? entitlements.seats;
   const billedSeats = summaryQuery.data?.billedSeats;
   const pendingSeatQuantity = summaryQuery.data?.pendingSeatQuantity;
@@ -553,7 +574,7 @@ function BillingTabContent() {
     entitlements,
     quotaUsageQuery.data,
     quotaUsageQuery.isError,
-    snapshotFreshness,
+    canUseEntitlementUnlimited,
   );
   const quotaResetAt =
     quotaUsage.kind === "metered"
@@ -613,7 +634,7 @@ function BillingTabContent() {
 
       {returnResult === "success" ? (
         <Alert>
-          {isFreshPro ? (
+          {isCheckoutProConfirmed ? (
             <CheckCircle2 />
           ) : (
             <Loader2
@@ -625,36 +646,16 @@ function BillingTabContent() {
             />
           )}
           <AlertTitle>
-            {isFreshPro
+            {isCheckoutProConfirmed
               ? t(($) => $.workspace.return.active_title)
               : t(($) => $.workspace.return.syncing_title)}
           </AlertTitle>
           <AlertDescription>
-            {isFreshPro
+            {isCheckoutProConfirmed
               ? t(($) => $.workspace.return.active_description)
               : syncTimedOut
                 ? t(($) => $.workspace.return.timeout_description)
                 : t(($) => $.workspace.return.syncing_description)}
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {snapshotFreshness === "stale" ? (
-        <Alert>
-          <RefreshCw />
-          <AlertTitle>{t(($) => $.workspace.snapshot_stale.title)}</AlertTitle>
-          <AlertDescription>
-            {t(($) => $.workspace.snapshot_stale.description)}
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {snapshotFreshness === "unknown" ? (
-        <Alert>
-          <RefreshCw />
-          <AlertTitle>{t(($) => $.workspace.snapshot_unknown.title)}</AlertTitle>
-          <AlertDescription>
-            {t(($) => $.workspace.snapshot_unknown.description)}
           </AlertDescription>
         </Alert>
       ) : null}
@@ -686,7 +687,7 @@ function BillingTabContent() {
           <AlertCircle />
           <AlertTitle>{t(($) => $.workspace.past_due.title)}</AlertTitle>
           <AlertDescription>
-            {graceUntil
+            {hasActiveProGrace && graceUntil
               ? t(($) => $.workspace.past_due.grace_description, {
                   date: graceUntil,
                 })
@@ -789,18 +790,8 @@ function BillingTabContent() {
               <Badge variant={planBadgeVariant(entitlements.plan)}>
                 {planLabel(entitlements.plan)}
               </Badge>
-              <Badge
-                variant={
-                  snapshotFreshness !== "fresh"
-                    ? "outline"
-                    : statusBadgeVariant(entitlements.status)
-                }
-              >
-                {snapshotFreshness === "stale"
-                  ? t(($) => $.workspace.status.stale)
-                  : snapshotFreshness === "unknown"
-                    ? t(($) => $.workspace.status.unknown)
-                    : statusLabel(entitlements.status)}
+              <Badge variant={statusBadgeVariant(entitlements.status)}>
+                {statusLabel(entitlements.status)}
               </Badge>
             </div>
           </SettingsRow>
@@ -828,12 +819,12 @@ function BillingTabContent() {
               </span>
             </SettingsRow>
           ) : null}
-          {periodEnd ? (
+          {summaryPeriodEnd ? (
             <SettingsRow
               label={t(($) => $.workspace.current.period_end)}
               description={t(($) => $.workspace.current.period_end_description)}
             >
-              <span className="tabular-nums">{periodEnd}</span>
+              <span className="tabular-nums">{summaryPeriodEnd}</span>
             </SettingsRow>
           ) : null}
         </SettingsCard>
@@ -994,11 +985,11 @@ function BillingTabContent() {
             description={t(($) => $.workspace.limits.issues_description)}
           >
             <span className="tabular-nums">
-              {snapshotFreshness !== "fresh"
-                ? t(($) => $.workspace.limits.unavailable)
-                : entitlements.issueWindow === null
+              {entitlements.issueWindow === null
+                ? canUseEntitlementUnlimited
                   ? t(($) => $.workspace.limits.unlimited)
-                  : numberFormatter.format(entitlements.issueWindow)}
+                  : t(($) => $.workspace.limits.unavailable)
+                : numberFormatter.format(entitlements.issueWindow)}
             </span>
           </SettingsRow>
           <SettingsRow
@@ -1054,8 +1045,7 @@ function BillingTabContent() {
               </div>
             ) : (
               <div className="flex flex-col gap-2 sm:items-end">
-                {snapshotFreshness === "fresh" &&
-                entitlements.autopilotRuns !== null ? (
+                {entitlements.autopilotRuns !== null ? (
                   <span className="tabular-nums">
                     {t(($) => $.workspace.limits.per_month, {
                       count: entitlements.autopilotRuns,

--- a/packages/views/settings/components/billing-tab.tsx
+++ b/packages/views/settings/components/billing-tab.tsx
@@ -60,7 +60,7 @@ import {
 } from "./settings-layout";
 import {
   hasManagedWorkspaceSubscription,
-  isBillingSnapshotExpired,
+  resolveBillingSnapshotFreshness,
   resolveAutopilotUsage,
 } from "./billing-state";
 
@@ -304,6 +304,11 @@ function BillingTabContent() {
     refetchInterval: isSyncingCheckout ? 2_000 : false,
   });
   const entitlements = entitlementQuery.data;
+  const snapshotFreshness = entitlements
+    ? resolveBillingSnapshotFreshness(entitlements.snapshotExpiresAt)
+    : "unknown";
+  const isFreshPro =
+    entitlements?.plan === "pro" && snapshotFreshness === "fresh";
   const summaryQuery = useQuery({
     ...workspaceSubscriptionSummaryOptions(wsId),
     refetchInterval: isSyncingCheckout ? 2_000 : false,
@@ -328,18 +333,22 @@ function BillingTabContent() {
   const refetchSummary = summaryQuery.refetch;
 
   useEffect(() => {
-    if (isSyncingCheckout && entitlements?.plan === "pro") {
+    if (isSyncingCheckout && isFreshPro) {
       setIsSyncingCheckout(false);
       setSyncTimedOut(false);
       checkoutIntentRef.current = null;
     }
-  }, [entitlements?.plan, isSyncingCheckout]);
+  }, [isFreshPro, isSyncingCheckout]);
 
   useEffect(() => {
     const expiresAt = entitlements?.snapshotExpiresAt;
     if (!expiresAt) return;
     const expiresAtMs = new Date(expiresAt).getTime();
-    if (Number.isNaN(expiresAtMs)) return;
+    if (Number.isNaN(expiresAtMs)) {
+      void refetchEntitlements();
+      void refetchSummary();
+      return;
+    }
     const delay = Math.max(0, expiresAtMs - Date.now()) + 100;
     const timeout = window.setTimeout(() => {
       void refetchEntitlements();
@@ -532,6 +541,10 @@ function BillingTabContent() {
   }
 
   const periodEnd = formatDate(entitlements.currentPeriodEnd, locale);
+  const summaryPeriodEnd = formatDate(
+    summaryQuery.data?.entitlement.currentPeriodEnd ?? null,
+    locale,
+  );
   const graceUntil = formatDate(summaryQuery.data?.graceUntil ?? null, locale);
   const actualSeats = summaryQuery.data?.actualSeats ?? entitlements.seats;
   const billedSeats = summaryQuery.data?.billedSeats;
@@ -540,16 +553,13 @@ function BillingTabContent() {
     entitlements,
     quotaUsageQuery.data,
     quotaUsageQuery.isError,
+    snapshotFreshness,
   );
   const quotaResetAt =
     quotaUsage.kind === "metered"
       ? formatDateTime(quotaUsage.resetAt, locale)
       : null;
   const numberFormatter = new Intl.NumberFormat(locale);
-  const snapshotExpired = isBillingSnapshotExpired(
-    entitlements.snapshotExpiresAt,
-  );
-  const isPro = entitlements.plan === "pro";
   const isMutating =
     checkoutMutation.isPending ||
     portalMutation.isPending ||
@@ -603,7 +613,7 @@ function BillingTabContent() {
 
       {returnResult === "success" ? (
         <Alert>
-          {isPro ? (
+          {isFreshPro ? (
             <CheckCircle2 />
           ) : (
             <Loader2
@@ -615,12 +625,12 @@ function BillingTabContent() {
             />
           )}
           <AlertTitle>
-            {isPro
+            {isFreshPro
               ? t(($) => $.workspace.return.active_title)
               : t(($) => $.workspace.return.syncing_title)}
           </AlertTitle>
           <AlertDescription>
-            {isPro
+            {isFreshPro
               ? t(($) => $.workspace.return.active_description)
               : syncTimedOut
                 ? t(($) => $.workspace.return.timeout_description)
@@ -629,12 +639,22 @@ function BillingTabContent() {
         </Alert>
       ) : null}
 
-      {snapshotExpired ? (
+      {snapshotFreshness === "stale" ? (
         <Alert>
           <RefreshCw />
           <AlertTitle>{t(($) => $.workspace.snapshot_stale.title)}</AlertTitle>
           <AlertDescription>
             {t(($) => $.workspace.snapshot_stale.description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {snapshotFreshness === "unknown" ? (
+        <Alert>
+          <RefreshCw />
+          <AlertTitle>{t(($) => $.workspace.snapshot_unknown.title)}</AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.snapshot_unknown.description)}
           </AlertDescription>
         </Alert>
       ) : null}
@@ -646,11 +666,11 @@ function BillingTabContent() {
             {t(($) => $.workspace.subscription_notice.canceling_title)}
           </AlertTitle>
           <AlertDescription>
-            {periodEnd
+            {summaryPeriodEnd
               ? t(
                   ($) =>
                     $.workspace.subscription_notice.canceling_description,
-                  { date: periodEnd },
+                  { date: summaryPeriodEnd },
                 )
               : t(
                   ($) =>
@@ -771,14 +791,16 @@ function BillingTabContent() {
               </Badge>
               <Badge
                 variant={
-                  snapshotExpired
+                  snapshotFreshness !== "fresh"
                     ? "outline"
                     : statusBadgeVariant(entitlements.status)
                 }
               >
-                {snapshotExpired
+                {snapshotFreshness === "stale"
                   ? t(($) => $.workspace.status.stale)
-                  : statusLabel(entitlements.status)}
+                  : snapshotFreshness === "unknown"
+                    ? t(($) => $.workspace.status.unknown)
+                    : statusLabel(entitlements.status)}
               </Badge>
             </div>
           </SettingsRow>
@@ -972,9 +994,11 @@ function BillingTabContent() {
             description={t(($) => $.workspace.limits.issues_description)}
           >
             <span className="tabular-nums">
-              {entitlements.issueWindow === null
-                ? t(($) => $.workspace.limits.unlimited)
-                : numberFormatter.format(entitlements.issueWindow)}
+              {snapshotFreshness !== "fresh"
+                ? t(($) => $.workspace.limits.unavailable)
+                : entitlements.issueWindow === null
+                  ? t(($) => $.workspace.limits.unlimited)
+                  : numberFormatter.format(entitlements.issueWindow)}
             </span>
           </SettingsRow>
           <SettingsRow
@@ -1030,7 +1054,8 @@ function BillingTabContent() {
               </div>
             ) : (
               <div className="flex flex-col gap-2 sm:items-end">
-                {entitlements.autopilotRuns !== null ? (
+                {snapshotFreshness === "fresh" &&
+                entitlements.autopilotRuns !== null ? (
                   <span className="tabular-nums">
                     {t(($) => $.workspace.limits.per_month, {
                       count: entitlements.autopilotRuns,
@@ -1173,11 +1198,11 @@ function BillingTabContent() {
               <span className="text-muted-foreground">
                 {t(($) => $.workspace.seats.none_pending)}
               </span>
-            ) : periodEnd ? (
+            ) : summaryPeriodEnd ? (
               <span className="tabular-nums">
                 {t(($) => $.workspace.seats.pending_with_date, {
                   count: pendingSeatQuantity,
-                  date: periodEnd,
+                  date: summaryPeriodEnd,
                 })}
               </span>
             ) : (

--- a/packages/views/settings/components/billing-tab.tsx
+++ b/packages/views/settings/components/billing-tab.tsx
@@ -12,12 +12,14 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import { ApiError } from "@multica/core/api";
+import { autopilotQuotaUsageOptions } from "@multica/core/autopilots";
 import {
   useCreateWorkspaceSubscriptionCheckout,
   useCreateWorkspaceSubscriptionPortal,
   useReconcileWorkspaceSubscriptionSeats,
   workspaceSubscriptionEntitlementsOptions,
   workspaceSubscriptionPricesOptions,
+  workspaceSubscriptionSummaryOptions,
 } from "@multica/core/billing";
 import { useFeatureEnabled } from "@multica/core/config";
 import { BILLING_WORKSPACE_SUBSCRIPTIONS_FLAG } from "@multica/core/feature-flags";
@@ -41,6 +43,11 @@ import {
 } from "@multica/ui/components/ui/alert-dialog";
 import { Badge } from "@multica/ui/components/ui/badge";
 import { Button } from "@multica/ui/components/ui/button";
+import {
+  Progress,
+  ProgressLabel,
+  ProgressValue,
+} from "@multica/ui/components/ui/progress";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useLocale, useT } from "../../i18n";
 import { useNavigation } from "../../navigation";
@@ -51,6 +58,11 @@ import {
   SettingsSection,
   SettingsTab,
 } from "./settings-layout";
+import {
+  hasManagedWorkspaceSubscription,
+  isBillingSnapshotExpired,
+  resolveAutopilotUsage,
+} from "./billing-state";
 
 const CHECKOUT_SYNC_TIMEOUT_MS = 30_000;
 
@@ -107,6 +119,16 @@ function formatDate(value: string | null, locale: string): string | null {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(date);
+}
+
+function formatDateTime(value: string | null, locale: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 /**
@@ -166,9 +188,13 @@ function statusBadgeVariant(
     case "trialing":
       return "default";
     case "past_due":
+    case "incomplete":
+    case "unpaid":
       return "destructive";
     case "inactive":
     case "canceled":
+    case "incomplete_expired":
+    case "paused":
       return "secondary";
     default:
       return "outline";
@@ -278,11 +304,19 @@ function BillingTabContent() {
     refetchInterval: isSyncingCheckout ? 2_000 : false,
   });
   const entitlements = entitlementQuery.data;
+  const summaryQuery = useQuery({
+    ...workspaceSubscriptionSummaryOptions(wsId),
+    refetchInterval: isSyncingCheckout ? 2_000 : false,
+  });
+  const summaryUnavailable =
+    summaryQuery.isError ||
+    (!summaryQuery.isPending && summaryQuery.data == null);
+  const quotaUsageQuery = useQuery(autopilotQuotaUsageOptions(wsId));
+  const hasManagedSubscription = entitlements
+    ? hasManagedWorkspaceSubscription(entitlements, summaryQuery.data)
+    : false;
   const canUpgrade =
-    entitlements?.plan === "free" &&
-    entitlements.status !== "active" &&
-    entitlements.status !== "trialing" &&
-    entitlements.status !== "past_due";
+    entitlements?.plan === "free" && !hasManagedSubscription;
   const pricesQuery = useQuery({
     ...workspaceSubscriptionPricesOptions(wsId),
     enabled: wsId.length > 0 && canUpgrade,
@@ -291,6 +325,7 @@ function BillingTabContent() {
   const portalMutation = useCreateWorkspaceSubscriptionPortal(wsId);
   const reconcileMutation = useReconcileWorkspaceSubscriptionSeats(wsId);
   const refetchEntitlements = entitlementQuery.refetch;
+  const refetchSummary = summaryQuery.refetch;
 
   useEffect(() => {
     if (isSyncingCheckout && entitlements?.plan === "pro") {
@@ -308,9 +343,10 @@ function BillingTabContent() {
     const delay = Math.max(0, expiresAtMs - Date.now()) + 100;
     const timeout = window.setTimeout(() => {
       void refetchEntitlements();
+      void refetchSummary();
     }, Math.min(delay, 2_147_000_000));
     return () => window.clearTimeout(timeout);
-  }, [entitlements?.snapshotExpiresAt, refetchEntitlements]);
+  }, [entitlements?.snapshotExpiresAt, refetchEntitlements, refetchSummary]);
 
   const planLabel = (plan: string) => {
     switch (plan) {
@@ -335,6 +371,14 @@ function BillingTabContent() {
         return t(($) => $.workspace.status.past_due);
       case "canceled":
         return t(($) => $.workspace.status.canceled);
+      case "incomplete":
+        return t(($) => $.workspace.status.incomplete);
+      case "incomplete_expired":
+        return t(($) => $.workspace.status.incomplete_expired);
+      case "paused":
+        return t(($) => $.workspace.status.paused);
+      case "unpaid":
+        return t(($) => $.workspace.status.unpaid);
       default:
         return t(($) => $.workspace.status.unknown);
     }
@@ -381,7 +425,7 @@ function BillingTabContent() {
       if (error instanceof ApiError && error.status === 409) {
         checkoutIntentRef.current = null;
         setActionError(t(($) => $.workspace.errors.already_subscribed));
-        await entitlementQuery.refetch();
+        await Promise.all([entitlementQuery.refetch(), summaryQuery.refetch()]);
         return;
       }
       reportActionError(error, t(($) => $.workspace.errors.checkout_failed));
@@ -414,7 +458,7 @@ function BillingTabContent() {
         portalIntentKeyRef.current = null;
         setPortalUnavailable(true);
         setActionError(t(($) => $.workspace.errors.portal_unavailable));
-        await entitlementQuery.refetch();
+        await Promise.all([entitlementQuery.refetch(), summaryQuery.refetch()]);
         return;
       }
       reportActionError(error, t(($) => $.workspace.errors.portal_failed));
@@ -436,6 +480,7 @@ function BillingTabContent() {
           billed: response.billedSeats,
         }),
       );
+      await Promise.all([entitlementQuery.refetch(), summaryQuery.refetch()]);
     } catch (error) {
       reportActionError(error, t(($) => $.workspace.errors.reconcile_failed));
     }
@@ -487,12 +532,24 @@ function BillingTabContent() {
   }
 
   const periodEnd = formatDate(entitlements.currentPeriodEnd, locale);
+  const graceUntil = formatDate(summaryQuery.data?.graceUntil ?? null, locale);
+  const actualSeats = summaryQuery.data?.actualSeats ?? entitlements.seats;
+  const billedSeats = summaryQuery.data?.billedSeats;
+  const pendingSeatQuantity = summaryQuery.data?.pendingSeatQuantity;
+  const quotaUsage = resolveAutopilotUsage(
+    entitlements,
+    quotaUsageQuery.data,
+    quotaUsageQuery.isError,
+  );
+  const quotaResetAt =
+    quotaUsage.kind === "metered"
+      ? formatDateTime(quotaUsage.resetAt, locale)
+      : null;
+  const numberFormatter = new Intl.NumberFormat(locale);
+  const snapshotExpired = isBillingSnapshotExpired(
+    entitlements.snapshotExpiresAt,
+  );
   const isPro = entitlements.plan === "pro";
-  const hasManagedSubscription =
-    isPro ||
-    entitlements.status === "active" ||
-    entitlements.status === "trialing" ||
-    entitlements.status === "past_due";
   const isMutating =
     checkoutMutation.isPending ||
     portalMutation.isPending ||
@@ -506,9 +563,9 @@ function BillingTabContent() {
       )
     : null;
   const formattedEstimatedTotal =
-    selectedPrice && entitlements.seats > 0
-    ? formatStripeMinorAmount(
-        selectedPrice.unitAmount * entitlements.seats,
+    selectedPrice && actualSeats > 0
+      ? formatStripeMinorAmount(
+        selectedPrice.unitAmount * actualSeats,
         selectedPrice.currency,
         locale,
       )
@@ -572,12 +629,114 @@ function BillingTabContent() {
         </Alert>
       ) : null}
 
+      {snapshotExpired ? (
+        <Alert>
+          <RefreshCw />
+          <AlertTitle>{t(($) => $.workspace.snapshot_stale.title)}</AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.snapshot_stale.description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {summaryQuery.data?.cancelAtPeriodEnd ? (
+        <Alert>
+          <AlertCircle />
+          <AlertTitle>
+            {t(($) => $.workspace.subscription_notice.canceling_title)}
+          </AlertTitle>
+          <AlertDescription>
+            {periodEnd
+              ? t(
+                  ($) =>
+                    $.workspace.subscription_notice.canceling_description,
+                  { date: periodEnd },
+                )
+              : t(
+                  ($) =>
+                    $.workspace.subscription_notice
+                      .canceling_description_without_date,
+                )}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
       {entitlements.status === "past_due" ? (
         <Alert variant="destructive">
           <AlertCircle />
           <AlertTitle>{t(($) => $.workspace.past_due.title)}</AlertTitle>
           <AlertDescription>
-            {t(($) => $.workspace.past_due.description)}
+            {graceUntil
+              ? t(($) => $.workspace.past_due.grace_description, {
+                  date: graceUntil,
+                })
+              : t(($) => $.workspace.past_due.description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {entitlements.status === "incomplete" ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>
+            {t(($) => $.workspace.subscription_notice.incomplete_title)}
+          </AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.subscription_notice.incomplete_description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {entitlements.status === "incomplete_expired" ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>
+            {t(
+              ($) => $.workspace.subscription_notice.incomplete_expired_title,
+            )}
+          </AlertTitle>
+          <AlertDescription>
+            {t(
+              ($) =>
+                $.workspace.subscription_notice
+                  .incomplete_expired_description,
+            )}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {entitlements.status === "paused" ? (
+        <Alert>
+          <AlertCircle />
+          <AlertTitle>
+            {t(($) => $.workspace.subscription_notice.paused_title)}
+          </AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.subscription_notice.paused_description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {entitlements.status === "unpaid" ? (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>
+            {t(($) => $.workspace.subscription_notice.unpaid_title)}
+          </AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.subscription_notice.unpaid_description)}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {entitlements.status === "canceled" ? (
+        <Alert>
+          <AlertCircle />
+          <AlertTitle>
+            {t(($) => $.workspace.subscription_notice.canceled_title)}
+          </AlertTitle>
+          <AlertDescription>
+            {t(($) => $.workspace.subscription_notice.canceled_description)}
           </AlertDescription>
         </Alert>
       ) : null}
@@ -610,8 +769,16 @@ function BillingTabContent() {
               <Badge variant={planBadgeVariant(entitlements.plan)}>
                 {planLabel(entitlements.plan)}
               </Badge>
-              <Badge variant={statusBadgeVariant(entitlements.status)}>
-                {statusLabel(entitlements.status)}
+              <Badge
+                variant={
+                  snapshotExpired
+                    ? "outline"
+                    : statusBadgeVariant(entitlements.status)
+                }
+              >
+                {snapshotExpired
+                  ? t(($) => $.workspace.status.stale)
+                  : statusLabel(entitlements.status)}
               </Badge>
             </div>
           </SettingsRow>
@@ -621,10 +788,24 @@ function BillingTabContent() {
           >
             <span className="tabular-nums">
               {t(($) => $.workspace.current.member_count, {
-                count: entitlements.seats,
+                count: actualSeats,
               })}
             </span>
           </SettingsRow>
+          {summaryQuery.data?.billingInterval ? (
+            <SettingsRow
+              label={t(($) => $.workspace.current.billing_interval)}
+              description={t(
+                ($) => $.workspace.current.billing_interval_description,
+              )}
+            >
+              <span>
+                {summaryQuery.data.billingInterval === "month"
+                  ? t(($) => $.workspace.upgrade.monthly)
+                  : t(($) => $.workspace.upgrade.yearly)}
+              </span>
+            </SettingsRow>
+          ) : null}
           {periodEnd ? (
             <SettingsRow
               label={t(($) => $.workspace.current.period_end)}
@@ -668,7 +849,7 @@ function BillingTabContent() {
               <div className="space-y-2">
                 <p className="text-body font-medium">
                   {t(($) => $.workspace.upgrade.pro_for_team, {
-                    count: entitlements.seats,
+                    count: actualSeats,
                   })}
                 </p>
                 {pricesQuery.isLoading ? (
@@ -793,22 +974,90 @@ function BillingTabContent() {
             <span className="tabular-nums">
               {entitlements.issueWindow === null
                 ? t(($) => $.workspace.limits.unlimited)
-                : new Intl.NumberFormat(locale).format(
-                    entitlements.issueWindow,
-                  )}
+                : numberFormatter.format(entitlements.issueWindow)}
             </span>
           </SettingsRow>
           <SettingsRow
             label={t(($) => $.workspace.limits.autopilots)}
             description={t(($) => $.workspace.limits.autopilots_description)}
           >
-            <span className="tabular-nums">
-              {entitlements.autopilotRuns === null
-                ? t(($) => $.workspace.limits.unlimited)
-                : t(($) => $.workspace.limits.per_month, {
-                    count: entitlements.autopilotRuns,
+            {quotaUsage.kind === "unlimited" ? (
+              <span className="tabular-nums">
+                {t(($) => $.workspace.limits.unlimited)}
+              </span>
+            ) : quotaUsageQuery.isPending ? (
+              <div
+                className="w-full max-w-72 space-y-2 motion-reduce:[&_[data-slot=skeleton]]:animate-none"
+                role="status"
+                aria-label={t(($) => $.workspace.limits.usage_loading)}
+              >
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            ) : quotaUsage.kind === "metered" ? (
+              <div className="w-full max-w-72 space-y-2">
+                <Progress
+                  value={quotaUsage.progress}
+                  aria-label={t(($) => $.workspace.limits.usage_label)}
+                >
+                  <ProgressLabel>
+                    {quotaUsage.reached
+                      ? t(($) => $.workspace.limits.reached)
+                      : t(($) => $.workspace.limits.current_usage)}
+                  </ProgressLabel>
+                  <ProgressValue>
+                    {() =>
+                      t(($) => $.workspace.limits.usage_total, {
+                        total: numberFormatter.format(quotaUsage.total),
+                        limit: numberFormatter.format(quotaUsage.limit),
+                      })
+                    }
+                  </ProgressValue>
+                </Progress>
+                <p className="text-caption text-muted-foreground tabular-nums">
+                  {t(($) => $.workspace.limits.usage_breakdown, {
+                    used: numberFormatter.format(quotaUsage.used),
+                    reserved: numberFormatter.format(quotaUsage.reserved),
                   })}
-            </span>
+                </p>
+                {quotaResetAt ? (
+                  <p className="text-caption text-muted-foreground tabular-nums">
+                    {t(($) => $.workspace.limits.resets_at, {
+                      date: quotaResetAt,
+                    })}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2 sm:items-end">
+                {entitlements.autopilotRuns !== null ? (
+                  <span className="tabular-nums">
+                    {t(($) => $.workspace.limits.per_month, {
+                      count: entitlements.autopilotRuns,
+                    })}
+                  </span>
+                ) : null}
+                <span className="text-caption text-muted-foreground">
+                  {t(($) => $.workspace.limits.usage_unavailable)}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  aria-label={t(($) => $.workspace.actions.retry_autopilots)}
+                  aria-busy={quotaUsageQuery.isFetching}
+                  disabled={quotaUsageQuery.isFetching}
+                  onClick={() => void quotaUsageQuery.refetch()}
+                >
+                  {quotaUsageQuery.isFetching ? (
+                    <Loader2 className="animate-spin motion-reduce:animate-none" />
+                  ) : (
+                    <RefreshCw />
+                  )}
+                  {t(($) => $.workspace.actions.retry)}
+                </Button>
+              </div>
+            )}
           </SettingsRow>
         </SettingsCard>
       </SettingsSection>
@@ -817,6 +1066,35 @@ function BillingTabContent() {
         title={t(($) => $.workspace.seats.title)}
         description={t(($) => $.workspace.seats.description)}
       >
+        {summaryUnavailable ? (
+          <Alert className="mb-3">
+            <AlertCircle />
+            <AlertTitle>
+              {t(($) => $.workspace.seats.summary_unavailable_title)}
+            </AlertTitle>
+            <AlertDescription>
+              <p>
+                {t(($) => $.workspace.seats.summary_unavailable_description)}
+              </p>
+              <Button
+                className="mt-3"
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-busy={summaryQuery.isFetching}
+                disabled={summaryQuery.isFetching}
+                onClick={() => void summaryQuery.refetch()}
+              >
+                {summaryQuery.isFetching ? (
+                  <Loader2 className="animate-spin motion-reduce:animate-none" />
+                ) : (
+                  <RefreshCw />
+                )}
+                {t(($) => $.workspace.actions.retry)}
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
         {reconcileMessage ? (
           <Alert className="mb-3">
             <CheckCircle2 />
@@ -832,7 +1110,7 @@ function BillingTabContent() {
             <div className="flex flex-col gap-2 sm:items-end">
               <span className="tabular-nums">
                 {t(($) => $.workspace.current.member_count, {
-                  count: entitlements.seats,
+                  count: actualSeats,
                 })}
               </span>
               {canManage && hasManagedSubscription ? (
@@ -852,6 +1130,64 @@ function BillingTabContent() {
               ) : null}
             </div>
           </SettingsRow>
+          <SettingsRow
+            label={t(($) => $.workspace.seats.billed)}
+            description={t(($) => $.workspace.seats.billed_description)}
+          >
+            {summaryQuery.isPending ? (
+              <Skeleton
+                className="h-5 w-20 motion-reduce:animate-none"
+                aria-label={t(($) => $.workspace.seats.summary_loading)}
+              />
+            ) : summaryUnavailable ? (
+              <span className="text-muted-foreground">
+                {t(($) => $.workspace.seats.unavailable)}
+              </span>
+            ) : billedSeats === null || billedSeats === undefined ? (
+              <span className="text-muted-foreground">
+                {t(($) => $.workspace.seats.not_subscribed)}
+              </span>
+            ) : (
+              <span className="tabular-nums">
+                {t(($) => $.workspace.seats.seat_count, {
+                  count: billedSeats,
+                })}
+              </span>
+            )}
+          </SettingsRow>
+          <SettingsRow
+            label={t(($) => $.workspace.seats.pending)}
+            description={t(($) => $.workspace.seats.pending_description)}
+          >
+            {summaryQuery.isPending ? (
+              <Skeleton
+                className="h-5 w-28 motion-reduce:animate-none"
+                aria-label={t(($) => $.workspace.seats.summary_loading)}
+              />
+            ) : summaryUnavailable ? (
+              <span className="text-muted-foreground">
+                {t(($) => $.workspace.seats.unavailable)}
+              </span>
+            ) : pendingSeatQuantity === null ||
+              pendingSeatQuantity === undefined ? (
+              <span className="text-muted-foreground">
+                {t(($) => $.workspace.seats.none_pending)}
+              </span>
+            ) : periodEnd ? (
+              <span className="tabular-nums">
+                {t(($) => $.workspace.seats.pending_with_date, {
+                  count: pendingSeatQuantity,
+                  date: periodEnd,
+                })}
+              </span>
+            ) : (
+              <span className="tabular-nums">
+                {t(($) => $.workspace.seats.seat_count, {
+                  count: pendingSeatQuantity,
+                })}
+              </span>
+            )}
+          </SettingsRow>
         </SettingsCard>
       </SettingsSection>
 
@@ -870,7 +1206,7 @@ function BillingTabContent() {
                   interval === "month"
                     ? t(($) => $.workspace.upgrade.monthly)
                     : t(($) => $.workspace.upgrade.yearly),
-                count: entitlements.seats,
+                count: actualSeats,
               })}
             </AlertDialogDescription>
           </AlertDialogHeader>


### PR DESCRIPTION
## Summary

- show workspace subscription summary facts, including billing interval and actual, billed, and scheduled seat quantities
- show server-accounted automation quota usage with reserved runs included in progress and limit-reached state
- add honest partial-failure, stale-snapshot, grace-period, cancellation, and Stripe status handling
- keep purchase and management controls permission-gated and add complete English, Simplified Chinese, Japanese, and Korean copy

This is PR1 of the staged MUL-6344 rollout. Cloud catalog/public pricing, the redesigned upgrade flow, and task-window usage remain outside this PR.

## Validation

- `pnpm --filter @multica/views exec vitest run settings/components/billing-state.test.ts settings/components/billing-tab.test.tsx locales/parity.test.ts` (198 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/core typecheck`
- ESLint on all changed TypeScript files
- JSON parsing and locale-key parity for all four billing bundles

Broader-suite note: the full Views run reached 4,425/4,426 passing with an unrelated sidebar resize assertion; the full Core run reached 1,504/1,512 passing with unrelated `localStorage` availability failures in workspace/project/realtime tests.
