### PR TITLE
fix(daemon): add the reference fact to the Mentions brief — @-as-attribution is not a mention need (MUL-6528)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5046,6 +5046,11 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			"completion notifications are platform-owned",
 			// The one real function, with its scope.
 			"pulls someone into work they are not doing yet",
+			// The reference fact (MUL-6528): @-as-attribution ("per @X's
+			// decision") read as a way to write a name and dispatched the
+			// agent being credited.
+			"prose about them, not work for them",
+			"so a reference stays plain text",
 			// The courtesy-loop fact (the incident class behind #1581/#6453).
 			"whose only possible reply is another courtesy",
 			// The asymmetry that breaks ambiguous cases toward not mentioning.

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -699,13 +699,16 @@ func writeMentions(b *strings.Builder) {
 	// invalidate the human-@-culture prior (cc-for-visibility, thanks-@X),
 	// not a rule. Every real incident was an agent acting on a false need:
 	// notifying followers who already see the comment (completion wakes are
-	// platform-owned too) or courtesy (a thank-you run whose only reply is
-	// another thank-you run). The notify caveat is scoped to FOLLOWERS on
+	// platform-owned too), courtesy (a thank-you run whose only reply is
+	// another thank-you run), or reference — the @-form used merely to write
+	// someone's name (MUL-6528: an agent attributing a product decision to
+	// "@Steve Jobs" in prose enqueued a run for the agent it was crediting).
+	// The notify caveat is scoped to FOLLOWERS on
 	// purpose — for a human who does not follow the issue, a mention is
 	// exactly how they find out, and that escalation must stay available
 	// (Elon's review catch on #7245). The cost asymmetry line is what breaks
 	// the ambiguous middle.
-	b.WriteString("A mention pulls someone into work they are not doing yet: escalate to a human owner, hand another agent a concrete new sub-task, loop someone in because the user asked. It is not needed merely to notify — followers of the issue already see your comment, and completion notifications are platform-owned. A thank-you / sign-off / FYI mention of another agent enqueues a paid run whose only possible reply is another courtesy; a missed mention costs one follow-up ask, a stray one costs a run. Silence ends conversations.\n\n")
+	b.WriteString("A mention pulls someone into work they are not doing yet: escalate to a human owner, hand another agent a concrete new sub-task, loop someone in because the user asked. It is not needed merely to notify — followers of the issue already see your comment, and completion notifications are platform-owned. Nor is it how a name is written — crediting a decision or citing someone's earlier point is prose about them, not work for them; the link form dispatches whoever it names, so a reference stays plain text. A thank-you / sign-off / FYI mention of another agent enqueues a paid run whose only possible reply is another courtesy; a missed mention costs one follow-up ask, a stray one costs a run. Silence ends conversations.\n\n")
 }
 
 // writeAttachments emits the Attachments pointer.


### PR DESCRIPTION
## Problem (MUL-6528)

After MUL-6417 (#7245) rewrote the `## Mentions` brief from a prescriptive rule to invalidating facts, an agent attributing a product decision in prose — "产品决策按 @Steve Jobs 的判断走" — used the `[@Name](mention://agent/…)` form and enqueued a run for the agent it was merely crediting.

## Root cause

The MUL-6417 paragraph invalidates two false priors from human @-culture: notify-for-visibility (followers already see the comment) and courtesy/thank-you (a paid run whose only reply is another courtesy). It is silent on the third prior: **@ as the way to write someone's name**. An agent doing attribution is neither notifying nor thanking, so neither existing fact applies, and "pulls someone into work" doesn't obviously exclude a reference — the syntax reads like a spelling of a name but is a dispatch.

## Fix

Add the missing fact in the section's established style (fact + why, no prescriptive rule):

> Nor is it how a name is written — crediting a decision or citing someone's earlier point is prose about them, not work for them; the link form dispatches whoever it names, so a reference stays plain text.

Also records MUL-6528 in the section's design comment and pins the new fact in `TestInjectRuntimeConfigMentionLoopHardening` alongside the existing ones.

## Verification

- `go test ./internal/daemon/execenv/ -count=1` — passes (with `MULTICA_TASK_CONFIG_ROOT` unset; the four Hermes path-layout tests fail on clean `main` too when that agent-runtime env var leaks in — pre-existing, unrelated).
- `gofmt -l` / `go vet` clean.
