### PR TITLE
MUL-6430: feat(tasks): default agent task max_attempts to 4 (3 retries)

### DIFF
--- a/server/internal/service/agent_task_max_attempts.go
+++ b/server/internal/service/agent_task_max_attempts.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"encoding/json"
+)
+
+// DefaultAgentTaskMaxAttempts is the platform default for agent_task_queue.max_attempts
+// on newly enqueued root tasks (first run + three auto-retries for retryable
+// infrastructure failures). Matches migration 368_agent_task_max_attempts_default_4.
+const DefaultAgentTaskMaxAttempts int32 = 4
+
+// AgentTaskMaxAttemptsSettingFloor/Ceiling bound workspace.settings.agent_task.max_attempts.
+const (
+	AgentTaskMaxAttemptsSettingFloor   int32 = 1
+	AgentTaskMaxAttemptsSettingCeiling int32 = 10
+)
+
+// ParseAgentTaskMaxAttemptsSetting reads workspace.settings JSON and returns
+// the configured agent-task max_attempts when present and in [1,10].
+// ok=false means "use the column/platform default".
+//
+// Schema:
+//
+//	{"agent_task":{"max_attempts":4}}
+//
+// The DB trigger agent_task_apply_workspace_max_attempts enforces the same key
+// at insert time; this helper exists so API/docs/tests share one contract.
+func ParseAgentTaskMaxAttemptsSetting(settingsJSON []byte) (maxAttempts int32, ok bool) {
+	if len(settingsJSON) == 0 {
+		return 0, false
+	}
+	var s struct {
+		AgentTask *struct {
+			MaxAttempts *int `json:"max_attempts"`
+		} `json:"agent_task"`
+	}
+	if err := json.Unmarshal(settingsJSON, &s); err != nil || s.AgentTask == nil || s.AgentTask.MaxAttempts == nil {
+		return 0, false
+	}
+	v := int32(*s.AgentTask.MaxAttempts)
+	if v < AgentTaskMaxAttemptsSettingFloor || v > AgentTaskMaxAttemptsSettingCeiling {
+		return 0, false
+	}
+	return v, true
+}

--- a/server/internal/service/agent_task_max_attempts_test.go
+++ b/server/internal/service/agent_task_max_attempts_test.go
@@ -1,0 +1,39 @@
+package service
+
+import "testing"
+
+func TestParseAgentTaskMaxAttemptsSetting(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want int32
+		ok   bool
+	}{
+		{"empty", "", 0, false},
+		{"empty object", `{}`, 0, false},
+		{"valid 4", `{"agent_task":{"max_attempts":4}}`, 4, true},
+		{"valid 1 disables retry", `{"agent_task":{"max_attempts":1}}`, 1, true},
+		{"valid 10", `{"agent_task":{"max_attempts":10}}`, 10, true},
+		{"too low", `{"agent_task":{"max_attempts":0}}`, 0, false},
+		{"too high", `{"agent_task":{"max_attempts":11}}`, 0, false},
+		{"wrong type", `{"agent_task":{"max_attempts":"3"}}`, 0, false},
+		{"null", `{"agent_task":{"max_attempts":null}}`, 0, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseAgentTaskMaxAttemptsSetting([]byte(tc.in))
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("Parse(%q) = (%d,%v), want (%d,%v)", tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestDefaultAgentTaskMaxAttempts(t *testing.T) {
+	if DefaultAgentTaskMaxAttempts != 4 {
+		t.Fatalf("DefaultAgentTaskMaxAttempts = %d, want 4", DefaultAgentTaskMaxAttempts)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4377,14 +4377,14 @@ const (
 // retryAttemptCeiling reports how many attempts the auto-retry path allows for
 // a failure reason. It only ever WIDENS the task's generic max_attempts, and
 // only for reasons with a bespoke schedule; everything else keeps the column's
-// value (default 2 = first run + one retry).
+// value (default 4 = first run + three retries).
 //
 // max_attempts <= 1 explicitly disables auto-retry (055_task_lease_and_retry.up
 // .sql: "1 disables retry"), so it is never overridden — a disabled task must
 // not be revived by a raised ceiling. Callers persist this value into the retry
 // child (CreateRetryTask's max_attempts) so the row stays self-consistent:
 // provider_network's chain records attempt=3, max_attempts=3, not a
-// contradictory attempt=3, max_attempts=2 (MUL-4910).
+// contradictory attempt=N, max_attempts=2 (legacy default) (MUL-4910).
 func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 	if taskMaxAttempts <= 1 {
 		return taskMaxAttempts

--- a/server/migrations/368_agent_task_max_attempts_default_4.down.sql
+++ b/server/migrations/368_agent_task_max_attempts_default_4.down.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS trg_agent_task_apply_workspace_max_attempts ON agent_task_queue;
+DROP FUNCTION IF EXISTS agent_task_apply_workspace_max_attempts();
+
+ALTER TABLE agent_task_queue
+  ALTER COLUMN max_attempts SET DEFAULT 2;

--- a/server/migrations/368_agent_task_max_attempts_default_4.up.sql
+++ b/server/migrations/368_agent_task_max_attempts_default_4.up.sql
@@ -1,0 +1,50 @@
+-- Raise the agent-task auto-retry budget so infrastructure-shaped failures
+-- get three retries after the first run (max_attempts=4 = attempts 1..4).
+--
+-- Historical default was 2 (first run + one retry) from 055_task_lease_and_retry.
+-- Workspace owners can override per workspace via
+--   workspace.settings.agent_task.max_attempts  (integer 1..10)
+-- The BEFORE INSERT trigger applies that override on root tasks only; retry
+-- children keep the ceiling stamped by CreateRetryTask / retryAttemptCeiling.
+
+ALTER TABLE agent_task_queue
+  ALTER COLUMN max_attempts SET DEFAULT 4;
+
+CREATE OR REPLACE FUNCTION agent_task_apply_workspace_max_attempts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cfg int;
+BEGIN
+  -- Root tasks only. Retry/rerun children set parent_task_id and/or
+  -- retry_of_task_id and already carry an explicit max_attempts.
+  IF NEW.parent_task_id IS NOT NULL
+     OR NEW.retry_of_task_id IS NOT NULL
+     OR NEW.rerun_of_task_id IS NOT NULL
+     OR NEW.attempt <> 1 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT NULLIF(btrim(w.settings #>> '{agent_task,max_attempts}'), '')::int
+    INTO cfg
+  FROM agent a
+  JOIN workspace w ON w.id = a.workspace_id
+  WHERE a.id = NEW.agent_id;
+
+  IF cfg IS NOT NULL AND cfg BETWEEN 1 AND 10 THEN
+    NEW.max_attempts := cfg;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_agent_task_apply_workspace_max_attempts ON agent_task_queue;
+CREATE TRIGGER trg_agent_task_apply_workspace_max_attempts
+  BEFORE INSERT ON agent_task_queue
+  FOR EACH ROW
+  EXECUTE FUNCTION agent_task_apply_workspace_max_attempts();
+
+COMMENT ON FUNCTION agent_task_apply_workspace_max_attempts() IS
+  'Applies workspace.settings.agent_task.max_attempts (1..10) to root agent tasks at insert. Absent/invalid → column default (4).';


### PR DESCRIPTION
## Summary

Raises the default agent-task auto-retry budget from **2** (first run + 1 retry) to **4** (first run + **3** retries) for infrastructure-shaped failures.

Also adds a per-workspace override:

```json
{
  "agent_task": {
    "max_attempts": 4
  }
}
```

(`workspace.settings`, integer **1..10**; `1` disables auto-retry per existing semantics.)

## Implementation

- Migration `368_agent_task_max_attempts_default_4`: column default `4` + `BEFORE INSERT` trigger that applies `settings.agent_task.max_attempts` on **root** tasks only.
- Retry children (`parent_task_id` / `retry_of_task_id` / `rerun_of_task_id`) keep the ceiling already stamped by `CreateRetryTask` / `retryAttemptCeiling`.
- Go helper `ParseAgentTaskMaxAttemptsSetting` + unit tests document the JSON contract.

## Notes

- Auto-retry still only covers infrastructure reasons (`runtime_offline`, `timeout`, `provider_network`, etc.) — intentional; agent logic failures are not auto-retried.
- `provider_network` keeps its bespoke schedule (ceiling raise to 3 when the task budget is lower); with default 4 the generic budget already covers three retries.

## Test plan

- [x] Local self-host: after migration, insert with empty settings → `max_attempts=4`
- [x] Local self-host: `settings.agent_task.max_attempts=3` → insert → `max_attempts=3`
- [ ] CI unit tests for `ParseAgentTaskMaxAttemptsSetting`
- [ ] Manual: enqueue issue task, fail with retryable reason, confirm up to attempt 4