### PR TITLE
MUL-6523: log task message batch size

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4400,6 +4400,7 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	slog.Info("task message batch received", "task_id", taskID, "count", len(req.Messages))
 
 	workspaceID := ""
 	if task.IssueID.Valid {


### PR DESCRIPTION
## Summary

- log the authenticated task-message batch size before persistence
- keep message content, tool input, and tool output out of logs

## Source analysis

The daemon sends `{"messages": []TaskMessageData}`. The API handler decodes that field into `[]TaskMessageRequest`, then iterates over the slice and invokes `CreateTaskMessage` once per element with one `CreateTaskMessageParams` value.

Therefore, the HTTP client sends an array, while each database query invocation receives a single message.

## Validation

- `go test ./internal/handler -run '^$' -count=1`
- `go test ./internal/daemon -run '^TestNonExistent$' -count=1`
- `git diff --check`
- Attempted `go test ./internal/handler -run 'TestReportTaskMessages' -count=1 -v`; the checkout's local database is behind the repository schema and fails before the changed line because `agent_task_queue.durable_work_dir` is missing.

Closes MUL-6523
