### PR TITLE
MUL-6509 fix(telegram): speak English in the Telegram bot

### DIFF
--- a/server/internal/integrations/telegram/outbound.go
+++ b/server/internal/integrations/telegram/outbound.go
@@ -178,7 +178,7 @@ const (
 const streamPlaceholder = "…"
 
 // taskFailedText is sent when the agent run fails outright.
-const taskFailedText = "❌ 智能体处理失败，请稍后重试。"
+const taskFailedText = "❌ The agent run failed. Please try again."
 
 // NewOutbound builds the Telegram outbound subscriber.
 func NewOutbound(q outboundQueries, decrypt Decrypter, apiBase string, client *http.Client, logger *slog.Logger) *Outbound {

--- a/server/internal/integrations/telegram/replier.go
+++ b/server/internal/integrations/telegram/replier.go
@@ -28,10 +28,10 @@ import (
 //   - Dropped addressed /issue commands: an authorization/status refusal.
 
 const (
-	msgFreshPending   = "✅ 已准备开始新对话。你的下一条聊天消息将不带之前的上下文运行。"
-	msgIssueUsage     = "请填写任务标题，格式如下：\n\n/issue <标题>\n[描述]（可选）"
-	msgIssueNotMember = "你不是该 Multica 工作区的成员，因此无法创建任务。请让工作区管理员邀请你后重试。"
-	msgIssueDisabled  = "该 Telegram 机器人未连接到 Multica（或已断开连接）。请让工作区管理员重新连接。"
+	msgFreshPending   = "✅ Fresh start ready. Your next chat message will run without previous context."
+	msgIssueUsage     = "Please include an issue title. Use:\n\n/issue <title>\n[description] (optional)"
+	msgIssueNotMember = "You're not a member of this Multica workspace, so I can't file an issue for you. Ask a workspace admin to invite you, then send the command again."
+	msgIssueDisabled  = "This Telegram bot isn't connected to Multica (or was disconnected). Ask a workspace admin to reconnect it."
 )
 
 // bindingMinter is the binding-token surface the replier needs.
@@ -168,7 +168,7 @@ func (r *OutboundReplier) sendBindingPrompt(ctx context.Context, inst engine.Res
 		return fmt.Errorf("mint binding token: %w", err)
 	}
 	bindURL := r.appURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
-	text := "👋 要开始和我对话，请先绑定你的 Multica 账号：\n" + bindURL + "\n（链接 15 分钟内有效）"
+	text := "👋 To start chatting with me, link your Telegram account to Multica:\n" + bindURL + "\n(This link expires in 15 minutes.)"
 	return r.post(ctx, inst, msg, text)
 }
 
@@ -210,18 +210,18 @@ func issueCreatedText(res engine.Result) string {
 	id := issueResultIdentifier(res)
 	title := strings.TrimSpace(res.IssueTitle)
 	if title == "" {
-		return "✅ 已创建 " + id
+		return "✅ Created " + id
 	}
-	return "✅ 已创建 " + id + " — " + title
+	return "✅ Created " + id + " — " + title
 }
 
 func issueDuplicateText(res engine.Result) string {
 	id := issueResultIdentifier(res)
 	title := strings.TrimSpace(res.IssueTitle)
 	if title == "" {
-		return "⚠️ 未创建：已存在进行中的任务 " + id + "。"
+		return "⚠️ Not created — active issue " + id + " already exists."
 	}
-	return "⚠️ 未创建：已存在进行中的任务 " + id + " — " + title
+	return "⚠️ Not created — active issue " + id + " already exists: " + title
 }
 
 func issueResultIdentifier(res engine.Result) string {

--- a/server/internal/integrations/telegram/sender.go
+++ b/server/internal/integrations/telegram/sender.go
@@ -12,14 +12,29 @@ import (
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 )
 
-// User-facing copy the bot speaks in Telegram. Chinese-first, aligned with
-// the Lark adapter's product voice (conventions.zh.mdx); the binding prompt
-// carries the redeem link.
+// User-facing copy the bot speaks in Telegram. English, matching the Slack
+// and DingTalk adapters word for word wherever they say the same thing.
+//
+// The language is chosen per channel by who is on the other end, and this is
+// the decision record so the next person does not "fix" it back (MUL-6509,
+// #7349). WeCom and Lark are Chinese-market products — WeCom is China-only
+// and their adapters keep Chinese copy on purpose. Telegram is blocked in
+// mainland China and reaches everyone else, so a Chinese-first bot there
+// speaks the wrong language to almost every user it has, starting with the
+// binding prompt they must act on before anything else works.
+//
+// English rather than a locale lookup because this bot speaks before it knows
+// who it is speaking to: the binding prompt is sent to an unbound sender, and
+// user.language is only ever written by the settings language switcher, so it
+// is NULL for anyone who never opened it. English is the product default
+// (DEFAULT_LOCALE in packages/core/i18n/types.ts).
+//
+// The binding prompt carries the redeem link.
 const (
-	msgAgentOffline     = "⚠️ 智能体当前离线，消息已记录。下次 daemon 上线后会自动继续处理。"
-	msgAgentArchived    = "⚠️ 该智能体已归档，无法回复。请联系工作区管理员。"
-	msgUnsupportedType  = "暂不支持此类消息，请发送文字内容。"
-	msgBindingGroupHint = "请先私聊我发送一条消息，再完成 Multica 账号绑定。"
+	msgAgentOffline     = "⚠️ The agent is offline right now. Your message was received and will be handled once it's back online."
+	msgAgentArchived    = "⚠️ This agent has been archived and can't respond. Please contact your workspace admin."
+	msgUnsupportedType  = "Sorry, I can't handle this kind of message yet. Please send text."
+	msgBindingGroupHint = "Please message me in a direct chat first, then link your Multica account."
 )
 
 // maxMessageUnits caps one outbound sendMessage body. Telegram hard-caps a

--- a/server/internal/integrations/telegram/telegram_channel.go
+++ b/server/internal/integrations/telegram/telegram_channel.go
@@ -134,7 +134,7 @@ func (c *telegramChannel) dispatch(ctx context.Context, u Update) error {
 
 const (
 	issueErrorReplyTimeout  = 5 * time.Second
-	issueDispatchFailedText = "⚠️ 创建任务时发生内部错误，请稍后重试。"
+	issueDispatchFailedText = "⚠️ I couldn't create that issue because an internal error occurred. Please try again."
 )
 
 // notifyIssueDispatchError prevents an addressed /issue command from failing


### PR DESCRIPTION
Closes #7349.

Every message the Telegram bot sends was hardcoded Chinese — including the account-binding prompt, which is the **first thing a new user ever sees** from the bot and the one they must act on before anything else works. A non-Chinese reader had no way through it.

## Telegram only — the language is chosen per channel, by who is on the other end

The reporter's evidence, reproduction and offered PR were all Telegram, and Telegram is the channel where Chinese-first is clearly wrong: it is blocked in mainland China and reaches everyone else, so the bot was speaking the wrong language to nearly every user it has.

**WeCom and Lark keep their Chinese copy on purpose** and are not touched here. They are Chinese-market products — WeCom is China-only, as its own source comments already said — and their users are the audience that copy was written for. `sender.go` now carries this as a decision record, because the absence of one is why the adapters drifted apart in the first place.

Slack and DingTalk needed no change: both have been English since their first commit (#4566, #4829). The issue's counts for them (8 and 3) were test fixtures — Chinese issue titles used as link-injection and escaping data (`slack/replier_test.go:224-293`, `dingtalk/markdown_test.go:128`) — not bot copy. Lark likewise already renders its issue-created and duplicate lines in English.

## What changed

15 strings, all in `server/internal/integrations/telegram/`:

- `replier.go` — binding prompt, `/issue` usage, not-a-member, bot-not-connected, created / duplicate
- `sender.go` — agent offline, agent archived, unsupported message type, group binding hint
- `telegram_channel.go` — issue dispatch failure
- `outbound.go` — agent run failure

The copy is taken word for word from the Slack and DingTalk adapters wherever they already say the same thing, rather than freshly invented. English is also the product default (`DEFAULT_LOCALE` in `packages/core/i18n/types.ts`). **No catalog, no migration, no i18n layer** — this is an alignment.

Every changed string goes out on a send path with no `parse_mode`, so `<title>` in the usage message is plain text exactly as `<标题>` was.

## Not in scope

**Localizing per user is deliberately not answered here.** The plumbing would be cheap — `ResolvedInstallation.InstallerUserID` already reaches the replier for pre-binding messages, and the Router already resolves `ResolvedIdentity{UserID}` for bound senders — but the signal is empty: `user.language` is only ever written by the settings language switcher (`packages/views/settings/components/preferences-tab.tsx:76`). Nothing populates it at signup, and `user-locale-sync.tsx` syncs server → local only, never the browser-detected locale back to the server. So it is NULL for anyone who never opened that switcher, and a locale lookup on this path would fall through to English for nearly everyone regardless. Worth revisiting once `user.language` is actually populated.

Also untouched: `cli/errors.go` (15 Chinese CLI error strings) and `lark/ws_endpoint.go:144` (hardcoded `locale: zh` header for Lark API error text — operator-facing). Same class of problem, different surfaces.

## Verification

```
go build ./...                                             OK
go vet ./internal/integrations/...                         OK
go test ./internal/integrations/{telegram,wecom,lark,slack,dingtalk}/... -count=1
  ok  telegram   ok  wecom   ok  lark   ok  slack   ok  dingtalk
```

No test changes were needed — the Telegram tests reference the constants by name rather than asserting their contents. `gofmt` clean.

One unrelated pre-existing failure in `internal/integrations/ghsnapshot` (`TestInFlightOldHeadKeepsTrailingRefresh`) reproduces on a clean tree at the same base commit.
