### PR TITLE
MUL-6462: feat(views): add a web-only Desktop download entry to the Help menu

### DIFF
--- a/packages/views/layout/help-launcher.test.tsx
+++ b/packages/views/layout/help-launcher.test.tsx
@@ -108,7 +108,7 @@ describe("HelpLauncher", () => {
   // through the marketing site. The Help menu is the persistent home for it.
   it("links to the download page on web", () => {
     render(<HelpLauncher />);
-    const link = screen.getByRole("link", { name: /Download Desktop/ });
+    const link = screen.getByRole("link", { name: /Desktop app/ });
     expect(link).toHaveAttribute("href", "https://multica.ai/download");
   });
 
@@ -117,7 +117,7 @@ describe("HelpLauncher", () => {
   it("hides the download entry inside the desktop shell", () => {
     vi.mocked(isDesktopShell).mockReturnValue(true);
     render(<HelpLauncher />);
-    expect(screen.queryByText("Download Desktop")).not.toBeInTheDocument();
+    expect(screen.queryByText("Desktop app")).not.toBeInTheDocument();
     // The rest of the menu is unaffected by the gate.
     expect(screen.getByText("Docs")).toBeInTheDocument();
   });

--- a/packages/views/layout/help-launcher.test.tsx
+++ b/packages/views/layout/help-launcher.test.tsx
@@ -1,9 +1,17 @@
-import type { ReactNode } from "react";
+import { cloneElement, type ReactElement, type ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configStore } from "@multica/core/config";
 import enLayout from "../locales/en/layout.json";
+import { isDesktopShell } from "../platform/local-directory";
 import { HelpLauncher } from "./help-launcher";
+
+// The download entry is gated on the desktop-shell probe, which reads a
+// preload-injected bridge that jsdom never has. Mock it so both platforms are
+// reachable from the same suite.
+vi.mock("../platform/local-directory", () => ({
+  isDesktopShell: vi.fn(() => false),
+}));
 
 // react-i18next isn't initialised in the views test env, so resolve the
 // selector against the real en/layout.json to assert on actual copy.
@@ -38,7 +46,17 @@ vi.mock("@multica/ui/components/ui/dropdown-menu", async () => {
   return {
     DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
     DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
-    DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+    // Base UI's `render` prop swaps in a caller-supplied element (here the
+    // <a>) and adopts the item's children. Flattening it to a bare fragment —
+    // as this mock originally did — would drop the anchor entirely and make an
+    // href assertion silently unfalsifiable.
+    DropdownMenuItem: ({
+      children,
+      render,
+    }: {
+      children: ReactNode;
+      render?: ReactElement;
+    }) => (render ? cloneElement(render, undefined, children) : <>{children}</>),
     DropdownMenuGroup: ({ children }: { children: ReactNode }) => (
       <GroupContext.Provider value={true}>{children}</GroupContext.Provider>
     ),
@@ -53,6 +71,10 @@ vi.mock("@multica/ui/components/ui/dropdown-menu", async () => {
     DropdownMenuSeparator: () => null,
     DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   };
+});
+
+beforeEach(() => {
+  vi.mocked(isDesktopShell).mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -79,5 +101,24 @@ describe("HelpLauncher", () => {
     configStore.getState().setServerVersion("9.9.9");
     expect(() => render(<HelpLauncher />)).not.toThrow();
     expect(screen.getByText("Server version 9.9.9")).toBeInTheDocument();
+  });
+
+  // MUL-6462: after web onboarding the desktop download CTA was unreachable —
+  // no entry anywhere in the app, so users had to remember the URL or detour
+  // through the marketing site. The Help menu is the persistent home for it.
+  it("links to the download page on web", () => {
+    render(<HelpLauncher />);
+    const link = screen.getByRole("link", { name: /Download Desktop/ });
+    expect(link).toHaveAttribute("href", "https://multica.ai/download");
+  });
+
+  // AppSidebar is shared: apps/desktop renders the same component tree. Without
+  // this gate the desktop app would offer to download the desktop app.
+  it("hides the download entry inside the desktop shell", () => {
+    vi.mocked(isDesktopShell).mockReturnValue(true);
+    render(<HelpLauncher />);
+    expect(screen.queryByText("Download Desktop")).not.toBeInTheDocument();
+    // The rest of the menu is unaffected by the gate.
+    expect(screen.getByText("Docs")).toBeInTheDocument();
   });
 });

--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -25,6 +25,10 @@ import { useT } from "../i18n";
 
 const DOCS_URL = "https://multica.ai/docs";
 const CHANGELOG_URL = "https://multica.ai/changelog";
+// Absolute, including on self-hosted deployments: the installers we ship are
+// the same binaries either way, and the desktop client can point at a
+// self-hosted backend once installed. A self-host-relative /download would
+// only serve a copy of this page that still has to reach our release assets.
 const DOWNLOAD_URL = "https://multica.ai/download";
 
 export function HelpLauncher() {

--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ArrowUpRight, BookOpen, CircleHelp, History, MessageCircle } from "lucide-react";
+import {
+  ArrowUpRight,
+  BookOpen,
+  CircleHelp,
+  Download,
+  History,
+  MessageCircle,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,15 +19,27 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useModalStore } from "@multica/core/modals";
 import { useConfigStore } from "@multica/core/config";
+import { isDesktopShell } from "../platform/local-directory";
 import { DISCORD_URL, DiscordIcon } from "./discord";
 import { useT } from "../i18n";
 
 const DOCS_URL = "https://multica.ai/docs";
 const CHANGELOG_URL = "https://multica.ai/changelog";
+const DOWNLOAD_URL = "https://multica.ai/download";
 
 export function HelpLauncher() {
   const { t } = useT("layout");
   const serverVersion = useConfigStore((state) => state.serverVersion);
+  // Web-only: offering "download the desktop app" inside the desktop app is
+  // nonsense, and this sidebar is shared — apps/desktop renders the same
+  // AppSidebar as the web dashboard, so the entry has to be gated here.
+  //
+  // No `mounted` deferral (cf. browser-notification-setting.tsx): the desktop
+  // renderer is a locally-bundled SPA with no SSR pass, and on web
+  // `isDesktopShell()` is false both on the server and after hydration. The
+  // markup matches either way, so the link can ship in the SSR payload instead
+  // of popping in a frame late.
+  const desktop = isDesktopShell();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -36,6 +55,24 @@ export function HelpLauncher() {
         sideOffset={8}
         className="min-w-40 max-w-56"
       >
+        {!desktop && (
+          <>
+            <DropdownMenuItem
+              render={
+                <a
+                  href={DOWNLOAD_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+            >
+              <Download className="h-3.5 w-3.5" />
+              {t(($) => $.help.download_desktop)}
+              <ArrowUpRight className="size-3 translate-y-px text-faint-foreground" />
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuItem
           render={
             <a href={DOCS_URL} target="_blank" rel="noopener noreferrer" />

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -29,7 +29,7 @@
   },
   "help": {
     "trigger": "Help",
-    "download_desktop": "Download Desktop",
+    "download_desktop": "Desktop app",
     "docs": "Docs",
     "changelog": "Change log",
     "discord": "Discord",

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -29,6 +29,7 @@
   },
   "help": {
     "trigger": "Help",
+    "download_desktop": "Download Desktop",
     "docs": "Docs",
     "changelog": "Change log",
     "discord": "Discord",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -29,6 +29,7 @@
   },
   "help": {
     "trigger": "ヘルプ",
+    "download_desktop": "デスクトップ版をダウンロード",
     "docs": "ドキュメント",
     "changelog": "変更ログ",
     "discord": "Discord",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -29,7 +29,7 @@
   },
   "help": {
     "trigger": "ヘルプ",
-    "download_desktop": "デスクトップ版をダウンロード",
+    "download_desktop": "デスクトップ版",
     "docs": "ドキュメント",
     "changelog": "変更ログ",
     "discord": "Discord",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -29,7 +29,7 @@
   },
   "help": {
     "trigger": "도움말",
-    "download_desktop": "데스크톱 다운로드",
+    "download_desktop": "데스크톱 앱",
     "docs": "문서",
     "changelog": "변경 로그",
     "discord": "Discord",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -29,6 +29,7 @@
   },
   "help": {
     "trigger": "도움말",
+    "download_desktop": "데스크톱 다운로드",
     "docs": "문서",
     "changelog": "변경 로그",
     "discord": "Discord",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -29,7 +29,7 @@
   },
   "help": {
     "trigger": "帮助",
-    "download_desktop": "下载桌面端",
+    "download_desktop": "桌面端",
     "docs": "文档",
     "changelog": "更新日志",
     "discord": "Discord",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -29,6 +29,7 @@
   },
   "help": {
     "trigger": "帮助",
+    "download_desktop": "下载桌面端",
     "docs": "文档",
     "changelog": "更新日志",
     "discord": "Discord",


### PR DESCRIPTION
Closes #7280

## Problem

After finishing web onboarding there was no way left inside the app to find the Desktop download. The onboarding welcome step has a "Download Desktop" button, but that screen is a one-shot funnel — once past it, nothing in the product points at the download page. Users had to remember the URL or detour back through the marketing site.

## Change

Adds a persistent **Desktop app** entry to the Help menu, as the first item followed by a separator.

Against the reported acceptance criteria:

| Criterion | How it is met |
| --- | --- |
| Reach the download page within two clicks | Help trigger → menu item. The Help launcher lives in the sidebar footer and is reachable from any dashboard screen. |
| Available whether or not a Runtime exists | Already satisfied by placement: `DashboardLayout` is gated by `DashboardGuard` (auth + workspace) only, so the sidebar renders in the no-Runtime empty state. |
| Visible on Web, hidden in Desktop | Gated on `isDesktopShell()`. |
| Reuse the existing localized label | Partially — see the copy note below. |

## Notes for reviewers

**The Help menu is shared, not web-only.** `apps/desktop` renders the same `AppSidebar` as the web dashboard, so without the gate the desktop app would offer to download the desktop app. The gate uses `isDesktopShell()` (`packages/views/platform/local-directory.ts`), the same probe `browser-notification-setting.tsx` uses.

**No `mounted` deferral.** The desktop renderer is a locally-bundled SPA with no SSR pass, and on web `isDesktopShell()` is false both on the server and after hydration — the markup matches either way, so the link ships in the SSR payload rather than popping in a frame late. This differs from `browser-notification-setting.tsx`, which defers because it additionally reads a live `Notification` permission.

**Copy is a noun, not the onboarding verb phrase.** The issue asked to reuse the existing `welcome.download_desktop` label. Reusing it verbatim read badly here: every other entry in this dropdown is a bare noun (Docs / Change log / Discord / Feedback), and the Japanese form ran 13 characters against a `max-w-56` menu. The entry is now `Desktop app` / `桌面端` / `デスクトップ版` / `데스크톱 앱`, with the Download icon carrying the verb. The strings live under `help.*` in the four `layout.json` bundles — `HelpLauncher` reads the `layout` namespace, and `locales/parity.test.ts` enforces all-locale parity, so they land together.

**The URL is absolute, including on self-hosted deployments.** The installers are the same binaries either way, and an installed desktop client can point at a self-hosted backend, so there is nothing for a self-host-relative `/download` to serve that the public page does not. This also matches the existing `DOCS_URL` / `CHANGELOG_URL` entries in the same menu. Rationale is recorded in a comment next to the constant.

**Test mock fix.** The suite's `DropdownMenuItem` mock flattened children and dropped Base UI's `render` prop, which meant the anchor never rendered and an `href` assertion would have passed vacuously. It now clones the supplied element. Existing cases assert on text only and are unaffected.

## Verification

- `packages/views` full suite: 389 files / 4517 tests pass.
- `tsc --noEmit` and `eslint` clean.
- Both new cases verified falsifiable: removing the desktop gate fails the hide test; changing the URL fails the href test.
- Not manually exercised in a running desktop build — the gate is covered by the unit test rather than a live client.
