### PR TITLE
MUL-6409: fix(issues): render custom-status cards in their category's column

### DIFF
--- a/packages/core/issues/index.ts
+++ b/packages/core/issues/index.ts
@@ -9,6 +9,7 @@ export * from "./stores";
 export {
   issueBehavesAs,
   issueBehavesAsAny,
+  issueColumnCategory,
   issueStatusCategory,
   statusCategoryOfKey,
   statusFilterColumns,

--- a/packages/core/issues/status-behavior.test.ts
+++ b/packages/core/issues/status-behavior.test.ts
@@ -2,7 +2,12 @@
 import { describe, expect, it } from "vitest";
 import { buildIssueStatusCatalog } from "../issue-statuses";
 import type { Issue, IssueStatusEntry } from "../types";
-import { issueBehavesAs, issueBehavesAsAny, statusFilterColumns } from "./status-category";
+import {
+  issueBehavesAs,
+  issueBehavesAsAny,
+  issueColumnCategory,
+  statusFilterColumns,
+} from "./status-category";
 
 function issue(status: string, statusCategory?: string): Pick<Issue, "status" | "status_category"> {
   return { status, status_category: statusCategory } as Pick<Issue, "status" | "status_category">;
@@ -57,6 +62,32 @@ describe("issueBehavesAs", () => {
   it("matches any of several categories", () => {
     expect(issueBehavesAsAny(issue("qa", "cancelled"), ["done", "cancelled"])).toBe(true);
     expect(issueBehavesAsAny(issue("qa", "in_review"), ["done", "cancelled"])).toBe(false);
+  });
+});
+
+/**
+ * The board/list/swimlane column a card renders in. Columns are categories and
+ * `issue.status` is a key, so a custom status has to be translated — the
+ * regression it guards is a card in NO column at all (MUL-6409).
+ */
+describe("issueColumnCategory", () => {
+  it("answers a built-in key with no server hint", () => {
+    expect(issueColumnCategory(issue("in_review"))).toBe("in_review");
+  });
+
+  it("puts a custom status in the column of the category it behaves as", () => {
+    expect(issueColumnCategory(issue("awaiting_response", "in_review"))).toBe("in_review");
+  });
+
+  // Never null: a card in a possibly-wrong column is recoverable, a card in no
+  // column is invisible. The server sends a category on every issue payload, so
+  // this is the unreachable-in-practice floor.
+  it("falls back to todo for a custom key the payload did not resolve", () => {
+    expect(issueColumnCategory(issue("awaiting_response"))).toBe("todo");
+  });
+
+  it("ignores a status_category the client does not recognise", () => {
+    expect(issueColumnCategory(issue("done", "shipped"))).toBe("done");
   });
 });
 

--- a/packages/core/issues/status-category.ts
+++ b/packages/core/issues/status-category.ts
@@ -37,6 +37,28 @@ export function statusCategoryOfKey(statusKey: string): IssueStatusCategory {
 }
 
 /**
+ * The board/list/swimlane COLUMN an issue renders in — always an answer, never
+ * null (MUL-6409).
+ *
+ * Columns are categories while `issue.status` is a concrete KEY, and bucketing
+ * a card by its key against category columns is how a custom status made cards
+ * disappear: `status:awaiting_response` matched no column id, so the rows the
+ * server had correctly returned were dropped on the floor. Filtering the board
+ * by that status made it total — every card in the one visible column was
+ * custom, so the column rendered empty next to a non-zero header count.
+ *
+ * The unresolved-custom-key fallback lands in `todo` rather than nowhere: a
+ * card in a possibly-wrong column is recoverable, a card in no column is
+ * invisible. In practice it is unreachable — the server sends a category on
+ * every issue payload, and a built-in key IS its own category.
+ */
+export function issueColumnCategory(
+  issue: Pick<Issue, "status" | "status_category">,
+): IssueStatusCategory {
+  return issueStatusCategory(issue) ?? statusCategoryOfKey(issue.status);
+}
+
+/**
  * Rewrites a patch's `status_category` to match its `status`, before the patch
  * reaches any cache (MUL-6243).
  *

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -514,7 +514,7 @@ function BoardViewImpl({
         onMoveIssue(
           activeId,
           {
-            ...getMoveUpdates(finalGroup, currentIssue.position),
+            ...getMoveUpdates(finalGroup, currentIssue.position, currentIssue),
             ...getMoveAnchors(targetIds, activeId),
           },
           beginSettle(),
@@ -543,7 +543,7 @@ function BoardViewImpl({
       onMoveIssue(
         activeId,
         {
-          ...getMoveUpdates(finalGroup, newPosition),
+          ...getMoveUpdates(finalGroup, newPosition, currentIssue),
           ...getMoveAnchors(finalIds, activeId),
         },
         beginSettle(),

--- a/packages/views/issues/components/list-view.test.tsx
+++ b/packages/views/issues/components/list-view.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
-import type { Issue, IssueStatus } from "@multica/core/types";
+import type { Issue, IssueStatus, IssueStatusCategory } from "@multica/core/types";
 import { ListView } from "./list-view";
 import { IssueContextMenuProvider } from "../actions";
 import { ScrollRestorationProvider } from "../../platform";
@@ -176,19 +176,24 @@ const ISSUES: Issue[] = [
   } as Issue,
 ];
 
+const emptyPage = {
+  hasMore: false,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  loadMore: vi.fn(),
+  retry: vi.fn(),
+};
+
 const PAGINATION = {
-  todo: {
-    hasMore: false,
-    isLoading: false,
-    isFetching: false,
-    isError: false,
-    total: 2,
-    loadMore: vi.fn(),
-    retry: vi.fn(),
-  },
+  todo: { ...emptyPage, total: 2 },
+  in_review: { ...emptyPage, total: 1 },
 } as unknown as IssueStatusPagination;
 
-function renderListView() {
+function renderListView(
+  issues: Issue[] = ISSUES,
+  visibleStatuses: IssueStatusCategory[] = ["todo"],
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
@@ -198,8 +203,8 @@ function renderListView() {
         <IssueContextMenuProvider>
           <ScrollRestorationProvider adapter={{ get: () => undefined }}>
             <ListView
-              issues={ISSUES}
-              visibleStatuses={["todo"]}
+              issues={issues}
+              visibleStatuses={visibleStatuses}
               statusPagination={PAGINATION}
               onMoveIssue={vi.fn()}
             />
@@ -247,5 +252,27 @@ describe("ListView status header collapse", () => {
     await user.click(trigger);
 
     expect(mockViewState.listCollapsedStatuses).toEqual(["todo"]);
+  });
+});
+
+// Sections are CATEGORIES, cards carry concrete status KEYS. Bucketing a card
+// by its key gave a custom status a section id no section has, so the card was
+// dropped: filtering the surface down to that status left the section rendering
+// "no issues" beside a non-zero header count (MUL-6409). The category mapping
+// itself is covered in utils/drag-utils.test.ts.
+describe("ListView custom statuses", () => {
+  it("renders a custom-status issue in its category's section", () => {
+    const custom = {
+      ...ISSUES[0]!,
+      id: "issue-custom",
+      identifier: "MUL-3",
+      title: "Waiting on the reporter",
+      status: "awaiting_response",
+      status_category: "in_review",
+    } as Issue;
+
+    renderListView([custom], ["in_review"]);
+
+    expect(screen.getByText("Waiting on the reporter")).toBeInTheDocument();
   });
 });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -278,7 +278,7 @@ function ListViewImpl({
         onMoveIssue(
           activeId,
           {
-            ...getMoveUpdates(finalGroup, currentIssue.position),
+            ...getMoveUpdates(finalGroup, currentIssue.position, currentIssue),
             ...getMoveAnchors(targetIds, activeId),
           },
           beginSettle(),
@@ -304,7 +304,7 @@ function ListViewImpl({
       onMoveIssue(
         activeId,
         {
-          ...getMoveUpdates(finalGroup, newPosition),
+          ...getMoveUpdates(finalGroup, newPosition, currentIssue),
           ...getMoveAnchors(finalIds, activeId),
         },
         beginSettle(),

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -459,6 +459,30 @@ describe("SwimLaneView", () => {
     expect(screen.getByText("Cancelled Orphan")).toBeInTheDocument();
   });
 
+  // Cells are CATEGORIES, cards carry concrete status KEYS. Keying the cell by
+  // the raw key gave a custom status a cell that does not exist, and the card
+  // fell out of the grid entirely (MUL-6409).
+  const customStatusOrphan: Issue = {
+    ...cancelledOrphan,
+    id: "custom-orphan",
+    number: 10,
+    identifier: "PROJ-10",
+    title: "Awaiting Reporter",
+    status: "awaiting_response",
+    status_category: "in_review",
+  };
+
+  it("renders a custom-status card in its category's column", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, customStatusOrphan]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Awaiting Reporter")).toBeInTheDocument();
+  });
+
   it("omits the Cancelled column when the status filter narrows to a subset without cancelled", () => {
     renderWithI18n(
       <SwimLaneView

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { issueStatusCategory, statusCategoryOfKey } from "@multica/core/issues";
+import { issueColumnCategory, issueStatusCategory, statusCategoryOfKey } from "@multica/core/issues";
 import { memo, useState, useCallback, useMemo, useEffect, useRef } from "react";
 import {
   DndContext,
@@ -886,7 +886,10 @@ function SwimLaneViewImpl({
             placed = true;
             break;
           }
-          const status = issue.status;
+          // Cells are CATEGORIES: a custom status belongs to the column it
+          // behaves as, and keying the cell by the raw status key dropped
+          // those cards out of the grid entirely (MUL-6409).
+          const status = issueColumnCategory(issue);
           if (result[lane.key]?.[status]) {
             result[lane.key]![status]!.push(issue.id);
             placed = true;
@@ -897,7 +900,7 @@ function SwimLaneViewImpl({
       // Parent grouping: a child whose parent isn't a header here falls
       // into the orphan fallback so it doesn't silently disappear.
       if (!placed && orphanLane && issue.parent_issue_id !== null) {
-        const status = issue.status;
+        const status = issueColumnCategory(issue);
         if (result[orphanLane.key]?.[status]) {
           result[orphanLane.key]![status]!.push(issue.id);
         }
@@ -1267,10 +1270,19 @@ function SwimLaneViewImpl({
         return;
       }
 
+      // The cell names a CATEGORY, so "already here" is a category question.
+      const staysInCell =
+        currentIssue !== undefined &&
+        issueColumnCategory(currentIssue) === finalOverCell.status;
+      // ...and a card already here on a CUSTOM status keeps it: writing the
+      // cell's canonical key would rewrite `awaiting_response` to `in_review`
+      // — a real status change, which starts an agent run (MUL-6409).
+      const keepsStatus =
+        staysInCell && currentIssue?.status !== finalOverCell.status;
       if (
         currentIssue &&
         targetLane.matches(currentIssue) &&
-        currentIssue.status === (finalOverCell.status as IssueStatus) &&
+        staysInCell &&
         currentIssue.position === newPosition
       ) {
         return;
@@ -1281,7 +1293,7 @@ function SwimLaneViewImpl({
         activeId,
         {
           ...targetLane.moveUpdates,
-          status: finalOverCell.status as IssueStatus,
+          ...(keepsStatus ? {} : { status: finalOverCell.status as IssueStatus }),
           position: newPosition,
           ...getMoveAnchors(finalIds, activeId),
         },

--- a/packages/views/issues/surface/use-issue-status-branches.category.test.tsx
+++ b/packages/views/issues/surface/use-issue-status-branches.category.test.tsx
@@ -186,6 +186,60 @@ describe("useIssueStatusBranches — category columns", () => {
       expect(result.current.pagination.in_review?.total).toBe(5),
     );
   });
+
+  // The status facet is disjunctive: the server answers it with the status
+  // filter dropped so the filter MENU can show per-option counts. A column
+  // header asks the opposite question, so an active filter has to narrow the
+  // fold — otherwise filtering by one custom status headed the In Review
+  // column with every in_review issue while showing only the matching cards
+  // beneath it. (MUL-6409)
+  it("counts only the selected statuses while a status filter is active", async () => {
+    setApiInstance({
+      listIssueTableRows: async (request: IssueTableRowsRequest) => ({
+        query_fingerprint: "test",
+        group_key: request.group_key ?? null,
+        parent_id: null,
+        total: 0,
+        rows: [],
+        branch_total: 0,
+        next_cursor: null,
+      }),
+      listIssueStatuses: async () => ({ statuses: [QA_ENTRY], categories: [], total: 1 }),
+    } as unknown as ApiClient);
+
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const { result } = renderHook(
+      () =>
+        useIssueStatusBranches({
+          wsId: "ws-1",
+          query: { ...QUERY, filters: { statuses: ["qa"] } },
+          statuses: ["in_review"],
+          facets: {
+            query_fingerprint: "test",
+            total: 5,
+            facets: [
+              {
+                kind: "status",
+                values: [
+                  { key: "in_review", count: 2 },
+                  { key: "qa", count: 3 },
+                ],
+              },
+            ],
+          },
+          facetsPending: false,
+          facetsFetching: false,
+          enabled: true,
+        }),
+      { wrapper: wrapper(qc) },
+    );
+
+    await waitFor(() =>
+      expect(result.current.pagination.in_review?.total).toBe(3),
+    );
+  });
 });
 
 /**

--- a/packages/views/issues/surface/use-issue-status-branches.ts
+++ b/packages/views/issues/surface/use-issue-status-branches.ts
@@ -13,7 +13,7 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import { ALL_STATUSES } from "@multica/core/issues/config";
-import { statusCategoryOfKey } from "@multica/core/issues";
+import { issueColumnCategory } from "@multica/core/issues";
 import type { IssueStatusCatalog } from "@multica/core/issue-statuses";
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import {
@@ -117,19 +117,6 @@ function rebaseCursorState(
 }
 
 /**
- * The column an issue belongs to.
- *
- * `status_category` is filled by the server for every issue payload, so this is
- * a plain read in the normal case. The fallback covers a row that predates the
- * field (an older backend, or an optimistic client-side patch): a built-in key
- * IS its own category, so it still resolves exactly, and a custom key with no
- * category lands in `todo` rather than disappearing.
- */
-function rowCategory(issue: Issue): IssueStatusCategory {
-  return issue.status_category ?? statusCategoryOfKey(issue.status);
-}
-
-/**
  * Per-column totals from the server's status facet.
  *
  * The facet is keyed by concrete status KEY, while columns are categories, so
@@ -142,14 +129,27 @@ function rowCategory(issue: Issue): IssueStatusCategory {
  * header is worse than a total that is briefly one card short. Before the
  * catalog loads there is nothing to fold, so only built-ins are counted — which
  * is exactly the pre-feature behavior. (MUL-6243)
+ *
+ * The status facet is DISJUNCTIVE — the server answers it with the status
+ * filter dropped, so the filter menu can show what each option would select.
+ * A column header is the opposite question, so an active filter narrows the
+ * fold to the keys it selected. Without that, filtering by one custom status
+ * headed the In Review column with every in_review issue (220) above the 5
+ * cards that actually matched. (MUL-6409)
  */
 function statusCountsFromFacets(
   facets: IssueTableFacetsResponse | undefined,
   catalog: Pick<IssueStatusCatalog, "entryOf" | "isLoaded">,
+  selectedStatuses: readonly string[] | undefined,
 ) {
   const counts = new Map<IssueStatusCategory, number>();
+  const selected =
+    selectedStatuses && selectedStatuses.length > 0
+      ? new Set(selectedStatuses)
+      : null;
   const statusFacet = facets?.facets.find((facet) => facet.kind === "status");
   for (const value of statusFacet?.values ?? []) {
+    if (selected && !selected.has(value.key)) continue;
     const builtIn = ALL_STATUSES.find((category) => category === value.key);
     const category = builtIn ?? (catalog.isLoaded ? catalog.entryOf(value.key)?.category : undefined);
     if (!category || !ALL_STATUSES.includes(category)) continue;
@@ -328,7 +328,7 @@ export function useIssueStatusBranches({
           // patched card under a column it no longer belongs to. The comparison
           // is against the CATEGORY, so a custom status stays in its column
           // instead of being dropped for not equalling the column key.
-          if (rowCategory(row.issue) !== target.status) continue;
+          if (issueColumnCategory(row.issue) !== target.status) continue;
           if (seen.has(row.issue.id)) continue;
           seen.add(row.issue.id);
           current.rows.push(row.issue);
@@ -395,8 +395,8 @@ export function useIssueStatusBranches({
   ]);
 
   const counts = useMemo(
-    () => statusCountsFromFacets(facets, catalog),
-    [facets, catalog],
+    () => statusCountsFromFacets(facets, catalog, query.filters.statuses),
+    [facets, catalog, query.filters.statuses],
   );
   const loadMore = useCallback(
     (status: IssueStatusCategory) => {

--- a/packages/views/issues/utils/drag-utils.test.ts
+++ b/packages/views/issues/utils/drag-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "@multica/core/types";
+import type { BoardColumnGroup } from "../components/board-column";
 import {
+  buildColumns,
   getIssueGroupId,
   getMoveAnchors,
   getMoveUpdates,
@@ -89,6 +91,67 @@ describe("insertIdByPosition", () => {
       "moved",
       "y",
     ]);
+  });
+});
+
+/**
+ * Status columns are CATEGORIES while `issue.status` is a concrete KEY. Every
+ * assertion here is a card on a custom status: bucketing it by the raw key
+ * produced a column id no column has, so the card was dropped from the board
+ * and the list — filtering by that status left a visibly empty column next to
+ * a non-zero header count (MUL-6409).
+ */
+describe("status grouping with custom statuses", () => {
+  const custom = {
+    ...mk("custom", 1),
+    status: "awaiting_response",
+    status_category: "in_review",
+  } as Issue;
+  const builtIn = { ...mk("built-in", 2), status: "in_review" } as Issue;
+  const inReviewColumn: BoardColumnGroup = {
+    id: "status:in_review",
+    title: "In Review",
+    status: "in_review",
+  };
+  const todoColumn: BoardColumnGroup = { id: "status:todo", title: "Todo", status: "todo" };
+  const doneColumn: BoardColumnGroup = { id: "status:done", title: "Done", status: "done" };
+
+  it("buckets a custom status into its category's column", () => {
+    expect(getIssueGroupId(custom, "status")).toBe("status:in_review");
+    expect(getIssueGroupId(builtIn, "status")).toBe("status:in_review");
+  });
+
+  it("renders the card in that column instead of dropping it", () => {
+    const columns = buildColumns([custom, builtIn], [inReviewColumn], "status");
+    expect(columns["status:in_review"]).toEqual(["custom", "built-in"]);
+  });
+
+  it("treats the card as already in the column it is drawn in", () => {
+    expect(issueMatchesGroup(custom, inReviewColumn)).toBe(true);
+    expect(issueMatchesGroup(custom, todoColumn)).toBe(false);
+  });
+
+  // A status change starts an agent run, so a same-column reorder that rewrote
+  // `awaiting_response` to `in_review` would be a silent, side-effecting edit.
+  it("reorders within the column without rewriting the status", () => {
+    expect(getMoveUpdates(inReviewColumn, 5, custom)).toEqual({ position: 5 });
+  });
+
+  it("still sets the status when the card moves to another column", () => {
+    expect(getMoveUpdates(doneColumn, 5, custom)).toEqual({ status: "done", position: 5 });
+  });
+
+  it("sets the status when the caller has no issue to compare", () => {
+    expect(getMoveUpdates(inReviewColumn, 5)).toEqual({ status: "in_review", position: 5 });
+  });
+
+  // A built-in card in its own column keeps carrying the (unchanged) key, so a
+  // workspace without custom statuses sends exactly the payload it always did.
+  it("keeps the status in the payload for a built-in card", () => {
+    expect(getMoveUpdates(inReviewColumn, 5, builtIn)).toEqual({
+      status: "in_review",
+      position: 5,
+    });
   });
 });
 

--- a/packages/views/issues/utils/drag-utils.ts
+++ b/packages/views/issues/utils/drag-utils.ts
@@ -6,6 +6,7 @@ import {
 import type { Issue, IssueAssigneeType, IssueStatus, UpdateIssueRequest } from "@multica/core/types";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
+import { issueColumnCategory } from "@multica/core/issues";
 import type { BoardColumnGroup } from "../components/board-column";
 
 export type DragMoveTargetUpdates = Pick<
@@ -52,7 +53,11 @@ export function getIssueGroupId(
   grouping: IssueGrouping,
   knownOptionIds?: ReadonlySet<string>,
 ): string {
-  if (grouping === "status") return statusGroupId(issue.status);
+  // Status columns are CATEGORIES, so the card buckets by the category it
+  // behaves as. Bucketing by the raw key gave a custom status a column id no
+  // column has, and the card was dropped from the board/list entirely
+  // (MUL-6409).
+  if (grouping === "status") return statusGroupId(issueColumnCategory(issue));
   const propertyId = propertyIdFromViewKey(grouping);
   if (propertyId) {
     const value = issue.properties?.[propertyId];
@@ -139,7 +144,10 @@ export function findColumn(
 }
 
 export function issueMatchesGroup(issue: Issue, group: BoardColumnGroup): boolean {
-  if (group.status) return issue.status === group.status;
+  // "Is this card already in that column?" — a category question, like the
+  // column itself. Comparing the raw key answered no for every custom status,
+  // so a drop that changed nothing still fired a status write (MUL-6409).
+  if (group.status) return issueColumnCategory(issue) === group.status;
   if (group.propertyId !== undefined) {
     const value = issue.properties?.[group.propertyId];
     const optionId = typeof value === "string" ? value : null;
@@ -154,8 +162,21 @@ export function issueMatchesGroup(issue: Issue, group: BoardColumnGroup): boolea
 export function getMoveUpdates(
   group: BoardColumnGroup,
   position: number,
+  /** The card being moved, when the caller has it. A status column names a
+   *  CATEGORY, and a card on a custom status is already in that column under a
+   *  DIFFERENT key — so writing the column's canonical key would silently
+   *  rewrite `awaiting_response` to `in_review`, and a status change starts an
+   *  agent run, for a drag that only changed the row order (MUL-6409). */
+  issue?: Pick<Issue, "status" | "status_category">,
 ): DragMoveTargetUpdates {
-  if (group.status) return { status: group.status, position };
+  if (group.status) {
+    const keepsStatus =
+      issue !== undefined &&
+      issue.status !== group.status &&
+      issueColumnCategory(issue) === group.status;
+    if (keepsStatus) return { position };
+    return { status: group.status, position };
+  }
   // Property columns: the value change is not part of UpdateIssueRequest —
   // the board applies it through useSetIssueProperty after the position move.
   if (group.propertyId !== undefined) return { position };


### PR DESCRIPTION
## Problem

Filtering the issue surface by a custom status (`Awaiting Response`, 5 issues) emptied the board: the one visible column, `In Review`, rendered "No issues" under a header counting 220.

Two independent conflations of "status category" with "status key", both client-side — the server returned the right rows all along.

**1. Cards were bucketed by their raw status key.** Columns are categories (`status:in_review`), so `getIssueGroupId` returning `status:awaiting_response` matched no column and the card was dropped. Not filter-specific: a custom-status card has been invisible on board, list and swimlane since custom statuses shipped — filtering just made every card in the visible column custom, so the loss became total.

**2. Column totals came from the disjunctive status facet.** The server answers the status facet with the status filter dropped so the filter menu can show per-option counts. A column header asks the opposite question, so it read 215 (`in_review`) + 5 (`awaiting_response`) = 220 while 5 rows matched.

## Changes

- `issueColumnCategory(issue)` in `@multica/core/issues` — the column a card renders in, always an answer. `use-issue-status-branches` drops its private `rowCategory` copy for it.
- Board/list (`getIssueGroupId`) and swimlane cells bucket by that category.
- Drag equality (`issueMatchesGroup`, the swimlane cell check) compares categories, and the move payload omits `status` when the card is already in that column under a custom key. Without it, reordering a row inside its own column rewrote `awaiting_response` → `in_review` — a real status change, which starts an agent run. Built-in cards keep sending the (unchanged) key, so a workspace with no custom statuses sends exactly the payload it did before.
- Column totals fold only the selected keys while a status filter is active. The filter menu still reads the facet directly and is unaffected.

## Verification

- `pnpm test` in `packages/views` (4435) and `packages/core` (1516) — all pass.
- `pnpm typecheck` — clean.
- New regression coverage, each verified to fail without the fix: `drag-utils.test.ts` (bucketing, drag equality, move payload), `list-view.test.tsx` (a custom-status card renders in its category's section), `swimlane-view.test.tsx` (same for a swimlane cell), `use-issue-status-branches.category.test.tsx` (filtered column total is 3, not 5).

Not covered here: `apps/mobile` keeps its own hand-mirrored status list and releases separately.
