### PR TITLE
ZQ-72: fix(issues): wake parent owners for child review handoffs

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3577,6 +3577,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// fails best-effort.
 	if statusChanged {
 		h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
+		h.notifyParentOfChildAttention(r.Context(), prevIssue, issue, actorType, actorID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -3964,6 +3965,8 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	// the parent/stage notification is evaluated once against the final state
 	// after the loop (MUL-4155) rather than per-child mid-batch.
 	var childDoneCompleted []db.Issue
+	var childAttentionNeeded []childAttentionEvent
+	batchActorType, batchActorID := h.resolveActor(r, userID, workspaceID)
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)
 		if err != nil {
@@ -4140,7 +4143,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 		resp := issueToResponse(issue, prefix)
-		actorType, actorID := h.resolveActor(r, userID, workspaceID)
+		actorType, actorID := batchActorType, batchActorID
 
 		fillBatch(&resp)
 		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&
@@ -4192,12 +4195,18 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		// comparison here left childDoneCompleted empty and silently skipped
 		// notifyParentsOfBatchChildDone entirely. (MUL-6243)
 		if statusChanged && issue.ParentIssueID.Valid {
-			prevTerminal := isTerminalChildStatus(
-				issuestatus.Effective(r.Context(), h.Queries, prevIssue.WorkspaceID, prevIssue.Status))
-			nowTerminal := isTerminalChildStatus(
-				issuestatus.Effective(r.Context(), h.Queries, issue.WorkspaceID, issue.Status))
+			prevEffective := issuestatus.Effective(r.Context(), h.Queries, prevIssue.WorkspaceID, prevIssue.Status)
+			nowEffective := issuestatus.Effective(r.Context(), h.Queries, issue.WorkspaceID, issue.Status)
+			prevTerminal := isTerminalChildStatus(prevEffective)
+			nowTerminal := isTerminalChildStatus(nowEffective)
 			if !prevTerminal && nowTerminal {
 				childDoneCompleted = append(childDoneCompleted, issue)
+			}
+			if childNeedsParentAttention(prevEffective, nowEffective) {
+				childAttentionNeeded = append(childAttentionNeeded, childAttentionEvent{
+					child:           issue,
+					effectiveStatus: nowEffective,
+				})
 			}
 		}
 
@@ -4209,6 +4218,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	// of issue_ids order (MUL-4155). Best-effort; failure does not abort the
 	// batch. Single-issue UpdateIssue is unchanged and still notifies inline.
 	h.notifyParentsOfBatchChildDone(r.Context(), childDoneCompleted)
+	h.notifyParentsOfBatchChildAttention(r.Context(), childAttentionNeeded, batchActorType, batchActorID)
 
 	slog.Info("batch update issues", append(logger.RequestAttrs(r), "count", updated)...)
 	writeJSON(w, http.StatusOK, map[string]any{"updated": updated})

--- a/server/internal/handler/issue_batch_test.go
+++ b/server/internal/handler/issue_batch_test.go
@@ -383,6 +383,26 @@ func TestBatchChildDoneCrossStage_Cancelled(t *testing.T) {
 	}
 }
 
+func TestBatchChildAttention_OneCommentOneWake(t *testing.T) {
+	fx := newStagedBatchFixture(t)
+
+	batchSetStatus(t, []string{fx.stage1[0].ID, fx.stage1[1].ID}, "blocked")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("expected exactly 1 attention comment on parent, got %d", got)
+	}
+	content, _, _, _ := systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "needs attention after a batch update") {
+		t.Errorf("expected batch attention handoff, got: %s", content)
+	}
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked status in handoff, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, fx.agentID); got != 1 {
+		t.Fatalf("expected exactly 1 pending parent task, got %d", got)
+	}
+}
+
 // TestBatchChildDoneClosesLowerStageOnly — when a batch finishes only the lower
 // stage (a later stage still has open children), the parent must be told Stage 1
 // is complete AND accurately pointed at Stage 2 as next. Guards against

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -145,6 +146,53 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false)
 }
 
+type childAttentionEvent struct {
+	child           db.Issue
+	effectiveStatus string
+}
+
+// childAttentionTransition resolves custom statuses to their canonical
+// behavior before deciding whether a child crossed into a review-ready or
+// blocked state. A raw custom-status rename inside the same category is only a
+// presentation change and must not wake the parent again.
+func (h *Handler) childAttentionTransition(ctx context.Context, prev, issue db.Issue) (childAttentionEvent, bool) {
+	prevStatus := issuestatus.Effective(ctx, h.Queries, prev.WorkspaceID, prev.Status)
+	nextStatus := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status)
+	if !childNeedsParentAttention(prevStatus, nextStatus) {
+		return childAttentionEvent{}, false
+	}
+	return childAttentionEvent{child: issue, effectiveStatus: nextStatus}, true
+}
+
+// notifyParentOfChildAttention posts a parent-level handoff when a child moves
+// into a state that needs intervention but is not terminal. Child completion is
+// handled separately by notifyParentOfChildDone because it has stage-barrier
+// semantics; review/block states must surface immediately or the parent can
+// stall with no coordinator wake.
+func (h *Handler) notifyParentOfChildAttention(ctx context.Context, prev, issue db.Issue, actorType, actorID string) {
+	if !issue.ParentIssueID.Valid {
+		return
+	}
+	event, ok := h.childAttentionTransition(ctx, prev, issue)
+	if !ok {
+		return
+	}
+
+	parent, err := h.Queries.GetIssue(ctx, issue.ParentIssueID)
+	if err != nil {
+		slog.Warn("child attention: failed to load parent",
+			"error", err,
+			"child_id", uuidToString(issue.ID),
+			"parent_id", uuidToString(issue.ParentIssueID))
+		return
+	}
+	parentStatus := issuestatus.Effective(ctx, h.Queries, parent.WorkspaceID, parent.Status)
+	if parentStatus == issuestatus.Done || parentStatus == issuestatus.Cancelled || parentStatus == issuestatus.Backlog {
+		return
+	}
+	h.postChildAttentionComment(ctx, parent, event, false, actorType, actorID)
+}
+
 // notifyParentsOfBatchChildDone emits child-done parent notifications for a
 // whole batch AFTER every status write has committed. `completed` is the set of
 // children that transitioned non-terminal -> terminal during the batch.
@@ -257,6 +305,54 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 	}
 }
 
+// notifyParentsOfBatchChildAttention emits at most one review/block handoff per
+// parent after a batch update has committed. If several children need
+// attention, blocked wins over in_review because it is the stronger escalation
+// signal.
+func (h *Handler) notifyParentsOfBatchChildAttention(ctx context.Context, events []childAttentionEvent, actorType, actorID string) {
+	if len(events) == 0 {
+		return
+	}
+
+	type parentGroup struct {
+		parentID pgtype.UUID
+		event    childAttentionEvent
+	}
+	var groups []*parentGroup
+	index := map[string]*parentGroup{}
+	for _, event := range events {
+		if !event.child.ParentIssueID.Valid {
+			continue
+		}
+		key := uuidToString(event.child.ParentIssueID)
+		group, ok := index[key]
+		if !ok {
+			group = &parentGroup{parentID: event.child.ParentIssueID, event: event}
+			index[key] = group
+			groups = append(groups, group)
+			continue
+		}
+		if group.event.effectiveStatus != issuestatus.Blocked && event.effectiveStatus == issuestatus.Blocked {
+			group.event = event
+		}
+	}
+
+	for _, group := range groups {
+		parent, err := h.Queries.GetIssue(ctx, group.parentID)
+		if err != nil {
+			slog.Warn("batch child attention: failed to load parent",
+				"error", err,
+				"parent_id", uuidToString(group.parentID))
+			continue
+		}
+		parentStatus := issuestatus.Effective(ctx, h.Queries, parent.WorkspaceID, parent.Status)
+		if parentStatus == issuestatus.Done || parentStatus == issuestatus.Cancelled || parentStatus == issuestatus.Backlog {
+			continue
+		}
+		h.postChildAttentionComment(ctx, parent, group.event, true, actorType, actorID)
+	}
+}
+
 // postChildDoneComment builds and posts the parent's child-done system comment
 // for a closed stage barrier, then dispatches the parent-assignee trigger. It
 // assumes every guard in notifyParentOfChildDone / notifyParentsOfBatchChildDone
@@ -348,6 +444,67 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
 }
 
+// postChildAttentionComment records a parent-level handoff for blocked or
+// review-ready child work, then routes the handoff to the parent owner. Unlike
+// child completion, this is immediate and has no stage-barrier requirement.
+func (h *Handler) postChildAttentionComment(ctx context.Context, parent db.Issue, event childAttentionEvent, batch bool, actorType, actorID string) {
+	child := event.child
+	prefix := h.getIssuePrefix(ctx, child.WorkspaceID)
+	identifier := prefix + "-" + strconv.Itoa(int(child.Number))
+	childID := uuidToString(child.ID)
+	title := sanitizeChildTitleForSystemComment(child.Title)
+	mentionPrefix := h.buildParentAssigneeMention(ctx, parent)
+
+	stateLabel := statusLabelForChildAttention(event.effectiveStatus)
+	action := "Review the child and decide whether to accept it, request follow-up, or continue the parent."
+	if event.effectiveStatus == issuestatus.Blocked {
+		action = "Review the child, unblock it, or decide who should continue the parent."
+	}
+
+	var content string
+	if batch {
+		content = fmt.Sprintf(
+			"%sA sub-issue needs attention after a batch update — [%s](mention://issue/%s) — \"%s\" is %s. %s",
+			mentionPrefix, identifier, childID, title, stateLabel, action,
+		)
+	} else {
+		content = fmt.Sprintf(
+			"%sA sub-issue needs attention — [%s](mention://issue/%s) — \"%s\" is %s. %s",
+			mentionPrefix, identifier, childID, title, stateLabel, action,
+		)
+	}
+
+	created, err := h.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     parent.ID,
+		WorkspaceID: parent.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    pgtype.UUID{Valid: false},
+	})
+	if err != nil {
+		slog.Warn("child attention: create system comment failed",
+			"error", err,
+			"child_id", childID,
+			"parent_id", uuidToString(parent.ID))
+		return
+	}
+	comment := created.Comment()
+
+	h.publish(protocol.EventCommentCreated, uuidToString(parent.WorkspaceID), "system", "", map[string]any{
+		"comment":             commentToResponse(comment, nil, nil),
+		"issue_title":         parent.Title,
+		"issue_assignee_type": textToPtr(parent.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(parent.AssigneeID),
+		"issue_status":        parent.Status,
+		"issue_revision":      created.IssueRevision,
+	})
+
+	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
+	h.notifyParentMemberOfChildAttention(ctx, parent, event, comment, actorType, actorID)
+}
+
 // isTerminalChildStatus reports whether a child issue status counts as
 // "finished" for stage-barrier purposes. Cancelled counts as terminal: a
 // cancelled sibling will never complete, so it must not hold a stage open.
@@ -357,6 +514,25 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 // cancelled category closes a stage exactly like Done and Cancelled do.
 func isTerminalChildStatus(status string) bool {
 	return status == "done" || status == "cancelled"
+}
+
+func isChildAttentionStatus(status string) bool {
+	return status == issuestatus.InReview || status == issuestatus.Blocked
+}
+
+func childNeedsParentAttention(prevStatus, nextStatus string) bool {
+	return prevStatus != nextStatus && isChildAttentionStatus(nextStatus)
+}
+
+func statusLabelForChildAttention(status string) string {
+	switch status {
+	case issuestatus.InReview:
+		return "in review"
+	case issuestatus.Blocked:
+		return "blocked"
+	default:
+		return status
+	}
 }
 
 // terminalChildPredicate returns the terminal test for a sibling set, resolving
@@ -567,11 +743,12 @@ func sanitizeMentionLabel(name string) string {
 
 // dispatchParentAssigneeTrigger fires the explicit side effect that pairs
 // with the @mention link in the system comment body — an agent task for
-// agent or squad-leader assignees. Member assignees never reach this code
-// path; notifyParentOfChildDone skips them outright. The generic comment
-// listener is intentionally bypassed (it short-circuits on
-// author_type='system'), so this is the single place where the platform
-// applies the idempotency guard for the child-done notification.
+// agent or squad-leader assignees. A member parent is a no-op here; attention
+// handoffs route that case through notifyParentMemberOfChildAttention instead,
+// while child-done skips members outright. The generic comment listener is
+// intentionally bypassed (it short-circuits on author_type='system'), so this
+// is the single place where the platform applies the agent-task idempotency
+// guard for parent handoffs.
 //
 // Side-effect semantics (intentionally narrower than a normal @mention):
 //   - agent parent: one EnqueueTaskForMention on the parent assignee, same
@@ -579,7 +756,7 @@ func sanitizeMentionLabel(name string) string {
 //     match what users already rely on.
 //   - squad parent: one EnqueueTaskForSquadLeader on the squad LEADER only.
 //     Unlike a human @squad mention, this does NOT fan out to squad members
-//     — child-done is a coordination signal, the leader decides whether
+//     — a child handoff is a coordination signal, the leader decides whether
 //     and how to wake the rest of the squad. Documented here so reviewers
 //     don't read "system mention" as inheriting the full member fan-out. The
 //     actor that closed the child is irrelevant to routing: the target is the
@@ -590,13 +767,13 @@ func sanitizeMentionLabel(name string) string {
 //     general notification. Per-user mute settings are evaluated by the
 //     downstream agent_task / inbox pipeline once the task is dispatched.
 //   - notification_listeners.go short-circuits on author_type='system', so
-//     subscriber emails and member-inbox rows from smuggled mentions in the
-//     child title are inert — only the explicit dispatch below runs.
+//     subscriber emails and mention-derived inbox rows from smuggled mentions
+//     in the child title are inert — only the explicit routing helpers run.
 //
 // Guards applied here:
 //   - No-op when the parent has no assignee row.
 //   - NO self-trigger guard on either the agent OR the squad path. Waking the
-//     parent assignee when one of its children finishes is a serial sub-task
+//     parent assignee when one of its children hands off is a serial sub-task
 //     handoff across two DIFFERENT issues, not a self-loop — legitimate per
 //     isAgentRunningOnIssue and the @mention self-trigger path
 //     (computeMentionedAgentCommentTriggers). The squad path used to skip a
@@ -610,9 +787,9 @@ func sanitizeMentionLabel(name string) string {
 //     mirrors the agent path (MUL-2808): always dispatch, bounded only by
 //     idempotency.
 //   - Idempotency: HasPendingTaskForIssueAndAgent dedupes rapid-fire enqueues
-//     for the same parent (e.g. two children finishing back-to-back). It also
+//     for the same parent (e.g. two children handing off back-to-back). It also
 //     bounds any re-trigger, since a leader waking on the parent does not by
-//     itself push a child back into a terminal transition.
+//     itself create a new child status transition.
 //   - Readiness: archived agents / missing runtimes are silently skipped
 //     so a closed-out agent does not surface as a phantom assignee.
 func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.Issue, systemComment db.Comment) {
@@ -626,6 +803,58 @@ func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.I
 	case "squad":
 		h.triggerChildDoneSquad(ctx, parent, systemComment.ID)
 	}
+}
+
+func (h *Handler) notifyParentMemberOfChildAttention(ctx context.Context, parent db.Issue, event childAttentionEvent, systemComment db.Comment, actorType, actorID string) {
+	if !parent.AssigneeType.Valid || parent.AssigneeType.String != "member" || !parent.AssigneeID.Valid {
+		return
+	}
+	parentMemberID := uuidToString(parent.AssigneeID)
+	if actorType == "member" && actorID == parentMemberID {
+		return
+	}
+
+	details, _ := json.Marshal(map[string]string{
+		"parent_issue_id":       uuidToString(parent.ID),
+		"child_issue_id":        uuidToString(event.child.ID),
+		"child_status":          event.child.Status,
+		"child_status_category": event.effectiveStatus,
+		"system_comment_id":     uuidToString(systemComment.ID),
+	})
+	item, err := h.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   parent.WorkspaceID,
+		RecipientType: "member",
+		RecipientID:   parent.AssigneeID,
+		Type:          "status_changed",
+		Severity:      "action_required",
+		IssueID:       event.child.ID,
+		Title:         event.child.Title,
+		Body:          strToText("A sub-issue under an issue you own needs attention."),
+		ActorType:     strToText(actorType),
+		ActorID:       optionalActorUUID(actorID),
+		Details:       details,
+	})
+	if err != nil {
+		slog.Warn("child attention: create parent member inbox failed",
+			"error", err,
+			"child_id", uuidToString(event.child.ID),
+			"parent_id", uuidToString(parent.ID),
+			"member_id", parentMemberID)
+		return
+	}
+
+	resp := inboxToResponse(item)
+	resp.IssueStatus = &event.child.Status
+	h.publish(protocol.EventInboxNew, uuidToString(parent.WorkspaceID), actorType, actorID, map[string]any{
+		"item": resp,
+	})
+}
+
+func optionalActorUUID(actorID string) pgtype.UUID {
+	if actorID == "" {
+		return pgtype.UUID{Valid: false}
+	}
+	return parseUUID(actorID)
 }
 
 // triggerChildDoneAgent enqueues a mention-style task for the parent's

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/issuestatus"
 )
 
 // childDoneFixture creates a parent + child pair so the parent-notification
@@ -375,6 +377,185 @@ func TestChildDoneSkippedWhenParentMember(t *testing.T) {
 	}
 	if got := countInboxItems(t, userID, fx.parent.ID); got != 0 {
 		t.Errorf("parent with member assignee should not receive an inbox row, got %d", got)
+	}
+}
+
+// TestChildAttentionInReviewWakesParentSquad is the direct-agent delivery
+// regression from #5464: a child assigned to an ordinary agent stops in
+// in_review while its parent is owned by a squad. The child transition must
+// create a parent-level handoff and wake the squad leader exactly once.
+func TestChildAttentionInReviewWakesParentSquad(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	setIssueAssigneeDirect(t, fx.parent.ID, "squad", sq.SquadID)
+	setIssueAssigneeDirect(t, fx.child.ID, "agent", sq.OtherID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`,
+			fx.parent.ID, fx.child.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	for _, want := range []string{
+		"A sub-issue needs attention",
+		"is in review",
+		"mention://issue/" + fx.child.ID,
+		"mention://squad/" + sq.SquadID,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in parent handoff, got: %s", want, content)
+		}
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("expected exactly 1 pending squad-leader task, got %d", got)
+	}
+
+	// Re-saving the same status is not a new delivery revision and must not
+	// duplicate either the timeline handoff or the leader task.
+	updateChildStatus(t, fx.child.ID, "in_review")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("same-status save duplicated the parent handoff: got %d comments", got)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("same-status save duplicated the leader task: got %d", got)
+	}
+
+	// Model the leader consuming the review wake. A later transition to blocked
+	// is a stronger attention state and deserves a fresh handoff.
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID); err != nil {
+		t.Fatalf("clear consumed parent task: %v", err)
+	}
+	updateChildStatus(t, fx.child.ID, "blocked")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 2 {
+		t.Fatalf("in_review -> blocked should add one handoff, got %d comments", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked handoff, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("expected a fresh leader task for blocked child, got %d", got)
+	}
+
+	// Attention is not completion. Once the only child becomes terminal, the
+	// existing stage-barrier path still emits its separate completion handoff.
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID); err != nil {
+		t.Fatalf("clear consumed blocked task: %v", err)
+	}
+	updateChildStatus(t, fx.child.ID, "done")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 3 {
+		t.Fatalf("terminal transition should retain the child-done barrier, got %d comments", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "All sub-issues are complete") {
+		t.Errorf("expected terminal barrier handoff, got: %s", content)
+	}
+}
+
+// TestChildAttentionUsesEffectiveStatus verifies that custom statuses inherit
+// their category's orchestration behavior. Moving between two custom statuses
+// in the same category is presentation-only and must not generate a duplicate
+// handoff; moving to the blocked category is a new escalation.
+func TestChildAttentionUsesEffectiveStatus(t *testing.T) {
+	createTestCustomStatus(t, "review_ready_a", issuestatus.InReview)
+	createTestCustomStatus(t, "review_ready_b", issuestatus.InReview)
+	createTestCustomStatus(t, "waiting_dependency", issuestatus.Blocked)
+	fx := newChildDoneFixture(t, "in_progress")
+
+	updateChildStatus(t, fx.child.ID, "review_ready_a")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("custom in-review status should create one handoff, got %d", got)
+	}
+	content, _, _, _ := systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is in review") {
+		t.Errorf("custom in-review status should use canonical wording, got: %s", content)
+	}
+
+	updateChildStatus(t, fx.child.ID, "review_ready_b")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("same effective category should not duplicate handoff, got %d", got)
+	}
+
+	updateChildStatus(t, fx.child.ID, "waiting_dependency")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 2 {
+		t.Fatalf("custom blocked status should add one escalation, got %d", got)
+	}
+	content, _, _, _ = systemCommentOn(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("custom blocked status should use canonical wording, got: %s", content)
+	}
+}
+
+func TestChildAttentionSkipsParkedOrClosedCustomParent(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		key      string
+		category string
+	}{
+		{name: "backlog", key: "parent_parked", category: issuestatus.Backlog},
+		{name: "done", key: "parent_accepted", category: issuestatus.Done},
+		{name: "cancelled", key: "parent_cancelled", category: issuestatus.Cancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			createTestCustomStatus(t, tc.key, tc.category)
+			fx := newChildDoneFixture(t, tc.key)
+
+			updateChildStatus(t, fx.child.ID, "in_review")
+			if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+				t.Fatalf("custom %s parent should stay inert, got %d comments", tc.category, got)
+			}
+		})
+	}
+}
+
+func TestChildAttentionBlockedNotifiesParentMember(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	memberID := createPermissionTestMember(t, "child-attention-owner@multica.test")
+
+	setIssueAssigneeDirect(t, fx.parent.ID, "member", memberID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM inbox_item WHERE issue_id IN ($1, $2)`, fx.parent.ID, fx.child.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "blocked")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "is blocked") {
+		t.Errorf("expected blocked status in handoff, got: %s", content)
+	}
+	if strings.Contains(content, "mention://member/") {
+		t.Errorf("system handoff should not inject a member mention, got: %s", content)
+	}
+
+	var notifType, severity, issueID, body string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT type, severity, issue_id::text, body
+		  FROM inbox_item
+		 WHERE recipient_type = 'member'
+		   AND recipient_id = $1
+		   AND issue_id = $2
+		 ORDER BY created_at DESC
+		 LIMIT 1
+	`, memberID, fx.child.ID).Scan(&notifType, &severity, &issueID, &body); err != nil {
+		t.Fatalf("read parent member inbox: %v", err)
+	}
+	if notifType != "status_changed" {
+		t.Errorf("inbox type = %q, want status_changed", notifType)
+	}
+	if severity != "action_required" {
+		t.Errorf("inbox severity = %q, want action_required", severity)
+	}
+	if issueID != fx.child.ID {
+		t.Errorf("inbox should point to child issue %s, got %s", fx.child.ID, issueID)
+	}
+	if !strings.Contains(body, "needs attention") {
+		t.Errorf("expected action body, got %q", body)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-squads/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-squads/SKILL.md
@@ -199,6 +199,23 @@ Current behavior: resolve the squad, read `leader_id`, enqueue a leader task,
 and use the current comment as the trigger comment. It does not enqueue every
 squad member.
 
+## Child handoffs to a squad parent
+
+When a sub-issue under a squad-assigned parent first enters `in_review` or
+`blocked`, Multica posts a system handoff on the parent and wakes the parent
+squad's leader. This also applies when the sub-issue itself is assigned directly
+to an ordinary agent: routing follows the parent owner, not the child owner.
+Custom statuses inherit this behavior from their `in_review` / `blocked`
+category, and moving between two custom statuses in the same category does not
+duplicate the handoff.
+
+This attention handoff is not stage completion. It does not mark the child
+`done`, close a stage barrier, or promote later stages. The leader reviews the
+child and decides the next action. If the child later reaches `done` or
+`cancelled`, the existing terminal stage-barrier handoff runs separately. Batch
+updates aggregate attention handoffs to at most one comment and wake per parent;
+pending-task dedup still prevents duplicate leader runs.
+
 ## Autopilot behavior
 
 Autopilots can be assigned to squads. For `assignee_type = "squad"`:

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -201,16 +201,28 @@ Contracts:
 - `run_only` creates task directly for leader (autopilot.go:99-106, dispatch via
   `resolveAutopilotLeader` at autopilot.go:284).
 
-## Child-done Parent Trigger
+## Child Parent Handoffs
 
 Source:
 
 ```text
-server/internal/handler/issue_child_done.go       # dispatchParentAssigneeTrigger ~246, triggerChildDoneSquad ~304
+server/internal/handler/issue.go                  # UpdateIssue / BatchUpdateIssues handoff hooks
+server/internal/handler/issue_child_done.go       # notifyParentOfChildAttention, notifyParentOfChildDone, dispatchParentAssigneeTrigger
 ```
 
 Contracts:
 
+- when a child first crosses into the effective `in_review` or `blocked`
+  category, `notifyParentOfChildAttention` posts an immediate system handoff on
+  the parent and routes it to the parent owner. A squad parent therefore wakes
+  its leader even when the child is assigned directly to an ordinary agent;
+- custom status keys are compared through `issuestatus.Effective`, so moving
+  within one category does not duplicate the handoff. Batch updates group the
+  transitions per parent and emit at most one comment/wake, preferring a
+  `blocked` representative;
+- attention does not close the stage barrier, auto-mark the child `done`, or
+  promote later stages. A later terminal transition still follows the separate
+  child-done path;
 - when a child issue closes a stage barrier and the parent is assigned to a
   squad, the parent squad leader is triggered (triggerChildDoneSquad in
   issue_child_done.go);
@@ -221,14 +233,14 @@ Contracts:
   only carrier of the stage-barrier "advance / wrap up" instruction (MUL-3969,
   mirrors the agent path from MUL-2808). Re-triggering is bounded only by
   `HasPendingTaskForIssueAndAgent` (idempotent per parent issue + agent).
-- no leader-invocation gate: child-done does NOT re-check whether the child's
+- no leader-invocation gate: parent handoffs do NOT re-check whether the child's
   completer can invoke the leader. The parent was already permission-checked at
   squad-assign time (`validateAssigneePair`), so waking its own leader is a
   coordination handoff, not a fresh invocation. Re-checking it here failed
   closed for the DEFAULT private leader (the child's completer is an
   agent/system actor with no resolvable human originator), stranding every
   process-squad pipeline after stage 1 while direct-to-leader-agent parents
-  advanced fine (MUL-4063 / GH #4928). Agent and squad child-done now share one
+  advanced fine (MUL-4063 / GH #4928). Agent and squad parent handoffs share one
   ungated path; any future invocation gate must be added to BOTH together.
 - parent status is not auto-advanced by the barrier: the system comment asks the
   leader to continue or — when the overall goal is met — run

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -200,8 +200,12 @@ on it. These are the contracts, not advice:
   `in_progress` step on the first assignment turn, keep the parent there while
   members work, and only move to `in_review` when a later re-trigger confirms
   the overall goal is met.
-- **`in_review`** is an accepted issue status. Some workflows use it while a PR
-  is open and awaiting review; moving to it is an explicit mutation.
+- **`in_review` / `blocked` on a child** immediately posts an attention handoff
+  on its parent. An agent or squad parent assignee gets the existing deduped
+  task wake; a human parent assignee gets an action-required inbox item. This
+  does not mark the child `done` or close its stage. Custom statuses inherit the
+  same behavior from their category, and switching between two statuses in the
+  same category does not emit a second handoff.
 - **`done`** on a child issue posts a system comment on its parent. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
@@ -263,6 +267,11 @@ status (`done`/`cancelled`). A completion that does not close a stage is silent
 (no comment, no wake). A sibling set with **no** stages is one implicit stage,
 so the parent is woken once when the *last* sub-issue finishes — not on every
 child.
+
+Review-ready and blocked handoffs are separate from this terminal barrier. A
+child entering `in_review` or `blocked` wakes its parent immediately for review,
+but remains non-terminal in stage progress; the leader must accept or unblock it
+and eventually move it to `done`/`cancelled` before the stage can close.
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -127,6 +127,7 @@ and is hidden from the PR list.
 | `shouldEnqueueAgentTask` returns false for `backlog` (parking lot) | `server/internal/handler/issue.go:2644-2648` | new citation |
 | Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
 | Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
+| Child → effective `in_review` / `blocked` posts an immediate parent attention handoff; batch groups once per parent | `server/internal/handler/issue_child_done.go` (`notifyParentOfChildAttention`, `notifyParentsOfBatchChildAttention`); hooks in `server/internal/handler/issue.go` (`UpdateIssue`, `BatchUpdateIssues`) | new citation |
 | Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
 | Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
@@ -166,6 +167,7 @@ on those assignments creating their normal queued runs.
 |---|---|
 | `issue.stage` column (nullable, `>= 1`) | `server/migrations/123_issue_stage.up.sql` |
 | Stage barrier: notify+wake fire only when the lowest unfinished stage is all-terminal; unstaged set = one implicit stage | `server/internal/handler/issue_child_done.go:231` (`stageBarrierClosed`) |
+| Review-ready / blocked child handoff is immediate and does not count as stage completion | `server/internal/handler/issue_child_done.go` (`childAttentionTransition`, `notifyParentOfChildAttention`) |
 | Per-stage summary + next stage for the wake comment | `server/internal/handler/issue_child_done.go:254` (`stageProgressSummary`) |
 | `--stage` on `issue create` / `issue update` | `server/cmd/multica/cmd_issue.go:328,350` |
 | `multica issue children <id>` (sub-issues grouped by stage) | `server/cmd/multica/cmd_issue.go:114,678`; stage `done` counting via `isTerminalChildIssue` (reads `status_category`, MUL-6243); route `GET /api/issues/{id}/children` → `ListChildIssues` |


### PR DESCRIPTION
## What does this PR do?

This adds the missing parent-coordination handoff when a child issue first
enters the effective `in_review` or `blocked` status category.

The deadlock was caused by two existing contracts meeting at a gap: ordinary
agents deliver work in `in_review`, while the parent stage-barrier path only
wakes on terminal `done` / `cancelled` transitions. If the child was assigned
directly to an ordinary agent and the parent was owned by an agent or squad,
neither the child comment route nor the terminal barrier woke the parent owner.
The daemon therefore had no parent task to claim, and coordination resumed only
after a human comment.

The new attention path sits beside, rather than inside, stage completion. It
posts a parent system handoff and routes it to the parent owner, but it never
marks the child done or promotes another stage. This preserves the leader as the
reviewer and leaves the existing terminal barrier responsible for advancement.

This is a current-`main` standalone version of the original design in #5625.
The implementation has been updated for custom status categories, revision-aware
comment events, and current batch behavior; the commit retains attribution to
the original authors.

## Related Issue

Closes #5464

Supersedes #5625.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Detect canonical transitions into `in_review` / `blocked` after single and
  batch status updates.
- Post one parent attention handoff and reuse the existing deduped agent/squad
  dispatch; notify member-owned parents through an action-required inbox item.
- Resolve child and parent custom statuses through `issuestatus.Effective`,
  aggregate batch handoffs once per parent, and prefer a blocked representative.
- Keep repeated saves, same-category custom status changes, parked/terminal
  parents, and existing terminal stage barriers from producing duplicate or
  invalid handoffs.
- Document the attention-versus-completion contract in the built-in squad and
  issue workflow skills.

## How to Test

1. Start PostgreSQL and apply migrations.
2. Run `go test ./internal/handler -count=1`.
3. Run `go build ./...`.
4. Run `go vet ./...`.

Fresh verification on this PR head passed all three commands above.

## Risks

The intentional behavior change is one additional parent wake per canonical
attention transition. Existing pending-task dedup bounds rapid handoffs; batch
updates aggregate once per parent; transitions within the same effective status
category do not re-wake. The handoff remains best-effort and does not mutate
child acceptance or stage advancement.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex through Multica Agent

**Prompt / approach:** Reproduced the missing parent handoff with a PostgreSQL-backed
regression test, inspected the fixed status/comment/dispatch paths, ported and
hardened #5625 against current `main`, then verified the complete handler package,
build, and vet before publishing.

## Screenshots (optional)

N/A — server-side coordination behavior only.
