### PR TITLE
fix(daemon): prefer the live re-resolved agent path over a deleted pin

### DIFF
--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -135,6 +136,85 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	t.Setenv("PATH", filepath.Join(root, "empty"))
 	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
 		t.Fatalf("cached self-heal not reused: got (%q, %q), want (%q, %q)", got.Path, ver, v2, "0.144.3")
+	}
+}
+
+// TestResolveAgentEntry_PrefersLivePathWhenVersionDetectFails is the regression
+// for GH #6452, the follow-up to MUL-4486. An in-place upgrade deletes the
+// pinned versioned directory, and the `--version` probe of the binary the
+// command now resolves to never returns — on macOS a freshly written,
+// quarantined Homebrew cask artifact blocks in _dyld_start until the probe
+// timeout kills it. The candidate cannot be adopted, since nothing about it was
+// verified. But answering with the pinned path is worse than answering with an
+// unknown version: that path is gone, so every consumer fails on a file the
+// upgrade removed instead of probing the one that is installed, and the retry
+// that would recover a transient probe failure never gets to run.
+func TestResolveAgentEntry_PrefersLivePathWhenVersionDetectFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+
+	// The probe is killed by its own timeout, as reported. detectVersionOK flips
+	// it back on to stand in for the repair (replacing the file with a fresh
+	// inode), so the same entry can be observed healing for real afterwards.
+	detectVersionOK := false
+	origDetect := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, runtimeCmd agent.Command) (string, error) {
+		if !detectVersionOK {
+			return "", errors.New("signal: killed")
+		}
+		return filepath.Base(filepath.Dir(filepath.Dir(runtimeCmd.Path))), nil
+	}
+	t.Cleanup(func() { detectAgentVersion = origDetect })
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: v1, Command: "codex"}
+	ctx := context.Background()
+
+	// In-place upgrade: the pinned versioned tree is deleted and the stable
+	// command name now resolves to v2.
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
+	if agentExecutablePresent(v1) {
+		t.Fatalf("v1 path still present after removing its tree: %q", v1)
+	}
+
+	got, ver := d.resolveAgentEntry(ctx, "codex", entry)
+	if got.Path == v1 {
+		t.Fatalf("kept the deleted pinned path %q; every consumer then fails on a file the upgrade removed", v1)
+	}
+	if got.Path != v2 {
+		t.Fatalf("resolved %q, want the live re-resolved path %q", got.Path, v2)
+	}
+	// An unknown version, never a wrong one: the last known value is reported,
+	// and the unverified pair is deliberately NOT published, so the next call
+	// probes again instead of pinning a path to a version nothing detected.
+	if ver != "0.144.1" {
+		t.Fatalf("returned version = %q, want the last known %q", ver, "0.144.1")
+	}
+	d.resolvedPathsMu.RLock()
+	cached, published := d.resolvedPaths["codex"]
+	d.resolvedPathsMu.RUnlock()
+	if published {
+		t.Fatalf("unverified path was published as a healed pair: %+v", cached)
+	}
+
+	// Once version detection recovers, the same entry heals for real and adopts
+	// the verified {path, version} pair.
+	detectVersionOK = true
+	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
+		t.Fatalf("heal did not complete after version detection recovered: got (%q, %q), want (%q, %q)",
+			got.Path, ver, v2, "0.144.3")
 	}
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -839,10 +839,13 @@ type healedAgent struct {
 // version detection at registration) then hard-fails with "executable not
 // found".
 //
-// The returned version always matches the returned path, so callers key
-// version-sensitive policy (e.g. the Codex sandbox) off it directly rather than
-// re-reading the shared version cache, which a concurrent heal could still be
-// updating.
+// The returned version matches the returned path in every case but one, so
+// callers key version-sensitive policy (e.g. the Codex sandbox) off it directly
+// rather than re-reading the shared version cache, which a concurrent heal could
+// still be updating. The one exception is the unverified case in the last bullet
+// below: a live-but-undetectable re-resolved path is returned paired with the
+// last known version, and the launch boundary refuses it precisely because that
+// pair was never verified.
 //
 // Behaviour:
 //   - A Windows stable entry point -> its final target is verified and returned
@@ -862,9 +865,14 @@ type healedAgent struct {
 //     through the same minimum-version gate registration applies. This
 //     reproduces exactly what a daemon restart would resolve, so it is no less
 //     safe than the documented restart workaround — only automatic.
-//   - Re-resolution fails, the candidate can't be version-detected, or it is
-//     below the minimum supported version -> entry is returned unchanged so the
-//     candidate is never launched and the downstream error still surfaces.
+//   - Pinned Path gone, re-resolution finds a candidate that is present but
+//     cannot be version-detected -> its path replaces the vanished pin so
+//     registration and model listing probe the real binary and can recover on a
+//     later retry, but it is returned paired with the last known version and is
+//     never launched, because that {path, version} pair is unverified (GH #6452).
+//   - Re-resolution finds nothing, or the candidate is below the minimum
+//     supported version -> entry is returned unchanged so the candidate is never
+//     launched and the downstream error still surfaces.
 func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string) {
 	resolved, version, _ := d.resolveAgentEntryWithHeal(ctx, provider, entry)
 	return resolved, version

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -895,10 +895,17 @@ func (d *Daemon) resolveAgentEntryForLaunch(ctx context.Context, provider string
 // version. rejected is nil unless the verdict is genuine — it is only ever set
 // from a *agent.BelowMinimumError, which by construction carries a version
 // that parsed.
+//
+// unverified is the third shape: the pinned path is gone and its command
+// re-resolved to a binary that is present but could not be version-detected.
+// It is not an adoption — nothing was verified, so nothing is published or
+// launched under it — only the observation that this path exists and the
+// pinned one does not (GH #6452).
 type healOutcome struct {
-	adopted  healedAgent
-	rejected *agent.BelowMinimumError
-	failure  error
+	adopted    healedAgent
+	rejected   *agent.BelowMinimumError
+	unverified string
+	failure    error
 }
 
 // resolveAgentEntryWithHeal is resolveAgentEntry plus what the self-heal
@@ -959,6 +966,17 @@ func (d *Daemon) resolveAgentEntryWithHeal(ctx context.Context, provider string,
 	})
 	outcome, _ := v.(healOutcome)
 	if outcome.adopted.path == "" {
+		// Nothing was adopted, but entry.Path was already established as gone
+		// above. Naming a path that provably cannot be executed makes every
+		// consumer fail on a ghost: registration probes it instead of the binary
+		// that is actually installed, so a version probe that would succeed on
+		// retry can never run, and the error the user sees blames a file the
+		// upgrade deleted. Prefer the live re-resolved path (GH #6452). The
+		// version stays the last known one and the pair is left unpublished,
+		// because this path is exactly the one we could not verify.
+		if outcome.unverified != "" {
+			entry.Path = outcome.unverified
+		}
 		return entry, d.agentVersion(provider), outcome
 	}
 	entry.Path = outcome.adopted.path
@@ -1059,7 +1077,16 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 			newPath = launchPath
 		}
 	}
-	return d.adoptAgentPath(ctx, provider, command, newPath, "re-resolved after pinned path vanished")
+	outcome := d.adoptAgentPath(ctx, provider, command, newPath, "re-resolved after pinned path vanished")
+	// Reached only when the pinned path has vanished, so an unadopted candidate
+	// still on disk is the better of the two paths to report. A below-minimum
+	// rejection is excluded: that is a verdict about the binary itself, and its
+	// callers demote the runtime rather than touch the path. Re-checked after the
+	// probe because a long `--version` gives the installer time to move it again.
+	if outcome.adopted.path == "" && outcome.rejected == nil && agentExecutablePresent(newPath) {
+		outcome.unverified = newPath
+	}
+	return outcome
 }
 
 func (d *Daemon) adoptAgentPath(ctx context.Context, provider, command, newPath, reason string) healOutcome {
@@ -1069,7 +1096,7 @@ func (d *Daemon) adoptAgentPath(ctx context.Context, provider, command, newPath,
 	// registration path applies (MUL-4486 review).
 	version, err := detectAgentVersion(ctx, agent.Command{Path: newPath})
 	if err != nil {
-		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
+		d.logger.Warn("re-resolved agent executable failed version detection; not adopting it",
 			"provider", provider, "command", command, "new_path", newPath, "error", err)
 		return healOutcome{failure: err}
 	}
@@ -1080,7 +1107,7 @@ func (d *Daemon) adoptAgentPath(ctx context.Context, provider, command, newPath,
 			// adopt is still right, but reporting a rejection would let the
 			// caller demote a runtime on an unreadable version — the exact
 			// transient case the below-minimum machinery must never act on.
-			d.logger.Warn("re-resolved agent executable version could not be validated; keeping pinned path",
+			d.logger.Warn("re-resolved agent executable version could not be validated; not adopting it",
 				"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
 			return healOutcome{failure: err}
 		}


### PR DESCRIPTION
## Summary

When a version manager (Homebrew Cask, nvm/fnm) upgrades an agent CLI in place, it deletes the versioned directory the daemon's pinned path points into and repoints the stable command name at the new version. The daemon self-heals by re-resolving the command — but when the re-resolved binary fails version detection (e.g. a slow `--version` under Gatekeeper), `resolveAgentEntryWithHeal` returned the original pinned path **unchanged**, i.e. a path that no longer exists. Every consumer (registration probe, model listing, launch) then fails on a ghost file, and the registration probe can never recover because it keeps probing the vanished path instead of the binary that is actually installed (#6452).

## Change

`healOutcome` gains an `unverified` field for the third outcome shape: the pin is gone and the command re-resolved to a binary that is present but could not be version-detected. `healAgentPath` records it (excluding a below-minimum rejection, which is a verdict about the binary itself and whose callers demote the runtime), and `resolveAgentEntryWithHeal` prefers it over the vanished pin in the no-adoption branch.

Preserved from #5355 (MUL-4486): the unverified `{path, version}` pair is never published into the resolved-path cache and never launched — `resolveAgentEntryForLaunch` still hard-errors on `outcome.failure != nil`, so version-sensitive policy (the Codex sandbox) never keys off a version that was not detected for the path. The improvement is that registration and model listing now probe the real installed binary and can recover on retry, and the launch error names the real file instead of a deleted one. Because the failure is not cached, the next call re-probes — which is how registration completes the heal once detection recovers.

Also corrected two now-false log lines (`keeping pinned path` → `not adopting it`) and tightened the `resolveAgentEntry` doc comment so its "returned version always matches the returned path" invariant calls out the unverified case as the one exception.

Scope: this addresses the primary symptom (consumers failing on the vanished pin). The issue's other asks — registering with an unknown version rather than skipping, distinguishing a probe timeout from a probe error, and a per-provider health signal — are deliberately left for their own changes.

## Test plan

- `server/internal/daemon/agent_path_selfheal_test.go`: `TestResolveAgentEntry_PrefersLivePathWhenVersionDetectFails` pins a deleted path, re-resolves to a live binary whose version probe is killed, and asserts the live path is preferred while nothing is published under an undetected version. Verified it fails before the change (`kept the deleted pinned path`) and passes after — a real regression guard. It reuses the #5355 harness (fake `#!/bin/sh` stubs under `t.TempDir()`, the `detectAgentVersion` function-var stub, PATH/SHELL pinned), so no real agent CLI is ever resolved or executed.
- `go test -race ./internal/daemon` ✅ · `go vet ./internal/daemon` ✅ · `gofmt` clean · `go build ./...` ✅
- The Windows retargetable-junction path is untouched; `config_windows_test.go` compiles under `GOOS=windows` (the Windows CI job exercises it).

Fixes #6452
