### PR TITLE
MUL-6519 fix(lark): keep the @_user_N placeholder when flattening post mentions

### DIFF
--- a/server/internal/integrations/lark/content_flatten.go
+++ b/server/internal/integrations/lark/content_flatten.go
@@ -95,10 +95,11 @@ type larkPostSpan struct {
 // ("Lark 集成", then a link "PR #3277") read as space-separated words.
 //
 // A link span renders as "text (href)" so the URL survives into the
-// agent's context; an `at` span renders as its @_user_N placeholder (or
-// the inline user_name when Lark already resolved it) so a downstream
-// resolveMentions pass can substitute the display name. Media spans
-// degrade to the same bracketed placeholders flattenContent uses.
+// agent's context; an `at` span renders as its @_user_N placeholder so
+// a downstream resolveMentions pass can substitute the display name
+// (falling back to the inline user_name when the placeholder is absent).
+// Media spans degrade to the same bracketed placeholders flattenContent
+// uses.
 func flattenPostContent(raw string) string {
 	if raw == "" {
 		return ""
@@ -142,14 +143,15 @@ func flattenPostParagraph(spans []larkPostSpan) string {
 				parts = append(parts, s.Href)
 			}
 		case "at":
-			// Prefer an already-resolved display name; otherwise emit
-			// the user_id, which on the receive side is the @_user_N
-			// placeholder a later resolveMentions pass maps to a name.
+			// Prefer the @_user_N placeholder so a later
+			// resolveMentions pass can map it to a display name and
+			// strip the bot's own mention; fall back to the inline
+			// user_name when the placeholder is absent.
 			switch {
-			case s.UserName != "":
-				parts = append(parts, "@"+s.UserName)
 			case s.UserID != "":
 				parts = append(parts, s.UserID)
+			case s.UserName != "":
+				parts = append(parts, "@"+s.UserName)
 			}
 		case "img":
 			parts = append(parts, "[Image]")

--- a/server/internal/integrations/lark/content_flatten_test.go
+++ b/server/internal/integrations/lark/content_flatten_test.go
@@ -1,6 +1,9 @@
 package lark
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestFlattenPostContent_IssueExample pins the exact rich-text `post`
 // example from MUL-2951: a title line, a prose paragraph, and a
@@ -51,12 +54,38 @@ func TestFlattenPostContent_MediaAndMentionSpans(t *testing.T) {
 	}
 }
 
-func TestFlattenPostContent_AtPrefersResolvedName(t *testing.T) {
+func TestFlattenPostContent_AtPrefersPlaceholderWhenBothPresent(t *testing.T) {
 	t.Parallel()
-	raw := `{"content":[[{"tag":"at","user_id":"@_user_1","user_name":"Tom"},{"tag":"text","text":"hi"}]]}`
-	want := "@Tom hi"
+	raw := `{"content":[[{"tag":"at","user_id":"@_user_1","user_name":"ReviewBot"}]]}`
+	want := "@_user_1"
 	if got := flattenPostContent(raw); got != want {
 		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFlattenPostContent_AtFallsBackToUserNameWhenNoPlaceholder(t *testing.T) {
+	t.Parallel()
+	raw := `{"content":[[{"tag":"at","user_id":"","user_name":"ReviewBot"}]]}`
+	want := "@ReviewBot"
+	if got := flattenPostContent(raw); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFlattenPostContent_TopicGroupMentionSlashCommand(t *testing.T) {
+	t.Parallel()
+	raw := `{"content":[[{"tag":"at","user_id":"@_user_1","user_name":"ReviewBot"},{"tag":"text","text":" /issue review this"}]]}`
+	flat := flattenPostContent(raw)
+	m := larkMention{Key: "@_user_1", Name: "ReviewBot"}
+	m.ID.OpenID = "ou_bot"
+	mentions := []larkMention{m}
+	got := resolveMentions(flat, mentions, "ou_bot", "")
+	got = strings.TrimSpace(got)
+	if want := "/issue review this"; got != want {
+		t.Errorf("after resolveMentions got %q want %q (flat was %q)", got, want, flat)
+	}
+	if len(got) == 0 || got[0] != '/' {
+		t.Errorf("first line should start with '/', got %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #7368.

### Problem

In a Lark topic group, a `post` message carries mention spans that have **both** `user_id` (`@_user_1`) and `user_name` (`ReviewBot`). `flattenPostParagraph` preferred `user_name`, so the `@_user_N` placeholder was gone by the time `resolveMentions` ran. `resolveMentions` strips the bot's own mention by matching the placeholder, so it had nothing to strip.

Result: the slash-command parser received `@ReviewBot /issue ...` instead of `/issue ...` and the command did not fire. Plain text messages were unaffected — `flattenContent` already prefers `user_id`.

### Fix

`flattenPostParagraph` now prefers `user_id` and falls back to `user_name` only when the placeholder is absent, matching `flattenContent`.

### Tests

Added coverage in `content_flatten_test.go` for a post span carrying both fields (placeholder is kept) and one carrying only `user_name` (fallback still works).

Verified locally:

```
cd server
go build ./...   # ok
go vet ./...     # ok
go test ./...    # all packages pass
```