### PR TITLE
ALL-150: classify execenv directory conflicts

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5234,6 +5234,9 @@ func taskRunFailureReason(err error) string {
 	if errors.Is(err, errInvalidTaskIdentity) {
 		return taskfailure.ReasonInvalidTaskIdentity.String()
 	}
+	if errors.Is(err, execenv.ErrEnvRootConflict) {
+		return taskfailure.ReasonEnvPrepDirConflict.String()
+	}
 	if errors.Is(err, errTaskPrepareTimeout) {
 		return taskfailure.ReasonTimeout.String()
 	}

--- a/server/internal/daemon/env_root_conflict_test.go
+++ b/server/internal/daemon/env_root_conflict_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+func TestTaskRunFailureReasonEnvRootConflicts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"remove existing env", fmt.Errorf("execenv: reset existing env: %w: directory is not empty", execenv.ErrEnvRootConflict)},
+		{"different owner", fmt.Errorf("execenv: %w: belongs to another task", execenv.ErrEnvRootConflict)},
+		{"unowned content", fmt.Errorf("execenv: %w: names no owning task", execenv.ErrEnvRootConflict)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, execenv.ErrEnvRootConflict) {
+				t.Fatalf("fixture does not wrap ErrEnvRootConflict: %v", tc.err)
+			}
+			if got, want := taskRunFailureReason(tc.err), taskfailure.ReasonEnvPrepDirConflict.String(); got != want {
+				t.Fatalf("taskRunFailureReason() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestTaskRunFailureReasonDoesNotTextMatchEnvRootConflict(t *testing.T) {
+	t.Parallel()
+	err := errors.New("execenv: env root belongs to task; directory is not empty")
+	if got := taskRunFailureReason(err); got == taskfailure.ReasonEnvPrepDirConflict.String() {
+		t.Fatalf("plain-text error classified as %q without the sentinel", got)
+	}
+}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -1127,6 +1127,11 @@ func (env *Environment) Cleanup(removeAll bool) error {
 // another task may still be executing in (#7326).
 const envRootOwnerFile = ".task_owner"
 
+// ErrEnvRootConflict marks an environment preparation failure caused by an
+// env root that cannot be safely claimed or reset. Callers use errors.Is so
+// diagnostics can evolve without breaking failure classification.
+var ErrEnvRootConflict = errors.New("environment root conflict")
+
 // claimEnvRoot atomically establishes that taskID owns envRoot.
 //
 // fresh is true when this call created the claim and the directory is the
@@ -1165,7 +1170,7 @@ func claimEnvRoot(envRoot, taskID string) (fresh bool, err error) {
 	case owner == taskID:
 		return false, nil
 	case owner != "":
-		return false, fmt.Errorf("env root %s belongs to task %s; refusing to reset it for task %s", envRoot, owner, taskID)
+		return false, fmt.Errorf("%w: env root %s belongs to task %s; refusing to reset it for task %s", ErrEnvRootConflict, envRoot, owner, taskID)
 	}
 
 	// No owner. A directory holding work is never ours to take — the marker is
@@ -1177,7 +1182,7 @@ func claimEnvRoot(envRoot, taskID string) (fresh bool, err error) {
 		return false, fmt.Errorf("inspect env root %s: %w", envRoot, err)
 	}
 	if !empty {
-		return false, fmt.Errorf("env root %s already holds files but names no owning task; refusing to delete it", envRoot)
+		return false, fmt.Errorf("%w: env root %s already holds files but names no owning task; refusing to delete it", ErrEnvRootConflict, envRoot)
 	}
 	if err := writeEnvRootOwnerExclusive(envRoot, taskID); err != nil {
 		// Lost the race for an empty directory: whoever won owns it now.
@@ -1199,7 +1204,7 @@ func writeEnvRootOwnerExclusive(envRoot, taskID string) error {
 		if owner == taskID {
 			return nil
 		}
-		return fmt.Errorf("env root %s was claimed by task %s while task %s was starting", envRoot, owner, taskID)
+		return fmt.Errorf("%w: env root %s was claimed by task %s while task %s was starting", ErrEnvRootConflict, envRoot, owner, taskID)
 	}
 	if err != nil {
 		return fmt.Errorf("claim env root %s: %w", envRoot, err)
@@ -1231,6 +1236,10 @@ func readEnvRootOwner(envRoot string) (string, error) {
 // would drop the claim for as long as the recreate takes, which is exactly the
 // window claimEnvRoot exists to close.
 func resetEnvRootContents(envRoot string) error {
+	return resetEnvRootContentsWithRemoveAll(envRoot, os.RemoveAll)
+}
+
+func resetEnvRootContentsWithRemoveAll(envRoot string, removeAll func(string) error) error {
 	entries, err := os.ReadDir(envRoot)
 	if err != nil {
 		return err
@@ -1239,8 +1248,9 @@ func resetEnvRootContents(envRoot string) error {
 		if e.Name() == envRootOwnerFile {
 			continue
 		}
-		if err := os.RemoveAll(filepath.Join(envRoot, e.Name())); err != nil {
-			return err
+		path := filepath.Join(envRoot, e.Name())
+		if err := removeAll(path); err != nil {
+			return fmt.Errorf("%w: remove %s: %w", ErrEnvRootConflict, path, err)
 		}
 	}
 	return nil

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -6297,6 +6297,9 @@ func TestPrepareRefusesEnvRootOwnedByAnotherTask(t *testing.T) {
 	if err == nil {
 		t.Fatal("Prepare accepted an env root owned by another task")
 	}
+	if !errors.Is(err, ErrEnvRootConflict) {
+		t.Fatalf("error = %v, want ErrEnvRootConflict", err)
+	}
 	if !strings.Contains(err.Error(), "belongs to task") {
 		t.Fatalf("error = %v, want it to name the owning task", err)
 	}
@@ -6432,11 +6435,36 @@ func TestClaimEnvRootRefusesUnownedDirectoryWithContent(t *testing.T) {
 
 	if _, err := claimEnvRoot(envRoot, "aaaaaaaa-1111-2222-3333-0123456789ab"); err == nil {
 		t.Fatal("claimEnvRoot took a directory holding files with no owner")
+	} else if !errors.Is(err, ErrEnvRootConflict) {
+		t.Fatalf("error = %v, want ErrEnvRootConflict", err)
 	} else if !strings.Contains(err.Error(), "names no owning task") {
 		t.Fatalf("error = %v, want it to explain the missing owner", err)
 	}
 	if _, err := os.Stat(filepath.Join(envRoot, "workdir", "work.txt")); err != nil {
 		t.Fatalf("claimEnvRoot deleted the content it refused to claim: %v", err)
+	}
+}
+
+func TestResetEnvRootContentsMarksRemovalFailureAsConflict(t *testing.T) {
+	t.Parallel()
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatalf("seed workdir: %v", err)
+	}
+
+	removeErr := errors.New("directory is not empty")
+	err := resetEnvRootContentsWithRemoveAll(envRoot, func(path string) error {
+		if path != workDir {
+			t.Fatalf("remove path = %q, want %q", path, workDir)
+		}
+		return removeErr
+	})
+	if !errors.Is(err, ErrEnvRootConflict) {
+		t.Fatalf("error = %v, want ErrEnvRootConflict", err)
+	}
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("error = %v, want wrapped removal error", err)
 	}
 }
 

--- a/server/internal/daemon/execenv/isolation.go
+++ b/server/internal/daemon/execenv/isolation.go
@@ -69,6 +69,8 @@ type preparationResponse struct {
 // local openclaw CLI missing its deadline (ErrOpenclawCLITimeout).
 const preparationErrorKindOpenclawCLITimeout = "openclaw_cli_timeout"
 
+const preparationErrorKindEnvRootConflict = "env_root_conflict"
+
 // preparationKindError re-attaches a sentinel to an error that crossed the
 // helper boundary as text, so the daemon's classifier sees the same
 // errors.Is result it would have seen in-process.
@@ -87,6 +89,9 @@ func preparationErrorKind(err error) string {
 	if errors.Is(err, ErrOpenclawCLITimeout) {
 		return preparationErrorKindOpenclawCLITimeout
 	}
+	if errors.Is(err, ErrEnvRootConflict) {
+		return preparationErrorKindEnvRootConflict
+	}
 	return ""
 }
 
@@ -97,6 +102,8 @@ func rehydratePreparationError(message, kind string) error {
 	switch kind {
 	case preparationErrorKindOpenclawCLITimeout:
 		return &preparationKindError{msg: message, kind: ErrOpenclawCLITimeout}
+	case preparationErrorKindEnvRootConflict:
+		return &preparationKindError{msg: message, kind: ErrEnvRootConflict}
 	default:
 		return errors.New(message)
 	}

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -239,6 +239,37 @@ func TestPreparationHelperPreservesOpenclawTimeoutKind(t *testing.T) {
 	}
 }
 
+func TestPreparationHelperPreservesEnvRootConflictKind(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	const taskID = "11111111-2222-3333-4444-555555555555"
+	envRoot := PredictRootDir(workspacesRoot, "ws-helper-conflict", taskID)
+	if err := os.MkdirAll(filepath.Join(envRoot, "workdir"), 0o755); err != nil {
+		t.Fatalf("seed conflicting env root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(envRoot, "workdir", "work.txt"), []byte("preserve"), 0o644); err != nil {
+		t.Fatalf("seed conflicting work: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := PrepareIsolated(ctx, preparationHelperTestCommand(), PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-helper-conflict",
+		TaskID:         taskID,
+		Task:           TaskContextForEnv{IssueID: "issue-helper-conflict"},
+	}, logger)
+	if err == nil {
+		t.Fatal("expected preparation to reject an unowned env root with content")
+	}
+	if !errors.Is(err, ErrEnvRootConflict) {
+		t.Fatalf("the env-root conflict sentinel must survive the helper boundary\ngot: %s", err)
+	}
+	if !strings.Contains(err.Error(), "names no owning task") {
+		t.Fatalf("the original diagnostic must survive too\ngot: %s", err)
+	}
+}
+
 // TestRehydratePreparationErrorUnknownKind pins the mixed-version direction of
 // the same wire: a helper newer than the daemon may name a kind this build has
 // never heard of, and the error must still arrive with its message intact
@@ -256,5 +287,13 @@ func TestRehydratePreparationErrorUnknownKind(t *testing.T) {
 	}
 	if kind := preparationErrorKind(fmt.Errorf("wrapped: %w", ErrOpenclawCLITimeout)); kind != preparationErrorKindOpenclawCLITimeout {
 		t.Errorf("preparationErrorKind(timeout) = %q, want %q", kind, preparationErrorKindOpenclawCLITimeout)
+	}
+	conflict := fmt.Errorf("wrapped: %w", ErrEnvRootConflict)
+	kind := preparationErrorKind(conflict)
+	if kind != preparationErrorKindEnvRootConflict {
+		t.Fatalf("preparationErrorKind(conflict) = %q, want %q", kind, preparationErrorKindEnvRootConflict)
+	}
+	if err := rehydratePreparationError(conflict.Error(), kind); !errors.Is(err, ErrEnvRootConflict) {
+		t.Fatalf("rehydrated error = %v, want ErrEnvRootConflict", err)
 	}
 }

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -138,6 +138,12 @@ const (
 	// only repeat an isolation failure.
 	ReasonInvalidTaskIdentity Reason = "invalid_task_identity"
 
+	// ReasonEnvPrepDirConflict: the daemon refused to prepare an execution
+	// environment because its env root could not be safely claimed or reset.
+	// The agent process is never launched, and retrying without repairing the
+	// host directory would repeat the same failure.
+	ReasonEnvPrepDirConflict Reason = "env_prep.dir_conflict"
+
 	// Agent process side: failure surfaced by the agent CLI / SDK as
 	// an error string. Classify(rawError) is responsible for picking
 	// the right sub-reason from the string. IsAgentError returns true
@@ -213,7 +219,7 @@ const (
 	ReasonAgentUnknown Reason = "agent_error.unknown"
 )
 
-// allReasons is the canonical ordered list of the 25 reasons. Order is
+// allReasons is the canonical ordered list of the 26 reasons. Order is
 // stable so callers (e.g. Prometheus collectors that pre-warm series via
 // AllReasons) can build deterministic label sets across restarts.
 //
@@ -235,6 +241,7 @@ var allReasons = []Reason{
 	ReasonSkillBundleUnavailable,
 	ReasonRuntimeCLITimeout,
 	ReasonInvalidTaskIdentity,
+	ReasonEnvPrepDirConflict,
 
 	// Agent process side: provider errors.
 	ReasonAgentProviderAuthOrAccess,

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -30,6 +30,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonSkillBundleUnavailable, "skill_bundle_unavailable"},
 		{ReasonRuntimeCLITimeout, "runtime_cli_timeout"},
 		{ReasonInvalidTaskIdentity, "invalid_task_identity"},
+		{ReasonEnvPrepDirConflict, "env_prep.dir_conflict"},
 		// Agent-side.
 		{ReasonAgentProviderAuthOrAccess, "agent_error.provider_auth_or_access"},
 		{ReasonAgentProviderQuotaLimit, "agent_error.provider_quota_limit"},
@@ -47,7 +48,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonAgentUnknown, "agent_error.unknown"},
 	}
 
-	if got, want := len(cases), 25; got != want {
+	if got, want := len(cases), 26; got != want {
 		t.Fatalf("constant count = %d, want %d (canonical taxonomy size)", got, want)
 	}
 
@@ -78,6 +79,7 @@ func TestIsAgentError(t *testing.T) {
 		ReasonSkillBundleUnavailable,
 		ReasonRuntimeCLITimeout,
 		ReasonInvalidTaskIdentity,
+		ReasonEnvPrepDirConflict,
 	}
 	for _, r := range platformSide {
 		if r.IsAgentError() {
@@ -118,8 +120,8 @@ func TestAllReasonsContents(t *testing.T) {
 	t.Parallel()
 
 	got := AllReasons()
-	if len(got) != 25 {
-		t.Fatalf("AllReasons() returned %d entries, want 25", len(got))
+	if len(got) != 26 {
+		t.Fatalf("AllReasons() returned %d entries, want 26", len(got))
 	}
 
 	seen := make(map[Reason]bool, len(got))
@@ -136,8 +138,8 @@ func TestAllReasonsContents(t *testing.T) {
 		}
 	}
 
-	if platformCount != 11 {
-		t.Errorf("AllReasons(): platform-side count = %d, want 11", platformCount)
+	if platformCount != 12 {
+		t.Errorf("AllReasons(): platform-side count = %d, want 12", platformCount)
 	}
 	if agentCount != 14 {
 		t.Errorf("AllReasons(): agent-side count = %d, want 14", agentCount)
@@ -153,6 +155,7 @@ func TestAllReasonsContents(t *testing.T) {
 		ReasonTimeout, ReasonIterationLimit, ReasonAgentBlocked,
 		ReasonAPIInvalidRequest, ReasonSkillBundleUnavailable,
 		ReasonRuntimeCLITimeout, ReasonInvalidTaskIdentity,
+		ReasonEnvPrepDirConflict,
 		ReasonAgentProviderAuthOrAccess, ReasonAgentProviderQuotaLimit,
 		ReasonAgentProviderCapacityOrRateLimit, ReasonAgentProviderServerError,
 		ReasonAgentProviderNetwork, ReasonAgentProcessFailure,


### PR DESCRIPTION
Closes ALL-150

## Summary

- export `execenv.ErrEnvRootConflict` and wrap removal, ownership, and unowned-content conflicts
- preserve the sentinel across the isolated preparation helper boundary
- classify the sentinel with `errors.Is` as `env_prep.dir_conflict` before textual classification
- register the new platform-side reason in the canonical failure taxonomy

## Verification

- `go test -race ./internal/daemon/execenv ./internal/daemon ./pkg/taskfailure -run 'Test(PrepareRefusesEnvRootOwnedByAnotherTask|ClaimEnvRootRefusesUnownedDirectoryWithContent|ResetEnvRootContentsMarksRemovalFailureAsConflict|PreparationHelperPreservesEnvRootConflictKind|TaskRunFailureReasonEnvRootConflicts|TaskRunFailureReasonDoesNotTextMatchEnvRootConflict|ReasonStringWireValues|IsAgentError|AllReasonsContents)' -count=1`
- `go test ./internal/daemon -run '.*(FailureReason|TaskIdentity|OpenclawCLITimeout|SkillBundleUnavailable).*' -count=1 -v`
- `go test ./pkg/taskfailure -count=1`
- `go vet ./internal/daemon/execenv ./internal/daemon ./pkg/taskfailure`

Full `execenv` and `daemon` package suites still contain pre-existing Windows-specific failures involving POSIX permissions, symlink privilege, runtime-local config, and path length; none touch this diff.
