### PR TITLE
MUL-6493 feat(issues): add Project as a grouping option on Board and Table

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -11,12 +11,16 @@ import { defaultStorage } from "../../platform/storage";
 export type ViewMode = "board" | "list" | "table" | "gantt" | "swimlane";
 export type GanttZoom = "day" | "week" | "month";
 /**
- * Board grouping. Besides the two built-ins, a select-type custom property
+ * Board grouping. Besides the three built-ins, a select-type custom property
  * groups columns by its options via the `property:<definitionId>` form.
  * Persisted values may reference a since-archived definition — consumers must
  * fall back to "status" when the definition can't be resolved.
  */
-export type IssueGrouping = "status" | "assignee" | `property:${string}`;
+export type IssueGrouping =
+  | "status"
+  | "assignee"
+  | "project"
+  | `property:${string}`;
 export type SwimlaneGrouping = "parent" | "project" | "assignee";
 /**
  * Sort key. `property:<definitionId>` is resolved server-side against the
@@ -55,7 +59,12 @@ export interface TableColumnConfig {
   key: TableColumnKey;
   width?: number;
 }
-export type TableGrouping = "none" | "status" | "assignee" | `property:${string}`;
+export type TableGrouping =
+  | "none"
+  | "status"
+  | "assignee"
+  | "project"
+  | `property:${string}`;
 export type TableCalculation = "none" | "sum" | "average" | "count";
 
 export const TABLE_SYSTEM_COLUMNS: readonly TableSystemColumnKey[] = [
@@ -155,6 +164,7 @@ export const SORT_OPTIONS: { value: StaticSortField; label: string }[] = [
 export const GROUPING_OPTIONS: { value: StaticIssueGrouping; label: string }[] = [
   { value: "status", label: "Status" },
   { value: "assignee", label: "Assignee" },
+  { value: "project", label: "Project" },
 ];
 
 export const CARD_PROPERTY_OPTIONS: { key: keyof CardProperties; label: string }[] = [

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useMemo, useState, type ReactNode } from "react";
 import { Virtuoso } from "react-virtuoso";
-import { EyeOff, MoreHorizontal, Plus, UserMinus } from "lucide-react";
+import { EyeOff, FolderMinus, MoreHorizontal, Plus, UserMinus } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type {
@@ -26,6 +26,7 @@ import { DraggableBoardCard } from "./board-card";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { ProjectIcon } from "../../projects/components/project-icon";
 import { useRestoredScrollOffset, useRestoredScrollRef } from "../../platform";
 import { DeferredPopup } from "../../common/deferred-popup";
 import { DeferredTooltip } from "../../common/deferred-tooltip";
@@ -78,6 +79,12 @@ export interface BoardColumnGroup {
   status?: IssueStatusCategory;
   assigneeType?: IssueAssigneeType | null;
   assigneeId?: string | null;
+  /** Project id for this column; null = the "No project" column. Set only
+   *  when the board is grouped by project. */
+  projectId?: string | null;
+  /** Display-only, for the column's leading icon. Null on the "No project"
+   *  column and on a project the projects query cannot resolve. */
+  project?: Pick<Project, "icon"> | null;
   /** Set when the board is grouped by a select-type custom property. */
   propertyId?: string;
   /** Option id for this column; null = the "No value" column. */
@@ -346,6 +353,26 @@ function BoardGroupHeading({
           className="size-2.5 shrink-0 rounded-full bg-muted-foreground/30"
           style={group.propertyOptionColor ? { backgroundColor: group.propertyOptionColor } : undefined}
         />
+        <span className="truncate text-body font-medium" title={group.title}>
+          {group.title}
+        </span>
+        <span className="shrink-0 rounded-full bg-background px-1.5 py-0.5 text-micro font-medium tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      </div>
+    );
+  }
+
+  if (group.projectId !== undefined) {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
+        {group.project ? (
+          <ProjectIcon project={group.project} size="sm" />
+        ) : (
+          <span className="flex size-[18px] shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground">
+            <FolderMinus className="size-3.5" />
+          </span>
+        )}
         <span className="truncate text-body font-medium" title={group.title}>
           {group.title}
         </span>

--- a/packages/views/issues/components/board-view-project-grouping.test.tsx
+++ b/packages/views/issues/components/board-view-project-grouping.test.tsx
@@ -129,33 +129,44 @@ const ISSUES = [
   makeIssue("loose", null),
 ];
 
-/** What `useIssueGroupBranches` hands the board for `{ kind: "project" }`. */
-const groupBranches: IssueGroupBranches = {
-  enabled: true,
-  descriptors: [
-    { key: "project:none", value: { kind: "project", project_id: null }, count: 1 },
-    {
-      key: `project:${ACME_ID}`,
-      value: { kind: "project", project_id: ACME_ID },
-      count: 4,
-    },
-    {
-      key: `project:${GHOST_ID}`,
-      value: { kind: "project", project_id: GHOST_ID },
-      count: 1,
-    },
-  ],
-  issues: ISSUES,
-  pagination: {},
-  total: 3,
-  isLoading: false,
-  isRefreshing: false,
-  isError: false,
-  hasMoreGroups: false,
-  isLoadingMoreGroups: false,
-  loadMoreGroups: () => {},
-  retryGroups: () => {},
+const NO_PROJECT_DESCRIPTOR = {
+  key: "project:none",
+  value: { kind: "project" as const, project_id: null },
+  count: 1,
 };
+const PROJECT_DESCRIPTORS = [
+  {
+    key: `project:${ACME_ID}`,
+    value: { kind: "project" as const, project_id: ACME_ID },
+    count: 4,
+  },
+  {
+    key: `project:${GHOST_ID}`,
+    value: { kind: "project" as const, project_id: GHOST_ID },
+    count: 1,
+  },
+];
+
+/** What `useIssueGroupBranches` hands the board for `{ kind: "project" }`. */
+function makeGroupBranches(
+  descriptors: IssueGroupBranches["descriptors"],
+  issues: Issue[],
+): IssueGroupBranches {
+  return {
+    enabled: true,
+    descriptors,
+    issues,
+    pagination: {},
+    total: issues.length,
+    isLoading: false,
+    isRefreshing: false,
+    isError: false,
+    hasMoreGroups: false,
+    isLoadingMoreGroups: false,
+    loadMoreGroups: () => {},
+    retryGroups: () => {},
+  };
+}
 
 class ObserverStub {
   observe() {}
@@ -182,7 +193,13 @@ describe("Board grouped by project", () => {
     vi.unstubAllGlobals();
   });
 
-  function render() {
+  function render({
+    descriptors = [NO_PROJECT_DESCRIPTOR, ...PROJECT_DESCRIPTORS],
+    issues = ISSUES,
+  }: {
+    descriptors?: IssueGroupBranches["descriptors"];
+    issues?: Issue[];
+  } = {}) {
     const store = getIssueSurfaceViewStore(
       `board-project-${Math.floor(Math.random() * 1e9)}`,
     );
@@ -197,14 +214,14 @@ describe("Board grouped by project", () => {
         <ViewStoreProvider store={store}>
           <IssueContextMenuProvider>
           <BoardView
-            issues={ISSUES}
+            issues={issues}
             visibleStatuses={["todo"]}
             hiddenStatuses={[]}
             onMoveIssue={() => {}}
             projectMap={
               new Map([[ACME_ID, makeProject(ACME_ID, "Acme Corp", "🚀")]])
             }
-            groupBranches={groupBranches}
+            groupBranches={makeGroupBranches(descriptors, issues)}
           />
           </IssueContextMenuProvider>
         </ViewStoreProvider>
@@ -212,14 +229,39 @@ describe("Board grouped by project", () => {
     );
   }
 
-  it("titles each column with its project and pins a No project column", () => {
+  it("titles each column with its project, never with its id", () => {
     render();
 
     expect(screen.getByText("Acme Corp")).toBeTruthy();
     expect(screen.getByText("No project")).toBeTruthy();
-    // The id is never user-facing text.
     expect(screen.queryByText(ACME_ID)).toBeNull();
     expect(screen.queryByText(GHOST_ID)).toBeNull();
+  });
+
+  it("keeps a No project column when the server returns no such group", () => {
+    // Clearing a card's project by dragging has to stay possible in a workspace
+    // where every card currently has one, so this column is not derived from
+    // the result set like the others.
+    render({
+      descriptors: PROJECT_DESCRIPTORS,
+      issues: ISSUES.filter((issue) => issue.project_id !== null),
+    });
+
+    const header = screen.getByText("No project").parentElement!;
+    expect(header.textContent).toContain("0");
+  });
+
+  it("keeps exactly one No project column when the server does return it", () => {
+    render();
+
+    expect(screen.getAllByText("No project")).toHaveLength(1);
+  });
+
+  it("reads an unresolvable project the way the Table does", () => {
+    // The board and the table must not describe the same project differently.
+    render();
+
+    expect(screen.getByText("Unavailable value")).toBeTruthy();
   });
 
   it("shows the server's group count, not the loaded card count", () => {

--- a/packages/views/issues/components/board-view-project-grouping.test.tsx
+++ b/packages/views/issues/components/board-view-project-grouping.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Board grouped by project. The server's group descriptors carry a project id
+ * and nothing else, so both the column header text and the column's leading
+ * glyph are resolved on the client — and `projectId` sits next to `assigneeId`
+ * on BoardColumnGroup, where an unguarded fallthrough renders a project column
+ * as the "no assignee" column.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { getIssueSurfaceViewStore } from "@multica/core/issues/stores/surface-view-store";
+import type { Issue, Project } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueContextMenuProvider } from "../actions/issue-actions-context-menu";
+import type { IssueGroupBranches } from "../surface/use-issue-group-branches";
+import { BoardView } from "./board-view";
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+
+vi.mock("@multica/core/properties", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/properties")>()),
+  propertyListOptions: () => ({
+    queryKey: ["properties"],
+    queryFn: async () => [],
+  }),
+  useSetIssueProperty: () => ({ mutate: () => {} }),
+  useUnsetIssueProperty: () => ({ mutate: () => {} }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/workspace/hooks")>()),
+  useActorName: () => ({ getActorName: () => "Someone" }),
+}));
+
+vi.mock("@multica/core/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/auth")>()),
+  useAuthStore: (selector: (state: { user: { id: string } }) => unknown) =>
+    selector({ user: { id: "viewer-1" } }),
+}));
+
+vi.mock("@multica/core/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/agents")>()),
+  isAgentRuntimeBound: () => true,
+  useAgentPresenceDetail: () => ({ availability: "offline", workload: null }),
+}));
+
+vi.mock("@multica/core/paths", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@multica/core/paths")>();
+  return {
+    ...actual,
+    useCurrentWorkspace: () => ({ id: "ws-1", slug: "acme" }),
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigation: () => ({
+    push: () => {},
+    openInNewTab: () => {},
+    getShareableUrl: (path: string) => `https://app.example${path}`,
+    pathname: "/",
+  }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+}));
+
+const ACME_ID = "11111111-1111-4111-8111-111111111111";
+const GHOST_ID = "22222222-2222-4222-8222-222222222222";
+
+function makeProject(id: string, title: string, icon: string | null): Project {
+  return {
+    id,
+    workspace_id: "ws-1",
+    title,
+    description: null,
+    icon,
+    status: "in_progress",
+    priority: "none",
+    lead_type: null,
+    lead_id: null,
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    issue_count: 0,
+    done_count: 0,
+    resource_count: 0,
+  };
+}
+
+function makeIssue(id: string, projectId: string | null): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `MUL-${id}`,
+    title: `Task ${id}`,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member-1",
+    parent_issue_id: null,
+    project_id: projectId,
+    position: 1,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    labels: [],
+    metadata: {},
+    properties: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const ISSUES = [
+  makeIssue("acme", ACME_ID),
+  makeIssue("ghost", GHOST_ID),
+  makeIssue("loose", null),
+];
+
+/** What `useIssueGroupBranches` hands the board for `{ kind: "project" }`. */
+const groupBranches: IssueGroupBranches = {
+  enabled: true,
+  descriptors: [
+    { key: "project:none", value: { kind: "project", project_id: null }, count: 1 },
+    {
+      key: `project:${ACME_ID}`,
+      value: { kind: "project", project_id: ACME_ID },
+      count: 4,
+    },
+    {
+      key: `project:${GHOST_ID}`,
+      value: { kind: "project", project_id: GHOST_ID },
+      count: 1,
+    },
+  ],
+  issues: ISSUES,
+  pagination: {},
+  total: 3,
+  isLoading: false,
+  isRefreshing: false,
+  isError: false,
+  hasMoreGroups: false,
+  isLoadingMoreGroups: false,
+  loadMoreGroups: () => {},
+  retryGroups: () => {},
+};
+
+class ObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+describe("Board grouped by project", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", ObserverStub);
+    vi.stubGlobal("ResizeObserver", ObserverStub);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  function render() {
+    const store = getIssueSurfaceViewStore(
+      `board-project-${Math.floor(Math.random() * 1e9)}`,
+    );
+    store.getState().setGrouping("project");
+    // Cards carry their own project chip by default, which would put the same
+    // title in two places and make "the column header says X" unprovable.
+    if (store.getState().cardProperties.project) {
+      store.getState().toggleCardProperty("project");
+    }
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <ViewStoreProvider store={store}>
+          <IssueContextMenuProvider>
+          <BoardView
+            issues={ISSUES}
+            visibleStatuses={["todo"]}
+            hiddenStatuses={[]}
+            onMoveIssue={() => {}}
+            projectMap={
+              new Map([[ACME_ID, makeProject(ACME_ID, "Acme Corp", "🚀")]])
+            }
+            groupBranches={groupBranches}
+          />
+          </IssueContextMenuProvider>
+        </ViewStoreProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("titles each column with its project and pins a No project column", () => {
+    render();
+
+    expect(screen.getByText("Acme Corp")).toBeTruthy();
+    expect(screen.getByText("No project")).toBeTruthy();
+    // The id is never user-facing text.
+    expect(screen.queryByText(ACME_ID)).toBeNull();
+    expect(screen.queryByText(GHOST_ID)).toBeNull();
+  });
+
+  it("shows the server's group count, not the loaded card count", () => {
+    render();
+
+    // Acme holds four issues; only one is on this page.
+    const header = screen.getByText("Acme Corp").parentElement!;
+    expect(header.textContent).toContain("4");
+  });
+
+  it("heads a project column with that project's own icon", () => {
+    render();
+
+    // BoardColumnGroup carries projectId beside assigneeId, so a project column
+    // that is not matched explicitly falls through to the ASSIGNEE heading —
+    // which renders the same title text next to a no-assignee actor glyph. The
+    // icon is what tells the two apart.
+    const header = screen.getByText("Acme Corp").parentElement!;
+    expect(header.textContent).toContain("\u{1F680}");
+  });
+
+  it("puts each card in its own project column", () => {
+    render();
+
+    const acmeColumn = screen.getByText("Acme Corp").closest("div.flex-col")!;
+    expect(acmeColumn.textContent).toContain("MUL-acme");
+    expect(acmeColumn.textContent).not.toContain("MUL-loose");
+  });
+});

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -58,6 +58,7 @@ import {
   issueMatchesGroup,
   getMoveUpdates,
   propertyGroupId,
+  projectGroupId,
 } from "../utils/drag-utils";
 
 function isStatusGroup(
@@ -66,14 +67,27 @@ function isStatusGroup(
   return group.status !== undefined;
 }
 
+interface BuildGroupsContext {
+  getActorName: (type: string, id: string) => string;
+  groupingProperty: IssueProperty | null;
+  projectMap: Map<string, Project> | undefined;
+  noAssigneeLabel: string;
+  noValueLabel: string;
+  noProjectLabel: string;
+}
+
 function buildGroups(
   issues: Issue[],
   visibleStatuses: IssueStatusCategory[],
   grouping: IssueGrouping,
-  getActorName: (type: string, id: string) => string,
-  noAssigneeLabel: string,
-  groupingProperty: IssueProperty | null,
-  noValueLabel: string,
+  {
+    getActorName,
+    groupingProperty,
+    projectMap,
+    noAssigneeLabel,
+    noValueLabel,
+    noProjectLabel,
+  }: BuildGroupsContext,
 ): BoardColumnGroup[] {
   if (grouping === "status") {
     return visibleStatuses.map((status) => ({
@@ -104,6 +118,35 @@ function buildGroups(
       propertyOptionId: null,
     });
     return columns;
+  }
+
+  // Project board: one column per project the loaded cards reference, plus the
+  // pinned "No project" column. Ordering mirrors the server's group order
+  // (no-project first, then project title) so the client fallback and the
+  // paged server columns cannot disagree.
+  if (grouping === "project") {
+    const columns = new Map<string, BoardColumnGroup>();
+    for (const issue of issues) {
+      const projectId = issue.project_id ?? null;
+      const id = projectGroupId(projectId);
+      if (columns.has(id)) continue;
+      const project = projectId ? projectMap?.get(projectId) ?? null : null;
+      columns.set(id, {
+        id,
+        // Same convention as the swimlane's project lanes: a project the
+        // projects query cannot resolve (deleted, or not visible to this
+        // member) keeps an empty title rather than reading as "No project".
+        title: projectId ? project?.title ?? "" : noProjectLabel,
+        projectId,
+        project,
+        createData: { project_id: projectId },
+      });
+    }
+    return Array.from(columns.values()).toSorted((a, b) => {
+      if (a.projectId === null) return b.projectId === null ? 0 : -1;
+      if (b.projectId === null) return 1;
+      return a.title.localeCompare(b.title);
+    });
   }
 
   const groups = new Map<string, BoardColumnGroup>();
@@ -275,6 +318,22 @@ function BoardViewImpl({
     }
     return undefined;
   }, [getActorName, groupBranches, grouping, t]);
+  const hydratedProjectGroups = useMemo<BoardColumnGroup[] | undefined>(() => {
+    if (grouping !== "project" || !groupBranches?.enabled) return undefined;
+    return groupBranches.descriptors.flatMap((descriptor): BoardColumnGroup[] => {
+      if (descriptor.value.kind !== "project") return [];
+      const projectId = descriptor.value.project_id ?? null;
+      const project = projectId ? projectMap?.get(projectId) ?? null : null;
+      return [{
+        id: descriptor.key,
+        title: projectId ? project?.title ?? "" : t(($) => $.swimlane.no_project),
+        projectId,
+        project,
+        totalCount: descriptor.count,
+        createData: { project_id: projectId },
+      }];
+    });
+  }, [groupBranches, grouping, projectMap, t]);
   const groupPagination = useMemo(() => {
     if (!groupBranches?.enabled) return undefined;
     const grouped = new Map<string, IssueGroupPageState[]>();
@@ -321,21 +380,21 @@ function BoardViewImpl({
     () => {
       const built =
         hydratedAssigneeGroups ??
-        buildGroups(
-        issues,
-        visibleStatuses,
-        grouping,
-        getActorName,
-        t(($) => $.filters.no_assignee),
-        groupingProperty,
-        t(($) => $.board.no_value),
-        );
+        hydratedProjectGroups ??
+        buildGroups(issues, visibleStatuses, grouping, {
+          getActorName,
+          groupingProperty,
+          projectMap,
+          noAssigneeLabel: t(($) => $.filters.no_assignee),
+          noValueLabel: t(($) => $.board.no_value),
+          noProjectLabel: t(($) => $.swimlane.no_project),
+        });
       return built.map((group) => ({
         ...group,
         totalCount: groupPagination?.[group.id]?.total ?? group.totalCount,
       }));
     },
-    [hydratedAssigneeGroups, issues, visibleStatuses, grouping, getActorName, groupingProperty, groupPagination, t],
+    [hydratedAssigneeGroups, hydratedProjectGroups, issues, visibleStatuses, grouping, getActorName, groupingProperty, projectMap, groupPagination, t],
   );
   const groupIds = useMemo(
     () => new Set(groups.map((group) => group.id)),

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -67,13 +67,66 @@ function isStatusGroup(
   return group.status !== undefined;
 }
 
-interface BuildGroupsContext {
+interface ProjectColumnLabels {
+  noProject: string;
+  /** A project id the projects query cannot resolve — deleted, or not visible
+   *  to this member. Shares the Table's wording so one board column and one
+   *  table group row never describe the same project differently. */
+  unavailableProject: string;
+}
+
+interface BuildGroupsContext extends ProjectColumnLabels {
   getActorName: (type: string, id: string) => string;
   groupingProperty: IssueProperty | null;
   projectMap: Map<string, Project> | undefined;
   noAssigneeLabel: string;
   noValueLabel: string;
-  noProjectLabel: string;
+}
+
+/**
+ * One project column. Shared by the client fallback (columns derived from
+ * loaded cards) and the server path (columns derived from group descriptors)
+ * so the two can never describe the same project differently.
+ */
+function projectColumn(
+  id: string,
+  projectId: string | null,
+  projectMap: Map<string, Project> | undefined,
+  labels: ProjectColumnLabels,
+  totalCount?: number,
+): BoardColumnGroup {
+  const project = projectId ? projectMap?.get(projectId) ?? null : null;
+  return {
+    id,
+    title: projectId
+      ? project?.title ?? labels.unavailableProject
+      : labels.noProject,
+    projectId,
+    project,
+    totalCount,
+    createData: { project_id: projectId },
+  };
+}
+
+/**
+ * Keep the "No project" column present as a drop target — clearing a card's
+ * project by dragging has to stay possible even in a workspace where every
+ * card currently has one. A board with no columns at all is left alone: that
+ * is the surface's empty state, not a board missing one column.
+ */
+function withNoProjectColumn(
+  columns: BoardColumnGroup[],
+  projectMap: Map<string, Project> | undefined,
+  labels: ProjectColumnLabels,
+): BoardColumnGroup[] {
+  if (columns.length === 0) return columns;
+  if (columns.some((column) => column.projectId === null)) return columns;
+  // No-project sorts first server-side, so it is always in the first page of
+  // descriptors when it exists — an absent one cannot arrive with a later page.
+  return [
+    projectColumn(projectGroupId(null), null, projectMap, labels, 0),
+    ...columns,
+  ];
 }
 
 function buildGroups(
@@ -86,7 +139,7 @@ function buildGroups(
     projectMap,
     noAssigneeLabel,
     noValueLabel,
-    noProjectLabel,
+    ...projectLabels
   }: BuildGroupsContext,
 ): BoardColumnGroup[] {
   if (grouping === "status") {
@@ -121,32 +174,23 @@ function buildGroups(
   }
 
   // Project board: one column per project the loaded cards reference, plus the
-  // pinned "No project" column. Ordering mirrors the server's group order
-  // (no-project first, then project title) so the client fallback and the
-  // paged server columns cannot disagree.
+  // "No project" column. Ordering mirrors the server's group order (no-project
+  // first, then project title) so the client fallback and the paged server
+  // columns cannot disagree.
   if (grouping === "project") {
     const columns = new Map<string, BoardColumnGroup>();
     for (const issue of issues) {
       const projectId = issue.project_id ?? null;
       const id = projectGroupId(projectId);
       if (columns.has(id)) continue;
-      const project = projectId ? projectMap?.get(projectId) ?? null : null;
-      columns.set(id, {
-        id,
-        // Same convention as the swimlane's project lanes: a project the
-        // projects query cannot resolve (deleted, or not visible to this
-        // member) keeps an empty title rather than reading as "No project".
-        title: projectId ? project?.title ?? "" : noProjectLabel,
-        projectId,
-        project,
-        createData: { project_id: projectId },
-      });
+      columns.set(id, projectColumn(id, projectId, projectMap, projectLabels));
     }
-    return Array.from(columns.values()).toSorted((a, b) => {
+    const ordered = Array.from(columns.values()).toSorted((a, b) => {
       if (a.projectId === null) return b.projectId === null ? 0 : -1;
       if (b.projectId === null) return 1;
       return a.title.localeCompare(b.title);
     });
+    return withNoProjectColumn(ordered, projectMap, projectLabels);
   }
 
   const groups = new Map<string, BoardColumnGroup>();
@@ -318,22 +362,34 @@ function BoardViewImpl({
     }
     return undefined;
   }, [getActorName, groupBranches, grouping, t]);
+  const projectColumnLabels = useMemo<ProjectColumnLabels>(
+    () => ({
+      noProject: t(($) => $.swimlane.no_project),
+      unavailableProject: t(($) => $.table.value_unavailable),
+    }),
+    [t],
+  );
   const hydratedProjectGroups = useMemo<BoardColumnGroup[] | undefined>(() => {
     if (grouping !== "project" || !groupBranches?.enabled) return undefined;
-    return groupBranches.descriptors.flatMap((descriptor): BoardColumnGroup[] => {
-      if (descriptor.value.kind !== "project") return [];
-      const projectId = descriptor.value.project_id ?? null;
-      const project = projectId ? projectMap?.get(projectId) ?? null : null;
-      return [{
-        id: descriptor.key,
-        title: projectId ? project?.title ?? "" : t(($) => $.swimlane.no_project),
-        projectId,
-        project,
-        totalCount: descriptor.count,
-        createData: { project_id: projectId },
-      }];
-    });
-  }, [groupBranches, grouping, projectMap, t]);
+    const columns = groupBranches.descriptors.flatMap(
+      (descriptor): BoardColumnGroup[] =>
+        descriptor.value.kind === "project"
+          ? [
+              projectColumn(
+                // The descriptor key, not our own: it is what `groupPagination`
+                // is keyed by. `projectGroupId` reproduces it exactly, which is
+                // what lets cards bucket into these columns at all.
+                descriptor.key,
+                descriptor.value.project_id ?? null,
+                projectMap,
+                projectColumnLabels,
+                descriptor.count,
+              ),
+            ]
+          : [],
+    );
+    return withNoProjectColumn(columns, projectMap, projectColumnLabels);
+  }, [groupBranches, grouping, projectColumnLabels, projectMap]);
   const groupPagination = useMemo(() => {
     if (!groupBranches?.enabled) return undefined;
     const grouped = new Map<string, IssueGroupPageState[]>();
@@ -387,14 +443,14 @@ function BoardViewImpl({
           projectMap,
           noAssigneeLabel: t(($) => $.filters.no_assignee),
           noValueLabel: t(($) => $.board.no_value),
-          noProjectLabel: t(($) => $.swimlane.no_project),
+          ...projectColumnLabels,
         });
       return built.map((group) => ({
         ...group,
         totalCount: groupPagination?.[group.id]?.total ?? group.totalCount,
       }));
     },
-    [hydratedAssigneeGroups, hydratedProjectGroups, issues, visibleStatuses, grouping, getActorName, groupingProperty, projectMap, groupPagination, t],
+    [hydratedAssigneeGroups, hydratedProjectGroups, issues, visibleStatuses, grouping, getActorName, groupingProperty, projectMap, projectColumnLabels, groupPagination, t],
   );
   const groupIds = useMemo(
     () => new Set(groups.map((group) => group.id)),

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -1731,9 +1731,10 @@ export function IssueDisplayControls({
     updated_at: "sort_updated",
     title: "sort_title",
   };
-  const GROUPING_LABEL_KEY: Record<typeof GROUPING_OPTIONS[number]["value"], "group_status" | "group_assignee"> = {
+  const GROUPING_LABEL_KEY: Record<typeof GROUPING_OPTIONS[number]["value"], "group_status" | "group_assignee" | "group_project"> = {
     status: "group_status",
     assignee: "group_assignee",
+    project: "group_project",
   };
   const SWIMLANE_GROUPING_LABEL_KEY: Record<SwimlaneGrouping, "group_parent" | "group_project" | "group_assignee"> = {
     parent: "group_parent",
@@ -1774,7 +1775,9 @@ export function IssueDisplayControls({
       ? t(($) => $.table.columns.status)
       : effectiveTableGrouping === "assignee"
         ? t(($) => $.table.columns.assignee)
-        : t(($) => $.table.group_none);
+        : effectiveTableGrouping === "project"
+          ? t(($) => $.table.columns.project)
+          : t(($) => $.table.group_none);
   const controlButtonClass = "h-8 w-8 gap-1 px-0 text-muted-foreground md:h-7 md:w-auto md:px-2.5";
 
   return (
@@ -1851,6 +1854,9 @@ export function IssueDisplayControls({
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="assignee">
                   {t(($) => $.table.columns.assignee)}
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="project">
+                  {t(($) => $.table.columns.project)}
                 </DropdownMenuRadioItem>
                 {tableGroupableProperties.map((property) => (
                   <DropdownMenuRadioItem

--- a/packages/views/issues/components/save-view-dialog.tsx
+++ b/packages/views/issues/components/save-view-dialog.tsx
@@ -108,6 +108,7 @@ const LAYOUT_LABEL_KEY = {
 const GROUPING_LABEL_KEY = {
   status: "group_status",
   assignee: "group_assignee",
+  project: "group_project",
 } as const;
 
 const SWIMLANE_LABEL_KEY = {

--- a/packages/views/issues/components/table-view-project-grouping.test.tsx
+++ b/packages/views/issues/components/table-view-project-grouping.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Table grouped by project. The server hands back only a project id per group,
+ * so the header text the user reads is resolved on the client — a group row
+ * that renders the raw uuid is the failure this file exists to catch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setApiInstance } from "@multica/core/api";
+import type { ApiClient } from "@multica/core/api/client";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { getIssueSurfaceViewStore } from "@multica/core/issues/stores/surface-view-store";
+import type {
+  Issue,
+  IssueTableGroupsRequest,
+  IssueTableQuerySpec,
+  IssueTableRowsRequest,
+} from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueSurfaceSelectionProvider } from "../surface/selection-context";
+import type { IssueSurfaceSelection } from "../surface/selection-context";
+import { TableView } from "./table-view";
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+
+// jsdom has no layout, so the real row virtualizer sees a 0-height viewport and
+// renders nothing. Render every row inline instead.
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (options: {
+    count: number;
+    getItemKey?: (index: number) => unknown;
+  }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: options.count }, (_, index) => ({
+        index,
+        key: options.getItemKey?.(index) ?? index,
+        start: index * 41,
+        end: (index + 1) * 41,
+        size: 41,
+        lane: 0,
+      })),
+    getTotalSize: () => options.count * 41,
+    measureElement: () => {},
+  }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Someone" }),
+  buildActorNameResolver: () => () => "Someone",
+}));
+
+const authState = { user: { id: "user-1", email: "t@t.co", name: "Tester" }, isAuthenticated: true };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: (state: unknown) => unknown) =>
+      selector ? selector(authState) : authState,
+    { getState: () => authState },
+  ),
+}));
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigation: () => ({
+    push: () => {},
+    openInNewTab: () => {},
+    getShareableUrl: (path: string) => `https://app.example${path}`,
+    pathname: "/",
+  }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/paths")>(
+      "@multica/core/paths",
+    );
+  return { ...actual, useWorkspacePaths: () => actual.paths.workspace("test") };
+});
+
+class ObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+/**
+ * Reports everything handed to it as visible. A collapsed group's rows load
+ * through an activation sentinel, so an inert observer leaves every group
+ * header rendered above an empty branch.
+ */
+class VisibleIntersectionObserver {
+  #callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.#callback = callback;
+  }
+  observe(target: Element) {
+    setTimeout(() => {
+      this.#callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver,
+      );
+    }, 0);
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+const ACME_ID = "11111111-1111-4111-8111-111111111111";
+/** A project the projects query does not answer for — deleted, or invisible to
+ *  this member. Its rows still exist, so its header still has to say something. */
+const GHOST_ID = "22222222-2222-4222-8222-222222222222";
+
+function makeIssue(id: string, projectId: string | null): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `MUL-${id}`,
+    title: `Task ${id}`,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member-1",
+    parent_issue_id: null,
+    project_id: projectId,
+    position: 1,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    labels: [],
+    metadata: {},
+    properties: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const ROWS_BY_GROUP: Record<string, Issue[]> = {
+  "project:none": [makeIssue("loose", null)],
+  [`project:${ACME_ID}`]: [makeIssue("acme", ACME_ID)],
+  [`project:${GHOST_ID}`]: [makeIssue("ghost", GHOST_ID)],
+};
+
+const serverQuery: IssueTableQuerySpec = {
+  scope: { kind: "workspace" },
+  filters: {},
+  sort: { field: "position", direction: "asc" },
+};
+
+const selection: IssueSurfaceSelection = {
+  selectedIds: new Set<string>(),
+  toggle: () => {},
+  select: () => {},
+  deselect: () => {},
+  clear: () => {},
+};
+
+describe("Table grouped by project", () => {
+  let queryClient: QueryClient;
+  let groupRequests: IssueTableGroupsRequest[];
+  let surfaceKey: string;
+
+  beforeEach(() => {
+    groupRequests = [];
+    surfaceKey = `project-grouping-${Math.floor(Math.random() * 1e9)}`;
+    vi.stubGlobal("IntersectionObserver", VisibleIntersectionObserver);
+    vi.stubGlobal("ResizeObserver", ObserverStub);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    setApiInstance({
+      listProperties: async () => ({ properties: [] }),
+      listMembers: async () => [],
+      listAgents: async () => [],
+      listSquads: async () => [],
+      getAssigneeFrequency: async () => [],
+      listIssueStatuses: async () => ({ statuses: [] }),
+      listProjects: async () => ({
+        projects: [
+          {
+            id: ACME_ID,
+            workspace_id: "ws-1",
+            title: "Acme Corp",
+            description: null,
+            status: "in_progress",
+            icon: null,
+            color: null,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+      }),
+      listIssueTableGroups: async (request: IssueTableGroupsRequest) => {
+        groupRequests.push(request);
+        return {
+          query_fingerprint: "test",
+          total: 3,
+          // No-project first, then by title — the server's own group order.
+          groups: [
+            { key: "project:none", value: { kind: "project", project_id: null }, count: 1 },
+            {
+              key: `project:${ACME_ID}`,
+              value: { kind: "project", project_id: ACME_ID },
+              count: 1,
+            },
+            {
+              key: `project:${GHOST_ID}`,
+              value: { kind: "project", project_id: GHOST_ID },
+              count: 1,
+            },
+          ],
+          next_cursor: null,
+        };
+      },
+      listIssueTableRows: async (request: IssueTableRowsRequest) => {
+        const rows = ROWS_BY_GROUP[request.group_key ?? ""] ?? [];
+        return {
+          query_fingerprint: "test",
+          group_key: request.group_key ?? null,
+          parent_id: request.parent_id ?? null,
+          total: rows.length,
+          rows: rows.map((issue) => ({ issue, direct_child_count: 0 })),
+          branch_total: rows.length,
+          next_cursor: null,
+        };
+      },
+    } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  function render() {
+    const store = getIssueSurfaceViewStore(surfaceKey);
+    store.getState().setTableGrouping("project");
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <ViewStoreProvider store={store}>
+          <IssueSurfaceSelectionProvider selection={selection}>
+            <TableView
+              serverQuery={serverQuery}
+              childProgressMap={new Map()}
+              search=""
+              onSearchChange={() => {}}
+              onLoadedIssuesChange={() => {}}
+              onCreateIssue={() => {}}
+              exportIssues={() => Promise.resolve([])}
+              resolveExportLookups={() =>
+                Promise.resolve({
+                  projectMap: new Map(),
+                  childProgressMap: new Map(),
+                })
+              }
+            />
+          </IssueSurfaceSelectionProvider>
+        </ViewStoreProvider>
+      </QueryClientProvider>,
+    );
+  }
+
+  it("asks the server for project groups", async () => {
+    render();
+    await waitFor(() => expect(groupRequests).not.toHaveLength(0));
+    expect(groupRequests[0]?.group).toEqual({ kind: "project" });
+  });
+
+  /** Group headers only exist while the branch catalog is settled, so every
+   *  assertion about a header runs inside one retried block rather than after
+   *  a separate await — a header read between two catalog states proves
+   *  nothing. */
+  async function groupHeaders(assert: () => void) {
+    await waitFor(() => {
+      expect(screen.getByText("Acme Corp")).toBeTruthy();
+      assert();
+    });
+  }
+
+  it("labels each group with the project title, never its id", async () => {
+    render();
+    await groupHeaders(() => {
+      expect(screen.queryByText(ACME_ID)).toBeNull();
+    });
+  });
+
+  it("names the no-project group instead of leaving it blank", async () => {
+    render();
+    await groupHeaders(() => {
+      expect(screen.getByText("No project")).toBeTruthy();
+    });
+  });
+
+  it("reads an unresolvable project as unavailable rather than as its id", async () => {
+    render();
+    await groupHeaders(() => {
+      expect(screen.queryByText(GHOST_ID)).toBeNull();
+      expect(screen.getByText("Unavailable value")).toBeTruthy();
+    });
+  });
+
+  it("lands each row under its own project group", async () => {
+    render();
+    await screen.findByText("MUL-acme");
+    await screen.findByText("MUL-loose");
+  });
+});

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -89,6 +89,7 @@ import {
 } from "@multica/core/issues/stores/view-store";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { propertyListOptions } from "@multica/core/properties";
+import { projectListOptions } from "@multica/core/projects/queries";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { buildActorNameResolver, useActorName } from "@multica/core/workspace/hooks";
 import {
@@ -262,6 +263,7 @@ function rebaseServerBranchState(
 function tableGroupSpec(grouping: string): IssueTableGroupSpec {
   if (grouping === "status") return { kind: "status" };
   if (grouping === "assignee") return { kind: "assignee" };
+  if (grouping === "project") return { kind: "project" };
   const propertyId = propertyIdFromViewKey(grouping);
   if (propertyId) return { kind: "property", property_id: propertyId };
   return { kind: "none" };
@@ -1370,6 +1372,23 @@ export function TableView({
     [effectiveTableGrouping],
   );
   const usesServerGrouping = serverGroupSpec.kind !== "none";
+  // Project group rows carry only a project id; the title comes from the
+  // shared projects query the surface already primes for this grouping.
+  //
+  // Read `data` rather than defaulting it in the destructure: an un-settled
+  // query has no data, so `= []` would hand this memo a fresh array on every
+  // render and churn every consumer of the map below (MUL-5477).
+  const groupProjectsQuery = useQuery({
+    ...projectListOptions(wsId),
+    enabled: serverGroupSpec.kind === "project",
+  });
+  const groupProjectMap = useMemo(
+    () =>
+      new Map(
+        (groupProjectsQuery.data ?? []).map((project) => [project.id, project]),
+      ),
+    [groupProjectsQuery.data],
+  );
   const serverGroupsRequestGroup =
     serverGroupSpec.kind === "none"
       ? ({ kind: "status" } as const)
@@ -1772,9 +1791,13 @@ export function TableView({
           : t(($) => $.table.unassigned);
       }
       if (value.kind === "project") {
-        return value.project_id
-          ? value.project_id
-          : t(($) => $.swimlane.no_project);
+        if (!value.project_id) return t(($) => $.swimlane.no_project);
+        // A project the query cannot resolve (deleted, or not visible to this
+        // member) reads as unavailable — never as its raw id.
+        return (
+          groupProjectMap.get(value.project_id)?.title ??
+          t(($) => $.table.value_unavailable)
+        );
       }
       if (value.kind === "parent") {
         if (value.value_state === "unset") {
@@ -1797,7 +1820,7 @@ export function TableView({
           ?.name ?? String(value.value ?? "")
       );
     },
-    [getActorName, propertyById, t],
+    [getActorName, groupProjectMap, propertyById, t],
   );
 
   const serverDisplayRows = useMemo<IssueTableDisplayRow[]>(() => {

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -797,6 +797,47 @@ describe("useIssueSurfaceController", () => {
     },
   );
 
+  it.each([
+    { grouping: "assignee" as const, expected: { kind: "assignee" } },
+    { grouping: "project" as const, expected: { kind: "project" } },
+  ])(
+    "asks the server for $grouping groups when the board is grouped that way",
+    async ({ grouping, expected }) => {
+      // The board's columns ARE the server's group descriptors, so the group
+      // spec it requests is the whole contract — a board that asks for the
+      // wrong dimension renders another dimension's columns.
+      const store = getIssueSurfaceViewStore("project:p1");
+      store.getState().setViewMode("board");
+      store.getState().setGrouping(grouping);
+      const tableMethods = statusTableMethodsFromLegacy(listIssues);
+      const listIssueTableGroups = vi.fn(tableMethods.listIssueTableGroups);
+      setApiInstance({
+        listIssueStatuses: async () => ({ statuses: [], categories: [], total: 0 }),
+        listIssues,
+        ...tableMethods,
+        listIssueTableGroups,
+        listGroupedIssues: vi.fn(() => never()),
+        listProjects: vi.fn(() => Promise.resolve({ projects: [], total: 0 })),
+        getAgentTaskSnapshot: vi.fn(() => Promise.resolve([])),
+        getChildIssueProgress: vi.fn(() => Promise.resolve([])),
+      } as unknown as ApiClient);
+
+      renderHook(
+        () =>
+          useIssueSurfaceController({
+            scope: { type: "project", projectId: "p1" },
+            modes: ["board", "list", "swimlane"],
+          }),
+        { wrapper: makeWrapper(qc, "project:p1") },
+      );
+
+      await waitFor(() => expect(listIssueTableGroups).toHaveBeenCalled());
+      expect(listIssueTableGroups.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({ group: expected }),
+      );
+    },
+  );
+
   it("fails Table export closed when schema fallback would truncate the CSV", async () => {
     const store = getIssueSurfaceViewStore("project:p1");
     store.getState().setViewMode("table");

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -233,6 +233,7 @@ export function useIssueSurfaceController({
   const cardProperties = useViewStore((s) => s.cardProperties);
   const swimlaneGrouping = useViewStore((s) => s.swimlaneGrouping);
   const tableColumns = useViewStore((s) => s.tableColumns);
+  const tableGrouping = useViewStore((s) => s.tableGrouping);
   const listCollapsedStatuses = useViewStore((s) => s.listCollapsedStatuses);
   const hiddenStatusCategories = useViewStore((s) => s.hiddenStatusCategories);
   const catalog = useIssueStatuses(wsId);
@@ -640,6 +641,7 @@ export function useIssueSurfaceController({
         secondary_values: serverStatuses,
       };
     }
+    if (effectiveGrouping === "project") return { kind: "project" };
     const propertyId = propertyIdFromViewKey(effectiveGrouping);
     if (propertyId) {
       return {
@@ -746,6 +748,11 @@ export function useIssueSurfaceController({
     loadProjects:
       cardProperties.project ||
       (usesTable && tableColumns.some((column) => column.key === "project")) ||
+      // Project group headers resolve their title through the projects query,
+      // so grouping by project has to load it even when no card/column shows
+      // the project itself.
+      (usesTable && tableGrouping === "project") ||
+      (effectiveViewMode === "board" && effectiveGrouping === "project") ||
       (effectiveViewMode === "swimlane" && swimlaneGrouping === "project"),
   });
 

--- a/packages/views/issues/utils/drag-utils.test.ts
+++ b/packages/views/issues/utils/drag-utils.test.ts
@@ -8,6 +8,7 @@ import {
   getMoveUpdates,
   insertIdByPosition,
   issueMatchesGroup,
+  projectGroupId,
   propertyGroupId,
 } from "./drag-utils";
 
@@ -191,5 +192,66 @@ describe("property grouping", () => {
 
   it("getMoveUpdates for property columns only carries position", () => {
     expect(getMoveUpdates({ id: "c1", title: "Staging", propertyId, propertyOptionId: "opt-staging" }, 5)).toEqual({ position: 5 });
+  });
+});
+
+describe("project grouping", () => {
+  const inProject = { id: "A", project_id: "proj-1" } as unknown as Issue;
+  const noProject = { id: "B", project_id: null } as unknown as Issue;
+  const projectColumn: BoardColumnGroup = {
+    id: projectGroupId("proj-1"),
+    title: "Acme",
+    projectId: "proj-1",
+  };
+  const noProjectColumn: BoardColumnGroup = {
+    id: projectGroupId(null),
+    title: "No project",
+    projectId: null,
+  };
+
+  it("projectGroupId mirrors the server group keys", () => {
+    // The board builds column ids from cards while the server builds them from
+    // descriptors; a mismatch silently drops every card off the board.
+    expect(projectGroupId("proj-1")).toBe("project:proj-1");
+    expect(projectGroupId(null)).toBe("project:none");
+  });
+
+  it("getIssueGroupId buckets unassigned-project cards into the none column", () => {
+    expect(getIssueGroupId(inProject, "project")).toBe(projectGroupId("proj-1"));
+    expect(getIssueGroupId(noProject, "project")).toBe(projectGroupId(null));
+  });
+
+  it("issueMatchesGroup distinguishes project and no-project columns", () => {
+    expect(issueMatchesGroup(inProject, projectColumn)).toBe(true);
+    expect(issueMatchesGroup(inProject, noProjectColumn)).toBe(false);
+    expect(issueMatchesGroup(noProject, noProjectColumn)).toBe(true);
+    expect(issueMatchesGroup(noProject, projectColumn)).toBe(false);
+  });
+
+  it("getMoveUpdates writes the column's project, clearing it on the none column", () => {
+    expect(getMoveUpdates(projectColumn, 5)).toEqual({
+      project_id: "proj-1",
+      position: 5,
+    });
+    expect(getMoveUpdates(noProjectColumn, 5)).toEqual({
+      project_id: null,
+      position: 5,
+    });
+  });
+
+  it("a project column never falls through to the unassigned-assignee update", () => {
+    // projectId/assigneeId are both optional on BoardColumnGroup, so an
+    // unguarded project column would read as "no assignee" and unassign the
+    // card on every drop.
+    expect(getMoveUpdates(projectColumn, 5)).not.toHaveProperty("assignee_type");
+  });
+
+  it("buildColumns places cards into their project column", () => {
+    expect(
+      buildColumns([inProject, noProject], [projectColumn, noProjectColumn], "project"),
+    ).toEqual({
+      [projectGroupId("proj-1")]: ["A"],
+      [projectGroupId(null)]: ["B"],
+    });
   });
 });

--- a/packages/views/issues/utils/drag-utils.ts
+++ b/packages/views/issues/utils/drag-utils.ts
@@ -11,7 +11,7 @@ import type { BoardColumnGroup } from "../components/board-column";
 
 export type DragMoveTargetUpdates = Pick<
   UpdateIssueRequest,
-  "status" | "assignee_type" | "assignee_id" | "position"
+  "status" | "assignee_type" | "assignee_id" | "project_id" | "position"
 >;
 
 export type DragMoveUpdates = DragMoveTargetUpdates & {
@@ -48,6 +48,12 @@ export function assigneeGroupId(
   return type && id ? `assignee:${type}:${id}` : UNASSIGNED_GROUP_ID;
 }
 
+/** Mirrors the server's project group key (`project:<id>` / `project:none`)
+ *  so a column built from a descriptor and one built from a card agree. */
+export function projectGroupId(projectId: string | null): string {
+  return `project:${projectId ?? "none"}`;
+}
+
 export function getIssueGroupId(
   issue: Issue,
   grouping: IssueGrouping,
@@ -58,6 +64,7 @@ export function getIssueGroupId(
   // column has, and the card was dropped from the board/list entirely
   // (MUL-6409).
   if (grouping === "status") return statusGroupId(issueColumnCategory(issue));
+  if (grouping === "project") return projectGroupId(issue.project_id ?? null);
   const propertyId = propertyIdFromViewKey(grouping);
   if (propertyId) {
     const value = issue.properties?.[propertyId];
@@ -153,6 +160,9 @@ export function issueMatchesGroup(issue: Issue, group: BoardColumnGroup): boolea
     const optionId = typeof value === "string" ? value : null;
     return optionId === (group.propertyOptionId ?? null);
   }
+  if (group.projectId !== undefined) {
+    return (issue.project_id ?? null) === group.projectId;
+  }
   return (
     (issue.assignee_type ?? null) === (group.assigneeType ?? null) &&
     (issue.assignee_id ?? null) === (group.assigneeId ?? null)
@@ -180,6 +190,9 @@ export function getMoveUpdates(
   // Property columns: the value change is not part of UpdateIssueRequest —
   // the board applies it through useSetIssueProperty after the position move.
   if (group.propertyId !== undefined) return { position };
+  if (group.projectId !== undefined) {
+    return { project_id: group.projectId, position };
+  }
   return {
     assignee_type: group.assigneeType ?? null,
     assignee_id: group.assigneeId ?? null,


### PR DESCRIPTION
Closes #7337.

## What this changes

`Project` becomes a grouping option on **Board** and **Table**, matching what Swimlane already offered. Sorting by project / assignee is deliberately **not** part of this change — see below.

Board grouped by project gets one column per project (plus a pinned "No project" column), with the project's own icon in the header, drag-to-reprojectise, and the same server-paged columns and load-more the assignee board uses. Table grouped by project gets the same groups as collapsible group rows.

## Why it is this small

The server side already exists. `server/internal/handler/issue_table_group.go` has carried `{ kind: "project" }` — group expression, `__no_project__` bucket, ordering by project title, `project:<id>` / `project:none` descriptor keys — since the Swimlane shipped, and `IssueTableGroupSpec` already accepted it. **There are no backend changes here**: this widens `IssueGrouping` / `TableGrouping` and routes them to the endpoint that was already answering.

Saved views store `display` as opaque JSON server-side, so no migration is needed either.

## Things worth a reviewer's attention

- **`projectGroupId()` reproduces the server's group key exactly.** The board builds column ids from cards while the server builds them from descriptors — if the two disagree, every card silently falls off the board. Pinned by a test.
- **`projectId` sits beside `assigneeId` on `BoardColumnGroup`.** Both are optional, so an unguarded project column reads as "no assignee": the drop handler would unassign the card on every drop, and the column heading would render a no-assignee glyph next to the project title. Both call sites now match `projectId` explicitly, and both failure modes have a test.
- **Group titles resolve through the projects query**, which the surface now primes when this grouping is active. A project the query cannot resolve (deleted, or invisible to the member) reads as unavailable — never as its raw uuid, which is what the pre-existing table branch would have rendered had anything ever reached it.
- **`buildGroups` takes a context object now.** It was at 7 positional parameters and this needed two more; the call site is the only one.
- One non-obvious constraint the existing suite caught: reading `data` off the projects query instead of destructuring `= []`. An un-settled query has no data, so the default array is fresh per render and churns every downstream memo — the MUL-5477 commit-storm guard in `table-view-virtualized-hierarchy.test.tsx` fails on it.

## Not included

Sorting by project / assignee (also requested in #7337) is a separate change: three ORDER BY paths, a correlated-subquery sort with no index behind keyset pagination, and the client comparator's `default: position` fallthrough, which would silently reorder Swimlane and Gantt. It deserves its own PR and its own performance check.

## Testing

- `packages/views/issues/utils/drag-utils.test.ts` — group key agreement, bucketing, move updates, and the assignee-fallthrough guard.
- `packages/views/issues/components/board-view-project-grouping.test.tsx` — column titles, server group counts, project icon in the header, cards landing in their own column.
- `packages/views/issues/components/table-view-project-grouping.test.tsx` — group spec, title resolution, no-project and unresolvable-project labels.
- `packages/views/issues/surface/use-issue-surface-controller.test.tsx` — the board requests the grouping dimension it is set to.

`pnpm typecheck`, `pnpm lint`, `pnpm test` (4600+ tests) all pass locally. Each new test was confirmed to fail against the unpatched code. No manual pass against a running stack — the reviewer may want to eyeball the board column header.
