### PR TITLE
fix(editor): wait for preview media upgrade

### DIFF
--- a/packages/views/editor/attachment-preview-modal.test.tsx
+++ b/packages/views/editor/attachment-preview-modal.test.tsx
@@ -15,6 +15,8 @@ vi.mock("../platform", () => ({
 // hoisted too because vi.mock is itself hoisted above the top-level `class`
 // declarations.
 const {
+  getAttachmentMock,
+  getAttachmentBlobMock,
   getAttachmentTextContentMock,
   downloadMock,
   getBaseUrlMock,
@@ -34,6 +36,8 @@ const {
     }
   }
   return {
+    getAttachmentMock: vi.fn(),
+    getAttachmentBlobMock: vi.fn(),
     getAttachmentTextContentMock: vi.fn(),
     downloadMock: vi.fn(),
     // Default to the web shape (empty base, same-origin). Tests covering
@@ -46,6 +50,8 @@ const {
 
 vi.mock("@multica/core/api", () => ({
   api: {
+    getAttachment: getAttachmentMock,
+    getAttachmentBlob: getAttachmentBlobMock,
     getAttachmentTextContent: getAttachmentTextContentMock,
     getBaseUrl: getBaseUrlMock,
   },
@@ -158,6 +164,16 @@ function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
     created_at: "2026-05-13T00:00:00Z",
     ...overrides,
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 function ClosablePreview({ attachment }: { attachment: Attachment }) {
@@ -415,6 +431,183 @@ describe("AttachmentPreviewModal — server-relative download_url resolution (MU
     expect(img?.getAttribute("src")).toBe(
       "https://cdn.example.test/att-1.png?Signature=s",
     );
+  });
+});
+
+describe("AttachmentPreviewModal — pending image URL upgrade", () => {
+  const attachmentId = "11111111-1111-4111-8111-111111111111";
+  const apiUrl = `https://api.example.test/api/attachments/${attachmentId}/download`;
+  const blobUrl = "blob:https://app.example/preview-att-1";
+  const originalCreateObjectURL = Object.getOwnPropertyDescriptor(
+    URL,
+    "createObjectURL",
+  );
+  const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(
+    URL,
+    "revokeObjectURL",
+  );
+  const originalDecode = Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    "decode",
+  );
+  let probedUrls: string[];
+
+  beforeEach(() => {
+    probedUrls = [];
+    getBaseUrlMock.mockReturnValue("https://api.example.test");
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => blobUrl),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "decode", {
+      configurable: true,
+      value: vi.fn(function (this: HTMLImageElement) {
+        probedUrls.push(this.src);
+        return this.src === apiUrl
+          ? Promise.reject(new Error("401"))
+          : Promise.resolve();
+      }),
+    });
+  });
+
+  afterEach(() => {
+    if (originalCreateObjectURL) {
+      Object.defineProperty(URL, "createObjectURL", originalCreateObjectURL);
+    } else {
+      Reflect.deleteProperty(URL, "createObjectURL");
+    }
+    if (originalRevokeObjectURL) {
+      Object.defineProperty(URL, "revokeObjectURL", originalRevokeObjectURL);
+    } else {
+      Reflect.deleteProperty(URL, "revokeObjectURL");
+    }
+    if (originalDecode) {
+      Object.defineProperty(
+        HTMLImageElement.prototype,
+        "decode",
+        originalDecode,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLImageElement.prototype, "decode");
+    }
+  });
+
+  function proxyAttachment(): Attachment {
+    return makeAttachment({
+      id: attachmentId,
+      filename: "cold-cache.png",
+      content_type: "image/png",
+      download_url: `/api/attachments/${attachmentId}/download`,
+      markdown_url: `/api/attachments/${attachmentId}/download`,
+      url: "/uploads/cold-cache.png",
+    });
+  }
+
+  it("waits for the authenticated blob fallback before probing or rendering the target", async () => {
+    const metadata = deferred<Attachment>();
+    const bytes = deferred<Blob>();
+    const onImageError = vi.fn();
+    getAttachmentMock.mockReturnValue(metadata.promise);
+    getAttachmentBlobMock.mockReturnValue(bytes.promise);
+
+    render(
+      <AttachmentPreviewModal
+        source={{ kind: "full", attachment: proxyAttachment() }}
+        open
+        onClose={() => {}}
+        onImageError={onImageError}
+      />,
+    );
+
+    expect(getAttachmentMock).toHaveBeenCalledWith(attachmentId);
+    expect(probedUrls).toEqual([]);
+    expect(document.querySelector(`img[src="${apiUrl}"]`)).toBeNull();
+    expect(onImageError).not.toHaveBeenCalled();
+
+    metadata.resolve(proxyAttachment());
+    await waitFor(() => {
+      expect(getAttachmentBlobMock).toHaveBeenCalledWith(attachmentId);
+    });
+    expect(probedUrls).toEqual([]);
+    expect(onImageError).not.toHaveBeenCalled();
+
+    bytes.resolve(new Blob(["png-bytes"], { type: "image/png" }));
+    await waitFor(() => {
+      expect(probedUrls).toEqual([blobUrl]);
+      expect(document.querySelector("img")?.getAttribute("src")).toBe(blobUrl);
+    });
+    expect(onImageError).not.toHaveBeenCalled();
+  });
+
+  it("reports a real failure after the blob fallback has definitively failed", async () => {
+    const onImageError = vi.fn();
+    getAttachmentMock.mockResolvedValue(proxyAttachment());
+    getAttachmentBlobMock.mockRejectedValue(new Error("blob fetch failed"));
+
+    render(
+      <AttachmentPreviewModal
+        source={{ kind: "full", attachment: proxyAttachment() }}
+        open
+        onClose={() => {}}
+        onImageError={onImageError}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onImageError).toHaveBeenCalledTimes(1);
+    });
+    expect(probedUrls).toEqual([apiUrl]);
+  });
+
+  it("probes an already-presigned URL immediately without metadata refresh", async () => {
+    const signedUrl =
+      `https://storage.example.test/${attachmentId}.png?X-Amz-Signature=signed`;
+
+    render(
+      <AttachmentPreviewModal
+        source={{
+          kind: "full",
+          attachment: makeAttachment({
+            id: attachmentId,
+            filename: "presigned.png",
+            content_type: "image/png",
+            download_url: signedUrl,
+          }),
+        }}
+        open
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(probedUrls).toEqual([signedUrl]);
+    });
+    expect(document.querySelector("img")?.getAttribute("src")).toBe(signedUrl);
+    expect(getAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps same-origin web previews on the existing immediate path", async () => {
+    getBaseUrlMock.mockReturnValue("");
+    const relativeUrl = `/api/attachments/${attachmentId}/download`;
+
+    render(
+      <AttachmentPreviewModal
+        source={{ kind: "full", attachment: proxyAttachment() }}
+        open
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(probedUrls).toHaveLength(1);
+    });
+    expect(probedUrls[0]?.endsWith(relativeUrl)).toBe(true);
+    expect(document.querySelector("img")?.getAttribute("src")).toBe(relativeUrl);
+    expect(getAttachmentMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/editor/attachment-preview-modal.tsx
+++ b/packages/views/editor/attachment-preview-modal.tsx
@@ -252,15 +252,15 @@ export function useAttachmentPreview(): AttachmentPreviewHandle {
 // pre-MUL-5752 behaviour, traded back for correctness there.
 function useSettledImageURL(
   targetUrl: string,
-  enabled: boolean,
+  ready: boolean,
   onLoadError?: () => void,
 ): string {
-  const [settled, setSettled] = useState(targetUrl);
+  const [settled, setSettled] = useState(ready ? targetUrl : "");
   const onErrorRef = useRef(onLoadError);
   onErrorRef.current = onLoadError;
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!ready) return;
     if (!targetUrl) {
       setSettled(targetUrl);
       return;
@@ -284,9 +284,9 @@ function useSettledImageURL(
     return () => {
       cancelled = true;
     };
-  }, [targetUrl, enabled]);
+  }, [targetUrl, ready]);
 
-  return enabled ? settled : targetUrl;
+  return settled;
 }
 
 // Warms the browser cache for a sequence neighbour so paging to it swaps
@@ -294,17 +294,17 @@ function useSettledImageURL(
 // then fetches the bytes through a detached <img>. Renders nothing.
 export function PreviewImagePrefetch({ source }: { source: PreviewSource }) {
   const state = normalize(source);
-  const url = useResignedInlineMediaURL(
+  const { url, pending } = useResignedInlineMediaURL(
     state.attachmentId ?? undefined,
     state.mediaUrl,
     true,
   );
 
   useEffect(() => {
-    if (!url) return;
+    if (pending || !url) return;
     const probe = new window.Image();
     probe.src = url;
-  }, [url]);
+  }, [pending, url]);
 
   return null;
 }
@@ -511,7 +511,7 @@ function PreviewPanel({
   // clicked, so — unlike the click-through path, where <Attachment> had
   // already upgraded the URL — the modal has to run the re-sign itself. A
   // no-op for URLs that are already loadable (signed CDN, public storage).
-  const targetUrl = useResignedInlineMediaURL(
+  const { url: targetUrl, pending: targetPending } = useResignedInlineMediaURL(
     state.attachmentId ?? undefined,
     state.mediaUrl,
     kind === "image",
@@ -519,7 +519,11 @@ function PreviewPanel({
   // The previous image stays on the canvas until this one has decoded — the
   // swap itself is what used to flash. Also absorbs the re-sign URL upgrade
   // (raw -> signed) without a second visible load.
-  const mediaUrl = useSettledImageURL(targetUrl, kind === "image", onImageError);
+  const mediaUrl = useSettledImageURL(
+    targetUrl,
+    kind === "image" && !targetPending,
+    onImageError,
+  );
 
   // Natural size is carried with the URL it was measured from, so a panel
   // reused for a different attachment can never fit the new image against the
@@ -652,7 +656,7 @@ function PreviewPanel({
             canvas={canvas}
             natural={natural}
             onNaturalSize={handleNaturalSize}
-            onError={onImageError}
+            onError={targetPending ? undefined : onImageError}
           />
         ) : (
           <PreviewContent
@@ -746,23 +750,25 @@ function ImagePreview({
       className="bg-black/40"
       autoFocus
     >
-      <img
-        // A cached image is already `complete` before React attaches onLoad,
-        // so that event never fires — measure from the ref as well.
-        ref={readNaturalSize}
-        onLoad={(e) => readNaturalSize(e.currentTarget)}
-        onError={onError}
-        src={url}
-        alt={state.filename}
-        className={cn(
-          "select-none",
-          natural
-            ? "block size-full"
-            : "max-h-full max-w-full rounded-lg object-contain",
-        )}
-        // Native image dragging would hijack the pan gesture.
-        draggable={false}
-      />
+      {url && (
+        <img
+          // A cached image is already `complete` before React attaches onLoad,
+          // so that event never fires — measure from the ref as well.
+          ref={readNaturalSize}
+          onLoad={(e) => readNaturalSize(e.currentTarget)}
+          onError={onError}
+          src={url}
+          alt={state.filename}
+          className={cn(
+            "select-none",
+            natural
+              ? "block size-full"
+              : "max-h-full max-w-full rounded-lg object-contain",
+          )}
+          // Native image dragging would hijack the pan gesture.
+          draggable={false}
+        />
+      )}
     </ZoomCanvas>
   );
 }

--- a/packages/views/editor/attachment.tsx
+++ b/packages/views/editor/attachment.tsx
@@ -339,7 +339,7 @@ export function Attachment({
   // on deployments that have no signed URL to give — to an object URL built
   // from the authenticated byte fetch. Only the image branch renders a native
   // resource load, so only it opts into that byte fetch.
-  const mediaUrl = useResignedInlineMediaURL(
+  const { url: mediaUrl } = useResignedInlineMediaURL(
     state.attachmentId,
     state.url,
     kind === "image",

--- a/packages/views/editor/hooks/use-inline-media-url.ts
+++ b/packages/views/editor/hooks/use-inline-media-url.ts
@@ -58,11 +58,16 @@ const INLINE_BLOB_GC_MS = 5 * 60 * 1000;
 // URL. `blobFallback` gates that on the caller actually rendering a native
 // `<img>`: a file card only needs a link, and downloading a 100 MB archive
 // into renderer memory to draw a chip would be a bad trade.
+//
+// `pending` is true only while `url` is the auth-gated placeholder that a
+// successful metadata refresh or blob fallback is still expected to replace.
+// Probe-style consumers must wait; inline media keeps its existing behaviour
+// by consuming `url` alone and swapping naturally when the upgrade lands.
 export function useResignedInlineMediaURL(
   attachmentId: string | undefined,
   pickedUrl: string,
   blobFallback: boolean,
-): string {
+): { url: string; pending: boolean } {
   const idFromPickedUrl = attachmentIdFromDownloadURL(pickedUrl);
   const resignAttachmentId = attachmentId ?? idFromPickedUrl;
   const isCrossOriginWebURL = (() => {
@@ -81,13 +86,14 @@ export function useResignedInlineMediaURL(
     idFromPickedUrl !== undefined &&
     ((api.getBaseUrl?.() ?? "") !== "" || isCrossOriginWebURL);
 
-  const { data: fresh } = useQuery({
+  const resignQuery = useQuery({
     queryKey: ["attachment-inline-resign", resignAttachmentId],
     queryFn: () => api.getAttachment(resignAttachmentId as string),
     enabled: needsResign,
     staleTime: RESIGN_STALE_MS,
     gcTime: RESIGN_STALE_MS,
   });
+  const fresh = resignQuery.data;
 
   const dl = fresh?.download_url ?? "";
   // Accept the fresh URL only when it is an actual upgrade — absolute and no
@@ -101,18 +107,34 @@ export function useResignedInlineMediaURL(
   // Only after `fresh` has landed do we know this deployment has nothing
   // signed to give — firing the byte fetch earlier would double-download on
   // every CloudFront / presign client.
-  const { data: blob } = useQuery({
+  const blobQuery = useQuery({
     queryKey: ["attachment-inline-blob", resignAttachmentId],
     queryFn: () => api.getAttachmentBlob(resignAttachmentId as string),
     enabled: needsResign && blobFallback && !!fresh && signedUrl === "",
     staleTime: Infinity,
     gcTime: INLINE_BLOB_GC_MS,
   });
+  const blob = blobQuery.data;
   const blobUrl = useObjectURL(blob);
+  // `useObjectURL` publishes from an effect, one render after the byte query
+  // succeeds. Keep the upgrade pending through that gap so a consumer cannot
+  // briefly fall back to the auth-gated URL before the object URL exists.
+  const objectURLPending =
+    !!blob &&
+    !blobUrl &&
+    typeof URL.createObjectURL === "function";
+  const pending =
+    needsResign &&
+    !signedUrl &&
+    (resignQuery.isPending ||
+      (blobFallback &&
+        !!fresh &&
+        !blobQuery.isError &&
+        (blobQuery.isPending || objectURLPending)));
 
-  if (!needsResign) return pickedUrl;
-  if (signedUrl) return signedUrl;
-  return blobUrl || pickedUrl;
+  if (!needsResign) return { url: pickedUrl, pending: false };
+  if (signedUrl) return { url: signedUrl, pending: false };
+  return { url: blobUrl || pickedUrl, pending };
 }
 
 // useObjectURL turns a Blob into a `blob:` URL for the lifetime of the calling


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop image-preview race in proxy download mode. A cold preview can initially receive an authenticated `/api/attachments/{id}/download` URL while attachment metadata and the authenticated blob fallback are still loading. Previously the preview decoded that placeholder immediately, treated the desktop renderer's 401 as permanent, and triggered the unavailable toast/auto-skip before the blob URL arrived.

The URL-upgrade hook now exposes an explicit pending state through the metadata query, blob query, and object-URL effect boundary. Image preview decoding and neighbour prefetching wait for that state to settle. Inline attachments continue consuming the selected URL exactly as before, while genuine final URL failures still reach the existing error handler.

## Related Issue

Closes #7207

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/hooks/use-inline-media-url.ts` — return URL readiness alongside the selected URL, including the render gap before `URL.createObjectURL` is published.
- `packages/views/editor/attachment-preview-modal.tsx` — pause decode probes, native error reporting, and neighbour prefetch while an auth-gated URL is pending replacement.
- `packages/views/editor/attachment.tsx` — preserve existing inline behavior by consuming only the URL field.
- `packages/views/editor/attachment-preview-modal.test.tsx` — cover cold-cache desktop proxy fallback, final failure reporting, immediate presigned URLs, and same-origin web.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run editor/attachment-preview-modal.test.tsx editor/attachment.test.tsx editor/image-sequence-context.test.tsx`.
2. Run `pnpm typecheck`.
3. Run `pnpm lint`.

The regression test holds metadata and blob promises separately. It verifies that the authenticated API URL is not probed or rendered while either is pending, then verifies that only the resulting blob URL is decoded and rendered. It also verifies that a definitive fallback failure still invokes `onImageError`.

## Verification Notes

- Directly related tests: 92 passed.
- Root typecheck: 7/7 tasks passed.
- Root lint: 6/6 tasks passed with existing warnings only.
- A full `@multica/views` run completed with 4511/4516 tests passing on Windows. Four unrelated search/autopilot timeouts passed when rerun individually. The remaining unrelated `rich-content-boundary` test consistently reports a Windows path separator (`editor\\extensions\\code-block-view.tsx`); this PR does not touch that area.

## Risks

The gate applies only while a replacement URL is still expected. If metadata or the blob fallback reaches a terminal failure, the existing URL is probed and the existing unavailable-image behavior remains active. PDF, video, audio, server attachment APIs, storage policy, and download behavior are unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The unchecked documentation, screenshot, runtime/tab, and Chinese-copy items are not applicable. The local-test checkbox is left unchecked because the full Windows views run retains the unrelated path-separator baseline failure documented above; all checks related to this change pass.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Issue-guided TDD: trace the preview URL state flow, add a deterministic cold-cache regression before implementation, introduce the smallest explicit readiness boundary, and verify the affected editor paths plus repository typecheck/lint.

## Screenshots (optional)

Not applicable; this changes asynchronous loading/error behavior without changing the preview UI.