### PR TITLE
fix(daemon): hydrate run-only autopilot project context

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2799,7 +2799,59 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				if resp.WorkspaceID == "" {
 					resp.WorkspaceID = uuidToString(ap.WorkspaceID)
 				}
-				if len(resp.Repos) == 0 {
+
+				// A run_only autopilot has no issue from which to inherit project
+				// context. Hydrate its configured project here so the daemon gets
+				// the same resource contract as issue-bound and quick-create tasks:
+				// project repositories scope checkout, while local_directory lets
+				// the daemon select the bound path and write its managed manifest.
+				var projectRepos []RepoData
+				if ap.ProjectID.Valid {
+					project, projectErr := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
+						ID:          ap.ProjectID,
+						WorkspaceID: ap.WorkspaceID,
+					})
+					if projectErr == nil {
+						resp.ProjectID = uuidToString(project.ID)
+						resp.ProjectTitle = project.Title
+						resp.ProjectDescription = project.Description.String
+
+						if rows := h.listProjectResourcesForProject(r.Context(), project.ID); len(rows) > 0 {
+							resources := make([]ProjectResourceData, 0, len(rows))
+							for _, row := range rows {
+								label := ""
+								if row.Label.Valid {
+									label = row.Label.String
+								}
+								ref := json.RawMessage(row.ResourceRef)
+								if len(ref) == 0 {
+									ref = json.RawMessage("{}")
+								}
+								resources = append(resources, ProjectResourceData{
+									ID:           uuidToString(row.ID),
+									ResourceType: row.ResourceType,
+									ResourceRef:  ref,
+									Label:        label,
+								})
+
+								if row.ResourceType == "github_repo" {
+									var payload struct {
+										URL string `json:"url"`
+										Ref string `json:"ref,omitempty"`
+									}
+									if json.Unmarshal(row.ResourceRef, &payload) == nil && payload.URL != "" {
+										projectRepos = append(projectRepos, RepoData{URL: payload.URL, Ref: strings.TrimSpace(payload.Ref)})
+									}
+								}
+							}
+							resp.ProjectResources = resources
+						}
+					}
+				}
+
+				if len(projectRepos) > 0 {
+					resp.Repos = projectRepos
+				} else if len(resp.Repos) == 0 {
 					if ws, err := h.Queries.GetWorkspace(r.Context(), ap.WorkspaceID); err == nil && ws.Repos != nil {
 						var repos []RepoData
 						if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2785,19 +2785,41 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	// issue for the agent to fetch.
 	if task.AutopilotRunID.Valid {
 		if run, err := h.Queries.GetAutopilotRun(r.Context(), task.AutopilotRunID); err == nil {
-			resp.AutopilotID = uuidToString(run.AutopilotID)
-			resp.AutopilotSource = run.Source
-			if run.TriggerPayload != nil {
-				resp.AutopilotTriggerPayload = json.RawMessage(run.TriggerPayload)
-			}
 			if ap, err := h.Queries.GetAutopilot(r.Context(), run.AutopilotID); err == nil {
+				autopilotWorkspaceID := uuidToString(ap.WorkspaceID)
+				if autopilotWorkspaceID == "" || autopilotWorkspaceID != runtimeWorkspaceID {
+					slog.Error("autopilot claim: workspace isolation check failed, cancelling task",
+						"task_id", uuidToString(task.ID),
+						"autopilot_run_id", uuidToString(task.AutopilotRunID),
+						"autopilot_id", uuidToString(run.AutopilotID),
+						"runtime_id", runtimeID,
+						"runtime_workspace", runtimeWorkspaceID,
+						"autopilot_workspace", autopilotWorkspaceID,
+					)
+					if _, cerr := h.TaskService.CancelTask(r.Context(), task.ID); cerr != nil {
+						slog.Error("autopilot claim: cancel after workspace check failed",
+							"task_id", uuidToString(task.ID), "error", cerr)
+					}
+					return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, &claimBuildFailure{
+						outcome: "error_workspace",
+						status:  http.StatusInternalServerError,
+						message: "task workspace isolation check failed",
+					}
+				}
+
+				// Only expose Autopilot-owned context after its workspace has been
+				// proven to match the claiming runtime. taskToResponse seeds the
+				// runtime workspace, so it cannot serve as this comparison.
+				resp.WorkspaceID = autopilotWorkspaceID
+				resp.AutopilotID = uuidToString(run.AutopilotID)
+				resp.AutopilotSource = run.Source
+				if run.TriggerPayload != nil {
+					resp.AutopilotTriggerPayload = json.RawMessage(run.TriggerPayload)
+				}
 				resp.AutopilotTitle = ap.Title
 				resp.ThreadName = ap.Title
 				if ap.Description.Valid {
 					resp.AutopilotDescription = ap.Description.String
-				}
-				if resp.WorkspaceID == "" {
-					resp.WorkspaceID = uuidToString(ap.WorkspaceID)
 				}
 
 				// A run_only autopilot has no issue from which to inherit project

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2185,12 +2185,11 @@ func TestClaimTask_ProjectWithoutRepos_FallsBackToWorkspaceRepos(t *testing.T) {
 	}
 }
 
-// Regression test for #1276: ClaimTaskByRuntime must populate workspace_id in
-// the response for run_only autopilot tasks. Before the fix, resp.WorkspaceID
-// stayed empty because ClaimTaskByRuntime only handled IssueID and
-// ChatSessionID branches, causing the daemon's execenv to fail with
-// "workspace ID is required".
-func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID(t *testing.T) {
+// Regression test for #1276: ClaimTaskByRuntime must populate both
+// workspace and project context for run_only autopilot tasks. Project context
+// is what lets the daemon select a bound local_directory and materialize the
+// managed .multica/project/resources.json source manifest before launch.
+func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceAndProjectContext(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
@@ -2202,8 +2201,29 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID(t *testing.T) {
 		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
 	`, testWorkspaceID).Scan(&agentID, &runtimeID)
 
+	const projectDescription = "Use only the bound project resources."
+	projectID := dbfx.Project(t, "Run-only autopilot project", testutil.Cols{
+		"description": projectDescription,
+	})
+	const projectRepoURL = "https://github.com/example/run-only-project"
+	dbfx.Insert(t, "project_resource", testutil.Cols{
+		"project_id":    projectID,
+		"workspace_id":  testWorkspaceID,
+		"resource_type": "github_repo",
+		"resource_ref":  `{"url":"` + projectRepoURL + `"}`,
+		"position":      0,
+	})
+	dbfx.Insert(t, "project_resource", testutil.Cols{
+		"project_id":    projectID,
+		"workspace_id":  testWorkspaceID,
+		"resource_type": "local_directory",
+		"resource_ref":  `{"daemon_id":"test-daemon-claim","local_path":"/srv/run-only-project","execution_mode":"in_place"}`,
+		"position":      1,
+	})
+
 	autopilotID := dbfx.Insert(t, "autopilot", testutil.Cols{
 		"workspace_id":    testWorkspaceID,
+		"project_id":      projectID,
 		"title":           "claim workspace fixture",
 		"assignee_id":     agentID,
 		"execution_mode":  "run_only",
@@ -2240,8 +2260,13 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID(t *testing.T) {
 
 	var resp struct {
 		Task *struct {
-			WorkspaceID string `json:"workspace_id"`
-			ThreadName  string `json:"thread_name"`
+			WorkspaceID        string                `json:"workspace_id"`
+			ThreadName         string                `json:"thread_name"`
+			Repos              []RepoData            `json:"repos"`
+			ProjectID          string                `json:"project_id"`
+			ProjectTitle       string                `json:"project_title"`
+			ProjectDescription string                `json:"project_description"`
+			ProjectResources   []ProjectResourceData `json:"project_resources"`
 		} `json:"task"`
 	}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
@@ -2258,6 +2283,44 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID(t *testing.T) {
 	}
 	if resp.Task.ThreadName != "claim workspace fixture" {
 		t.Fatalf("autopilot task thread_name = %q, want autopilot title", resp.Task.ThreadName)
+	}
+	if resp.Task.ProjectID != projectID {
+		t.Errorf("project_id = %q, want %q", resp.Task.ProjectID, projectID)
+	}
+	if resp.Task.ProjectTitle != "Run-only autopilot project" {
+		t.Errorf("project_title = %q, want run-only project title", resp.Task.ProjectTitle)
+	}
+	if resp.Task.ProjectDescription != projectDescription {
+		t.Errorf("project_description = %q, want %q", resp.Task.ProjectDescription, projectDescription)
+	}
+	if len(resp.Task.ProjectResources) != 2 {
+		t.Fatalf("project_resources count = %d, want 2", len(resp.Task.ProjectResources))
+	}
+	var localDirectory struct {
+		DaemonID      string `json:"daemon_id"`
+		LocalPath     string `json:"local_path"`
+		ExecutionMode string `json:"execution_mode"`
+	}
+	foundLocalDirectory := false
+	for _, resource := range resp.Task.ProjectResources {
+		if resource.ResourceType != "local_directory" {
+			continue
+		}
+		foundLocalDirectory = true
+		if err := json.Unmarshal(resource.ResourceRef, &localDirectory); err != nil {
+			t.Fatalf("decode local_directory resource: %v", err)
+		}
+	}
+	if !foundLocalDirectory {
+		t.Fatal("local_directory project resource missing from claim")
+	}
+	if localDirectory.DaemonID != "test-daemon-claim" ||
+		localDirectory.LocalPath != "/srv/run-only-project" ||
+		localDirectory.ExecutionMode != "in_place" {
+		t.Fatalf("local_directory = %+v, want bound daemon/path/in_place", localDirectory)
+	}
+	if len(resp.Task.Repos) != 1 || resp.Task.Repos[0].URL != projectRepoURL {
+		t.Fatalf("repos = %+v, want only project repo %q", resp.Task.Repos, projectRepoURL)
 	}
 }
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2324,6 +2324,93 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceAndProjectContext(t *testi
 	}
 }
 
+// A corrupt cross-workspace autopilot_run_id must be rejected before any
+// Autopilot-owned project context is hydrated into the daemon claim response.
+func TestClaimTask_AutopilotRunOnlyWorkspaceMismatch_CancelsWithoutForeignContext(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	var localAgentID, localRuntimeID string
+	dbfx.QueryRow(t, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&localAgentID, &localRuntimeID)
+
+	foreignWorkspaceID := dbfx.Insert(t, "workspace", testutil.Cols{
+		"name":         "Foreign autopilot claim workspace",
+		"slug":         "foreign-autopilot-claim-workspace",
+		"description":  "",
+		"issue_prefix": "FAC",
+	})
+	const foreignProjectTitle = "Foreign project must not leak"
+	foreignProjectID := dbfx.Project(t, foreignProjectTitle, testutil.Cols{
+		"workspace_id": foreignWorkspaceID,
+	})
+	const foreignRepoURL = "https://github.com/example/foreign-claim-project"
+	const foreignLocalPath = "/srv/foreign-claim-project"
+	dbfx.Insert(t, "project_resource", testutil.Cols{
+		"project_id":    foreignProjectID,
+		"workspace_id":  foreignWorkspaceID,
+		"resource_type": "github_repo",
+		"resource_ref":  `{"url":"` + foreignRepoURL + `"}`,
+		"position":      0,
+	})
+	dbfx.Insert(t, "project_resource", testutil.Cols{
+		"project_id":    foreignProjectID,
+		"workspace_id":  foreignWorkspaceID,
+		"resource_type": "local_directory",
+		"resource_ref":  `{"daemon_id":"foreign-daemon","local_path":"` + foreignLocalPath + `","execution_mode":"in_place"}`,
+		"position":      1,
+	})
+
+	const foreignAutopilotTitle = "Foreign autopilot must not leak"
+	foreignAutopilotID := dbfx.Insert(t, "autopilot", testutil.Cols{
+		"workspace_id":    foreignWorkspaceID,
+		"project_id":      foreignProjectID,
+		"title":           foreignAutopilotTitle,
+		"assignee_id":     localAgentID,
+		"execution_mode":  "run_only",
+		"created_by_type": "member",
+		"created_by_id":   testUserID,
+	})
+	foreignRunID := dbfx.Insert(t, "autopilot_run", testutil.Cols{
+		"autopilot_id": foreignAutopilotID,
+		"source":       "manual",
+		"status":       "running",
+	})
+	taskID := dbfx.Task(t, localAgentID, testutil.Cols{
+		"runtime_id":       localRuntimeID,
+		"issue_id":         nil,
+		"autopilot_run_id": foreignRunID,
+	})
+
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+localRuntimeID+"/claim", nil,
+		testWorkspaceID, "local-daemon")
+	req = withURLParam(req, "runtimeId", localRuntimeID)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusInternalServerError)
+	if !strings.Contains(w.Text(), "task workspace isolation check failed") {
+		t.Fatalf("claim error response = %q, want workspace isolation failure", w.Text())
+	}
+
+	for _, foreignValue := range []string{
+		foreignAutopilotTitle,
+		foreignProjectTitle,
+		foreignProjectID,
+		foreignRepoURL,
+		foreignLocalPath,
+	} {
+		if strings.Contains(w.Text(), foreignValue) {
+			t.Errorf("claim error response leaked foreign project context %q: %s", foreignValue, w.Text())
+		}
+	}
+
+	var status string
+	dbfx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status)
+	if status != "cancelled" {
+		t.Fatalf("cross-workspace autopilot task status = %q, want cancelled", status)
+	}
+}
+
 // TestClaimTaskByRuntime_TaskWorkspaceMismatch_CancelsAndRejects verifies
 // the defense-in-depth check in ClaimTaskByRuntime: if a task is somehow
 // dispatched to a runtime whose workspace doesn't match the task's


### PR DESCRIPTION
## Summary

- hydrate `run_only` autopilot claims with their configured project metadata and resources
- validate the Autopilot workspace before exposing any run or project context
- cancel cross-workspace claims without returning foreign project, repository, or resource data
- scope repository context to project GitHub resources while preserving workspace fallback

## Verification

- `env -u MULTICA_TASK_CONFIG_ROOT go test ./internal/handler -run 'TestClaimTask_AutopilotRunOnly' -count=1 -v` (compiled; database-backed tests skipped because native PostgreSQL is unavailable)
- `env -u MULTICA_TASK_CONFIG_ROOT go test ./internal/daemon/execenv -count=1`
- `env -u MULTICA_TASK_CONFIG_ROOT go test ./pkg/agent -count=1`
- `go vet ./internal/handler ./internal/daemon/execenv`
- full native Go suite passed except one `pkg/agent` timing failure while two full-suite runs overlapped; the package passed in isolation immediately afterward
