### PR TITLE
MUL-6531: H-412: support single-character issue prefixes in PR webhooks

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1033,7 +1033,7 @@ func (h *Handler) broadcastPRSnapshotApplied(ctx context.Context, prID pgtype.UU
 // uppercase. Word boundary on the left prevents matching inside email-style
 // strings (e.g. "abc@MUL-1") and the digit anchor on the right rules out
 // version numbers like "v1.2-3".
-var identifierRe = regexp.MustCompile(`(?i)\b([a-z][a-z0-9]{1,9})-(\d+)\b`)
+var identifierRe = regexp.MustCompile(`(?i)\b([a-z][a-z0-9]{0,9})-(\d+)\b`)
 
 // closingIdentifierRe extracts identifiers that appear immediately after a
 // GitHub-style closing keyword ("close[sd]?", "fix(e[sd])?", "resolve[sd]?"),
@@ -1045,7 +1045,7 @@ var identifierRe = regexp.MustCompile(`(?i)\b([a-z][a-z0-9]{1,9})-(\d+)\b`)
 // title prefixes like "MUL-1: ..." link the PR (via identifierRe) but
 // never auto-close.
 var closingIdentifierRe = regexp.MustCompile(
-	`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[:\s]+([a-z][a-z0-9]{1,9})-(\d+)\b`,
+	`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[:\s]+([a-z][a-z0-9]{0,9})-(\d+)\b`,
 )
 
 // HandleGitHubWebhook (POST /api/webhooks/github) is GitHub's destination for

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -42,6 +42,11 @@ func TestExtractIdentifiers(t *testing.T) {
 			want: []string{"MUL-1510"},
 		},
 		{
+			name: "single_character_prefix",
+			in:   []string{"H-412: fix widget parity"},
+			want: []string{"H-412"},
+		},
+		{
 			name: "title_and_body",
 			in:   []string{"Fix MUL-82", "Closes MUL-1510 and ABC-7", ""},
 			want: []string{"MUL-82", "MUL-1510", "ABC-7"},
@@ -88,6 +93,11 @@ func TestExtractClosingIdentifiers(t *testing.T) {
 			name: "single_closes",
 			in:   []string{"", "Closes MUL-1"},
 			want: []string{"MUL-1"},
+		},
+		{
+			name: "single_character_prefix",
+			in:   []string{"", "Closes H-412"},
+			want: []string{"H-412"},
 		},
 		{
 			name: "all_keyword_inflections",


### PR DESCRIPTION
## Summary

- accept one-character issue prefixes in the shared PR identifier scanner
- cover both ordinary linking (`H-412`) and close intent (`Closes H-412`)
- preserve the existing 10-character maximum and first-letter requirement

## Root cause

Workspace issue prefixes allow one character, but both webhook regular expressions required at least two. A valid `H-412` therefore produced no identifier and no issue ↔ PR link.

## Verification

- `GOTOOLCHAIN=auto go test ./internal/handler -count=1`
- `GOTOOLCHAIN=auto go vet ./internal/handler`
- `git diff --check`

Related: H-412
