### PR TITLE
MUL-6456: retire the issue last activity index

### DIFF
--- a/server/cmd/backfill_issue_last_activity/README.md
+++ b/server/cmd/backfill_issue_last_activity/README.md
@@ -1,7 +1,7 @@
 # Issue last-activity backfill runbook
 
-Use this command only after migrations 360 and 361 are applied and every
-issue-writing backend has been upgraded to maintain `issue.last_activity_at`.
+Use this command only after migration 360 is applied and every issue-writing
+backend has been upgraded to maintain `issue.last_activity_at`.
 Running it while an older writer is still live can make that writer's later
 changes invisible to the activity clock.
 
@@ -21,15 +21,11 @@ counting the table forever. Release the long-held row locks and rerun, or adjust
 Completion is explicit: do not depend on complete historical activity ordering
 until the command logs `remaining=0`.
 
-Migration 361 builds the serving index before this operator-run backfill so
-new application versions can sort safely throughout a rolling deployment. The
-tradeoff is index maintenance and possible bloat while historical rows are
-updated. After a large backfill, rebuild it online during a normal maintenance
-window:
-
-```sql
-REINDEX INDEX CONCURRENTLY idx_issue_workspace_last_activity;
-```
+Migration 375 retires the `idx_issue_workspace_last_activity` serving index
+because neither the planned recent-issue window nor a first-party
+last-activity sort is active. The backfill remains useful as the semantic
+activity clock, but an explicit API `sort=last_activity` request uses a scan and
+sort until a replacement serving design is introduced.
 
 Do not roll application writers back to a version that predates
 `last_activity_at` after the backfill. The nullable column keeps old readers

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -257,6 +257,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"303_drop_redundant_lark_chat_session_binding_index":    "idx_lark_chat_session_binding_session",
 	"312_drop_global_plugin_identity_key_index":             "idx_plugin_identity_key",
 	"371_comment_content_search_index_strategy":             "idx_comment_content_trgm",
+	"375_drop_issue_last_activity_index":                    "idx_issue_workspace_last_activity",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {
@@ -279,6 +280,10 @@ var preRollbackHooks = func() map[string]preMigrationHook {
 }()
 
 var upMigrationConditions = map[string]migrationCondition{
+	// The recent-activity issue window that migration 361 prepared has not been
+	// enabled. Migration 375 retires its write-heavy serving index, so a fresh
+	// install should not build that index only to drop it a few versions later.
+	"361_issue_last_activity_index": skipMigrationSQL("index retired by migration 375"),
 	// Fresh databases that successfully built the CJK-friendly bigram index do
 	// not need to build the trigram fallback only to remove it at migration 371.
 	"140_comment_content_trgm_index": whenIndexNotUsable(commentContentBigramIndex),
@@ -286,6 +291,12 @@ var upMigrationConditions = map[string]migrationCondition{
 	// fallback only after proving the preferred index has the exact usable shape;
 	// pg_bigm-less self-hosted databases keep trgm and record 371 as a no-op.
 	"371_comment_content_search_index_strategy": whenIndexUsable(commentContentBigramIndex),
+}
+
+func skipMigrationSQL(reason string) migrationCondition {
+	return func(context.Context, *pgxpool.Conn) (bool, string, error) {
+		return false, reason, nil
+	}
 }
 
 func hooksForDirection(direction string) map[string]preMigrationHook {

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -280,10 +280,6 @@ var preRollbackHooks = func() map[string]preMigrationHook {
 }()
 
 var upMigrationConditions = map[string]migrationCondition{
-	// The recent-activity issue window that migration 361 prepared has not been
-	// enabled. Migration 375 retires its write-heavy serving index, so a fresh
-	// install should not build that index only to drop it a few versions later.
-	"361_issue_last_activity_index": skipMigrationSQL("index retired by migration 375"),
 	// Fresh databases that successfully built the CJK-friendly bigram index do
 	// not need to build the trigram fallback only to remove it at migration 371.
 	"140_comment_content_trgm_index": whenIndexNotUsable(commentContentBigramIndex),
@@ -291,12 +287,6 @@ var upMigrationConditions = map[string]migrationCondition{
 	// fallback only after proving the preferred index has the exact usable shape;
 	// pg_bigm-less self-hosted databases keep trgm and record 371 as a no-op.
 	"371_comment_content_search_index_strategy": whenIndexUsable(commentContentBigramIndex),
-}
-
-func skipMigrationSQL(reason string) migrationCondition {
-	return func(context.Context, *pgxpool.Conn) (bool, string, error) {
-		return false, reason, nil
-	}
 }
 
 func hooksForDirection(direction string) map[string]preMigrationHook {

--- a/server/cmd/migrate/migrate_issue_last_activity_index_retirement_test.go
+++ b/server/cmd/migrate/migrate_issue_last_activity_index_retirement_test.go
@@ -16,7 +16,7 @@ func TestIssueLastActivityIndexRetirement(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	t.Run("fresh install skips retired index build", func(t *testing.T) {
+	t.Run("fresh install builds then retires historical index", func(t *testing.T) {
 		schema, pool := createIssueLastActivityIndexFixture(t, ctx, adminPool)
 		migrationsTable := schema + ".schema_migrations"
 		options := runOptions{
@@ -31,7 +31,7 @@ func TestIssueLastActivityIndexRetirement(t *testing.T) {
 		if err := runMigrations(ctx, pool, options); err != nil {
 			t.Fatalf("apply historical index migration: %v", err)
 		}
-		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
+		assertIndexValidity(t, pool, schema, "idx_issue_workspace_last_activity", true)
 		assertMigrationVersionRecorded(t, ctx, pool, schema, "361_issue_last_activity_index", true)
 
 		options.Files = realMigrationFiles(t, []string{"375_drop_issue_last_activity_index"}, "up")
@@ -40,6 +40,11 @@ func TestIssueLastActivityIndexRetirement(t *testing.T) {
 		}
 		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
 		assertMigrationVersionRecorded(t, ctx, pool, schema, "375_drop_issue_last_activity_index", true)
+
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("repeat applied index retirement migration: %v", err)
+		}
+		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
 	})
 
 	t.Run("existing deployment drops index and rollback restores it", func(t *testing.T) {

--- a/server/cmd/migrate/migrate_issue_last_activity_index_retirement_test.go
+++ b/server/cmd/migrate/migrate_issue_last_activity_index_retirement_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestIssueLastActivityIndexRetirement(t *testing.T) {
+	adminPool := openTestPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	t.Run("fresh install skips retired index build", func(t *testing.T) {
+		schema, pool := createIssueLastActivityIndexFixture(t, ctx, adminPool)
+		migrationsTable := schema + ".schema_migrations"
+		options := runOptions{
+			Direction:             "up",
+			SchemaMigrationsTable: migrationsTable,
+			AdvisoryLockKey:       int64(rand.Uint64()&0x7fffffffffffffff) | 1,
+			Hooks:                 hooksForDirection("up"),
+			Conditions:            conditionsForDirection("up"),
+		}
+
+		options.Files = realMigrationFiles(t, []string{"361_issue_last_activity_index"}, "up")
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("apply historical index migration: %v", err)
+		}
+		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
+		assertMigrationVersionRecorded(t, ctx, pool, schema, "361_issue_last_activity_index", true)
+
+		options.Files = realMigrationFiles(t, []string{"375_drop_issue_last_activity_index"}, "up")
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("apply index retirement migration: %v", err)
+		}
+		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
+		assertMigrationVersionRecorded(t, ctx, pool, schema, "375_drop_issue_last_activity_index", true)
+	})
+
+	t.Run("existing deployment drops index and rollback restores it", func(t *testing.T) {
+		schema, pool := createIssueLastActivityIndexFixture(t, ctx, adminPool)
+		migrationsTable := schema + ".schema_migrations"
+		options := runOptions{
+			Direction:             "up",
+			SchemaMigrationsTable: migrationsTable,
+			AdvisoryLockKey:       int64(rand.Uint64()&0x7fffffffffffffff) | 1,
+			Hooks:                 hooksForDirection("up"),
+		}
+
+		options.Files = realMigrationFiles(t, []string{"361_issue_last_activity_index"}, "up")
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("apply existing index migration: %v", err)
+		}
+		assertIndexValidity(t, pool, schema, "idx_issue_workspace_last_activity", true)
+
+		options.Files = realMigrationFiles(t, []string{"375_drop_issue_last_activity_index"}, "up")
+		options.Conditions = conditionsForDirection("up")
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("apply index retirement migration: %v", err)
+		}
+		assertIndexExists(t, pool, schema, "idx_issue_workspace_last_activity", false)
+
+		options.Direction = "down"
+		options.Files = realMigrationFiles(t, []string{"375_drop_issue_last_activity_index"}, "down")
+		options.Hooks = hooksForDirection("down")
+		options.Conditions = conditionsForDirection("down")
+		if err := runMigrations(ctx, pool, options); err != nil {
+			t.Fatalf("roll back index retirement migration: %v", err)
+		}
+		assertIndexValidity(t, pool, schema, "idx_issue_workspace_last_activity", true)
+		assertMigrationVersionRecorded(t, ctx, pool, schema, "375_drop_issue_last_activity_index", false)
+	})
+}
+
+func createIssueLastActivityIndexFixture(
+	t *testing.T,
+	ctx context.Context,
+	adminPool *pgxpool.Pool,
+) (string, *pgxpool.Pool) {
+	t.Helper()
+	suffix := fmt.Sprintf("%d_%d", time.Now().UnixNano(), rand.Uint32())
+	schema := "migrate_issue_activity_" + suffix
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schemaIdent); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if _, err := adminPool.Exec(cleanupCtx, "DROP SCHEMA IF EXISTS "+schemaIdent+" CASCADE"); err != nil {
+			t.Logf("drop schema %s: %v", schema, err)
+		}
+	})
+
+	pool := openTestPoolWithSearchPath(t, schema)
+	if _, err := pool.Exec(ctx, `CREATE TABLE issue (
+		id UUID PRIMARY KEY,
+		workspace_id UUID NOT NULL,
+		last_activity_at TIMESTAMPTZ
+	)`); err != nil {
+		t.Fatalf("create issue fixture: %v", err)
+	}
+	return schema, pool
+}

--- a/server/migrations/375_drop_issue_last_activity_index.down.sql
+++ b/server/migrations/375_drop_issue_last_activity_index.down.sql
@@ -1,0 +1,3 @@
+-- Restore the serving index when rolling back the retirement migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_workspace_last_activity
+    ON issue (workspace_id, last_activity_at DESC NULLS LAST, id DESC);

--- a/server/migrations/375_drop_issue_last_activity_index.up.sql
+++ b/server/migrations/375_drop_issue_last_activity_index.up.sql
@@ -1,0 +1,3 @@
+-- The recent-activity issue window is not active, while maintaining this index
+-- makes every last_activity_at update ineligible for a HOT update.
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_workspace_last_activity;


### PR DESCRIPTION
## Purpose

`idx_issue_workspace_last_activity` was introduced to serve the planned Free recent-1,000 issue window and explicit `sort=last_activity` requests. The window is not active, and no first-party web, desktop, mobile, or CLI caller exposes that sort. Keeping the index makes semantic `last_activity_at` updates ineligible for HOT updates and adds write amplification.

## Changes

- drop `idx_issue_workspace_last_activity` concurrently while preserving the `last_activity_at` column and its update semantics
- let historical migration 361 execute normally so the migration ledger continues to match the schema changes that actually ran
- rebuild the index concurrently on rollback, including invalid-index retry cleanup
- update the last-activity backfill runbook for the retired serving index
- cover fresh install, existing deployment, repeated up, and rollback paths with migration integration tests

Migration 375 is intentional: open draft PR #7241 already reserves migration prefixes 372–374.

Explicit API `sort=last_activity` remains valid but uses a scan and sort until the recent-window feature gets a replacement serving design.

## Measured scope

Deleting the index restores HOT eligibility; it does not guarantee an immediate order-of-magnitude reduction. In a synthetic 5,000-row fixture using the production default `fillfactor=100`, repeated issue touches reached about 13.5% HOT updates after 10 rounds, versus 0% while the index remained. A non-HOT touch reduced WAL bytes from 3,216 to 3,120 (about 3%); including the newly eligible HOT updates, the estimated overall reduction was around 15% in that fixture.

Those figures are not a production forecast: real row width, free space, and autovacuum cadence differ. Evaluating `issue` table `fillfactor=85` remains a separate follow-up because it reserves heap space and has its own storage and rollout tradeoffs; the same fixture reached 100% HOT with that setting.

## Validation

- `go test ./cmd/migrate ./internal/migrations -count=1`
- `go vet ./cmd/migrate ./internal/migrations`
- `go build ./...`
- `git diff --check`

Closes MUL-6456
