### PR TITLE
MUL-6506: fix(agent): route all Windows Pi runs through powershell -Command to preserve stdin

### DIFF
--- a/server/pkg/agent/pi_invocation.go
+++ b/server/pkg/agent/pi_invocation.go
@@ -1,6 +1,18 @@
 package agent
 
-import "log/slog"
+import (
+	"log/slog"
+	"strings"
+)
+
+// piPowerShellCommandArgs builds the argv for the -Command route, which is the
+// only PowerShell route that leaves stdin bytes untouched (#7355).
+func piPowerShellCommandArgs(ps1 string, args []string) []string {
+	quotedPS1 := strings.ReplaceAll(ps1, "'", "''")
+	full := make([]string, 0, 6+len(args))
+	full = append(full, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& '"+quotedPS1+"' @args")
+	return append(full, args...)
+}
 
 // choosePiInvocation selects the actual program (argv[0]) and the full
 // argv to spawn a Pi run.
@@ -16,11 +28,13 @@ import "log/slog"
 //     containing newlines or other whitespace — for Pi, that's the
 //     multi-line positional prompt passed by buildPiArgs. Symptom: the
 //     Pi session JSONL records only the first line of the prompt
-//     (#3306). To stay on the official launch path while avoiding that
-//     re-tokenisation, we resolve pi.ps1 next to the .cmd and invoke
-//     PowerShell with `-File <ps1>` directly. The task prompt now travels on
-//     stdin (#6457), but the rewrite remains necessary for multi-line custom
-//     option values and installations that still use the npm batch launcher.
+//     (#3306). We resolve pi.ps1 next to the .cmd and invoke PowerShell
+//     with `-Command & 'pi.ps1' @args`. The prompt moved to stdin in
+//     #6457, and -File re-encodes stdin under the console ANSI codepage,
+//     destroying every non-ASCII byte (#7355) — so every Pi invocation
+//     takes the -Command route, which forwards stdin untouched. The
+//     residual #3306 exposure is a multi-line custom option value, which
+//     @args still forwards as one token.
 //
 // The Windows-specific behaviour is implemented in
 // pi_invocation_windows.go; on other platforms we fall through to a

--- a/server/pkg/agent/pi_invocation_test.go
+++ b/server/pkg/agent/pi_invocation_test.go
@@ -34,3 +34,47 @@ func TestChoosePiInvocation_PassthroughForNonLauncher(t *testing.T) {
 		t.Errorf("argv changed unexpectedly:\n got  %#v\n want %#v", gotArgs, args)
 	}
 }
+
+// TestPiPowerShellCommandArgs pins the argv shape of the -Command route,
+// which is the only PowerShell route that leaves stdin bytes untouched
+// (#7355). Runs on every platform: it tests the pure helper, not the
+// Windows-tagged rewrite.
+func TestPiPowerShellCommandArgs(t *testing.T) {
+	ps1 := `C:\Users\X\npm\pi.ps1`
+	args := []string{"-p", "--mode", "json"}
+
+	got := piPowerShellCommandArgs(ps1, args)
+	want := []string{
+		"-NoProfile",
+		"-ExecutionPolicy", "Bypass",
+		"-Command", "& '" + ps1 + "' @args",
+		"-p", "--mode", "json",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("argv mismatch:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+func TestPiPowerShellCommandArgs_EscapesSingleQuotesInPath(t *testing.T) {
+	ps1 := `C:\Users\O'Brien\npm\pi.ps1`
+	got := piPowerShellCommandArgs(ps1, nil)
+	want := []string{
+		"-NoProfile",
+		"-ExecutionPolicy", "Bypass",
+		"-Command", "& 'C:\\Users\\O''Brien\\npm\\pi.ps1' @args",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("argv mismatch:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+func TestPiPowerShellCommandArgs_ForwardsMultiLineArgVerbatim(t *testing.T) {
+	multiLine := "line one\n\nline two\n"
+	got := piPowerShellCommandArgs(`C:\pi.ps1`, []string{"-p", multiLine})
+	if len(got) != 7 {
+		t.Fatalf("len(got) = %d, want 7: %#v", len(got), got)
+	}
+	if got[len(got)-1] != multiLine {
+		t.Errorf("multi-line arg was not forwarded verbatim:\n got  %q\n want %q", got[len(got)-1], multiLine)
+	}
+}

--- a/server/pkg/agent/pi_invocation_windows.go
+++ b/server/pkg/agent/pi_invocation_windows.go
@@ -9,27 +9,13 @@ import (
 	"strings"
 )
 
-// platformPiInvocation rewrites pi.cmd → PowerShell -File pi.ps1 on
-// Windows to avoid cmd.exe %* re-tokenisation (see #3306).
+// platformPiInvocation rewrites pi.cmd → PowerShell -Command pi.ps1 on
+// Windows. -Command with @args is the only route that preserves stdin bytes:
+// -File re-encodes stdin under the console ANSI codepage, destroying
+// non-ASCII input (#7355). It also avoids cmd.exe %* re-tokenisation (#3306).
 // powerShellLookup and rewriteCmdToPS1 are defined in cursor_invocation_windows.go.
 func platformPiInvocation(lookedUp string, args []string, logger *slog.Logger) (string, []string, bool) {
-	if isPiRPCInvocation(args) {
-		return rewriteCmdToPS1Command("pi", lookedUp, args, logger)
-	}
-	return rewriteCmdToPS1("pi", lookedUp, args, logger)
-}
-
-func isPiRPCInvocation(args []string) bool {
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--mode" && i+1 < len(args) && args[i+1] == "rpc" {
-			return true
-		}
-		if arg == "--mode=rpc" {
-			return true
-		}
-	}
-	return false
+	return rewriteCmdToPS1Command("pi", lookedUp, args, logger)
 }
 
 func rewriteCmdToPS1Command(toolName, lookedUp string, args []string, logger *slog.Logger) (string, []string, bool) {
@@ -47,13 +33,10 @@ func rewriteCmdToPS1Command(toolName, lookedUp string, args []string, logger *sl
 		return "", nil, false
 	}
 
-	quotedPS1 := strings.ReplaceAll(ps1, "'", "''")
-	full := make([]string, 0, 6+len(args))
-	full = append(full, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& '"+quotedPS1+"' @args")
-	full = append(full, args...)
+	full := piPowerShellCommandArgs(ps1, args)
 
 	if logger != nil {
-		logger.Info(toolName+": routing RPC through powershell -Command to preserve stdin",
+		logger.Info(toolName+": routing through powershell -Command to preserve stdin",
 			"powershell", psExe,
 			"ps1", ps1,
 			"original", lookedUp,

--- a/server/pkg/agent/pi_invocation_windows_test.go
+++ b/server/pkg/agent/pi_invocation_windows_test.go
@@ -10,14 +10,15 @@ import (
 	"testing"
 )
 
-// TestPlatformPiInvocation_RewritesCmdLauncherToPowerShellFile is the core
+// TestPlatformPiInvocation_RewritesCmdLauncherToPowerShellCommand is the core
 // Windows test: when LookPath resolves pi to the npm-installed .cmd
-// launcher and a sibling pi.ps1 exists, we should invoke PowerShell with
-// -File <ps1> and forward every original arg unchanged — including a synthetic
-// multi-line value that cmd.exe %* would otherwise mangle. The task prompt now
-// travels on stdin (#6457), but this preserves the #3306 launcher guarantee for
-// custom option values and keeps the historical failure mode covered.
-func TestPlatformPiInvocation_RewritesCmdLauncherToPowerShellFile(t *testing.T) {
+// launcher and a sibling pi.ps1 exists, we invoke PowerShell with
+// -Command & 'pi.ps1' @args and forward every original arg unchanged —
+// including a multi-line value. The task prompt travels on stdin (#6457) and
+// -File re-encodes stdin under the console codepage (#7355), so every Pi
+// invocation takes the -Command route; @args also preserves the #3306
+// multi-line custom option value guarantee.
+func TestPlatformPiInvocation_RewritesCmdLauncherToPowerShellCommand(t *testing.T) {
 	dir := t.TempDir()
 	cmdPath := filepath.Join(dir, "pi.cmd")
 	ps1Path := filepath.Join(dir, "pi.ps1")
@@ -48,25 +49,28 @@ func TestPlatformPiInvocation_RewritesCmdLauncherToPowerShellFile(t *testing.T) 
 	wantArgs := append([]string{
 		"-NoProfile",
 		"-ExecutionPolicy", "Bypass",
-		"-File", ps1Path,
+		"-Command", "& '" + ps1Path + "' @args",
 	}, args...)
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Errorf("argv mismatch:\n got  %#v\n want %#v", gotArgs, wantArgs)
 	}
 
 	// Explicit check: the last argv (the positional prompt) must still
-	// contain every line of the original multi-line prompt. This is the
-	// concrete property #3306 violates when cmd.exe re-tokenises %*.
+	// contain every line of the original multi-line prompt — forwarded
+	// verbatim through @args.
 	if gotArgs[len(gotArgs)-1] != multiLinePrompt {
 		t.Errorf("multi-line prompt was mangled:\n got  %q\n want %q", gotArgs[len(gotArgs)-1], multiLinePrompt)
+	}
+	for _, arg := range gotArgs {
+		if arg == "-File" {
+			t.Fatalf("task runs must not use powershell -File (re-encodes stdin, #7355): %#v", gotArgs)
+		}
 	}
 }
 
 // TestPlatformPiInvocation_RPCRoutesThroughPowerShellCommand pins the model
-// discovery path. Pi RPC keeps stdin open for bidirectional JSON-RPC, while the
-// npm pi.ps1 -File wrapper can wait for EOF before forwarding stdin. Use
-// -Command with @args only for RPC so ordinary task execution keeps the
-// established -File launcher behaviour above.
+// discovery path: --mode rpc takes the same -Command route as every other Pi
+// invocation, since the route is now unconditional.
 func TestPlatformPiInvocation_RPCRoutesThroughPowerShellCommand(t *testing.T) {
 	dir := t.TempDir()
 	cmdPath := filepath.Join(dir, "pi.cmd")


### PR DESCRIPTION
Fixes #7355.

## Problem

`platformPiInvocation` gated the PowerShell route on `isPiRPCInvocation(args)` — true only for `--mode rpc`. Task and chat runs pass `--mode json`, so every real Pi run went down `rewriteCmdToPS1` (`powershell -File pi.ps1`).

In `-File` mode Windows PowerShell 5.1 reads stdin through the console ANSI codepage. The prompt has travelled on stdin since #6457, so non-ASCII bytes were destroyed before Pi ever saw them.

## Change

- `platformPiInvocation` now always calls `rewriteCmdToPS1Command` (`-Command` + `@args`), which forwards stdin untouched.
- Deletes the now-dead `isPiRPCInvocation` predicate and its test.
- Extracts the argv construction into an untagged `piPowerShellCommandArgs` helper in `pi_invocation.go` so the argv shape is unit-testable off Windows; `rewriteCmdToPS1Command` calls it.
- Updates the `choosePiInvocation` doc comment: the #3306 `-File` rationale is stale for Pi now that the prompt is on stdin. The residual #3306 exposure is a multi-line custom option value, which `@args` splatting forwards as one token.

## Verification

- `go test ./pkg/agent/ -count=1` — ok
- `go test ./... -count=1` from `server/` — all packages ok
- `GOOS=windows go vet ./pkg/agent/...` and `GOOS=windows go test -c -o /dev/null ./pkg/agent/` — exit 0
- `gofmt -l`, `go build ./...`, `go vet ./...` — clean on the touched files
- Regression probe: reverting `piPowerShellCommandArgs` to emit `-File <ps1>` fails `TestPiPowerShellCommandArgs` and `TestPiPowerShellCommandArgs_EscapesSingleQuotesInPath` with an argv mismatch. Restored after.

## Limitations, stated plainly

No Windows host was available. The Windows-tagged behaviour was compiled and vetted for `GOOS=windows` but not executed, and the claim that `-Command`/`@args` preserves stdin encoding is read from the PowerShell semantics and #7355's report, not observed here. `piPowerShellCommandArgs` is deliberately untagged so at least the argv shape is covered by a test that runs everywhere.
