### PR TITLE
fix(inbox): MUL-6404 give the desktop shell navigation feedback when switching issues

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.test.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.test.tsx
@@ -64,6 +64,7 @@ vi.mock("@multica/views/platform", () => ({
 vi.mock("@multica/views/layout", () => ({
   AppSidebar: () => null,
   GlobalShortcuts: () => null,
+  NavigationProgress: () => null,
 }));
 
 vi.mock("@multica/views/modals/registry", () => ({ ModalRegistry: () => null }));

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -13,7 +13,11 @@ import {
   useSidebar,
 } from "@multica/ui/components/ui/sidebar";
 import { ModalRegistry } from "@multica/views/modals/registry";
-import { AppSidebar, GlobalShortcuts } from "@multica/views/layout";
+import {
+  AppSidebar,
+  GlobalShortcuts,
+  NavigationProgress,
+} from "@multica/views/layout";
 import { SearchCommand, SearchTrigger } from "@multica/views/search";
 import { FloatingChat } from "@multica/views/chat";
 import { WorkspaceSlugProvider, paths, useCurrentWorkspace } from "@multica/core/paths";
@@ -288,6 +292,12 @@ export function DesktopShell() {
             <div className="flex flex-1 min-w-0 flex-col">
               <MainTopBar />
               <MainCanvas>
+                {/* Same indicator, same anchor as web: DashboardLayout puts it
+                    at the top of SidebarInset, and MainCanvas is desktop's
+                    equivalent relative/overflow-hidden content box. Desktop
+                    used to have no navigation feedback at all — a click just
+                    froze until the destination committed (MUL-6404). */}
+                <NavigationProgress />
                 <TabContent />
                 {slug && <FloatingChat />}
               </MainCanvas>

--- a/apps/desktop/src/renderer/src/components/desktop-layout.workspace-gate.test.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.workspace-gate.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { RESOURCES } from "@multica/views/locales";
@@ -77,6 +77,7 @@ vi.mock("@multica/views/platform", () => ({
 vi.mock("@multica/views/layout", () => ({
   AppSidebar: () => <div data-testid="app-sidebar" />,
   GlobalShortcuts: () => <div data-testid="global-shortcuts" />,
+  NavigationProgress: () => <div data-testid="navigation-progress" />,
 }));
 
 vi.mock("@multica/views/modals/registry", () => ({
@@ -169,6 +170,19 @@ describe("DesktopShell workspace gating", () => {
     const { queryByTestId } = renderShell();
 
     expect(queryByTestId("tab-content")).not.toBeNull();
+  });
+
+  // The shell had no navigation feedback at all before MUL-6404 — the bar
+  // only ever shipped inside web's DashboardLayout. It sits beside TabContent
+  // in the canvas and, like it, is not workspace-gated: a cold workspace
+  // resolve is exactly when the wait is longest.
+  it("mounts the navigation progress bar, workspace or not", () => {
+    expect(renderShell().queryByTestId("navigation-progress")).not.toBeNull();
+
+    cleanup();
+    state.wsList = [];
+
+    expect(renderShell().queryByTestId("navigation-progress")).not.toBeNull();
   });
 
   it("drops chrome for a slug belonging to a workspace the user lost access to", () => {

--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -5,6 +5,7 @@ import {
   getInboxDisplayTitle,
   getQuickCreateOutcomeDetail,
   isQuickCreateOutcome,
+  resolveDetailItem,
   stripQuickCreatePrefix,
 } from "./inbox-display";
 
@@ -101,5 +102,47 @@ describe("inbox display helpers", () => {
     expect(getInboxDisplayTitle(unconfirmedItem)).toBe(
       "File a bug about the flaky test",
     );
+  });
+});
+
+describe("resolveDetailItem", () => {
+  // Rows the inbox keys by issue_id, plus one plain notification that has none
+  // and is therefore keyed by its own id.
+  const a = item({ id: "inbox-a", issue_id: "issue-a" });
+  const b = item({ id: "inbox-b", issue_id: "issue-b" });
+  const plain = item({ id: "inbox-plain", issue_id: null });
+  const list = [a, b, plain];
+
+  it("holds the row the pane is still on while the list has moved on", () => {
+    expect(resolveDetailItem(list, "issue-b", "issue-a")).toBe(a);
+  });
+
+  it("shows the live selection once the pane has caught up", () => {
+    expect(resolveDetailItem(list, "issue-b", "issue-b")).toBe(b);
+  });
+
+  it("keys a notification without an issue by its own id", () => {
+    expect(resolveDetailItem(list, "inbox-plain", "inbox-plain")).toBe(plain);
+  });
+
+  // Archive moves the selection to the neighbour and drops the actioned row in
+  // the same commit, so the deferred key resolves to nothing. Holding that miss
+  // would blink the empty state between the two issues.
+  it("falls forward to the live selection when the held row is gone", () => {
+    expect(resolveDetailItem([b, plain], "issue-b", "issue-a")).toBe(b);
+  });
+
+  it("stays empty while the first selection is still rendering", () => {
+    expect(resolveDetailItem(list, "issue-a", "")).toBeNull();
+  });
+
+  it("stays empty when the selection is cleared and the pane agrees", () => {
+    expect(resolveDetailItem(list, "", "")).toBeNull();
+  });
+
+  // Deep link to a notification that is not in this user's inbox: the page
+  // redirects to the issue page, and the pane must not invent a row meanwhile.
+  it("resolves nothing when neither key is in the list", () => {
+    expect(resolveDetailItem(list, "issue-gone", "issue-also-gone")).toBeNull();
   });
 });

--- a/packages/views/inbox/components/inbox-display.ts
+++ b/packages/views/inbox/components/inbox-display.ts
@@ -56,3 +56,33 @@ export function getQuickCreateOutcomeDetail(item: InboxItem): string {
   const details = item.details ?? {};
   return singleLine(details.error) || singleLine(item.body);
 }
+
+/**
+ * Which row the detail pane renders while its selection lags the list's.
+ *
+ * The pane's key is deferred (`useDeferredValue`) so mounting the issue
+ * detail runs at transition priority instead of blocking the click, which
+ * means there is a window where the list highlight has already moved and the
+ * pane has not. Normally the pane should keep showing the row it is still on
+ * — that is the whole point, and it is what the progress bar is covering.
+ *
+ * The exception is a stale key that no longer resolves: archive advances the
+ * selection to the neighbour and drops the actioned row in the same commit,
+ * so there is nothing left to hold. Rendering the miss would blink the empty
+ * state between the two issues, so that case jumps straight to the live
+ * selection instead.
+ */
+export function resolveDetailItem(
+  visibleItems: InboxItem[],
+  selectedKey: string,
+  detailKey: string,
+): InboxItem | null {
+  const byKey = (key: string) =>
+    visibleItems.find((i) => (i.issue_id ?? i.id) === key) ?? null;
+  const deferred = detailKey ? byKey(detailKey) : null;
+  if (deferred) return deferred;
+  // No stale row to hold: either the pane is empty (nothing selected yet) or
+  // the row it was on is gone. Only the second case falls forward.
+  if (!detailKey || detailKey === selectedKey) return null;
+  return selectedKey ? byKey(selectedKey) : null;
+}

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -100,6 +100,9 @@ let searchParams = new URLSearchParams();
 
 vi.mock("../../navigation", () => ({
   useNavigation: () => ({ searchParams, replace }),
+  // Real hook: reports the detail-pane swap to the shell's progress bar.
+  // Nothing here renders that bar, and the page reads nothing back from it.
+  useReportNavigating: () => {},
 }));
 
 // Drive the layout from a viewport width so a test can name the device it

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useDeferredValue,
+  useMemo,
+  useRef,
+} from "react";
 import { useDefaultLayout } from "react-resizable-panels";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -35,7 +42,7 @@ import {
 import { IssueDetail, issueHighlightMementoKey } from "../../issues/components";
 import { useViewStateWriter } from "../../platform";
 import { ErrorBoundary } from "@multica/ui/components/common/error-boundary";
-import { useNavigation } from "../../navigation";
+import { useNavigation, useReportNavigating } from "../../navigation";
 import { toast } from "sonner";
 import {
   MoreHorizontal,
@@ -72,7 +79,11 @@ import { InboxList } from "./inbox-list";
 import { InboxContextMenuProvider } from "./inbox-context-menu";
 import { ARCHIVED_VIEW_PARAM, type InboxView } from "./inbox-view";
 import { useTypeLabels } from "./inbox-detail-label";
-import { getInboxDisplayTitle, isQuickCreateOutcome } from "./inbox-display";
+import {
+  getInboxDisplayTitle,
+  isQuickCreateOutcome,
+  resolveDetailItem,
+} from "./inbox-display";
 import { useT } from "../../i18n";
 
 export function InboxPage() {
@@ -116,6 +127,24 @@ export function InboxPage() {
 
   const selected =
     visibleItems.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+
+  // What the DETAIL pane shows, one React transition behind the click.
+  //
+  // Mounting `IssueDetail` is the expensive half of switching rows, and driven
+  // straight off `selectedKey` it ran as an urgent update: the main thread
+  // blocked from the click until the new detail was ready, which is the
+  // "click, freeze, jump" the desktop shell showed (MUL-6404). Deferred, the
+  // click commits the row highlight and the URL right away, React renders the
+  // new detail at transition priority — interruptible, so the shell keeps
+  // painting — and the previous issue stays on screen until it is ready.
+  const detailKey = useDeferredValue(selectedKey);
+  const detailSwapping = detailKey !== selectedKey;
+  const detailItem = resolveDetailItem(visibleItems, selectedKey, detailKey);
+
+  // The gap above is invisible to the navigation adapter — the inbox stays on
+  // the same route and only rewrites `?issue=` — so report it explicitly and
+  // the shell's progress bar covers the swap on both platforms.
+  useReportNavigating(detailSwapping);
 
   // Track the last key we actually resolved against the inbox list. Lets the
   // fallback effect distinguish "shared-link to a notification not in our
@@ -564,13 +593,13 @@ export function InboxPage() {
     </div>
   ) : null;
 
-  const detailContent = selected?.issue_id ? (
+  const detailContent = detailItem?.issue_id ? (
     // Key by issue_id (not inbox-item id): a new comment/reaction generates a
     // new inbox notification for the same issue, and the dedup helper picks the
     // newest one — keying on its id would remount IssueDetail on every event,
     // wiping the comment composer draft and resetting scroll position.
     <ErrorBoundary
-      resetKeys={[selected.issue_id]}
+      resetKeys={[detailItem.issue_id]}
       // The default fallback is a bare message card. On a phone it would be the
       // only thing on screen, so it has to carry the way back too — the bar is
       // the point here, the message is whatever the boundary caught.
@@ -584,11 +613,11 @@ export function InboxPage() {
       ) : undefined}
     >
       <IssueDetail
-        key={selected.issue_id}
-        issueId={selected.issue_id}
+        key={detailItem.issue_id}
+        issueId={detailItem.issue_id}
         defaultSidebarOpen={false}
         layoutId="multica_inbox_issue_detail_layout"
-        highlightCommentId={selected.details?.comment_id ?? undefined}
+        highlightCommentId={detailItem.details?.comment_id ?? undefined}
         highlightRequestToken={highlightRequestToken}
         leadingAction={compactBackAction}
         onDelete={() => {
@@ -599,31 +628,31 @@ export function InboxPage() {
           setSelectedKey("");
         }}
         onDone={() => {
-          handleArchive(selected.id);
+          handleArchive(detailItem.id);
         }}
       />
     </ErrorBoundary>
-  ) : selected ? (
+  ) : detailItem ? (
     <div className="p-6">
-      <h2 className="text-title font-semibold">{getInboxDisplayTitle(selected)}</h2>
+      <h2 className="text-title font-semibold">{getInboxDisplayTitle(detailItem)}</h2>
       <p className="mt-1 text-body text-muted-foreground">
-        {typeLabels[selected.type]} · {timeAgo(selected.created_at)}
+        {typeLabels[detailItem.type]} · {timeAgo(detailItem.created_at)}
       </p>
-      {selected.body && (
+      {detailItem.body && (
         <div className="mt-4 whitespace-pre-wrap text-body leading-relaxed text-foreground">
-          {selected.body}
+          {detailItem.body}
         </div>
       )}
-      {isQuickCreateOutcome(selected.type) && selected.details?.original_prompt && (
+      {isQuickCreateOutcome(detailItem.type) && detailItem.details?.original_prompt && (
         <div className="mt-4 rounded-md border bg-muted/40 p-3">
           <p className="text-caption font-medium text-muted-foreground">
             {t(($) => $.detail.original_input)}
           </p>
-          <p className="mt-1 whitespace-pre-wrap text-body">{selected.details.original_prompt}</p>
+          <p className="mt-1 whitespace-pre-wrap text-body">{detailItem.details.original_prompt}</p>
         </div>
       )}
       <div className="mt-4 flex gap-2">
-        {isQuickCreateOutcome(selected.type) && (
+        {isQuickCreateOutcome(detailItem.type) && (
           <Button
             size="sm"
             onClick={() => {
@@ -631,8 +660,8 @@ export function InboxPage() {
               // user can recover their input in the full editor instead of
               // retyping. The agent picker hint becomes the assignee
               // candidate (still editable).
-              const prompt = selected.details?.original_prompt ?? "";
-              const agentId = selected.details?.agent_id;
+              const prompt = detailItem.details?.original_prompt ?? "";
+              const agentId = detailItem.details?.agent_id;
               useIssueDraftStore.getState().setManual({
                 description: prompt,
                 ...(agentId
@@ -651,7 +680,7 @@ export function InboxPage() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleUnarchive(selected.id)}
+            onClick={() => handleUnarchive(detailItem.id)}
           >
             <ArchiveRestore className="mr-1.5 h-3.5 w-3.5" />
             {t(($) => $.detail.unarchive)}
@@ -660,7 +689,7 @@ export function InboxPage() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleArchive(selected.id)}
+            onClick={() => handleArchive(detailItem.id)}
           >
             <Archive className="mr-1.5 h-3.5 w-3.5" />
             {t(($) => $.detail.archive)}
@@ -698,7 +727,7 @@ export function InboxPage() {
     // of selection get their chrome from different places, so they render
     // differently — `InboxItem.issue_id` is nullable and a null one is a plain
     // notification (a failed quick-create, say), not an issue.
-    if (selected?.issue_id) {
+    if (detailItem?.issue_id) {
       // No scroll container and no back bar of our own: `IssueDetail` owns
       // both, and takes the way back through `leadingAction`. Wrapping it in
       // an `overflow-y-auto` used to collapse its inner scroller to content
@@ -710,7 +739,7 @@ export function InboxPage() {
       return <div className="flex flex-1 flex-col min-h-0">{detailContent}</div>;
     }
 
-    if (selected) {
+    if (detailItem) {
       // A notification body is a plain block with no header to host a leading
       // slot and no scroller of its own, so this branch keeps supplying both.
       return (

--- a/packages/views/layout/index.ts
+++ b/packages/views/layout/index.ts
@@ -16,3 +16,4 @@ export { useDashboardGuard } from "./use-dashboard-guard";
 export { WorkspaceLoader } from "./workspace-loader";
 export { WorkspacePresencePrefetch } from "./workspace-presence-prefetch";
 export { GlobalShortcuts } from "./global-shortcuts";
+export { NavigationProgress } from "./navigation-progress";

--- a/packages/views/layout/navigation-progress.test.tsx
+++ b/packages/views/layout/navigation-progress.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NavigationProvider, useReportNavigating } from "../navigation";
+import type { NavigationAdapter } from "../navigation";
+import { NavigationProgress } from "./navigation-progress";
+
+const adapter: NavigationAdapter = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  pathname: "/",
+  searchParams: new URLSearchParams(),
+  getShareableUrl: (p) => p,
+};
+
+function Reporter({ pending }: { pending: boolean }) {
+  useReportNavigating(pending);
+  return <span data-testid="reporter" />;
+}
+
+function renderBar(pending: boolean) {
+  const view = render(
+    <NavigationProvider value={adapter}>
+      <NavigationProgress />
+      <Reporter pending={pending} />
+    </NavigationProvider>,
+  );
+  const bar = () => screen.getByTestId("reporter").previousElementSibling!;
+  return { ...view, bar };
+}
+
+describe("NavigationProgress", () => {
+  it("stays hidden while nothing is pending", () => {
+    const { bar } = renderBar(false);
+
+    expect(bar().getAttribute("data-visible")).toBe("false");
+  });
+
+  // The desktop shell's push/replace are synchronous store writes, so the
+  // provider's own transition flag is already settled while the destination
+  // content is still rendering. In-page swaps report the gap themselves.
+  it("shows while a view reports an in-page swap", () => {
+    const { bar } = renderBar(true);
+
+    expect(bar().getAttribute("data-visible")).toBe("true");
+  });
+
+  it("hides again once the reported swap settles", () => {
+    const { bar, rerender } = renderBar(true);
+
+    rerender(
+      <NavigationProvider value={adapter}>
+        <NavigationProgress />
+        <Reporter pending={false} />
+      </NavigationProvider>,
+    );
+
+    expect(bar().getAttribute("data-visible")).toBe("false");
+  });
+
+  it("hides when the only reporting view unmounts mid-swap", () => {
+    const { bar, rerender } = renderBar(true);
+
+    rerender(
+      <NavigationProvider value={adapter}>
+        <NavigationProgress />
+        <span data-testid="reporter" />
+      </NavigationProvider>,
+    );
+
+    expect(bar().getAttribute("data-visible")).toBe("false");
+  });
+});

--- a/packages/views/navigation/context.tsx
+++ b/packages/views/navigation/context.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import { createContext, use, useMemo, useTransition } from "react";
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 import type { NavigationAdapter } from "./types";
 
 const NavigationContext = createContext<NavigationAdapter | null>(null);
 const NavigationPendingContext = createContext<boolean>(false);
+
+/** `+1` while a reported swap is in flight, `-1` when it settles. */
+type PendingReporter = (delta: 1 | -1) => void;
+const NavigationPendingReportContext = createContext<PendingReporter | null>(
+  null,
+);
 
 export function NavigationProvider({
   value,
@@ -19,6 +33,15 @@ export function NavigationProvider({
   // Next.js commits the new RSC payload; on desktop it flips off quickly
   // because react-router commits synchronously — both are correct.
   const [isPending, startTransition] = useTransition();
+  // Second pending source: in-page content swaps reported through
+  // `useReportNavigating`. The transition above only spans the adapter's
+  // push/replace, which on desktop is a synchronous store write — it is
+  // already settled while the destination content is still being rendered,
+  // so on its own it can never keep the progress bar on screen there.
+  const [reportedPending, setReportedPending] = useState(0);
+  const report = useCallback<PendingReporter>((delta) => {
+    setReportedPending((n) => Math.max(0, n + delta));
+  }, []);
   const wrapped = useMemo<NavigationAdapter>(
     () => ({
       ...value,
@@ -29,9 +52,13 @@ export function NavigationProvider({
   );
   return (
     <NavigationContext.Provider value={wrapped}>
-      <NavigationPendingContext.Provider value={isPending}>
-        {children}
-      </NavigationPendingContext.Provider>
+      <NavigationPendingReportContext.Provider value={report}>
+        <NavigationPendingContext.Provider
+          value={isPending || reportedPending > 0}
+        >
+          {children}
+        </NavigationPendingContext.Provider>
+      </NavigationPendingReportContext.Provider>
     </NavigationContext.Provider>
   );
 }
@@ -53,7 +80,32 @@ export function useNavigation(): NavigationAdapter {
   return ctx;
 }
 
-/** True while a transition-wrapped push/replace is committing. */
+/**
+ * True while a transition-wrapped push/replace is committing, or while any
+ * mounted view is reporting an in-page content swap.
+ */
 export function useIsNavigating(): boolean {
   return use(NavigationPendingContext);
+}
+
+/**
+ * Report an in-page content swap to the shell's `<NavigationProgress />`.
+ *
+ * For destinations that never change the route — the inbox's detail pane is
+ * the case this exists for. There the click updates the list highlight and
+ * the URL immediately and the expensive part (mounting the new issue detail)
+ * runs behind a `useDeferredValue`, so nothing the navigation adapter can see
+ * is still pending while the user waits. Pass that gap in here and the same
+ * bar a real route change gets covers it.
+ *
+ * Safe to call outside a `NavigationProvider` (leaf views mounted in
+ * isolation, and their tests) — it simply reports nowhere.
+ */
+export function useReportNavigating(pending: boolean): void {
+  const report = use(NavigationPendingReportContext);
+  useEffect(() => {
+    if (!pending || !report) return;
+    report(1);
+    return () => report(-1);
+  }, [pending, report]);
 }

--- a/packages/views/navigation/index.ts
+++ b/packages/views/navigation/index.ts
@@ -3,6 +3,7 @@ export {
   useNavigation,
   useOptionalNavigation,
   useIsNavigating,
+  useReportNavigating,
 } from "./context";
 export { AppLink } from "./app-link";
 export { resolveClickIntent } from "./click-intent";


### PR DESCRIPTION
## Problem

Switching between issues in the **desktop** inbox has no loading affordance: the click freezes the window until the new issue detail commits, then everything appears at once. Web does the same work but feels smooth because a progress bar covers the swap.

## Root cause

Two independent things, both fixed here:

1. **The bar was never mounted on desktop.** `NavigationProgress` only ever shipped inside web's `DashboardLayout`. Desktop builds its shell from `desktop-layout.tsx` and never rendered the component, so the indicator did not exist there at all.
2. **The pending signal could not cover the wait.** `useIsNavigating()` tracked only the adapter's `push`/`replace` transition. On desktop those are synchronous tab-store writes, so the flag settles before the destination content has rendered — even mounted, the bar would have flashed and gone. (The existing comment in `navigation/context.tsx` already noted this.)

Separately, the inbox drove its detail pane straight off `selectedKey`, an urgent state update — so mounting `IssueDetail`, the expensive half of a switch, blocked the main thread from click to commit. That is the "click, freeze, jump" itself, on both platforms; web just had feedback over it.

## Changes

- `packages/views/navigation/context.tsx` — second pending source alongside the transition flag. `useReportNavigating(pending)` lets a view report an in-page content swap into the same signal `NavigationProgress` reads. No-op outside a provider.
- `apps/desktop/.../desktop-layout.tsx` — mount `NavigationProgress` at the top of `MainCanvas`, desktop's equivalent of web's `SidebarInset`. Not workspace-gated (like `TabContent`): a cold workspace resolve is when the wait is longest.
- `packages/views/inbox/components/inbox-page.tsx` — the detail pane's selection is now a `useDeferredValue`. The click commits the row highlight and the URL immediately, React renders the new detail at transition priority (interruptible, so the shell keeps painting), the previous issue stays on screen, and the gap is reported to the bar.
- `resolveDetailItem` (`inbox-display.ts`) — the rule for which row the pane holds while it lags. It holds the stale row only while that row is still in the list: archive advances the selection to the neighbour and drops the actioned row in the same commit, and rendering the miss would blink the empty state between the two issues.

Net effect on desktop: click → row highlights and the blue sweep appears → detail swaps when it is ready. Web gets the same non-blocking swap; its bar behaviour is unchanged.

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — pass (no new warnings on any changed file)
- `pnpm test` — pass, 5/5 workspaces (`@multica/views` 382 files / 4433 tests)

New tests:
- `packages/views/layout/navigation-progress.test.tsx` — a reported swap shows the bar, settling or unmounting the reporter hides it again.
- `packages/views/inbox/components/inbox-display.test.ts` — `resolveDetailItem`, including the archive fall-forward and the deep-link miss.
- `desktop-layout.workspace-gate.test.tsx` — the bar mounts with or without a resolved workspace.

Not run: `make check` (needs a live DB + Playwright); this change is renderer-only.
