### PR TITLE
fix(selfhost): pass GitHub App credentials into the backend container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -460,6 +460,11 @@ GITHUB_WEBHOOK_SECRET=
 # GITHUB_APP_ID is the numeric "App ID" shown on the App's settings page.
 # GITHUB_APP_PRIVATE_KEY is the full PEM block (including BEGIN/END lines)
 # generated under "Private keys" on that same page; preserve newlines.
+# In this file that means wrapping the value in double quotes and keeping
+# the real line breaks - an unquoted multi-line value stops at line one:
+#   GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+#   ...
+#   -----END RSA PRIVATE KEY-----"
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
 

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -113,6 +113,16 @@ services:
       MULTICA_ENTITLEMENT_EMERGENCY_DISABLED: ${MULTICA_ENTITLEMENT_EMERGENCY_DISABLED:-false}
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
+      # App API credentials. The pull_request webhook is what mirrors a PR
+      # onto a card; these are what let the server authenticate as the App
+      # and pull the CI / mergeability snapshot that enriches it, plus
+      # Settings -> Repositories -> Choose from GitHub. Left unset,
+      # ghsnapshot.NewClientFromEnv returns a nil client and the enrichment
+      # degrades off silently - no error and no log line to notice.
+      # GITHUB_APP_PRIVATE_KEY is a PEM block: double-quote it in .env so
+      # its newlines survive into the container.
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
       # Public URL the API is reachable at from the open internet, no
       # trailing slash. Used to mint absolute webhook URLs for autopilot
       # webhook triggers. Leave unset behind a same-origin reverse proxy


### PR DESCRIPTION
## Problem

`docker-compose.selfhost.yml` forwards `GITHUB_APP_SLUG` and `GITHUB_WEBHOOK_SECRET` to the backend, but not `GITHUB_APP_ID` or `GITHUB_APP_PRIVATE_KEY`. Setting those two in `.env` therefore has no effect on a Compose self-host — they never reach the container.

The server reads both via `os.Getenv`:

- `server/internal/handler/github.go:676-677`
- `server/internal/integrations/ghsnapshot/client.go:88`

When either is missing, `ghsnapshot.NewClientFromEnv()` returns `(nil, nil)` by design and the caller degrades the feature off. The result is that PR-card **CI status**, **mergeability**, and **Settings → Repositories → Choose from GitHub** silently stop working — no error, no log line, nothing for an operator to notice.

`.env.example` already documents both variables as required for exactly those features, so the omission reads as operator error rather than a gap in the compose file.

## Fix

Pass both variables through, with a comment explaining what they buy and how they fail.

Also documents in `.env.example` that the PEM must be **double-quoted** there. Compose reads an unquoted multi-line value as its first line only, which then fails `jwt.ParseRSAPrivateKeyFromPEM` at startup. Verified:

```
GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
...
-----END RSA PRIVATE KEY-----"
```

resolves to a correct multi-line value in `docker compose config`.

## Scope checked

- `docker-compose.selfhost.build.yml` overrides only `image`/`build` and inherits this `environment` block — confirmed via `docker compose -f ... -f ... config` that the new variables reach the `multica-backend:dev` service. No change needed.
- `docker-compose.yml` defines only the dev `postgres` service — no backend to configure.
- No builtin skill under `server/internal/service/builtin_skills/` references these variables, so no `SKILL.md` update applies.
- Docs already describe the degradation accurately; no doc change included.

## Testing

- `docker compose -f docker-compose.selfhost.yml config` validates.
- With `GITHUB_APP_ID=probe123` set, the value now appears in the rendered backend environment for both the official-image and build-override compositions; before this change it was absent from both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
