### PR TITLE
feat(agent): add Junie CLI as a native ACP runtime

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -220,6 +220,7 @@ The daemon auto-detects these AI CLIs on your PATH:
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | `reasonix` | DeepSeek-focused ACP coding agent (run `reasonix setup` first) |
 | Dim | `dim` | DimCode ACP coding agent (speaks the ACP protocol via `dim acp`) |
 | Kiro CLI | `kiro-cli` | Kiro ACP coding agent |
+| [Junie](https://junie.jetbrains.com/) | `junie` | JetBrains Junie ACP coding agent (ACP via `junie --acp=true`) |
 | [Qoder CLI](https://docs.qoder.com/) | `qodercli` | Qoder ACP coding agent |
 | [Qoder CN CLI](https://help.aliyun.com/en/lingma/qodercli-cn/product-overview/what-is-qoder-cli-cn) | `qoderclicn` | Qoder CN ACP coding agent |
 | [Trae](https://docs.trae.cn/cli) | `traecli` | ByteDance TRAE CLI (ACP via `traecli acp serve`) |
@@ -328,6 +329,8 @@ Agent-specific overrides:
 | `MULTICA_DIM_MODEL` | Override the Dim model used |
 | `MULTICA_KIRO_PATH` | Custom path to the `kiro-cli` binary |
 | `MULTICA_KIRO_MODEL` | Override the Kiro model used |
+| `MULTICA_JUNIE_PATH` | Custom path to the `junie` binary |
+| `MULTICA_JUNIE_MODEL` | Override the Junie model used |
 | `MULTICA_QODER_PATH` | Custom path to the `qodercli` binary |
 | `MULTICA_QODER_MODEL` | Override the Qoder model used |
 | `MULTICA_QODERCLICN_PATH` | Custom path to the `qoderclicn` binary |
@@ -352,7 +355,7 @@ The daemon launches Qwen Code as `qwen -p <prompt> --output-format stream-json`.
 
 #### `mcp_config` on ACP runtimes
 
-ACP-family runtimes — Hermes, Kimi, Kiro, Grok, Qoder, Reasonix, Trae, QwenPaw, MiniMax Code, Dim, and any custom runtime profile whose `protocol_family` is one of them — receive MCP servers **over the ACP session protocol**, not through a config file. The daemon translates the agent's `mcp_config` into ACP's `McpServer` array and sends it with `session/new`, and again with that runtime's resume request (`session/resume` on Hermes, Kimi, Qoder and Reasonix; `session/load` on Kiro, Grok, Trae, QwenPaw and Dim) so a resumed task keeps the same tools. MiniMax Code 0.1.2 advertises no session-loading capability, so a later run falls back to a fresh session.
+ACP-family runtimes — Hermes, Kimi, Kiro, Junie, Grok, Qoder, Reasonix, Trae, QwenPaw, MiniMax Code, Dim, and any custom runtime profile whose `protocol_family` is one of them — receive MCP servers **over the ACP session protocol**, not through a config file. The daemon translates the agent's `mcp_config` into ACP's `McpServer` array and sends it with `session/new`, and again with that runtime's resume request (`session/resume` on Hermes, Kimi, Qoder and Reasonix; `session/load` on Kiro, Junie, Grok, Trae, QwenPaw and Dim) so a resumed task keeps the same tools. MiniMax Code 0.1.2 advertises no session-loading capability, so a later run falls back to a fresh session.
 
 Nothing is written to the runtime's own config file, and the runtime's own file is not read or merged. `~/.hermes/…`, `~/.jcode/mcp.json` and the like stay untouched; an agent's servers travel with its tasks instead of being installed per machine.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ authenticated, so switching providers is a dropdown, not a migration.
 | Qwen Code | `qwen` | QwenPaw | `qwenpaw` |
 | Reasonix | `reasonix` | Trae CLI | `traecli` |
 | DeepSeek Harness | `dsh` | Oh-My-Pi | `omp` |
-| MiniMax Code | `mcode` | — | — |
+| MiniMax Code | `mcode` | Junie | `junie` |
 | Dim | `dim` | | |
 
 Installing and authenticating them: [Install an agent runtime](https://multica.ai/docs/install-agent-runtime) ·

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -124,6 +124,7 @@ You also need at least one AI agent CLI installed:
 - [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) (`reasonix` on PATH; run `reasonix setup` first)
 - Dim (`dim` on PATH)
 - Kiro CLI (`kiro-cli` on PATH)
+- [Junie](https://junie.jetbrains.com/) (`junie` on PATH)
 - Qoder CLI (`qodercli` on PATH)
 - Qoder CN CLI (`qoderclicn` on PATH)
 - Trae CLI (`traecli` on PATH)

--- a/apps/docs/content/docs/providers.ja.mdx
+++ b/apps/docs/content/docs/providers.ja.mdx
@@ -30,6 +30,7 @@ Multica は、普段使っている AI コーディングツールの代わり�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 1 回の実行専用の `HERMES_HOME/skills/` |
+| Junie | `junie` | ✓ | ✓ | — |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.ja.mdx
+++ b/apps/docs/content/docs/providers.ja.mdx
@@ -30,7 +30,7 @@ Multica は、普段使っている AI コーディングツールの代わり�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 1 回の実行専用の `HERMES_HOME/skills/` |
-| Junie | `junie` | ✓ | ✓ | — |
+| Junie | `junie` | ✓ | ✓ | `.junie/skills/` |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.ko.mdx
+++ b/apps/docs/content/docs/providers.ko.mdx
@@ -30,7 +30,7 @@ Multica는 사용 중인 AI 코딩 도구를 대체하지 않습니다. 런타�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 실행별 `HERMES_HOME/skills/` |
-| Junie | `junie` | ✓ | ✓ | — |
+| Junie | `junie` | ✓ | ✓ | `.junie/skills/` |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.ko.mdx
+++ b/apps/docs/content/docs/providers.ko.mdx
@@ -30,6 +30,7 @@ Multica는 사용 중인 AI 코딩 도구를 대체하지 않습니다. 런타�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 실행별 `HERMES_HOME/skills/` |
+| Junie | `junie` | ✓ | ✓ | — |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -30,7 +30,7 @@ Install steps are in [Install AI coding tools](/install-agent-runtime).
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | per-task `HERMES_HOME/skills/` |
-| Junie | `junie` | ✓ | ✓ | — |
+| Junie | `junie` | ✓ | ✓ | `.junie/skills/` |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -30,6 +30,7 @@ Install steps are in [Install AI coding tools](/install-agent-runtime).
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | per-task `HERMES_HOME/skills/` |
+| Junie | `junie` | ✓ | ✓ | — |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.zh.mdx
+++ b/apps/docs/content/docs/providers.zh.mdx
@@ -30,6 +30,7 @@ Multica 不会替代你使用的 AI 编程工具。运行时会调用电脑上�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 单次执行的 `HERMES_HOME/skills/` |
+| Junie | `junie` | ✓ | ✓ | — |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/apps/docs/content/docs/providers.zh.mdx
+++ b/apps/docs/content/docs/providers.zh.mdx
@@ -30,7 +30,7 @@ Multica 不会替代你使用的 AI 编程工具。运行时会调用电脑上�
 | DevEco Code | `deveco` | ✓ | — | `.deveco/skills/` |
 | Grok | `grok` | ✓ | ✓ | `.grok/skills/` |
 | Hermes | `hermes` | ✓ | ✓ | 单次执行的 `HERMES_HOME/skills/` |
-| Junie | `junie` | ✓ | ✓ | — |
+| Junie | `junie` | ✓ | ✓ | `.junie/skills/` |
 | Kimi CLI | `kimi` | ✓ | ✓ | `.kimi/skills/` |
 | Kiro CLI | `kiro-cli` | ✓ | ✓ | `.kiro/skills/` |
 | MiniMax Code | `mcode` | — | ✓ | `.minimax/skills/` |

--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -16,6 +16,7 @@ const MCP_SUPPORTED_PROVIDERS = new Set([
   "reasonix",
   "dsh",
   "kiro",
+  "junie",
   "opencode",
   "openclaw",
   "qoder",

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -122,6 +122,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "dsh",
   "dim",
   "kiro",
+  "junie",
   "antigravity",
   "qoder",
   "qoderclicn",

--- a/packages/views/runtimes/components/provider-logo.test.tsx
+++ b/packages/views/runtimes/components/provider-logo.test.tsx
@@ -76,6 +76,20 @@ describe("ProviderLogo", () => {
     expect(logo?.classList.contains("runtime-logo")).toBe(true);
   });
 
+  it("renders the Junie mark instead of the generic fallback", () => {
+    const { container } = render(
+      <ProviderLogo provider="junie" className="runtime-logo" />,
+    );
+
+    const logo = container.querySelector("svg");
+
+    // Placeholder tile in the JetBrains Junie brand color until an official
+    // vector mark is sourced (see the comment above JunieLogo).
+    expect(logo?.querySelector('rect[fill="#000000"]')).not.toBeNull();
+    expect(logo?.querySelector('path[fill="#40FF40"]')).not.toBeNull();
+    expect(logo?.classList.contains("runtime-logo")).toBe(true);
+  });
+
   it("renders the MiniMax Code mark instead of the generic fallback", () => {
     const { container } = render(
       <ProviderLogo provider="mcode" className="runtime-logo" />,

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -219,6 +219,24 @@ function QoderLogo({ className }: { className: string }) {
   );
 }
 
+// Junie (JetBrains) — JetBrains publishes an official Junie wordmark
+// (colored/black/white SVG variants, brand color #40FF40) at
+// jetbrains.com/company/brand/, but no official mark asset was available to
+// embed verbatim here. This is a placeholder monochrome tile in the Junie
+// brand color, matching the compact letter-tile style already used for
+// Grok/Kimi/MCode; swap in the real vector mark once it is sourced.
+function JunieLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
+      <rect width="24" height="24" rx="5" fill="#000000" />
+      <path
+        d="M14.7 7.2h2.1v6.4c0 2.1-1.4 3.5-3.6 3.5-1.5 0-2.7-.6-3.4-1.7l1.6-1.3c.4.6 1 1 1.7 1 1 0 1.6-.6 1.6-1.7V7.2z"
+        fill="#40FF40"
+      />
+    </svg>
+  );
+}
+
 // Antigravity (Google) — official mark, shipped as a PNG asset next to this file.
 import antigravityLogo from "./antigravity-logo.png";
 const antigravityLogoSrc = staticAssetSrc(antigravityLogo);
@@ -381,6 +399,8 @@ export function ProviderLogo({
       return <ReasonixLogo className={className} />;
     case "kiro":
       return <KiroLogo className={className} />;
+    case "junie":
+      return <JunieLogo className={className} />;
     case "qoder":
     case "qoderclicn":
       return <QoderLogo className={className} />;

--- a/scripts/agent-cli-command-names.txt
+++ b/scripts/agent-cli-command-names.txt
@@ -9,6 +9,7 @@ dim
 dsh
 grok
 hermes
+junie
 kimi
 kiro-cli
 mcode

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -206,6 +206,13 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 	if e, ok := probe("MULTICA_KIRO_PATH", "kiro-cli", "MULTICA_KIRO_MODEL"); ok {
 		agents["kiro"] = e
 	}
+	// JetBrains Junie CLI (`junie`), driven over ACP via `junie --acp=true`.
+	// MULTICA_JUNIE_MODEL seeds the daemon-wide default model when one is
+	// configured; Junie's model catalog is not yet enumerable (see the
+	// case "junie" comment in models.go), so this is manual-entry only today.
+	if e, ok := probe("MULTICA_JUNIE_PATH", "junie", "MULTICA_JUNIE_MODEL"); ok {
+		agents["junie"] = e
+	}
 	if e, ok := probe("MULTICA_CODEBUDDY_PATH", "codebuddy", "MULTICA_CODEBUDDY_MODEL"); ok {
 		agents["codebuddy"] = e
 	}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -97,7 +97,7 @@ type Config struct {
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
-	Agents                         map[string]AgentEntry // keyed by provider: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, reasonix, dsh, kiro, antigravity, qoder, qoderclicn, traecli, grok, qwen, qwenpaw, mcode, dim (plus built-in runtime identities from agent.BuiltinRuntimes, e.g. omp)
+	Agents                         map[string]AgentEntry // keyed by provider: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, reasonix, dsh, kiro, junie, antigravity, qoder, qoderclicn, traecli, grok, qwen, qwenpaw, mcode, dim (plus built-in runtime identities from agent.BuiltinRuntimes, e.g. omp)
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
@@ -243,7 +243,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// can re-run the same discovery on a live daemon (MUL-5439).
 	agents := probeAgentCLIs()
 	if len(agents) == 0 && !overrides.AllowNoAgents {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, deveco, openclaw, hermes, pi, omp, cursor-agent, kimi, reasonix, dsh, kiro-cli, agy, qodercli, qoderclicn, traecli, grok, qwen, qwenpaw, mcode, or dim and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, deveco, openclaw, hermes, pi, omp, cursor-agent, kimi, reasonix, dsh, kiro-cli, junie, agy, qodercli, qoderclicn, traecli, grok, qwen, qwenpaw, mcode, or dim and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
@@ -865,7 +865,7 @@ func isExecutableFile(path string) bool {
 // doesn't require editing this list by hand.
 var defaultAgentCommandNames = append([]string{
 	"claude", "codex", "opencode", "deveco", "openclaw", "hermes",
-	"pi", "cursor-agent", "copilot", "kimi", "reasonix", "dsh", "kiro-cli", "codebuddy", "agy", "qodercli", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode", "dim",
+	"pi", "cursor-agent", "copilot", "kimi", "reasonix", "dsh", "kiro-cli", "junie", "codebuddy", "agy", "qodercli", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode", "dim",
 }, agent.BuiltinRuntimeCommands()...)
 
 // codexDesktopAppBundlePaths returns candidate macOS app-bundle locations for

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -436,6 +436,12 @@ func skillsDirPath(workDir, provider string) string {
 		// (and also scans .agents/skills/). Prefer the native .grok tree.
 		// See Grok user-guide skills.md.
 		return filepath.Join(workDir, ".grok", "skills")
+	case "junie":
+		// JetBrains Junie CLI auto-discovers project-level skills from
+		// .junie/skills/<name>/SKILL.md in the project root; a project skill
+		// wins over a same-named ~/.junie/skills one.
+		// See https://junie.jetbrains.com/docs/agent-skills.html
+		return filepath.Join(workDir, ".junie", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		return filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
 func testLogger() *slog.Logger {
@@ -815,7 +817,7 @@ func TestReuseReclaimsManagedSkillDirWithStrayAgentFile(t *testing.T) {
 func TestReuseSkillRefreshIsCanonicalAcrossProviders(t *testing.T) {
 	t.Parallel()
 
-	for _, provider := range []string{"claude", "codebuddy", "openclaw", "copilot", "qwen", ""} {
+	for _, provider := range []string{"claude", "codebuddy", "openclaw", "copilot", "qwen", "junie", ""} {
 		provider := provider
 		name := provider
 		if name == "" {
@@ -894,6 +896,54 @@ func TestMcodeUsesNativeProjectSkillRoot(t *testing.T) {
 	want := filepath.Join(workDir, ".minimax", "skills")
 	if got := skillsDirPath(workDir, "mcode"); got != want {
 		t.Fatalf("skillsDirPath(mcode) = %q, want %q", got, want)
+	}
+}
+
+func TestJunieUsesNativeProjectSkillRoot(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	want := filepath.Join(workDir, ".junie", "skills")
+	if got := skillsDirPath(workDir, "junie"); got != want {
+		t.Fatalf("skillsDirPath(junie) = %q, want %q", got, want)
+	}
+}
+
+// skillsDirPathFallbackExempt lists the providers that legitimately resolve to
+// the .agent_context/skills fallback because their skills do not live under
+// the task workdir at all.
+var skillsDirPathFallbackExempt = map[string]string{
+	"codex":  "skills are hydrated into CODEX_HOME, not the workdir (see hydrateCodexSkills)",
+	"hermes": "skills live in the per-task HERMES_HOME/skills (see hermes_home.go)",
+	// TODO: dim has no native project skills dir either. That is a
+	// pre-existing gap, tracked separately rather than widened here.
+	"dim": "no native project skills dir mapped yet — pre-existing gap",
+}
+
+// TestSkillsDirPathCoversEverySupportedType is the skillsDirPath twin of
+// TestRuntimeConfigPathCoversEverySupportedType. Without it a newly supported
+// provider silently inherits the .agent_context/skills fallback, which no CLI
+// scans — the skills are written, the prompt claims they were discovered, and
+// the agent never sees a single SKILL.md. Junie shipped exactly that way.
+func TestSkillsDirPathCoversEverySupportedType(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	fallback := filepath.Join(workDir, ".agent_context", "skills")
+	for _, provider := range agent.SupportedTypes {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			got := skillsDirPath(workDir, provider)
+			if got != fallback {
+				return
+			}
+			if reason, ok := skillsDirPathFallbackExempt[provider]; ok {
+				t.Logf("%s uses the fallback by design: %s", provider, reason)
+				return
+			}
+			t.Fatalf("skillsDirPath(%q) fell through to the .agent_context fallback %q; "+
+				"map it to the provider's native project skills dir, or document it in skillsDirPathFallbackExempt",
+				provider, fallback)
+		})
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -214,7 +214,7 @@ func runtimeConfigPath(workDir, provider string) string {
 		return filepath.Join(workDir, "CODEBUDDY.md")
 	case "qwen":
 		return filepath.Join(workDir, "QWEN.md")
-	case "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwenpaw", "mcode", "dim":
+	case "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwenpaw", "mcode", "dim", "junie":
 		return filepath.Join(workDir, "AGENTS.md")
 	default:
 		return ""

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -173,6 +173,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Reasonix:    writes {workDir}/AGENTS.md  (Reasonix reads AGENTS.md and .reasonix/skills/ natively)
 // For DSH:         writes {workDir}/AGENTS.md  (DSH reads AGENTS.md and .dsh/skills/ natively)
 // For Kiro:        writes {workDir}/AGENTS.md  (Kiro CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
+// For Junie:       writes {workDir}/AGENTS.md  (skills discovered natively from .junie/skills/ — see https://junie.jetbrains.com/docs/agent-skills.html)
 // For Qoder/Qoder CN: writes {workDir}/AGENTS.md  (skills discovered from .qoder/skills/; user-level roots are unaffected)
 // For Antigravity: writes {workDir}/AGENTS.md  (agy CLI reads AGENTS.md natively; skills discovered natively from .agents/skills/ — see https://antigravity.google/docs/gcli-migration)
 // For Traecli:     writes {workDir}/AGENTS.md  (traecli reads .trae/rules/ not AGENTS.md, so the brief is delivered inline via providerNeedsInlineSystemPrompt; the file is written for parity/visibility only)

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
+	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
 // Sub-issue Creation section — after MUL-2538 the platform posts the
@@ -1084,6 +1085,25 @@ func TestInjectRuntimeConfigUnknownProviderSkipsWrite(t *testing.T) {
 		}
 		if string(got) != "untouched\n" {
 			t.Errorf("unknown provider must not write %s; got:\n%s", name, string(got))
+		}
+	}
+}
+
+// Guard against the class of bug found in #1163's review: a provider added to
+// agent.SupportedTypes (so it is offered as a custom runtime profile) but
+// never added to runtimeConfigPath's switch. runtimeConfigPath then falls to
+// its default "" case, InjectRuntimeConfig silently no-ops, and every task on
+// that provider runs with no workflow brief at all — traecli shipped with
+// exactly this gap once already (#4945/#4946: "its agents were silently
+// missing the workflow section... leaving issues stuck in todo with no
+// comment and no error"). Every officially supported provider must resolve to
+// a real config path.
+func TestRuntimeConfigPathCoversEverySupportedType(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, provider := range agent.SupportedTypes {
+		if got := runtimeConfigPath(dir, provider); got == "" {
+			t.Errorf("runtimeConfigPath(%q) = \"\" — provider is in agent.SupportedTypes but has no runtime config file, so InjectRuntimeConfig will silently skip it", provider)
 		}
 	}
 }

--- a/server/internal/daemon/execenv/sidecar_manifest_test.go
+++ b/server/internal/daemon/execenv/sidecar_manifest_test.go
@@ -158,6 +158,7 @@ var allFileBasedProviders = []string{
 	"dsh",
 	"dim",
 	"kiro",
+	"junie",
 	"antigravity",
 	"qwen",
 	"qwenpaw",
@@ -241,6 +242,7 @@ func TestPrepareThenCleanupSidecarsPreservesUserSkillSibling(t *testing.T) {
 		{"kimi", filepath.Join(".kimi", "skills", "my-own"), "SKILL.md"},
 		{"reasonix", filepath.Join(".reasonix", "skills", "my-own"), "SKILL.md"},
 		{"kiro", filepath.Join(".kiro", "skills", "my-own"), "SKILL.md"},
+		{"junie", filepath.Join(".junie", "skills", "my-own"), "SKILL.md"},
 		{"antigravity", filepath.Join(".agents", "skills", "my-own"), "SKILL.md"},
 		{"qwen", filepath.Join(".qwen", "skills", "my-own"), "SKILL.md"},
 		{"hermes", filepath.Join(".agent_context", "skills", "my-own"), "SKILL.md"},
@@ -308,6 +310,9 @@ func TestPrepareThenCleanupSidecarsPreservesUnrelatedUserFiles(t *testing.T) {
 		{"kimi", filepath.Join(".kimi", "config.json")},
 		{"reasonix", filepath.Join(".reasonix", "config.toml")},
 		{"kiro", filepath.Join(".kiro", "config.json")},
+		// Junie's project guidelines file is the realistic pre-existing
+		// sibling of .junie/skills/; Cleanup must leave .junie/ alive.
+		{"junie", filepath.Join(".junie", "guidelines.md")},
 		{"antigravity", filepath.Join(".agents", "config.json")},
 		{"qwen", filepath.Join(".qwen", "settings.json")},
 	}
@@ -640,6 +645,7 @@ var sameSlugSkillProviderCases = []struct {
 	{"reasonix", filepath.Join(".reasonix", "skills", "issue-review")},
 	{"dsh", filepath.Join(".dsh", "skills", "issue-review")},
 	{"kiro", filepath.Join(".kiro", "skills", "issue-review")},
+	{"junie", filepath.Join(".junie", "skills", "issue-review")},
 	{"antigravity", filepath.Join(".agents", "skills", "issue-review")},
 	{"qwen", filepath.Join(".qwen", "skills", "issue-review")},
 	{"hermes", filepath.Join(".agent_context", "skills", "issue-review")},

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -106,6 +106,8 @@ const (
 //     (https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
 //   - Kimi: ~/.kimi/skills mirrors Kimi CLI's project-level .kimi/skills layout
 //   - Kiro: project and user-level .kiro/skills directories discovered by Kiro CLI
+//   - Junie: project and user-level .junie/skills directories
+//     (https://junie.jetbrains.com/docs/agent-skills.html)
 //   - Qoder: ~/.qoder/skills mirrors Qoder CLI's project-level .qoder/skills layout
 //   - Antigravity: ~/.gemini/antigravity-cli/skills user-level skill root
 //     (https://antigravity.google/docs/gcli-migration "Global skills")
@@ -182,6 +184,10 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 			providerRoot = filepath.Join(dshHome, "skills")
 		case "kiro":
 			providerRoot = filepath.Join(home, ".kiro", "skills")
+		case "junie":
+			// JetBrains Junie CLI's user-level skill root; the project
+			// .junie/skills tree is injected separately under <workDir>.
+			providerRoot = filepath.Join(home, ".junie", "skills")
 		case "qoder":
 			providerRoot = filepath.Join(home, ".qoder", "skills")
 		case "qoderclicn":

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -334,6 +334,14 @@ func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
 			wantPath: "~/.grok/skills/review-helper",
 			wantName: "Grok Review",
 		},
+		{
+			// ~/.junie/skills is not env-overridable, so unlike grok/qwen/
+			// reasonix/dsh this row needs no home-var clearing below.
+			provider: "junie",
+			root:     filepath.Join(".junie", "skills"),
+			wantPath: "~/.junie/skills/review-helper",
+			wantName: "Junie Review",
+		},
 	}
 
 	for _, tc := range tests {

--- a/server/internal/metrics/labels.go
+++ b/server/internal/metrics/labels.go
@@ -144,6 +144,7 @@ var (
 		"gemini":        "gemini",
 		"grok":          "grok",
 		"hermes":        "hermes",
+		"junie":         "junie",
 		"kiro":          "kiro",
 		"kimi":          "kimi",
 		"reasonix":      "reasonix",

--- a/server/migrations/377_runtime_profile_add_junie.down.sql
+++ b/server/migrations/377_runtime_profile_add_junie.down.sql
@@ -1,0 +1,31 @@
+-- Restore the pre-377 whitelist (including dim from migration 370).
+-- Existing Junie rows remain valid because the replacement constraint is NOT
+-- VALID, but new Junie profiles are blocked.
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'reasonix',
+        'dsh',
+        'kiro',
+        'antigravity',
+        'qoder',
+        'qoderclicn',
+        'traecli',
+        'deveco',
+        'grok',
+        'qwen',
+        'qwenpaw',
+        'mcode',
+        'dim'
+    )) NOT VALID;

--- a/server/migrations/377_runtime_profile_add_junie.up.sql
+++ b/server/migrations/377_runtime_profile_add_junie.up.sql
@@ -1,0 +1,32 @@
+-- Add Junie (JetBrains) as a first-party ACP protocol family. NOT VALID
+-- preserves historical-row tolerance while enforcing the expanded whitelist
+-- for new rows. The whitelist includes dim (added by migration 370) and junie.
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'reasonix',
+        'dsh',
+        'kiro',
+        'antigravity',
+        'qoder',
+        'qoderclicn',
+        'traecli',
+        'deveco',
+        'grok',
+        'qwen',
+        'qwenpaw',
+        'mcode',
+        'dim',
+        'junie'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, CodeBuddy, Codex, Copilot, OpenCode, DevEco Code,
-// OpenClaw, Hermes, Pi, Oh-My-Pi, Cursor, Kimi, Reasonix, Kiro, Antigravity, Qoder,
+// OpenClaw, Hermes, Pi, Oh-My-Pi, Cursor, Kimi, Reasonix, Kiro, Junie, Antigravity, Qoder,
 // Trae, Grok, Qwen Code, QwenPaw, MiniMax Code). It
 // mirrors the happy-cli AgentBackend pattern, translated to idiomatic Go.
 package agent
@@ -278,7 +278,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode".
+// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "reasonix", "dsh", "kiro", "junie", "antigravity", "qoder", "qoderclicn", "traecli", "grok", "qwen", "qwenpaw", "mcode".
 //
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
@@ -287,7 +287,7 @@ type Config struct {
 // add deveco, migration 179 to add grok, migration 202 to add qwen,
 // migration 242 to add qoderclicn, migration 253 to add qwenpaw,
 // migration 254 to add reasonix, migration 313 to add dsh, migration 327 to
-// add mcode): a
+// add mcode, migration 377 to add junie): a
 // custom runtime profile may only
 // be based on a backend Multica officially supports.
 // qoder and qoderclicn share the same ACP backend; keeping both provider keys
@@ -296,7 +296,8 @@ type Config struct {
 // header and provider branding but was previously missing from this whitelist,
 // so the family picker rejected it (#4945). grok is the xAI Grok Build CLI
 // ACP backend (`grok agent --always-approve stdio`). qwen is Qwen Code's
-// native `qwen -p <prompt> --output-format stream-json` backend.
+// native `qwen -p <prompt> --output-format stream-json` backend. junie is the
+// JetBrains Junie CLI ACP backend (`junie --acp=true`).
 var SupportedTypes = []string{
 	"claude",
 	"codebuddy",
@@ -312,6 +313,7 @@ var SupportedTypes = []string{
 	"reasonix",
 	"dsh",
 	"kiro",
+	"junie",
 	"antigravity",
 	"qoder",
 	"qoderclicn",
@@ -407,6 +409,8 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &dimBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "junie":
+		return &junieBackend{cfg: cfg}, nil
 	case "antigravity":
 		return &antigravityBackend{cfg: cfg}, nil
 	case "qoder", "qoderclicn":
@@ -455,6 +459,7 @@ var launchHeaders = map[string]string{
 	"reasonix":    "reasonix acp",
 	"dsh":         "dsh --profile multica (stdio)",
 	"kiro":        "kiro-cli acp",
+	"junie":       "junie --acp=true",
 	"openclaw":    "openclaw agent (json)",
 	"opencode":    "opencode run (json)",
 	"pi":          "pi (json mode)",

--- a/server/pkg/agent/agent_supported_types_test.go
+++ b/server/pkg/agent/agent_supported_types_test.go
@@ -39,7 +39,7 @@ func TestSupportedTypesMatchesMigrationWhitelist(t *testing.T) {
 	want := map[string]bool{
 		"claude": true, "codebuddy": true, "codex": true, "copilot": true,
 		"opencode": true, "deveco": true, "openclaw": true, "hermes": true,
-		"pi": true, "cursor": true, "kimi": true, "reasonix": true, "dsh": true, "kiro": true, "antigravity": true,
+		"pi": true, "cursor": true, "kimi": true, "reasonix": true, "dsh": true, "kiro": true, "junie": true, "antigravity": true,
 		"qoder": true, "qoderclicn": true, "traecli": true, "grok": true, "qwen": true, "qwenpaw": true, "mcode": true,
 		"dim": true,
 	}

--- a/server/pkg/agent/junie.go
+++ b/server/pkg/agent/junie.go
@@ -1,0 +1,414 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// junieBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. --acp=true selects ACP mode;
+// letting custom_args drop or replace it would break the daemon↔Junie
+// communication contract the same way an overridden `acp` subcommand would
+// for Kiro/Reasonix. Junie CLI documents this as a flag (`--acp=true`), not a
+// subcommand — a different shape from Kiro's `acp --trust-all-tools` and
+// Reasonix's `acp --profile ...`.
+var junieBlockedArgs = map[string]blockedArgMode{
+	"--acp": blockedWithValue,
+}
+
+// junieReaderDrainGrace bounds how long the turn waits for trailing ACP
+// notifications after the session/prompt response. A var, not a const, so
+// tests can shorten it. Mirrors kiroReaderDrainGrace / reasonixReaderDrainGrace.
+var junieReaderDrainGrace = 2 * time.Second
+
+// junieBackend implements Backend by spawning `junie --acp=true` and
+// communicating via the standard ACP JSON-RPC 2.0 transport over
+// stdin/stdout.
+//
+// JetBrains Junie CLI advertises ACP support through the --acp=true flag
+// (confirmed against junie.jetbrains.com/docs/junie-cli-acp.html), unlike
+// Kiro's `acp` subcommand or Reasonix's `acp` subcommand with extra flags, so
+// the existing Hermes/Kimi/Kiro ACP client can drive it with only
+// provider-specific launch args.
+//
+// Two things this adapter deliberately does NOT do, pending a live protocol
+// check against an installed `junie` binary (see the issue's "Protocol
+// check" step, same as the Kiro PR):
+//
+//  1. Permission auto-approval uses the generic kind-based
+//     selectACPPermissionOption (see hermes.go) unmodified rather than a
+//     Junie-specific selectPermission override. That function already grants
+//     purely off the standard ACP PermissionOptionKind values
+//     (allow_once/allow_always/reject_once), so it should work for any
+//     ACP-compliant agent out of the box; Reasonix only needed an override
+//     because it multiplexes protected decisions and free-form questions
+//     through the same request_permission call, which has not been observed
+//     for Junie.
+//  2. No junieToolNameFromTitle mapping (contrast kiroToolNameFromTitle /
+//     reasonixToolNameFromTitle): hermesClient already falls back to the
+//     standard ACP ToolCallKind (read/edit/execute/search/fetch/think) when a
+//     title doesn't parse, which should cover a compliant agent reasonably
+//     well. Add a Junie-specific title mapper here once real tool_call
+//     titles from a live session are known to need it.
+type junieBackend struct {
+	cfg Config
+}
+
+func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "junie"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("junie executable not found at %q: %w", execPath, err)
+	}
+
+	// Translate the agent's mcp_config (Claude-style object of objects)
+	// into the array shape ACP `session/new` and `session/load` expect.
+	// Fail closed on malformed JSON so the launch surfaces the real error
+	// instead of silently dropping all MCP servers.
+	mcpServers, err := buildACPMcpServers(opts.McpConfig, b.cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("junie: invalid mcp_config: %w", err)
+	}
+
+	timeout := opts.Timeout
+	runCtx, cancel := runContext(ctx, timeout)
+
+	junieArgs := append([]string{"--acp=true"}, filterCustomArgs(opts.CustomArgs, junieBlockedArgs, b.cfg.Logger)...)
+	cmd := b.cfg.commandAt(execPath).exec(runCtx, junieArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.logAgentCommand(cmd, newAgentCommandLogArgs(junieArgs, trustAgentCommandPositional(0, "--acp=true")))
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("junie stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("junie stdin pipe: %w", err)
+	}
+	// StderrPipe + an explicit copier give us a join point
+	// (`stderrDone`) that fires before the failure-promotion
+	// decision; see the matching comment in hermes.go for why the
+	// io.MultiWriter form races with stopReason=end_turn under load.
+	providerErr := newACPProviderErrorSniffer("junie")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("junie stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start junie: %w", err)
+	}
+
+	stderrSink := io.MultiWriter(newLogWriter(b.cfg.Logger, "[junie:stderr] "), providerErr)
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(stderrSink, stderr)
+	}()
+
+	b.cfg.Logger.Info("junie acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var deliverable acpDeliverableTracker
+	// streamingCurrentTurn gates all session updates so that any history
+	// replay or queued notifications from a resumed session are dropped
+	// instead of duplicating a previous answer into output. It flips to
+	// true only after session/prompt is sent. Mirrors kiro.go / reasonix.go.
+	var streamingCurrentTurn atomic.Bool
+
+	promptDone := make(chan hermesPromptResult, 1)
+	activity := make(chan struct{}, 1)
+
+	// Reuse the hermesClient ACP transport — Junie speaks the same protocol.
+	c := &hermesClient{
+		cfg:          b.cfg,
+		stdin:        stdin,
+		pending:      make(map[int]*pendingRPC),
+		pendingTools: make(map[string]*pendingToolCall),
+		acceptNotification: func(string) bool {
+			return streamingCurrentTurn.Load()
+		},
+		onActivity: func() {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
+		},
+		onMessage: func(msg Message) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			deliverable.observe(msg)
+			trySend(msgCh, msg)
+		},
+		onPromptDone: func(result hermesPromptResult) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			select {
+			case promptDone <- result:
+			default:
+			}
+		},
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := newAgentStreamScanner(stdout)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("junie process exited"))
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+		var sessionID string
+		// Set when the ACP runtime refuses the session we asked to
+		// resume. Only that is curable by starting a fresh session, so
+		// handshake/network failures below must leave it false.
+		var resumeRejected bool
+		effectiveModel := strings.TrimSpace(opts.Model)
+
+		initResult, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("junie initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// Drop MCP entries whose remote transport the runtime didn't
+		// advertise. See the matching comment in hermes.go for why
+		// unconditionally sending http/sse to a stdio-only ACP runtime
+		// tanks the whole session/new.
+		mcpServers = filterACPMcpServersByCapability(mcpServers, extractACPMcpCapabilities(initResult), "junie", b.cfg)
+
+		cwd := opts.Cwd
+		if cwd == "" {
+			cwd = "."
+		}
+
+		if opts.ResumeSessionID != "" {
+			result, err := c.request(runCtx, "session/load", map[string]any{
+				"cwd":        cwd,
+				"sessionId":  opts.ResumeSessionID,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("junie session/load failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			// Apply the same defensive resolution kimi/hermes/kiro use: if
+			// junie echoes a sessionId in the session/load response, prefer
+			// it (the canonical id the backend is committed to). When the
+			// response is empty or doesn't include sessionId, the helper
+			// falls back to the requested id.
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "junie",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
+			if effectiveModel == "" {
+				effectiveModel = extractACPCurrentModelID(result)
+			}
+		} else {
+			result, err := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("junie session/new failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			sessionID = extractACPSessionID(result)
+			if sessionID == "" {
+				finalStatus = "failed"
+				finalError = "junie session/new returned no session ID"
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			if effectiveModel == "" {
+				effectiveModel = extractACPCurrentModelID(result)
+			}
+		}
+
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("junie session created", "session_id", sessionID)
+
+		if opts.Model != "" {
+			if _, err := c.request(runCtx, "session/set_model", map[string]any{
+				"sessionId": sessionID,
+				"modelId":   opts.Model,
+			}); err != nil {
+				b.cfg.Logger.Warn("junie set_session_model failed", "error", err, "requested_model", opts.Model)
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("junie could not switch to model %q: %v", opts.Model, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// On a resumed session with a model override, the dead
+					// session surfaces here instead of at session/prompt.
+					// Same fix as the prompt path below: clear the id so
+					// the daemon's resume-failure fallback retries fresh.
+					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
+						"backend", "junie",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+					resumeRejected = true
+				}
+				resCh <- Result{
+					Status:         finalStatus,
+					Error:          finalError,
+					DurationMs:     time.Since(startTime).Milliseconds(),
+					SessionID:      sessionID,
+					ResumeRejected: resumeRejected,
+				}
+				return
+			}
+			b.cfg.Logger.Info("junie session model set", "model", opts.Model)
+		}
+
+		userText := prompt
+		if opts.SystemPrompt != "" {
+			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
+		}
+
+		promptBlocks := []map[string]any{
+			{"type": "text", "text": userText},
+		}
+		streamingCurrentTurn.Store(true)
+		_, err = c.request(runCtx, "session/prompt", map[string]any{
+			"sessionId": sessionID,
+			"prompt":    promptBlocks,
+		})
+		if err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("junie timed out after %s", timeout)
+			} else if runCtx.Err() == context.Canceled {
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			} else {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("junie session/prompt failed: %v", err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// See the hermes/kiro backends: the runtime may echo the
+					// requested id back from session/load even when the
+					// session is gone, so the stale id only fails here, at
+					// prompt time. Empty SessionID lets the daemon's
+					// resume-failure fallback retry fresh and store the
+					// replacement id.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "junie",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+					resumeRejected = true
+				}
+			}
+		} else {
+			select {
+			case pr := <-promptDone:
+				if pr.stopReason == "cancelled" {
+					finalStatus = "aborted"
+					finalError = "junie cancelled the prompt"
+				}
+				c.mergeUsage(pr.usage)
+			default:
+			}
+			waitForACPNotificationQuiescence(runCtx, activity, readerDone, acpNotificationQuietTime, junieReaderDrainGrace)
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("junie finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		stdin.Close()
+		cancel()
+
+		<-readerDone
+		// Ensure the stderr copier has drained before consulting the
+		// provider-error sniffer; see hermes.go for the failure mode.
+		<-stderrDone
+
+		finalOutput, providerErrorOutput := deliverable.result()
+
+		// Promote completed→failed when stderr or the agent text
+		// stream show a terminal upstream-LLM failure (HTTP 4xx /
+		// rate-limit / expired token). See the helper docs for the
+		// full signal set; the key safety property is that transient
+		// per-attempt warnings followed by a successful retry stay
+		// "completed".
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
+
+		u := c.accumulatedUsage()
+
+		var usageMap map[string]TokenUsage
+		if acpUsagePresent(u) {
+			model := effectiveModel
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:         finalStatus,
+			Output:         finalOutput,
+			Error:          finalError,
+			DurationMs:     duration.Milliseconds(),
+			SessionID:      sessionID,
+			ResumeRejected: resumeRejected,
+			Usage:          usageMap,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}

--- a/server/pkg/agent/junie.go
+++ b/server/pkg/agent/junie.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -19,9 +20,27 @@ import (
 // for Kiro/Reasonix. Junie CLI documents this as a flag (`--acp=true`), not a
 // subcommand — a different shape from Kiro's `acp --trust-all-tools` and
 // Reasonix's `acp --profile ...`.
+//
+// --brave is daemon-owned for the same reason --trust-all-tools is on Kiro and
+// --yolo is on Qoder/Traecli: the permission bypass is part of the unattended
+// contract, not a user preference. `junie --help` scopes the flag to
+// interactive mode, so the ACP path sets it through session/set_config_option
+// (see applyJunieBraveMode) — blocking it here keeps custom_args from
+// half-setting the same knob through a route that does nothing in ACP mode.
 var junieBlockedArgs = map[string]blockedArgMode{
-	"--acp": blockedWithValue,
+	"--acp":   blockedWithValue,
+	"--brave": blockedStandalone,
 }
+
+// junieBraveModeConfigID is the session configOption Junie advertises for its
+// permission gate. Captured from session/new against @jetbrains/junie-cli
+// 1468.30.0: {"type":"select","id":"brave_mode","name":"Brave Mode",
+// "description":"When enabled, Junie will execute commands without asking for
+// approval","currentValue":"off","options":[{"value":"on"},{"value":"off"}]}.
+const junieBraveModeConfigID = "brave_mode"
+
+// junieBraveModeOn is the advertised option value that disables the gate.
+const junieBraveModeOn = "on"
 
 // junieSessionNotFoundRe matches Junie's unknown-session wording, which
 // interpolates the id between the noun and the verdict:
@@ -66,6 +85,70 @@ func isJunieSessionNotFound(err error) bool {
 	return junieSessionNotFoundRe.MatchString(rpcErr.Message + " " + rpcErr.Data)
 }
 
+// applyJunieBraveMode turns off Junie's per-command approval prompt for the
+// life of the process by setting the advertised brave_mode configOption.
+//
+// Junie 1468.30 defaults brave_mode to "off", i.e. it asks before executing
+// commands — unusable for an unattended daemon run. Every other unattended ACP
+// backend pins an equivalent bypass (kiro --trust-all-tools, qoder/traecli
+// --yolo, hermes HERMES_YOLO_MODE=1, dim permission=full-access). Junie's own
+// --brave flag is documented interactive-only, so session/set_config_option is
+// the only route in ACP mode. The parameter is `configId`: sending `optionId`
+// is answered -32700 "Missing 'configId'" (captured).
+//
+// Best-effort by design, unlike dim.go's fail-closed equivalent. Dim's default
+// is a read-only preset that denies every write, so a failed set there
+// guarantees a dead session; Junie's default only *asks*, and an ACP
+// session/request_permission is already auto-answered by the shared
+// selectACPPermissionOption. Turning a probably-working run into a hard
+// failure would cost more than it saves.
+//
+// Known side effect: Junie persists this to the user's global
+// ~/.junie/settings.json ("braveMode": "true") and does not revert it when the
+// session ends, so it outlives the task and also affects the user's own
+// interactive junie runs. That is in tension with the rule
+// selectACPPermissionOption follows (hermes.go), which refuses to auto-select a
+// permanent allow_always grant for exactly this reason. It is accepted here
+// because Junie advertises no session-scoped equivalent, and restoring the
+// previous value at exit would be a second global write — racy against
+// concurrent junie processes and unreachable when the daemon is killed.
+func applyJunieBraveMode(ctx context.Context, request acpRequestFn, logger *slog.Logger, sessionID string) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	result, err := request(ctx, "session/set_config_option", map[string]any{
+		"sessionId": sessionID,
+		"configId":  junieBraveModeConfigID,
+		"value":     junieBraveModeOn,
+	})
+	if err != nil {
+		logger.Warn("junie rejected the brave-mode request; sending the prompt anyway (the run may stall on an approval prompt)",
+			"backend", "junie",
+			"config_id", junieBraveModeConfigID,
+			"session_id", sessionID,
+			"error", err,
+		)
+		return
+	}
+	// Read back rather than assume: the response echoes the session's
+	// configOptions, so a runtime that accepts the call and leaves the value
+	// where it was is visible here instead of at the first blocked command.
+	effective, confirmed := acpConfigOptionCurrentValue(result, junieBraveModeConfigID)
+	if !confirmed || effective != junieBraveModeOn {
+		if !confirmed {
+			effective = "unknown"
+		}
+		logger.Warn("junie did not confirm brave mode; sending the prompt anyway (the run may stall on an approval prompt)",
+			"backend", "junie",
+			"config_id", junieBraveModeConfigID,
+			"session_id", sessionID,
+			"effective_value", effective,
+		)
+		return
+	}
+	logger.Info("junie brave mode enabled", "session_id", sessionID)
+}
+
 // junieReaderDrainGrace bounds how long the turn waits for trailing ACP
 // notifications after the session/prompt response. A var, not a const, so
 // tests can shorten it. Mirrors kiroReaderDrainGrace / reasonixReaderDrainGrace.
@@ -84,6 +167,9 @@ var junieReaderDrainGrace = 2 * time.Second
 // What a protocol capture against @jetbrains/junie-cli 1468.30.0 established,
 // and what it could not:
 //
+//   - session/new advertises a "brave_mode" configOption defaulting to "off",
+//     i.e. Junie asks before executing commands. applyJunieBraveMode turns it
+//     on; see there for the global-settings side effect that carries.
 //   - session/load answers ANY session id — live, expired or invented — with
 //     an ordinary success frame carrying only configOptions and no sessionId.
 //     It is not a session-existence probe, and neither is session/list, which
@@ -109,7 +195,9 @@ var junieReaderDrainGrace = 2 * time.Second
 //     ACP-compliant agent out of the box; Reasonix only needed an override
 //     because it multiplexes protected decisions and free-form questions
 //     through the same request_permission call, which has not been observed
-//     for Junie. No session/request_permission frame has been captured at all.
+//     for Junie. No session/request_permission frame has been captured at all,
+//     so whether brave mode or this path is what keeps a run unattended is
+//     still open.
 //  2. No junieToolNameFromTitle mapping (contrast kiroToolNameFromTitle /
 //     reasonixToolNameFromTitle): hermesClient already falls back to the
 //     standard ACP ToolCallKind (read/edit/execute/search/fetch/think) when a
@@ -382,6 +470,12 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("junie session created", "session_id", sessionID)
+
+		// Runs on both the fresh and the resumed path: brave mode is a session
+		// setting, a resumed session whose first run failed before configuring
+		// it would otherwise carry the gate into the resume, and the call is
+		// idempotent.
+		applyJunieBraveMode(runCtx, c.request, b.cfg.Logger, sessionID)
 
 		if opts.Model != "" {
 			if _, err := c.request(runCtx, "session/set_model", map[string]any{

--- a/server/pkg/agent/junie.go
+++ b/server/pkg/agent/junie.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -19,6 +21,49 @@ import (
 // Reasonix's `acp --profile ...`.
 var junieBlockedArgs = map[string]blockedArgMode{
 	"--acp": blockedWithValue,
+}
+
+// junieSessionNotFoundRe matches Junie's unknown-session wording, which
+// interpolates the id between the noun and the verdict:
+//
+//	{"code":-32602,"message":"Session session-260824-112848-191m not found"}
+//
+// The shared isACPSessionNotFound only matches contiguous phrases ("session
+// not found" / "no session found" / "unknown session"), so it returns false
+// for every rejection Junie 1468.30 actually emits.
+//
+// The interleaved token must look like an id — one word carrying a digit,
+// hyphen or underscore — so that unrelated "session <noun> not found" errors
+// (a "session config not found", a "session log file x.json not found") keep
+// failing the match. Erring towards NOT matching is the safe direction: a
+// false positive discards a healthy session id and re-runs the turn from zero.
+var junieSessionNotFoundRe = regexp.MustCompile(`(?i)\bsession\s+['"` + "`" + `]?[a-z0-9]*[-_0-9][a-z0-9._-]*['"` + "`" + `]?\s+not found\b`)
+
+// isJunieSessionNotFound reports whether err is Junie refusing a session id it
+// no longer knows. It is a strict superset of the shared helper: the
+// contiguous ACP wordings still match, and Junie's id-interpolating phrasing
+// matches on top of that.
+//
+// Kept Junie-local rather than widened into isACPSessionNotFound (hermes.go)
+// on purpose. That predicate is shared by ~11 ACP backends, and every widening
+// can only add false positives — each of which makes a backend clear a live
+// session and replay a turn. Precedent for a provider-local predicate:
+// isKiroOversizedHistoryImage (kiro.go) and hermesResumeSessionLost (hermes.go).
+func isJunieSessionNotFound(err error) bool {
+	if isACPSessionNotFound(err) {
+		return true
+	}
+	var rpcErr *acpRPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	// Same code gate as the shared helper: wording alone must not be enough to
+	// retire a session when the runtime classified the failure as something
+	// else entirely.
+	if rpcErr.Code != -32603 && rpcErr.Code != -32602 && rpcErr.Code != -32002 {
+		return false
+	}
+	return junieSessionNotFoundRe.MatchString(rpcErr.Message + " " + rpcErr.Data)
 }
 
 // junieReaderDrainGrace bounds how long the turn waits for trailing ACP
@@ -36,9 +81,25 @@ var junieReaderDrainGrace = 2 * time.Second
 // the existing Hermes/Kimi/Kiro ACP client can drive it with only
 // provider-specific launch args.
 //
-// Two things this adapter deliberately does NOT do, pending a live protocol
-// check against an installed `junie` binary (see the issue's "Protocol
-// check" step, same as the Kiro PR):
+// What a protocol capture against @jetbrains/junie-cli 1468.30.0 established,
+// and what it could not:
+//
+//   - session/load answers ANY session id — live, expired or invented — with
+//     an ordinary success frame carrying only configOptions and no sessionId.
+//     It is not a session-existence probe, and neither is session/list, which
+//     returned {"sessions":[]} for sessions that were live in the same process.
+//   - session/set_model DOES validate the session, answering -32602
+//     "Session <id> not found" for an unknown id and "Unsupported Junie model
+//     '<x>'" for a live one. That wording is what isJunieSessionNotFound
+//     exists to match.
+//   - Everything past the auth wall is unverified: session/prompt answered
+//     -32000 "Authentication is required before this operation can be
+//     performed" on an unauthenticated CLI, so no capture shows a real turn,
+//     a session/request_permission, or what prompt does with a dead session.
+//
+// Two things this adapter deliberately does NOT do, pending a live run against
+// an authenticated `junie` (see the issue's "Protocol check" step, same as the
+// Kiro PR):
 //
 //  1. Permission auto-approval uses the generic kind-based
 //     selectACPPermissionOption (see hermes.go) unmodified rather than a
@@ -48,7 +109,7 @@ var junieReaderDrainGrace = 2 * time.Second
 //     ACP-compliant agent out of the box; Reasonix only needed an override
 //     because it multiplexes protected decisions and free-form questions
 //     through the same request_permission call, which has not been observed
-//     for Junie.
+//     for Junie. No session/request_permission frame has been captured at all.
 //  2. No junieToolNameFromTitle mapping (contrast kiroToolNameFromTitle /
 //     reasonixToolNameFromTitle): hermesClient already falls back to the
 //     standard ACP ToolCallKind (read/edit/execute/search/fetch/think) when a
@@ -242,14 +303,28 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("junie session/load failed: %v", err)
-				if isACPSessionNotFound(err) {
-					// The runtime refused the session outright, so flag the
-					// rejection: without it the daemon reads the zero value as
-					// "checked, and this was not a rejection" and keeps
-					// replaying the dead id on every later turn instead of
-					// retrying from a fresh session. sessionID is still empty
-					// on this path — cleared explicitly to stay in lockstep
-					// with the set_model and prompt branches below.
+				if isJunieSessionNotFound(err) {
+					// Junie 1468.30 does not take this path for a MISSING
+					// session: session/load answers any id, live or invented,
+					// with a success frame carrying only configOptions. A dead
+					// resume surfaces later instead — at session/set_model or
+					// session/prompt, where the runtime does check. The branch
+					// stays for load errors that are real (transport, cwd,
+					// malformed mcpServers) and in case JetBrains makes load
+					// strict; it is not this backend's resume-rejection
+					// detector. There is no load-time detector to write:
+					// session/load echoes nothing distinguishing, and
+					// session/list — though advertised — returned
+					// {"sessions":[]} for sessions that were live in the same
+					// process, so it cannot serve as an existence probe.
+					//
+					// When it does fire, flagging the rejection matters:
+					// without it the daemon reads the zero value as "checked,
+					// and this was not a rejection" and keeps replaying the
+					// dead id on every later turn instead of retrying from a
+					// fresh session. sessionID is still empty on this path —
+					// cleared explicitly to stay in lockstep with the
+					// set_model and prompt branches below.
 					b.cfg.Logger.Warn("resumed session not found at session/load time; clearing session id so the daemon retries fresh",
 						"backend", "junie",
 						"requested_session", opts.ResumeSessionID,
@@ -316,11 +391,13 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				b.cfg.Logger.Warn("junie set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("junie could not switch to model %q: %v", opts.Model, err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID != "" && isJunieSessionNotFound(err) {
 					// On a resumed session with a model override, the dead
-					// session surfaces here instead of at session/prompt.
-					// Same fix as the prompt path below: clear the id so
-					// the daemon's resume-failure fallback retries fresh.
+					// session surfaces here instead of at session/prompt —
+					// this is the one branch a capture proves Junie reaches,
+					// since session/load lets any id through. Same fix as the
+					// prompt path below: clear the id so the daemon's
+					// resume-failure fallback retries fresh.
 					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
 						"backend", "junie",
 						"session_id", sessionID,
@@ -363,13 +440,20 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("junie session/prompt failed: %v", err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if opts.ResumeSessionID != "" && isJunieSessionNotFound(err) {
 					// See the hermes/kiro backends: the runtime may echo the
 					// requested id back from session/load even when the
 					// session is gone, so the stale id only fails here, at
-					// prompt time. Empty SessionID lets the daemon's
-					// resume-failure fallback retry fresh and store the
-					// replacement id.
+					// prompt time. Junie is the extreme case — its session/load
+					// accepts any id at all — so without a model override this
+					// is the first place a dead resume can be caught. Empty
+					// SessionID lets the daemon's resume-failure fallback retry
+					// fresh and store the replacement id.
+					//
+					// The unknown-session wording is verified for set_model
+					// only; the auth wall blocked every captured prompt. The
+					// predicate is a strict superset of the previous shared
+					// one, so the worst case here is that it keeps not firing.
 					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
 						"backend", "junie",
 						"session_id", sessionID,

--- a/server/pkg/agent/junie.go
+++ b/server/pkg/agent/junie.go
@@ -185,11 +185,15 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}()
 
 	go func() {
-		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
 		defer func() {
 			stdin.Close()
+			// Cancellation must be reachable before Wait. A pathological child
+			// can close stdout/stderr (so the pipe drain succeeds) but keep the
+			// process alive; waiting first would then block until the overall
+			// task timeout and make a later deferred cancel ineffective.
+			cancel()
 			_ = cmd.Wait()
 		}()
 
@@ -238,7 +242,27 @@ func (b *junieBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("junie session/load failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				if isACPSessionNotFound(err) {
+					// The runtime refused the session outright, so flag the
+					// rejection: without it the daemon reads the zero value as
+					// "checked, and this was not a rejection" and keeps
+					// replaying the dead id on every later turn instead of
+					// retrying from a fresh session. sessionID is still empty
+					// on this path — cleared explicitly to stay in lockstep
+					// with the set_model and prompt branches below.
+					b.cfg.Logger.Warn("resumed session not found at session/load time; clearing session id so the daemon retries fresh",
+						"backend", "junie",
+						"requested_session", opts.ResumeSessionID,
+					)
+					sessionID = ""
+					resumeRejected = true
+				}
+				resCh <- Result{
+					Status:         finalStatus,
+					Error:          finalError,
+					DurationMs:     time.Since(startTime).Milliseconds(),
+					ResumeRejected: resumeRejected,
+				}
 				return
 			}
 			// Apply the same defensive resolution kimi/hermes/kiro use: if

--- a/server/pkg/agent/junie_test.go
+++ b/server/pkg/agent/junie_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,10 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_new","models":{"currentModelId":"auto","availableModels":[{"modelId":"auto","name":"auto"}]}}}\n' "$id"
       ;;
     *'"method":"session/load"'*)
+      if [ -n "$JUNIE_SESSION_NOT_FOUND" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"session not found"}}\n' "$id"
+        exit 0
+      fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
       ;;
     *'"method":"session/set_model"'*)
@@ -222,6 +227,11 @@ func TestJunieBackendUsesSessionLoadForResume(t *testing.T) {
 	if result.SessionID != "ses_existing" {
 		t.Fatalf("session id = %q, want ses_existing", result.SessionID)
 	}
+	// Negative control for TestJunieSessionLoadNotFoundSignalsResumeRejected:
+	// a successful session/load must never claim the resume was rejected.
+	if result.ResumeRejected {
+		t.Fatalf("ResumeRejected must be false when session/load succeeded")
+	}
 
 	raw, err := os.ReadFile(requestsFile)
 	if err != nil {
@@ -281,5 +291,172 @@ func TestJunieBackendSetModelFailureFailsTask(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestJunieSessionLoadNotFoundSignalsResumeRejected pins the resume-recovery
+// contract at the session/load boundary. When the runtime refuses the session
+// outright, the backend must clear the session id and set ResumeRejected so
+// shouldRetryWithFreshSession starts a new session; without it the daemon
+// reads the zero value as "checked, not a rejection" and replays the dead id
+// on every subsequent turn. Mirrors TestQwenpawSessionLoadNotFound.
+func TestJunieSessionLoadNotFoundSignalsResumeRejected(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "junie")
+	writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+	backend, err := New("junie", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"JUNIE_SESSION_NOT_FOUND": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new junie backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "continue", ExecOptions{
+		ResumeSessionID: "ses_gone",
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "session/load failed") {
+			t.Errorf("expected the error to name session/load, got %q", result.Error)
+		}
+		if !result.ResumeRejected {
+			t.Fatal("expected ResumeRejected=true so the daemon retries from a fresh session")
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected the dead session id to be cleared, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestJunieBackendCancelsBeforeWaitingForLingeringProcess proves the run
+// goroutine's cleanup reaches cancel() before cmd.Wait(). A child that closes
+// stdout/stderr (so the pipe drain completes) but stays alive would otherwise
+// pin Wait until the task timeout, leaving the deferred cancel unreachable and
+// both channels open.
+//
+// The fixture must fail on an INIT-PATH request rather than at session/prompt:
+// the success path already calls cancel() unconditionally before draining, so
+// a happy-path fixture goes green even against the unfixed ordering.
+func TestJunieBackendCancelsBeforeWaitingForLingeringProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	cases := []struct {
+		name      string
+		script    string
+		wantError string
+	}{
+		{
+			name: "initialize",
+			script: `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"init boom"}}\n' "$id"
+      exec 1>&-
+      exec 2>&-
+      while :; do sleep 1; done
+      ;;
+  esac
+done
+`,
+			wantError: "junie initialize failed",
+		},
+		{
+			name: "session/new",
+			script: `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"new boom"}}\n' "$id"
+      exec 1>&-
+      exec 2>&-
+      while :; do sleep 1; done
+      ;;
+  esac
+done
+`,
+			wantError: "junie session/new failed",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fakePath := filepath.Join(t.TempDir(), "junie")
+			writeTestExecutable(t, fakePath, []byte(tc.script))
+
+			backend, err := New("junie", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+			if err != nil {
+				t.Fatalf("new junie backend: %v", err)
+			}
+			// The per-run timeout is deliberately far longer than the
+			// assertion windows below: if the deadline could fire first it
+			// would unblock Wait on its own and mask the regression.
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			session, err := backend.Execute(ctx, "prompt", ExecOptions{Timeout: 30 * time.Second})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+
+			select {
+			case result, ok := <-session.Result:
+				if !ok {
+					t.Fatal("result channel closed without a value")
+				}
+				if result.Status != "failed" {
+					t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+				}
+				if !strings.Contains(result.Error, tc.wantError) {
+					t.Fatalf("expected error %q, got %q", tc.wantError, result.Error)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+
+			select {
+			case _, ok := <-session.Result:
+				if ok {
+					t.Fatal("result channel produced an unexpected second value")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("result channel did not close; cmd.Wait likely ran before cancel")
+			}
+		})
 	}
 }

--- a/server/pkg/agent/junie_test.go
+++ b/server/pkg/agent/junie_test.go
@@ -1,0 +1,285 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewReturnsJunieBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("junie", Config{ExecutablePath: "/nonexistent/junie"})
+	if err != nil {
+		t.Fatalf("New(junie) error: %v", err)
+	}
+	if _, ok := b.(*junieBackend); !ok {
+		t.Fatalf("expected *junieBackend, got %T", b)
+	}
+}
+
+// TestJunieBlockedArgsProtectsACPFlag verifies custom_args cannot drop or
+// override the --acp launch flag, in either inline (--acp=false) or
+// two-token (--acp false) form, while unrelated custom args pass through
+// unchanged. Mirrors the equivalent coverage in kiro_test.go / reasonix_test.go
+// for their own protocol-critical flags.
+func TestJunieBlockedArgsProtectsACPFlag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "inline override is stripped",
+			in:   []string{"--acp=false", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "two-token override is stripped along with its value",
+			in:   []string{"--acp", "false", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "unrelated args pass through untouched",
+			in:   []string{"--verbose", "--log-level=debug"},
+			want: []string{"--verbose", "--log-level=debug"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterCustomArgs(tt.in, junieBlockedArgs, slog.Default())
+			if len(got) != len(tt.want) {
+				t.Fatalf("filterCustomArgs(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("filterCustomArgs(%v) = %v, want %v", tt.in, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// fakeJunieACPScript is a minimal ACP server that answers the handshake
+// junieBackend.Execute drives: initialize, session/new, session/load,
+// session/set_model, session/prompt. Mirrors fakeKiroACPScript's shape.
+func fakeJunieACPScript() string {
+	return `#!/bin/sh
+if [ -n "$JUNIE_ARGS_FILE" ]; then
+  for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$JUNIE_ARGS_FILE"
+  done
+fi
+while IFS= read -r line; do
+  if [ -n "$JUNIE_REQUESTS_FILE" ]; then
+    printf '%s\n' "$line" >> "$JUNIE_REQUESTS_FILE"
+  fi
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_new","models":{"currentModelId":"auto","availableModels":[{"modelId":"auto","name":"auto"}]}}}\n' "$id"
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+    *'"method":"session/set_model"'*)
+      case "$line" in
+        *bogus-model*)
+          printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"model not available: bogus-model"}}\n' "$id"
+          exit 0
+          ;;
+        *)
+          printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+          ;;
+      esac
+      ;;
+    *'"method":"session/prompt"'*)
+      case "$line" in
+        *'"prompt":'*)
+          ;;
+        *)
+          printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"session/prompt must send prompt"}}\n' "$id"
+          exit 0
+          ;;
+      esac
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_loaded","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"loaded"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":2,"outputTokens":1}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestJunieBackendInvokesACPWithFlag(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePath := filepath.Join(tempDir, "junie")
+	writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+	backend, err := New("junie", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"JUNIE_ARGS_FILE": argsFile},
+	})
+	if err != nil {
+		t.Fatalf("new junie backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:    5 * time.Second,
+		CustomArgs: []string{"--acp=false", "--verbose"},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed result, got status=%q error=%q", result.Status, result.Error)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) == 0 || lines[0] != "--acp=true" {
+		t.Fatalf("expected --acp=true as the first launch arg, got %q", lines)
+	}
+	for _, got := range lines {
+		if got == "--acp=false" {
+			t.Errorf("protocol-critical custom arg override was not filtered: %q", lines)
+		}
+	}
+	found := false
+	for _, got := range lines {
+		if got == "--verbose" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("unrelated custom arg was dropped: %q", lines)
+	}
+}
+
+func TestJunieBackendUsesSessionLoadForResume(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	requestsFile := filepath.Join(tempDir, "requests.jsonl")
+	fakePath := filepath.Join(tempDir, "junie")
+	writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+	backend, err := New("junie", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"JUNIE_REQUESTS_FILE": requestsFile},
+	})
+	if err != nil {
+		t.Fatalf("new junie backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "continue", ExecOptions{
+		ResumeSessionID: "ses_existing",
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed result, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "loaded" {
+		t.Fatalf("output = %q, want loaded", result.Output)
+	}
+	if result.SessionID != "ses_existing" {
+		t.Fatalf("session id = %q, want ses_existing", result.SessionID)
+	}
+
+	raw, err := os.ReadFile(requestsFile)
+	if err != nil {
+		t.Fatalf("read requests file: %v", err)
+	}
+	requests := string(raw)
+	if !strings.Contains(requests, `"method":"session/load"`) {
+		t.Fatalf("expected session/load request, got:\n%s", requests)
+	}
+	if strings.Contains(requests, `"method":"session/new"`) {
+		t.Fatalf("junie backend must not call session/new on a resume, got:\n%s", requests)
+	}
+	if !strings.Contains(requests, `"mcpServers":[]`) {
+		t.Fatalf("session/load must include mcpServers, got:\n%s", requests)
+	}
+}
+
+func TestJunieBackendSetModelFailureFailsTask(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "junie")
+	writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+	backend, err := New("junie", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new junie backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Model:   "bogus-model",
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, `could not switch to model "bogus-model"`) {
+			t.Errorf("expected error to name the requested model, got %q", result.Error)
+		}
+		if result.SessionID != "ses_new" {
+			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}

--- a/server/pkg/agent/junie_test.go
+++ b/server/pkg/agent/junie_test.go
@@ -25,9 +25,10 @@ func TestNewReturnsJunieBackend(t *testing.T) {
 
 // TestJunieBlockedArgsProtectsACPFlag verifies custom_args cannot drop or
 // override the --acp launch flag, in either inline (--acp=false) or
-// two-token (--acp false) form, while unrelated custom args pass through
-// unchanged. Mirrors the equivalent coverage in kiro_test.go / reasonix_test.go
-// for their own protocol-critical flags.
+// two-token (--acp false) form, nor hand-set the daemon-owned --brave
+// permission bypass, while unrelated custom args pass through unchanged.
+// Mirrors the equivalent coverage in kiro_test.go / reasonix_test.go for their
+// own protocol-critical flags.
 func TestJunieBlockedArgsProtectsACPFlag(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -43,6 +44,11 @@ func TestJunieBlockedArgsProtectsACPFlag(t *testing.T) {
 		{
 			name: "two-token override is stripped along with its value",
 			in:   []string{"--acp", "false", "--verbose"},
+			want: []string{"--verbose"},
+		},
+		{
+			name: "daemon-owned brave-mode flag is stripped",
+			in:   []string{"--brave", "--verbose"},
 			want: []string{"--verbose"},
 		},
 		{
@@ -70,13 +76,15 @@ func TestJunieBlockedArgsProtectsACPFlag(t *testing.T) {
 
 // fakeJunieACPScript is a minimal ACP server that answers the handshake
 // junieBackend.Execute drives: initialize, session/new, session/load,
-// session/set_model, session/prompt. Mirrors fakeKiroACPScript's shape.
+// session/set_config_option, session/set_model, session/prompt. Mirrors
+// fakeKiroACPScript's shape.
 //
 // The frames follow a capture of @jetbrains/junie-cli 1468.30.0 wherever one
 // exists, because the previous fixture invented both the wording and the
 // behaviour of a missing session and so certified a path the real CLI cannot
 // produce. In particular:
 //
+//   - session/new advertises the brave_mode configOption, defaulting to "off".
 //   - session/load answers ANY id with a success frame carrying only
 //     configOptions — no sessionId echo, no error. JUNIE_SESSION_NOT_FOUND
 //     forces the generic-ACP error shape instead; that is a shape other ACP
@@ -111,6 +119,15 @@ while IFS= read -r line; do
         exit 0
       fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[{"type":"select","id":"brave_mode","currentValue":"off","options":[{"value":"on"},{"value":"off"}]}]}}\n' "$id"
+      ;;
+    *'"method":"session/set_config_option"'*)
+      if [ -n "$JUNIE_BRAVE_FAIL" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"config set failed"}}\n' "$id"
+      elif [ -n "$JUNIE_BRAVE_UNCONFIRMED" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[{"type":"select","id":"brave_mode","currentValue":"off","options":[{"value":"on"},{"value":"off"}]}]}}\n' "$id"
+      else
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[{"type":"select","id":"brave_mode","currentValue":"on","options":[{"value":"on"},{"value":"off"}]}]}}\n' "$id"
+      fi
       ;;
     *'"method":"session/set_model"'*)
       if [ -n "$JUNIE_STALE_AT_SET_MODEL" ]; then
@@ -583,6 +600,150 @@ func TestJunieStaleResumeSignalsResumeRejected(t *testing.T) {
 				}
 				if result.SessionID != "" {
 					t.Errorf("expected the dead session id to be cleared, got %q", result.SessionID)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+		})
+	}
+}
+
+// TestJunieEnablesBraveModeBeforePrompt pins the unattended-execution
+// contract. Junie's brave_mode configOption defaults to "off" — it asks before
+// executing commands — and its --brave flag is interactive-only, so
+// session/set_config_option is the only route. The parameter name is load
+// bearing: Junie answers `optionId` with -32700 "Missing 'configId'".
+//
+// It must run on the resumed path too: a resumed session whose first run died
+// before configuring the gate would otherwise carry it into the resume.
+func TestJunieEnablesBraveModeBeforePrompt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		opts ExecOptions
+	}{
+		{name: "fresh session", opts: ExecOptions{Timeout: 5 * time.Second}},
+		{name: "resumed session", opts: ExecOptions{ResumeSessionID: "ses_existing", Timeout: 5 * time.Second}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			requestsFile := filepath.Join(tempDir, "requests.jsonl")
+			fakePath := filepath.Join(tempDir, "junie")
+			writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+			backend, err := New("junie", Config{
+				ExecutablePath: fakePath,
+				Logger:         slog.Default(),
+				Env:            map[string]string{"JUNIE_REQUESTS_FILE": requestsFile},
+			})
+			if err != nil {
+				t.Fatalf("new junie backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			session, err := backend.Execute(ctx, "do the thing", tc.opts)
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+			result := <-session.Result
+			if result.Status != "completed" {
+				t.Fatalf("expected completed result, got status=%q error=%q", result.Status, result.Error)
+			}
+
+			raw, err := os.ReadFile(requestsFile)
+			if err != nil {
+				t.Fatalf("read requests file: %v", err)
+			}
+			requests := string(raw)
+			configAt := strings.Index(requests, `"method":"session/set_config_option"`)
+			if configAt < 0 {
+				t.Fatalf("expected a session/set_config_option request, got:\n%s", requests)
+			}
+			if !strings.Contains(requests, `"configId":"brave_mode"`) {
+				t.Fatalf("brave mode must be set through configId, not optionId, got:\n%s", requests)
+			}
+			if !strings.Contains(requests, `"value":"on"`) {
+				t.Fatalf("expected brave_mode to be switched on, got:\n%s", requests)
+			}
+			promptAt := strings.Index(requests, `"method":"session/prompt"`)
+			if promptAt < 0 {
+				t.Fatalf("expected a session/prompt request, got:\n%s", requests)
+			}
+			if configAt > promptAt {
+				t.Fatalf("brave mode must be enabled before the prompt, got:\n%s", requests)
+			}
+		})
+	}
+}
+
+// TestJunieBraveModeFailureStillRuns keeps the brave-mode call best-effort.
+// Unlike dim's read-only preset — whose default denies every write, so failing
+// to raise it guarantees a dead session — Junie's default only asks for
+// approval, and an ACP session/request_permission is already auto-answered by
+// selectACPPermissionOption. Aborting here would turn a probably-working run
+// into a hard failure.
+func TestJunieBraveModeFailureStillRuns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "runtime rejects the request", env: map[string]string{"JUNIE_BRAVE_FAIL": "1"}},
+		{name: "runtime does not confirm the value", env: map[string]string{"JUNIE_BRAVE_UNCONFIRMED": "1"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakePath := filepath.Join(t.TempDir(), "junie")
+			writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+			backend, err := New("junie", Config{
+				ExecutablePath: fakePath,
+				Logger:         slog.Default(),
+				Env:            tc.env,
+			})
+			if err != nil {
+				t.Fatalf("new junie backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			session, err := backend.Execute(ctx, "do the thing", ExecOptions{Timeout: 5 * time.Second})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+
+			select {
+			case result, ok := <-session.Result:
+				if !ok {
+					t.Fatal("result channel closed without a value")
+				}
+				if result.Status != "completed" {
+					t.Fatalf("a failed brave-mode call must not fail the run, got status=%q error=%q", result.Status, result.Error)
+				}
+				if result.Output != "loaded" {
+					t.Errorf("expected the turn to still produce output, got %q", result.Output)
 				}
 			case <-time.After(10 * time.Second):
 				t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/junie_test.go
+++ b/server/pkg/agent/junie_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -70,6 +71,21 @@ func TestJunieBlockedArgsProtectsACPFlag(t *testing.T) {
 // fakeJunieACPScript is a minimal ACP server that answers the handshake
 // junieBackend.Execute drives: initialize, session/new, session/load,
 // session/set_model, session/prompt. Mirrors fakeKiroACPScript's shape.
+//
+// The frames follow a capture of @jetbrains/junie-cli 1468.30.0 wherever one
+// exists, because the previous fixture invented both the wording and the
+// behaviour of a missing session and so certified a path the real CLI cannot
+// produce. In particular:
+//
+//   - session/load answers ANY id with a success frame carrying only
+//     configOptions — no sessionId echo, no error. JUNIE_SESSION_NOT_FOUND
+//     forces the generic-ACP error shape instead; that is a shape other ACP
+//     runtimes produce and this backend still handles, not one Junie 1468.30
+//     was observed to produce.
+//   - an unknown session is rejected by the stateful methods with
+//     -32602 "Session <id> not found" (JUNIE_STALE_AT_SET_MODEL /
+//     JUNIE_STALE_AT_PROMPT), which is the id-interpolating wording the
+//     shared isACPSessionNotFound does not match.
 func fakeJunieACPScript() string {
 	return `#!/bin/sh
 if [ -n "$JUNIE_ARGS_FILE" ]; then
@@ -87,16 +103,20 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
       ;;
     *'"method":"session/new"'*)
-      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_new","models":{"currentModelId":"auto","availableModels":[{"modelId":"auto","name":"auto"}]}}}\n' "$id"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_new","configOptions":[{"type":"select","id":"brave_mode","currentValue":"off","options":[{"value":"on"},{"value":"off"}]}],"models":{"currentModelId":"auto","availableModels":[{"modelId":"auto","name":"auto"}]}}}\n' "$id"
       ;;
     *'"method":"session/load"'*)
       if [ -n "$JUNIE_SESSION_NOT_FOUND" ]; then
-        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"session not found"}}\n' "$id"
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Session ses_gone not found"}}\n' "$id"
         exit 0
       fi
-      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[{"type":"select","id":"brave_mode","currentValue":"off","options":[{"value":"on"},{"value":"off"}]}]}}\n' "$id"
       ;;
     *'"method":"session/set_model"'*)
+      if [ -n "$JUNIE_STALE_AT_SET_MODEL" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Session ses_gone not found"}}\n' "$id"
+        exit 0
+      fi
       case "$line" in
         *bogus-model*)
           printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"model not available: bogus-model"}}\n' "$id"
@@ -108,6 +128,10 @@ while IFS= read -r line; do
       esac
       ;;
     *'"method":"session/prompt"'*)
+      if [ -n "$JUNIE_STALE_AT_PROMPT" ]; then
+        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Session ses_gone not found"}}\n' "$id"
+        exit 0
+      fi
       case "$line" in
         *'"prompt":'*)
           ;;
@@ -300,6 +324,14 @@ func TestJunieBackendSetModelFailureFailsTask(t *testing.T) {
 // shouldRetryWithFreshSession starts a new session; without it the daemon
 // reads the zero value as "checked, not a rejection" and replays the dead id
 // on every subsequent turn. Mirrors TestQwenpawSessionLoadNotFound.
+//
+// This is a generic-ACP shape, NOT what Junie 1468.30 does — its session/load
+// answers an unknown id with an ordinary success frame, so the branch under
+// test is unreachable for that build (see the fixture comment, and
+// fakeHermesACPStaleResumeScript in hermes_test.go for the same annotation on
+// the Hermes side). It stays covered because the branch must keep behaving if
+// JetBrains makes load strict. The surfaces a capture proves Junie DOES reject
+// on are covered by TestJunieStaleResumeSignalsResumeRejected.
 func TestJunieSessionLoadNotFoundSignalsResumeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -349,6 +381,213 @@ func TestJunieSessionLoadNotFoundSignalsResumeRejected(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestIsJunieSessionNotFound pins the wording discrimination the whole resume
+// recovery hangs on. Junie interpolates the id — "Session <id> not found" —
+// which the shared isACPSessionNotFound (contiguous phrases only) misses, so
+// every ResumeRejected branch in junie.go stayed dead against the real CLI.
+//
+// The near-misses matter as much as the matches. A false positive here makes
+// the backend clear a HEALTHY session id and report a rejection, which drives
+// shouldRetryWithFreshSession to discard the conversation pointer and re-run
+// the turn from zero — strictly worse than failing loudly. The interleaved
+// token must therefore look like an id, not any noun.
+func TestIsJunieSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// Captured verbatim from @jetbrains/junie-cli 1468.30.0 replying
+			// to session/set_model with an unknown session id.
+			name: "junie interpolates the session id",
+			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "Session session-260824-112848-191m not found"},
+			want: true,
+		},
+		{
+			name: "junie wording with a quoted id",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32602, Message: `Session "ses_1a" not found`},
+			want: true,
+		},
+		{
+			name: "junie wording carried in data",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32602, Message: "Invalid params", Data: "Session ses-9 not found"},
+			want: true,
+		},
+		{
+			// The shared helper's wordings must keep matching: this predicate
+			// is a superset, not a replacement.
+			name: "contiguous hermes wording still matches",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Session not found"},
+			want: true,
+		},
+		{
+			name: "kiro data wording still matches",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Internal error", Data: "No session found with id ses_abc"},
+			want: true,
+		},
+		{
+			name: "wrapped rpc error",
+			err:  fmt.Errorf("request failed: %w", &acpRPCError{Method: "session/set_model", Code: -32602, Message: "Session ses-1 not found"}),
+			want: true,
+		},
+		{
+			// The interleaved word is a plain noun, not an id: a missing
+			// config is not a missing session, and treating it as one would
+			// retire a live conversation.
+			name: "missing session config is not a missing session",
+			err:  &acpRPCError{Method: "session/new", Code: -32602, Message: "session config not found"},
+			want: false,
+		},
+		{
+			name: "missing session config file is not a missing session",
+			err:  &acpRPCError{Method: "session/new", Code: -32602, Message: "session config file not found"},
+			want: false,
+		},
+		{
+			// An id-shaped token elsewhere in the sentence must not count:
+			// only the token directly between the noun and the verdict does.
+			name: "missing session log file is not a missing session",
+			err:  &acpRPCError{Method: "session/load", Code: -32603, Message: "session log file ses-1.json not found"},
+			want: false,
+		},
+		{
+			name: "missing model on a live session",
+			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "Model gpt-9 not found for session ses-1"},
+			want: false,
+		},
+		{
+			// Junie's answer for a live session with a bad model. Sharing the
+			// code with the not-found reply is exactly why the text gate has
+			// to be narrow.
+			name: "unsupported model on a live session",
+			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "Unsupported Junie model 'gpt-5'"},
+			want: false,
+		},
+		{
+			name: "junie auth wall",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32000, Message: "Authentication is required before this operation can be performed."},
+			want: false,
+		},
+		{
+			name: "junie wording under an unrelated code",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32601, Message: "Session ses-1 not found"},
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  fmt.Errorf("session/set_model: Session ses-1 not found (code=-32602)"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isJunieSessionNotFound(tc.err); got != tc.want {
+				t.Errorf("isJunieSessionNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestJunieStaleResumeSignalsResumeRejected covers the surfaces a real Junie
+// actually rejects a dead session on. Its session/load lets any id through, so
+// the failure only lands at session/set_model (verified against 1468.30) or,
+// without a model override, at session/prompt (same runtime, same error
+// vocabulary — the captured run hit the auth wall before prompt, so that half
+// is extrapolated).
+//
+// Both must clear the session id and set ResumeRejected. junie is absent from
+// resumeRejectionUndetectable, so a false ResumeRejected is read by
+// shouldRetryWithFreshSession as an authoritative "checked, not a rejection"
+// and the daemon replays the dead id forever.
+func TestJunieStaleResumeSignalsResumeRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		env       map[string]string
+		model     string
+		wantError string
+	}{
+		{
+			name:      "set_model rejects the stale session",
+			env:       map[string]string{"JUNIE_STALE_AT_SET_MODEL": "1"},
+			model:     "junie-default",
+			wantError: `could not switch to model "junie-default"`,
+		},
+		{
+			name:      "prompt rejects the stale session",
+			env:       map[string]string{"JUNIE_STALE_AT_PROMPT": "1"},
+			wantError: "session/prompt failed",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakePath := filepath.Join(t.TempDir(), "junie")
+			writeTestExecutable(t, fakePath, []byte(fakeJunieACPScript()))
+
+			backend, err := New("junie", Config{
+				ExecutablePath: fakePath,
+				Logger:         slog.Default(),
+				Env:            tc.env,
+			})
+			if err != nil {
+				t.Fatalf("new junie backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			session, err := backend.Execute(ctx, "continue", ExecOptions{
+				ResumeSessionID: "ses_gone",
+				Model:           tc.model,
+				Timeout:         5 * time.Second,
+			})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+
+			select {
+			case result, ok := <-session.Result:
+				if !ok {
+					t.Fatal("result channel closed without a value")
+				}
+				if result.Status != "failed" {
+					t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+				}
+				if !strings.Contains(result.Error, tc.wantError) {
+					t.Errorf("expected the error to name the failing step %q, got %q", tc.wantError, result.Error)
+				}
+				if !result.ResumeRejected {
+					t.Fatal("expected ResumeRejected=true so the daemon retries from a fresh session")
+				}
+				if result.SessionID != "" {
+					t.Errorf("expected the dead session id to be cleared, got %q", result.SessionID)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+		})
 	}
 }
 

--- a/server/pkg/agent/launch.go
+++ b/server/pkg/agent/launch.go
@@ -310,6 +310,7 @@ var launchPrefixBlockedArgs = map[string]map[string]blockedArgMode{
 	"deveco":      devecoBlockedArgs,
 	"grok":        grokBlockedArgs,
 	"hermes":      hermesBlockedArgs,
+	"junie":       junieBlockedArgs,
 	"kimi":        kimiBlockedArgs,
 	"kiro":        kiroBlockedArgs,
 	"opencode":    opencodeBlockedArgs,

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -203,6 +203,17 @@ func ListModels(ctx context.Context, providerType string, runtimeCmd Command) (C
 		return cachedDiscovery(discoveryCacheKey(providerType, runtimeCmd), func() (Catalog, error) {
 			return discovered(discoverKiroModels(ctx, runtimeCmd))
 		})
+	case "junie":
+		// JetBrains Junie's ACP session/new model-catalog shape has not been
+		// confirmed against a live handshake yet (unlike kiro/reasonix, whose
+		// discovery was verified against an installed binary before landing).
+		// Per builtin_runtimes.go's documented ModelDiscovery: nil fallback
+		// pattern, degrade to an empty catalog rather than guess a discovery
+		// parser at a response shape nobody has observed — the runtime
+		// default plus manual model entry stay available either way (same
+		// posture as qwen). Replace with a discoverJunieModels call modelled
+		// on discoverKiroModels once the shape is confirmed.
+		return Catalog{Models: []Model{}}, nil
 	case "qoder", "qoderclicn":
 		return cachedDiscovery(discoveryCacheKey(providerType, runtimeCmd), func() (Catalog, error) {
 			return discovered(discoverQoderModels(ctx, runtimeCmd, qoderDefaultBinary(providerType)))

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -48,6 +48,23 @@ func TestListModelsQwenUsesRuntimeDefaultAndManualEntry(t *testing.T) {
 	}
 }
 
+func TestListModelsJunieUsesRuntimeDefaultAndManualEntry(t *testing.T) {
+	// Junie returns its manual-entry catalog without resolving or executing a
+	// CLI: its ACP model-catalog shape has not been confirmed against a live
+	// handshake yet, so discovery deliberately degrades to empty rather than
+	// guess at a parser (see the case "junie" comment in models.go).
+	got, err := ListModels(context.Background(), "junie", Command{Path: ""})
+	if err != nil {
+		t.Fatalf("ListModels(junie) error: %v", err)
+	}
+	if len(got.Models) != 0 {
+		t.Fatalf("ListModels(junie) = %+v, want no static catalog", got)
+	}
+	if got.Fallback {
+		t.Error("junie's empty catalog is deliberate, not a discovery fallback")
+	}
+}
+
 func TestListModelsCopilotFallsBackToStatic(t *testing.T) {
 	// Copilot uses dynamic ACP discovery, but with no `copilot`
 	// binary on PATH (the discovery LookPath fails) it must fall


### PR DESCRIPTION
## Summary

Adds Junie (JetBrains' coding agent) as a native ACP runtime. Kiro CLI support for #1163 already landed in #1780; multica-eve kept this issue open specifically for the remaining Junie CLI part.

## Change

- `server/pkg/agent/junie.go`: new ACP backend (`junie --acp=true`), mirroring the Kiro backend's session lifecycle — `session/new`, `session/load` resume, `session/set_model`, provider-error promotion, MCP capability filtering.
- `agent.go` (`SupportedTypes`, `New`, launch header), `models.go` (empty-catalog degradation matching the `qwen` precedent), `internal/daemon/agents_probe.go` + `config.go`, `scripts/agent-cli-command-names.txt`, and the frontend runtime-provider wiring (`packages/core/types/agent.ts`, `packages/core/agents/mcp-support.ts`, `packages/views/runtimes/components/provider-logo.tsx`).
- Migration 377: widens the `runtime_profile.protocol_family` CHECK constraint (`ALTER TABLE ... NOT VALID`, matching migration 370's `dim` pattern).
- Docs (`providers.mdx` + locales, `README.md`, `CLI_AND_DAEMON.md`, `SELF_HOSTING.md`).

Follow-up fix in the second commit: `runtimeConfigPath` (`internal/daemon/execenv/runtime_config.go`) didn't have a case for `"junie"`, so it fell through to `default: return ""` and `InjectRuntimeConfig` silently skipped writing `AGENTS.md` into every Junie task's workdir — every Junie-assigned task would have run with no workflow brief at all (no `multica issue status`/`comment add` instructions, no project/skill context). Same failure mode traecli shipped with once before (#4945/#4946). Fixed by adding `"junie"` alongside `"kiro"` (both ACP backends that load `AGENTS.md` from the task cwd themselves), plus registering `junieBlockedArgs` in `launchPrefixBlockedArgs` and adding `"junie"` to the metrics `knownRuntimeProviders` allowlist. Added `TestRuntimeConfigPathCoversEverySupportedType`, a guard that walks every `agent.SupportedTypes` entry and fails if `runtimeConfigPath` returns `""` for it, so this class of bug can't recur silently for any future runtime addition.

## Test plan

- `gofmt -l`, `go vet ./...`, `go build ./...` clean.
- Full `go test ./pkg/agent/...`, `./internal/daemon/execenv/...`, `./internal/metrics/...` — all pass, including the new guard test and `junie_test.go`'s ACP fake-script coverage (backend selection, blocked-arg stripping in both `--acp=false` and `--acp false` forms, `session/load` resume, `set_model` failure handling).
- `pnpm --filter @multica/views test` for `provider-logo` — pass.

Fixes #1163
