### PR TITLE
MUL-6457 feat(mobile): resolve custom issue statuses by category

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
@@ -5,10 +5,14 @@
  * (`involves_user_id`, MUL-2397) surfaces both the user's owned agents and
  * squads they're involved in (member / leader / has an owned agent inside).
  *
- * Issues are grouped by status using SectionList in `BOARD_STATUSES` order;
- * empty status sections are filtered out so the screen doesn't fill with
- * "(0)" headers. Section grouping uses `BOARD_STATUSES` (cancelled excluded)
- * to match web — same source `packages/views/my-issues/components/my-issues-page.tsx:117-125`.
+ * Issues are grouped by status CATEGORY using SectionList in
+ * `BOARD_CATEGORIES` order; empty sections are filtered out so the screen
+ * doesn't fill with "(0)" headers. Grouping is by category, not by status key,
+ * because a workspace's custom statuses live inside their category's section
+ * rather than adding one of their own — bucketing by key is what made
+ * custom-status issues disappear from this list (MUL-6457). `cancelled` stays
+ * excluded, so a custom status in that category is hidden here exactly like the
+ * built-in Cancelled is: a custom status inherits its category's behavior.
  *
  * Status + Priority filters mirror web's MyIssuesHeader filter sub-menus.
  * Filter state lives in `useMyIssuesViewStore` and is cleared on workspace
@@ -20,7 +24,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useIsFocused } from "@react-navigation/native";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
+import type {
+  IssuePriority,
+  IssueStatus,
+  IssueStatusCategory,
+} from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Header } from "@/components/ui/header";
@@ -37,11 +45,9 @@ import { useAuthStore } from "@/data/auth-store";
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { useMyIssuesViewStore } from "@/data/stores/my-issues-view-store";
 import { useClearFiltersOnWorkspaceChange } from "@/lib/use-clear-filters-on-workspace-change";
-import {
-  BOARD_STATUSES,
-  PRIORITY_LABEL,
-  STATUS_LABEL,
-} from "@/lib/issue-status";
+import { PRIORITY_LABEL, STATUS_LABEL } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
+import { groupIssuesByCategory } from "@/lib/group-issues-by-category";
 import { filterIssues } from "@/lib/filter-issues";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
@@ -57,8 +63,6 @@ const SCOPES: { value: MyIssuesScope; label: string }[] = [
   { value: "created", label: "Created" },
   { value: "agents", label: "Agents" },
 ];
-
-type IssueSection = { status: IssueStatus; data: Issue[] };
 
 export default function MyIssues() {
   const isFocused = useIsFocused();
@@ -94,6 +98,11 @@ export default function MyIssues() {
     enabled: !!wsId && !!userId,
   });
 
+  // Only the active-filter chips need the catalog: sections group on the
+  // category the server already resolved onto each issue, so the list never
+  // waits for this. (MUL-6243)
+  const catalog = useIssueStatuses();
+
   // Apply client-side status + priority filter. Mirrors the predicate at
   // packages/views/issues/utils/filter.ts:30-34 via filterIssues().
   const filtered = useMemo(
@@ -101,24 +110,7 @@ export default function MyIssues() {
     [data, statusFilters, priorityFilters],
   );
 
-  // When statusFilters is non-empty, intersect visible status order with it
-  // so hidden statuses don't render an empty section header. Uses
-  // BOARD_STATUSES (cancelled excluded) to match web.
-  const sections = useMemo<IssueSection[]>(() => {
-    if (filtered.length === 0) return [];
-    const byStatus = new Map<IssueStatus, Issue[]>();
-    for (const issue of filtered) {
-      const list = byStatus.get(issue.status);
-      if (list) list.push(issue);
-      else byStatus.set(issue.status, [issue]);
-    }
-    const visibleStatuses = statusFilters.length > 0
-      ? BOARD_STATUSES.filter((s) => statusFilters.includes(s))
-      : BOARD_STATUSES;
-    return visibleStatuses
-      .map((status) => ({ status, data: byStatus.get(status) ?? [] }))
-      .filter((s) => s.data.length > 0);
-  }, [filtered, statusFilters]);
+  const sections = useMemo(() => groupIssuesByCategory(filtered), [filtered]);
 
   const hasActiveFilters =
     statusFilters.length > 0 || priorityFilters.length > 0;
@@ -140,6 +132,7 @@ export default function MyIssues() {
         <ActiveFilterChips
           statusFilters={statusFilters}
           priorityFilters={priorityFilters}
+          statusLabelOf={catalog.labelOf}
           onClearStatus={(s) =>
             useMyIssuesViewStore.getState().toggleStatusFilter(s)
           }
@@ -178,7 +171,7 @@ export default function MyIssues() {
           )}
           renderSectionHeader={({ section }) => (
             <SectionHeader
-              status={section.status}
+              category={section.category}
               count={section.data.length}
             />
           )}
@@ -297,18 +290,21 @@ function ScopeToolbar<S extends string>({
 function ActiveFilterChips({
   statusFilters,
   priorityFilters,
+  statusLabelOf,
   onClearStatus,
   onClearPriority,
 }: {
   statusFilters: IssueStatus[];
   priorityFilters: IssuePriority[];
+  /** Resolves a status KEY — which can be a custom one — to its label. */
+  statusLabelOf: (statusKey: string) => string;
   onClearStatus: (s: IssueStatus) => void;
   onClearPriority: (p: IssuePriority) => void;
 }) {
   return (
     <View className="flex-row flex-wrap gap-1.5 px-4 pb-2">
       {statusFilters.map((s) => (
-        <Chip key={`s-${s}`} label={STATUS_LABEL[s]} onClear={() => onClearStatus(s)} />
+        <Chip key={`s-${s}`} label={statusLabelOf(s)} onClear={() => onClearStatus(s)} />
       ))}
       {priorityFilters.map((p) => (
         <Chip key={`p-${p}`} label={PRIORITY_LABEL[p]} onClear={() => onClearPriority(p)} />
@@ -334,18 +330,22 @@ function Chip({ label, onClear }: { label: string; onClear: () => void }) {
   );
 }
 
+// The header names the CATEGORY, not any one status inside it, so it keeps
+// mobile's own copy and its category glyph even when the section holds custom
+// statuses.
 function SectionHeader({
-  status,
+  category,
   count,
 }: {
-  status: IssueStatus;
+  category: IssueStatusCategory;
   count: number;
 }) {
   return (
     <View className="flex-row items-center gap-2 px-4 py-2 bg-background">
-      <StatusIcon status={status} size={14} />
+      {/* A category IS a built-in status key, so it resolves to its own glyph. */}
+      <StatusIcon status={category} size={14} />
       <Text className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
-        {STATUS_LABEL[status]}
+        {STATUS_LABEL[category]}
       </Text>
       <Text className="text-xs text-muted-foreground/60">{count}</Text>
     </View>

--- a/apps/mobile/app/(app)/[workspace]/issues-filter.tsx
+++ b/apps/mobile/app/(app)/[workspace]/issues-filter.tsx
@@ -17,10 +17,9 @@ import { StatusIcon } from "@/components/ui/status-icon";
 import { PriorityIcon } from "@/components/ui/priority-icon";
 import { useIssuesViewStore } from "@/data/stores/issues-view-store";
 import { useMyIssuesViewStore } from "@/data/stores/my-issues-view-store";
-import { BOARD_STATUSES, STATUS_LABEL } from "@/lib/issue-status";
+import { statusOptions } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { cn } from "@/lib/utils";
-
-const ALL_STATUSES: IssueStatus[] = [...BOARD_STATUSES, "cancelled"];
 
 // Mirrors PRIORITY_ORDER in packages/core/issues/config/priority.ts.
 const PRIORITY_ORDER: IssuePriority[] = [
@@ -49,6 +48,10 @@ export default function IssuesFilterRoute() {
 
   const statusFilters = useScopedFilters(resolvedScope, "status");
   const priorityFilters = useScopedFilters(resolvedScope, "priority");
+  // Same option list the status picker offers, so every status a user can set
+  // is also a status they can filter by. (MUL-6243)
+  const catalog = useIssueStatuses();
+  const statusChoices = statusOptions(catalog);
 
   const onToggleStatus = (s: IssueStatus) => {
     if (resolvedScope === "all") {
@@ -90,20 +93,25 @@ export default function IssuesFilterRoute() {
       </View>
       <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
         <SectionLabel>Status</SectionLabel>
-        {ALL_STATUSES.map((status) => {
-          const checked = statusFilters.includes(status);
+        {statusChoices.map((option) => {
+          const checked = statusFilters.includes(option.key);
           return (
             <Pressable
-              key={status}
-              onPress={() => onToggleStatus(status)}
+              key={option.key}
+              onPress={() => onToggleStatus(option.key)}
               className={cn(
                 "flex-row items-center gap-3 px-4 py-2.5 active:bg-secondary",
                 checked && "bg-secondary/60",
               )}
             >
-              <StatusIcon status={status} size={16} />
+              <StatusIcon
+                status={option.key}
+                category={option.category}
+                color={option.color}
+                size={16}
+              />
               <Text className="flex-1 text-sm text-foreground">
-                {STATUS_LABEL[status]}
+                {option.label}
               </Text>
               <CheckMark checked={checked} />
             </Pressable>

--- a/apps/mobile/app/(app)/[workspace]/more/issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/more/issues.tsx
@@ -25,7 +25,11 @@ import { Pressable, SectionList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
+import type {
+  IssuePriority,
+  IssueStatus,
+  IssueStatusCategory,
+} from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 // Header chrome (back + "Issues" title) comes from the parent Stack
@@ -42,16 +46,12 @@ import {
   type IssuesScope,
 } from "@/data/stores/issues-view-store";
 import { useClearFiltersOnWorkspaceChange } from "@/lib/use-clear-filters-on-workspace-change";
-import {
-  BOARD_STATUSES,
-  PRIORITY_LABEL,
-  STATUS_LABEL,
-} from "@/lib/issue-status";
+import { PRIORITY_LABEL, STATUS_LABEL } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
+import { groupIssuesByCategory } from "@/lib/group-issues-by-category";
 import { filterIssues } from "@/lib/filter-issues";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
-
-type IssueSection = { status: IssueStatus; data: Issue[] };
 
 // Scope tab definitions. Mirrors web `issuesScopeStore`. Counts are NOT
 // rendered on the pill labels — web's `IssuesHeader` doesn't show them
@@ -90,6 +90,10 @@ export default function IssuesPage() {
     issueListOptions(wsId),
   );
 
+  // Only the active-filter chips need the catalog — sections group on the
+  // category the server already resolved onto each issue. (MUL-6243)
+  const catalog = useIssueStatuses();
+
   const allIssues = data ?? [];
 
   // Scope pre-filter — mirrors web `issues-page.tsx:90-94`. Applied before
@@ -111,24 +115,7 @@ export default function IssuesPage() {
     [scopedIssues, statusFilters, priorityFilters],
   );
 
-  // Section grouping uses BOARD_STATUSES (cancelled excluded) — matches web
-  // `issues-page.tsx:117-125`.
-  const sections = useMemo<IssueSection[]>(() => {
-    if (filtered.length === 0) return [];
-    const byStatus = new Map<IssueStatus, Issue[]>();
-    for (const issue of filtered) {
-      const list = byStatus.get(issue.status);
-      if (list) list.push(issue);
-      else byStatus.set(issue.status, [issue]);
-    }
-    const visibleStatuses =
-      statusFilters.length > 0
-        ? BOARD_STATUSES.filter((s) => statusFilters.includes(s))
-        : BOARD_STATUSES;
-    return visibleStatuses
-      .map((status) => ({ status, data: byStatus.get(status) ?? [] }))
-      .filter((s) => s.data.length > 0);
-  }, [filtered, statusFilters]);
+  const sections = useMemo(() => groupIssuesByCategory(filtered), [filtered]);
 
   const hasActiveFilters =
     statusFilters.length > 0 || priorityFilters.length > 0;
@@ -148,6 +135,7 @@ export default function IssuesPage() {
         <ActiveFilterChips
           statusFilters={statusFilters}
           priorityFilters={priorityFilters}
+          statusLabelOf={catalog.labelOf}
           onClearStatus={(s) =>
             useIssuesViewStore.getState().toggleStatusFilter(s)
           }
@@ -185,7 +173,10 @@ export default function IssuesPage() {
             <View className="h-px bg-border ml-4" />
           )}
           renderSectionHeader={({ section }) => (
-            <SectionHeader status={section.status} count={section.data.length} />
+            <SectionHeader
+              category={section.category}
+              count={section.data.length}
+            />
           )}
           contentContainerClassName="pb-6"
           renderItem={({ item }) => (
@@ -298,11 +289,14 @@ function ScopeToolbar<S extends string>({
 function ActiveFilterChips({
   statusFilters,
   priorityFilters,
+  statusLabelOf,
   onClearStatus,
   onClearPriority,
 }: {
   statusFilters: IssueStatus[];
   priorityFilters: IssuePriority[];
+  /** Resolves a status KEY — which can be a custom one — to its label. */
+  statusLabelOf: (statusKey: string) => string;
   onClearStatus: (s: IssueStatus) => void;
   onClearPriority: (p: IssuePriority) => void;
 }) {
@@ -311,7 +305,7 @@ function ActiveFilterChips({
       {statusFilters.map((s) => (
         <Chip
           key={`s-${s}`}
-          label={STATUS_LABEL[s]}
+          label={statusLabelOf(s)}
           onClear={() => onClearStatus(s)}
         />
       ))}
@@ -343,18 +337,22 @@ function Chip({ label, onClear }: { label: string; onClear: () => void }) {
   );
 }
 
+// The header names the CATEGORY, not any one status inside it, so it keeps
+// mobile's own copy and its category glyph even when the section holds custom
+// statuses.
 function SectionHeader({
-  status,
+  category,
   count,
 }: {
-  status: IssueStatus;
+  category: IssueStatusCategory;
   count: number;
 }) {
   return (
     <View className="flex-row items-center gap-2 px-4 py-2 bg-background">
-      <StatusIcon status={status} size={14} />
+      {/* A category IS a built-in status key, so it resolves to its own glyph. */}
+      <StatusIcon status={category} size={14} />
       <Text className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
-        {STATUS_LABEL[status]}
+        {STATUS_LABEL[category]}
       </Text>
       <Text className="text-xs text-muted-foreground/60">{count}</Text>
     </View>

--- a/apps/mobile/app/(app)/[workspace]/search.tsx
+++ b/apps/mobile/app/(app)/[workspace]/search.tsx
@@ -29,7 +29,7 @@ import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type {
   Issue,
-  IssueStatus,
+  IssueStatusCategory,
   SearchIssueResult,
   SearchProjectResult,
 } from "@multica/core/types";
@@ -45,7 +45,8 @@ import {
   useViewedIssuesStore,
 } from "@/data/viewed-issues-store";
 import { issueDetailOptions } from "@/data/queries/issues";
-import { STATUS_LABEL } from "@/lib/issue-status";
+import { issueColumnCategory } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { projectStatusLabel } from "@/lib/project-status";
 import { buildSearchRows, type RowItem } from "@/lib/search-rows";
 
@@ -120,11 +121,12 @@ function HighlightText({
 // RowItem + buildSearchRows live in lib/search-rows.ts so the ordering rules
 // (including the cancelled partition) are testable without mounting the screen.
 
-function issueIconColor(status: IssueStatus): string {
+function issueIconColor(category: IssueStatusCategory): string {
   // Tag color for the status label at the end of an issue row.
-  // Mirrors STATUS_CONFIG.iconColor (status-icon.tsx STATUS_COLOR) so the
-  // text tint matches the leading status icon visually.
-  switch (status) {
+  // Mirrors STATUS_CONFIG.iconColor (status-icon.tsx CATEGORY_COLOR) so the
+  // text tint matches the leading status icon visually. Keyed on CATEGORY: a
+  // custom status inherits its category's tint, exactly as its glyph does.
+  switch (category) {
     case "in_progress":
       return "text-warning";
     case "in_review":
@@ -161,14 +163,21 @@ function SearchIssueRow({ item, query, slug }: SearchIssueRowProps) {
   // (server/internal/handler/issue.go:592). Keep mobile strictly aligned.
   const showSnippet =
     item.match_source === "comment" && !!item.matched_snippet;
-  const statusLabel = STATUS_LABEL[item.status as IssueStatus] ?? item.status;
+  const { colorOf, labelOf } = useIssueStatuses();
+  const category = issueColumnCategory(item);
+  const statusLabel = labelOf(item.status);
   return (
     <Pressable
       onPress={() => navigateOnTap(slug, `/${slug}/issue/${item.id}`)}
       className="active:bg-secondary px-4 py-3"
     >
       <View className="flex-row items-center gap-3">
-        <StatusIcon status={item.status as IssueStatus} size={14} />
+        <StatusIcon
+          status={item.status}
+          category={category}
+          color={colorOf(item.status)}
+          size={14}
+        />
         <PriorityIcon priority={item.priority} size={14} />
         <Text className="text-xs text-muted-foreground shrink-0 w-16">
           {item.identifier}
@@ -181,7 +190,7 @@ function SearchIssueRow({ item, query, slug }: SearchIssueRowProps) {
             numberOfLines={1}
           />
         </View>
-        <Text className={`text-xs shrink-0 ${issueIconColor(item.status as IssueStatus)}`}>
+        <Text className={`text-xs shrink-0 ${issueIconColor(category)}`}>
           {statusLabel}
         </Text>
       </View>
@@ -260,21 +269,28 @@ interface RecentRowProps {
 }
 
 function RecentRow({ item, slug }: RecentRowProps) {
-  const statusLabel = STATUS_LABEL[item.status as IssueStatus] ?? item.status;
+  const { colorOf, labelOf } = useIssueStatuses();
+  const category = issueColumnCategory(item);
+  const statusLabel = labelOf(item.status);
   return (
     <Pressable
       onPress={() => navigateOnTap(slug, `/${slug}/issue/${item.id}`)}
       className="active:bg-secondary px-4 py-3"
     >
       <View className="flex-row items-center gap-3">
-        <StatusIcon status={item.status as IssueStatus} size={14} />
+        <StatusIcon
+          status={item.status}
+          category={category}
+          color={colorOf(item.status)}
+          size={14}
+        />
         <Text className="text-xs text-muted-foreground shrink-0 w-16">
           {item.identifier}
         </Text>
         <Text className="flex-1 text-sm text-foreground" numberOfLines={1}>
           {item.title}
         </Text>
-        <Text className={`text-xs shrink-0 ${issueIconColor(item.status as IssueStatus)}`}>
+        <Text className={`text-xs shrink-0 ${issueIconColor(category)}`}>
           {statusLabel}
         </Text>
       </View>

--- a/apps/mobile/components/inbox/detail-label.tsx
+++ b/apps/mobile/components/inbox/detail-label.tsx
@@ -14,7 +14,6 @@ import { View } from "react-native";
 import type {
   InboxItem,
   InboxItemType,
-  IssueStatus,
   IssuePriority,
 } from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
@@ -22,18 +21,8 @@ import { Text } from "@/components/ui/text";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { PriorityIcon } from "@/components/ui/priority-icon";
 import { useActorLookup } from "@/data/use-actor-name";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { cn } from "@/lib/utils";
-
-// Mirrors STATUS_CONFIG.label in packages/core/issues/config/status.ts
-const STATUS_LABEL: Record<IssueStatus, string> = {
-  backlog: "Backlog",
-  todo: "Todo",
-  in_progress: "In Progress",
-  in_review: "In Review",
-  done: "Done",
-  blocked: "Blocked",
-  cancelled: "Cancelled",
-};
 
 // Mirrors PRIORITY_CONFIG.label in packages/core/issues/config/priority.ts
 const PRIORITY_LABEL: Record<IssuePriority, string> = {
@@ -84,17 +73,25 @@ export function InboxDetailLabel({
   className?: string;
 }) {
   const { getName } = useActorLookup();
+  // `details.to` is a status KEY and may be a custom one, so its name, colour
+  // and glyph all resolve through the workspace catalog. (MUL-6243)
+  const { categoryOf, colorOf, labelOf } = useIssueStatuses();
   const details = item.details ?? {};
 
   // Cases with inline icons → Row layout.
   if (item.type === "status_changed" && details.to) {
-    const status = details.to as IssueStatus;
+    const status = details.to;
     return (
       <View className={cn("flex-row items-center gap-1", className)}>
         <Text className="text-xs text-muted-foreground">Set status to</Text>
-        <StatusIcon status={status} size={12} />
+        <StatusIcon
+          status={status}
+          category={categoryOf(status)}
+          color={colorOf(status)}
+          size={12}
+        />
         <Text className="text-xs text-muted-foreground" numberOfLines={1}>
-          {STATUS_LABEL[status] ?? status}
+          {labelOf(status)}
         </Text>
       </View>
     );

--- a/apps/mobile/components/inbox/inbox-row.tsx
+++ b/apps/mobile/components/inbox/inbox-row.tsx
@@ -17,6 +17,7 @@ import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { InboxDetailLabel } from "@/components/inbox/detail-label";
 import { getInboxDisplayTitle } from "@/lib/inbox-display";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { timeAgo } from "@/lib/time-ago";
 import { cn } from "@/lib/utils";
 
@@ -27,6 +28,7 @@ interface Props {
 
 export function InboxRow({ item, onPress }: Props) {
   const isUnread = !item.read;
+  const { categoryOf, colorOf } = useIssueStatuses();
   const displayTitle = getInboxDisplayTitle(item);
   const actorType = item.actor_type ?? item.recipient_type;
   const actorId = item.actor_id ?? item.recipient_id;
@@ -54,8 +56,19 @@ export function InboxRow({ item, onPress }: Props) {
                 {displayTitle}
               </Text>
             </View>
+            {/* The glyph is per category, so it alone cannot tell "In Review"
+                from a custom "Human Review" — a move between two statuses of
+                one category would leave this row pixel-identical and read as
+                "the inbox never updated" (MUL-6395). Colour is what carries a
+                custom status's identity; `colorOf` is null for a built-in,
+                which keeps it on its category token. */}
             {item.issue_status ? (
-              <StatusIcon status={item.issue_status} size={14} />
+              <StatusIcon
+                status={item.issue_status}
+                category={categoryOf(item.issue_status)}
+                color={colorOf(item.issue_status)}
+                size={14}
+              />
             ) : null}
           </View>
           {/* Bottom row: [type-aware detail label] (left) | [time] (right).

--- a/apps/mobile/components/issue/activity-row.tsx
+++ b/apps/mobile/components/issue/activity-row.tsx
@@ -21,11 +21,7 @@
  */
 import { View } from "react-native";
 import Svg, { Line, Rect } from "react-native-svg";
-import type {
-  IssuePriority,
-  IssueStatus,
-  TimelineEntry,
-} from "@multica/core/types";
+import type { IssuePriority, TimelineEntry } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { PriorityIcon } from "@/components/ui/priority-icon";
@@ -33,6 +29,8 @@ import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { formatActivity } from "@/lib/format-activity";
 import { timeAgo } from "@/lib/time-ago";
 import { useActorLookup } from "@/data/use-actor-name";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
+import type { IssueStatusCatalog } from "@/lib/issue-status";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
 
@@ -79,14 +77,25 @@ function CalendarGlyph({
 
 function LeadIcon({
   entry,
+  catalog,
   mutedFg,
 }: {
   entry: TimelineEntry;
+  catalog: IssueStatusCatalog;
   mutedFg: string;
 }) {
   const details = (entry.details ?? {}) as Record<string, string>;
   if (entry.action === "status_changed" && details.to) {
-    return <StatusIcon status={details.to as IssueStatus} size={14} />;
+    // `details.to` is a status KEY: the glyph comes from its category and the
+    // colour from the catalog, so a custom status is recognizable. (MUL-6243)
+    return (
+      <StatusIcon
+        status={details.to}
+        category={catalog.categoryOf(details.to)}
+        color={catalog.colorOf(details.to)}
+        size={14}
+      />
+    );
   }
   if (entry.action === "priority_changed" && details.to) {
     return <PriorityIcon priority={details.to as IssuePriority} size={14} />;
@@ -108,6 +117,7 @@ function LeadIcon({
 
 export function ActivityRow({ entry }: { entry: TimelineEntry }) {
   const { getName } = useActorLookup();
+  const catalog = useIssueStatuses();
   const { colorScheme } = useColorScheme();
   const mutedFg = THEME[colorScheme].mutedForeground;
   const resolveName = (
@@ -116,7 +126,7 @@ export function ActivityRow({ entry }: { entry: TimelineEntry }) {
   ): string =>
     getName(type as "member" | "agent" | null | undefined, id);
   const actorName = resolveName(entry.actor_type, entry.actor_id);
-  const verb = formatActivity(entry, resolveName);
+  const verb = formatActivity(entry, resolveName, catalog.labelOf);
   const showCoalesceBadge =
     (entry.coalesced_count ?? 1) > 1 &&
     entry.action !== "task_completed" &&
@@ -125,7 +135,7 @@ export function ActivityRow({ entry }: { entry: TimelineEntry }) {
   return (
     <View className="flex-row items-center px-4 gap-2">
       <View className="w-4 items-center justify-center shrink-0">
-        <LeadIcon entry={entry} mutedFg={mutedFg} />
+        <LeadIcon entry={entry} catalog={catalog} mutedFg={mutedFg} />
       </View>
       <Text
         className="text-xs text-muted-foreground flex-1"

--- a/apps/mobile/components/issue/attribute-row.tsx
+++ b/apps/mobile/components/issue/attribute-row.tsx
@@ -33,10 +33,8 @@ import { AttributeChip } from "./attribute-chip";
 import { useActorLookup } from "@/data/use-actor-name";
 import { findProject, projectListOptions } from "@/data/queries/projects";
 import { useWorkspaceStore } from "@/data/workspace-store";
-import {
-  STATUS_LABEL,
-  PRIORITY_LABEL as PRIORITY_FULL_LABEL,
-} from "@/lib/issue-status";
+import { PRIORITY_LABEL as PRIORITY_FULL_LABEL } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 
 // Chip placeholder shortens `none` from "No priority" → "Priority" so the
 // unset chip reads as a placeholder, not as a confusing assigned value.
@@ -79,6 +77,10 @@ export function AttributeRow({ issue }: { issue: Issue }) {
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const wsSlug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
   const { getName } = useActorLookup();
+  // The chip shows the issue's own status, which may be a custom one — name
+  // and colour come from the workspace catalog, the glyph from its category.
+  // (MUL-6243)
+  const { categoryOf, colorOf, labelOf } = useIssueStatuses();
 
   // Project read-only — fetch list to look up the title + icon. Cheap
   // (cached after first issue-detail visit).
@@ -112,8 +114,15 @@ export function AttributeRow({ issue }: { issue: Issue }) {
     <View className="flex-row flex-wrap gap-2">
       {/* Status — always shown */}
       <AttributeChip
-        icon={<StatusIcon status={issue.status} size={14} />}
-        label={STATUS_LABEL[issue.status]}
+        icon={
+          <StatusIcon
+            status={issue.status}
+            category={categoryOf(issue.status)}
+            color={colorOf(issue.status)}
+            size={14}
+          />
+        }
+        label={labelOf(issue.status)}
         variant="filled"
         onPress={() => openPicker("status")}
       />

--- a/apps/mobile/components/issue/create-form-attribute-row.tsx
+++ b/apps/mobile/components/issue/create-form-attribute-row.tsx
@@ -22,7 +22,8 @@ import { formatDateOnly } from "@multica/core/issues/date";
 import { useActorLookup } from "@/data/use-actor-name";
 import { useNewIssueDraftStore } from "@/data/stores/new-issue-draft-store";
 import { useWorkspaceStore } from "@/data/workspace-store";
-import { PRIORITY_LABEL, STATUS_LABEL } from "@/lib/issue-status";
+import { PRIORITY_LABEL } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 
 /**
  * Picker fields the new-issue draft form can open. Bound to a typed map
@@ -53,6 +54,8 @@ export function CreateFormAttributeRow() {
   const project = useNewIssueDraftStore((s) => s.project);
 
   const { getName } = useActorLookup();
+  // The draft can hold a custom status the user picked in the sheet. (MUL-6243)
+  const { categoryOf, colorOf, labelOf } = useIssueStatuses();
   const assigneeLabel = assignee
     ? getName(assignee.type, assignee.id)
     : "Assignee";
@@ -71,8 +74,15 @@ export function CreateFormAttributeRow() {
     <View>
       <View className="flex-row flex-wrap gap-2">
         <AttributeChip
-          icon={<StatusIcon status={status} size={12} />}
-          label={STATUS_LABEL[status]}
+          icon={
+            <StatusIcon
+              status={status}
+              category={categoryOf(status)}
+              color={colorOf(status)}
+              size={12}
+            />
+          }
+          label={labelOf(status)}
           variant="filled"
           onPress={() => open("status")}
         />

--- a/apps/mobile/components/issue/custom-status-chip.tsx
+++ b/apps/mobile/components/issue/custom-status-chip.tsx
@@ -1,0 +1,43 @@
+/**
+ * Names an issue's status when the surface around it only shows the CATEGORY
+ * (MUL-6243).
+ *
+ * List sections are categories, so two issues sitting in the same "In Review"
+ * section can be on different statuses — "Code Review" and "QA" — with nothing
+ * on the row to tell them apart. This chip is that missing signal, mirroring
+ * web's `packages/views/issues/components/custom-status-chip.tsx`.
+ *
+ * It renders NOTHING for a status that already is its category's built-in: the
+ * section header says "In Review" and a chip repeating it is pure noise. So a
+ * workspace that never defined a custom status sees no visual change at all.
+ *
+ * Divergence from web: the catalog arrives as a PROP rather than from a hook
+ * inside. Every mobile caller is a virtualized list row that already resolved
+ * the catalog for its status icon's colour, and subscribing twice per row is
+ * free on the network (React Query dedupes) but not on re-renders.
+ */
+import { View } from "react-native";
+import type { IssueStatus } from "@multica/core/types";
+import { Text } from "@/components/ui/text";
+import { StatusIcon } from "@/components/ui/status-icon";
+import { isCustomStatus, type IssueStatusCatalog } from "@/lib/issue-status";
+
+export function CustomStatusChip({
+  status,
+  catalog,
+}: {
+  status: IssueStatus;
+  catalog: IssueStatusCatalog;
+}) {
+  const entry = catalog.entryOf(status);
+  if (!isCustomStatus(catalog, status) || !entry) return null;
+
+  return (
+    <View className="flex-row items-center gap-1 shrink-0 max-w-[120px] rounded-full bg-secondary/60 pl-1 pr-1.5 py-0.5">
+      <StatusIcon status={status} category={entry.category} color={entry.color} size={10} />
+      <Text className="text-[10px] text-muted-foreground shrink" numberOfLines={1}>
+        {entry.name}
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/components/issue/issue-row.tsx
+++ b/apps/mobile/components/issue/issue-row.tsx
@@ -30,6 +30,7 @@ import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { PriorityIcon } from "@/components/ui/priority-icon";
 import { StatusIcon } from "@/components/ui/status-icon";
+import { issueColumnCategory } from "@/lib/issue-status";
 
 interface Props {
   issue: Issue;
@@ -42,7 +43,15 @@ export function IssueRow({ issue, onPress, showStatus = false }: Props) {
   return (
     <Pressable onPress={onPress} className="active:bg-secondary px-4 py-3">
       <View className="flex-row items-center gap-3">
-        {showStatus ? <StatusIcon status={issue.status} size={14} /> : null}
+        {/* The glyph is per CATEGORY, so a custom status draws its category's
+            icon rather than falling back to Todo's. (MUL-6243) */}
+        {showStatus ? (
+          <StatusIcon
+            status={issue.status}
+            category={issueColumnCategory(issue)}
+            size={14}
+          />
+        ) : null}
         <PriorityIcon priority={issue.priority} size={14} />
         <Text className="text-xs text-muted-foreground shrink-0 w-16">
           {issue.identifier}

--- a/apps/mobile/components/issue/issue-row.tsx
+++ b/apps/mobile/components/issue/issue-row.tsx
@@ -6,11 +6,17 @@
  * Layout mirrors web's `packages/views/issues/components/list-row.tsx`:
  *   [status?]  priority  identifier  title  …  assignee
  *
- * `showStatus` is opt-in because the my-issues SectionList already groups
- * by status (rendering it again per-row would be visual noise). The
- * project-related-issues view doesn't section by status, so it asks for
- * the inline status icon. New callers should default to false unless they
- * mix multiple statuses inside a single ungrouped list.
+ * `showStatus` is opt-in because the grouped lists already carry the status
+ * CATEGORY in their section header (rendering the glyph again per-row would be
+ * visual noise). Ungrouped surfaces that mix statuses — the pins list — ask for
+ * it. New callers should default to false unless they mix multiple statuses
+ * inside a single ungrouped list.
+ *
+ * The `<CustomStatusChip>` is NOT gated on `showStatus`: a section header names
+ * a category, so "Code Review" and "QA" both land under In Review and the row
+ * is the only place left to tell them apart. It stays silent for built-in
+ * statuses, so a workspace without custom statuses renders exactly as before.
+ * (MUL-6243)
  *
  * Behavioral parity:
  *   - Same `Issue` type, same `assignee_type`/`assignee_id` semantics
@@ -30,7 +36,9 @@ import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { PriorityIcon } from "@/components/ui/priority-icon";
 import { StatusIcon } from "@/components/ui/status-icon";
+import { CustomStatusChip } from "@/components/issue/custom-status-chip";
 import { issueColumnCategory } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 
 interface Props {
   issue: Issue;
@@ -40,15 +48,20 @@ interface Props {
 }
 
 export function IssueRow({ issue, onPress, showStatus = false }: Props) {
+  // One catalog read for both the icon's colour and the chip — see the
+  // divergence note in `custom-status-chip.tsx`.
+  const catalog = useIssueStatuses();
   return (
     <Pressable onPress={onPress} className="active:bg-secondary px-4 py-3">
       <View className="flex-row items-center gap-3">
         {/* The glyph is per CATEGORY, so a custom status draws its category's
-            icon rather than falling back to Todo's. (MUL-6243) */}
+            icon rather than falling back to Todo's; the colour is what tells
+            two statuses of one category apart. (MUL-6243) */}
         {showStatus ? (
           <StatusIcon
             status={issue.status}
             category={issueColumnCategory(issue)}
+            color={catalog.colorOf(issue.status)}
             size={14}
           />
         ) : null}
@@ -56,9 +69,12 @@ export function IssueRow({ issue, onPress, showStatus = false }: Props) {
         <Text className="text-xs text-muted-foreground shrink-0 w-16">
           {issue.identifier}
         </Text>
-        <Text className="flex-1 text-sm text-foreground" numberOfLines={1}>
-          {issue.title}
-        </Text>
+        <View className="flex-1 flex-row items-center gap-1.5 min-w-0">
+          <Text className="text-sm text-foreground shrink" numberOfLines={1}>
+            {issue.title}
+          </Text>
+          <CustomStatusChip status={issue.status} catalog={catalog} />
+        </View>
         {issue.assignee_type && issue.assignee_id ? (
           <ActorAvatar
             type={issue.assignee_type}

--- a/apps/mobile/components/issue/mention-suggestion-bar.tsx
+++ b/apps/mobile/components/issue/mention-suggestion-bar.tsx
@@ -30,7 +30,12 @@ import { canAssignAgentToIssue } from "@multica/core/permissions";
 import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { StatusIcon } from "@/components/ui/status-icon";
-import { issueColumnCategory } from "@/lib/issue-status";
+import {
+  CLOSED_CATEGORIES,
+  issueBehavesAsAny,
+  issueColumnCategory,
+} from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { memberListOptions } from "@/data/queries/members";
 import { agentListOptions } from "@/data/queries/agents";
 import { squadListOptions } from "@/data/queries/squads";
@@ -77,6 +82,9 @@ export function MentionSuggestionBar({
 }: Props) {
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const isChat = mode === "chat";
+  // Rows are icon-only, so colour is the only thing that can carry a custom
+  // status's identity here. (MUL-6243)
+  const catalog = useIssueStatuses();
 
   // Comment-mode data — disabled in chat mode to avoid wasted fetches.
   const { data: members = [] } = useQuery({
@@ -351,9 +359,11 @@ export function MentionSuggestionBar({
             );
           }
           // issue
-          const closed =
-            item.issue.status === "done" ||
-            item.issue.status === "cancelled";
+          // By CATEGORY, not by key: a custom status in the done category IS
+          // done, and `status === "done"` silently disagrees — the row would
+          // render at full opacity as though the work were still open.
+          // (MUL-6243)
+          const closed = issueBehavesAsAny(item.issue, CLOSED_CATEGORIES);
           return (
             <Pressable
               onPress={() =>
@@ -372,6 +382,7 @@ export function MentionSuggestionBar({
                 <StatusIcon
                   status={item.issue.status}
                   category={issueColumnCategory(item.issue)}
+                  color={catalog.colorOf(item.issue.status)}
                   size={16}
                 />
               </View>

--- a/apps/mobile/components/issue/mention-suggestion-bar.tsx
+++ b/apps/mobile/components/issue/mention-suggestion-bar.tsx
@@ -30,6 +30,7 @@ import { canAssignAgentToIssue } from "@multica/core/permissions";
 import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { StatusIcon } from "@/components/ui/status-icon";
+import { issueColumnCategory } from "@/lib/issue-status";
 import { memberListOptions } from "@/data/queries/members";
 import { agentListOptions } from "@/data/queries/agents";
 import { squadListOptions } from "@/data/queries/squads";
@@ -368,7 +369,11 @@ export function MentionSuggestionBar({
               )}
             >
               <View className="size-7 items-center justify-center">
-                <StatusIcon status={item.issue.status} size={16} />
+                <StatusIcon
+                  status={item.issue.status}
+                  category={issueColumnCategory(item.issue)}
+                  size={16}
+                />
               </View>
               <Text className="text-sm font-medium text-foreground">
                 {item.issue.identifier}

--- a/apps/mobile/components/issue/pickers/mention-picker-body.tsx
+++ b/apps/mobile/components/issue/pickers/mention-picker-body.tsx
@@ -33,6 +33,7 @@ import type {
 import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { StatusIcon } from "@/components/ui/status-icon";
+import { issueColumnCategory } from "@/lib/issue-status";
 import { memberListOptions } from "@/data/queries/members";
 import { agentListOptions } from "@/data/queries/agents";
 import { squadListOptions } from "@/data/queries/squads";
@@ -261,7 +262,11 @@ export function MentionPickerBody({ query, mode = "comment" }: Props) {
                 className="items-center justify-center"
                 style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
               >
-                <StatusIcon status={item.issue.status} size={22} />
+                <StatusIcon
+                  status={item.issue.status}
+                  category={issueColumnCategory(item.issue)}
+                  size={22}
+                />
               </View>
             )}
             {item.kind === "issue" ? (

--- a/apps/mobile/components/issue/pickers/mention-picker-body.tsx
+++ b/apps/mobile/components/issue/pickers/mention-picker-body.tsx
@@ -34,6 +34,7 @@ import { Text } from "@/components/ui/text";
 import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { issueColumnCategory } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { memberListOptions } from "@/data/queries/members";
 import { agentListOptions } from "@/data/queries/agents";
 import { squadListOptions } from "@/data/queries/squads";
@@ -71,6 +72,8 @@ interface Props {
 
 export function MentionPickerBody({ query, mode = "comment" }: Props) {
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  // Rows are icon-only here too — colour is what names a custom status.
+  const catalog = useIssueStatuses();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: squads = [] } = useQuery(squadListOptions(wsId));
@@ -265,6 +268,7 @@ export function MentionPickerBody({ query, mode = "comment" }: Props) {
                 <StatusIcon
                   status={item.issue.status}
                   category={issueColumnCategory(item.issue)}
+                  color={catalog.colorOf(item.issue.status)}
                   size={22}
                 />
               </View>

--- a/apps/mobile/components/issue/pickers/status-picker-body.tsx
+++ b/apps/mobile/components/issue/pickers/status-picker-body.tsx
@@ -1,12 +1,18 @@
 /**
- * Pure picker body for issue status — single-select over BOARD_STATUSES +
- * cancelled. No shell, no modal — the caller (a formSheet route screen, or
+ * Pure picker body for issue status — single-select over the workspace's
+ * status catalog. No shell, no modal — the caller (a formSheet route screen, or
  * any embedding surface) renders it inside whatever container it needs.
  *
  * Split from the old `status-picker-sheet.tsx` so the same row UI can serve
  * both the issue-detail route (`issue/[id]/picker/status.tsx`, which writes
  * via useUpdateIssue) and the new-issue draft route
  * (`new-issue-picker/status.tsx`, which writes via useNewIssueDraftStore).
+ *
+ * Options come from `statusOptions()` — the same list the status filter reads,
+ * so a status offered in one and missing from the other can't happen (that is
+ * how an issue becomes unfindable). Until the catalog lands, or against a
+ * backend that predates it, that list is exactly the 7 built-ins this picker
+ * always offered. (MUL-6243)
  */
 import { Pressable, ScrollView, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -14,10 +20,9 @@ import { useColorScheme } from "nativewind";
 import type { IssueStatus } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { StatusIcon } from "@/components/ui/status-icon";
-import { BOARD_STATUSES, STATUS_LABEL } from "@/lib/issue-status";
+import { statusOptions } from "@/lib/issue-status";
+import { useIssueStatuses } from "@/lib/use-issue-statuses";
 import { THEME } from "@/lib/theme";
-
-const ALL_STATUSES: IssueStatus[] = [...BOARD_STATUSES, "cancelled"];
 
 interface Props {
   value: IssueStatus;
@@ -28,6 +33,8 @@ export function StatusPickerBody({ value, onChange }: Props) {
   const { colorScheme } = useColorScheme();
   const checkColor =
     colorScheme === "dark" ? THEME.dark.primary : THEME.light.primary;
+  const catalog = useIssueStatuses();
+  const options = statusOptions(catalog);
 
   return (
     <ScrollView showsVerticalScrollIndicator={false}>
@@ -35,17 +42,22 @@ export function StatusPickerBody({ value, onChange }: Props) {
         <Text className="text-lg font-semibold text-foreground">Status</Text>
       </View>
       <View className="px-2">
-        {ALL_STATUSES.map((status) => {
-          const selected = status === value;
+        {options.map((option) => {
+          const selected = option.key === value;
           return (
             <Pressable
-              key={status}
-              onPress={() => onChange(status)}
+              key={option.key}
+              onPress={() => onChange(option.key)}
               className="flex-row items-center gap-3 rounded-lg px-3 py-3 active:bg-secondary"
             >
-              <StatusIcon status={status} size={18} />
+              <StatusIcon
+                status={option.key}
+                category={option.category}
+                color={option.color}
+                size={18}
+              />
               <Text className="flex-1 text-base text-foreground">
-                {STATUS_LABEL[status]}
+                {option.label}
               </Text>
               {selected ? (
                 <Ionicons name="checkmark" size={20} color={checkColor} />

--- a/apps/mobile/components/project/project-related-issues.tsx
+++ b/apps/mobile/components/project/project-related-issues.tsx
@@ -11,20 +11,22 @@
  *     small-screen pattern for the same data.
  *   - This is a UI divergence, NOT semantic divergence (per
  *     mobile/CLAUDE.md "Behavioral parity"): same issues, same status
- *     enum, same 6 BOARD_STATUSES grouping as web — only the layout
+ *     categories, same 6 visible groups as web — only the layout
  *     differs. UI may diverge when semantics agree.
  *
- * Status grouping uses full `BOARD_STATUSES` (six visible groups, cancelled
- * excluded) to match web `packages/views/projects/components/project-detail.tsx`.
- * The earlier mobile-only "Open / Done" two-bucket layout was a parity
- * violation: same status enum value would appear in different visible
+ * Groups are status CATEGORIES (`BOARD_CATEGORIES`, cancelled excluded) to
+ * match web `packages/views/projects/components/project-detail.tsx`, NOT status
+ * keys: a workspace's custom statuses live inside their category's group rather
+ * than adding one of their own, and grouping by key dropped them from the list
+ * entirely (MUL-6457). The earlier mobile-only "Open / Done" two-bucket layout
+ * was a parity violation: the same status would appear in different visible
  * groups on mobile vs web. Cancelled is omitted on both clients.
  */
 import { useMemo } from "react";
 import { View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { router } from "expo-router";
-import type { Issue, IssueStatus } from "@multica/core/types";
+import type { Issue, IssueStatusCategory } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { StatusIcon } from "@/components/ui/status-icon";
@@ -32,7 +34,11 @@ import { IssueRow } from "@/components/issue/issue-row";
 import { IssuesLoading } from "@/components/issue/issues-loading";
 import { projectIssuesOptions } from "@/data/queries/projects";
 import { useWorkspaceStore } from "@/data/workspace-store";
-import { BOARD_STATUSES, STATUS_LABEL } from "@/lib/issue-status";
+import {
+  BOARD_CATEGORIES,
+  STATUS_LABEL,
+  issueColumnCategory,
+} from "@/lib/issue-status";
 
 interface Props {
   projectId: string;
@@ -45,12 +51,12 @@ export function ProjectRelatedIssues({ projectId }: Props) {
     projectIssuesOptions(wsId, projectId),
   );
 
-  const byStatus = useMemo(() => {
-    const m = new Map<IssueStatus, Issue[]>();
-    for (const status of BOARD_STATUSES) m.set(status, []);
+  const byCategory = useMemo(() => {
+    const m = new Map<IssueStatusCategory, Issue[]>();
+    for (const category of BOARD_CATEGORIES) m.set(category, []);
     for (const issue of data ?? []) {
-      const list = m.get(issue.status);
-      if (list) list.push(issue);
+      // Issues in the cancelled category have no group here, same as before.
+      m.get(issueColumnCategory(issue))?.push(issue);
     }
     return m;
   }, [data]);
@@ -85,12 +91,12 @@ export function ProjectRelatedIssues({ projectId }: Props) {
 
   return (
     <View>
-      {BOARD_STATUSES.map((status) => {
-        const issues = byStatus.get(status) ?? [];
+      {BOARD_CATEGORIES.map((category) => {
+        const issues = byCategory.get(category) ?? [];
         if (issues.length === 0) return null;
         return (
-          <View key={status}>
-            <SectionHeader status={status} count={issues.length} />
+          <View key={category}>
+            <SectionHeader category={category} count={issues.length} />
             {issues.map((issue) => (
               <IssueRow
                 key={issue.id}
@@ -106,17 +112,18 @@ export function ProjectRelatedIssues({ projectId }: Props) {
 }
 
 function SectionHeader({
-  status,
+  category,
   count,
 }: {
-  status: IssueStatus;
+  category: IssueStatusCategory;
   count: number;
 }) {
   return (
     <View className="flex-row items-center gap-2 px-4 py-2 bg-background">
-      <StatusIcon status={status} size={14} />
+      {/* A category IS a built-in status key, so it resolves to its own glyph. */}
+      <StatusIcon status={category} size={14} />
       <Text className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
-        {STATUS_LABEL[status]}
+        {STATUS_LABEL[category]}
       </Text>
       <Text className="text-xs text-muted-foreground/60">{count}</Text>
     </View>

--- a/apps/mobile/components/ui/status-icon.tsx
+++ b/apps/mobile/components/ui/status-icon.tsx
@@ -10,10 +10,17 @@
  * Code is mobile-owned — we read and adapt the SVG primitives, we don't
  * import the web component. SVG ops are written with react-native-svg
  * primitives instead of HTML <svg>.
+ *
+ * The glyph set is per CATEGORY, not per status key: a workspace's custom
+ * status renders with its category's icon, which is what makes it read as "the
+ * same kind of thing" (MUL-6243). Callers that hold the workspace catalog pass
+ * `category` and `color`; callers that only hold a key get the built-in
+ * resolution, which is exact for the 7 built-ins.
  */
 import * as React from "react";
 import Svg, { Circle, G, Line, Path } from "react-native-svg";
-import type { IssueStatus } from "@multica/core/types";
+import type { IssueStatus, IssueStatusCategory } from "@multica/core/types";
+import { statusCategoryOfKey } from "@/lib/issue-status";
 
 const CX = 7;
 const CY = 7;
@@ -21,8 +28,10 @@ const OUTER_R = 6;
 const FILL_R = 3.5;
 
 // Mirrors STATUS_CONFIG.iconColor in packages/core/issues/config/status.ts —
-// translated to hex (see apps/mobile/tailwind.config.js).
-const STATUS_COLOR: Record<IssueStatus, string> = {
+// translated to hex (see apps/mobile/tailwind.config.js). Keyed on CATEGORY:
+// a custom status inherits its category's token unless the catalog gave it a
+// colour of its own.
+const CATEGORY_COLOR: Record<IssueStatusCategory, string> = {
   backlog: "#71717a", // muted-foreground
   todo: "#71717a",
   in_progress: "#eab308", // warning
@@ -129,27 +138,38 @@ function CancelledX({ color }: { color: string }) {
 
 export function StatusIcon({
   status,
+  category: categoryProp,
+  color: colorProp,
   size = 16,
 }: {
   status: IssueStatus;
+  /**
+   * Resolved category, for callers that hold the workspace catalog. Without it
+   * the key resolves on its own — exact for the 7 built-ins, `todo` for a
+   * custom key this render has no catalog for.
+   */
+  category?: IssueStatusCategory;
+  /** A custom status's `#rrggbb`. Built-ins keep their category token. */
+  color?: string | null;
   size?: number;
 }) {
-  const color = STATUS_COLOR[status];
+  const category = categoryProp ?? statusCategoryOfKey(status);
+  const color = colorProp ?? CATEGORY_COLOR[category];
   return (
     <Svg width={size} height={size} viewBox="0 0 14 14">
-      {status === "backlog" ? (
+      {category === "backlog" ? (
         <BacklogIcon color={color} />
-      ) : status === "todo" ? (
+      ) : category === "todo" ? (
         <ProgressCircle progress={0} color={color} />
-      ) : status === "in_progress" ? (
+      ) : category === "in_progress" ? (
         <ProgressCircle progress={0.5} color={color} />
-      ) : status === "in_review" ? (
+      ) : category === "in_review" ? (
         <ProgressCircle progress={0.75} color={color} />
-      ) : status === "done" ? (
+      ) : category === "done" ? (
         <ProgressCircle progress={1} color={color}>
           <DoneCheck />
         </ProgressCircle>
-      ) : status === "blocked" ? (
+      ) : category === "blocked" ? (
         <ProgressCircle progress={0} color={color}>
           <BlockedSlash color={color} />
         </ProgressCircle>

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -45,6 +45,7 @@ import type {
   RuntimeDevice,
   SearchIssuesResponse,
   SearchProjectsResponse,
+  ListIssueStatusesResponse,
   SendChatMessageResponse,
   Squad,
   NotificationPreferenceResponse,
@@ -58,10 +59,12 @@ import type {
   Workspace,
 } from "@multica/core/types";
 import {
+  EMPTY_LIST_ISSUE_STATUSES_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_ENTRIES,
   IssueSchema,
   ListIssuesResponseSchema,
+  ListIssueStatusesResponseSchema,
   TimelineEntriesSchema,
 } from "@multica/core/api/schemas";
 import {
@@ -864,6 +867,32 @@ class ApiClient {
     return this.fetch<IssueLabelsResponse>(
       `/api/issues/${issueId}/labels/${labelId}`,
       { method: "DELETE" },
+    );
+  }
+
+  // --- Issue status catalog (MUL-6243) ---
+  /**
+   * The workspace's issue statuses — the 7 built-ins plus any custom ones an
+   * admin defined. Reads are open to every workspace member; the catalog
+   * mutations are owner/admin only and live on web's settings screen, which is
+   * why mobile ships the read alone.
+   *
+   * `include_archived` is on by design. Archiving retires a status from FUTURE
+   * assignment but leaves the issues already on it, and those issues must keep
+   * their real name, colour and category — dropping archived rows here would
+   * degrade them to a raw key with a guessed category. Pickers filter them out
+   * via `IssueStatusCatalog.activeStatuses` instead.
+   */
+  async listIssueStatuses(
+    includeArchived = false,
+    opts?: { signal?: AbortSignal },
+  ): Promise<ListIssueStatusesResponse> {
+    const query = includeArchived ? "?include_archived=true" : "";
+    return this.fetchValidated(
+      `/api/issue-statuses${query}`,
+      ListIssueStatusesResponseSchema,
+      EMPTY_LIST_ISSUE_STATUSES_RESPONSE,
+      { ...opts, endpoint: "GET /api/issue-statuses" },
     );
   }
 

--- a/apps/mobile/data/mutations/issues.ts
+++ b/apps/mobile/data/mutations/issues.ts
@@ -19,12 +19,14 @@ import type {
   CreateIssueRequest,
   Issue,
   IssueReaction,
+  IssueStatus,
   Label,
   Reaction,
   TimelineEntry,
   UpdateIssueRequest,
 } from "@multica/core/types";
 import { api } from "@/data/api";
+import { isIssueStatusCategory } from "@/lib/issue-status";
 import { issueKeys } from "@/data/queries/issues";
 import { inboxKeys } from "@/data/queries/inbox";
 import { useAuthStore } from "@/data/auth-store";
@@ -476,6 +478,25 @@ export function useToggleIssueReaction(issueId: string) {
 }
 
 /**
+ * Keeps `status_category` consistent with an optimistic `status` write
+ * (MUL-6243).
+ *
+ * A cached issue looks like `{status: "todo", status_category: "todo"}` while a
+ * patch carries only `{status: "human_review"}`, so a bare spread would leave
+ * the STALE category on an issue that no longer behaves that way — and category
+ * is what every list groups on. A custom key this response cannot resolve gets
+ * `undefined` rather than the inherited value: unresolvable is honest, stale is
+ * not, and `issueColumnCategory` falls back from there. The server's full
+ * response lands moments later and settles it either way.
+ */
+function statusCategoryPatch(status: IssueStatus | undefined): Partial<Issue> {
+  if (status === undefined) return {};
+  return {
+    status_category: isIssueStatusCategory(status) ? status : undefined,
+  };
+}
+
+/**
  * Update an issue's editable fields (status / priority / assignee / due_date /
  * project_id / etc). Predictable fields merge optimistically into the detail
  * cache; description stays authoritative because the server resolves it
@@ -506,7 +527,11 @@ export function useUpdateIssue(issueId: string) {
           expected_revision: _expectedRevision,
           ...optimisticPatch
         } = patch;
-        qc.setQueryData<Issue>(key, { ...prev, ...optimisticPatch });
+        qc.setQueryData<Issue>(key, {
+          ...prev,
+          ...optimisticPatch,
+          ...statusCategoryPatch(optimisticPatch.status),
+        });
       }
       return { prev, key };
     },

--- a/apps/mobile/data/queries/issue-statuses.ts
+++ b/apps/mobile/data/queries/issue-statuses.ts
@@ -1,0 +1,32 @@
+/**
+ * Workspace issue status catalog (MUL-6243).
+ *
+ * Key shape mirrors web's `packages/core/issue-statuses/queries.ts` —
+ * `["issue-statuses", wsId, "list"]` — so the cross-platform mental model
+ * stays the same. Keying on wsId means a workspace switch naturally refetches.
+ *
+ * The catalog only changes when an admin edits it, which is rare, so a generous
+ * `staleTime` keeps it off the critical path of every render that needs a
+ * status label. Mobile has no catalog mutations (settings live on web), so
+ * nothing local ever has to invalidate it.
+ */
+import { queryOptions } from "@tanstack/react-query";
+import { api } from "@/data/api";
+
+export const issueStatusKeys = {
+  all: (wsId: string | null) => ["issue-statuses", wsId] as const,
+  list: (wsId: string | null) =>
+    [...issueStatusKeys.all(wsId), "list"] as const,
+};
+
+export const issueStatusListOptions = (wsId: string | null) =>
+  queryOptions({
+    queryKey: issueStatusKeys.list(wsId),
+    // Archived entries included on purpose — see `api.listIssueStatuses`.
+    queryFn: async ({ signal }) => {
+      const res = await api.listIssueStatuses(true, { signal });
+      return res.statuses;
+    },
+    enabled: !!wsId,
+    staleTime: 5 * 60_000,
+  });

--- a/apps/mobile/lib/format-activity.ts
+++ b/apps/mobile/lib/format-activity.ts
@@ -10,22 +10,9 @@
  * mobile clients in the wild must render them as a generic fallback, not
  * crash).
  */
-import type {
-  IssuePriority,
-  IssueStatus,
-  TimelineEntry,
-} from "@multica/core/types";
+import type { IssuePriority, TimelineEntry } from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
-
-const STATUS_LABEL: Record<IssueStatus, string> = {
-  backlog: "Backlog",
-  todo: "Todo",
-  in_progress: "In Progress",
-  in_review: "In Review",
-  done: "Done",
-  blocked: "Blocked",
-  cancelled: "Cancelled",
-};
+import { STATUS_LABEL, isIssueStatusCategory } from "@/lib/issue-status";
 
 const PRIORITY_LABEL: Record<IssuePriority, string> = {
   urgent: "Urgent",
@@ -35,9 +22,21 @@ const PRIORITY_LABEL: Record<IssuePriority, string> = {
   none: "No priority",
 };
 
-function statusName(s: string | undefined): string {
-  if (s && s in STATUS_LABEL) return STATUS_LABEL[s as IssueStatus];
-  return s ?? "?";
+/**
+ * Names a status KEY out of a timeline entry. `resolveLabel` comes from the
+ * workspace catalog and is what names a CUSTOM status; without it (or for a key
+ * the catalog never heard of) a built-in still gets its own copy and anything
+ * else falls back to the raw key rather than rendering blank. Mirrors web's
+ * `statusLabel` in packages/views/issues/components/issue-detail.tsx.
+ * (MUL-6243)
+ */
+function statusName(
+  s: string | undefined,
+  resolveLabel?: (statusKey: string) => string,
+): string {
+  if (!s) return "?";
+  if (resolveLabel) return resolveLabel(s);
+  return isIssueStatusCategory(s) ? STATUS_LABEL[s] : s;
 }
 
 function priorityName(p: string | undefined): string {
@@ -58,13 +57,14 @@ export function formatActivity(
     type: string | null | undefined,
     id: string | null | undefined,
   ) => string,
+  resolveStatusLabel?: (statusKey: string) => string,
 ): string {
   const details = (entry.details ?? {}) as Record<string, string>;
   switch (entry.action) {
     case "created":
       return "created the issue";
     case "status_changed":
-      return `changed status: ${statusName(details.from)} → ${statusName(details.to)}`;
+      return `changed status: ${statusName(details.from, resolveStatusLabel)} → ${statusName(details.to, resolveStatusLabel)}`;
     case "priority_changed":
       return `changed priority: ${priorityName(details.from)} → ${priorityName(details.to)}`;
     case "assignee_changed": {

--- a/apps/mobile/lib/group-issues-by-category.test.ts
+++ b/apps/mobile/lib/group-issues-by-category.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@multica/core/types";
+import { groupIssuesByCategory } from "./group-issues-by-category";
+
+function issue(id: string, status: string, statusCategory?: string): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `MUL-${id}`,
+    title: id,
+    description: null,
+    status,
+    ...(statusCategory ? { status_category: statusCategory as Issue["status_category"] } : {}),
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    properties: {},
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+describe("groupIssuesByCategory", () => {
+  // The regression this exists for: bucketing by `issue.status` created a `qa`
+  // bucket no section ever read, so the issue was simply not on the screen
+  // while the header counts said nothing was wrong (MUL-6457).
+  it("puts a custom status in its category's section", () => {
+    const sections = groupIssuesByCategory([
+      issue("a", "qa", "in_review"),
+      issue("b", "in_review"),
+    ]);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].category).toBe("in_review");
+    expect(sections[0].data.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("orders sections canonically and drops empty ones", () => {
+    const sections = groupIssuesByCategory([
+      issue("a", "done"),
+      issue("b", "backlog"),
+      issue("c", "in_progress"),
+    ]);
+    expect(sections.map((s) => s.category)).toEqual(["backlog", "in_progress", "done"]);
+  });
+
+  // A workspace with no custom statuses must behave exactly as it did before
+  // the catalog existed — one section per built-in that has rows.
+  it("groups built-in statuses one section each", () => {
+    const sections = groupIssuesByCategory([
+      issue("a", "todo"),
+      issue("b", "todo"),
+      issue("c", "blocked"),
+    ]);
+    expect(sections.map((s) => [s.category, s.data.length])).toEqual([
+      ["todo", 2],
+      ["blocked", 1],
+    ]);
+  });
+
+  // Cancelled has no section on mobile. A custom status in that category is
+  // hidden here for the same reason the built-in is: it inherits the category's
+  // behavior.
+  it("omits the cancelled category, built-in or custom", () => {
+    expect(groupIssuesByCategory([issue("a", "cancelled")])).toEqual([]);
+    expect(groupIssuesByCategory([issue("a", "wont_do", "cancelled")])).toEqual([]);
+  });
+
+  // Older backends predate `status_category`; a custom key then resolves to
+  // nothing. Landing it in `todo` keeps the row on screen, which beats a row in
+  // no section at all.
+  it("still shows a custom status the payload could not resolve", () => {
+    const sections = groupIssuesByCategory([issue("a", "qa")]);
+    expect(sections.map((s) => s.category)).toEqual(["todo"]);
+    expect(sections[0].data.map((i) => i.id)).toEqual(["a"]);
+  });
+
+  it("returns nothing for an empty list", () => {
+    expect(groupIssuesByCategory([])).toEqual([]);
+  });
+});

--- a/apps/mobile/lib/group-issues-by-category.test.ts
+++ b/apps/mobile/lib/group-issues-by-category.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { Issue } from "@multica/core/types";
 import { groupIssuesByCategory } from "./group-issues-by-category";

--- a/apps/mobile/lib/group-issues-by-category.ts
+++ b/apps/mobile/lib/group-issues-by-category.ts
@@ -1,0 +1,46 @@
+/**
+ * Groups issues into the sections mobile's grouped lists render (MUL-6457).
+ *
+ * Extracted from `(tabs)/my-issues.tsx` + `more/issues.tsx` — which held the
+ * same fifteen lines twice, and the same bug twice — so the rule is stated
+ * once and testable without mounting a screen (same reason as
+ * `lib/search-rows.ts`).
+ *
+ * Sections are status CATEGORIES, not status keys. A workspace's custom
+ * statuses live inside their category's section rather than adding one of their
+ * own, so bucketing by `issue.status` left every custom-status bucket unread
+ * and its issues invisible — the "counts and visibility must agree" rule in
+ * apps/mobile/CLAUDE.md.
+ *
+ * An active status filter needs no special handling: callers filter the rows by
+ * KEY first, so a bucket can only be non-empty if one of those rows landed in
+ * it. Intersecting the section order with the filter keys directly would be
+ * wrong now that the two live in different spaces.
+ */
+import type { Issue, IssueStatusCategory } from "@multica/core/types";
+import { BOARD_CATEGORIES, issueColumnCategory } from "./issue-status";
+
+export interface IssueSection {
+  category: IssueStatusCategory;
+  data: Issue[];
+}
+
+/**
+ * Non-empty sections in canonical category order. `cancelled` has no section on
+ * mobile, so an issue in that category is omitted here exactly as the built-in
+ * Cancelled always was — a custom status inherits its category's behavior.
+ */
+export function groupIssuesByCategory(issues: Issue[]): IssueSection[] {
+  if (issues.length === 0) return [];
+  const byCategory = new Map<IssueStatusCategory, Issue[]>();
+  for (const issue of issues) {
+    const category = issueColumnCategory(issue);
+    const list = byCategory.get(category);
+    if (list) list.push(issue);
+    else byCategory.set(category, [issue]);
+  }
+  return BOARD_CATEGORIES.map((category) => ({
+    category,
+    data: byCategory.get(category) ?? [],
+  })).filter((section) => section.data.length > 0);
+}

--- a/apps/mobile/lib/issue-status.test.ts
+++ b/apps/mobile/lib/issue-status.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import type { Issue, IssueStatusEntry } from "@multica/core/types";
+import {
+  BOARD_CATEGORIES,
+  buildIssueStatusCatalog,
+  issueColumnCategory,
+  issueStatusColor,
+  statusOptions,
+} from "./issue-status";
+
+function entry(
+  key: string,
+  category: string,
+  overrides: Partial<IssueStatusEntry> = {},
+): IssueStatusEntry {
+  return {
+    id: key,
+    workspace_id: "ws-1",
+    key,
+    name: key,
+    description: "",
+    category: category as IssueStatusEntry["category"],
+    color: "#123456",
+    is_system: false,
+    position: 0,
+    archived_at: null,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function issue(overrides: Partial<Issue>): Pick<Issue, "status" | "status_category"> {
+  return { status: "todo", ...overrides } as Pick<Issue, "status" | "status_category">;
+}
+
+describe("issueColumnCategory", () => {
+  // Grouping must not wait on the catalog, so it reads the category the server
+  // already resolved onto the payload.
+  it("prefers the server-resolved category", () => {
+    expect(
+      issueColumnCategory(issue({ status: "human_review", status_category: "in_review" })),
+    ).toBe("in_review");
+  });
+
+  it("falls back to the key when it is a built-in", () => {
+    expect(issueColumnCategory(issue({ status: "blocked" }))).toBe("blocked");
+  });
+
+  // An unresolvable custom key lands SOMEWHERE rather than nowhere: a row in a
+  // possibly-wrong section is recoverable, a row in no section is invisible —
+  // which is the bug this file exists to prevent (MUL-6457).
+  it("never leaves an unresolved custom status without a section", () => {
+    expect(issueColumnCategory(issue({ status: "qa" }))).toBe("todo");
+  });
+
+  it("ignores a category value this build does not know", () => {
+    expect(
+      issueColumnCategory(issue({ status: "qa", status_category: "started" as never })),
+    ).toBe("todo");
+  });
+
+  it("puts every built-in in a board section except cancelled", () => {
+    for (const key of ["backlog", "todo", "in_progress", "in_review", "done", "blocked"]) {
+      expect(BOARD_CATEGORIES).toContain(issueColumnCategory(issue({ status: key })));
+    }
+    expect(BOARD_CATEGORIES).not.toContain(issueColumnCategory(issue({ status: "cancelled" })));
+  });
+});
+
+describe("buildIssueStatusCatalog", () => {
+  // A status has to render on the very first paint. Built-in keys are their own
+  // category, so an unloaded catalog still resolves all 7 — which is what keeps
+  // a workspace with no custom statuses identical before the request lands.
+  it("resolves every built-in with no catalog loaded", () => {
+    const c = buildIssueStatusCatalog(undefined);
+    expect(c.isLoaded).toBe(false);
+    for (const key of ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"]) {
+      expect(c.categoryOf(key)).toBe(key);
+    }
+    expect(c.labelOf("in_review")).toBe("In Review");
+    expect(c.colorOf("in_review")).toBeNull();
+  });
+
+  it("maps a custom status to its category and name", () => {
+    const c = buildIssueStatusCatalog([entry("human_review", "in_review", { name: "Human Review" })]);
+    expect(c.categoryOf("human_review")).toBe("in_review");
+    expect(c.labelOf("human_review")).toBe("Human Review");
+    expect(c.colorOf("human_review")).toBe("#123456");
+  });
+
+  // An issue can carry a status created moments ago in another session. Naming
+  // it by its raw key beats rendering blank.
+  it("falls back for a status the catalog does not know", () => {
+    const c = buildIssueStatusCatalog([]);
+    expect(c.categoryOf("ghost")).toBe("todo");
+    expect(c.labelOf("ghost")).toBe("ghost");
+    expect(c.entryOf("ghost")).toBeUndefined();
+  });
+
+  // The 7 built-ins carry a server-seeded name and hex that nobody can edit.
+  // Mobile owns their copy and paints them from their category token, so
+  // reading the catalog row for either would drift from every other surface.
+  it("keeps mobile's own copy and token colour for a built-in", () => {
+    const builtIn = entry("in_review", "in_review", {
+      name: "In Review",
+      is_system: true,
+      color: "#22c55e",
+    });
+    const c = buildIssueStatusCatalog([builtIn, entry("qa", "in_review", { name: "QA" })]);
+    expect(c.labelOf("in_review")).toBe("In Review");
+    expect(c.colorOf("in_review")).toBeNull();
+    expect(c.colorOf("qa")).toBe("#123456");
+  });
+
+  it("issueStatusColor answers the same question for an entry in hand", () => {
+    expect(issueStatusColor(undefined)).toBeNull();
+    expect(issueStatusColor(entry("qa", "in_review", { is_system: true }))).toBeNull();
+    expect(issueStatusColor(entry("qa", "in_review"))).toBe("#123456");
+  });
+});
+
+// Archiving retires a status from FUTURE assignment but leaves existing issues
+// on it. Those issues must keep their real name, colour and category — dropping
+// archived rows from resolution would degrade them to a raw key.
+describe("archived statuses stay resolvable", () => {
+  const archived = entry("gate_approved", "done", {
+    name: "Gate Approved",
+    archived_at: "2026-01-01T00:00:00Z",
+  });
+  const active = entry("human_review", "in_review", { name: "Human Review" });
+  const c = buildIssueStatusCatalog([active, archived]);
+
+  it("keeps name and category for an issue left on an archived status", () => {
+    expect(c.labelOf("gate_approved")).toBe("Gate Approved");
+    expect(c.categoryOf("gate_approved")).toBe("done");
+  });
+
+  it("excludes archived from the assignable set", () => {
+    expect(c.activeStatuses.map((e) => e.key)).toEqual(["human_review"]);
+    expect(c.inCategory("done")).toEqual([]);
+  });
+});
+
+describe("statusOptions", () => {
+  // The picker and the status filter both read this list. A cold render — or a
+  // backend that predates the catalog — must still offer all 7 lifecycle steps
+  // rather than an empty sheet.
+  it("offers the 7 built-ins with no catalog loaded", () => {
+    const options = statusOptions(buildIssueStatusCatalog(undefined));
+    expect(options.map((o) => o.key)).toEqual([
+      "backlog",
+      "todo",
+      "in_progress",
+      "in_review",
+      "done",
+      "blocked",
+      "cancelled",
+    ]);
+    expect(options.every((o) => o.color === null)).toBe(true);
+  });
+
+  // A category's catalog rows REPLACE its built-in fallback, so the built-in
+  // must come back through its own is_system row — otherwise turning on custom
+  // statuses would silently remove "In Review" from the picker.
+  it("keeps the built-in alongside its category's custom statuses", () => {
+    const c = buildIssueStatusCatalog([
+      entry("in_review", "in_review", { name: "In Review", is_system: true }),
+      entry("human_review", "in_review", { name: "Human Review" }),
+    ]);
+    const inReview = statusOptions(c).filter((o) => o.category === "in_review");
+    expect(inReview.map((o) => o.key)).toEqual(["in_review", "human_review"]);
+    expect(inReview.map((o) => o.label)).toEqual(["In Review", "Human Review"]);
+    expect(inReview.map((o) => o.color)).toEqual([null, "#123456"]);
+  });
+
+  it("never offers an archived status", () => {
+    const c = buildIssueStatusCatalog([
+      entry("done", "done", { name: "Done", is_system: true }),
+      entry("gate_approved", "done", { archived_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    expect(statusOptions(c).map((o) => o.key)).not.toContain("gate_approved");
+  });
+});

--- a/apps/mobile/lib/issue-status.test.ts
+++ b/apps/mobile/lib/issue-status.test.ts
@@ -1,8 +1,13 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { Issue, IssueStatusEntry } from "@multica/core/types";
 import {
   BOARD_CATEGORIES,
+  CLOSED_CATEGORIES,
   buildIssueStatusCatalog,
+  isCustomStatus,
+  issueBehavesAs,
+  issueBehavesAsAny,
   issueColumnCategory,
   issueStatusColor,
   statusOptions,
@@ -180,5 +185,65 @@ describe("statusOptions", () => {
       entry("gate_approved", "done", { archived_at: "2026-01-01T00:00:00Z" }),
     ]);
     expect(statusOptions(c).map((o) => o.key)).not.toContain("gate_approved");
+  });
+});
+
+describe("issueBehavesAs", () => {
+  // The regression: the mention bar dimmed closed issues with
+  // `status === "done"`, so an issue on a custom status in the done category
+  // rendered at full opacity as though the work were still open. A custom
+  // status inherits its category's behavior in full. (MUL-6243)
+  it("treats a custom status in the done category as done", () => {
+    const shipped = issue({ status: "shipped", status_category: "done" });
+    expect(issueBehavesAs(shipped, "done")).toBe(true);
+    expect(issueBehavesAsAny(shipped, CLOSED_CATEGORIES)).toBe(true);
+  });
+
+  it("treats a custom status in the cancelled category as closed", () => {
+    expect(
+      issueBehavesAsAny(issue({ status: "wont_do", status_category: "cancelled" }), CLOSED_CATEGORIES),
+    ).toBe(true);
+  });
+
+  it("still answers for the built-ins", () => {
+    expect(issueBehavesAsAny(issue({ status: "done" }), CLOSED_CATEGORIES)).toBe(true);
+    expect(issueBehavesAsAny(issue({ status: "cancelled" }), CLOSED_CATEGORIES)).toBe(true);
+    expect(issueBehavesAsAny(issue({ status: "in_review" }), CLOSED_CATEGORIES)).toBe(false);
+  });
+
+  // An unresolved custom key fails SAFE: false keeps the row at full opacity
+  // rather than dimming work that may well still be open.
+  it("says no for a status it cannot resolve", () => {
+    expect(issueBehavesAsAny(issue({ status: "qa" }), CLOSED_CATEGORIES)).toBe(false);
+  });
+});
+
+describe("isCustomStatus", () => {
+  // Drives the row chip: a section header already names the category, so the
+  // chip must speak only when the status adds something the header does not.
+  it("is true for a custom status the catalog knows", () => {
+    const c = buildIssueStatusCatalog([entry("qa", "in_review", { name: "QA" })]);
+    expect(isCustomStatus(c, "qa")).toBe(true);
+  });
+
+  it("stays silent for a built-in", () => {
+    const c = buildIssueStatusCatalog([
+      entry("in_review", "in_review", { name: "In Review", is_system: true }),
+    ]);
+    expect(isCustomStatus(c, "in_review")).toBe(false);
+  });
+
+  // Backstop for a server that omits `is_system` — the schema defaults it to
+  // false, and a built-in must stay silent either way.
+  it("stays silent for a built-in row missing is_system", () => {
+    const c = buildIssueStatusCatalog([entry("done", "done", { name: "Done" })]);
+    expect(isCustomStatus(c, "done")).toBe(false);
+  });
+
+  // No catalog means no name to show, so the row renders exactly as it did
+  // before the catalog existed rather than flashing a chip.
+  it("stays silent when the catalog has not landed", () => {
+    expect(isCustomStatus(buildIssueStatusCatalog(undefined), "qa")).toBe(false);
+    expect(isCustomStatus(buildIssueStatusCatalog([]), "qa")).toBe(false);
   });
 });

--- a/apps/mobile/lib/issue-status.ts
+++ b/apps/mobile/lib/issue-status.ts
@@ -127,6 +127,37 @@ export function issueColumnCategory(
 }
 
 /**
+ * Whether an issue BEHAVES as a given category (MUL-6243).
+ *
+ * The one question every status-coupled product rule actually asks. Comparing
+ * `issue.status` to a built-in key answers it only for a workspace with no
+ * custom statuses: a custom status in the `done` category IS done, and code
+ * that checks `status === "done"` silently disagrees.
+ *
+ * An unresolved custom key answers `false`, and that direction is deliberate —
+ * callers fail safe that way. "Is it done/cancelled?" false keeps a row at full
+ * opacity rather than dimming work that is still open.
+ */
+export function issueBehavesAs(
+  issue: Pick<Issue, "status" | "status_category">,
+  category: IssueStatusCategory,
+): boolean {
+  return issueStatusCategory(issue) === category;
+}
+
+/** True when the issue behaves as any of the given categories. */
+export function issueBehavesAsAny(
+  issue: Pick<Issue, "status" | "status_category">,
+  categories: readonly IssueStatusCategory[],
+): boolean {
+  const resolved = issueStatusCategory(issue);
+  return resolved !== null && categories.includes(resolved);
+}
+
+/** The categories that mean "this issue is closed" — done or cancelled. */
+export const CLOSED_CATEGORIES: readonly IssueStatusCategory[] = ["done", "cancelled"];
+
+/**
  * The `#rrggbb` a surface must paint one catalog entry with, or null when it
  * keeps its category's semantic token.
  *
@@ -201,6 +232,25 @@ export function buildIssueStatusCatalog(
       list.filter((entry) => entry.category === category && !entry.archived_at),
     isLoaded: entries !== undefined,
   };
+}
+
+/**
+ * Whether a status key names a CUSTOM status — i.e. whether a surface that
+ * already shows the CATEGORY still has something left to say (MUL-6243).
+ *
+ * Pure, and takes the catalog the caller already holds, so a row does not open
+ * a second observer to answer the same question it just asked for a colour.
+ */
+export function isCustomStatus(
+  catalog: IssueStatusCatalog,
+  statusKey: string,
+): boolean {
+  const entry = catalog.entryOf(statusKey);
+  if (!entry) return false;
+  // `is_system` is the authority. The key comparison is the backstop for a
+  // server that does not send it — the schema defaults it to false, and a
+  // built-in must stay silent either way.
+  return entry.is_system !== true && statusKey !== catalog.categoryOf(statusKey);
 }
 
 /** One row in the status picker / status filter. */

--- a/apps/mobile/lib/issue-status.ts
+++ b/apps/mobile/lib/issue-status.ts
@@ -1,28 +1,64 @@
 /**
- * Mirror of the BOARD_STATUSES order + status labels from
- * packages/core/issues/config/status.ts.
+ * Issue status resolution for mobile (MUL-6243).
  *
- * Mirrored, not imported: the source file co-exports `STATUS_CONFIG` with
- * web colour tokens (Tailwind v4 syntax) that mobile must not pull in.
- * Keeping this list owned by mobile keeps the import boundary clean.
+ * A workspace always has the 7 built-in statuses and may define custom ones.
+ * Every status — built-in or custom — belongs to exactly one of the 7
+ * CATEGORIES, and the category IS the behavior: a custom status in `in_review`
+ * carries In Review's platform semantics, renders In Review's glyph, and sits
+ * in In Review's section. So the value stored on an issue is a status KEY, and
+ * nothing may group, label or draw it before resolving that key to a category.
  *
- * If web ever reorders BOARD_STATUSES or adds/removes a status, this file
- * must be updated to keep the "Counts and visibility must agree" rule
- * (apps/mobile/CLAUDE.md) intact.
+ * Mirrored from `packages/core/issues/status-category.ts` and
+ * `packages/core/issue-statuses/queries.ts` rather than imported: those modules
+ * reach `../issue-statuses/index`, which pulls web's API client and React Query
+ * key factories into the graph — not on mobile's import whitelist
+ * (apps/mobile/CLAUDE.md). The TYPES are shared, so the two sides cannot drift
+ * on shape; the fallback rules below are restated verbatim so they cannot drift
+ * on behavior either.
  */
-import type { IssuePriority, IssueStatus } from "@multica/core/types";
+import type {
+  Issue,
+  IssuePriority,
+  IssueStatus,
+  IssueStatusCategory,
+  IssueStatusEntry,
+} from "@multica/core/types";
 
-/** Statuses surfaced in list/board views (matches web — `cancelled` excluded). */
-export const BOARD_STATUSES: IssueStatus[] = [
+/**
+ * The 7 categories in canonical display order. Mirrors `ALL_STATUSES` in
+ * packages/core/issues/config/status.ts.
+ */
+export const STATUS_CATEGORIES: IssueStatusCategory[] = [
   "backlog",
   "todo",
   "in_progress",
   "in_review",
   "done",
   "blocked",
+  "cancelled",
 ];
 
-export const STATUS_LABEL: Record<IssueStatus, string> = {
+/**
+ * The categories that get a section in mobile's grouped issue lists —
+ * `cancelled` excluded, which is a documented mobile divergence (see
+ * `components/project/project-related-issues.tsx`).
+ *
+ * These are CATEGORIES, not status keys: a workspace's custom statuses live
+ * inside their category's section rather than adding one of their own. Grouping
+ * by key is what made custom-status issues vanish from these lists (MUL-6457) —
+ * the bucket existed but no section ever read it.
+ */
+export const BOARD_CATEGORIES: IssueStatusCategory[] = STATUS_CATEGORIES.filter(
+  (category) => category !== "cancelled",
+);
+
+/**
+ * Mobile's own copy for the 7 built-ins. Deliberately NOT the catalog's `name`
+ * for those rows: the server seeds built-in names in English and mobile owns
+ * its labels, exactly as web resolves built-ins through i18n and only custom
+ * statuses through the catalog (`useStatusLabel`).
+ */
+export const STATUS_LABEL: Record<IssueStatusCategory, string> = {
   backlog: "Backlog",
   todo: "Todo",
   in_progress: "In Progress",
@@ -39,3 +75,169 @@ export const PRIORITY_LABEL: Record<IssuePriority, string> = {
   high: "High",
   urgent: "Urgent",
 };
+
+const CATEGORY_SET = new Set<string>(STATUS_CATEGORIES);
+
+export function isIssueStatusCategory(value: string): value is IssueStatusCategory {
+  return CATEGORY_SET.has(value);
+}
+
+/**
+ * Category for a bare status KEY, for render paths that hold only the string
+ * and no catalog. Exact for the 7 built-ins — which is every status that exists
+ * until an admin defines a custom one. A custom key answers `todo` so a lookup
+ * always resolves to something renderable; surfaces that must show the real
+ * status resolve through the catalog instead.
+ */
+export function statusCategoryOfKey(statusKey: string): IssueStatusCategory {
+  return isIssueStatusCategory(statusKey) ? statusKey : "todo";
+}
+
+/**
+ * The category an issue's status belongs to, or null when this payload cannot
+ * answer. Reads the server-resolved `status_category` first and otherwise falls
+ * back to the rule that makes that field optional — a built-in key IS its own
+ * category.
+ *
+ * Pure: no catalog, so list grouping never has to wait on a fetch and never
+ * guesses a category while one is in flight.
+ */
+export function issueStatusCategory(
+  issue: Pick<Issue, "status" | "status_category">,
+): IssueStatusCategory | null {
+  const fromServer = issue.status_category;
+  if (fromServer && isIssueStatusCategory(fromServer)) return fromServer;
+  if (isIssueStatusCategory(issue.status)) return issue.status;
+  return null;
+}
+
+/**
+ * The section an issue renders in — always an answer, never null.
+ *
+ * The unresolved fallback lands in `todo` rather than nowhere: a row in a
+ * possibly-wrong section is recoverable, a row in no section is invisible, and
+ * invisible is the bug this exists to prevent ("counts and visibility must
+ * agree", apps/mobile/CLAUDE.md). Unreachable in practice — the server sends a
+ * category on every issue payload, and a built-in key is its own category.
+ */
+export function issueColumnCategory(
+  issue: Pick<Issue, "status" | "status_category">,
+): IssueStatusCategory {
+  return issueStatusCategory(issue) ?? statusCategoryOfKey(issue.status);
+}
+
+/**
+ * The `#rrggbb` a surface must paint one catalog entry with, or null when it
+ * keeps its category's semantic token.
+ *
+ * ALWAYS null for a built-in: the 7 carry a seeded hex the server refuses to
+ * let anyone edit, and every surface draws them from their category token so
+ * they follow the theme into dark mode. Reading the seed instead paints the
+ * same status in two different greens depending on which control you look at
+ * (MUL-6440).
+ */
+export function issueStatusColor(entry: IssueStatusEntry | undefined): string | null {
+  if (!entry || entry.is_system === true) return null;
+  return entry.color || null;
+}
+
+/**
+ * A resolved view over the workspace catalog. Every lookup falls back to
+ * something renderable, because an issue can legitimately carry a status this
+ * client has not heard of: one created moments ago in another session, or one
+ * whose catalog fetch has not landed yet.
+ */
+export interface IssueStatusCatalog {
+  /**
+   * Every status in display order, ARCHIVED INCLUDED, so an issue left on an
+   * archived status still resolves to its real name, colour and category. Use
+   * `activeStatuses` for anything that OFFERS a status to pick.
+   */
+  statuses: IssueStatusEntry[];
+  /** Assignable statuses — `statuses` minus archived ones. */
+  activeStatuses: IssueStatusEntry[];
+  /** Category for a status key; the key itself when built-in, else `todo`. */
+  categoryOf: (statusKey: string) => IssueStatusCategory;
+  /** Label for a status key: mobile's copy for built-ins, the catalog's `name`
+   *  for custom statuses, the raw key when neither resolves. */
+  labelOf: (statusKey: string) => string;
+  /** Catalog entry for a status key, when the catalog knows it. */
+  entryOf: (statusKey: string) => IssueStatusEntry | undefined;
+  /** See {@link issueStatusColor} — null keeps the category's token colour. */
+  colorOf: (statusKey: string) => string | null;
+  /** ACTIVE statuses in one category, in display order. */
+  inCategory: (category: IssueStatusCategory) => IssueStatusEntry[];
+  /** True once the catalog has loaded; false while it is still in flight. */
+  isLoaded: boolean;
+}
+
+/**
+ * Builds the resolved catalog from a raw entry list. Pure, so a non-React
+ * caller can use a list it already holds.
+ */
+export function buildIssueStatusCatalog(
+  entries: IssueStatusEntry[] | undefined,
+): IssueStatusCatalog {
+  const list = entries ?? [];
+  const byKey = new Map(list.map((entry) => [entry.key, entry]));
+
+  return {
+    statuses: list,
+    activeStatuses: list.filter((entry) => !entry.archived_at),
+    categoryOf: (statusKey) => {
+      const category = byKey.get(statusKey)?.category;
+      if (category && isIssueStatusCategory(category)) return category;
+      return statusCategoryOfKey(statusKey);
+    },
+    entryOf: (statusKey) => byKey.get(statusKey),
+    colorOf: (statusKey) => issueStatusColor(byKey.get(statusKey)),
+    labelOf: (statusKey) => {
+      // Built-in first, so a workspace that never opened status settings reads
+      // exactly as it did before the catalog existed.
+      if (isIssueStatusCategory(statusKey)) return STATUS_LABEL[statusKey];
+      return byKey.get(statusKey)?.name ?? statusKey;
+    },
+    inCategory: (category) =>
+      list.filter((entry) => entry.category === category && !entry.archived_at),
+    isLoaded: entries !== undefined,
+  };
+}
+
+/** One row in the status picker / status filter. */
+export interface StatusOption {
+  key: IssueStatus;
+  /** The category this status behaves as — drives its glyph. */
+  category: IssueStatusCategory;
+  label: string;
+  /** `#rrggbb` for a custom status; null for a built-in, which keeps its token. */
+  color: string | null;
+}
+
+/**
+ * The statuses a user can pick or filter by, as one flat list in canonical
+ * category order. Mirrors web's `useStatusOptions`
+ * (packages/views/issues/utils/status-options.ts).
+ *
+ * Shared by the picker and the filter so the two can never drift — a status
+ * offered in one and missing from the other is exactly how an issue becomes
+ * unfindable. Archived statuses are excluded: archiving retires a status from
+ * future assignment, and issues already on one keep it and keep their label.
+ *
+ * A category with no catalog row falls back to its built-in, so a cold render
+ * (or a backend that predates the endpoint) offers the same 7 rows it always
+ * did instead of an empty sheet.
+ */
+export function statusOptions(catalog: IssueStatusCatalog): StatusOption[] {
+  return STATUS_CATEGORIES.flatMap<StatusOption>((category) => {
+    const entries = catalog.inCategory(category);
+    if (entries.length === 0) {
+      return [{ key: category, category, label: STATUS_LABEL[category], color: null }];
+    }
+    return entries.map((entry) => ({
+      key: entry.key,
+      category,
+      label: catalog.labelOf(entry.key),
+      color: issueStatusColor(entry),
+    }));
+  });
+}

--- a/apps/mobile/lib/use-issue-statuses.ts
+++ b/apps/mobile/lib/use-issue-statuses.ts
@@ -1,0 +1,33 @@
+/**
+ * The workspace status catalog, resolved and memoized (MUL-6243).
+ *
+ * Mobile-owned mirror of `packages/core/issue-statuses/hooks.ts`. Two
+ * deliberate differences:
+ *
+ * 1. **No `wsId` parameter.** Every mobile request is scoped by the
+ *    `X-Workspace-Slug` header of the CURRENT workspace (see `data/api.ts`), so
+ *    a catalog fetched under some other workspace's id would cache that
+ *    workspace's key with this workspace's rows. Web passes an id because its
+ *    inbox is cross-workspace; mobile's inbox is a single-workspace list, so
+ *    reading the store is both simpler and the only correct option.
+ * 2. **No `isPending` / `isError` / `retry`.** Web needs those because its
+ *    board routes a status FILTER to server-side column branches and must hold
+ *    its loading state rather than guess. Mobile filters client-side over an
+ *    already-fetched list and groups on the server-sent `status_category`, so
+ *    nothing here blocks on the catalog — a catalog that never arrives degrades
+ *    to exactly the pre-catalog rendering (built-in labels, category glyphs).
+ */
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { issueStatusListOptions } from "@/data/queries/issue-statuses";
+import { useWorkspaceStore } from "@/data/workspace-store";
+import {
+  buildIssueStatusCatalog,
+  type IssueStatusCatalog,
+} from "@/lib/issue-status";
+
+export function useIssueStatuses(): IssueStatusCatalog {
+  const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const { data } = useQuery(issueStatusListOptions(wsId));
+  return useMemo(() => buildIssueStatusCatalog(data), [data]);
+}


### PR DESCRIPTION
Closes MUL-6457. Parent: MUL-6243 (web side: #7065, #7084, #7103).

## The problem

Mobile had no awareness of the workspace status catalog. `custom_issue_statuses` is a deployment-level flag, so a status created on web hit iOS users of the same deployment immediately — and degraded badly:

1. **My Issues silently dropped the issue.** `my-issues.tsx` bucketed by `issue.status`, then rendered only the buckets named in `BOARD_STATUSES`. A `qa` bucket existed that no section ever read, so the row was not on screen at all. Same in `more/issues.tsx` and project detail's related-issues list.
2. **The picker could not set one.** Candidates were the hardcoded `[...BOARD_STATUSES, "cancelled"]`.
3. **Labels did not resolve.** `STATUS_LABEL[<custom>]` is `undefined` — search fell back to the raw key, the filter sheet rendered blank.

One mistake repeated: mobile treated a status KEY as if it carried presentation and behavior, when both come from its CATEGORY.

## The change

- **Catalog**: `GET /api/issue-statuses` behind a 5-minute-stale query keyed on `wsId`. Archived rows included, so an issue left on an archived status keeps its real name and category; pickers read `activeStatuses` instead. Reuses core's zod schema, which is already covered by a malformed-response test.
- **Grouping**: `groupIssuesByCategory()`, extracted from the two screens that held the same fifteen lines — and the same bug — twice. It reads the server-resolved `status_category` (#7065) and falls back to "a built-in key is its own category", so grouping never waits on the catalog and never guesses a column while one is in flight.
- **Options**: `statusOptions()` feeds both the picker and the status filter, so a status settable in one can never be missing from the other. With no catalog loaded it returns exactly the 7 built-ins the picker always offered.
- **Presentation**: name and colour resolve through the catalog wherever a status key is displayed — detail chip, search rows, inbox row + detail label, timeline. Built-ins keep mobile's own copy and their category token (the server seeds their names in English and refuses recolours, so reading the catalog row for either would drift). The glyph stays per category, matching web's `StatusIcon`.
- **Cache consistency**: an optimistic `{status}` write now drops the inherited `status_category` instead of keeping a stale one — the detail cache feeds search's recent-issues rows, which group by category.

`cancelled` still gets no section on mobile, so a custom status in that category is hidden there exactly like the built-in Cancelled always was. That is the same rule the rest of this PR follows: a custom status inherits its category's behavior in full.

## Compatibility

A workspace with no custom statuses renders identically to before — a built-in key is its own category, so every lookup resolves without the catalog. Same for a backend that predates the endpoint: the query errors, the catalog stays empty, and every surface falls back to the built-in path. Nothing blocks on the fetch.

## Verification

- `pnpm typecheck` (mobile + repo-wide): pass
- `pnpm lint` (mobile): 0 errors; the 7 warnings are pre-existing and untouched
- `pnpm exec vitest run` (mobile): 101 pass, including 21 new cases across `lib/issue-status.test.ts` (category resolution, built-in vs custom label/colour, archived, option list) and `lib/group-issues-by-category.test.ts` (the disappearing-card regression, canonical order, cancelled omission, unresolved-key fallback)

Not run: the iOS simulator — no backend with custom statuses available in this environment. The grouping and resolution rules are covered by the unit tests above; the rendering wiring is a mechanical prop pass mirroring web's `StatusIcon` API.
