### PR TITLE
fix(repocache): recover repo checkout from a stale worktree registration (#7404)

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -1368,6 +1368,30 @@ func createWorktreeContext(ctx context.Context, gitRoot, worktreePath, branchNam
 	}
 
 	err := runWorktreeAddContext(ctx, gitRoot, worktreePath, branchName, baseRef)
+	if err != nil && isStaleWorktreeRegistrationError(err) {
+		// Stale registration (#7404): a previous run's worktree directory
+		// was deleted while its registration remained in the bare cache.
+		// The registration is prunable — prune and retry once with the SAME
+		// branch name. The branch did not collide; suffixing here would leak
+		// a branch on every cycle of a fixed-slug periodic job. This path is
+		// independent of the branch-collision retry below and must not fall
+		// through into it.
+		if pruneErr := runGitContext(ctx, "-C", gitRoot, "worktree", "prune"); pruneErr == nil {
+			// A failed `worktree add -b` creates the branch ref BEFORE
+			// hitting the stale-registration check, so the retry must reuse
+			// the existing branch when it is present — otherwise the -b
+			// retry collides with the branch the failed attempt left behind.
+			if gitRefExistsContext(ctx, gitRoot, "refs/heads/"+branchName) {
+				if out, retryErr := runGitCombinedOutputContext(ctx, "-C", gitRoot, "worktree", "add", worktreePath, branchName); retryErr != nil {
+					err = fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), retryErr)
+				} else {
+					err = nil
+				}
+			} else {
+				err = runWorktreeAddContext(ctx, gitRoot, worktreePath, branchName, baseRef)
+			}
+		}
+	}
 	if err != nil && isBranchCollisionError(err) {
 		// Branch name collision: append timestamp and retry once.
 		branchName = fmt.Sprintf("%s-%d", branchName, time.Now().Unix())
@@ -1402,6 +1426,18 @@ func isBranchCollisionError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	// Git's message is "fatal: a branch named 'X' already exists".
 	return strings.Contains(msg, "a branch named")
+}
+
+// isStaleWorktreeRegistrationError returns true if err is git's
+// "missing but already registered worktree" failure: the worktree directory
+// was removed without `git worktree remove` or `prune`, leaving a prunable
+// registration behind. Deliberately separate from isBranchCollisionError —
+// recovery here is prune-and-retry-same-branch, not suffix-and-retry.
+func isStaleWorktreeRegistrationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already registered worktree")
 }
 
 // isGitWorktree checks if a path is an existing git worktree.

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -2192,5 +2193,112 @@ func TestBranchNameDistinctForSharedUUIDv7Prefix(t *testing.T) {
 	b := fmt.Sprintf("agent/%s/%s", sanitizeName("Windows Codex"), taskKey("01a01ec0-f014-7000-8000-000000000002"))
 	if a == b {
 		t.Fatalf("both tasks resolved to branch %q", a)
+	}
+}
+
+func staleRegistrationSetup(t *testing.T) (barePath, baseRef string) {
+	t.Helper()
+	sourceRepo := createTestRepo(t)
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	barePath = cache.Lookup("ws-1", sourceRepo)
+	if barePath == "" {
+		t.Fatal("lookup returned empty bare path")
+	}
+	baseRef = getRemoteDefaultBranch(barePath)
+	if baseRef == "" {
+		t.Fatal("no default branch ref in bare cache")
+	}
+	return barePath, baseRef
+}
+
+// Registers a worktree in the bare cache and then deletes its directory,
+// leaving the prunable registration behind — the #7404 state.
+func registerStaleWorktree(t *testing.T, barePath, baseRef, path, branch string) {
+	t.Helper()
+	if err := runWorktreeAdd(barePath, path, branch, baseRef); err != nil {
+		t.Fatalf("setup worktree add failed: %v", err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("setup remove worktree dir failed: %v", err)
+	}
+}
+
+func TestCreateWorktreeRecoversFromStaleRegistration(t *testing.T) {
+	t.Parallel()
+	barePath, baseRef := staleRegistrationSetup(t)
+
+	wtPath := filepath.Join(t.TempDir(), "run-dir")
+	// The stale registration is from a PREVIOUS cycle under a different
+	// branch name — the realistic #7404 shape: the path slug repeats, the
+	// branch (agent/<name>/<task-id>) does not.
+	registerStaleWorktree(t, barePath, baseRef, wtPath, "previous-cycle-branch")
+
+	branch, err := createWorktreeContext(context.Background(), barePath, wtPath, "task-branch", baseRef)
+	if err != nil {
+		t.Fatalf("createWorktreeContext did not recover from stale registration: %v", err)
+	}
+	if branch != "task-branch" {
+		t.Fatalf("branch = %q, want requested name %q with no suffix", branch, "task-branch")
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, ".git")); err != nil {
+		t.Fatalf("worktree not created at %s: %v", wtPath, err)
+	}
+}
+
+func TestCreateWorktreeStaleRegistrationDoesNotSuffixBranch(t *testing.T) {
+	t.Parallel()
+	barePath, baseRef := staleRegistrationSetup(t)
+
+	wtPath := filepath.Join(t.TempDir(), "run-dir")
+	registerStaleWorktree(t, barePath, baseRef, wtPath, "previous-cycle-branch")
+
+	if _, err := createWorktreeContext(context.Background(), barePath, wtPath, "task-branch", baseRef); err != nil {
+		t.Fatalf("createWorktreeContext did not recover from stale registration: %v", err)
+	}
+
+	out, err := runGitOutput("-C", barePath, "branch", "--list")
+	if err != nil {
+		t.Fatalf("branch --list failed: %v", err)
+	}
+	branches := strings.TrimSpace(string(out))
+	if !strings.Contains(branches, "task-branch") {
+		t.Fatalf("requested branch missing after recovery:\n%s", branches)
+	}
+	for _, line := range strings.Split(branches, "\n") {
+		name := strings.TrimSpace(strings.TrimPrefix(line, "* "))
+		if regexp.MustCompile(`^task-branch-\d+$`).MatchString(name) {
+			t.Fatalf("recovery leaked a timestamp-suffixed branch %q; branches:\n%s", name, branches)
+		}
+	}
+}
+
+func TestCreateWorktreeBranchCollisionDoesNotPrune(t *testing.T) {
+	t.Parallel()
+	barePath, baseRef := staleRegistrationSetup(t)
+
+	// A stale registration at an unrelated path must survive a branch
+	// collision elsewhere: collision takes the suffix path, never a prune.
+	stalePath := filepath.Join(t.TempDir(), "stale-run-dir")
+	registerStaleWorktree(t, barePath, baseRef, stalePath, "stale-branch")
+
+	if err := runGit("-C", barePath, "branch", "collide-branch", baseRef); err != nil {
+		t.Fatalf("setup branch creation failed: %v", err)
+	}
+
+	freshPath := filepath.Join(t.TempDir(), "fresh-run-dir")
+	branch, err := createWorktreeContext(context.Background(), barePath, freshPath, "collide-branch", baseRef)
+	if err != nil {
+		t.Fatalf("createWorktreeContext with genuine collision failed: %v", err)
+	}
+	if branch == "collide-branch" || !regexp.MustCompile(`^collide-branch-\d+$`).MatchString(branch) {
+		t.Fatalf("branch = %q, want timestamp-suffixed collision resolution", branch)
+	}
+
+	// The prune must NOT have run: the stale registration is still fatal.
+	if err := runWorktreeAdd(barePath, stalePath, "another-branch", baseRef); err == nil {
+		t.Fatal("stale registration was pruned by the branch-collision path; it must survive")
 	}
 }


### PR DESCRIPTION
Fixes #7404.

### Problem

`repo checkout` dies permanently once the daemon's bare cache holds a worktree registration whose directory has been deleted:

```
fatal: '<workdir>/<repo>' is a missing but already registered worktree;
use 'add -f' to override, or 'prune' or 'remove' to clear
```

`createWorktreeContext` retries only on a *branch* collision. A stale registration is a different failure with a different fix, so it falls straight through and the checkout returns the fatal error. The worktree path is derived from the workdir slug (`repocache/cache.go`), so a job that reuses the same workdir hits the same stale registration on every cycle and never recovers on its own.

### Fix

Add a narrow `isStaleWorktreeRegistrationError` (matches only `already registered worktree`) and, on that error only, `git worktree prune` and retry once with the **same** branch name. Suffixing here would leak a branch per cycle, so the branch-collision path is deliberately left untouched — `isBranchCollisionError` has other callers that depend on it staying narrow.

One detail worth calling out: `git worktree add -b <branch> <path> <base>` creates `refs/heads/<branch>` **before** it checks the registration, so the branch survives the failed attempt. A naive `-b` retry after the prune then collides with the ref the failed attempt just left behind. The retry therefore checks `refs/heads/<branch>` and, when present, uses `git worktree add <path> <branch>` instead of `-b`. The requested branch name survives either way.

### Tests

Three real-git tests in `repocache/cache_test.go`:

- `TestCreateWorktreeRecoversFromStaleRegistration` — stale registration from a previous cycle; checkout recovers and returns the requested branch name.
- `TestCreateWorktreeStaleRegistrationDoesNotSuffixBranch` — `branch --list` contains no `<name>-<digits>` variant after recovery.
- `TestCreateWorktreeBranchCollisionDoesNotPrune` — a genuine branch collision still takes the suffix path, and an unrelated stale registration elsewhere is **not** pruned by it.

Both mechanisms were checked by deletion probe (each keeps the tree compiling):

- prune-and-retry block removed → the two recovery tests fail.
- branch-reuse retry replaced with a plain `-b` retry → `TestCreateWorktreeRecoversFromStaleRegistration` fails.

### Verification

```
go build ./...                                  exit 0
GOOS=windows GOARCH=amd64 go build ./cmd/...    exit 0
go vet ./...                                    exit 0
go test ./...                                   exit 0, no failures
gofmt -l internal/daemon/repocache/             clean
```

Diffstat: `cache.go +36`, `cache_test.go +108`. The isolated-metadata checkout path (`createIsolatedCheckoutContext`) is a local clone rather than a linked worktree and is unaffected.
