### PR TITLE
fix(build): add Windows executable suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,11 +278,12 @@ multica: ## Run the multica CLI entrypoint directly from the Go source tree
 VERSION ?= $(shell git describe --tags --match 'v[0-9]*' --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+EXE     := $(if $(filter windows,$(shell go env GOOS)),.exe,)
 
 build: ## Build the server, CLI, and migrate binaries into server/bin
-	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server ./cmd/server
-	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
-	cd server && go build -o bin/migrate ./cmd/migrate
+	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server$(EXE) ./cmd/server
+	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica$(EXE) ./cmd/multica
+	cd server && go build -o bin/migrate$(EXE) ./cmd/migrate
 
 test: ## Run Go tests after ensuring the target DB exists and migrations are applied
 	$(REQUIRE_ENV)


### PR DESCRIPTION
## What does this PR do?

Fixes source builds on Windows producing extensionless executables that Windows cannot re-execute.

The failure comes from the `build` target's hardcoded extensionless output paths. The Makefile now derives a platform suffix from `go env GOOS` and applies it consistently to the server, CLI, and migration binaries. On non-Windows targets, the suffix remains empty, so the existing output paths are unchanged.

## Related Issue

Closes #7255

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `Makefile` to append `.exe` when `go env GOOS` is `windows`.
- Applied the suffix consistently to `server`, `multica`, and `migrate` build outputs.
- Left non-Windows output names unchanged.

## How to Test

1. On Windows, run `make -n build` and confirm the output paths are `bin/server.exe`, `bin/multica.exe`, and `bin/migrate.exe`.
2. Set `GOOS=linux`, run `make -n build`, and confirm the output paths remain `bin/server`, `bin/multica`, and `bin/migrate`.
3. On Windows, run `make build` and confirm `server/bin/server.exe`, `server/bin/multica.exe`, and `server/bin/migrate.exe` are generated.

Locally verified with GNU Make 4.4.1 on Windows. The exact Windows build completed successfully and produced all three non-empty `.exe` files.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used to inspect the issue and repository state, make the narrowly scoped Makefile change, and run Windows and non-Windows verification.

## Screenshots (optional)

N/A