### PR TITLE
fix(views): explain disabled project creation

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -111,6 +111,7 @@
     "members_group": "Members",
     "agents_group": "Agents",
     "no_results": "No results",
+    "title_required": "Enter a title to create",
     "submit": "Create Project",
     "submitting": "Creating...",
     "toast_created": "Project created",

--- a/packages/views/locales/ja/modals.json
+++ b/packages/views/locales/ja/modals.json
@@ -110,6 +110,7 @@
     "members_group": "メンバー",
     "agents_group": "エージェント",
     "no_results": "結果なし",
+    "title_required": "作成するにはタイトルを入力してください",
     "submit": "プロジェクトを作成",
     "submitting": "作成中...",
     "toast_created": "プロジェクトを作成しました",

--- a/packages/views/locales/ko/modals.json
+++ b/packages/views/locales/ko/modals.json
@@ -110,6 +110,7 @@
     "members_group": "멤버",
     "agents_group": "에이전트",
     "no_results": "결과 없음",
+    "title_required": "만들려면 제목을 입력하세요",
     "submit": "프로젝트 만들기",
     "submitting": "만드는 중...",
     "toast_created": "프로젝트를 만들었습니다",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -110,6 +110,7 @@
     "members_group": "成员",
     "agents_group": "智能体",
     "no_results": "未找到结果",
+    "title_required": "请输入标题后再创建",
     "submit": "创建项目",
     "submitting": "创建中...",
     "toast_created": "已创建项目",

--- a/packages/views/modals/create-project.test.tsx
+++ b/packages/views/modals/create-project.test.tsx
@@ -133,6 +133,7 @@ vi.mock("@multica/ui/components/ui/popover", () => ({
 }));
 
 vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
   TooltipContent: ({ children }: { children: React.ReactNode }) => (
@@ -146,13 +147,26 @@ vi.mock("@multica/ui/components/ui/button", () => ({
     disabled,
     onClick,
     type = "button",
+    className,
+    "aria-disabled": ariaDisabled,
+    "aria-busy": ariaBusy,
   }: {
     children: React.ReactNode;
     disabled?: boolean;
     onClick?: () => void;
     type?: "button" | "submit" | "reset";
+    className?: string;
+    "aria-disabled"?: boolean;
+    "aria-busy"?: boolean;
   }) => (
-    <button type={type} disabled={disabled} onClick={onClick}>
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={className}
+      aria-disabled={ariaDisabled}
+      aria-busy={ariaBusy}
+    >
       {children}
     </button>
   ),
@@ -177,6 +191,32 @@ vi.mock("sonner", () => ({
 import { CreateProjectModal } from "./create-project";
 
 describe("CreateProjectModal", () => {
+  it("explains why Create Project is unavailable when the title is empty", () => {
+    renderWithI18n(<CreateProjectModal onClose={vi.fn()} />);
+
+    const createButton = screen.getByRole("button", { name: "Create Project" });
+
+    expect(createButton).toHaveAttribute("aria-disabled", "true");
+    expect(createButton).not.toBeDisabled();
+    expect(createButton.className).toContain("aria-disabled:opacity-50");
+    expect(createButton.className).toContain("aria-disabled:cursor-not-allowed");
+    expect(createButton.className).not.toContain("aria-disabled:pointer-events-none");
+    createButton.focus();
+    expect(createButton).toHaveFocus();
+    expect(screen.getByRole("tooltip", { name: "Enter a title to create" })).toBeInTheDocument();
+  });
+
+  it("enables Create Project and removes the missing-title hint after typing a title", async () => {
+    const user = userEvent.setup();
+    renderWithI18n(<CreateProjectModal onClose={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText("Project title"), "Website refresh");
+
+    const createButton = screen.getByRole("button", { name: "Create Project" });
+    expect(createButton).not.toHaveAttribute("aria-disabled");
+    expect(screen.queryByRole("tooltip", { name: "Enter a title to create" })).toBeNull();
+  });
+
   it("exposes full repository URLs in the repository picker", () => {
     render(<CreateProjectModal onClose={vi.fn()} />);
 

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -44,7 +44,12 @@ import {
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { Popover, PopoverTrigger, PopoverContent } from "@multica/ui/components/ui/popover";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { EmojiPicker } from "@multica/ui/components/common/emoji-picker";
 import { ContentEditor, type ContentEditorRef, TitleEditor } from "../editor";
@@ -390,6 +395,26 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
     setSelectedRepos((prev) => (prev.includes(url) ? prev : [...prev, url]));
     setCustomRepoUrl("");
   };
+
+  const submitState: "submitting" | "missing_title" | "ready" = submitting
+    ? "submitting"
+    : !title.trim()
+      ? "missing_title"
+      : "ready";
+  const createButton = (
+    <Button
+      size="sm"
+      onClick={handleSubmit}
+      disabled={submitState === "submitting"}
+      aria-disabled={submitState === "missing_title" || undefined}
+      aria-busy={submitState === "submitting" || undefined}
+      className="shrink-0 aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:active:translate-y-0"
+    >
+      {submitState === "submitting"
+        ? t(($) => $.create_project.submitting)
+        : t(($) => $.create_project.submit)}
+    </Button>
+  );
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
@@ -981,14 +1006,18 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
         {/* Footer action bar — primary action in its own strip, matching
             create-issue. */}
         <div className="flex items-center justify-end border-t px-4 py-3 shrink-0">
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            disabled={!title.trim() || submitting}
-            className="shrink-0"
-          >
-            {submitting ? t(($) => $.create_project.submitting) : t(($) => $.create_project.submit)}
-          </Button>
+          {submitState === "missing_title" ? (
+            <TooltipProvider delay={200}>
+              <Tooltip>
+                <TooltipTrigger render={createButton} />
+                <TooltipContent side="top">
+                  {t(($) => $.create_project.title_required)}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            createButton
+          )}
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## What does this PR do?

The Create Project button is grayed out while the title is empty, but the modal does not explain why creation is unavailable. This aligns project creation with the existing Create Issue affordance:

- use `aria-disabled` for the missing-title state so the button remains hoverable and keyboard-focusable
- preserve native `disabled` for the real submitting/busy state
- show the existing-style tooltip, “Enter a title to create,” after 200 ms
- keep the disabled visual treatment without blocking tooltip pointer events
- remove the hint and restore the ready state as soon as a title is entered

## Related Issue

No existing issue. This is the project-create counterpart to the issue-create behavior established in #2943 and refined in #5583.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)
- [ ] New feature
- [ ] Documentation update

## Changes Made

- Updated `packages/views/modals/create-project.tsx` to model submitting, missing-title, and ready states explicitly.
- Added missing-title tooltip copy in all four locales: English, Simplified Chinese, Japanese, and Korean.
- Added component coverage for focusability, disabled styling, tooltip visibility, and the empty-to-filled transition.

## How to Test

1. Open the Create Project modal with an empty title.
2. Hover over or keyboard-focus “Create Project.”
3. Confirm the button remains visually disabled and the missing-title tooltip appears.
4. Enter a title and confirm the tooltip disappears and creation becomes available.

## Verification

- `pnpm --filter @multica/views test` — 389 files / 4519 tests passed
- `pnpm --filter @multica/views typecheck` — passed
- `pnpm --filter @multica/views exec eslint modals/create-project.tsx modals/create-project.test.tsx` — passed
- `git diff --check` — passed

## Checklist

- [x] I have added or updated tests where applicable.
- [x] I checked the Chinese copy against the repository conventions.
- [x] I considered keyboard and screen-reader accessibility.
- [x] I will address reviewer comments before requesting merge.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** A user reported that title-gated Create buttons were grayed out without explaining the requirement. I verified upstream behavior and prior PRs, found Issue creation already fixed while Project creation still used native disabled with no hint, reused the established Issue interaction pattern, added locale copy and regression tests, and validated the full views suite.
