### PR TITLE
feat(daemon): add MULTICA_LOGIN_SHELL_PROBE to disable the login-shell agent PATH probe

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -256,6 +256,7 @@ Daemon behavior is configured via flags or environment variables:
 | Runtime name | `--runtime-name` | `MULTICA_AGENT_RUNTIME_NAME` | `Local Agent` |
 | Workspaces root | — | `MULTICA_WORKSPACES_ROOT` | `~/multica_workspaces` |
 | GC enabled | — | `MULTICA_GC_ENABLED` | `true` (set `false`/`0` to disable) |
+| Login-shell agent PATH probe | — | `MULTICA_LOGIN_SHELL_PROBE` | `true` (set `false`/`0` to disable) |
 | GC scan interval | — | `MULTICA_GC_INTERVAL` | `2h` |
 | GC TTL (done/cancelled issues) | — | `MULTICA_GC_TTL` | `24h` |
 | GC completed-task TTL (issue tasks) | — | `MULTICA_GC_COMPLETED_TASK_TTL` | `14d` on Multica Cloud, `0` (disabled) elsewhere |

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -924,6 +924,10 @@ var supportedLoginShells = map[string]struct{}{
 // of name → path for whatever the shell could find, and an empty map if the
 // shell is unavailable / unsupported / times out / produces no usable output.
 //
+// The probe can be disabled via MULTICA_LOGIN_SHELL_PROBE=false/0, in which
+// case the daemon falls back to exec.LookPath and explicit MULTICA_*_PATH. A
+// CLI reachable only through ~/.zshrc will then not be found.
+//
 // Why we need this:
 //
 // Daemon-style processes on macOS/Linux do not inherit the user's interactive
@@ -951,10 +955,26 @@ var supportedLoginShells = map[string]struct{}{
 //     (`[A-Za-z0-9._-]` only); we inline them into the script unquoted to
 //     keep the script readable. Custom MULTICA_*_PATH values never reach this
 //     resolver — those go through exec.LookPath directly.
-//
+
+// loginShellProbeEnabled reports whether the daemon may fork the user's login
+// shell to resolve agent paths (#7047). Some host-security products flag
+// `$SHELL -ilc` as interactive-shell reconnaissance, so operators need a way
+// to switch it off and rely on exec.LookPath plus explicit MULTICA_*_PATH.
+func loginShellProbeEnabled() bool {
+	v := os.Getenv("MULTICA_LOGIN_SHELL_PROBE")
+	if v == "false" || v == "0" {
+		return false
+	}
+	return true
+}
+
 // A var so tests can stub the fork without a real login shell.
 var resolveAgentsViaLoginShell = func(names []string) map[string]string {
 	out := map[string]string{}
+	if !loginShellProbeEnabled() {
+		slog.Debug("login-shell probe disabled via MULTICA_LOGIN_SHELL_PROBE")
+		return out
+	}
 	if len(names) == 0 {
 		return out
 	}

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -303,6 +303,7 @@ func TestBuildLoginShellResolveScript_ShapeAndContent(t *testing.T) {
 // doesn't honour ENV (which would defeat the simulation — not the function's
 // fault).
 func TestResolveAgentsViaLoginShell_ResolvesViaInteractiveShell(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell not available on Windows")
 	}
@@ -357,6 +358,7 @@ func TestResolveAgentsViaLoginShell_ResolvesViaInteractiveShell(t *testing.T) {
 }
 
 func TestResolveAgentsViaLoginShell_SkipsUnsupportedShell(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	t.Setenv("SHELL", "/usr/bin/fish")
 	got := resolveAgentsViaLoginShell([]string{"claude"})
 	if len(got) != 0 {
@@ -365,6 +367,7 @@ func TestResolveAgentsViaLoginShell_SkipsUnsupportedShell(t *testing.T) {
 }
 
 func TestResolveAgentsViaLoginShell_EmptyShellNoCrash(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	t.Setenv("SHELL", "")
 	got := resolveAgentsViaLoginShell([]string{"claude"})
 	if len(got) != 0 {
@@ -373,6 +376,7 @@ func TestResolveAgentsViaLoginShell_EmptyShellNoCrash(t *testing.T) {
 }
 
 func TestResolveAgentsViaLoginShell_EmptyInput(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	t.Setenv("SHELL", "/bin/sh")
 	got := resolveAgentsViaLoginShell(nil)
 	if len(got) != 0 {
@@ -535,6 +539,7 @@ func TestLoadConfig_SkipsMulticaHooksShadowingAgentBinaries(t *testing.T) {
 }
 
 func TestLoadConfig_SkipsMulticaHooksFromLoginShellFallback(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell not available on Windows")
 	}
@@ -959,6 +964,7 @@ func TestLoadConfig_AutoReload_OffSwitches(t *testing.T) {
 // suite but silently dropped this case (alias text is not absolute, so the
 // `case "$p" in /*)` filter rejected it).
 func TestResolveAgentsViaLoginShell_StripsAliasShadowing(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell not available on Windows")
 	}
@@ -1028,6 +1034,7 @@ func TestResolveAgentsViaLoginShell_StripsAliasShadowing(t *testing.T) {
 // loginShellResolveTimeout + loginShellResolveWaitDelay, not the survivor's
 // lifetime.
 func TestResolveAgentsViaLoginShell_HardTimeoutOnBackgroundedStdout(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell not available on Windows")
 	}
@@ -1074,6 +1081,7 @@ func TestResolveAgentsViaLoginShell_HardTimeoutOnBackgroundedStdout(t *testing.T
 // the shell-fallback path must not run. We assert this by pointing SHELL at
 // a sentinel script that touches a marker file when invoked.
 func TestLoadConfig_SkipsLoginShellWhenLookPathSucceeds(t *testing.T) {
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell not available on Windows")
 	}

--- a/server/internal/daemon/login_shell_probe_test.go
+++ b/server/internal/daemon/login_shell_probe_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoginShellProbeEnabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"false", false},
+		{"0", false},
+		{"", true},
+		{"true", true},
+		{"1", true},
+		{"no", true},
+	}
+	for _, c := range cases {
+		t.Run(c.val, func(t *testing.T) {
+			if c.val == "" {
+				// unset: need to clear env
+				t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "")
+				os.Unsetenv("MULTICA_LOGIN_SHELL_PROBE")
+			} else {
+				t.Setenv("MULTICA_LOGIN_SHELL_PROBE", c.val)
+			}
+			if got := loginShellProbeEnabled(); got != c.want {
+				t.Fatalf("val %q got %v want %v", c.val, got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentsViaLoginShell_DisabledSkipsFork(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "sentinel")
+	script := filepath.Join(dir, "zsh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntouch \""+sentinel+"\"\n"), 0o755)
+	t.Setenv("SHELL", script)
+
+	// enabled: should fork and touch sentinel
+	os.Unsetenv("MULTICA_LOGIN_SHELL_PROBE")
+	os.Remove(sentinel)
+	resolveAgentsViaLoginShell([]string{"claude"})
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected sentinel to exist when probe enabled, err %v", err)
+	}
+
+	// disabled with 0
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "0")
+	os.Remove(sentinel)
+	m := resolveAgentsViaLoginShell([]string{"claude"})
+	if len(m) != 0 {
+		t.Fatalf("expected empty map when disabled, got %v", m)
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatalf("sentinel should not exist when disabled (0)")
+	}
+
+	// disabled with false
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "false")
+	os.Remove(sentinel)
+	m = resolveAgentsViaLoginShell([]string{"claude"})
+	if len(m) != 0 {
+		t.Fatalf("expected empty map when disabled false, got %v", m)
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatalf("sentinel should not exist when disabled (false)")
+	}
+}

--- a/server/internal/daemon/login_shell_probe_test.go
+++ b/server/internal/daemon/login_shell_probe_test.go
@@ -20,13 +20,7 @@ func TestLoginShellProbeEnabled(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.val, func(t *testing.T) {
-			if c.val == "" {
-				// unset: need to clear env
-				t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "")
-				os.Unsetenv("MULTICA_LOGIN_SHELL_PROBE")
-			} else {
-				t.Setenv("MULTICA_LOGIN_SHELL_PROBE", c.val)
-			}
+			t.Setenv("MULTICA_LOGIN_SHELL_PROBE", c.val)
 			if got := loginShellProbeEnabled(); got != c.want {
 				t.Fatalf("val %q got %v want %v", c.val, got, c.want)
 			}
@@ -42,7 +36,7 @@ func TestResolveAgentsViaLoginShell_DisabledSkipsFork(t *testing.T) {
 	t.Setenv("SHELL", script)
 
 	// enabled: should fork and touch sentinel
-	os.Unsetenv("MULTICA_LOGIN_SHELL_PROBE")
+	t.Setenv("MULTICA_LOGIN_SHELL_PROBE", "true")
 	os.Remove(sentinel)
 	resolveAgentsViaLoginShell([]string{"claude"})
 	if _, err := os.Stat(sentinel); err != nil {


### PR DESCRIPTION
Addresses #7047.

## Problem

The daemon forks the user's login shell (`$SHELL -ilc ...`) to resolve agent CLI paths that only exist behind `~/.zshrc` / `~/.bashrc`. Host-security products flag `-ilc` as interactive-shell reconnaissance, and there is currently no way to turn it off — an operator whose EDR blocks or alerts on the fork has no supported escape hatch.

## Change

`MULTICA_LOGIN_SHELL_PROBE=false` (or `0`) disables the probe. The daemon then resolves agents through `exec.LookPath` plus explicit `MULTICA_*_PATH` values only.

**Default is unchanged — the probe stays enabled.** Disabling it by default would break every user whose agent CLI is reachable only through a login-shell rc file.

The gate lives inside `resolveAgentsViaLoginShell` itself, not at the call sites, so no future caller can bypass it by construction.

Also documents the variable in the `CLI_AND_DAEMON.md` daemon-configuration table.

## Verification

- `go test ./internal/daemon -count=1` — ok
- `go build ./...`, `go vet ./...` — clean
- `GOOS=windows GOARCH=amd64 go build ./cmd/...` — ok
- `gofmt -l` clean on the touched files
- Regression probe: deleting the gate block from `resolveAgentsViaLoginShell` fails `TestResolveAgentsViaLoginShell_DisabledSkipsFork` ("sentinel should not exist when disabled"), i.e. the fork happens again. Restored after; tree clean.
