### PR TITLE
MUL-6451: label the webhook event-filter add/remove controls

### DIFF
--- a/packages/views/autopilots/components/webhook-event-filter-section.test.tsx
+++ b/packages/views/autopilots/components/webhook-event-filter-section.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithI18n } from "../../test/i18n";
+import { WebhookEventFilterSection } from "./webhook-event-filter-section";
+
+// The two icon-only controls in this section used to render with no
+// accessible name at all, so a screen reader announced a bare "button" and
+// sighted users had nothing telling them the row still had to be committed.
+// getByRole(..., { name }) is the assertion that keeps them named.
+
+describe("WebhookEventFilterSection", () => {
+  it("names the add control instead of shipping a bare + icon", () => {
+    renderWithI18n(<WebhookEventFilterSection filters={[]} onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("names the remove control on a committed row", () => {
+    renderWithI18n(
+      <WebhookEventFilterSection
+        filters={[{ event: "workflow_run", actions: ["completed"] }]}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove filter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps add disabled until an event is typed", () => {
+    renderWithI18n(<WebhookEventFilterSection filters={[]} onChange={vi.fn()} />);
+    const add = screen.getByRole("button", { name: "Add" });
+    expect(add).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. workflow_run"), {
+      target: { value: "workflow_run" },
+    });
+    expect(add).toBeEnabled();
+  });
+
+  it("stays disabled for whitespace-only input", () => {
+    renderWithI18n(<WebhookEventFilterSection filters={[]} onChange={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("e.g. workflow_run"), {
+      target: { value: "   " },
+    });
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+  });
+
+  it("commits the row through onChange when add is clicked", () => {
+    const onChange = vi.fn();
+    renderWithI18n(<WebhookEventFilterSection filters={[]} onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText("e.g. workflow_run"), {
+      target: { value: "workflow_run" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("completed, failed"), {
+      target: { value: "completed, failed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      { event: "workflow_run", actions: ["completed", "failed"] },
+    ]);
+  });
+
+  it("drops the row from the list when remove is clicked", () => {
+    const onChange = vi.fn();
+    renderWithI18n(
+      <WebhookEventFilterSection
+        filters={[{ event: "issues" }, { event: "workflow_run" }]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Remove filter" })[1]!,
+    );
+    expect(onChange).toHaveBeenCalledWith([{ event: "issues" }]);
+  });
+});

--- a/packages/views/autopilots/components/webhook-event-filter-section.tsx
+++ b/packages/views/autopilots/components/webhook-event-filter-section.tsx
@@ -75,6 +75,8 @@ export function WebhookEventFilterSection({
               <button
                 type="button"
                 onClick={() => removeFilter(idx)}
+                aria-label={t(($) => $.dialog.event_filter_remove_label)}
+                title={t(($) => $.dialog.event_filter_remove_label)}
                 className="ml-auto rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               >
                 <X className="size-3" />
@@ -116,13 +118,14 @@ export function WebhookEventFilterSection({
           onClick={addFilter}
           disabled={!newEvent.trim()}
           className={cn(
-            "inline-flex items-center justify-center rounded-md border px-2.5 py-1.5 text-caption font-medium transition-colors",
+            "inline-flex shrink-0 items-center justify-center gap-1 rounded-md border px-2.5 py-1.5 text-caption font-medium transition-colors",
             newEvent.trim()
-              ? "bg-background text-foreground hover:bg-accent/40 cursor-pointer"
+              ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer"
               : "bg-muted text-muted-foreground cursor-not-allowed",
           )}
         >
           <Plus className="size-3.5" />
+          {t(($) => $.dialog.event_filter_add)}
         </button>
       </div>
       <p className="text-micro text-muted-foreground">

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -309,6 +309,8 @@
     "event_filter_docs_link_label": "Learn how event filters work",
     "event_filter_event_placeholder": "e.g. workflow_run",
     "event_filter_actions_placeholder": "completed, failed",
+    "event_filter_add": "Add",
+    "event_filter_remove_label": "Remove filter",
     "event_filter_hint": "Only process webhooks matching these events. Leave empty to accept all.",
     "schedule_disabled_reason": "This autopilot has multiple schedules — edit them in the detail page.",
     "schedule_empty": "No schedule — this autopilot only runs when triggered manually.",

--- a/packages/views/locales/ja/autopilots.json
+++ b/packages/views/locales/ja/autopilots.json
@@ -309,6 +309,8 @@
     "event_filter_docs_link_label": "イベントフィルターの仕組みを学ぶ",
     "event_filter_event_placeholder": "例: workflow_run",
     "event_filter_actions_placeholder": "completed, failed",
+    "event_filter_add": "追加",
+    "event_filter_remove_label": "フィルターを削除",
     "event_filter_hint": "これらのイベントに一致する Webhook のみを処理します。空にするとすべて許可します。",
     "schedule_disabled_reason": "このオートパイロットには複数のスケジュールがあります。詳細ページで編集してください。",
     "schedule_empty": "スケジュールはありません。このオートパイロットは手動で実行したときだけ動きます。",

--- a/packages/views/locales/ko/autopilots.json
+++ b/packages/views/locales/ko/autopilots.json
@@ -309,6 +309,8 @@
     "event_filter_docs_link_label": "이벤트 필터 작동 방식 알아보기",
     "event_filter_event_placeholder": "예: workflow_run",
     "event_filter_actions_placeholder": "completed, failed",
+    "event_filter_add": "추가",
+    "event_filter_remove_label": "필터 제거",
     "event_filter_hint": "이 이벤트와 일치하는 Webhook만 처리합니다. 비워 두면 모두 허용합니다.",
     "schedule_disabled_reason": "이 오토파일럿에는 여러 일정이 있습니다. 상세 페이지에서 수정하세요.",
     "schedule_empty": "일정이 없습니다. 이 오토파일럿은 수동으로 실행할 때만 동작합니다.",

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -309,6 +309,8 @@
     "event_filter_docs_link_label": "了解事件过滤的工作方式",
     "event_filter_event_placeholder": "例如 workflow_run",
     "event_filter_actions_placeholder": "completed, failed",
+    "event_filter_add": "添加",
+    "event_filter_remove_label": "移除过滤条件",
     "event_filter_hint": "只处理匹配这些事件的 webhook。留空则接受所有事件。",
     "schedule_disabled_reason": "该自动化有多个时间表——请到详情页编辑。",
     "schedule_empty": "还没有时间表——这个自动化只在手动触发时运行。",


### PR DESCRIPTION
## Summary

Follow-up to the triage of #7270. The **Event filters** section of the Autopilot webhook panel commits a filter row only when the user presses <kbd>Enter</kbd> or clicks the button beside the inputs — typing into the fields and hitting **Save** discards the draft. The control gave no indication of that:

- the add button rendered as a bare `+` icon with **no visible text, no `aria-label`, no `title`**;
- the remove `x` on each committed row had nothing either;
- its enabled state (`bg-background` + border) was nearly indistinguishable from its disabled state, so the "you can commit this now" signal barely registered.

A screen reader announced both controls as an unnamed "button". Sighted users had no wording anywhere telling them the typed row still needed committing.

## Changes

- **Add button gets a visible label** — `Add` / `添加` / `追加` / `추가`. Visible text supplies the accessible name, so no `aria-label` is needed once the button has text.
- **Remove button gets an accessible name** — `Remove filter` and friends, on both `aria-label` and `title`.
- **Enabled state now reads as lit up** — `border-primary bg-primary text-primary-foreground` instead of the previous border-only styling, so the transition from disabled to enabled as the user types is obvious. Matches the idiom already used elsewhere in `packages/views`.
- **New test file** for a component that previously had none.

The disabled-while-empty behaviour is **unchanged** — it already existed (`disabled={!newEvent.trim()}`). It now has a test so it cannot silently regress.

New i18n keys `dialog.event_filter_add` and `dialog.event_filter_remove_label` are added to all four bundles (`en`, `zh-Hans`, `ja`, `ko`) to satisfy `packages/views/locales/parity.test.ts`.

## Not in scope

The hint copy (`event_filter_hint`, currently *"Leave empty to accept all"*) describes the input fields rather than the committed list, which is arguably what cements the misreading — a user with text in the boxes does not see "empty". Reworking that copy was deliberately left out of this PR.

## Verification

Run from `packages/views`:

- `pnpm vitest run autopilots locales/parity.test.ts` → 15 files, 645 tests passing, including the 6 new ones.
- `pnpm typecheck` → clean.
- `pnpm exec eslint` on both changed files → clean. (Repo-wide `pnpm lint` reports 28 pre-existing warnings in unrelated files, 0 errors.)

Not verified in a browser — no screenshot of the rendered button. The change is a label, an aria attribute and a class swap, all covered by the tests above.
