### PR TITLE
fix(build): honor GOOS as a Make variable for the Windows exe suffix (MUL-6433)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
               - 'scripts/helm-config.test.sh'
               - 'scripts/test-go.sh'
               - 'scripts/test-go.test.sh'
+              # makefile-build.test.sh asserts how `make build` names its
+              # output binaries, so a change to either side must run it.
+              - 'scripts/makefile-build.test.sh'
               - 'Makefile'
               - '.github/workflows/ci.yml'
             sqlc:
@@ -498,6 +501,10 @@ jobs:
       - name: Test Helm chart
         if: ${{ needs.changes.outputs.backend == 'true' }}
         run: bash scripts/helm-config.test.sh
+
+      - name: Test build output naming
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        run: bash scripts/makefile-build.test.sh
 
       - name: Build
         if: ${{ needs.changes.outputs.backend == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -278,8 +278,18 @@ multica: ## Run the multica CLI entrypoint directly from the Go source tree
 VERSION ?= $(shell git describe --tags --match 'v[0-9]*' --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
-EXE     := $(if $(filter windows,$(shell go env GOOS)),.exe,)
-
+# Windows will not execute an extensionless binary, so a source build there has
+# to name its outputs the way the target platform expects — otherwise the CLI
+# builds fine and then fails to re-exec itself as a daemon (#7255). GOOS reaches
+# a build two ways: as an environment variable (`GOOS=windows make build`) and
+# as a Make variable (`make build GOOS=windows`). The top-level `export` sends
+# both forms to the recipe, so `go build` honors both and the suffix has to as
+# well; `$(GOOS)` covers the Make-variable form, which a parse-time
+# `go env GOOS` cannot see. Target-specific so only `build` pays for the probe:
+# a global assignment runs `go env` on every target — `export` expands even a
+# recursive one — which prints `go: Command not found` on frontend-only
+# checkouts with no Go toolchain installed.
+build: EXE = $(if $(filter windows,$(or $(GOOS),$(shell go env GOOS))),.exe,)
 build: ## Build the server, CLI, and migrate binaries into server/bin
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server$(EXE) ./cmd/server
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica$(EXE) ./cmd/multica

--- a/scripts/makefile-build.test.sh
+++ b/scripts/makefile-build.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `make build` has to name its outputs the way the *target* platform expects.
+# Windows refuses to execute an extensionless file, so a Windows source build
+# whose artifacts are named `multica` produces a CLI that cannot re-exec itself
+# as a daemon (#7255) — the build succeeds and the failure surfaces later as a
+# misleading "not found" at startup.
+#
+# The suffix is derived from GOOS, which reaches a build two ways: as an
+# environment variable and as a Make variable on the command line. `go build`
+# honors both, so a suffix that honors only one silently rebuilds the original
+# bug. Nothing else covers this: the Go test suite never runs the Makefile, and
+# CI's own build steps call `go build` directly.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+# The recipe reads `-o bin/server$(EXE) ./cmd/server`, so the trailing space is
+# what keeps an expected `bin/server` from matching an emitted `bin/server.exe`.
+require_outputs() {
+  local label=$1 suffix=$2 output=$3 binary
+
+  for binary in server multica migrate; do
+    grep -Fq -- "-o bin/${binary}${suffix} " <<<"$output" ||
+      fail "$label: expected 'go build ... -o bin/${binary}${suffix}', got:
+$output"
+  done
+}
+
+# A `go` shim that records every invocation, so the assertions below can tell
+# "the Makefile probed the toolchain" from "the Makefile did not" without
+# depending on how the host PATH is laid out.
+probe_dir="$(mktemp -d)"
+trap 'rm -rf "$probe_dir"' EXIT
+real_go="$(command -v go || true)"
+cat >"$probe_dir/go" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >>"$probe_dir/invocations"
+[ -n "$real_go" ] || exit 1
+exec "$real_go" "\$@"
+EOF
+chmod +x "$probe_dir/go"
+
+probe_count() {
+  [ -f "$probe_dir/invocations" ] || { echo 0; return; }
+  wc -l <"$probe_dir/invocations" | tr -d ' '
+}
+
+require_outputs "GOOS=windows in the environment" .exe \
+  "$(GOOS=windows make -n build)"
+require_outputs "GOOS=windows as a Make variable" .exe \
+  "$(make -n build GOOS=windows)"
+require_outputs "GOOS=linux in the environment" "" \
+  "$(GOOS=linux make -n build)"
+require_outputs "GOOS=darwin as a Make variable" "" \
+  "$(make -n build GOOS=darwin)"
+
+# Non-build targets must not reach for a Go toolchain: `make help` and
+# `make clean` are the first thing a frontend-only contributor runs, and a
+# global suffix assignment makes every one of them print `go: Command not
+# found` on a checkout with no Go installed.
+PATH="$probe_dir:$PATH" make -n clean >/dev/null
+PATH="$probe_dir:$PATH" make help >/dev/null
+[ "$(probe_count)" = 0 ] ||
+  fail "non-build targets invoked go $(probe_count) time(s): $(cat "$probe_dir/invocations")"
+
+# With no GOOS given, the suffix has to follow the toolchain's own default.
+if [ -n "$real_go" ]; then
+  host_suffix=""
+  [ "$("$real_go" env GOOS)" = windows ] && host_suffix=.exe
+  require_outputs "no GOOS set" "$host_suffix" \
+    "$(PATH="$probe_dir:$PATH" make -n build)"
+  [ "$(probe_count)" != 0 ] ||
+    fail "no GOOS set: expected the build target to resolve GOOS via go env"
+else
+  echo "skipping the host-default case: no go toolchain on PATH"
+fi
+
+echo "✓ make build names its outputs for the target platform"


### PR DESCRIPTION
## What does this PR do?

Follow-up to #7271, which fixed the Windows source build (#7255) but derives the `.exe` suffix from a parse-time `$(shell go env GOOS)`. Two gaps remain:

1. **GOOS passed as a Make variable is ignored.** `make build GOOS=windows` still produces extensionless PE binaries — the exact artifacts #7255 reported as unable to re-exec themselves. The Makefile's top-level `export` puts the Make variable into the recipe's environment, so `go build` really does target Windows; only the parse-time `$(shell ...)`, which never sees command-line variables, disagrees. `GOOS=windows make build` (environment form) was already correct.

   ```
   $ make build GOOS=windows GOARCH=amd64   # on main
   $ file server/bin/*
   server/bin/migrate: PE32+ executable (console) x86-64
   server/bin/multica: PE32+ executable (console) x86-64
   server/bin/server:  PE32+ executable (console) x86-64
   ```

2. **Every Make target now probes the Go toolchain.** The assignment is global and immediate, so `make help`, `make clean`, and CI's `make sqlc` all shell out to `go env GOOS`, and a checkout without Go prints `make: go: Command not found` on every invocation. Switching `:=` to `=` does *not* fix this — the top-level `export` expands every variable to build each recipe's environment, including recursive ones.

Reading `$(GOOS)` before falling back to `go env` covers both invocation forms, and a target-specific assignment keeps the probe on `build` alone. Non-Windows output paths are unchanged.

## Related Issue

Follow-up to #7271 / #7255. No separate issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `Makefile`: replaced the global `EXE :=` with a target-specific `build: EXE = $(if $(filter windows,$(or $(GOOS),$(shell go env GOOS))),.exe,)`.
- `scripts/makefile-build.test.sh` (new): asserts the suffix for GOOS via environment and via Make variable, the unsuffixed non-Windows names, the host default, and that non-build targets never invoke `go` (checked with a recording `go` shim rather than by rearranging `PATH`).
- `.github/workflows/ci.yml`: runs that script in `backend-tests` alongside the other Makefile-adjacent shell tests, and adds it to the backend path filter.

## How to Test

1. `bash scripts/makefile-build.test.sh` → passes on this branch; on `main` it fails with `expected 'go build ... -o bin/server.exe'`.
2. `make build GOOS=windows GOARCH=amd64 && file server/bin/*` → three `PE32+ executable (console) x86-64` files, all named `.exe`.
3. `make build && ./server/bin/multica --version` → unsuffixed binaries, version/commit/date intact.
4. `GOOS=linux make -n build` → output paths unchanged (`bin/server`, `bin/multica`, `bin/migrate`).
5. With a `PATH` that has no `go`: `make help` and `make clean` no longer print `go: Command not found`.

Verified on macOS with GNU Make 3.81 and Go 1.26.6. `shellcheck` is clean on the new script.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Risk:** build-time only. No runtime, API, or data behavior changes; the Docker image, the goreleaser release pipeline, and `apps/desktop/scripts/bundle-cli.mjs` each run their own `go build` and are untouched. Windows users who built before #7271 keep stale extensionless binaries in `server/bin` that the new build won't overwrite — `make clean` clears them.

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** Reviewing #7271 surfaced the Make-variable gap; reproduced it with a real cross-compile (`file` on the artifacts), confirmed the `export`-defeats-lazy-evaluation behavior with minimal Makefiles, then wrote the fix plus a regression script and verified the script fails against `main` and passes here.

## Screenshots (optional)

N/A
