### PR TITLE
fix(CAL-2): authorize worker issue reopen renewals

### DIFF
--- a/apps/docs/content/docs/issues.mdx
+++ b/apps/docs/content/docs/issues.mdx
@@ -52,6 +52,15 @@ Assignment does not bypass an agent's Access; when assigning to a squad, the lea
 
 There is no fixed flow between statuses — members and agents can change them directly.
 
+Reopening a terminal issue is claim-aware for workers. A trusted worker can
+move `done` or `cancelled` to an active status only when the issue is still
+assigned to that worker and its `(issue, worker)` claim has no active task; the
+server then queues one replacement run. Reopening to `backlog` cannot renew a
+claim, and workers receive a denial for active claims or issues assigned to a
+different worker. Human members retain the normal status-edit behavior.
+Worker reopen cannot be combined with `--no-start` / `suppress_run`, because
+that would reopen the issue without renewing its claim.
+
 Once an issue is assigned to an agent, the agent is expected to move the status from `backlog` / `todo` to `in_progress` when it starts, then to `in_review` when it has delivered. These updates are written explicitly by the agent through the Multica CLI during the run — the server does not flip issue status when a task starts or completes (apart from the two system exceptions below). `done` is usually a human confirmation, or an integration such as a PR with close intent that merges.
 
 <Callout type="info">

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -9,14 +9,14 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/auth"
 )
 
-// authRequestWithAgent makes an authenticated request with X-Agent-ID +
-// X-Task-ID headers, causing the server to resolve the actor as an agent
-// instead of a member. resolveActor requires both headers to grant agent
-// identity (defense against header forgery — see #2359 PR review), so we
-// seed a queued task for the agent on demand and pass its UUID as
-// X-Task-ID. The task is best-effort cleaned up via test teardown elsewhere.
+// authRequestWithAgent authenticates through a real server-bound mat_ task
+// token. Normal JWT/PAT requests must not be able to turn X-Agent-ID and
+// X-Task-ID headers into an agent actor; this helper exercises the same trust
+// boundary as a daemon-launched agent.
 func authRequestWithAgent(t *testing.T, method, path string, body any, agentID string) *http.Response {
 	t.Helper()
 	var bodyReader io.Reader
@@ -29,10 +29,24 @@ func authRequestWithAgent(t *testing.T, method, path string, body any, agentID s
 		t.Fatalf("failed to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+testToken)
+	taskID := ensureAgentTask(t, agentID)
+	taskToken, err := auth.GenerateAgentTaskToken()
+	if err != nil {
+		t.Fatalf("generate task token: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO task_token (token_hash, task_id, agent_id, workspace_id, user_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5, now() + interval '1 hour')
+	`, auth.HashToken(taskToken), taskID, agentID, testWorkspaceID, testUserID); err != nil {
+		t.Fatalf("insert task token: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM task_token WHERE token_hash = $1`, auth.HashToken(taskToken))
+	})
+	req.Header.Set("Authorization", "Bearer "+taskToken)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 	req.Header.Set("X-Agent-ID", agentID)
-	req.Header.Set("X-Task-ID", ensureAgentTask(t, agentID))
+	req.Header.Set("X-Task-ID", taskID)
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -479,12 +479,27 @@ func TestIssueReopenRouteDoesNotTrustForgedWorkerHeaders(t *testing.T) {
 	})
 
 	// Put the fixture into the terminal/unused-claim state without relying on
-	// the route under test, and remove the create-triggered task.
+	// the route under test. Keep the create-triggered task row, but complete it,
+	// so the forged header carries a real task UUID while the claim remains
+	// unused. This prevents the regression from passing only because the task
+	// header was syntactically invalid.
 	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET status = 'done' WHERE id = $1`, issueID); err != nil {
 		t.Fatalf("prepare terminal issue: %v", err)
 	}
-	if _, err := testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID); err != nil {
-		t.Fatalf("clear create task: %v", err)
+	var taskID string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT id::text FROM agent_task_queue
+		 WHERE issue_id = $1 AND agent_id = $2
+		 ORDER BY created_at DESC LIMIT 1
+	`, issueID, agentID).Scan(&taskID); err != nil {
+		t.Fatalf("read create task: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE agent_task_queue
+		   SET status = 'completed', completed_at = now()
+		 WHERE id = $1
+	`, taskID); err != nil {
+		t.Fatalf("complete create task: %v", err)
 	}
 
 	body, err := json.Marshal(map[string]any{"status": "in_progress"})
@@ -499,7 +514,7 @@ func TestIssueReopenRouteDoesNotTrustForgedWorkerHeaders(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 	req.Header.Set("X-Agent-ID", agentID)
-	req.Header.Set("X-Task-ID", "00000000-0000-0000-0000-000000000001")
+	req.Header.Set("X-Task-ID", taskID)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("reopen request: %v", err)
@@ -513,7 +528,9 @@ func TestIssueReopenRouteDoesNotTrustForgedWorkerHeaders(t *testing.T) {
 
 	var queued int
 	if err := testPool.QueryRow(context.Background(), `
-		SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2
+		SELECT count(*) FROM agent_task_queue
+		 WHERE issue_id = $1 AND agent_id = $2
+		   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 	`, issueID, agentID).Scan(&queued); err != nil {
 		t.Fatalf("count forged worker renewal: %v", err)
 	}

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -441,6 +441,87 @@ func TestProtectedRoutesRequireAuth(t *testing.T) {
 	}
 }
 
+// TestIssueReopenRouteDoesNotTrustForgedWorkerHeaders exercises the complete
+// Auth -> workspace -> issue route. A member may use the ordinary member
+// reopen behavior, but forged X-Agent-ID/X-Task-ID headers must not turn that
+// request into a worker claim renewal.
+func TestIssueReopenRouteDoesNotTrustForgedWorkerHeaders(t *testing.T) {
+	resp := authRequest(t, "GET", "/api/agents?workspace_id="+testWorkspaceID, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list agents: expected 200, got %d", resp.StatusCode)
+	}
+	var agents []map[string]any
+	readJSON(t, resp, &agents)
+	if len(agents) == 0 {
+		t.Fatal("expected integration fixture agent")
+	}
+	agentID, _ := agents[0]["id"].(string)
+
+	resp = authRequest(t, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "forged worker header reopen",
+		"status":        "todo",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("create issue: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+	var issue map[string]any
+	readJSON(t, resp, &issue)
+	issueID, _ := issue["id"].(string)
+	if issueID == "" {
+		t.Fatal("create issue returned no id")
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	// Put the fixture into the terminal/unused-claim state without relying on
+	// the route under test, and remove the create-triggered task.
+	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET status = 'done' WHERE id = $1`, issueID); err != nil {
+		t.Fatalf("prepare terminal issue: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID); err != nil {
+		t.Fatalf("clear create task: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]any{"status": "in_progress"})
+	if err != nil {
+		t.Fatalf("marshal reopen: %v", err)
+	}
+	req, err := http.NewRequest("PUT", testServer.URL+"/api/issues/"+issueID, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build reopen request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", "00000000-0000-0000-0000-000000000001")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("reopen request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("forged member reopen: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	var queued int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2
+	`, issueID, agentID).Scan(&queued); err != nil {
+		t.Fatalf("count forged worker renewal: %v", err)
+	}
+	if queued != 0 {
+		t.Fatalf("forged member headers created %d worker task(s)", queued)
+	}
+}
+
 func TestInvalidJWT(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -767,6 +767,12 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	if actor, ok := middleware.AuthenticatedActorFromContext(r.Context()); ok {
 		return actor.Type, actor.ID
 	}
+	// Direct handler callers from the daemon/test seam predate the shared
+	// authenticated context. Keep their server-stamped source compatibility,
+	// but never let it override an Auth/DaemonAuth context (the branch above).
+	if r.Header.Get("X-Actor-Source") == "task_token" && r.Header.Get("X-Agent-ID") != "" {
+		return "agent", r.Header.Get("X-Agent-ID")
+	}
 	agentID := r.Header.Get("X-Agent-ID")
 	if agentID == "" {
 		return "member", userID

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -746,16 +746,15 @@ func requestUserID(r *http.Request) string {
 
 // resolveActor determines whether the request is from an agent or a human member.
 //
-// First-class signal: X-Actor-Source set to "task_token" means the request
-// authenticated via an `mat_` task-scoped token. The auth middleware sets
-// that header (and stripped any client-supplied value first), so it is
-// authoritative — the bound (agent_id, task_id) cannot be forged or
-// stripped by the agent process. This is the path MUL-2600 relies on to
-// reject agent-process traffic on owner-only endpoints.
+// First-class signal: Auth or DaemonAuth sets the authenticated actor context
+// only after server-side token validation. A task token binds the agent to
+// the token row; a member token binds the request to the member. Headers are
+// never authoritative on an authenticated route.
 //
-// Fallback signal (legacy CLI / member-token paths): the request MUST
-// carry both X-Agent-ID and a valid X-Task-ID, and the task must belong
-// to the claimed agent. Otherwise we fall back to "member".
+// Fallback signal (direct handler tests and legacy callers that do not pass
+// through auth middleware): the request MUST carry both X-Agent-ID and a
+// valid X-Task-ID, and the task must belong to the claimed agent. Production
+// authenticated routes always take the context path above.
 //
 // X-Agent-ID alone is not trusted: any workspace member can guess or observe
 // an agent's UUID, and a member-supplied X-Agent-ID would otherwise let that
@@ -765,10 +764,8 @@ func requestUserID(r *http.Request) string {
 //
 // Returns ("agent", agentID) on success, ("member", userID) otherwise.
 func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (actorType, actorID string) {
-	if r.Header.Get("X-Actor-Source") == "task_token" {
-		// Server-set header — auth middleware also forced X-Agent-ID
-		// from the token row. Trust it directly without re-querying.
-		return "agent", r.Header.Get("X-Agent-ID")
+	if actor, ok := middleware.AuthenticatedActorFromContext(r.Context()); ok {
+		return actor.Type, actor.ID
 	}
 	agentID := r.Header.Get("X-Agent-ID")
 	if agentID == "" {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -770,7 +770,7 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	// Direct handler callers from the daemon/test seam predate the shared
 	// authenticated context. Keep their server-stamped source compatibility,
 	// but never let it override an Auth/DaemonAuth context (the branch above).
-	if r.Header.Get("X-Actor-Source") == "task_token" && r.Header.Get("X-Agent-ID") != "" {
+	if r.Header.Get("X-Actor-Source") == "task_token" {
 		return "agent", r.Header.Get("X-Agent-ID")
 	}
 	agentID := r.Header.Get("X-Agent-ID")

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3470,7 +3470,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	var workerGuard *workerReopenGuard
-	if workerReopen {
+	if actorType == "agent" && req.Status != nil {
 		workerGuard = &workerReopenGuard{
 			actorID:            actorID,
 			targetStatus:       statusKeyForGuard,
@@ -4213,11 +4213,15 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		workerReopen := workerReopenByIssue[uuidToString(prevIssue.ID)]
 		var workerGuard *workerReopenGuard
-		if workerReopen {
+		if actorType == "agent" && req.Updates.Status != nil {
 			if workerReopenProcessed[uuidToString(prevIssue.ID)] {
-				continue
+				if workerReopen {
+					continue
+				}
 			}
-			workerReopenProcessed[uuidToString(prevIssue.ID)] = true
+			if workerReopen {
+				workerReopenProcessed[uuidToString(prevIssue.ID)] = true
+			}
 			workerGuard = &workerReopenGuard{
 				actorID:            actorID,
 				targetStatus:       batchStatusKey,

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3139,13 +3139,13 @@ func refreshUntouchedNullableIssueParams(params *db.UpdateIssueParams, current d
 
 var errIssueFieldConflict = errors.New("issue text field conflict")
 
-func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.UUID, params db.UpdateIssueParams, rawFields map[string]json.RawMessage, titleBase, descriptionBase *string, attachmentIDs []pgtype.UUID, statusKey string, workerGuard *workerReopenGuard) (db.Issue, db.Issue, bool, error) {
+func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.UUID, params db.UpdateIssueParams, rawFields map[string]json.RawMessage, titleBase, descriptionBase *string, attachmentIDs []pgtype.UUID, statusKey string, workerGuard *workerReopenGuard) (db.Issue, db.Issue, bool, db.AgentTaskQueue, error) {
 	if h.TxStarter == nil {
-		return db.Issue{}, db.Issue{}, false, errors.New("atomic issue update requires transaction starter")
+		return db.Issue{}, db.Issue{}, false, db.AgentTaskQueue{}, errors.New("atomic issue update requires transaction starter")
 	}
 	tx, err := h.TxStarter.Begin(ctx)
 	if err != nil {
-		return db.Issue{}, db.Issue{}, false, fmt.Errorf("begin atomic issue update: %w", err)
+		return db.Issue{}, db.Issue{}, false, db.AgentTaskQueue{}, fmt.Errorf("begin atomic issue update: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
@@ -3154,14 +3154,14 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 	// itself rather than going through runWithIssueStatusGuard. The catalog lock
 	// must precede both attachment and issue row locks everywhere. (MUL-6243)
 	if err := assertIssueStatusStillActive(ctx, qtx, workspaceID, statusKey); err != nil {
-		return db.Issue{}, db.Issue{}, false, err
+		return db.Issue{}, db.Issue{}, false, db.AgentTaskQueue{}, err
 	}
 	if len(attachmentIDs) > 0 {
 		if _, err := qtx.LockAttachmentsForIssueLink(ctx, db.LockAttachmentsForIssueLinkParams{
 			WorkspaceID:   workspaceID,
 			AttachmentIds: attachmentIDs,
 		}); err != nil {
-			return db.Issue{}, db.Issue{}, false, fmt.Errorf("lock issue attachments: %w", err)
+			return db.Issue{}, db.Issue{}, false, db.AgentTaskQueue{}, fmt.Errorf("lock issue attachments: %w", err)
 		}
 	}
 	current, err := qtx.LockIssueForDescriptionUpdate(ctx, db.LockIssueForDescriptionUpdateParams{
@@ -3169,16 +3169,16 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 		WorkspaceID: workspaceID,
 	})
 	if err != nil {
-		return db.Issue{}, db.Issue{}, false, fmt.Errorf("lock issue for update: %w", err)
+		return db.Issue{}, db.Issue{}, false, db.AgentTaskQueue{}, fmt.Errorf("lock issue for update: %w", err)
 	}
 	if workerGuard != nil {
 		if err := enforceWorkerReopenOnLockedIssue(ctx, qtx, current, *workerGuard); err != nil {
-			return db.Issue{}, current, false, err
+			return db.Issue{}, current, false, db.AgentTaskQueue{}, err
 		}
 	}
 
 	if params.Title.Valid && titleBase != nil && current.Title != *titleBase && current.Title != params.Title.String {
-		return db.Issue{}, current, false, errIssueFieldConflict
+		return db.Issue{}, current, false, db.AgentTaskQueue{}, errIssueFieldConflict
 	}
 
 	if params.Description.Valid {
@@ -3187,7 +3187,7 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 			WorkspaceID: current.WorkspaceID,
 		})
 		if listErr != nil {
-			return db.Issue{}, current, false, fmt.Errorf("list issue attachments for description merge: %w", listErr)
+			return db.Issue{}, current, false, db.AgentTaskQueue{}, fmt.Errorf("list issue attachments for description merge: %w", listErr)
 		}
 		currentDescription := ""
 		if current.Description.Valid {
@@ -3197,7 +3197,7 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 		if descriptionBase != nil && currentDescription != *descriptionBase && currentDescription != incomingDescription {
 			baseWithLateMedia := mergeIssueChannelMediaDescription(currentDescription, *descriptionBase, descriptionBase, attachments)
 			if currentDescription != baseWithLateMedia {
-				return db.Issue{}, current, false, errIssueFieldConflict
+				return db.Issue{}, current, false, db.AgentTaskQueue{}, errIssueFieldConflict
 			}
 		}
 		params.Description = pgtype.Text{
@@ -3209,7 +3209,19 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 
 	issue, err := qtx.UpdateIssue(ctx, params)
 	if err != nil {
-		return db.Issue{}, current, false, fmt.Errorf("update locked issue: %w", err)
+		return db.Issue{}, current, false, db.AgentTaskQueue{}, fmt.Errorf("update locked issue: %w", err)
+	}
+
+	var renewalTask db.AgentTaskQueue
+	if workerGuard != nil && workerGuard.requireRenewal {
+		if h.TaskService == nil {
+			return db.Issue{}, current, false, db.AgentTaskQueue{}, workerReopenRenewalError{err: errors.New("worker renewal enqueue service is unavailable")}
+		}
+		var enqueueErr error
+		renewalTask, enqueueErr = h.TaskService.EnqueueTaskForIssueWithQueries(ctx, qtx, issue, "", pgtype.UUID{})
+		if enqueueErr != nil {
+			return db.Issue{}, current, false, db.AgentTaskQueue{}, workerReopenRenewalError{err: enqueueErr}
+		}
 	}
 
 	attachmentsChanged := false
@@ -3221,7 +3233,7 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 			BumpRevision:  issue.Revision == current.Revision,
 		})
 		if linkErr != nil {
-			return db.Issue{}, current, false, fmt.Errorf("link issue attachments: %w", linkErr)
+			return db.Issue{}, current, false, db.AgentTaskQueue{}, fmt.Errorf("link issue attachments: %w", linkErr)
 		}
 		attachmentsChanged = linked.LinkedCount > 0
 		if linked.IssueRevision > 0 {
@@ -3230,14 +3242,14 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 				WorkspaceID: issue.WorkspaceID,
 			})
 			if err != nil {
-				return db.Issue{}, current, false, fmt.Errorf("reload issue after attachment link: %w", err)
+				return db.Issue{}, current, false, db.AgentTaskQueue{}, fmt.Errorf("reload issue after attachment link: %w", err)
 			}
 		}
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return db.Issue{}, current, false, fmt.Errorf("commit atomic issue update: %w", err)
+		return db.Issue{}, current, false, db.AgentTaskQueue{}, fmt.Errorf("commit atomic issue update: %w", err)
 	}
-	return issue, current, attachmentsChanged, nil
+	return issue, current, attachmentsChanged, renewalTask, nil
 }
 
 func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
@@ -3487,9 +3499,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 
 	var issue db.Issue
 	attachmentsChanged := false
+	var renewalTask db.AgentTaskQueue
 	if workerReopen || req.Description != nil || req.TitleBase != nil || req.DescriptionBase != nil || len(attachmentIDs) > 0 {
 		var lockedPrev db.Issue
-		issue, lockedPrev, attachmentsChanged, err = h.updateIssueAtomically(
+		issue, lockedPrev, attachmentsChanged, renewalTask, err = h.updateIssueAtomically(
 			r.Context(), prevIssue.WorkspaceID, params, rawFields, req.TitleBase, req.DescriptionBase, attachmentIDs, statusKeyForGuard, workerGuard,
 		)
 		if lockedPrev.ID.Valid {
@@ -3506,6 +3519,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		var workerDenied workerReopenDeniedError
 		if errors.As(err, &workerDenied) {
 			writeError(w, workerDenied.status, workerDenied.message)
+			return
+		}
+		var renewalErr workerReopenRenewalError
+		if errors.As(err, &renewalErr) {
+			writeError(w, http.StatusServiceUnavailable, "worker reopen could not renew the issue claim")
 			return
 		}
 		if writeIssueStatusRaceError(w, err) {
@@ -3580,6 +3598,9 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			"issue_revision": issue.Revision,
 		})
 	}
+	if renewalTask.ID.Valid {
+		h.TaskService.NotifyTaskEnqueued(r.Context(), renewalTask)
+	}
 
 	// Reconcile the task queue. Whether this write starts an agent run — and
 	// for whom (agent assignee or squad leader) — is decided by the single
@@ -3598,17 +3619,26 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// it stops in-flight agent runs, so that implicit coupling is gone
 	// (MUL-4465). Deleting an issue still cancels its tasks (see DeleteIssue),
 	// because the tasks' owning issue ceases to exist.
-	if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
-		service.IssueTriggerInput{
-			Issue:           issue,
-			PrevStatus:      prevIssue.Status,
-			AssigneeChanged: assigneeChanged,
-			StatusChanged:   statusChanged,
-			WorkerReopen:    workerReopen,
-		},
-		h.issueTriggerWriteProbe(r, actorType, actorID, issue),
-	); ok && !req.SuppressRun {
-		h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.HandoffNote)
+	if !renewalTask.ID.Valid {
+		if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
+			service.IssueTriggerInput{
+				Issue:           issue,
+				PrevStatus:      prevIssue.Status,
+				AssigneeChanged: assigneeChanged,
+				StatusChanged:   statusChanged,
+				WorkerReopen:    workerReopen,
+			},
+			h.issueTriggerWriteProbe(r, actorType, actorID, issue),
+		); ok && !req.SuppressRun {
+			if err := h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.HandoffNote); err != nil {
+				slog.Error("issue run dispatch failed",
+					"issue_id", uuidToString(issue.ID),
+					"agent_id", uuidToString(trigger.AgentID),
+					"source", string(trigger.Source),
+					"error", err,
+				)
+			}
+		}
 	}
 
 	// Platform-driven parent notification: when this issue transitions into
@@ -3894,6 +3924,15 @@ type BatchUpdateIssuesRequest struct {
 	Updates  UpdateIssueRequest `json:"updates"`
 }
 
+// BatchUpdateIssues intentionally has per-item commit scope. Every item gets
+// its own issue transaction; for a worker reopen that transaction includes the
+// replacement task insert, so an accepted item is always renewed atomically.
+// Earlier successful items remain committed when a later item is missing,
+// skipped by validation, or encounters an item-local error. Shared request
+// validation (including worker authorization preflight and status catalog
+// races) still rejects before or aborts the batch when the whole request is
+// invalid. This boundary is part of the API contract, not an accidental
+// approximation of all-or-nothing semantics.
 func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -4233,12 +4272,13 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var issue db.Issue
+		var renewalTask db.AgentTaskQueue
 		if workerReopen || req.Updates.Description != nil {
 			// One batch-level base cannot describe multiple issue documents.
 			// Preserve every marked channel-media block conservatively, matching
 			// legacy single-update clients that omit description_base.
 			var lockedPrev db.Issue
-			issue, lockedPrev, _, err = h.updateIssueAtomically(
+			issue, lockedPrev, _, renewalTask, err = h.updateIssueAtomically(
 				r.Context(), prevIssue.WorkspaceID, params, rawUpdates, nil, nil, nil, batchStatusKey, workerGuard,
 			)
 			if err == nil {
@@ -4255,6 +4295,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			var workerDenied workerReopenDeniedError
 			if errors.As(err, &workerDenied) {
 				writeError(w, workerDenied.status, workerDenied.message)
+				return
+			}
+			var renewalErr workerReopenRenewalError
+			if errors.As(err, &renewalErr) {
+				writeError(w, http.StatusServiceUnavailable, "worker reopen could not renew the issue claim")
 				return
 			}
 			// The archive race is a property of the batch's shared target
@@ -4284,6 +4329,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			"priority_changed": priorityChanged,
 			"project_changed":  projectChanged,
 		})
+		if renewalTask.ID.Valid {
+			h.TaskService.NotifyTaskEnqueued(r.Context(), renewalTask)
+		}
 
 		// Reassignment does not cancel existing tasks (#4963 / MUL-4113) —
 		// mirrors UpdateIssue. See that handler for the rationale.
@@ -4291,17 +4339,26 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		// Same single predicate as UpdateIssue — batch must not grow its own
 		// copy of the enqueue rule (the historical source of four-entry-point
 		// drift, MUL-3375). suppress_run applies batch-wide.
-		if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
-			service.IssueTriggerInput{
-				Issue:           issue,
-				PrevStatus:      prevIssue.Status,
-				AssigneeChanged: assigneeChanged,
-				StatusChanged:   statusChanged,
-				WorkerReopen:    workerReopen,
-			},
-			h.issueTriggerWriteProbe(r, actorType, actorID, issue),
-		); ok && !req.Updates.SuppressRun {
-			h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.Updates.HandoffNote)
+		if !renewalTask.ID.Valid {
+			if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
+				service.IssueTriggerInput{
+					Issue:           issue,
+					PrevStatus:      prevIssue.Status,
+					AssigneeChanged: assigneeChanged,
+					StatusChanged:   statusChanged,
+					WorkerReopen:    workerReopen,
+				},
+				h.issueTriggerWriteProbe(r, actorType, actorID, issue),
+			); ok && !req.Updates.SuppressRun {
+				if err := h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.Updates.HandoffNote); err != nil {
+					slog.Error("batch issue run dispatch failed",
+						"issue_id", uuidToString(issue.ID),
+						"agent_id", uuidToString(trigger.AgentID),
+						"source", string(trigger.Source),
+						"error", err,
+					)
+				}
+			}
 		}
 
 		// No status change — not even → cancelled — cancels active tasks here,

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3139,7 +3139,7 @@ func refreshUntouchedNullableIssueParams(params *db.UpdateIssueParams, current d
 
 var errIssueFieldConflict = errors.New("issue text field conflict")
 
-func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.UUID, params db.UpdateIssueParams, rawFields map[string]json.RawMessage, titleBase, descriptionBase *string, attachmentIDs []pgtype.UUID, statusKey string) (db.Issue, db.Issue, bool, error) {
+func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.UUID, params db.UpdateIssueParams, rawFields map[string]json.RawMessage, titleBase, descriptionBase *string, attachmentIDs []pgtype.UUID, statusKey string, workerGuard *workerReopenGuard) (db.Issue, db.Issue, bool, error) {
 	if h.TxStarter == nil {
 		return db.Issue{}, db.Issue{}, false, errors.New("atomic issue update requires transaction starter")
 	}
@@ -3170,6 +3170,11 @@ func (h *Handler) updateIssueAtomically(ctx context.Context, workspaceID pgtype.
 	})
 	if err != nil {
 		return db.Issue{}, db.Issue{}, false, fmt.Errorf("lock issue for update: %w", err)
+	}
+	if workerGuard != nil {
+		if err := enforceWorkerReopenOnLockedIssue(ctx, qtx, current, *workerGuard); err != nil {
+			return db.Issue{}, current, false, err
+		}
 	}
 
 	if params.Title.Valid && titleBase != nil && current.Title != *titleBase && current.Title != params.Title.String {
@@ -3464,6 +3469,15 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	var workerGuard *workerReopenGuard
+	if workerReopen {
+		workerGuard = &workerReopenGuard{
+			actorID:            actorID,
+			targetStatus:       statusKeyForGuard,
+			targetAssigneeType: params.AssigneeType,
+			targetAssigneeID:   params.AssigneeID,
+		}
+	}
 
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
 	if !ok {
@@ -3472,10 +3486,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 
 	var issue db.Issue
 	attachmentsChanged := false
-	if req.Description != nil || req.TitleBase != nil || req.DescriptionBase != nil || len(attachmentIDs) > 0 {
+	if workerReopen || req.Description != nil || req.TitleBase != nil || req.DescriptionBase != nil || len(attachmentIDs) > 0 {
 		var lockedPrev db.Issue
 		issue, lockedPrev, attachmentsChanged, err = h.updateIssueAtomically(
-			r.Context(), prevIssue.WorkspaceID, params, rawFields, req.TitleBase, req.DescriptionBase, attachmentIDs, statusKeyForGuard,
+			r.Context(), prevIssue.WorkspaceID, params, rawFields, req.TitleBase, req.DescriptionBase, attachmentIDs, statusKeyForGuard, workerGuard,
 		)
 		if lockedPrev.ID.Valid {
 			prevIssue = lockedPrev
@@ -3488,6 +3502,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	if err != nil {
+		var workerDenied workerReopenDeniedError
+		if errors.As(err, &workerDenied) {
+			writeError(w, workerDenied.status, workerDenied.message)
+			return
+		}
 		if writeIssueStatusRaceError(w, err) {
 			return
 		}
@@ -4193,35 +4212,28 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		}
 
 		workerReopen := workerReopenByIssue[uuidToString(prevIssue.ID)]
+		var workerGuard *workerReopenGuard
 		if workerReopen {
 			if workerReopenProcessed[uuidToString(prevIssue.ID)] {
 				continue
 			}
 			workerReopenProcessed[uuidToString(prevIssue.ID)] = true
-			if !params.AssigneeType.Valid || params.AssigneeType.String != "agent" ||
-				!params.AssigneeID.Valid || actorID != uuidToString(params.AssigneeID) {
-				writeError(w, http.StatusForbidden, "only the assigned worker can reopen this issue")
-				return
-			}
-			active, activeErr := h.hasActiveTaskForIssueAndAgent(r.Context(), prevIssue.ID, params.AssigneeID)
-			if activeErr != nil {
-				writeError(w, http.StatusServiceUnavailable, "cannot verify whether the worker claim is active")
-				return
-			}
-			if active {
-				writeError(w, http.StatusConflict, "cannot reopen an issue while its worker claim is active")
-				return
+			workerGuard = &workerReopenGuard{
+				actorID:            actorID,
+				targetStatus:       batchStatusKey,
+				targetAssigneeType: params.AssigneeType,
+				targetAssigneeID:   params.AssigneeID,
 			}
 		}
 
 		var issue db.Issue
-		if req.Updates.Description != nil {
+		if workerReopen || req.Updates.Description != nil {
 			// One batch-level base cannot describe multiple issue documents.
 			// Preserve every marked channel-media block conservatively, matching
 			// legacy single-update clients that omit description_base.
 			var lockedPrev db.Issue
 			issue, lockedPrev, _, err = h.updateIssueAtomically(
-				r.Context(), prevIssue.WorkspaceID, params, rawUpdates, nil, nil, nil, batchStatusKey,
+				r.Context(), prevIssue.WorkspaceID, params, rawUpdates, nil, nil, nil, batchStatusKey, workerGuard,
 			)
 			if err == nil {
 				prevIssue = lockedPrev
@@ -4234,6 +4246,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		if err != nil {
+			var workerDenied workerReopenDeniedError
+			if errors.As(err, &workerDenied) {
+				writeError(w, workerDenied.status, workerDenied.message)
+				return
+			}
 			// The archive race is a property of the batch's shared target
 			// status, not of one issue, so every remaining item would fail the
 			// same way. Abort with 409 instead of reporting a partial update.

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3476,6 +3476,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			targetStatus:       statusKeyForGuard,
 			targetAssigneeType: params.AssigneeType,
 			targetAssigneeID:   params.AssigneeID,
+			requireRenewal:     workerReopen,
 		}
 	}
 
@@ -4227,6 +4228,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				targetStatus:       batchStatusKey,
 				targetAssigneeType: params.AssigneeType,
 				targetAssigneeID:   params.AssigneeID,
+				requireRenewal:     workerReopen,
 			}
 		}
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3442,6 +3442,29 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A trusted worker can reopen only its still-owned issue and only when the
+	// issue/worker claim is currently unused. Members retain the existing
+	// status-edit behavior; the narrow worker gate is recorded for the trigger
+	// predicate below so an accepted reopen renews the claim with a new run.
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	workerReopen := false
+	if req.Status != nil {
+		var reopenStatus int
+		var reopenMessage string
+		workerReopen, reopenStatus, reopenMessage = h.authorizeWorkerReopen(
+			r.Context(), prevIssue, statusKeyForGuard, actorType, actorID,
+			params.AssigneeType, params.AssigneeID,
+		)
+		if reopenStatus != 0 {
+			writeError(w, reopenStatus, reopenMessage)
+			return
+		}
+		if workerReopen && req.SuppressRun {
+			writeError(w, http.StatusForbidden, "worker reopen must renew the issue claim")
+			return
+		}
+	}
+
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
 	if !ok {
 		return
@@ -3483,9 +3506,6 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update issue: "+err.Error())
 		return
 	}
-
-	// Determine actor identity: agent (via X-Agent-ID header) or member.
-	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
@@ -3564,6 +3584,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			PrevStatus:      prevIssue.Status,
 			AssigneeChanged: assigneeChanged,
 			StatusChanged:   statusChanged,
+			WorkerReopen:    workerReopen,
 		},
 		h.issueTriggerWriteProbe(r, actorType, actorID, issue),
 	); ok && !req.SuppressRun {
@@ -3956,6 +3977,68 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		batchProjectID = projectUUID
 	}
 
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	workerReopenByIssue := make(map[string]bool)
+	batchTargetStatus := ""
+	if req.Updates.Status != nil && actorType == "agent" {
+		batchTargetStatus = issuestatus.Effective(r.Context(), h.Queries, wsUUID, batchStatusKey)
+	}
+	// Reject every unauthorized worker reopen before the batch mutates its
+	// first issue. The write loop repeats the occupancy check immediately
+	// before each authorized update to close the normal check-to-write race as
+	// far as this non-transactional batch endpoint can.
+	if req.Updates.Status != nil && actorType == "agent" {
+		for _, issueID := range req.IssueIDs {
+			issueUUID, err := util.ParseUUID(issueID)
+			if err != nil {
+				continue
+			}
+			prevIssue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          issueUUID,
+				WorkspaceID: wsUUID,
+			})
+			if err != nil {
+				continue
+			}
+
+			targetAssigneeType := prevIssue.AssigneeType
+			targetAssigneeID := prevIssue.AssigneeID
+			if _, touched := rawUpdates["assignee_type"]; touched {
+				if req.Updates.AssigneeType == nil {
+					targetAssigneeType = pgtype.Text{Valid: false}
+				} else {
+					targetAssigneeType = pgtype.Text{String: *req.Updates.AssigneeType, Valid: true}
+				}
+			}
+			if _, touched := rawUpdates["assignee_id"]; touched {
+				if req.Updates.AssigneeID == nil {
+					targetAssigneeID = pgtype.UUID{Valid: false}
+				} else {
+					targetAssigneeID, err = util.ParseUUID(*req.Updates.AssigneeID)
+					if err != nil {
+						continue
+					}
+				}
+			}
+
+			workerReopen, reopenStatus, reopenMessage := h.authorizeWorkerReopenWithEffectiveStatuses(
+				r.Context(), prevIssue, batchStatusKey, actorType, actorID,
+				targetAssigneeType, targetAssigneeID,
+				issuestatus.Effective(r.Context(), h.Queries, wsUUID, prevIssue.Status),
+				batchTargetStatus,
+			)
+			if reopenStatus != 0 {
+				writeError(w, reopenStatus, reopenMessage)
+				return
+			}
+			workerReopenByIssue[uuidToString(prevIssue.ID)] = workerReopen
+			if workerReopen && req.Updates.SuppressRun {
+				writeError(w, http.StatusForbidden, "worker reopen must renew the issue claim")
+				return
+			}
+		}
+	}
+
 	updated := 0
 	// One Resolver for the whole batch — a per-issue filler would query the
 	// catalog once per custom-status row. (MUL-6243)
@@ -3964,6 +4047,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	// the parent/stage notification is evaluated once against the final state
 	// after the loop (MUL-4155) rather than per-child mid-batch.
 	var childDoneCompleted []db.Issue
+	workerReopenProcessed := make(map[string]bool)
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)
 		if err != nil {
@@ -4108,6 +4192,28 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		workerReopen := workerReopenByIssue[uuidToString(prevIssue.ID)]
+		if workerReopen {
+			if workerReopenProcessed[uuidToString(prevIssue.ID)] {
+				continue
+			}
+			workerReopenProcessed[uuidToString(prevIssue.ID)] = true
+			if !params.AssigneeType.Valid || params.AssigneeType.String != "agent" ||
+				!params.AssigneeID.Valid || actorID != uuidToString(params.AssigneeID) {
+				writeError(w, http.StatusForbidden, "only the assigned worker can reopen this issue")
+				return
+			}
+			active, activeErr := h.hasActiveTaskForIssueAndAgent(r.Context(), prevIssue.ID, params.AssigneeID)
+			if activeErr != nil {
+				writeError(w, http.StatusServiceUnavailable, "cannot verify whether the worker claim is active")
+				return
+			}
+			if active {
+				writeError(w, http.StatusConflict, "cannot reopen an issue while its worker claim is active")
+				return
+			}
+		}
+
 		var issue db.Issue
 		if req.Updates.Description != nil {
 			// One batch-level base cannot describe multiple issue documents.
@@ -4140,7 +4246,6 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 		resp := issueToResponse(issue, prefix)
-		actorType, actorID := h.resolveActor(r, userID, workspaceID)
 
 		fillBatch(&resp)
 		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&
@@ -4169,6 +4274,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				PrevStatus:      prevIssue.Status,
 				AssigneeChanged: assigneeChanged,
 				StatusChanged:   statusChanged,
+				WorkerReopen:    workerReopen,
 			},
 			h.issueTriggerWriteProbe(r, actorType, actorID, issue),
 		); ok && !req.Updates.SuppressRun {

--- a/server/internal/handler/issue_reopen.go
+++ b/server/internal/handler/issue_reopen.go
@@ -25,6 +25,23 @@ type workerReopenDeniedError struct {
 
 func (e workerReopenDeniedError) Error() string { return e.message }
 
+// workerReopenRenewalError marks a failure after authorization but before the
+// issue+replacement-task transaction can commit. It is deliberately rendered
+// as 503: the caller was authorized, but the server could not guarantee the
+// required claim renewal.
+type workerReopenRenewalError struct {
+	err error
+}
+
+func (e workerReopenRenewalError) Error() string {
+	if e.err == nil {
+		return "worker reopen renewal failed"
+	}
+	return "worker reopen renewal failed: " + e.err.Error()
+}
+
+func (e workerReopenRenewalError) Unwrap() error { return e.err }
+
 // enforceWorkerReopenOnLockedIssue is the authoritative check. Its caller
 // must hold the issue row lock in the same transaction that performs the
 // update, so a competing task insert or issue mutation cannot pass the check

--- a/server/internal/handler/issue_reopen.go
+++ b/server/internal/handler/issue_reopen.go
@@ -15,6 +15,7 @@ type workerReopenGuard struct {
 	targetStatus       string
 	targetAssigneeType pgtype.Text
 	targetAssigneeID   pgtype.UUID
+	requireRenewal     bool
 }
 
 type workerReopenDeniedError struct {
@@ -42,6 +43,12 @@ func enforceWorkerReopenOnLockedIssue(
 		return workerReopenDeniedError{status: status, message: message}
 	}
 	if !workerReopen {
+		if guard.requireRenewal {
+			return workerReopenDeniedError{
+				status:  http.StatusConflict,
+				message: "issue changed before worker claim renewal",
+			}
+		}
 		// The guard is also installed for ordinary agent status mutations so a
 		// row that becomes terminal after advisory preflight cannot turn into an
 		// unrenewed reopen. Non-terminal transitions remain on their existing

--- a/server/internal/handler/issue_reopen.go
+++ b/server/internal/handler/issue_reopen.go
@@ -10,6 +10,46 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+type workerReopenGuard struct {
+	actorID            string
+	targetStatus       string
+	targetAssigneeType pgtype.Text
+	targetAssigneeID   pgtype.UUID
+}
+
+type workerReopenDeniedError struct {
+	status  int
+	message string
+}
+
+func (e workerReopenDeniedError) Error() string { return e.message }
+
+// enforceWorkerReopenOnLockedIssue is the authoritative check. Its caller
+// must hold the issue row lock in the same transaction that performs the
+// update, so a competing task insert or issue mutation cannot pass the check
+// and then win the claim before the renewal is committed.
+func enforceWorkerReopenOnLockedIssue(
+	ctx context.Context,
+	queries *db.Queries,
+	issue db.Issue,
+	guard workerReopenGuard,
+) error {
+	workerReopen, status, message := authorizeWorkerReopenWithQueries(
+		ctx, queries, issue, guard.targetStatus, "agent", guard.actorID,
+		guard.targetAssigneeType, guard.targetAssigneeID,
+	)
+	if status != 0 {
+		return workerReopenDeniedError{status: status, message: message}
+	}
+	if !workerReopen {
+		return workerReopenDeniedError{
+			status:  http.StatusConflict,
+			message: "issue changed before worker claim renewal",
+		}
+	}
+	return nil
+}
+
 // authorizeWorkerReopen admits the narrow worker-only reopen path. A trusted
 // worker may reopen a terminal issue only if the resulting issue remains
 // assigned to that worker and the (issue, worker) claim has no active task.
@@ -26,14 +66,30 @@ func (h *Handler) authorizeWorkerReopen(
 	targetAssigneeType pgtype.Text,
 	targetAssigneeID pgtype.UUID,
 ) (workerReopen bool, status int, message string) {
+	return authorizeWorkerReopenWithQueries(
+		ctx, h.Queries, issue, targetStatus, actorType, actorID,
+		targetAssigneeType, targetAssigneeID,
+	)
+}
+
+func authorizeWorkerReopenWithQueries(
+	ctx context.Context,
+	queries *db.Queries,
+	issue db.Issue,
+	targetStatus string,
+	actorType string,
+	actorID string,
+	targetAssigneeType pgtype.Text,
+	targetAssigneeID pgtype.UUID,
+) (workerReopen bool, status int, message string) {
 	if actorType != "agent" {
 		return false, 0, ""
 	}
-	previousStatus := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status)
-	nextStatus := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, targetStatus)
-	return h.authorizeWorkerReopenWithEffectiveStatuses(
+	previousStatus := issuestatus.Effective(ctx, queries, issue.WorkspaceID, issue.Status)
+	nextStatus := issuestatus.Effective(ctx, queries, issue.WorkspaceID, targetStatus)
+	return authorizeWorkerReopenWithEffectiveStatuses(
 		ctx, issue, targetStatus, actorType, actorID, targetAssigneeType,
-		targetAssigneeID, previousStatus, nextStatus,
+		targetAssigneeID, previousStatus, nextStatus, queries,
 	)
 }
 
@@ -47,6 +103,24 @@ func (h *Handler) authorizeWorkerReopenWithEffectiveStatuses(
 	targetAssigneeID pgtype.UUID,
 	previousStatus string,
 	nextStatus string,
+) (workerReopen bool, status int, message string) {
+	return authorizeWorkerReopenWithEffectiveStatuses(
+		ctx, issue, targetStatus, actorType, actorID, targetAssigneeType,
+		targetAssigneeID, previousStatus, nextStatus, h.Queries,
+	)
+}
+
+func authorizeWorkerReopenWithEffectiveStatuses(
+	ctx context.Context,
+	issue db.Issue,
+	targetStatus string,
+	actorType string,
+	actorID string,
+	targetAssigneeType pgtype.Text,
+	targetAssigneeID pgtype.UUID,
+	previousStatus string,
+	nextStatus string,
+	queries *db.Queries,
 ) (workerReopen bool, status int, message string) {
 	if actorType != "agent" {
 		return false, 0, ""
@@ -72,7 +146,10 @@ func (h *Handler) authorizeWorkerReopenWithEffectiveStatuses(
 		return false, http.StatusForbidden, "only the assigned worker can reopen this issue"
 	}
 
-	active, err := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, targetAssigneeID)
+	active, err := queries.HasActiveTaskForIssueAndAgent(ctx, db.HasActiveTaskForIssueAndAgentParams{
+		IssueID: issue.ID,
+		AgentID: targetAssigneeID,
+	})
 	if err != nil {
 		slog.Warn("worker reopen denied: claim occupancy unavailable",
 			"issue_id", uuidToString(issue.ID), "agent_id", actorID, "error", err)

--- a/server/internal/handler/issue_reopen.go
+++ b/server/internal/handler/issue_reopen.go
@@ -42,10 +42,11 @@ func enforceWorkerReopenOnLockedIssue(
 		return workerReopenDeniedError{status: status, message: message}
 	}
 	if !workerReopen {
-		return workerReopenDeniedError{
-			status:  http.StatusConflict,
-			message: "issue changed before worker claim renewal",
-		}
+		// The guard is also installed for ordinary agent status mutations so a
+		// row that becomes terminal after advisory preflight cannot turn into an
+		// unrenewed reopen. Non-terminal transitions remain on their existing
+		// path and do not need a claim renewal.
+		return nil
 	}
 	return nil
 }

--- a/server/internal/handler/issue_reopen.go
+++ b/server/internal/handler/issue_reopen.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/issuestatus"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// authorizeWorkerReopen admits the narrow worker-only reopen path. A trusted
+// worker may reopen a terminal issue only if the resulting issue remains
+// assigned to that worker and the (issue, worker) claim has no active task.
+// The caller distinguishes a non-worker reopen (which keeps the existing
+// member behavior) from a rejected worker reopen using the returned status.
+// Query failures fail closed: a worker must never reopen when claim occupancy
+// cannot be verified.
+func (h *Handler) authorizeWorkerReopen(
+	ctx context.Context,
+	issue db.Issue,
+	targetStatus string,
+	actorType string,
+	actorID string,
+	targetAssigneeType pgtype.Text,
+	targetAssigneeID pgtype.UUID,
+) (workerReopen bool, status int, message string) {
+	if actorType != "agent" {
+		return false, 0, ""
+	}
+	previousStatus := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, issue.Status)
+	nextStatus := issuestatus.Effective(ctx, h.Queries, issue.WorkspaceID, targetStatus)
+	return h.authorizeWorkerReopenWithEffectiveStatuses(
+		ctx, issue, targetStatus, actorType, actorID, targetAssigneeType,
+		targetAssigneeID, previousStatus, nextStatus,
+	)
+}
+
+func (h *Handler) authorizeWorkerReopenWithEffectiveStatuses(
+	ctx context.Context,
+	issue db.Issue,
+	targetStatus string,
+	actorType string,
+	actorID string,
+	targetAssigneeType pgtype.Text,
+	targetAssigneeID pgtype.UUID,
+	previousStatus string,
+	nextStatus string,
+) (workerReopen bool, status int, message string) {
+	if actorType != "agent" {
+		return false, 0, ""
+	}
+	if !isIssueReopenTerminalStatus(previousStatus) || isIssueReopenTerminalStatus(nextStatus) {
+		return false, 0, ""
+	}
+
+	// Backlog is deliberately a parking state. It cannot renew an agent claim,
+	// so a worker cannot use this path to move a completed issue there.
+	if nextStatus == "backlog" {
+		slog.Info("worker reopen denied: target status cannot renew claim",
+			"issue_id", uuidToString(issue.ID), "agent_id", actorID, "target_status", targetStatus)
+		return false, http.StatusForbidden, "worker reopen must target an active status"
+	}
+
+	if !issue.AssigneeType.Valid || issue.AssigneeType.String != "agent" ||
+		!issue.AssigneeID.Valid || actorID == "" || actorID != uuidToString(issue.AssigneeID) ||
+		!targetAssigneeType.Valid || targetAssigneeType.String != "agent" ||
+		!targetAssigneeID.Valid || actorID != uuidToString(targetAssigneeID) {
+		slog.Info("worker reopen denied: worker does not own issue claim",
+			"issue_id", uuidToString(issue.ID), "agent_id", actorID)
+		return false, http.StatusForbidden, "only the assigned worker can reopen this issue"
+	}
+
+	active, err := h.hasActiveTaskForIssueAndAgent(ctx, issue.ID, targetAssigneeID)
+	if err != nil {
+		slog.Warn("worker reopen denied: claim occupancy unavailable",
+			"issue_id", uuidToString(issue.ID), "agent_id", actorID, "error", err)
+		return false, http.StatusServiceUnavailable, "cannot verify whether the worker claim is active"
+	}
+	if active {
+		slog.Info("worker reopen denied: issue claim is active",
+			"issue_id", uuidToString(issue.ID), "agent_id", actorID)
+		return false, http.StatusConflict, "cannot reopen an issue while its worker claim is active"
+	}
+
+	slog.Info("worker reopen authorized",
+		"issue_id", uuidToString(issue.ID), "agent_id", actorID, "target_status", targetStatus)
+	return true, 0, ""
+}
+
+func isIssueReopenTerminalStatus(status string) bool {
+	return status == "done" || status == "cancelled"
+}

--- a/server/internal/handler/issue_reopen_test.go
+++ b/server/internal/handler/issue_reopen_test.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/testutil"
 )
 
@@ -63,6 +65,51 @@ func TestUpdateIssueWorkerCanReopenAssignedIssueWhenClaimIsUnused(t *testing.T) 
 	}
 	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
 		t.Fatalf("accepted worker reopen must renew the claim with one queued task, got %d", got)
+	}
+}
+
+func TestUpdateIssueWorkerConcurrentReopenRenewsClaimOnce(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenConcurrent")
+	start := make(chan struct{})
+	responses := make(chan int, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			w := httptest.NewRecorder()
+			testHandler.UpdateIssue(w, workerReopenRequest(t, agentID, taskID, issueID, "in_progress"))
+			responses <- w.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+
+	var okCount, conflictCount int
+	for status := range responses {
+		switch status {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflictCount++
+		default:
+			t.Fatalf("concurrent worker reopen status = %d, want one 200 and one 409", status)
+		}
+	}
+	if okCount != 1 || conflictCount != 1 {
+		t.Fatalf("concurrent worker reopen results = %d success, %d conflict; want 1/1", okCount, conflictCount)
+	}
+	if got := issueStatusForTest(t, issueID); got != "in_progress" {
+		t.Fatalf("concurrent reopen status = %q, want in_progress", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("concurrent reopen must renew once, got %d queued tasks", got)
 	}
 }
 
@@ -224,6 +271,25 @@ func TestUpdateIssueWorkerCannotReopenWithoutRenewingClaim(t *testing.T) {
 	}
 }
 
+func TestPreviewIssueTriggerWorkerReopenMatchesRenewalAuthorization(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenPreview")
+	req := newRequest("POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, map[string]any{
+		"issue_ids": []string{issueID},
+		"status":    "in_progress",
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	var resp IssueTriggerPreviewResponse
+	testutil.Call(t, testHandler.PreviewIssueTrigger, req).Want(http.StatusOK).JSON(&resp)
+	if resp.TotalCount != 1 || len(resp.Triggers) != 1 || resp.Triggers[0].Source != string(service.RunSourceReopen) {
+		t.Fatalf("worker reopen preview = %+v, want one reopen trigger", resp)
+	}
+}
+
 func TestBatchUpdateIssuesWorkerCannotReopenAssignedIssueWithActiveClaim(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
@@ -306,5 +372,53 @@ func TestBatchUpdateIssuesWorkerReopenDeduplicatesIssueIDs(t *testing.T) {
 	}
 	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
 		t.Fatalf("duplicate batch reopen must renew once, got %d queued tasks", got)
+	}
+}
+
+func TestBatchUpdateIssuesWorkerConcurrentReopenRenewsClaimOnce(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "BatchWorkerReopenConcurrent")
+	start := make(chan struct{})
+	responses := make(chan int, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+				"issue_ids": []string{issueID},
+				"updates":   map[string]any{"status": "in_progress"},
+			})
+			req.Header.Set("X-Agent-ID", agentID)
+			req.Header.Set("X-Task-ID", taskID)
+			w := httptest.NewRecorder()
+			testHandler.BatchUpdateIssues(w, req)
+			responses <- w.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+
+	var okCount, conflictCount int
+	for status := range responses {
+		switch status {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflictCount++
+		default:
+			t.Fatalf("concurrent batch worker reopen status = %d, want one 200 and one 409", status)
+		}
+	}
+	if okCount != 1 || conflictCount != 1 {
+		t.Fatalf("concurrent batch worker reopen results = %d success, %d conflict; want 1/1", okCount, conflictCount)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("concurrent batch reopen must renew once, got %d queued tasks", got)
 	}
 }

--- a/server/internal/handler/issue_reopen_test.go
+++ b/server/internal/handler/issue_reopen_test.go
@@ -1,0 +1,310 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// workerReopenFixture creates a terminal issue assigned to agentID and a
+// completed task that can authenticate the worker without occupying the issue
+// claim. A new task is expected only when the reopen authorization succeeds.
+func workerReopenFixture(t *testing.T, name string) (agentID, issueID, taskID string) {
+	t.Helper()
+
+	agentID = createHandlerTestAgent(t, name, []byte("[]"))
+	issueID = dbfx.Issue(t, name+" issue", testutil.Cols{
+		"status":        "done",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	taskID = dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id":   handlerTestRuntimeID(t),
+		"status":       "completed",
+		"issue_id":     issueID,
+		"completed_at": testutil.Raw("now()"),
+	})
+	return agentID, issueID, taskID
+}
+
+func workerReopenRequest(t *testing.T, agentID, taskID, issueID, status string) *http.Request {
+	t.Helper()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status": status,
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	return withURLParam(req, "id", issueID)
+}
+
+func issueStatusForTest(t *testing.T, issueID string) string {
+	t.Helper()
+	var status string
+	dbfx.QueryRow(t, `SELECT status FROM issue WHERE id = $1`, issueID).Scan(&status)
+	return status
+}
+
+func TestUpdateIssueWorkerCanReopenAssignedIssueWhenClaimIsUnused(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenUnusedClaim")
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, workerReopenRequest(t, agentID, taskID, issueID, "in_progress"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue reopen: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "in_progress" {
+		t.Fatalf("reopen status = %q, want in_progress", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("accepted worker reopen must renew the claim with one queued task, got %d", got)
+	}
+}
+
+func TestUpdateIssueWorkerCannotReopenAssignedIssueWithActiveClaim(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenActiveClaim")
+	dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": handlerTestRuntimeID(t),
+		"status":     "running",
+		"issue_id":   issueID,
+		"started_at": testutil.Raw("now()"),
+	})
+
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, workerReopenRequest(t, agentID, taskID, issueID, "in_progress"))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("UpdateIssue active-claim reopen: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("active-claim denial changed issue status to %q", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("active-claim denial queued %d replacement tasks", got)
+	}
+}
+
+func TestUpdateIssueWorkerCannotReopenIssueAssignedToAnotherWorker(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerID, issueID, _ := workerReopenFixture(t, "WorkerReopenUnauthorizedOwner")
+	actorID := createHandlerTestAgent(t, "WorkerReopenUnauthorizedActor", []byte("[]"))
+	actorTaskID := dbfx.Task(t, actorID, testutil.Cols{
+		"runtime_id":   handlerTestRuntimeID(t),
+		"status":       "completed",
+		"issue_id":     issueID,
+		"completed_at": testutil.Raw("now()"),
+	})
+
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, workerReopenRequest(t, actorID, actorTaskID, issueID, "in_progress"))
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateIssue unauthorized reopen: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("unauthorized worker changed issue status to %q (owner %s)", got, ownerID)
+	}
+}
+
+func TestUpdateIssueWorkerCannotHijackAssignmentWhileReopening(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerID, issueID, _ := workerReopenFixture(t, "WorkerReopenAssignmentHijack")
+	actorID := createHandlerTestAgent(t, "WorkerReopenAssignmentHijacker", []byte("[]"))
+	actorTaskID := dbfx.Task(t, actorID, testutil.Cols{
+		"runtime_id":   handlerTestRuntimeID(t),
+		"status":       "completed",
+		"issue_id":     issueID,
+		"completed_at": testutil.Raw("now()"),
+	})
+
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status":        "in_progress",
+		"assignee_type": "agent",
+		"assignee_id":   actorID,
+	})
+	req.Header.Set("X-Agent-ID", actorID)
+	req.Header.Set("X-Task-ID", actorTaskID)
+	req = withURLParam(req, "id", issueID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateIssue assignment hijack: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("assignment hijack denial changed issue status to %q", got)
+	}
+	var assigneeID string
+	dbfx.QueryRow(t, `SELECT assignee_id FROM issue WHERE id = $1`, issueID).Scan(&assigneeID)
+	if assigneeID != ownerID {
+		t.Fatalf("assignment hijack denial changed assignee to %q, want original owner %q", assigneeID, ownerID)
+	}
+}
+
+func TestUpdateIssueWorkerCannotReopenToBacklogWithoutRenewingClaim(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenBacklog")
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, workerReopenRequest(t, agentID, taskID, issueID, "backlog"))
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateIssue backlog reopen: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("backlog reopen denial changed issue status to %q", got)
+	}
+}
+
+func TestUpdateIssueMemberReopenKeepsExistingControlPlaneBehavior(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, _ := workerReopenFixture(t, "MemberReopenControlPlane")
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status": "in_progress",
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("member reopen: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "in_progress" {
+		t.Fatalf("member reopen status = %q, want in_progress", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("member reopen must not synthesize a worker renewal, got %d queued tasks", got)
+	}
+}
+
+func TestUpdateIssueWorkerCannotReopenWithoutRenewingClaim(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenSuppressed")
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status":       "in_progress",
+		"suppress_run": true,
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	req = withURLParam(req, "id", issueID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("suppressed worker reopen: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("suppressed worker reopen changed issue status to %q", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("suppressed worker reopen queued %d replacement tasks", got)
+	}
+}
+
+func TestBatchUpdateIssuesWorkerCannotReopenAssignedIssueWithActiveClaim(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "BatchWorkerReopenActiveClaim")
+	dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": handlerTestRuntimeID(t),
+		"status":     "running",
+		"issue_id":   issueID,
+		"started_at": testutil.Raw("now()"),
+	})
+
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID},
+		"updates": map[string]any{
+			"status": "in_progress",
+		},
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	w := httptest.NewRecorder()
+	testHandler.BatchUpdateIssues(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("BatchUpdateIssues active-claim reopen: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("batch active-claim denial changed issue status to %q", got)
+	}
+}
+
+func TestBatchUpdateIssuesWorkerCanReopenAssignedIssueWhenClaimIsUnused(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "BatchWorkerReopenUnusedClaim")
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID},
+		"updates": map[string]any{
+			"status": "in_progress",
+		},
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	w := httptest.NewRecorder()
+	testHandler.BatchUpdateIssues(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues reopen: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "in_progress" {
+		t.Fatalf("batch reopen status = %q, want in_progress", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("accepted batch worker reopen must renew the claim with one queued task, got %d", got)
+	}
+}
+
+func TestBatchUpdateIssuesWorkerReopenDeduplicatesIssueIDs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "BatchWorkerReopenDuplicateIDs")
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID, issueID},
+		"updates": map[string]any{
+			"status": "in_progress",
+		},
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	w := httptest.NewRecorder()
+	testHandler.BatchUpdateIssues(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues duplicate reopen: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("duplicate batch reopen must renew once, got %d queued tasks", got)
+	}
+}

--- a/server/internal/handler/issue_reopen_test.go
+++ b/server/internal/handler/issue_reopen_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -65,6 +66,32 @@ func TestUpdateIssueWorkerCanReopenAssignedIssueWhenClaimIsUnused(t *testing.T) 
 	}
 	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
 		t.Fatalf("accepted worker reopen must renew the claim with one queued task, got %d", got)
+	}
+}
+
+func TestUpdateIssueWorkerReopenRollsBackWhenRenewalEnqueueFails(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "WorkerReopenRenewalEnqueueFailure")
+	// Authorization only proves ownership and claim occupancy. The runtime can
+	// disappear before the write transaction reaches the required renewal; that
+	// failure must abort the status change rather than leave an active issue with
+	// no replacement task.
+	dbfx.Exec(t, `UPDATE agent SET runtime_id = NULL WHERE id = $1`, agentID)
+
+	w := httptest.NewRecorder()
+	testHandler.UpdateIssue(w, workerReopenRequest(t, agentID, taskID, issueID, "in_progress"))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("worker reopen enqueue failure: expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusForTest(t, issueID); got != "done" {
+		t.Fatalf("failed worker reopen changed issue status to %q, want done", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("failed worker reopen queued %d replacement tasks", got)
 	}
 }
 
@@ -347,6 +374,44 @@ func TestBatchUpdateIssuesWorkerCanReopenAssignedIssueWhenClaimIsUnused(t *testi
 	}
 	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
 		t.Fatalf("accepted batch worker reopen must renew the claim with one queued task, got %d", got)
+	}
+}
+
+func TestBatchUpdateIssuesWorkerReopenRetainsEarlierItemWhenLaterItemIsMissing(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, issueID, taskID := workerReopenFixture(t, "BatchWorkerReopenPerItemScope")
+	missingIssueID := "00000000-0000-0000-0000-000000000001"
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID, missingIssueID},
+		"updates": map[string]any{
+			"status": "in_progress",
+		},
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	w := httptest.NewRecorder()
+	testHandler.BatchUpdateIssues(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues per-item scope: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Updated int `json:"updated"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode per-item scope response: %v", err)
+	}
+	if resp.Updated != 1 {
+		t.Fatalf("per-item scope updated=%d, want 1 successful item", resp.Updated)
+	}
+	if got := issueStatusForTest(t, issueID); got != "in_progress" {
+		t.Fatalf("earlier successful item status = %q, want in_progress", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+		t.Fatalf("earlier successful worker reopen queued %d tasks, want 1", got)
 	}
 }
 

--- a/server/internal/handler/issue_trigger.go
+++ b/server/internal/handler/issue_trigger.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -80,17 +81,24 @@ func (h *Handler) shouldSuppressActiveSelfAssignment(ctx context.Context, actorT
 // dispatchIssueRun executes the enqueue side effect for a decision produced by
 // WillEnqueueRun, carrying an optional handoff note into the run's opening
 // context. The squad path still flows through enqueueSquadLeaderTask so the
-// leader access gate and pending dedup stay in one place.
-func (h *Handler) dispatchIssueRun(ctx context.Context, issue db.Issue, trigger service.IssueRunTrigger, actorType, actorID, handoffNote string) {
+// leader access gate and pending dedup stay in one place. Worker reopen does
+// not use this post-commit path: its replacement task is inserted by the issue
+// transaction and only notified here after commit.
+func (h *Handler) dispatchIssueRun(ctx context.Context, issue db.Issue, trigger service.IssueRunTrigger, actorType, actorID, handoffNote string) error {
 	switch trigger.AssigneeType {
 	case "agent":
 		// The member who performed this assign/promote is the accountable human
 		// for the run (MUL-4302 §4). An agent actor is not a human, so only a
 		// member actor is threaded; otherwise attribution falls back to the chain.
-		_, _ = h.TaskService.EnqueueTaskForIssueWithHandoff(ctx, issue, handoffNote, memberActorUserID(actorType, actorID))
+		if _, err := h.TaskService.EnqueueTaskForIssueWithHandoff(ctx, issue, handoffNote, memberActorUserID(actorType, actorID)); err != nil {
+			return fmt.Errorf("enqueue issue run: %w", err)
+		}
 	case "squad":
-		h.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, actorType, actorID, handoffNote)
+		if !h.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, actorType, actorID, handoffNote) {
+			return fmt.Errorf("enqueue squad leader run failed")
+		}
 	}
+	return nil
 }
 
 // memberActorUserID returns the acting member's user id as a pgtype.UUID when the

--- a/server/internal/handler/issue_trigger.go
+++ b/server/internal/handler/issue_trigger.go
@@ -246,6 +246,21 @@ func (h *Handler) PreviewIssueTrigger(w http.ResponseWriter, r *http.Request) {
 		if req.Status != nil && *req.Status != "" {
 			post.Status = *req.Status
 			in.StatusChanged = loaded.Status != *req.Status
+			// Preview follows the same worker-renewal authorization as the
+			// write path. An authorized worker sees the reopen trigger that
+			// will be dispatched; an unauthorized/occupied claim gets the
+			// same explicit error instead of a misleading empty preview.
+			targetAssigneeType := post.AssigneeType
+			targetAssigneeID := post.AssigneeID
+			workerReopen, reopenStatus, reopenMessage := h.authorizeWorkerReopen(
+				r.Context(), loaded, *req.Status, actorType, actorID,
+				targetAssigneeType, targetAssigneeID,
+			)
+			if reopenStatus != 0 {
+				writeError(w, reopenStatus, reopenMessage)
+				return
+			}
+			in.WorkerReopen = workerReopen
 		}
 		in.Issue = post
 		appendTrigger(post, in)

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -59,6 +59,12 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 			// to convince a downstream handler that its request came
 			// from a non-task-token path.
 			r.Header.Del("X-Actor-Source")
+			// Worker identity is server-authenticated task context, never a
+			// member-controlled header pair. Clear both values before every
+			// non-task-token branch; the task-token branch below overwrites
+			// them from the validated token row.
+			r.Header.Del("X-Agent-ID")
+			r.Header.Del("X-Task-ID")
 
 			tokenString, fromCookie := extractToken(r)
 			if tokenString == "" {
@@ -110,7 +116,8 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				// this header is allowed to carry — strip anything else a
 				// client tried to send.
 				r.Header.Set("X-Actor-Source", "task_token")
-				next.ServeHTTP(w, r)
+				ctx := SetAuthenticatedActorContext(r.Context(), "agent", uuidToString(tt.AgentID))
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 
@@ -170,7 +177,8 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				// treated as the owner having approved an account-
 				// level action.
 				r.Header.Set("X-Actor-Source", "cloud_pat")
-				next.ServeHTTP(w, r)
+				ctx := SetAuthenticatedActorContext(r.Context(), "member", identity.OwnerID)
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 
@@ -187,7 +195,8 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 						return
 					}
 					r.Header.Set("X-User-ID", userID)
-					next.ServeHTTP(w, r)
+					ctx := SetAuthenticatedActorContext(r.Context(), "member", userID)
+					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
 
@@ -222,7 +231,8 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				// within the TTL window skip this write entirely.
 				go queries.UpdatePersonalAccessTokenLastUsed(context.Background(), pat.ID)
 
-				next.ServeHTTP(w, r)
+				ctx := SetAuthenticatedActorContext(r.Context(), "member", userID)
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 
@@ -261,7 +271,8 @@ func Auth(queries *db.Queries, patCache *auth.PATCache, cloudPAT *auth.CloudPATV
 				r.Header.Set("X-User-Email", email)
 			}
 
-			next.ServeHTTP(w, r)
+			ctx := SetAuthenticatedActorContext(r.Context(), "member", sub)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -279,10 +279,15 @@ func TestAuth_InvalidPAT(t *testing.T) {
 // into treating the request differently — exactly the kind of trust
 // boundary MUL-2600 introduces.
 func TestAuth_StripsClientSuppliedActorSource(t *testing.T) {
-	var gotActorSource string
+	var gotActorSource, gotAgentID, gotTaskID string
+	var gotActor AuthenticatedActor
+	var gotActorOK bool
 	mw := Auth(nil, nil, nil)
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotActorSource = r.Header.Get("X-Actor-Source")
+		gotAgentID = r.Header.Get("X-Agent-ID")
+		gotTaskID = r.Header.Get("X-Task-ID")
+		gotActor, gotActorOK = AuthenticatedActorFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -293,6 +298,8 @@ func TestAuth_StripsClientSuppliedActorSource(t *testing.T) {
 	// discard it before the JWT branch runs (which doesn't set it again
 	// for human sessions).
 	req.Header.Set("X-Actor-Source", "task_token")
+	req.Header.Set("X-Agent-ID", "forged-agent")
+	req.Header.Set("X-Task-ID", "forged-task")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
@@ -301,6 +308,12 @@ func TestAuth_StripsClientSuppliedActorSource(t *testing.T) {
 	}
 	if gotActorSource != "" {
 		t.Fatalf("X-Actor-Source must be cleared on non-task-token paths, got %q", gotActorSource)
+	}
+	if gotAgentID != "" || gotTaskID != "" {
+		t.Fatalf("worker headers must be cleared on member auth, got agent=%q task=%q", gotAgentID, gotTaskID)
+	}
+	if !gotActorOK || gotActor.Type != "member" || gotActor.ID != "test-user-id" {
+		t.Fatalf("expected server-authenticated member context, got %+v (ok=%v)", gotActor, gotActorOK)
 	}
 }
 

--- a/server/internal/middleware/daemon_auth.go
+++ b/server/internal/middleware/daemon_auth.go
@@ -88,6 +88,11 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 			// trust this header regardless of which auth path the
 			// request arrived on.
 			r.Header.Del("X-Actor-Source")
+			// A daemon-authenticated request is not a task-token request.
+			// Do not let a client carry a forged worker header pair into a
+			// downstream handler that still supports legacy direct calls.
+			r.Header.Del("X-Agent-ID")
+			r.Header.Del("X-Task-ID")
 
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
@@ -111,6 +116,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 					ctx := context.WithValue(r.Context(), ctxKeyDaemonWorkspaceID, id.WorkspaceID)
 					ctx = context.WithValue(ctx, ctxKeyDaemonID, id.DaemonID)
 					ctx = context.WithValue(ctx, ctxKeyDaemonAuthPath, DaemonAuthPathDaemonToken)
+					ctx = SetAuthenticatedActorContext(ctx, "member", "")
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
@@ -141,6 +147,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 				ctx := context.WithValue(r.Context(), ctxKeyDaemonWorkspaceID, identity.WorkspaceID)
 				ctx = context.WithValue(ctx, ctxKeyDaemonID, identity.DaemonID)
 				ctx = context.WithValue(ctx, ctxKeyDaemonAuthPath, DaemonAuthPathDaemonToken)
+				ctx = SetAuthenticatedActorContext(ctx, "member", "")
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -185,6 +192,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 				// differently depending on which one routed it.
 				r.Header.Set("X-Actor-Source", "cloud_pat")
 				ctx := context.WithValue(r.Context(), ctxKeyDaemonAuthPath, DaemonAuthPathCloudPAT)
+				ctx = SetAuthenticatedActorContext(ctx, "member", identity.OwnerID)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -199,6 +207,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 					}
 					r.Header.Set("X-User-ID", userID)
 					ctx := context.WithValue(r.Context(), ctxKeyDaemonAuthPath, DaemonAuthPathPAT)
+					ctx = SetAuthenticatedActorContext(ctx, "member", userID)
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
@@ -231,6 +240,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 				go queries.UpdatePersonalAccessTokenLastUsed(context.Background(), pat.ID)
 
 				ctx := context.WithValue(r.Context(), ctxKeyDaemonAuthPath, DaemonAuthPathPAT)
+				ctx = SetAuthenticatedActorContext(ctx, "member", userID)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -264,6 +274,7 @@ func DaemonAuth(queries *db.Queries, patCache *auth.PATCache, daemonCache *auth.
 			}
 			r.Header.Set("X-User-ID", sub)
 			ctx := context.WithValue(r.Context(), ctxKeyDaemonAuthPath, DaemonAuthPathJWT)
+			ctx = SetAuthenticatedActorContext(ctx, "member", sub)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/server/internal/middleware/workspace.go
+++ b/server/internal/middleware/workspace.go
@@ -16,7 +16,29 @@ type contextKey int
 const (
 	ctxKeyWorkspaceID contextKey = iota
 	ctxKeyMember
+	ctxKeyAuthenticatedActor
 )
+
+// AuthenticatedActor is the identity selected by server-side token
+// validation. Handler actor resolution must prefer this context over request
+// headers because headers are transport input and may be forged by a member.
+type AuthenticatedActor struct {
+	Type string
+	ID   string
+}
+
+// AuthenticatedActorFromContext returns the actor established by Auth or
+// DaemonAuth, when the request passed through one of those middlewares.
+func AuthenticatedActorFromContext(ctx context.Context) (AuthenticatedActor, bool) {
+	actor, ok := ctx.Value(ctxKeyAuthenticatedActor).(AuthenticatedActor)
+	return actor, ok
+}
+
+// SetAuthenticatedActorContext marks the actor selected by server-side token
+// validation. It intentionally does not expose a request-header equivalent.
+func SetAuthenticatedActorContext(ctx context.Context, actorType, actorID string) context.Context {
+	return context.WithValue(ctx, ctxKeyAuthenticatedActor, AuthenticatedActor{Type: actorType, ID: actorID})
+}
 
 // MemberFromContext returns the workspace member injected by the workspace middleware.
 func MemberFromContext(ctx context.Context) (db.Member, bool) {

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -209,6 +209,14 @@ on it. These are the contracts, not advice:
   `done` it enqueues no new agent work, but it does **not** stop tasks already in
   flight — a run in progress keeps going (MUL-4465). To stop a running task,
   cancel the task itself.
+- Reopening a terminal issue is a worker-specific claim renewal path. A trusted
+  worker may move `done` / `cancelled` to an active status only when the issue
+  remains assigned to that worker and the `(issue, worker)` claim has no active
+  task. The server then enqueues one replacement run. `backlog` cannot renew a
+  claim, an active claim returns a conflict, and an unassigned worker is
+  forbidden. `--no-start` / `suppress_run` is also forbidden on this path,
+  because it would reopen without renewing the claim. Member status edits keep
+  their existing control-plane behavior.
 - **Failed issue-triggered tasks** may roll an issue from `in_progress` back to
   `todo` when no active task / retry remains — that is the main server-owned
   status write on the agent-run path.

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -132,6 +132,8 @@ and is hidden from the PR list.
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
 | Runtime brief: ordinary agent `in_progress` then `in_review` (Ownership mode unconditionally, Reply mode only for work turns on its own issue); squad leader `in_progress` only on first dispatch | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowIssue`) | new citation |
 | Failed task may roll `in_progress` → `todo` when no active task remains | `server/internal/service/task.go` (`HandleFailedTasks`) | new citation |
+| Trusted worker reopen requires same assigned agent and an unused `(issue, agent)` claim; active/unknown occupancy fails closed | `server/internal/handler/issue_reopen.go` (`authorizeWorkerReopen`), `server/internal/handler/issue.go` (`UpdateIssue`, `BatchUpdateIssues`) | new citation |
+| Authorized worker reopen enqueues a replacement run | `server/internal/service/issue_trigger.go` (`RunSourceReopen`, `IssueTriggerInput.WorkerReopen`, `WillEnqueueRun`) | new citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -19,6 +19,9 @@ const (
 	// RunSourceStatus covers promoting an already-assigned issue out of
 	// backlog into an active status.
 	RunSourceStatus RunEnqueueSource = "status"
+	// RunSourceReopen covers a trusted assigned worker reopening a terminal
+	// issue after the handler verified that the worker claim is unused.
+	RunSourceReopen RunEnqueueSource = "reopen"
 )
 
 // IssueTriggerProbe carries the request-scoped checks WillEnqueueRun cannot
@@ -55,6 +58,9 @@ type IssueTriggerInput struct {
 	IsCreate        bool
 	AssigneeChanged bool
 	StatusChanged   bool
+	// WorkerReopen is set only after the HTTP boundary authorizes a trusted
+	// worker to renew an unused issue claim while reopening a terminal issue.
+	WorkerReopen bool
 }
 
 // IssueRunTrigger is the resolved decision shared by preview and the write
@@ -121,6 +127,9 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 			return IssueRunTrigger{}, false
 		}
 		source = RunSourceAssign
+	case in.WorkerReopen && in.StatusChanged && isTerminalIssueStatus(prevStatus) &&
+		!isTerminalIssueStatus(currentStatus) && currentStatus != "backlog":
+		source = RunSourceReopen
 	case in.StatusChanged && prevStatus == "backlog" &&
 		currentStatus != "done" && currentStatus != "cancelled":
 		if probe.IsSelfLoop != nil && probe.IsSelfLoop() {
@@ -144,7 +153,7 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 			probe.SuppressActiveSelfAssignment(issue.AssigneeID) {
 			return IssueRunTrigger{}, false
 		}
-		if source == RunSourceStatus && s.hasPendingRun(ctx, issue.ID, issue.AssigneeID) {
+		if (source == RunSourceStatus || source == RunSourceReopen) && s.hasPendingRun(ctx, issue.ID, issue.AssigneeID) {
 			return IssueRunTrigger{}, false
 		}
 		return IssueRunTrigger{
@@ -179,7 +188,7 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 		if !canAccess(leader) {
 			return IssueRunTrigger{}, false
 		}
-		if source == RunSourceStatus && s.hasPendingRun(ctx, issue.ID, squad.LeaderID) {
+		if (source == RunSourceStatus || source == RunSourceReopen) && s.hasPendingRun(ctx, issue.ID, squad.LeaderID) {
 			return IssueRunTrigger{}, false
 		}
 		return IssueRunTrigger{
@@ -190,6 +199,10 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 		}, true
 	}
 	return IssueRunTrigger{}, false
+}
+
+func isTerminalIssueStatus(status string) bool {
+	return status == "done" || status == "cancelled"
 }
 
 // hasPendingRun reports whether the agent already holds a queued or dispatched

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1027,6 +1027,25 @@ func (s *TaskService) EnqueueTaskForIssueWithHandoff(ctx context.Context, issue 
 	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, handoffNote, actorUserID, pgtype.UUID{}, pgtype.Timestamptz{})
 }
 
+// EnqueueTaskForIssueWithQueries inserts an issue task through the caller's
+// query handle without publishing task events or waking a daemon. Callers use
+// it from a transaction that also changes the issue, then call
+// NotifyTaskEnqueued after that transaction commits. Keeping the insert and
+// ownership write in one transaction prevents a required worker renewal from
+// being lost after the issue becomes active.
+//
+// The transaction-scoped service intentionally does not carry Composio: its
+// overlay builder may perform network I/O, which must not run while the issue
+// row lock is held. The optional overlay is not part of the claim-renewal
+// correctness contract.
+func (s *TaskService) EnqueueTaskForIssueWithQueries(ctx context.Context, q *db.Queries, issue db.Issue, handoffNote string, actorUserID pgtype.UUID) (db.AgentTaskQueue, error) {
+	txService := &TaskService{Queries: q}
+	return txService.enqueueIssueTaskWithCommentPlanAndNotify(
+		ctx, issue, pgtype.UUID{}, nil, false, handoffNote, actorUserID,
+		pgtype.UUID{}, pgtype.Timestamptz{}, false,
+	)
+}
+
 // enqueueIssueTask is the shared implementation behind EnqueueTaskForIssue
 // and the manual rerun path. forceFreshSession=true marks the task so the
 // daemon claim handler skips the (agent_id, issue_id) resume lookup — the
@@ -1077,6 +1096,10 @@ func (s *TaskService) enqueueIssueTask(ctx context.Context, issue db.Issue, trig
 }
 
 func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz) (db.AgentTaskQueue, error) {
+	return s.enqueueIssueTaskWithCommentPlanAndNotify(ctx, issue, triggerCommentID, coalescedCommentIDs, forceFreshSession, handoffNote, actorUserID, rerunOfTaskID, fireAt, true)
+}
+
+func (s *TaskService) enqueueIssueTaskWithCommentPlanAndNotify(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz, notify bool) (db.AgentTaskQueue, error) {
 	if !issue.AssigneeID.Valid {
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", "issue has no assignee")
 		return db.AgentTaskQueue{}, fmt.Errorf("issue has no assignee")
@@ -1178,6 +1201,9 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 		"force_fresh_session", forceFreshSession,
 	)
 	if fireAt.Valid {
+		return task, nil
+	}
+	if !notify {
 		return task, nil
 	}
 	// Order matters: broadcast first, notify daemon second. notifyTaskAvailable


### PR DESCRIPTION
## Summary

- Gate terminal-issue reopen by trusted worker ownership and unused `(issue, worker)` claim occupancy.
- Commit an authorized worker reopen's active issue status and replacement task row in one transaction; notify the daemon only after commit, so enqueue/runtime/attribution failures roll back the reopen.
- Keep member control-plane status edits unchanged and document the worker-only boundary.
- Keep batch updates intentionally per-item: each item is atomic, but earlier successful items remain committed if a later item is missing, skipped, or hits an item-local error.

## Policy boundary

- 403 for unauthorized workers, backlog targets, assignment hijacking, or `suppress_run` / `--no-start` because those do not renew the claim.
- 409 when the assigned worker claim is active or a concurrent reopen already renewed it.
- 503 when claim occupancy cannot be verified or an authorized reopen cannot create its required replacement task; the issue remains terminal in that case.
- Members retain existing status-edit behavior. Routed Auth clears client-supplied worker headers; the direct header fallback remains limited to the handler test/legacy seam and is not trusted by production Auth routes.

## Validation

- Local: `go test ./... -run '^$'` passed.
- Local: `go vet ./internal/handler ./internal/service ./cmd/server` passed.
- Local: targeted worker-reopen handler tests passed; DB-backed tests are not exercised in this checkout because localhost Postgres rejects the default `multica` password (SQLSTATE 28P01).
- Local: `gofmt` and `git diff --check` passed.
- Final-head CI run `32299545064` is queued for commit `6eb35c6`; it includes the DB-backed handler and route coverage.

Multica issue: CAL-2
