### PR TITLE
fix(agent): drop stdio MCP servers for the dim ACP runtime

### DIFF
--- a/server/pkg/agent/dim.go
+++ b/server/pkg/agent/dim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"strings"
 	"sync"
@@ -168,6 +169,39 @@ func (s *dimMessageStream) close() {
 	close(s.ch)
 }
 
+// dropDimUnsupportedMcpServers removes stdio MCP entries (an entry with a
+// `command` field and no `type` field) from the ACP mcpServers list.
+//
+// Dim's ACP server only declares http/sse in `agentCapabilities.mcpCapabilities`
+// and silently ignores stdio servers: session/new still succeeds, but the
+// server's tools never load and the only trace is an `unsupported_transport`
+// warning on stderr. If Multica forwarded stdio entries verbatim, a user's
+// configured MCP tools would fail silently with no surface error — exactly
+// the class of bug this filter exists to make visible. The dropped server
+// names are logged as warnings so the mismatch is diagnosable from the daemon
+// log.
+func dropDimUnsupportedMcpServers(servers []any, logger *slog.Logger) []any {
+	filtered := make([]any, 0, len(servers))
+	for _, raw := range servers {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+			continue
+		}
+		if _, hasType := entry["type"]; !hasType {
+			if cmd, _ := entry["command"].(string); cmd != "" {
+				if logger != nil {
+					logger.Warn("dropping stdio MCP server: dim's ACP runtime only supports http/sse MCP transports and ignores stdio servers",
+						"backend", "dim", "name", entry["name"])
+				}
+				continue
+			}
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
 func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
 	execPath := b.cfg.ExecutablePath
 	if execPath == "" {
@@ -185,6 +219,14 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 	if err != nil {
 		return nil, fmt.Errorf("dim: invalid mcp_config: %w", err)
 	}
+	// Dim's ACP server only advertises http/sse remote transports (see the
+	// dimBackend contract note above) and silently ignores stdio MCP entries
+	// (stderr: "ACP MCP stdio transport is unsupported") while still
+	// succeeding session/new. If we forwarded stdio servers as-is, users would
+	// see "configured" MCP tools that never load, with no error anywhere.
+	// Filter them here, before the wire, and log an explicit warning so the
+	// failure mode is visible instead of silent.
+	mcpServers = dropDimUnsupportedMcpServers(mcpServers, b.cfg.Logger)
 
 	timeout := opts.Timeout
 	runCtx, cancel := runContext(ctx, timeout)

--- a/server/pkg/agent/dim_test.go
+++ b/server/pkg/agent/dim_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -28,6 +29,66 @@ func TestDimModelSelectionSupported(t *testing.T) {
 	// Dim's session/set_model is session-scoped, so model override works.
 	if !ModelSelectionSupported("dim") {
 		t.Fatal("ModelSelectionSupported(dim) should return true")
+	}
+}
+
+// TestDimDropsStdioMcpServers verifies the full mcp_config pipeline: a
+// Claude-style mcp_config with a stdio entry and an http entry goes through
+// buildACPMcpServers and then dropDimUnsupportedMcpServers, and only the http
+// entry survives.
+//
+// Dim's ACP server only advertises http/sse remote transports and silently
+// ignores stdio servers (stderr: "ACP MCP stdio transport is unsupported")
+// while still succeeding session/new. Forwarding stdio entries verbatim would
+// leave users with "configured" MCP tools that never load and no error
+// anywhere, so the backend drops them before the wire and logs a warning.
+func TestDimDropsStdioMcpServers(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mcpConfig := json.RawMessage(`{"mcpServers":{
+		"playwright": {"command":"npx","args":["@playwright/mcp@latest","--extension"]},
+		"remote-http": {"type":"http","url":"https://example.com/mcp"}
+	}}`)
+	servers, err := buildACPMcpServers(mcpConfig, logger)
+	if err != nil {
+		t.Fatalf("buildACPMcpServers error: %v", err)
+	}
+	got := dropDimUnsupportedMcpServers(servers, logger)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 server after dropping stdio, got %d: %#v", len(got), got)
+	}
+	entry, ok := got[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map entry, got %T", got[0])
+	}
+	if entry["name"] != "remote-http" {
+		t.Fatalf("expected remote-http to survive, got %v", entry["name"])
+	}
+	if _, hasCommand := entry["command"]; hasCommand {
+		t.Fatal("stdio entry leaked into the filtered result")
+	}
+}
+
+// TestDimDropDimUnsupportedMcpServers exercises dropDimUnsupportedMcpServers
+// directly: stdio entries (command, no type) are dropped, http/sse entries are
+// kept, and unclassifiable entries are kept.
+func TestDimDropDimUnsupportedMcpServers(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	servers := []any{
+		map[string]any{"name": "stdio-a", "command": "node", "args": []string{"a.js"}},
+		map[string]any{"name": "http-a", "type": "http", "url": "https://a.example/mcp"},
+		map[string]any{"name": "sse-a", "type": "sse", "url": "https://s.example/mcp"},
+	}
+	got := dropDimUnsupportedMcpServers(servers, logger)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 servers after dropping stdio, got %d: %#v", len(got), got)
+	}
+	for _, raw := range got {
+		entry := raw.(map[string]any)
+		if entry["name"] == "stdio-a" {
+			t.Fatal("stdio MCP server must be dropped")
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Dim's ACP runtime (`dim acp`) only advertises `http` / `sse` in its `initialize` response's `agentCapabilities.mcpCapabilities` and **silently ignores stdio MCP servers**: `session/new` still succeeds, but the stdio server's tools never load and the only trace is an `unsupported_transport` warning on the agent's stderr:

```
[dimcode] acp mcp warning {
  code: "unsupported_transport",
  phase: "acp-session",
  serverId: "<mcp name>",
  message: "ACP MCP stdio transport is unsupported",
}
```

The shared `filterACPMcpServersByCapability` intentionally lets stdio entries pass through for every ACP runtime (per the ACP spec, stdio is a mandatory baseline transport), so Multica forwarded users' stdio MCP servers to dim verbatim. The result: a user who configures e.g. a filesystem/playwright stdio MCP on a Dim agent sees "configured" tools that never load, with **no error anywhere** — a silent failure that is very hard to diagnose.

## Fix

Filter stdio MCP entries out in the dim backend (`dim.go`) **before** they reach the wire, and log an explicit warning naming each dropped server so the mismatch is visible in the daemon log instead of silent.

- `server/pkg/agent/dim.go`: new `dropDimUnsupportedMcpServers` helper (drops entries with a `command` field and no `type` field; keeps http/sse and unclassifiable entries), wired into `dimBackend.Execute` right after `buildACPMcpServers`.
- `server/pkg/agent/dim_test.go`: unit tests covering the filter and the full `buildACPMcpServers` → filter pipeline (stdio dropped, http kept).

## Notes

- This is a dim-specific workaround; other ACP runtimes (hermes, kimi, kiro, traecli, qwenpaw, …) that accept stdio MCP keep the existing pass-through behavior untouched.
- A follow-up fix on the dimcode side (supporting stdio MCP in `dim acp`) would let this filter be removed; until then this makes the failure mode explicit instead of invisible.
- Verified with `go test ./pkg/agent/ -run 'TestDimDropsStdioMcpServers|TestDimDropDimUnsupportedMcpServers' -count=1` and `go vet ./pkg/agent/`.
