### PR TITLE
feat(dingtalk): persist bot conversation participant profiles

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1581,6 +1581,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Delete("/dingtalk/installations/{installationId}", h.RevokeDingTalkInstallation)
 					r.Post("/dingtalk/install/byo", h.RegisterDingTalkBYO)
 					r.Patch("/dingtalk/group-routes/{routeId}", h.UpdateDingTalkGroupRoute)
+					r.Get("/dingtalk/participants", h.ListDingTalkParticipants)
 				})
 
 				// Telegram integration. Same admin/member split as Slack:

--- a/server/internal/handler/dingtalk.go
+++ b/server/internal/handler/dingtalk.go
@@ -48,6 +48,24 @@ type DingTalkGroupRouteResponse struct {
 	UpdatedAt         string `json:"updated_at"`
 }
 
+// DingTalkParticipantResponse is the minimal sender profile observed on
+// successfully validated bot messages. The endpoint is admin-only because the
+// platform identifiers must not be disclosed to regular workspace members.
+type DingTalkParticipantResponse struct {
+	InstallationID         string `json:"installation_id"`
+	MulticaUserID          string `json:"multica_user_id"`
+	MulticaUserName        string `json:"multica_user_name"`
+	DingTalkStaffID        string `json:"dingtalk_staff_id"`
+	DingTalkSenderID       string `json:"dingtalk_sender_id"`
+	DingTalkCorpID         string `json:"dingtalk_corp_id"`
+	DingTalkNickname       string `json:"dingtalk_nickname"`
+	IsAdmin                bool   `json:"is_admin"`
+	FirstSeenAt            string `json:"first_seen_at"`
+	LastSeenAt             string `json:"last_seen_at"`
+	MessageCount           int64  `json:"message_count"`
+	LastMessageCreatedAtMS int64  `json:"last_message_created_at_ms,omitempty"`
+}
+
 func dingtalkInstallationToResponse(row db.ChannelInstallation) DingTalkInstallationResponse {
 	return DingTalkInstallationResponse{
 		ID:              uuidToString(row.ID),
@@ -72,6 +90,45 @@ func dingtalkGroupRouteToResponse(row db.DingtalkGroupRoute) DingTalkGroupRouteR
 		DiscoveredAt:      row.DiscoveredAt.Time.UTC().Format(time.RFC3339),
 		UpdatedAt:         row.UpdatedAt.Time.UTC().Format(time.RFC3339),
 	}
+}
+
+func dingtalkParticipantToResponse(row db.ListDingTalkParticipantsByWorkspaceRow) DingTalkParticipantResponse {
+	return DingTalkParticipantResponse{
+		InstallationID:         uuidToString(row.InstallationID),
+		MulticaUserID:          uuidToString(row.MulticaUserID),
+		MulticaUserName:        row.MulticaUserName,
+		DingTalkStaffID:        row.DingtalkStaffID,
+		DingTalkSenderID:       row.DingtalkSenderID,
+		DingTalkCorpID:         row.DingtalkCorpID,
+		DingTalkNickname:       row.DingtalkNickname,
+		IsAdmin:                row.IsAdmin,
+		FirstSeenAt:            row.FirstSeenAt.Time.UTC().Format(time.RFC3339),
+		LastSeenAt:             row.LastSeenAt.Time.UTC().Format(time.RFC3339),
+		MessageCount:           row.MessageCount,
+		LastMessageCreatedAtMS: row.LastMessageCreatedAtMs,
+	}
+}
+
+// ListDingTalkParticipants (GET
+// /api/workspaces/{id}/dingtalk/participants) lists the linked DingTalk members
+// observed on successfully validated bot messages. The route is registered
+// under owner/admin middleware; the query additionally limits rows to current
+// workspace members.
+func (h *Handler) ListDingTalkParticipants(w http.ResponseWriter, r *http.Request) {
+	wsUUID, ok := parseUUIDOrBadRequest(w, chi.URLParam(r, "id"), "workspace id")
+	if !ok {
+		return
+	}
+	rows, err := h.Queries.ListDingTalkParticipantsByWorkspace(r.Context(), wsUUID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list dingtalk participants")
+		return
+	}
+	out := make([]DingTalkParticipantResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, dingtalkParticipantToResponse(row))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"participants": out})
 }
 
 // ListDingTalkGroupRoutes (GET /api/workspaces/{id}/dingtalk/group-routes)

--- a/server/internal/handler/dingtalk_group_routes_test.go
+++ b/server/internal/handler/dingtalk_group_routes_test.go
@@ -502,6 +502,81 @@ func TestListDingTalkInstallationsAdvertisesGroupRoutingCapability(t *testing.T)
 	})
 }
 
+func TestListDingTalkParticipantsReturnsObservedSenderMetadata(t *testing.T) {
+	fx := newDingTalkGroupRouteHandlerFixture(t)
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO channel_user_binding (
+			workspace_id, multica_user_id, installation_id,
+			channel_type, channel_user_id, config
+		) VALUES ($1, $2, $3, 'dingtalk', 'staff-participant', '{"unrelated":"preserved"}'::jsonb)
+	`, testWorkspaceID, testUserID, fx.installationID); err != nil {
+		t.Fatalf("seed DingTalk participant binding: %v", err)
+	}
+
+	queries := db.New(testPool)
+	record := func(params db.RecordDingTalkParticipantParams) {
+		t.Helper()
+		rows, err := queries.RecordDingTalkParticipant(ctx, params)
+		if err != nil || rows != 1 {
+			t.Fatalf("record DingTalk participant rows=%d err=%v", rows, err)
+		}
+	}
+	base := db.RecordDingTalkParticipantParams{
+		SenderID: "encrypted-open-id", CorpID: "corp-42", Nickname: "Ada Lovelace",
+		IsAdmin: true, MessageCreatedAtMs: 1_777_777_777_000,
+		InstallationID: parseUUID(fx.installationID), WorkspaceID: parseUUID(testWorkspaceID),
+		MulticaUserID: parseUUID(testUserID), DingtalkStaffID: "staff-participant",
+	}
+	record(base)
+	base.SenderID = ""
+	base.CorpID = ""
+	base.Nickname = "Ada Byron"
+	base.IsAdmin = false
+	base.MessageCreatedAtMs++
+	record(base)
+
+	req := requestWithRouteParams(
+		newRequest(http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/dingtalk/participants", nil),
+		testWorkspaceID,
+		"",
+	)
+	rec := httptest.NewRecorder()
+	testHandler.ListDingTalkParticipants(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("participants status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Participants []DingTalkParticipantResponse `json:"participants"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode participants: %v", err)
+	}
+	if len(body.Participants) != 1 {
+		t.Fatalf("participants = %+v", body.Participants)
+	}
+	participant := body.Participants[0]
+	if participant.InstallationID != fx.installationID ||
+		participant.MulticaUserID != testUserID ||
+		participant.DingTalkStaffID != "staff-participant" ||
+		participant.DingTalkSenderID != "encrypted-open-id" ||
+		participant.DingTalkCorpID != "corp-42" ||
+		participant.DingTalkNickname != "Ada Byron" ||
+		participant.IsAdmin || participant.MessageCount != 2 ||
+		participant.LastMessageCreatedAtMS != 1_777_777_777_001 ||
+		participant.FirstSeenAt == "" || participant.LastSeenAt == "" {
+		t.Fatalf("participant = %+v", participant)
+	}
+	var unrelated string
+	if err := testPool.QueryRow(ctx, `
+		SELECT config ->> 'unrelated'
+		FROM channel_user_binding
+		WHERE installation_id = $1 AND channel_user_id = 'staff-participant'
+	`, fx.installationID).Scan(&unrelated); err != nil || unrelated != "preserved" {
+		t.Fatalf("unrelated binding config = %q, err=%v", unrelated, err)
+	}
+}
+
 func TestDingTalkGroupRouteHandlersValidationAndErrors(t *testing.T) {
 	fx := newDingTalkGroupRouteHandlerFixture(t)
 
@@ -734,6 +809,7 @@ func TestDingTalkGroupRouteAuthorizationWiring(t *testing.T) {
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.RequireWorkspaceRoleFromURL(testHandler.Queries, "id", "owner", "admin"))
 			r.Patch("/dingtalk/group-routes/{routeId}", testHandler.UpdateDingTalkGroupRoute)
+			r.Get("/dingtalk/participants", testHandler.ListDingTalkParticipants)
 		})
 	})
 
@@ -779,6 +855,19 @@ func TestDingTalkGroupRouteAuthorizationWiring(t *testing.T) {
 	}
 	if rec := exercise(http.MethodGet, base, "", nil); rec.Code != http.StatusUnauthorized {
 		t.Errorf("anonymous GET status = %d: %s", rec.Code, rec.Body.String())
+	}
+	participantsBase := "/api/workspaces/" + testWorkspaceID + "/dingtalk/participants"
+	if rec := exercise(http.MethodGet, participantsBase, memberID, nil); rec.Code != http.StatusForbidden {
+		t.Errorf("member participants GET status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := exercise(http.MethodGet, participantsBase, outsiderID, nil); rec.Code != http.StatusNotFound {
+		t.Errorf("outsider participants GET status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := exercise(http.MethodGet, participantsBase, "", nil); rec.Code != http.StatusUnauthorized {
+		t.Errorf("anonymous participants GET status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := exercise(http.MethodGet, participantsBase, testUserID, nil); rec.Code != http.StatusOK {
+		t.Errorf("owner participants GET status = %d: %s", rec.Code, rec.Body.String())
 	}
 	patchBody := UpdateDingTalkGroupRouteRequest{AgentID: fx.targetAgentID}
 	if rec := exercise(http.MethodPatch, base+"/"+fx.routeID, memberID, patchBody); rec.Code != http.StatusForbidden {

--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -113,6 +113,7 @@ type AppendParams struct {
 	SessionID           pgtype.UUID
 	Sender              pgtype.UUID
 	InstallationID      pgtype.UUID
+	WorkspaceID         pgtype.UUID
 	AgentID             pgtype.UUID
 	RouteRevision       int64
 	Message             channel.InboundMessage

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -444,6 +444,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 			SessionID:           sessionID,
 			Sender:              identity.UserID,
 			InstallationID:      inst.ID,
+			WorkspaceID:         inst.WorkspaceID,
 			AgentID:             inst.AgentID,
 			RouteRevision:       inst.RouteRevision,
 			Message:             msg,

--- a/server/internal/integrations/dingtalk/group_route_pipeline_db_test.go
+++ b/server/internal/integrations/dingtalk/group_route_pipeline_db_test.go
@@ -89,20 +89,38 @@ func TestDingTalkRejectedGroupCallbacksDoNotDiscoverRoutesDB(t *testing.T) {
 			t.Fatalf("%s persisted %d rejected group route(s)", label, count)
 		}
 	}
+	assertNoParticipants := func(label string) {
+		t.Helper()
+		var count int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*)
+			FROM channel_user_binding
+			WHERE installation_id = $1
+			  AND config ? 'dingtalk_participant'
+		`, installation).Scan(&count); err != nil {
+			t.Fatalf("%s: count participant profiles: %v", label, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s persisted %d rejected participant profile(s)", label, count)
+		}
+	}
 
 	if err := router.Handle(ctx, message("unmentioned", "cid-unmentioned", false)); err != nil {
 		t.Fatalf("unmentioned callback: %v", err)
 	}
 	assertNoRoutes("unmentioned callback")
+	assertNoParticipants("unmentioned callback")
 
 	if err := router.Handle(ctx, message("unbound", "cid-unbound", true)); err != nil {
 		t.Fatalf("unbound callback: %v", err)
 	}
 	assertNoRoutes("unbound callback")
+	assertNoParticipants("unbound callback")
 
 	exec(`INSERT INTO channel_user_binding (workspace_id, multica_user_id, installation_id, channel_type, channel_user_id) VALUES ($1, $2, $3, 'dingtalk', $4)`, workspaceID, boundUserID, installation, staffID)
 	if err := router.Handle(ctx, message("nonmember", "cid-nonmember", true)); err != nil {
 		t.Fatalf("non-member callback: %v", err)
 	}
 	assertNoRoutes("non-member callback")
+	assertNoParticipants("non-member callback")
 }

--- a/server/internal/integrations/dingtalk/inbound.go
+++ b/server/internal/integrations/dingtalk/inbound.go
@@ -23,7 +23,12 @@ type botCallbackData struct {
 	ConversationId    string          `json:"conversationId"`
 	ConversationTitle string          `json:"conversationTitle"`
 	ConversationType  string          `json:"conversationType"`
+	SenderId          string          `json:"senderId"`
 	SenderStaffId     string          `json:"senderStaffId"`
+	SenderCorpId      string          `json:"senderCorpId"`
+	SenderNick        string          `json:"senderNick"`
+	IsAdmin           bool            `json:"isAdmin"`
+	CreateAt          int64           `json:"createAt"`
 	MsgId             string          `json:"msgId"`
 	Msgtype           string          `json:"msgtype"`
 	IsInAtList        bool            `json:"isInAtList"`
@@ -75,7 +80,21 @@ func refAlt(downloadCode, pictureDownloadCode string) (ref, alt string) {
 type dingtalkRawEvent struct {
 	AppID             string                  `json:"app_id"`
 	ConversationTitle string                  `json:"conversation_title,omitempty"`
+	Sender            dingtalkSenderProfile   `json:"sender"`
 	Media             []dingtalkMediaResource `json:"media,omitempty"`
+}
+
+// dingtalkSenderProfile contains only stable, non-secret sender metadata from
+// the Stream callback. It is carried through the opaque adapter envelope so the
+// append transaction can update the linked member's participant profile beside
+// the durable message and dedup mark. Session webhooks and message bodies
+// deliberately never enter this structure.
+type dingtalkSenderProfile struct {
+	SenderID           string `json:"sender_id,omitempty"`
+	CorpID             string `json:"corp_id,omitempty"`
+	Nickname           string `json:"nickname,omitempty"`
+	IsAdmin            bool   `json:"is_admin"`
+	MessageCreatedAtMS int64  `json:"message_created_at_ms,omitempty"`
 }
 
 type dingtalkMediaResource struct {
@@ -116,7 +135,17 @@ func inboundFromCallback(data *botCallbackData, appID string) (channel.InboundMe
 	}
 
 	chatType := dingtalkChatType(data.ConversationType)
-	rawEvent := dingtalkRawEvent{AppID: appID, ConversationTitle: strings.TrimSpace(data.ConversationTitle)}
+	rawEvent := dingtalkRawEvent{
+		AppID:             appID,
+		ConversationTitle: strings.TrimSpace(data.ConversationTitle),
+		Sender: dingtalkSenderProfile{
+			SenderID:           strings.TrimSpace(data.SenderId),
+			CorpID:             strings.TrimSpace(data.SenderCorpId),
+			Nickname:           strings.TrimSpace(data.SenderNick),
+			IsAdmin:            data.IsAdmin,
+			MessageCreatedAtMS: data.CreateAt,
+		},
+	}
 	msg := channel.InboundMessage{
 		EventID:        data.MsgId,
 		MessageID:      data.MsgId,

--- a/server/internal/integrations/dingtalk/inbound_test.go
+++ b/server/internal/integrations/dingtalk/inbound_test.go
@@ -37,6 +37,31 @@ func TestInboundFromCallback_P2PAddressedAndTrimmed(t *testing.T) {
 	}
 }
 
+func TestInboundFromCallback_CarriesSenderProfileMetadata(t *testing.T) {
+	callback := textCallback(convTypeP2P, false)
+	callback.SenderId = "encrypted-open-id"
+	callback.SenderCorpId = "corp-42"
+	callback.SenderNick = "Ada Lovelace"
+	callback.IsAdmin = true
+	callback.CreateAt = 1_777_777_777_000
+
+	msg, ok := inboundFromCallback(callback, "appkey-A")
+	if !ok {
+		t.Fatal("expected sender profile callback to be ingested")
+	}
+	raw, err := decodeDingTalkRaw(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw.Sender.SenderID != "encrypted-open-id" ||
+		raw.Sender.CorpID != "corp-42" ||
+		raw.Sender.Nickname != "Ada Lovelace" ||
+		!raw.Sender.IsAdmin ||
+		raw.Sender.MessageCreatedAtMS != 1_777_777_777_000 {
+		t.Fatalf("sender profile metadata = %+v", raw.Sender)
+	}
+}
+
 func TestInboundFromCallback_GroupAddressing(t *testing.T) {
 	callback := textCallback(convTypeGroup, true)
 	callback.ConversationTitle = "Platform team"

--- a/server/internal/integrations/dingtalk/resolvers.go
+++ b/server/internal/integrations/dingtalk/resolvers.go
@@ -21,6 +21,8 @@ import (
 // constraint, like the existing lark_chat and slack_chat channel origins.
 const originDingTalkChat = "dingtalk_chat"
 
+var errDingTalkParticipantBindingUnavailable = errors.New("dingtalk: participant binding is no longer valid")
+
 // This file is the DingTalk ResolverSet: the platform-specific seams the
 // channel-agnostic engine.Router runs the inbound pipeline through. It is built
 // entirely on the generic channel_* queries plus the shared engine.ChatSession,
@@ -38,12 +40,15 @@ func NewDingTalkResolverSet(q *db.Queries, tx engine.TxStarter, replier engine.O
 		_, err := q.WithTx(appendTx).LockDingTalkGroupRouteForAppend(ctx, arg)
 		return err
 	}
+	recordParticipantForAppend := func(ctx context.Context, appendTx pgx.Tx, arg db.RecordDingTalkParticipantParams) (int64, error) {
+		return q.WithTx(appendTx).RecordDingTalkParticipant(ctx, arg)
+	}
 	set := engine.ResolverSet{
 		Installation: &installationResolver{q: q},
 		Identity:     &identityResolver{q: q},
 		Validated:    &validatedInboundResolver{q: q},
 		Dedup:        &deduper{q: q},
-		Session: &sessionBinder{q: q, lockRouteForAppend: lockRouteForAppend, session: engine.NewChatSession(q, tx, TypeDingTalk, engine.SessionTitles{
+		Session: &sessionBinder{q: q, lockRouteForAppend: lockRouteForAppend, recordParticipantForAppend: recordParticipantForAppend, session: engine.NewChatSession(q, tx, TypeDingTalk, engine.SessionTitles{
 			Group:    "DingTalk group",
 			Direct:   "DingTalk direct message",
 			Fallback: "DingTalk chat",
@@ -293,9 +298,10 @@ type sessionQueries interface {
 }
 
 type sessionBinder struct {
-	q                  sessionQueries
-	lockRouteForAppend func(context.Context, pgx.Tx, db.LockDingTalkGroupRouteForAppendParams) error
-	session            chatSession
+	q                          sessionQueries
+	lockRouteForAppend         func(context.Context, pgx.Tx, db.LockDingTalkGroupRouteForAppendParams) error
+	recordParticipantForAppend func(context.Context, pgx.Tx, db.RecordDingTalkParticipantParams) (int64, error)
+	session                    chatSession
 }
 
 func (r *sessionBinder) EnsureSession(ctx context.Context, p engine.EnsureSessionParams) (pgtype.UUID, error) {
@@ -363,6 +369,14 @@ func (r *sessionBinder) MarkPendingFresh(ctx context.Context, sessionID pgtype.U
 }
 
 func (r *sessionBinder) AppendMessage(ctx context.Context, p engine.AppendParams) (engine.AppendResult, error) {
+	var raw dingtalkRawEvent
+	if r.recordParticipantForAppend != nil {
+		var err error
+		raw, err = decodeDingTalkRaw(p.Message)
+		if err != nil {
+			return engine.AppendResult{}, err
+		}
+	}
 	commandText := p.Message.CommandText
 	if commandText == "" {
 		commandText = p.Message.Text
@@ -379,19 +393,41 @@ func (r *sessionBinder) AppendMessage(ctx context.Context, p engine.AppendParams
 		MediaPendingSeconds: p.MediaPendingSeconds,
 		ForceFresh:          p.Message.ForceFresh,
 	}
-	if p.Message.Source.ChatType == channel.ChatTypeGroup && r.lockRouteForAppend != nil {
-		params := db.LockDingTalkGroupRouteForAppendParams{
+	if r.recordParticipantForAppend != nil || (p.Message.Source.ChatType == channel.ChatTypeGroup && r.lockRouteForAppend != nil) {
+		routeParams := db.LockDingTalkGroupRouteForAppendParams{
 			InstallationID: p.InstallationID,
 			ConversationID: p.Message.Source.ChatID,
 			AgentID:        p.AgentID,
 			RouteRevision:  p.RouteRevision,
 		}
+		participantParams := db.RecordDingTalkParticipantParams{
+			SenderID:           raw.Sender.SenderID,
+			CorpID:             raw.Sender.CorpID,
+			Nickname:           raw.Sender.Nickname,
+			IsAdmin:            raw.Sender.IsAdmin,
+			MessageCreatedAtMs: raw.Sender.MessageCreatedAtMS,
+			InstallationID:     p.InstallationID,
+			WorkspaceID:        p.WorkspaceID,
+			MulticaUserID:      p.Sender,
+			DingtalkStaffID:    p.Message.Source.SenderID,
+		}
 		input.BeforeWrite = func(ctx context.Context, tx pgx.Tx) error {
-			if err := r.lockRouteForAppend(ctx, tx, params); err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					return engine.ErrRouteChanged
+			if p.Message.Source.ChatType == channel.ChatTypeGroup && r.lockRouteForAppend != nil {
+				if err := r.lockRouteForAppend(ctx, tx, routeParams); err != nil {
+					if errors.Is(err, pgx.ErrNoRows) {
+						return engine.ErrRouteChanged
+					}
+					return fmt.Errorf("lock dingtalk group route for append: %w", err)
 				}
-				return fmt.Errorf("lock dingtalk group route for append: %w", err)
+			}
+			if r.recordParticipantForAppend != nil {
+				recorded, err := r.recordParticipantForAppend(ctx, tx, participantParams)
+				if err != nil {
+					return fmt.Errorf("record dingtalk participant: %w", err)
+				}
+				if recorded != 1 {
+					return errDingTalkParticipantBindingUnavailable
+				}
 			}
 			return nil
 		}

--- a/server/internal/integrations/dingtalk/resolvers_test.go
+++ b/server/internal/integrations/dingtalk/resolvers_test.go
@@ -195,10 +195,11 @@ func TestDingTalkP2PSkipsGroupDiscoveryAndUsesDefaultAgentSession(t *testing.T) 
 	msg := channel.InboundMessage{Source: channel.Source{
 		ChatID: "cid-direct", ChatType: channel.ChatTypeP2P, SenderID: "staff-7",
 	}}
+	msg.Raw, _ = json.Marshal(dingtalkRawEvent{})
 	discovery := &fakeValidatedInboundQueries{err: errors.New("must not query group routes for p2p")}
 
 	resolved, err := (&validatedInboundResolver{q: discovery}).ResolveValidatedInbound(
-		context.Background(), inst, engine.ResolvedIdentity{}, msg,
+		context.Background(), inst, engine.ResolvedIdentity{UserID: senderID}, msg,
 	)
 	if err != nil || resolved.AgentID != defaultAgentID || discovery.calls != 0 {
 		t.Fatalf("p2p validated resolution = %+v err=%v discovery calls=%d", resolved, err, discovery.calls)
@@ -242,19 +243,22 @@ func TestDingTalkP2PSkipsGroupDiscoveryAndUsesDefaultAgentSession(t *testing.T) 
 }
 
 func TestValidatedInboundResolverDiscoversGroupAndFinalizesAgent(t *testing.T) {
-	var installationID, workspaceID, defaultAgentID, routeAgentID pgtype.UUID
-	installationID.Bytes[0], workspaceID.Bytes[0], defaultAgentID.Bytes[0], routeAgentID.Bytes[0] = 1, 2, 3, 4
-	installationID.Valid, workspaceID.Valid, defaultAgentID.Valid, routeAgentID.Valid = true, true, true, true
+	var installationID, workspaceID, defaultAgentID, routeAgentID, multicaUserID pgtype.UUID
+	installationID.Bytes[0], workspaceID.Bytes[0], defaultAgentID.Bytes[0], routeAgentID.Bytes[0], multicaUserID.Bytes[0] = 1, 2, 3, 4, 5
+	installationID.Valid, workspaceID.Valid, defaultAgentID.Valid, routeAgentID.Valid, multicaUserID.Valid = true, true, true, true, true
 	fake := &fakeValidatedInboundQueries{row: db.DiscoverDingTalkGroupRouteRow{
 		AgentID: routeAgentID, Revision: 7, AgentActive: true,
 	}}
-	raw, _ := json.Marshal(dingtalkRawEvent{ConversationTitle: "Platform team"})
+	raw, _ := json.Marshal(dingtalkRawEvent{
+		ConversationTitle: "Platform team",
+		Sender:            dingtalkSenderProfile{Nickname: "Grace Hopper"},
+	})
 	resolved, err := (&validatedInboundResolver{q: fake}).ResolveValidatedInbound(
 		context.Background(),
 		engine.ResolvedInstallation{ID: installationID, WorkspaceID: workspaceID, AgentID: defaultAgentID},
-		engine.ResolvedIdentity{},
+		engine.ResolvedIdentity{UserID: multicaUserID},
 		channel.InboundMessage{
-			Source: channel.Source{ChatID: "cid-platform", ChatType: channel.ChatTypeGroup},
+			Source: channel.Source{ChatID: "cid-platform", ChatType: channel.ChatTypeGroup, SenderID: "staff-group"},
 			Raw:    raw,
 		},
 	)
@@ -283,6 +287,113 @@ func TestValidatedInboundResolverPreservesArchivedRoute(t *testing.T) {
 	}
 	if resolved.AgentID != routeAgentID {
 		t.Fatalf("archived route agent = %v, want preserved %v", resolved.AgentID, routeAgentID)
+	}
+}
+
+func TestSessionBinderRecordsParticipantInsideAppendTransaction(t *testing.T) {
+	var sessionID, installationID, workspaceID, multicaUserID pgtype.UUID
+	sessionID.Bytes[0], installationID.Bytes[0], workspaceID.Bytes[0], multicaUserID.Bytes[0] = 1, 2, 3, 4
+	sessionID.Valid, installationID.Valid, workspaceID.Valid, multicaUserID.Valid = true, true, true, true
+	raw, _ := json.Marshal(dingtalkRawEvent{Sender: dingtalkSenderProfile{
+		SenderID: "encrypted-open-id", CorpID: "corp-42", Nickname: "Ada Lovelace",
+		IsAdmin: true, MessageCreatedAtMS: 1_777_777_777_000,
+	}})
+	capture := &captureChatSession{runGuard: true}
+	var participantParams db.RecordDingTalkParticipantParams
+	participantCalls := 0
+	binder := &sessionBinder{
+		session: capture,
+		recordParticipantForAppend: func(_ context.Context, _ pgx.Tx, params db.RecordDingTalkParticipantParams) (int64, error) {
+			participantCalls++
+			participantParams = params
+			return 1, nil
+		},
+	}
+
+	_, err := binder.AppendMessage(context.Background(), engine.AppendParams{
+		SessionID: sessionID, Sender: multicaUserID,
+		InstallationID: installationID, WorkspaceID: workspaceID,
+		Message: channel.InboundMessage{
+			Text: "hello", Raw: raw,
+			Source: channel.Source{ChatType: channel.ChatTypeP2P, SenderID: "staff-9"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := db.RecordDingTalkParticipantParams{
+		SenderID: "encrypted-open-id", CorpID: "corp-42", Nickname: "Ada Lovelace",
+		IsAdmin: true, MessageCreatedAtMs: 1_777_777_777_000,
+		InstallationID: installationID, WorkspaceID: workspaceID,
+		MulticaUserID: multicaUserID, DingtalkStaffID: "staff-9",
+	}
+	if participantCalls != 1 || participantParams != want || capture.appended != 1 {
+		t.Fatalf("participant calls=%d params=%+v durable appends=%d", participantCalls, participantParams, capture.appended)
+	}
+}
+
+func TestSessionBinderParticipantFailurePreventsDurableAppend(t *testing.T) {
+	queryErr := errors.New("participant database unavailable")
+	raw, _ := json.Marshal(dingtalkRawEvent{})
+	capture := &captureChatSession{runGuard: true}
+	binder := &sessionBinder{
+		session: capture,
+		recordParticipantForAppend: func(context.Context, pgx.Tx, db.RecordDingTalkParticipantParams) (int64, error) {
+			return 0, queryErr
+		},
+	}
+
+	_, err := binder.AppendMessage(context.Background(), engine.AppendParams{
+		Message: channel.InboundMessage{Raw: raw},
+	})
+	if !errors.Is(err, queryErr) || capture.appended != 0 {
+		t.Fatalf("participant failure err=%v durable appends=%d", err, capture.appended)
+	}
+}
+
+func TestSessionBinderMissingParticipantBindingPreventsDurableAppend(t *testing.T) {
+	raw, _ := json.Marshal(dingtalkRawEvent{})
+	capture := &captureChatSession{runGuard: true}
+	binder := &sessionBinder{
+		session: capture,
+		recordParticipantForAppend: func(context.Context, pgx.Tx, db.RecordDingTalkParticipantParams) (int64, error) {
+			return 0, nil
+		},
+	}
+
+	_, err := binder.AppendMessage(context.Background(), engine.AppendParams{
+		Message: channel.InboundMessage{Raw: raw},
+	})
+	if !errors.Is(err, errDingTalkParticipantBindingUnavailable) || capture.appended != 0 {
+		t.Fatalf("missing participant binding err=%v durable appends=%d", err, capture.appended)
+	}
+}
+
+func TestSessionBinderRouteChangeDoesNotRecordParticipant(t *testing.T) {
+	raw, _ := json.Marshal(dingtalkRawEvent{})
+	capture := &captureChatSession{runGuard: true}
+	participantCalls := 0
+	binder := &sessionBinder{
+		session: capture,
+		lockRouteForAppend: func(context.Context, pgx.Tx, db.LockDingTalkGroupRouteForAppendParams) error {
+			return pgx.ErrNoRows
+		},
+		recordParticipantForAppend: func(context.Context, pgx.Tx, db.RecordDingTalkParticipantParams) (int64, error) {
+			participantCalls++
+			return 1, nil
+		},
+	}
+
+	_, err := binder.AppendMessage(context.Background(), engine.AppendParams{
+		Message: channel.InboundMessage{
+			Raw: raw,
+			Source: channel.Source{
+				ChatType: channel.ChatTypeGroup, ChatID: "group-1", SenderID: "staff-9",
+			},
+		},
+	})
+	if !errors.Is(err, engine.ErrRouteChanged) || participantCalls != 0 || capture.appended != 0 {
+		t.Fatalf("route change err=%v participant calls=%d durable appends=%d", err, participantCalls, capture.appended)
 	}
 }
 

--- a/server/pkg/db/generated/dingtalk.sql.go
+++ b/server/pkg/db/generated/dingtalk.sql.go
@@ -347,6 +347,96 @@ func (q *Queries) ListDingTalkGroupRoutesByWorkspace(ctx context.Context, worksp
 	return items, nil
 }
 
+const listDingTalkParticipantsByWorkspace = `-- name: ListDingTalkParticipantsByWorkspace :many
+SELECT
+    binding.installation_id,
+    binding.multica_user_id,
+    user_record.name AS multica_user_name,
+    binding.channel_user_id AS dingtalk_staff_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,sender_id}', '')::text AS dingtalk_sender_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,corp_id}', '')::text AS dingtalk_corp_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,nickname}', '')::text AS dingtalk_nickname,
+    COALESCE((binding.config #>> '{dingtalk_participant,is_admin}')::boolean, false)::boolean AS is_admin,
+    COALESCE(
+        (binding.config #>> '{dingtalk_participant,first_seen_at}')::timestamptz,
+        binding.bound_at
+    ) AS first_seen_at,
+    COALESCE(
+        (binding.config #>> '{dingtalk_participant,last_seen_at}')::timestamptz,
+        binding.bound_at
+    ) AS last_seen_at,
+    CASE
+        WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,message_count}') = 'number'
+            THEN (binding.config #>> '{dingtalk_participant,message_count}')::bigint
+        ELSE 0
+    END::bigint AS message_count,
+    CASE
+        WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,last_message_created_at_ms}') = 'number'
+            THEN (binding.config #>> '{dingtalk_participant,last_message_created_at_ms}')::bigint
+        ELSE 0
+    END::bigint AS last_message_created_at_ms
+FROM channel_user_binding binding
+JOIN member current_member
+  ON current_member.workspace_id = binding.workspace_id
+ AND current_member.user_id = binding.multica_user_id
+JOIN "user" user_record ON user_record.id = binding.multica_user_id
+WHERE binding.workspace_id = $1
+  AND binding.channel_type = 'dingtalk'
+  AND binding.config ? 'dingtalk_participant'
+ORDER BY last_seen_at DESC, binding.installation_id ASC, binding.channel_user_id ASC
+`
+
+type ListDingTalkParticipantsByWorkspaceRow struct {
+	InstallationID         pgtype.UUID        `json:"installation_id"`
+	MulticaUserID          pgtype.UUID        `json:"multica_user_id"`
+	MulticaUserName        string             `json:"multica_user_name"`
+	DingtalkStaffID        string             `json:"dingtalk_staff_id"`
+	DingtalkSenderID       string             `json:"dingtalk_sender_id"`
+	DingtalkCorpID         string             `json:"dingtalk_corp_id"`
+	DingtalkNickname       string             `json:"dingtalk_nickname"`
+	IsAdmin                bool               `json:"is_admin"`
+	FirstSeenAt            pgtype.Timestamptz `json:"first_seen_at"`
+	LastSeenAt             pgtype.Timestamptz `json:"last_seen_at"`
+	MessageCount           int64              `json:"message_count"`
+	LastMessageCreatedAtMs int64              `json:"last_message_created_at_ms"`
+}
+
+// Admin-only API query. Join current membership defensively even though member
+// removal prunes the binding in the same application transaction. No email,
+// mobile number, callback credential, or message content is returned.
+func (q *Queries) ListDingTalkParticipantsByWorkspace(ctx context.Context, workspaceID pgtype.UUID) ([]ListDingTalkParticipantsByWorkspaceRow, error) {
+	rows, err := q.db.Query(ctx, listDingTalkParticipantsByWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListDingTalkParticipantsByWorkspaceRow{}
+	for rows.Next() {
+		var i ListDingTalkParticipantsByWorkspaceRow
+		if err := rows.Scan(
+			&i.InstallationID,
+			&i.MulticaUserID,
+			&i.MulticaUserName,
+			&i.DingtalkStaffID,
+			&i.DingtalkSenderID,
+			&i.DingtalkCorpID,
+			&i.DingtalkNickname,
+			&i.IsAdmin,
+			&i.FirstSeenAt,
+			&i.LastSeenAt,
+			&i.MessageCount,
+			&i.LastMessageCreatedAtMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDingTalkUserBindingsForMember = `-- name: ListDingTalkUserBindingsForMember :many
 
 SELECT installation_id, channel_user_id
@@ -562,4 +652,96 @@ func (q *Queries) ReassignDingTalkGroupRoute(ctx context.Context, arg ReassignDi
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const recordDingTalkParticipant = `-- name: RecordDingTalkParticipant :execrows
+UPDATE channel_user_binding AS binding
+SET config = jsonb_set(
+    binding.config,
+    '{dingtalk_participant}',
+    (
+        CASE
+            WHEN jsonb_typeof(binding.config -> 'dingtalk_participant') = 'object'
+                THEN binding.config -> 'dingtalk_participant'
+            ELSE '{}'::jsonb
+        END
+        || jsonb_strip_nulls(jsonb_build_object(
+            'sender_id', NULLIF($1::text, ''),
+            'corp_id', NULLIF($2::text, ''),
+            'nickname', NULLIF($3::text, ''),
+            'is_admin', $4::boolean,
+            'last_message_created_at_ms', CASE
+                WHEN $5::bigint > 0
+                    THEN to_jsonb($5::bigint)
+                ELSE NULL
+            END
+        ))
+        || jsonb_build_object(
+            'first_seen_at', COALESCE(
+                binding.config #> '{dingtalk_participant,first_seen_at}',
+                to_jsonb(now())
+            ),
+            'last_seen_at', to_jsonb(now()),
+            'message_count', CASE
+                WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,message_count}') = 'number'
+                    THEN (binding.config #>> '{dingtalk_participant,message_count}')::bigint
+                ELSE 0
+            END + 1
+        )
+    ),
+    true
+)
+WHERE binding.installation_id = $6
+  AND binding.workspace_id = $7
+  AND binding.multica_user_id = $8
+  AND binding.channel_type = 'dingtalk'
+  AND binding.channel_user_id = $9
+  AND EXISTS (
+      SELECT 1
+      FROM member current_member
+      WHERE current_member.workspace_id = binding.workspace_id
+        AND current_member.user_id = binding.multica_user_id
+  )
+`
+
+type RecordDingTalkParticipantParams struct {
+	SenderID           string      `json:"sender_id"`
+	CorpID             string      `json:"corp_id"`
+	Nickname           string      `json:"nickname"`
+	IsAdmin            bool        `json:"is_admin"`
+	MessageCreatedAtMs int64       `json:"message_created_at_ms"`
+	InstallationID     pgtype.UUID `json:"installation_id"`
+	WorkspaceID        pgtype.UUID `json:"workspace_id"`
+	MulticaUserID      pgtype.UUID `json:"multica_user_id"`
+	DingtalkStaffID    string      `json:"dingtalk_staff_id"`
+}
+
+// Enrich the already-linked DingTalk identity only after the shared inbound
+// router has validated both account binding and current workspace membership.
+// The binding row is the natural participant record: it is already unique by
+// (installation_id, channel_user_id), and all member/install/workspace cleanup
+// paths already delete it. Keeping the profile under one namespaced config key
+// avoids a second identity table and preserves any unrelated binding config.
+//
+// Empty mutable string fields do not erase a previously observed value. The
+// callback's admin flag is authoritative on every message. Interaction counts
+// use one atomic UPDATE inside the durable message transaction, and malformed
+// legacy JSON falls back to a clean object and zero count instead of aborting
+// inbound processing.
+func (q *Queries) RecordDingTalkParticipant(ctx context.Context, arg RecordDingTalkParticipantParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recordDingTalkParticipant,
+		arg.SenderID,
+		arg.CorpID,
+		arg.Nickname,
+		arg.IsAdmin,
+		arg.MessageCreatedAtMs,
+		arg.InstallationID,
+		arg.WorkspaceID,
+		arg.MulticaUserID,
+		arg.DingtalkStaffID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/server/pkg/db/queries/dingtalk.sql
+++ b/server/pkg/db/queries/dingtalk.sql
@@ -13,6 +13,108 @@ WHERE workspace_id = sqlc.arg(workspace_id)
   AND channel_type = 'dingtalk'
 ORDER BY bound_at DESC, id ASC;
 
+-- name: RecordDingTalkParticipant :execrows
+-- Enrich the already-linked DingTalk identity only after the shared inbound
+-- router has validated both account binding and current workspace membership.
+-- The binding row is the natural participant record: it is already unique by
+-- (installation_id, channel_user_id), and all member/install/workspace cleanup
+-- paths already delete it. Keeping the profile under one namespaced config key
+-- avoids a second identity table and preserves any unrelated binding config.
+--
+-- Empty mutable string fields do not erase a previously observed value. The
+-- callback's admin flag is authoritative on every message. Interaction counts
+-- use one atomic UPDATE inside the durable message transaction, and malformed
+-- legacy JSON falls back to a clean object and zero count instead of aborting
+-- inbound processing.
+UPDATE channel_user_binding AS binding
+SET config = jsonb_set(
+    binding.config,
+    '{dingtalk_participant}',
+    (
+        CASE
+            WHEN jsonb_typeof(binding.config -> 'dingtalk_participant') = 'object'
+                THEN binding.config -> 'dingtalk_participant'
+            ELSE '{}'::jsonb
+        END
+        || jsonb_strip_nulls(jsonb_build_object(
+            'sender_id', NULLIF(sqlc.arg(sender_id)::text, ''),
+            'corp_id', NULLIF(sqlc.arg(corp_id)::text, ''),
+            'nickname', NULLIF(sqlc.arg(nickname)::text, ''),
+            'is_admin', sqlc.arg(is_admin)::boolean,
+            'last_message_created_at_ms', CASE
+                WHEN sqlc.arg(message_created_at_ms)::bigint > 0
+                    THEN to_jsonb(sqlc.arg(message_created_at_ms)::bigint)
+                ELSE NULL
+            END
+        ))
+        || jsonb_build_object(
+            'first_seen_at', COALESCE(
+                binding.config #> '{dingtalk_participant,first_seen_at}',
+                to_jsonb(now())
+            ),
+            'last_seen_at', to_jsonb(now()),
+            'message_count', CASE
+                WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,message_count}') = 'number'
+                    THEN (binding.config #>> '{dingtalk_participant,message_count}')::bigint
+                ELSE 0
+            END + 1
+        )
+    ),
+    true
+)
+WHERE binding.installation_id = sqlc.arg(installation_id)
+  AND binding.workspace_id = sqlc.arg(workspace_id)
+  AND binding.multica_user_id = sqlc.arg(multica_user_id)
+  AND binding.channel_type = 'dingtalk'
+  AND binding.channel_user_id = sqlc.arg(dingtalk_staff_id)
+  AND EXISTS (
+      SELECT 1
+      FROM member current_member
+      WHERE current_member.workspace_id = binding.workspace_id
+        AND current_member.user_id = binding.multica_user_id
+  );
+
+-- name: ListDingTalkParticipantsByWorkspace :many
+-- Admin-only API query. Join current membership defensively even though member
+-- removal prunes the binding in the same application transaction. No email,
+-- mobile number, callback credential, or message content is returned.
+SELECT
+    binding.installation_id,
+    binding.multica_user_id,
+    user_record.name AS multica_user_name,
+    binding.channel_user_id AS dingtalk_staff_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,sender_id}', '')::text AS dingtalk_sender_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,corp_id}', '')::text AS dingtalk_corp_id,
+    COALESCE(binding.config #>> '{dingtalk_participant,nickname}', '')::text AS dingtalk_nickname,
+    COALESCE((binding.config #>> '{dingtalk_participant,is_admin}')::boolean, false)::boolean AS is_admin,
+    COALESCE(
+        (binding.config #>> '{dingtalk_participant,first_seen_at}')::timestamptz,
+        binding.bound_at
+    ) AS first_seen_at,
+    COALESCE(
+        (binding.config #>> '{dingtalk_participant,last_seen_at}')::timestamptz,
+        binding.bound_at
+    ) AS last_seen_at,
+    CASE
+        WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,message_count}') = 'number'
+            THEN (binding.config #>> '{dingtalk_participant,message_count}')::bigint
+        ELSE 0
+    END::bigint AS message_count,
+    CASE
+        WHEN jsonb_typeof(binding.config #> '{dingtalk_participant,last_message_created_at_ms}') = 'number'
+            THEN (binding.config #>> '{dingtalk_participant,last_message_created_at_ms}')::bigint
+        ELSE 0
+    END::bigint AS last_message_created_at_ms
+FROM channel_user_binding binding
+JOIN member current_member
+  ON current_member.workspace_id = binding.workspace_id
+ AND current_member.user_id = binding.multica_user_id
+JOIN "user" user_record ON user_record.id = binding.multica_user_id
+WHERE binding.workspace_id = sqlc.arg(workspace_id)
+  AND binding.channel_type = 'dingtalk'
+  AND binding.config ? 'dingtalk_participant'
+ORDER BY last_seen_at DESC, binding.installation_id ASC, binding.channel_user_id ASC;
+
 -- name: DiscoverDingTalkGroupRoute :one
 -- Persist a group only after the shared inbound router has accepted the @bot
 -- message and validated the sender's identity/workspace membership. The INSERT


### PR DESCRIPTION
## What does this PR do?

Persist the minimal DingTalk sender profile observed when a linked workspace member successfully sends a validated bot message.

The callback metadata is carried through the adapter envelope and written to the existing `channel_user_binding.config` under a namespaced `dingtalk_participant` key. The update runs inside the same transaction as the durable message append and dedup mark, so route retries and rejected callbacks do not inflate interaction counts.

An owner/admin-only endpoint exposes the recorded participant list:

`GET /api/workspaces/{id}/dingtalk/participants`

It returns linked Multica identity, DingTalk identifiers and nickname, admin flag, first/last seen timestamps, and message count. It does not return message content, email, mobile number, webhook data, or credentials.

### Thinking path and risks

- The existing user binding is the lifecycle owner for a DingTalk identity, so namespaced config avoids a redundant table and inherits member, installation, and workspace cleanup behavior.
- Recording happens only after account binding and current workspace membership validation.
- The group route fence runs before recording inside the append transaction, preventing stale-route retries from double-counting participants.
- If the binding disappears before append, the message is rejected rather than persisting a message without its participant record.
- Stable platform identifiers are available only through the existing owner/admin authorization boundary.

## Related Issue

Closes #7330

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Decode DingTalk `senderId`, `senderCorpId`, `senderNick`, `isAdmin`, and `createAt` callback fields.
- Atomically enrich the linked `channel_user_binding` while appending accepted messages.
- Add an owner/admin-only participant listing query and HTTP handler.
- Add coverage for metadata normalization, transactional failure behavior, route conflicts, rejected callbacks, field refresh/preservation, and authorization.

## How to Test

1. Run `make sqlc`.
2. Run `cd server && env GOCACHE=/private/tmp/mutica-go-cache go test -race ./internal/integrations/dingtalk ./internal/integrations/channel/engine ./internal/handler -count=1`.
3. Run `cd server && env GOCACHE=/private/tmp/mutica-go-cache go build ./...`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: no public documentation change required)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect the existing DingTalk inbound pipeline and identity-binding lifecycle, confirm the official callback sender fields, implement transactional persistence and an admin-only query endpoint, add regression and authorization coverage, review the complete diff, and run sqlc generation, race tests, and a full backend build.

## Screenshots (optional)

N/A: backend-only change.
