### PR TITLE
MUL-6525: docs: document GitHub App Contents permission for PR snapshots

### DIFF
--- a/apps/docs/content/docs/github-integration.ja.mdx
+++ b/apps/docs/content/docs/github-integration.ja.mdx
@@ -123,6 +123,7 @@ Repository permissions:
 | 権限 | レベル |
 |---|---|
 | Metadata | Read-only |
+| Contents | Read-only。GitHub GraphQL の PR スナップショットが head commit をたどり、その CI ロールアップを読み取るために必要 |
 | Pull requests | Read-only |
 | Checks | Read-only。CI の状態表示に使用 |
 | Commit statuses | Read-only。legacy status 形式の CI 集計に使用 |

--- a/apps/docs/content/docs/github-integration.ja.mdx
+++ b/apps/docs/content/docs/github-integration.ja.mdx
@@ -123,7 +123,7 @@ Repository permissions:
 | 権限 | レベル |
 |---|---|
 | Metadata | Read-only |
-| Contents | Read-only。GitHub GraphQL の PR スナップショットが head commit をたどり、その CI ロールアップを読み取るために必要 |
+| Contents | Read-only。PR スナップショットのクエリが head commit・マージ可否・CI ロールアップをまとめて読み取るために必要 |
 | Pull requests | Read-only |
 | Checks | Read-only。CI の状態表示に使用 |
 | Commit statuses | Read-only。legacy status 形式の CI 集計に使用 |
@@ -133,7 +133,7 @@ Repository permissions:
 - **Pull request**
 - **Check suite**、**Check run**、**Status**。CI とマージ可能性を更新するために使用します。
 
-Multica で CI を表示しない場合は、Checks と Commit statuses の権限、および関連イベントの購読を省略できます。
+Multica で CI を表示しない場合は、Checks と Commit statuses の権限、および関連イベントの購読を省略できます。ただし Contents は必須です。付与しないとスナップショットのクエリ自体が失敗し、PR カードからマージ状態も消えます。
 
 <Callout type="warning">
 必要なのは **Webhook secret** であり、OAuth Client secret ではありません。GitHub と Multica に入力した Webhook secret が異なる場合、GitHub delivery は `401 invalid signature` を返します。
@@ -176,7 +176,7 @@ API サービスを再起動し、**設定 → GitHub** から接続します。
 - **Webhook が 401 を返す**: GitHub App と API が同じ Webhook secret を使っていることを確認し、GitHub の **Recent Deliveries** から再配信します。
 - **PR が紐づかない**: リポジトリが App の許可範囲にあること、PR の自動紐づけが有効であること、番号が現在のワークスペースのものかを確認します。
 - **本文に番号を書いても表示されない**: `Closes MUL-123` を使うか、番号をブランチ名または PR タイトルに入れます。
-- **CI の状態がない**: `GITHUB_APP_ID` と `GITHUB_APP_PRIVATE_KEY` が設定済みで、App に Checks と Commit statuses の read-only 権限があり、関連イベントを購読していることを確認します。インストール済み App に権限を追加した場合は、各 installation の所有者が GitHub 上で承認するまで有効になりません。
+- **CI の状態がない**: `GITHUB_APP_ID` と `GITHUB_APP_PRIVATE_KEY` が設定済みで、App に Contents、Checks、Commit statuses の read-only 権限があり、関連イベントを購読していることを確認します。Contents が欠けるとスナップショット全体が失敗し、PR カードには CI もマージ状態も表示されません。インストール済み App に権限を追加した場合は、各 installation の所有者が GitHub 上で承認するまで有効になりません。
 - **PR のマージ後もイシューが完了しない**: PR で closing keyword を使っていることと、`Open` または `Draft` の関連 PR がほかに残っていないことを確認します。
 
 ## 次のステップ

--- a/apps/docs/content/docs/github-integration.ko.mdx
+++ b/apps/docs/content/docs/github-integration.ko.mdx
@@ -123,6 +123,7 @@ Repository permissions:
 | 권한 | 수준 |
 |---|---|
 | Metadata | Read-only |
+| Contents | Read-only. GitHub GraphQL PR snapshot이 head commit을 따라가고 CI rollup을 읽는 데 필요 |
 | Pull requests | Read-only |
 | Checks | Read-only. CI 상태 표시에 사용 |
 | Commit statuses | Read-only. legacy status 형식의 CI 집계에 사용 |

--- a/apps/docs/content/docs/github-integration.ko.mdx
+++ b/apps/docs/content/docs/github-integration.ko.mdx
@@ -123,7 +123,7 @@ Repository permissions:
 | 권한 | 수준 |
 |---|---|
 | Metadata | Read-only |
-| Contents | Read-only. GitHub GraphQL PR snapshot이 head commit을 따라가고 CI rollup을 읽는 데 필요 |
+| Contents | Read-only. PR snapshot 쿼리가 head commit과 머지 가능 여부, CI rollup을 함께 읽는 데 필요 |
 | Pull requests | Read-only |
 | Checks | Read-only. CI 상태 표시에 사용 |
 | Commit statuses | Read-only. legacy status 형식의 CI 집계에 사용 |
@@ -133,7 +133,7 @@ Repository permissions:
 - **Pull request**
 - CI와 merge 가능 여부 새로 고침을 트리거할 **Check suite**, **Check run**, **Status**
 
-Multica에서 CI를 표시할 필요가 없다면 Checks 및 Commit statuses 권한을 부여하거나 관련 이벤트를 구독하지 않아도 됩니다.
+Multica에서 CI를 표시할 필요가 없다면 Checks 및 Commit statuses 권한을 부여하거나 관련 이벤트를 구독하지 않아도 됩니다. 단, Contents는 반드시 필요합니다. 없으면 snapshot 쿼리 자체가 실패해 PR 카드에서 머지 상태도 사라집니다.
 
 <Callout type="warning">
 여기에는 OAuth Client secret이 아니라 **Webhook secret**이 필요합니다. 양쪽에 입력한 Webhook secret이 다르면 GitHub delivery가 `401 invalid signature`를 반환합니다.
@@ -176,7 +176,7 @@ API 서비스를 다시 시작한 뒤 **설정 → GitHub**에서 연결을 완�
 - **Webhook이 401을 반환함**: GitHub App과 API가 같은 Webhook secret을 사용하는지 확인하고 GitHub의 **Recent Deliveries**에서 다시 전달합니다.
 - **PR이 연결되지 않음**: 저장소가 App 승인 범위에 있는지, 자동 연결이 켜져 있는지, 번호가 현재 워크스페이스에 속하는지 확인합니다.
 - **본문에 번호를 썼지만 표시되지 않음**: `Closes MUL-123`을 사용하거나 번호를 브랜치 이름 또는 PR 제목에 넣습니다.
-- **CI 상태가 없음**: `GITHUB_APP_ID`와 `GITHUB_APP_PRIVATE_KEY`가 설정되었는지, App에 Checks 및 Commit statuses 읽기 권한이 있고 관련 이벤트를 구독했는지 확인합니다. 설치된 App에 권한을 추가한 뒤에는 각 installation owner가 GitHub에서 승인해야 적용됩니다.
+- **CI 상태가 없음**: `GITHUB_APP_ID`와 `GITHUB_APP_PRIVATE_KEY`가 설정되었는지, App에 Contents, Checks 및 Commit statuses 읽기 권한이 있고 관련 이벤트를 구독했는지 확인합니다. Contents가 없으면 snapshot 전체가 실패해 PR 카드에 CI도 머지 상태도 표시되지 않습니다. 설치된 App에 권한을 추가한 뒤에는 각 installation owner가 GitHub에서 승인해야 적용됩니다.
 - **PR merge 후 이슈가 완료되지 않음**: PR에 종료 문구가 있는지 확인하고 다른 연결 PR이 Open 또는 Draft 상태로 남아 있는지 확인합니다.
 
 ## 다음 단계

--- a/apps/docs/content/docs/github-integration.mdx
+++ b/apps/docs/content/docs/github-integration.mdx
@@ -124,7 +124,7 @@ Repository permissions:
 | Permission | Level |
 |---|---|
 | Metadata | Read-only |
-| Contents | Read-only; required by the GitHub GraphQL PR snapshot to traverse the head commit and read its CI rollup |
+| Contents | Read-only; required by the PR snapshot query, which reads the head commit together with mergeability and the CI rollup |
 | Pull requests | Read-only |
 | Checks | Read-only; used to show CI status |
 | Commit statuses | Read-only; used to aggregate legacy-status CI |
@@ -134,7 +134,7 @@ Subscribe to these events:
 - **Pull request**;
 - **Check suite**, **Check run**, and **Status**, which trigger CI and mergeability refreshes.
 
-If you don't need CI shown in Multica, you can skip the Checks and Commit statuses permissions and their events.
+If you don't need CI shown in Multica, you can skip the Checks and Commit statuses permissions and their events. Contents is still required — without it the snapshot query fails outright and the PR card also loses merge state.
 
 <Callout type="warning">
 This is the **Webhook secret**, not the OAuth Client secret. If the two sides have different webhook secrets, GitHub deliveries return `401 invalid signature`.
@@ -177,7 +177,7 @@ Restart the API server, then complete the connection in **Settings → GitHub**.
 - **Webhook returns 401**: confirm the GitHub App and the API use the same webhook secret, then redeliver from GitHub's **Recent Deliveries**.
 - **PR not linked**: check that the repository is in the App's authorized scope, auto-linking is on, and the identifier belongs to the current workspace.
 - **Identifier in the body but not shown**: switch to `Closes MUL-123`, or put the identifier in the branch name or PR title.
-- **No CI status**: confirm `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` are configured, and that the App has read-only Checks and Commit statuses permissions with the matching events subscribed. After adding permissions to an installed App, each installation's owner must also approve them on GitHub before they take effect.
+- **No CI status**: confirm `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` are configured, and that the App has read-only Contents, Checks, and Commit statuses permissions with the matching events subscribed. Without Contents the whole snapshot fails, so the PR card shows neither CI nor merge state. After adding permissions to an installed App, each installation's owner must also approve them on GitHub before they take effect.
 - **Issue not completed after the PR merged**: confirm the PR used a close intent, and check whether other linked PRs are still Open or Draft.
 
 ## Next steps

--- a/apps/docs/content/docs/github-integration.mdx
+++ b/apps/docs/content/docs/github-integration.mdx
@@ -124,6 +124,7 @@ Repository permissions:
 | Permission | Level |
 |---|---|
 | Metadata | Read-only |
+| Contents | Read-only; required by the GitHub GraphQL PR snapshot to traverse the head commit and read its CI rollup |
 | Pull requests | Read-only |
 | Checks | Read-only; used to show CI status |
 | Commit statuses | Read-only; used to aggregate legacy-status CI |

--- a/apps/docs/content/docs/github-integration.zh.mdx
+++ b/apps/docs/content/docs/github-integration.zh.mdx
@@ -124,6 +124,7 @@ Repository permissions：
 | 权限 | 级别 |
 |---|---|
 | Metadata | Read-only |
+| Contents | Read-only；GitHub GraphQL PR 快照需要遍历 head commit 并读取其 CI 汇总 |
 | Pull requests | Read-only |
 | Checks | Read-only；用于显示 CI 状态 |
 | Commit statuses | Read-only；用于汇总 legacy status 形式的 CI |

--- a/apps/docs/content/docs/github-integration.zh.mdx
+++ b/apps/docs/content/docs/github-integration.zh.mdx
@@ -124,7 +124,7 @@ Repository permissions：
 | 权限 | 级别 |
 |---|---|
 | Metadata | Read-only |
-| Contents | Read-only；GitHub GraphQL PR 快照需要遍历 head commit 并读取其 CI 汇总 |
+| Contents | Read-only；PR 快照查询需要它，一次读取 head commit、可合并状态与 CI 汇总 |
 | Pull requests | Read-only |
 | Checks | Read-only；用于显示 CI 状态 |
 | Commit statuses | Read-only；用于汇总 legacy status 形式的 CI |
@@ -134,7 +134,7 @@ Repository permissions：
 - **Pull request**；
 - **Check suite**、**Check run** 和 **Status**，用于触发 CI 与可合并性刷新。
 
-如果不需要在 Multica 中显示 CI，可以不授予 Checks 和 Commit statuses 权限，也不订阅对应事件。
+如果不需要在 Multica 中显示 CI，可以不授予 Checks 和 Commit statuses 权限，也不订阅对应事件。但 Contents 仍然必须授予——缺少它时整个快照查询会直接失败，PR 卡片连合并状态也会一起消失。
 
 <Callout type="warning">
 这里需要的是 **Webhook secret**，不是 OAuth Client secret。两边填写的 Webhook secret 不一致时，GitHub delivery 会返回 `401 invalid signature`。
@@ -177,7 +177,7 @@ make migrate-up
 - **Webhook 返回 401**：确认 GitHub App 与 API 使用同一个 Webhook secret，然后在 GitHub 的 **Recent Deliveries** 中重新投递。
 - **PR 没有关联**：检查仓库是否在 App 授权范围内、自动关联是否开启，以及编号是否属于当前工作区。
 - **正文写了编号但没显示**：改用 `Closes MUL-123`，或把编号放到分支名、PR 标题中。
-- **没有 CI 状态**：确认 `GITHUB_APP_ID` 和 `GITHUB_APP_PRIVATE_KEY` 已配置，App 具有 Checks 与 Commit statuses 的只读权限并订阅了对应事件。给已安装的 App 补加权限后，还需要各 installation 的所有者在 GitHub 上批准才会生效。
+- **没有 CI 状态**：确认 `GITHUB_APP_ID` 和 `GITHUB_APP_PRIVATE_KEY` 已配置，App 具有 Contents、Checks 与 Commit statuses 的只读权限并订阅了对应事件。缺少 Contents 会让整个快照失败，PR 卡片既没有 CI 也没有合并状态。给已安装的 App 补加权限后，还需要各 installation 的所有者在 GitHub 上批准才会生效。
 - **PR 合并后 issue 没完成**：确认 PR 使用了关闭语句，并检查是否还有其他关联 PR 处于 Open 或 Draft。
 
 ## 接下来


### PR DESCRIPTION
## Problem

The self-hosting documentation listed the GitHub App permissions for PR snapshots as Metadata, Pull requests, Checks, and Commit statuses, but omitted the repository Contents permission.

## Why this permission is required

The PR snapshot uses GitHub GraphQL to traverse `pullRequest.commits` to the head commit and read `commit.statusCheckRollup`. GitHub requires the App to have **Contents: Read-only** access to read that Commit object. Without it, the documented permission set is incomplete and the CI rollup snapshot can fail even when Checks and Commit statuses are enabled.

## Changes

- Added **Contents — Read-only** with the GraphQL snapshot context to the English GitHub integration documentation.
- Updated the corresponding permission tables in the Japanese, Korean, and Simplified Chinese translations.

The implementation is referenced in [`snapshot.go`](https://github.com/multica-ai/multica/blob/38c992ad0a757434fb51584fa34e3bc57d1b78e1/server/internal/integrations/ghsnapshot/snapshot.go#L21-L39), and the affected documentation section is [here](https://github.com/multica-ai/multica/blob/38c992ad0a757434fb51584fa34e3bc57d1b78e1/apps/docs/content/docs/github-integration.mdx#L122-L129).

## Verification

- `git diff --check`
- Documentation typecheck could not run because `apps/docs/node_modules` is not installed (`fumadocs-mdx: command not found`).