### PR TITLE
MUL-6546 fix(util): ignore mentions inside markdown code blocks and inline code

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -18,8 +18,9 @@ import (
 //
 // Keep this text English-only (matches existing agent-harness conventions)
 // and keep the mention syntax exactly aligned with util.MentionRe — the
-// "Squad Roster" block below renders concrete examples that round-trip
-// through util.ParseMentions, and the protocol text refers to that format.
+// "Squad Roster" block below renders copyable examples as inline code so the
+// briefing itself does not trigger, and the pasted syntax round-trips
+// through util.ParseMentions. The protocol text refers to that format.
 const squadOperatingProtocolHeader = `## Squad Operating Protocol
 
 **If you are reading this section, you have been activated as a squad LEADER

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -326,36 +326,42 @@ func TestBuildSquadLeaderBriefing_SkipsArchivedAgent(t *testing.T) {
 }
 
 // TestBuildSquadLeaderBriefing_MentionsRoundTrip is the contract test
-// guaranteeing every emitted mention markdown string parses back through
-// util.ParseMentions to its (type, id). If this ever breaks, the leader's
+// guaranteeing every roster mention is copyable inline code: the briefing
+// itself must not trigger ParseMentions, but pasting the unwrapped syntax
+// must round-trip to its (type, id). If this ever breaks, the leader's
 // dispatch comments will silently fail to trigger anyone.
 func TestBuildSquadLeaderBriefing_MentionsRoundTrip(t *testing.T) {
 	ctx := context.Background()
-	leaderID, _ := seededLeaderAgent(t)
+	leaderID, leaderName := seededLeaderAgent(t)
 	squad := seedSquadForBriefing(t, leaderID, "Mention Round Trip", "")
 
 	helper := createHandlerTestAgent(t, "Round Trip Bot", []byte("[]"))
 	addAgentMember(t, squad.ID, helper, "")
 
-	memberRowID, userID, _ := seededHumanMember(t)
+	memberRowID, userID, userName := seededHumanMember(t)
 	_ = memberRowID
 	addHumanMember(t, squad.ID, userID, "")
 
 	out := buildSquadLeaderBriefing(ctx, testHandler.Queries, squad, true)
-	mentions := util.ParseMentions(out)
+	if triggered := util.ParseMentions(out); len(triggered) != 0 {
+		t.Errorf("briefing code examples must not trigger ParseMentions, got %#v", triggered)
+	}
 
-	wantIDs := map[string]string{
-		leaderID: "agent",
-		helper:   "agent",
-		userID:   "member",
+	wants := []struct {
+		id, kind, name string
+	}{
+		{leaderID, "agent", leaderName},
+		{helper, "agent", "Round Trip Bot"},
+		{userID, "member", userName},
 	}
-	got := make(map[string]string, len(mentions))
-	for _, m := range mentions {
-		got[m.ID] = m.Type
-	}
-	for id, kind := range wantIDs {
-		if got[id] != kind {
-			t.Errorf("expected %s mention for id %s, got %q (all parsed: %#v)", kind, id, got[id], mentions)
+	for _, w := range wants {
+		md := formatMention(w.name, w.kind, w.id)
+		if !strings.Contains(out, "`"+md+"`") {
+			t.Errorf("expected copyable inline-code mention %s in roster:\n%s", md, out)
+		}
+		pasted := util.ParseMentions(md)
+		if len(pasted) != 1 || pasted[0].Type != w.kind || pasted[0].ID != w.id {
+			t.Errorf("pasted %s mention for id %s = %#v, want [{Type:%s ID:%s}]", w.kind, w.id, pasted, w.kind, w.id)
 		}
 	}
 }

--- a/server/internal/util/mention.go
+++ b/server/internal/util/mention.go
@@ -2,7 +2,10 @@ package util
 
 import (
 	"regexp"
-	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 // Mention represents a parsed @mention from markdown content.
@@ -18,138 +21,47 @@ type Mention struct {
 // enough to prevent over-matching.
 var MentionRe = regexp.MustCompile(`\[@?(.+?)\]\(mention://(member|agent|squad|issue|all)/([0-9a-fA-F-]+|all)\)`)
 
+var mentionDestRe = regexp.MustCompile(`^mention://(member|agent|squad|issue|all)/([0-9a-fA-F-]+|all)$`)
+
 // IsMentionAll returns true if the mention is an @all mention.
 func (m Mention) IsMentionAll() bool {
 	return m.Type == "all"
-}
-
-// codeRanges returns the [start, end) byte ranges of content that sit inside
-// markdown code: fenced code blocks (``` or ~~~, with info strings and fences
-// longer than three characters) and inline code spans (including
-// multi-backtick spans). An unterminated fence suppresses everything after it.
-func codeRanges(content string) [][2]int {
-	var ranges [][2]int
-
-	lineStart := 0
-	fenceChar := byte(0)
-	fenceLen := 0
-	for lineStart <= len(content) {
-		lineEnd := lineStart
-		for lineEnd < len(content) && content[lineEnd] != '\n' {
-			lineEnd++
-		}
-		line := content[lineStart:lineEnd]
-
-		if fenceChar != 0 {
-			trimmed := strings.TrimLeft(line, " \t")
-			if len(trimmed) >= fenceLen {
-				closing := true
-				for i := 0; i < fenceLen; i++ {
-					if trimmed[i] != fenceChar {
-						closing = false
-						break
-					}
-				}
-				if closing && strings.TrimLeft(trimmed[fenceLen:], " \t") == "" {
-					ranges = append(ranges, [2]int{lineStart, lineEnd})
-					fenceChar = 0
-					fenceLen = 0
-				}
-			}
-			if fenceChar != 0 {
-				ranges = append(ranges, [2]int{lineStart, lineEnd})
-			}
-		} else if fc, fl, ok := openingFence(line); ok {
-			fenceChar = fc
-			fenceLen = fl
-			ranges = append(ranges, [2]int{lineStart, lineEnd})
-		} else {
-			ranges = append(ranges, inlineCodeRanges(line, lineStart)...)
-		}
-
-		if lineEnd == len(content) {
-			break
-		}
-		lineStart = lineEnd + 1
-	}
-	return ranges
-}
-
-// openingFence reports whether the line opens a fenced code block, returning
-// the fence character and its length.
-func openingFence(line string) (byte, int, bool) {
-	indent := 0
-	for indent < len(line) && indent < 3 && (line[indent] == ' ' || line[indent] == '\t') {
-		indent++
-	}
-	rest := line[indent:]
-	if len(rest) < 3 || (rest[0] != '`' && rest[0] != '~') {
-		return 0, 0, false
-	}
-	n := 0
-	for n < len(rest) && rest[n] == rest[0] {
-		n++
-	}
-	if n < 3 {
-		return 0, 0, false
-	}
-	return rest[0], n, true
-}
-
-// inlineCodeRanges returns the ranges of inline code spans on a single line.
-func inlineCodeRanges(line string, offset int) [][2]int {
-	var ranges [][2]int
-	i := 0
-	for i < len(line) {
-		if line[i] != '`' {
-			i++
-			continue
-		}
-		n := 0
-		for i+n < len(line) && line[i+n] == '`' {
-			n++
-		}
-		closer := strings.Index(line[i+n:], strings.Repeat("`", n))
-		if closer < 0 {
-			i += n
-			continue
-		}
-		end := i + n + closer + n
-		ranges = append(ranges, [2]int{offset + i, offset + end})
-		i = end
-	}
-	return ranges
-}
-
-func inRanges(pos int, ranges [][2]int) bool {
-	for _, r := range ranges {
-		if pos >= r[0] && pos < r[1] {
-			return true
-		}
-	}
-	return false
 }
 
 // ParseMentions extracts deduplicated mentions from markdown content.
 // Mentions inside fenced code blocks or inline code spans are ignored — they
 // document the mention syntax rather than trigger an agent run. Mentions in
 // blockquotes are still returned on purpose.
+//
+// The walk uses goldmark's CommonMark AST and only considers Link nodes, so
+// code spans, fenced blocks (including nested-in-blockquote and CommonMark
+// fence-length rules), and multiline code spans are excluded without a
+// hand-rolled scanner.
 func ParseMentions(content string) []Mention {
-	matches := MentionRe.FindAllStringSubmatchIndex(content, -1)
-	code := codeRanges(content)
+	source := []byte(content)
+	doc := goldmark.New().Parser().Parse(text.NewReader(source))
 	seen := make(map[string]bool)
 	var result []Mention
-	for _, m := range matches {
-		if inRanges(m[0], code) {
-			continue
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
 		}
-		key := content[m[4]:m[5]] + ":" + content[m[6]:m[7]]
+		link, ok := n.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		m := mentionDestRe.FindStringSubmatch(string(link.Destination))
+		if len(m) != 3 {
+			return ast.WalkContinue, nil
+		}
+		key := m[1] + ":" + m[2]
 		if seen[key] {
-			continue
+			return ast.WalkContinue, nil
 		}
 		seen[key] = true
-		result = append(result, Mention{Type: content[m[4]:m[5]], ID: content[m[6]:m[7]]})
-	}
+		result = append(result, Mention{Type: m[1], ID: m[2]})
+		return ast.WalkContinue, nil
+	})
 	return result
 }
 

--- a/server/internal/util/mention.go
+++ b/server/internal/util/mention.go
@@ -1,6 +1,9 @@
 package util
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // Mention represents a parsed @mention from markdown content.
 type Mention struct {
@@ -20,18 +23,132 @@ func (m Mention) IsMentionAll() bool {
 	return m.Type == "all"
 }
 
+// codeRanges returns the [start, end) byte ranges of content that sit inside
+// markdown code: fenced code blocks (``` or ~~~, with info strings and fences
+// longer than three characters) and inline code spans (including
+// multi-backtick spans). An unterminated fence suppresses everything after it.
+func codeRanges(content string) [][2]int {
+	var ranges [][2]int
+
+	lineStart := 0
+	fenceChar := byte(0)
+	fenceLen := 0
+	for lineStart <= len(content) {
+		lineEnd := lineStart
+		for lineEnd < len(content) && content[lineEnd] != '\n' {
+			lineEnd++
+		}
+		line := content[lineStart:lineEnd]
+
+		if fenceChar != 0 {
+			trimmed := strings.TrimLeft(line, " \t")
+			if len(trimmed) >= fenceLen {
+				closing := true
+				for i := 0; i < fenceLen; i++ {
+					if trimmed[i] != fenceChar {
+						closing = false
+						break
+					}
+				}
+				if closing && strings.TrimLeft(trimmed[fenceLen:], " \t") == "" {
+					ranges = append(ranges, [2]int{lineStart, lineEnd})
+					fenceChar = 0
+					fenceLen = 0
+				}
+			}
+			if fenceChar != 0 {
+				ranges = append(ranges, [2]int{lineStart, lineEnd})
+			}
+		} else if fc, fl, ok := openingFence(line); ok {
+			fenceChar = fc
+			fenceLen = fl
+			ranges = append(ranges, [2]int{lineStart, lineEnd})
+		} else {
+			ranges = append(ranges, inlineCodeRanges(line, lineStart)...)
+		}
+
+		if lineEnd == len(content) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return ranges
+}
+
+// openingFence reports whether the line opens a fenced code block, returning
+// the fence character and its length.
+func openingFence(line string) (byte, int, bool) {
+	indent := 0
+	for indent < len(line) && indent < 3 && (line[indent] == ' ' || line[indent] == '\t') {
+		indent++
+	}
+	rest := line[indent:]
+	if len(rest) < 3 || (rest[0] != '`' && rest[0] != '~') {
+		return 0, 0, false
+	}
+	n := 0
+	for n < len(rest) && rest[n] == rest[0] {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, false
+	}
+	return rest[0], n, true
+}
+
+// inlineCodeRanges returns the ranges of inline code spans on a single line.
+func inlineCodeRanges(line string, offset int) [][2]int {
+	var ranges [][2]int
+	i := 0
+	for i < len(line) {
+		if line[i] != '`' {
+			i++
+			continue
+		}
+		n := 0
+		for i+n < len(line) && line[i+n] == '`' {
+			n++
+		}
+		closer := strings.Index(line[i+n:], strings.Repeat("`", n))
+		if closer < 0 {
+			i += n
+			continue
+		}
+		end := i + n + closer + n
+		ranges = append(ranges, [2]int{offset + i, offset + end})
+		i = end
+	}
+	return ranges
+}
+
+func inRanges(pos int, ranges [][2]int) bool {
+	for _, r := range ranges {
+		if pos >= r[0] && pos < r[1] {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseMentions extracts deduplicated mentions from markdown content.
+// Mentions inside fenced code blocks or inline code spans are ignored — they
+// document the mention syntax rather than trigger an agent run. Mentions in
+// blockquotes are still returned on purpose.
 func ParseMentions(content string) []Mention {
-	matches := MentionRe.FindAllStringSubmatch(content, -1)
+	matches := MentionRe.FindAllStringSubmatchIndex(content, -1)
+	code := codeRanges(content)
 	seen := make(map[string]bool)
 	var result []Mention
 	for _, m := range matches {
-		key := m[2] + ":" + m[3]
+		if inRanges(m[0], code) {
+			continue
+		}
+		key := content[m[4]:m[5]] + ":" + content[m[6]:m[7]]
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		result = append(result, Mention{Type: m[2], ID: m[3]})
+		result = append(result, Mention{Type: content[m[4]:m[5]], ID: content[m[6]:m[7]]})
 	}
 	return result
 }

--- a/server/internal/util/mention_test.go
+++ b/server/internal/util/mention_test.go
@@ -63,6 +63,51 @@ func TestParseMentions(t *testing.T) {
 			content: `[@David\[TF\]](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa) hi`,
 			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
 		},
+		{
+			name:    "mention inside fenced code block is ignored",
+			content: "```\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n```",
+			want:    nil,
+		},
+		{
+			name:    "mention inside tilde fenced code block is ignored",
+			content: "~~~\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n~~~",
+			want:    nil,
+		},
+		{
+			name:    "mention inside fenced block with info string is ignored",
+			content: "```markdown\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n```",
+			want:    nil,
+		},
+		{
+			name:    "mention inside inline code span is ignored",
+			content: "use `[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)` to mention",
+			want:    nil,
+		},
+		{
+			name:    "mention inside double-backtick span containing a backtick is ignored",
+			content: "use ``[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)` `` to mention",
+			want:    nil,
+		},
+		{
+			name:    "mention before a fenced block is still returned",
+			content: "[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n```\n[@B](mention://agent/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb)\n```",
+			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
+		},
+		{
+			name:    "mention after a closing fence is still returned",
+			content: "```\ncode\n```\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)",
+			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
+		},
+		{
+			name:    "mention inside blockquote is still returned",
+			content: "> [@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)",
+			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
+		},
+		{
+			name:    "unterminated fence suppresses everything after it",
+			content: "```\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\nand more text",
+			want:    nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/util/mention_test.go
+++ b/server/internal/util/mention_test.go
@@ -108,6 +108,31 @@ func TestParseMentions(t *testing.T) {
 			content: "```\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\nand more text",
 			want:    nil,
 		},
+		{
+			name:    "longer closing fence still closes and mention after it is returned",
+			content: "```\ncode\n````\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)",
+			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
+		},
+		{
+			name:    "four-space indented fence is not a closer so mention stays inert",
+			content: "```\ncode\n    ```\n[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n```",
+			want:    nil,
+		},
+		{
+			name:    "mention inside multiline code span is ignored",
+			content: "use ``[@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\nstill code`` to mention",
+			want:    nil,
+		},
+		{
+			name:    "fenced code inside a blockquote is ignored",
+			content: "> ```\n> [@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n> ```",
+			want:    nil,
+		},
+		{
+			name:    "prose mention inside a blockquote is still returned next to quoted code",
+			content: "> [@A](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)\n>\n> ```\n> [@B](mention://agent/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb)\n> ```",
+			want:    []Mention{{Type: "agent", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Mentions written inside markdown code are documentation of the mention syntax, not a request to run an agent. Today `util.ParseMentions` matches them anyway, so pasting a code sample that contains a mention link triggers a real agent run.

This is suggestion 4 from #7237.

## What changed

`ParseMentions` now skips matches that fall inside markdown code:

- Fenced blocks, backtick and tilde, including info strings (```` ```markdown ````) and fences longer than three characters.
- Inline code spans, including multi-backtick spans that themselves contain a backtick.
- An unterminated fence suppresses everything after it, matching how the content renders.

Blockquote mentions are deliberately still returned. Quoting a mention in a reply is a real notification, not documentation of the syntax. There is a test asserting this.

The suppression lives inside `ParseMentions` itself, so all four call sites (`notification_listeners.go`, `handler/comment.go` x2, `handler/squad.go`) get it by construction.

Only the other suggestions in #7237 are out of scope here.

## Test plan

```
cd server
go test ./internal/util/ -count=1     # ok
go build ./... && go vet ./...        # clean
GOOS=windows GOARCH=amd64 go build ./cmd/...   # clean
gofmt -l internal/util/               # no output
```

Nine new table cases in `mention_test.go`. Verified by mutation: forcing `openingFence` to return false fails the five fence cases; forcing `inlineCodeRanges` to return nil fails the two inline-span cases. Both mutations compile, so the tests are load-bearing rather than passing on a build break.
