### PR TITLE
MUL-6461: fix(channel): cancel completed supervisor contexts

### DIFF
--- a/server/internal/integrations/channel/engine/supervisor.go
+++ b/server/internal/integrations/channel/engine/supervisor.go
@@ -589,7 +589,14 @@ func (s *Supervisor) startSupervisor(parent context.Context, inst Installation) 
 	}
 	s.wg.Add(1)
 	s.mu.Unlock()
-	go s.supervise(ctx, inst, id, gen, done)
+	go func() {
+		defer s.wg.Done()
+		// A supervisor can exit without an explicit cancellation when lease
+		// acquisition is contended or fails. Always detach its child context
+		// from Run's long-lived parent when the goroutine returns.
+		defer cancel()
+		s.supervise(ctx, inst, id, gen, done)
+	}()
 }
 
 // leaseToken composes the per-supervisor lease token: the process-wide
@@ -615,7 +622,6 @@ func leaseToken(nodeID string, gen uint64) string {
 // while it runs → on exit, release + back off → repeat. Returns when ctx is
 // cancelled.
 func (s *Supervisor) supervise(ctx context.Context, inst Installation, id string, gen uint64, done chan<- struct{}) {
-	defer s.wg.Done()
 	defer close(done)
 	defer func() {
 		// Only clear the map entry if it still belongs to us — gen

--- a/server/internal/integrations/channel/engine/supervisor_test.go
+++ b/server/internal/integrations/channel/engine/supervisor_test.go
@@ -158,6 +158,27 @@ func (f *fakeStore) leaseHolder(id pgtype.UUID) (string, bool) {
 	return owner, ok
 }
 
+type contextCapturingContendedLeaseStore struct {
+	acquireCtx chan context.Context
+}
+
+func (s *contextCapturingContendedLeaseStore) ListHeldWSLeases(_ context.Context, _ []pgtype.UUID) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+func (s *contextCapturingContendedLeaseStore) TryAcquireWSLease(ctx context.Context, _ AcquireLeaseParams) error {
+	s.acquireCtx <- ctx
+	return ErrLeaseNotAcquired
+}
+
+func (s *contextCapturingContendedLeaseStore) RenewWSLease(_ context.Context, _ AcquireLeaseParams) error {
+	return errors.New("unexpected lease renewal")
+}
+
+func (s *contextCapturingContendedLeaseStore) ReleaseWSLease(_ context.Context, _ ReleaseLeaseParams) error {
+	return nil
+}
+
 // fakeChannel is a channel.Channel whose Connect behaves per a script
 // (default: block until ctx is cancelled). It records connect/disconnect
 // counts and captures the injected handler.
@@ -387,6 +408,39 @@ func TestSupervisorInjectsHandler(t *testing.T) {
 
 	cancel()
 	sup.Wait()
+}
+
+func TestSupervisorCancelsChildContextAfterContendedAcquire(t *testing.T) {
+	q := newFakeStore()
+	instID := uuidFromString(t, "21212121-2121-2121-2121-212121212121")
+	inst := activeInst(instID, "fp1")
+	leases := &contextCapturingContendedLeaseStore{acquireCtx: make(chan context.Context, 1)}
+
+	fc := &fakeChannel{typ: channel.TypeFeishu}
+	var builds int32
+	sup := NewSupervisor(q, leases, fakeRegistry(fc, &builds, nil), nil, fastConfig())
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	defer func() {
+		parentCancel()
+		sup.wg.Wait()
+	}()
+
+	sup.startSupervisor(parentCtx, inst)
+	var acquireCtx context.Context
+	select {
+	case acquireCtx = <-leases.acquireCtx:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("supervisor did not attempt to acquire the lease")
+	}
+
+	select {
+	case <-acquireCtx.Done():
+		if !errors.Is(acquireCtx.Err(), context.Canceled) {
+			t.Fatalf("acquire context error = %v, want context.Canceled", acquireCtx.Err())
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("supervisor returned after lease contention without cancelling its child context")
+	}
 }
 
 func TestSupervisorSkipsWhenAnotherReplicaHoldsLease(t *testing.T) {

--- a/server/internal/integrations/channel/engine/supervisor_test.go
+++ b/server/internal/integrations/channel/engine/supervisor_test.go
@@ -167,7 +167,10 @@ func (s *contextCapturingContendedLeaseStore) ListHeldWSLeases(_ context.Context
 }
 
 func (s *contextCapturingContendedLeaseStore) TryAcquireWSLease(ctx context.Context, _ AcquireLeaseParams) error {
-	s.acquireCtx <- ctx
+	select {
+	case s.acquireCtx <- ctx:
+	default:
+	}
 	return ErrLeaseNotAcquired
 }
 
@@ -425,6 +428,8 @@ func TestSupervisorCancelsChildContextAfterContendedAcquire(t *testing.T) {
 		sup.wg.Wait()
 	}()
 
+	// Start one supervisor directly so the test observes exactly one lease
+	// attempt; Run would continue sweeping and could start another attempt.
 	sup.startSupervisor(parentCtx, inst)
 	var acquireCtx context.Context
 	select {
@@ -440,6 +445,9 @@ func TestSupervisorCancelsChildContextAfterContendedAcquire(t *testing.T) {
 		}
 	case <-time.After(300 * time.Millisecond):
 		t.Fatal("supervisor returned after lease contention without cancelling its child context")
+	}
+	if got := atomic.LoadInt32(&builds); got != 0 {
+		t.Fatalf("contended lease should not build a channel, builds=%d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- cancel each derived supervisor context on every goroutine exit, including contended and failed lease acquisition
- keep WaitGroup completion after context cleanup so Wait returns only after detachment
- add a regression test that captures the lease-acquisition context and verifies cancellation after a contended return

## Production evidence

A heap profile from the prd API pod attributed about 492 MB to Supervisor.startSupervisor context creation and about 1.96 GB to the acquireLease / pgx context watcher path. The pod had accumulated 5.7 million contended lease attempts. The PostgreSQL lease backend retries installations owned by other replicas each sweep, and the previous natural-return path removed the supervisor map entry without invoking its cancel function.

## Verification

- go test ./internal/integrations/channel/engine -run TestSupervisorCancelsChildContextAfterContendedAcquire -count=20
- go test ./internal/integrations/channel/engine -count=1
- go test -race ./internal/integrations/channel/engine -count=1
- go test ./internal/integrations/channel/... -count=1
- go vet ./internal/integrations/channel/engine
- git diff --check