### PR TITLE
fix(daemon): GC-reclaim orphaned per-task temp dirs under the task temp base

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -73,6 +73,7 @@ const (
 	DefaultGCOrphanTTL                    = 72 * time.Hour      // 3 days — orphans with no meta (crashes, pre-GC leftovers)
 	DefaultGCArtifactTTL                  = 12 * time.Hour      // 12h — drop regenerable artifacts once a task has been completed this long
 	DefaultGCCodexSessionTTL              = 14 * 24 * time.Hour // 14 days — reclaim per-issue Codex session stores untouched this long
+	DefaultGCTaskTempTTL                  = 72 * time.Hour      // 3 days — reclaim an orphaned per-task temp dir (the agent's TMPDIR) this stale; well above the longest task runtime because liveness comes from the active-store guard, not mtime
 	DefaultGCHermesMemoryTTL              = 90 * 24 * time.Hour // 90 days — reclaim per-agent Hermes memory stores untouched this long (long: reclaiming these is visible amnesia, and they are a few markdown files)
 	DefaultGCHermesSessionTTL             = 14 * 24 * time.Hour // 14 days — reclaim per-conversation Hermes session stores untouched this long (matches Codex: these hold transcripts, and losing an idle one restarts the thread rather than the agent's notes)
 	DefaultGCRepoTTL                      = 30 * 24 * time.Hour // 30 days — evict a bare repo cache no task has checked out this long
@@ -112,6 +113,7 @@ type Config struct {
 	GCRepoTTL                      time.Duration         // evict a cached bare repo under .repos once no task has created a worktree from it for this long, it has no worktrees left, and it is no longer attached to any watched workspace (default: 30d, set 0 to disable)
 	GCRepoMaintenanceEnabled       bool                  // run reflog expiry and git gc after stale agent refs are removed (default: true; disable independently as an operational kill switch)
 	GCCodexSessionTTL              time.Duration         // reclaim a per-issue Codex session store (~/.codex/multica-sessions/<agent>/<issue>) untouched for at least this long, so a done/abandoned issue's conversation history does not accumulate forever (default: 14d, set 0 to disable)
+	GCTaskTempTTL                  time.Duration         // reclaim an orphaned per-task temp dir (the agent's TMPDIR under the task temp base) untouched for at least this long; a live task's dir is protected by the active-store guard, so this only backstops dirs orphaned by a daemon restart (default: 72h, set 0 to disable)
 	GCHermesMemoryTTL              time.Duration         // reclaim a per-agent Hermes memory store (<profile dir>/hermes-state/<agent>/<profile>) untouched for at least this long, so a deleted agent's memory does not sit on disk forever (default: 90d, set 0 to disable)
 	GCHermesSessionTTL             time.Duration         // reclaim a per-conversation Hermes session store (<profile dir>/hermes-sessions/<agent>/<profile>/<conversation>) untouched for at least this long, so a done or abandoned conversation's transcript does not accumulate forever (default: 14d, set 0 to disable)
 	AutoUpdateEnabled              bool                  // periodically check for a newer CLI release and self-update when idle (default: true on Multica Cloud, false on self-host)
@@ -471,6 +473,10 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	gcTaskTempTTL, err := durationFromEnv("MULTICA_GC_TASK_TEMP_TTL", DefaultGCTaskTempTTL)
+	if err != nil {
+		return Config{}, err
+	}
 	gcHermesMemoryTTL, err := durationFromEnv("MULTICA_GC_HERMES_MEMORY_TTL", DefaultGCHermesMemoryTTL)
 	if err != nil {
 		return Config{}, err
@@ -538,6 +544,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		GCRepoTTL:                       gcRepoTTL,
 		GCRepoMaintenanceEnabled:        gcRepoMaintenanceEnabled,
 		GCCodexSessionTTL:               gcCodexSessionTTL,
+		GCTaskTempTTL:                   gcTaskTempTTL,
 		GCHermesMemoryTTL:               gcHermesMemoryTTL,
 		GCHermesSessionTTL:              gcHermesSessionTTL,
 		AutoUpdateEnabled:               autoUpdateEnabled,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6971,10 +6971,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)
 	}
+	// The GC temp-base sweep uses the same reservation protocol as the store
+	// pruners: while this mark is held, the dir cannot be reserved for
+	// deletion, so a long-running task whose TMPDIR root goes untouched never
+	// loses it to an mtime-only rule.
+	d.markActiveStore(taskTempDir)
 	defer func() {
 		if cerr := os.RemoveAll(taskTempDir); cerr != nil {
 			taskLog.Warn("task temp dir cleanup failed", "path", taskTempDir, "error", cerr)
 		}
+		d.unmarkActiveStore(taskTempDir)
 	}()
 
 	// Issue #3999 race A: now that env.WorkDir is on disk, transition the
@@ -8421,10 +8427,26 @@ func (d *Daemon) markActiveStore(store string) {
 	}
 	d.activeStoresMu.Lock()
 	defer d.activeStoresMu.Unlock()
+	d.ensureActiveStoreStateLocked()
 	for d.deletingStores[store] {
 		d.activeStoresCond.Wait()
 	}
 	d.activeStores[store]++
+}
+
+// ensureActiveStoreStateLocked lazily initialises the store-guard state, the
+// same way ensureActiveEnvRootStateLocked does, so a Daemon built without
+// New (tests) still tolerates a mark/unmark.
+func (d *Daemon) ensureActiveStoreStateLocked() {
+	if d.activeStores == nil {
+		d.activeStores = make(map[string]int)
+	}
+	if d.deletingStores == nil {
+		d.deletingStores = make(map[string]bool)
+	}
+	if d.activeStoresCond == nil {
+		d.activeStoresCond = sync.NewCond(&d.activeStoresMu)
+	}
 }
 
 func (d *Daemon) unmarkActiveStore(store string) {
@@ -8433,6 +8455,7 @@ func (d *Daemon) unmarkActiveStore(store string) {
 	}
 	d.activeStoresMu.Lock()
 	defer d.activeStoresMu.Unlock()
+	d.ensureActiveStoreStateLocked()
 	if d.activeStores[store] <= 1 {
 		delete(d.activeStores, store)
 		return
@@ -8451,6 +8474,7 @@ func (d *Daemon) unmarkActiveStore(store string) {
 func (d *Daemon) reserveStoreForDeletion(store string) (commit func(), ok bool) {
 	d.activeStoresMu.Lock()
 	defer d.activeStoresMu.Unlock()
+	d.ensureActiveStoreStateLocked()
 	if d.activeStores[store] > 0 || d.deletingStores[store] {
 		return nil, false
 	}

--- a/server/internal/daemon/execenv/task_temp.go
+++ b/server/internal/daemon/execenv/task_temp.go
@@ -1,0 +1,64 @@
+package execenv
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// taskTempDirPrefix matches the per-task temp dirs ensureTaskTempDir creates
+// under the task temp base (daemon.go). The base is usually a shared /tmp, so
+// only entries with this prefix may ever be touched.
+const taskTempDirPrefix = "multica-task-"
+
+// PruneTaskTempDirs reclaims orphaned per-task temp dirs (the agent's TMPDIR)
+// from the task temp base. Every task gets one, and its only removal path is
+// a defer in runTask — a daemon crash or a failed removal on Windows leaves
+// the dir forever, unbounded in size.
+//
+// Liveness comes from the caller's reservation protocol (reserve), not mtime:
+// a running task can go tens of minutes without touching the root of its temp
+// dir, so an mtime-only rule would delete a live task's TMPDIR. The mtime TTL
+// is only the backstop for dirs orphaned by a daemon restart, when the active
+// set is gone. retention <= 0 disables the sweep; an unreadable root is a
+// no-op. A removal failure is logged and retried on the next cycle.
+func PruneTaskTempDirs(root string, retention time.Duration, now time.Time, reserve func(dir string) (commit func(), ok bool), logger *slog.Logger) (removed int, bytesFreed int64) {
+	if retention <= 0 {
+		return 0, 0
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return 0, 0 // not created yet, or unreadable — nothing to prune
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), taskTempDirPrefix) {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		newest, size := codexStoreStat(dir)
+		if newest.IsZero() || now.Sub(newest) <= retention {
+			continue
+		}
+		var commit func()
+		if reserve != nil {
+			c, ok := reserve(dir)
+			if !ok {
+				continue // a live task holds it
+			}
+			commit = c
+		}
+		err := os.RemoveAll(dir)
+		if commit != nil {
+			commit()
+		}
+		if err != nil {
+			logger.Warn("execenv: prune task temp dir failed", "dir", dir, "error", err)
+			continue
+		}
+		removed++
+		bytesFreed += size
+	}
+	return removed, bytesFreed
+}

--- a/server/internal/daemon/execenv/task_temp_test.go
+++ b/server/internal/daemon/execenv/task_temp_test.go
@@ -1,0 +1,120 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// seedTaskTempDir creates a multica-task-* dir under base holding one file of
+// the given size, and returns the dir path.
+func seedTaskTempDir(t *testing.T, base string, size int64) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(base, taskTempDirPrefix)
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload.bin"), make([]byte, size), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return dir
+}
+
+func TestPruneTaskTempDirs_RemovesOrphanPastTTL(t *testing.T) {
+	base := t.TempDir()
+	orphan := seedTaskTempDir(t, base, 128)
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	chtimesTree(t, orphan, old)
+
+	removed, freed := PruneTaskTempDirs(base, 7*24*time.Hour, time.Now(), nil, testLogger())
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if freed <= 0 {
+		t.Errorf("bytesFreed = %d, want > 0", freed)
+	}
+	assertAbsent(t, orphan)
+}
+
+func TestPruneTaskTempDirs_MarkedActiveSurvivesStaleMtime(t *testing.T) {
+	base := t.TempDir()
+	live := seedTaskTempDir(t, base, 128)
+	// A running task can go tens of minutes without touching the root of its
+	// temp dir, so the mtime is at creation time — well past any short TTL.
+	chtimesTree(t, live, time.Now().Add(-30*24*time.Hour))
+
+	reserved := ""
+	release := func() {}
+	reserve := func(dir string) (func(), bool) {
+		if dir == live {
+			reserved = dir
+			return release, false // a live task holds it
+		}
+		return nil, true
+	}
+
+	removed, _ := PruneTaskTempDirs(base, 7*24*time.Hour, time.Now(), reserve, testLogger())
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0 (a marked-active dir must survive a stale mtime)", removed)
+	}
+	if reserved != live {
+		t.Errorf("reserve was not consulted for the live dir %s", live)
+	}
+	assertPresent(t, live)
+}
+
+func TestPruneTaskTempDirs_YoungerThanTTLKept(t *testing.T) {
+	base := t.TempDir()
+	fresh := seedTaskTempDir(t, base, 64)
+
+	removed, _ := PruneTaskTempDirs(base, 7*24*time.Hour, time.Now(), nil, testLogger())
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+	assertPresent(t, fresh)
+}
+
+func TestPruneTaskTempDirs_OnlyMulticaTaskPrefix(t *testing.T) {
+	base := t.TempDir()
+	stale := time.Now().Add(-30 * 24 * time.Hour)
+
+	sibling := filepath.Join(base, "not-a-task-dir")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	siblingFile := filepath.Join(base, "multica-task-not-a-dir.txt")
+	if err := os.WriteFile(siblingFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := seedTaskTempDir(t, base, 32)
+	chtimesTree(t, sibling, stale)
+	chtimesTree(t, siblingFile, stale)
+	chtimesTree(t, task, stale)
+
+	removed, _ := PruneTaskTempDirs(base, 7*24*time.Hour, time.Now(), nil, testLogger())
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	assertPresent(t, sibling)
+	assertPresent(t, siblingFile)
+	assertAbsent(t, task)
+}
+
+func TestPruneTaskTempDirs_RetentionZeroDisables(t *testing.T) {
+	base := t.TempDir()
+	dir := seedTaskTempDir(t, base, 32)
+	chtimesTree(t, dir, time.Now().Add(-30*24*time.Hour))
+
+	if removed, _ := PruneTaskTempDirs(base, 0, time.Now(), nil, testLogger()); removed != 0 {
+		t.Fatalf("retention<=0 must disable the sweep, removed=%d", removed)
+	}
+	assertPresent(t, dir)
+}
+
+func TestPruneTaskTempDirs_UnreadableRootIsNoop(t *testing.T) {
+	removed, freed := PruneTaskTempDirs(filepath.Join(t.TempDir(), "missing"), 7*24*time.Hour, time.Now(), nil, testLogger())
+	if removed != 0 || freed != 0 {
+		t.Fatalf("unreadable root must return (0,0), got (%d,%d)", removed, freed)
+	}
+}

--- a/server/internal/daemon/execenv/task_temp_test.go
+++ b/server/internal/daemon/execenv/task_temp_test.go
@@ -118,3 +118,32 @@ func TestPruneTaskTempDirs_UnreadableRootIsNoop(t *testing.T) {
 		t.Fatalf("unreadable root must return (0,0), got (%d,%d)", removed, freed)
 	}
 }
+
+// TestPruneTaskTempDirs_RemovalFailureRetriedNextCycle covers the failure
+// path: a base dir without write permission makes RemoveAll of the child
+// fail (unlink needs write on the parent). The sweep must report removed=0,
+// leave the dir in place, and let the next cycle retry. Skipped as root —
+// root unlinks regardless of mode, so the failure cannot be produced.
+func TestPruneTaskTempDirs_RemovalFailureRetriedNextCycle(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based removal failure cannot be produced")
+	}
+	base := t.TempDir()
+	dir := seedTaskTempDir(t, base, 32)
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	chtimesTree(t, dir, old)
+
+	if err := os.Chmod(base, 0o500); err != nil {
+		t.Fatalf("chmod base: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(base, 0o700) })
+
+	removed, freed := PruneTaskTempDirs(base, 7*24*time.Hour, time.Now(), nil, testLogger())
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0 (removal must fail without write permission on the base)", removed)
+	}
+	if freed != 0 {
+		t.Errorf("bytesFreed = %d, want 0 when nothing was removed", freed)
+	}
+	assertPresent(t, dir)
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -72,6 +72,7 @@ type gcStats struct {
 	hermesMemoryStoresReclaimed  int            // per-agent Hermes memory stores reclaimed past their TTL
 	hermesSessionStoresReclaimed int            // per-conversation Hermes session stores reclaimed past their TTL
 	repoCachesReclaimed          int            // bare repo caches under .repos evicted past their TTL
+	taskTempDirsReclaimed        int            // orphaned per-task temp dirs (the agent's TMPDIR) reclaimed past their TTL
 	bytesReclaimed               int64          // total bytes freed in this cycle
 	byPattern                    map[string]int // configured basename or managed path label -> reclaim count
 }
@@ -134,7 +135,20 @@ func (d *Daemon) runGC(ctx context.Context) {
 		stats.bytesReclaimed += storeBytes
 	}
 
-	if stats.cleaned > 0 || stats.orphaned > 0 || stats.artifactDirs > 0 || stats.storesReclaimed > 0 || stats.hermesMemoryStoresReclaimed > 0 || stats.hermesSessionStoresReclaimed > 0 || stats.repoCachesReclaimed > 0 {
+	// Reclaim orphaned per-task temp dirs. Every task's TMPDIR lives under the
+	// task temp base (usually /tmp), outside WorkspacesRoot, and its only
+	// removal path is a defer in runTask — a daemon crash or a failed removal
+	// on Windows leaves it forever, unbounded in size. Liveness comes from the
+	// active-store reservation, not mtime: a running task can go tens of
+	// minutes without touching the root of its temp dir.
+	if tempBase, _, err := taskTempBaseDir(); err != nil {
+		d.logger.Warn("gc: resolve task temp base failed", "error", err)
+	} else if removed, freed := execenv.PruneTaskTempDirs(tempBase, d.cfg.GCTaskTempTTL, time.Now(), d.reserveStoreForDeletion, d.logger); removed > 0 {
+		stats.taskTempDirsReclaimed += removed
+		stats.bytesReclaimed += freed
+	}
+
+	if stats.cleaned > 0 || stats.orphaned > 0 || stats.artifactDirs > 0 || stats.storesReclaimed > 0 || stats.hermesMemoryStoresReclaimed > 0 || stats.hermesSessionStoresReclaimed > 0 || stats.repoCachesReclaimed > 0 || stats.taskTempDirsReclaimed > 0 {
 		d.logger.Info("gc: cycle complete",
 			"cleaned", stats.cleaned,
 			"orphaned", stats.orphaned,
@@ -145,6 +159,7 @@ func (d *Daemon) runGC(ctx context.Context) {
 			"hermes_memory_stores_reclaimed", stats.hermesMemoryStoresReclaimed,
 			"hermes_session_stores_reclaimed", stats.hermesSessionStoresReclaimed,
 			"repo_caches_reclaimed", stats.repoCachesReclaimed,
+			"task_temp_dirs_reclaimed", stats.taskTempDirsReclaimed,
 			"bytes_reclaimed", stats.bytesReclaimed,
 			"by_pattern", stats.byPattern,
 		)

--- a/server/internal/daemon/gc_tasktemp_test.go
+++ b/server/internal/daemon/gc_tasktemp_test.go
@@ -3,11 +3,14 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -79,5 +82,86 @@ func TestRunGC_MarkedActiveTaskTempDirSurvivesStaleMtime(t *testing.T) {
 
 	if _, err := os.Stat(live); err != nil {
 		t.Fatalf("marked-active task temp dir must survive GC despite stale mtime: %v", err)
+	}
+}
+
+// TestRunTask_MarksTaskTempDirActiveWhileInFlight proves the runTask wiring,
+// not just the pruner: while a task is in flight, its multica-task-* temp dir
+// is held via markActiveStore, so reserveStoreForDeletion refuses it; after
+// runTask returns (dir removed and unmarked), the reservation succeeds. With
+// the markActiveStore call deleted from runTask, the mid-task reserve would
+// return ok=true and this test fails.
+func TestRunTask_MarksTaskTempDirActiveWhileInFlight(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("MULTICA_AGENT_TEMP_BASE", tempBase)
+
+	var (
+		startCalled      atomic.Bool
+		midTaskReserveOK atomic.Bool
+		tempDirSeen      atomic.Bool
+		daemonRef        atomic.Pointer[Daemon]
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/start") {
+			startCalled.Store(true)
+			d := daemonRef.Load()
+			if d == nil {
+				t.Error("daemon not registered when /start fired")
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			matches, err := filepath.Glob(filepath.Join(tempBase, "multica-task-*"))
+			if err != nil {
+				t.Errorf("glob temp base: %v", err)
+			}
+			if len(matches) != 1 {
+				t.Errorf("expected exactly 1 task temp dir in flight, got %d", len(matches))
+				return
+			}
+			tempDirSeen.Store(true)
+			_, ok := d.reserveStoreForDeletion(matches[0])
+			midTaskReserveOK.Store(ok)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	missingBin := filepath.Join(t.TempDir(), "definitely-not-claude")
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:     make(map[string]*workspaceState),
+		runtimeIndex:   map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "claude"}},
+		activeEnvRoots: make(map[string]int),
+		cfg: Config{
+			WorkspacesRoot: t.TempDir(),
+			Agents: map[string]AgentEntry{
+				"claude": {Path: missingBin, Model: ""},
+			},
+		},
+	}
+	daemonRef.Store(d)
+
+	task := Task{
+		ID:          "task-temp-mark",
+		WorkspaceID: "ws-temp-mark",
+		RuntimeID:   "rt-1",
+		IssueID:     "issue-temp-mark",
+		AgentID:     "agent-temp-mark",
+		Agent:       &AgentData{ID: "agent-temp-mark", Name: "test-agent"},
+	}
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, _ = d.runTask(context.Background(), task, "claude", 0, taskLog)
+
+	if !startCalled.Load() {
+		t.Fatal("runTask did not call /start — test harness never reached the task window")
+	}
+	if !tempDirSeen.Load() {
+		t.Fatal("no multica-task-* dir existed under the temp base when /start fired")
+	}
+	if midTaskReserveOK.Load() {
+		t.Fatal("reserveStoreForDeletion succeeded on the task temp dir mid-task — runTask did not mark it active")
 	}
 }

--- a/server/internal/daemon/gc_tasktemp_test.go
+++ b/server/internal/daemon/gc_tasktemp_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunGC_PrunesTaskTempDirs proves the temp-base sweep is wired into
+// runGC: an orphaned multica-task-* dir past the TTL is reclaimed and the
+// new counter reaches the "gc: cycle complete" log line.
+func TestRunGC_PrunesTaskTempDirs(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("MULTICA_AGENT_TEMP_BASE", tempBase)
+
+	orphan := filepath.Join(tempBase, "multica-task-orphan")
+	if err := os.MkdirAll(orphan, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "payload.bin"), make([]byte, 64), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := filepath.Walk(orphan, func(p string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(p, old, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuf bytes.Buffer
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCTaskTempTTL = 7 * 24 * time.Hour
+	d.logger = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	d.runGC(context.Background())
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphaned task temp dir %s must be removed by runGC", orphan)
+	}
+	if !strings.Contains(logBuf.String(), "gc: cycle complete") {
+		t.Fatalf("cycle complete log missing:\n%s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "task_temp_dirs_reclaimed=1") {
+		t.Fatalf("task_temp_dirs_reclaimed counter missing from cycle summary:\n%s", logBuf.String())
+	}
+}
+
+// The safety property, end to end through the real reservation protocol: a
+// dir a live task holds via markActiveStore survives runGC even when its
+// mtime is far past the TTL.
+func TestRunGC_MarkedActiveTaskTempDirSurvivesStaleMtime(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("MULTICA_AGENT_TEMP_BASE", tempBase)
+
+	live := filepath.Join(tempBase, "multica-task-live")
+	if err := os.MkdirAll(live, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(live, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCTaskTempTTL = 7 * 24 * time.Hour
+	d.markActiveStore(live)
+	defer d.unmarkActiveStore(live)
+
+	d.runGC(context.Background())
+
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("marked-active task temp dir must survive GC despite stale mtime: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #7376.

Every task gets a private TMPDIR (`multica-task-*` under the task temp base, usually `/tmp`) from `ensureTaskTempDir`. Its only removal path is a defer in `runTask`, so a daemon crash — or a failed removal on Windows — leaves it forever. `runGC` scans `WorkspacesRoot` only, so these are invisible to it and unbounded in size.

## Change

- `execenv.PruneTaskTempDirs(root, retention, now, reserve, logger)` in `execenv/task_temp.go`, in the shape of the existing `PruneCodexSessionStores` / `PruneHermesMemoryStores`: returns `(removed, bytesFreed)`, `retention <= 0` disables the sweep, an unreadable root is a no-op, only `multica-task-*` directories are ever considered, and a removal failure is logged and retried on the next cycle.
- `runGC` calls it after the Hermes pruners with the root from `taskTempBaseDir()`; new `taskTempDirsReclaimed` counter in `gcStats`, in the cycle-complete guard and the log line.
- `Config.GCTaskTempTTL` / `DefaultGCTaskTempTTL` (72h) / `MULTICA_GC_TASK_TEMP_TTL`.
- `runTask` marks the temp dir active right after `ensureTaskTempDir` and unmarks it in the cleanup defer, after `RemoveAll`.

## Why liveness is not mtime

A running task can go tens of minutes without touching the *root* of its temp dir, so the root mtime stays at creation time. An mtime-only rule would delete a live task's TMPDIR. Liveness comes from the existing `markActiveStore` / `reserveStoreForDeletion` reservation protocol — the same exclusive check-and-mark the store pruners use (MUL-4424). The mtime TTL is only the backstop for dirs orphaned by a daemon restart, when the active set is gone. Size and age come from `codexStoreStat`, which reports the newest mtime across the whole tree rather than the root's.

## Tests

9 new tests. Two cover the safety property directly — a marked-active dir with a 30-day-stale mtime survives, both through a stub `reserve` at the pruner level and through real `markActiveStore` / `reserveStoreForDeletion` via `runGC`. A `runTask` harness test proves the wiring rather than the pruner alone: from the agent `/start` handler it globs the in-flight `multica-task-*` dir and asserts `reserveStoreForDeletion` refuses it. The removal-failure path is covered by chmod-ing the base to `0500` (self-skips under root).

Verified with `go build ./...`, `go vet ./...`, `gofmt`, `GOOS=windows`/`GOOS=linux GOARCH=amd64 go build ./cmd/... ./internal/...`, and `go test ./... -count=1` — zero failures.
