### PR TITLE
fix(views): offer Europe/Kyiv instead of legacy Europe/Kiev in timezone pickers

### DIFF
--- a/packages/views/common/timezone-select.test.tsx
+++ b/packages/views/common/timezone-select.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TimezoneSelect,
+  canonicalizeTimezone,
+  resetBrowserTimezoneCache,
+  timezoneOptions,
+} from "./timezone-select";
+
+function renderTimezoneSelect(
+  value: string,
+  props: Partial<{ browserSuffix: string }> = {},
+) {
+  render(
+    <TimezoneSelect
+      value={value}
+      onValueChange={() => {}}
+      browserSuffix={props.browserSuffix ?? ""}
+    />,
+  );
+}
+
+function stubResolvedTimeZone(tz: string) {
+  const real = Intl.DateTimeFormat;
+  const Impl = function (
+    this: unknown,
+    locales?: string | string[],
+    options?: Intl.DateTimeFormatOptions,
+  ) {
+    if (!options || Object.keys(options).length === 0) {
+      return {
+        resolvedOptions: () => ({ timeZone: tz }),
+      } as unknown as Intl.DateTimeFormat;
+    }
+    return new real(locales, options);
+  } as unknown as typeof Intl.DateTimeFormat;
+  Object.defineProperty(Intl, "DateTimeFormat", {
+    value: Impl,
+    configurable: true,
+    writable: true,
+  });
+}
+
+const realSupportedValuesOf = Intl.supportedValuesOf;
+const realDateTimeFormat = Intl.DateTimeFormat;
+
+function stubSupported(values: string[] | undefined) {
+  Object.defineProperty(Intl, "supportedValuesOf", {
+    value: values
+      ? (((_key: "timeZone") => values) as typeof Intl.supportedValuesOf)
+      : undefined,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function stubDateTimeFormat(throwFor: string[]) {
+  const Impl = function (
+    this: unknown,
+    _locales?: string | string[],
+    options?: Intl.DateTimeFormatOptions,
+  ) {
+    if (options?.timeZone && throwFor.includes(options.timeZone)) {
+      throw new RangeError(`Invalid time zone: ${options.timeZone}`);
+    }
+    return new realDateTimeFormat(undefined, options);
+  } as unknown as typeof Intl.DateTimeFormat;
+  Object.defineProperty(Intl, "DateTimeFormat", {
+    value: Impl,
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  resetBrowserTimezoneCache();
+});
+
+afterEach(() => {
+  Object.defineProperty(Intl, "supportedValuesOf", {
+    value: realSupportedValuesOf,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(Intl, "DateTimeFormat", {
+    value: realDateTimeFormat,
+    configurable: true,
+    writable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("timezoneOptions legacy aliases", () => {
+  it("maps Europe/Kiev to Europe/Kyiv when only the legacy name is reported", () => {
+    stubSupported(["Europe/Kiev", "UTC"]);
+    const options = timezoneOptions("UTC");
+    expect(options).toContain("Europe/Kyiv");
+    expect(options).not.toContain("Europe/Kiev");
+  });
+
+  it("collapses both names to a single Europe/Kyiv entry", () => {
+    stubSupported(["Europe/Kiev", "Europe/Kyiv", "UTC"]);
+    const options = timezoneOptions("UTC");
+    expect(options.filter((tz) => tz === "Europe/Kyiv")).toHaveLength(1);
+    expect(options).not.toContain("Europe/Kiev");
+  });
+
+  it("keeps a stored legacy value selectable without throwing", () => {
+    stubSupported(["Europe/Kiev", "UTC"]);
+    expect(() => timezoneOptions("Europe/Kiev")).not.toThrow();
+  });
+
+  it("renders a stored legacy value as its modern name in the trigger", () => {
+    stubSupported(["Europe/Kiev", "UTC"]);
+    renderTimezoneSelect("Europe/Kiev");
+    expect(screen.getByRole("combobox")).toHaveTextContent("Europe/Kyiv");
+    expect(screen.getByRole("combobox")).not.toHaveTextContent("Europe/Kiev");
+  });
+
+  it("marks the canonicalized browser zone with the browser suffix", () => {
+    stubSupported(["Europe/Kiev", "UTC"]);
+    stubResolvedTimeZone("Europe/Kiev");
+    resetBrowserTimezoneCache();
+    renderTimezoneSelect("Europe/Kiev", { browserSuffix: " (browser)" });
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "Europe/Kyiv (browser)",
+    );
+  });
+
+  it("keeps the legacy name on an old ICU build that rejects the modern name", () => {
+    stubSupported(["Europe/Kiev", "UTC"]);
+    stubDateTimeFormat(["Europe/Kyiv"]);
+    const options = timezoneOptions("UTC");
+    expect(options).toContain("Europe/Kiev");
+    expect(options).not.toContain("Europe/Kyiv");
+  });
+
+  it("falls back to COMMON_TIMEZONES when supportedValuesOf is missing", () => {
+    stubSupported(undefined);
+    const options = timezoneOptions("UTC");
+    expect(options).toContain("UTC");
+  });
+});
+
+describe("canonicalizeTimezone", () => {
+  it("returns an unmapped identifier unchanged", () => {
+    expect(canonicalizeTimezone("Asia/Tokyo")).toBe("Asia/Tokyo");
+  });
+
+  it("maps a known legacy identifier to its modern name", () => {
+    expect(canonicalizeTimezone("Europe/Kiev")).toBe("Europe/Kyiv");
+  });
+});

--- a/packages/views/common/timezone-select.tsx
+++ b/packages/views/common/timezone-select.tsx
@@ -69,10 +69,47 @@ function supportedTimezones(): string[] {
   }
 }
 
+// IANA renamed identifiers, mapped to their current names. Each entry
+// cites the tzdata release that made the rename (NEWS file).
+// Renamed in tzdata 2022b.
+export const LEGACY_TIMEZONE_ALIASES: Record<string, string> = {
+  "Europe/Kiev": "Europe/Kyiv",
+};
+
+// Returns the modern name for a legacy identifier, or the input when it
+// is not a known rename.
+export function canonicalizeTimezone(tz: string): string {
+  return LEGACY_TIMEZONE_ALIASES[tz] ?? tz;
+}
+
+function runtimeAccepts(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Canonicalize an identifier for this runtime: map a legacy rename to its
+// modern name, but keep the legacy name when the runtime's ICU is too old
+// to format the modern identifier.
+function canonicalizeForRuntime(tz: string): string {
+  const mapped = canonicalizeTimezone(tz);
+  return mapped !== tz && runtimeAccepts(mapped) ? mapped : tz;
+}
+
 export function timezoneOptions(current: string): string[] {
   const browser = browserTimezone();
+  // Canonicalize before dedupe so a legacy name and its modern name
+  // collapse to one option.
   return Array.from(
-    new Set([current, browser, ...COMMON_TIMEZONES, ...supportedTimezones()]),
+    new Set([
+      canonicalizeForRuntime(current),
+      canonicalizeForRuntime(browser),
+      ...COMMON_TIMEZONES,
+      ...supportedTimezones().map(canonicalizeForRuntime),
+    ]),
   ).filter(Boolean);
 }
 
@@ -89,8 +126,9 @@ export function TimezoneSelect({
   disabled?: boolean;
   triggerClassName?: string;
 }) {
-  const browser = browserTimezone();
-  const options = timezoneOptions(value);
+  const browser = canonicalizeForRuntime(browserTimezone());
+  const canonicalValue = canonicalizeForRuntime(value);
+  const options = timezoneOptions(canonicalValue);
   const render = (tz: string) =>
     tz === browser ? `${tz}${browserSuffix}` : tz;
   const items = options.map((value) => ({ value, label: render(value) }));
@@ -98,7 +136,7 @@ export function TimezoneSelect({
   return (
     <Select
       items={items}
-      value={value}
+      value={canonicalValue}
       disabled={disabled}
       onValueChange={(next) => {
         if (next) onValueChange(next);
@@ -108,7 +146,7 @@ export function TimezoneSelect({
         size="sm"
         className={triggerClassName ?? "w-full rounded-md font-mono text-caption"}
       >
-        <SelectValue>{render(value)}</SelectValue>
+        <SelectValue>{render(canonicalValue)}</SelectValue>
       </SelectTrigger>
       <SelectContent align="start" className="max-h-72">
         {items.map((item) => (


### PR DESCRIPTION
Fixes #7158.

## Problem

IANA renamed `Europe/Kiev` to `Europe/Kyiv` in tzdata 2022b. On runtimes whose ICU still reports the old identifier, `Intl.supportedValuesOf("timeZone")` returns `Europe/Kiev`, so every timezone picker offers the legacy name. A stored `Europe/Kiev` preference also rendered the legacy name in the trigger with no matching entry in the open list, so nothing appeared selected.

## Change

`packages/views/common/timezone-select.tsx`:

- `LEGACY_TIMEZONE_ALIASES` maps renamed identifiers to their current names, with the tzdata release cited.
- `canonicalizeForRuntime` applies the mapping only when the runtime can construct an `Intl.DateTimeFormat` for the modern name, so an older ICU build keeps the name it can actually format.
- `timezoneOptions` canonicalizes before the `Set` dedupe, so a runtime reporting both names collapses them to one `Europe/Kyiv` entry.
- `TimezoneSelect` applies the same mapping to the `Select` value, the trigger label, and the browser-zone suffix comparison.

No persistence or migration. A stored legacy value is displayed and selected as its modern name; it is rewritten only when the user picks a zone.

## Tests

New `packages/views/common/timezone-select.test.tsx` (9 tests), all written failing-first:

- legacy-only runtime maps to `Europe/Kyiv` and drops `Europe/Kiev`
- a runtime reporting both names yields exactly one `Europe/Kyiv` option
- a stored `Europe/Kiev` renders as `Europe/Kyiv` in the trigger
- a browser zone of `Europe/Kiev` renders as `Europe/Kyiv (browser)`
- an ICU build that rejects `Europe/Kyiv` keeps `Europe/Kiev`
- `supportedValuesOf` missing falls back to `COMMON_TIMEZONES`

Reverting the `TimezoneSelect` canonicalization fails the two render tests; reverting the `timezoneOptions` canonicalization fails the first.

```
cd packages/views
pnpm vitest run common/timezone-select.test.tsx   # 9 passed
pnpm typecheck                                    # exit 0
pnpm lint                                         # 0 errors
```

The full `packages/views` suite passes apart from four failures (`sidebar-resize`, `billing-tab` x3) that reproduce unchanged on `main`.