### PR TITLE
MUL-6456: stop comment creation from advancing issue activity

### DIFF
--- a/server/internal/handler/comment_touch_issue_test.go
+++ b/server/internal/handler/comment_touch_issue_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
-// TestCreateComment_BumpsIssueActivity pins MUL-5009 and MUL-6343: a new
-// comment advances both the legacy updated_at clock and the semantic activity
-// clock in the same statement.
-func TestCreateComment_BumpsIssueActivity(t *testing.T) {
+// TestCreateComment_BumpsUpdatedAtWithoutChangingLastActivity pins MUL-5009
+// and MUL-6456: a new comment advances the legacy updated_at clock without
+// moving the separate semantic activity clock.
+func TestCreateComment_BumpsUpdatedAtWithoutChangingLastActivity(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -56,8 +56,8 @@ func TestCreateComment_BumpsIssueActivity(t *testing.T) {
 	if !after.After(before) {
 		t.Fatalf("issue updated_at was not bumped by a new comment: before=%s after=%s", before, after)
 	}
-	if !activityAfter.After(activityBefore) {
-		t.Fatalf("issue last_activity_at was not bumped by a new comment: before=%s after=%s", activityBefore, activityAfter)
+	if !activityAfter.Equal(activityBefore) {
+		t.Fatalf("new comment changed issue last_activity_at: before=%s after=%s", activityBefore, activityAfter)
 	}
 }
 

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -201,8 +201,7 @@ const createComment = `-- name: CreateComment :one
 WITH touched_issue AS (
     UPDATE issue SET
         updated_at = now(),
-        revision = revision + 1,
-        last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now())
+        revision = revision + 1
     WHERE issue.id = $1 AND issue.workspace_id = $2
     RETURNING issue.id, issue.workspace_id, issue.revision
 ), inserted_comment AS (
@@ -251,8 +250,9 @@ type CreateCommentRow struct {
 	IssueRevision  int64              `json:"issue_revision"`
 }
 
-// A new comment counts as activity on its issue, so the same statement bumps
-// the parent issue's updated_at and last_activity_at. The touch is a leading data-modifying CTE and
+// A new comment still advances its parent issue's updated_at and revision, but
+// intentionally preserves the separate last_activity_at clock. The touch is a
+// leading data-modifying CTE and
 // the INSERT selects the issue/workspace back out of it, which makes the two
 // inseparable and gives two query-level guarantees:
 //   - atomicity — the insert and the timestamp bump commit or roll back

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -422,8 +422,9 @@ SELECT c.* FROM comment c
 WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1);
 
 -- name: CreateComment :one
--- A new comment counts as activity on its issue, so the same statement bumps
--- the parent issue's updated_at and last_activity_at. The touch is a leading data-modifying CTE and
+-- A new comment still advances its parent issue's updated_at and revision, but
+-- intentionally preserves the separate last_activity_at clock. The touch is a
+-- leading data-modifying CTE and
 -- the INSERT selects the issue/workspace back out of it, which makes the two
 -- inseparable and gives two query-level guarantees:
 --   * atomicity — the insert and the timestamp bump commit or roll back
@@ -440,8 +441,7 @@ WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1);
 WITH touched_issue AS (
     UPDATE issue SET
         updated_at = now(),
-        revision = revision + 1,
-        last_activity_at = GREATEST(COALESCE(last_activity_at, updated_at), now())
+        revision = revision + 1
     WHERE issue.id = sqlc.arg(issue_id) AND issue.workspace_id = sqlc.arg(workspace_id)
     RETURNING issue.id, issue.workspace_id, issue.revision
 ), inserted_comment AS (


### PR DESCRIPTION
## Purpose

`CreateComment` is a hot write path. It currently advances `issue.last_activity_at` for every new comment, which changes an indexed column and prevents that issue touch from using a HOT update. The issue window is moving to creation-time ordering, so comment creation no longer needs to advance the separate activity clock.

## Changes

- preserve `issue.last_activity_at` when creating a comment
- continue advancing `issue.updated_at` and `revision` in the same data-modifying CTE
- preserve the atomic workspace guard: a mismatched issue/workspace pair still writes neither the comment nor the issue touch
- regenerate sqlc output and invert the regression test to assert `updated_at` advances while `last_activity_at` remains unchanged

This changes every comment entry point that uses the canonical `CreateComment` query. Comment edits and deletes keep their existing activity behavior. There is no schema migration or API shape change; during a mixed-version rollout, older server instances may continue advancing the clock until they are replaced.

This PR is independent of #7296: this one removes the indexed-column mutation from comment creation, while #7296 retires the unused serving index for other issue activity writes.

## Validation

- regression test failed against the old query and passes with this change
- `go test ./internal/handler ./internal/service ./pkg/db/generated -count=1`
- `go vet ./internal/handler ./internal/service ./pkg/db/generated`
- `go build ./...`
- `make sqlc` followed by a clean generated diff check
- `git diff --check`
