### PR TITLE
feat(issues): extend property filter to text / number / date / url (MUL-6423)

### DIFF
--- a/packages/core/issues/stores/view-store-property-filter.test.ts
+++ b/packages/core/issues/stores/view-store-property-filter.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, expect, it, beforeEach } from "vitest";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { viewStoreSlice, type IssueViewState } from "./view-store";
+
+// The "__none__" sentinel is a plain string option id from the store's
+// perspective; the filter menu (views) builds the array including it.
+const NO_PROPERTY_VALUE = "__none__";
+const PROP = "prop-estimate";
+
+describe("setPropertyFilterValues", () => {
+  let store: StoreApi<IssueViewState>;
+  beforeEach(() => {
+    store = createStore<IssueViewState>()((set) => viewStoreSlice(set));
+  });
+
+  it("replaces the property's full value set", () => {
+    store.getState().togglePropertyFilter(PROP, "3.5");
+    store.getState().setPropertyFilterValues(PROP, ["4"]);
+
+    expect(store.getState().propertyFilters[PROP]).toEqual(["4"]);
+  });
+
+  it("clears the property filter when given an empty set", () => {
+    store.getState().togglePropertyFilter(PROP, "3.5");
+    store.getState().setPropertyFilterValues(PROP, []);
+
+    expect(store.getState().propertyFilters[PROP]).toBeUndefined();
+  });
+
+  it("stores the no-value sentinel like any other value", () => {
+    store.getState().setPropertyFilterValues(PROP, [NO_PROPERTY_VALUE]);
+
+    expect(store.getState().propertyFilters[PROP]).toEqual([NO_PROPERTY_VALUE]);
+  });
+});

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -245,6 +245,9 @@ export interface IssueViewState {
   toggleNoProject: () => void;
   toggleLabelFilter: (labelId: string) => void;
   togglePropertyFilter: (propertyId: string, optionId: string) => void;
+  /** Replace a property's full filter value set (used by scalar value inputs
+   *  for text/number/date/url, which build the array including "__none__"). */
+  setPropertyFilterValues: (propertyId: string, optionIds: string[]) => void;
   setDateFilter: (filter: IssueDateFilter | null) => void;
   toggleAgentRunningFilter: () => void;
   hideStatus: (category: IssueStatusCategory) => void;
@@ -388,6 +391,13 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
       const propertyFilters = { ...state.propertyFilters };
       if (next.length === 0) delete propertyFilters[propertyId];
       else propertyFilters[propertyId] = next;
+      return { propertyFilters };
+    }),
+  setPropertyFilterValues: (propertyId, optionIds) =>
+    set((state) => {
+      const propertyFilters = { ...state.propertyFilters };
+      if (optionIds.length === 0) delete propertyFilters[propertyId];
+      else propertyFilters[propertyId] = optionIds;
       return { propertyFilters };
     }),
   setDateFilter: (filter) => set({ dateFilter: filter }),

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -105,7 +105,7 @@ export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferen
 export type { Comment, CommentType, CommentAuthorType, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, CommentTriggerOutcome, CommentTriggerStatus, Reaction } from "./comment";
 export type { Label, LabelResourceType, CreateLabelRequest, UpdateLabelRequest, ListLabelsResponse, IssueLabelsResponse, ResourceLabelsResponse } from "./label";
 export type { IssueProperty, IssuePropertyType, IssuePropertyOption, IssuePropertyConfig, IssuePropertyValue, IssuePropertyValues, CreatePropertyRequest, UpdatePropertyRequest, ListPropertiesResponse, IssuePropertiesResponse, IssuePropertyActorKind, IssuePropertyActorRef } from "./property";
-export { ISSUE_PROPERTY_TYPES, isKnownPropertyType, ISSUE_PROPERTY_ACTOR_KINDS, MAX_ISSUE_PROPERTY_ACTOR_VALUES, isActorPropertyType, formatActorRef, parseActorRef, actorRefsFromValue, actorRefValuesFromValue, hasUnknownActorRef } from "./property";
+export { ISSUE_PROPERTY_TYPES, isKnownPropertyType, ISSUE_PROPERTY_ACTOR_KINDS, MAX_ISSUE_PROPERTY_ACTOR_VALUES, isActorPropertyType, isFilterablePropertyType, isScalarPropertyType, formatActorRef, parseActorRef, actorRefsFromValue, actorRefValuesFromValue, hasUnknownActorRef } from "./property";
 export type {
   QuickAction,
   QuickActionVisibility,

--- a/packages/core/types/property.test.ts
+++ b/packages/core/types/property.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   actorRefsFromValue,
@@ -5,7 +6,9 @@ import {
   hasUnknownActorRef,
   formatActorRef,
   isActorPropertyType,
+  isFilterablePropertyType,
   isKnownPropertyType,
+  isScalarPropertyType,
   parseActorRef,
 } from "./property";
 
@@ -30,6 +33,39 @@ describe("isActorPropertyType", () => {
     expect(isActorPropertyType("multi_actor")).toBe(true);
     expect(isActorPropertyType("select")).toBe(false);
     expect(isActorPropertyType("multi_select")).toBe(false);
+  });
+});
+
+describe("isFilterablePropertyType", () => {
+  it("admits every type the filter menu supports", () => {
+    for (const type of [
+      "select",
+      "multi_select",
+      "checkbox",
+      "text",
+      "number",
+      "date",
+      "url",
+      "actor",
+      "multi_actor",
+    ]) {
+      expect(isFilterablePropertyType(type)).toBe(true);
+    }
+  });
+
+  it("rejects unknown types", () => {
+    expect(isFilterablePropertyType("relation")).toBe(false);
+  });
+});
+
+describe("isScalarPropertyType", () => {
+  it("covers the four single-valued types and nothing else", () => {
+    for (const type of ["text", "number", "date", "url"]) {
+      expect(isScalarPropertyType(type)).toBe(true);
+    }
+    expect(isScalarPropertyType("select")).toBe(false);
+    expect(isScalarPropertyType("checkbox")).toBe(false);
+    expect(isScalarPropertyType("actor")).toBe(false);
   });
 });
 

--- a/packages/core/types/property.ts
+++ b/packages/core/types/property.ts
@@ -62,7 +62,12 @@ export function isActorPropertyType(type: string): boolean {
   return type === "actor" || type === "multi_actor";
 }
 
-/** Types the issue filter menu exposes for value + "No value" filtering. */
+/**
+ * Types the issue filter menu exposes for value + "No value" filtering.
+ * Kept as an explicit enumeration (rather than delegating to
+ * isKnownPropertyType) so a future property type must opt into filtering —
+ * it should never become filterable by default.
+ */
 export function isFilterablePropertyType(type: string): boolean {
   return (
     type === "select" ||

--- a/packages/core/types/property.ts
+++ b/packages/core/types/property.ts
@@ -62,6 +62,22 @@ export function isActorPropertyType(type: string): boolean {
   return type === "actor" || type === "multi_actor";
 }
 
+/** Types the issue filter menu exposes for value + "No value" filtering. */
+export function isFilterablePropertyType(type: string): boolean {
+  return (
+    type === "select" ||
+    type === "multi_select" ||
+    type === "checkbox" ||
+    isScalarPropertyType(type) ||
+    isActorPropertyType(type)
+  );
+}
+
+/** Single-valued scalar properties: text / number / date / url. */
+export function isScalarPropertyType(type: string): boolean {
+  return type === "text" || type === "url" || type === "number" || type === "date";
+}
+
 export function formatActorRef(kind: IssuePropertyActorKind, id: string): string {
   return `${kind}:${id}`;
 }

--- a/packages/views/issues/components/filter-chips-bar.tsx
+++ b/packages/views/issues/components/filter-chips-bar.tsx
@@ -21,7 +21,7 @@ import { memberListOptions, agentListOptions, squadListOptions } from "@multica/
 import { projectListOptions } from "@multica/core/projects/queries";
 import { labelListOptions } from "@multica/core/labels/queries";
 import { propertyListOptions } from "@multica/core/properties";
-import { isActorPropertyType, parseActorRef } from "@multica/core/types";
+import { isActorPropertyType, isScalarPropertyType, parseActorRef } from "@multica/core/types";
 import {
   type ActorFilterValue,
   type FilterDimension,
@@ -469,6 +469,10 @@ function useFilterChips(
         return optionId === "true"
           ? t(($) => $.pickers.custom_property.true_label)
           : t(($) => $.pickers.custom_property.false_label);
+      }
+      // Scalar properties have no option list — the filter value IS the label.
+      if (isScalarPropertyType(definition.type)) {
+        return optionId;
       }
       return definition.config.options?.find((o) => o.id === optionId)?.name;
     };

--- a/packages/views/issues/components/issues-header.property-filter.test.tsx
+++ b/packages/views/issues/components/issues-header.property-filter.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+/**
+ * The scalar custom-property filter (text / number / date / url), driven
+ * against the REAL Base UI menu primitives — not a flattened mock, because the
+ * menu popup's typeahead/list-navigation handlers are exactly what break the
+ * value input (they stopEvent() every printable key). See
+ * issues-header.status-filter.test.tsx for the same rationale on the status
+ * section.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createStore } from "zustand/vanilla";
+import { setApiInstance } from "@multica/core/api";
+import type { ApiClient } from "@multica/core/api/client";
+import { createAuthStore, registerAuthStore } from "@multica/core/auth";
+import {
+  type IssueViewState,
+  viewStoreSlice,
+} from "@multica/core/issues/stores/view-store";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import type { IssueProperty } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueFilterMenu } from "./issues-header";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+function textProperty(id: string, name: string): IssueProperty {
+  return {
+    id,
+    workspace_id: "ws-1",
+    name,
+    type: "text",
+    config: {},
+    position: 1,
+    archived: false,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function renderFilterMenu(props: IssueProperty[]) {
+  setApiInstance({
+    listIssueStatuses: async () => ({ statuses: [], categories: [], total: 0 }),
+    listProperties: async () => ({ properties: props }),
+  } as unknown as ApiClient);
+  // PropertyFilterOptions reads the signed-in member via useAuthStore to sort
+  // actor options; register a minimal store so the menu renders for scalar
+  // types too.
+  registerAuthStore(
+    createAuthStore({
+      api: {} as ApiClient,
+      storage: {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+      },
+    }),
+  );
+
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const store = createStore<IssueViewState>()(viewStoreSlice);
+
+  const view = renderWithI18n(
+    <QueryClientProvider client={qc}>
+      <ViewStoreProvider store={store}>
+        <IssueFilterMenu trigger={<button type="button">Filter</button>} />
+      </ViewStoreProvider>
+    </QueryClientProvider>,
+  );
+  return { store, ...view };
+}
+
+async function openPropertySubmenu(name: string) {
+  fireEvent.click(screen.getByRole("button", { name: "Filter" }));
+  const trigger = await screen.findByRole("menuitem", { name: new RegExp(name) });
+  fireEvent.click(trigger);
+  await waitFor(() =>
+    expect(screen.getByRole("textbox")).toBeInTheDocument(),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  // Base UI portals the menu onto document.body; leftovers would duplicate
+  // labels across tests.
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("IssueFilterMenu scalar property filter", () => {
+  const PROP = "prop-note";
+
+  it("types into the scalar value input", async () => {
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    await openPropertySubmenu("Note");
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "hello");
+
+    // The regression: Base UI's menu popup stops every printable key, so the
+    // input swallowed characters — value stayed "".
+    expect(input).toHaveValue("hello");
+    // Typing alone must not commit; the filter changes only on Enter/blur.
+    expect(store.getState().propertyFilters).toEqual({});
+  });
+
+  it("commits the value on Enter", async () => {
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    await openPropertySubmenu("Note");
+
+    await userEvent.type(screen.getByRole("textbox"), "hello{Enter}");
+
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
+  });
+
+  it("commits the value when focus blurs to a non-menu element", async () => {
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    await openPropertySubmenu("Note");
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "hello");
+    fireEvent.blur(input);
+
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
+  });
+
+  it("checking No value clears a committed value; unchecking restores the draft", async () => {
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    await openPropertySubmenu("Note");
+
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "hello{Enter}");
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
+
+    // Checking "No value" clears the value (mutual exclusion).
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["__none__"] });
+
+    // Re-type and uncheck: the value still in the input is committed.
+    await userEvent.type(screen.getByRole("textbox"), "world");
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["world"] });
+  });
+
+  it("unchecking No value restores a typed (uncommitted) value", async () => {
+    // Seed the filter with No value checked, then type before unchecking.
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    store.getState().setPropertyFilterValues(PROP, ["__none__"]);
+    await openPropertySubmenu("Note");
+
+    await userEvent.type(screen.getByRole("textbox"), "abc");
+    // Clicking the checkbox blurs the input first; the blur guard must skip the
+    // premature commit so the checkbox reads the pre-blur state and the draft
+    // survives for the uncheck.
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["abc"] });
+  });
+});

--- a/packages/views/issues/components/issues-header.property-filter.test.tsx
+++ b/packages/views/issues/components/issues-header.property-filter.test.tsx
@@ -132,7 +132,9 @@ describe("IssueFilterMenu scalar property filter", () => {
     expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
   });
 
-  it("checking No value clears a committed value; unchecking restores the draft", async () => {
+  it("checking and unchecking No value preserves the committed value", async () => {
+    // Regression (review round 2): unchecking "No value" used to drop the
+    // committed value because the draft effect wiped it when the set changed.
     const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
     await openPropertySubmenu("Note");
 
@@ -140,28 +142,41 @@ describe("IssueFilterMenu scalar property filter", () => {
     await userEvent.type(input, "hello{Enter}");
     expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
 
-    // Checking "No value" clears the value (mutual exclusion).
+    // "No value" composes OR-style with the value, like every other type.
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello", "__none__"] });
+
+    // Unchecking removes only the membership — the committed value survives
+    // without any draft round-trip.
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["hello"] });
+  });
+
+  it("committing a value preserves an existing No-value membership", async () => {
+    const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
+    await openPropertySubmenu("Note");
+
     await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
     expect(store.getState().propertyFilters).toEqual({ [PROP]: ["__none__"] });
 
-    // Re-type and uncheck: the value still in the input is committed.
-    await userEvent.type(screen.getByRole("textbox"), "world");
-    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
-    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["world"] });
+    await userEvent.type(screen.getByRole("textbox"), "abc{Enter}");
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["abc", "__none__"] });
   });
 
-  it("unchecking No value restores a typed (uncommitted) value", async () => {
-    // Seed the filter with No value checked, then type before unchecking.
+  it("an uncommitted draft survives checking No value, then commits alongside it", async () => {
     const { store } = renderFilterMenu([textProperty(PROP, "Note")]);
-    store.getState().setPropertyFilterValues(PROP, ["__none__"]);
     await openPropertySubmenu("Note");
 
     await userEvent.type(screen.getByRole("textbox"), "abc");
     // Clicking the checkbox blurs the input first; the blur guard must skip the
     // premature commit so the checkbox reads the pre-blur state and the draft
-    // survives for the uncheck.
+    // stays uncommitted in the input.
     await userEvent.click(screen.getByRole("menuitemcheckbox", { name: /No value/ }));
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["__none__"] });
+    expect(screen.getByRole("textbox")).toHaveValue("abc");
 
-    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["abc"] });
+    // Enter commits the draft as another member of the OR-set.
+    await userEvent.type(screen.getByRole("textbox"), "{Enter}");
+    expect(store.getState().propertyFilters).toEqual({ [PROP]: ["abc", "__none__"] });
   });
 });

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -679,7 +679,7 @@ function PropertyFilterOptions({
   selected: string[];
   onToggle: (optionId: string) => void;
   /** Replace the property's full filter value set (scalar types only). */
-  onSetValues?: (optionIds: string[]) => void;
+  onSetValues: (optionIds: string[]) => void;
   fixedIds?: Set<string>;
   fixedTitle?: string;
 }) {
@@ -723,13 +723,14 @@ function PropertyFilterOptions({
   };
   // Scalar value state lives at the top level so the hooks stay unconditional
   // (Rules of Hooks): it is only rendered for text / number / date / url, but
-  // must be declared regardless of which branch runs. The draft is NOT synced
-  // back to `scalarValue`: toggling "No value" must keep the typed value so
-  // unchecking it can restore the filter (the input initializes from
-  // `scalarValue` on mount, so a reopened menu always shows the committed one).
+  // must be declared regardless of which branch runs. The draft syncs to the
+  // committed `scalarValue` only when that changes (e.g. an external clear) —
+  // during typing scalarValue is unchanged, so the draft survives long enough
+  // for an in-menu "No value" uncheck to restore it.
   const scalarValue = selected.find((id) => id !== NO_PROPERTY_VALUE) ?? "";
   const hasNoValue = selected.includes(NO_PROPERTY_VALUE);
   const [draft, setDraft] = useState(scalarValue);
+  useEffect(() => setDraft(scalarValue), [scalarValue]);
   const options = [
     ...(actorProperty
       ? actorOptions.map((option) => ({
@@ -754,7 +755,7 @@ function PropertyFilterOptions({
     noValueOption,
   ];
 
-  if (scalarProperty && onSetValues) {
+  if (scalarProperty) {
     const placeholder =
       property.type === "url"
         ? t(($) => $.pickers.custom_property.url_placeholder)
@@ -796,7 +797,16 @@ function PropertyFilterOptions({
               if (!movedToMenuItem) commitValue(draft);
             }}
             onKeyDown={(event) => {
+              // Base UI's menu popup merges typeahead + list-navigation handlers
+              // onto the role="menu" element and stopEvent()s every printable
+              // key — without stopping propagation, the input would swallow no
+              // characters at all (and arrow keys on number/date inputs would
+              // be hijacked). Escape/Tab are left for the menu to close/move
+              // focus; Enter commits and still needs stopPropagation so it does
+              // not bubble up and activate the highlighted "No value" item.
+              if (event.key === "Escape" || event.key === "Tab") return;
               if (event.key === "Enter") commitValue(draft);
+              event.stopPropagation();
             }}
             disabled={locked}
             placeholder={placeholder}

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Spinner } from "@multica/ui/components/ui/spinner";
+import { Input } from "@multica/ui/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -74,7 +75,7 @@ import type {
   IssueTableFacetsResponse,
   WorkingAgentSummary,
 } from "@multica/core/types";
-import { formatActorRef, isActorPropertyType } from "@multica/core/types";
+import { formatActorRef, isActorPropertyType, isFilterablePropertyType, isScalarPropertyType } from "@multica/core/types";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PropertyIcon } from "../../common/property-icon";
@@ -669,6 +670,7 @@ function PropertyFilterOptions({
   counts,
   selected,
   onToggle,
+  onSetValues,
   fixedIds,
   fixedTitle,
 }: {
@@ -676,6 +678,8 @@ function PropertyFilterOptions({
   counts: Map<string, number> | undefined;
   selected: string[];
   onToggle: (optionId: string) => void;
+  /** Replace the property's full filter value set (scalar types only). */
+  onSetValues?: (optionIds: string[]) => void;
   fixedIds?: Set<string>;
   fixedTitle?: string;
 }) {
@@ -683,6 +687,9 @@ function PropertyFilterOptions({
   const wsId = useWorkspaceId();
   const currentUserId = useAuthStore((s) => s.user?.id);
   const actorProperty = isActorPropertyType(property.type);
+  // Scalar properties (text / number / date / url) have no option list — the
+  // filter menu shows a value input plus "No value".
+  const scalarProperty = isScalarPropertyType(property.type);
   const { data: actorMembers = [] } = useQuery({
     ...memberListOptions(wsId),
     enabled: actorProperty,
@@ -714,6 +721,15 @@ function PropertyFilterOptions({
     actorType: undefined as string | undefined,
     actorId: undefined as string | undefined,
   };
+  // Scalar value state lives at the top level so the hooks stay unconditional
+  // (Rules of Hooks): it is only rendered for text / number / date / url, but
+  // must be declared regardless of which branch runs. The draft is NOT synced
+  // back to `scalarValue`: toggling "No value" must keep the typed value so
+  // unchecking it can restore the filter (the input initializes from
+  // `scalarValue` on mount, so a reopened menu always shows the committed one).
+  const scalarValue = selected.find((id) => id !== NO_PROPERTY_VALUE) ?? "";
+  const hasNoValue = selected.includes(NO_PROPERTY_VALUE);
+  const [draft, setDraft] = useState(scalarValue);
   const options = [
     ...(actorProperty
       ? actorOptions.map((option) => ({
@@ -737,6 +753,78 @@ function PropertyFilterOptions({
           }))),
     noValueOption,
   ];
+
+  if (scalarProperty && onSetValues) {
+    const placeholder =
+      property.type === "url"
+        ? t(($) => $.pickers.custom_property.url_placeholder)
+        : property.type === "number"
+          ? t(($) => $.pickers.custom_property.number_placeholder)
+          : t(($) => $.pickers.custom_property.value_placeholder);
+    const noneCount = counts?.get(NO_PROPERTY_VALUE) ?? 0;
+    // A saved view locks this dimension: the scalar value AND "No value" are
+    // both part of the view's identity, so neither can be edited in place.
+    const locked = fixedIds !== undefined && fixedIds.size > 0;
+    const commitValue = (raw: string) => {
+      const value = raw.trim();
+      // NO_PROPERTY_VALUE is the reserved "no value" sentinel — it cannot be
+      // filtered as a literal value. Setting a value also clears "No value":
+      // the two are mutually exclusive for a scalar.
+      if (value === NO_PROPERTY_VALUE) return;
+      onSetValues(value ? [value] : []);
+    };
+    return (
+      <>
+        <div className="px-2 py-1.5">
+          <Input
+            type={property.type === "number" ? "number" : property.type === "date" ? "date" : "text"}
+            step={property.type === "number" ? "any" : undefined}
+            inputMode={property.type === "number" ? "decimal" : undefined}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={(event) => {
+              // Clicking the "No value" menu item moves focus off the input,
+              // firing blur first. That premature commit would flip the
+              // checkbox's controlled state before its click handler reads it
+              // — so when focus moves into a menu item in this popup, skip the
+              // blur commit and let onCheckedChange decide from the pre-blur
+              // state.
+              const next = event.relatedTarget;
+              const movedToMenuItem =
+                next instanceof HTMLElement &&
+                next.closest('[role="menuitemcheckbox"]') !== null;
+              if (!movedToMenuItem) commitValue(draft);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitValue(draft);
+            }}
+            disabled={locked}
+            placeholder={placeholder}
+            className="h-8"
+          />
+        </div>
+        <DropdownMenuCheckboxItem
+          checked={hasNoValue}
+          disabled={locked}
+          onCheckedChange={(checked) => {
+            if (checked) {
+              onSetValues([NO_PROPERTY_VALUE]);
+            } else {
+              // Unchecking "No value" restores the value still in the input.
+              onSetValues(draft.trim() ? [draft.trim()] : []);
+            }
+          }}
+          className={FILTER_ITEM_CLASS}
+        >
+          <HoverCheck checked={hasNoValue} />
+          <span className="truncate">{noValueOption.name}</span>
+          {noneCount > 0 && (
+            <span className="ml-auto text-caption text-muted-foreground">{noneCount}</span>
+          )}
+        </DropdownMenuCheckboxItem>
+      </>
+    );
+  }
 
   return (
     <>
@@ -1229,13 +1317,7 @@ export function IssueFilterMenu({
   const { data: workspaceProperties = [] } = useQuery(propertyListOptions(wsId));
   const filterableProperties = useMemo(
     () =>
-      workspaceProperties.filter(
-        (p) =>
-          p.type === "select" ||
-          p.type === "multi_select" ||
-          p.type === "checkbox" ||
-          isActorPropertyType(p.type),
-      ),
+      workspaceProperties.filter((p) => isFilterablePropertyType(p.type)),
     [workspaceProperties],
   );
   const counts = useIssueCounts(
@@ -1569,6 +1651,7 @@ export function IssueFilterMenu({
                       counts={counts.property.get(property.id)}
                       selected={selected}
                       onToggle={(optionId) => act.togglePropertyFilter(property.id, optionId)}
+                      onSetValues={(optionIds) => act.setPropertyFilterValues(property.id, optionIds)}
                       fixedIds={viewBaseline?.property.get(property.id)}
                       fixedTitle={fixedTitle}
                     />
@@ -1667,13 +1750,7 @@ export function IssueDisplayControls({
   );
   const filterableProperties = useMemo(
     () =>
-      workspaceProperties.filter(
-        (p) =>
-          p.type === "select" ||
-          p.type === "multi_select" ||
-          p.type === "checkbox" ||
-          isActorPropertyType(p.type),
-      ),
+      workspaceProperties.filter((p) => isFilterablePropertyType(p.type)),
     [workspaceProperties],
   );
   const sortableProperties = useMemo(

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -724,9 +724,8 @@ function PropertyFilterOptions({
   // Scalar value state lives at the top level so the hooks stay unconditional
   // (Rules of Hooks): it is only rendered for text / number / date / url, but
   // must be declared regardless of which branch runs. The draft syncs to the
-  // committed `scalarValue` only when that changes (e.g. an external clear) —
-  // during typing scalarValue is unchanged, so the draft survives long enough
-  // for an in-menu "No value" uncheck to restore it.
+  // committed `scalarValue` whenever that changes, so a filter cleared or
+  // rewritten elsewhere cannot be written back from a stale input.
   const scalarValue = selected.find((id) => id !== NO_PROPERTY_VALUE) ?? "";
   const hasNoValue = selected.includes(NO_PROPERTY_VALUE);
   const [draft, setDraft] = useState(scalarValue);
@@ -769,10 +768,11 @@ function PropertyFilterOptions({
     const commitValue = (raw: string) => {
       const value = raw.trim();
       // NO_PROPERTY_VALUE is the reserved "no value" sentinel — it cannot be
-      // filtered as a literal value. Setting a value also clears "No value":
-      // the two are mutually exclusive for a scalar.
+      // filtered as a literal value. The value and "No value" compose like
+      // every other property type: committing a value replaces only the value
+      // member and preserves "No value" membership.
       if (value === NO_PROPERTY_VALUE) return;
-      onSetValues(value ? [value] : []);
+      onSetValues(value ? [value, ...(hasNoValue ? [NO_PROPERTY_VALUE] : [])] : hasNoValue ? [NO_PROPERTY_VALUE] : []);
     };
     return (
       <>
@@ -817,12 +817,15 @@ function PropertyFilterOptions({
           checked={hasNoValue}
           disabled={locked}
           onCheckedChange={(checked) => {
-            if (checked) {
-              onSetValues([NO_PROPERTY_VALUE]);
-            } else {
-              // Unchecking "No value" restores the value still in the input.
-              onSetValues(draft.trim() ? [draft.trim()] : []);
-            }
+            // "No value" toggles membership in the same OR-set as the value —
+            // checking/unchecking never touches the committed value member, so
+            // unchecking restores it without any draft round-trip.
+            const valueMembers = selected.filter((id) => id !== NO_PROPERTY_VALUE);
+            onSetValues(
+              checked
+                ? [...valueMembers, NO_PROPERTY_VALUE]
+                : valueMembers,
+            );
           }}
           className={FILTER_ITEM_CLASS}
         >

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -508,6 +508,17 @@ describe("property filters", () => {
     expect(result.map((i) => i.id)).toEqual(["P7"]);
   });
 
+  it("a literal __none__ text value does not match a No-value filter", () => {
+    // The server's key-absence predicate excludes it; this path must agree.
+    const literalNone = makeIssue({ id: "P8", properties: { [textId]: NO_PROPERTY_VALUE } });
+    expect(
+      filterIssues([literalNone, unset], {
+        ...NO_FILTER,
+        propertyFilters: { [textId]: [NO_PROPERTY_VALUE] },
+      }).map((i) => i.id),
+    ).toEqual(["P3"]);
+  });
+
   it("ANDs across definitions", () => {
     const result = filterIssues([critical, minor], {
       ...NO_FILTER,

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -399,10 +399,15 @@ describe("property filters", () => {
   const sevId = "prop-severity";
   const platId = "prop-platforms";
   const doneId = "prop-done";
+  const numId = "prop-estimate";
   const critical = makeIssue({ id: "P1", properties: { [sevId]: "opt-critical" } });
   const minor = makeIssue({ id: "P2", properties: { [sevId]: "opt-minor", [platId]: ["opt-ios", "opt-web"] } });
   const unset = makeIssue({ id: "P3" });
   const checked = makeIssue({ id: "P4", properties: { [doneId]: true } });
+  const estimate = makeIssue({ id: "P5", properties: { [numId]: 3.5 } });
+  const wholeNumber = makeIssue({ id: "P6", properties: { [numId]: 1 } });
+  const textId = "prop-note";
+  const textNote = makeIssue({ id: "P7", properties: { [textId]: "hello" } });
 
   it("select values match by option id (OR within the definition)", () => {
     const result = filterIssues([critical, minor, unset], {
@@ -460,6 +465,47 @@ describe("property filters", () => {
       propertyFilters: { [sevId]: ["opt-minor"], [doneId]: [NO_PROPERTY_VALUE] },
     });
     expect(result.map((i) => i.id)).toEqual(["P2"]);
+  });
+
+  it("number values match by their string form", () => {
+    const result = filterIssues([estimate, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [numId]: ["3.5"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P5"]);
+  });
+
+  it("number values match non-canonical numeric forms like the server", () => {
+    // Server containment matches the stored jsonb number, so "3.50" and "1"
+    // must match 3.5 and 1 here too.
+    expect(
+      filterIssues([estimate, wholeNumber, unset], {
+        ...NO_FILTER,
+        propertyFilters: { [numId]: ["3.50"] },
+      }).map((i) => i.id),
+    ).toEqual(["P5"]);
+    expect(
+      filterIssues([estimate, wholeNumber, unset], {
+        ...NO_FILTER,
+        propertyFilters: { [numId]: ["1"] },
+      }).map((i) => i.id),
+    ).toEqual(["P6"]);
+  });
+
+  it("number no-value matches issues without the property", () => {
+    const result = filterIssues([estimate, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [numId]: [NO_PROPERTY_VALUE] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P3"]);
+  });
+
+  it("text values match by exact string", () => {
+    const result = filterIssues([textNote, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [textId]: ["hello"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P7"]);
   });
 
   it("ANDs across definitions", () => {

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -81,6 +81,10 @@ export function issueMatchesPropertyFilters(
     }
     if (typeof value === "string") {
       if (!selected.includes(value)) return false;
+    } else if (typeof value === "number") {
+      // Compare numerically so "3.50" and 3.5 agree with the server's jsonb
+      // number containment; NO_PROPERTY_VALUE never matches a set value.
+      if (!selected.some((id) => id !== NO_PROPERTY_VALUE && Number(id) === value)) return false;
     } else if (Array.isArray(value)) {
       if (!value.some((id) => selected.includes(id))) return false;
     } else if (typeof value === "boolean") {

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -80,7 +80,11 @@ export function issueMatchesPropertyFilters(
       return false;
     }
     if (typeof value === "string") {
-      if (!selected.includes(value)) return false;
+      // Skip the "No value" sentinel when comparing stored values: a literal
+      // "__none__" text value is a real value (the server's key-absence
+      // predicate excludes it from a No-value filter), and this path must
+      // agree with the server.
+      if (!selected.some((id) => id !== NO_PROPERTY_VALUE && id === value)) return false;
     } else if (typeof value === "number") {
       // Compare numerically so "3.50" and 3.5 agree with the server's jsonb
       // number containment; NO_PROPERTY_VALUE never matches a set value.

--- a/server/internal/handler/issue_table_facets.go
+++ b/server/internal/handler/issue_table_facets.go
@@ -246,19 +246,22 @@ GROUP BY a.id`, compiled.where)
 		}
 		propertyKey := "'" + util.UUIDToString(property.ID) + "'"
 		switch property.Type {
-		case "select", "actor", "text", "url", "date":
+		case "select", "actor":
 			// Unset issues count under the "__none__" bucket so the filter menu's
 			// "No value" option carries a real count (issues without the key).
-			// text/url/date store as strings, exactly like select option ids.
 			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'string' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
+		case "text", "url", "date", "number":
+			// Scalar values are free-form, so grouping by distinct value would
+			// return one row per observed value with no bound. The filter menu
+			// only reads the "__none__" bucket for these types, so compute just
+			// the two bounded buckets instead of pulling the whole value space.
+			// Key existence is exact for "no value": stored values can never be
+			// null or empty, so a present key is always a set value.
+			query = fmt.Sprintf(`SELECT CASE WHEN i.properties ? %s THEN '__set__' ELSE '__none__' END, COUNT(*)::bigint FROM issue i WHERE %s GROUP BY 1`, propertyKey, compiled.where)
 		case "multi_select", "multi_actor":
 			query = fmt.Sprintf(`SELECT COALESCE(property_value.value, '__none__'), COUNT(DISTINCT i.id)::bigint FROM issue i JOIN LATERAL (SELECT jsonb_array_elements_text(CASE WHEN jsonb_typeof(i.properties -> %s) = 'array' THEN i.properties -> %s ELSE '[]'::jsonb END) AS value UNION ALL SELECT NULL WHERE NOT (i.properties ? %s)) property_value(value) ON TRUE WHERE %s GROUP BY 1`, propertyKey, propertyKey, propertyKey, compiled.where)
 		case "checkbox":
 			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'boolean' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
-		case "number":
-			// Numbers facet by their text form (->>) so the "3.5" key lines up
-			// with the filter value the UI sends for the property.
-			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'number' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
 		default:
 			writeIssueTableUnsupportedGroup(w, "property_type_unsupported", "This property type cannot be used as a filter facet.")
 			return response, false

--- a/server/internal/handler/issue_table_facets.go
+++ b/server/internal/handler/issue_table_facets.go
@@ -246,14 +246,19 @@ GROUP BY a.id`, compiled.where)
 		}
 		propertyKey := "'" + util.UUIDToString(property.ID) + "'"
 		switch property.Type {
-		case "select", "actor":
+		case "select", "actor", "text", "url", "date":
 			// Unset issues count under the "__none__" bucket so the filter menu's
 			// "No value" option carries a real count (issues without the key).
+			// text/url/date store as strings, exactly like select option ids.
 			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'string' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
 		case "multi_select", "multi_actor":
 			query = fmt.Sprintf(`SELECT COALESCE(property_value.value, '__none__'), COUNT(DISTINCT i.id)::bigint FROM issue i JOIN LATERAL (SELECT jsonb_array_elements_text(CASE WHEN jsonb_typeof(i.properties -> %s) = 'array' THEN i.properties -> %s ELSE '[]'::jsonb END) AS value UNION ALL SELECT NULL WHERE NOT (i.properties ? %s)) property_value(value) ON TRUE WHERE %s GROUP BY 1`, propertyKey, propertyKey, propertyKey, compiled.where)
 		case "checkbox":
 			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'boolean' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
+		case "number":
+			// Numbers facet by their text form (->>) so the "3.5" key lines up
+			// with the filter value the UI sends for the property.
+			query = fmt.Sprintf(`SELECT COALESCE(i.properties ->> %s, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s AND (jsonb_typeof(i.properties -> %s) = 'number' OR NOT (i.properties ? %s)) GROUP BY 1`, propertyKey, compiled.where, propertyKey, propertyKey)
 		default:
 			writeIssueTableUnsupportedGroup(w, "property_type_unsupported", "This property type cannot be used as a filter facet.")
 			return response, false

--- a/server/internal/handler/property.go
+++ b/server/internal/handler/property.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -1154,6 +1156,16 @@ func parsePropertiesFilterParam(w http.ResponseWriter, raw string) ([][]json.Raw
 			}
 			if value == "true" || value == "false" {
 				if !appendAlt(value == "true") { // checkbox boolean
+					return nil, false
+				}
+			}
+			if num, err := strconv.ParseFloat(value, 64); err == nil &&
+				!math.IsNaN(num) && !math.IsInf(num, 0) {
+				// number property scalar: a numeric filter value must match the
+				// stored jsonb number, not the string form appended above. NaN /
+				// Infinity are skipped: they are not representable as JSON, so
+				// marshaling them would 400 the whole filter.
+				if !appendAlt(num) {
 					return nil, false
 				}
 			}

--- a/server/internal/handler/property_test.go
+++ b/server/internal/handler/property_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -623,6 +624,20 @@ func TestListIssuesPropertyFilterAndSort(t *testing.T) {
 	if len(openNone) == 0 {
 		t.Fatalf("open_only no-value filter returned nothing")
 	}
+
+	// A number property matches a numeric filter value (the stored jsonb number,
+	// not the "3.5" string form).
+	numLowGot := ids(listIssues(filterQuery(num.ID, "1")))
+	if _, present := numLowGot[numLow]; !present {
+		t.Fatalf("number filter missed the issue with value 1")
+	}
+	if _, present := numLowGot[numHigh]; present {
+		t.Fatalf("number filter matched the wrong numeric value")
+	}
+	numHighGot := ids(listIssues(filterQuery(num.ID, "9.5")))
+	if _, present := numHighGot[numHigh]; !present {
+		t.Fatalf("number filter missed the issue with value 9.5")
+	}
 }
 
 func TestParsePropertiesFilterNoValueUnit(t *testing.T) {
@@ -678,6 +693,61 @@ func TestParsePropertiesFilterNoValueUnit(t *testing.T) {
 	}
 	if len(groups[0]) != 1 {
 		t.Fatalf("duplicate sentinel produced %d alternatives, want 1", len(groups[0]))
+	}
+
+	// A numeric filter value also emits the stored jsonb number form, so a
+	// number property matches the scalar instead of only the "3.5" string.
+	groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["3.5"]}`, defID))
+	if !ok {
+		t.Fatalf("numeric parse failed: %s", w.Body.String())
+	}
+	hasNumber := false
+	for _, alt := range groups[0] {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(alt, &m); err != nil {
+			continue
+		}
+		var num float64
+		if err := json.Unmarshal(m[defID], &num); err == nil && num == 3.5 {
+			hasNumber = true
+		}
+	}
+	if !hasNumber {
+		t.Fatalf("numeric filter value did not emit a jsonb number containment form: %v", groups[0])
+	}
+	// A date value must NOT be misread as a number.
+	groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":["2026-08-19"]}`, defID))
+	if !ok {
+		t.Fatalf("date parse failed: %s", w.Body.String())
+	}
+	for _, alt := range groups[0] {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(alt, &m); err != nil {
+			continue
+		}
+		var num float64
+		if err := json.Unmarshal(m[defID], &num); err == nil {
+			t.Fatalf("date value misread as a number: %v", alt)
+		}
+	}
+
+	// NaN / Infinity parse as floats but are not valid JSON — they must be
+	// skipped, not marshaled into a 400.
+	for _, bad := range []string{"NaN", "Infinity", "-Infinity"} {
+		groups, ok = parsePropertiesFilterParam(w, fmt.Sprintf(`{"%s":[%q]}`, defID, bad))
+		if !ok {
+			t.Fatalf("non-finite parse of %q failed: %s", bad, w.Body.String())
+		}
+		for _, alt := range groups[0] {
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(alt, &m); err != nil {
+				continue
+			}
+			var num float64
+			if err := json.Unmarshal(m[defID], &num); err == nil && (math.IsNaN(num) || math.IsInf(num, 0)) {
+				t.Fatalf("non-finite value %q leaked a number containment form: %v", bad, alt)
+			}
+		}
 	}
 }
 
@@ -1130,6 +1200,88 @@ func TestIssuePropertyFacetNoValue(t *testing.T) {
 	}
 	if counts["true"] != 1 || counts["__none__"] != 1 {
 		t.Fatalf("hold facet counts wrong: %v", counts)
+	}
+}
+
+// TestIssuePropertyFacetScalarTypes covers the facet branches added for
+// text / number / date / url, which previously fell through to the 422
+// default. A marker select narrows the facet to exactly two issues.
+func TestIssuePropertyFacetScalarTypes(t *testing.T) {
+	marker := createTestProperty(t, map[string]any{
+		"name": "FM" + uuid.NewString()[:8], "type": "select",
+		"config": map[string]any{"options": []map[string]any{{"name": "Only", "color": "#3b82f6"}}},
+	})
+	markerOpt := marker.Config.Options[0].ID
+	num := createTestProperty(t, map[string]any{"name": "FN" + uuid.NewString()[:8], "type": "number"})
+	text := createTestProperty(t, map[string]any{"name": "FT" + uuid.NewString()[:8], "type": "text"})
+	date := createTestProperty(t, map[string]any{"name": "FD" + uuid.NewString()[:8], "type": "date"})
+	url := createTestProperty(t, map[string]any{"name": "FU" + uuid.NewString()[:8], "type": "url"})
+
+	withNum := createPropertyTestIssue(t, "scalar facet num")
+	withText := createPropertyTestIssue(t, "scalar facet text")
+	for _, id := range []string{withNum, withText} {
+		if w := setIssuePropertyRaw(t, id, marker.ID, markerOpt); w.Code != http.StatusOK {
+			t.Fatalf("seed marker: %d %s", w.Code, w.Body.String())
+		}
+	}
+	if w := setIssuePropertyRaw(t, withNum, num.ID, 3.5); w.Code != http.StatusOK {
+		t.Fatalf("seed number: %d %s", w.Code, w.Body.String())
+	}
+	if w := setIssuePropertyRaw(t, withText, text.ID, "hello"); w.Code != http.StatusOK {
+		t.Fatalf("seed text: %d %s", w.Code, w.Body.String())
+	}
+	// A date set on neither issue keeps its facet to a single __none__ bucket.
+	if w := setIssuePropertyRaw(t, withNum, date.ID, "2026-08-19"); w.Code != http.StatusOK {
+		t.Fatalf("seed date: %d %s", w.Code, w.Body.String())
+	}
+	if w := setIssuePropertyRaw(t, withText, url.ID, "https://example.com"); w.Code != http.StatusOK {
+		t.Fatalf("seed url: %d %s", w.Code, w.Body.String())
+	}
+
+	facetCounts := func(propertyID string) map[string]int64 {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest(http.MethodPost, "/api/issues/table/facets", map[string]any{
+			"query": map[string]any{
+				"scope":   map[string]any{"kind": "workspace"},
+				"filters": map[string]any{"properties": map[string][]string{marker.ID: {markerOpt}}},
+				"sort":    map[string]any{"field": "position", "direction": "asc"},
+			},
+			"facets":        []map[string]any{{"kind": "property", "property_id": propertyID}},
+			"include_total": false,
+		})
+		testHandler.ListIssueTableFacets(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("ListIssueTableFacets(%s): expected 200, got %d: %s", propertyID, w.Code, w.Body.String())
+		}
+		var resp issueTableFacetsResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode facets: %v", err)
+		}
+		counts := map[string]int64{}
+		for _, facet := range resp.Facets {
+			for _, value := range facet.Values {
+				counts[value.Key] = value.Count
+			}
+		}
+		return counts
+	}
+
+	numCounts := facetCounts(num.ID)
+	if numCounts["3.5"] != 1 || numCounts["__none__"] != 1 {
+		t.Fatalf("number facet counts wrong: %v", numCounts)
+	}
+	textCounts := facetCounts(text.ID)
+	if textCounts["hello"] != 1 || textCounts["__none__"] != 1 {
+		t.Fatalf("text facet counts wrong: %v", textCounts)
+	}
+	dateCounts := facetCounts(date.ID)
+	if dateCounts["2026-08-19"] != 1 || dateCounts["__none__"] != 1 {
+		t.Fatalf("date facet counts wrong: %v", dateCounts)
+	}
+	urlCounts := facetCounts(url.ID)
+	if urlCounts["https://example.com"] != 1 || urlCounts["__none__"] != 1 {
+		t.Fatalf("url facet counts wrong: %v", urlCounts)
 	}
 }
 

--- a/server/internal/handler/property_test.go
+++ b/server/internal/handler/property_test.go
@@ -1267,21 +1267,16 @@ func TestIssuePropertyFacetScalarTypes(t *testing.T) {
 		return counts
 	}
 
-	numCounts := facetCounts(num.ID)
-	if numCounts["3.5"] != 1 || numCounts["__none__"] != 1 {
-		t.Fatalf("number facet counts wrong: %v", numCounts)
-	}
-	textCounts := facetCounts(text.ID)
-	if textCounts["hello"] != 1 || textCounts["__none__"] != 1 {
-		t.Fatalf("text facet counts wrong: %v", textCounts)
-	}
-	dateCounts := facetCounts(date.ID)
-	if dateCounts["2026-08-19"] != 1 || dateCounts["__none__"] != 1 {
-		t.Fatalf("date facet counts wrong: %v", dateCounts)
-	}
-	urlCounts := facetCounts(url.ID)
-	if urlCounts["https://example.com"] != 1 || urlCounts["__none__"] != 1 {
-		t.Fatalf("url facet counts wrong: %v", urlCounts)
+	// Scalar facets collapse to the bounded "__set__"/"__none__" buckets (the
+	// UI only reads the "No value" count for these types).
+	for _, tc := range []struct {
+		name string
+		id   string
+	}{{"number", num.ID}, {"text", text.ID}, {"date", date.ID}, {"url", url.ID}} {
+		counts := facetCounts(tc.id)
+		if counts["__set__"] != 1 || counts["__none__"] != 1 {
+			t.Fatalf("%s facet counts wrong: %v", tc.name, counts)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #7235

## Summary

Extends the custom-property filter (value + "No value") from `select` /
`multi_select` / `checkbox` / `actor` to the four scalar types — `text`,
`number`, `date`, `url` — so the same filter menu and the `__none__` sentinel
work across every property type.

For a scalar property the filter menu now shows a **value input** (text / url,
number, or date) plus a mutually-exclusive **"No value"** option.

## What changed

**Backend**
- `parsePropertiesFilterParam` (`server/internal/handler/property.go`) emits a
  jsonb **number** containment form for numeric filter values, so a number
  property matches its stored scalar instead of only a `"3.5"` string.
  `NaN` / `Infinity` are guarded out — they are not JSON-representable and
  would otherwise 400 the whole filter.
- Property table facets (`issue_table_facets.go`) gain `text` / `url` / `date`
  (string) and `number` branches, replacing the previous 422 `default`, each
  with the unset `__none__` bucket so "No value" carries a real count.

**Frontend**
- `isFilterablePropertyType` (core) now admits the scalar types.
- `PropertyFilterOptions` renders the value input + "No value" for scalar
  types; both are disabled when a saved view locks the dimension. Setting a
  value clears "No value" and vice-versa.
- Filter chips display the scalar value directly.
- The client matcher compares number values numerically
  (`selected.some((id) => Number(id) === value)`), matching the server's jsonb
  number containment for forms like `"3.50"`.
- New `setPropertyFilterValues` store action replaces a property's full filter
  value set.

## Verification

- Backend: full `internal/handler` suite passes; new tests cover numeric +
  `NaN`/`Infinity`/date parse, scalar facet buckets (number / text / date /
  url), and numeric list filtering.
- Frontend: `@multica/views` issues suite (78 files / 779 tests) and core
  type/store tests pass; `tsc --noEmit` clean for `@multica/core` and
  `@multica/views` (pre-existing `@multica/plugin-sdk` resolution errors in
  views are unrelated).

## Notes

- A text property value literally stored as `"__none__"` is reserved: the
  sentinel means "no value", and the filter input rejects it as a literal
  value.
- The client-side `useIssueCounts` fallback path (used outside server facets)
  does not yet count number values / the `__none__` bucket for scalar types —
  a pre-existing limitation that predates this PR.
