### PR TITLE
MUL-6486: reduce stale dispatch reclaim load

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -244,6 +244,7 @@ var concurrentIndexCleanups = map[string]string{
 	"361_issue_last_activity_index":                             "idx_issue_workspace_last_activity",
 	"363_plugin_invocation_installation_index":                  "idx_plugin_invocation_installation_created",
 	"364_plugin_invocation_created_at_index":                    "idx_plugin_invocation_created_at",
+	"390_agent_task_queue_dispatched_reclaim_v2_index":          "idx_agent_task_queue_dispatched_reclaim_v2",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction
@@ -264,6 +265,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"312_drop_global_plugin_identity_key_index":             "idx_plugin_identity_key",
 	"371_comment_content_search_index_strategy":             "idx_comment_content_trgm",
 	"375_drop_issue_last_activity_index":                    "idx_issue_workspace_last_activity",
+	"391_drop_agent_task_queue_dispatched_prepare_index":    "idx_agent_task_queue_dispatched_prepare",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1140,6 +1140,10 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	// task. Returns nil when rdb is nil — TaskService treats that
 	// as "no cache, always hit DB" (existing behavior).
 	h.TaskService.EmptyClaim = service.NewEmptyClaimCache(rdb)
+	// Stale-dispatch reclaim has a separate schedule because an empty queued
+	// verdict cannot represent a claim response lost after commit. Missing or
+	// failed Redis state keeps the historical PostgreSQL fallback.
+	h.TaskService.ReclaimCheck = service.NewReclaimCheckCache(rdb)
 
 	// Wire WS heartbeat after stores are finalized so the WS path uses the
 	// same (possibly Redis-backed) stores as the HTTP path.

--- a/server/internal/service/reclaim_check_cache.go
+++ b/server/internal/service/reclaim_check_cache.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"strconv"
 	"time"
@@ -13,22 +12,26 @@ import (
 const (
 	reclaimCheckSchedulePrefix = "mul:claim:runtime:reclaim-schedule:"
 	reclaimCheckBackstopPrefix = "mul:claim:runtime:reclaim-backstop:"
-)
 
-// ReclaimCheckCacheTTL is both the steady-state fallback cadence and the TTL
-// for reclaim scheduling hints. It must not exceed the claim response recovery
-// window: if a dispatch-side Redis write is lost, the prior backstop expires no
-// later than the newly dispatched task first becomes reclaimable.
-const ReclaimCheckCacheTTL = claimResponseRecoveryWindow
+	// The backstop remains at or below the PostgreSQL recovery window so a
+	// missed dispatch-side Redis write cannot delay recovery beyond one window.
+	ReclaimCheckBackstopInterval = claimResponseRecoveryWindow
+	// A fresh task's first hint is one recovery window in the future. Keep the
+	// containing ZSET alive for another full window so Redis cannot expire the
+	// hint at the exact instant it first becomes observable as due.
+	ReclaimCheckScheduleTTL = 2 * claimResponseRecoveryWindow
+)
 
 // ReclaimCheckCache keeps the batch/singular claim hot paths from issuing a
 // stale-dispatch UPDATE when no task can possibly be reclaimed yet.
 //
 // Each runtime owns a sorted set of task IDs scored by their earliest known
-// reclaim time. A separate backstop timestamp forces a periodic DB check for
-// cache loss, pre-deployment rows, or a missed write. Missing keys and Redis
-// errors always mean "check PostgreSQL now", so the cache can only reduce load;
-// it is never authoritative for task recovery.
+// reclaim time. A separate last-checked timestamp forces a periodic DB check
+// for cache loss, pre-deployment rows, or a missed write. Task scores and the
+// last-checked timestamp are both application-clock values; PostgreSQL remains
+// authoritative for actual eligibility when the query runs. Missing keys and
+// Redis errors always mean "check PostgreSQL now", so the cache can only reduce
+// load; it is never authoritative for task recovery.
 type ReclaimCheckCache struct {
 	rdb *redis.Client
 }
@@ -52,9 +55,14 @@ func (c *ReclaimCheckCache) bounded(ctx context.Context) (context.Context, conte
 	return context.WithTimeout(ctx, emptyClaimRedisTimeout)
 }
 
-// DueRuntimeIDs returns only runtimes whose earliest task hint or periodic
-// backstop is due. A nil cache, missing backstop, malformed value, or Redis
-// failure returns every input runtime so callers preserve the pre-cache DB path.
+// DueRuntimeIDs returns only runtimes with a task hint added after their last
+// successful DB check and now due, or whose periodic backstop has elapsed. A
+// checked hint stays in the ZSET until a real task transition removes/updates it
+// or the schedule TTL expires, but it cannot retrigger every poll because its
+// score is not newer than the last-checked marker.
+//
+// A nil cache, missing/malformed backstop, or Redis failure fails open. Batch
+// callers treat any due runtime as a reason to query their complete runtime set.
 func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []string, now time.Time) []string {
 	if len(runtimeIDs) == 0 {
 		return nil
@@ -65,52 +73,78 @@ func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []stri
 
 	bctx, cancel := c.bounded(ctx)
 	defer cancel()
-	type runtimeCommands struct {
-		runtimeID string
-		schedule  *redis.ZSliceCmd
-		backstop  *redis.StringCmd
-	}
-	pipe := c.rdb.Pipeline()
-	commands := make([]runtimeCommands, 0, len(runtimeIDs))
+	validRuntimeIDs := make([]string, 0, len(runtimeIDs))
+	backstopKeys := make([]string, 0, len(runtimeIDs))
 	for _, runtimeID := range runtimeIDs {
 		if runtimeID == "" {
 			continue
 		}
-		commands = append(commands, runtimeCommands{
-			runtimeID: runtimeID,
-			schedule:  pipe.ZRangeWithScores(bctx, reclaimCheckScheduleKey(runtimeID), 0, 0),
-			backstop:  pipe.Get(bctx, reclaimCheckBackstopKey(runtimeID)),
-		})
+		validRuntimeIDs = append(validRuntimeIDs, runtimeID)
+		backstopKeys = append(backstopKeys, reclaimCheckBackstopKey(runtimeID))
 	}
-	if _, err := pipe.Exec(bctx); err != nil && !errors.Is(err, redis.Nil) {
-		slog.Warn("reclaim_check_cache: read failed; falling back to DB", "error", err)
+	if len(validRuntimeIDs) == 0 {
+		return nil
+	}
+	backstops, err := c.rdb.MGet(bctx, backstopKeys...).Result()
+	if err != nil {
+		slog.Warn("reclaim_check_cache: backstop read failed; falling back to DB", "error", err)
+		return append([]string(nil), runtimeIDs...)
+	}
+	if len(backstops) != len(validRuntimeIDs) {
+		slog.Warn("reclaim_check_cache: incomplete backstop read; falling back to DB")
 		return append([]string(nil), runtimeIDs...)
 	}
 
 	nowMillis := now.UnixMilli()
-	due := make([]string, 0, len(commands))
-	for _, command := range commands {
-		scheduled, err := command.schedule.Result()
-		if err != nil {
-			slog.Warn("reclaim_check_cache: schedule read failed; falling back to DB", "error", err)
-			return append([]string(nil), runtimeIDs...)
-		}
-		if len(scheduled) > 0 && int64(scheduled[0].Score) <= nowMillis {
-			due = append(due, command.runtimeID)
+	type scheduleCommand struct {
+		runtimeID string
+		count     *redis.IntCmd
+	}
+	due := make([]string, 0, len(validRuntimeIDs))
+	pipe := c.rdb.Pipeline()
+	scheduleCommands := make([]scheduleCommand, 0, len(validRuntimeIDs))
+	for i, runtimeID := range validRuntimeIDs {
+		backstop, ok := backstops[i].(string)
+		if !ok {
+			// A missing or non-string value means this runtime has no trustworthy
+			// successful-check marker.
+			due = append(due, runtimeID)
 			continue
 		}
-
-		backstop, err := command.backstop.Result()
-		if errors.Is(err, redis.Nil) {
-			due = append(due, command.runtimeID)
+		checkedMillis, err := strconv.ParseInt(backstop, 10, 64)
+		if err != nil {
+			due = append(due, runtimeID)
 			continue
 		}
+		nextBackstop := checkedMillis + ReclaimCheckBackstopInterval.Milliseconds()
+		if nextBackstop < checkedMillis || nextBackstop <= nowMillis {
+			due = append(due, runtimeID)
+			continue
+		}
+		scheduleCommands = append(scheduleCommands, scheduleCommand{
+			runtimeID: runtimeID,
+			count: pipe.ZCount(
+				bctx,
+				reclaimCheckScheduleKey(runtimeID),
+				"("+strconv.FormatInt(checkedMillis, 10),
+				strconv.FormatInt(nowMillis, 10),
+			),
+		})
+	}
+	if len(scheduleCommands) == 0 {
+		return due
+	}
+	if _, err := pipe.Exec(bctx); err != nil {
+		slog.Warn("reclaim_check_cache: schedule read failed; falling back to DB", "error", err)
+		return append([]string(nil), runtimeIDs...)
+	}
+	for _, command := range scheduleCommands {
+		count, err := command.count.Result()
 		if err != nil {
-			slog.Warn("reclaim_check_cache: backstop read failed; falling back to DB", "error", err)
+			slog.Warn("reclaim_check_cache: schedule result failed; falling back to DB", "error", err)
 			return append([]string(nil), runtimeIDs...)
 		}
-		backstopMillis, err := strconv.ParseInt(backstop, 10, 64)
-		if err != nil || backstopMillis <= nowMillis {
+		if count > 0 {
 			due = append(due, command.runtimeID)
 		}
 	}
@@ -118,10 +152,23 @@ func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []stri
 }
 
 // Track records the earliest known reclaim time for one dispatched task. ZADD
-// updates the task's score when a prepare lease is extended; multiple tasks on
+// replaces the task's score after a fresh dispatch/reclaim; multiple tasks on
 // one runtime remain independent, avoiding a runtime-level timestamp losing a
 // second task's earlier recovery deadline.
 func (c *ReclaimCheckCache) Track(ctx context.Context, runtimeID, taskID string, checkAfter time.Time) {
+	c.track(ctx, runtimeID, taskID, checkAfter, false)
+}
+
+// TrackLater advances an existing task hint only when a prepare-lease extension
+// protects it beyond its current recovery deadline. It deliberately does not
+// create a missing member: without the initial dispatch deadline, a short lease
+// could schedule an early failed check and delay recovery until the next
+// backstop. Missing state already fails open through that bounded backstop.
+func (c *ReclaimCheckCache) TrackLater(ctx context.Context, runtimeID, taskID string, checkAfter time.Time) {
+	c.track(ctx, runtimeID, taskID, checkAfter, true)
+}
+
+func (c *ReclaimCheckCache) track(ctx context.Context, runtimeID, taskID string, checkAfter time.Time, onlyLater bool) {
 	if c == nil || runtimeID == "" || taskID == "" || checkAfter.IsZero() {
 		return
 	}
@@ -129,8 +176,13 @@ func (c *ReclaimCheckCache) Track(ctx context.Context, runtimeID, taskID string,
 	defer cancel()
 	key := reclaimCheckScheduleKey(runtimeID)
 	pipe := c.rdb.Pipeline()
-	pipe.ZAdd(bctx, key, redis.Z{Score: float64(checkAfter.UnixMilli()), Member: taskID})
-	pipe.Expire(bctx, key, ReclaimCheckCacheTTL)
+	member := redis.Z{Score: float64(checkAfter.UnixMilli()), Member: taskID}
+	if onlyLater {
+		pipe.ZAddArgs(bctx, key, redis.ZAddArgs{XX: true, GT: true, Members: []redis.Z{member}})
+	} else {
+		pipe.ZAdd(bctx, key, member)
+	}
+	pipe.Expire(bctx, key, ReclaimCheckScheduleTTL)
 	if _, err := pipe.Exec(bctx); err != nil {
 		slog.Warn("reclaim_check_cache: track failed; DB fallback remains active", "error", err)
 	}
@@ -150,28 +202,25 @@ func (c *ReclaimCheckCache) Forget(ctx context.Context, runtimeID, taskID string
 	}
 }
 
-// MarkChecked records a successful PostgreSQL reclaim pass. When the UPDATE
-// returned fewer rows than its LIMIT, it exhausted currently eligible rows, so
-// task hints due before the query began can be discarded. Hints added or moved
-// by a concurrent dispatch/lease extension have a later score and survive.
-func (c *ReclaimCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough time.Time, exhausted bool) {
+// MarkChecked records a successful PostgreSQL reclaim pass for every runtime in
+// the machine-level polling set. It deliberately does not delete task hints:
+// SKIP LOCKED and runtime-health predicates mean a short result cannot prove
+// those tasks no longer need recovery. DueRuntimeIDs ignores scores at or before
+// this marker until the bounded backstop elapses, while newer concurrent hints
+// can still trigger an earlier check.
+func (c *ReclaimCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough time.Time) {
 	if c == nil || len(runtimeIDs) == 0 {
 		return
 	}
 	bctx, cancel := c.bounded(ctx)
 	defer cancel()
-	nextBackstop := checkedThrough.Add(ReclaimCheckCacheTTL).UnixMilli()
-	maxChecked := strconv.FormatInt(checkedThrough.UnixMilli(), 10)
+	checkedMillis := strconv.FormatInt(checkedThrough.UnixMilli(), 10)
 	pipe := c.rdb.Pipeline()
 	for _, runtimeID := range runtimeIDs {
 		if runtimeID == "" {
 			continue
 		}
-		if exhausted {
-			pipe.ZRemRangeByScore(bctx, reclaimCheckScheduleKey(runtimeID), "-inf", maxChecked)
-		}
-		pipe.Set(bctx, reclaimCheckBackstopKey(runtimeID), strconv.FormatInt(nextBackstop, 10), ReclaimCheckCacheTTL)
-		pipe.Expire(bctx, reclaimCheckScheduleKey(runtimeID), ReclaimCheckCacheTTL)
+		pipe.Set(bctx, reclaimCheckBackstopKey(runtimeID), checkedMillis, ReclaimCheckBackstopInterval)
 	}
 	if _, err := pipe.Exec(bctx); err != nil {
 		slog.Warn("reclaim_check_cache: mark checked failed; falling back to DB", "error", err)

--- a/server/internal/service/reclaim_check_cache.go
+++ b/server/internal/service/reclaim_check_cache.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	reclaimCheckSchedulePrefix = "mul:claim:runtime:reclaim-schedule:"
+	reclaimCheckBackstopPrefix = "mul:claim:runtime:reclaim-backstop:"
+)
+
+// ReclaimCheckCacheTTL is both the steady-state fallback cadence and the TTL
+// for reclaim scheduling hints. It must not exceed the claim response recovery
+// window: if a dispatch-side Redis write is lost, the prior backstop expires no
+// later than the newly dispatched task first becomes reclaimable.
+const ReclaimCheckCacheTTL = claimResponseRecoveryWindow
+
+// ReclaimCheckCache keeps the batch/singular claim hot paths from issuing a
+// stale-dispatch UPDATE when no task can possibly be reclaimed yet.
+//
+// Each runtime owns a sorted set of task IDs scored by their earliest known
+// reclaim time. A separate backstop timestamp forces a periodic DB check for
+// cache loss, pre-deployment rows, or a missed write. Missing keys and Redis
+// errors always mean "check PostgreSQL now", so the cache can only reduce load;
+// it is never authoritative for task recovery.
+type ReclaimCheckCache struct {
+	rdb *redis.Client
+}
+
+func NewReclaimCheckCache(rdb *redis.Client) *ReclaimCheckCache {
+	if rdb == nil {
+		return nil
+	}
+	return &ReclaimCheckCache{rdb: rdb}
+}
+
+func reclaimCheckScheduleKey(runtimeID string) string {
+	return reclaimCheckSchedulePrefix + runtimeID
+}
+
+func reclaimCheckBackstopKey(runtimeID string) string {
+	return reclaimCheckBackstopPrefix + runtimeID
+}
+
+func (c *ReclaimCheckCache) bounded(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, emptyClaimRedisTimeout)
+}
+
+// DueRuntimeIDs returns only runtimes whose earliest task hint or periodic
+// backstop is due. A nil cache, missing backstop, malformed value, or Redis
+// failure returns every input runtime so callers preserve the pre-cache DB path.
+func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []string, now time.Time) []string {
+	if len(runtimeIDs) == 0 {
+		return nil
+	}
+	if c == nil {
+		return append([]string(nil), runtimeIDs...)
+	}
+
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	type runtimeCommands struct {
+		runtimeID string
+		schedule  *redis.ZSliceCmd
+		backstop  *redis.StringCmd
+	}
+	pipe := c.rdb.Pipeline()
+	commands := make([]runtimeCommands, 0, len(runtimeIDs))
+	for _, runtimeID := range runtimeIDs {
+		if runtimeID == "" {
+			continue
+		}
+		commands = append(commands, runtimeCommands{
+			runtimeID: runtimeID,
+			schedule:  pipe.ZRangeWithScores(bctx, reclaimCheckScheduleKey(runtimeID), 0, 0),
+			backstop:  pipe.Get(bctx, reclaimCheckBackstopKey(runtimeID)),
+		})
+	}
+	if _, err := pipe.Exec(bctx); err != nil && !errors.Is(err, redis.Nil) {
+		slog.Warn("reclaim_check_cache: read failed; falling back to DB", "error", err)
+		return append([]string(nil), runtimeIDs...)
+	}
+
+	nowMillis := now.UnixMilli()
+	due := make([]string, 0, len(commands))
+	for _, command := range commands {
+		scheduled, err := command.schedule.Result()
+		if err != nil {
+			slog.Warn("reclaim_check_cache: schedule read failed; falling back to DB", "error", err)
+			return append([]string(nil), runtimeIDs...)
+		}
+		if len(scheduled) > 0 && int64(scheduled[0].Score) <= nowMillis {
+			due = append(due, command.runtimeID)
+			continue
+		}
+
+		backstop, err := command.backstop.Result()
+		if errors.Is(err, redis.Nil) {
+			due = append(due, command.runtimeID)
+			continue
+		}
+		if err != nil {
+			slog.Warn("reclaim_check_cache: backstop read failed; falling back to DB", "error", err)
+			return append([]string(nil), runtimeIDs...)
+		}
+		backstopMillis, err := strconv.ParseInt(backstop, 10, 64)
+		if err != nil || backstopMillis <= nowMillis {
+			due = append(due, command.runtimeID)
+		}
+	}
+	return due
+}
+
+// Track records the earliest known reclaim time for one dispatched task. ZADD
+// updates the task's score when a prepare lease is extended; multiple tasks on
+// one runtime remain independent, avoiding a runtime-level timestamp losing a
+// second task's earlier recovery deadline.
+func (c *ReclaimCheckCache) Track(ctx context.Context, runtimeID, taskID string, checkAfter time.Time) {
+	if c == nil || runtimeID == "" || taskID == "" || checkAfter.IsZero() {
+		return
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	key := reclaimCheckScheduleKey(runtimeID)
+	pipe := c.rdb.Pipeline()
+	pipe.ZAdd(bctx, key, redis.Z{Score: float64(checkAfter.UnixMilli()), Member: taskID})
+	pipe.Expire(bctx, key, ReclaimCheckCacheTTL)
+	if _, err := pipe.Exec(bctx); err != nil {
+		slog.Warn("reclaim_check_cache: track failed; DB fallback remains active", "error", err)
+	}
+}
+
+// Forget removes a task that can no longer be reclaimed (started, requeued,
+// waiting on a local directory, or terminal). Failures are harmless: the stale
+// hint can cause one extra DB check but cannot make an ineligible task run.
+func (c *ReclaimCheckCache) Forget(ctx context.Context, runtimeID, taskID string) {
+	if c == nil || runtimeID == "" || taskID == "" {
+		return
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	if err := c.rdb.ZRem(bctx, reclaimCheckScheduleKey(runtimeID), taskID).Err(); err != nil {
+		slog.Warn("reclaim_check_cache: forget failed; stale hint will expire", "error", err)
+	}
+}
+
+// MarkChecked records a successful PostgreSQL reclaim pass. When the UPDATE
+// returned fewer rows than its LIMIT, it exhausted currently eligible rows, so
+// task hints due before the query began can be discarded. Hints added or moved
+// by a concurrent dispatch/lease extension have a later score and survive.
+func (c *ReclaimCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough time.Time, exhausted bool) {
+	if c == nil || len(runtimeIDs) == 0 {
+		return
+	}
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	nextBackstop := checkedThrough.Add(ReclaimCheckCacheTTL).UnixMilli()
+	maxChecked := strconv.FormatInt(checkedThrough.UnixMilli(), 10)
+	pipe := c.rdb.Pipeline()
+	for _, runtimeID := range runtimeIDs {
+		if runtimeID == "" {
+			continue
+		}
+		if exhausted {
+			pipe.ZRemRangeByScore(bctx, reclaimCheckScheduleKey(runtimeID), "-inf", maxChecked)
+		}
+		pipe.Set(bctx, reclaimCheckBackstopKey(runtimeID), strconv.FormatInt(nextBackstop, 10), ReclaimCheckCacheTTL)
+		pipe.Expire(bctx, reclaimCheckScheduleKey(runtimeID), ReclaimCheckCacheTTL)
+	}
+	if _, err := pipe.Exec(bctx); err != nil {
+		slog.Warn("reclaim_check_cache: mark checked failed; falling back to DB", "error", err)
+	}
+}

--- a/server/internal/service/reclaim_check_cache.go
+++ b/server/internal/service/reclaim_check_cache.go
@@ -12,15 +12,46 @@ import (
 const (
 	reclaimCheckSchedulePrefix = "mul:claim:runtime:reclaim-schedule:"
 	reclaimCheckBackstopPrefix = "mul:claim:runtime:reclaim-backstop:"
+	reclaimCheckRetryBatchSize = 256
 
 	// The backstop remains at or below the PostgreSQL recovery window so a
 	// missed dispatch-side Redis write cannot delay recovery beyond one window.
 	ReclaimCheckBackstopInterval = claimResponseRecoveryWindow
-	// A fresh task's first hint is one recovery window in the future. Keep the
-	// containing ZSET alive for another full window so Redis cannot expire the
-	// hint at the exact instant it first becomes observable as due.
-	ReclaimCheckScheduleTTL = 2 * claimResponseRecoveryWindow
+	// A due hint that produces no reclaimed row is retried at the daemon's next
+	// normal polling cadence instead of becoming inert until the backstop.
+	ReclaimCheckRetryInterval = 30 * time.Second
+	// The Redis hint is captured immediately before the PostgreSQL dispatch
+	// command. Leave a small margin for that command to commit so a hint cannot
+	// fire just before the database's strict recovery-window predicate does.
+	ReclaimCheckHintSafetyMargin = 5 * time.Second
+	// A fresh task's first hint is one recovery window plus the safety margin in
+	// the future. Keep the containing ZSET alive for another full window so the
+	// hint survives its deadline and several bounded retries.
+	ReclaimCheckScheduleTTL = 2*claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin
 )
+
+// These scripts use only Redis 2.6-era primitives. In particular, they avoid
+// ZADD GT (Redis 6.2+) so self-hosted installations do not silently lose the
+// scheduling optimization on older Redis versions.
+const reclaimCheckTrackLaterScript = `
+local current = redis.call('ZSCORE', KEYS[1], ARGV[1])
+if not current then
+    return 0
+end
+if tonumber(current) < tonumber(ARGV[2]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+end
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return 1
+`
+
+const reclaimCheckDeferDueScript = `
+local members = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', '0', ARGV[3])
+for _, member in ipairs(members) do
+    redis.call('ZADD', KEYS[1], ARGV[2], member)
+end
+return #members
+`
 
 // ReclaimCheckCache keeps the batch/singular claim hot paths from issuing a
 // stale-dispatch UPDATE when no task can possibly be reclaimed yet.
@@ -55,11 +86,11 @@ func (c *ReclaimCheckCache) bounded(ctx context.Context) (context.Context, conte
 	return context.WithTimeout(ctx, emptyClaimRedisTimeout)
 }
 
-// DueRuntimeIDs returns only runtimes with a task hint added after their last
-// successful DB check and now due, or whose periodic backstop has elapsed. A
-// checked hint stays in the ZSET until a real task transition removes/updates it
-// or the schedule TTL expires, but it cannot retrigger every poll because its
-// score is not newer than the last-checked marker.
+// DueRuntimeIDs returns only runtimes with a due task hint or whose periodic
+// backstop has elapsed. It preserves the relative order of non-empty input IDs.
+// MarkChecked advances hints seen by a completed DB check to a bounded retry
+// deadline, so an unrecovered task is tried again without retriggering every
+// poll. The schedule TTL remains a hard bound on stale cleanup hints.
 //
 // A nil cache, missing/malformed backstop, or Redis failure fails open. Batch
 // callers treat any due runtime as a reason to query their complete runtime set.
@@ -67,40 +98,42 @@ func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []stri
 	if len(runtimeIDs) == 0 {
 		return nil
 	}
-	if c == nil {
-		return append([]string(nil), runtimeIDs...)
-	}
-
-	bctx, cancel := c.bounded(ctx)
-	defer cancel()
 	validRuntimeIDs := make([]string, 0, len(runtimeIDs))
-	backstopKeys := make([]string, 0, len(runtimeIDs))
 	for _, runtimeID := range runtimeIDs {
 		if runtimeID == "" {
 			continue
 		}
 		validRuntimeIDs = append(validRuntimeIDs, runtimeID)
-		backstopKeys = append(backstopKeys, reclaimCheckBackstopKey(runtimeID))
 	}
 	if len(validRuntimeIDs) == 0 {
 		return nil
 	}
+	if c == nil {
+		return validRuntimeIDs
+	}
+
+	bctx, cancel := c.bounded(ctx)
+	defer cancel()
+	backstopKeys := make([]string, 0, len(validRuntimeIDs))
+	for _, runtimeID := range validRuntimeIDs {
+		backstopKeys = append(backstopKeys, reclaimCheckBackstopKey(runtimeID))
+	}
 	backstops, err := c.rdb.MGet(bctx, backstopKeys...).Result()
 	if err != nil {
 		slog.Warn("reclaim_check_cache: backstop read failed; falling back to DB", "error", err)
-		return append([]string(nil), runtimeIDs...)
+		return validRuntimeIDs
 	}
 	if len(backstops) != len(validRuntimeIDs) {
 		slog.Warn("reclaim_check_cache: incomplete backstop read; falling back to DB")
-		return append([]string(nil), runtimeIDs...)
+		return validRuntimeIDs
 	}
 
 	nowMillis := now.UnixMilli()
 	type scheduleCommand struct {
-		runtimeID string
-		count     *redis.IntCmd
+		index int
+		count *redis.IntCmd
 	}
-	due := make([]string, 0, len(validRuntimeIDs))
+	due := make([]bool, len(validRuntimeIDs))
 	pipe := c.rdb.Pipeline()
 	scheduleCommands := make([]scheduleCommand, 0, len(validRuntimeIDs))
 	for i, runtimeID := range validRuntimeIDs {
@@ -108,47 +141,52 @@ func (c *ReclaimCheckCache) DueRuntimeIDs(ctx context.Context, runtimeIDs []stri
 		if !ok {
 			// A missing or non-string value means this runtime has no trustworthy
 			// successful-check marker.
-			due = append(due, runtimeID)
+			due[i] = true
 			continue
 		}
 		checkedMillis, err := strconv.ParseInt(backstop, 10, 64)
 		if err != nil {
-			due = append(due, runtimeID)
+			due[i] = true
 			continue
 		}
 		nextBackstop := checkedMillis + ReclaimCheckBackstopInterval.Milliseconds()
 		if nextBackstop < checkedMillis || nextBackstop <= nowMillis {
-			due = append(due, runtimeID)
+			due[i] = true
 			continue
 		}
 		scheduleCommands = append(scheduleCommands, scheduleCommand{
-			runtimeID: runtimeID,
+			index: i,
 			count: pipe.ZCount(
 				bctx,
 				reclaimCheckScheduleKey(runtimeID),
-				"("+strconv.FormatInt(checkedMillis, 10),
+				"-inf",
 				strconv.FormatInt(nowMillis, 10),
 			),
 		})
 	}
-	if len(scheduleCommands) == 0 {
-		return due
-	}
-	if _, err := pipe.Exec(bctx); err != nil {
-		slog.Warn("reclaim_check_cache: schedule read failed; falling back to DB", "error", err)
-		return append([]string(nil), runtimeIDs...)
-	}
-	for _, command := range scheduleCommands {
-		count, err := command.count.Result()
-		if err != nil {
-			slog.Warn("reclaim_check_cache: schedule result failed; falling back to DB", "error", err)
-			return append([]string(nil), runtimeIDs...)
+	if len(scheduleCommands) > 0 {
+		if _, err := pipe.Exec(bctx); err != nil {
+			slog.Warn("reclaim_check_cache: schedule read failed; falling back to DB", "error", err)
+			return validRuntimeIDs
 		}
-		if count > 0 {
-			due = append(due, command.runtimeID)
+		for _, command := range scheduleCommands {
+			count, err := command.count.Result()
+			if err != nil {
+				slog.Warn("reclaim_check_cache: schedule result failed; falling back to DB", "error", err)
+				return validRuntimeIDs
+			}
+			if count > 0 {
+				due[command.index] = true
+			}
 		}
 	}
-	return due
+	dueRuntimeIDs := make([]string, 0, len(validRuntimeIDs))
+	for i, runtimeID := range validRuntimeIDs {
+		if due[i] {
+			dueRuntimeIDs = append(dueRuntimeIDs, runtimeID)
+		}
+	}
+	return dueRuntimeIDs
 }
 
 // Track records the earliest known reclaim time for one dispatched task. ZADD
@@ -175,13 +213,22 @@ func (c *ReclaimCheckCache) track(ctx context.Context, runtimeID, taskID string,
 	bctx, cancel := c.bounded(ctx)
 	defer cancel()
 	key := reclaimCheckScheduleKey(runtimeID)
+	if onlyLater {
+		if err := c.rdb.Eval(
+			bctx,
+			reclaimCheckTrackLaterScript,
+			[]string{key},
+			taskID,
+			checkAfter.UnixMilli(),
+			ReclaimCheckScheduleTTL.Milliseconds(),
+		).Err(); err != nil {
+			slog.Warn("reclaim_check_cache: extend hint failed; DB fallback remains active", "error", err)
+		}
+		return
+	}
 	pipe := c.rdb.Pipeline()
 	member := redis.Z{Score: float64(checkAfter.UnixMilli()), Member: taskID}
-	if onlyLater {
-		pipe.ZAddArgs(bctx, key, redis.ZAddArgs{XX: true, GT: true, Members: []redis.Z{member}})
-	} else {
-		pipe.ZAdd(bctx, key, member)
-	}
+	pipe.ZAdd(bctx, key, member)
 	pipe.Expire(bctx, key, ReclaimCheckScheduleTTL)
 	if _, err := pipe.Exec(bctx); err != nil {
 		slog.Warn("reclaim_check_cache: track failed; DB fallback remains active", "error", err)
@@ -203,23 +250,36 @@ func (c *ReclaimCheckCache) Forget(ctx context.Context, runtimeID, taskID string
 }
 
 // MarkChecked records a successful PostgreSQL reclaim pass for every runtime in
-// the machine-level polling set. It deliberately does not delete task hints:
-// SKIP LOCKED and runtime-health predicates mean a short result cannot prove
-// those tasks no longer need recovery. DueRuntimeIDs ignores scores at or before
-// this marker until the bounded backstop elapses, while newer concurrent hints
-// can still trigger an earlier check.
-func (c *ReclaimCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough time.Time) {
+// the machine-level polling set. Hints that actually triggered this pass are
+// atomically moved to retryAfter instead of deleted or made inert: SKIP LOCKED
+// and runtime-health predicates mean an empty result cannot prove those tasks no
+// longer need recovery. Concurrent hints newer than checkedThrough are left
+// untouched. The bounded batch prevents a pathological ZSET from monopolizing
+// Redis; any excess due hints remain due and fail open to another DB pass.
+func (c *ReclaimCheckCache) MarkChecked(ctx context.Context, runtimeIDs []string, checkedThrough, retryAfter time.Time) {
 	if c == nil || len(runtimeIDs) == 0 {
 		return
+	}
+	if retryAfter.IsZero() || !retryAfter.After(checkedThrough) {
+		retryAfter = checkedThrough.Add(ReclaimCheckRetryInterval)
 	}
 	bctx, cancel := c.bounded(ctx)
 	defer cancel()
 	checkedMillis := strconv.FormatInt(checkedThrough.UnixMilli(), 10)
+	retryMillis := strconv.FormatInt(retryAfter.UnixMilli(), 10)
 	pipe := c.rdb.Pipeline()
 	for _, runtimeID := range runtimeIDs {
 		if runtimeID == "" {
 			continue
 		}
+		pipe.Eval(
+			bctx,
+			reclaimCheckDeferDueScript,
+			[]string{reclaimCheckScheduleKey(runtimeID)},
+			checkedMillis,
+			retryMillis,
+			reclaimCheckRetryBatchSize,
+		)
 		pipe.Set(bctx, reclaimCheckBackstopKey(runtimeID), checkedMillis, ReclaimCheckBackstopInterval)
 	}
 	if _, err := pipe.Exec(bctx); err != nil {

--- a/server/internal/service/reclaim_check_cache_test.go
+++ b/server/internal/service/reclaim_check_cache_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestTaskReclaimCheckAfter(t *testing.T) {
+	dispatchedAt := time.Date(2026, time.August, 21, 4, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		task db.AgentTaskQueue
+		want time.Time
+	}{
+		{
+			name: "missing dispatch timestamp has no schedule",
+			task: db.AgentTaskQueue{},
+		},
+		{
+			name: "recovery window",
+			task: db.AgentTaskQueue{
+				DispatchedAt: pgtype.Timestamptz{Time: dispatchedAt, Valid: true},
+			},
+			want: dispatchedAt.Add(claimResponseRecoveryWindow),
+		},
+		{
+			name: "later prepare lease",
+			task: db.AgentTaskQueue{
+				DispatchedAt:          pgtype.Timestamptz{Time: dispatchedAt, Valid: true},
+				PrepareLeaseExpiresAt: pgtype.Timestamptz{Time: dispatchedAt.Add(2 * time.Minute), Valid: true},
+			},
+			want: dispatchedAt.Add(2 * time.Minute),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := taskReclaimCheckAfter(tt.task); !got.Equal(tt.want) {
+				t.Fatalf("taskReclaimCheckAfter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReclaimCheckCache_NilFallsBackToEveryRuntime(t *testing.T) {
+	var cache *ReclaimCheckCache
+	runtimes := []string{"rt-a", "rt-b"}
+	due := cache.DueRuntimeIDs(context.Background(), runtimes, time.Now())
+	if len(due) != len(runtimes) || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("nil cache due runtimes = %v, want %v", due, runtimes)
+	}
+	cache.Track(context.Background(), "rt-a", "task-a", time.Now())
+	cache.Forget(context.Background(), "rt-a", "task-a")
+	cache.MarkChecked(context.Background(), runtimes, time.Now(), true)
+}
+
+func TestNewReclaimCheckCache_NilRedisReturnsNil(t *testing.T) {
+	if cache := NewReclaimCheckCache(nil); cache != nil {
+		t.Fatalf("NewReclaimCheckCache(nil) = %#v, want nil", cache)
+	}
+}
+
+func TestReclaimCheckCache_RedisFailureFallsBackToEveryRuntime(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	if err := rdb.Close(); err != nil {
+		t.Fatalf("close Redis client: %v", err)
+	}
+	cache := NewReclaimCheckCache(rdb)
+	runtimes := []string{"rt-a", "rt-b"}
+	due := cache.DueRuntimeIDs(context.Background(), runtimes, time.Now())
+	if len(due) != len(runtimes) || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("failed Redis due runtimes = %v, want %v", due, runtimes)
+	}
+}
+
+func TestReclaimCheckCache_BackstopAndTaskSchedule(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now); len(due) != 1 {
+		t.Fatalf("missing cache must fall back to DB, got %v", due)
+	}
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(time.Second)); len(due) != 0 {
+		t.Fatalf("fresh backstop should skip DB, got %v", due)
+	}
+
+	cache.Track(ctx, "rt-a", "task-a", now.Add(10*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(9*time.Second)); len(due) != 0 {
+		t.Fatalf("task must not be checked before its recovery time, got %v", due)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(11*time.Second)); len(due) != 1 {
+		t.Fatalf("task recovery time must override the later backstop, got %v", due)
+	}
+}
+
+func TestReclaimCheckCache_LeaseMoveForgetAndExhaustedCleanup(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
+	cache.Track(ctx, "rt-a", "task-a", now.Add(5*time.Second))
+	cache.Track(ctx, "rt-a", "task-b", now.Add(20*time.Second))
+	// A prepare-lease extension moves the same task rather than adding a second
+	// member, so task-b remains the earliest hint.
+	cache.Track(ctx, "rt-a", "task-a", now.Add(30*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(21*time.Second)); len(due) != 1 {
+		t.Fatalf("task-b should remain due after task-a lease extension, got %v", due)
+	}
+
+	cache.Forget(ctx, "rt-a", "task-b")
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(21*time.Second)); len(due) != 0 {
+		t.Fatalf("forgotten task must no longer trigger a check, got %v", due)
+	}
+
+	cache.Track(ctx, "rt-a", "old-task", now.Add(-time.Second))
+	cache.Track(ctx, "rt-a", "future-task", now.Add(40*time.Second))
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
+	if score, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "old-task").Result(); err == nil {
+		t.Fatalf("exhausted check retained old task score %v", score)
+	}
+	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "future-task").Result(); err != nil {
+		t.Fatalf("exhausted check removed concurrent/future task: %v", err)
+	}
+}

--- a/server/internal/service/reclaim_check_cache_test.go
+++ b/server/internal/service/reclaim_check_cache_test.go
@@ -2,50 +2,12 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/redis/go-redis/v9"
 )
-
-func TestTaskReclaimCheckAfter(t *testing.T) {
-	dispatchedAt := time.Date(2026, time.August, 21, 4, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name string
-		task db.AgentTaskQueue
-		want time.Time
-	}{
-		{
-			name: "missing dispatch timestamp has no schedule",
-			task: db.AgentTaskQueue{},
-		},
-		{
-			name: "recovery window",
-			task: db.AgentTaskQueue{
-				DispatchedAt: pgtype.Timestamptz{Time: dispatchedAt, Valid: true},
-			},
-			want: dispatchedAt.Add(claimResponseRecoveryWindow),
-		},
-		{
-			name: "later prepare lease",
-			task: db.AgentTaskQueue{
-				DispatchedAt:          pgtype.Timestamptz{Time: dispatchedAt, Valid: true},
-				PrepareLeaseExpiresAt: pgtype.Timestamptz{Time: dispatchedAt.Add(2 * time.Minute), Valid: true},
-			},
-			want: dispatchedAt.Add(2 * time.Minute),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := taskReclaimCheckAfter(tt.task); !got.Equal(tt.want) {
-				t.Fatalf("taskReclaimCheckAfter() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestReclaimCheckCache_NilFallsBackToEveryRuntime(t *testing.T) {
 	var cache *ReclaimCheckCache
@@ -55,8 +17,9 @@ func TestReclaimCheckCache_NilFallsBackToEveryRuntime(t *testing.T) {
 		t.Fatalf("nil cache due runtimes = %v, want %v", due, runtimes)
 	}
 	cache.Track(context.Background(), "rt-a", "task-a", time.Now())
+	cache.TrackLater(context.Background(), "rt-a", "task-a", time.Now())
 	cache.Forget(context.Background(), "rt-a", "task-a")
-	cache.MarkChecked(context.Background(), runtimes, time.Now(), true)
+	cache.MarkChecked(context.Background(), runtimes, time.Now())
 }
 
 func TestNewReclaimCheckCache_NilRedisReturnsNil(t *testing.T) {
@@ -78,57 +41,116 @@ func TestReclaimCheckCache_RedisFailureFallsBackToEveryRuntime(t *testing.T) {
 	}
 }
 
-func TestReclaimCheckCache_BackstopAndTaskSchedule(t *testing.T) {
+func TestReclaimCheckCache_ProductionWindowHintOutlivesDeadline(t *testing.T) {
 	rdb := newRedisTestClient(t)
 	cache := NewReclaimCheckCache(rdb)
 	ctx := context.Background()
 	now := time.Now()
+	hint := now.Add(claimResponseRecoveryWindow)
 
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now); len(due) != 1 {
-		t.Fatalf("missing cache must fall back to DB, got %v", due)
-	}
-	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(time.Second)); len(due) != 0 {
-		t.Fatalf("fresh backstop should skip DB, got %v", due)
-	}
+	// Put the backstop after the task hint so this test exercises the schedule,
+	// not the periodic fallback, at the production 90-second distance.
+	cache.MarkChecked(ctx, []string{"rt-a"}, now.Add(30*time.Second))
+	cache.Track(ctx, "rt-a", "task-a", hint)
 
-	cache.Track(ctx, "rt-a", "task-a", now.Add(10*time.Second))
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(9*time.Second)); len(due) != 0 {
+	ttl, err := rdb.PTTL(ctx, reclaimCheckScheduleKey("rt-a")).Result()
+	if err != nil {
+		t.Fatalf("schedule PTTL: %v", err)
+	}
+	if ttl <= claimResponseRecoveryWindow {
+		t.Fatalf("schedule TTL = %v, must strictly outlive %v hint distance", ttl, claimResponseRecoveryWindow)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, hint.Add(-time.Millisecond)); len(due) != 0 {
 		t.Fatalf("task must not be checked before its recovery time, got %v", due)
 	}
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(11*time.Second)); len(due) != 1 {
-		t.Fatalf("task recovery time must override the later backstop, got %v", due)
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, hint.Add(time.Millisecond)); len(due) != 1 {
+		t.Fatalf("production-window hint must remain observable when due, got %v", due)
 	}
 }
 
-func TestReclaimCheckCache_LeaseMoveForgetAndExhaustedCleanup(t *testing.T) {
+func TestReclaimCheckCache_CheckedHintIsRetainedWithoutRetriggering(t *testing.T) {
 	rdb := newRedisTestClient(t)
 	cache := NewReclaimCheckCache(rdb)
 	ctx := context.Background()
 	now := time.Now()
 
-	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
-	cache.Track(ctx, "rt-a", "task-a", now.Add(5*time.Second))
+	cache.MarkChecked(ctx, []string{"rt-a"}, now)
+	cache.Track(ctx, "rt-a", "task-a", now.Add(10*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(11*time.Second)); len(due) != 1 {
+		t.Fatalf("task-a should trigger its first check, got %v", due)
+	}
+	cache.MarkChecked(ctx, []string{"rt-a"}, now.Add(11*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(12*time.Second)); len(due) != 0 {
+		t.Fatalf("already-checked hint must not retrigger the next poll, got %v", due)
+	}
+	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result(); err != nil {
+		t.Fatalf("successful check must retain task hint: %v", err)
+	}
+
+	// A new task added after the check can still trigger before the backstop,
+	// even though the older retained member remains first in score order.
 	cache.Track(ctx, "rt-a", "task-b", now.Add(20*time.Second))
-	// A prepare-lease extension moves the same task rather than adding a second
-	// member, so task-b remains the earliest hint.
-	cache.Track(ctx, "rt-a", "task-a", now.Add(30*time.Second))
 	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(21*time.Second)); len(due) != 1 {
-		t.Fatalf("task-b should remain due after task-a lease extension, got %v", due)
+		t.Fatalf("newer task hint should override the backstop, got %v", due)
+	}
+}
+
+func TestReclaimCheckCache_TrackLaterAndForget(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	cache.Track(ctx, "rt-a", "task-a", now.Add(claimResponseRecoveryWindow))
+	cache.TrackLater(ctx, "rt-a", "task-a", now.Add(prepareLeaseDuration))
+	score, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result()
+	if err != nil {
+		t.Fatalf("read task score after shorter lease: %v", err)
+	}
+	if got := int64(score); got != now.Add(claimResponseRecoveryWindow).UnixMilli() {
+		t.Fatalf("shorter lease moved hint to %d, want %d", got, now.Add(claimResponseRecoveryWindow).UnixMilli())
 	}
 
-	cache.Forget(ctx, "rt-a", "task-b")
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(21*time.Second)); len(due) != 0 {
-		t.Fatalf("forgotten task must no longer trigger a check, got %v", due)
+	later := now.Add(claimResponseRecoveryWindow + prepareLeaseDuration)
+	cache.TrackLater(ctx, "rt-a", "task-a", later)
+	score, err = rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result()
+	if err != nil {
+		t.Fatalf("read task score after later lease: %v", err)
+	}
+	if got := int64(score); got != later.UnixMilli() {
+		t.Fatalf("later lease left hint at %d, want %d", got, later.UnixMilli())
 	}
 
-	cache.Track(ctx, "rt-a", "old-task", now.Add(-time.Second))
-	cache.Track(ctx, "rt-a", "future-task", now.Add(40*time.Second))
-	cache.MarkChecked(ctx, []string{"rt-a"}, now, true)
-	if score, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "old-task").Result(); err == nil {
-		t.Fatalf("exhausted check retained old task score %v", score)
+	cache.Forget(ctx, "rt-a", "task-a")
+	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("forgotten task score error = %v, want redis.Nil", err)
 	}
-	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "future-task").Result(); err != nil {
-		t.Fatalf("exhausted check removed concurrent/future task: %v", err)
+	cache.TrackLater(ctx, "rt-a", "missing-task", later)
+	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "missing-task").Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("lease-only missing task score error = %v, want redis.Nil", err)
+	}
+}
+
+func TestReclaimCheckCache_CollectionCheckAlignsBackstops(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+	runtimes := []string{"rt-a", "rt-b"}
+
+	cache.MarkChecked(ctx, []string{"rt-a"}, now)
+	cache.MarkChecked(ctx, []string{"rt-b"}, now.Add(30*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(91*time.Second)); len(due) != 1 || due[0] != "rt-a" {
+		t.Fatalf("staggered backstops due = %v, want [rt-a]", due)
+	}
+
+	// ClaimTasksForRuntimes queries the complete set when any member is due and
+	// records that successful pass for the complete set as well.
+	cache.MarkChecked(ctx, runtimes, now.Add(91*time.Second))
+	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(150*time.Second)); len(due) != 0 {
+		t.Fatalf("collection backstops drifted after joint check: %v", due)
+	}
+	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(182*time.Second)); len(due) != 2 {
+		t.Fatalf("aligned collection backstops due = %v, want both runtimes", due)
 	}
 }

--- a/server/internal/service/reclaim_check_cache_test.go
+++ b/server/internal/service/reclaim_check_cache_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ func TestReclaimCheckCache_NilFallsBackToEveryRuntime(t *testing.T) {
 	cache.Track(context.Background(), "rt-a", "task-a", time.Now())
 	cache.TrackLater(context.Background(), "rt-a", "task-a", time.Now())
 	cache.Forget(context.Background(), "rt-a", "task-a")
-	cache.MarkChecked(context.Background(), runtimes, time.Now())
+	cache.MarkChecked(context.Background(), runtimes, time.Now(), time.Now().Add(ReclaimCheckRetryInterval))
 }
 
 func TestNewReclaimCheckCache_NilRedisReturnsNil(t *testing.T) {
@@ -46,19 +47,26 @@ func TestReclaimCheckCache_ProductionWindowHintOutlivesDeadline(t *testing.T) {
 	cache := NewReclaimCheckCache(rdb)
 	ctx := context.Background()
 	now := time.Now()
-	hint := now.Add(claimResponseRecoveryWindow)
+	hintDistance := claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin
+	hint := now.Add(hintDistance)
 
 	// Put the backstop after the task hint so this test exercises the schedule,
-	// not the periodic fallback, at the production 90-second distance.
-	cache.MarkChecked(ctx, []string{"rt-a"}, now.Add(30*time.Second))
+	// not the periodic fallback, at the production recovery deadline including
+	// its command-commit safety margin.
+	cache.MarkChecked(
+		ctx,
+		[]string{"rt-a"},
+		now.Add(30*time.Second),
+		now.Add(30*time.Second+ReclaimCheckRetryInterval),
+	)
 	cache.Track(ctx, "rt-a", "task-a", hint)
 
 	ttl, err := rdb.PTTL(ctx, reclaimCheckScheduleKey("rt-a")).Result()
 	if err != nil {
 		t.Fatalf("schedule PTTL: %v", err)
 	}
-	if ttl <= claimResponseRecoveryWindow {
-		t.Fatalf("schedule TTL = %v, must strictly outlive %v hint distance", ttl, claimResponseRecoveryWindow)
+	if ttl <= hintDistance {
+		t.Fatalf("schedule TTL = %v, must strictly outlive %v hint distance", ttl, hintDistance)
 	}
 	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, hint.Add(-time.Millisecond)); len(due) != 0 {
 		t.Fatalf("task must not be checked before its recovery time, got %v", due)
@@ -68,28 +76,54 @@ func TestReclaimCheckCache_ProductionWindowHintOutlivesDeadline(t *testing.T) {
 	}
 }
 
-func TestReclaimCheckCache_CheckedHintIsRetainedWithoutRetriggering(t *testing.T) {
+func TestReclaimCheckCache_CheckedHintIsDeferredAndRetriggers(t *testing.T) {
 	rdb := newRedisTestClient(t)
 	cache := NewReclaimCheckCache(rdb)
 	ctx := context.Background()
 	now := time.Now()
 
-	cache.MarkChecked(ctx, []string{"rt-a"}, now)
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(ReclaimCheckRetryInterval))
 	cache.Track(ctx, "rt-a", "task-a", now.Add(10*time.Second))
+	cache.Track(ctx, "rt-a", "task-b", now.Add(20*time.Second))
 	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(11*time.Second)); len(due) != 1 {
 		t.Fatalf("task-a should trigger its first check, got %v", due)
 	}
-	cache.MarkChecked(ctx, []string{"rt-a"}, now.Add(11*time.Second))
-	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(12*time.Second)); len(due) != 0 {
-		t.Fatalf("already-checked hint must not retrigger the next poll, got %v", due)
+	ttlBefore, err := rdb.PTTL(ctx, reclaimCheckScheduleKey("rt-a")).Result()
+	if err != nil {
+		t.Fatalf("read schedule TTL before retry: %v", err)
 	}
-	if _, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result(); err != nil {
+	retryAt := now.Add(11*time.Second + ReclaimCheckRetryInterval)
+	cache.MarkChecked(ctx, []string{"rt-a"}, now.Add(11*time.Second), retryAt)
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(12*time.Second)); len(due) != 0 {
+		t.Fatalf("deferred hint must not retrigger the next poll, got %v", due)
+	}
+	score, err := rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-a").Result()
+	if err != nil {
 		t.Fatalf("successful check must retain task hint: %v", err)
 	}
+	if got := int64(score); got != retryAt.UnixMilli() {
+		t.Fatalf("checked hint score = %d, want retry at %d", got, retryAt.UnixMilli())
+	}
+	ttlAfter, err := rdb.PTTL(ctx, reclaimCheckScheduleKey("rt-a")).Result()
+	if err != nil {
+		t.Fatalf("read schedule TTL after retry: %v", err)
+	}
+	if ttlAfter > ttlBefore {
+		t.Fatalf("retry extended stale-hint lifetime from %v to %v", ttlBefore, ttlAfter)
+	}
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, retryAt.Add(time.Millisecond)); len(due) != 1 {
+		t.Fatalf("unrecovered hint must retrigger after the bounded retry, got %v", due)
+	}
 
-	// A new task added after the check can still trigger before the backstop,
-	// even though the older retained member remains first in score order.
-	cache.Track(ctx, "rt-a", "task-b", now.Add(20*time.Second))
+	// A newer hint that existed when the check began is not deferred with the
+	// task that actually triggered the query.
+	score, err = rdb.ZScore(ctx, reclaimCheckScheduleKey("rt-a"), "task-b").Result()
+	if err != nil {
+		t.Fatalf("read newer task hint: %v", err)
+	}
+	if got := int64(score); got != now.Add(20*time.Second).UnixMilli() {
+		t.Fatalf("newer hint moved to %d, want %d", got, now.Add(20*time.Second).UnixMilli())
+	}
 	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(21*time.Second)); len(due) != 1 {
 		t.Fatalf("newer task hint should override the backstop, got %v", due)
 	}
@@ -138,19 +172,80 @@ func TestReclaimCheckCache_CollectionCheckAlignsBackstops(t *testing.T) {
 	now := time.Now()
 	runtimes := []string{"rt-a", "rt-b"}
 
-	cache.MarkChecked(ctx, []string{"rt-a"}, now)
-	cache.MarkChecked(ctx, []string{"rt-b"}, now.Add(30*time.Second))
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(ReclaimCheckRetryInterval))
+	cache.MarkChecked(
+		ctx,
+		[]string{"rt-b"},
+		now.Add(30*time.Second),
+		now.Add(30*time.Second+ReclaimCheckRetryInterval),
+	)
 	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(91*time.Second)); len(due) != 1 || due[0] != "rt-a" {
 		t.Fatalf("staggered backstops due = %v, want [rt-a]", due)
 	}
 
 	// ClaimTasksForRuntimes queries the complete set when any member is due and
 	// records that successful pass for the complete set as well.
-	cache.MarkChecked(ctx, runtimes, now.Add(91*time.Second))
+	cache.MarkChecked(
+		ctx,
+		runtimes,
+		now.Add(91*time.Second),
+		now.Add(91*time.Second+ReclaimCheckRetryInterval),
+	)
 	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(150*time.Second)); len(due) != 0 {
 		t.Fatalf("collection backstops drifted after joint check: %v", due)
 	}
 	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(182*time.Second)); len(due) != 2 {
 		t.Fatalf("aligned collection backstops due = %v, want both runtimes", due)
+	}
+}
+
+func TestReclaimCheckCache_DueRuntimeIDsPreservesInputOrder(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	cache.MarkChecked(ctx, []string{"rt-b"}, now, now.Add(ReclaimCheckRetryInterval))
+	cache.Track(ctx, "rt-b", "task-b", now.Add(time.Second))
+	cache.MarkChecked(
+		ctx,
+		[]string{"rt-a"},
+		now.Add(-ReclaimCheckBackstopInterval-time.Second),
+		now.Add(ReclaimCheckRetryInterval),
+	)
+
+	runtimes := []string{"rt-b", "rt-a"}
+	if due := cache.DueRuntimeIDs(ctx, runtimes, now.Add(2*time.Second)); len(due) != 2 || due[0] != runtimes[0] || due[1] != runtimes[1] {
+		t.Fatalf("due runtimes = %v, want input order %v", due, runtimes)
+	}
+}
+
+func TestReclaimCheckCache_MarkCheckedBatchLimitFailsOpen(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	cache := NewReclaimCheckCache(rdb)
+	ctx := context.Background()
+	now := time.Now()
+
+	members := make([]redis.Z, 0, reclaimCheckRetryBatchSize+1)
+	for i := 0; i <= reclaimCheckRetryBatchSize; i++ {
+		members = append(members, redis.Z{
+			Score:  float64(now.Add(-time.Second).UnixMilli()),
+			Member: "task-" + strconv.Itoa(i),
+		})
+	}
+	key := reclaimCheckScheduleKey("rt-a")
+	if err := rdb.ZAdd(ctx, key, members...).Err(); err != nil {
+		t.Fatalf("seed due hints: %v", err)
+	}
+	if err := rdb.Expire(ctx, key, ReclaimCheckScheduleTTL).Err(); err != nil {
+		t.Fatalf("expire due hints: %v", err)
+	}
+	cache.MarkChecked(ctx, []string{"rt-a"}, now, now.Add(ReclaimCheckRetryInterval))
+
+	// The Lua script deliberately defers only a bounded number of members. Any
+	// overflow remains due, forcing another DB pass instead of being hidden by
+	// the newly written backstop.
+	if due := cache.DueRuntimeIDs(ctx, []string{"rt-a"}, now.Add(time.Second)); len(due) != 1 {
+		t.Fatalf("overflow hint did not fail open to another check: %v", due)
 	}
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3084,7 +3084,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 		}
 
 		t0 = time.Now()
-		reclaimCheckAfter = t0.Add(claimResponseRecoveryWindow)
+		reclaimCheckAfter = t0.Add(claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin)
 		task, err := qtx.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
 			AgentID:          agentID,
 			RuntimeID:        claimRuntimeID,
@@ -3202,7 +3202,7 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 	// the UPDATE until a task hint or bounded DB backstop is due.
 	checkStarted := time.Now()
 	if due := s.ReclaimCheck.DueRuntimeIDs(ctx, []string{runtimeKey}, checkStarted); len(due) > 0 {
-		reclaimCheckAfter := time.Now().Add(claimResponseRecoveryWindow)
+		reclaimCheckAfter := time.Now().Add(claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin)
 		stale, err := s.Queries.ReclaimStaleDispatchedTaskForRuntime(ctx, db.ReclaimStaleDispatchedTaskForRuntimeParams{
 			RuntimeID:         runtimeID,
 			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
@@ -3210,7 +3210,12 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 			RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
 		})
 		if err == nil {
-			s.ReclaimCheck.MarkChecked(ctx, []string{runtimeKey}, checkStarted)
+			s.ReclaimCheck.MarkChecked(
+				ctx,
+				[]string{runtimeKey},
+				checkStarted,
+				time.Now().Add(ReclaimCheckRetryInterval),
+			)
 			s.trackTaskForReclaim(stale, reclaimCheckAfter)
 			outcome = "reclaimed_dispatched"
 			claimedFlag = true
@@ -3225,7 +3230,12 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 			outcome = "error_reclaim_dispatched"
 			return nil, fmt.Errorf("reclaim stale dispatched task: %w", err)
 		}
-		s.ReclaimCheck.MarkChecked(ctx, []string{runtimeKey}, checkStarted)
+		s.ReclaimCheck.MarkChecked(
+			ctx,
+			[]string{runtimeKey},
+			checkStarted,
+			time.Now().Add(ReclaimCheckRetryInterval),
+		)
 	}
 
 	if s.EmptyClaim.IsEmpty(ctx, runtimeKey) {
@@ -3456,7 +3466,7 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	var reclaimed []db.AgentTaskQueue
 	var reclaimCheckAfter time.Time
 	if len(dueKeys) > 0 {
-		reclaimCheckAfter = time.Now().Add(claimResponseRecoveryWindow)
+		reclaimCheckAfter = time.Now().Add(claimResponseRecoveryWindow + ReclaimCheckHintSafetyMargin)
 		reclaimed, err = s.Queries.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
 			RuntimeIds:        uniqueIDs,
 			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
@@ -3470,7 +3480,12 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		// The UPDATE's fixed setup/locking cost dominates array width. Query and
 		// advance the complete machine-level set together so per-runtime backstops
 		// cannot drift into one UPDATE on almost every daemon poll.
-		s.ReclaimCheck.MarkChecked(ctx, runtimeKeys, checkStarted)
+		s.ReclaimCheck.MarkChecked(
+			ctx,
+			runtimeKeys,
+			checkStarted,
+			time.Now().Add(ReclaimCheckRetryInterval),
+		)
 	}
 	for i := range reclaimed {
 		s.trackTaskForReclaim(reclaimed[i], reclaimCheckAfter)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -51,6 +51,10 @@ type TaskService struct {
 	// goes through the DB. Wired in router.go from the shared Redis
 	// client.
 	EmptyClaim *EmptyClaimCache
+	// ReclaimCheck schedules the next time a runtime can plausibly contain a
+	// stale dispatched task. It removes the unconditional reclaim UPDATE from
+	// idle claim polls while missing/error states preserve the DB fallback.
+	ReclaimCheck *ReclaimCheckCache
 	// Composio computes the per-task MCP overlay (Stage 3 of the Composio
 	// epic, MUL-3721) — the integration's "current user's connected apps
 	// → MCP session URL" hook called from each Enqueue* path. Optional: a
@@ -177,6 +181,40 @@ const (
 	claimResponseRecoveryWindow = 90 * time.Second
 	prepareLeaseDuration        = 45 * time.Second
 )
+
+func taskReclaimCheckAfter(task db.AgentTaskQueue) time.Time {
+	if !task.DispatchedAt.Valid {
+		return time.Time{}
+	}
+	checkAfter := task.DispatchedAt.Time.Add(claimResponseRecoveryWindow)
+	if task.PrepareLeaseExpiresAt.Valid && task.PrepareLeaseExpiresAt.Time.After(checkAfter) {
+		checkAfter = task.PrepareLeaseExpiresAt.Time
+	}
+	return checkAfter
+}
+
+func (s *TaskService) trackTaskForReclaim(task db.AgentTaskQueue) {
+	if !task.RuntimeID.Valid || task.Status != "dispatched" {
+		return
+	}
+	s.ReclaimCheck.Track(
+		context.Background(),
+		util.UUIDToString(task.RuntimeID),
+		util.UUIDToString(task.ID),
+		taskReclaimCheckAfter(task),
+	)
+}
+
+func (s *TaskService) forgetTaskReclaim(task db.AgentTaskQueue) {
+	if !task.RuntimeID.Valid || !task.ID.Valid {
+		return
+	}
+	s.ReclaimCheck.Forget(
+		context.Background(),
+		util.UUIDToString(task.RuntimeID),
+		util.UUIDToString(task.ID),
+	)
+}
 
 // buildCommentTriggerSummary fetches the comment content and truncates
 // it for storage on the task row. Returns an invalid pgtype.Text when
@@ -3084,6 +3122,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 	if claimed == nil {
 		return nil, nil
 	}
+	s.trackTaskForReclaim(*claimed)
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(claimed.ID), "agent_id", util.UUIDToString(agentID))
 	s.captureTaskDispatched(ctx, *claimed)
@@ -3144,27 +3183,34 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 		return nil, err
 	}
 
-	// Check this before EmptyClaim: a lost claim response moves the task out of
-	// `queued`, so the empty-queued cache cannot represent recoverability.
-	stale, err := s.Queries.ReclaimStaleDispatchedTaskForRuntime(ctx, db.ReclaimStaleDispatchedTaskForRuntimeParams{
-		RuntimeID:         runtimeID,
-		ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
-		PrepareLeaseSecs:  prepareLeaseDuration.Seconds(),
-		RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
-	})
-	if err == nil {
-		outcome = "reclaimed_dispatched"
-		claimedFlag = true
-		slog.Info("stale dispatched task reclaimed",
-			"task_id", util.UUIDToString(stale.ID),
-			"runtime_id", runtimeKey,
-			"agent_id", util.UUIDToString(stale.AgentID),
-		)
-		return &stale, nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
-		outcome = "error_reclaim_dispatched"
-		return nil, fmt.Errorf("reclaim stale dispatched task: %w", err)
+	// Keep stale-response recovery before EmptyClaim because the queued-only
+	// cache cannot represent dispatched work. ReclaimCheck independently skips
+	// the UPDATE until a task hint or bounded DB backstop is due.
+	checkStarted := time.Now()
+	if due := s.ReclaimCheck.DueRuntimeIDs(ctx, []string{runtimeKey}, checkStarted); len(due) > 0 {
+		stale, err := s.Queries.ReclaimStaleDispatchedTaskForRuntime(ctx, db.ReclaimStaleDispatchedTaskForRuntimeParams{
+			RuntimeID:         runtimeID,
+			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
+			PrepareLeaseSecs:  prepareLeaseDuration.Seconds(),
+			RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
+		})
+		if err == nil {
+			s.ReclaimCheck.MarkChecked(ctx, due, checkStarted, false)
+			s.trackTaskForReclaim(stale)
+			outcome = "reclaimed_dispatched"
+			claimedFlag = true
+			slog.Info("stale dispatched task reclaimed",
+				"task_id", util.UUIDToString(stale.ID),
+				"runtime_id", runtimeKey,
+				"agent_id", util.UUIDToString(stale.AgentID),
+			)
+			return &stale, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			outcome = "error_reclaim_dispatched"
+			return nil, fmt.Errorf("reclaim stale dispatched task: %w", err)
+		}
+		s.ReclaimCheck.MarkChecked(ctx, due, checkStarted, true)
 	}
 
 	if s.EmptyClaim.IsEmpty(ctx, runtimeKey) {
@@ -3293,6 +3339,7 @@ func (s *TaskService) RequeueTaskAfterClaimFailure(ctx context.Context, task db.
 	if err != nil {
 		return nil, fmt.Errorf("requeue task after claim failure: %w", err)
 	}
+	s.forgetTaskReclaim(requeued)
 	s.ReconcileAgentStatus(ctx, requeued.AgentID)
 	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, requeued)
 	s.notifyTaskAvailable(requeued)
@@ -3380,18 +3427,41 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		s.NotifyTaskEnqueued(ctx, task)
 	}
 
-	// 2. Reclaim lost-response dispatched tasks across the set, up to maxTasks.
-	reclaimed, err := s.Queries.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
-		RuntimeIds:        uniqueIDs,
-		ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
-		PrepareLeaseSecs:  prepareLeaseDuration.Seconds(),
-		RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
-		MaxTasks:          int32(maxTasks),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("reclaim stale dispatched tasks: %w", err)
+	// 2. Reclaim lost-response dispatched tasks only for runtimes whose task
+	// schedule or bounded DB backstop is due. A nil/missing/failed cache returns
+	// the complete runtime set and preserves the historical query path.
+	runtimeKeys := make([]string, 0, len(uniqueIDs))
+	for _, rid := range uniqueIDs {
+		runtimeKeys = append(runtimeKeys, util.UUIDToString(rid))
+	}
+	checkStarted := time.Now()
+	dueKeys := s.ReclaimCheck.DueRuntimeIDs(ctx, runtimeKeys, checkStarted)
+	dueSet := make(map[string]struct{}, len(dueKeys))
+	for _, key := range dueKeys {
+		dueSet[key] = struct{}{}
+	}
+	dueIDs := make([]pgtype.UUID, 0, len(dueSet))
+	for _, rid := range uniqueIDs {
+		if _, ok := dueSet[util.UUIDToString(rid)]; ok {
+			dueIDs = append(dueIDs, rid)
+		}
+	}
+	var reclaimed []db.AgentTaskQueue
+	if len(dueIDs) > 0 {
+		reclaimed, err = s.Queries.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
+			RuntimeIds:        dueIDs,
+			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
+			PrepareLeaseSecs:  prepareLeaseDuration.Seconds(),
+			RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
+			MaxTasks:          int32(maxTasks),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reclaim stale dispatched tasks: %w", err)
+		}
+		s.ReclaimCheck.MarkChecked(ctx, dueKeys, checkStarted, len(reclaimed) < maxTasks)
 	}
 	for i := range reclaimed {
+		s.trackTaskForReclaim(reclaimed[i])
 		claimed = append(claimed, reclaimed[i])
 		slog.Info("stale dispatched task reclaimed (batch)",
 			"task_id", util.UUIDToString(reclaimed[i].ID),
@@ -3581,6 +3651,7 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 	if err != nil {
 		return nil, fmt.Errorf("start task: %w", err)
 	}
+	s.forgetTaskReclaim(task)
 	s.cancelDeferredEscalationsForTask(ctx, task.ID)
 
 	slog.Info("task started", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
@@ -3648,6 +3719,11 @@ func (s *TaskService) ExtendTaskPrepareLease(ctx context.Context, taskID, runtim
 	if err != nil {
 		return nil, fmt.Errorf("extend task prepare lease: %w", err)
 	}
+	if task.Status == "dispatched" {
+		s.trackTaskForReclaim(task)
+	} else {
+		s.forgetTaskReclaim(task)
+	}
 	return &task, nil
 }
 
@@ -3667,6 +3743,7 @@ func (s *TaskService) MarkTaskWaitingLocalDirectory(ctx context.Context, taskID 
 	if err != nil {
 		return nil, fmt.Errorf("mark task waiting_local_directory: %w", err)
 	}
+	s.forgetTaskReclaim(task)
 
 	slog.Info("task waiting_local_directory",
 		"task_id", util.UUIDToString(task.ID),
@@ -6003,6 +6080,7 @@ func (s *TaskService) NotifyTaskEnqueued(ctx context.Context, task db.AgentTaskQ
 // is not available; the hint only means that a queued successor may have
 // become claimable because an agent-capacity or serialization barrier cleared.
 func (s *TaskService) NotifyTaskFinished(task db.AgentTaskQueue) {
+	s.forgetTaskReclaim(task)
 	s.notifyRuntimeMayHaveWork(task.RuntimeID, "")
 }
 
@@ -6012,6 +6090,7 @@ func (s *TaskService) NotifyTaskFinished(task db.AgentTaskQueue) {
 func (s *TaskService) notifyTasksFinished(tasks []db.AgentTaskQueue) {
 	seen := make(map[string]struct{}, len(tasks))
 	for _, task := range tasks {
+		s.forgetTaskReclaim(task)
 		if !task.RuntimeID.Valid {
 			continue
 		}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -182,26 +182,36 @@ const (
 	prepareLeaseDuration        = 45 * time.Second
 )
 
-func taskReclaimCheckAfter(task db.AgentTaskQueue) time.Time {
-	if !task.DispatchedAt.Valid {
-		return time.Time{}
-	}
-	checkAfter := task.DispatchedAt.Time.Add(claimResponseRecoveryWindow)
-	if task.PrepareLeaseExpiresAt.Valid && task.PrepareLeaseExpiresAt.Time.After(checkAfter) {
-		checkAfter = task.PrepareLeaseExpiresAt.Time
-	}
-	return checkAfter
-}
-
-func (s *TaskService) trackTaskForReclaim(task db.AgentTaskQueue) {
-	if !task.RuntimeID.Valid || task.Status != "dispatched" {
+func (s *TaskService) trackTaskForReclaim(task db.AgentTaskQueue, checkAfter time.Time) {
+	if !task.RuntimeID.Valid || !task.ID.Valid || task.Status != "dispatched" {
 		return
 	}
+	// The Redis hint is advisory and intentionally uses an application-clock
+	// elapsed deadline captured beside the DB command. Comparing PostgreSQL's
+	// absolute dispatched_at/lease timestamps with time.Now would mix clocks;
+	// PostgreSQL remains authoritative when the reclaim query actually runs.
+	// A bounded background context lets this best-effort write outlive a request
+	// cancellation without allowing Redis to stall the hot path indefinitely.
 	s.ReclaimCheck.Track(
 		context.Background(),
 		util.UUIDToString(task.RuntimeID),
 		util.UUIDToString(task.ID),
-		taskReclaimCheckAfter(task),
+		checkAfter,
+	)
+}
+
+func (s *TaskService) extendTaskReclaimHint(task db.AgentTaskQueue, checkAfter time.Time) {
+	if !task.RuntimeID.Valid || !task.ID.Valid || task.Status != "dispatched" {
+		return
+	}
+	// Preserve a later initial recovery deadline; a short prepare lease should
+	// only move the hint when repeated extensions actually protect the task for
+	// longer. See trackTaskForReclaim for the clock/context rationale.
+	s.ReclaimCheck.TrackLater(
+		context.Background(),
+		util.UUIDToString(task.RuntimeID),
+		util.UUIDToString(task.ID),
+		checkAfter,
 	)
 }
 
@@ -209,6 +219,8 @@ func (s *TaskService) forgetTaskReclaim(task db.AgentTaskQueue) {
 	if !task.RuntimeID.Valid || !task.ID.Valid {
 		return
 	}
+	// This cleanup is best-effort and uses the cache's bounded timeout; request
+	// cancellation must not make a committed task transition leave a stale hint.
 	s.ReclaimCheck.Forget(
 		context.Background(),
 		util.UUIDToString(task.RuntimeID),
@@ -3036,6 +3048,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 	outcome := "unknown"
 	var getAgentMs, countRunningMs, claimAgentMs, reanchorMs, updateStatusMs, dispatchMs int64
 	var claimed *db.AgentTaskQueue
+	var reclaimCheckAfter time.Time
 	defer func() {
 		s.maybeLogClaimSlow(agentID, outcome, start, getAgentMs, countRunningMs, claimAgentMs, reanchorMs, updateStatusMs, dispatchMs)
 	}()
@@ -3071,6 +3084,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 		}
 
 		t0 = time.Now()
+		reclaimCheckAfter = t0.Add(claimResponseRecoveryWindow)
 		task, err := qtx.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
 			AgentID:          agentID,
 			RuntimeID:        claimRuntimeID,
@@ -3122,7 +3136,7 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 	if claimed == nil {
 		return nil, nil
 	}
-	s.trackTaskForReclaim(*claimed)
+	s.trackTaskForReclaim(*claimed, reclaimCheckAfter)
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(claimed.ID), "agent_id", util.UUIDToString(agentID))
 	s.captureTaskDispatched(ctx, *claimed)
@@ -3188,6 +3202,7 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 	// the UPDATE until a task hint or bounded DB backstop is due.
 	checkStarted := time.Now()
 	if due := s.ReclaimCheck.DueRuntimeIDs(ctx, []string{runtimeKey}, checkStarted); len(due) > 0 {
+		reclaimCheckAfter := time.Now().Add(claimResponseRecoveryWindow)
 		stale, err := s.Queries.ReclaimStaleDispatchedTaskForRuntime(ctx, db.ReclaimStaleDispatchedTaskForRuntimeParams{
 			RuntimeID:         runtimeID,
 			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
@@ -3195,8 +3210,8 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 			RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
 		})
 		if err == nil {
-			s.ReclaimCheck.MarkChecked(ctx, due, checkStarted, false)
-			s.trackTaskForReclaim(stale)
+			s.ReclaimCheck.MarkChecked(ctx, []string{runtimeKey}, checkStarted)
+			s.trackTaskForReclaim(stale, reclaimCheckAfter)
 			outcome = "reclaimed_dispatched"
 			claimedFlag = true
 			slog.Info("stale dispatched task reclaimed",
@@ -3210,7 +3225,7 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 			outcome = "error_reclaim_dispatched"
 			return nil, fmt.Errorf("reclaim stale dispatched task: %w", err)
 		}
-		s.ReclaimCheck.MarkChecked(ctx, due, checkStarted, true)
+		s.ReclaimCheck.MarkChecked(ctx, []string{runtimeKey}, checkStarted)
 	}
 
 	if s.EmptyClaim.IsEmpty(ctx, runtimeKey) {
@@ -3427,29 +3442,23 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		s.NotifyTaskEnqueued(ctx, task)
 	}
 
-	// 2. Reclaim lost-response dispatched tasks only for runtimes whose task
-	// schedule or bounded DB backstop is due. A nil/missing/failed cache returns
-	// the complete runtime set and preserves the historical query path.
+	// 2. Reclaim lost-response dispatched tasks when any runtime's task schedule
+	// or bounded DB backstop is due. The query always receives the complete
+	// machine-level set so per-runtime backstops stay aligned and fixed UPDATE
+	// setup/locking cost is paid at a predictable cadence. A nil/missing/failed
+	// cache preserves the historical query path.
 	runtimeKeys := make([]string, 0, len(uniqueIDs))
 	for _, rid := range uniqueIDs {
 		runtimeKeys = append(runtimeKeys, util.UUIDToString(rid))
 	}
 	checkStarted := time.Now()
 	dueKeys := s.ReclaimCheck.DueRuntimeIDs(ctx, runtimeKeys, checkStarted)
-	dueSet := make(map[string]struct{}, len(dueKeys))
-	for _, key := range dueKeys {
-		dueSet[key] = struct{}{}
-	}
-	dueIDs := make([]pgtype.UUID, 0, len(dueSet))
-	for _, rid := range uniqueIDs {
-		if _, ok := dueSet[util.UUIDToString(rid)]; ok {
-			dueIDs = append(dueIDs, rid)
-		}
-	}
 	var reclaimed []db.AgentTaskQueue
-	if len(dueIDs) > 0 {
+	var reclaimCheckAfter time.Time
+	if len(dueKeys) > 0 {
+		reclaimCheckAfter = time.Now().Add(claimResponseRecoveryWindow)
 		reclaimed, err = s.Queries.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
-			RuntimeIds:        dueIDs,
+			RuntimeIds:        uniqueIDs,
 			ClaimRecoverySecs: claimResponseRecoveryWindow.Seconds(),
 			PrepareLeaseSecs:  prepareLeaseDuration.Seconds(),
 			RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
@@ -3458,10 +3467,13 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		if err != nil {
 			return nil, fmt.Errorf("reclaim stale dispatched tasks: %w", err)
 		}
-		s.ReclaimCheck.MarkChecked(ctx, dueKeys, checkStarted, len(reclaimed) < maxTasks)
+		// The UPDATE's fixed setup/locking cost dominates array width. Query and
+		// advance the complete machine-level set together so per-runtime backstops
+		// cannot drift into one UPDATE on almost every daemon poll.
+		s.ReclaimCheck.MarkChecked(ctx, runtimeKeys, checkStarted)
 	}
 	for i := range reclaimed {
-		s.trackTaskForReclaim(reclaimed[i])
+		s.trackTaskForReclaim(reclaimed[i], reclaimCheckAfter)
 		claimed = append(claimed, reclaimed[i])
 		slog.Info("stale dispatched task reclaimed (batch)",
 			"task_id", util.UUIDToString(reclaimed[i].ID),
@@ -3720,7 +3732,11 @@ func (s *TaskService) ExtendTaskPrepareLease(ctx context.Context, taskID, runtim
 		return nil, fmt.Errorf("extend task prepare lease: %w", err)
 	}
 	if task.Status == "dispatched" {
-		s.trackTaskForReclaim(task)
+		// Use the successful response time as a conservative application-clock
+		// approximation of the DB lease start. Scheduling slightly late by query
+		// latency is safer than an early failed check suppressing the hint until
+		// the next backstop.
+		s.extendTaskReclaimHint(task, time.Now().Add(prepareLeaseDuration))
 	} else {
 		s.forgetTaskReclaim(task)
 	}
@@ -6090,10 +6106,10 @@ func (s *TaskService) NotifyTaskFinished(task db.AgentTaskQueue) {
 func (s *TaskService) notifyTasksFinished(tasks []db.AgentTaskQueue) {
 	seen := make(map[string]struct{}, len(tasks))
 	for _, task := range tasks {
-		s.forgetTaskReclaim(task)
 		if !task.RuntimeID.Valid {
 			continue
 		}
+		s.forgetTaskReclaim(task)
 		runtimeKey := util.UUIDToString(task.RuntimeID)
 		if _, ok := seen[runtimeKey]; ok {
 			continue

--- a/server/internal/service/task_batch_claim_test.go
+++ b/server/internal/service/task_batch_claim_test.go
@@ -165,6 +165,59 @@ func TestClaimTasksForRuntimes_MaxTasksCap(t *testing.T) {
 	}
 }
 
+// TestClaimTasksForRuntimes_AnyDueRuntimeChecksTheCompleteSet pins MUL-6486's
+// collection-level reclaim gate. Per-runtime backstops can begin staggered, but
+// one due member must run the single UPDATE over every runtime on that daemon;
+// filtering the SQL array to only the due member both misses recoverable work
+// and lets fixed query overhead drift back toward one call per poll.
+func TestClaimTasksForRuntimes_AnyDueRuntimeChecksTheCompleteSet(t *testing.T) {
+	ctx := context.Background()
+	rdb := newRedisTestClient(t)
+	pool := newTaskClaimRacePool(t)
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.ReclaimCheck = NewReclaimCheckCache(rdb)
+
+	rt1, rt2 := batchClaimFixture(t, ctx, pool)
+	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
+
+	var staleTaskID string
+	if err := pool.QueryRow(ctx, `
+		SELECT id FROM agent_task_queue
+		WHERE runtime_id = $1
+		ORDER BY created_at
+		LIMIT 1
+	`, rt2).Scan(&staleTaskID); err != nil {
+		t.Fatalf("load rt2 task: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'dispatched', dispatched_at = now() - interval '10 minutes',
+		    started_at = NULL, prepare_lease_expires_at = NULL
+		WHERE id = $1
+	`, staleTaskID); err != nil {
+		t.Fatalf("make rt2 task stale: %v", err)
+	}
+
+	now := time.Now()
+	svc.ReclaimCheck.MarkChecked(ctx, []string{rt1}, now.Add(-ReclaimCheckBackstopInterval-time.Second))
+	svc.ReclaimCheck.MarkChecked(ctx, []string{rt2}, now)
+	due := svc.ReclaimCheck.DueRuntimeIDs(ctx, []string{rt1, rt2}, now)
+	if len(due) != 1 || due[0] != rt1 {
+		t.Fatalf("precondition due runtimes = %v, want [%s]", due, rt1)
+	}
+
+	claimed, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	if err != nil {
+		t.Fatalf("batch claim: %v", err)
+	}
+	for _, task := range claimed {
+		if util.UUIDToString(task.ID) == staleTaskID {
+			return
+		}
+	}
+	t.Fatalf("batch claim omitted stale task %s on non-due runtime %s: got %v", staleTaskID, rt2, claimed)
+}
+
 // TestClaimTasksForRuntimes_EmptyInputs guards the trivial short-circuits.
 func TestClaimTasksForRuntimes_EmptyInputs(t *testing.T) {
 	ctx := context.Background()

--- a/server/internal/service/task_batch_claim_test.go
+++ b/server/internal/service/task_batch_claim_test.go
@@ -199,8 +199,13 @@ func TestClaimTasksForRuntimes_AnyDueRuntimeChecksTheCompleteSet(t *testing.T) {
 	}
 
 	now := time.Now()
-	svc.ReclaimCheck.MarkChecked(ctx, []string{rt1}, now.Add(-ReclaimCheckBackstopInterval-time.Second))
-	svc.ReclaimCheck.MarkChecked(ctx, []string{rt2}, now)
+	svc.ReclaimCheck.MarkChecked(
+		ctx,
+		[]string{rt1},
+		now.Add(-ReclaimCheckBackstopInterval-time.Second),
+		now.Add(ReclaimCheckRetryInterval),
+	)
+	svc.ReclaimCheck.MarkChecked(ctx, []string{rt2}, now, now.Add(ReclaimCheckRetryInterval))
 	due := svc.ReclaimCheck.DueRuntimeIDs(ctx, []string{rt1, rt2}, now)
 	if len(due) != 1 || due[0] != rt1 {
 		t.Fatalf("precondition due runtimes = %v, want [%s]", due, rt1)
@@ -216,6 +221,82 @@ func TestClaimTasksForRuntimes_AnyDueRuntimeChecksTheCompleteSet(t *testing.T) {
 		}
 	}
 	t.Fatalf("batch claim omitted stale task %s on non-due runtime %s: got %v", staleTaskID, rt2, claimed)
+}
+
+// TestClaimTasksForRuntimes_EmptyReclaimDefersHintForRetry covers the recovery
+// hole where the task hint was previously made inert after one empty UPDATE.
+// A temporarily stale runtime heartbeat is intentionally correlated with a
+// lost claim response: the task remains dispatched, and its hint must become
+// due again after the short retry rather than waiting for the 90-second
+// backstop.
+func TestClaimTasksForRuntimes_EmptyReclaimDefersHintForRetry(t *testing.T) {
+	ctx := context.Background()
+	rdb := newRedisTestClient(t)
+	pool := newTaskClaimRacePool(t)
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.ReclaimCheck = NewReclaimCheckCache(rdb)
+
+	rt1, _ := batchClaimFixture(t, ctx, pool)
+	runtimeID := util.MustParseUUID(rt1)
+	var taskID string
+	if err := pool.QueryRow(ctx, `
+		SELECT id FROM agent_task_queue
+		WHERE runtime_id = $1
+		ORDER BY created_at
+		LIMIT 1
+	`, rt1).Scan(&taskID); err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'dispatched', dispatched_at = now() - interval '10 minutes',
+		    started_at = NULL, prepare_lease_expires_at = NULL
+		WHERE id = $1
+	`, taskID); err != nil {
+		t.Fatalf("make task stale: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE agent_runtime
+		SET status = 'online', last_seen_at = now() - interval '10 minutes'
+		WHERE id = $1
+	`, rt1); err != nil {
+		t.Fatalf("make runtime temporarily ineligible: %v", err)
+	}
+
+	now := time.Now()
+	svc.ReclaimCheck.MarkChecked(ctx, []string{rt1}, now, now.Add(ReclaimCheckRetryInterval))
+	svc.ReclaimCheck.Track(ctx, rt1, taskID, now.Add(-time.Second))
+	if due := svc.ReclaimCheck.DueRuntimeIDs(ctx, []string{rt1}, now); len(due) != 1 {
+		t.Fatalf("precondition due runtimes = %v, want [%s]", due, rt1)
+	}
+
+	if claimed, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{runtimeID}, 5); err != nil {
+		t.Fatalf("batch claim: %v", err)
+	} else if len(claimed) != 0 {
+		t.Fatalf("claimed tasks with stale runtime heartbeat: %v", claimed)
+	}
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+		t.Fatalf("read task after empty reclaim: %v", err)
+	}
+	if status != "dispatched" {
+		t.Fatalf("task status after empty reclaim = %q, want dispatched", status)
+	}
+
+	score, err := rdb.ZScore(ctx, reclaimCheckScheduleKey(rt1), taskID).Result()
+	if err != nil {
+		t.Fatalf("read deferred hint: %v", err)
+	}
+	retryAt := time.UnixMilli(int64(score))
+	if retryAt.Before(now.Add(ReclaimCheckRetryInterval)) || retryAt.After(time.Now().Add(ReclaimCheckRetryInterval+time.Second)) {
+		t.Fatalf("retry hint = %v, want approximately one retry interval after the check", retryAt)
+	}
+	if due := svc.ReclaimCheck.DueRuntimeIDs(ctx, []string{rt1}, retryAt.Add(-time.Millisecond)); len(due) != 0 {
+		t.Fatalf("hint retriggered before retry deadline: %v", due)
+	}
+	if due := svc.ReclaimCheck.DueRuntimeIDs(ctx, []string{rt1}, retryAt.Add(time.Millisecond)); len(due) != 1 {
+		t.Fatalf("hint did not retrigger after empty reclaim: %v", due)
+	}
 }
 
 // TestClaimTasksForRuntimes_EmptyInputs guards the trivial short-circuits.

--- a/server/migrations/390_agent_task_queue_dispatched_reclaim_v2_index.down.sql
+++ b/server/migrations/390_agent_task_queue_dispatched_reclaim_v2_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_dispatched_reclaim_v2;

--- a/server/migrations/390_agent_task_queue_dispatched_reclaim_v2_index.up.sql
+++ b/server/migrations/390_agent_task_queue_dispatched_reclaim_v2_index.up.sql
@@ -1,0 +1,5 @@
+-- Put dispatched_at directly after runtime_id so stale-reclaim scans can use
+-- both equality and time-range conditions before applying the priority sort.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_dispatched_reclaim_v2
+    ON agent_task_queue (runtime_id, dispatched_at ASC, priority DESC)
+    WHERE status = 'dispatched' AND started_at IS NULL;

--- a/server/migrations/391_drop_agent_task_queue_dispatched_prepare_index.down.sql
+++ b/server/migrations/391_drop_agent_task_queue_dispatched_prepare_index.down.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_dispatched_prepare
+    ON agent_task_queue (runtime_id, priority DESC, dispatched_at ASC)
+    WHERE status = 'dispatched' AND started_at IS NULL;

--- a/server/migrations/391_drop_agent_task_queue_dispatched_prepare_index.up.sql
+++ b/server/migrations/391_drop_agent_task_queue_dispatched_prepare_index.up.sql
@@ -1,0 +1,3 @@
+-- Migration 390 replaces this index with the same partial predicate and a key
+-- order that makes dispatched_at usable as a stale-reclaim range condition.
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_dispatched_prepare;


### PR DESCRIPTION
## Summary

- gate singular and batch stale-dispatch reclaim queries with a per-task Redis schedule, while failing open to PostgreSQL on cache misses or Redis errors
- run one reclaim UPDATE over the complete machine-level runtime set when any member is due, then align the full set on the same 90-second backstop cadence
- defer checked-but-unreclaimed hints by 30 seconds instead of making them inert until the backstop; this covers `SKIP LOCKED`, temporarily stale runtime heartbeats, and boundary timing
- replace Redis 6.2-only `ZADD GT` with atomic Lua built from older Redis primitives, and preserve input ordering from `DueRuntimeIDs`
- replace the dispatched-task index with `(runtime_id, dispatched_at ASC, priority DESC)` and remove the redundant prior index in a separate concurrent migration
- register both concurrent index build directions with the migrator's invalid-index retry cleanup

## Safety and rollout

- Redis remains advisory: nil, missing, malformed, expired, or failed state preserves the previous database reclaim path
- fresh task hints include a 5-second command-commit safety margin; schedule ZSETs live for 185 seconds, strictly beyond the 95-second first hint, while the independent DB backstop remains 90 seconds
- a completed DB pass atomically moves only hints due when that pass began; concurrent newer hints are untouched, and the retry does not extend the schedule's hard TTL
- retry work is capped at 256 hints per runtime per pass; overflow remains due and therefore fails open to another DB pass instead of being suppressed
- Redis hint and last-checked scores use application-relative deadlines; PostgreSQL remains authoritative for actual reclaim eligibility
- the Lua path uses Redis 2.6-era commands and was exercised against Redis 6.0, so self-hosted deployments do not need a new Redis minimum version
- migration 390 creates the replacement index before migration 391 drops the old one; both are concurrent and their down migrations restore the reverse order safely
- old and new application versions remain compatible throughout the two-migration rollout

## Validation

- `go test -race ./internal/service -count=1` with Redis 7 and a clean isolated PostgreSQL database
- reclaim-cache regression suite against Redis 6.0
- `go test ./cmd/server -count=1`
- `go test ./cmd/migrate -count=1`
- `go vet ./internal/service ./cmd/migrate ./cmd/server`
- regressions cover the production hint span plus safety margin, empty reclaim retry with a temporarily stale runtime heartbeat, concurrent newer hints, bounded retry overflow, stable runtime ordering, later prepare leases, aligned multi-runtime backstops, and reclaiming from a non-due runtime when another member triggers the collection check
- isolated PostgreSQL migrations applied cleanly from an empty database; the earlier `up -> down -> re-apply` cycle also verified exact old/new index presence

The cache writes on dispatch/lease/transition paths remain synchronous and bounded by the existing 250 ms Redis timeout. Making them asynchronous safely requires a bounded worker queue plus shutdown/drain and dropped-write observability, which is intentionally left out of this performance fix rather than adding unbounded goroutines.

Follow-up: MUL-6526 verifies prepared-statement reuse and planning cost in production or equivalent staging.

Closes MUL-6486
