### PR TITLE
MUL-6518 ALL-151: retry task temp cleanup on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,11 @@ jobs:
           go test ./internal/daemon/execenv -v -run '^(TestSeedUserCodexSkills|TestHydrateCodexSkills)' -count=1 -timeout=5m
           go test ./internal/daemon -v -run '^(TestCleanTaskArtifacts_DoesNotFollowDirectoryJunction|TestTaskSize_DoesNotCountDirectoryJunction)$' -count=1 -timeout=5m
 
+      - name: Test Windows task temp cleanup retry
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        working-directory: server
+        run: go test ./internal/daemon -v -run '^TestCleanupTaskTempDirRetriesWindowsSharingViolation$' -count=1 -timeout=5m
+
       - name: Test Windows agent executable junction resolution
         if: ${{ needs.changes.outputs.backend == 'true' }}
         working-directory: server

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6951,8 +6951,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)
 	}
 	defer func() {
-		if cerr := os.RemoveAll(taskTempDir); cerr != nil {
-			taskLog.Warn("task temp dir cleanup failed", "path", taskTempDir, "error", cerr)
+		attempts, cerr := cleanupTaskTempDir(taskTempDir)
+		if cerr != nil {
+			taskLog.Warn("task temp dir cleanup failed after retries", "path", taskTempDir, "attempts", attempts, "error", cerr)
+		} else if attempts > 1 {
+			taskLog.Info("task temp dir cleanup succeeded after retry", "path", taskTempDir, "attempts", attempts)
 		}
 	}()
 

--- a/server/internal/daemon/task_temp_cleanup.go
+++ b/server/internal/daemon/task_temp_cleanup.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+var taskTempCleanupRetryDelays = [...]time.Duration{
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	time.Second,
+	2 * time.Second,
+}
+
+func cleanupTaskTempDir(path string) (int, error) {
+	return cleanupTaskTempDirWith(path, os.RemoveAll, time.Sleep, taskTempCleanupRetryDelays[:])
+}
+
+func cleanupTaskTempDirWith(
+	path string,
+	removeAll func(string) error,
+	sleep func(time.Duration),
+	retryDelays []time.Duration,
+) (int, error) {
+	attempts := 1
+	err := removeAll(path)
+	for _, delay := range retryDelays {
+		if err == nil {
+			return attempts, nil
+		}
+		sleep(delay)
+		attempts++
+		err = removeAll(path)
+	}
+	if err != nil {
+		return attempts, fmt.Errorf("remove task temp dir after %d attempts: %w", attempts, err)
+	}
+	return attempts, nil
+}

--- a/server/internal/daemon/task_temp_cleanup_test.go
+++ b/server/internal/daemon/task_temp_cleanup_test.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCleanupTaskTempDirWithRetriesTransientFailure(t *testing.T) {
+	wantErr := errors.New("file is in use")
+	removeCalls := 0
+	var sleeps []time.Duration
+
+	attempts, err := cleanupTaskTempDirWith(
+		"task-temp",
+		func(string) error {
+			removeCalls++
+			if removeCalls < 3 {
+				return wantErr
+			}
+			return nil
+		},
+		func(delay time.Duration) { sleeps = append(sleeps, delay) },
+		[]time.Duration{time.Millisecond, 2 * time.Millisecond, 4 * time.Millisecond},
+	)
+
+	if err != nil {
+		t.Fatalf("cleanupTaskTempDirWith(): %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{time.Millisecond, 2 * time.Millisecond}) {
+		t.Fatalf("sleeps = %v, want [1ms 2ms]", sleeps)
+	}
+}
+
+func TestCleanupTaskTempDirWithRetriesExhausted(t *testing.T) {
+	wantErr := errors.New("file is still in use")
+	removeCalls := 0
+
+	attempts, err := cleanupTaskTempDirWith(
+		"task-temp",
+		func(string) error {
+			removeCalls++
+			return wantErr
+		},
+		func(time.Duration) {},
+		[]time.Duration{time.Millisecond, 2 * time.Millisecond},
+	)
+
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, wantErr)
+	}
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Fatalf("error = %q, want attempt count", err)
+	}
+}

--- a/server/internal/daemon/task_temp_cleanup_windows_test.go
+++ b/server/internal/daemon/task_temp_cleanup_windows_test.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestCleanupTaskTempDirRetriesWindowsSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "node-compile-cache")
+	if err := os.Mkdir(cacheDir, 0o700); err != nil {
+		t.Fatalf("create node compile cache: %v", err)
+	}
+	lockedFile := filepath.Join(cacheDir, "cache.bin")
+	if err := os.WriteFile(lockedFile, []byte("cache"), 0o600); err != nil {
+		t.Fatalf("write locked file: %v", err)
+	}
+
+	path, err := windows.UTF16PtrFromString(lockedFile)
+	if err != nil {
+		t.Fatalf("encode locked file path: %v", err)
+	}
+	handle, err := windows.CreateFile(
+		path,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("open locked file: %v", err)
+	}
+
+	if err := os.RemoveAll(dir); err == nil {
+		_ = windows.CloseHandle(handle)
+		t.Fatal("RemoveAll unexpectedly succeeded while delete sharing was denied")
+	} else {
+		t.Logf("reproduced Windows sharing violation: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		_ = windows.CloseHandle(handle)
+		close(released)
+	}()
+
+	attempts, err := cleanupTaskTempDirWith(
+		dir,
+		os.RemoveAll,
+		time.Sleep,
+		[]time.Duration{25 * time.Millisecond, 75 * time.Millisecond, 150 * time.Millisecond},
+	)
+	<-released
+	if err != nil {
+		t.Fatalf("cleanupTaskTempDirWith(): %v", err)
+	}
+	if attempts < 2 {
+		t.Fatalf("attempts = %d, want a retry after the sharing violation", attempts)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("task temp dir still exists after retry: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- retry task temp directory cleanup with bounded backoff after transient file-sharing failures
- log retry recovery separately from exhausted cleanup failures
- reproduce the Windows `node-compile-cache` sharing violation and run the regression in Windows CI

## Impact

- measured 174 residual `multica-task-*` directories using 334,484,328 bytes (318.989 MiB) in the local Windows temp directory
- cleanup adds no delay on the normal path and at most 3.85 seconds only after repeated failures

## Verification

- `go test ./internal/daemon -run '^(TestCleanupTaskTempDirWithRetriesTransientFailure|TestCleanupTaskTempDirWithRetriesExhausted|TestCleanupTaskTempDirRetriesWindowsSharingViolation|TestTaskTempBaseDir)$' -count=1`
- `go vet ./internal/daemon`
- `go test ./internal/daemon -run '^$' -count=1`

Related: ALL-151
