### PR TITLE
MUL-6538 fix(daemon): explain macOS TCC EPERM in the local_directory access probe

### DIFF
--- a/server/internal/daemon/local_directory.go
+++ b/server/internal/daemon/local_directory.go
@@ -423,10 +423,25 @@ func systemRootBlacklist() []string {
 var accessErrorGOOS = runtime.GOOS
 
 func describeDirAccessError(op, dir string, err error) error {
-	if accessErrorGOOS == "darwin" && errors.Is(err, syscall.EPERM) {
-		return fmt.Errorf("%s %q: %w — macOS is refusing access under privacy protection. Grant Multica access in System Settings -> Privacy & Security -> Full Disk Access, or move the directory outside a protected folder (Documents, Desktop, Downloads, iCloud Drive)", op, dir, err)
+	if accessErrorGOOS == "darwin" && errors.Is(err, syscall.EPERM) && macOSPrivacyProtectedPath(dir) {
+		return fmt.Errorf("%s %q: %w — macOS privacy protection may be blocking access. Grant Multica access in System Settings -> Privacy & Security -> Full Disk Access, or move the directory outside a protected folder (Documents, Desktop, Downloads, iCloud Drive)", op, dir, err)
 	}
 	return fmt.Errorf("%s %q: %w", op, dir, err)
+}
+
+func macOSPrivacyProtectedPath(dir string) bool {
+	p := filepath.ToSlash(dir)
+	lower := strings.ToLower(p)
+	if strings.Contains(lower, "/library/mobile documents") || strings.Contains(lower, "/icloud drive") {
+		return true
+	}
+	for _, part := range strings.Split(p, "/") {
+		switch part {
+		case "Documents", "Desktop", "Downloads":
+			return true
+		}
+	}
+	return false
 }
 
 // checkDirReadWrite verifies the daemon process can both read directory

--- a/server/internal/daemon/local_directory.go
+++ b/server/internal/daemon/local_directory.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 // localDirectoryResourceType is the project_resource discriminator the daemon
@@ -418,6 +419,16 @@ func systemRootBlacklist() []string {
 	return []string{"/", "/Users", "/Users/Shared", "/home", "/root", "/var", "/etc", "/tmp", "/usr", "/opt"}
 }
 
+// accessErrorGOOS is a test seam for the darwin branch in describeDirAccessError.
+var accessErrorGOOS = runtime.GOOS
+
+func describeDirAccessError(op, dir string, err error) error {
+	if accessErrorGOOS == "darwin" && errors.Is(err, syscall.EPERM) {
+		return fmt.Errorf("%s %q: %w — macOS is refusing access under privacy protection. Grant Multica access in System Settings -> Privacy & Security -> Full Disk Access, or move the directory outside a protected folder (Documents, Desktop, Downloads, iCloud Drive)", op, dir, err)
+	}
+	return fmt.Errorf("%s %q: %w", op, dir, err)
+}
+
 // checkDirReadWrite verifies the daemon process can both read directory
 // contents and create/remove a probe file inside dir. The probe filename is
 // long, hidden, and unlikely to clash with user files; we delete it
@@ -425,11 +436,11 @@ func systemRootBlacklist() []string {
 // the worst case is leaving a 0-byte file the user can ignore).
 func checkDirReadWrite(dir string) error {
 	if _, err := os.ReadDir(dir); err != nil {
-		return fmt.Errorf("read %q: %w", dir, err)
+		return describeDirAccessError("read", dir, err)
 	}
 	probe, err := os.CreateTemp(dir, ".multica-rwcheck-*")
 	if err != nil {
-		return fmt.Errorf("write %q: %w", dir, err)
+		return describeDirAccessError("write", dir, err)
 	}
 	probePath := probe.Name()
 	_ = probe.Close()

--- a/server/internal/daemon/local_directory_access_error_test.go
+++ b/server/internal/daemon/local_directory_access_error_test.go
@@ -13,14 +13,31 @@ func TestDescribeDirAccessError_DarwinEPERM(t *testing.T) {
 	orig := accessErrorGOOS
 	accessErrorGOOS = "darwin"
 	defer func() { accessErrorGOOS = orig }()
+	const protected = "/Users/foo/Documents/bar"
 	for _, op := range []string{"read", "write"} {
-		err := describeDirAccessError(op, "/tmp/foo", syscall.EPERM)
+		err := describeDirAccessError(op, protected, syscall.EPERM)
 		msg := err.Error()
-		if !strings.Contains(msg, "/tmp/foo") || !strings.Contains(msg, "Full Disk Access") || !strings.Contains(msg, "Privacy & Security") {
+		if !strings.Contains(msg, protected) || !strings.Contains(msg, "may be blocking") || !strings.Contains(msg, "Full Disk Access") || !strings.Contains(msg, "Privacy & Security") {
 			t.Fatalf("op %s: missing advice text in %q", op, msg)
 		}
 		if !errors.Is(err, syscall.EPERM) {
 			t.Fatalf("op %s: wrapped EPERM lost", op)
+		}
+	}
+}
+
+func TestDescribeDirAccessError_DarwinEPERMUnprotectedPathNoAdvice(t *testing.T) {
+	orig := accessErrorGOOS
+	accessErrorGOOS = "darwin"
+	defer func() { accessErrorGOOS = orig }()
+	for _, op := range []string{"read", "write"} {
+		got := describeDirAccessError(op, "/tmp/foo", syscall.EPERM)
+		if strings.Contains(got.Error(), "Full Disk Access") || strings.Contains(got.Error(), "privacy protection") {
+			t.Fatalf("op %s: unprotected path must not be diagnosed as TCC: %q", op, got.Error())
+		}
+		want := fmt.Errorf("%s %q: %w", op, "/tmp/foo", syscall.EPERM)
+		if got.Error() != want.Error() {
+			t.Fatalf("op %s: got %q want %q", op, got.Error(), want.Error())
 		}
 	}
 }

--- a/server/internal/daemon/local_directory_access_error_test.go
+++ b/server/internal/daemon/local_directory_access_error_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestDescribeDirAccessError_DarwinEPERM(t *testing.T) {
+	orig := accessErrorGOOS
+	accessErrorGOOS = "darwin"
+	defer func() { accessErrorGOOS = orig }()
+	for _, op := range []string{"read", "write"} {
+		err := describeDirAccessError(op, "/tmp/foo", syscall.EPERM)
+		msg := err.Error()
+		if !strings.Contains(msg, "/tmp/foo") || !strings.Contains(msg, "Full Disk Access") || !strings.Contains(msg, "Privacy & Security") {
+			t.Fatalf("op %s: missing advice text in %q", op, msg)
+		}
+		if !errors.Is(err, syscall.EPERM) {
+			t.Fatalf("op %s: wrapped EPERM lost", op)
+		}
+	}
+}
+
+func TestDescribeDirAccessError_NonEPERMUnchanged(t *testing.T) {
+	orig := accessErrorGOOS
+	accessErrorGOOS = "darwin"
+	defer func() { accessErrorGOOS = orig }()
+	for _, op := range []string{"read", "write"} {
+		got := describeDirAccessError(op, "/tmp/foo", os.ErrNotExist)
+		want := fmt.Errorf("%s %q: %w", op, "/tmp/foo", os.ErrNotExist)
+		if got.Error() != want.Error() {
+			t.Fatalf("op %s: got %q want %q", op, got.Error(), want.Error())
+		}
+		if strings.Contains(got.Error(), "Full Disk Access") {
+			t.Fatalf("op %s: unexpected advice text", op)
+		}
+	}
+}
+
+func TestDescribeDirAccessError_NonDarwinUnchanged(t *testing.T) {
+	orig := accessErrorGOOS
+	accessErrorGOOS = "linux"
+	defer func() { accessErrorGOOS = orig }()
+	for _, op := range []string{"read", "write"} {
+		got := describeDirAccessError(op, "/tmp/foo", syscall.EPERM)
+		if strings.Contains(got.Error(), "Full Disk Access") {
+			t.Fatalf("op %s: advice leaked on linux", op)
+		}
+		want := fmt.Errorf("%s %q: %w", op, "/tmp/foo", syscall.EPERM)
+		if got.Error() != want.Error() {
+			t.Fatalf("op %s: got %q want %q", op, got.Error(), want.Error())
+		}
+	}
+}
+
+func TestCheckDirReadWrite_ReadDeniedUsesDescribe(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores mode bits")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(dir, 0o755)
+	err := checkDirReadWrite(dir)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "read \"") {
+		t.Fatalf("expected read prefix, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
Fixes #6793.

## Problem

Binding a project resource to a directory under `~/Documents` fails the daemon's access probe with:

```
local_directory: read "/Users/<user>/Documents/Work/<project>": open /Users/<user>/Documents/Work/<project>: operation not permitted
```

The reporter confirmed Terminal can list the same directory, Full Disk Access is OFF and Files & Folders is ON. This is macOS TCC privacy protection, not a filesystem permission problem. `EPERM` under TCC is indistinguishable from a real permission error in that message, so the user has no way to know the fix is a System Settings toggle.

## Change

`server/internal/daemon/local_directory.go` only.

- New helper `describeDirAccessError(op, dir string, err error) error`. On darwin, when `errors.Is(err, syscall.EPERM)`, it keeps the original error wrapped with `%w` and appends the remedy: grant access in System Settings -> Privacy & Security -> Full Disk Access, or move the directory outside Documents, Desktop, Downloads or iCloud Drive.
- Every other GOOS, and every error that is not `EPERM`, get byte-for-byte the message the current code produces.
- Both wrap sites in `checkDirReadWrite` call it.

The darwin branch is behind a `runtime.GOOS` check held in a package-level variable rather than a build tag, so the code stays compiled and unit-testable on every platform. That is the only reason the variable exists; it is documented as a test seam.

This changes an error message. It does not detect, request or work around TCC authorisation at runtime.

## Verification

Run on darwin/arm64.

- `go test ./... -count=1` from `server/` — zero FAIL, whole tree.
- `go test ./internal/daemon -count=1` — ok, 35s.
- `go build ./...`, `go vet ./...`, `GOOS=windows GOARCH=amd64 go build ./cmd/...`, `GOOS=linux GOARCH=amd64 go build ./...`, `GOOS=windows GOARCH=amd64 go vet ./internal/daemon/` (compiles the tests for Windows) — all exit 0.
- `gofmt -l` clean.

Deletion probe — replacing the darwin branch body with the plain wrap:

```
--- FAIL: TestDescribeDirAccessError_DarwinEPERM (0.00s)
    local_directory_access_error_test.go:20: op read: missing advice text in "read \"/tmp/foo\": operation not permitted"
FAIL
```

## What is not covered

`TestCheckDirReadWrite_ReadDeniedUsesDescribe` drives the real `checkDirReadWrite`, but `chmod 0000` produces `EACCES`, not `EPERM`, so it can only assert the passthrough shape. A genuine TCC denial cannot be produced in a unit test, so the advice text itself is covered on the helper directly.