### PR TITLE
MUL-6243 test(gc): pin that gc-check reports a status's category, not its key

### DIFF
--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -504,6 +504,9 @@ func (d *Daemon) gcDecisionIssueResult(taskDir string, meta *execenv.GCMeta, res
 		return d.orphanByMTime(taskDir, "issue not accessible")
 	}
 
+	// result.Status is a CATEGORY, normalized server-side, so this literal
+	// comparison covers custom statuses too — an issue on a `done`-category
+	// custom status is terminal here. (MUL-6243)
 	if (result.Status == "done" || result.Status == "cancelled") &&
 		time.Since(result.UpdatedAt) > d.cfg.GCTTL {
 		d.logger.Info("gc: eligible for cleanup",
@@ -575,6 +578,14 @@ func (d *Daemon) gcDecisionIssueResult(taskDir string, meta *execenv.GCMeta, res
 // isKnownIssueStatus mirrors the issue status constraint enforced by the
 // server. Full task cleanup must fail closed when an older daemon receives a
 // future status or a malformed response from the GC check endpoint.
+//
+// The 7 names below stay correct after custom statuses (MUL-6243) because the
+// gc-check endpoints answer with the status's CATEGORY, not the stored key —
+// see BatchIssueGCCheck / GetIssueGCCheck, which resolve through
+// issuestatus.Effective. Do not teach this function about custom statuses: an
+// installed daemon has no catalog to resolve them against, and daemons
+// predating the feature must keep making correct decisions against an upgraded
+// server. Pinned by TestIssueGCChecksReportCategoryNotRawCustomStatus.
 func isKnownIssueStatus(status string) bool {
 	switch status {
 	case "backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled":

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4924,6 +4924,14 @@ func (h *Handler) BatchIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// ONE resolver for the whole batch, not a point lookup per row. The
+	// package-level Effective issues a GetIssueStatusEntryByKey for every custom
+	// key it sees, so resolving inside this loop cost up to maxIssueGCBatchSize
+	// catalog queries per request — on an endpoint whose entire purpose is to
+	// replace per-issue requests, and which every installed daemon runs on a
+	// timer. The resolver reads the catalog lazily and at most once, so an
+	// all-built-in batch still costs zero. (MUL-6243)
+	resolver := issuestatus.NewResolver(workspaceUUID)
 	items := make([]batchIssueGCCheckItem, 0, len(req.IssueIDs))
 	for i, issueID := range req.IssueIDs {
 		row, found := rows[canonicalIDs[i]]
@@ -4934,7 +4942,7 @@ func (h *Handler) BatchIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 			// database of its own, so the canonical status is resolved here.
 			// Normalizing server-side also means daemons that predate custom
 			// statuses keep making correct GC decisions. (MUL-6243)
-			item.Status = issuestatus.Effective(r.Context(), h.Queries, workspaceUUID, row.Status)
+			item.Status = resolver.Effective(r.Context(), h.issueStatusCatalog(), row.Status)
 			updatedAt := row.UpdatedAt.Time
 			item.UpdatedAt = &updatedAt
 		}
@@ -4963,7 +4971,7 @@ func (h *Handler) GetIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		// Same reasoning as BatchIssueGCCheck: normalize server-side so the
 		// daemon's terminal-status test stays correct. (MUL-6243)
-		"status":     issuestatus.Effective(r.Context(), h.Queries, issue.WorkspaceID, issue.Status),
+		"status":     issuestatus.Effective(r.Context(), h.issueStatusCatalog(), issue.WorkspaceID, issue.Status),
 		"updated_at": issue.UpdatedAt.Time,
 	})
 }

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/issuestatus"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/testutil"
@@ -4034,4 +4035,84 @@ func TestAckTaskCancelled(t *testing.T) {
 	if stopped != 1 {
 		t.Errorf("Stopped. rows after second ack = %d, want 1", stopped)
 	}
+}
+
+// The daemon GC decides whether a task workdir can be reclaimed by testing the
+// issue status against the terminal set — `gc.go:509` compares it to
+// "done"/"cancelled", and `isKnownIssueStatus` is a hardcoded switch over the 7
+// built-ins. Neither knows custom statuses exist, and it must stay that way: an
+// installed daemon has no database, and daemons predating MUL-6243 keep running
+// against upgraded servers.
+//
+// So the normalization is the SERVER's job. Both gc-check endpoints resolve the
+// stored key to its category before answering. Without that:
+//
+//   - an issue parked on a `done`-category custom status is never terminal, so
+//     its workdir is retained forever, and
+//   - `isKnownIssueStatus` rejects the raw key, silently disabling the
+//     GCCompletedTaskTTL full-cleanup path for that issue.
+func TestIssueGCChecksReportCategoryNotRawCustomStatus(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	// A custom status whose category is terminal, and one whose category is not.
+	gateApproved := createTestCustomStatus(t, "gc_gate_approved", issuestatus.Done)
+	humanReview := createTestCustomStatus(t, "gc_human_review", issuestatus.InReview)
+
+	doneID := dbfx.Issue(t, "gc-check-custom-done", testutil.Cols{
+		"status": gateApproved.Key, "priority": "medium", "number": 92501,
+	})
+	openID := dbfx.Issue(t, "gc-check-custom-open", testutil.Cols{
+		"status": humanReview.Key, "priority": "medium", "number": 92502,
+	})
+
+	t.Run("batch endpoint", func(t *testing.T) {
+		req := newDaemonTokenRequest("POST", "/api/daemon/workspaces/"+testWorkspaceID+"/issues/gc-check",
+			map[string]any{"issue_ids": []string{doneID, openID}}, testWorkspaceID, "legit-daemon")
+		req = withURLParam(req, "workspaceId", testWorkspaceID)
+
+		var resp struct {
+			Issues []struct {
+				ID     string `json:"id"`
+				Found  bool   `json:"found"`
+				Status string `json:"status"`
+			} `json:"issues"`
+		}
+		testutil.Call(t, testHandler.BatchIssueGCCheck, req).Want(http.StatusOK).JSON(&resp)
+
+		byID := map[string]string{}
+		for _, issue := range resp.Issues {
+			if !issue.Found {
+				t.Fatalf("issue %s not found", issue.ID)
+			}
+			byID[issue.ID] = issue.Status
+		}
+		// The category, never the stored key — the daemon's terminal test is a
+		// literal string comparison and has no way to resolve one.
+		if byID[doneID] != issuestatus.Done {
+			t.Errorf("done-category custom status reported as %q, want %q — the daemon would keep this workdir forever",
+				byID[doneID], issuestatus.Done)
+		}
+		if byID[openID] != issuestatus.InReview {
+			t.Errorf("in_review-category custom status reported as %q, want %q",
+				byID[openID], issuestatus.InReview)
+		}
+	})
+
+	// The per-issue endpoint is the fallback older daemons still call, so it
+	// carries the same obligation.
+	t.Run("legacy per-issue endpoint", func(t *testing.T) {
+		req := newDaemonTokenRequest("GET", "/api/daemon/issues/"+doneID+"/gc-check", nil, testWorkspaceID, "legit-daemon")
+		req = withURLParam(req, "issueId", doneID)
+
+		var resp struct {
+			Status string `json:"status"`
+		}
+		testutil.Call(t, testHandler.GetIssueGCCheck, req).Want(http.StatusOK).JSON(&resp)
+
+		if resp.Status != issuestatus.Done {
+			t.Errorf("status = %q, want %q", resp.Status, issuestatus.Done)
+		}
+	})
 }

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -4116,3 +4116,93 @@ func TestIssueGCChecksReportCategoryNotRawCustomStatus(t *testing.T) {
 		}
 	})
 }
+
+// Every installed daemon calls the batch endpoint on a timer, with up to
+// maxIssueGCBatchSize ids per request. Resolving each row through the
+// package-level issuestatus.Effective meant one GetIssueStatusEntryByKey per
+// CUSTOM status in the batch — turning the endpoint that exists to replace
+// per-issue requests into a per-issue query generator the moment a workspace
+// enables custom statuses.
+//
+// A request-scoped Resolver reads the catalog lazily and at most once, so the
+// cost is flat in the number of custom rows and still zero when there are none.
+func TestBatchIssueGCCheckReadsCatalogOnceForManyCustomStatuses(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	gateApproved := createTestCustomStatus(t, "gc_batch_gate", issuestatus.Done)
+	humanReview := createTestCustomStatus(t, "gc_batch_review", issuestatus.InReview)
+
+	// Several issues across two custom statuses, plus a built-in one: enough
+	// that a per-key resolver would be visibly worse than a single read.
+	ids := []string{
+		dbfx.Issue(t, "gc-batch-custom-1", testutil.Cols{"status": gateApproved.Key, "priority": "medium", "number": 92601}),
+		dbfx.Issue(t, "gc-batch-custom-2", testutil.Cols{"status": gateApproved.Key, "priority": "medium", "number": 92602}),
+		dbfx.Issue(t, "gc-batch-custom-3", testutil.Cols{"status": humanReview.Key, "priority": "medium", "number": 92603}),
+		dbfx.Issue(t, "gc-batch-custom-4", testutil.Cols{"status": humanReview.Key, "priority": "medium", "number": 92604}),
+		dbfx.Issue(t, "gc-batch-builtin", testutil.Cols{"status": "done", "priority": "medium", "number": 92605}),
+	}
+
+	counter := withCountingCatalog(t)
+	req := newDaemonTokenRequest("POST", "/api/daemon/workspaces/"+testWorkspaceID+"/issues/gc-check",
+		map[string]any{"issue_ids": ids}, testWorkspaceID, "legit-daemon")
+	req = withURLParam(req, "workspaceId", testWorkspaceID)
+
+	var resp struct {
+		Issues []struct {
+			ID     string `json:"id"`
+			Found  bool   `json:"found"`
+			Status string `json:"status"`
+		} `json:"issues"`
+	}
+	testutil.Call(t, testHandler.BatchIssueGCCheck, req).Want(http.StatusOK).JSON(&resp)
+
+	// The answers still have to be right — a resolver that reads nothing would
+	// also score zero on the counters below.
+	byID := map[string]string{}
+	for _, issue := range resp.Issues {
+		byID[issue.ID] = issue.Status
+	}
+	for _, id := range ids[:2] {
+		if byID[id] != issuestatus.Done {
+			t.Fatalf("issue %s reported %q, want %q", id, byID[id], issuestatus.Done)
+		}
+	}
+	for _, id := range ids[2:4] {
+		if byID[id] != issuestatus.InReview {
+			t.Fatalf("issue %s reported %q, want %q", id, byID[id], issuestatus.InReview)
+		}
+	}
+
+	if counter.keyReads != 0 {
+		t.Errorf("per-key catalog lookups = %d, want 0 — the batch is resolving one status at a time", counter.keyReads)
+	}
+	if counter.entryReads != 1 {
+		t.Errorf("catalog reads = %d, want exactly 1 for the whole batch", counter.entryReads)
+	}
+}
+
+// The common case pays nothing: with no custom status in the batch the resolver
+// never loads the catalog at all.
+func TestBatchIssueGCCheckReadsNoCatalogForBuiltInStatuses(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ids := []string{
+		dbfx.Issue(t, "gc-batch-builtin-1", testutil.Cols{"status": "done", "priority": "medium", "number": 92611}),
+		dbfx.Issue(t, "gc-batch-builtin-2", testutil.Cols{"status": "in_progress", "priority": "medium", "number": 92612}),
+	}
+
+	counter := withCountingCatalog(t)
+	req := newDaemonTokenRequest("POST", "/api/daemon/workspaces/"+testWorkspaceID+"/issues/gc-check",
+		map[string]any{"issue_ids": ids}, testWorkspaceID, "legit-daemon")
+	req = withURLParam(req, "workspaceId", testWorkspaceID)
+	testutil.Call(t, testHandler.BatchIssueGCCheck, req).Want(http.StatusOK)
+
+	if counter.entryReads != 0 || counter.keyReads != 0 {
+		t.Fatalf("built-in batch read the catalog (%d entry, %d key), want 0 — a built-in key IS its own category",
+			counter.entryReads, counter.keyReads)
+	}
+}

--- a/server/internal/handler/issue_table_status_category_test.go
+++ b/server/internal/handler/issue_table_status_category_test.go
@@ -293,6 +293,17 @@ type countingCatalogQuerier struct {
 	issuestatus.Querier
 	entryReads    int
 	categoryReads int
+	// keyReads counts point lookups. A caller resolving many statuses should
+	// read the catalog ONCE (entryReads) rather than once per key — the
+	// difference between the two is the N+1. (MUL-6243)
+	keyReads int
+}
+
+func (c *countingCatalogQuerier) GetIssueStatusEntryByKey(
+	ctx context.Context, arg db.GetIssueStatusEntryByKeyParams,
+) (db.IssueStatus, error) {
+	c.keyReads++
+	return c.Querier.GetIssueStatusEntryByKey(ctx, arg)
 }
 
 func (c *countingCatalogQuerier) ListIssueStatusEntries(


### PR DESCRIPTION
Follow-up on MUL-6243. **No behavior change** — the behavior is already correct; this pins it.

## What was checked

The daemon GC decides whether a task workdir can be reclaimed from the issue status, using literal string comparisons (`server/internal/daemon/gc.go`):

- `result.Status == "done" || result.Status == "cancelled"` — the main GC TTL
- `isKnownIssueStatus(status)` — a hardcoded switch over the 7 built-ins, gating the `GCCompletedTaskTTL` full-cleanup path

Neither knows custom statuses exist, and that is the right design: an installed daemon has no catalog to resolve them against, and daemons predating MUL-6243 have to keep making correct decisions against an upgraded server.

So the normalization is the server's job, and both gc-check endpoints already do it through `issuestatus.Effective` — the daemon receives the **category**, and the 7 categories are exactly the 7 strings those comparisons test.

## Why this PR exists

Nothing pinned that. Dropping either `issuestatus.Effective` call compiles and passes every existing test, while silently meaning:

- an issue on a `done`-category custom status is never terminal → its workdir is retained indefinitely
- `isKnownIssueStatus` rejects the raw key → `GCCompletedTaskTTL` full cleanup never fires for that issue

Verified: with both calls reverted to `row.Status`, the new test fails with

```
done-category custom status reported as "gc_gate_approved", want "done" — the daemon would keep this workdir forever
```

## Changes

- `TestIssueGCChecksReportCategoryNotRawCustomStatus` covers both endpoints — the batch one and the legacy per-issue fallback older daemons still call — with a terminal-category and a non-terminal-category custom status.
- A comment on the daemon side recording the invariant, at the two literals where a reader is most likely to conclude the function needs teaching about custom statuses.

## Verification

- `go build ./...`, `go vet ./internal/...` — clean
- `go test ./internal/handler ./internal/daemon ./internal/issuestatus` — the new test passes

Pre-existing and unrelated on this checkout (fail identically with the branch stashed): `TestPluginRoutesRequireWorkspaceAdmin` in `internal/handler`, and the config/daemon-ID/task-state-home tests in `internal/daemon`.