### PR TITLE
fix(cli): redact webhook credential in autopilot get

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -115,6 +115,7 @@ func init() {
 
 	// get
 	autopilotGetCmd.Flags().String("output", "json", "Output format: table or json")
+	autopilotGetCmd.Flags().Bool("show-secrets", false, "Show live webhook credentials (webhook_token, webhook_url, webhook_path)")
 
 	// create
 	autopilotCreateCmd.Flags().String("title", "", "Autopilot title (required)")
@@ -241,6 +242,13 @@ func runAutopilotGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get autopilot: %w", err)
 	}
 
+	showSecrets, _ := cmd.Flags().GetBool("show-secrets")
+	if showSecrets {
+		fmt.Fprintln(os.Stderr, "warning: output contains a live webhook credential")
+	} else {
+		redactAutopilotWebhookSecrets(resp)
+	}
+
 	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {
 		return cli.PrintJSON(os.Stdout, resp)
@@ -259,6 +267,50 @@ func runAutopilotGet(cmd *cobra.Command, args []string) error {
 	}}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
+}
+
+func redactAutopilotWebhookSecrets(resp map[string]any) {
+	raw, ok := resp["triggers"]
+	if !ok {
+		return
+	}
+	var triggers []any
+	switch v := raw.(type) {
+	case []any:
+		triggers = v
+	case []map[string]any:
+		triggers = make([]any, len(v))
+		for i := range v {
+			triggers[i] = v[i]
+		}
+	default:
+		return
+	}
+	for _, t := range triggers {
+		m, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["kind"] != "webhook" {
+			continue
+		}
+		hasToken := false
+		if v, ok := m["webhook_token"]; ok && v != nil {
+			if s, ok := v.(string); ok && s != "" {
+				hasToken = true
+				m["webhook_token"] = "[redacted]"
+			}
+		}
+		m["has_webhook_token"] = hasToken
+		if hasToken {
+			if _, ok := m["webhook_url"]; ok {
+				m["webhook_url"] = "[redacted]"
+			}
+			if _, ok := m["webhook_path"]; ok {
+				m["webhook_path"] = "[redacted]"
+			}
+		}
+	}
 }
 
 func runAutopilotCreate(cmd *cobra.Command, _ []string) error {

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -451,6 +453,132 @@ func assertAutopilotSubscriberBody(t *testing.T, body map[string]any, userID str
 	}
 	if sub["user_id"] != userID {
 		t.Fatalf("user_id = %#v, want %q", sub["user_id"], userID)
+	}
+}
+
+func TestRunAutopilotGetRedactsWebhookSecrets(t *testing.T) {
+	const autopilotID = "33333333-3333-3333-3333-333333333333"
+	fixtureToken := "tok_live_abc123"
+	fixtureURL := "https://example.com/hooks/tok_live_abc123"
+	fixturePath := "/hooks/tok_live_abc123"
+	baseResp := func() map[string]any {
+		return map[string]any{
+			"autopilot": map[string]any{"id": autopilotID, "title": "T"},
+			"triggers": []any{
+				map[string]any{"id": "trig-1", "kind": "webhook", "webhook_token": fixtureToken, "webhook_url": fixtureURL, "webhook_path": fixturePath, "enabled": true},
+				map[string]any{"id": "trig-2", "kind": "schedule", "cron_expression": "0 * * * *", "enabled": true},
+			},
+		}
+	}
+	newGetCmd := func(showSecrets bool, output string) *cobra.Command {
+		cmd := &cobra.Command{Use: "get"}
+		cmd.Flags().String("output", "json", "")
+		cmd.Flags().Bool("show-secrets", false, "")
+		_ = cmd.Flags().Set("output", output)
+		if showSecrets {
+			_ = cmd.Flags().Set("show-secrets", "true")
+		}
+		return cmd
+	}
+	t.Run("json without show-secrets redacts and adds has_webhook_token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(baseResp())
+		}))
+		defer srv.Close()
+		t.Setenv("MULTICA_SERVER_URL", srv.URL)
+		t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+		t.Setenv("MULTICA_TOKEN", "test-token")
+		cmd := newGetCmd(false, "json")
+		out, errOut := runAutopilotGetCaptured(t, cmd, autopilotID)
+		if strings.Contains(out, fixtureToken) || strings.Contains(out, fixtureURL) || strings.Contains(out, fixturePath) {
+			t.Fatalf("output should not contain token, url or path, got %q", out)
+		}
+		if !strings.Contains(out, `"has_webhook_token": true`) && !strings.Contains(out, `"has_webhook_token":true`) {
+			t.Fatalf("expected has_webhook_token true, got %q", out)
+		}
+		if !strings.Contains(out, "[redacted]") {
+			t.Fatalf("expected [redacted], got %q", out)
+		}
+		// schedule trigger unchanged - check its cron still present and not redacted
+		if !strings.Contains(out, "0 * * * *") {
+			t.Fatalf("schedule trigger should be unchanged, got %q", out)
+		}
+		if strings.Contains(errOut, "warning") {
+			t.Fatalf("should not warn without show-secrets, stderr %q", errOut)
+		}
+	})
+	t.Run("json with show-secrets contains token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(baseResp())
+		}))
+		defer srv.Close()
+		t.Setenv("MULTICA_SERVER_URL", srv.URL)
+		t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+		t.Setenv("MULTICA_TOKEN", "test-token")
+		cmd := newGetCmd(true, "json")
+		out, errOut := runAutopilotGetCaptured(t, cmd, autopilotID)
+		if !strings.Contains(out, fixtureToken) {
+			t.Fatalf("expected token in output with show-secrets, got %q", out)
+		}
+		if !strings.Contains(errOut, "warning: output contains a live webhook credential") {
+			t.Fatalf("expected warning on stderr, got %q", errOut)
+		}
+	})
+	t.Run("missing token yields has_webhook_token false and no redacted", func(t *testing.T) {
+		resp := map[string]any{
+			"autopilot": map[string]any{"id": autopilotID},
+			"triggers": []any{
+				map[string]any{"id": "trig-1", "kind": "webhook", "enabled": true},
+				map[string]any{"id": "trig-2", "kind": "webhook", "webhook_token": "", "enabled": true},
+			},
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer srv.Close()
+		t.Setenv("MULTICA_SERVER_URL", srv.URL)
+		t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+		t.Setenv("MULTICA_TOKEN", "test-token")
+		cmd := newGetCmd(false, "json")
+		out, _ := runAutopilotGetCaptured(t, cmd, autopilotID)
+		if strings.Contains(out, "[redacted]") {
+			t.Fatalf("should not contain [redacted] when token absent/empty, got %q", out)
+		}
+		// should contain has_webhook_token false
+		if !strings.Contains(out, `"has_webhook_token": false`) && !strings.Contains(out, `"has_webhook_token":false`) {
+			t.Fatalf("expected has_webhook_token false, got %q", out)
+		}
+	})
+}
+
+func runAutopilotGetCaptured(t *testing.T, cmd *cobra.Command, id string) (string, string) {
+	t.Helper()
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	oldOut := os.Stdout
+	oldErr := os.Stderr
+	os.Stdout = wOut
+	os.Stderr = wErr
+	err := runAutopilotGet(cmd, []string{id})
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldOut
+	os.Stderr = oldErr
+	if err != nil {
+		t.Fatalf("runAutopilotGet: %v", err)
+	}
+	out, _ := io.ReadAll(rOut)
+	errOut, _ := io.ReadAll(rErr)
+	return string(out), string(errOut)
+}
+
+func TestAutopilotGetFlagRegistered(t *testing.T) {
+	f := autopilotGetCmd.Flags().Lookup("show-secrets")
+	if f == nil {
+		t.Fatal("autopilotGetCmd missing --show-secrets flag")
+	}
+	if f.DefValue != "false" {
+		t.Fatalf("show-secrets default = %q, want false", f.DefValue)
 	}
 }
 


### PR DESCRIPTION
Fixes #7352.

### Problem

`multica autopilot get` printed the raw API response. For a caller with writer access that response contains the live `webhook_token`, plus `webhook_url` and `webhook_path` which embed it. Anyone who ran the command in a shared terminal, a CI log, or a pasted bug report leaked a working credential.

### Fix

- Redact `webhook_token`, `webhook_url`, and `webhook_path` to `[redacted]` in the default output.
- Add `has_webhook_token` (bool) so scripts can still check whether one is configured.
- Add `--show-secrets` to print the real values, with a warning on stderr.

Text and JSON output paths are both covered.

### Tests

`cmd_autopilot_test.go` asserts the token never appears in default output, that `has_webhook_token` reflects presence, that `--show-secrets` restores the raw values, and that the flag is registered on the real command (deleting the registration fails the suite).

Verified locally:

```
cd server
go build ./...   # ok
go vet ./...     # ok
go test ./...    # all packages pass
```