### PR TITLE
fix(ui): support list grids on Chromium 116

### DIFF
--- a/packages/ui/components/ui/list-grid.tsx
+++ b/packages/ui/components/ui/list-grid.tsx
@@ -8,7 +8,8 @@ import { cn } from "../../lib/utils";
 // a literal `grid-cols-[...]` class (plus responsive variants); the header and
 // each row span the full template with `grid-cols-subgrid`, so column widths
 // have a single source of truth and never drift between header, rows, and
-// skeletons.
+// skeletons. `list-grid-subgrid` supplies the inherited-template fallback for
+// Chromium <= 116, which predates CSS subgrid support.
 //
 // Conventions the container class must follow:
 // - First and last tracks are edge-padding columns (e.g. 1.25rem) so row
@@ -53,7 +54,7 @@ function ListGridHeader({
     <div
       role="row"
       className={cn(
-        "group/header sticky top-0 z-10 col-span-full grid h-9 grid-cols-subgrid items-center bg-background after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-3 after:bg-gradient-to-b after:from-background after:to-transparent",
+        "list-grid-subgrid group/header sticky top-0 z-10 col-span-full grid h-9 grid-cols-subgrid items-center bg-background after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-3 after:bg-gradient-to-b after:from-background after:to-transparent",
         className,
       )}
       {...props}
@@ -156,7 +157,7 @@ function ListGridBody({
     <div
       role="rowgroup"
       className={cn(
-        "col-span-full grid grid-cols-subgrid content-start",
+        "list-grid-subgrid col-span-full grid grid-cols-subgrid content-start",
         className,
       )}
       {...props}
@@ -185,7 +186,7 @@ function ListGridRow({ className, children, ...props }: ListGridRowProps) {
     <div
       role="row"
       className={cn(
-        "group/row col-span-full grid h-12 grid-cols-subgrid items-center transition-colors hover:bg-accent/40",
+        "list-grid-subgrid group/row col-span-full grid h-12 grid-cols-subgrid items-center transition-colors hover:bg-accent/40",
         className,
       )}
       {...props}

--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -366,6 +366,18 @@ html[data-dnd-dragging="true"] * {
   }
 }
 
+/* Chrome implemented CSS Grid subgrid in 117. Self-hosted clients can remain
+ * on Chromium 116 for a long time, where `grid-template-columns: subgrid` is
+ * discarded and nested list cells collapse into implicit tracks. Repeat the
+ * computed parent tracks and gap through Header -> Body -> Row on those older
+ * engines. Modern browsers keep the native subgrid path. */
+@supports not (grid-template-columns: subgrid) {
+  .list-grid-subgrid {
+    grid-template-columns: inherit;
+    column-gap: inherit;
+  }
+}
+
 /* In-page find (Cmd/Ctrl+F on the issue detail page). Matches are painted with
  * the CSS Custom Highlight API — ranges only, no DOM mutation — so the tint
  * layers cleanly over React-rendered markdown and the contenteditable

--- a/packages/views/layout/list-grid.test.tsx
+++ b/packages/views/layout/list-grid.test.tsx
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ListGrid,
+  ListGridBody,
+  ListGridHeader,
+  ListGridRow,
+} from "@multica/ui/components/ui/list-grid";
+
+describe("ListGrid", () => {
+  it("keeps a shared inherited-track fallback for Chromium before 117", () => {
+    render(
+      <ListGrid>
+        <ListGridHeader>Header</ListGridHeader>
+        <ListGridBody>
+          <ListGridRow>Row</ListGridRow>
+        </ListGridBody>
+      </ListGrid>,
+    );
+
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    for (const nestedGrid of [
+      ...screen.getAllByRole("row"),
+      screen.getByRole("rowgroup"),
+    ]) {
+      expect(nestedGrid).toHaveClass("list-grid-subgrid");
+    }
+
+    const baseCss = readFileSync(
+      resolve(process.cwd(), "../ui/styles/base.css"),
+      "utf8",
+    );
+    expect(baseCss).toContain(
+      "@supports not (grid-template-columns: subgrid)",
+    );
+    expect(baseCss).toMatch(
+      /\.list-grid-subgrid\s*\{[^}]*grid-template-columns:\s*inherit;[^}]*column-gap:\s*inherit;/s,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared inherited-grid fallback for Chromium 116 and earlier, where CSS Grid subgrid is unsupported
- apply the fallback consistently to list headers, virtualized bodies, and rows
- retain native subgrid behavior on Chromium 117+ and add a regression test

## Root cause

Chrome added CSS Grid subgrid in version 117. On Chrome 116, `grid-template-columns: subgrid` is discarded, so nested list cells fall into implicit tracks and can overlap.

Reference: https://developer.chrome.com/blog/chrome-117-beta/

## Validation

- Chrome for Testing 116.0.5845.96: `CSS.supports("grid-template-columns", "subgrid")` is false; Agents, Skills, and Autopilots all report no row overlap, aligned header/body columns, and stable row heights
- `pnpm --dir packages/views exec vitest run layout/list-grid.test.tsx --maxWorkers=1`
- full `@multica/views` suite: 390 files and 4,516 tests passed
- `@multica/ui` and `@multica/views` lint and typecheck (existing warnings only, no errors)
- `pnpm --filter @multica/web build`
