### PR TITLE
MUL-6416: fix Vercel frontend upload exclusions

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -31,8 +31,11 @@ _features
 /e2e/
 /server/
 /apps/*
-!/apps/web/
-!/apps/docs/
+# Vercel checks directory entries without a trailing slash before descending.
+!/apps/web
+!/apps/web/**
+!/apps/docs
+!/apps/docs/**
 /scripts/
 
 *.log


### PR DESCRIPTION
## Summary

- re-include the `apps/web` and `apps/docs` directory entries during Vercel's upload traversal
- re-include both apps' descendants while keeping desktop, mobile, and deployment-only exclusions intact

## Validation

- `git diff --check`
- exercised `.vercelignore` with the ignore implementation bundled in Vercel CLI 51.0.0 and a directory-pruning traversal
- verified Web and Docs manifests/source files are included while desktop/mobile and deployment-only trims remain excluded

Closes MUL-6416
