### PR TITLE
MUL-6479 feat(dev): make a local environment a named object with one verb per lifecycle step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
               - 'scripts/drop-database.sh'
               - 'scripts/remove-worktree.sh'
               - 'scripts/worktree-db.test.sh'
+              - 'scripts/dev-env.sh'
+              - 'scripts/dev-env.test.sh'
               - 'scripts/selfhost-wait.sh'
               # selfhost-config.test.sh asserts on the installers' side of
               # the port contract, so a change to either must run it.
@@ -254,6 +256,10 @@ jobs:
       - name: Test worktree database cleanup
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: bash scripts/worktree-db.test.sh
+
+      - name: Test development environment registry
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: bash scripts/dev-env.test.sh
 
       - name: Verify reserved-slugs.ts is up to date
         if: ${{ needs.changes.outputs.frontend == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,12 @@ Mobile is independent. It may import types and pure functions from `@multica/cor
 Use the repo scripts as the source of truth. Common commands:
 
 ```bash
-make dev              # auto-setup and start the app
+make up               # start this checkout's environment (C=api,web,daemon,desktop)
+make status           # what is running, with pid/commit proof it is yours
+make list             # every development environment on this machine
+make down             # stop the processes, keep the database
+make destroy          # stop, then drop the database and free the slot
+make dev              # auto-setup and start the app in the foreground
 make start            # start backend + frontend
 make stop             # stop app processes for this checkout
 make db-drop          # permanently drop this checkout's local database
@@ -95,6 +100,8 @@ pnpm test             # TS/Vitest tests through Turborepo
 pnpm exec playwright test
 pnpm ui:add badge     # shadcn/Base UI component into packages/ui
 ```
+
+`make up` records each environment in `~/.multica/dev/`, allocates its ports and database name under a lock instead of recomputing them from the path, and verifies the database through `DATABASE_URL` rather than `docker exec` — a `docker exec` create lands in the wrong server whenever a native PostgreSQL owns 5432. `make down` keeps the data; `make destroy` consumes it.
 
 Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. `pnpm dev:desktop` additionally self-isolates per worktree (its own renderer port + app name) automatically, independent of `.env.worktree`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ pnpm exec playwright test
 pnpm ui:add badge     # shadcn/Base UI component into packages/ui
 ```
 
-`make up` records each environment in `~/.multica/dev/`, allocates its ports and database name under a lock instead of recomputing them from the path, and verifies the database through `DATABASE_URL` rather than `docker exec` — a `docker exec` create lands in the wrong server whenever a native PostgreSQL owns 5432. `make down` keeps the data; `make destroy` consumes it.
+`make up` records each environment in `~/.multica/dev/`, allocates its API, Web and Desktop renderer ports plus database name under a lock instead of recomputing them from the path, and verifies the database through `DATABASE_URL` rather than `docker exec` — a `docker exec` create lands in the wrong server whenever a native PostgreSQL owns 5432. It reuses an API only when `/health` proves its listener pid, process group and commit belong to this checkout. `make down` keeps the data; `make destroy` consumes the database, profile, daemon workspaces, Desktop userData and registry entry. Agent-owned TTL environments are collected best-effort on the next `make up`, or explicitly with `make gc`.
 
-Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. `pnpm dev:desktop` additionally self-isolates per worktree (its own renderer port + app name) automatically, independent of `.env.worktree`.
+Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. Direct `pnpm dev:desktop` self-isolates from the path; `make up C=desktop` overrides that fallback with the registry-allocated renderer port and app name so Desktop shares the environment ledger.
 
 CI runs Node 22, the latest Go 1.26 patch, and a `pgvector/pgvector:pg17` PostgreSQL service.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ This guide documents the local development workflow for contributors working on 
 It covers:
 
 - first-time setup
+- environments: starting, inspecting, stopping and deleting them
 - day-to-day development in the main checkout
 - isolated worktree development
 - the shared PostgreSQL model
@@ -107,6 +108,51 @@ To regenerate a worktree env file:
 ```bash
 FORCE=1 make worktree-env
 ```
+
+## Environments
+
+An environment is the database, ports, CLI profile and processes that belong to
+one checkout. It is a named object: it can be listed, inspected and deleted.
+
+```bash
+make up                      # start this checkout's environment (api + web)
+make up C=api,web,daemon     # choose the components
+make status                  # what is running, and whether it is yours
+make list                    # every environment on this machine
+make down                    # stop the processes, keep the data
+make destroy                 # stop, then drop the database and free the slot
+make gc                      # collect environments whose checkout is gone
+```
+
+Components are `api` (Go backend), `web` (Next.js), `daemon` (agent daemon) and
+`desktop` (Electron). Selecting any of them implies `api`. `make up` is
+idempotent: re-running it against a live environment reuses the database, the
+profile and any component already healthy.
+
+Three properties are worth knowing because the old flow lacked them:
+
+- **Ports, database names and profiles are allocated, not recomputed.** The
+  allocator starts from this directory's path hash, so a checkout keeps the
+  numbers it has always had, and moves only when the registry or a live
+  listener says the slot is taken. The registry lives in `~/.multica/dev/`;
+  deleting it and re-running `make up` is a supported recovery.
+- **Nothing reports success for something it has not reached.** The database is
+  created and verified through `DATABASE_URL` — the same string the backend
+  uses — and `GET /health` reports `pid`, `commit` and `started_at` so `make up`
+  can prove the process answering is the one it just started rather than a
+  leftover on the same port.
+- **`down` and `destroy` differ deliberately.** `down` stops processes and
+  keeps the database, profile and slot, so the next `make up` is seconds.
+  `destroy` consumes them.
+
+Run any command inside an environment's variables without repeating them:
+
+```bash
+make env-exec ARGS="-- pnpm exec playwright test"
+```
+
+`make dev` (below) still runs backend and frontend in the foreground of your
+terminal, which is the right thing when you want Ctrl-C to stop everything.
 
 ## First-Time Setup
 
@@ -345,220 +391,60 @@ It registers runtimes for all watched workspaces from the CLI config.
 
 ## Full-Stack Isolated Testing
 
-This section covers running the complete stack (backend, frontend, daemon) from
-source in a fully isolated environment. Useful for testing end-to-end changes
-that span multiple components, or for automated CI/AI workflows that need zero
-human intervention.
-
-### Why Not Just `make daemon`?
-
-`make daemon` uses the system-installed CLI's stored token and connects to
-whatever server is configured in `~/.multica/config.json`. That's fine for
-day-to-day development against a shared server, but for fully isolated testing
-you need:
-
-- a local backend and frontend (from source)
-- a local daemon (from source) with its own profile
-- automated authentication (no browser login)
-- no interference with your production CLI config
-
-### Dynamic Profile Naming
-
-Each worktree must use a unique daemon profile to avoid collisions when
-multiple features run in parallel.
-
-The profile name is derived from the worktree directory using the same
-slug + hash pattern as `scripts/init-worktree-env.sh`:
+Running the complete stack — backend, frontend and daemon — from source, with
+its own database and CLI profile, is one command:
 
 ```bash
-WORKTREE_DIR="$(basename "$PWD")"
-SLUG="$(printf '%s' "$WORKTREE_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
-HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
-OFFSET=$((HASH % 1000))
-PROFILE="dev-${SLUG}-${OFFSET}"
+make up C=api,web,daemon
 ```
 
-Example: worktree at `../multica-feat-auth` produces profile
-`dev-multica_feat_auth-347`, matching that worktree's port and database
-allocation.
+It creates the environment if needed, sets the fixed local verification code
+before the first launch, logs in as `dev@localhost`, mints a personal access
+token, creates a workspace, writes the CLI profile, builds `server/bin/multica`
+and starts the daemon from that binary. It then prints the URL, the login, the
+commit, and the stop command.
 
-### Start the Isolated Environment
+Two constraints are enforced rather than documented:
 
-Run all steps from the worktree root (where the Makefile is).
+- **The daemon runs from a built binary, never `go run`.** The daemon records
+  its own executable path at startup and re-execs it as the
+  execution-environment helper for every task; `go run` deletes that binary when
+  the launcher exits, so the daemon would register, heartbeat, and then fail
+  every task with `fork/exec …/go-build…/exe/multica: no such file or directory`.
+- **`daemon start` is refused under a daemon-managed task.** A checkout below a
+  `.multica/daemon_task_context.json` marker cannot start a second daemon
+  competing for its own work, so `make up C=daemon` stops with that explanation
+  before spending a login on it. Use `C=api,web` there.
 
-#### 1. Start backend, frontend, and database
+### Desktop
 
 ```bash
-make dev
+make up C=desktop
 ```
 
-Wait for the backend to be healthy:
+This points `apps/desktop/.env.development.local` at this environment's backend
+and starts Electron. `pnpm dev:desktop` derives its own renderer port and app
+name per worktree, so several checkouts can run desktop side by side; which
+backend each one talks to is decided by that env file alone.
 
-```bash
-PORT=$(grep '^PORT=' .env.worktree 2>/dev/null || grep '^PORT=' .env | head -1 | cut -d= -f2)
-PORT=${PORT:-8080}
-SERVER="http://localhost:${PORT}"
-
-for i in $(seq 1 30); do
-  curl -sf "$SERVER/health" > /dev/null 2>&1 && break
-  sleep 2
-done
-```
-
-#### 2. Create a test user and token (automated auth)
-
-For deterministic local automation, set `MULTICA_DEV_VERIFICATION_CODE=888888`
-in your env file before starting the backend:
-
-```bash
-curl -s -X POST "$SERVER/auth/send-code" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "dev@localhost"}'
-
-JWT=$(curl -s -X POST "$SERVER/auth/verify-code" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "dev@localhost", "code": "888888"}' | jq -r '.token')
-
-PAT=$(curl -s -X POST "$SERVER/api/tokens" \
-  -H "Authorization: Bearer $JWT" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "auto-dev", "expires_in_days": 365}' | jq -r '.token')
-```
-
-#### 3. Create a workspace
-
-```bash
-WS=$(curl -s -X POST "$SERVER/api/workspaces" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Dev", "slug": "dev"}' | jq -r '.id')
-```
-
-#### 4. Compute profile name and write CLI config
-
-```bash
-# Compute profile (see Dynamic Profile Naming above)
-WORKTREE_DIR="$(basename "$PWD")"
-SLUG="$(printf '%s' "$WORKTREE_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
-HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
-OFFSET=$((HASH % 1000))
-PROFILE="dev-${SLUG}-${OFFSET}"
-
-FRONTEND_PORT=$(grep '^FRONTEND_PORT=' .env.worktree 2>/dev/null || grep '^FRONTEND_PORT=' .env | head -1 | cut -d= -f2)
-FRONTEND_PORT=${FRONTEND_PORT:-3000}
-
-CONFIG_DIR="$HOME/.multica/profiles/$PROFILE"
-mkdir -p "$CONFIG_DIR"
-
-cat > "$CONFIG_DIR/config.json" << EOF
-{
-  "server_url": "$SERVER",
-  "app_url": "http://localhost:${FRONTEND_PORT}",
-  "token": "$PAT",
-  "workspace_id": "$WS",
-  "watched_workspaces": [{"id": "$WS", "name": "Dev"}]
-}
-EOF
-```
-
-#### 5. Start the daemon from source
-
-```bash
-make cli ARGS="daemon start --profile $PROFILE"
-```
-
-The daemon runs from the current worktree's Go source, connecting to the
-local backend. Agent-executed `multica` commands automatically use the same
-binary (the daemon prepends its own directory to `PATH`).
-
-### Stop the Isolated Environment
-
-```bash
-# Compute profile (same formula)
-PROFILE="dev-$(printf '%s' "$(basename "$PWD")" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')-$(( $(printf '%s' "$PWD" | cksum | awk '{print $1}') % 1000 ))"
-
-# 1. Stop daemon
-make cli ARGS="daemon stop --profile $PROFILE"
-
-# 2. Stop backend + frontend
-make stop            # main checkout
-make stop-worktree   # worktree checkout
-
-# 3. (Optional) Stop shared PostgreSQL
-make db-down
-
-# 4. (Optional) Clean build artifacts
-make clean
-
-# 5. (Optional) Remove profile config
-rm -rf "$HOME/.multica/profiles/$PROFILE"
-```
-
-### Desktop App Local Testing
-
-To test the Electron desktop app against a local backend:
-
-```bash
-# After backend is running (make dev)
-pnpm dev:desktop
-```
-
-This automatically:
-
-1. Compiles the `multica` CLI from `server/cmd/multica` into
-   `apps/desktop/resources/bin/multica`
-2. Creates an isolated profile named `desktop-localhost-<PORT>`
-3. Starts and manages its own daemon instance
-4. Connects to the local backend
-
-Login in the Desktop UI with `dev@localhost` and the generated code from the
-backend logs. If you set `MULTICA_DEV_VERIFICATION_CODE=888888` before starting
-the backend, you can use `888888` instead.
-
-If the backend runs on a non-default port (worktree), create
-`apps/desktop/.env.development.local`:
-
-```bash
-VITE_API_URL=http://localhost:<backend-port>
-VITE_WS_URL=ws://localhost:<backend-port>/ws
-```
-
-#### Running multiple worktrees side-by-side
-
-`pnpm dev:desktop` auto-isolates a worktree so several worktrees can run their
-own desktop dev instance at once — no extra setup. From a linked worktree it
-derives, from the worktree path (same `cksum % 1000` offset as the backend /
-frontend ports in `.env.worktree`):
-
-- `DESKTOP_RENDERER_PORT` = `5174 + offset` — its own Vite dev server (`5174`
-  base leaves `5173` for the primary checkout, even when `offset` is `0`). The
-  one offset that would land on `6000` gets `6174` instead: Chromium treats
-  `6000` as a restricted port and fails the load with `ERR_UNSAFE_PORT`
-- `DESKTOP_APP_SUFFIX` = `<folder>-<offset>` — its own single-instance lock /
-  `userData`, and an app named `Multica Canary <folder>-<offset>` so it is
-  distinguishable in Cmd+Tab. The offset keeps it unique across worktrees that
-  share a folder name at different paths.
-
-The primary checkout is left untouched (`5173`, `Multica Canary`). Set either
-env var explicitly to override the derived value. Which backend each instance
-talks to is still controlled only by `apps/desktop/.env*` above — point each
-worktree's desktop at its own backend to also isolate the daemon profile.
+Log in with `dev@localhost` and `888888`.
 
 ### Isolation Guarantee
 
 Nothing in this flow touches the system-installed `multica` or the default
 `~/.multica/config.json`:
 
-| Resource | System / Production | Local Dev (per-worktree) |
+| Resource | System / Production | Local Dev (per environment) |
 |---|---|---|
-| Config | `~/.multica/config.json` | `~/.multica/profiles/dev-<slug>-<hash>/config.json` |
-| Daemon PID | `~/.multica/daemon.pid` | `~/.multica/profiles/dev-<slug>-<hash>/daemon.pid` |
-| Health port | `19514` | `19514 + 1 + (name_hash % 1000)` |
-| Workspaces dir | `~/multica_workspaces/` | `~/multica_workspaces_dev-<slug>-<hash>/` |
-| Database | remote / production | local Docker: `multica_<slug>_<hash>` |
+| Config | `~/.multica/config.json` | `~/.multica/profiles/dev-<slug>-<offset>/config.json` |
+| Daemon PID | `~/.multica/daemon.pid` | `~/.multica/profiles/dev-<slug>-<offset>/daemon.pid` |
+| Workspaces dir | `~/multica_workspaces/` | `~/multica_workspaces_dev-<slug>-<offset>/` |
+| Database | remote / production | local: `multica_<slug>_<offset>` |
+| Registry | — | `~/.multica/dev/envs/<name>/` |
 | Desktop profile | `desktop-api.multica.ai` | `desktop-localhost-<port>` |
 
-Multiple worktrees can run simultaneously without conflict.
+Multiple environments run simultaneously without conflict; `make list` shows
+all of them.
 
 ## Troubleshooting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ make status                  # what is running, and whether it is yours
 make list                    # every environment on this machine
 make down                    # stop the processes, keep the data
 make destroy                 # stop, then drop the database and free the slot
-make gc                      # collect environments whose checkout is gone
+make gc                      # collect expired environments or ones whose checkout is gone
 ```
 
 Components are `api` (Go backend), `web` (Next.js), `daemon` (agent daemon) and
@@ -131,7 +131,7 @@ profile and any component already healthy.
 
 Three properties are worth knowing because the old flow lacked them:
 
-- **Ports, database names and profiles are allocated, not recomputed.** The
+- **API, Web and Desktop renderer ports, database names and profiles are allocated, not recomputed.** The
   allocator starts from this directory's path hash, so a checkout keeps the
   numbers it has always had, and moves only when the registry or a live
   listener says the slot is taken. The registry lives in `~/.multica/dev/`;
@@ -143,7 +143,13 @@ Three properties are worth knowing because the old flow lacked them:
   leftover on the same port.
 - **`down` and `destroy` differ deliberately.** `down` stops processes and
   keeps the database, profile and slot, so the next `make up` is seconds.
-  `destroy` consumes them.
+  `destroy` consumes the database, profile, daemon task workspaces, Desktop
+  userData and slot. If any deletion fails, it keeps the manifest and exits
+  non-zero so cleanup can be retried instead of losing the deletion recipe.
+- **Temporary environments have a best-effort fallback.** `make up
+  ARGS=--ephemeral` records a 24-hour TTL. The next `make up` automatically
+  collects expired and directory-less environments; `make gc` runs the same
+  collection explicitly.
 
 Run any command inside an environment's variables without repeating them:
 
@@ -422,10 +428,13 @@ Two constraints are enforced rather than documented:
 make up C=desktop
 ```
 
-This points `apps/desktop/.env.development.local` at this environment's backend
-and starts Electron. `pnpm dev:desktop` derives its own renderer port and app
-name per worktree, so several checkouts can run desktop side by side; which
-backend each one talks to is decided by that env file alone.
+This writes a marked `apps/desktop/.env.development.local` pointing at this
+environment's backend, starts Electron with the renderer port and app name from
+the environment registry, and waits until that renderer is actually serving.
+Several checkouts can therefore run Desktop side by side without maintaining a
+second path-derived identity. `make destroy` removes the marked env file and
+this environment's Electron userData. Direct `pnpm dev:desktop` still uses its
+path-derived fallback when it is run outside `make up`.
 
 Log in with `dev@localhost` and `888888`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree remove-worktree db-up db-down db-drop db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree remove-worktree db-up db-down db-drop db-reset selfhost selfhost-build selfhost-stop up down status list destroy gc env-exec api-dev web-dev desktop-dev
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -70,7 +70,7 @@ endef
 ##@ Help
 
 help: ## Show available make targets and common local workflows
-	@awk 'BEGIN {FS = ":.*## "; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nQuick start:\n  \033[36mmake dev\033[0m          Bootstrap the current checkout and start everything\n  \033[36mmake check\033[0m        Run the full local verification pipeline\n\nCheckout modes:\n  Main checkout uses \033[36m.env\033[0m\n  Worktrees use \033[36m.env.worktree\033[0m (generate with \033[36mmake worktree-env\033[0m)\n\n"} \
+	@awk 'BEGIN {FS = ":.*## "; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nQuick start:\n  \033[36mmake up\033[0m           Start this checkout'"'"'s environment (C=api,web,daemon,desktop)\n  \033[36mmake status\033[0m       Show what is running, and prove it is yours\n  \033[36mmake down\033[0m         Stop it again, keeping the database\n  \033[36mmake check\033[0m        Run the full local verification pipeline\n\nCheckout modes:\n  Main checkout uses \033[36m.env\033[0m\n  Worktrees use \033[36m.env.worktree\033[0m (generate with \033[36mmake worktree-env\033[0m)\n\n"} \
 		/^##@/ {printf "\n\033[1m%s\033[0m\n", substr($$0, 5); next} \
 		/^[a-zA-Z0-9_.-]+:.*## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
@@ -142,6 +142,52 @@ selfhost-stop: ## Stop the self-hosted Docker Compose stack
 	@echo "==> Stopping Multica services..."
 	$(COMPOSE) -f docker-compose.selfhost.yml down
 	@echo "✓ All services stopped."
+
+# ---------- Environments ----------
+##@ Environments
+
+# One verb per lifecycle step, shared by humans and agents. C= picks the
+# components; ARGS= forwards anything else to the script.
+#
+#   make up                     api + web
+#   make up C=api,web,daemon    add the agent daemon
+#   make up C=desktop           Electron against this environment's backend
+#   make up ARGS=--ephemeral    agent-owned, expires, collected by `make gc`
+
+up: ## Start this checkout's environment (C=api,web,daemon,desktop; default api,web)
+	@bash scripts/dev-env.sh up $(if $(C),--components $(C)) $(ARGS)
+
+down: ## Stop this environment's processes, keeping its database and profile
+	@bash scripts/dev-env.sh down $(ARGS)
+
+status: ## Show what is running for this environment, with proof of identity
+	@bash scripts/dev-env.sh status $(ARGS)
+
+list: ## List every registered development environment on this machine
+	@bash scripts/dev-env.sh list $(ARGS)
+
+destroy: ## Stop this environment, drop its database and profile, free its slot
+	@bash scripts/dev-env.sh destroy $(ARGS)
+
+gc: ## Collect environments whose directory is gone or whose TTL expired
+	@bash scripts/dev-env.sh gc $(ARGS)
+
+env-exec: ## Run a command with this environment's variables (ARGS="-- pnpm dev:desktop")
+	@bash scripts/dev-env.sh exec $(ARGS)
+
+# Single-component entry points. No database preflight: `up` has already proven
+# the database is reachable before it launches anything, and repeating the
+# check here would make each component slower to restart on its own.
+# The commit ldflag is what makes /health's identity useful: without it every
+# environment reports "unknown" and cannot prove which revision it is serving.
+api-dev: ## Run only the Go backend for the current env file
+	cd server && go run -ldflags "-X main.commit=$(COMMIT)" ./cmd/server
+
+web-dev: ## Run only the Next.js dev server for the current env file
+	pnpm dev:web
+
+desktop-dev: ## Run only the Electron desktop app for the current env file
+	pnpm dev:desktop
 
 # ---------- One-click commands ----------
 ##@ One-click

--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,8 @@ start: ## Start backend and frontend for the current checkout and run migrations
 stop: ## Stop backend and frontend processes for the current checkout
 	$(REQUIRE_ENV)
 	@echo "Stopping services..."
-	@-lsof -ti:$(PORT) | xargs kill -9 2>/dev/null
-	@-lsof -ti:$(FRONTEND_PORT) | xargs kill -9 2>/dev/null
+	@-lsof -nP -iTCP:$(PORT) -sTCP:LISTEN -t | xargs kill -9 2>/dev/null
+	@-lsof -nP -iTCP:$(FRONTEND_PORT) -sTCP:LISTEN -t | xargs kill -9 2>/dev/null
 	@case "$(DATABASE_URL)" in \
 		""|*@localhost:*|*@localhost/*|*@127.0.0.1:*|*@127.0.0.1/*|*@\[::1\]:*|*@\[::1\]/*) \
 			echo "✓ App processes stopped. Shared PostgreSQL is still running on localhost:$(POSTGRES_PORT)." ;; \

--- a/apps/docs/content/docs/developers/contributing.mdx
+++ b/apps/docs/content/docs/developers/contributing.mdx
@@ -70,12 +70,22 @@ Different worktrees share the PostgreSQL container, not the database. Do not sta
 ### Full workflow
 
 ```bash
-make dev              # Prepare and start the current checkout
-make start            # Start API and Web with the existing environment
-make stop             # Stop processes for the current checkout
+make up               # Start this checkout's environment (C=api,web,daemon,desktop)
+make status           # Show what is running and prove it is this environment
+make list             # List every environment on this machine
+make down             # Stop the processes, keep the database
+make destroy          # Stop, then drop the database and free the slot
+make dev              # Prepare and start the current checkout in the foreground
 make check            # Run the complete local verification workflow
 make build            # Build the server, CLI, and migrate binaries
 ```
+
+`make up` treats an environment as a named object: it allocates the ports,
+database name and CLI profile under a lock and records them in `~/.multica/dev/`,
+so two checkouts cannot land on the same slot without one of them being told.
+It verifies the database through `DATABASE_URL` and the backend through
+`GET /health`, which reports `pid`, `commit` and `started_at` — a 200 alone
+would also come from a leftover process on the same port.
 
 ### Frontend
 

--- a/apps/docs/content/docs/developers/contributing.mdx
+++ b/apps/docs/content/docs/developers/contributing.mdx
@@ -75,17 +75,21 @@ make status           # Show what is running and prove it is this environment
 make list             # List every environment on this machine
 make down             # Stop the processes, keep the database
 make destroy          # Stop, then drop the database and free the slot
+make gc               # Collect expired or directory-less environments
 make dev              # Prepare and start the current checkout in the foreground
 make check            # Run the complete local verification workflow
 make build            # Build the server, CLI, and migrate binaries
 ```
 
-`make up` treats an environment as a named object: it allocates the ports,
+`make up` treats an environment as a named object: it allocates the API, Web and Desktop renderer ports,
 database name and CLI profile under a lock and records them in `~/.multica/dev/`,
 so two checkouts cannot land on the same slot without one of them being told.
 It verifies the database through `DATABASE_URL` and the backend through
 `GET /health`, which reports `pid`, `commit` and `started_at` — a 200 alone
-would also come from a leftover process on the same port.
+would also come from a leftover process on the same port. `make destroy`
+removes the database, CLI profile, daemon workspaces, Desktop userData and
+registry entry; a failed deletion keeps the registry entry for retry. Temporary
+environments are collected best-effort on the next `make up` after their TTL.
 
 ### Frontend
 

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,1084 @@
+#!/usr/bin/env bash
+# Local development environments as named, listable, deletable objects.
+#
+#   make up                      # start this checkout's environment (api + web)
+#   make up C=api,web,daemon     # pick the components
+#   make status                  # what is running, and is it mine
+#   make list                    # every environment on this machine
+#   make down                    # stop the processes, keep the data
+#   make destroy                 # stop, then delete database + profile + slot
+#
+# Three rules the old flow got wrong, and why they are here:
+#
+#  1. Ports, database names and CLI profiles are ALLOCATED under a lock and
+#     recorded in a registry, not recomputed from cksum($PWD) by every caller.
+#     Deriving an identity in a 1000-slot namespace with no coordination
+#     collides, and a collision here is silent: the loser's process fails to
+#     bind while the winner keeps answering.
+#  2. Nothing prints a checkmark for a resource it has not reached the way the
+#     application reaches it. The database is verified through DATABASE_URL,
+#     never through `docker exec` — when a native PostgreSQL owns 5432 the
+#     container never binds the host port, so a docker-exec create lands in a
+#     server the backend never talks to.
+#  3. Creating an environment writes down how to destroy it. Without that
+#     record there is no destroy, only archaeology; the databases, ports and
+#     daemons leak, and nothing on the machine can even list them.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DEV_HOME="${MULTICA_DEV_HOME:-$HOME/.multica/dev}"
+ENVS_DIR="$DEV_HOME/envs"
+LOCK_DIR="$DEV_HOME/lock.d"
+
+DEV_EMAIL="${MULTICA_DEV_EMAIL:-dev@localhost}"
+DEV_CODE_DEFAULT=888888
+WORKSPACE_NAME="${MULTICA_DEV_WORKSPACE_NAME:-Dev}"
+WORKSPACE_SLUG="${MULTICA_DEV_WORKSPACE_SLUG:-dev}"
+
+ALL_COMPONENTS="api web daemon desktop"
+DEFAULT_COMPONENTS="api web"
+
+# An agent runs with TMPDIR=/tmp/multica-task-<id>, deleted when the run ends.
+# Anything the Go toolchain builds there goes with it, so a binary started from
+# such a build stops being re-executable the moment its creator finishes.
+DEV_TMPDIR="${MULTICA_DEV_TMPDIR:-$HOME/.multica/dev-tmp}"
+
+# The agent runtime exports these pointing at PRODUCTION, and MULTICA_SERVER_URL
+# silently outranks server_url in a saved profile config. Every long-lived child
+# is launched without them, so a local daemon cannot authenticate its local
+# token against the production API — which fails as a bare 401 and reads like a
+# product bug. PATH is never stripped: the daemon resolves agent CLI paths by
+# forking the login shell.
+CLEAN_ENV=(env
+  -u MULTICA_SERVER_URL -u MULTICA_TOKEN -u MULTICA_WORKSPACE_ID
+  -u MULTICA_DAEMON_PORT -u MULTICA_AGENT_ID -u MULTICA_AGENT_NAME
+  -u MULTICA_TASK_ID -u MULTICA_TASK_SLOT)
+
+# ---------------------------------------------------------------- output ----
+
+if [ -t 1 ]; then
+  C_BOLD=$'\033[1m'; C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_DIM=$'\033[2m'; C_OFF=$'\033[0m'
+else
+  C_BOLD=""; C_GREEN=""; C_RED=""; C_DIM=""; C_OFF=""
+fi
+
+step() { printf '\n%s==> %s%s\n' "$C_BOLD" "$1" "$C_OFF"; }
+info() { printf '    %s\n' "$1"; }
+ok()   { printf '    %s✓%s %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+warn() { printf '    %s!%s %s\n' "$C_RED" "$C_OFF" "$1"; }
+die()  { printf '\n%s✗ %s%s\n' "$C_RED" "$1" "$C_OFF" >&2; exit 1; }
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g'
+}
+
+now_iso() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+now_epoch() { date -u '+%s'; }
+
+# ----------------------------------------------------------------- locking ---
+
+# flock is not on a stock macOS, so the lock is an atomic mkdir. The holder's
+# pid is recorded so a lock left behind by a killed process is recoverable
+# instead of wedging every later command.
+acquire_lock() {
+  local waited=0
+  mkdir -p "$DEV_HOME"
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    local holder=""
+    holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$LOCK_DIR"
+      continue
+    fi
+    waited=$((waited + 1))
+    [ "$waited" -lt 100 ] || die "Timed out waiting for the allocation lock at $LOCK_DIR. If nothing else is running, remove it."
+    sleep 0.1
+  done
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+}
+
+release_lock() { rm -rf "$LOCK_DIR"; }
+
+# ---------------------------------------------------------------- registry ---
+
+env_dir()      { printf '%s/%s' "$ENVS_DIR" "$1"; }
+manifest_of()  { printf '%s/%s/manifest.env' "$ENVS_DIR" "$1"; }
+
+list_env_names() {
+  [ -d "$ENVS_DIR" ] || return 0
+  local path
+  for path in "$ENVS_DIR"/*/manifest.env; do
+    [ -f "$path" ] || continue
+    basename "$(dirname "$path")"
+  done
+  return 0
+}
+
+# Loads a manifest into NAME/DIR/BACKEND_PORT/... in the caller's scope.
+load_manifest() {
+  local file
+  file="$(manifest_of "$1")"
+  [ -f "$file" ] || return 1
+  # shellcheck disable=SC1090
+  . "$file"
+}
+
+# Prints nothing (and succeeds) for a missing manifest or key: callers compare
+# the value, and a non-zero return from a command substitution is fatal under
+# `set -e` on bash 3.2.
+manifest_field() {
+  local file value
+  file="$(manifest_of "$1")"
+  [ -f "$file" ] || return 0
+  value="$(grep "^$2=" "$file" | head -1 | cut -d= -f2- || true)"
+  printf '%s' "$value"
+}
+
+env_name_for_dir() {
+  local name
+  while read -r name; do
+    [ -n "$name" ] || continue
+    if [ "$(manifest_field "$name" DIR)" = "$1" ]; then
+      printf '%s' "$name"
+      return 0
+    fi
+  done <<EOF
+$(list_env_names)
+EOF
+  return 1
+}
+
+# ------------------------------------------------------------------- ports ---
+
+# -sTCP:LISTEN matters: an unfiltered lsof also returns CLIENTS of the port, and
+# the daemon holds a long-lived connection to the backend. Killing what the
+# unfiltered lookup returns takes the daemon down with the server (#6573).
+#
+# The trailing `|| true` is load-bearing on macOS's bash 3.2: `x="$(fn)"` inside
+# a function aborts the script under `set -e` when fn's last command fails, and
+# "no process is listening" is the normal answer here, not an error.
+port_listener_pid() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN -t 2>/dev/null | head -1 || true
+}
+
+port_free() { [ -z "$(port_listener_pid "$1")" ]; }
+
+describe_port_owner() {
+  local pid
+  pid="$(port_listener_pid "$1")"
+  [ -n "$pid" ] || { printf 'free'; return; }
+  printf 'pid %s (%s), up %s' "$pid" \
+    "$(ps -p "$pid" -o comm= 2>/dev/null | sed 's/^ *//' || echo unknown)" \
+    "$(ps -p "$pid" -o etime= 2>/dev/null | sed 's/^ *//' || echo unknown)"
+}
+
+# -------------------------------------------------------------- allocation ---
+
+slugify() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//'
+}
+
+path_offset() {
+  local sum
+  sum="$(printf '%s' "$1" | cksum | awk '{print $1}')"
+  printf '%s' $((sum % 1000))
+}
+
+offset_registered() {
+  local name
+  while read -r name; do
+    [ -n "$name" ] || continue
+    [ "$name" = "${2:-}" ] && continue
+    if [ "$(manifest_field "$name" OFFSET)" = "$1" ]; then
+      return 0
+    fi
+  done <<EOF
+$(list_env_names)
+EOF
+  return 1
+}
+
+# Probes for a usable slot starting at the path hash, so the common case keeps
+# the deterministic number a checkout has always had, and only a real conflict
+# moves it. A slot is usable when the registry does not hold it AND both ports
+# are actually free — the registry alone cannot see a process started before
+# this tooling existed.
+allocate_offset() {
+  local dir=$1 self=${2:-} start i offset backend frontend
+  start="$(path_offset "$dir")"
+  for i in $(seq 0 999); do
+    offset=$(((start + i) % 1000))
+    backend=$((18080 + offset))
+    frontend=$((13000 + offset))
+    offset_registered "$offset" "$self" && continue
+    port_free "$backend" || continue
+    port_free "$frontend" || continue
+    printf '%s' "$offset"
+    return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------- env file ---
+
+detect_env_file() {
+  if [ -f "$REPO_ROOT/.env" ]; then
+    printf '.env'
+  elif [ -f "$REPO_ROOT/.env.worktree" ]; then
+    printf '.env.worktree'
+  elif [ -f "$REPO_ROOT/.git" ] && [ ! -d "$REPO_ROOT/.git" ]; then
+    printf '.env.worktree'
+  else
+    printf '.env'
+  fi
+}
+
+load_env_file() {
+  set -a
+  # shellcheck disable=SC1090
+  . "$REPO_ROOT/$1"
+  set +a
+  # shellcheck disable=SC1091
+  . "$REPO_ROOT/scripts/local-env.sh"
+}
+
+# The verification code has to be in the file BEFORE the backend starts: the
+# handler reads the variable at request time, but the process loads the file
+# once. Setting it here removes the start → edit → restart detour, and is what
+# makes `up` able to log itself in without a human reading a log for a code.
+ensure_dev_code() {
+  local file="$REPO_ROOT/$1" tmp
+  if grep -qE '^MULTICA_DEV_VERIFICATION_CODE=[0-9]{6}$' "$file"; then
+    return 0
+  fi
+  if grep -q '^MULTICA_DEV_VERIFICATION_CODE=' "$file"; then
+    tmp="$(mktemp)"
+    sed "s/^MULTICA_DEV_VERIFICATION_CODE=.*/MULTICA_DEV_VERIFICATION_CODE=$DEV_CODE_DEFAULT/" "$file" > "$tmp"
+    mv "$tmp" "$file"
+  else
+    printf '\nMULTICA_DEV_VERIFICATION_CODE=%s\n' "$DEV_CODE_DEFAULT" >> "$file"
+  fi
+  info "Set MULTICA_DEV_VERIFICATION_CODE=$DEV_CODE_DEFAULT in $1 (ignored when APP_ENV=production)."
+}
+
+rewrite_env_ports() {
+  local file="$REPO_ROOT/$1" offset=$2 backend=$3 frontend=$4 db=$5 tmp
+  tmp="$(mktemp)"
+  sed \
+    -e "s|^PORT=.*|PORT=${backend}|" \
+    -e "s|^FRONTEND_PORT=.*|FRONTEND_PORT=${frontend}|" \
+    -e "s|^FRONTEND_ORIGIN=.*|FRONTEND_ORIGIN=http://localhost:${frontend}|" \
+    -e "s|^POSTGRES_DB=.*|POSTGRES_DB=${db}|" \
+    -e "s|^DATABASE_URL=.*|DATABASE_URL=postgres://multica:multica@localhost:5432/${db}?sslmode=disable|" \
+    -e "s|^MULTICA_SERVER_URL=.*|MULTICA_SERVER_URL=ws://localhost:${backend}/ws|" \
+    -e "s|^MULTICA_PUBLIC_URL=.*|MULTICA_PUBLIC_URL=http://localhost:${backend}|" \
+    -e "s|^MULTICA_APP_URL=.*|MULTICA_APP_URL=http://localhost:${frontend}|" \
+    -e "s|^NEXT_PUBLIC_API_URL=.*|NEXT_PUBLIC_API_URL=http://localhost:${backend}|" \
+    -e "s|^NEXT_PUBLIC_WS_URL=.*|NEXT_PUBLIC_WS_URL=ws://localhost:${backend}/ws|" \
+    "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# ---------------------------------------------------------------- database ---
+
+admin_database_url() {
+  node -e '
+    const url = new URL(process.argv[1]);
+    url.pathname = "/postgres";
+    process.stdout.write(url.toString());
+  ' "$1" 2>/dev/null || true
+}
+
+# Diagnoses the failure mode this whole script exists to make impossible:
+# something other than the container owns 5432, so the container never bound
+# the host port and a docker-exec create landed in the wrong server.
+diagnose_database() {
+  local owner
+  owner="$(lsof -nP -iTCP:"${POSTGRES_PORT:-5432}" -sTCP:LISTEN 2>/dev/null | awk 'NR==2 {print $1" (pid "$2", user "$3")"}')"
+  printf '\n'
+  warn "The database the tooling created is not the one the application reaches."
+  info "Port ${POSTGRES_PORT:-5432} is served by: ${owner:-nothing}"
+  info "DATABASE_URL: ${DATABASE_URL}"
+  info "If that is a native PostgreSQL, the Docker container never bound the host port."
+  info "Either stop it (brew services stop postgresql@17) or point DATABASE_URL at it."
+}
+
+ensure_database() {
+  local admin_url=""
+  if command -v psql >/dev/null 2>&1 && [ -n "${DATABASE_URL:-}" ]; then
+    admin_url="$(admin_database_url "$DATABASE_URL")"
+  fi
+
+  # Preferred path: create through the same connection string the application
+  # uses, so "created" and "reachable" cannot describe two different servers.
+  if [ -n "$admin_url" ] && PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc 'SELECT 1' >/dev/null 2>&1; then
+    if ! PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc "SELECT 1 FROM pg_database WHERE datname='${POSTGRES_DB}'" | grep -q 1; then
+      psql "$admin_url" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"${POSTGRES_DB}\"" >/dev/null
+      info "Created database ${POSTGRES_DB} through DATABASE_URL."
+    fi
+  else
+    info "Nothing is answering on ${POSTGRES_PORT:-5432} yet; starting the shared container."
+    bash "$REPO_ROOT/scripts/ensure-postgres.sh" "$ENV_FILE" | sed 's/^/    /'
+  fi
+}
+
+migrate_database() {
+  # `migrate up` connects with DATABASE_URL and pings before doing anything, so
+  # a successful run is the proof that the application can reach the database
+  # this script just prepared. That is why nothing above prints a checkmark.
+  if ! (cd "$REPO_ROOT/server" && go run ./cmd/migrate up) > "$LOG_DIR/migrate.log" 2>&1; then
+    tail -5 "$LOG_DIR/migrate.log" | sed 's/^/    /' >&2 || true
+    if grep -q '3D000\|does not exist' "$LOG_DIR/migrate.log"; then
+      diagnose_database
+    fi
+    die "Migrations failed. Full log: $LOG_DIR/migrate.log"
+  fi
+}
+
+# -------------------------------------------------------------- components ---
+
+component_selected() {
+  case " $COMPONENTS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+pid_file()  { printf '%s/%s.pid' "$STATE_DIR" "$1"; }
+log_file()  { printf '%s/%s.log' "$LOG_DIR" "$1"; }
+
+component_pid() {
+  local file
+  file="$(pid_file "$1")"
+  [ -f "$file" ] || return 1
+  local pid
+  pid="$(cat "$file")"
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s' "$pid"
+}
+
+# set -m puts the launcher in its own process group, so stopping can signal the
+# whole tree (make → go run → server) with one kill, and the child's own
+# `trap 'kill 0'` can never reach back into this shell.
+launch_detached() {
+  local name=$1
+  shift
+  (
+    set -m
+    nohup "${CLEAN_ENV[@]}" "$@" > "$(log_file "$name")" 2>&1 < /dev/null &
+    printf '%s\n' "$!" > "$(pid_file "$name")"
+  )
+}
+
+health_json() { curl -sf --max-time 3 "http://localhost:${BACKEND_PORT}/health" 2>/dev/null; }
+
+json_field() {
+  node -e '
+    let payload;
+    try { payload = JSON.parse(process.argv[1]); } catch { process.exit(1); }
+    const value = process.argv[2].split(".").reduce((acc, key) => (acc == null ? acc : acc[key]), payload);
+    if (value === undefined || value === null || value === "") process.exit(1);
+    process.stdout.write(String(value));
+  ' "$1" "$2" 2>/dev/null
+}
+
+api_started_after() {
+  local started_at epoch
+  started_at="$(json_field "$1" started_at || true)"
+  [ -n "$started_at" ] || return 0 # older build without process identity
+  epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$started_at" 2>/dev/null || echo 0)"
+  [ "$epoch" -ge $(($2 - 5)) ]
+}
+
+start_api() {
+  local launched_at health waited=0
+  if health="$(health_json)" && [ -n "$health" ] && component_pid api >/dev/null; then
+    ok "api already running on :$BACKEND_PORT"
+    return 0
+  fi
+  if ! port_free "$BACKEND_PORT"; then
+    die "Port $BACKEND_PORT is busy: $(describe_port_owner "$BACKEND_PORT").
+Run 'make down' here first — a leftover instance answers /health with 200 and you would test it instead of your build."
+  fi
+
+  launched_at="$(now_epoch)"
+  launch_detached api make -C "$REPO_ROOT" -s api-dev ENV_FILE="$ENV_FILE"
+  info "api launching (pid $(cat "$(pid_file api)")), log: $(log_file api)"
+
+  while [ "$waited" -lt 300 ]; do
+    health="$(health_json || true)"
+    if [ -n "$health" ]; then
+      # A 200 is not enough. If the answer predates this launch, something else
+      # owns the port and every later step would configure the wrong server.
+      api_started_after "$health" "$launched_at" \
+        || die "Something else is serving :$BACKEND_PORT — it started before this run. Stop it and retry."
+      ok "api healthy at http://localhost:$BACKEND_PORT (pid $(json_field "$health" pid || echo '?'), commit $(json_field "$health" commit || echo '?'))"
+      return 0
+    fi
+    component_pid api >/dev/null || { tail -20 "$(log_file api)" | sed 's/^/    /' >&2; die "api exited during startup. Log: $(log_file api)"; }
+    sleep 2
+    waited=$((waited + 2))
+  done
+  die "api never became healthy. Log: $(log_file api)"
+}
+
+start_web() {
+  local waited=0 listener
+  if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1 && component_pid web >/dev/null; then
+    ok "web already running on :$FRONTEND_PORT"
+    return 0
+  fi
+  if ! port_free "$FRONTEND_PORT"; then
+    die "Port $FRONTEND_PORT is busy: $(describe_port_owner "$FRONTEND_PORT"). Run 'make down' here first."
+  fi
+
+  launch_detached web make -C "$REPO_ROOT" -s web-dev ENV_FILE="$ENV_FILE"
+  info "web launching (pid $(cat "$(pid_file web)")), log: $(log_file web)"
+
+  while [ "$waited" -lt 300 ]; do
+    if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+      listener="$(port_listener_pid "$FRONTEND_PORT")"
+      ok "web serving http://localhost:$FRONTEND_PORT (pid ${listener:-?})"
+      return 0
+    fi
+    component_pid web >/dev/null || { tail -20 "$(log_file web)" | sed 's/^/    /' >&2; die "web exited during startup. Log: $(log_file web)"; }
+    sleep 2
+    waited=$((waited + 2))
+  done
+  die "web never came up. Log: $(log_file web)"
+}
+
+# send-code once, verify-code once. Repeated verify attempts lock the code out
+# and start returning 400 even when it is correct, so retrying is self-defeating.
+ensure_credentials() {
+  local server="http://localhost:${BACKEND_PORT}" config="$PROFILE_DIR/config.json"
+  local code="${MULTICA_DEV_VERIFICATION_CODE:-$DEV_CODE_DEFAULT}"
+  local verify jwt pat ws
+
+  if [ -f "$config" ]; then
+    pat="$(json_field "$(cat "$config")" token || true)"
+    ws="$(json_field "$(cat "$config")" workspace_id || true)"
+    if [ -n "$pat" ] && curl -sf --max-time 5 "$server/api/me" -H "Authorization: Bearer $pat" >/dev/null 2>&1; then
+      WORKSPACE_ID="$ws"
+      ok "CLI profile $PROFILE already authenticated"
+      return 0
+    fi
+  fi
+
+  curl -sf -X POST "$server/auth/send-code" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"${DEV_EMAIL}\"}" >/dev/null \
+    || die "send-code failed. Is MULTICA_DEV_VERIFICATION_CODE set and APP_ENV non-production?"
+
+  verify="$(curl -sS -X POST "$server/auth/verify-code" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"${DEV_EMAIL}\",\"code\":\"${code}\"}")"
+  jwt="$(json_field "$verify" token || true)"
+  [ -n "$jwt" ] || die "verify-code failed: $verify
+Do not retry immediately — repeated attempts lock the code. Wait ~40s and re-run."
+
+  local pat_response
+  pat_response="$(curl -sS -X POST "$server/api/tokens" -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' -d '{"name":"dev-env","expires_in_days":365}')"
+  pat="$(json_field "$pat_response" token || true)"
+  [ -n "$pat" ] || die "Personal access token creation failed: $pat_response"
+
+  local ws_response
+  ws_response="$(curl -sS -X POST "$server/api/workspaces" -H "Authorization: Bearer $pat" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"${WORKSPACE_NAME}\",\"slug\":\"${WORKSPACE_SLUG}\"}")"
+  ws="$(json_field "$ws_response" id || true)"
+  if [ -z "$ws" ]; then
+    ws="$(node -e '
+      let list;
+      try { list = JSON.parse(process.argv[1]); } catch { process.exit(1); }
+      const match = (Array.isArray(list) ? list : []).find(w => w.slug === process.argv[2]);
+      if (!match) process.exit(1);
+      process.stdout.write(match.id);
+    ' "$(curl -sS "$server/api/workspaces" -H "Authorization: Bearer $pat")" "$WORKSPACE_SLUG" 2>/dev/null || true)"
+  fi
+  [ -n "$ws" ] || die "Workspace creation failed: $ws_response"
+
+  # A fresh user has onboarded_at = NULL and a browser login is bounced to
+  # /onboarding, so the URL this script prints would not land in the app.
+  curl -sS -X POST "$server/api/me/onboarding/complete" \
+    -H "Authorization: Bearer $pat" -H "X-Workspace-ID: $ws" \
+    -H 'Content-Type: application/json' -d '{"exit":"existing"}' >/dev/null 2>&1 || true
+
+  mkdir -p "$PROFILE_DIR"
+  cat > "$config" <<EOF
+{
+  "server_url": "http://localhost:${BACKEND_PORT}",
+  "app_url": "http://localhost:${FRONTEND_PORT}",
+  "token": "$pat",
+  "workspace_id": "$ws"
+}
+EOF
+  chmod 600 "$config"
+  WORKSPACE_ID="$ws"
+  ok "Logged in as $DEV_EMAIL and wrote profile $PROFILE"
+}
+
+# The CLI refuses `daemon start` anywhere under a daemon-task marker, so a task
+# cannot spawn a second daemon that competes for its own work. Checking the
+# marker here turns that refusal into one actionable line, before this component
+# has spent a login and a CLI build on an outcome it cannot reach.
+daemon_task_marker() {
+  local dir="$REPO_ROOT" marker
+  while :; do
+    marker="$dir/.multica/daemon_task_context.json"
+    if [ -f "$marker" ] && grep -q 'multica-daemon-task' "$marker" 2>/dev/null; then
+      printf '%s' "$marker"
+      return 0
+    fi
+    [ "$dir" != "/" ] || break
+    dir="$(dirname "$dir")"
+  done
+  return 0
+}
+
+start_daemon() {
+  local status state
+  ensure_credentials
+
+  # Built, never `go run`: the daemon records its own executable path at startup
+  # and re-execs it as the execution-environment helper for every task. Under
+  # `go run` the toolchain deletes that binary when the launcher exits, so the
+  # daemon registers, heartbeats, and then fails every task with
+  # "fork/exec .../go-build.../exe/multica: no such file or directory".
+  info "Building $MULTICA_BIN (a go run daemon would fail every task later)."
+  (cd "$REPO_ROOT/server" && go build -o bin/multica ./cmd/multica) || die "Failed to build the multica CLI."
+
+  "${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon start --profile "$PROFILE" 2>&1 | sed 's/^/    /' || true
+
+  status="$("${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+  state="$(json_field "$status" status || echo unknown)"
+  # `daemon status` reports "stopped" plus port_conflict when the daemon
+  # answering this profile's health port belongs to another profile, so a
+  # collision can never be read here as a healthy daemon.
+  if [ "$state" != running ]; then
+    if [ -n "$(json_field "$status" port_conflict.profile || true)" ]; then
+      die "The health port for $PROFILE is served by profile $(json_field "$status" port_conflict.profile). Rename one of them."
+    fi
+    die "Daemon is '$state' after start. Log: $PROFILE_DIR/daemon.log"
+  fi
+  ok "daemon running for profile $PROFILE (pid $(json_field "$status" pid || echo '?'))"
+}
+
+start_desktop() {
+  local desktop_env="$REPO_ROOT/apps/desktop/.env.development.local"
+  if component_pid desktop >/dev/null; then
+    ok "desktop already running (pid $(component_pid desktop))"
+    return 0
+  fi
+  # Which backend the renderer talks to is controlled only by this file; the
+  # per-worktree renderer port and app name are derived by dev:desktop itself.
+  cat > "$desktop_env" <<EOF
+VITE_API_URL=http://localhost:${BACKEND_PORT}
+VITE_WS_URL=ws://localhost:${BACKEND_PORT}/ws
+EOF
+  launch_detached desktop make -C "$REPO_ROOT" -s desktop-dev ENV_FILE="$ENV_FILE"
+  sleep 2
+  component_pid desktop >/dev/null \
+    || { tail -20 "$(log_file desktop)" | sed 's/^/    /' >&2; die "desktop exited immediately. Log: $(log_file desktop)"; }
+  ok "desktop launching (pid $(component_pid desktop)), pointed at :$BACKEND_PORT — log: $(log_file desktop)"
+}
+
+stop_component() {
+  local name=$1 pid
+  case "$name" in
+    daemon)
+      if [ -x "$MULTICA_BIN" ]; then
+        "${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon stop --profile "$PROFILE" >/dev/null 2>&1 \
+          && ok "daemon stopped" || info "daemon was not running"
+      else
+        info "daemon skipped ($MULTICA_BIN not built, so nothing here started one)"
+      fi
+      return 0
+      ;;
+  esac
+
+  pid="$(component_pid "$name" || true)"
+  if [ -n "$pid" ]; then
+    # Negative pid targets the process group, so make → go run → server all go
+    # down together instead of leaving the real listener orphaned.
+    kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    sleep 1
+    kill -0 "$pid" 2>/dev/null && { kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; }
+    rm -f "$(pid_file "$name")"
+    ok "$name stopped (pid $pid)"
+  else
+    rm -f "$(pid_file "$name")"
+    info "$name was not running"
+  fi
+
+  # A process group kill misses a listener that reparented away from it. Only
+  # LISTEN sockets are considered, never clients of the port.
+  local port=""
+  case "$name" in
+    api) port="$BACKEND_PORT" ;;
+    web) port="$FRONTEND_PORT" ;;
+  esac
+  if [ -n "$port" ]; then
+    local listener
+    listener="$(port_listener_pid "$port")"
+    if [ -n "$listener" ]; then
+      kill -TERM "$listener" 2>/dev/null || true
+      sleep 1
+      kill -0 "$listener" 2>/dev/null && kill -KILL "$listener" 2>/dev/null || true
+      info "released :$port (pid $listener)"
+    fi
+  fi
+}
+
+# ------------------------------------------------------------------ status ---
+
+component_state() {
+  case "$1" in
+    api)
+      local health
+      health="$(health_json || true)"
+      if [ -n "$health" ]; then
+        printf 'running|http://localhost:%s|pid %s commit %s started %s' "$BACKEND_PORT" \
+          "$(json_field "$health" pid || echo '?')" \
+          "$(json_field "$health" commit || echo '?')" \
+          "$(json_field "$health" started_at || echo '?')"
+      else
+        printf 'stopped|http://localhost:%s|' "$BACKEND_PORT"
+      fi
+      ;;
+    web)
+      if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+        printf 'running|http://localhost:%s|pid %s' "$FRONTEND_PORT" "$(port_listener_pid "$FRONTEND_PORT")"
+      else
+        printf 'stopped|http://localhost:%s|' "$FRONTEND_PORT"
+      fi
+      ;;
+    daemon)
+      local status state
+      if [ -x "$MULTICA_BIN" ]; then
+        status="$("${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+        state="$(json_field "$status" status || echo stopped)"
+        printf '%s|%s|pid %s' "$state" "$PROFILE" "$(json_field "$status" pid || echo '-')"
+      else
+        printf 'stopped|%s|not built' "$PROFILE"
+      fi
+      ;;
+    desktop)
+      local pid
+      pid="$(component_pid desktop || true)"
+      if [ -n "$pid" ]; then printf 'running||pid %s' "$pid"; else printf 'stopped||'; fi
+      ;;
+  esac
+}
+
+print_status_human() {
+  local comp state url detail row
+  printf '\n%s%s%s  %s%s%s\n' "$C_BOLD" "$NAME" "$C_OFF" "$C_DIM" "$DIR" "$C_OFF"
+  printf '  %-9s %-9s %-32s %s\n' COMPONENT STATE ADDRESS DETAIL
+  for comp in $ALL_COMPONENTS; do
+    row="$(component_state "$comp")"
+    state="${row%%|*}"; row="${row#*|}"
+    url="${row%%|*}"; detail="${row#*|}"
+    printf '  %-9s %-9s %-32s %s\n' "$comp" "$state" "${url:--}" "${detail:--}"
+  done
+  printf '  %-9s %-9s %-32s %s\n' database "$(database_state)" "$DB_NAME" "${DATABASE_URL%%\?*}"
+  printf '\n  owner %s · created %s%s\n' "$OWNER" "$CREATED_AT" "$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' · ttl %sh' "$TTL_HOURS" )"
+  printf '  logs  %s\n' "$LOG_DIR"
+}
+
+# Reported from the connection string the application uses, so "present" can
+# never mean "present in a server nothing talks to".
+database_state() {
+  local admin_url
+  command -v psql >/dev/null 2>&1 || { printf 'unknown'; return; }
+  admin_url="$(admin_database_url "$DATABASE_URL")"
+  PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc 'SELECT 1' >/dev/null 2>&1 || { printf 'no-server'; return; }
+  if PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" 2>/dev/null | grep -q 1; then
+    printf 'present'
+  else
+    printf 'missing'
+  fi
+}
+
+print_status_json() {
+  local comp row state url detail first=1
+  printf '{"name":"%s","dir":"%s","owner":"%s","created_at":"%s","ttl_hours":%s,' \
+    "$(json_escape "$NAME")" "$(json_escape "$DIR")" "$(json_escape "$OWNER")" \
+    "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}"
+  printf '"backend_port":%s,"frontend_port":%s,"database":"%s","profile":"%s","env_file":"%s","logs":"%s","components":{' \
+    "$BACKEND_PORT" "$FRONTEND_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$PROFILE")" \
+    "$(json_escape "$ENV_FILE")" "$(json_escape "$LOG_DIR")"
+  for comp in $ALL_COMPONENTS; do
+    row="$(component_state "$comp")"
+    state="${row%%|*}"; row="${row#*|}"
+    url="${row%%|*}"; detail="${row#*|}"
+    [ "$first" = 1 ] || printf ','
+    first=0
+    printf '"%s":{"state":"%s","address":"%s","detail":"%s"}' \
+      "$comp" "$(json_escape "$state")" "$(json_escape "$url")" "$(json_escape "$detail")"
+  done
+  printf '}}\n'
+}
+
+print_handoff() {
+  cat <<EOF
+
+${C_GREEN}✓ Environment ready.${C_OFF}
+
+  Open        http://localhost:${FRONTEND_PORT}/${WORKSPACE_SLUG}/issues
+  Sign in     ${DEV_EMAIL}  ·  code ${MULTICA_DEV_VERIFICATION_CODE:-$DEV_CODE_DEFAULT}
+  Backend     http://localhost:${BACKEND_PORT}   (GET /health reports pid + commit + started_at)
+  Commit      $(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)
+  Environment ${NAME}$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' (expires in %sh)' "$TTL_HOURS" )
+
+  Inspect     make status
+  Stop        make down            (keeps the database, restarts in seconds)
+  Delete      make destroy         (drops the database and frees the slot)
+EOF
+}
+
+# ------------------------------------------------------------------- verbs ---
+
+resolve_env_for_read() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    name="$(env_name_for_dir "$REPO_ROOT" || true)"
+    [ -n "$name" ] || die "No environment registered for $REPO_ROOT. Run 'make up' first."
+  fi
+  load_manifest "$name" || die "Unknown environment '$name'. Run 'make list' to see what exists."
+  bind_paths
+}
+
+bind_paths() {
+  STATE_DIR="$(env_dir "$NAME")"
+  LOG_DIR="$STATE_DIR/logs"
+  PROFILE_DIR="$HOME/.multica/profiles/$PROFILE"
+  MULTICA_BIN="$REPO_ROOT/server/bin/multica"
+  mkdir -p "$LOG_DIR"
+}
+
+cmd_up() {
+  local requested="$DEFAULT_COMPONENTS" name="" owner=human ttl=0 comp
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --components|-c) requested="$(printf '%s' "$2" | tr ',' ' ')"; shift 2 ;;
+      --all) requested="$ALL_COMPONENTS"; shift ;;
+      --name) name="$2"; shift 2 ;;
+      --ephemeral) owner=agent; [ "$ttl" != 0 ] || ttl=24; shift ;;
+      --ttl) ttl="$2"; owner=agent; shift 2 ;;
+      *) die "Unknown flag for up: $1" ;;
+    esac
+  done
+
+  for comp in $requested; do
+    case " $ALL_COMPONENTS " in *" $comp "*) ;; *) die "Unknown component '$comp'. Valid: $ALL_COMPONENTS" ;; esac
+  done
+  # web, daemon and desktop are all clients of the backend; selecting one
+  # without api would produce an environment that cannot serve a single request.
+  case " $requested " in *" api "*) ;; *) requested="api $requested" ;; esac
+  COMPONENTS="$requested"
+
+  step "Prerequisites"
+  local missing=() tool needed="node go curl"
+  # pnpm is only required by the components that actually build JavaScript, so
+  # `up C=api` works on a checkout that has never run an install.
+  if component_selected web || component_selected desktop; then needed="$needed pnpm"; fi
+  for tool in $needed; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+  done
+  [ ${#missing[@]} -eq 0 ] || die "Missing prerequisites: ${missing[*]}"
+  mkdir -p "$DEV_TMPDIR"
+  if [ "${TMPDIR:-}" != "$DEV_TMPDIR" ]; then
+    info "TMPDIR pinned to $DEV_TMPDIR (was ${TMPDIR:-<unset>}) so builds outlive the run that made them."
+    export TMPDIR="$DEV_TMPDIR" TMP="$DEV_TMPDIR" TEMP="$DEV_TMPDIR"
+  fi
+  ok "node, go, curl found"
+
+  if component_selected daemon; then
+    local marker
+    marker="$(daemon_task_marker)"
+    [ -z "$marker" ] || die "The daemon component cannot start under a daemon-managed task.
+This checkout sits below $marker, and the CLI refuses 'daemon start' there so a
+task cannot spawn a second daemon competing for its own work.
+Start the rest with 'make up C=api,web', or run 'make up C=daemon' from your own shell."
+  fi
+
+  step "Environment"
+  ENV_FILE="$(detect_env_file)"
+  if [ ! -f "$REPO_ROOT/$ENV_FILE" ]; then
+    if [ "$ENV_FILE" = .env.worktree ]; then
+      bash "$REPO_ROOT/scripts/init-worktree-env.sh" "$ENV_FILE" >/dev/null
+    else
+      cp "$REPO_ROOT/.env.example" "$REPO_ROOT/$ENV_FILE"
+    fi
+    info "Created $ENV_FILE"
+  fi
+  ensure_dev_code "$ENV_FILE"
+  load_env_file "$ENV_FILE"
+
+  acquire_lock
+  trap release_lock EXIT
+  local existing offset
+  existing="$(env_name_for_dir "$REPO_ROOT" || true)"
+  if [ -n "$existing" ] && [ -z "$name" ]; then
+    name="$existing"
+  fi
+
+  if [ -n "$existing" ]; then
+    load_manifest "$existing"
+    NAME="$existing"
+    info "Reusing environment $NAME (ports $BACKEND_PORT/$FRONTEND_PORT, database $DB_NAME)"
+  else
+    offset=$((PORT - 18080))
+    # A slot is adopted only when the registry does not hold it and both ports
+    # are genuinely free; otherwise a fresh one is allocated and the env file is
+    # rewritten, which is the whole point of allocating instead of computing.
+    if [ "$PORT" -lt 18080 ] || offset_registered "$offset" || ! port_free "$PORT" || ! port_free "$FRONTEND_PORT"; then
+      if [ "$PORT" -ge 18080 ] && { offset_registered "$offset" || ! port_free "$PORT"; }; then
+        warn "Slot $offset (port $PORT) is taken: $(describe_port_owner "$PORT"). Allocating another."
+      fi
+      offset="$(allocate_offset "$REPO_ROOT")" || die "No free slot left; run 'make gc' or 'make list'."
+      local new_backend=$((18080 + offset)) new_frontend=$((13000 + offset))
+      local new_db="multica_$(slugify "$(basename "$REPO_ROOT")")_${offset}"
+      rewrite_env_ports "$ENV_FILE" "$offset" "$new_backend" "$new_frontend" "$new_db"
+      load_env_file "$ENV_FILE"
+      info "Allocated slot $offset — backend $new_backend, frontend $new_frontend, database $new_db"
+    fi
+
+    NAME="${name:-$(slugify "$(basename "$REPO_ROOT")")-${offset}}"
+    [ ! -f "$(manifest_of "$NAME")" ] || die "Environment '$NAME' already exists for a different directory."
+    mkdir -p "$(env_dir "$NAME")/logs"
+    cat > "$(manifest_of "$NAME")" <<EOF
+NAME=$NAME
+DIR=$REPO_ROOT
+CREATED_AT=$(now_iso)
+OWNER=$owner
+TTL_HOURS=$ttl
+ENV_FILE=$ENV_FILE
+OFFSET=$offset
+BACKEND_PORT=$PORT
+FRONTEND_PORT=$FRONTEND_PORT
+DB_NAME=$POSTGRES_DB
+DATABASE_URL=$DATABASE_URL
+PROFILE=dev-$(slugify "$(basename "$REPO_ROOT")")-${offset}
+EOF
+    load_manifest "$NAME"
+    ok "Registered environment $NAME"
+  fi
+  release_lock
+  trap - EXIT
+
+  bind_paths
+  # The manifest is the source of truth from here on; re-export so every child
+  # sees the same values the registry recorded.
+  export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
+
+  if [ ! -d "$REPO_ROOT/node_modules" ] && { component_selected web || component_selected desktop; }; then
+    step "Dependencies"
+    (cd "$REPO_ROOT" && pnpm install) || die "pnpm install failed."
+  fi
+
+  step "Database"
+  ensure_database
+  migrate_database
+  ok "$DB_NAME reachable through DATABASE_URL and migrated"
+
+  step "Components: $COMPONENTS"
+  component_selected api && start_api
+  component_selected web && start_web
+  component_selected daemon && start_daemon
+  component_selected desktop && start_desktop
+
+  print_handoff
+}
+
+cmd_down() {
+  local name="" requested="$ALL_COMPONENTS"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --components|-c) requested="$(printf '%s' "$2" | tr ',' ' ')"; shift 2 ;;
+      -*) die "Unknown flag for down: $1" ;;
+      *) name="$1"; shift ;;
+    esac
+  done
+  resolve_env_for_read "$name"
+  export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
+
+  step "Stopping $NAME: $requested"
+  local comp
+  for comp in $requested; do stop_component "$comp"; done
+  printf '\n%s✓ %s stopped.%s Database, profile and slot kept — `make up` restarts in seconds.\n' "$C_GREEN" "$NAME" "$C_OFF"
+}
+
+cmd_destroy() {
+  local name="" assume_yes=0 reply admin_url
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --yes|-y) assume_yes=1; shift ;;
+      -*) die "Unknown flag for destroy: $1" ;;
+      *) name="$1"; shift ;;
+    esac
+  done
+  resolve_env_for_read "$name"
+
+  if [ "$assume_yes" != 1 ]; then
+    printf 'Destroy %s? This drops database %s and profile %s. [y/N] ' "$NAME" "$DB_NAME" "$PROFILE"
+    read -r reply || reply=n
+    case "$reply" in y|Y|yes|YES) ;; *) printf 'Cancelled.\n'; return 0 ;; esac
+  fi
+
+  export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
+  step "Destroying $NAME"
+  local comp
+  for comp in $ALL_COMPONENTS; do stop_component "$comp"; done
+
+  if command -v psql >/dev/null 2>&1; then
+    admin_url="$(admin_database_url "$DATABASE_URL")"
+    if PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc 'SELECT 1' >/dev/null 2>&1; then
+      psql "$admin_url" -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$DB_NAME\" WITH (FORCE)" >/dev/null \
+        && ok "dropped database $DB_NAME"
+    else
+      warn "Nothing answered on the database host; $DB_NAME was left in place."
+    fi
+  else
+    warn "psql not found; $DB_NAME was left in place."
+  fi
+
+  rm -rf "$PROFILE_DIR" && ok "removed CLI profile $PROFILE"
+  rm -rf "$(env_dir "$NAME")" && ok "released slot $OFFSET"
+  printf '\n%s✓ %s destroyed.%s\n' "$C_GREEN" "$NAME" "$C_OFF"
+}
+
+cmd_status() {
+  local name="" as_json=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) as_json=1; shift ;;
+      -*) die "Unknown flag for status: $1" ;;
+      *) name="$1"; shift ;;
+    esac
+  done
+  resolve_env_for_read "$name"
+  if [ "$as_json" = 1 ]; then print_status_json; else print_status_human; fi
+}
+
+cmd_list() {
+  local as_json=0 name first=1 alive
+  [ "${1:-}" = "--json" ] && as_json=1
+
+  if [ "$as_json" = 1 ]; then printf '['; fi
+  local printed=0
+  while read -r name; do
+    [ -n "$name" ] || continue
+    (
+      load_manifest "$name"
+      bind_paths
+      alive=stopped
+      curl -sf --max-time 2 "http://localhost:${BACKEND_PORT}/health" >/dev/null 2>&1 && alive=running
+      if [ "$as_json" = 1 ]; then
+        printf '{"name":"%s","dir":"%s","owner":"%s","api":"%s","backend_port":%s,"frontend_port":%s,"database":"%s","created_at":"%s","ttl_hours":%s}' \
+          "$(json_escape "$NAME")" "$(json_escape "$DIR")" "$(json_escape "$OWNER")" "$alive" \
+          "$BACKEND_PORT" "$FRONTEND_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}"
+      else
+        printf '%-24s %-8s %-8s %-6s %-28s %s\n' "$NAME" "$alive" "$OWNER" \
+          "$BACKEND_PORT" "$DB_NAME" "$( [ -d "$DIR" ] && printf '%s' "$DIR" || printf '%s(directory gone)%s' "$C_RED" "$C_OFF" )"
+      fi
+    ) | { if [ "$as_json" = 1 ] && [ "$printed" != 0 ]; then printf ','; fi; cat; }
+    printed=1
+    first=0
+  done <<EOF
+$(list_env_names)
+EOF
+  if [ "$as_json" = 1 ]; then
+    printf ']\n'
+  elif [ "$printed" = 0 ]; then
+    printf 'No environments registered. Run `make up`.\n'
+  fi
+}
+
+# Leaks become visible here rather than being discovered by counting databases
+# in psql: an environment whose directory is gone, or whose TTL has passed, has
+# no owner left to stop it.
+cmd_gc() {
+  local dry_run=0 name age_hours created_epoch reason
+  [ "${1:-}" = "--dry-run" ] && dry_run=1
+
+  while read -r name; do
+    [ -n "$name" ] || continue
+    (
+      load_manifest "$name"
+      reason=""
+      [ -d "$DIR" ] || reason="its checkout directory is gone"
+      if [ -z "$reason" ] && [ "${TTL_HOURS:-0}" != 0 ]; then
+        created_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$CREATED_AT" 2>/dev/null || echo 0)"
+        age_hours=$(( ($(now_epoch) - created_epoch) / 3600 ))
+        [ "$age_hours" -lt "$TTL_HOURS" ] || reason="it expired ${age_hours}h after a ${TTL_HOURS}h ttl"
+      fi
+      [ -n "$reason" ] || exit 0
+      if [ "$dry_run" = 1 ]; then
+        printf '%s would be collected: %s\n' "$NAME" "$reason"
+      else
+        printf '%s: %s\n' "$NAME" "$reason"
+        bash "$REPO_ROOT/scripts/dev-env.sh" destroy "$NAME" --yes
+      fi
+    )
+  done <<EOF
+$(list_env_names)
+EOF
+}
+
+# Runs a command with this environment's variables, without the agent runtime's
+# production MULTICA_* values and with a durable TMPDIR. Replaces the prefix
+# people used to have to copy out of a document by hand.
+cmd_exec() {
+  local name=""
+  if [ "${1:-}" != "--" ] && [ $# -gt 0 ]; then name="$1"; shift; fi
+  [ "${1:-}" = "--" ] && shift
+  [ $# -gt 0 ] || die "Usage: dev-env.sh exec [name] -- <command> [args...]"
+
+  resolve_env_for_read "$name"
+  mkdir -p "$DEV_TMPDIR"
+  cd "$DIR"
+  load_env_file "$ENV_FILE"
+  export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
+  export TMPDIR="$DEV_TMPDIR" TMP="$DEV_TMPDIR" TEMP="$DEV_TMPDIR"
+  export MULTICA_DEV_PROFILE="$PROFILE"
+  exec "${CLEAN_ENV[@]}" "$@"
+}
+
+usage() {
+  cat <<'EOF'
+Local development environments: named, listable, deletable.
+
+  dev-env.sh up      [--components api,web,daemon,desktop] [--all]
+                     [--name N] [--ephemeral] [--ttl HOURS]
+  dev-env.sh status  [name] [--json]
+  dev-env.sh list    [--json]
+  dev-env.sh down    [name] [--components ...]
+  dev-env.sh destroy [name] [--yes]
+  dev-env.sh gc      [--dry-run]
+  dev-env.sh exec    [name] -- <command> [args...]
+
+Components: api (Go backend), web (Next.js), daemon (agent daemon),
+desktop (Electron). Anything selected implies api.
+
+down keeps the database, the CLI profile and the allocated slot.
+destroy consumes them.
+EOF
+}
+
+main() {
+  local verb="${1:-}"
+  [ $# -gt 0 ] && shift || true
+  case "$verb" in
+    up) cmd_up "$@" ;;
+    down) cmd_down "$@" ;;
+    status) cmd_status "$@" ;;
+    list|ls) cmd_list "$@" ;;
+    destroy) cmd_destroy "$@" ;;
+    gc) cmd_gc "$@" ;;
+    exec) cmd_exec "$@" ;;
+    ""|-h|--help|help) usage ;;
+    *) usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -30,6 +30,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_HOME="${MULTICA_DEV_HOME:-$HOME/.multica/dev}"
 ENVS_DIR="$DEV_HOME/envs"
 LOCK_DIR="$DEV_HOME/lock.d"
+DEV_WORKSPACES_PARENT="${MULTICA_DEV_WORKSPACES_PARENT:-$HOME}"
+DEV_DESKTOP_APP_DATA="${MULTICA_DEV_DESKTOP_APP_DATA:-}"
+DEV_PROFILES_HOME="${MULTICA_DEV_PROFILES_HOME:-$HOME/.multica/profiles}"
 
 DEV_EMAIL="${MULTICA_DEV_EMAIL:-dev@localhost}"
 DEV_CODE_DEFAULT=888888
@@ -53,7 +56,9 @@ DEV_TMPDIR="${MULTICA_DEV_TMPDIR:-$HOME/.multica/dev-tmp}"
 CLEAN_ENV=(env
   -u MULTICA_SERVER_URL -u MULTICA_TOKEN -u MULTICA_WORKSPACE_ID
   -u MULTICA_DAEMON_PORT -u MULTICA_AGENT_ID -u MULTICA_AGENT_NAME
-  -u MULTICA_TASK_ID -u MULTICA_TASK_SLOT)
+  -u MULTICA_TASK_ID -u MULTICA_TASK_SLOT
+  -u MULTICA_TASK_CONFIG_ROOT -u MULTICA_TASK_WORKSPACES_ROOT
+  -u MULTICA_WORKSPACES_ROOT)
 
 # ---------------------------------------------------------------- output ----
 
@@ -75,6 +80,13 @@ json_escape() {
 
 now_iso() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
 now_epoch() { date -u '+%s'; }
+
+expires_at_after_hours() {
+  node -e '
+    const hours = Number(process.argv[1]);
+    process.stdout.write(new Date(Date.now() + hours * 3600_000).toISOString().replace(/\.\d{3}Z$/, "Z"));
+  ' "$1"
+}
 
 # ----------------------------------------------------------------- locking ---
 
@@ -105,6 +117,23 @@ release_lock() { rm -rf "$LOCK_DIR"; }
 env_dir()      { printf '%s/%s' "$ENVS_DIR" "$1"; }
 manifest_of()  { printf '%s/%s/manifest.env' "$ENVS_DIR" "$1"; }
 
+valid_env_name() {
+  case "$1" in
+    ""|*[!a-z0-9_-]*|-*|_*) return 1 ;;
+    *) [ "${#1}" -le 128 ] ;;
+  esac
+}
+
+require_env_name() {
+  valid_env_name "$1" || die "Invalid environment name '$1'. Use 1-128 lowercase letters, numbers, '-' or '_', starting with a letter or number."
+}
+
+require_ttl() {
+  case "$1" in
+    ""|0|*[!0-9]*) die "TTL must be a positive integer number of hours." ;;
+  esac
+}
+
 list_env_names() {
   [ -d "$ENVS_DIR" ] || return 0
   local path
@@ -118,21 +147,37 @@ list_env_names() {
 # Loads a manifest into NAME/DIR/BACKEND_PORT/... in the caller's scope.
 load_manifest() {
   local file
+  require_env_name "$1"
   file="$(manifest_of "$1")"
   [ -f "$file" ] || return 1
   # shellcheck disable=SC1090
   . "$file"
+  [ "$NAME" = "$1" ] || die "Manifest $file declares NAME=$NAME; expected $1."
 }
 
 # Prints nothing (and succeeds) for a missing manifest or key: callers compare
 # the value, and a non-zero return from a command substitution is fatal under
 # `set -e` on bash 3.2.
 manifest_field() {
-  local file value
+  local file key=$2
+  require_env_name "$1"
   file="$(manifest_of "$1")"
   [ -f "$file" ] || return 0
-  value="$(grep "^$2=" "$file" | head -1 | cut -d= -f2- || true)"
-  printf '%s' "$value"
+  (
+    # shellcheck disable=SC1090
+    . "$file"
+    case "$key" in
+      DIR) printf '%s' "$DIR" ;;
+      OFFSET) printf '%s' "$OFFSET" ;;
+      *) return 1 ;;
+    esac
+  )
+}
+
+write_manifest_value() {
+  printf '%s=' "$1"
+  printf '%q' "$2"
+  printf '\n'
 }
 
 env_name_for_dir() {
@@ -176,13 +221,37 @@ describe_port_owner() {
 # -------------------------------------------------------------- allocation ---
 
 slugify() {
-  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//'
+  local slug
+  slug="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
+  printf '%s' "${slug:-env}"
 }
 
 path_offset() {
   local sum
   sum="$(printf '%s' "$1" | cksum | awk '{print $1}')"
   printf '%s' $((sum % 1000))
+}
+
+renderer_port_for_offset() {
+  local port=$((5174 + $1))
+  [ "$port" -ne 6000 ] || port=6174
+  printf '%s' "$port"
+}
+
+desktop_app_data_root() {
+  if [ -n "$DEV_DESKTOP_APP_DATA" ]; then
+    printf '%s' "$DEV_DESKTOP_APP_DATA"
+    return 0
+  fi
+  case "$(uname -s)" in
+    Darwin) printf '%s/Library/Application Support' "$HOME" ;;
+    MINGW*|MSYS*|CYGWIN*) printf '%s' "${APPDATA:-$HOME/AppData/Roaming}" ;;
+    *) printf '%s' "${XDG_CONFIG_HOME:-$HOME/.config}" ;;
+  esac
+}
+
+desktop_user_data_dir() {
+  printf '%s/Multica Canary %s' "$(desktop_app_data_root)" "$1"
 }
 
 offset_registered() {
@@ -205,15 +274,17 @@ EOF
 # are actually free — the registry alone cannot see a process started before
 # this tooling existed.
 allocate_offset() {
-  local dir=$1 self=${2:-} start i offset backend frontend
+  local dir=$1 self=${2:-} start i offset backend frontend renderer
   start="$(path_offset "$dir")"
   for i in $(seq 0 999); do
     offset=$(((start + i) % 1000))
     backend=$((18080 + offset))
     frontend=$((13000 + offset))
+    renderer="$(renderer_port_for_offset "$offset")"
     offset_registered "$offset" "$self" && continue
     port_free "$backend" || continue
     port_free "$frontend" || continue
+    port_free "$renderer" || continue
     printf '%s' "$offset"
     return 0
   done
@@ -235,12 +306,13 @@ detect_env_file() {
 }
 
 load_env_file() {
+  local root="${2:-$REPO_ROOT}"
   set -a
   # shellcheck disable=SC1090
-  . "$REPO_ROOT/$1"
+  . "$root/$1"
   set +a
   # shellcheck disable=SC1091
-  . "$REPO_ROOT/scripts/local-env.sh"
+  . "$root/scripts/local-env.sh"
 }
 
 # The verification code has to be in the file BEFORE the backend starts: the
@@ -263,14 +335,17 @@ ensure_dev_code() {
 }
 
 rewrite_env_ports() {
-  local file="$REPO_ROOT/$1" offset=$2 backend=$3 frontend=$4 db=$5 tmp
+  local file="$REPO_ROOT/$1" offset=$2 backend=$3 frontend=$4 db=$5 tmp database_url escaped_database_url
+  database_url="$(database_url_with_name "${DATABASE_URL:-}" "$db")" \
+    || die "DATABASE_URL is not a valid PostgreSQL URL: ${DATABASE_URL:-<unset>}"
+  escaped_database_url="$(printf '%s' "$database_url" | sed 's/[\\&|]/\\&/g')"
   tmp="$(mktemp)"
   sed \
     -e "s|^PORT=.*|PORT=${backend}|" \
     -e "s|^FRONTEND_PORT=.*|FRONTEND_PORT=${frontend}|" \
     -e "s|^FRONTEND_ORIGIN=.*|FRONTEND_ORIGIN=http://localhost:${frontend}|" \
     -e "s|^POSTGRES_DB=.*|POSTGRES_DB=${db}|" \
-    -e "s|^DATABASE_URL=.*|DATABASE_URL=postgres://multica:multica@localhost:5432/${db}?sslmode=disable|" \
+    -e "s|^DATABASE_URL=.*|DATABASE_URL=${escaped_database_url}|" \
     -e "s|^MULTICA_SERVER_URL=.*|MULTICA_SERVER_URL=ws://localhost:${backend}/ws|" \
     -e "s|^MULTICA_PUBLIC_URL=.*|MULTICA_PUBLIC_URL=http://localhost:${backend}|" \
     -e "s|^MULTICA_APP_URL=.*|MULTICA_APP_URL=http://localhost:${frontend}|" \
@@ -288,6 +363,15 @@ admin_database_url() {
     url.pathname = "/postgres";
     process.stdout.write(url.toString());
   ' "$1" 2>/dev/null || true
+}
+
+database_url_with_name() {
+  node -e '
+    const url = new URL(process.argv[1]);
+    if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") process.exit(1);
+    url.pathname = "/" + process.argv[2];
+    process.stdout.write(url.toString());
+  ' "$1" "$2" 2>/dev/null
 }
 
 # Diagnoses the failure mode this whole script exists to make impossible:
@@ -343,6 +427,7 @@ component_selected() {
 }
 
 pid_file()  { printf '%s/%s.pid' "$STATE_DIR" "$1"; }
+listener_pid_file() { printf '%s/%s.listener.pid' "$STATE_DIR" "$1"; }
 log_file()  { printf '%s/%s.log' "$LOG_DIR" "$1"; }
 
 component_pid() {
@@ -383,16 +468,60 @@ json_field() {
 api_started_after() {
   local started_at epoch
   started_at="$(json_field "$1" started_at || true)"
-  [ -n "$started_at" ] || return 0 # older build without process identity
+  [ -n "$started_at" ] || return 1
   epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$started_at" 2>/dev/null || echo 0)"
   [ "$epoch" -ge $(($2 - 5)) ]
 }
 
+checkout_commit() {
+  git -C "${DIR:-$REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || printf 'unknown'
+}
+
+process_group_id() {
+  ps -p "$1" -o pgid= 2>/dev/null | tr -d ' ' || true
+}
+
+listener_belongs_to_component() {
+  local component=$1 port=$2 launcher listener recorded
+  launcher="$(component_pid "$component" || true)"
+  listener="$(port_listener_pid "$port")"
+  [ -n "$launcher" ] && [ -n "$listener" ] || return 1
+  recorded="$(cat "$(listener_pid_file "$component")" 2>/dev/null || true)"
+  [ -n "$recorded" ] && [ "$listener" = "$recorded" ] && return 0
+  [ "$(process_group_id "$listener")" = "$launcher" ]
+}
+
+health_belongs_to_api() {
+  local health=$1 health_pid listener
+  health_pid="$(json_field "$health" pid || true)"
+  listener="$(port_listener_pid "$BACKEND_PORT")"
+  [ -n "$health_pid" ] && [ "$health_pid" = "$listener" ] \
+    && listener_belongs_to_component api "$BACKEND_PORT"
+}
+
+api_identity_matches() {
+  local health=$1 expected_commit=$2 launched_at=${3:-0} reported_commit started_at
+  health_belongs_to_api "$health" || return 1
+  reported_commit="$(json_field "$health" commit || true)"
+  started_at="$(json_field "$health" started_at || true)"
+  [ -n "$started_at" ] && [ "$reported_commit" = "$expected_commit" ] || return 1
+  [ "$launched_at" = 0 ] || api_started_after "$health" "$launched_at"
+}
+
 start_api() {
-  local launched_at health waited=0
+  local launched_at health waited=0 expected_commit
+  expected_commit="$(checkout_commit)"
   if health="$(health_json)" && [ -n "$health" ] && component_pid api >/dev/null; then
-    ok "api already running on :$BACKEND_PORT"
-    return 0
+    if api_identity_matches "$health" "$expected_commit"; then
+      ok "api already running on :$BACKEND_PORT (pid $(json_field "$health" pid), commit $expected_commit)"
+      return 0
+    fi
+    if health_belongs_to_api "$health"; then
+      warn "api on :$BACKEND_PORT is ours but not commit $expected_commit; restarting it."
+      stop_component api
+    else
+      die "Port $BACKEND_PORT answers /health, but its pid/commit does not match this environment. Refusing to reuse or kill it."
+    fi
   fi
   if ! port_free "$BACKEND_PORT"; then
     die "Port $BACKEND_PORT is busy: $(describe_port_owner "$BACKEND_PORT").
@@ -406,11 +535,13 @@ Run 'make down' here first — a leftover instance answers /health with 200 and 
   while [ "$waited" -lt 300 ]; do
     health="$(health_json || true)"
     if [ -n "$health" ]; then
-      # A 200 is not enough. If the answer predates this launch, something else
-      # owns the port and every later step would configure the wrong server.
-      api_started_after "$health" "$launched_at" \
-        || die "Something else is serving :$BACKEND_PORT — it started before this run. Stop it and retry."
-      ok "api healthy at http://localhost:$BACKEND_PORT (pid $(json_field "$health" pid || echo '?'), commit $(json_field "$health" commit || echo '?'))"
+      # A 200 is not enough: pid, process group, commit and launch time all have
+      # to identify the process this environment just started.
+      if ! api_identity_matches "$health" "$expected_commit" "$launched_at"; then
+        stop_component api
+        die "Something else is serving :$BACKEND_PORT, or the launched api did not report pid/commit/started_at for commit $expected_commit."
+      fi
+      ok "api healthy at http://localhost:$BACKEND_PORT (pid $(json_field "$health" pid), commit $expected_commit)"
       return 0
     fi
     component_pid api >/dev/null || { tail -20 "$(log_file api)" | sed 's/^/    /' >&2; die "api exited during startup. Log: $(log_file api)"; }
@@ -422,7 +553,8 @@ Run 'make down' here first — a leftover instance answers /health with 200 and 
 
 start_web() {
   local waited=0 listener
-  if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1 && component_pid web >/dev/null; then
+  if curl -sf --max-time 15 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1 \
+    && listener_belongs_to_component web "$FRONTEND_PORT"; then
     ok "web already running on :$FRONTEND_PORT"
     return 0
   fi
@@ -434,8 +566,12 @@ start_web() {
   info "web launching (pid $(cat "$(pid_file web)")), log: $(log_file web)"
 
   while [ "$waited" -lt 300 ]; do
-    if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+    if curl -sf --max-time 15 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
       listener="$(port_listener_pid "$FRONTEND_PORT")"
+      if ! listener_belongs_to_component web "$FRONTEND_PORT"; then
+        stop_component web
+        die "Web on :$FRONTEND_PORT is not owned by the process group this environment launched."
+      fi
       ok "web serving http://localhost:$FRONTEND_PORT (pid ${listener:-?})"
       return 0
     fi
@@ -448,6 +584,21 @@ start_web() {
 
 # send-code once, verify-code once. Repeated verify attempts lock the code out
 # and start returning 400 even when it is correct, so retrying is self-defeating.
+write_profile_config() {
+  local config=$1 pat=$2 ws=$3
+  mkdir -p "$PROFILE_DIR"
+  cat > "$config" <<EOF
+{
+  "server_url": "http://localhost:${BACKEND_PORT}",
+  "app_url": "http://localhost:${FRONTEND_PORT}",
+  "token": "$(json_escape "$pat")",
+  "workspace_id": "$(json_escape "$ws")",
+  "workspaces_root": "$(json_escape "$WORKSPACES_ROOT")"
+}
+EOF
+  chmod 600 "$config"
+}
+
 ensure_credentials() {
   local server="http://localhost:${BACKEND_PORT}" config="$PROFILE_DIR/config.json"
   local code="${MULTICA_DEV_VERIFICATION_CODE:-$DEV_CODE_DEFAULT}"
@@ -458,6 +609,7 @@ ensure_credentials() {
     ws="$(json_field "$(cat "$config")" workspace_id || true)"
     if [ -n "$pat" ] && curl -sf --max-time 5 "$server/api/me" -H "Authorization: Bearer $pat" >/dev/null 2>&1; then
       WORKSPACE_ID="$ws"
+      write_profile_config "$config" "$pat" "$ws"
       ok "CLI profile $PROFILE already authenticated"
       return 0
     fi
@@ -501,16 +653,7 @@ Do not retry immediately — repeated attempts lock the code. Wait ~40s and re-r
     -H "Authorization: Bearer $pat" -H "X-Workspace-ID: $ws" \
     -H 'Content-Type: application/json' -d '{"exit":"existing"}' >/dev/null 2>&1 || true
 
-  mkdir -p "$PROFILE_DIR"
-  cat > "$config" <<EOF
-{
-  "server_url": "http://localhost:${BACKEND_PORT}",
-  "app_url": "http://localhost:${FRONTEND_PORT}",
-  "token": "$pat",
-  "workspace_id": "$ws"
-}
-EOF
-  chmod 600 "$config"
+  write_profile_config "$config" "$pat" "$ws"
   WORKSPACE_ID="$ws"
   ok "Logged in as $DEV_EMAIL and wrote profile $PROFILE"
 }
@@ -545,9 +688,11 @@ start_daemon() {
   info "Building $MULTICA_BIN (a go run daemon would fail every task later)."
   (cd "$REPO_ROOT/server" && go build -o bin/multica ./cmd/multica) || die "Failed to build the multica CLI."
 
-  "${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon start --profile "$PROFILE" 2>&1 | sed 's/^/    /' || true
+  "${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" \
+    "$MULTICA_BIN" daemon start --profile "$PROFILE" 2>&1 | sed 's/^/    /' || true
 
-  status="$("${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+  status="$("${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" \
+    "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
   state="$(json_field "$status" status || echo unknown)"
   # `daemon status` reports "stopped" plus port_conflict when the daemon
   # answering this profile's health port belongs to another profile, so a
@@ -562,45 +707,117 @@ start_daemon() {
 }
 
 start_desktop() {
-  local desktop_env="$REPO_ROOT/apps/desktop/.env.development.local"
-  if component_pid desktop >/dev/null; then
-    ok "desktop already running (pid $(component_pid desktop))"
-    return 0
+  local waited=0 listener stable_listener
+  if component_pid desktop >/dev/null \
+    && curl -sf --max-time 10 "http://localhost:${DESKTOP_RENDERER_PORT}" >/dev/null 2>&1 \
+    && listener_belongs_to_component desktop "$DESKTOP_RENDERER_PORT" \
+    && desktop_env_matches; then
+      ok "desktop already running (pid $(component_pid desktop), renderer :$DESKTOP_RENDERER_PORT)"
+      return 0
   fi
-  # Which backend the renderer talks to is controlled only by this file; the
-  # per-worktree renderer port and app name are derived by dev:desktop itself.
-  cat > "$desktop_env" <<EOF
+  if component_pid desktop >/dev/null; then
+    warn "desktop launcher exists but its renderer/backend identity is stale; restarting it."
+    stop_component desktop
+  fi
+  if ! port_free "$DESKTOP_RENDERER_PORT"; then
+    die "Desktop renderer port $DESKTOP_RENDERER_PORT is busy: $(describe_port_owner "$DESKTOP_RENDERER_PORT")."
+  fi
+
+  # The marker makes destroy remove only a file this tool owns. Explicit
+  # renderer/app values bind Desktop to the registry allocation rather than
+  # independently hashing the checkout path again.
+  cat > "$DESKTOP_ENV_FILE" <<EOF
+# Managed by scripts/dev-env.sh for environment ${NAME}.
 VITE_API_URL=http://localhost:${BACKEND_PORT}
 VITE_WS_URL=ws://localhost:${BACKEND_PORT}/ws
 EOF
-  launch_detached desktop make -C "$REPO_ROOT" -s desktop-dev ENV_FILE="$ENV_FILE"
-  sleep 2
-  component_pid desktop >/dev/null \
-    || { tail -20 "$(log_file desktop)" | sed 's/^/    /' >&2; die "desktop exited immediately. Log: $(log_file desktop)"; }
-  ok "desktop launching (pid $(component_pid desktop)), pointed at :$BACKEND_PORT — log: $(log_file desktop)"
+  launch_detached desktop env \
+    DESKTOP_RENDERER_PORT="$DESKTOP_RENDERER_PORT" DESKTOP_APP_SUFFIX="$DESKTOP_APP_SUFFIX" \
+    make -C "$REPO_ROOT" -s desktop-dev ENV_FILE="$ENV_FILE"
+
+  while [ "$waited" -lt 300 ]; do
+    if curl -sf --max-time 10 "http://localhost:${DESKTOP_RENDERER_PORT}" >/dev/null 2>&1; then
+      listener="$(port_listener_pid "$DESKTOP_RENDERER_PORT")"
+      if ! component_pid desktop >/dev/null || [ -z "$listener" ] || ! desktop_env_matches; then
+        stop_component desktop
+        die "Desktop renderer on :$DESKTOP_RENDERER_PORT does not belong to this environment."
+      fi
+      # Electron can bring Vite up and then crash during renderer bootstrap.
+      # Require a short stable window before the environment claims readiness.
+      sleep 5
+      stable_listener="$(port_listener_pid "$DESKTOP_RENDERER_PORT")"
+      if ! component_pid desktop >/dev/null || [ "$stable_listener" != "$listener" ] \
+        || ! curl -sf --max-time 10 "http://localhost:${DESKTOP_RENDERER_PORT}" >/dev/null 2>&1; then
+        tail -20 "$(log_file desktop)" | sed 's/^/    /' >&2 || true
+        stop_component desktop
+        die "desktop exited during renderer bootstrap. Log: $(log_file desktop)"
+      fi
+      printf '%s\n' "$listener" > "$(listener_pid_file desktop)"
+      ok "desktop ready (launcher $(component_pid desktop), renderer pid ${listener:-?}, backend :$BACKEND_PORT)"
+      return 0
+    fi
+    component_pid desktop >/dev/null \
+      || { tail -20 "$(log_file desktop)" | sed 's/^/    /' >&2; die "desktop exited during startup. Log: $(log_file desktop)"; }
+    sleep 2
+    waited=$((waited + 2))
+  done
+  stop_component desktop
+  die "desktop renderer never became ready on :$DESKTOP_RENDERER_PORT. Log: $(log_file desktop)"
+}
+
+desktop_env_matches() {
+  [ -f "$DESKTOP_ENV_FILE" ] \
+    && grep -Fqx "# Managed by scripts/dev-env.sh for environment ${NAME}." "$DESKTOP_ENV_FILE" \
+    && grep -Fqx "VITE_API_URL=http://localhost:${BACKEND_PORT}" "$DESKTOP_ENV_FILE" \
+    && grep -Fqx "VITE_WS_URL=ws://localhost:${BACKEND_PORT}/ws" "$DESKTOP_ENV_FILE"
 }
 
 stop_component() {
-  local name=$1 pid
+  local name=$1 pid launcher="" status state recorded_listener=""
   case "$name" in
     daemon)
       if [ -x "$MULTICA_BIN" ]; then
-        "${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon stop --profile "$PROFILE" >/dev/null 2>&1 \
-          && ok "daemon stopped" || info "daemon was not running"
+        if "${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" \
+          "$MULTICA_BIN" daemon stop --profile "$PROFILE" >/dev/null 2>&1; then
+          ok "daemon stopped"
+        else
+          status="$("${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" \
+            "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+          state="$(json_field "$status" status || echo stopped)"
+          if [ "$state" = running ]; then
+            warn "daemon for profile $PROFILE is still running"
+            return 1
+          fi
+          info "daemon was not running"
+        fi
       else
-        info "daemon skipped ($MULTICA_BIN not built, so nothing here started one)"
+        pid="$(cat "$PROFILE_DIR/daemon.pid" 2>/dev/null || true)"
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+          warn "cannot stop daemon pid $pid because no usable multica binary was found"
+          return 1
+        fi
+        info "daemon skipped (no usable binary and no live profile pid)"
       fi
       return 0
       ;;
   esac
 
+  recorded_listener="$(cat "$(listener_pid_file "$name")" 2>/dev/null || true)"
   pid="$(component_pid "$name" || true)"
   if [ -n "$pid" ]; then
+    launcher="$pid"
     # Negative pid targets the process group, so make → go run → server all go
     # down together instead of leaving the real listener orphaned.
     kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
     sleep 1
-    kill -0 "$pid" 2>/dev/null && { kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true; }
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+      sleep 1
+    fi
+    if kill -0 "$pid" 2>/dev/null; then
+      warn "$name launcher pid $pid is still running"
+      return 1
+    fi
     rm -f "$(pid_file "$name")"
     ok "$name stopped (pid $pid)"
   else
@@ -608,23 +825,39 @@ stop_component() {
     info "$name was not running"
   fi
 
-  # A process group kill misses a listener that reparented away from it. Only
-  # LISTEN sockets are considered, never clients of the port.
+  # A process group kill can miss a listener that has reparented away from its
+  # launcher. Only kill that listener when its process group still proves it
+  # belongs to the recorded launcher; a stale manifest must never kill an
+  # unrelated process that later reused the port.
   local port=""
   case "$name" in
     api) port="$BACKEND_PORT" ;;
     web) port="$FRONTEND_PORT" ;;
+    desktop) port="$DESKTOP_RENDERER_PORT" ;;
   esac
   if [ -n "$port" ]; then
     local listener
     listener="$(port_listener_pid "$port")"
     if [ -n "$listener" ]; then
-      kill -TERM "$listener" 2>/dev/null || true
-      sleep 1
-      kill -0 "$listener" 2>/dev/null && kill -KILL "$listener" 2>/dev/null || true
-      info "released :$port (pid $listener)"
+      if { [ -n "$recorded_listener" ] && [ "$listener" = "$recorded_listener" ]; } \
+        || { [ -n "$launcher" ] && [ "$(process_group_id "$listener")" = "$launcher" ]; }; then
+        kill -TERM "$listener" 2>/dev/null || true
+        sleep 1
+        if kill -0 "$listener" 2>/dev/null; then
+          kill -KILL "$listener" 2>/dev/null || true
+          sleep 1
+        fi
+        if kill -0 "$listener" 2>/dev/null; then
+          warn "$name listener pid $listener is still running"
+          return 1
+        fi
+        info "released :$port (pid $listener)"
+      else
+        warn "left :$port alone: listener pid $listener is not owned by this environment"
+      fi
     fi
   fi
+  rm -f "$(listener_pid_file "$name")"
 }
 
 # ------------------------------------------------------------------ status ---
@@ -634,18 +867,23 @@ component_state() {
     api)
       local health
       health="$(health_json || true)"
-      if [ -n "$health" ]; then
+      if [ -n "$health" ] && api_identity_matches "$health" "$(checkout_commit)"; then
         printf 'running|http://localhost:%s|pid %s commit %s started %s' "$BACKEND_PORT" \
           "$(json_field "$health" pid || echo '?')" \
           "$(json_field "$health" commit || echo '?')" \
           "$(json_field "$health" started_at || echo '?')"
+      elif [ -n "$health" ]; then
+        printf 'mismatch|http://localhost:%s|health responder is not this checkout/process' "$BACKEND_PORT"
       else
         printf 'stopped|http://localhost:%s|' "$BACKEND_PORT"
       fi
       ;;
     web)
-      if curl -sf --max-time 3 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1; then
+      if curl -sf --max-time 10 "http://localhost:${FRONTEND_PORT}" >/dev/null 2>&1 \
+        && listener_belongs_to_component web "$FRONTEND_PORT"; then
         printf 'running|http://localhost:%s|pid %s' "$FRONTEND_PORT" "$(port_listener_pid "$FRONTEND_PORT")"
+      elif [ -n "$(port_listener_pid "$FRONTEND_PORT")" ]; then
+        printf 'mismatch|http://localhost:%s|listener is not owned by this environment' "$FRONTEND_PORT"
       else
         printf 'stopped|http://localhost:%s|' "$FRONTEND_PORT"
       fi
@@ -653,7 +891,8 @@ component_state() {
     daemon)
       local status state
       if [ -x "$MULTICA_BIN" ]; then
-        status="$("${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+        status="$("${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" \
+          "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
         state="$(json_field "$status" status || echo stopped)"
         printf '%s|%s|pid %s' "$state" "$PROFILE" "$(json_field "$status" pid || echo '-')"
       else
@@ -663,7 +902,17 @@ component_state() {
     desktop)
       local pid
       pid="$(component_pid desktop || true)"
-      if [ -n "$pid" ]; then printf 'running||pid %s' "$pid"; else printf 'stopped||'; fi
+      if [ -n "$pid" ] \
+        && curl -sf --max-time 10 "http://localhost:${DESKTOP_RENDERER_PORT}" >/dev/null 2>&1 \
+        && listener_belongs_to_component desktop "$DESKTOP_RENDERER_PORT" \
+        && desktop_env_matches; then
+        printf 'running|http://localhost:%s|launcher %s renderer %s' \
+          "$DESKTOP_RENDERER_PORT" "$pid" "$(port_listener_pid "$DESKTOP_RENDERER_PORT")"
+      elif [ -n "$pid" ] || [ -n "$(port_listener_pid "$DESKTOP_RENDERER_PORT")" ]; then
+        printf 'mismatch|http://localhost:%s|renderer/backend identity does not match' "$DESKTOP_RENDERER_PORT"
+      else
+        printf 'stopped|http://localhost:%s|' "$DESKTOP_RENDERER_PORT"
+      fi
       ;;
   esac
 }
@@ -679,7 +928,7 @@ print_status_human() {
     printf '  %-9s %-9s %-32s %s\n' "$comp" "$state" "${url:--}" "${detail:--}"
   done
   printf '  %-9s %-9s %-32s %s\n' database "$(database_state)" "$DB_NAME" "${DATABASE_URL%%\?*}"
-  printf '\n  owner %s · created %s%s\n' "$OWNER" "$CREATED_AT" "$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' · ttl %sh' "$TTL_HOURS" )"
+  printf '\n  owner %s · created %s%s\n' "$OWNER" "$CREATED_AT" "$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' · expires %s' "$EXPIRES_AT" )"
   printf '  logs  %s\n' "$LOG_DIR"
 }
 
@@ -699,11 +948,11 @@ database_state() {
 
 print_status_json() {
   local comp row state url detail first=1
-  printf '{"name":"%s","dir":"%s","owner":"%s","created_at":"%s","ttl_hours":%s,' \
+  printf '{"name":"%s","dir":"%s","owner":"%s","created_at":"%s","ttl_hours":%s,"expires_at":"%s",' \
     "$(json_escape "$NAME")" "$(json_escape "$DIR")" "$(json_escape "$OWNER")" \
-    "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}"
-  printf '"backend_port":%s,"frontend_port":%s,"database":"%s","profile":"%s","env_file":"%s","logs":"%s","components":{' \
-    "$BACKEND_PORT" "$FRONTEND_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$PROFILE")" \
+    "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}" "$(json_escape "$EXPIRES_AT")"
+  printf '"backend_port":%s,"frontend_port":%s,"desktop_renderer_port":%s,"database":"%s","profile":"%s","env_file":"%s","logs":"%s","components":{' \
+    "$BACKEND_PORT" "$FRONTEND_PORT" "$DESKTOP_RENDERER_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$PROFILE")" \
     "$(json_escape "$ENV_FILE")" "$(json_escape "$LOG_DIR")"
   for comp in $ALL_COMPONENTS; do
     row="$(component_state "$comp")"
@@ -718,15 +967,23 @@ print_status_json() {
 }
 
 print_handoff() {
+  local entrypoint
+  if component_selected web; then
+    entrypoint="Open        http://localhost:${FRONTEND_PORT}/${WORKSPACE_SLUG}/issues"
+  elif component_selected desktop; then
+    entrypoint="Desktop     renderer http://localhost:${DESKTOP_RENDERER_PORT} → backend :${BACKEND_PORT}"
+  else
+    entrypoint="API only    http://localhost:${BACKEND_PORT}"
+  fi
   cat <<EOF
 
 ${C_GREEN}✓ Environment ready.${C_OFF}
 
-  Open        http://localhost:${FRONTEND_PORT}/${WORKSPACE_SLUG}/issues
+  ${entrypoint}
   Sign in     ${DEV_EMAIL}  ·  code ${MULTICA_DEV_VERIFICATION_CODE:-$DEV_CODE_DEFAULT}
   Backend     http://localhost:${BACKEND_PORT}   (GET /health reports pid + commit + started_at)
   Commit      $(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)
-  Environment ${NAME}$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' (expires in %sh)' "$TTL_HOURS" )
+  Environment ${NAME}$( [ "${TTL_HOURS:-0}" != 0 ] && printf ' (expires %s)' "$EXPIRES_AT" )
 
   Inspect     make status
   Stop        make down            (keeps the database, restarts in seconds)
@@ -742,6 +999,7 @@ resolve_env_for_read() {
     name="$(env_name_for_dir "$REPO_ROOT" || true)"
     [ -n "$name" ] || die "No environment registered for $REPO_ROOT. Run 'make up' first."
   fi
+  require_env_name "$name"
   load_manifest "$name" || die "Unknown environment '$name'. Run 'make list' to see what exists."
   bind_paths
 }
@@ -749,24 +1007,59 @@ resolve_env_for_read() {
 bind_paths() {
   STATE_DIR="$(env_dir "$NAME")"
   LOG_DIR="$STATE_DIR/logs"
-  PROFILE_DIR="$HOME/.multica/profiles/$PROFILE"
-  MULTICA_BIN="$REPO_ROOT/server/bin/multica"
+  PROFILE_DIR="$DEV_PROFILES_HOME/$PROFILE"
+  WORKSPACES_ROOT="${WORKSPACES_ROOT:-$DEV_WORKSPACES_PARENT/multica_workspaces_$PROFILE}"
+  DESKTOP_RENDERER_PORT="${DESKTOP_RENDERER_PORT:-$(renderer_port_for_offset "$OFFSET")}"
+  DESKTOP_APP_SUFFIX="${DESKTOP_APP_SUFFIX:-$NAME}"
+  DESKTOP_USER_DATA_DIR="${DESKTOP_USER_DATA_DIR:-$(desktop_user_data_dir "$DESKTOP_APP_SUFFIX")}"
+  DESKTOP_ENV_FILE="${DESKTOP_ENV_FILE:-$DIR/apps/desktop/.env.development.local}"
+  EXPIRES_AT="${EXPIRES_AT:-}"
+  MULTICA_BIN="$DIR/server/bin/multica"
+  if [ ! -x "$MULTICA_BIN" ] && [ -x "$REPO_ROOT/server/bin/multica" ]; then
+    MULTICA_BIN="$REPO_ROOT/server/bin/multica"
+  fi
   mkdir -p "$LOG_DIR"
 }
 
+save_manifest() {
+  {
+    write_manifest_value NAME "$NAME"
+    write_manifest_value DIR "$DIR"
+    write_manifest_value CREATED_AT "$CREATED_AT"
+    write_manifest_value OWNER "$OWNER"
+    write_manifest_value TTL_HOURS "$TTL_HOURS"
+    write_manifest_value EXPIRES_AT "$EXPIRES_AT"
+    write_manifest_value ENV_FILE "$ENV_FILE"
+    write_manifest_value OFFSET "$OFFSET"
+    write_manifest_value BACKEND_PORT "$BACKEND_PORT"
+    write_manifest_value FRONTEND_PORT "$FRONTEND_PORT"
+    write_manifest_value DB_NAME "$DB_NAME"
+    write_manifest_value DATABASE_URL "$DATABASE_URL"
+    write_manifest_value PROFILE "$PROFILE"
+    write_manifest_value WORKSPACES_ROOT "$WORKSPACES_ROOT"
+    write_manifest_value DESKTOP_RENDERER_PORT "$DESKTOP_RENDERER_PORT"
+    write_manifest_value DESKTOP_APP_SUFFIX "$DESKTOP_APP_SUFFIX"
+    write_manifest_value DESKTOP_USER_DATA_DIR "$DESKTOP_USER_DATA_DIR"
+    write_manifest_value DESKTOP_ENV_FILE "$DESKTOP_ENV_FILE"
+  } > "$(manifest_of "$NAME")"
+}
+
 cmd_up() {
-  local requested="$DEFAULT_COMPONENTS" name="" owner=human ttl=0 comp
+  local requested="$DEFAULT_COMPONENTS" name="" owner=human ttl=0 lifecycle_requested=0 comp
 
   while [ $# -gt 0 ]; do
     case "$1" in
       --components|-c) requested="$(printf '%s' "$2" | tr ',' ' ')"; shift 2 ;;
       --all) requested="$ALL_COMPONENTS"; shift ;;
       --name) name="$2"; shift 2 ;;
-      --ephemeral) owner=agent; [ "$ttl" != 0 ] || ttl=24; shift ;;
-      --ttl) ttl="$2"; owner=agent; shift 2 ;;
+      --ephemeral) owner=agent; lifecycle_requested=1; [ "$ttl" != 0 ] || ttl=24; shift ;;
+      --ttl) ttl="$2"; owner=agent; lifecycle_requested=1; shift 2 ;;
       *) die "Unknown flag for up: $1" ;;
     esac
   done
+
+  [ -z "$name" ] || require_env_name "$name"
+  [ "$ttl" = 0 ] || require_ttl "$ttl"
 
   for comp in $requested; do
     case " $ALL_COMPONENTS " in *" $comp "*) ;; *) die "Unknown component '$comp'. Valid: $ALL_COMPONENTS" ;; esac
@@ -775,6 +1068,10 @@ cmd_up() {
   # without api would produce an environment that cannot serve a single request.
   case " $requested " in *" api "*) ;; *) requested="api $requested" ;; esac
   COMPONENTS="$requested"
+
+  # No resident cleanup service is required: every future environment start is
+  # a safe opportunity to collect expired or directory-less environments.
+  cmd_gc --auto
 
   step "Prerequisites"
   local missing=() tool needed="node go curl"
@@ -825,13 +1122,24 @@ Start the rest with 'make up C=api,web', or run 'make up C=daemon' from your own
   if [ -n "$existing" ]; then
     load_manifest "$existing"
     NAME="$existing"
+    bind_paths
+    if [ "$lifecycle_requested" = 1 ]; then
+      OWNER="$owner"
+      TTL_HOURS="$ttl"
+      EXPIRES_AT="$(expires_at_after_hours "$ttl")"
+      save_manifest
+    fi
     info "Reusing environment $NAME (ports $BACKEND_PORT/$FRONTEND_PORT, database $DB_NAME)"
   else
     offset=$((PORT - 18080))
     # A slot is adopted only when the registry does not hold it and both ports
     # are genuinely free; otherwise a fresh one is allocated and the env file is
     # rewritten, which is the whole point of allocating instead of computing.
-    if [ "$PORT" -lt 18080 ] || offset_registered "$offset" || ! port_free "$PORT" || ! port_free "$FRONTEND_PORT"; then
+    local candidate_renderer
+    candidate_renderer="$(renderer_port_for_offset "$offset")"
+    if [ "$PORT" -lt 18080 ] || [ "$FRONTEND_PORT" -ne $((13000 + offset)) ] \
+      || offset_registered "$offset" || ! port_free "$PORT" \
+      || ! port_free "$FRONTEND_PORT" || ! port_free "$candidate_renderer"; then
       if [ "$PORT" -ge 18080 ] && { offset_registered "$offset" || ! port_free "$PORT"; }; then
         warn "Slot $offset (port $PORT) is taken: $(describe_port_owner "$PORT"). Allocating another."
       fi
@@ -844,22 +1152,25 @@ Start the rest with 'make up C=api,web', or run 'make up C=daemon' from your own
     fi
 
     NAME="${name:-$(slugify "$(basename "$REPO_ROOT")")-${offset}}"
+    require_env_name "$NAME"
+    PROFILE="dev-$(slugify "$(basename "$REPO_ROOT")")-${offset}"
+    WORKSPACES_ROOT="$DEV_WORKSPACES_PARENT/multica_workspaces_$PROFILE"
+    DESKTOP_RENDERER_PORT="$(renderer_port_for_offset "$offset")"
+    DESKTOP_APP_SUFFIX="$NAME"
+    DESKTOP_USER_DATA_DIR="$(desktop_user_data_dir "$DESKTOP_APP_SUFFIX")"
+    DESKTOP_ENV_FILE="$REPO_ROOT/apps/desktop/.env.development.local"
     [ ! -f "$(manifest_of "$NAME")" ] || die "Environment '$NAME' already exists for a different directory."
     mkdir -p "$(env_dir "$NAME")/logs"
-    cat > "$(manifest_of "$NAME")" <<EOF
-NAME=$NAME
-DIR=$REPO_ROOT
-CREATED_AT=$(now_iso)
-OWNER=$owner
-TTL_HOURS=$ttl
-ENV_FILE=$ENV_FILE
-OFFSET=$offset
-BACKEND_PORT=$PORT
-FRONTEND_PORT=$FRONTEND_PORT
-DB_NAME=$POSTGRES_DB
-DATABASE_URL=$DATABASE_URL
-PROFILE=dev-$(slugify "$(basename "$REPO_ROOT")")-${offset}
-EOF
+    DIR="$REPO_ROOT"
+    CREATED_AT="$(now_iso)"
+    OWNER="$owner"
+    TTL_HOURS="$ttl"
+    EXPIRES_AT=""
+    [ "$ttl" = 0 ] || EXPIRES_AT="$(expires_at_after_hours "$ttl")"
+    OFFSET="$offset"
+    BACKEND_PORT="$PORT"
+    DB_NAME="$POSTGRES_DB"
+    save_manifest
     load_manifest "$NAME"
     ok "Registered environment $NAME"
   fi
@@ -904,12 +1215,16 @@ cmd_down() {
 
   step "Stopping $NAME: $requested"
   local comp
-  for comp in $requested; do stop_component "$comp"; done
+  for comp in $requested; do
+    case " $ALL_COMPONENTS " in *" $comp "*) ;; *) die "Unknown component '$comp'. Valid: $ALL_COMPONENTS" ;; esac
+    stop_component "$comp"
+  done
   printf '\n%s✓ %s stopped.%s Database, profile and slot kept — `make up` restarts in seconds.\n' "$C_GREEN" "$NAME" "$C_OFF"
 }
 
 cmd_destroy() {
-  local name="" assume_yes=0 reply admin_url
+  local name="" assume_yes=0 reply admin_url failures=0
+  local expected_workspaces expected_desktop_data
   while [ $# -gt 0 ]; do
     case "$1" in
       --yes|-y) assume_yes=1; shift ;;
@@ -928,22 +1243,73 @@ cmd_destroy() {
   export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
   step "Destroying $NAME"
   local comp
-  for comp in $ALL_COMPONENTS; do stop_component "$comp"; done
+  for comp in $ALL_COMPONENTS; do
+    if ! stop_component "$comp"; then failures=$((failures + 1)); fi
+  done
 
   if command -v psql >/dev/null 2>&1; then
     admin_url="$(admin_database_url "$DATABASE_URL")"
     if PGCONNECT_TIMEOUT=3 psql "$admin_url" -tAc 'SELECT 1' >/dev/null 2>&1; then
-      psql "$admin_url" -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$DB_NAME\" WITH (FORCE)" >/dev/null \
-        && ok "dropped database $DB_NAME"
+      if psql "$admin_url" -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$DB_NAME\" WITH (FORCE)" >/dev/null; then
+        ok "dropped database $DB_NAME"
+      else
+        warn "failed to drop database $DB_NAME; keeping its manifest"
+        failures=$((failures + 1))
+      fi
     else
       warn "Nothing answered on the database host; $DB_NAME was left in place."
+      failures=$((failures + 1))
     fi
   else
     warn "psql not found; $DB_NAME was left in place."
+    failures=$((failures + 1))
   fi
 
-  rm -rf "$PROFILE_DIR" && ok "removed CLI profile $PROFILE"
-  rm -rf "$(env_dir "$NAME")" && ok "released slot $OFFSET"
+  if rm -rf "$PROFILE_DIR"; then
+    ok "removed CLI profile $PROFILE"
+  else
+    warn "failed to remove CLI profile $PROFILE"
+    failures=$((failures + 1))
+  fi
+
+  expected_workspaces="$DEV_WORKSPACES_PARENT/multica_workspaces_$PROFILE"
+  if [ "$WORKSPACES_ROOT" != "$expected_workspaces" ]; then
+    warn "refusing to remove unexpected workspaces root $WORKSPACES_ROOT (expected $expected_workspaces)"
+    failures=$((failures + 1))
+  elif rm -rf "$WORKSPACES_ROOT"; then
+    ok "removed daemon workspaces $WORKSPACES_ROOT"
+  else
+    warn "failed to remove daemon workspaces $WORKSPACES_ROOT"
+    failures=$((failures + 1))
+  fi
+
+  expected_desktop_data="$(desktop_user_data_dir "$DESKTOP_APP_SUFFIX")"
+  if [ "$DESKTOP_USER_DATA_DIR" != "$expected_desktop_data" ]; then
+    warn "refusing to remove unexpected Desktop userData $DESKTOP_USER_DATA_DIR"
+    failures=$((failures + 1))
+  elif rm -rf "$DESKTOP_USER_DATA_DIR"; then
+    ok "removed Desktop userData $DESKTOP_USER_DATA_DIR"
+  else
+    warn "failed to remove Desktop userData $DESKTOP_USER_DATA_DIR"
+    failures=$((failures + 1))
+  fi
+
+  if [ -f "$DESKTOP_ENV_FILE" ] \
+    && grep -Fqx "# Managed by scripts/dev-env.sh for environment ${NAME}." "$DESKTOP_ENV_FILE"; then
+    if rm -f "$DESKTOP_ENV_FILE"; then
+      ok "removed managed Desktop env file"
+    else
+      warn "failed to remove $DESKTOP_ENV_FILE"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if [ "$failures" -ne 0 ]; then
+    die "$NAME was only partially destroyed ($failures cleanup failure(s)). Its manifest and slot were kept so 'make destroy' can retry."
+  fi
+
+  rm -rf "$(env_dir "$NAME")"
+  ok "released slot $OFFSET"
   printf '\n%s✓ %s destroyed.%s\n' "$C_GREEN" "$NAME" "$C_OFF"
 }
 
@@ -971,12 +1337,12 @@ cmd_list() {
     (
       load_manifest "$name"
       bind_paths
-      alive=stopped
-      curl -sf --max-time 2 "http://localhost:${BACKEND_PORT}/health" >/dev/null 2>&1 && alive=running
+      alive="$(component_state api)"
+      alive="${alive%%|*}"
       if [ "$as_json" = 1 ]; then
-        printf '{"name":"%s","dir":"%s","owner":"%s","api":"%s","backend_port":%s,"frontend_port":%s,"database":"%s","created_at":"%s","ttl_hours":%s}' \
+        printf '{"name":"%s","dir":"%s","owner":"%s","api":"%s","backend_port":%s,"frontend_port":%s,"desktop_renderer_port":%s,"database":"%s","created_at":"%s","ttl_hours":%s,"expires_at":"%s"}' \
           "$(json_escape "$NAME")" "$(json_escape "$DIR")" "$(json_escape "$OWNER")" "$alive" \
-          "$BACKEND_PORT" "$FRONTEND_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}"
+          "$BACKEND_PORT" "$FRONTEND_PORT" "$DESKTOP_RENDERER_PORT" "$(json_escape "$DB_NAME")" "$(json_escape "$CREATED_AT")" "${TTL_HOURS:-0}" "$(json_escape "$EXPIRES_AT")"
       else
         printf '%-24s %-8s %-8s %-6s %-28s %s\n' "$NAME" "$alive" "$OWNER" \
           "$BACKEND_PORT" "$DB_NAME" "$( [ -d "$DIR" ] && printf '%s' "$DIR" || printf '%s(directory gone)%s' "$C_RED" "$C_OFF" )"
@@ -998,8 +1364,15 @@ EOF
 # in psql: an environment whose directory is gone, or whose TTL has passed, has
 # no owner left to stop it.
 cmd_gc() {
-  local dry_run=0 name age_hours created_epoch reason
-  [ "${1:-}" = "--dry-run" ] && dry_run=1
+  local dry_run=0 automatic=0 name age_hours created_epoch expiry_epoch reason
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) dry_run=1 ;;
+      --auto) automatic=1 ;;
+      *) die "Unknown flag for gc: $1" ;;
+    esac
+    shift
+  done
 
   while read -r name; do
     [ -n "$name" ] || continue
@@ -1008,16 +1381,27 @@ cmd_gc() {
       reason=""
       [ -d "$DIR" ] || reason="its checkout directory is gone"
       if [ -z "$reason" ] && [ "${TTL_HOURS:-0}" != 0 ]; then
-        created_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$CREATED_AT" 2>/dev/null || echo 0)"
-        age_hours=$(( ($(now_epoch) - created_epoch) / 3600 ))
-        [ "$age_hours" -lt "$TTL_HOURS" ] || reason="it expired ${age_hours}h after a ${TTL_HOURS}h ttl"
+        if [ -n "${EXPIRES_AT:-}" ]; then
+          expiry_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$EXPIRES_AT" 2>/dev/null || echo 0)"
+          [ "$(now_epoch)" -lt "$expiry_epoch" ] || reason="it expired at $EXPIRES_AT"
+        else
+          created_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$CREATED_AT" 2>/dev/null || echo 0)"
+          age_hours=$(( ($(now_epoch) - created_epoch) / 3600 ))
+          [ "$age_hours" -lt "$TTL_HOURS" ] || reason="it expired ${age_hours}h after a ${TTL_HOURS}h ttl"
+        fi
       fi
       [ -n "$reason" ] || exit 0
       if [ "$dry_run" = 1 ]; then
         printf '%s would be collected: %s\n' "$NAME" "$reason"
       else
         printf '%s: %s\n' "$NAME" "$reason"
-        bash "$REPO_ROOT/scripts/dev-env.sh" destroy "$NAME" --yes
+        if ! bash "$REPO_ROOT/scripts/dev-env.sh" destroy "$NAME" --yes; then
+          if [ "$automatic" = 1 ]; then
+            warn "automatic cleanup of $NAME failed; its manifest was kept for retry"
+          else
+            exit 1
+          fi
+        fi
       fi
     )
   done <<EOF
@@ -1037,11 +1421,11 @@ cmd_exec() {
   resolve_env_for_read "$name"
   mkdir -p "$DEV_TMPDIR"
   cd "$DIR"
-  load_env_file "$ENV_FILE"
+  load_env_file "$ENV_FILE" "$DIR"
   export PORT="$BACKEND_PORT" FRONTEND_PORT DATABASE_URL POSTGRES_DB="$DB_NAME"
   export TMPDIR="$DEV_TMPDIR" TMP="$DEV_TMPDIR" TEMP="$DEV_TMPDIR"
   export MULTICA_DEV_PROFILE="$PROFILE"
-  exec "${CLEAN_ENV[@]}" "$@"
+  exec "${CLEAN_ENV[@]}" MULTICA_WORKSPACES_ROOT="$WORKSPACES_ROOT" "$@"
 }
 
 usage() {
@@ -1081,4 +1465,6 @@ main() {
   esac
 }
 
-main "$@"
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/scripts/dev-env.test.sh
+++ b/scripts/dev-env.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Registry-level behaviour of scripts/dev-env.sh, with no services started.
+#
+# Everything here runs against a throwaway MULTICA_DEV_HOME holding hand-written
+# manifests, so the verbs are exercised end to end without a database, a
+# backend, or a port.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+export MULTICA_DEV_HOME="$tmp_dir/dev"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_contains() {
+  local file=$1 expected=$2
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected output to contain: $expected" >&2
+    echo "Observed:" >&2
+    sed 's/^/  /' "$file" >&2
+    exit 1
+  fi
+}
+
+dev_env() {
+  bash "$root_dir/scripts/dev-env.sh" "$@"
+}
+
+write_manifest() {
+  local name=$1 dir=$2 offset=$3
+  mkdir -p "$MULTICA_DEV_HOME/envs/$name/logs"
+  cat > "$MULTICA_DEV_HOME/envs/$name/manifest.env" <<EOF
+NAME=$name
+DIR=$dir
+CREATED_AT=2026-01-01T00:00:00Z
+OWNER=agent
+TTL_HOURS=0
+ENV_FILE=.env.worktree
+OFFSET=$offset
+BACKEND_PORT=$((18080 + offset))
+FRONTEND_PORT=$((13000 + offset))
+DB_NAME=multica_dev_env_test_$offset
+DATABASE_URL=postgres://multica:multica@localhost:5432/multica_dev_env_test_$offset?sslmode=disable
+PROFILE=dev-dev-env-test-$offset
+EOF
+}
+
+out="$tmp_dir/out"
+
+# ---------------------------------------------------------------------------
+# An empty registry is a normal state, not an error.
+# ---------------------------------------------------------------------------
+dev_env list > "$out" 2>&1 || fail "list on an empty registry must succeed"
+require_contains "$out" "No environments registered"
+
+dev_env list --json > "$out" 2>&1 || fail "list --json on an empty registry must succeed"
+if [ "$(cat "$out")" != "[]" ]; then
+  fail "list --json on an empty registry = $(cat "$out"), want []"
+fi
+
+# ---------------------------------------------------------------------------
+# A registered environment is visible to both renderings, and the JSON one
+# parses — agents read it, so a stray log line in it is a broken contract.
+# ---------------------------------------------------------------------------
+write_manifest "probe-901" "$tmp_dir/checkout" 901
+mkdir -p "$tmp_dir/checkout"
+
+dev_env list > "$out" 2>&1 || fail "list must succeed with one environment"
+require_contains "$out" "probe-901"
+require_contains "$out" "18981"
+
+dev_env status probe-901 --json > "$out" 2>&1 || fail "status --json must succeed"
+node -e '
+  const fs = require("fs");
+  const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (payload.name !== "probe-901") throw new Error("name = " + payload.name);
+  if (payload.backend_port !== 18981) throw new Error("backend_port = " + payload.backend_port);
+  for (const key of ["api", "web", "daemon", "desktop"]) {
+    if (!payload.components[key]) throw new Error("missing component " + key);
+    if (payload.components[key].state !== "stopped") {
+      throw new Error(key + " state = " + payload.components[key].state);
+    }
+  }
+' "$out" || fail "status --json is not machine-readable"
+
+# ---------------------------------------------------------------------------
+# Stopping an environment that is not running is a no-op that SUCCEEDS.
+#
+# This is the regression that made `make down` exit 1 after reporting success:
+# on bash 3.2 a command substitution whose function ends in a failing command
+# aborts the whole script under `set -e`, and "no process is listening on this
+# port" is that function's normal answer.
+# ---------------------------------------------------------------------------
+status=0
+dev_env down probe-901 --components api,web > "$out" 2>&1 || status=$?
+if [ "$status" -ne 0 ]; then
+  echo "Observed:" >&2
+  sed 's/^/  /' "$out" >&2
+  fail "down on a stopped environment exited $status, want 0"
+fi
+require_contains "$out" "stopped"
+
+# ---------------------------------------------------------------------------
+# Unknown names and components fail loudly instead of doing something else.
+# ---------------------------------------------------------------------------
+status=0
+dev_env status no-such-env > "$out" 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "status on an unknown environment must fail"
+require_contains "$out" "Unknown environment"
+
+status=0
+dev_env up --components nope > "$out" 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "up with an unknown component must fail"
+require_contains "$out" "Unknown component"
+
+# ---------------------------------------------------------------------------
+# gc reports what it would collect and touches nothing in --dry-run. An
+# environment whose checkout is gone has no owner left to stop it, which is how
+# 152 databases accumulated with nothing on the machine able to list them.
+# ---------------------------------------------------------------------------
+write_manifest "orphan-902" "$tmp_dir/deleted-checkout" 902
+
+dev_env gc --dry-run > "$out" 2>&1 || fail "gc --dry-run must succeed"
+require_contains "$out" "orphan-902 would be collected"
+if grep -Fq "probe-901 would be collected" "$out"; then
+  fail "gc must not collect an environment whose directory still exists"
+fi
+[ -f "$MULTICA_DEV_HOME/envs/orphan-902/manifest.env" ] || fail "gc --dry-run deleted a manifest"
+
+# ---------------------------------------------------------------------------
+# destroy consumes the manifest: the slot is free afterwards, which is what
+# makes the registry an allocator rather than a second place to leak.
+# ---------------------------------------------------------------------------
+dev_env destroy probe-901 --yes > "$out" 2>&1 || fail "destroy must succeed"
+[ ! -d "$MULTICA_DEV_HOME/envs/probe-901" ] || fail "destroy left the environment directory behind"
+
+dev_env list > "$out" 2>&1 || fail "list must succeed after destroy"
+if grep -Fq "probe-901" "$out"; then
+  fail "destroyed environment is still listed"
+fi
+
+# Declining the confirmation is a successful no-op, not a failure.
+printf 'n\n' | dev_env destroy orphan-902 > "$out" 2>&1 || fail "declining destroy must exit 0"
+require_contains "$out" "Cancelled."
+[ -d "$MULTICA_DEV_HOME/envs/orphan-902" ] || fail "declined destroy removed the environment anyway"
+
+echo "✓ dev-env.sh registry behaviour verified"

--- a/scripts/dev-env.test.sh
+++ b/scripts/dev-env.test.sh
@@ -11,6 +11,21 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 export MULTICA_DEV_HOME="$tmp_dir/dev"
+export MULTICA_DEV_WORKSPACES_PARENT="$tmp_dir/workspaces-parent"
+export MULTICA_DEV_DESKTOP_APP_DATA="$tmp_dir/app-data"
+export MULTICA_DEV_PROFILES_HOME="$tmp_dir/profiles"
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/psql" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" DROP DATABASE "*) [ "${FAIL_DROP:-0}" != 1 ] ;;
+  *) printf '1\n' ;;
+esac
+EOF
+chmod +x "$fake_bin/psql"
+export PATH="$fake_bin:$PATH"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -33,20 +48,24 @@ dev_env() {
 
 write_manifest() {
   local name=$1 dir=$2 offset=$3
+  local profile="dev-dev-env-test-$offset"
   mkdir -p "$MULTICA_DEV_HOME/envs/$name/logs"
   cat > "$MULTICA_DEV_HOME/envs/$name/manifest.env" <<EOF
 NAME=$name
-DIR=$dir
+DIR=$(printf '%q' "$dir")
 CREATED_AT=2026-01-01T00:00:00Z
 OWNER=agent
 TTL_HOURS=0
-ENV_FILE=.env.worktree
+ENV_FILE=.env.example
 OFFSET=$offset
 BACKEND_PORT=$((18080 + offset))
 FRONTEND_PORT=$((13000 + offset))
 DB_NAME=multica_dev_env_test_$offset
 DATABASE_URL=postgres://multica:multica@localhost:5432/multica_dev_env_test_$offset?sslmode=disable
-PROFILE=dev-dev-env-test-$offset
+PROFILE=$profile
+WORKSPACES_ROOT=$(printf '%q' "$MULTICA_DEV_WORKSPACES_PARENT/multica_workspaces_$profile")
+DESKTOP_RENDERER_PORT=$((5174 + offset))
+DESKTOP_APP_SUFFIX=$name
 EOF
 }
 
@@ -62,6 +81,37 @@ dev_env list --json > "$out" 2>&1 || fail "list --json on an empty registry must
 if [ "$(cat "$out")" != "[]" ]; then
   fail "list --json on an empty registry = $(cat "$out"), want []"
 fi
+
+# ---------------------------------------------------------------------------
+# Manifest serialization and user-provided names are safe. A manifest is
+# sourced by Bash, so values must be shell-escaped and a name must never be
+# able to walk outside envs/ before destroy eventually runs rm -rf.
+# ---------------------------------------------------------------------------
+quoted="$tmp_dir/quoted.env"
+dangerous='a path with spaces;$(touch should-not-exist)'
+bash -c 'source "$1"; write_manifest_value DIR "$2"' _ "$root_dir/scripts/dev-env.sh" "$dangerous" > "$quoted"
+loaded="$(bash -c 'source "$1"; printf %s "$DIR"' _ "$quoted")"
+[ "$loaded" = "$dangerous" ] || fail "manifest value did not round-trip safely"
+[ ! -e "$root_dir/should-not-exist" ] || fail "loading a manifest executed its value"
+
+status=0
+dev_env up --name ../../escape > "$out" 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "up accepted a path-traversing environment name"
+require_contains "$out" "Invalid environment name"
+
+status=0
+dev_env up --ttl nope > "$out" 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "up accepted a non-numeric TTL"
+require_contains "$out" "TTL must be a positive integer"
+
+# Rewriting an allocated database name must preserve the existing connection
+# endpoint, credentials and query parameters.
+rewritten="$(bash -c 'source "$1"; database_url_with_name "$2" "$3"' _ \
+  "$root_dir/scripts/dev-env.sh" \
+  'postgres://dev:p%40ss@127.0.0.1:55432/old_db?sslmode=require&application_name=dev' \
+  'new_db')"
+[ "$rewritten" = 'postgres://dev:p%40ss@127.0.0.1:55432/new_db?sslmode=require&application_name=dev' ] \
+  || fail "database URL rewrite changed more than the database name: $rewritten"
 
 # ---------------------------------------------------------------------------
 # A registered environment is visible to both renderings, and the JSON one
@@ -105,6 +155,25 @@ if [ "$status" -ne 0 ]; then
 fi
 require_contains "$out" "stopped"
 
+# Commands launched through env-exec must not inherit the daemon-task identity
+# hints that make human/profile CLI commands reject --profile.
+write_manifest "clean-env-903" "$root_dir" 903
+MULTICA_TASK_CONFIG_ROOT=/task/config \
+MULTICA_TASK_WORKSPACES_ROOT=/task/workspaces \
+MULTICA_WORKSPACES_ROOT=/owner/workspaces \
+  dev_env exec clean-env-903 -- sh -c '
+    test -z "${MULTICA_TASK_CONFIG_ROOT:-}" &&
+    test -z "${MULTICA_TASK_WORKSPACES_ROOT:-}" &&
+    test "$MULTICA_WORKSPACES_ROOT" = "$1"
+  ' _ "$MULTICA_DEV_WORKSPACES_PARENT/multica_workspaces_dev-dev-env-test-903" \
+  > "$out" 2>&1 || fail "env-exec leaked daemon task identity or owner workspaces root"
+
+# A health response without process identity is never proof that the process is
+# this checkout's freshly launched API.
+if bash -c 'source "$1"; api_started_after '\''{"status":"ok"}'\'' 1' _ "$root_dir/scripts/dev-env.sh"; then
+  fail "legacy /health without started_at was accepted as current"
+fi
+
 # ---------------------------------------------------------------------------
 # Unknown names and components fail loudly instead of doing something else.
 # ---------------------------------------------------------------------------
@@ -131,6 +200,17 @@ if grep -Fq "probe-901 would be collected" "$out"; then
   fail "gc must not collect an environment whose directory still exists"
 fi
 [ -f "$MULTICA_DEV_HOME/envs/orphan-902/manifest.env" ] || fail "gc --dry-run deleted a manifest"
+
+# A failed database drop keeps the manifest and slot so cleanup can be retried;
+# destroy must never print success and forget the only deletion recipe.
+write_manifest "drop-fails-904" "$root_dir" 904
+status=0
+FAIL_DROP=1 dev_env destroy drop-fails-904 --yes > "$out" 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "destroy succeeded after DROP DATABASE failed"
+[ -f "$MULTICA_DEV_HOME/envs/drop-fails-904/manifest.env" ] \
+  || fail "destroy discarded the manifest after DROP DATABASE failed"
+require_contains "$out" "manifest and slot were kept"
+dev_env destroy drop-fails-904 --yes > "$out" 2>&1 || fail "retrying destroy after database recovery failed"
 
 # ---------------------------------------------------------------------------
 # destroy consumes the manifest: the slot is free afterwards, which is what

--- a/server/cmd/server/health.go
+++ b/server/cmd/server/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -36,6 +37,14 @@ type serverHealth struct {
 	cacheTTL           time.Duration
 	refreshMu          sync.Mutex
 	cache              atomic.Pointer[cachedReadiness]
+	// startedAt and pid identify the process answering /health. A 200 alone
+	// only proves something is listening on the port: when a restart fails to
+	// bind, the previous instance keeps serving and every readiness check
+	// still passes, so a caller can configure or test the wrong build without
+	// any visible error. Local tooling compares started_at against its own
+	// launch time to prove the answer came from the process it just started.
+	startedAt time.Time
+	pid       int
 }
 
 type cachedReadiness struct {
@@ -45,7 +54,10 @@ type cachedReadiness struct {
 }
 
 type liveResponse struct {
-	Status string `json:"status"`
+	Status    string `json:"status"`
+	PID       int    `json:"pid,omitempty"`
+	Commit    string `json:"commit,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
 }
 
 type readinessResponse struct {
@@ -65,11 +77,17 @@ func newServerHealth(pool *pgxpool.Pool) *serverHealth {
 		requiredMigrations: requiredMigrations,
 		initErr:            err,
 		cacheTTL:           readinessCacheTTL,
+		startedAt:          time.Now().UTC(),
+		pid:                os.Getpid(),
 	}
 }
 
 func (h *serverHealth) liveHandler(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, liveResponse{Status: "ok"})
+	resp := liveResponse{Status: "ok", PID: h.pid, Commit: commit}
+	if !h.startedAt.IsZero() {
+		resp.StartedAt = h.startedAt.Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *serverHealth) readyHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/cmd/server/health_test.go
+++ b/server/cmd/server/health_test.go
@@ -160,3 +160,53 @@ func TestServerHealthReadinessCachesResult(t *testing.T) {
 		t.Fatalf("QueryRow calls = %d, want 1", got)
 	}
 }
+
+// A restart that fails to bind leaves the previous instance serving the port,
+// and every /health probe still returns 200. The process identity below is what
+// lets a caller tell "my build answered" from "something answered".
+func TestServerHealthLiveHandlerReportsProcessIdentity(t *testing.T) {
+	startedAt := time.Date(2026, 8, 20, 10, 30, 0, 0, time.UTC)
+	h := &serverHealth{startedAt: startedAt, pid: 4242}
+
+	rec := httptest.NewRecorder()
+	h.liveHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body liveResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /health: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status = %q, want ok", body.Status)
+	}
+	if body.PID != 4242 {
+		t.Fatalf("pid = %d, want 4242", body.PID)
+	}
+	if body.StartedAt != "2026-08-20T10:30:00Z" {
+		t.Fatalf("started_at = %q, want 2026-08-20T10:30:00Z", body.StartedAt)
+	}
+	if body.Commit != commit {
+		t.Fatalf("commit = %q, want %q", body.Commit, commit)
+	}
+}
+
+// newServerHealth is the only production constructor, so startedAt is never
+// zero in a running server. Tests build the struct literally; a zero time must
+// not be rendered as year 0001, which a caller would read as "started before
+// my launch" and report as a stale instance.
+func TestServerHealthLiveHandlerOmitsZeroStartedAt(t *testing.T) {
+	h := &serverHealth{pid: 7}
+
+	rec := httptest.NewRecorder()
+	h.liveHandler(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	var body liveResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /health: %v", err)
+	}
+	if body.StartedAt != "" {
+		t.Fatalf("started_at = %q, want empty for a zero time", body.StartedAt)
+	}
+}


### PR DESCRIPTION
Implements the approved RFC on MUL-6479.

## What changes for you

```bash
make up                      # start this checkout's environment (api + web)
make up C=api,web,daemon     # pick the components
make status                  # what is running, and whether it is yours
make list                    # every environment on this machine
make down                    # stop the processes, keep the data
make destroy                 # stop, drop the database, free the slot
make gc                      # collect environments whose checkout is gone
make env-exec ARGS="-- pnpm exec playwright test"
```

Components are `api`, `web`, `daemon`, `desktop`; any of them implies `api`.
`make dev` is unchanged and still runs in the foreground.

## Why, with the three defects it closes

**The database the tooling created was not the one the application reached.**
`ensure-postgres.sh` creates through `docker exec`. When a native PostgreSQL
owns 5432 the container never binds the host port, so that create lands in a
server the backend never talks to — it prints `✓ PostgreSQL ready` and the next
step dies with `SQLSTATE 3D000`. On the machine this was written on the two
servers had already diverged: 94 same-named databases on both, 69 more in the
container with no counterpart. `up` creates through `DATABASE_URL` and treats a
successful `migrate up` (which pings that same string) as the only proof;
failure names the process that owns the port instead of reporting a missing
database.

**Identity was computed, not allocated.** Ports, database names and profiles all
came from `cksum($PWD) % 1000`, and a collision is silent — the loser fails to
bind while the winner keeps answering 200. Allocation now happens under a lock,
probing from the same path hash so a checkout keeps its familiar numbers, and
requires the slot to be both unregistered and free of a live listener.

**Creating an environment left no record of how to destroy it**, so there was no
destroy, only archaeology. The manifest under `~/.multica/dev/envs/<name>/` is
that record: `down` stops processes and keeps the data, `destroy` consumes it,
`list` makes leaks visible, `gc` collects the abandoned ones.

`GET /health` now reports `pid`, `commit` and `started_at`. A 200 alone is what
let a failed restart keep serving the previous build; `up` compares `started_at`
against its own launch time and refuses an answer that predates it.

Two constraints are enforced rather than documented: the daemon starts from a
built `server/bin/multica`, never `go run` (it re-execs its own path for every
task, and `go run` deletes that binary when the launcher exits); and `C=daemon`
under a `.multica/daemon_task_context.json` marker stops with that explanation
before spending a login on a refusal it cannot avoid.

## Verification

Run on a real checkout, against the machine that has the two-PostgreSQL problem:

- `make up C=api,web` from a fresh checkout: 46s including `pnpm install`; warm
  restart 19s. Database created through `DATABASE_URL`, migrations applied,
  `/health` reporting `pid 14440, commit 8c9b7503a`.
- Headless login through the frontend proxy: `send-code` 200, `verify-code` 200,
  `/api/me` 200, `/dev/issues` 200.
- `make down` releases both ports (0 listeners afterwards); `make up` again
  reuses the database and profile.
- `make up C=daemon` inside an agent task stops with the marker explanation.
- `bash scripts/dev-env.test.sh`, `scripts/worktree-db.test.sh`,
  `scripts/makefile-build.test.sh` pass; `go vet ./cmd/server`,
  `go build ./...`, `go test ./cmd/server -run TestServerHealth` pass.

`scripts/dev-env.test.sh` runs the verbs against a throwaway `MULTICA_DEV_HOME`
with no services started, and pins the regression that made `down` exit 1 after
reporting success: on bash 3.2 a command substitution whose function ends in a
failing command aborts the script under `set -e`, and "no process is listening"
is that function's normal answer.

## Not in this PR

The RFC's one-time cleanup of the existing leak on the primary dev machine (two
PostgreSQL servers, ~3.2 GB of databases, 12 orphaned backends, 8 orphaned
daemons) is deliberately separate — it operates on a live machine, and `destroy`
/ `gc` land here first so the cleanup has a tool to use.
