### PR TITLE
MUL-6460: feat(brief): inject the workspace status catalog into the agent brief

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6623,6 +6623,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		InitiatorName:                    task.InitiatorName,
 		InitiatorEmail:                   task.InitiatorEmail,
 		WorkspaceContext:                 task.WorkspaceContext,
+		IssueStatuses:                    convertIssueStatusesForEnv(task.IssueStatuses),
+		IssueStatusesOmitted:             task.IssueStatusesOmitted,
 		ConnectedApps:                    task.ConnectedApps,
 	}
 
@@ -8496,6 +8498,17 @@ func repoDataToInfo(repos []RepoData) []repocache.RepoInfo {
 		info[i] = repocache.RepoInfo{URL: r.URL}
 	}
 	return info
+}
+
+func convertIssueStatusesForEnv(statuses []IssueStatusData) []execenv.IssueStatusForEnv {
+	if len(statuses) == 0 {
+		return nil
+	}
+	result := make([]execenv.IssueStatusForEnv, len(statuses))
+	for i, s := range statuses {
+		result[i] = execenv.IssueStatusForEnv{Key: s.Key, Name: s.Name, Category: s.Category, Description: s.Description}
+	}
+	return result
 }
 
 func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -200,6 +200,19 @@ type TaskContextForEnv struct {
 	// non-empty so every agent in the workspace sees the same shared context,
 	// regardless of issue / chat / autopilot / quick-create.
 	WorkspaceContext string
+	// IssueStatuses is the workspace's active CUSTOM status catalog from the
+	// claim payload (MUL-6460), in catalog order. Rendered into the brief's
+	// status-command line so agents can see and use statuses beyond the seven
+	// built-ins. Like WorkspaceContext, this is durable workspace configuration,
+	// not per-turn state: it may legitimately change brief bytes when an admin
+	// edits the catalog between runs of a resumed session, exactly as a
+	// Workspace Context edit does. Empty — including on old servers that never
+	// send the field — renders the built-in-only line byte-identical to before.
+	IssueStatuses []IssueStatusForEnv
+	// IssueStatusesOmitted is the count of active custom statuses the server's
+	// cap dropped from IssueStatuses, so the brief can disclose truncation
+	// instead of presenting a partial catalog as complete.
+	IssueStatusesOmitted int
 	// ConnectedApps lists per-run external app capabilities mounted through
 	// MCP overlays. Rendered briefly so the agent can map app names such as
 	// Notion to the actual MCP server name (`composio`).
@@ -225,6 +238,18 @@ type TaskContextForEnv struct {
 }
 
 // SkillContextForEnv represents a skill to be written into the execution environment.
+// IssueStatusForEnv is one active custom workspace status rendered into the
+// brief (MUL-6460). Name and Description are user-authored text and MUST pass
+// through the brief sanitizers before rendering; Key is constrained by the
+// storage CHECK to `^[a-z0-9][a-z0-9_]{0,31}$` but is still guarded with
+// sanitizeBriefCodeToken as defense-in-depth.
+type IssueStatusForEnv struct {
+	Key         string
+	Name        string
+	Category    string
+	Description string
+}
+
 type SkillContextForEnv struct {
 	Name        string
 	Description string

--- a/server/internal/daemon/execenv/runtime_config_issue_status_test.go
+++ b/server/internal/daemon/execenv/runtime_config_issue_status_test.go
@@ -1,0 +1,94 @@
+package execenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// legacyStatusLine is the pre-MUL-6460 status bullet. Workspaces without
+// custom statuses — including every deployment behind an old server — must
+// keep rendering it byte-identical: it is part of the prompt-cache prefix and
+// the no-custom-statuses path is the compatibility contract of MUL-6460.
+const legacyStatusLine = "- `multica issue status <id> <status> [--no-start]` — flip status (todo / in_progress / in_review / done / blocked / backlog / cancelled).\n"
+
+// catalogBridgeBullet is the workflow-section bridge from category rules to a
+// concrete key choice; it must appear exactly when a catalog is present.
+const catalogBridgeBullet = "- The status rules above are category rules — every status in this workspace's catalog (`## Available Commands`) inherits them from its category. When a category holds more than one status, pick the specific one by its name/description or your instructions.\n"
+
+func TestBriefStatusCatalogAbsentKeepsLegacyLine(t *testing.T) {
+	t.Parallel()
+	base := TaskContextForEnv{IssueID: "issue-1", AgentID: "a-1", AgentName: "Eve"}
+	out := buildMetaSkillContent("claude", base)
+	if !strings.Contains(out, legacyStatusLine) {
+		t.Fatalf("brief without a catalog must keep the legacy status line\n---\n%s", out)
+	}
+	if strings.Contains(out, catalogBridgeBullet) {
+		t.Errorf("brief without a catalog must not carry the catalog bridge bullet")
+	}
+
+	withEmpty := base
+	withEmpty.IssueStatuses = []IssueStatusForEnv{}
+	if got := buildMetaSkillContent("claude", withEmpty); got != out {
+		t.Errorf("empty catalog must render byte-identical to absent catalog:\n%s", firstBriefDiff(out, got))
+	}
+}
+
+func TestBriefStatusCatalogRendered(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "issue-1", AgentID: "a-1", AgentName: "Eve",
+		IssueStatuses: []IssueStatusForEnv{
+			{Key: "later", Name: "Later", Category: "backlog", Description: "Deferred on purpose"},
+			{Key: "rework", Name: "Rework", Category: "todo"},
+			{Key: "human_review", Name: "Human Review", Category: "in_review", Description: "Awaiting human acceptance"},
+		},
+	}
+	out := buildMetaSkillContent("claude", ctx)
+	if strings.Contains(out, legacyStatusLine) {
+		t.Errorf("catalog brief must replace the legacy seven-value enumeration")
+	}
+	for _, want := range []string{
+		"- `multica issue status <id> <status> [--no-start]` — flip status. This workspace's statuses by category — a custom status inherits its category's platform behavior in full:\n",
+		"  - `backlog`: `backlog` (built-in), `later` (Later — Deferred on purpose)\n",
+		"  - `todo`: `todo` (built-in), `rework` (Rework)\n",
+		"  - `in_review`: `in_review` (built-in), `human_review` (Human Review — Awaiting human acceptance)\n",
+		"  - Built-in key only: `in_progress`, `done`, `blocked`, `cancelled`.\n",
+		catalogBridgeBullet,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("catalog brief missing %q\n---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "more custom statuses not listed") {
+		t.Errorf("no truncation disclosure may appear when nothing was omitted")
+	}
+}
+
+// TestBriefStatusCatalogSanitizesAndDiscloses pins the two safety properties:
+// user-authored name/description cannot inject markdown structure into the
+// trusted brief, and a key that fails the code-token guard drops its entry
+// entirely instead of rendering mangled.
+func TestBriefStatusCatalogSanitizesAndDiscloses(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "issue-1", AgentID: "a-1", AgentName: "Eve",
+		IssueStatuses: []IssueStatusForEnv{
+			{Key: "qa", Name: "QA *bold*\n# Heading", Category: "in_review", Description: "line1\nline2 [x]"},
+			{Key: "bad key!", Name: "Evil", Category: "todo", Description: "must be dropped"},
+		},
+		IssueStatusesOmitted: 4,
+	}
+	out := buildMetaSkillContent("claude", ctx)
+	for _, want := range []string{
+		`  - ` + "`in_review`: `in_review`" + ` (built-in), ` + "`qa`" + ` (QA \*bold\* # Heading — line1 line2 \[x\])` + "\n",
+		"  - Built-in key only: `backlog`, `todo`, `in_progress`, `done`, `blocked`, `cancelled`.\n",
+		"  - …and 4 more custom statuses not listed; an invalid status errors with the full valid list.\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("catalog brief missing %q\n---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Evil") || strings.Contains(out, "bad key") {
+		t.Errorf("entry with an invalid key must be dropped entirely\n---\n%s", out)
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -266,7 +266,7 @@ func writeAvailableCommands(b *strings.Builder, ctx TaskContextForEnv) {
 	// create an unaware cross-issue run, and agents cannot discover the safe
 	// ownership-only --no-start path if the command is hidden behind --help.
 	b.WriteString("- `multica issue assign <id> (--to X | --to-id <uuid> | --unassign) [--no-start]` — change ownership. On assign/update/status, `--no-start` records the change without starting another run — use it when the work is already underway.\n")
-	b.WriteString("- `multica issue status <id> <status> [--no-start]` — flip status (todo / in_progress / in_review / done / blocked / backlog / cancelled).\n")
+	writeIssueStatusCommand(b, ctx)
 	b.WriteString("- `multica issue children <id> [--output json]` — list a parent's sub-issues grouped by stage.\n")
 	b.WriteString("- `multica issue comment add <issue-id> [--content \"...\" | --content-file <path> | --content-stdin] [--parent <comment-id>] [--attachment <path>]` — post a comment. Agent-authored bodies MUST use `--content-file`; see `## Comment Formatting` for why. `multica issue comment add --help` for full flags.\n")
 	b.WriteString("- `multica issue metadata list <issue-id> [--output json]` — list KV metadata.\n")
@@ -283,6 +283,75 @@ func writeAvailableCommands(b *strings.Builder, ctx TaskContextForEnv) {
 	if ctx.IsSquadLeader {
 		b.WriteString("### Squad maintenance\n")
 		b.WriteString("- `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role> [--output json]` — change role in place (use this instead of remove+add).\n\n")
+	}
+}
+
+// briefStatusCategoryOrder is the category order the catalog block renders in:
+// the board's category rank (matching ListIssueStatusEntries' ORDER BY), NOT
+// the static line's historical enumeration order. Local to the brief on
+// purpose — importing the issuestatus package would pull the db package into
+// execenv for a 7-element constant.
+var briefStatusCategoryOrder = []string{"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"}
+
+// writeIssueStatusCommand emits the `multica issue status` bullet.
+//
+// With no custom statuses on the claim (the overwhelmingly common case, and
+// every old-server case) it emits the exact pre-MUL-6460 line — byte-identical
+// so existing deployments see no brief change and no prompt-cache loss.
+//
+// With custom statuses it replaces the seven-value enumeration with the
+// workspace's catalog, grouped by category. Category is the anchor an agent
+// reasons from — the semantic rules in `## Workflow` are category rules, and a
+// custom status inherits its category's platform behavior in full — so each
+// line leads with the category key, then the statuses inside it. Name and
+// description ride along because instructions and users refer to statuses by
+// display name ("move it to Human Review"), and the description is the
+// admin's disambiguator when a category holds more than one status.
+//
+// Name/description are user-authored: they pass through
+// sanitizeNameForBriefMarkdown so a crafted status name cannot inject
+// headings or break out of the surrounding inline markdown. Keys are
+// CHECK-constrained server-side; sanitizeBriefCodeToken is defense-in-depth,
+// and an entry whose key fails it is dropped rather than rendered mangled.
+func writeIssueStatusCommand(b *strings.Builder, ctx TaskContextForEnv) {
+	if len(ctx.IssueStatuses) == 0 {
+		b.WriteString("- `multica issue status <id> <status> [--no-start]` — flip status (todo / in_progress / in_review / done / blocked / backlog / cancelled).\n")
+		return
+	}
+	byCategory := make(map[string][]IssueStatusForEnv, len(briefStatusCategoryOrder))
+	for _, s := range ctx.IssueStatuses {
+		if sanitizeBriefCodeToken(s.Key) == "" {
+			continue
+		}
+		byCategory[s.Category] = append(byCategory[s.Category], s)
+	}
+	b.WriteString("- `multica issue status <id> <status> [--no-start]` — flip status. This workspace's statuses by category — a custom status inherits its category's platform behavior in full:\n")
+	builtInOnly := make([]string, 0, len(briefStatusCategoryOrder))
+	for _, category := range briefStatusCategoryOrder {
+		customs := byCategory[category]
+		if len(customs) == 0 {
+			builtInOnly = append(builtInOnly, "`"+category+"`")
+			continue
+		}
+		fmt.Fprintf(b, "  - `%s`: `%s` (built-in)", category, category)
+		for _, s := range customs {
+			name := sanitizeNameForBriefMarkdown(s.Name)
+			desc := sanitizeNameForBriefMarkdown(s.Description)
+			fmt.Fprintf(b, ", `%s`", sanitizeBriefCodeToken(s.Key))
+			switch {
+			case name != "" && desc != "":
+				fmt.Fprintf(b, " (%s — %s)", name, desc)
+			case name != "":
+				fmt.Fprintf(b, " (%s)", name)
+			}
+		}
+		b.WriteString("\n")
+	}
+	if len(builtInOnly) > 0 {
+		fmt.Fprintf(b, "  - Built-in key only: %s.\n", strings.Join(builtInOnly, ", "))
+	}
+	if ctx.IssueStatusesOmitted > 0 {
+		fmt.Fprintf(b, "  - …and %d more custom statuses not listed; an invalid status errors with the full valid list.\n", ctx.IssueStatusesOmitted)
 	}
 }
 
@@ -636,6 +705,13 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("- You cannot proceed without something you are missing → `blocked`, and post a comment explaining the blocker unless your Agent Identity forbids issue comments.\n")
 	if ctx.IsSquadLeader {
 		b.WriteString("- Squad leader: dispatching members is not delivery — a dispatch turn leaves the parent `in_progress`, and it moves to `in_review` only on the later turn (a member update or stage-barrier re-trigger) where you confirm the overall goal is met.\n")
+	}
+	// Emitted only when the workspace has custom statuses (MUL-6460): the
+	// bullets above stay category rules and need no rewording, but the agent
+	// needs the bridge from "category rule" to "which specific status key to
+	// write" when a category holds more than one.
+	if len(ctx.IssueStatuses) > 0 {
+		b.WriteString("- The status rules above are category rules — every status in this workspace's catalog (`## Available Commands`) inherits them from its category. When a category holds more than one status, pick the specific one by its name/description or your instructions.\n")
 	}
 	b.WriteString("- Your turn produced none of the issue's own deliverable — you answered a question or consulted on work owned elsewhere → write nothing, at any point; questions, discussion, and acknowledgements never touch status. This no-write default is what keeps concurrent runs from flapping the board.\n\n")
 }

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -68,6 +68,16 @@ type ActiveSiblingRunData struct {
 	StartedAt       string `json:"started_at,omitempty"`
 }
 
+// IssueStatusData mirrors one active custom workspace status from the claim
+// payload (MUL-6460). Mirror field: internal/handler/agent.go
+// TaskIssueStatusData, same JSON names.
+type IssueStatusData struct {
+	Key         string `json:"key"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Description string `json:"description,omitempty"`
+}
+
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
@@ -88,7 +98,14 @@ type Task struct {
 	// prompt set in Settings → General). Server populates this on every claim
 	// regardless of task kind so the daemon can inject `## Workspace Context`
 	// into the brief. Empty when the owner hasn't set one.
-	WorkspaceContext              string                 `json:"workspace_context,omitempty"`
+	WorkspaceContext string `json:"workspace_context,omitempty"`
+	// IssueStatuses mirrors the claim payload's active CUSTOM status catalog
+	// (MUL-6460): key/name/category/description per status, already in catalog
+	// order. Rendered into the brief's status-command line; empty (including on
+	// old servers that never send the field) keeps the brief byte-identical to
+	// the built-in-only form. IssueStatusesOmitted is the cap overflow count.
+	IssueStatuses                 []IssueStatusData      `json:"issue_statuses,omitempty"`
+	IssueStatusesOmitted          int                    `json:"issue_statuses_omitted,omitempty"`
 	ActiveSiblingRuns             []ActiveSiblingRunData `json:"active_sibling_runs,omitempty"`
 	ThreadName                    string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
 	Agent                         *AgentData             `json:"agent,omitempty"`

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -308,6 +308,28 @@ type ActiveSiblingRunData struct {
 	StartedAt       string `json:"started_at,omitempty"`
 }
 
+// taskIssueStatusCap bounds the custom statuses a claim payload carries. A
+// defensive ceiling, not a product limit: a real catalog holds a handful of
+// entries, and the brief must not grow without bound on a workspace that
+// scripted hundreds. Overflow is reported via IssueStatusesOmitted so the
+// brief can disclose the truncation.
+const taskIssueStatusCap = 30
+
+// TaskIssueStatusData is one active CUSTOM workspace status on the claim wire
+// (MUL-6460). Only the fields an agent needs to choose and write the status
+// travel: key is the CLI argument, name is what users call it in instructions,
+// category anchors the inherited platform behavior, and description is the
+// admin's "when to use me" guidance — the disambiguator when a category holds
+// more than one status. Color/position/id stay off the wire: they carry no
+// behavioral meaning for an agent, and the server already emits entries in
+// catalog order (category rank, then position, then key).
+type TaskIssueStatusData struct {
+	Key         string `json:"key"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Description string `json:"description,omitempty"`
+}
+
 type AgentTaskResponse struct {
 	ID                   string                 `json:"id"`
 	AgentID              string                 `json:"agent_id"`
@@ -329,32 +351,45 @@ type AgentTaskResponse struct {
 	// as `## Workspace Context` so every agent running in this workspace —
 	// regardless of issue / chat / autopilot / quick-create — sees the same
 	// shared context. Empty when the workspace owner hasn't set it.
-	WorkspaceContext   string                 `json:"workspace_context,omitempty"`
-	ActiveSiblingRuns  []ActiveSiblingRunData `json:"active_sibling_runs,omitempty"`
-	ThreadName         string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
-	Status             string                 `json:"status"`
-	Priority           int32                  `json:"priority"`
-	DispatchedAt       *string                `json:"dispatched_at"`
-	StartedAt          *string                `json:"started_at"`
-	CompletedAt        *string                `json:"completed_at"`
-	Result             any                    `json:"result"`
-	Error              *string                `json:"error"`
-	FailureReason      string                 `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt            int32                  `json:"attempt"`
-	MaxAttempts        int32                  `json:"max_attempts"`
-	ParentTaskID       *string                `json:"parent_task_id,omitempty"`
-	IsLeaderTask       bool                   `json:"is_leader_task,omitempty"`
-	LeaderRoleResolved bool                   `json:"leader_role_resolved,omitempty"` // claim-only capability, always true here: IsLeaderTask/SquadID authoritatively answer "is this a leader run", so the daemon must not infer the role from briefing text. Servers predating it make no such promise — before #4951 they sent no is_leader_task at all, after it they sent the flag without guaranteeing a briefing — so a daemon seeing no capability keeps the legacy inference. Never rendered into a prompt; see daemon.taskIsSquadLeader (MUL-5811). Mirror field: internal/daemon/types.go, same JSON name
-	Agent              *TaskAgentData         `json:"agent,omitempty"`
-	ConnectedApps      []ConnectedAppData     `json:"connected_apps,omitempty"` // daemon-claim only: per-run app capabilities mounted through runtime MCP overlays
-	Repos              []RepoData             `json:"repos,omitempty"`
-	ProjectID          string                 `json:"project_id,omitempty"`          // issue's project, when present
-	ProjectTitle       string                 `json:"project_title,omitempty"`       // for surfacing in agent context
-	ProjectDescription string                 `json:"project_description,omitempty"` // durable project-level context injected into the brief
-	ProjectResources   []ProjectResourceData  `json:"project_resources,omitempty"`   // resources attached to the project
-	CreatedAt          string                 `json:"created_at"`
-	PriorSessionID     string                 `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
-	PriorWorkDir       string                 `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
+	WorkspaceContext string `json:"workspace_context,omitempty"`
+	// IssueStatuses is the workspace's ACTIVE CUSTOM status catalog (MUL-6460),
+	// injected into the agent brief so agents can see and use statuses beyond
+	// the seven built-ins. Built-ins are omitted: their keys, names, and
+	// semantics are locked (is_system rows cannot be renamed or archived), so
+	// the daemon already knows them. Empty for a workspace with no custom
+	// statuses — the daemon then renders the brief exactly as before, keeping
+	// existing deployments byte-identical. Capped at taskIssueStatusCap
+	// entries; IssueStatusesOmitted carries the overflow count.
+	IssueStatuses []TaskIssueStatusData `json:"issue_statuses,omitempty"`
+	// IssueStatusesOmitted is how many active custom statuses were dropped by
+	// the cap, so the brief can say the list is incomplete instead of
+	// presenting a truncated catalog as the whole one.
+	IssueStatusesOmitted int                    `json:"issue_statuses_omitted,omitempty"`
+	ActiveSiblingRuns    []ActiveSiblingRunData `json:"active_sibling_runs,omitempty"`
+	ThreadName           string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
+	Status               string                 `json:"status"`
+	Priority             int32                  `json:"priority"`
+	DispatchedAt         *string                `json:"dispatched_at"`
+	StartedAt            *string                `json:"started_at"`
+	CompletedAt          *string                `json:"completed_at"`
+	Result               any                    `json:"result"`
+	Error                *string                `json:"error"`
+	FailureReason        string                 `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt              int32                  `json:"attempt"`
+	MaxAttempts          int32                  `json:"max_attempts"`
+	ParentTaskID         *string                `json:"parent_task_id,omitempty"`
+	IsLeaderTask         bool                   `json:"is_leader_task,omitempty"`
+	LeaderRoleResolved   bool                   `json:"leader_role_resolved,omitempty"` // claim-only capability, always true here: IsLeaderTask/SquadID authoritatively answer "is this a leader run", so the daemon must not infer the role from briefing text. Servers predating it make no such promise — before #4951 they sent no is_leader_task at all, after it they sent the flag without guaranteeing a briefing — so a daemon seeing no capability keeps the legacy inference. Never rendered into a prompt; see daemon.taskIsSquadLeader (MUL-5811). Mirror field: internal/daemon/types.go, same JSON name
+	Agent                *TaskAgentData         `json:"agent,omitempty"`
+	ConnectedApps        []ConnectedAppData     `json:"connected_apps,omitempty"` // daemon-claim only: per-run app capabilities mounted through runtime MCP overlays
+	Repos                []RepoData             `json:"repos,omitempty"`
+	ProjectID            string                 `json:"project_id,omitempty"`          // issue's project, when present
+	ProjectTitle         string                 `json:"project_title,omitempty"`       // for surfacing in agent context
+	ProjectDescription   string                 `json:"project_description,omitempty"` // durable project-level context injected into the brief
+	ProjectResources     []ProjectResourceData  `json:"project_resources,omitempty"`   // resources attached to the project
+	CreatedAt            string                 `json:"created_at"`
+	PriorSessionID       string                 `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
+	PriorWorkDir         string                 `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
 	// PriorSessionResumeUnavailable is set when a more recent Codex session was
 	// withheld because its rollout was missing (MUL-5305); PriorSessionID (if
 	// any) is then an older fallback. The daemon surfaces the continuity gap in

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3030,6 +3030,40 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		)
 	}
 
+	// Workspace status catalog (MUL-6460): active CUSTOM statuses only, so the
+	// daemon can render them into the brief's status-command line. Not gated on
+	// the custom_issue_statuses flag — the flag only guards creation, and a
+	// catalog written before a flag flip must stay visible to agents as long as
+	// issues can sit on it. Read on every claim, like the agent row, so an
+	// admin's edit lands on the next task. Failure degrades to the built-in-only
+	// brief rather than failing the claim.
+	if entries, err := h.Queries.ListIssueStatusEntries(r.Context(), db.ListIssueStatusEntriesParams{
+		WorkspaceID:     parseUUID(resp.WorkspaceID),
+		IncludeArchived: false,
+	}); err != nil {
+		slog.Warn("task claim: failed to load issue status catalog for brief injection",
+			"task_id", uuidToString(task.ID),
+			"workspace_id", resp.WorkspaceID,
+			"error", err,
+		)
+	} else {
+		for _, entry := range entries {
+			if entry.IsSystem {
+				continue
+			}
+			if len(resp.IssueStatuses) == taskIssueStatusCap {
+				resp.IssueStatusesOmitted++
+				continue
+			}
+			resp.IssueStatuses = append(resp.IssueStatuses, TaskIssueStatusData{
+				Key:         entry.Key,
+				Name:        entry.Name,
+				Category:    entry.Category,
+				Description: entry.Description,
+			})
+		}
+	}
+
 	// Last gate before dispatch: refuse to hand a worktree-mode local_directory
 	// task to a daemon that cannot implement the mode.
 	//

--- a/server/internal/handler/daemon_claim_issue_status_test.go
+++ b/server/internal/handler/daemon_claim_issue_status_test.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// TestClaimTaskByRuntime_PopulatesIssueStatusCatalog verifies the claim
+// response carries the workspace's active CUSTOM statuses — and only those —
+// so the daemon can render them into the agent brief (MUL-6460). Built-ins
+// stay off the wire (the daemon knows them), archived statuses stay off the
+// wire (they reject writes), and entries arrive in catalog order (category
+// rank first), because the daemon renders them verbatim without re-sorting.
+func TestClaimTaskByRuntime_PopulatesIssueStatusCatalog(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	createTestCustomStatus(t, "rework", "todo")
+	dbfx.Exec(t, `UPDATE issue_status SET name = 'Rework', description = 'Sent back by review' WHERE workspace_id = $1 AND key = 'rework'`, testWorkspaceID)
+	createTestCustomStatus(t, "later", "backlog")
+	archived := createTestCustomStatus(t, "old_qa", "in_review")
+	dbfx.Exec(t, `UPDATE issue_status SET archived_at = now() WHERE id = $1`, archived.ID)
+
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Issue status catalog claim runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Issue status catalog claim agent")
+	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "120 seconds", false)
+
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
+		testWorkspaceID, "issue-status-catalog-claim")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
+
+	var resp struct {
+		Task *struct {
+			ID            string `json:"id"`
+			IssueStatuses []struct {
+				Key         string `json:"key"`
+				Name        string `json:"name"`
+				Category    string `json:"category"`
+				Description string `json:"description"`
+			} `json:"issue_statuses"`
+			IssueStatusesOmitted int `json:"issue_statuses_omitted"`
+		} `json:"task"`
+	}
+	w.JSON(&resp)
+	if resp.Task == nil {
+		t.Fatalf("expected dispatched task %s to be claimed, got nil response: %s", taskID, w.Body.String())
+	}
+	if resp.Task.ID != taskID {
+		t.Fatalf("claimed task id = %s, want %s", resp.Task.ID, taskID)
+	}
+	if got := len(resp.Task.IssueStatuses); got != 2 {
+		t.Fatalf("issue_statuses count = %d, want 2 (active customs only): %+v", got, resp.Task.IssueStatuses)
+	}
+	// Catalog order: backlog (rank 0) precedes todo (rank 1).
+	if resp.Task.IssueStatuses[0].Key != "later" || resp.Task.IssueStatuses[0].Category != "backlog" {
+		t.Errorf("issue_statuses[0] = %+v, want key=later category=backlog first by category rank", resp.Task.IssueStatuses[0])
+	}
+	second := resp.Task.IssueStatuses[1]
+	if second.Key != "rework" || second.Category != "todo" || second.Name != "Rework" || second.Description != "Sent back by review" {
+		t.Errorf("issue_statuses[1] = %+v, want the full rework entry (key/name/category/description)", second)
+	}
+	if resp.Task.IssueStatusesOmitted != 0 {
+		t.Errorf("issue_statuses_omitted = %d, want 0 under the cap", resp.Task.IssueStatusesOmitted)
+	}
+}
+
+// TestClaimTaskByRuntime_IssueStatusCatalogAbsentWithoutCustoms pins the
+// compatibility contract: a workspace with no custom statuses claims with NO
+// issue_statuses field at all (omitempty), which is what keeps the daemon's
+// brief byte-identical to the pre-MUL-6460 form for existing deployments.
+func TestClaimTaskByRuntime_IssueStatusCatalogAbsentWithoutCustoms(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	seedTestCatalog(t)
+
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Issue status catalog empty claim runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Issue status catalog empty claim agent")
+	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "120 seconds", false)
+
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
+		testWorkspaceID, "issue-status-catalog-empty-claim")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
+
+	var resp struct {
+		Task *map[string]any `json:"task"`
+	}
+	w.JSON(&resp)
+	if resp.Task == nil {
+		t.Fatalf("expected dispatched task %s to be claimed, got nil response: %s", taskID, w.Body.String())
+	}
+	if _, present := (*resp.Task)["issue_statuses"]; present {
+		t.Errorf("issue_statuses must be absent for a workspace with only built-in statuses")
+	}
+	if _, present := (*resp.Task)["issue_statuses_omitted"]; present {
+		t.Errorf("issue_statuses_omitted must be absent when nothing was omitted")
+	}
+}

--- a/server/internal/service/builtin_skills/multica-squads/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-squads/SKILL.md
@@ -180,6 +180,10 @@ Current behavior:
   — on those paths the protocol instead carries an explicit "do not change this
   issue's status".
 
+The status names above are category rules: a workspace may define custom
+statuses beyond the built-ins, and each one inherits its category's behavior in
+full (the runtime brief lists the workspace catalog when any exist).
+
 Assignment validation rejects a missing type/id pair, non-existent squad,
 archived squad, archived leader, and private leader when the actor cannot access
 it.

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -152,6 +152,11 @@ Contracts:
   do not write issue status. There is no assignee gate anymore: a guest leader
   writes nothing not because it lacks a grant but because a turn that did not
   move the issue's state has nothing to record.
+- status names are category rules: custom statuses inherit their category's
+  behavior in full (MUL-6243, `server/internal/issuestatus/issuestatus.go`
+  `Effective`/`Resolve`); the brief lists the workspace catalog when any custom
+  statuses exist (MUL-6460, `writeIssueStatusCommand` in
+  `server/internal/daemon/execenv/runtime_config_sections.go`).
 
 ## Comment / Mention
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -185,6 +185,14 @@ multica issue property unset <issue-id> --name Environment
 A status change is not cosmetic — the server enqueues or skips agent work based
 on it. These are the contracts, not advice:
 
+A workspace may define custom statuses beyond the seven built-ins; when any
+exist, the runtime brief's Available Commands section lists this workspace's
+catalog. A custom status inherits its category's behavior in full, and each
+built-in key below is also the name of its category — so read these bullets as
+category rules. Two writes are literal-key exceptions, not category rules: the
+failed-task rollback below writes the literal `todo` key, and a merged PR with
+close intent writes the literal `done` key.
+
 - **`backlog`** parks an agent-assigned issue: the assignee is set but no task
   fires. Moving `backlog → todo` (or any non-done/non-cancelled status) enqueues
   the assigned agent then.

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -132,6 +132,9 @@ and is hidden from the PR list.
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
 | Runtime brief: status written whenever the work changes it, mid-turn included — starting the issue's own ask → `in_progress` immediately (workflow step 3); delivery → `in_review`, continuing → `in_progress`, stuck → `blocked`; a turn producing none of the issue's own deliverable → no write at any point; the activity kind never decides (research/design/planning/review count as work when they are the ask); no assignee gate; squad leader dispatch is not delivery (MUL-6417) | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowIssue`) | new citation |
 | Failed task may roll `in_progress` → `todo` when no active task remains | `server/internal/service/task.go` (`HandleFailedTasks`) | new citation |
+| Custom statuses inherit their category's behavior in full; enqueue/park contracts resolve the effective category via `issuestatus.Effective` / `Resolve` (MUL-6243) | `server/internal/issuestatus/issuestatus.go` (`Effective`, `Resolve`) | new citation |
+| Runtime brief lists the workspace's active custom statuses grouped by category; catalog rides the claim payload (MUL-6460) | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeIssueStatusCommand`); claim injection in `server/internal/handler/daemon.go` (`buildClaimedTaskResponse`, status catalog block) | new citation |
+| Literal-key exceptions to category rules: failed-task rollback writes the `todo` key; merged close-intent PR writes the `done` key | `server/internal/service/task.go` (`HandleFailedTasks`); `server/internal/handler/github.go` (merge close-intent path) | new citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee


### PR DESCRIPTION
Closes nothing automatically — review and merge gates stay human (MUL-6460 moves to in_review).

## What

Agents cannot see custom issue statuses (parent: MUL-6243). The brief's status command line hardcodes the seven built-in keys (`runtime_config_sections.go:269`), and the CLI has no catalog read to fall back on — so a workspace's `Human Review` / `Rework` are invisible to every agent even when instructions name them.

This PR ships the workspace status catalog to agents over the claim payload — the same path `WorkspaceContext` already rides — and renders it in the brief:

- **Server** (`buildClaimedTaskResponse`): reads the workspace's **active custom** statuses via `ListIssueStatusEntries` and puts `issue_statuses` (key / name / category / description, catalog order) on the claim. Built-ins stay off the wire (locked, daemon already knows them). Capped at 30 with an `issue_statuses_omitted` count. Not gated on the `custom_issue_statuses` flag — the flag only guards creation; a catalog written before a flag flip must stay visible while issues sit on it. Read failure degrades to the built-in-only brief, never fails the claim.
- **Daemon** (`writeIssueStatusCommand`): with no custom statuses the status bullet renders **byte-identical to today** — that is the compatibility contract (prompt-cache prefix, MUL-5377), and it covers both old-server/new-daemon and new-server/old-daemon pairings automatically. With custom statuses it renders the catalog grouped by category, plus one bridge bullet in the issue workflow connecting the existing category-level status rules (unchanged) to the concrete key choice.
- **Safety**: name/description are user-authored text entering a trusted brief — they pass through `sanitizeNameForBriefMarkdown`; an entry whose key fails `sanitizeBriefCodeToken` is dropped.
- **Skills** (same-PR rule in CLAUDE.md): `multica-working-on-issues` and `multica-squads` SKILL.md now state that status rules are category rules which custom statuses inherit in full, with the two literal-key exceptions (failed-task rollback → literal `todo`; merged close-intent PR → literal `done`); source maps updated.

## Rendered example

With `later` (backlog), `rework` (todo), `human_review` (in_review) defined:

```markdown
- `multica issue status <id> <status> [--no-start]` — flip status. This workspace's statuses by category — a custom status inherits its category's platform behavior in full:
  - `backlog`: `backlog` (built-in), `later` (Later — Deferred on purpose)
  - `todo`: `todo` (built-in), `rework` (Rework)
  - `in_review`: `in_review` (built-in), `human_review` (Human Review — Awaiting human acceptance)
  - Built-in key only: `in_progress`, `done`, `blocked`, `cancelled`.
```

Design discussion and decision record: MUL-6460 comments.

## Tests

- `execenv`: absent/empty catalog renders byte-identical (the zero-change contract); grouped rendering + bridge bullet; markdown-injection names sanitized and invalid keys dropped; truncation disclosure.
- `handler`: claim carries active customs only (archived + built-ins excluded) in catalog order; workspace without customs omits the field entirely.
- Ran: `go build ./...`, `go vet` on touched packages, full `execenv` suite (only pre-existing Hermes env-dependent failures on this machine, present on clean main), `go test ./internal/handler/ -run TestClaimTask` all green.
