### PR TITLE
MUL-6476 fix(execenv): expand $OPENCLAW_HOME in the openclaw active config path

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -823,7 +823,15 @@ func openclawTildeRest(path string) (string, bool) {
 // install, so the wrapper drops the user's `$include` and the task boots
 // without their model providers or auth profiles.
 //
-// Both the bare and braced spellings are accepted, and both separators
+// The shape is guaranteed rather than incidental. At `v2026.5.27`,
+// `src/cli/config-cli.ts`'s `runConfigFile` prints `shortenHomePath(...)`, and
+// `src/utils.ts:147-157` uses the `$OPENCLAW_HOME` prefix whenever that variable
+// is non-empty and `~` otherwise — so setting the variable is what selects this
+// form.
+//
+// Only the bare spelling is emitted by that code path. `${OPENCLAW_HOME}` is
+// accepted as defense against a release that spells it the other way, not
+// because anything is known to print it. Both separators are accepted
 // regardless of runtime.GOOS, for the reason openclawTildeRest gives above.
 func openclawHomeRest(path string) (string, bool) {
 	for _, prefix := range []string{"$OPENCLAW_HOME", "${OPENCLAW_HOME}"} {
@@ -838,15 +846,51 @@ func openclawHomeRest(path string) (string, bool) {
 	return "", false
 }
 
+// openclawHomeFromEnv resolves OPENCLAW_HOME to the directory the CLI's printed
+// `$OPENCLAW_HOME` prefix actually stands for.
+//
+// The value itself may be a tilde path. Upstream documents it
+// (`docs/help/environment.md` at `v2026.5.27`: "OPENCLAW_HOME can also be set to
+// a tilde path (e.g. `~/svc`), which gets expanded using the same OS home
+// fallback chain before use") and implements it in `src/infra/home-dir.ts:41-47`.
+// It expands the value *before* computing the home that `config file` then
+// shortens, so on such a host the printed `$OPENCLAW_HOME` stands for
+// `<os-home>/svc`, and landing on the same file means resolving it the same way.
+// Joining the raw value instead leaves the `~` embedded, filepath.Abs turns that
+// into a confident absolute path under the daemon's working directory, and the
+// stat miss reproduces the silent fresh-install failure this whole branch exists
+// to remove.
+//
+// Only the tilde is expanded here, deliberately — not the variable form — so a
+// self-referential value cannot resolve against itself.
+func openclawHomeFromEnv() (string, error) {
+	home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
+	if home == "" {
+		return "", errors.New("environment variable is empty")
+	}
+	rest, isTilde := openclawTildeRest(home)
+	if !isTilde {
+		return home, nil
+	}
+	osHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("expand `~` in OPENCLAW_HOME: %w", err)
+	}
+	if rest == "" {
+		return osHome, nil
+	}
+	return filepath.Join(osHome, rest), nil
+}
+
 func expandOpenclawPath(path string) (string, error) {
 	// OPENCLAW_HOME before `~`: the two shapes are mutually exclusive, but the
 	// variable form is checked first because an empty OPENCLAW_HOME has to fail
 	// loudly rather than fall through to a relative-path resolution that would
 	// quietly produce a wrong absolute path.
 	if rest, isOpenclawHome := openclawHomeRest(path); isOpenclawHome {
-		home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
-		if home == "" {
-			return "", fmt.Errorf("expand OPENCLAW_HOME in openclaw config path: environment variable is empty")
+		home, herr := openclawHomeFromEnv()
+		if herr != nil {
+			return "", fmt.Errorf("expand OPENCLAW_HOME in openclaw config path %q: %w", path, herr)
 		}
 		if rest == "" {
 			path = home
@@ -856,7 +900,7 @@ func expandOpenclawPath(path string) (string, error) {
 	} else if rest, isTilde := openclawTildeRest(path); isTilde {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
-			return "", fmt.Errorf("expand `~` in openclaw config path: %w", herr)
+			return "", fmt.Errorf("expand `~` in openclaw config path %q: %w", path, herr)
 		}
 		if rest == "" {
 			path = home

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -814,8 +814,46 @@ func openclawTildeRest(path string) (string, bool) {
 	return "", false
 }
 
+// openclawHomeRest recognizes the symbolic shape current OpenClaw releases
+// print when OPENCLAW_HOME is set: the variable name rather than its value, for
+// example `$OPENCLAW_HOME\.openclaw\openclaw.json`. Nothing downstream expands
+// it, so the line reaches filepath.Abs as an ordinary relative path and lands
+// under the daemon's working directory — the same stat miss #6630 fixed for the
+// tilde form, with the same consequence: indistinguishable from a fresh
+// install, so the wrapper drops the user's `$include` and the task boots
+// without their model providers or auth profiles.
+//
+// Both the bare and braced spellings are accepted, and both separators
+// regardless of runtime.GOOS, for the reason openclawTildeRest gives above.
+func openclawHomeRest(path string) (string, bool) {
+	for _, prefix := range []string{"$OPENCLAW_HOME", "${OPENCLAW_HOME}"} {
+		if path == prefix {
+			return "", true
+		}
+		if len(path) > len(prefix) && strings.HasPrefix(path, prefix) &&
+			(path[len(prefix)] == '/' || path[len(prefix)] == '\\') {
+			return path[len(prefix)+1:], true
+		}
+	}
+	return "", false
+}
+
 func expandOpenclawPath(path string) (string, error) {
-	if rest, isTilde := openclawTildeRest(path); isTilde {
+	// OPENCLAW_HOME before `~`: the two shapes are mutually exclusive, but the
+	// variable form is checked first because an empty OPENCLAW_HOME has to fail
+	// loudly rather than fall through to a relative-path resolution that would
+	// quietly produce a wrong absolute path.
+	if rest, isOpenclawHome := openclawHomeRest(path); isOpenclawHome {
+		home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
+		if home == "" {
+			return "", fmt.Errorf("expand OPENCLAW_HOME in openclaw config path: environment variable is empty")
+		}
+		if rest == "" {
+			path = home
+		} else {
+			path = filepath.Join(home, rest)
+		}
+	} else if rest, isTilde := openclawTildeRest(path); isTilde {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
 			return "", fmt.Errorf("expand `~` in openclaw config path: %w", herr)

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1746,6 +1746,106 @@ func TestExpandOpenclawPathTildeSeparators(t *testing.T) {
 	}
 }
 
+// TestExpandOpenclawPathOpenclawHome — the same failure as #6630 in a second
+// shape. When OPENCLAW_HOME is set, current releases print the variable name
+// instead of its value, and an unexpanded `$OPENCLAW_HOME\...` line is not
+// absolute, so it lands under the daemon's working directory and stats as
+// missing — reported as a fresh install, wrapper without the user's $include.
+func TestExpandOpenclawPathOpenclawHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OPENCLAW_HOME", home)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "dollar Windows separator", in: `$OPENCLAW_HOME\.openclaw\openclaw.json`, want: filepath.Join(home, `.openclaw\openclaw.json`)},
+		{name: "braced POSIX separator", in: `${OPENCLAW_HOME}/.openclaw/openclaw.json`, want: filepath.Join(home, ".openclaw", "openclaw.json")},
+		{name: "bare variable", in: `$OPENCLAW_HOME`, want: home},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandOpenclawPath(tc.in)
+			if err != nil {
+				t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandOpenclawPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExpandOpenclawPathOpenclawHomeUnsetFailsLoudly — the variable form with
+// nothing to expand it to must be an error, not a relative-path fallback.
+// Falling through would resolve the literal `$OPENCLAW_HOME` segment against
+// the daemon's working directory and hand back a confident absolute path to a
+// file that cannot exist, which is exactly the silent-fresh-install failure
+// this shape causes in the first place.
+func TestExpandOpenclawPathOpenclawHomeUnsetFailsLoudly(t *testing.T) {
+	t.Setenv("OPENCLAW_HOME", "")
+
+	got, err := expandOpenclawPath(`$OPENCLAW_HOME/.openclaw/openclaw.json`)
+	if err == nil {
+		t.Fatalf("expandOpenclawPath returned %q, want an error when OPENCLAW_HOME is empty", got)
+	}
+	if !strings.Contains(err.Error(), "OPENCLAW_HOME") {
+		t.Errorf("error %q does not name the variable that could not be expanded", err.Error())
+	}
+}
+
+// TestPrepareOpenclawConfigExpandsOpenclawHome — end-to-end guard, mirroring
+// TestPrepareOpenclawConfigExpandsWindowsTilde below: the banner-then-path
+// output shape with the variable form must still produce a wrapper that
+// $includes the user's config, and the include-root grant that goes with it.
+func TestPrepareOpenclawConfigExpandsOpenclawHome(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	openclawHome := t.TempDir()
+	t.Setenv("OPENCLAW_HOME", openclawHome)
+
+	// Built with filepath.Join for the reason the tilde test gives: the
+	// remainder arrives with the CLI's separators and production normalizes it
+	// the same way, so on a non-Windows host this is one oddly-named file.
+	wantPath := filepath.Join(openclawHome, `.openclaw\openclaw.json`)
+	if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+		t.Fatalf("mkdir user cfg dir: %v", err)
+	}
+	if err := os.WriteFile(wantPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	banner := "|\no  Config warnings ---------------------------------+\n" +
+		"|  - plugins.entries.duckduckgo: plugin not found  |\n" +
+		"+--------------------------------------------------+\n" +
+		`$OPENCLAW_HOME\.openclaw\openclaw.json` + "\n"
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: banner},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	include, ok := got["$include"].([]any)
+	if !ok {
+		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
+	}
+	if include[0] != wantPath {
+		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
+	}
+	if result.IncludeRoot != filepath.Dir(wantPath) {
+		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
+	}
+}
+
 // TestPrepareOpenclawConfigExpandsWindowsTilde — end-to-end guard for #6630:
 // the reporter's exact `openclaw config file` output (a config-warning banner
 // followed by a Windows-shortened path) must still produce a wrapper that

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1793,6 +1793,10 @@ func TestExpandOpenclawPathOpenclawHomeUnsetFailsLoudly(t *testing.T) {
 	if !strings.Contains(err.Error(), "OPENCLAW_HOME") {
 		t.Errorf("error %q does not name the variable that could not be expanded", err.Error())
 	}
+	// The path is what the reader of a daemon log needs in order to act.
+	if !strings.Contains(err.Error(), `"$OPENCLAW_HOME/.openclaw/openclaw.json"`) {
+		t.Errorf("error %q does not name the path being expanded", err.Error())
+	}
 }
 
 // TestPrepareOpenclawConfigExpandsOpenclawHome — end-to-end guard, mirroring
@@ -1826,6 +1830,151 @@ func TestPrepareOpenclawConfigExpandsOpenclawHome(t *testing.T) {
 		`$OPENCLAW_HOME\.openclaw\openclaw.json` + "\n"
 	stub := installOpenclawStub(t, map[string]openclawResponse{
 		"config file":                   {stdout: banner},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	include, ok := got["$include"].([]any)
+	if !ok {
+		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
+	}
+	if include[0] != wantPath {
+		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
+	}
+	if result.IncludeRoot != filepath.Dir(wantPath) {
+		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
+	}
+}
+
+// TestExpandOpenclawPathOpenclawHomeIsItselfATilde — the variable's *value* may
+// be a tilde path. Upstream documents that and expands it before computing the
+// home `config file` then shortens (`docs/help/environment.md` and
+// `src/infra/home-dir.ts:41-47` at `v2026.5.27`), so the printed
+// `$OPENCLAW_HOME` stands for `<os-home>/svc` and the daemon has to land on the
+// same file. Joining the raw value leaves the `~` embedded, filepath.Abs makes
+// that absolute under the daemon's working directory, and the stat miss is once
+// again reported as a fresh install — the failure this whole branch removes,
+// reached through the branch itself.
+func TestExpandOpenclawPathOpenclawHomeIsItselfATilde(t *testing.T) {
+	osHome := t.TempDir()
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+
+	cases := []struct {
+		name string
+		env  string
+		in   string
+		want string
+	}{
+		{
+			name: "tilde value, posix remainder",
+			env:  "~/svc",
+			in:   `$OPENCLAW_HOME/.openclaw/openclaw.json`,
+			want: filepath.Join(osHome, "svc", ".openclaw", "openclaw.json"),
+		},
+		{
+			name: "tilde value, windows remainder",
+			env:  "~/svc",
+			in:   `$OPENCLAW_HOME\.openclaw\openclaw.json`,
+			want: filepath.Join(osHome, "svc", `.openclaw\openclaw.json`),
+		},
+		{
+			name: "tilde value with windows separator",
+			env:  `~\svc`,
+			in:   `$OPENCLAW_HOME/.openclaw/openclaw.json`,
+			want: filepath.Join(osHome, "svc", ".openclaw", "openclaw.json"),
+		},
+		{
+			name: "bare tilde value",
+			env:  "~",
+			in:   `$OPENCLAW_HOME/.openclaw/openclaw.json`,
+			want: filepath.Join(osHome, ".openclaw", "openclaw.json"),
+		},
+		{
+			name: "bare variable, tilde value",
+			env:  "~/svc",
+			in:   `$OPENCLAW_HOME`,
+			want: filepath.Join(osHome, "svc"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OPENCLAW_HOME", tc.env)
+			got, err := expandOpenclawPath(tc.in)
+			if err != nil {
+				t.Fatalf("expandOpenclawPath(%q) with OPENCLAW_HOME=%q: %v", tc.in, tc.env, err)
+			}
+			if strings.Contains(got, "~") {
+				t.Errorf("expandOpenclawPath(%q) = %q, want the value's `~` expanded (a literal ~ can never stat)", tc.in, got)
+			}
+			if got != tc.want {
+				t.Errorf("expandOpenclawPath(%q) with OPENCLAW_HOME=%q = %q, want %q", tc.in, tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExpandOpenclawPathLeavesLookalikePrefixesAlone — the risk claim is that no
+// path which works today changes, and this is what guards it. A variable whose
+// name merely starts with OPENCLAW_HOME must not be treated as the shape.
+func TestExpandOpenclawPathLeavesLookalikePrefixesAlone(t *testing.T) {
+	t.Setenv("OPENCLAW_HOME", t.TempDir())
+
+	for _, in := range []string{
+		`$OPENCLAW_HOMEX/y`,
+		`$OPENCLAW_HOME_EXTRA/y`,
+		`${OPENCLAW_HOMEX}/y`,
+		`$OPENCLAW/y`,
+	} {
+		t.Run(in, func(t *testing.T) {
+			got, err := expandOpenclawPath(in)
+			if err != nil {
+				t.Fatalf("expandOpenclawPath(%q): %v", in, err)
+			}
+			// Untouched by the new branch: still resolved as an ordinary
+			// relative path, exactly as on `main`.
+			want, aerr := filepath.Abs(in)
+			if aerr != nil {
+				t.Fatalf("filepath.Abs(%q): %v", in, aerr)
+			}
+			if got != want {
+				t.Errorf("expandOpenclawPath(%q) = %q, want it left as a relative path -> %q", in, got, want)
+			}
+		})
+	}
+}
+
+// TestPrepareOpenclawConfigExpandsTildeValuedOpenclawHome — the same defect at
+// the level that decides what the user actually gets. A unit assertion on
+// expandOpenclawPath would not have caught it: the value's `~` survived into a
+// path that looks absolute, so only following it through to the wrapper shows
+// the `$include` going missing.
+func TestPrepareOpenclawConfigExpandsTildeValuedOpenclawHome(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	osHome := t.TempDir()
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("OPENCLAW_HOME", "~/svc")
+
+	wantPath := filepath.Join(osHome, "svc", ".openclaw", "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+		t.Fatalf("mkdir user cfg dir: %v", err)
+	}
+	if err := os.WriteFile(wantPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: `$OPENCLAW_HOME/.openclaw/openclaw.json` + "\n"},
 		"config get agents.list --json": {stdout: "null"},
 	})
 


### PR DESCRIPTION
## What does this PR do?

#6630 was this bug in the tilde shape, and #6643 fixed that shape. This is the
other one.

`openclaw config file` is how the daemon finds the user's active config. With
`OPENCLAW_HOME` set, current releases print the variable name rather than its
value:

```
$OPENCLAW_HOME\.openclaw\openclaw.json
```

The shape is guaranteed rather than incidental, and checkable at that tag:
`src/cli/config-cli.ts`'s `runConfigFile` prints `shortenHomePath(snapshot.path)`,
and `src/utils.ts:147-157` selects the `$OPENCLAW_HOME` prefix whenever that
variable is non-empty and `~` otherwise. So setting the variable is what selects
this form — which is a better argument for fixing it at the parser than any single
field observation. Only the bare spelling is emitted by that path; the
`${OPENCLAW_HOME}` branch below is defense against a release that spells it
differently, not a shape anything is known to print.

Nothing expands it, and it is not absolute, so `filepath.Abs` joins it onto the
daemon's working directory:

```
<daemon-cwd>/$OPENCLAW_HOME\.openclaw\openclaw.json
```

which cannot exist. `openclawParseActiveConfigPath` tolerates `os.ErrNotExist`,
so the miss is indistinguishable from a fresh install: `prepareOpenclawConfig`
omits the `$include`, and every task on that host runs without the user's model
providers and auth profiles. The user sees an agent that starts and then behaves
as if OpenClaw had never been configured — the same end state #6630 reported,
reached from a different input shape.

The failure is silent by construction, which is why it is worth fixing at the
parser rather than waiting for a report: the only signal is the warning
`prepareOpenclawConfig` already logs for a genuine fresh install, and the two are
indistinguishable from the outside.

## Related Issue

Same class as #6630, whose tilde half shipped as #6643. Relates to #3853
(OpenClaw runtime losing the user's model / credentials in execenv prep).

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/execenv/openclaw_config.go`
  - `openclawHomeRest` accepts `$OPENCLAW_HOME` and `${OPENCLAW_HOME}`, bare or
    followed by either separator. Keyed on the character rather than
    `runtime.GOOS`, so the Windows form is exercised from the ordinary Linux and
    macOS test jobs — the same trade `openclawTildeRest` documents directly above
    it.
  - `openclawHomeFromEnv` resolves the variable to the directory the printed
    prefix stands for. The value itself may be a tilde path: upstream documents it
    (`docs/help/environment.md` at `v2026.5.27`) and implements it in
    `src/infra/home-dir.ts:41-47`, expanding it *before* computing the home that
    `config file` then shortens — so `OPENCLAW_HOME=~/svc` means the printed
    prefix stands for `<os-home>/svc`, and joining the raw value would leave the
    `~` embedded for `filepath.Abs` to make confidently absolute under the
    daemon's working directory. Only the tilde in the value is expanded, not the
    variable form, so a self-referential value cannot resolve against itself.
    This also removes a disagreement inside the file: `openclawFallbackConfigCandidates`
    already ran the value through `expandOpenclawPath`, so the two discovery
    routes previously gave different answers for the same variable.
  - `expandOpenclawPath` checks the shape before the tilde branch, and treats an
    empty `OPENCLAW_HOME` as an error rather than falling through. Falling through
    would resolve the literal variable name against the working directory and
    return a confident absolute path to a file that cannot exist. Note this error
    is effectively unreachable from `config file` — the CLI inherits the daemon's
    environment (`execOpenclawCLI` sets `cmd.Env = os.Environ()`), and with an
    empty value upstream prints `~`, not the variable name — so it earns its keep
    on the `OPENCLAW_CONFIG_PATH` fallback route rather than this one.
  - Both expansion errors name the path with `%q`, not just the variable, since
    the path is what makes the log line actionable.

Tests: the two path shapes plus the bare variable; a tilde-valued
`OPENCLAW_HOME` at both the unit level and the `prepareOpenclawConfig` level,
because the value's `~` survives into a path that *looks* absolute and only
following it to the wrapper shows the `$include` going missing; a negative case
(`$OPENCLAW_HOMEX/y` and friends) which is what actually guards the risk claim
below; the empty-variable error; and an end-to-end guard on the reporter's
banner-then-path output shape, mirroring
`TestPrepareOpenclawConfigExpandsWindowsTilde`.

## How to Test

1. `cd server && go test ./internal/daemon/execenv/ -run 'ExpandOpenclaw|ExpandsOpenclawHome' -v`
2. Mutation-check the fix: replace the `openclawHomeRest` condition in
   `expandOpenclawPath` with `false`. The unit tests then report the path resolved
   against the test's own directory —

   ```
   expandOpenclawPath("$OPENCLAW_HOME\\.openclaw\\openclaw.json") =
     ".../internal/daemon/execenv/$OPENCLAW_HOME\\.openclaw\\openclaw.json"
   ```

   — and the end-to-end test reports a wrapper with no `$include` at all, which is
   the user-visible failure:

   ```
   wrapper has no $include — the user's models and auth profiles would be lost:
   map["agents":map["defaults":map["workspace":".../workdir"]]]
   ```

3. Mutation-check the tilde-valued value: make `openclawHomeFromEnv` return the
   raw environment value. The unit cases then report the literal `~` left in the
   path, and `TestPrepareOpenclawConfigExpandsTildeValuedOpenclawHome` reports
   `wrapper has no $include`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, daemon-only
- [ ] I have updated relevant documentation to reflect my changes — N/A, no documented behaviour changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy and docs — N/A
- [ ] If this PR touches Chinese product copy — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risks

Low. The new branch only fires on a line that starts with the literal
`$OPENCLAW_HOME` or `${OPENCLAW_HOME}`, a shape nothing currently resolves to
anything usable, so no path that works today changes. The one deliberate
behaviour choice is that an empty `OPENCLAW_HOME` now errors where it previously
produced a nonsense absolute path; that path could only ever fail a stat, so the
error replaces a silent failure with a named one.

## Relationship to #6275

Split out of it, at review's suggestion in spirit and following #6643's
precedent: #6275 is process-tree ownership, and this is a path-parsing fix that
happened to be found on the same host. Neither depends on the other, and #6275's
head no longer contains this change.

One hand-off, so it is not left to whoever merges second: #6275 adds
`openclawConfigPathComplete`, a completeness rule for `openclaw config file`
output, and that rule deliberately does **not** recognize the `$OPENCLAW_HOME`
shape while `main` cannot expand it — accepting the line there would hand the
caller a path the parser then fails on. Whichever of the two lands second should
teach that rule this shape. The comment on that function says so, so a rebase
cannot drop it silently.

## AI Disclosure

**AI tool used:** Kiro CLI

**Prompt / approach:** The shape was observed while diagnosing #6275 against a
host running openclaw 2026.5.27, then re-derived against current `main` rather
than cherry-picked, since it originally sat inside that branch. The AI-assisted
loop was: confirm the bug is still present on `main`, read #6643 to match the
existing tilde fix's structure and its reasoning about separators versus
`runtime.GOOS`, then mutation-verify each new test by disabling the branch it
guards and confirming it fails for the stated reason.

