### PR TITLE
MUL-6414: bound Redis relay stream retention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -379,12 +379,12 @@ CORS_ALLOWED_ORIGINS=
 # caches and lease state. Requires Redis/Valkey with XTRIM MINID support
 # (Redis 6.2+). When unset, the relay falls back to REDIS_URL.
 # REALTIME_RELAY_REDIS_URL=redis://realtime-redis:6379/0
-# Relay retention defaults: 8 shards, 8192 entries per shard, 5m replay, and
+# Relay retention defaults: 8 shards, 2000 entries per shard, 5m replay, and
 # exact time trimming after 10m. MAXLEN is the immediate operational pressure
 # valve; size it from observed entry bytes, event rate, and the Redis memory
 # budget. MAXLEN, trim, and TTL controls apply consistently to sharded,
 # legacy, and dual mode; replay grace applies to sharded readers.
-# REALTIME_RELAY_STREAM_MAXLEN=8192
+# REALTIME_RELAY_STREAM_MAXLEN=2000
 # REALTIME_RELAY_REPLAY_GRACE=5m
 # REALTIME_RELAY_TRIM_HORIZON=10m
 # Stream TTL is a staged, opt-in fallback for volatile-* policies; it evicts a

--- a/.env.example
+++ b/.env.example
@@ -379,14 +379,23 @@ CORS_ALLOWED_ORIGINS=
 # caches and lease state. Requires Redis/Valkey with XTRIM MINID support
 # (Redis 6.2+). When unset, the relay falls back to REDIS_URL.
 # REALTIME_RELAY_REDIS_URL=redis://realtime-redis:6379/0
-# Relay retention defaults: 8 shards, 8192 entries per shard, 5m replay,
-# exact time trimming after 10m, and a 15m key TTL. MAXLEN is the immediate
-# operational pressure valve; size it from observed entry bytes, event rate,
-# and the Redis memory budget. TTL only makes whole stream keys eligible for
-# volatile-* eviction and does not protect a noeviction instance.
+# Relay retention defaults: 8 shards, 8192 entries per shard, 5m replay, and
+# exact time trimming after 10m. MAXLEN is the immediate operational pressure
+# valve; size it from observed entry bytes, event rate, and the Redis memory
+# budget. MAXLEN, trim, and TTL controls apply consistently to sharded,
+# legacy, and dual mode; replay grace applies to sharded readers.
 # REALTIME_RELAY_STREAM_MAXLEN=8192
 # REALTIME_RELAY_REPLAY_GRACE=5m
 # REALTIME_RELAY_TRIM_HORIZON=10m
+# Stream TTL is a staged, opt-in fallback for volatile-* policies; it evicts a
+# whole stream and does not protect a noeviction instance before expiry.
+# Safe rollout: first deploy this version everywhere with TTL disabled (the
+# default). Then set the flag to true and roll every replica a second time.
+# Safe rollback: set the flag to false and update every replica, then wait for
+# a complete legacy SCAN cycle (large keyspaces may need several maintenance
+# intervals) and verify relay PTTL values are -1 before rolling back the binary.
+# Do not roll directly back while TTL remains enabled.
+# REALTIME_RELAY_STREAM_TTL_ENABLED=false
 # REALTIME_RELAY_STREAM_TTL=15m
 # REALTIME_RELAY_TTL_REFRESH_INTERVAL=30s
 # REALTIME_RELAY_MAINTENANCE_INTERVAL=1m

--- a/.env.example
+++ b/.env.example
@@ -372,9 +372,24 @@ CORS_ALLOWED_ORIGINS=
 # (/auth/send-code, /auth/verify-code, /auth/google). Backed by Redis.
 # When REDIS_URL is unset the limiter is a no-op (fail-open) and the
 # backend logs "auth rate limiting disabled: REDIS_URL not configured" at
-# startup. The same REDIS_URL is reused by the realtime fan-out hub,
-# the PAT cache, and the daemon-token cache.
+# startup. By default the same REDIS_URL is reused by the realtime fan-out
+# hub, the PAT cache, and the daemon-token cache.
 # REDIS_URL=redis://localhost:6379/0
+# Recommended for production: isolate realtime streams from request-path
+# caches and lease state. Requires Redis/Valkey with XTRIM MINID support
+# (Redis 6.2+). When unset, the relay falls back to REDIS_URL.
+# REALTIME_RELAY_REDIS_URL=redis://realtime-redis:6379/0
+# Relay retention defaults: 8 shards, 8192 entries per shard, 5m replay,
+# exact time trimming after 10m, and a 15m key TTL. MAXLEN is the immediate
+# operational pressure valve; size it from observed entry bytes, event rate,
+# and the Redis memory budget. TTL only makes whole stream keys eligible for
+# volatile-* eviction and does not protect a noeviction instance.
+# REALTIME_RELAY_STREAM_MAXLEN=8192
+# REALTIME_RELAY_REPLAY_GRACE=5m
+# REALTIME_RELAY_TRIM_HORIZON=10m
+# REALTIME_RELAY_STREAM_TTL=15m
+# REALTIME_RELAY_TTL_REFRESH_INTERVAL=30s
+# REALTIME_RELAY_MAINTENANCE_INTERVAL=1m
 # Set to "true" to skip the CLIENT SETNAME handshake on every Redis
 # connection. Required for managed Redis providers that block the CLIENT
 # command (e.g. GCP Memorystore, AWS ElastiCache with restricted ACLs).

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -61,6 +61,13 @@ func channelLeaseRedisURLFromEnv() string {
 	return strings.TrimSpace(os.Getenv("REDIS_URL"))
 }
 
+func realtimeRelayRedisURLFromEnv() string {
+	if dedicated := strings.TrimSpace(os.Getenv("REALTIME_RELAY_REDIS_URL")); dedicated != "" {
+		return dedicated
+	}
+	return strings.TrimSpace(os.Getenv("REDIS_URL"))
+}
+
 func closeRedisClient(label string, client *redis.Client) {
 	if client == nil {
 		return
@@ -77,7 +84,14 @@ func shardedRelayConfigFromEnv() realtime.ShardedStreamRelayConfig {
 	cfg.ReadCount = envPositiveInt64("REALTIME_RELAY_XREAD_COUNT", cfg.ReadCount)
 	cfg.ReadBlock = envDuration("REALTIME_RELAY_XREAD_BLOCK", cfg.ReadBlock)
 	cfg.ReplayGrace = envDuration("REALTIME_RELAY_REPLAY_GRACE", cfg.ReplayGrace)
-	return cfg
+	cfg.TrimHorizon = envDuration("REALTIME_RELAY_TRIM_HORIZON", 2*cfg.ReplayGrace)
+	cfg.StreamTTL = envDuration("REALTIME_RELAY_STREAM_TTL", cfg.TrimHorizon+cfg.ReplayGrace)
+	cfg.TTLRefreshInterval = envDuration("REALTIME_RELAY_TTL_REFRESH_INTERVAL", cfg.TTLRefreshInterval)
+	cfg.MaintenanceInterval = envDuration("REALTIME_RELAY_MAINTENANCE_INTERVAL", cfg.MaintenanceInterval)
+	if err := cfg.Validate(); err != nil {
+		slog.Warn("invalid realtime relay retention config; normalizing to safe values", "error", err)
+	}
+	return cfg.Normalized()
 }
 
 func realtimeRelayModeFromEnv() string {
@@ -338,15 +352,23 @@ func main() {
 		closeRedisClient("channel-lease", channelLeaseRedis)
 		closeRedisClient("store", storeRedis)
 	}()
-	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
-		opts, err := redis.ParseURL(redisURL)
-		if err != nil {
-			slog.Error("invalid REDIS_URL — falling back to in-memory hub", "error", err)
+	sharedRedisURL := strings.TrimSpace(os.Getenv("REDIS_URL"))
+	relayRedisURL := realtimeRelayRedisURLFromEnv()
+	if (sharedRedisURL != "" || relayRedisURL != "") && envBool("REDIS_DISABLE_CLIENT_NAME", false) {
+		slog.Info("redis: CLIENT SETNAME disabled (REDIS_DISABLE_CLIENT_NAME=true) for managed Redis compatibility")
+	}
+	if sharedRedisURL != "" {
+		if opts, err := redis.ParseURL(sharedRedisURL); err != nil {
+			slog.Error("invalid REDIS_URL — request-path Redis features disabled", "error", err)
 		} else {
-			if envBool("REDIS_DISABLE_CLIENT_NAME", false) {
-				slog.Info("redis: CLIENT SETNAME disabled (REDIS_DISABLE_CLIENT_NAME=true) for managed Redis compatibility")
-			}
 			storeRedis = newNamedRedisClient(opts, "store")
+		}
+	}
+	if relayRedisURL != "" {
+		opts, err := redis.ParseURL(relayRedisURL)
+		if err != nil {
+			slog.Error("invalid realtime relay Redis URL — falling back to in-memory hub", "error", err)
+		} else {
 			relayWriteRedis = newNamedRedisClient(opts, "realtime-write")
 
 			relayMode := realtimeRelayModeFromEnv()
@@ -373,21 +395,29 @@ func main() {
 			}
 			relay.Start(relayCtx)
 			broadcaster = realtime.NewDualWriteBroadcaster(hub, relay)
+			storePoolSize := 0
+			if storeRedis != nil {
+				storePoolSize = storeRedis.Options().PoolSize
+			}
 			slog.Info(
 				"realtime: Redis relay enabled",
 				"node_id", relay.NodeID(),
 				"mode", relayMode,
+				"dedicated_instance", strings.TrimSpace(os.Getenv("REALTIME_RELAY_REDIS_URL")) != "",
 				"shards", relayConfig.Shards,
 				"stream_max_len", relayConfig.StreamMaxLen,
+				"replay_grace", relayConfig.ReplayGrace.String(),
+				"trim_horizon", relayConfig.TrimHorizon.String(),
+				"stream_ttl", relayConfig.StreamTTL.String(),
 				"xread_count", relayConfig.ReadCount,
 				"xread_block", relayConfig.ReadBlock.String(),
-				"store_pool_size", opts.PoolSize,
+				"store_pool_size", storePoolSize,
 				"realtime_write_pool_size", opts.PoolSize,
 				"realtime_read_pool_size", opts.PoolSize,
 			)
 		}
 	} else {
-		slog.Info("realtime: REDIS_URL not set — using in-memory hub (single-node mode)")
+		slog.Info("realtime: REDIS_URL and REALTIME_RELAY_REDIS_URL are unset — using in-memory hub (single-node mode)")
 	}
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("CHANNEL_WS_LEASE_BACKEND")), "redis") {
 		leaseRedisURL := channelLeaseRedisURLFromEnv()

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -88,6 +88,7 @@ func shardedRelayConfigFromEnv() realtime.ShardedStreamRelayConfig {
 	cfg.StreamTTL = envDuration("REALTIME_RELAY_STREAM_TTL", cfg.TrimHorizon+cfg.ReplayGrace)
 	cfg.TTLRefreshInterval = envDuration("REALTIME_RELAY_TTL_REFRESH_INTERVAL", cfg.TTLRefreshInterval)
 	cfg.MaintenanceInterval = envDuration("REALTIME_RELAY_MAINTENANCE_INTERVAL", cfg.MaintenanceInterval)
+	cfg.StreamTTLEnabled = envBool("REALTIME_RELAY_STREAM_TTL_ENABLED", false)
 	if err := cfg.Validate(); err != nil {
 		slog.Warn("invalid realtime relay retention config; normalizing to safe values", "error", err)
 	}
@@ -376,14 +377,14 @@ func main() {
 			switch relayMode {
 			case "legacy":
 				relayReadRedis = newNamedRedisClient(opts, "realtime-read")
-				relay = realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+				relay = realtime.NewRedisRelayWithClientsAndConfig(hub, relayWriteRedis, relayReadRedis, relayConfig.RetentionConfig())
 				slog.Info("daemon websocket wakeup: Redis fanout disabled in legacy realtime relay mode")
 			case "dual":
 				shardedReadRedis = newNamedRedisClient(opts, "realtime-read-sharded")
 				legacyReadRedis = newNamedRedisClient(opts, "realtime-read-legacy")
 				sharded := realtime.NewShardedStreamRelay(hub, relayWriteRedis, shardedReadRedis, relayConfig)
 				sharded.SetDaemonRuntimeDeliverer(daemonHub)
-				legacy := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, legacyReadRedis)
+				legacy := realtime.NewRedisRelayWithClientsAndConfig(hub, relayWriteRedis, legacyReadRedis, relayConfig.RetentionConfig())
 				relay = realtime.NewMirroredRelay(sharded, legacy)
 				daemonWakeup = daemonws.NewRelayNotifier(daemonHub, sharded)
 			default:
@@ -409,6 +410,7 @@ func main() {
 				"replay_grace", relayConfig.ReplayGrace.String(),
 				"trim_horizon", relayConfig.TrimHorizon.String(),
 				"stream_ttl", relayConfig.StreamTTL.String(),
+				"stream_ttl_enabled", relayConfig.StreamTTLEnabled,
 				"xread_count", relayConfig.ReadCount,
 				"xread_block", relayConfig.ReadBlock.String(),
 				"store_pool_size", storePoolSize,

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -55,6 +55,56 @@ func TestChannelLeaseRedisURLFromEnvFallsBackToSharedRedis(t *testing.T) {
 	}
 }
 
+func TestRealtimeRelayRedisURLFromEnvPrefersDedicatedInstance(t *testing.T) {
+	t.Setenv("REDIS_URL", "redis://shared:6379/0")
+	t.Setenv("REALTIME_RELAY_REDIS_URL", " redis://relay:6379/0 ")
+	if got := realtimeRelayRedisURLFromEnv(); got != "redis://relay:6379/0" {
+		t.Fatalf("realtime relay Redis URL = %q", got)
+	}
+}
+
+func TestRealtimeRelayRedisURLFromEnvFallsBackToSharedRedis(t *testing.T) {
+	t.Setenv("REDIS_URL", " redis://shared:6379/0 ")
+	t.Setenv("REALTIME_RELAY_REDIS_URL", "")
+	if got := realtimeRelayRedisURLFromEnv(); got != "redis://shared:6379/0" {
+		t.Fatalf("realtime relay Redis URL = %q", got)
+	}
+}
+
+func TestShardedRelayConfigFromEnvDerivesSafeRetention(t *testing.T) {
+	t.Setenv("REALTIME_RELAY_REPLAY_GRACE", "20m")
+	t.Setenv("REALTIME_RELAY_TRIM_HORIZON", "")
+	t.Setenv("REALTIME_RELAY_STREAM_TTL", "")
+
+	cfg := shardedRelayConfigFromEnv()
+	if cfg.TrimHorizon != 40*time.Minute {
+		t.Fatalf("trim horizon = %s, want 40m", cfg.TrimHorizon)
+	}
+	if cfg.StreamTTL != 60*time.Minute {
+		t.Fatalf("stream TTL = %s, want 60m", cfg.StreamTTL)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("derived retention config is invalid: %v", err)
+	}
+}
+
+func TestShardedRelayConfigFromEnvNormalizesUnsafeOverrides(t *testing.T) {
+	t.Setenv("REALTIME_RELAY_REPLAY_GRACE", "5m")
+	t.Setenv("REALTIME_RELAY_TRIM_HORIZON", "4m")
+	t.Setenv("REALTIME_RELAY_STREAM_TTL", "3m")
+
+	cfg := shardedRelayConfigFromEnv()
+	if cfg.TrimHorizon != 10*time.Minute {
+		t.Fatalf("trim horizon = %s, want 10m", cfg.TrimHorizon)
+	}
+	if cfg.StreamTTL != 15*time.Minute {
+		t.Fatalf("stream TTL = %s, want 15m", cfg.StreamTTL)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("normalized retention config is invalid: %v", err)
+	}
+}
+
 func TestNewNamedRedisClient_SetsClientName(t *testing.T) {
 	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "")
 	base := &redis.Options{Addr: "localhost:6379"}

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -83,8 +83,24 @@ func TestShardedRelayConfigFromEnvDerivesSafeRetention(t *testing.T) {
 	if cfg.StreamTTL != 60*time.Minute {
 		t.Fatalf("stream TTL = %s, want 60m", cfg.StreamTTL)
 	}
+	if cfg.StreamTTLEnabled {
+		t.Fatal("stream TTL must remain disabled until the staged rollout flag is enabled")
+	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("derived retention config is invalid: %v", err)
+	}
+}
+
+func TestShardedRelayConfigFromEnvEnablesTTLExplicitly(t *testing.T) {
+	t.Setenv("REALTIME_RELAY_STREAM_TTL_ENABLED", "true")
+
+	cfg := shardedRelayConfigFromEnv()
+	if !cfg.StreamTTLEnabled {
+		t.Fatal("stream TTL flag was not applied")
+	}
+	retention := cfg.RetentionConfig()
+	if !retention.StreamTTLEnabled || retention.StreamTTL != cfg.StreamTTL {
+		t.Fatalf("legacy retention config diverged from sharded config: %+v", retention)
 	}
 }
 

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -72,11 +72,15 @@ func TestRealtimeRelayRedisURLFromEnvFallsBackToSharedRedis(t *testing.T) {
 }
 
 func TestShardedRelayConfigFromEnvDerivesSafeRetention(t *testing.T) {
+	t.Setenv("REALTIME_RELAY_STREAM_MAXLEN", "")
 	t.Setenv("REALTIME_RELAY_REPLAY_GRACE", "20m")
 	t.Setenv("REALTIME_RELAY_TRIM_HORIZON", "")
 	t.Setenv("REALTIME_RELAY_STREAM_TTL", "")
 
 	cfg := shardedRelayConfigFromEnv()
+	if cfg.StreamMaxLen != 2000 {
+		t.Fatalf("stream max len = %d, want 2000", cfg.StreamMaxLen)
+	}
 	if cfg.TrimHorizon != 40*time.Minute {
 		t.Fatalf("trim horizon = %s, want 40m", cfg.TrimHorizon)
 	}

--- a/server/internal/metrics/realtime.go
+++ b/server/internal/metrics/realtime.go
@@ -9,42 +9,62 @@ import (
 type RealtimeCollector struct {
 	metrics *realtime.Metrics
 
-	connectsTotal       *prometheus.Desc
-	disconnectsTotal    *prometheus.Desc
-	activeConnections   *prometheus.Desc
-	slowEvictionsTotal  *prometheus.Desc
-	messagesSentTotal   *prometheus.Desc
-	messagesDropped     *prometheus.Desc
-	inboundTooLarge     *prometheus.Desc
-	redisConnected      *prometheus.Desc
-	redisXAddTotal      *prometheus.Desc
-	redisXAddErrors     *prometheus.Desc
-	redisXReadTotal     *prometheus.Desc
-	redisXReadErrors    *prometheus.Desc
-	redisAckTotal       *prometheus.Desc
-	redisMirrorErrors   *prometheus.Desc
-	redisMirrorDiverged *prometheus.Desc
+	connectsTotal          *prometheus.Desc
+	disconnectsTotal       *prometheus.Desc
+	activeConnections      *prometheus.Desc
+	slowEvictionsTotal     *prometheus.Desc
+	messagesSentTotal      *prometheus.Desc
+	messagesDropped        *prometheus.Desc
+	inboundTooLarge        *prometheus.Desc
+	redisConnected         *prometheus.Desc
+	redisXAddTotal         *prometheus.Desc
+	redisXAddErrors        *prometheus.Desc
+	redisXReadTotal        *prometheus.Desc
+	redisXReadErrors       *prometheus.Desc
+	redisAckTotal          *prometheus.Desc
+	redisMirrorErrors      *prometheus.Desc
+	redisMirrorDiverged    *prometheus.Desc
+	redisStreamTrimmed     *prometheus.Desc
+	redisStreamMissing     *prometheus.Desc
+	redisRetentionErrors   *prometheus.Desc
+	redisStreamsWithoutTTL *prometheus.Desc
+	redisUsedMemoryBytes   *prometheus.Desc
+	redisMaxMemoryBytes    *prometheus.Desc
+	redisEvictedKeys       *prometheus.Desc
+	redisStreamEntries     *prometheus.Desc
+	redisStreamMemory      *prometheus.Desc
+	redisStreamPTTL        *prometheus.Desc
 }
 
 func NewRealtimeCollector(m *realtime.Metrics) *RealtimeCollector {
 	return &RealtimeCollector{
 		metrics: m,
 
-		connectsTotal:       newRealtimeDesc("connects_total", "Total realtime WebSocket connections opened."),
-		disconnectsTotal:    newRealtimeDesc("disconnects_total", "Total realtime WebSocket connections closed."),
-		activeConnections:   newRealtimeDesc("active_connections", "Current realtime WebSocket connections."),
-		slowEvictionsTotal:  newRealtimeDesc("slow_evictions_total", "Total realtime clients evicted for slow consumption."),
-		messagesSentTotal:   newRealtimeDesc("messages_sent_total", "Total realtime messages sent."),
-		messagesDropped:     newRealtimeDesc("messages_dropped_total", "Total realtime messages dropped."),
-		inboundTooLarge:     newRealtimeDesc("inbound_too_large_total", "Total realtime connections closed for exceeding the inbound message size limit."),
-		redisConnected:      newRealtimeDesc("redis_connected", "Whether the realtime Redis relay is connected."),
-		redisXAddTotal:      newRealtimeDesc("redis_xadd_total", "Total Redis XADD operations by the realtime relay."),
-		redisXAddErrors:     newRealtimeDesc("redis_xadd_errors_total", "Total Redis XADD errors by the realtime relay."),
-		redisXReadTotal:     newRealtimeDesc("redis_xread_total", "Total Redis XREAD operations by the realtime relay."),
-		redisXReadErrors:    newRealtimeDesc("redis_xread_errors_total", "Total Redis XREAD errors by the realtime relay."),
-		redisAckTotal:       newRealtimeDesc("redis_ack_total", "Total Redis stream acknowledgements by the realtime relay."),
-		redisMirrorErrors:   prometheus.NewDesc("multica_realtime_redis_mirror_errors_total", "Total Redis mirror write errors by the realtime relay.", []string{"target"}, nil),
-		redisMirrorDiverged: newRealtimeDesc("redis_mirror_divergence_total", "Total Redis mirror divergence events by the realtime relay."),
+		connectsTotal:          newRealtimeDesc("connects_total", "Total realtime WebSocket connections opened."),
+		disconnectsTotal:       newRealtimeDesc("disconnects_total", "Total realtime WebSocket connections closed."),
+		activeConnections:      newRealtimeDesc("active_connections", "Current realtime WebSocket connections."),
+		slowEvictionsTotal:     newRealtimeDesc("slow_evictions_total", "Total realtime clients evicted for slow consumption."),
+		messagesSentTotal:      newRealtimeDesc("messages_sent_total", "Total realtime messages sent."),
+		messagesDropped:        newRealtimeDesc("messages_dropped_total", "Total realtime messages dropped."),
+		inboundTooLarge:        newRealtimeDesc("inbound_too_large_total", "Total realtime connections closed for exceeding the inbound message size limit."),
+		redisConnected:         newRealtimeDesc("redis_connected", "Whether the realtime Redis relay is connected."),
+		redisXAddTotal:         newRealtimeDesc("redis_xadd_total", "Total Redis XADD operations by the realtime relay."),
+		redisXAddErrors:        newRealtimeDesc("redis_xadd_errors_total", "Total Redis XADD errors by the realtime relay."),
+		redisXReadTotal:        newRealtimeDesc("redis_xread_total", "Total Redis XREAD operations by the realtime relay."),
+		redisXReadErrors:       newRealtimeDesc("redis_xread_errors_total", "Total Redis XREAD errors by the realtime relay."),
+		redisAckTotal:          newRealtimeDesc("redis_ack_total", "Total Redis stream acknowledgements by the realtime relay."),
+		redisMirrorErrors:      prometheus.NewDesc("multica_realtime_redis_mirror_errors_total", "Total Redis mirror write errors by the realtime relay.", []string{"target"}, nil),
+		redisMirrorDiverged:    newRealtimeDesc("redis_mirror_divergence_total", "Total Redis mirror divergence events by the realtime relay."),
+		redisStreamTrimmed:     newRealtimeDesc("redis_stream_trimmed_entries_total", "Total Redis Stream entries removed by retention maintenance."),
+		redisStreamMissing:     newRealtimeDesc("redis_stream_missing_total", "Total observed relay stream disappearance transitions, including eviction and expiry."),
+		redisRetentionErrors:   newRealtimeDesc("redis_retention_errors_total", "Total Redis relay retention maintenance errors."),
+		redisStreamsWithoutTTL: newRealtimeDesc("redis_streams_without_ttl", "Current number of observed relay streams without an expiry."),
+		redisUsedMemoryBytes:   newRealtimeDesc("redis_used_memory_bytes", "Redis used_memory sampled by the realtime relay."),
+		redisMaxMemoryBytes:    newRealtimeDesc("redis_maxmemory_bytes", "Redis maxmemory sampled by the realtime relay; zero means unlimited."),
+		redisEvictedKeys:       newRealtimeDesc("redis_evicted_keys", "Redis instance evicted_keys sampled by the realtime relay."),
+		redisStreamEntries:     prometheus.NewDesc("multica_realtime_redis_stream_entries", "Current entry count of a sampled relay stream.", []string{"stream"}, nil),
+		redisStreamMemory:      prometheus.NewDesc("multica_realtime_redis_stream_memory_bytes", "Sampled memory usage of a relay stream.", []string{"stream"}, nil),
+		redisStreamPTTL:        prometheus.NewDesc("multica_realtime_redis_stream_pttl_milliseconds", "Remaining relay stream TTL in milliseconds; -1 means no TTL and -2 means missing.", []string{"stream"}, nil),
 	}
 }
 
@@ -69,6 +89,16 @@ func (c *RealtimeCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.redisAckTotal,
 		c.redisMirrorErrors,
 		c.redisMirrorDiverged,
+		c.redisStreamTrimmed,
+		c.redisStreamMissing,
+		c.redisRetentionErrors,
+		c.redisStreamsWithoutTTL,
+		c.redisUsedMemoryBytes,
+		c.redisMaxMemoryBytes,
+		c.redisEvictedKeys,
+		c.redisStreamEntries,
+		c.redisStreamMemory,
+		c.redisStreamPTTL,
 	} {
 		ch <- desc
 	}
@@ -95,6 +125,18 @@ func (c *RealtimeCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.redisMirrorErrors, prometheus.CounterValue, float64(m.RedisMirrorPrimaryErrors.Load()), "primary")
 	ch <- prometheus.MustNewConstMetric(c.redisMirrorErrors, prometheus.CounterValue, float64(m.RedisMirrorSecondaryErrors.Load()), "secondary")
 	ch <- prometheus.MustNewConstMetric(c.redisMirrorDiverged, prometheus.CounterValue, float64(m.RedisMirrorDivergenceTotal.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisStreamTrimmed, prometheus.CounterValue, float64(m.RedisRelayStreamTrimmedTotal.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisStreamMissing, prometheus.CounterValue, float64(m.RedisRelayStreamMissingTotal.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisRetentionErrors, prometheus.CounterValue, float64(m.RedisRelayRetentionErrors.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisStreamsWithoutTTL, prometheus.GaugeValue, float64(m.RedisRelayStreamsWithoutTTL.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisUsedMemoryBytes, prometheus.GaugeValue, float64(m.RedisUsedMemoryBytes.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisMaxMemoryBytes, prometheus.GaugeValue, float64(m.RedisMaxMemoryBytes.Load()))
+	ch <- prometheus.MustNewConstMetric(c.redisEvictedKeys, prometheus.GaugeValue, float64(m.RedisEvictedKeys.Load()))
+	for stream, observation := range m.RedisStreamObservations() {
+		ch <- prometheus.MustNewConstMetric(c.redisStreamEntries, prometheus.GaugeValue, float64(observation.Entries), stream)
+		ch <- prometheus.MustNewConstMetric(c.redisStreamMemory, prometheus.GaugeValue, float64(observation.MemoryBytes), stream)
+		ch <- prometheus.MustNewConstMetric(c.redisStreamPTTL, prometheus.GaugeValue, float64(observation.PTTLMillis), stream)
+	}
 }
 
 func boolFloat(v bool) float64 {

--- a/server/internal/metrics/realtime.go
+++ b/server/internal/metrics/realtime.go
@@ -58,7 +58,7 @@ func NewRealtimeCollector(m *realtime.Metrics) *RealtimeCollector {
 		redisStreamTrimmed:     newRealtimeDesc("redis_stream_trimmed_entries_total", "Total Redis Stream entries removed by retention maintenance."),
 		redisStreamMissing:     newRealtimeDesc("redis_stream_missing_total", "Total observed relay stream disappearance transitions, including eviction and expiry."),
 		redisRetentionErrors:   newRealtimeDesc("redis_retention_errors_total", "Total Redis relay retention maintenance errors."),
-		redisStreamsWithoutTTL: newRealtimeDesc("redis_streams_without_ttl", "Current number of observed relay streams without an expiry."),
+		redisStreamsWithoutTTL: newRealtimeDesc("redis_streams_without_ttl", "Current number of observed relay streams missing an expiry while TTL protection is enabled."),
 		redisUsedMemoryBytes:   newRealtimeDesc("redis_used_memory_bytes", "Redis used_memory sampled by the realtime relay."),
 		redisMaxMemoryBytes:    newRealtimeDesc("redis_maxmemory_bytes", "Redis maxmemory sampled by the realtime relay; zero means unlimited."),
 		redisEvictedKeys:       newRealtimeDesc("redis_evicted_keys", "Redis instance evicted_keys sampled by the realtime relay."),

--- a/server/internal/metrics/realtime_test.go
+++ b/server/internal/metrics/realtime_test.go
@@ -17,6 +17,13 @@ func TestRealtimeCollectorExposesCounters(t *testing.T) {
 	m.RedisConnected.Store(true)
 	m.RedisMirrorPrimaryErrors.Store(2)
 	m.RedisMirrorSecondaryErrors.Store(5)
+	m.RedisRelayStreamTrimmedTotal.Store(13)
+	m.RedisRelayStreamMissingTotal.Store(1)
+	m.RedisRelayStreamsWithoutTTL.Store(2)
+	m.RedisUsedMemoryBytes.Store(4096)
+	m.RedisMaxMemoryBytes.Store(8192)
+	m.RedisEvictedKeys.Store(3)
+	m.ObserveRedisStream("ws:relay:shard:0", 23, 2048, 60000)
 
 	registry := NewRegistry(RegistryOptions{Realtime: m})
 	rec := httptest.NewRecorder()
@@ -30,6 +37,15 @@ func TestRealtimeCollectorExposesCounters(t *testing.T) {
 		"multica_realtime_redis_connected 1",
 		`multica_realtime_redis_mirror_errors_total{target="primary"} 2`,
 		`multica_realtime_redis_mirror_errors_total{target="secondary"} 5`,
+		"multica_realtime_redis_stream_trimmed_entries_total 13",
+		"multica_realtime_redis_stream_missing_total 1",
+		"multica_realtime_redis_streams_without_ttl 2",
+		"multica_realtime_redis_used_memory_bytes 4096",
+		"multica_realtime_redis_maxmemory_bytes 8192",
+		"multica_realtime_redis_evicted_keys 3",
+		`multica_realtime_redis_stream_entries{stream="ws:relay:shard:0"} 23`,
+		`multica_realtime_redis_stream_memory_bytes{stream="ws:relay:shard:0"} 2048`,
+		`multica_realtime_redis_stream_pttl_milliseconds{stream="ws:relay:shard:0"} 60000`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("metrics body missing %q\n%s", want, body)

--- a/server/internal/realtime/metrics.go
+++ b/server/internal/realtime/metrics.go
@@ -37,15 +37,25 @@ type Metrics struct {
 	scopeRooms           sync.Map
 
 	// Redis relay counters. Zero unless the Redis broadcaster is enabled.
-	RedisXAddTotal             atomic.Int64
-	RedisXAddErrors            atomic.Int64
-	RedisXReadTotal            atomic.Int64
-	RedisXReadErrors           atomic.Int64
-	RedisAckTotal              atomic.Int64
-	RedisLastXAddLagMicros     atomic.Int64
-	RedisMirrorPrimaryErrors   atomic.Int64
-	RedisMirrorSecondaryErrors atomic.Int64
-	RedisMirrorDivergenceTotal atomic.Int64
+	RedisXAddTotal               atomic.Int64
+	RedisXAddErrors              atomic.Int64
+	RedisXReadTotal              atomic.Int64
+	RedisXReadErrors             atomic.Int64
+	RedisAckTotal                atomic.Int64
+	RedisLastXAddLagMicros       atomic.Int64
+	RedisMirrorPrimaryErrors     atomic.Int64
+	RedisMirrorSecondaryErrors   atomic.Int64
+	RedisMirrorDivergenceTotal   atomic.Int64
+	RedisRelayStreamTrimmedTotal atomic.Int64
+	RedisRelayStreamMissingTotal atomic.Int64
+	RedisRelayRetentionErrors    atomic.Int64
+	RedisRelayStreamsWithoutTTL  atomic.Int64
+	RedisUsedMemoryBytes         atomic.Int64
+	RedisMaxMemoryBytes          atomic.Int64
+	RedisEvictedKeys             atomic.Int64
+
+	redisStreamsMu sync.RWMutex
+	redisStreams   map[string]RedisStreamObservation
 
 	// RedisConnected is set by the relay on startup / reconnect.
 	RedisConnected atomic.Bool
@@ -55,6 +65,15 @@ type Metrics struct {
 
 	// NodeID is set once at boot by the relay (or empty in single-node mode).
 	NodeID atomic.Value // string
+}
+
+// RedisStreamObservation is the latest low-frequency retention sample for one
+// relay stream. PTTLMillis uses Redis sentinel values: -1 means no expiry and
+// -2 means the key does not exist.
+type RedisStreamObservation struct {
+	Entries     int64 `json:"entries"`
+	MemoryBytes int64 `json:"memory_bytes"`
+	PTTLMillis  int64 `json:"pttl_millis"`
 }
 
 // M is the package-level metrics singleton.
@@ -112,6 +131,31 @@ func (m *Metrics) lastRedisErr() string {
 	return m.redisLastErr
 }
 
+// ObserveRedisStream replaces the latest sampled statistics for stream.
+func (m *Metrics) ObserveRedisStream(stream string, entries, memoryBytes, pttlMillis int64) {
+	m.redisStreamsMu.Lock()
+	defer m.redisStreamsMu.Unlock()
+	if m.redisStreams == nil {
+		m.redisStreams = make(map[string]RedisStreamObservation)
+	}
+	m.redisStreams[stream] = RedisStreamObservation{
+		Entries:     entries,
+		MemoryBytes: memoryBytes,
+		PTTLMillis:  pttlMillis,
+	}
+}
+
+// RedisStreamObservations returns a copy safe for metrics collection.
+func (m *Metrics) RedisStreamObservations() map[string]RedisStreamObservation {
+	m.redisStreamsMu.RLock()
+	defer m.redisStreamsMu.RUnlock()
+	out := make(map[string]RedisStreamObservation, len(m.redisStreams))
+	for stream, observation := range m.redisStreams {
+		out[stream] = observation
+	}
+	return out
+}
+
 func snapshotCounters(s *sync.Map) map[string]int64 {
 	out := map[string]int64{}
 	s.Range(func(k, v any) bool {
@@ -161,6 +205,14 @@ func (m *Metrics) Snapshot() map[string]any {
 			"mirror_primary_errors":   m.RedisMirrorPrimaryErrors.Load(),
 			"mirror_secondary_errors": m.RedisMirrorSecondaryErrors.Load(),
 			"mirror_divergence_total": m.RedisMirrorDivergenceTotal.Load(),
+			"stream_trimmed_total":    m.RedisRelayStreamTrimmedTotal.Load(),
+			"stream_missing_total":    m.RedisRelayStreamMissingTotal.Load(),
+			"retention_errors":        m.RedisRelayRetentionErrors.Load(),
+			"streams_without_ttl":     m.RedisRelayStreamsWithoutTTL.Load(),
+			"used_memory_bytes":       m.RedisUsedMemoryBytes.Load(),
+			"max_memory_bytes":        m.RedisMaxMemoryBytes.Load(),
+			"evicted_keys":            m.RedisEvictedKeys.Load(),
+			"streams":                 m.RedisStreamObservations(),
 			"last_error":              m.lastRedisErr(),
 		},
 	}
@@ -189,6 +241,16 @@ func (m *Metrics) Reset() {
 	m.RedisMirrorPrimaryErrors.Store(0)
 	m.RedisMirrorSecondaryErrors.Store(0)
 	m.RedisMirrorDivergenceTotal.Store(0)
+	m.RedisRelayStreamTrimmedTotal.Store(0)
+	m.RedisRelayStreamMissingTotal.Store(0)
+	m.RedisRelayRetentionErrors.Store(0)
+	m.RedisRelayStreamsWithoutTTL.Store(0)
+	m.RedisUsedMemoryBytes.Store(0)
+	m.RedisMaxMemoryBytes.Store(0)
+	m.RedisEvictedKeys.Store(0)
+	m.redisStreamsMu.Lock()
+	m.redisStreams = nil
+	m.redisStreamsMu.Unlock()
 	m.RedisConnected.Store(false)
 	m.SetRedisLastError("")
 }

--- a/server/internal/realtime/metrics.go
+++ b/server/internal/realtime/metrics.go
@@ -57,6 +57,9 @@ type Metrics struct {
 	redisStreamsMu sync.RWMutex
 	redisStreams   map[string]RedisStreamObservation
 
+	redisTTLStatusMu              sync.Mutex
+	redisStreamsWithoutTTLByRelay map[string]int64
+
 	// RedisConnected is set by the relay on startup / reconnect.
 	RedisConnected atomic.Bool
 	// RedisLastError stores the most recent consumer error message.
@@ -156,6 +159,23 @@ func (m *Metrics) RedisStreamObservations() map[string]RedisStreamObservation {
 	return out
 }
 
+// SetRedisStreamsWithoutTTL updates one relay mode's latest count and exposes
+// the process-wide sum. Keeping per-mode state prevents dual mode collectors
+// from overwriting each other with whichever maintenance loop ran last.
+func (m *Metrics) SetRedisStreamsWithoutTTL(relay string, count int64) {
+	m.redisTTLStatusMu.Lock()
+	defer m.redisTTLStatusMu.Unlock()
+	if m.redisStreamsWithoutTTLByRelay == nil {
+		m.redisStreamsWithoutTTLByRelay = make(map[string]int64)
+	}
+	m.redisStreamsWithoutTTLByRelay[relay] = count
+	var total int64
+	for _, relayCount := range m.redisStreamsWithoutTTLByRelay {
+		total += relayCount
+	}
+	m.RedisRelayStreamsWithoutTTL.Store(total)
+}
+
 func snapshotCounters(s *sync.Map) map[string]int64 {
 	out := map[string]int64{}
 	s.Range(func(k, v any) bool {
@@ -245,6 +265,9 @@ func (m *Metrics) Reset() {
 	m.RedisRelayStreamMissingTotal.Store(0)
 	m.RedisRelayRetentionErrors.Store(0)
 	m.RedisRelayStreamsWithoutTTL.Store(0)
+	m.redisTTLStatusMu.Lock()
+	m.redisStreamsWithoutTTLByRelay = nil
+	m.redisTTLStatusMu.Unlock()
 	m.RedisUsedMemoryBytes.Store(0)
 	m.RedisMaxMemoryBytes.Store(0)
 	m.RedisEvictedKeys.Store(0)

--- a/server/internal/realtime/metrics_test.go
+++ b/server/internal/realtime/metrics_test.go
@@ -77,6 +77,20 @@ func TestMetrics_Snapshot_IncludesCounters(t *testing.T) {
 	}
 }
 
+func TestMetricsAggregatesStreamsWithoutTTLAcrossRelayModes(t *testing.T) {
+	m := &Metrics{}
+	m.SetRedisStreamsWithoutTTL("sharded", 1)
+	m.SetRedisStreamsWithoutTTL("legacy", 2)
+	if got := m.RedisRelayStreamsWithoutTTL.Load(); got != 3 {
+		t.Fatalf("streams without TTL = %d, want 3", got)
+	}
+
+	m.SetRedisStreamsWithoutTTL("sharded", 0)
+	if got := m.RedisRelayStreamsWithoutTTL.Load(); got != 2 {
+		t.Fatalf("streams without TTL after sharded repair = %d, want 2", got)
+	}
+}
+
 // Compile-time guarantee that *Hub continues to satisfy Broadcaster, in case
 // someone changes hub.go method signatures without updating the interface.
 func TestHubImplementsBroadcaster(t *testing.T) {

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -26,12 +26,10 @@ func HeartbeatKey(nodeID string) string {
 }
 
 const (
-	streamMaxLen          int64 = 10000
-	heartbeatTTL                = 90 * time.Second
-	heartbeatPeriod             = 30 * time.Second
-	consumerIdleGrace           = 10 * time.Minute
-	consumerSweepPeriod         = 5 * time.Minute
-	legacyStreamScanCount       = 128
+	heartbeatTTL          = 90 * time.Second
+	heartbeatPeriod       = 30 * time.Second
+	consumerIdleGrace     = 10 * time.Minute
+	legacyStreamScanCount = 128
 )
 
 // envelope is what we serialise into each XADD message. It is opaque to the
@@ -130,19 +128,23 @@ func deliverEnvelope(hub *Hub, daemonRuntime DaemonRuntimeDeliverer, ev envelope
 // per-scope Redis Stream and consumes streams for which there are local
 // subscribers. Local fanout is delegated to the wrapped *Hub.
 type RedisRelay struct {
-	hub      *Hub
-	writeRDB *redis.Client
-	readRDB  *redis.Client
-	nodeID   string
-	ttl      *streamTTLRefresher
-	now      func() time.Time
+	hub       *Hub
+	writeRDB  *redis.Client
+	readRDB   *redis.Client
+	nodeID    string
+	retention StreamRetentionConfig
+	ttl       *streamTTLRefresher
+	now       func() time.Time
 
 	mu        sync.Mutex
 	consumers map[scopeKey]*scopeConsumer
 	stopping  bool
 	wg        sync.WaitGroup
 
-	legacyScanCursor uint64
+	legacyScanCursor  uint64
+	ttlStatusMu       sync.Mutex
+	streamsWithoutTTL map[string]struct{}
+	ttlScanSeen       map[string]struct{}
 
 	daemonRuntime DaemonRuntimeDeliverer
 }
@@ -163,17 +165,27 @@ func NewRedisRelay(hub *Hub, rdb *redis.Client) *RedisRelay {
 // calls so long-polling stream consumers cannot exhaust the pool used by XADD,
 // heartbeats, acks, and other request-path Redis operations.
 func NewRedisRelayWithClients(hub *Hub, writeRDB, readRDB *redis.Client) *RedisRelay {
+	return NewRedisRelayWithClientsAndConfig(hub, writeRDB, readRDB, DefaultStreamRetentionConfig())
+}
+
+// NewRedisRelayWithClientsAndConfig applies the same stream retention controls
+// used by sharded mode so legacy and dual-mode rollouts cannot silently diverge.
+func NewRedisRelayWithClientsAndConfig(hub *Hub, writeRDB, readRDB *redis.Client, retention StreamRetentionConfig) *RedisRelay {
 	if readRDB == nil {
 		readRDB = writeRDB
 	}
+	retention = retention.withDefaults()
 	return &RedisRelay{
-		hub:       hub,
-		writeRDB:  writeRDB,
-		readRDB:   readRDB,
-		nodeID:    ulid.Make().String(),
-		ttl:       newStreamTTLRefresher(defaultRelayStreamTTL, defaultRelayStreamTTLRefreshInterval),
-		now:       time.Now,
-		consumers: make(map[scopeKey]*scopeConsumer),
+		hub:               hub,
+		writeRDB:          writeRDB,
+		readRDB:           readRDB,
+		nodeID:            ulid.Make().String(),
+		retention:         retention,
+		ttl:               newStreamTTLRefresher(retention.StreamTTL, retention.TTLRefreshInterval),
+		now:               time.Now,
+		consumers:         make(map[scopeKey]*scopeConsumer),
+		streamsWithoutTTL: make(map[string]struct{}),
+		ttlScanSeen:       make(map[string]struct{}),
 	}
 }
 
@@ -281,7 +293,7 @@ func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []b
 	stream := StreamKey(scopeType, scopeID)
 	args := &redis.XAddArgs{
 		Stream: stream,
-		MaxLen: streamMaxLen,
+		MaxLen: r.retention.StreamMaxLen,
 		Approx: true,
 		Values: envelopeRedisValues(ev),
 	}
@@ -296,8 +308,10 @@ func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []b
 	}
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
-	if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
-		r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+	if r.retention.StreamTTLEnabled {
+		if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
+			r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+		}
 	}
 	return nil
 }
@@ -353,8 +367,10 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 	if err := r.ensureConsumerGroup(createCtx, stream, group, "$"); err != nil {
 		slog.Warn("realtime/redis: XGROUP CREATE failed", "error", err, "scope", scopeType, "scope_id", scopeID)
 	}
-	if err := r.ttl.refreshIfDue(createCtx, r.writeRDB, stream); err != nil {
-		r.recordRetentionError("consumer stream PEXPIRE failed", err, "stream", stream)
+	if r.retention.StreamTTLEnabled {
+		if err := r.ttl.refreshIfDue(createCtx, r.writeRDB, stream); err != nil {
+			r.recordRetentionError("consumer stream PEXPIRE failed", err, "stream", stream)
+		}
 	}
 	createCancel()
 
@@ -384,7 +400,7 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 				repairCtx, repairCancel := context.WithTimeout(ctx, 2*time.Second)
 				r.ttl.forget(stream)
 				repairErr := r.ensureConsumerGroup(repairCtx, stream, group, "0-0")
-				if repairErr == nil {
+				if repairErr == nil && r.retention.StreamTTLEnabled {
 					repairErr = r.ttl.refreshIfDue(repairCtx, r.writeRDB, stream)
 				}
 				repairCancel()
@@ -481,7 +497,7 @@ func (r *RedisRelay) heartbeatOnce(ctx context.Context) {
 // bounded SCAN over legacy per-scope streams. The scan repairs keys created by
 // older pods before TTL retention was introduced without blocking Redis.
 func (r *RedisRelay) consumerSweeper(ctx context.Context) {
-	t := time.NewTicker(consumerSweepPeriod)
+	t := time.NewTicker(r.retention.MaintenanceInterval)
 	defer t.Stop()
 	for {
 		r.sweepLegacyStreams(ctx)
@@ -497,12 +513,13 @@ func (r *RedisRelay) sweepLegacyStreams(ctx context.Context) {
 	sweepCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	now := r.now()
-	minID := streamMinID(now, defaultRelayStreamTrimHorizon)
+	minID := streamMinID(now, r.retention.TrimHorizon)
 	localStreams := make(map[string]struct{})
 
 	for _, key := range r.hub.LocalScopes() {
 		stream := StreamKey(key.Type, key.ID)
 		localStreams[stream] = struct{}{}
+		r.observeLegacyScanKey(stream)
 		r.maintainLegacyStream(sweepCtx, stream, minID)
 		r.writeRDB.ZRemRangeByScore(sweepCtx, NodesKey(key.Type, key.ID), "-inf", fmt.Sprintf("%f", float64(now.Unix())))
 	}
@@ -512,6 +529,7 @@ func (r *RedisRelay) sweepLegacyStreams(ctx context.Context) {
 		r.recordRetentionError("legacy stream SCAN failed", err, "cursor", r.legacyScanCursor)
 	} else {
 		for _, stream := range keys {
+			r.observeLegacyScanKey(stream)
 			if _, alreadyMaintained := localStreams[stream]; alreadyMaintained {
 				continue
 			}
@@ -519,9 +537,12 @@ func (r *RedisRelay) sweepLegacyStreams(ctx context.Context) {
 		}
 		if sweepCtx.Err() == nil {
 			r.legacyScanCursor = nextCursor
+			if nextCursor == 0 {
+				r.completeLegacyTTLScan()
+			}
 		}
 	}
-	r.ttl.forgetStale(now.Add(-defaultRelayStreamTTL))
+	r.ttl.forgetStale(now.Add(-r.retention.StreamTTL))
 }
 
 func (r *RedisRelay) maintainLegacyStream(ctx context.Context, stream, minID string) {
@@ -530,9 +551,44 @@ func (r *RedisRelay) maintainLegacyStream(ctx context.Context, stream, minID str
 	} else if trimmed > 0 {
 		M.RedisRelayStreamTrimmedTotal.Add(trimmed)
 	}
-	if _, err := r.ttl.repairMissingTTL(ctx, r.writeRDB, stream); err != nil {
+	ttl, err := r.ttl.reconcileTTL(ctx, r.writeRDB, stream, r.retention.StreamTTLEnabled)
+	if err == nil || ttl == -1 || ttl == -2 {
+		r.observeLegacyTTL(stream, ttl)
+	}
+	if err != nil {
 		r.recordRetentionError("stream TTL repair failed", err, "stream", stream)
 	}
+}
+
+func (r *RedisRelay) observeLegacyTTL(stream string, ttl time.Duration) {
+	r.ttlStatusMu.Lock()
+	if r.retention.StreamTTLEnabled && ttl == -1 {
+		r.streamsWithoutTTL[stream] = struct{}{}
+	} else {
+		delete(r.streamsWithoutTTL, stream)
+	}
+	count := int64(len(r.streamsWithoutTTL))
+	r.ttlStatusMu.Unlock()
+	M.SetRedisStreamsWithoutTTL("legacy", count)
+}
+
+func (r *RedisRelay) observeLegacyScanKey(stream string) {
+	r.ttlStatusMu.Lock()
+	r.ttlScanSeen[stream] = struct{}{}
+	r.ttlStatusMu.Unlock()
+}
+
+func (r *RedisRelay) completeLegacyTTLScan() {
+	r.ttlStatusMu.Lock()
+	for stream := range r.streamsWithoutTTL {
+		if _, exists := r.ttlScanSeen[stream]; !exists {
+			delete(r.streamsWithoutTTL, stream)
+		}
+	}
+	r.ttlScanSeen = make(map[string]struct{})
+	count := int64(len(r.streamsWithoutTTL))
+	r.ttlStatusMu.Unlock()
+	M.SetRedisStreamsWithoutTTL("legacy", count)
 }
 
 func (r *RedisRelay) recordRetentionError(message string, err error, attrs ...any) {

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -26,11 +26,12 @@ func HeartbeatKey(nodeID string) string {
 }
 
 const (
-	streamMaxLen        int64 = 10000
-	heartbeatTTL              = 90 * time.Second
-	heartbeatPeriod           = 30 * time.Second
-	consumerIdleGrace         = 10 * time.Minute
-	consumerSweepPeriod       = 5 * time.Minute
+	streamMaxLen          int64 = 10000
+	heartbeatTTL                = 90 * time.Second
+	heartbeatPeriod             = 30 * time.Second
+	consumerIdleGrace           = 10 * time.Minute
+	consumerSweepPeriod         = 5 * time.Minute
+	legacyStreamScanCount       = 128
 )
 
 // envelope is what we serialise into each XADD message. It is opaque to the
@@ -133,11 +134,15 @@ type RedisRelay struct {
 	writeRDB *redis.Client
 	readRDB  *redis.Client
 	nodeID   string
+	ttl      *streamTTLRefresher
+	now      func() time.Time
 
 	mu        sync.Mutex
 	consumers map[scopeKey]*scopeConsumer
 	stopping  bool
 	wg        sync.WaitGroup
+
+	legacyScanCursor uint64
 
 	daemonRuntime DaemonRuntimeDeliverer
 }
@@ -166,6 +171,8 @@ func NewRedisRelayWithClients(hub *Hub, writeRDB, readRDB *redis.Client) *RedisR
 		writeRDB:  writeRDB,
 		readRDB:   readRDB,
 		nodeID:    ulid.Make().String(),
+		ttl:       newStreamTTLRefresher(defaultRelayStreamTTL, defaultRelayStreamTTLRefreshInterval),
+		now:       time.Now,
 		consumers: make(map[scopeKey]*scopeConsumer),
 	}
 }
@@ -266,10 +273,14 @@ func (r *RedisRelay) Broadcast(message []byte) {
 }
 
 func (r *RedisRelay) publish(scopeType, scopeID, exclude string, frame []byte) {
-	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, ulid.Make().String())
+	_ = r.publishWithID(scopeType, scopeID, exclude, frame, ulid.Make().String())
+}
 
+func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
+	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
+	stream := StreamKey(scopeType, scopeID)
 	args := &redis.XAddArgs{
-		Stream: StreamKey(scopeType, scopeID),
+		Stream: stream,
 		MaxLen: streamMaxLen,
 		Approx: true,
 		Values: envelopeRedisValues(ev),
@@ -281,10 +292,14 @@ func (r *RedisRelay) publish(scopeType, scopeID, exclude string, frame []byte) {
 		M.RedisXAddErrors.Add(1)
 		M.SetRedisLastError(err.Error())
 		slog.Warn("realtime/redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID)
-		return
+		return err
 	}
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
+	if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
+		r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+	}
+	return nil
 }
 
 // startConsumer kicks off a single per-scope XREADGROUP loop if not already
@@ -335,8 +350,11 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 
 	// MKSTREAM ensures the stream exists. Ignore BUSYGROUP.
 	createCtx, createCancel := context.WithTimeout(ctx, 2*time.Second)
-	if err := r.writeRDB.XGroupCreateMkStream(createCtx, stream, group, "$").Err(); err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+	if err := r.ensureConsumerGroup(createCtx, stream, group, "$"); err != nil {
 		slog.Warn("realtime/redis: XGROUP CREATE failed", "error", err, "scope", scopeType, "scope_id", scopeID)
+	}
+	if err := r.ttl.refreshIfDue(createCtx, r.writeRDB, stream); err != nil {
+		r.recordRetentionError("consumer stream PEXPIRE failed", err, "stream", stream)
 	}
 	createCancel()
 
@@ -362,6 +380,20 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 			continue
 		}
 		if err != nil {
+			if strings.Contains(err.Error(), "NOGROUP") {
+				repairCtx, repairCancel := context.WithTimeout(ctx, 2*time.Second)
+				r.ttl.forget(stream)
+				repairErr := r.ensureConsumerGroup(repairCtx, stream, group, "0-0")
+				if repairErr == nil {
+					repairErr = r.ttl.refreshIfDue(repairCtx, r.writeRDB, stream)
+				}
+				repairCancel()
+				if repairErr == nil {
+					M.RedisRelayStreamMissingTotal.Add(1)
+					continue
+				}
+				r.recordRetentionError("consumer group recovery failed", repairErr, "stream", stream)
+			}
 			M.RedisXReadErrors.Add(1)
 			M.SetRedisLastError(err.Error())
 			// Brief backoff to avoid busy-looping on a flapping connection.
@@ -391,6 +423,14 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 	cleanCtx, cleanCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	r.writeRDB.XGroupDelConsumer(cleanCtx, stream, group, consumerName)
 	cleanCancel()
+}
+
+func (r *RedisRelay) ensureConsumerGroup(ctx context.Context, stream, group, startID string) error {
+	err := r.writeRDB.XGroupCreateMkStream(ctx, stream, group, startID).Err()
+	if err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+		return err
+	}
+	return nil
 }
 
 func (r *RedisRelay) deliverMessage(scopeType, scopeID string, msg redis.XMessage) {
@@ -437,26 +477,69 @@ func (r *RedisRelay) heartbeatOnce(ctx context.Context) {
 	}
 }
 
-// consumerSweeper periodically drops stale ZSET entries (nodes whose TTL
-// expired). Best-effort: we only sweep the scopes this node currently has
-// local subscribers for, since they're the only ones we can reason about
-// without scanning all keys.
+// consumerSweeper periodically drops stale ZSET entries and advances a
+// bounded SCAN over legacy per-scope streams. The scan repairs keys created by
+// older pods before TTL retention was introduced without blocking Redis.
 func (r *RedisRelay) consumerSweeper(ctx context.Context) {
 	t := time.NewTicker(consumerSweepPeriod)
 	defer t.Stop()
 	for {
+		r.sweepLegacyStreams(ctx)
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
 		}
-		now := float64(time.Now().Unix())
-		for _, key := range r.hub.LocalScopes() {
-			swCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			r.writeRDB.ZRemRangeByScore(swCtx, NodesKey(key.Type, key.ID), "-inf", fmt.Sprintf("%f", now))
-			cancel()
+	}
+}
+
+func (r *RedisRelay) sweepLegacyStreams(ctx context.Context) {
+	sweepCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	now := r.now()
+	minID := streamMinID(now, defaultRelayStreamTrimHorizon)
+	localStreams := make(map[string]struct{})
+
+	for _, key := range r.hub.LocalScopes() {
+		stream := StreamKey(key.Type, key.ID)
+		localStreams[stream] = struct{}{}
+		r.maintainLegacyStream(sweepCtx, stream, minID)
+		r.writeRDB.ZRemRangeByScore(sweepCtx, NodesKey(key.Type, key.ID), "-inf", fmt.Sprintf("%f", float64(now.Unix())))
+	}
+
+	keys, nextCursor, err := r.writeRDB.Scan(sweepCtx, r.legacyScanCursor, "ws:scope:*:stream", legacyStreamScanCount).Result()
+	if err != nil {
+		r.recordRetentionError("legacy stream SCAN failed", err, "cursor", r.legacyScanCursor)
+	} else {
+		for _, stream := range keys {
+			if _, alreadyMaintained := localStreams[stream]; alreadyMaintained {
+				continue
+			}
+			r.maintainLegacyStream(sweepCtx, stream, minID)
+		}
+		if sweepCtx.Err() == nil {
+			r.legacyScanCursor = nextCursor
 		}
 	}
+	r.ttl.forgetStale(now.Add(-defaultRelayStreamTTL))
+}
+
+func (r *RedisRelay) maintainLegacyStream(ctx context.Context, stream, minID string) {
+	if trimmed, err := r.writeRDB.XTrimMinID(ctx, stream, minID).Result(); err != nil && !errors.Is(err, redis.Nil) {
+		r.recordRetentionError("XTRIM MINID failed", err, "stream", stream, "min_id", minID)
+	} else if trimmed > 0 {
+		M.RedisRelayStreamTrimmedTotal.Add(trimmed)
+	}
+	if _, err := r.ttl.repairMissingTTL(ctx, r.writeRDB, stream); err != nil {
+		r.recordRetentionError("stream TTL repair failed", err, "stream", stream)
+	}
+}
+
+func (r *RedisRelay) recordRetentionError(message string, err error, attrs ...any) {
+	M.RedisRelayRetentionErrors.Add(1)
+	M.SetRedisLastError(err.Error())
+	attrs = append([]any{"error", err}, attrs...)
+	slog.Warn("realtime/redis: "+message, attrs...)
 }
 
 // peekTypeActor parses the WS frame just enough to lift event_type / actor_id
@@ -552,25 +635,7 @@ func (d *DualWriteBroadcaster) Broadcast(message []byte) {
 // PublishWithID is like publish but uses a caller-supplied event id so the
 // dual-write path can dedup.
 func (r *RedisRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
-	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
-	args := &redis.XAddArgs{
-		Stream: StreamKey(scopeType, scopeID),
-		MaxLen: streamMaxLen,
-		Approx: true,
-		Values: envelopeRedisValues(ev),
-	}
-	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := r.writeRDB.XAdd(ctx, args).Err(); err != nil {
-		M.RedisXAddErrors.Add(1)
-		M.SetRedisLastError(err.Error())
-		slog.Warn("realtime/redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID)
-		return err
-	}
-	M.RedisXAddTotal.Add(1)
-	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
-	return nil
+	return r.publishWithID(scopeType, scopeID, exclude, frame, id)
 }
 
 var _ Broadcaster = (*RedisRelay)(nil)

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -3,9 +3,12 @@ package realtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	redismock "github.com/go-redis/redismock/v9"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -44,6 +47,75 @@ func TestRedisRelayStopPreventsNewConsumers(t *testing.T) {
 		t.Fatalf("expected no consumers after Stop, got %d", consumerCount)
 	}
 	relay.Wait()
+}
+
+func TestRedisRelaySweepUsesExactTimeTrimAndRepairsTTL(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	hub := NewHub()
+	attachRealtimeTestClient(hub, ScopeWorkspace, "workspace-1")
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+	relay := NewRedisRelay(hub, rdb)
+	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	relay.now = func() time.Time { return now }
+	relay.ttl.now = relay.now
+	stream := StreamKey(ScopeWorkspace, "workspace-1")
+
+	mock.ExpectXTrimMinID(stream, streamMinID(now, defaultRelayStreamTrimHorizon)).SetVal(7)
+	mock.ExpectPTTL(stream).SetVal(-1)
+	mock.ExpectPExpire(stream, defaultRelayStreamTTL).SetVal(true)
+	mock.ExpectZRemRangeByScore(NodesKey(ScopeWorkspace, "workspace-1"), "-inf", fmt.Sprintf("%f", float64(now.Unix()))).SetVal(1)
+	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal(nil, 0)
+
+	relay.sweepLegacyStreams(context.Background())
+
+	if got := M.RedisRelayStreamTrimmedTotal.Load(); got != 7 {
+		t.Fatalf("trimmed total = %d, want 7", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisRelaySweepRepairsInactiveLegacyStreamsIncrementally(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+	relay := NewRedisRelay(NewHub(), rdb)
+	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	relay.now = func() time.Time { return now }
+	relay.ttl.now = relay.now
+	stream := StreamKey(ScopeWorkspace, "inactive-workspace")
+
+	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal([]string{stream}, 42)
+	mock.ExpectXTrimMinID(stream, streamMinID(now, defaultRelayStreamTrimHorizon)).SetVal(3)
+	mock.ExpectPTTL(stream).SetVal(-1)
+	mock.ExpectPExpire(stream, defaultRelayStreamTTL).SetVal(true)
+
+	relay.sweepLegacyStreams(context.Background())
+
+	if relay.legacyScanCursor != 42 {
+		t.Fatalf("scan cursor = %d, want 42", relay.legacyScanCursor)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisRelayEnsureConsumerGroupIgnoresBusyGroup(t *testing.T) {
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+	relay := NewRedisRelay(NewHub(), rdb)
+
+	mock.ExpectXGroupCreateMkStream("stream", "group", "$").SetErr(errors.New("BUSYGROUP Consumer Group name already exists"))
+	if err := relay.ensureConsumerGroup(context.Background(), "stream", "group", "$"); err != nil {
+		t.Fatalf("BUSYGROUP should be ignored: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDualWriteBroadcasterFansOutLocallyBeforePublishing(t *testing.T) {

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+func enabledTestRetentionConfig() StreamRetentionConfig {
+	cfg := DefaultStreamRetentionConfig()
+	cfg.StreamTTLEnabled = true
+	return cfg
+}
+
 func TestNewRedisRelayWithClientsSeparatesBlockingReadPool(t *testing.T) {
 	hub := NewHub()
 	writeClient := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
@@ -56,15 +62,21 @@ func TestRedisRelaySweepUsesExactTimeTrimAndRepairsTTL(t *testing.T) {
 	attachRealtimeTestClient(hub, ScopeWorkspace, "workspace-1")
 	rdb, mock := redismock.NewClientMock()
 	t.Cleanup(func() { _ = rdb.Close() })
-	relay := NewRedisRelay(hub, rdb)
+	retention := enabledTestRetentionConfig()
+	retention.StreamMaxLen = 321
+	retention.TrimHorizon = 20 * time.Minute
+	retention.StreamTTL = 30 * time.Minute
+	retention.TTLRefreshInterval = time.Minute
+	retention.MaintenanceInterval = 2 * time.Minute
+	relay := NewRedisRelayWithClientsAndConfig(hub, rdb, rdb, retention)
 	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
 	relay.now = func() time.Time { return now }
 	relay.ttl.now = relay.now
 	stream := StreamKey(ScopeWorkspace, "workspace-1")
 
-	mock.ExpectXTrimMinID(stream, streamMinID(now, defaultRelayStreamTrimHorizon)).SetVal(7)
+	mock.ExpectXTrimMinID(stream, streamMinID(now, retention.TrimHorizon)).SetVal(7)
 	mock.ExpectPTTL(stream).SetVal(-1)
-	mock.ExpectPExpire(stream, defaultRelayStreamTTL).SetVal(true)
+	mock.ExpectPExpire(stream, retention.StreamTTL).SetVal(true)
 	mock.ExpectZRemRangeByScore(NodesKey(ScopeWorkspace, "workspace-1"), "-inf", fmt.Sprintf("%f", float64(now.Unix()))).SetVal(1)
 	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal(nil, 0)
 
@@ -72,6 +84,9 @@ func TestRedisRelaySweepUsesExactTimeTrimAndRepairsTTL(t *testing.T) {
 
 	if got := M.RedisRelayStreamTrimmedTotal.Load(); got != 7 {
 		t.Fatalf("trimmed total = %d, want 7", got)
+	}
+	if relay.retention.StreamMaxLen != 321 || relay.retention.MaintenanceInterval != 2*time.Minute {
+		t.Fatalf("legacy relay did not retain shared config: %+v", relay.retention)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
@@ -83,21 +98,70 @@ func TestRedisRelaySweepRepairsInactiveLegacyStreamsIncrementally(t *testing.T) 
 	t.Cleanup(M.Reset)
 	rdb, mock := redismock.NewClientMock()
 	t.Cleanup(func() { _ = rdb.Close() })
-	relay := NewRedisRelay(NewHub(), rdb)
+	retention := enabledTestRetentionConfig()
+	relay := NewRedisRelayWithClientsAndConfig(NewHub(), rdb, rdb, retention)
 	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
 	relay.now = func() time.Time { return now }
 	relay.ttl.now = relay.now
 	stream := StreamKey(ScopeWorkspace, "inactive-workspace")
 
 	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal([]string{stream}, 42)
-	mock.ExpectXTrimMinID(stream, streamMinID(now, defaultRelayStreamTrimHorizon)).SetVal(3)
+	mock.ExpectXTrimMinID(stream, streamMinID(now, retention.TrimHorizon)).SetVal(3)
 	mock.ExpectPTTL(stream).SetVal(-1)
-	mock.ExpectPExpire(stream, defaultRelayStreamTTL).SetVal(true)
+	mock.ExpectPExpire(stream, retention.StreamTTL).SetVal(true)
 
 	relay.sweepLegacyStreams(context.Background())
 
 	if relay.legacyScanCursor != 42 {
 		t.Fatalf("scan cursor = %d, want 42", relay.legacyScanCursor)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisRelayCountsTTLRepairFailure(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+	retention := enabledTestRetentionConfig()
+	relay := NewRedisRelayWithClientsAndConfig(NewHub(), rdb, rdb, retention)
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	relay.now = func() time.Time { return now }
+	relay.ttl.now = relay.now
+	stream := StreamKey(ScopeWorkspace, "workspace-without-ttl")
+
+	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal([]string{stream}, 0)
+	mock.ExpectXTrimMinID(stream, streamMinID(now, retention.TrimHorizon)).SetVal(0)
+	mock.ExpectPTTL(stream).SetVal(-1)
+	mock.ExpectPExpire(stream, retention.StreamTTL).SetErr(errors.New("PEXPIRE denied"))
+
+	relay.sweepLegacyStreams(context.Background())
+
+	if got := M.RedisRelayStreamsWithoutTTL.Load(); got != 1 {
+		t.Fatalf("streams without TTL = %d, want 1", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisRelayCompleteScanPrunesMissingTTLForDeletedStreams(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+	retention := enabledTestRetentionConfig()
+	relay := NewRedisRelayWithClientsAndConfig(NewHub(), rdb, rdb, retention)
+	relay.streamsWithoutTTL[StreamKey(ScopeWorkspace, "deleted")] = struct{}{}
+	M.SetRedisStreamsWithoutTTL("legacy", 1)
+
+	mock.ExpectScan(0, "ws:scope:*:stream", legacyStreamScanCount).SetVal(nil, 0)
+	relay.sweepLegacyStreams(context.Background())
+
+	if got := M.RedisRelayStreamsWithoutTTL.Load(); got != 0 {
+		t.Fatalf("streams without TTL after full scan = %d, want 0", got)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -14,8 +15,11 @@ import (
 )
 
 const (
-	defaultShardedRelayShards       = 8
-	defaultShardedRelayStreamMaxLen = 100000
+	defaultShardedRelayShards = 8
+	// At the measured baseline of roughly 1 KiB per relay entry, 8192 entries
+	// across each of eight shards estimates about 64 MiB instead of the former
+	// ~800 MiB default. Operators can tune this from observed entry sizes.
+	defaultShardedRelayStreamMaxLen = 8192
 	defaultShardedRelayReadCount    = 128
 	defaultShardedRelayReadBlock    = 5 * time.Second
 	defaultShardedRelayReplayGrace  = 5 * time.Minute
@@ -36,7 +40,11 @@ type ShardedStreamRelayConfig struct {
 	// consuming from (now - ReplayGrace) rather than "$" so that any events
 	// published while this pod was down are replayed. Events are bounded by
 	// the stream's MAXLEN, and downstream consumers must be idempotent.
-	ReplayGrace time.Duration
+	ReplayGrace         time.Duration
+	TrimHorizon         time.Duration
+	StreamTTL           time.Duration
+	TTLRefreshInterval  time.Duration
+	MaintenanceInterval time.Duration
 }
 
 // DefaultShardedStreamRelayConfig returns production-safe defaults: a small
@@ -44,11 +52,15 @@ type ShardedStreamRelayConfig struct {
 // batched reads.
 func DefaultShardedStreamRelayConfig() ShardedStreamRelayConfig {
 	return ShardedStreamRelayConfig{
-		Shards:       defaultShardedRelayShards,
-		StreamMaxLen: defaultShardedRelayStreamMaxLen,
-		ReadCount:    defaultShardedRelayReadCount,
-		ReadBlock:    defaultShardedRelayReadBlock,
-		ReplayGrace:  defaultShardedRelayReplayGrace,
+		Shards:              defaultShardedRelayShards,
+		StreamMaxLen:        defaultShardedRelayStreamMaxLen,
+		ReadCount:           defaultShardedRelayReadCount,
+		ReadBlock:           defaultShardedRelayReadBlock,
+		ReplayGrace:         defaultShardedRelayReplayGrace,
+		TrimHorizon:         defaultRelayStreamTrimHorizon,
+		StreamTTL:           defaultRelayStreamTTL,
+		TTLRefreshInterval:  defaultRelayStreamTTLRefreshInterval,
+		MaintenanceInterval: defaultRelayStreamMaintenanceInterval,
 	}
 }
 
@@ -69,7 +81,56 @@ func (c ShardedStreamRelayConfig) withDefaults() ShardedStreamRelayConfig {
 	if c.ReplayGrace <= 0 {
 		c.ReplayGrace = def.ReplayGrace
 	}
+	if c.TrimHorizon <= c.ReplayGrace {
+		c.TrimHorizon = 2 * c.ReplayGrace
+	}
+	if c.StreamTTL < c.TrimHorizon {
+		c.StreamTTL = c.TrimHorizon + c.ReplayGrace
+	}
+	if c.TTLRefreshInterval <= 0 || c.TTLRefreshInterval >= c.StreamTTL {
+		c.TTLRefreshInterval = retentionSubinterval(c.StreamTTL, def.TTLRefreshInterval)
+	}
+	if c.MaintenanceInterval <= 0 || c.MaintenanceInterval >= c.StreamTTL {
+		c.MaintenanceInterval = retentionSubinterval(c.StreamTTL, def.MaintenanceInterval)
+	}
 	return c
+}
+
+func retentionSubinterval(ttl, preferred time.Duration) time.Duration {
+	if preferred > 0 && preferred < ttl {
+		return preferred
+	}
+	interval := ttl / 3
+	if interval <= 0 {
+		return time.Nanosecond
+	}
+	return interval
+}
+
+// Normalized fills missing fields and repairs unsafe retention relationships.
+func (c ShardedStreamRelayConfig) Normalized() ShardedStreamRelayConfig {
+	return c.withDefaults()
+}
+
+// Validate checks the retention relationship that keeps trimming outside the
+// replay window while allowing idle stream keys to expire safely.
+func (c ShardedStreamRelayConfig) Validate() error {
+	if c.ReplayGrace <= 0 {
+		return errors.New("ReplayGrace must be positive")
+	}
+	if c.TrimHorizon <= c.ReplayGrace {
+		return fmt.Errorf("TrimHorizon (%s) must be greater than ReplayGrace (%s)", c.TrimHorizon, c.ReplayGrace)
+	}
+	if c.StreamTTL < c.TrimHorizon {
+		return fmt.Errorf("StreamTTL (%s) must be at least TrimHorizon (%s)", c.StreamTTL, c.TrimHorizon)
+	}
+	if c.TTLRefreshInterval <= 0 || c.TTLRefreshInterval >= c.StreamTTL {
+		return fmt.Errorf("TTLRefreshInterval (%s) must be positive and less than StreamTTL (%s)", c.TTLRefreshInterval, c.StreamTTL)
+	}
+	if c.MaintenanceInterval <= 0 || c.MaintenanceInterval >= c.StreamTTL {
+		return fmt.Errorf("MaintenanceInterval (%s) must be positive and less than StreamTTL (%s)", c.MaintenanceInterval, c.StreamTTL)
+	}
+	return nil
 }
 
 // ShardedStreamRelay publishes all realtime events into a fixed set of Redis
@@ -82,10 +143,15 @@ type ShardedStreamRelay struct {
 	readRDB  *redis.Client
 	nodeID   string
 	config   ShardedStreamRelayConfig
+	now      func() time.Time
+	ttl      *streamTTLRefresher
 
 	mu       sync.Mutex
 	stopping bool
 	wg       sync.WaitGroup
+
+	streamSeen       []atomic.Bool
+	streamGeneration []atomic.Uint64
 
 	daemonRuntime DaemonRuntimeDeliverer
 }
@@ -94,12 +160,17 @@ func NewShardedStreamRelay(hub *Hub, writeRDB, readRDB *redis.Client, config Sha
 	if readRDB == nil {
 		readRDB = writeRDB
 	}
+	config = config.withDefaults()
 	return &ShardedStreamRelay{
-		hub:      hub,
-		writeRDB: writeRDB,
-		readRDB:  readRDB,
-		nodeID:   ulid.Make().String(),
-		config:   config.withDefaults(),
+		hub:              hub,
+		writeRDB:         writeRDB,
+		readRDB:          readRDB,
+		nodeID:           ulid.Make().String(),
+		config:           config,
+		now:              time.Now,
+		ttl:              newStreamTTLRefresher(config.StreamTTL, config.TTLRefreshInterval),
+		streamSeen:       make([]atomic.Bool, config.Shards),
+		streamGeneration: make([]atomic.Uint64, config.Shards),
 	}
 }
 
@@ -127,10 +198,14 @@ func (r *ShardedStreamRelay) Start(ctx context.Context) {
 		M.RedisConnected.Store(true)
 	}
 
-	r.wg.Add(1 + r.config.Shards)
+	r.wg.Add(2 + r.config.Shards)
 	go func() {
 		defer r.wg.Done()
 		r.heartbeatLoop(ctx)
+	}()
+	go func() {
+		defer r.wg.Done()
+		r.retentionLoop(ctx)
 	}()
 	for shard := 0; shard < r.config.Shards; shard++ {
 		shard := shard
@@ -173,7 +248,8 @@ func (r *ShardedStreamRelay) Broadcast(message []byte) {
 
 func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
 	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
-	stream := ShardedStreamKey(r.shardFor(scopeType, scopeID))
+	shard := r.shardFor(scopeType, scopeID)
+	stream := ShardedStreamKey(shard)
 	args := &redis.XAddArgs{
 		Stream: stream,
 		MaxLen: r.config.StreamMaxLen,
@@ -192,6 +268,10 @@ func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, f
 	}
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
+	r.streamSeen[shard].Store(true)
+	if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
+		r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+	}
 	return nil
 }
 
@@ -208,11 +288,7 @@ func (r *ShardedStreamRelay) shardFor(scopeType, scopeID string) int {
 // rather than the entire retained stream. The "-0" suffix matches any
 // sequence number at that millisecond.
 func (r *ShardedStreamRelay) replayStartID() string {
-	ms := time.Now().Add(-r.config.ReplayGrace).UnixMilli()
-	if ms < 0 {
-		ms = 0
-	}
-	return fmt.Sprintf("%d-0", ms)
+	return streamMinID(r.now(), r.config.ReplayGrace)
 }
 
 func (r *ShardedStreamRelay) readShard(ctx context.Context, shard int) {
@@ -222,14 +298,123 @@ func (r *ShardedStreamRelay) readShard(ctx context.Context, shard int) {
 	// short enough that replay volume stays manageable, and downstream
 	// consumers (daemon wakeups, client reconnects) are idempotent.
 	lastID := r.replayStartID()
+	generation := r.streamGeneration[shard].Load()
 	for {
 		if ctx.Err() != nil || r.isStopping() {
 			return
+		}
+		if current := r.streamGeneration[shard].Load(); current != generation {
+			lastID = r.replayStartID()
+			generation = current
 		}
 		if !r.readShardOnce(ctx, shard, stream, &lastID) {
 			return
 		}
 	}
+}
+
+func (r *ShardedStreamRelay) retentionLoop(ctx context.Context) {
+	r.maintainStreams(ctx)
+	ticker := time.NewTicker(r.config.MaintenanceInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.maintainStreams(ctx)
+		}
+	}
+}
+
+func (r *ShardedStreamRelay) maintainStreams(ctx context.Context) {
+	maintCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	minID := streamMinID(r.now(), r.config.TrimHorizon)
+	withoutTTL := int64(0)
+
+	for shard := 0; shard < r.config.Shards; shard++ {
+		if maintCtx.Err() != nil {
+			return
+		}
+		stream := ShardedStreamKey(shard)
+		exists, err := r.writeRDB.Exists(maintCtx, stream).Result()
+		if err != nil {
+			r.recordRetentionError("EXISTS failed", err, "stream", stream)
+			continue
+		}
+		if exists == 0 {
+			r.updateStreamPresence(shard, false)
+			M.ObserveRedisStream(stream, 0, 0, -2)
+			continue
+		}
+		r.updateStreamPresence(shard, true)
+
+		trimmed, err := r.writeRDB.XTrimMinID(maintCtx, stream, minID).Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			r.recordRetentionError("XTRIM MINID failed", err, "stream", stream, "min_id", minID)
+		} else if trimmed > 0 {
+			M.RedisRelayStreamTrimmedTotal.Add(trimmed)
+		}
+
+		ttl, err := r.ttl.repairMissingTTL(maintCtx, r.writeRDB, stream)
+		if err != nil {
+			r.recordRetentionError("stream TTL repair failed", err, "stream", stream)
+		} else if ttl == -1 {
+			withoutTTL++
+		}
+
+		length, err := r.writeRDB.XLen(maintCtx, stream).Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			r.recordRetentionError("XLEN failed", err, "stream", stream)
+			continue
+		}
+		memoryBytes, err := r.writeRDB.MemoryUsage(maintCtx, stream).Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			r.recordRetentionError("MEMORY USAGE failed", err, "stream", stream)
+			memoryBytes = 0
+		}
+		M.ObserveRedisStream(stream, length, memoryBytes, redisTTLMillis(ttl))
+	}
+	M.RedisRelayStreamsWithoutTTL.Store(withoutTTL)
+	r.observeRedisServer(maintCtx)
+}
+
+func (r *ShardedStreamRelay) updateStreamPresence(shard int, exists bool) {
+	if exists {
+		r.streamSeen[shard].Store(true)
+		return
+	}
+	if r.streamSeen[shard].Swap(false) {
+		r.streamGeneration[shard].Add(1)
+		r.ttl.forget(ShardedStreamKey(shard))
+		M.RedisRelayStreamMissingTotal.Add(1)
+	}
+}
+
+func (r *ShardedStreamRelay) observeRedisServer(ctx context.Context) {
+	memoryInfo, err := r.writeRDB.Info(ctx, "memory").Result()
+	if err == nil {
+		if used, ok := redisInfoInt64(memoryInfo, "used_memory"); ok {
+			M.RedisUsedMemoryBytes.Store(used)
+		}
+		if max, ok := redisInfoInt64(memoryInfo, "maxmemory"); ok {
+			M.RedisMaxMemoryBytes.Store(max)
+		}
+	}
+	statsInfo, err := r.writeRDB.Info(ctx, "stats").Result()
+	if err == nil {
+		if evicted, ok := redisInfoInt64(statsInfo, "evicted_keys"); ok {
+			M.RedisEvictedKeys.Store(evicted)
+		}
+	}
+}
+
+func (r *ShardedStreamRelay) recordRetentionError(message string, err error, attrs ...any) {
+	M.RedisRelayRetentionErrors.Add(1)
+	M.SetRedisLastError(err.Error())
+	attrs = append([]any{"error", err}, attrs...)
+	slog.Warn("realtime/sharded-redis: "+message, attrs...)
 }
 
 // readShardOnce performs a single XREAD iteration for one shard. It returns

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -16,10 +16,10 @@ import (
 
 const (
 	defaultShardedRelayShards = 8
-	// At the measured baseline of roughly 1 KiB per relay entry, 8192 entries
-	// across each of eight shards estimates about 64 MiB instead of the former
+	// At the measured baseline of roughly 1 KiB per relay entry, 2000 entries
+	// across each of eight shards estimates about 16 MiB instead of the former
 	// ~800 MiB default. Operators can tune this from observed entry sizes.
-	defaultShardedRelayStreamMaxLen = 8192
+	defaultShardedRelayStreamMaxLen = 2000
 	defaultShardedRelayReadCount    = 128
 	defaultShardedRelayReadBlock    = 5 * time.Second
 	defaultShardedRelayReplayGrace  = 5 * time.Minute

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -45,22 +45,38 @@ type ShardedStreamRelayConfig struct {
 	StreamTTL           time.Duration
 	TTLRefreshInterval  time.Duration
 	MaintenanceInterval time.Duration
+	StreamTTLEnabled    bool
 }
 
 // DefaultShardedStreamRelayConfig returns production-safe defaults: a small
 // fixed number of blocking readers per pod, bounded stream retention, and
 // batched reads.
 func DefaultShardedStreamRelayConfig() ShardedStreamRelayConfig {
+	retention := DefaultStreamRetentionConfig()
 	return ShardedStreamRelayConfig{
 		Shards:              defaultShardedRelayShards,
-		StreamMaxLen:        defaultShardedRelayStreamMaxLen,
+		StreamMaxLen:        retention.StreamMaxLen,
 		ReadCount:           defaultShardedRelayReadCount,
 		ReadBlock:           defaultShardedRelayReadBlock,
 		ReplayGrace:         defaultShardedRelayReplayGrace,
-		TrimHorizon:         defaultRelayStreamTrimHorizon,
-		StreamTTL:           defaultRelayStreamTTL,
-		TTLRefreshInterval:  defaultRelayStreamTTLRefreshInterval,
-		MaintenanceInterval: defaultRelayStreamMaintenanceInterval,
+		TrimHorizon:         retention.TrimHorizon,
+		StreamTTL:           retention.StreamTTL,
+		TTLRefreshInterval:  retention.TTLRefreshInterval,
+		MaintenanceInterval: retention.MaintenanceInterval,
+		StreamTTLEnabled:    retention.StreamTTLEnabled,
+	}
+}
+
+// RetentionConfig returns the mode-independent stream retention settings.
+func (c ShardedStreamRelayConfig) RetentionConfig() StreamRetentionConfig {
+	c = c.withDefaults()
+	return StreamRetentionConfig{
+		StreamMaxLen:        c.StreamMaxLen,
+		TrimHorizon:         c.TrimHorizon,
+		StreamTTL:           c.StreamTTL,
+		TTLRefreshInterval:  c.TTLRefreshInterval,
+		MaintenanceInterval: c.MaintenanceInterval,
+		StreamTTLEnabled:    c.StreamTTLEnabled,
 	}
 }
 
@@ -269,8 +285,10 @@ func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, f
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
 	r.streamSeen[shard].Store(true)
-	if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
-		r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+	if r.config.StreamTTLEnabled {
+		if err := r.ttl.refreshIfDue(ctx, r.writeRDB, stream); err != nil {
+			r.recordRetentionError("PEXPIRE failed", err, "stream", stream)
+		}
 	}
 	return nil
 }
@@ -357,11 +375,12 @@ func (r *ShardedStreamRelay) maintainStreams(ctx context.Context) {
 			M.RedisRelayStreamTrimmedTotal.Add(trimmed)
 		}
 
-		ttl, err := r.ttl.repairMissingTTL(maintCtx, r.writeRDB, stream)
+		ttl, err := r.ttl.reconcileTTL(maintCtx, r.writeRDB, stream, r.config.StreamTTLEnabled)
+		if r.config.StreamTTLEnabled && ttl == -1 {
+			withoutTTL++
+		}
 		if err != nil {
 			r.recordRetentionError("stream TTL repair failed", err, "stream", stream)
-		} else if ttl == -1 {
-			withoutTTL++
 		}
 
 		length, err := r.writeRDB.XLen(maintCtx, stream).Result()
@@ -376,7 +395,7 @@ func (r *ShardedStreamRelay) maintainStreams(ctx context.Context) {
 		}
 		M.ObserveRedisStream(stream, length, memoryBytes, redisTTLMillis(ttl))
 	}
-	M.RedisRelayStreamsWithoutTTL.Store(withoutTTL)
+	M.SetRedisStreamsWithoutTTL("sharded", withoutTTL)
 	r.observeRedisServer(maintCtx)
 }
 

--- a/server/internal/realtime/sharded_stream_relay_test.go
+++ b/server/internal/realtime/sharded_stream_relay_test.go
@@ -3,6 +3,7 @@ package realtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -34,6 +35,9 @@ func TestShardedStreamRelayConfigDefaults(t *testing.T) {
 	}
 	if relay.config.StreamTTL != defaultRelayStreamTTL {
 		t.Fatalf("expected default stream TTL %s, got %s", defaultRelayStreamTTL, relay.config.StreamTTL)
+	}
+	if relay.config.StreamTTLEnabled {
+		t.Fatal("stream TTL must default to disabled for staged rollout safety")
 	}
 	if err := relay.config.Validate(); err != nil {
 		t.Fatalf("default config is invalid: %v", err)
@@ -204,10 +208,11 @@ func TestShardedStreamRelayMaintenanceTrimsExactlyAndRepairsTTL(t *testing.T) {
 
 	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
 	relay := NewShardedStreamRelay(NewHub(), rdb, rdb, ShardedStreamRelayConfig{
-		Shards:      1,
-		ReplayGrace: 5 * time.Minute,
-		TrimHorizon: 10 * time.Minute,
-		StreamTTL:   15 * time.Minute,
+		Shards:           1,
+		ReplayGrace:      5 * time.Minute,
+		TrimHorizon:      10 * time.Minute,
+		StreamTTL:        15 * time.Minute,
+		StreamTTLEnabled: true,
 	})
 	relay.now = func() time.Time { return now }
 	relay.ttl.now = relay.now
@@ -240,6 +245,43 @@ func TestShardedStreamRelayMaintenanceTrimsExactlyAndRepairsTTL(t *testing.T) {
 	}
 	if got := M.RedisEvictedKeys.Load(); got != 3 {
 		t.Fatalf("evicted keys = %d, want 3", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestShardedStreamRelayMaintenanceCountsTTLRepairFailure(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	relay := NewShardedStreamRelay(NewHub(), rdb, rdb, ShardedStreamRelayConfig{
+		Shards:           1,
+		StreamTTLEnabled: true,
+	})
+	relay.now = func() time.Time { return now }
+	relay.ttl.now = relay.now
+	stream := ShardedStreamKey(0)
+
+	mock.ExpectExists(stream).SetVal(1)
+	mock.ExpectXTrimMinID(stream, streamMinID(now, relay.config.TrimHorizon)).SetVal(0)
+	mock.ExpectPTTL(stream).SetVal(-1)
+	mock.ExpectPExpire(stream, relay.config.StreamTTL).SetErr(errors.New("PEXPIRE denied"))
+	mock.ExpectXLen(stream).SetVal(1)
+	mock.ExpectMemoryUsage(stream).SetVal(1024)
+	mock.ExpectInfo("memory").SetVal("used_memory:1024\r\nmaxmemory:2048\r\n")
+	mock.ExpectInfo("stats").SetVal("evicted_keys:0\r\n")
+
+	relay.maintainStreams(context.Background())
+
+	if got := M.RedisRelayStreamsWithoutTTL.Load(); got != 1 {
+		t.Fatalf("streams without TTL = %d, want 1", got)
+	}
+	if got := M.RedisRelayRetentionErrors.Load(); got != 1 {
+		t.Fatalf("retention errors = %d, want 1", got)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/server/internal/realtime/sharded_stream_relay_test.go
+++ b/server/internal/realtime/sharded_stream_relay_test.go
@@ -18,8 +18,8 @@ func TestShardedStreamRelayConfigDefaults(t *testing.T) {
 	if relay.config.Shards != defaultShardedRelayShards {
 		t.Fatalf("expected default shard count %d, got %d", defaultShardedRelayShards, relay.config.Shards)
 	}
-	if relay.config.StreamMaxLen != defaultShardedRelayStreamMaxLen {
-		t.Fatalf("expected default stream max len %d, got %d", defaultShardedRelayStreamMaxLen, relay.config.StreamMaxLen)
+	if relay.config.StreamMaxLen != 2000 {
+		t.Fatalf("expected default stream max len 2000, got %d", relay.config.StreamMaxLen)
 	}
 	if relay.config.ReadCount != defaultShardedRelayReadCount {
 		t.Fatalf("expected default read count %d, got %d", defaultShardedRelayReadCount, relay.config.ReadCount)

--- a/server/internal/realtime/sharded_stream_relay_test.go
+++ b/server/internal/realtime/sharded_stream_relay_test.go
@@ -29,6 +29,35 @@ func TestShardedStreamRelayConfigDefaults(t *testing.T) {
 	if relay.config.ReplayGrace != defaultShardedRelayReplayGrace {
 		t.Fatalf("expected default replay grace %s, got %s", defaultShardedRelayReplayGrace, relay.config.ReplayGrace)
 	}
+	if relay.config.TrimHorizon != defaultRelayStreamTrimHorizon {
+		t.Fatalf("expected default trim horizon %s, got %s", defaultRelayStreamTrimHorizon, relay.config.TrimHorizon)
+	}
+	if relay.config.StreamTTL != defaultRelayStreamTTL {
+		t.Fatalf("expected default stream TTL %s, got %s", defaultRelayStreamTTL, relay.config.StreamTTL)
+	}
+	if err := relay.config.Validate(); err != nil {
+		t.Fatalf("default config is invalid: %v", err)
+	}
+}
+
+func TestShardedStreamRelayConfigNormalizesRetentionInvariants(t *testing.T) {
+	cfg := ShardedStreamRelayConfig{
+		ReplayGrace:         20 * time.Minute,
+		TrimHorizon:         10 * time.Minute,
+		StreamTTL:           15 * time.Minute,
+		TTLRefreshInterval:  time.Hour,
+		MaintenanceInterval: time.Hour,
+	}.Normalized()
+
+	if cfg.TrimHorizon != 40*time.Minute {
+		t.Fatalf("trim horizon = %s, want 40m", cfg.TrimHorizon)
+	}
+	if cfg.StreamTTL != 60*time.Minute {
+		t.Fatalf("stream TTL = %s, want 60m", cfg.StreamTTL)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("normalized config is invalid: %v", err)
+	}
 }
 
 func TestShardedStreamRelayShardForScopeIsStableAndBounded(t *testing.T) {
@@ -164,5 +193,72 @@ func TestShardedStreamRelayReadShardOnceReplaysRetainedMessages(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestShardedStreamRelayMaintenanceTrimsExactlyAndRepairsTTL(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	relay := NewShardedStreamRelay(NewHub(), rdb, rdb, ShardedStreamRelayConfig{
+		Shards:      1,
+		ReplayGrace: 5 * time.Minute,
+		TrimHorizon: 10 * time.Minute,
+		StreamTTL:   15 * time.Minute,
+	})
+	relay.now = func() time.Time { return now }
+	relay.ttl.now = relay.now
+	stream := ShardedStreamKey(0)
+	minID := streamMinID(now, 10*time.Minute)
+
+	mock.ExpectExists(stream).SetVal(1)
+	mock.ExpectXTrimMinID(stream, minID).SetVal(17)
+	mock.ExpectPTTL(stream).SetVal(-1)
+	mock.ExpectPExpire(stream, 15*time.Minute).SetVal(true)
+	mock.ExpectXLen(stream).SetVal(23)
+	mock.ExpectMemoryUsage(stream).SetVal(4096)
+	mock.ExpectInfo("memory").SetVal("used_memory:8192\r\nmaxmemory:65536\r\n")
+	mock.ExpectInfo("stats").SetVal("evicted_keys:3\r\n")
+
+	relay.maintainStreams(context.Background())
+
+	if got := M.RedisRelayStreamTrimmedTotal.Load(); got != 17 {
+		t.Fatalf("trimmed total = %d, want 17", got)
+	}
+	observation := M.RedisStreamObservations()[stream]
+	if observation.Entries != 23 || observation.MemoryBytes != 4096 || observation.PTTLMillis != (15*time.Minute).Milliseconds() {
+		t.Fatalf("unexpected observation: %+v", observation)
+	}
+	if got := M.RedisUsedMemoryBytes.Load(); got != 8192 {
+		t.Fatalf("used memory = %d, want 8192", got)
+	}
+	if got := M.RedisMaxMemoryBytes.Load(); got != 65536 {
+		t.Fatalf("max memory = %d, want 65536", got)
+	}
+	if got := M.RedisEvictedKeys.Load(); got != 3 {
+		t.Fatalf("evicted keys = %d, want 3", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestShardedStreamRelayMissingTransitionResetsGenerationOnce(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+	relay := NewShardedStreamRelay(NewHub(), nil, nil, ShardedStreamRelayConfig{Shards: 1})
+
+	relay.updateStreamPresence(0, true)
+	relay.updateStreamPresence(0, false)
+	relay.updateStreamPresence(0, false)
+
+	if got := relay.streamGeneration[0].Load(); got != 1 {
+		t.Fatalf("generation = %d, want 1", got)
+	}
+	if got := M.RedisRelayStreamMissingTotal.Load(); got != 1 {
+		t.Fatalf("missing total = %d, want 1", got)
 	}
 }

--- a/server/internal/realtime/stream_retention.go
+++ b/server/internal/realtime/stream_retention.go
@@ -18,6 +18,51 @@ const (
 	defaultRelayStreamMaintenanceInterval = time.Minute
 )
 
+// StreamRetentionConfig is shared by sharded and legacy relay modes so one
+// set of operator controls has the same meaning during a dual-mode rollout.
+// TTL is deliberately opt-in: deploy the compatible code with TTL disabled,
+// then enable it only after every replica can refresh or remove expirations.
+type StreamRetentionConfig struct {
+	StreamMaxLen        int64
+	TrimHorizon         time.Duration
+	StreamTTL           time.Duration
+	TTLRefreshInterval  time.Duration
+	MaintenanceInterval time.Duration
+	StreamTTLEnabled    bool
+}
+
+// DefaultStreamRetentionConfig returns safe cross-mode retention defaults.
+func DefaultStreamRetentionConfig() StreamRetentionConfig {
+	return StreamRetentionConfig{
+		StreamMaxLen:        defaultShardedRelayStreamMaxLen,
+		TrimHorizon:         defaultRelayStreamTrimHorizon,
+		StreamTTL:           defaultRelayStreamTTL,
+		TTLRefreshInterval:  defaultRelayStreamTTLRefreshInterval,
+		MaintenanceInterval: defaultRelayStreamMaintenanceInterval,
+		StreamTTLEnabled:    false,
+	}
+}
+
+func (c StreamRetentionConfig) withDefaults() StreamRetentionConfig {
+	def := DefaultStreamRetentionConfig()
+	if c.StreamMaxLen <= 0 {
+		c.StreamMaxLen = def.StreamMaxLen
+	}
+	if c.TrimHorizon <= 0 {
+		c.TrimHorizon = def.TrimHorizon
+	}
+	if c.StreamTTL < c.TrimHorizon {
+		c.StreamTTL = c.TrimHorizon + defaultShardedRelayReplayGrace
+	}
+	if c.TTLRefreshInterval <= 0 || c.TTLRefreshInterval >= c.StreamTTL {
+		c.TTLRefreshInterval = retentionSubinterval(c.StreamTTL, def.TTLRefreshInterval)
+	}
+	if c.MaintenanceInterval <= 0 || c.MaintenanceInterval >= c.StreamTTL {
+		c.MaintenanceInterval = retentionSubinterval(c.StreamTTL, def.MaintenanceInterval)
+	}
+	return c
+}
+
 // streamTTLRefresher limits PEXPIRE calls on the publish path while ensuring
 // active stream keys remain eligible for volatile-* eviction policies. A
 // maintenance pass repairs any TTL that was missed after a partial failure.
@@ -60,9 +105,31 @@ func (r *streamTTLRefresher) refreshIfDue(ctx context.Context, client *redis.Cli
 // repairMissingTTL assigns a TTL only when a stream exists without one. It
 // intentionally does not refresh a healthy TTL, so an idle stream can expire.
 func (r *streamTTLRefresher) repairMissingTTL(ctx context.Context, client *redis.Client, key string) (time.Duration, error) {
+	return r.reconcileTTL(ctx, client, key, true)
+}
+
+// reconcileTTL repairs a missing TTL when enabled and removes any persisted
+// TTL when disabled. The disabled path is the compatibility and rollback
+// phase: once all new replicas have observed it, old binaries can keep writing
+// without an inherited expiry deleting an active stream.
+func (r *streamTTLRefresher) reconcileTTL(ctx context.Context, client *redis.Client, key string, enabled bool) (time.Duration, error) {
 	ttl, err := client.PTTL(ctx, key).Result()
 	if err != nil {
 		return 0, err
+	}
+	if !enabled {
+		r.forget(key)
+		if ttl == -2 || ttl == -1 {
+			return ttl, nil
+		}
+		ok, err := client.Persist(ctx, key).Result()
+		if err != nil {
+			return ttl, err
+		}
+		if !ok {
+			return -2, nil
+		}
+		return -1, nil
 	}
 	switch ttl {
 	case -2: // key does not exist

--- a/server/internal/realtime/stream_retention.go
+++ b/server/internal/realtime/stream_retention.go
@@ -1,0 +1,147 @@
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultRelayStreamTrimHorizon         = 10 * time.Minute
+	defaultRelayStreamTTL                 = 15 * time.Minute
+	defaultRelayStreamTTLRefreshInterval  = 30 * time.Second
+	defaultRelayStreamMaintenanceInterval = time.Minute
+)
+
+// streamTTLRefresher limits PEXPIRE calls on the publish path while ensuring
+// active stream keys remain eligible for volatile-* eviction policies. A
+// maintenance pass repairs any TTL that was missed after a partial failure.
+type streamTTLRefresher struct {
+	ttl          time.Duration
+	refreshEvery time.Duration
+	now          func() time.Time
+
+	mu          sync.Mutex
+	lastRefresh map[string]time.Time
+}
+
+func newStreamTTLRefresher(ttl, refreshEvery time.Duration) *streamTTLRefresher {
+	return &streamTTLRefresher{
+		ttl:          ttl,
+		refreshEvery: refreshEvery,
+		now:          time.Now,
+		lastRefresh:  make(map[string]time.Time),
+	}
+}
+
+func (r *streamTTLRefresher) refreshIfDue(ctx context.Context, client *redis.Client, key string) error {
+	now := r.now()
+	if !r.claimRefresh(key, now) {
+		return nil
+	}
+
+	ok, err := client.PExpire(ctx, key, r.ttl).Result()
+	if err != nil {
+		r.releaseRefresh(key, now)
+		return err
+	}
+	if !ok {
+		r.releaseRefresh(key, now)
+		return fmt.Errorf("stream %q disappeared before TTL refresh", key)
+	}
+	return nil
+}
+
+// repairMissingTTL assigns a TTL only when a stream exists without one. It
+// intentionally does not refresh a healthy TTL, so an idle stream can expire.
+func (r *streamTTLRefresher) repairMissingTTL(ctx context.Context, client *redis.Client, key string) (time.Duration, error) {
+	ttl, err := client.PTTL(ctx, key).Result()
+	if err != nil {
+		return 0, err
+	}
+	switch ttl {
+	case -2: // key does not exist
+		return ttl, nil
+	case -1: // key exists without expiry
+		ok, err := client.PExpire(ctx, key, r.ttl).Result()
+		if err != nil {
+			return ttl, err
+		}
+		if !ok {
+			return -2, nil
+		}
+		r.mu.Lock()
+		r.lastRefresh[key] = r.now()
+		r.mu.Unlock()
+		return r.ttl, nil
+	default:
+		return ttl, nil
+	}
+}
+
+func (r *streamTTLRefresher) forgetStale(before time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, refreshedAt := range r.lastRefresh {
+		if refreshedAt.Before(before) {
+			delete(r.lastRefresh, key)
+		}
+	}
+}
+
+func (r *streamTTLRefresher) forget(key string) {
+	r.mu.Lock()
+	delete(r.lastRefresh, key)
+	r.mu.Unlock()
+}
+
+func (r *streamTTLRefresher) claimRefresh(key string, now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if last, ok := r.lastRefresh[key]; ok && now.Sub(last) < r.refreshEvery {
+		return false
+	}
+	r.lastRefresh[key] = now
+	return true
+}
+
+func (r *streamTTLRefresher) releaseRefresh(key string, claimedAt time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if current, ok := r.lastRefresh[key]; ok && current.Equal(claimedAt) {
+		delete(r.lastRefresh, key)
+	}
+}
+
+func streamMinID(now time.Time, horizon time.Duration) string {
+	millis := now.Add(-horizon).UnixMilli()
+	if millis < 0 {
+		millis = 0
+	}
+	return fmt.Sprintf("%d-0", millis)
+}
+
+func redisTTLMillis(ttl time.Duration) int64 {
+	if ttl == -2 || ttl == -1 {
+		return int64(ttl)
+	}
+	return ttl.Milliseconds()
+}
+
+func redisInfoInt64(info, key string) (int64, bool) {
+	prefix := key + ":"
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, prefix)), 10, 64)
+		return value, err == nil
+	}
+	return 0, false
+}

--- a/server/internal/realtime/stream_retention_test.go
+++ b/server/internal/realtime/stream_retention_test.go
@@ -1,0 +1,92 @@
+package realtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	redismock "github.com/go-redis/redismock/v9"
+)
+
+func TestStreamTTLRefresherRateLimitsPublishPath(t *testing.T) {
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	now := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	refresher := newStreamTTLRefresher(15*time.Minute, 30*time.Second)
+	refresher.now = func() time.Time { return now }
+
+	mock.ExpectPExpire("stream", 15*time.Minute).SetVal(true)
+	if err := refresher.refreshIfDue(context.Background(), rdb, "stream"); err != nil {
+		t.Fatal(err)
+	}
+	if err := refresher.refreshIfDue(context.Background(), rdb, "stream"); err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(30 * time.Second)
+	mock.ExpectPExpire("stream", 15*time.Minute).SetVal(true)
+	if err := refresher.refreshIfDue(context.Background(), rdb, "stream"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStreamTTLRefresherRetriesAfterFailure(t *testing.T) {
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	refresher := newStreamTTLRefresher(15*time.Minute, 30*time.Second)
+	mock.ExpectPExpire("stream", 15*time.Minute).SetErr(errors.New("redis unavailable"))
+	if err := refresher.refreshIfDue(context.Background(), rdb, "stream"); err == nil {
+		t.Fatal("expected PEXPIRE failure")
+	}
+	mock.ExpectPExpire("stream", 15*time.Minute).SetVal(true)
+	if err := refresher.refreshIfDue(context.Background(), rdb, "stream"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStreamTTLRefresherRepairsOnlyMissingTTL(t *testing.T) {
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	refresher := newStreamTTLRefresher(15*time.Minute, 30*time.Second)
+	mock.ExpectPTTL("stream").SetVal(-1)
+	mock.ExpectPExpire("stream", 15*time.Minute).SetVal(true)
+	ttl, err := refresher.repairMissingTTL(context.Background(), rdb, "stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 15*time.Minute {
+		t.Fatalf("repaired TTL = %s, want 15m", ttl)
+	}
+
+	mock.ExpectPTTL("stream").SetVal(10 * time.Minute)
+	ttl, err = refresher.repairMissingTTL(context.Background(), rdb, "stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 10*time.Minute {
+		t.Fatalf("healthy TTL = %s, want 10m", ttl)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRedisInfoInt64(t *testing.T) {
+	info := "# Memory\r\nused_memory:2160328\r\nmaxmemory:2097152\r\n"
+	if got, ok := redisInfoInt64(info, "used_memory"); !ok || got != 2160328 {
+		t.Fatalf("used_memory = %d, %v", got, ok)
+	}
+	if _, ok := redisInfoInt64(info, "missing"); ok {
+		t.Fatal("expected missing field not to parse")
+	}
+}

--- a/server/internal/realtime/stream_retention_test.go
+++ b/server/internal/realtime/stream_retention_test.go
@@ -81,6 +81,25 @@ func TestStreamTTLRefresherRepairsOnlyMissingTTL(t *testing.T) {
 	}
 }
 
+func TestStreamTTLRefresherDisabledPersistsStreamForSafeRollback(t *testing.T) {
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	refresher := newStreamTTLRefresher(15*time.Minute, 30*time.Second)
+	mock.ExpectPTTL("stream").SetVal(10 * time.Minute)
+	mock.ExpectPersist("stream").SetVal(true)
+	ttl, err := refresher.reconcileTTL(context.Background(), rdb, "stream", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != -1 {
+		t.Fatalf("TTL after disabled reconciliation = %s, want -1", ttl)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRedisInfoInt64(t *testing.T) {
 	info := "# Memory\r\nused_memory:2160328\r\nmaxmemory:2097152\r\n"
 	if got, ok := redisInfoInt64(info, "used_memory"); !ok || got != 2160328 {


### PR DESCRIPTION
## What does this PR do?

Bounds realtime Redis Stream retention so relay traffic cannot consume `maxmemory` and starve unrelated Redis-backed request paths.

The former sharded default retained up to 800,000 entries (roughly 800 MiB at the measured ~1 KiB entry size) while replay only needed five minutes. This change combines an immediate count cap with exact time trimming, an optional staged TTL fallback, and support for moving relay traffic to a dedicated Redis instance.

## Related Issue

Closes #7226

Closes MUL-6414

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Reduce the default cap from 100,000 to 2,000 entries per stream (about 16 MiB across the eight fixed sharded streams at the measured baseline), while preserving `REALTIME_RELAY_STREAM_MAXLEN` as the immediate operational pressure valve. In legacy and dual mode the same cap applies per scope stream, not globally.
- Add exact `XTRIM MINID` retention at 10 minutes and low-frequency retention/memory observations.
- Add a rate-limited 15-minute Stream TTL fallback behind `REALTIME_RELAY_STREAM_TTL_ENABLED`. It defaults to `false` so mixed-version rollout is safe; disabled replicas actively `PERSIST` inherited TTLs for a staged rollback.
- Apply the same MAXLEN, trim, TTL, refresh, and maintenance configuration to legacy and dual-write streams, including a bounded incremental `SCAN` that repairs pre-existing per-scope keys.
- Recover readers/groups when a whole stream key expires or is evicted, and expose stream length, memory, TTL, Redis memory, eviction, trim, missing-key, and retention-error metrics.
- Add optional `REALTIME_RELAY_REDIS_URL` isolation with backward-compatible fallback to `REDIS_URL`.

## How to Test

1. `go test ./internal/realtime ./internal/metrics -count=1`
2. `go test ./cmd/server -run 'Test(RealtimeRelayRedisURL|ShardedRelayConfig)' -count=1`
3. `go test -race ./internal/realtime ./internal/metrics -count=1`
4. `go vet ./internal/realtime ./internal/metrics ./cmd/server`
5. Against Redis 7, verify exact `XTRIM MINID`, TTL assignment, and that disabling TTL runs `PERSIST` (`PTTL == -1`) after an old-version-style `XADD`.

`go test ./cmd/server -count=1` still fails only at `TestReadinessEndpoints` in this local environment because the test receives 503 from the readiness probe; the same failure was reproduced from an untouched `origin/main` worktree. The relevant server configuration tests pass.

## Safety / Rollout

- The new environment variables are additive and existing deployments continue to use `REDIS_URL` unless a dedicated relay URL is configured.
- `MAXLEN` remains the primary bound under `noeviction`; TTL makes whole keys eligible under `volatile-*` policies but is not treated as an entry-level eviction mechanism.
- With the 2,000-entry default and a five-minute replay target, sustained traffic above roughly 6.7 events/second on one shard can make the count cap shorten the available replay window. Operators should size `REALTIME_RELAY_STREAM_MAXLEN` from observed per-shard event rate, entry bytes, and memory budget.
- Exact `XTRIM MINID` requires Redis/Valkey compatibility with Redis 6.2+. If maintenance is unsupported, publish remains available and the count cap still bounds new writes while retention errors surface in logs and metrics.
- The trim horizon is kept beyond the replay window, and configuration is normalized to preserve `ReplayGrace < TrimHorizon <= StreamTTL`.
- Safe TTL rollout is two-phase: deploy this version everywhere with `REALTIME_RELAY_STREAM_TTL_ENABLED=false`, then enable it and roll every replica again.
- Safe rollback reverses that sequence: disable TTL on every replica, wait for a complete legacy SCAN cycle (large keyspaces may require multiple maintenance intervals), verify relay PTTL values are `-1`, then roll back the binary. Do not directly roll back while TTL is enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Investigated and reproduced the Redis memory failure, incorporated Eve's solution review, implemented bounded count/time retention and observability, then addressed review findings around mixed-version TTL rollout, rollback, legacy/dual configuration parity, failure-path metrics, and the final 2,000-entry default. Validation included unit, race, vet, baseline-comparison, and live Redis checks.

## Screenshots (optional)

Not applicable; this is a backend retention and configuration change.
