### PR TITLE
fix(cli): redact autopilot webhook credentials

### DIFF
--- a/apps/docs/content/docs/autopilots.ja.mdx
+++ b/apps/docs/content/docs/autopilots.ja.mdx
@@ -143,10 +143,13 @@ Multica は最近の実行が継続的に失敗していないか定期的に確
 ## CLI を使う
 
 ```bash
+multica autopilot get <autopilot-id> --output json
 multica autopilot trigger <autopilot-id>
 multica autopilot runs <autopilot-id>
 multica autopilot trigger-rotate-url <autopilot-id> <trigger-id>
 ```
+
+`autopilot get` はデフォルトで `webhook_token`、`webhook_path`、`webhook_url` を `null` にし、代わりに `has_webhook_token` と `webhook_token_hint` を返します。実際の認証情報が必要な場合に限り `--show-secrets` を追加してください。CLI は警告を stderr に出力するため、パイプされた JSON は有効なままです。
 
 すべての引数は [CLI](/cli)を参照してください。
 

--- a/apps/docs/content/docs/autopilots.ko.mdx
+++ b/apps/docs/content/docs/autopilots.ko.mdx
@@ -143,10 +143,13 @@ Multica는 최근 실행이 계속 실패하는지 정기적으로 확인합니�
 ## CLI 사용
 
 ```bash
+multica autopilot get <autopilot-id> --output json
 multica autopilot trigger <autopilot-id>
 multica autopilot runs <autopilot-id>
 multica autopilot trigger-rotate-url <autopilot-id> <trigger-id>
 ```
+
+`autopilot get`은 기본적으로 `webhook_token`, `webhook_path`, `webhook_url`을 `null`로 설정하고 대신 `has_webhook_token`과 `webhook_token_hint`를 반환합니다. 실제 자격 증명이 꼭 필요할 때만 `--show-secrets`를 추가하세요. CLI는 경고를 stderr로 출력하므로 파이프로 전달되는 JSON은 유효하게 유지됩니다.
 
 전체 인수는 [CLI 사용](/cli)을 참고하세요.
 

--- a/apps/docs/content/docs/autopilots.mdx
+++ b/apps/docs/content/docs/autopilots.mdx
@@ -143,10 +143,13 @@ Pausing manually stops schedules, webhooks, and **Run now**. Deletion is actuall
 ## Use the CLI
 
 ```bash
+multica autopilot get <autopilot-id> --output json
 multica autopilot trigger <autopilot-id>
 multica autopilot runs <autopilot-id>
 multica autopilot trigger-rotate-url <autopilot-id> <trigger-id>
 ```
+
+`autopilot get` sets `webhook_token`, `webhook_path`, and `webhook_url` to `null` by default, and returns `has_webhook_token` plus `webhook_token_hint` instead. Add `--show-secrets` only when you intentionally need the live credential; the CLI prints a warning to stderr so piped JSON stays valid.
 
 See [Using the CLI](/cli) for the full parameters.
 

--- a/apps/docs/content/docs/autopilots.zh.mdx
+++ b/apps/docs/content/docs/autopilots.zh.mdx
@@ -143,10 +143,13 @@ Multica 会定期检查近期运行是否持续失败：过去 7 天内已完成
 ## 使用 CLI
 
 ```bash
+multica autopilot get <autopilot-id> --output json
 multica autopilot trigger <autopilot-id>
 multica autopilot runs <autopilot-id>
 multica autopilot trigger-rotate-url <autopilot-id> <trigger-id>
 ```
+
+`autopilot get` 默认把 `webhook_token`、`webhook_path` 和 `webhook_url` 设为 `null`，并返回 `has_webhook_token` 与 `webhook_token_hint`。只有确实需要获取当前有效凭证时才添加 `--show-secrets`；CLI 会把警告输出到 stderr，确保管道中的 JSON 仍然有效。
 
 完整参数见[使用 CLI](/cli)。
 

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -28,7 +28,7 @@ var autopilotListCmd = &cobra.Command{
 
 var autopilotGetCmd = &cobra.Command{
 	Use:   "get <id>",
-	Short: "Get autopilot details (includes triggers)",
+	Short: "Get autopilot details (webhook credentials redacted by default)",
 	Args:  exactArgs(1),
 	RunE:  runAutopilotGet,
 }
@@ -115,6 +115,7 @@ func init() {
 
 	// get
 	autopilotGetCmd.Flags().String("output", "json", "Output format: table or json")
+	autopilotGetCmd.Flags().Bool("show-secrets", false, "Include live webhook credentials in JSON output (unsafe for logs)")
 
 	// create
 	autopilotCreateCmd.Flags().String("title", "", "Autopilot title (required)")
@@ -223,6 +224,12 @@ func runAutopilotList(cmd *cobra.Command, _ []string) error {
 }
 
 func runAutopilotGet(cmd *cobra.Command, args []string) error {
+	output, _ := cmd.Flags().GetString("output")
+	showSecrets, _ := cmd.Flags().GetBool("show-secrets")
+	if showSecrets && output != "json" {
+		return fmt.Errorf("--show-secrets requires --output json")
+	}
+
 	client, err := newAPIClient(cmd)
 	if err != nil {
 		return err
@@ -241,7 +248,12 @@ func runAutopilotGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get autopilot: %w", err)
 	}
 
-	output, _ := cmd.Flags().GetString("output")
+	if showSecrets {
+		fmt.Fprintln(os.Stderr, "Warning: --show-secrets exposes live webhook credentials; keep this output out of logs and shared transcripts.")
+	} else {
+		redactAutopilotWebhookCredentials(resp)
+	}
+
 	if output == "json" {
 		return cli.PrintJSON(os.Stdout, resp)
 	}
@@ -259,6 +271,44 @@ func runAutopilotGet(cmd *cobra.Command, args []string) error {
 	}}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
+}
+
+func redactAutopilotWebhookCredentials(resp map[string]any) {
+	triggers, ok := resp["triggers"].([]any)
+	if !ok {
+		return
+	}
+	for _, raw := range triggers {
+		trigger, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		_, hasTokenField := trigger["webhook_token"]
+		_, hasPathField := trigger["webhook_path"]
+		_, hasURLField := trigger["webhook_url"]
+		if !hasTokenField && !hasPathField && !hasURLField {
+			continue
+		}
+
+		token := strVal(trigger, "webhook_token")
+		hasToken := token != "" || strVal(trigger, "webhook_path") != "" || strVal(trigger, "webhook_url") != ""
+		trigger["has_webhook_token"] = hasToken
+		if hint := webhookTokenHint(token); hint != "" {
+			trigger["webhook_token_hint"] = hint
+		} else {
+			trigger["webhook_token_hint"] = nil
+		}
+		trigger["webhook_token"] = nil
+		trigger["webhook_path"] = nil
+		trigger["webhook_url"] = nil
+	}
+}
+
+func webhookTokenHint(token string) string {
+	if len(token) < 4 {
+		return ""
+	}
+	return token[len(token)-4:]
 }
 
 func runAutopilotCreate(cmd *cobra.Command, _ []string) error {

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -291,7 +291,12 @@ func redactAutopilotWebhookCredentials(resp map[string]any) {
 		}
 
 		token := strVal(trigger, "webhook_token")
-		hasToken := token != "" || strVal(trigger, "webhook_path") != "" || strVal(trigger, "webhook_url") != ""
+		hasToken, _ := trigger["has_webhook_token"].(bool)
+		hasToken = hasToken ||
+			strVal(trigger, "kind") == "webhook" ||
+			token != "" ||
+			strVal(trigger, "webhook_path") != "" ||
+			strVal(trigger, "webhook_url") != ""
 		trigger["has_webhook_token"] = hasToken
 		if hint := webhookTokenHint(token); hint != "" {
 			trigger["webhook_token_hint"] = hint

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -254,6 +254,33 @@ func TestRedactAutopilotWebhookCredentialsDoesNotDependOnTriggerKind(t *testing.
 	}
 }
 
+func TestRedactAutopilotWebhookCredentialsReportsServerRedactedToken(t *testing.T) {
+	trigger := map[string]any{
+		"id":            "trigger-1",
+		"kind":          "webhook",
+		"webhook_token": nil,
+		"webhook_path":  nil,
+		"webhook_url":   nil,
+	}
+	resp := map[string]any{"triggers": []any{trigger}}
+
+	redactAutopilotWebhookCredentials(resp)
+
+	if trigger["has_webhook_token"] != true {
+		t.Fatalf("has_webhook_token = %#v, want true for a permission-redacted webhook", trigger["has_webhook_token"])
+	}
+	if trigger["webhook_token_hint"] != nil {
+		t.Fatalf("webhook_token_hint = %#v, want null when the server withheld the token", trigger["webhook_token_hint"])
+	}
+}
+
+func TestWebhookTokenHintDoesNotExposeShortToken(t *testing.T) {
+	const shortToken = "abc"
+	if hint := webhookTokenHint(shortToken); hint != "" {
+		t.Fatalf("webhookTokenHint(%q) = %q, want empty hint", shortToken, hint)
+	}
+}
+
 func TestRunAutopilotGetRejectsShowSecretsWithTableOutput(t *testing.T) {
 	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1")
 	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -43,6 +43,235 @@ func newAutopilotUpdateTestCmd() *cobra.Command {
 	return cmd
 }
 
+func newAutopilotGetTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().Bool("show-secrets", false, "")
+	return cmd
+}
+
+func TestRunAutopilotGetRedactsWebhookCredentialsByDefault(t *testing.T) {
+	const (
+		autopilotID  = "11111111-1111-1111-1111-111111111111"
+		webhookToken = "awt_super-secret-7890"
+		webhookPath  = "/api/webhooks/autopilots/" + webhookToken
+		webhookURL   = "https://hooks.example.com" + webhookPath
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"autopilot": map[string]any{"id": autopilotID, "title": "Deploy"},
+			"triggers": []map[string]any{
+				{
+					"id":                  "trigger-1",
+					"kind":                "webhook",
+					"webhook_token":       webhookToken,
+					"webhook_path":        webhookPath,
+					"webhook_url":         webhookURL,
+					"has_signing_secret":  true,
+					"signing_secret_hint": "abcd",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	out, err := captureStdout(t, func() error {
+		return runAutopilotGet(newAutopilotGetTestCmd(), []string{autopilotID})
+	})
+	if err != nil {
+		t.Fatalf("runAutopilotGet: %v", err)
+	}
+	for _, secret := range []string{webhookToken, webhookPath, webhookURL} {
+		if strings.Contains(out, secret) {
+			t.Fatalf("default output leaked webhook credential %q:\n%s", secret, out)
+		}
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("default output is not valid JSON: %v\n%s", err, out)
+	}
+	triggers, ok := got["triggers"].([]any)
+	if !ok || len(triggers) != 1 {
+		t.Fatalf("triggers = %#v, want one trigger", got["triggers"])
+	}
+	trigger, ok := triggers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("trigger = %#v, want object", triggers[0])
+	}
+	for _, field := range []string{"webhook_token", "webhook_path", "webhook_url"} {
+		if trigger[field] != nil {
+			t.Errorf("%s = %#v, want null", field, trigger[field])
+		}
+	}
+	if trigger["has_webhook_token"] != true {
+		t.Errorf("has_webhook_token = %#v, want true", trigger["has_webhook_token"])
+	}
+	if trigger["webhook_token_hint"] != "7890" {
+		t.Errorf("webhook_token_hint = %#v, want %q", trigger["webhook_token_hint"], "7890")
+	}
+	if trigger["signing_secret_hint"] != "abcd" {
+		t.Errorf("signing_secret_hint = %#v, want existing non-credential metadata preserved", trigger["signing_secret_hint"])
+	}
+}
+
+func TestRunAutopilotGetShowSecretsIsExplicitAndWarns(t *testing.T) {
+	const (
+		autopilotID  = "11111111-1111-1111-1111-111111111111"
+		webhookToken = "awt_super-secret-7890"
+		webhookPath  = "/api/webhooks/autopilots/" + webhookToken
+		webhookURL   = "https://hooks.example.com" + webhookPath
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"autopilot": map[string]any{"id": autopilotID, "title": "Deploy"},
+			"triggers": []map[string]any{
+				{
+					"id":            "trigger-1",
+					"kind":          "webhook",
+					"webhook_token": webhookToken,
+					"webhook_path":  webhookPath,
+					"webhook_url":   webhookURL,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotGetTestCmd()
+	_ = cmd.Flags().Set("show-secrets", "true")
+	stderr := captureStderr(t)
+	out, err := captureStdout(t, func() error {
+		return runAutopilotGet(cmd, []string{autopilotID})
+	})
+	errOut := stderr.read()
+	if err != nil {
+		t.Fatalf("runAutopilotGet: %v", err)
+	}
+	for _, secret := range []string{webhookToken, webhookPath, webhookURL} {
+		if !strings.Contains(out, secret) {
+			t.Errorf("--show-secrets output missing %q:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(strings.ToLower(errOut), "warning") ||
+		!strings.Contains(strings.ToLower(errOut), "webhook credentials") ||
+		!strings.Contains(strings.ToLower(errOut), "logs") {
+		t.Fatalf("stderr = %q, want credential exposure warning", errOut)
+	}
+	if strings.Contains(errOut, webhookToken) {
+		t.Fatalf("warning itself leaked webhook token: %q", errOut)
+	}
+}
+
+func TestRunAutopilotGetTableOutputDoesNotExposeWebhookCredentials(t *testing.T) {
+	const (
+		autopilotID  = "11111111-1111-1111-1111-111111111111"
+		webhookToken = "awt_super-secret-7890"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"autopilot": map[string]any{
+				"id":             autopilotID,
+				"title":          "Deploy",
+				"status":         "active",
+				"execution_mode": "run_only",
+			},
+			"triggers": []map[string]any{
+				{
+					"id":            "trigger-1",
+					"kind":          "webhook",
+					"webhook_token": webhookToken,
+					"webhook_path":  "/api/webhooks/autopilots/" + webhookToken,
+					"webhook_url":   "https://hooks.example.com/api/webhooks/autopilots/" + webhookToken,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotGetTestCmd()
+	_ = cmd.Flags().Set("output", "table")
+	out, err := captureStdout(t, func() error {
+		return runAutopilotGet(cmd, []string{autopilotID})
+	})
+	if err != nil {
+		t.Fatalf("runAutopilotGet: %v", err)
+	}
+	if strings.Contains(out, webhookToken) {
+		t.Fatalf("table output leaked webhook token:\n%s", out)
+	}
+	if !strings.Contains(out, "Deploy") || !strings.Contains(out, "run_only") {
+		t.Fatalf("table output lost ordinary autopilot details:\n%s", out)
+	}
+}
+
+func TestRedactAutopilotWebhookCredentialsDoesNotDependOnTriggerKind(t *testing.T) {
+	const webhookToken = "awt_schema-drift-secret-1234"
+	trigger := map[string]any{
+		"id":            "trigger-1",
+		"webhook_token": webhookToken,
+		"webhook_path":  "/api/webhooks/autopilots/" + webhookToken,
+		"webhook_url":   "https://hooks.example.com/api/webhooks/autopilots/" + webhookToken,
+	}
+	resp := map[string]any{"triggers": []any{trigger}}
+
+	redactAutopilotWebhookCredentials(resp)
+
+	for _, field := range []string{"webhook_token", "webhook_path", "webhook_url"} {
+		if trigger[field] != nil {
+			t.Errorf("%s = %#v, want null", field, trigger[field])
+		}
+	}
+	if trigger["has_webhook_token"] != true || trigger["webhook_token_hint"] != "1234" {
+		t.Fatalf("redaction metadata = has:%#v hint:%#v", trigger["has_webhook_token"], trigger["webhook_token_hint"])
+	}
+}
+
+func TestRunAutopilotGetRejectsShowSecretsWithTableOutput(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotGetTestCmd()
+	_ = cmd.Flags().Set("output", "table")
+	_ = cmd.Flags().Set("show-secrets", "true")
+
+	err := runAutopilotGet(cmd, []string{"11111111-1111-1111-1111-111111111111"})
+	if err == nil {
+		t.Fatal("expected --show-secrets with table output to fail")
+	}
+	if !strings.Contains(err.Error(), "--show-secrets requires --output json") {
+		t.Fatalf("error = %v, want output-mode guidance", err)
+	}
+}
+
 func TestResolveAgent(t *testing.T) {
 	agentsResp := []map[string]any{
 		{"id": "11111111-1111-1111-1111-111111111111", "name": "Lambda"},

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -49,7 +49,7 @@ multica autopilot trigger-rotate-url <autopilot-id> <trigger-id> --yes --output 
 
 Use `trigger` only when the user explicitly asks for a manual run. Use `trigger-rotate-url` only when rotating a webhook URL; the old URL stops being valid.
 
-Webhook trigger output can include a URL/token. Do not paste webhook tokens or signing material into comments, logs, docs, or PRs. Redact secrets.
+`autopilot get` redacts `webhook_token`, `webhook_path`, and `webhook_url` by default while reporting whether a token exists and its non-sensitive hint. Only add `--show-secrets` when the user explicitly asks to retrieve the live webhook credential; the command warns on stderr. Do not paste webhook tokens or signing material into comments, logs, docs, or PRs.
 
 ## Debugging
 

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -1,7 +1,7 @@
 # Autopilots source map
 
 - `server/cmd/multica/cmd_autopilot.go` registers `list`, `get`, `create`, `update`, `delete`, `trigger`, `runs`, `trigger-add`, `trigger-update`, `trigger-delete`, and `trigger-rotate-url`.
-- The CLI maps reads/writes to `/api/autopilots`, `/api/autopilots/{id}`, `/api/autopilots/{id}/trigger`, `/api/autopilots/{id}/runs`, and trigger subroutes.
+- The CLI maps reads/writes to `/api/autopilots`, `/api/autopilots/{id}`, `/api/autopilots/{id}/trigger`, `/api/autopilots/{id}/runs`, and trigger subroutes. `autopilot get` nulls `webhook_token`, `webhook_path`, and `webhook_url` in normal JSON output and adds `has_webhook_token` plus `webhook_token_hint`; `--show-secrets` is an explicit JSON-only escape hatch that prints a credential-exposure warning to stderr.
 - `server/internal/service/autopilot.go` has `DispatchAutopilot`, synchronous delivery-idempotent `AdmitAutopilotWebhookDelivery`, and worker-side `DispatchAutopilotForWebhookDelivery`; it creates `autopilot_run` and switches on `execution_mode`.
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.


### PR DESCRIPTION
## What does this PR do?

Makes `multica autopilot get` safe for routine terminal, log, automation, and agent use. Normal JSON output now nulls reusable webhook credentials and supplies only `has_webhook_token` plus a four-character `webhook_token_hint`. Users who intentionally need the live credential must opt in with the JSON-only `--show-secrets` flag, which prints an exposure warning to stderr without corrupting piped JSON.

The API response is intentionally unchanged because the product UI still needs the live URL for its hidden copy flow. Redaction happens at the CLI presentation boundary and is keyed by credential fields rather than trigger kind, so a missing or changed discriminator cannot bypass it.

## Related Issue

Closes #7352

Fixes MUL-6508

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Redact `webhook_token`, `webhook_path`, and `webhook_url` from default `autopilot get` JSON output.
- Add non-sensitive presence and suffix metadata for webhook credentials.
- Add an explicit `--show-secrets` escape hatch restricted to JSON output, with a stderr warning.
- Cover default JSON, table output, explicit reveal, incompatible flags, and trigger-schema drift with CLI regression tests.
- Update the built-in Autopilots skill and the English, Chinese, Japanese, and Korean Autopilots docs.

## How to Test

1. Run `go test ./cmd/multica -run 'TestRunAutopilotGet|TestRedactAutopilotWebhookCredentials' -count=1`.
2. Run `go test -race ./cmd/multica -run 'TestRunAutopilotGet|TestRedactAutopilotWebhookCredentials' -count=1`.
3. Run `go test ./cmd/multica -count=1` and `go vet ./cmd/multica`.
4. With a migrated temporary PostgreSQL database, run `bash scripts/test-go.sh --race`.
5. Run `pnpm exec turbo test '--filter=!@multica/mobile' --concurrency=1`, `pnpm typecheck`, and `pnpm lint`.
6. Build the CLI and inspect `multica autopilot get --help`.

## Test Results

- Focused CLI tests: passed, including race detection.
- Full `server/cmd/multica` suite and vet: passed.
- Full Go suite under `-race`: passed after applying all current migrations.
- Frontend unit tests: 5 test tasks passed, including 392 Views files / 4,586 tests, 133 Core files / 1,568 tests, 54 Desktop files / 518 tests, 30 Web files / 246 tests, and 4 Docs files / 17 tests.
- TypeScript typecheck: 7/7 tasks passed.
- Lint: 6/6 tasks passed with existing warnings and no errors.
- CLI build and help smoke test: passed.

## Risks

- `--show-secrets` deliberately restores the existing secret-bearing JSON for workflows that explicitly request it. The warning is sent to stderr and the flag is rejected for table output.
- Default JSON preserves the credential keys as `null` rather than deleting them, reducing breakage for consumers that expect the response shape.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The UI and runtime/tool inventory are unchanged, so screenshots and landing-copy synchronization are not applicable.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I used Codex to inspect issue #7352 and the existing CLI/API boundaries, implement the smallest client-side protection that does not break the UI, add adversarial regression coverage, update the canonical docs and built-in skill, and run the repository's verification suites. I manually reviewed the final diff for credential leakage, output compatibility, schema-drift behavior, docs parity, and flag ergonomics before opening this draft.

## Screenshots (optional)

Not applicable: this change affects CLI output only.
