### PR TITLE
docs(plugins): drop the "never executes plugin code" claim

### DIFF
--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -14,9 +14,7 @@ multica.ui.resize(320);
 
 ## What a surface is
 
-An ordinary script in a sandboxed iframe. Multica never executes plugin code on
-its servers — a surface runs in the user's browser, or on your own server behind
-a hook.
+An ordinary script in a sandboxed iframe.
 
 The frame is mounted with `sandbox="allow-scripts"` and **not**
 `allow-same-origin`, so it has an opaque origin. Consequences worth knowing

--- a/server/internal/service/plugin.go
+++ b/server/internal/service/plugin.go
@@ -33,8 +33,7 @@ import (
 const LocalSourcePrefix = "local:"
 
 // PluginService owns plugin installation, configuration, and plugin-owned
-// state. It never executes plugin code: a plugin runs only in the user's
-// browser inside a sandboxed iframe, or on the author's own server.
+// state.
 type PluginService struct {
 	Queries   *db.Queries
 	TxStarter TxStarter


### PR DESCRIPTION
Removes the "Multica never executes plugin code" claim from the two places it appeared.

The sentence conflated two different things: not **executing** plugin code and not **hosting** it. Serving a static file is not executing it, so the claim was doing rhetorical work it could not support — in practice it read as a security rationale for requiring plugin authors to self-host their surface script, which the isolation model does not actually require.

The isolation that *is* real stays documented where it is enforced:

- `sandbox="allow-scripts"` without `allow-same-origin` (`plugin-surface-frame.tsx`)
- the host-generated surface document, which is what makes the `net:` CSP enforceable (`surface-document.ts`)
- the no-credential-in-frame bridge (`surface-bridge.ts`, `plugin-sdk/protocol.ts`)

Comment/docs only — no behaviour change. `gofmt` and `go vet ./internal/service/` clean.

Context: MUL-6438.
