### PR TITLE
fix(mobile): constrain user chat bubble measurement

### DIFF
--- a/apps/mobile/components/chat/chat-message-list.tsx
+++ b/apps/mobile/components/chat/chat-message-list.tsx
@@ -40,9 +40,14 @@
  * `startRenderingFromBottom` (initial paint at bottom, no setTimeout
  * hacks). Cell recycling also keeps scroll-up smooth.
  */
-import { useMemo, useState } from "react";
-import { ActivityIndicator, Pressable, View } from "react-native";
-import { FlashList } from "@shopify/flash-list";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  type LayoutChangeEvent,
+  View,
+} from "react-native";
+import { FlashList, useLayoutState } from "@shopify/flash-list";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
 import type {
@@ -276,6 +281,31 @@ function MessageRow({
     (s) => s.selectingId === message.id,
   );
   const longPress = useChatMessageLongPress(message);
+  const [, setBubbleLayoutVersion] = useLayoutState(0);
+  const lastBubbleLayout = useRef<{
+    messageId: string;
+    height: number;
+  } | null>(null);
+  const onUserBubbleLayout = useCallback(
+    ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
+      const previous = lastBubbleLayout.current;
+      if (
+        previous?.messageId === message.id &&
+        previous.height === layout.height
+      ) {
+        return;
+      }
+      lastBubbleLayout.current = {
+        messageId: message.id,
+        height: layout.height,
+      };
+      // EnrichedMarkdownText can grow after FlashList has measured its cell.
+      // useLayoutState tells FlashList v2 to remeasure this recycled cell, so
+      // the bubble background cannot paint over the following message.
+      setBubbleLayoutVersion((version) => version + 1);
+    },
+    [message.id, setBubbleLayoutVersion],
+  );
 
   if (isFailure) {
     return (
@@ -298,6 +328,7 @@ function MessageRow({
     // trailing alignment instead of stretching across the column.
     const body = (
       <View
+        onLayout={onUserBubbleLayout}
         className={cn(
           "self-end max-w-[80%] gap-1.5 rounded-2xl border-2 px-3.5 py-2 transition-colors",
           isSelecting

--- a/apps/mobile/components/chat/chat-message-list.tsx
+++ b/apps/mobile/components/chat/chat-message-list.tsx
@@ -40,14 +40,13 @@
  * `startRenderingFromBottom` (initial paint at bottom, no setTimeout
  * hacks). Cell recycling also keeps scroll-up smooth.
  */
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
-  type LayoutChangeEvent,
   View,
 } from "react-native";
-import { FlashList, useLayoutState } from "@shopify/flash-list";
+import { FlashList } from "@shopify/flash-list";
 import { Ionicons } from "@expo/vector-icons";
 import { useQuery } from "@tanstack/react-query";
 import type {
@@ -281,32 +280,6 @@ function MessageRow({
     (s) => s.selectingId === message.id,
   );
   const longPress = useChatMessageLongPress(message);
-  const [, setBubbleLayoutVersion] = useLayoutState(0);
-  const lastBubbleLayout = useRef<{
-    messageId: string;
-    height: number;
-  } | null>(null);
-  const onUserBubbleLayout = useCallback(
-    ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
-      const previous = lastBubbleLayout.current;
-      if (
-        previous?.messageId === message.id &&
-        previous.height === layout.height
-      ) {
-        return;
-      }
-      lastBubbleLayout.current = {
-        messageId: message.id,
-        height: layout.height,
-      };
-      // EnrichedMarkdownText can grow after FlashList has measured its cell.
-      // useLayoutState tells FlashList v2 to remeasure this recycled cell, so
-      // the bubble background cannot paint over the following message.
-      setBubbleLayoutVersion((version) => version + 1);
-    },
-    [message.id, setBubbleLayoutVersion],
-  );
-
   if (isFailure) {
     return (
       <FailureBubble
@@ -328,9 +301,11 @@ function MessageRow({
     // trailing alignment instead of stretching across the column.
     const body = (
       <View
-        onLayout={onUserBubbleLayout}
         className={cn(
-          "self-end max-w-[80%] gap-1.5 rounded-2xl border-2 px-3.5 py-2 transition-colors",
+          // EnrichedMarkdownText must receive its final width during the
+          // first Yoga pass. A max width leaves native content intrinsically
+          // measured, which can disagree with the recycled cell's width.
+          "self-end w-[80%] gap-1.5 rounded-2xl border-2 px-3.5 py-2 transition-colors",
           isSelecting
             ? "bg-primary/5 border-primary/30"
             : longPress.isPressed


### PR DESCRIPTION
## Summary

Replaces the previous remeasurement approach. User bubbles now provide a definite 80% width to `EnrichedMarkdownText` during the first Yoga pass, rather than a maximum width that leaves native markdown intrinsically measured.

The prior `useLayoutState` callback asked FlashList to lay out again from an observer-only `onLayout`. When native markdown changed height, this formed a recycling feedback loop and could create the large blank bubble reported in build 21.

## Validation

- iPhone 17 Pro simulator (iOS 26.5): long text, GFM table, and fenced code block.
- Automated top/bottom scroll sequence across 36 variable-height rows; no overlap or excess bubble height.
- `pnpm --dir apps/mobile typecheck`
- `pnpm --dir apps/mobile lint` (0 errors; 7 pre-existing warnings)
- `pnpm --dir apps/mobile test` (109 passing)

Closes #7398.
