### PR TITLE
test(dispatch): pin priority claim contract (MUL-6487)

### DIFF
--- a/docs/issue-task-dispatch-priority.md
+++ b/docs/issue-task-dispatch-priority.md
@@ -1,0 +1,70 @@
+# Issue task dispatch priority
+
+Multica applies issue priority when a runtime claims its next queued issue task. Priority changes which not-yet-started task receives an available slot; it never cancels, interrupts, or replaces a `dispatched`, `running`, or `waiting_local_directory` task.
+
+## Ordering contract
+
+Issue priorities map to the task queue as follows:
+
+| Issue priority | Queue rank |
+| --- | ---: |
+| `urgent` | 4 |
+| `high` | 3 |
+| `medium` | 2 |
+| `low` | 1 |
+| `none` or an unknown legacy value | 0 |
+
+The authoritative per-agent claim query is `server/pkg/db/queries/agent.sql::ClaimAgentTask`. It selects only `queued` tasks on the requested healthy runtime, excludes a task when the same agent already has active work for that issue or chat, and orders eligible rows by:
+
+1. task priority descending;
+2. task creation time ascending;
+3. task UUID ascending as the deterministic final tie-break.
+
+`server/internal/service/task.go::ClaimTaskForRuntime` and `ClaimTasksForRuntimes` list candidates with the same priority/FIFO order and then call `claimTask`, which uses `ClaimAgentTask` inside the agent capacity transaction. The singular and batch daemon poll APIs therefore share one final selector.
+
+If the highest-priority candidate's agent has no free slot, the claim loop may select the next eligible agent. Capacity is checked while the agent row is locked. A lower-priority healthy run that already owns a slot stays active; a newly queued high-priority task can only win the next slot that becomes available.
+
+## Entry-point funnel
+
+Workspace issue dispatch entry points persist either the issue's current priority or, for an automatic retry, the parent task's priority snapshot before the runtime claim boundary:
+
+| Entry point | Server funnel |
+| --- | --- |
+| Issue creation or assignment | `IssueService.maybeEnqueueOnAssign` → `TaskService.EnqueueTaskForIssue` |
+| Promotion from backlog to an active status | `IssueService.WillEnqueueRun` → the same issue enqueue path |
+| Agent-created sub-issue with an executable assignee/status | normal issue creation path |
+| Explicit agent mention or comment wake | `EnqueueTaskForMention`, `EnqueueTaskForThreadParent`, or assignee fallback → `enqueueMentionTaskWithCommentPlan` |
+| Autopilot `create_issue` | creates the issue, then uses the normal issue/squad enqueue path |
+| Manual rerun | `RerunIssue` → `enqueueRerunTask`; the new task uses the issue's current priority |
+| Automatic retry | `CreateRetryTask`; the child inherits the parent task priority |
+| Deferred issue-media or retry promotion | preserves the stored task priority; due rows are promoted in priority/FIFO order |
+
+The enqueue helpers call `priorityToInt` for issue-backed tasks. The claim log records `priority`, `priority_rank`, and `selection_reason=highest_priority_then_fifo` with the selected task, agent, and runtime IDs. Lower-priority work remains `queued` and visible through the task APIs; it is waiting for a slot, not terminally skipped.
+
+## Eligibility gates
+
+Priority never makes an ineligible issue executable:
+
+- Assignment and status writes use `IssueService.WillEnqueueRun`. An issue in the built-in backlog or a custom backlog-category status does not enqueue. Moving between two backlog-category statuses also does not enqueue.
+- A member assignee does not create an agent task.
+- Archived agents, agents without a usable runtime, failed invocation-permission checks, and duplicate pending plans are rejected or coalesced before claim.
+- Comments and explicit mentions are conversational triggers and intentionally work independently of issue status. A mention on a backlog issue is not backlog assignment promotion; it is an explicit request to run the mentioned agent.
+
+## Paths outside issue-priority scheduling
+
+These task kinds share runtime capacity but do not have workspace issue priority semantics:
+
+- Autopilot `run_only` tasks have no issue and use their task kind's fixed priority.
+- Direct chat tasks have no issue and use the chat priority policy.
+- Quick-create tasks run before the requested issue exists and use the quick-create selection's task priority.
+- Stale-dispatch reclaim re-delivers an already selected task. It orders recovery attempts by stored task priority but does not choose new issue work or preempt a healthy run.
+
+Changing those policies requires a task-kind scheduling contract; it must not be inferred from a nonexistent issue priority.
+
+## Regression coverage
+
+- `service.TestIssueTaskClaimUsesPriorityThenFIFO` pins all five ranks and FIFO tie-breaking at the singular runtime claim boundary.
+- `service.TestHighPriorityTakesNextFreeSlotWithoutPreemption` pins the arriving-high case and asserts the healthy low run and queued low successor are unchanged.
+- `service.TestBatchClaimPrioritizesAcrossAgentsOnOneRuntime` pins priority selection across agents sharing one runtime when the batch has one available result slot.
+- `service.TestSharedIssueDispatchFunnelsPreserveQueuePriority` pins assignment/status/sub-issue/autopilot-create-issue's shared issue funnel, mention/wake-comment's shared mention funnel, manual rerun, and automatic retry before those tasks reach the shared claim boundary.
+- `handler.TestPreviewIssueTrigger_CreateAgentVsBacklog`, `TestPreviewIssueTrigger_MemberNoTrigger`, and `TestPreviewIssueTrigger_MatchesWritePath` pin the handler gates that keep backlog-category and human-assigned issues out of the task queue.

--- a/docs/issue-task-dispatch-priority.md
+++ b/docs/issue-task-dispatch-priority.md
@@ -14,13 +14,13 @@ Issue priorities map to the task queue as follows:
 | `low` | 1 |
 | `none` or an unknown legacy value | 0 |
 
-The authoritative per-agent claim query is `server/pkg/db/queries/agent.sql::ClaimAgentTask`. It selects only `queued` tasks on the requested healthy runtime, excludes a task when the same agent already has active work for that issue or chat, and orders eligible rows by:
+The runtime candidate queries first exclude tasks when the same agent already has active work for that issue or chat, then order the globally eligible rows by:
 
 1. task priority descending;
 2. task creation time ascending;
 3. task UUID ascending as the deterministic final tie-break.
 
-`server/internal/service/task.go::ClaimTaskForRuntime` and `ClaimTasksForRuntimes` list candidates with the same priority/FIFO order and then call `claimTask`, which uses `ClaimAgentTask` inside the agent capacity transaction. The singular and batch daemon poll APIs therefore share one final selector.
+`server/internal/service/task.go::ClaimTaskForRuntime` and `ClaimTasksForRuntimes` pass each candidate's exact ID to `claimTask`. Inside the agent capacity transaction, `server/pkg/db/queries/agent.sql::ClaimAgentTask` re-checks runtime health and the same serialization predicate for that exact row. If capacity or eligibility changed after the candidate snapshot, the attempt returns no task and the outer loop continues in global priority/FIFO order; it cannot silently substitute a lower-priority row from that agent. The singular and batch daemon poll APIs therefore share one final selector contract.
 
 If the highest-priority candidate's agent has no free slot, the claim loop may select the next eligible agent. Capacity is checked while the agent row is locked. A lower-priority healthy run that already owns a slot stays active; a newly queued high-priority task can only win the next slot that becomes available.
 
@@ -66,5 +66,7 @@ Changing those policies requires a task-kind scheduling contract; it must not be
 - `service.TestIssueTaskClaimUsesPriorityThenFIFO` pins all five ranks and FIFO tie-breaking at the singular runtime claim boundary.
 - `service.TestHighPriorityTakesNextFreeSlotWithoutPreemption` pins the arriving-high case and asserts the healthy low run and queued low successor are unchanged.
 - `service.TestBatchClaimPrioritizesAcrossAgentsOnOneRuntime` pins priority selection across agents sharing one runtime when the batch has one available result slot.
+- `service.TestRuntimeClaimSkipsBlockedPriorityHeadAcrossAgents` and its batch counterpart pin global ordering when one agent's highest queued row is blocked by per-issue serialization.
+- `service.TestRuntimeScopedClaimNeverDowngradesExactCandidate` pins the race re-check: an exact candidate that becomes ineligible cannot silently dispatch a lower-priority row from the same agent.
 - `service.TestSharedIssueDispatchFunnelsPreserveQueuePriority` pins assignment/status/sub-issue/autopilot-create-issue's shared issue funnel, mention/wake-comment's shared mention funnel, manual rerun, and automatic retry before those tasks reach the shared claim boundary.
 - `handler.TestPreviewIssueTrigger_CreateAgentVsBacklog`, `TestPreviewIssueTrigger_MemberNoTrigger`, and `TestPreviewIssueTrigger_MatchesWritePath` pin the handler gates that keep backlog-category and human-assigned issues out of the task queue.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3085,7 +3085,14 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 		return nil, nil
 	}
 
-	slog.Info("task claimed", "task_id", util.UUIDToString(claimed.ID), "agent_id", util.UUIDToString(agentID))
+	slog.Info("task claimed",
+		"task_id", util.UUIDToString(claimed.ID),
+		"agent_id", util.UUIDToString(agentID),
+		"runtime_id", util.UUIDToString(claimed.RuntimeID),
+		"priority", priorityFromInt(claimed.Priority),
+		"priority_rank", claimed.Priority,
+		"selection_reason", "highest_priority_then_fifo",
+	)
 	s.captureTaskDispatched(ctx, *claimed)
 
 	// Refresh agent status from active tasks. This avoids a stale unconditional
@@ -5921,6 +5928,23 @@ func priorityToInt(p string) int32 {
 		return 1
 	default:
 		return 0
+	}
+}
+
+func priorityFromInt(p int32) string {
+	switch p {
+	case 4:
+		return "urgent"
+	case 3:
+		return "high"
+	case 2:
+		return "medium"
+	case 1:
+		return "low"
+	case 0:
+		return "none"
+	default:
+		return "unknown"
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2985,15 +2985,17 @@ func (s *TaskService) broadcastChatCancelFinalized(ctx context.Context, task db.
 // ClaimTask atomically claims the next queued task for an agent on its current
 // runtime, respecting max_concurrent_tasks.
 func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.AgentTaskQueue, error) {
-	return s.claimTask(ctx, agentID, pgtype.UUID{})
+	return s.claimTask(ctx, agentID, pgtype.UUID{}, pgtype.UUID{})
 }
 
 // claimTask is the runtime-scoped claim primitive used by daemon poll paths.
 // The exported ClaimTask wrapper omits runtimeID and therefore resolves the
 // agent's currently bound runtime. Scoping the SQL claim itself prevents an
 // offline candidate on runtime A from causing the same agent's task on runtime
-// B to be dispatched and then dropped by the caller's runtime guard.
-func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.UUID) (*db.AgentTaskQueue, error) {
+// B to be dispatched and then dropped by the caller's runtime guard. Runtime
+// poll paths also provide candidateTaskID so a failed eligibility re-check can
+// never downgrade the claim to a lower-priority row for the same agent.
+func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID, candidateTaskID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	start := time.Now()
 	outcome := "unknown"
 	var getAgentMs, countRunningMs, claimAgentMs, reanchorMs, updateStatusMs, dispatchMs int64
@@ -3036,6 +3038,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 		task, err := qtx.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
 			AgentID:          agentID,
 			RuntimeID:        claimRuntimeID,
+			CandidateTaskID:  candidateTaskID,
 			PrepareLeaseSecs: prepareLeaseDuration.Seconds(),
 			RuntimeStaleSecs: RuntimeClaimFreshnessSeconds,
 		})
@@ -3213,7 +3216,7 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 		triedAgents[agentKey] = struct{}{}
 		tried++
 
-		task, err := s.claimTask(ctx, candidate.AgentID, runtimeID)
+		task, err := s.claimTask(ctx, candidate.AgentID, runtimeID, candidate.ID)
 		if err != nil {
 			loopMs = time.Since(loopStart).Milliseconds()
 			outcome = "error_claim"
@@ -3472,7 +3475,7 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		}
 		triedAgents[agentKey] = struct{}{}
 
-		task, err := s.claimTask(ctx, candidates[i].AgentID, candidates[i].RuntimeID)
+		task, err := s.claimTask(ctx, candidates[i].AgentID, candidates[i].RuntimeID, candidates[i].ID)
 		if err != nil {
 			// Each scoped claim commits in its own transaction, so earlier
 			// iterations (and step-2 reclaims) are already dispatched

--- a/server/internal/service/task_priority_claim_test.go
+++ b/server/internal/service/task_priority_claim_test.go
@@ -1,0 +1,317 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	dbfx "github.com/multica-ai/multica/server/internal/testutil"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type priorityClaimFixture struct {
+	fx        *dbfx.Fixture
+	queries   *db.Queries
+	service   *TaskService
+	userID    string
+	runtimeID string
+	agentID   string
+}
+
+func newPriorityClaimFixture(t *testing.T, maxConcurrent int) priorityClaimFixture {
+	t.Helper()
+	pool := newTaskClaimRacePool(t)
+	suffix := time.Now().UnixNano()
+	fx := dbfx.New(pool, "", "")
+	userID := fx.User(t, "Priority Claim", fmt.Sprintf("priority-claim-%d@multica.test", suffix))
+	workspaceID := fx.Workspace(t, "Priority Claim", fmt.Sprintf("priority-claim-%d", suffix), dbfx.Cols{
+		"issue_prefix": "PC",
+	})
+	fx.WorkspaceID = workspaceID
+	fx.UserID = userID
+	fx.Member(t, workspaceID, userID, "owner")
+	runtimeID := fx.Runtime(t, "Priority Claim Runtime", dbfx.Cols{
+		"provider": "priority_claim_test",
+	})
+	agentID := fx.Agent(t, "Priority Claim Agent", runtimeID, dbfx.Cols{
+		"max_concurrent_tasks": maxConcurrent,
+	})
+	queries := db.New(pool)
+	return priorityClaimFixture{
+		fx:        fx,
+		queries:   queries,
+		service:   NewTaskService(queries, pool, nil, events.New()),
+		userID:    userID,
+		runtimeID: runtimeID,
+		agentID:   agentID,
+	}
+}
+
+func (f priorityClaimFixture) issue(t *testing.T, title, priority string) db.Issue {
+	t.Helper()
+	id := f.fx.Issue(t, title, dbfx.Cols{
+		"priority":      priority,
+		"assignee_type": "agent",
+		"assignee_id":   f.agentID,
+	})
+	issue, err := f.queries.GetIssue(context.Background(), util.MustParseUUID(id))
+	if err != nil {
+		t.Fatalf("load issue %s: %v", title, err)
+	}
+	return issue
+}
+
+func (f priorityClaimFixture) trackServiceTask(t *testing.T, task db.AgentTaskQueue) {
+	t.Helper()
+	f.fx.Cleanup(t, `DELETE FROM agent_task_queue WHERE id = $1`, util.UUIDToString(task.ID))
+}
+
+func TestIssueTaskClaimUsesPriorityThenFIFO(t *testing.T) {
+	ctx := context.Background()
+	f := newPriorityClaimFixture(t, 10)
+
+	want := []struct {
+		name string
+		rank int32
+	}{
+		{name: "urgent", rank: 4},
+		{name: "high", rank: 3},
+		{name: "medium", rank: 2},
+		{name: "low", rank: 1},
+		{name: "none", rank: 0},
+	}
+	ids := make(map[string]string, len(want))
+	// Insert in the reverse of dispatch order. The result must come from
+	// priority, not enqueue time.
+	for i := len(want) - 1; i >= 0; i-- {
+		issue := f.issue(t, "priority "+want[i].name, want[i].name)
+		task, err := f.service.EnqueueTaskForIssue(ctx, issue)
+		if err != nil {
+			t.Fatalf("enqueue %s: %v", want[i].name, err)
+		}
+		f.trackServiceTask(t, task)
+		ids[want[i].name] = util.UUIDToString(task.ID)
+	}
+
+	for _, expected := range want {
+		claimed, err := f.service.ClaimTaskForRuntime(ctx, util.MustParseUUID(f.runtimeID))
+		if err != nil {
+			t.Fatalf("claim %s: %v", expected.name, err)
+		}
+		if claimed == nil {
+			t.Fatalf("claim %s: got no task", expected.name)
+		}
+		if got := util.UUIDToString(claimed.ID); got != ids[expected.name] {
+			t.Fatalf("claim %s: task = %s, want %s", expected.name, got, ids[expected.name])
+		}
+		if claimed.Priority != expected.rank {
+			t.Fatalf("claim %s: rank = %d, want %d", expected.name, claimed.Priority, expected.rank)
+		}
+	}
+
+	older := f.issue(t, "older high", "high")
+	olderTask, err := f.service.EnqueueTaskForIssue(ctx, older)
+	if err != nil {
+		t.Fatalf("enqueue older high: %v", err)
+	}
+	f.trackServiceTask(t, olderTask)
+	newer := f.issue(t, "newer high", "high")
+	newerTask, err := f.service.EnqueueTaskForIssue(ctx, newer)
+	if err != nil {
+		t.Fatalf("enqueue newer high: %v", err)
+	}
+	f.trackServiceTask(t, newerTask)
+	f.fx.Exec(t, `UPDATE agent_task_queue SET created_at = now() - interval '1 second' WHERE id = $1`, util.UUIDToString(olderTask.ID))
+	claimed, err := f.service.ClaimTaskForRuntime(ctx, util.MustParseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("claim FIFO high: %v", err)
+	}
+	if claimed == nil || claimed.ID != olderTask.ID {
+		t.Fatalf("same-priority claim did not preserve FIFO: got %+v, want %s", claimed, util.UUIDToString(olderTask.ID))
+	}
+}
+
+func TestHighPriorityTakesNextFreeSlotWithoutPreemption(t *testing.T) {
+	ctx := context.Background()
+	f := newPriorityClaimFixture(t, 2)
+	runningIssue := f.issue(t, "healthy running low", "low")
+	queuedLowIssue := f.issue(t, "queued low", "low")
+	queuedHighIssue := f.issue(t, "arriving high", "high")
+
+	runningID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id": f.runtimeID,
+		"issue_id":   util.UUIDToString(runningIssue.ID),
+		"status":     "running",
+		"priority":   1,
+		"started_at": dbfx.Raw("now() - interval '1 minute'"),
+	})
+	lowID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id": f.runtimeID,
+		"issue_id":   util.UUIDToString(queuedLowIssue.ID),
+		"priority":   1,
+	})
+	highID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id": f.runtimeID,
+		"issue_id":   util.UUIDToString(queuedHighIssue.ID),
+		"priority":   3,
+	})
+
+	claimed, err := f.service.ClaimTaskForRuntime(ctx, util.MustParseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("claim next free slot: %v", err)
+	}
+	if claimed == nil || util.UUIDToString(claimed.ID) != highID {
+		t.Fatalf("claimed = %+v, want arriving high %s", claimed, highID)
+	}
+
+	var runningStatus, lowStatus string
+	f.fx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, runningID).Scan(&runningStatus)
+	f.fx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, lowID).Scan(&lowStatus)
+	if runningStatus != "running" {
+		t.Fatalf("healthy low run was preempted: status = %s", runningStatus)
+	}
+	if lowStatus != "queued" {
+		t.Fatalf("lower-priority successor = %s, want queued", lowStatus)
+	}
+}
+
+func TestBatchClaimPrioritizesAcrossAgentsOnOneRuntime(t *testing.T) {
+	ctx := context.Background()
+	f := newPriorityClaimFixture(t, 1)
+	otherAgentID := f.fx.Agent(t, "Other Priority Agent", f.runtimeID)
+	lowIssue := f.issue(t, "batch low", "low")
+	highIssueID := f.fx.Issue(t, "batch high", dbfx.Cols{
+		"priority":      "high",
+		"assignee_type": "agent",
+		"assignee_id":   otherAgentID,
+	})
+	lowTaskID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id": f.runtimeID,
+		"issue_id":   util.UUIDToString(lowIssue.ID),
+		"priority":   1,
+	})
+	highTaskID := f.fx.Task(t, otherAgentID, dbfx.Cols{
+		"runtime_id": f.runtimeID,
+		"issue_id":   highIssueID,
+		"priority":   3,
+	})
+
+	claimed, err := f.service.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(f.runtimeID)}, 1)
+	if err != nil {
+		t.Fatalf("batch claim: %v", err)
+	}
+	if len(claimed) != 1 || util.UUIDToString(claimed[0].ID) != highTaskID {
+		t.Fatalf("batch claimed = %+v, want high task %s", claimed, highTaskID)
+	}
+	var lowStatus string
+	f.fx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, lowTaskID).Scan(&lowStatus)
+	if lowStatus != "queued" {
+		t.Fatalf("batch lower-priority task = %s, want queued", lowStatus)
+	}
+}
+
+// TestSharedIssueDispatchFunnelsPreserveQueuePriority exercises each
+// distinct task-construction funnel. Assignment, status promotion, sub-issue
+// creation, and autopilot create_issue all use EnqueueTaskForIssue; explicit
+// mention, wake-comment, and thread-parent paths all use the mention helper.
+// Rerun and automatic retry have separate construction paths and are covered
+// directly below.
+func TestSharedIssueDispatchFunnelsPreserveQueuePriority(t *testing.T) {
+	ctx := context.Background()
+	f := newPriorityClaimFixture(t, 10)
+
+	assignmentIssue := f.issue(t, "assignment high", "high")
+	assignment, err := f.service.EnqueueTaskForIssue(ctx, assignmentIssue)
+	if err != nil {
+		t.Fatalf("assignment enqueue: %v", err)
+	}
+	f.trackServiceTask(t, assignment)
+	if assignment.Priority != 3 {
+		t.Fatalf("assignment priority = %d, want 3", assignment.Priority)
+	}
+
+	mentionIssue := f.issue(t, "mention medium", "medium")
+	mention, err := f.service.EnqueueTaskForMention(ctx, mentionIssue, util.MustParseUUID(f.agentID), pgtype.UUID{})
+	if err != nil {
+		t.Fatalf("mention enqueue: %v", err)
+	}
+	f.trackServiceTask(t, mention)
+	if mention.Priority != 2 {
+		t.Fatalf("mention priority = %d, want 2", mention.Priority)
+	}
+
+	rerunIssue := f.issue(t, "rerun urgent", "urgent")
+	sourceID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id":   f.runtimeID,
+		"issue_id":     util.UUIDToString(rerunIssue.ID),
+		"status":       "completed",
+		"priority":     0,
+		"completed_at": dbfx.Raw("now()"),
+	})
+	rerun, err := f.service.RerunIssue(
+		ctx,
+		rerunIssue.ID,
+		util.MustParseUUID(sourceID),
+		pgtype.UUID{},
+		util.MustParseUUID(f.userID),
+		func(db.Agent) bool { return true },
+	)
+	if err != nil {
+		t.Fatalf("rerun enqueue: %v", err)
+	}
+	f.trackServiceTask(t, *rerun)
+	if rerun.Priority != 4 {
+		t.Fatalf("rerun priority = %d, want current issue rank 4", rerun.Priority)
+	}
+
+	retryIssue := f.issue(t, "retry low", "low")
+	failedID := f.fx.Task(t, f.agentID, dbfx.Cols{
+		"runtime_id":     f.runtimeID,
+		"issue_id":       util.UUIDToString(retryIssue.ID),
+		"status":         "failed",
+		"priority":       1,
+		"attempt":        1,
+		"max_attempts":   2,
+		"failure_reason": "runtime_recovery",
+		"completed_at":   dbfx.Raw("now()"),
+	})
+	failed, err := f.queries.GetAgentTask(ctx, util.MustParseUUID(failedID))
+	if err != nil {
+		t.Fatalf("load failed task: %v", err)
+	}
+	retry, err := f.service.MaybeRetryFailedTask(ctx, failed)
+	if err != nil {
+		t.Fatalf("retry enqueue: %v", err)
+	}
+	if retry == nil || retry.Priority != 1 {
+		t.Fatalf("retry priority = %+v, want inherited rank 1", retry)
+	}
+	f.trackServiceTask(t, *retry)
+}
+
+func TestIssuePriorityConversionsAreStable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rank int32
+	}{
+		{name: "urgent", rank: 4},
+		{name: "high", rank: 3},
+		{name: "medium", rank: 2},
+		{name: "low", rank: 1},
+		{name: "none", rank: 0},
+	} {
+		if got := priorityToInt(tc.name); got != tc.rank {
+			t.Errorf("priorityToInt(%q) = %d, want %d", tc.name, got, tc.rank)
+		}
+		if got := priorityFromInt(tc.rank); got != tc.name {
+			t.Errorf("priorityFromInt(%d) = %q, want %q", tc.rank, got, tc.name)
+		}
+	}
+	if got := priorityFromInt(99); got != "unknown" {
+		t.Fatalf("unknown rank = %q, want unknown", got)
+	}
+}

--- a/server/internal/service/task_priority_claim_test.go
+++ b/server/internal/service/task_priority_claim_test.go
@@ -214,6 +214,133 @@ func TestBatchClaimPrioritizesAcrossAgentsOnOneRuntime(t *testing.T) {
 	}
 }
 
+type blockedPriorityHeadFixture struct {
+	priorityClaimFixture
+	runningID string
+	highID    string
+	lowID     string
+	mediumID  string
+}
+
+func newBlockedPriorityHeadFixture(t *testing.T) blockedPriorityHeadFixture {
+	t.Helper()
+	f := newPriorityClaimFixture(t, 2)
+	otherAgentID := f.fx.Agent(t, "Eligible Medium Agent", f.runtimeID, dbfx.Cols{
+		"max_concurrent_tasks": 1,
+	})
+	runningIssue := f.issue(t, "running issue X", "high")
+	lowIssue := f.issue(t, "eligible low issue Y", "low")
+	mediumIssueID := f.fx.Issue(t, "eligible medium issue Z", dbfx.Cols{
+		"priority":      "medium",
+		"assignee_type": "agent",
+		"assignee_id":   otherAgentID,
+	})
+
+	return blockedPriorityHeadFixture{
+		priorityClaimFixture: f,
+		runningID: f.fx.Task(t, f.agentID, dbfx.Cols{
+			"runtime_id": f.runtimeID,
+			"issue_id":   util.UUIDToString(runningIssue.ID),
+			"status":     "running",
+			"priority":   3,
+			"started_at": dbfx.Raw("now() - interval '1 minute'"),
+		}),
+		highID: f.fx.Task(t, f.agentID, dbfx.Cols{
+			"runtime_id": f.runtimeID,
+			"issue_id":   util.UUIDToString(runningIssue.ID),
+			"priority":   3,
+		}),
+		lowID: f.fx.Task(t, f.agentID, dbfx.Cols{
+			"runtime_id": f.runtimeID,
+			"issue_id":   util.UUIDToString(lowIssue.ID),
+			"priority":   1,
+		}),
+		mediumID: f.fx.Task(t, otherAgentID, dbfx.Cols{
+			"runtime_id": f.runtimeID,
+			"issue_id":   mediumIssueID,
+			"priority":   2,
+		}),
+	}
+}
+
+func (f blockedPriorityHeadFixture) assertOnlyMediumClaimed(t *testing.T, claimedID string) {
+	t.Helper()
+	if claimedID != f.mediumID {
+		t.Fatalf("claimed task = %s, want globally eligible medium %s", claimedID, f.mediumID)
+	}
+
+	wantStatuses := map[string]string{
+		f.runningID: "running",
+		f.highID:    "queued",
+		f.lowID:     "queued",
+	}
+	for id, want := range wantStatuses {
+		var got string
+		f.fx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, id).Scan(&got)
+		if got != want {
+			t.Fatalf("task %s status = %s, want %s", id, got, want)
+		}
+	}
+}
+
+func TestRuntimeClaimSkipsBlockedPriorityHeadAcrossAgents(t *testing.T) {
+	ctx := context.Background()
+	f := newBlockedPriorityHeadFixture(t)
+
+	claimed, err := f.service.ClaimTaskForRuntime(ctx, util.MustParseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("singular runtime claim: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("singular runtime claim returned no task")
+	}
+	f.assertOnlyMediumClaimed(t, util.UUIDToString(claimed.ID))
+}
+
+func TestBatchRuntimeClaimSkipsBlockedPriorityHeadAcrossAgents(t *testing.T) {
+	ctx := context.Background()
+	f := newBlockedPriorityHeadFixture(t)
+
+	claimed, err := f.service.ClaimTasksForRuntimes(
+		ctx,
+		[]pgtype.UUID{util.MustParseUUID(f.runtimeID)},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("batch runtime claim: %v", err)
+	}
+	if len(claimed) != 1 {
+		t.Fatalf("batch runtime claim returned %d tasks, want 1", len(claimed))
+	}
+	f.assertOnlyMediumClaimed(t, util.UUIDToString(claimed[0].ID))
+}
+
+func TestRuntimeScopedClaimNeverDowngradesExactCandidate(t *testing.T) {
+	ctx := context.Background()
+	f := newBlockedPriorityHeadFixture(t)
+
+	claimed, err := f.service.claimTask(
+		ctx,
+		util.MustParseUUID(f.agentID),
+		util.MustParseUUID(f.runtimeID),
+		util.MustParseUUID(f.highID),
+	)
+	if err != nil {
+		t.Fatalf("exact candidate claim: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("exact blocked candidate downgraded to task %s", util.UUIDToString(claimed.ID))
+	}
+
+	for _, id := range []string{f.highID, f.lowID} {
+		var status string
+		f.fx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, id).Scan(&status)
+		if status != "queued" {
+			t.Fatalf("task %s status = %s, want queued", id, status)
+		}
+	}
+}
+
 // TestSharedIssueDispatchFunnelsPreserveQueuePriority exercises each
 // distinct task-construction funnel. Assignment, status promotion, sub-issue
 // creation, and autopilot create_issue all use EnqueueTaskForIssue; explicit

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1557,13 +1557,14 @@ WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $2
       AND atq.runtime_id = $3
+      AND ($4::uuid IS NULL OR atq.id = $4::uuid)
       AND atq.status = 'queued'
       AND EXISTS (
           SELECT 1 FROM agent_runtime r
           WHERE r.id = atq.runtime_id
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
-                now() - make_interval(secs => $4::double precision)
+                now() - make_interval(secs => $5::double precision)
       )
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
@@ -1593,6 +1594,7 @@ type ClaimAgentTaskParams struct {
 	PrepareLeaseSecs float64     `json:"prepare_lease_secs"`
 	AgentID          pgtype.UUID `json:"agent_id"`
 	RuntimeID        pgtype.UUID `json:"runtime_id"`
+	CandidateTaskID  pgtype.UUID `json:"candidate_task_id"`
 	RuntimeStaleSecs float64     `json:"runtime_stale_secs"`
 }
 
@@ -1611,6 +1613,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 		arg.PrepareLeaseSecs,
 		arg.AgentID,
 		arg.RuntimeID,
+		arg.CandidateTaskID,
 		arg.RuntimeStaleSecs,
 	)
 	var i AgentTaskQueue
@@ -5591,19 +5594,32 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC
+SELECT candidate.id, candidate.agent_id, candidate.issue_id, candidate.status, candidate.priority, candidate.dispatched_at, candidate.started_at, candidate.completed_at, candidate.result, candidate.error, candidate.created_at, candidate.context, candidate.runtime_id, candidate.session_id, candidate.work_dir, candidate.trigger_comment_id, candidate.chat_session_id, candidate.autopilot_run_id, candidate.attempt, candidate.max_attempts, candidate.parent_task_id, candidate.failure_reason, candidate.trigger_summary, candidate.force_fresh_session, candidate.is_leader_task, candidate.wait_reason, candidate.initiator_user_id, candidate.handoff_note, candidate.prepare_lease_expires_at, candidate.squad_id, candidate.runtime_mcp_overlay, candidate.escalation_for_task_id, candidate.fire_at, candidate.originator_user_id, candidate.runtime_connected_apps, candidate.coalesced_comment_ids, candidate.delivered_comment_ids, candidate.chat_input_task_id, candidate.chat_finalize_deferred_at, candidate.originator_source, candidate.delegated_from_task_id, candidate.retry_of_task_id, candidate.rerun_of_task_id, candidate.rule_version_id, candidate.trigger_evidence_kind, candidate.trigger_evidence_ref_id, candidate.accountable_user_id, candidate.session_rollout_missing, candidate.retired_session_id, candidate.quick_actions_disabled, candidate.regenerate_quick_actions_for, candidate.branch_name, candidate.durable_work_dir FROM agent_task_queue candidate
+WHERE candidate.runtime_id = $1
+  AND candidate.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue active
+      WHERE active.agent_id = candidate.agent_id
+        AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+        AND (
+          (candidate.issue_id IS NOT NULL AND active.issue_id = candidate.issue_id)
+          OR (candidate.chat_session_id IS NOT NULL AND active.chat_session_id = candidate.chat_session_id)
+          OR (
+            candidate.issue_id IS NULL
+            AND candidate.chat_session_id IS NULL
+            AND candidate.autopilot_run_id IS NULL
+            AND active.issue_id IS NULL
+            AND active.chat_session_id IS NULL
+            AND active.autopilot_run_id IS NULL
+          )
+        )
+  )
+ORDER BY candidate.priority DESC, candidate.created_at ASC, candidate.id ASC
 `
 
-// Returns rows the runtime can attempt to claim. Status is restricted to
-// 'queued' (in contrast to ListPendingTasksByRuntime which also includes
-// 'dispatched') because dispatched rows are by definition already owned
-// and cannot be re-claimed — including them in the candidate list pads
-// the result with rows that always lose the per-(issue, agent) race in
-// ClaimAgentTask, wasting CPU and a SELECT every poll cycle when the
-// runtime is busy on a long-running task. Backed by the partial index
-// idx_agent_task_queue_claim_candidates so the warm path is cheap.
+// Returns serialization-eligible rows in the global order the runtime must
+// preserve. ClaimAgentTask re-checks the same predicate while locking the exact
+// candidate, closing the race between this snapshot and the claim transaction.
 func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtimeID pgtype.UUID) ([]AgentTaskQueue, error) {
 	rows, err := q.db.Query(ctx, listQueuedClaimCandidatesByRuntime, runtimeID)
 	if err != nil {
@@ -5679,9 +5695,27 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 }
 
 const listQueuedClaimCandidatesByRuntimes = `-- name: ListQueuedClaimCandidatesByRuntimes :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir FROM agent_task_queue
-WHERE runtime_id = ANY($1::uuid[]) AND status = 'queued'
-ORDER BY priority DESC, created_at ASC
+SELECT candidate.id, candidate.agent_id, candidate.issue_id, candidate.status, candidate.priority, candidate.dispatched_at, candidate.started_at, candidate.completed_at, candidate.result, candidate.error, candidate.created_at, candidate.context, candidate.runtime_id, candidate.session_id, candidate.work_dir, candidate.trigger_comment_id, candidate.chat_session_id, candidate.autopilot_run_id, candidate.attempt, candidate.max_attempts, candidate.parent_task_id, candidate.failure_reason, candidate.trigger_summary, candidate.force_fresh_session, candidate.is_leader_task, candidate.wait_reason, candidate.initiator_user_id, candidate.handoff_note, candidate.prepare_lease_expires_at, candidate.squad_id, candidate.runtime_mcp_overlay, candidate.escalation_for_task_id, candidate.fire_at, candidate.originator_user_id, candidate.runtime_connected_apps, candidate.coalesced_comment_ids, candidate.delivered_comment_ids, candidate.chat_input_task_id, candidate.chat_finalize_deferred_at, candidate.originator_source, candidate.delegated_from_task_id, candidate.retry_of_task_id, candidate.rerun_of_task_id, candidate.rule_version_id, candidate.trigger_evidence_kind, candidate.trigger_evidence_ref_id, candidate.accountable_user_id, candidate.session_rollout_missing, candidate.retired_session_id, candidate.quick_actions_disabled, candidate.regenerate_quick_actions_for, candidate.branch_name, candidate.durable_work_dir FROM agent_task_queue candidate
+WHERE candidate.runtime_id = ANY($1::uuid[])
+  AND candidate.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue active
+      WHERE active.agent_id = candidate.agent_id
+        AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+        AND (
+          (candidate.issue_id IS NOT NULL AND active.issue_id = candidate.issue_id)
+          OR (candidate.chat_session_id IS NOT NULL AND active.chat_session_id = candidate.chat_session_id)
+          OR (
+            candidate.issue_id IS NULL
+            AND candidate.chat_session_id IS NULL
+            AND candidate.autopilot_run_id IS NULL
+            AND active.issue_id IS NULL
+            AND active.chat_session_id IS NULL
+            AND active.autopilot_run_id IS NULL
+          )
+        )
+  )
+ORDER BY candidate.priority DESC, candidate.created_at ASC, candidate.id ASC
 `
 
 // Batch variant of ListQueuedClaimCandidatesByRuntime (MUL-4257): returns

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -738,6 +738,7 @@ WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = @agent_id
       AND atq.runtime_id = @runtime_id
+      AND (sqlc.narg(candidate_task_id)::uuid IS NULL OR atq.id = sqlc.narg(candidate_task_id)::uuid)
       AND atq.status = 'queued'
       AND EXISTS (
           SELECT 1 FROM agent_runtime r
@@ -1971,17 +1972,30 @@ WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC;
 
 -- name: ListQueuedClaimCandidatesByRuntime :many
--- Returns rows the runtime can attempt to claim. Status is restricted to
--- 'queued' (in contrast to ListPendingTasksByRuntime which also includes
--- 'dispatched') because dispatched rows are by definition already owned
--- and cannot be re-claimed — including them in the candidate list pads
--- the result with rows that always lose the per-(issue, agent) race in
--- ClaimAgentTask, wasting CPU and a SELECT every poll cycle when the
--- runtime is busy on a long-running task. Backed by the partial index
--- idx_agent_task_queue_claim_candidates so the warm path is cheap.
-SELECT * FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC;
+-- Returns serialization-eligible rows in the global order the runtime must
+-- preserve. ClaimAgentTask re-checks the same predicate while locking the exact
+-- candidate, closing the race between this snapshot and the claim transaction.
+SELECT candidate.* FROM agent_task_queue candidate
+WHERE candidate.runtime_id = $1
+  AND candidate.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue active
+      WHERE active.agent_id = candidate.agent_id
+        AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+        AND (
+          (candidate.issue_id IS NOT NULL AND active.issue_id = candidate.issue_id)
+          OR (candidate.chat_session_id IS NOT NULL AND active.chat_session_id = candidate.chat_session_id)
+          OR (
+            candidate.issue_id IS NULL
+            AND candidate.chat_session_id IS NULL
+            AND candidate.autopilot_run_id IS NULL
+            AND active.issue_id IS NULL
+            AND active.chat_session_id IS NULL
+            AND active.autopilot_run_id IS NULL
+          )
+        )
+  )
+ORDER BY candidate.priority DESC, candidate.created_at ASC, candidate.id ASC;
 
 -- name: CancelSupersededDeferredRetriesForRuntimes :many
 -- Cancels deferred auto-retry rows that a newer active task has already
@@ -2086,9 +2100,27 @@ RETURNING *;
 -- a sort step (each runtime's slice is index-ordered, but merging several
 -- runtimes' rows into one priority/FIFO order is not). The per-machine
 -- candidate set is small, so this is cheap in practice.
-SELECT * FROM agent_task_queue
-WHERE runtime_id = ANY(@runtime_ids::uuid[]) AND status = 'queued'
-ORDER BY priority DESC, created_at ASC;
+SELECT candidate.* FROM agent_task_queue candidate
+WHERE candidate.runtime_id = ANY(@runtime_ids::uuid[])
+  AND candidate.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue active
+      WHERE active.agent_id = candidate.agent_id
+        AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+        AND (
+          (candidate.issue_id IS NOT NULL AND active.issue_id = candidate.issue_id)
+          OR (candidate.chat_session_id IS NOT NULL AND active.chat_session_id = candidate.chat_session_id)
+          OR (
+            candidate.issue_id IS NULL
+            AND candidate.chat_session_id IS NULL
+            AND candidate.autopilot_run_id IS NULL
+            AND active.issue_id IS NULL
+            AND active.chat_session_id IS NULL
+            AND active.autopilot_run_id IS NULL
+          )
+        )
+  )
+ORDER BY candidate.priority DESC, candidate.created_at ASC, candidate.id ASC;
 
 -- name: PromoteDueDeferredTasksForRuntimes :many
 -- Batch variant of PromoteDueDeferredTasksForRuntime (MUL-4257): promotes all


### PR DESCRIPTION
## Summary

- rank only serialization-eligible runtime candidates by priority/FIFO
- re-check and claim the exact candidate inside the existing agent-capacity transaction
- prevent a blocked high row from silently downgrading to the same agent's low row ahead of another agent's eligible medium
- retain non-preemption, runtime-health, partial-success, and direct per-agent claim behavior
- document the atomic selector and expose selected priority metadata

## Verification

- full `go test ./internal/service -count=1` against isolated PostgreSQL 18 with migrations through 376
- daemon claim API plus backlog/member/write-path handler tests against the same database
- singular and batch blocked-head regressions, plus exact-candidate no-downgrade race regression
- `go vet ./...`
- regenerated sqlc with `make sqlc`
- full `go test ./... -count=1` from detached `/tmp` worktree with task-scoped Multica environment removed: exit 0

The daemon batch claim handler returned two correctly routed tasks and minted tokens in 13 ms. The blocked-head regressions remained in the 20–30 ms fixture range while changing the selected row from low to the globally eligible medium.

## Context

Workspace issue R-119. Reviewer reproduced a cross-agent priority inversion on the first PR head: the outer list ranked an unclaimable high row, then the per-agent inner selector substituted low. This revision binds the two layers to the same exact candidate so an eligibility/capacity race continues globally instead of downgrading locally.

<!-- generated-by-cyrus -->
