### PR TITLE
MUL-6445: fix(daemon): keep skill cache failures from blocking skill loads

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6004,7 +6004,15 @@ func (d *Daemon) resolveSkillBundle(ctx context.Context, task *Task, ref SkillRe
 	if err := d.skillCache.WithRefLock(task.WorkspaceID, validationRef, func() error {
 		return d.skillCache.Store(task.WorkspaceID, bundle)
 	}); err != nil {
-		return SkillData{}, fmt.Errorf("store skill bundle cache: %w", err)
+		if d.logger != nil {
+			d.logger.Warn("skill bundle cache store failed; continuing with downloaded bundle",
+				"workspace_id", task.WorkspaceID,
+				"skill_id", bundle.ID,
+				"source", bundle.Source,
+				"hash", bundle.Hash,
+				"error", err,
+			)
+		}
 	}
 	return bundle, nil
 }

--- a/server/internal/daemon/skill_bundle_resolve_test.go
+++ b/server/internal/daemon/skill_bundle_resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -230,6 +231,36 @@ func TestEnsureTaskSkillBundles_AcceptsServerSideSkillUpdate(t *testing.T) {
 	}
 	if _, ok := d.skillCache.Load("ws-1", currentRef); !ok {
 		t.Error("updated bundle should be cached under its own (new) hash")
+	}
+}
+
+func TestEnsureTaskSkillBundles_CacheRemovalFailureDoesNotDiscardDownloadedBundle(t *testing.T) {
+	bundle := makeResolvableSkillBundle("skill-1")
+	ref := skillRefFromBundle(bundle)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"bundles": []SkillData{bundle}})
+	}))
+	defer server.Close()
+
+	cache := NewSkillBundleCache(t.TempDir())
+	cache.removeAll = func(string) error { return fs.ErrPermission }
+	daemon := &Daemon{client: NewClient(server.URL), skillCache: cache}
+	task := &Task{
+		ID:          "task-1",
+		RuntimeID:   "rt-1",
+		WorkspaceID: "ws-1",
+		Agent:       &AgentData{ID: "agent-1", SkillRefs: []SkillRefData{ref}},
+	}
+
+	if err := daemon.ensureTaskSkillBundles(context.Background(), task); err != nil {
+		t.Fatalf("cache removal failure must not discard a downloaded bundle: %v", err)
+	}
+	if len(task.Agent.Skills) != 1 || task.Agent.Skills[0].Hash != bundle.Hash {
+		t.Fatalf("downloaded bundle was not attached to the task: %+v", task.Agent.Skills)
+	}
+	if _, ok := cache.Load(task.WorkspaceID, ref); ok {
+		t.Fatal("bundle must not appear cached after the removal failure")
 	}
 }
 

--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -15,17 +15,19 @@ import (
 )
 
 type SkillBundleCache struct {
-	root   string
-	rename func(string, string) error
-	mu     sync.Mutex
-	locks  map[string]*sync.Mutex
+	root      string
+	rename    func(string, string) error
+	removeAll func(string) error
+	mu        sync.Mutex
+	locks     map[string]*sync.Mutex
 }
 
 func NewSkillBundleCache(root string) *SkillBundleCache {
 	return &SkillBundleCache{
-		root:   root,
-		rename: os.Rename,
-		locks:  make(map[string]*sync.Mutex),
+		root:      root,
+		rename:    os.Rename,
+		removeAll: os.RemoveAll,
+		locks:     make(map[string]*sync.Mutex),
 	}
 }
 
@@ -71,14 +73,14 @@ func (c *SkillBundleCache) Store(workspaceID string, bundle SkillData) error {
 	if err := os.WriteFile(filepath.Join(tmp, "bundle.json"), data, 0o644); err != nil {
 		return err
 	}
-	if err := os.RemoveAll(dir); err != nil {
+	if err := c.removeAll(dir); err != nil {
 		return err
 	}
 	if err := c.rename(tmp, dir); err != nil {
 		if !errors.Is(err, fs.ErrExist) {
 			return err
 		}
-		if err := os.RemoveAll(dir); err != nil {
+		if err := c.removeAll(dir); err != nil {
 			return err
 		}
 		if err := c.rename(tmp, dir); err != nil {

--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,13 +15,18 @@ import (
 )
 
 type SkillBundleCache struct {
-	root  string
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	root   string
+	rename func(string, string) error
+	mu     sync.Mutex
+	locks  map[string]*sync.Mutex
 }
 
 func NewSkillBundleCache(root string) *SkillBundleCache {
-	return &SkillBundleCache{root: root, locks: make(map[string]*sync.Mutex)}
+	return &SkillBundleCache{
+		root:   root,
+		rename: os.Rename,
+		locks:  make(map[string]*sync.Mutex),
+	}
 }
 
 func (c *SkillBundleCache) Load(workspaceID string, ref SkillRefData) (SkillData, bool) {
@@ -64,9 +71,19 @@ func (c *SkillBundleCache) Store(workspaceID string, bundle SkillData) error {
 	if err := os.WriteFile(filepath.Join(tmp, "bundle.json"), data, 0o644); err != nil {
 		return err
 	}
-	_ = os.RemoveAll(dir)
-	if err := os.Rename(tmp, dir); err != nil {
+	if err := os.RemoveAll(dir); err != nil {
 		return err
+	}
+	if err := c.rename(tmp, dir); err != nil {
+		if !errors.Is(err, fs.ErrExist) {
+			return err
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+		if err := c.rename(tmp, dir); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/server/internal/daemon/skill_cache_test.go
+++ b/server/internal/daemon/skill_cache_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -19,6 +21,36 @@ func TestSkillBundleCacheLoadStore(t *testing.T) {
 	}
 	if got.Content != bundle.Content || len(got.Files) != 1 || got.Files[0].Content != "rules" {
 		t.Fatalf("unexpected bundle: %+v", got)
+	}
+}
+
+func TestSkillBundleCacheStoreRetriesRenameWhenDestinationExists(t *testing.T) {
+	cache := NewSkillBundleCache(t.TempDir())
+	bundle := testSkillBundle()
+	ref := skillRefFromBundle(bundle)
+	renameCalls := 0
+	cache.rename = func(oldPath, newPath string) error {
+		renameCalls++
+		if renameCalls == 1 {
+			if err := os.MkdirAll(newPath, 0o755); err != nil {
+				return err
+			}
+			return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: fs.ErrExist}
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	if err := cache.Store("ws-1", bundle); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if renameCalls != 2 {
+		t.Fatalf("rename calls = %d, want 2", renameCalls)
+	}
+	if _, ok := cache.Load("ws-1", ref); !ok {
+		t.Fatal("expected cache hit after EEXIST recovery")
+	}
+	if _, err := os.Stat(filepath.Dir(cache.bundlePath("ws-1", ref))); err != nil {
+		t.Fatalf("stat stored bundle directory: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Prevents local skill-cache persistence failures from discarding a bundle that was already downloaded and validated. The fix does not assume whether Google Drive rejects destination removal or delays its visibility: it preserves a bounded recovery attempt when rename reports `EEXIST`, and otherwise continues the task with the verified in-memory bundle while logging the cache failure.

## Related Issue

Closes #7264

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/daemon/skill_cache.go` to return destination-removal errors and retry rename exactly once when a wrapped `EEXIST` indicates the destination survived.
- Updated `resolveSkillBundle` so cache persistence is best-effort only after the downloaded bundle has passed identity and content validation.
- Added deterministic regression tests for both a surviving destination and a destination-removal failure.

## How to Test

1. Run `cd server && go test ./internal/daemon -run '^TestSkillBundleCache' -count=1`.
2. Run `cd server && go test ./internal/daemon -run '^(TestSkillBundleCache|TestEnsureTaskSkillBundles_)' -count=1`.
3. Run `cd server && go test -race ./internal/daemon ./internal/daemon/execenv -count=1`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI, so screenshots are not applicable
- [x] No documentation update is required for this internal cache recovery
- [x] This change does not add a runtime, coding tool, or UI tab
- [x] This change does not touch Chinese product copy
- [x] I have considered and documented risks below
- [x] I will address all reviewer comments before requesting merge

## Risks

The retry is limited to `EEXIST` and one additional rename attempt. Persistent cache failures remain visible in daemon warnings and may cause the bundle to be downloaded again on a later task, but they no longer prevent the current task from using a bundle that has already passed validation. Download, identity, hash, and content validation failures remain fatal.

## AI Disclosure

**AI tool used:** OpenAI coding agent

**Prompt / approach:** Implement the smallest root-cause-independent fix for issue #7264. The approach evaluated both destination-removal failure and delayed deletion, added deterministic tests for each relevant outcome, kept retries bounded, and verified the affected daemon packages with race detection.
