### PR TITLE
MUL-6363: refactor(i18n): reuse custom_property.none for the no-value filter

### DIFF
--- a/packages/views/issues/components/filter-chips-bar.tsx
+++ b/packages/views/issues/components/filter-chips-bar.tsx
@@ -459,7 +459,7 @@ function useFilterChips(
     const actorValues = actorProperty ? actorFilterValues(selected) : [];
     const optionName = (optionId: string): string | undefined => {
       if (optionId === NO_PROPERTY_VALUE) {
-        return t(($) => $.pickers.custom_property.no_value_label);
+        return t(($) => $.pickers.custom_property.none);
       }
       if (actorProperty) {
         const ref = parseActorRef(optionId);

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -709,7 +709,7 @@ function PropertyFilterOptions({
   // property is unset, the inverse of picking one of the options below.
   const noValueOption = {
     id: NO_PROPERTY_VALUE,
-    name: t(($) => $.pickers.custom_property.no_value_label),
+    name: t(($) => $.pickers.custom_property.none),
     color: undefined as string | undefined,
     actorType: undefined as string | undefined,
     actorId: undefined as string | undefined,

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -660,7 +660,6 @@
       "none": "No value",
       "true_label": "Yes",
       "false_label": "No",
-      "no_value_label": "No value",
       "value_placeholder": "Enter value…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -630,7 +630,6 @@
       "none": "値なし",
       "true_label": "はい",
       "false_label": "いいえ",
-      "no_value_label": "値なし",
       "value_placeholder": "値を入力…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -630,7 +630,6 @@
       "none": "값 없음",
       "true_label": "예",
       "false_label": "아니요",
-      "no_value_label": "값 없음",
       "value_placeholder": "값 입력…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -629,7 +629,6 @@
       "empty": "空",
       "true_label": "是",
       "false_label": "否",
-      "no_value_label": "未设置",
       "value_placeholder": "输入值…",
       "url_placeholder": "https://…",
       "number_placeholder": "0",
@@ -638,7 +637,7 @@
       "archived_hint": "已归档属性——值为只读",
       "unknown_value": "无法显示",
       "unknown_value_hint": "该值由更新版本的 Multica 设置，当前版本无法编辑——请更新应用，或清除该值",
-      "none": "无值"
+      "none": "未设置"
     },
     "filter_options_aria": "筛选选项",
     "no_results": "无结果",


### PR DESCRIPTION
Follow-up nit from the review of #7156 (MUL-6363), which introduced the "No value" custom-property filter.

That PR added a new `pickers.custom_property.no_value_label` key, but `pickers.custom_property.none` already meant exactly the same thing — it labels the "clear the value" row in the property value picker. In en/ja/ko the two keys held byte-identical strings. In zh-Hans they diverged: the new filter option said `未设置` while the picker said `无值`, so the same concept got two Chinese wordings inside one namespace.

The new key's choice of `未设置` was the right one — it matches `table.no_value` and `board.no_value`. So this keeps that wording and drops the extra key:

- delete `no_value_label` from all four locales
- point the filter menu and the chips bar at `none`
- align zh-Hans `none` from `无值` to `未设置`

Net effect: the value picker, the table cell, the board column and the filter menu all read the same in every locale, and there is one key per concept instead of two.

No behavior change — labels only. The locale parity test and the full `@multica/views` issues suite (78 files / 763 tests) pass locally.
