### PR TITLE
fix(issues): keep built-in statuses on their token color everywhere (MUL-6440)

### DIFF
--- a/packages/core/issue-statuses/index.ts
+++ b/packages/core/issue-statuses/index.ts
@@ -3,6 +3,7 @@ export {
   issueStatusListOptions,
   buildIssueStatusCatalog,
   isIssueStatusCategory,
+  issueStatusColor,
   type IssueStatusCatalog,
 } from "./queries";
 export { compareIssueStatusEntries } from "./queries";

--- a/packages/core/issue-statuses/queries.test.ts
+++ b/packages/core/issue-statuses/queries.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { buildIssueStatusCatalog, compareIssueStatusEntries, isIssueStatusCategory } from "./queries";
+import {
+  buildIssueStatusCatalog,
+  compareIssueStatusEntries,
+  isIssueStatusCategory,
+  issueStatusColor,
+} from "./queries";
 import type { IssueStatusEntry } from "../types";
 
 function entry(key: string, category: string, name = key, archivedAt: string | null = null): IssueStatusEntry {
@@ -45,6 +50,29 @@ describe("buildIssueStatusCatalog", () => {
   it("ignores a corrupt category rather than trusting it", () => {
     const c = buildIssueStatusCatalog([entry("weird", "started")]);
     expect(c.categoryOf("weird")).toBe("todo");
+  });
+
+  // The 7 built-ins carry a seeded hex the server refuses to let anyone edit,
+  // and every surface paints them from their category token instead. A caller
+  // that read the seed drew the SAME status in two different greens depending
+  // on which control it was looking at. (MUL-6440)
+  it("gives a built-in no color of its own", () => {
+    const builtIn = { ...entry("in_review", "in_review", "In Review"), is_system: true, color: "#22c55e" };
+    const c = buildIssueStatusCatalog([builtIn, entry("qa", "in_review", "QA")]);
+    expect(c.colorOf("in_review")).toBeNull();
+    expect(c.colorOf("qa")).toBe("#123456");
+  });
+
+  it("gives no color to a status it cannot resolve", () => {
+    const c = buildIssueStatusCatalog(undefined);
+    expect(c.colorOf("in_review")).toBeNull();
+    expect(c.colorOf("ghost")).toBeNull();
+  });
+
+  it("issueStatusColor answers the same question for an entry in hand", () => {
+    expect(issueStatusColor(undefined)).toBeNull();
+    expect(issueStatusColor({ ...entry("qa", "in_review"), is_system: true })).toBeNull();
+    expect(issueStatusColor(entry("qa", "in_review"))).toBe("#123456");
   });
 
   it("groups by category in catalog order", () => {

--- a/packages/core/issue-statuses/queries.ts
+++ b/packages/core/issue-statuses/queries.ts
@@ -56,6 +56,18 @@ export interface IssueStatusCatalog {
   labelOf: (statusKey: string) => string;
   /** Catalog entry for a status key, when the catalog knows it. */
   entryOf: (statusKey: string) => IssueStatusEntry | undefined;
+  /**
+   * The `#rrggbb` a surface must paint a status with, or null when it keeps
+   * its category's semantic token.
+   *
+   * ALWAYS null for a built-in. The 7 built-ins carry a seeded hex in the
+   * catalog, but they are not recolorable (the server rejects any edit to a
+   * system row) and every surface renders them from the token — `text-success`
+   * and friends, which is what makes them follow the theme into dark mode. A
+   * caller that reaches for `entryOf(key)?.color` instead paints the raw seed
+   * and drifts from the same status two pixels away. (MUL-6440)
+   */
+  colorOf: (statusKey: string) => string | null;
   /** ACTIVE statuses belonging to one category, in display order. */
   inCategory: (category: IssueStatusCategory) => IssueStatusEntry[];
   /** True once the catalog has loaded; false while it is still in flight. */
@@ -128,6 +140,18 @@ export function isIssueStatusCategory(value: string): value is IssueStatusCatego
 }
 
 /**
+ * The color to paint one catalog entry with — its own hex for a custom status,
+ * null for a built-in or an entry this client has not resolved yet.
+ *
+ * The pure form of {@link IssueStatusCatalog.colorOf}, for callers that already
+ * hold the entry (a list they are mapping over) instead of just its key.
+ */
+export function issueStatusColor(entry: IssueStatusEntry | undefined): string | null {
+  if (!entry || entry.is_system === true) return null;
+  return entry.color;
+}
+
+/**
  * Builds the resolved catalog from a raw entry list. Pure, so the store and
  * other non-React callers can use it with a list they already hold.
  */
@@ -154,6 +178,7 @@ export function buildIssueStatusCatalog(
     activeStatuses: list.filter((e) => !e.archived_at),
     categoryOf,
     entryOf: (statusKey) => byKey.get(statusKey),
+    colorOf: (statusKey) => issueStatusColor(byKey.get(statusKey)),
     labelOf: (statusKey) => {
       const entry = byKey.get(statusKey);
       if (entry) return entry.name;

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -49,7 +49,7 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
   const { getActorName } = useActorName();
   // Inbox is a cross-workspace surface, so the catalog is read per item's own
   // workspace rather than from the route. (MUL-6243)
-  const { categoryOf, entryOf } = useIssueStatuses(item.workspace_id);
+  const { categoryOf, entryOf, colorOf } = useIssueStatuses(item.workspace_id);
   const details = item.details ?? {};
 
   switch (item.type) {
@@ -62,7 +62,7 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
           <StatusIcon
             status={details.to as IssueStatus}
             category={categoryOf(details.to)}
-            color={entry?.is_system === true ? null : entry?.color}
+            color={colorOf(details.to)}
             className="h-3 w-3"
           />
           {entry?.name ?? details.to}

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -55,7 +55,7 @@ export function InboxListItem({
   const timeAgo = useTimeAgo();
   // Inbox is a cross-workspace surface, so the catalog is read against the
   // item's OWN workspace rather than the route's. (MUL-6243)
-  const { categoryOf: statusCategoryOf, entryOf: statusEntryOf } =
+  const { categoryOf: statusCategoryOf, colorOf: statusColorOf } =
     useIssueStatuses(item.workspace_id);
   const statusLabelOf = useStatusLabel(item.workspace_id);
   const openContextMenu = useInboxContextMenu();
@@ -83,12 +83,9 @@ export function InboxListItem({
   // custom "Human Review" — moving between two statuses of the same category
   // left this row pixel-identical and read as "the inbox never updated"
   // (MUL-6395). Colour is what carries a custom status's own identity, exactly
-  // as the status-changed detail label already renders it. Built-ins pass null
-  // so they keep their semantic token colour rather than the catalog's seed.
-  const statusEntry = item.issue_status
-    ? statusEntryOf(item.issue_status)
-    : undefined;
-  const statusColor = statusEntry?.is_system === true ? null : statusEntry?.color;
+  // as the status-changed detail label already renders it. `colorOf` returns
+  // null for a built-in, which keeps it on its semantic token.
+  const statusColor = item.issue_status ? statusColorOf(item.issue_status) : null;
 
   return (
     // A div, not a <button>: the row carries its own controls (the action

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -108,7 +108,7 @@ export function IssueActionsMenuItems({
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
   const statusOptions = useStatusOptions(wsId);
-  const { categoryOf, entryOf } = useIssueStatuses(wsId);
+  const { categoryOf, colorOf } = useIssueStatuses(wsId);
   const {
     isPinned,
     updateField,
@@ -177,7 +177,7 @@ export function IssueActionsMenuItems({
           <StatusIcon
             status={issue.status}
             category={categoryOf(issue.status)}
-            color={entryOf(issue.status)?.color}
+            color={colorOf(issue.status)}
             className="h-3.5 w-3.5"
           />
           {t(($) => $.actions.status)}

--- a/packages/views/issues/components/filter-chips-bar.tsx
+++ b/packages/views/issues/components/filter-chips-bar.tsx
@@ -182,7 +182,7 @@ function useFilterChips(
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
   const resolveStatusLabel = useStatusLabel(wsId);
-  const { categoryOf, entryOf } = useIssueStatuses(wsId);
+  const { categoryOf, colorOf } = useIssueStatuses(wsId);
 
   const statusFilters = useViewStore((s) => s.statusFilters);
   const priorityFilters = useViewStore((s) => s.priorityFilters);
@@ -352,7 +352,7 @@ function useFilterChips(
               key={s}
               status={s}
               category={categoryOf(s)}
-              color={entryOf(s)?.is_system === true ? null : entryOf(s)?.color}
+              color={colorOf(s)}
               className="size-3"
             />
           ))}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1138,22 +1138,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { data: allIssues = [] } = useQuery(issueListOptions(wsId));
   const { getActorName } = useActorName();
   const resolveStatusLabel = useStatusLabel(wsId);
-  const { categoryOf: resolveStatusCategory, entryOf: statusEntryOf } =
-    useIssueStatuses(wsId);
   // The glyph set is per CATEGORY (MUL-6243), so a status-change entry for a
   // custom status drew the same icon as the built-in it sits beside — an
   // "In Review → Awaiting Response" line looked like nothing had moved. Colour
   // is what carries a custom status's own identity, as the inbox row and the
-  // status-changed detail label already render it. Built-ins resolve to null so
-  // they keep their semantic token rather than the catalog's English seed hex.
-  const resolveStatusColor = useCallback(
-    (statusKey: string): string | null => {
-      const entry = statusEntryOf(statusKey);
-      if (!entry || entry.is_system === true) return null;
-      return entry.color;
-    },
-    [statusEntryOf],
-  );
+  // status-changed detail label already render it. `colorOf` is what keeps a
+  // built-in on its semantic token instead of the catalog's seed hex.
+  const { categoryOf: resolveStatusCategory, colorOf: resolveStatusColor } =
+    useIssueStatuses(wsId);
   // Description autosave is deliberately NOT gated (no explicit submit; the
   // editor already strips `blob:` before serializing and binds ids on the
   // later save). It still needs the failure toast, or a failed upload just

--- a/packages/views/issues/components/pickers/status-picker.test.tsx
+++ b/packages/views/issues/components/pickers/status-picker.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildIssueStatusCatalog } from "@multica/core/issue-statuses";
+import type { IssueStatusEntry } from "@multica/core/types";
+import { renderWithI18n } from "../../../test/i18n";
+import { StatusPicker } from "./status-picker";
+
+// The catalog is server state; this suite is about what the picker PAINTS with
+// it, so the entries are fed in directly. The color matrix behind `colorOf`
+// lives in packages/core/issue-statuses/queries.test.ts — this file only proves
+// the trigger and the list read it from the same place.
+let catalogEntries: IssueStatusEntry[] | undefined;
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/issue-statuses/hooks", () => ({
+  useIssueStatuses: () => buildIssueStatusCatalog(catalogEntries),
+}));
+
+function entry(overrides: Partial<IssueStatusEntry>): IssueStatusEntry {
+  return {
+    id: overrides.key ?? "id",
+    workspace_id: "workspace-1",
+    key: "custom",
+    name: "Custom",
+    description: "",
+    category: "in_review",
+    // Seeded per status by the server — including for the built-ins, which
+    // are not recolorable and must ignore it.
+    color: "#22c55e",
+    is_system: false,
+    position: 1,
+    archived_at: null,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+const IN_REVIEW = entry({
+  id: "in_review",
+  key: "in_review",
+  name: "In Review",
+  is_system: true,
+  position: 0,
+});
+
+const QA = entry({ id: "qa", key: "qa", name: "QA", color: "#ec7a2d" });
+
+/** StatusIcon's own glyph, told apart from the lucide check mark beside it. */
+const STATUS_ICON = 'svg[viewBox="0 0 14 14"]';
+
+function iconOf(row: Element | null): SVGElement | null {
+  return row?.querySelector<SVGElement>(STATUS_ICON) ?? null;
+}
+
+/** The list row for one status — the trigger is a button carrying the same
+ *  label, so the picker-item marker is what tells the two apart. */
+function optionRow(label: string): HTMLElement {
+  const row = Array.from(
+    document.querySelectorAll<HTMLElement>("button[data-picker-item]"),
+  ).find((el) => el.textContent?.trim() === label);
+  if (!row) throw new Error(`no picker row for "${label}"`);
+  return row;
+}
+
+afterEach(() => {
+  cleanup();
+  catalogEntries = undefined;
+});
+
+describe("StatusPicker trigger color", () => {
+  // The bug: the trigger read the catalog entry's raw color while the list read
+  // the resolved one, so a built-in rendered as the server's seeded #22c55e in
+  // one and as the `text-success` token in the other — the same status in two
+  // visibly different greens, side by side. (MUL-6440)
+  it("paints a built-in from the token, exactly like its row in the list", () => {
+    catalogEntries = [IN_REVIEW, QA];
+    const { container } = renderWithI18n(
+      <StatusPicker status="in_review" onUpdate={() => {}} open onOpenChange={() => {}} />,
+    );
+
+    const trigger = iconOf(container);
+    const row = iconOf(optionRow("In Review"));
+
+    // No inline color on either: an inline color is precisely what overrides
+    // the token and produces the two-greens mismatch.
+    expect(trigger?.getAttribute("style")).toBeNull();
+    expect(row?.getAttribute("style")).toBeNull();
+    expect(trigger?.getAttribute("class")).toContain("text-success");
+    expect(row?.getAttribute("class")).toContain("text-success");
+  });
+
+  // The other half of the same rule: a CUSTOM status has no token to fall back
+  // on, so its own color has to reach both controls.
+  it("paints a custom status from its own color in both places", () => {
+    catalogEntries = [IN_REVIEW, QA];
+    const { container } = renderWithI18n(
+      <StatusPicker status="qa" onUpdate={() => {}} open onOpenChange={() => {}} />,
+    );
+
+    const trigger = iconOf(container);
+    const row = iconOf(optionRow("QA"));
+
+    expect(trigger?.style.color).toBe("rgb(236, 122, 45)");
+    expect(row?.style.color).toBe(trigger?.style.color);
+  });
+});

--- a/packages/views/issues/components/pickers/status-picker.tsx
+++ b/packages/views/issues/components/pickers/status-picker.tsx
@@ -46,7 +46,7 @@ export function StatusPicker({
   // detail, table, board batch toolbar, create-issue modal), so the provider
   // is guaranteed here.
   const wsId = useWorkspaceId();
-  const { categoryOf, entryOf } = useIssueStatuses(wsId);
+  const { categoryOf, colorOf } = useIssueStatuses(wsId);
   const labelOf = useStatusLabel(wsId);
 
   /**
@@ -87,7 +87,7 @@ export function StatusPicker({
             <StatusIcon
               status={status}
               category={categoryOf(status)}
-              color={entryOf(status)?.color}
+              color={colorOf(status)}
               className="h-3.5 w-3.5 shrink-0"
             />
             <span className="truncate">{labelOf(status)}</span>

--- a/packages/views/issues/utils/status-options.ts
+++ b/packages/views/issues/utils/status-options.ts
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { ALL_STATUSES } from "@multica/core/issues/config";
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
+import { issueStatusColor } from "@multica/core/issue-statuses/queries";
 import type { IssueStatus, IssueStatusCategory } from "@multica/core/types";
 import { useStatusLabel } from "./status-label";
 
@@ -49,7 +50,7 @@ export function useStatusOptions(wsId: string): StatusOption[] {
           key: e.key as IssueStatus,
           category,
           label: labelOf(e.key),
-          color: e.is_system ? null : e.color,
+          color: issueStatusColor(e),
         }));
       }),
     [activeStatuses, labelOf],

--- a/packages/views/settings/components/issue-statuses-tab.test.tsx
+++ b/packages/views/settings/components/issue-statuses-tab.test.tsx
@@ -26,7 +26,10 @@ vi.mock("@multica/core/config", () => ({ useFeatureEnabled: () => flagOn }));
 vi.mock("@multica/core/workspace/queries", () => ({
   memberListOptions: () => ({ queryKey: ["members", "ws-1"] }),
 }));
-vi.mock("@multica/core/issue-statuses/queries", () => ({
+// Only the fetch is stubbed. The module's pure helpers (`issueStatusColor`)
+// are what the rows render with, and a stub of those would test the stub.
+vi.mock("@multica/core/issue-statuses/queries", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/issue-statuses/queries")>()),
   issueStatusListOptions: () => ({ queryKey: ["issue-statuses", "ws-1"] }),
 }));
 vi.mock("@multica/core/issue-statuses/mutations", () => ({

--- a/packages/views/settings/components/issue-statuses-tab.tsx
+++ b/packages/views/settings/components/issue-statuses-tab.tsx
@@ -29,7 +29,7 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { useAuthStore } from "@multica/core/auth";
 import { useFeatureEnabled } from "@multica/core/config";
 import { memberListOptions } from "@multica/core/workspace/queries";
-import { issueStatusListOptions } from "@multica/core/issue-statuses/queries";
+import { issueStatusColor, issueStatusListOptions } from "@multica/core/issue-statuses/queries";
 import {
   useArchiveIssueStatus,
   useCreateIssueStatus,
@@ -411,7 +411,7 @@ function CustomStatusRow({
       <StatusIcon
         status={entry.key}
         category={entry.category}
-        color={entry.color}
+        color={issueStatusColor(entry)}
         className="size-4"
       />
       {/* Name over description, the way the row is read. The old layout pinned


### PR DESCRIPTION
## What

A built-in status rendered in two different colors on the same screen: the "Status" row in the issue actions menu (and the StatusPicker trigger) painted the catalog's seeded hex `#22c55e`, while the list right beside it painted the `text-success` token — a visibly lighter/darker green for the same "In Review".

Built-in statuses are not recolorable (the server returns 403 on any edit to a system row), so their seeded hex is data the UI must never render — every surface is meant to use the category token, which is also what follows the theme into dark mode. Two call sites read `entryOf(key)?.color` and got the seed.

## How

- `colorOf(statusKey)` on `IssueStatusCatalog` (plus the pure `issueStatusColor(entry)` for callers already holding an entry) is now the single answer to "what color does this status paint with": its own hex for a custom status, `null` for a built-in or an unresolved key.
- Fixed: `issue-actions-menu-items` Status submenu trigger, `status-picker` trigger.
- Also moved onto it: `filter-chips-bar`, `inbox-list-item`, `inbox-detail-label`, `issue-detail`'s activity timeline (all were open-coding the same `is_system` guard), and the settings status list, which was the last surface still painting a built-in from the seed.

No server or schema change.

## Testing

- `packages/core/issue-statuses/queries.test.ts` — the color matrix: built-in → null, custom → its hex, unknown/cold catalog → null.
- `packages/views/issues/components/pickers/status-picker.test.tsx` — new regression test asserting the trigger and the matching list row paint identically. Reverting the one-line fix makes it fail with `expected 'color: rgb(34, 197, 94);' to be null` — exactly the reported symptom.
- `pnpm typecheck`, `pnpm lint` (0 errors), views `issues` / `inbox` / `settings` suites (1088 tests) and the `@multica/core` suites pass locally.
