### PR TITLE
MUL-6468: fix(docs): replace dead dimcode.ai link with official Dim CLI docs

### DIFF
--- a/apps/docs/content/docs/install-agent-runtime.ja.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ja.mdx
@@ -38,7 +38,7 @@ Multica は現在、次のコマンドを検出します。
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE 公式サイト](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimcode.ai) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
 
 ここでの「対応」とは、Multica が該当する CLI を呼び出せるという意味です。そのツールのアカウント、サブスクリプション、モデルの利用枠を Multica が提供するわけではありません。
 

--- a/apps/docs/content/docs/install-agent-runtime.ja.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ja.mdx
@@ -38,7 +38,7 @@ Multica は現在、次のコマンドを検出します。
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE 公式サイト](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/en/docs/cli) |
 
 ここでの「対応」とは、Multica が該当する CLI を呼び出せるという意味です。そのツールのアカウント、サブスクリプション、モデルの利用枠を Multica が提供するわけではありません。
 

--- a/apps/docs/content/docs/install-agent-runtime.ko.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ko.mdx
@@ -38,7 +38,7 @@ Multica는 현재 다음 명령을 감지합니다.
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE 공식 사이트](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimcode.ai) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
 
 "지원됨"은 Multica가 해당 CLI를 호출할 수 있다는 뜻이며 Multica가 도구의 계정, 구독, 모델 사용량을 제공한다는 뜻은 아닙니다.
 

--- a/apps/docs/content/docs/install-agent-runtime.ko.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ko.mdx
@@ -38,7 +38,7 @@ Multica는 현재 다음 명령을 감지합니다.
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE 공식 사이트](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/en/docs/cli) |
 
 "지원됨"은 Multica가 해당 CLI를 호출할 수 있다는 뜻이며 Multica가 도구의 계정, 구독, 모델 사용량을 제공한다는 뜻은 아닙니다.
 

--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -38,7 +38,7 @@ Multica currently detects these commands:
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE official site](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimcode.ai) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
 
 "Supported" means Multica can invoke that CLI. It does not mean Multica provides the tool's account, subscription, or model quota for you.
 

--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -38,7 +38,7 @@ Multica currently detects these commands:
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE official site](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/en/docs/cli) |
 
 "Supported" means Multica can invoke that CLI. It does not mean Multica provides the tool's account, subscription, or model quota for you.
 

--- a/apps/docs/content/docs/install-agent-runtime.zh.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.zh.mdx
@@ -38,7 +38,7 @@ Multica 当前会检测以下命令：
 | QwenPaw | `qwenpaw` | [QwenPaw](https://github.com/agentscope-ai/QwenPaw) |
 | Reasonix | `reasonix` | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) |
 | TRAE CLI | `traecli` | [TRAE 官方站](https://www.trae.cn/) |
-| Dim | `dim` | [DimCode](https://dimcode.ai) |
+| Dim | `dim` | [DimCode](https://dimagent.cn/docs/cli) |
 
 "受支持"表示 Multica 能够调用对应 CLI，不代表 Multica 会替你提供该工具的账号、订阅或模型额度。
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Dim install guide link in `install-agent-runtime` across all 4 language versions (en/zh/ja/ko).

The merged PR #6675 linked Dim to `https://dimcode.ai`, which does not resolve (no DNS). Replaced with the official CLI documentation at `https://dimagent.cn/docs/cli`.

## Changes

- `apps/docs/content/docs/install-agent-runtime.mdx` (en)
- `apps/docs/content/docs/install-agent-runtime.zh.mdx` (zh)
- `apps/docs/content/docs/install-agent-runtime.ja.mdx` (ja)
- `apps/docs/content/docs/install-agent-runtime.ko.mdx` (ko)

Each file: `[DimCode](https://dimcode.ai)` → `[DimCode](https://dimagent.cn/docs/cli)`

## Type of Change

- [x] Documentation update (no code changes)

## Verification

- Both `https://dimagent.cn/` and `https://dimagent.cn/docs/cli` return HTTP 200.
- No other files reference `dimcode.ai`.