### PR TITLE
feat(desktop): bring up the local self-hosted stack on app launch

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { setupLocalDirectory } from "./local-directory";
+import { setupLocalStack } from "./local-stack";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
@@ -831,6 +832,9 @@ if (!gotTheLock) {
 
     setupAutoUpdater(() => mainWindow);
     setupDaemonManager(() => mainWindow);
+    if (runtimeConfigResult.ok) {
+      setupLocalStack(() => mainWindow, runtimeConfigResult.config.apiUrl);
+    }
     setupLocalDirectory(() => mainWindow);
 
     app.on("activate", () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -562,7 +562,13 @@ if (is.dev) {
   // to "Multica", but anchoring it here makes WM_CLASS ↔ StartupWMClass
   // (declared in electron-builder.yml) survive a regression in
   // productName / the build pipeline. Must run before requestSingleInstanceLock().
-  app.setName("Multica");
+  //
+  // Read it back from app.getName() rather than hardcoding the literal: a
+  // hardcoded name overrides electron-builder's productName override, which
+  // would make a differently-branded build (e.g. a local self-host package)
+  // silently share userData and the single-instance lock with the official
+  // app. For official builds this is identical to "Multica".
+  app.setName(app.getName());
 }
 
 // --- Protocol registration -----------------------------------------------

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -834,13 +834,23 @@ if (!gotTheLock) {
     });
 
     desktopInitialized = true;
+
+    // Register the local-stack IPC surface before the first window exists: the
+    // preload reads the supervisor's initial state synchronously, so the
+    // handler has to be installed before any renderer boots. Registration is
+    // unconditional — when the runtime config failed to parse there is no
+    // apiUrl to gate on, and the supervisor resolves to `ready` so the renderer
+    // can show the actionable configuration-error screen instead of hanging on
+    // a button-less startup overlay.
+    setupLocalStack(
+      () => mainWindow,
+      runtimeConfigResult.ok ? runtimeConfigResult.config.apiUrl : null,
+    );
+
     createWindow();
 
     setupAutoUpdater(() => mainWindow);
     setupDaemonManager(() => mainWindow);
-    if (runtimeConfigResult.ok) {
-      setupLocalStack(() => mainWindow, runtimeConfigResult.config.apiUrl);
-    }
     setupLocalDirectory(() => mainWindow);
 
     app.on("activate", () => {

--- a/apps/desktop/src/main/local-stack-config.test.ts
+++ b/apps/desktop/src/main/local-stack-config.test.ts
@@ -1,0 +1,69 @@
+// src/main/local-stack-config.test.ts
+import { mkdtemp, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { describe, expect, it } from "vitest";
+import { isLocalApiUrl, loadLocalStackConfig } from "./local-stack-config";
+
+describe("loadLocalStackConfig", () => {
+  it("returns null when the file is absent so the supervisor stays disabled", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "multica-local-stack-"));
+    await expect(loadLocalStackConfig(join(dir, "missing.json"))).resolves.toBeNull();
+  });
+
+  it("parses a complete config", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "multica-local-stack-"));
+    const path = join(dir, "config.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        repoDir: "/repo",
+        composeFile: "docker-compose.selfhost.yml",
+        backendPort: 8081,
+      }),
+    );
+    await expect(loadLocalStackConfig(path)).resolves.toEqual({
+      repoDir: "/repo",
+      composeFile: "docker-compose.selfhost.yml",
+      backendPort: 8081,
+    });
+  });
+
+  it("defaults composeFile and backendPort when omitted", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "multica-local-stack-"));
+    const path = join(dir, "config.json");
+    await writeFile(path, JSON.stringify({ repoDir: "/repo" }));
+    await expect(loadLocalStackConfig(path)).resolves.toEqual({
+      repoDir: "/repo",
+      composeFile: "docker-compose.selfhost.yml",
+      backendPort: 8080,
+    });
+  });
+
+  it("throws on a config without repoDir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "multica-local-stack-"));
+    const path = join(dir, "config.json");
+    await writeFile(path, JSON.stringify({ backendPort: 8081 }));
+    await expect(loadLocalStackConfig(path)).rejects.toThrow(/repoDir/);
+  });
+
+  it("throws on malformed JSON rather than silently disabling", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "multica-local-stack-"));
+    const path = join(dir, "config.json");
+    await writeFile(path, "{ not json");
+    await expect(loadLocalStackConfig(path)).rejects.toThrow();
+  });
+});
+
+describe("isLocalApiUrl", () => {
+  it.each([
+    ["http://localhost:8081", true],
+    ["http://127.0.0.1:8081", true],
+    ["http://[::1]:8081", true],
+    ["https://api.multica.ai", false],
+    ["https://multica-api.copilothub.ai", false],
+    ["not a url", false],
+  ])("%s -> %s", (url, expected) => {
+    expect(isLocalApiUrl(url)).toBe(expected);
+  });
+});

--- a/apps/desktop/src/main/local-stack-config.ts
+++ b/apps/desktop/src/main/local-stack-config.ts
@@ -25,8 +25,13 @@ const DEFAULT_BACKEND_PORT = 8080;
 /**
  * Reads the supervisor config. Returns null when the file does not exist, which
  * is the "supervisor disabled" signal — the app then behaves exactly as it does
- * without this feature. A present-but-broken file throws instead, because
- * silently ignoring a typo would look identical to the feature being off.
+ * without this feature.
+ *
+ * A present file that is not a JSON object, or that is missing `repoDir`,
+ * throws: silently ignoring those would look identical to the feature being
+ * off. `composeFile` and `backendPort` are optional and fall back to the
+ * defaults below whenever they are absent *or* of the wrong type, so a typo in
+ * either one is not reported.
  */
 export async function loadLocalStackConfig(
   path: string,

--- a/apps/desktop/src/main/local-stack-config.ts
+++ b/apps/desktop/src/main/local-stack-config.ts
@@ -1,0 +1,88 @@
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Where the supervisor is configured. Deliberately outside the repo: a packaged
+ * app has no idea where the checkout lives, and this machine-specific pointer
+ * must never be committed.
+ */
+export function localStackConfigPath(): string {
+  return join(homedir(), ".multica", "desktop-local-stack.json");
+}
+
+export interface LocalStackConfig {
+  repoDir: string;
+  composeFile: string;
+  backendPort: number;
+}
+
+const DEFAULT_COMPOSE_FILE = "docker-compose.selfhost.yml";
+// Matches the compose file's own default (`${BACKEND_PORT:-8080}`). Installs
+// that moved the backend off 8080 set `backendPort` in the config file.
+const DEFAULT_BACKEND_PORT = 8080;
+
+/**
+ * Reads the supervisor config. Returns null when the file does not exist, which
+ * is the "supervisor disabled" signal — the app then behaves exactly as it does
+ * without this feature. A present-but-broken file throws instead, because
+ * silently ignoring a typo would look identical to the feature being off.
+ */
+export async function loadLocalStackConfig(
+  path: string,
+): Promise<LocalStackConfig | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err) {
+    if (isMissingFileError(err)) return null;
+    throw err;
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("local stack config: expected a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  const repoDir = obj.repoDir;
+  if (typeof repoDir !== "string" || repoDir.length === 0) {
+    throw new Error("local stack config: repoDir is required");
+  }
+
+  const composeFile =
+    typeof obj.composeFile === "string" && obj.composeFile.length > 0
+      ? obj.composeFile
+      : DEFAULT_COMPOSE_FILE;
+
+  const backendPort =
+    typeof obj.backendPort === "number" && Number.isInteger(obj.backendPort)
+      ? obj.backendPort
+      : DEFAULT_BACKEND_PORT;
+
+  return { repoDir, composeFile, backendPort };
+}
+
+/**
+ * Whether the app is pointed at a backend on this machine. This is the gate for
+ * the whole supervisor: a build aimed at SaaS must never touch docker.
+ */
+export function isLocalApiUrl(apiUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(apiUrl).hostname;
+  } catch {
+    return false;
+  }
+  // URL normalizes [::1] to the bracket-less form in hostname on some runtimes.
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+}
+
+function isMissingFileError(err: unknown): boolean {
+  return Boolean(
+    err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT",
+  );
+}

--- a/apps/desktop/src/main/local-stack-supervisor.test.ts
+++ b/apps/desktop/src/main/local-stack-supervisor.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow, WebContents } from "electron";
+import type { LocalStackState } from "../shared/local-stack";
+import type { LocalStackConfig } from "./local-stack-config";
+
+type IpcHandler = (...args: unknown[]) => unknown;
+type SyncIpcListener = (event: { returnValue?: unknown }) => void;
+
+const config: LocalStackConfig = {
+  repoDir: "/repo",
+  composeFile: "docker-compose.selfhost.yml",
+  backendPort: 8081,
+};
+
+type ExecCallback = (
+  err: Error | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+const ctx = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  syncListeners: new Map<string, (event: { returnValue?: unknown }) => void>(),
+  ipcHandle: vi.fn(),
+  ipcOn: vi.fn(),
+  loadConfig: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: ctx.ipcHandle,
+    on: ctx.ipcOn,
+  },
+}));
+
+// The real loader reads ~/.multica/desktop-local-stack.json, which exists on
+// the machine this feature targets. Stub it so the suite never depends on it.
+vi.mock("./local-stack-config", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./local-stack-config")>();
+  return {
+    ...actual,
+    localStackConfigPath: () => "/nonexistent/desktop-local-stack.json",
+    loadLocalStackConfig: ctx.loadConfig,
+  };
+});
+
+// Nothing in the default suite may execute colima or docker. Both the named
+// and default shapes are replaced so the interop cannot reach the real one.
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  const mocked = { ...actual, execFile: ctx.execFile };
+  return { ...mocked, default: mocked };
+});
+
+import { setupLocalStack } from "./local-stack";
+
+function invoke(channel: string, ...args: unknown[]): unknown {
+  const handler = ctx.ipcHandlers.get(channel);
+  if (!handler) throw new Error(`Missing IPC handler: ${channel}`);
+  return handler({}, ...args);
+}
+
+function readSync(channel: string): unknown {
+  const listener = ctx.syncListeners.get(channel);
+  if (!listener) throw new Error(`Missing sync IPC listener: ${channel}`);
+  const event: { returnValue?: unknown } = {};
+  listener(event);
+  return event.returnValue;
+}
+
+function makeWindow() {
+  const send = vi.fn();
+  return {
+    win: {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => false, send },
+    } as unknown as BrowserWindow,
+    send,
+  };
+}
+
+/** Mirrors updater.test.ts: touching webContents on a dead window throws. */
+function makeDestroyedWindow(): BrowserWindow {
+  return {
+    isDestroyed: () => true,
+    get webContents(): WebContents {
+      throw new TypeError("Object has been destroyed");
+    },
+  } as unknown as BrowserWindow;
+}
+
+function sentStates(send: ReturnType<typeof vi.fn>): LocalStackState[] {
+  return send.mock.calls.map(([, state]) => state as LocalStackState);
+}
+
+/** Every command succeeds; colima reports itself as already running. */
+function allCommandsSucceed() {
+  ctx.execFile.mockImplementation(
+    (bin: string, args: string[], _opts: unknown, cb: ExecCallback) => {
+      const stdout = bin === "colima" && args[0] === "status" ? "running" : "";
+      cb(null, stdout, "");
+    },
+  );
+}
+
+describe("setupLocalStack", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ctx.ipcHandlers.clear();
+    ctx.syncListeners.clear();
+    ctx.ipcHandle.mockReset();
+    ctx.ipcOn.mockReset();
+    ctx.loadConfig.mockReset();
+    ctx.execFile.mockReset();
+    ctx.ipcHandle.mockImplementation((channel: string, handler: IpcHandler) => {
+      ctx.ipcHandlers.set(channel, handler);
+    });
+    ctx.ipcOn.mockImplementation((channel: string, listener: SyncIpcListener) => {
+      ctx.syncListeners.set(channel, listener);
+    });
+    // Backend never answers, so the bring-up always reaches the backend poll.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+    );
+    ctx.loadConfig.mockResolvedValue(config);
+    allCommandsSucceed();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // CRITICAL: a malformed ~/.multica/desktop.json leaves main with no apiUrl.
+  // The IPC surface must still exist, and must resolve open, or the renderer
+  // blocks forever on a button-less overlay instead of showing the config error
+  // screen that names the file.
+  describe("without a runtime config to gate on", () => {
+    it("still registers the synchronous initial-state channel", () => {
+      setupLocalStack(() => null, null);
+
+      expect(ctx.syncListeners.has("local-stack:get-initial-state")).toBe(true);
+      expect(ctx.ipcHandlers.has("local-stack:get-state")).toBe(true);
+      expect(ctx.ipcHandlers.has("local-stack:retry")).toBe(true);
+      expect(ctx.ipcHandlers.has("local-stack:skip")).toBe(true);
+    });
+
+    it("resolves ready synchronously, before any renderer can read it", () => {
+      setupLocalStack(() => null, null);
+
+      expect(readSync("local-stack:get-initial-state")).toEqual({
+        phase: "ready",
+      });
+      expect(ctx.loadConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  it("never touches docker for a SaaS apiUrl", async () => {
+    const { win, send } = makeWindow();
+    setupLocalStack(() => win, "https://api.multica.ai");
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sentStates(send)).toEqual([{ phase: "ready" }]);
+    expect(ctx.execFile).not.toHaveBeenCalled();
+    expect(ctx.loadConfig).not.toHaveBeenCalled();
+  });
+
+  // IMPORTANT 2. Skip is pressed most often during the backend step, which then
+  // polls for up to 90 more seconds. A late `failed` would re-block the window
+  // and unmount CoreProvider (React Query cache, WebSocket, editor state)
+  // mid-session with no user action.
+  it("keeps a late bring-up failure from re-blocking after skip", async () => {
+    const { win, send } = makeWindow();
+    setupLocalStack(() => win, "http://localhost:8081");
+
+    // Let the run reach the backend poll.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(sentStates(send).at(-1)).toEqual({
+      phase: "running",
+      step: "backend",
+    });
+
+    await invoke("local-stack:skip");
+    expect(sentStates(send).at(-1)).toEqual({ phase: "ready" });
+    expect(readSync("local-stack:get-initial-state")).toEqual({
+      phase: "ready",
+    });
+
+    // Run the abandoned bring-up past its 90s ceiling.
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(sentStates(send).filter((s) => s.phase === "failed")).toEqual([]);
+    expect(sentStates(send).at(-1)).toEqual({ phase: "ready" });
+    expect(readSync("local-stack:get-initial-state")).toEqual({
+      phase: "ready",
+    });
+  });
+
+  // IMPORTANT 6. Both buttons are on screen between the click and the first
+  // `running` broadcast, so a double-click is enough. Two concurrent
+  // `compose up` runs on the same project produce container-name conflicts, and
+  // the two runs then race to set the state.
+  it("coalesces concurrent retries onto a single bring-up", async () => {
+    const { win } = makeWindow();
+    setupLocalStack(() => win, "http://localhost:8081");
+    await vi.advanceTimersByTimeAsync(200_000);
+
+    const composeCallsBefore = composeUpCount();
+    const first = invoke("local-stack:retry");
+    const second = invoke("local-stack:retry");
+    expect(first).toBe(second);
+
+    await vi.advanceTimersByTimeAsync(200_000);
+
+    expect(composeUpCount() - composeCallsBefore).toBe(1);
+  });
+
+  it("starts a fresh bring-up once the previous one has settled", async () => {
+    const { win } = makeWindow();
+    setupLocalStack(() => win, "http://localhost:8081");
+    await vi.advanceTimersByTimeAsync(200_000);
+
+    const composeCallsBefore = composeUpCount();
+    const rerun = invoke("local-stack:retry") as Promise<LocalStackState>;
+    await vi.advanceTimersByTimeAsync(200_000);
+    await rerun;
+
+    expect(composeUpCount() - composeCallsBefore).toBe(1);
+  });
+
+  // IMPORTANT 4. A throw out of the broadcast would reject the bring-up, land
+  // as an unhandled rejection off `void start()`, and freeze the overlay on the
+  // last running step with no Retry and no Skip until relaunch.
+  describe("broadcasting into a dying window", () => {
+    it("keeps advancing state when the window is already destroyed", async () => {
+      setupLocalStack(() => makeDestroyedWindow(), "http://localhost:8081");
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(readSync("local-stack:get-initial-state")).toEqual({
+        phase: "failed",
+        step: "backend",
+        message: expect.stringMatching(/did not respond/i),
+      });
+    });
+
+    it("swallows a destroyed-object throw from send", async () => {
+      const send = vi.fn(() => {
+        throw new TypeError("Object has been destroyed");
+      });
+      const win = {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send },
+      } as unknown as BrowserWindow;
+
+      setupLocalStack(() => win, "http://localhost:8081");
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(readSync("local-stack:get-initial-state")).toMatchObject({
+        phase: "failed",
+        step: "backend",
+      });
+    });
+
+    it("turns an unexpected send failure into a failed state, not a rejection", async () => {
+      const send = vi.fn(() => {
+        throw new Error("kaboom");
+      });
+      const win = {
+        isDestroyed: () => false,
+        webContents: { isDestroyed: () => false, send },
+      } as unknown as BrowserWindow;
+
+      setupLocalStack(() => win, "http://localhost:8081");
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      // The very first broadcast throws, and it is attributed to the step that
+      // broadcast was carrying rather than being lost as a rejection.
+      expect(readSync("local-stack:get-initial-state")).toEqual({
+        phase: "failed",
+        step: "probe",
+        message: "kaboom",
+      });
+    });
+  });
+
+  it("reports a broken supervisor config on the config step", async () => {
+    ctx.loadConfig.mockRejectedValue(
+      new Error("local stack config: repoDir is required"),
+    );
+    const { win, send } = makeWindow();
+
+    setupLocalStack(() => win, "http://localhost:8081");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sentStates(send).at(-1)).toEqual({
+      phase: "failed",
+      step: "config",
+      message: "local stack config: repoDir is required",
+    });
+  });
+});
+
+function composeUpCount(): number {
+  return ctx.execFile.mock.calls.filter(
+    ([bin, args]) =>
+      bin === "docker" && (args as string[]).includes("up"),
+  ).length;
+}

--- a/apps/desktop/src/main/local-stack.test.ts
+++ b/apps/desktop/src/main/local-stack.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LocalStackState } from "../shared/local-stack";
+import type { CommandRunner } from "./local-stack";
+import { bringUpLocalStack } from "./local-stack";
+
+const config = {
+  repoDir: "/repo",
+  composeFile: "docker-compose.selfhost.yml",
+  backendPort: 8081,
+};
+
+function okRunner() {
+  return vi.fn<CommandRunner>(async () => ({ ok: true, stdout: "", stderr: "" }));
+}
+
+describe("bringUpLocalStack", () => {
+  it("takes the fast path when the backend already answers", async () => {
+    const run = okRunner();
+    const states: LocalStackState[] = [];
+
+    const result = await bringUpLocalStack({
+      config,
+      run,
+      probeBackend: async () => true,
+      onState: (s) => states.push(s),
+      sleep: async () => {},
+    });
+
+    expect(result).toEqual({ phase: "ready" });
+    expect(run).not.toHaveBeenCalled();
+    expect(states.at(-1)).toEqual({ phase: "ready" });
+  });
+
+  it("starts colima only when it is not already running", async () => {
+    const run = vi.fn(async (bin: string, args: string[]) => {
+      if (bin === "colima" && args[0] === "status") {
+        return { ok: true, stdout: "colima is running", stderr: "" };
+      }
+      return { ok: true, stdout: "", stderr: "" };
+    });
+    let probes = 0;
+
+    await bringUpLocalStack({
+      config,
+      run,
+      probeBackend: async () => ++probes > 1,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    const calls = run.mock.calls.map(([bin, args]) => [bin, ...args].join(" "));
+    expect(calls).not.toContain("colima start --cpu 2 --memory 4");
+    expect(calls).toContain(
+      "docker compose -f docker-compose.selfhost.yml up -d",
+    );
+  });
+
+  it("starts colima when status reports it is stopped", async () => {
+    const run = vi.fn(async (bin: string, args: string[]) => {
+      if (bin === "colima" && args[0] === "status") {
+        return { ok: false, stdout: "", stderr: "colima is not running" };
+      }
+      return { ok: true, stdout: "", stderr: "" };
+    });
+    let probes = 0;
+
+    await bringUpLocalStack({
+      config,
+      run,
+      probeBackend: async () => ++probes > 1,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    const calls = run.mock.calls.map(([bin, args]) => [bin, ...args].join(" "));
+    expect(calls).toContain("colima start --cpu 2 --memory 4");
+  });
+
+  it("emits steps in order", async () => {
+    let probes = 0;
+    const states: LocalStackState[] = [];
+
+    await bringUpLocalStack({
+      config,
+      run: vi.fn(async (bin: string, args: string[]) =>
+        bin === "colima" && args[0] === "status"
+          ? { ok: false, stdout: "", stderr: "" }
+          : { ok: true, stdout: "", stderr: "" },
+      ),
+      probeBackend: async () => ++probes > 1,
+      onState: (s) => states.push(s),
+      sleep: async () => {},
+    });
+
+    const steps = states
+      .filter((s) => s.phase === "running")
+      .map((s) => (s as { step: string }).step);
+    expect(steps).toEqual(["probe", "engine", "containers", "backend"]);
+  });
+
+  it("fails with the engine step and stderr when colima start fails", async () => {
+    const result = await bringUpLocalStack({
+      config,
+      run: vi.fn(async (bin: string, args: string[]) => {
+        if (bin === "colima" && args[0] === "status") {
+          return { ok: false, stdout: "", stderr: "" };
+        }
+        return { ok: false, stdout: "", stderr: "no space left on device" };
+      }),
+      probeBackend: async () => false,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    expect(result).toEqual({
+      phase: "failed",
+      step: "engine",
+      message: "no space left on device",
+    });
+  });
+
+  it("fails with the containers step when compose up fails", async () => {
+    const result = await bringUpLocalStack({
+      config,
+      run: vi.fn(async (bin: string, _args: string[]) => {
+        if (bin === "colima") return { ok: true, stdout: "running", stderr: "" };
+        return { ok: false, stdout: "", stderr: "compose exploded" };
+      }),
+      probeBackend: async () => false,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    expect(result).toEqual({
+      phase: "failed",
+      step: "containers",
+      message: "compose exploded",
+    });
+  });
+
+  it("times out waiting for the backend instead of hanging", async () => {
+    const result = await bringUpLocalStack({
+      config,
+      run: okRunner(),
+      probeBackend: async () => false,
+      onState: () => {},
+      sleep: async () => {},
+      backendTimeoutMs: 30,
+    });
+
+    expect(result.phase).toBe("failed");
+    expect((result as { step: string }).step).toBe("backend");
+    expect((result as { message: string }).message).toMatch(/did not respond/i);
+  });
+
+  it("uses the configured compose file rather than a hardcoded one", async () => {
+    const run = okRunner();
+    let probes = 0;
+    await bringUpLocalStack({
+      config: { ...config, composeFile: "docker-compose.custom.yml" },
+      run,
+      probeBackend: async () => ++probes > 1,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    const calls = run.mock.calls.map(([bin, args]) => [bin, ...args].join(" "));
+    expect(calls).toContain("docker compose -f docker-compose.custom.yml up -d");
+  });
+
+  it("never pulls images — the backend tag is a local shadow tag", async () => {
+    const run = okRunner();
+    let probes = 0;
+    await bringUpLocalStack({
+      config,
+      run,
+      probeBackend: async () => ++probes > 1,
+      onState: () => {},
+      sleep: async () => {},
+    });
+
+    const calls = run.mock.calls.map(([bin, args]) => [bin, ...args].join(" "));
+    expect(calls.some((c) => c.includes("pull"))).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/local-stack.test.ts
+++ b/apps/desktop/src/main/local-stack.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { LocalStackState } from "../shared/local-stack";
 import type { CommandRunner } from "./local-stack";
-import { bringUpLocalStack } from "./local-stack";
+import { bringUpLocalStack, resolveStartDecision } from "./local-stack";
 
 const config = {
   repoDir: "/repo",
@@ -181,5 +181,51 @@ describe("bringUpLocalStack", () => {
 
     const calls = run.mock.calls.map(([bin, args]) => [bin, ...args].join(" "));
     expect(calls.some((c) => c.includes("pull"))).toBe(false);
+  });
+});
+
+describe("resolveStartDecision", () => {
+  it("is inert for a non-local apiUrl without ever consulting loadConfig", async () => {
+    const loadConfig = vi.fn(async () => config);
+
+    const decision = await resolveStartDecision({
+      apiUrl: "https://api.multica.ai",
+      loadConfig,
+    });
+
+    expect(decision).toEqual({ kind: "inert", reason: "non-local-api" });
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("is inert when the supervisor is not configured", async () => {
+    const decision = await resolveStartDecision({
+      apiUrl: "http://localhost:8080",
+      loadConfig: async () => null,
+    });
+
+    expect(decision).toEqual({ kind: "inert", reason: "not-configured" });
+  });
+
+  it("carries the thrown message when loading the config fails", async () => {
+    const decision = await resolveStartDecision({
+      apiUrl: "http://localhost:8080",
+      loadConfig: async () => {
+        throw new Error("local stack config: repoDir is required");
+      },
+    });
+
+    expect(decision).toEqual({
+      kind: "config-error",
+      message: "local stack config: repoDir is required",
+    });
+  });
+
+  it("carries the loaded config when bring-up should proceed", async () => {
+    const decision = await resolveStartDecision({
+      apiUrl: "http://localhost:8080",
+      loadConfig: async () => config,
+    });
+
+    expect(decision).toEqual({ kind: "bring-up", config });
   });
 });

--- a/apps/desktop/src/main/local-stack.ts
+++ b/apps/desktop/src/main/local-stack.ts
@@ -1,0 +1,127 @@
+import type { LocalStackState } from "../shared/local-stack";
+import type { LocalStackConfig } from "./local-stack-config";
+
+export interface CommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (
+  bin: string,
+  args: string[],
+) => Promise<CommandResult>;
+
+export interface BringUpDeps {
+  config: LocalStackConfig;
+  run: CommandRunner;
+  probeBackend: () => Promise<boolean>;
+  onState: (state: LocalStackState) => void;
+  sleep: (ms: number) => Promise<void>;
+  /** Ceiling for the post-compose backend wait. Default 90s. */
+  backendTimeoutMs?: number;
+}
+
+const DEFAULT_BACKEND_TIMEOUT_MS = 90_000;
+const BACKEND_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Ordered bring-up of the self-hosted stack.
+ *
+ * The order is not cosmetic: the daemon connects to the backend API as soon as
+ * it starts, and login cannot succeed before the backend answers, so every
+ * later stage depends on the earlier one actually being up.
+ */
+export async function bringUpLocalStack(
+  deps: BringUpDeps,
+): Promise<LocalStackState> {
+  const {
+    config,
+    run,
+    probeBackend,
+    onState,
+    sleep,
+    backendTimeoutMs = DEFAULT_BACKEND_TIMEOUT_MS,
+  } = deps;
+
+  const emit = (state: LocalStackState): LocalStackState => {
+    onState(state);
+    return state;
+  };
+
+  // Fast path. With the stack left running between app launches this is the
+  // common case, and it costs exactly one request.
+  emit({ phase: "running", step: "probe" });
+  if (await probeBackend()) return emit({ phase: "ready" });
+
+  // Docker engine.
+  emit({ phase: "running", step: "engine" });
+  const status = await run("colima", ["status"]);
+  if (!colimaRunning(status)) {
+    const started = await run("colima", [
+      "start",
+      "--cpu",
+      "2",
+      "--memory",
+      "4",
+    ]);
+    if (!started.ok) {
+      return emit({
+        phase: "failed",
+        step: "engine",
+        message: lastLine(started.stderr || started.stdout) || "colima start failed",
+      });
+    }
+  }
+
+  // Containers. `up -d` is a no-op for services already running, so this is
+  // safe to re-run. Never `pull` — the backend image name is a local shadow tag.
+  emit({ phase: "running", step: "containers" });
+  const composed = await run("docker", [
+    "compose",
+    "-f",
+    config.composeFile,
+    "up",
+    "-d",
+  ]);
+  if (!composed.ok) {
+    return emit({
+      phase: "failed",
+      step: "containers",
+      message: lastLine(composed.stderr || composed.stdout) || "compose up failed",
+    });
+  }
+
+  // Backend readiness. Containers being "up" says nothing about migrations
+  // having finished, so poll the API rather than trusting compose.
+  emit({ phase: "running", step: "backend" });
+  const deadline = backendTimeoutMs;
+  let waited = 0;
+  for (;;) {
+    if (await probeBackend()) return emit({ phase: "ready" });
+    if (waited >= deadline) {
+      return emit({
+        phase: "failed",
+        step: "backend",
+        message: `backend did not respond within ${Math.round(deadline / 1000)}s`,
+      });
+    }
+    await sleep(BACKEND_POLL_INTERVAL_MS);
+    waited += BACKEND_POLL_INTERVAL_MS;
+  }
+}
+
+/**
+ * `colima status` exits non-zero when the VM is stopped, and prints its state
+ * to stderr when running. Treat any non-ok exit as "needs starting" — starting
+ * an already-running colima is harmless, while skipping a needed start is not.
+ */
+function colimaRunning(result: CommandResult): boolean {
+  if (!result.ok) return false;
+  return /running/i.test(`${result.stdout}${result.stderr}`);
+}
+
+function lastLine(text: string): string {
+  const lines = text.trim().split("\n").filter(Boolean);
+  return lines.at(-1)?.trim() ?? "";
+}

--- a/apps/desktop/src/main/local-stack.ts
+++ b/apps/desktop/src/main/local-stack.ts
@@ -1,5 +1,5 @@
 import type { LocalStackState } from "../shared/local-stack";
-import type { LocalStackConfig } from "./local-stack-config";
+import { isLocalApiUrl, type LocalStackConfig } from "./local-stack-config";
 
 export interface CommandResult {
   ok: boolean;
@@ -126,19 +126,53 @@ function lastLine(text: string): string {
   return lines.at(-1)?.trim() ?? "";
 }
 
+/**
+ * What `setupLocalStack`'s `start()` should do next, given the app's
+ * configured apiUrl and a way to load the supervisor config. Kept pure and
+ * electron-free (no fs, no ipcMain) so the branch that enforces "a
+ * SaaS-pointed build must never touch docker" is directly testable without
+ * mocking electron.
+ */
+export type StartDecision =
+  | { kind: "inert"; reason: "non-local-api" | "not-configured" }
+  | { kind: "config-error"; message: string }
+  | { kind: "bring-up"; config: LocalStackConfig };
+
+export async function resolveStartDecision(deps: {
+  apiUrl: string;
+  loadConfig: () => Promise<LocalStackConfig | null>;
+}): Promise<StartDecision> {
+  if (!isLocalApiUrl(deps.apiUrl)) {
+    return { kind: "inert", reason: "non-local-api" };
+  }
+
+  let config: LocalStackConfig | null;
+  try {
+    config = await deps.loadConfig();
+  } catch (err) {
+    return {
+      kind: "config-error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  // Not configured — behave exactly as the app does without this feature.
+  if (!config) {
+    return { kind: "inert", reason: "not-configured" };
+  }
+
+  return { kind: "bring-up", config };
+}
+
 // --- Electron wiring ------------------------------------------------------
 // Kept in this file so the state machine above and its only real caller stay
 // together; everything electron-coupled lives below this line.
 
 import { execFile } from "child_process";
 import { BrowserWindow, ipcMain } from "electron";
-import {
-  isLocalApiUrl,
-  loadLocalStackConfig,
-  localStackConfigPath,
-} from "./local-stack-config";
-// LocalStackState and LocalStackConfig are already imported at the top of
-// this file for the state machine above; no second import is needed here.
+import { loadLocalStackConfig, localStackConfigPath } from "./local-stack-config";
+// LocalStackState, LocalStackConfig, and isLocalApiUrl are already imported
+// at the top of this file for the pure logic above; no second import here.
 
 const COMMAND_TIMEOUT_MS = 180_000;
 
@@ -215,36 +249,31 @@ export function setupLocalStack(
   });
 
   const start = async (): Promise<LocalStackState> => {
-    if (!isLocalApiUrl(apiUrl)) {
-      broadcast(windowGetter, { phase: "ready" });
-      return currentState;
-    }
-
-    let config: LocalStackConfig | null;
-    try {
-      config = await loadLocalStackConfig(localStackConfigPath());
-    } catch (err) {
-      broadcast(windowGetter, {
-        phase: "failed",
-        step: "probe",
-        message: err instanceof Error ? err.message : String(err),
-      });
-      return currentState;
-    }
-
-    // Not configured — behave exactly as the app does without this feature.
-    if (!config) {
-      broadcast(windowGetter, { phase: "ready" });
-      return currentState;
-    }
-
-    return bringUpLocalStack({
-      config,
-      run: createCommandRunner(config),
-      probeBackend: createBackendProbe(apiUrl),
-      onState: (state) => broadcast(windowGetter, state),
-      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    const decision = await resolveStartDecision({
+      apiUrl,
+      loadConfig: () => loadLocalStackConfig(localStackConfigPath()),
     });
+
+    switch (decision.kind) {
+      case "inert":
+        broadcast(windowGetter, { phase: "ready" });
+        return currentState;
+      case "config-error":
+        broadcast(windowGetter, {
+          phase: "failed",
+          step: "config",
+          message: decision.message,
+        });
+        return currentState;
+      case "bring-up":
+        return bringUpLocalStack({
+          config: decision.config,
+          run: createCommandRunner(decision.config),
+          probeBackend: createBackendProbe(apiUrl),
+          onState: (state) => broadcast(windowGetter, state),
+          sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+        });
+    }
   };
 
   ipcMain.handle("local-stack:retry", () => start());

--- a/apps/desktop/src/main/local-stack.ts
+++ b/apps/desktop/src/main/local-stack.ts
@@ -1,4 +1,4 @@
-import type { LocalStackState } from "../shared/local-stack";
+import type { LocalStackState, LocalStackStep } from "../shared/local-stack";
 import { isLocalApiUrl, type LocalStackConfig } from "./local-stack-config";
 
 export interface CommandResult {
@@ -169,7 +169,8 @@ export async function resolveStartDecision(deps: {
 // together; everything electron-coupled lives below this line.
 
 import { execFile } from "child_process";
-import { BrowserWindow, ipcMain } from "electron";
+import { ipcMain } from "electron";
+import type { BrowserWindow } from "electron";
 import { loadLocalStackConfig, localStackConfigPath } from "./local-stack-config";
 // LocalStackState, LocalStackConfig, and isLocalApiUrl are already imported
 // at the top of this file for the pure logic above; no second import here.
@@ -221,34 +222,71 @@ function createBackendProbe(apiUrl: string): () => Promise<boolean> {
   };
 }
 
-let currentState: LocalStackState = { phase: "idle" };
-
-function broadcast(
-  windowGetter: () => BrowserWindow | null,
-  state: LocalStackState,
-): void {
-  currentState = state;
-  const win = windowGetter();
-  if (win && !win.isDestroyed()) {
-    win.webContents.send("local-stack:state", state);
-  }
+/**
+ * Same guard shape as `sendToLiveRenderer` in updater.ts. A window can be torn
+ * down between the `isDestroyed()` check and the send, and accessing
+ * `webContents` on a destroyed window throws rather than returning null.
+ */
+function isDestroyedObjectError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("Object has been destroyed");
 }
 
 /**
  * Brings the local stack up when this build points at a backend on this machine
  * and the supervisor is configured. Any other configuration resolves to `ready`
  * immediately, so the renderer's gate is a no-op for SaaS builds.
+ *
+ * `apiUrl` is null when the runtime config failed to parse. There is then no
+ * backend URL to gate on, so the supervisor resolves to `ready` and lets the
+ * renderer render its blocking configuration-error screen. Registering the IPC
+ * surface is NOT conditional on that: the renderer reads the initial state
+ * synchronously and would otherwise hang on a channel with no handler.
  */
 export function setupLocalStack(
   windowGetter: () => BrowserWindow | null,
-  apiUrl: string,
+  apiUrl: string | null,
 ): void {
-  ipcMain.handle("local-stack:get-state", () => currentState);
-  ipcMain.handle("local-stack:skip", () => {
-    broadcast(windowGetter, { phase: "ready" });
-  });
+  let currentState: LocalStackState = { phase: "idle" };
+  // Bring-up generation. Both `skip` and `retry` bump it, and a broadcast
+  // carrying a stale generation is dropped. Without this, the bring-up already
+  // in flight when the user pressed "Continue anyway" — most likely the 90s
+  // backend poll — would broadcast its failure a minute later, re-block the
+  // window, and unmount CoreProvider (React Query cache, WebSocket, editor
+  // state) mid-session with no user action.
+  let generation = 0;
+  // Set by `skip`, cleared by `retry`. Redundant with the generation check for
+  // the runs we know about, and deliberately so: "the user chose to continue"
+  // outranks anything a background run has to say.
+  let dismissed = false;
+  let inFlight: Promise<LocalStackState> | null = null;
+  // Last step the current run reached, so a thrown bring-up can be attributed
+  // to where it actually died rather than to a generic bucket.
+  let lastStep: LocalStackStep = "config";
 
-  const start = async (): Promise<LocalStackState> => {
+  const broadcast = (state: LocalStackState, gen: number): void => {
+    if (gen !== generation) return;
+    if (dismissed && state.phase !== "ready") return;
+    if (state.phase === "running") lastStep = state.step;
+    currentState = state;
+
+    const win = windowGetter();
+    if (!win || win.isDestroyed()) return;
+    try {
+      const { webContents } = win;
+      if (webContents.isDestroyed()) return;
+      webContents.send("local-stack:state", state);
+    } catch (err) {
+      if (isDestroyedObjectError(err)) return;
+      throw err;
+    }
+  };
+
+  const runStart = async (gen: number): Promise<LocalStackState> => {
+    if (apiUrl === null) {
+      broadcast({ phase: "ready" }, gen);
+      return currentState;
+    }
+
     const decision = await resolveStartDecision({
       apiUrl,
       loadConfig: () => loadLocalStackConfig(localStackConfigPath()),
@@ -256,26 +294,78 @@ export function setupLocalStack(
 
     switch (decision.kind) {
       case "inert":
-        broadcast(windowGetter, { phase: "ready" });
+        broadcast({ phase: "ready" }, gen);
         return currentState;
       case "config-error":
-        broadcast(windowGetter, {
-          phase: "failed",
-          step: "config",
-          message: decision.message,
-        });
+        broadcast(
+          { phase: "failed", step: "config", message: decision.message },
+          gen,
+        );
         return currentState;
       case "bring-up":
         return bringUpLocalStack({
           config: decision.config,
           run: createCommandRunner(decision.config),
           probeBackend: createBackendProbe(apiUrl),
-          onState: (state) => broadcast(windowGetter, state),
+          onState: (state) => broadcast(state, gen),
           sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
         });
     }
   };
 
+  /**
+   * Single-flight bring-up, mirroring `checkForUpdatesOnce` in updater.ts. The
+   * retry button is an IPC round-trip away from its first `running` broadcast,
+   * so a double-click would otherwise launch two concurrent `compose up` runs
+   * on the same project (container-name conflicts) that then race to set the
+   * state.
+   */
+  const start = (): Promise<LocalStackState> => {
+    if (inFlight) return inFlight;
+    generation += 1;
+    dismissed = false;
+    lastStep = "config";
+    const gen = generation;
+    const p = runStart(gen)
+      .catch((err): LocalStackState => {
+        // Anything thrown here (including a send into a renderer that died
+        // mid-broadcast) would otherwise be an unhandled rejection off
+        // `void start()`, freezing the overlay on the last running step with
+        // no Retry and no Skip until the app is relaunched.
+        const failure: LocalStackState = {
+          phase: "failed",
+          step: lastStep,
+          message: err instanceof Error ? err.message : String(err),
+        };
+        try {
+          broadcast(failure, gen);
+        } catch {
+          // Renderer torn down mid-send; currentState already carries it.
+        }
+        return failure;
+      })
+      .finally(() => {
+        if (inFlight === p) inFlight = null;
+      });
+    inFlight = p;
+    return p;
+  };
+
+  // Synchronous read, mirroring the other boot-critical preload reads
+  // (app:get-info, runtime-config:get, freeze:get-last). The renderer seeds its
+  // initial state from this, so the overlay is never the first painted frame on
+  // a build that has nothing to bring up, and a missing async handler can never
+  // leave the window stuck on a button-less overlay.
+  ipcMain.on("local-stack:get-initial-state", (event) => {
+    event.returnValue = currentState;
+  });
+  ipcMain.handle("local-stack:get-state", () => currentState);
+  ipcMain.handle("local-stack:skip", () => {
+    generation += 1;
+    dismissed = true;
+    broadcast({ phase: "ready" }, generation);
+  });
   ipcMain.handle("local-stack:retry", () => start());
+
   void start();
 }

--- a/apps/desktop/src/main/local-stack.ts
+++ b/apps/desktop/src/main/local-stack.ts
@@ -125,3 +125,128 @@ function lastLine(text: string): string {
   const lines = text.trim().split("\n").filter(Boolean);
   return lines.at(-1)?.trim() ?? "";
 }
+
+// --- Electron wiring ------------------------------------------------------
+// Kept in this file so the state machine above and its only real caller stay
+// together; everything electron-coupled lives below this line.
+
+import { execFile } from "child_process";
+import { BrowserWindow, ipcMain } from "electron";
+import {
+  isLocalApiUrl,
+  loadLocalStackConfig,
+  localStackConfigPath,
+} from "./local-stack-config";
+// LocalStackState and LocalStackConfig are already imported at the top of
+// this file for the state machine above; no second import is needed here.
+
+const COMMAND_TIMEOUT_MS = 180_000;
+
+/**
+ * Runs a command inside the checkout with BACKEND_PORT exported, mirroring what
+ * multica-start.sh does. process.env is already PATH-corrected by the fixPath()
+ * block in index.ts, which is how colima and docker (both in /opt/homebrew/bin)
+ * are found from a GUI launch.
+ */
+function createCommandRunner(config: LocalStackConfig): CommandRunner {
+  return (bin, args) =>
+    new Promise((resolve) => {
+      execFile(
+        bin,
+        args,
+        {
+          cwd: config.repoDir,
+          timeout: COMMAND_TIMEOUT_MS,
+          env: {
+            ...process.env,
+            BACKEND_PORT: String(config.backendPort),
+          },
+          maxBuffer: 4 * 1024 * 1024,
+        },
+        (err, stdout, stderr) => {
+          resolve({
+            ok: !err,
+            stdout: stdout?.toString() ?? "",
+            stderr: stderr?.toString() ?? (err ? err.message : ""),
+          });
+        },
+      );
+    });
+}
+
+function createBackendProbe(apiUrl: string): () => Promise<boolean> {
+  return async () => {
+    try {
+      const res = await fetch(`${apiUrl}/api/config`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  };
+}
+
+let currentState: LocalStackState = { phase: "idle" };
+
+function broadcast(
+  windowGetter: () => BrowserWindow | null,
+  state: LocalStackState,
+): void {
+  currentState = state;
+  const win = windowGetter();
+  if (win && !win.isDestroyed()) {
+    win.webContents.send("local-stack:state", state);
+  }
+}
+
+/**
+ * Brings the local stack up when this build points at a backend on this machine
+ * and the supervisor is configured. Any other configuration resolves to `ready`
+ * immediately, so the renderer's gate is a no-op for SaaS builds.
+ */
+export function setupLocalStack(
+  windowGetter: () => BrowserWindow | null,
+  apiUrl: string,
+): void {
+  ipcMain.handle("local-stack:get-state", () => currentState);
+  ipcMain.handle("local-stack:skip", () => {
+    broadcast(windowGetter, { phase: "ready" });
+  });
+
+  const start = async (): Promise<LocalStackState> => {
+    if (!isLocalApiUrl(apiUrl)) {
+      broadcast(windowGetter, { phase: "ready" });
+      return currentState;
+    }
+
+    let config: LocalStackConfig | null;
+    try {
+      config = await loadLocalStackConfig(localStackConfigPath());
+    } catch (err) {
+      broadcast(windowGetter, {
+        phase: "failed",
+        step: "probe",
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return currentState;
+    }
+
+    // Not configured — behave exactly as the app does without this feature.
+    if (!config) {
+      broadcast(windowGetter, { phase: "ready" });
+      return currentState;
+    }
+
+    return bringUpLocalStack({
+      config,
+      run: createCommandRunner(config),
+      probeBackend: createBackendProbe(apiUrl),
+      onState: (state) => broadcast(windowGetter, state),
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    });
+  };
+
+  ipcMain.handle("local-stack:retry", () => start());
+  void start();
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -149,6 +149,8 @@ interface DaemonAPI {
 }
 
 interface LocalStackAPI {
+  /** Supervisor state captured synchronously at preload time. */
+  initialState: LocalStackState;
   getState: () => Promise<LocalStackState>;
   retry: () => Promise<LocalStackState>;
   skip: () => Promise<void>;

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -16,6 +16,7 @@ import type {
   DaemonPrefs,
   LocalRuntimeProbe,
 } from "../shared/daemon-types";
+import type { LocalStackState } from "../shared/local-stack";
 
 interface DesktopAPI {
   /** App version + normalized OS, captured synchronously at preload time. */
@@ -147,6 +148,13 @@ interface DaemonAPI {
   openLogFile: () => Promise<{ success: boolean; error?: string }>;
 }
 
+interface LocalStackAPI {
+  getState: () => Promise<LocalStackState>;
+  retry: () => Promise<LocalStackState>;
+  skip: () => Promise<void>;
+  onState: (callback: (state: LocalStackState) => void) => () => void;
+}
+
 interface UpdaterAPI {
   onUpdateAvailable: (callback: (info: { version: string; releaseNotes?: string }) => void) => () => void;
   onDownloadProgress: (callback: (progress: { percent: number }) => void) => () => void;
@@ -165,6 +173,7 @@ declare global {
     electron: ElectronAPI;
     desktopAPI: DesktopAPI;
     daemonAPI: DaemonAPI;
+    localStackAPI: LocalStackAPI;
     updater: UpdaterAPI;
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -28,6 +28,7 @@ import {
   MAIN_RENDERER_CHANNEL_STATE_CHANNEL,
   type MainRendererMessageChannel,
 } from "../shared/main-renderer-messages";
+import type { LocalStackState } from "../shared/local-stack";
 
 // Synchronously fetch app metadata from main at preload time so the renderer
 // can pass it into CoreProvider during the initial render — the alternative
@@ -285,6 +286,23 @@ const daemonAPI = {
     ipcRenderer.invoke("daemon:open-log-file"),
 };
 
+const localStackAPI = {
+  /** Current supervisor state; call on mount before subscribing. */
+  getState: (): Promise<LocalStackState> =>
+    ipcRenderer.invoke("local-stack:get-state"),
+  /** Re-run the bring-up after a failure. */
+  retry: (): Promise<LocalStackState> => ipcRenderer.invoke("local-stack:retry"),
+  /** Dismiss the overlay and use the app anyway. */
+  skip: (): Promise<void> => ipcRenderer.invoke("local-stack:skip"),
+  /** Subscribe to state transitions. Returns an unsubscribe function. */
+  onState: (callback: (state: LocalStackState) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, state: LocalStackState) =>
+      callback(state);
+    ipcRenderer.on("local-stack:state", handler);
+    return () => ipcRenderer.removeListener("local-stack:state", handler);
+  },
+};
+
 const updaterAPI = {
   onUpdateAvailable: (callback: (info: { version: string; releaseNotes?: string }) => void) => {
     const handler = (_: unknown, info: { version: string; releaseNotes?: string }) => callback(info);
@@ -318,6 +336,7 @@ if (process.contextIsolated) {
   contextBridge.exposeInMainWorld("electron", electronAPI);
   contextBridge.exposeInMainWorld("desktopAPI", desktopAPI);
   contextBridge.exposeInMainWorld("daemonAPI", daemonAPI);
+  contextBridge.exposeInMainWorld("localStackAPI", localStackAPI);
   contextBridge.exposeInMainWorld("updater", updaterAPI);
 } else {
   // @ts-expect-error - fallback for non-isolated context
@@ -326,6 +345,8 @@ if (process.contextIsolated) {
   window.desktopAPI = desktopAPI;
   // @ts-expect-error - fallback for non-isolated context
   window.daemonAPI = daemonAPI;
+  // @ts-expect-error - fallback for non-isolated context
+  window.localStackAPI = localStackAPI;
   // @ts-expect-error - fallback for non-isolated context
   window.updater = updaterAPI;
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -65,8 +65,30 @@ function fetchRuntimeConfig(): RuntimeConfigResult {
   return { ok: false, error: { message: "Runtime config unavailable" } };
 }
 
+// Synchronously read the local-stack supervisor's current state, for the same
+// reason as the two reads above: the renderer gates the whole app on it, and an
+// async round-trip would (a) paint the startup overlay as the first frame of
+// every launch, including SaaS builds that have nothing to bring up, and (b)
+// leave the gate closed forever if the handler is missing or the invoke
+// rejects. `ready` is the fallback because a supervisor we cannot reach must
+// never be able to trap the window.
+function fetchInitialLocalStackState(): LocalStackState {
+  try {
+    const state = ipcRenderer.sendSync("local-stack:get-initial-state") as
+      | LocalStackState
+      | undefined;
+    if (state && typeof state === "object" && typeof state.phase === "string") {
+      return state;
+    }
+  } catch {
+    // fall through
+  }
+  return { phase: "ready" };
+}
+
 const appInfo = fetchAppInfo();
 const runtimeConfig = fetchRuntimeConfig();
+const initialLocalStackState = fetchInitialLocalStackState();
 const windowContext = readDesktopWindowContext(process.argv);
 
 // Read the OS-preferred locale that main injected via additionalArguments.
@@ -287,6 +309,9 @@ const daemonAPI = {
 };
 
 const localStackAPI = {
+  /** Supervisor state captured synchronously at preload time, so the renderer
+   *  has a definitive value on its very first render. */
+  initialState: initialLocalStackState,
   /** Current supervisor state; call on mount before subscribing. */
   getState: (): Promise<LocalStackState> =>
     ipcRenderer.invoke("local-stack:get-state"),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -453,8 +453,21 @@ export default function App() {
   }, [localeAdapter, locale]);
 
   const localStackState = useLocalStackState();
+  // The daemon auto-start gate is structural, not a condition anyone checks:
+  // the auto-start effect lives in AppContent, inside the CoreProvider subtree
+  // that this overlay *replaces*. Rendering the overlay as a sibling of
+  // CoreProvider instead of in place of it would silently un-gate
+  // daemon:auto-start against a backend that is not up yet — the one ordering
+  // constraint the whole supervisor exists to enforce.
+  //
+  // `runtimeConfigResult.ok` is part of the condition because the supervisor
+  // has nothing to gate on without a parsed config: without it, a malformed
+  // ~/.multica/desktop.json would hold the overlay up forever and hide the
+  // BlockingRuntimeConfigError screen that actually names the problem.
   const localStackBlocking =
-    windowContext.kind === "main" && localStackState.phase !== "ready";
+    windowContext.kind === "main" &&
+    runtimeConfigResult.ok &&
+    localStackState.phase !== "ready";
 
   return (
     <ThemeProvider>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -17,6 +17,10 @@ import { DesktopAuthRecoveryPage } from "./pages/auth-recovery";
 import { DesktopShell } from "./components/desktop-layout";
 import { UpdateNotification } from "./components/update-notification";
 import { IssueWindow } from "./components/issue-window";
+import {
+  LocalStackOverlay,
+  useLocalStackState,
+} from "./components/local-stack-overlay";
 import { useTabStore } from "./stores/tab-store";
 import { useWindowOverlayStore } from "./stores/window-overlay-store";
 import { useOpenSettingsShortcut } from "./hooks/use-open-settings-shortcut";
@@ -448,9 +452,19 @@ export default function App() {
     });
   }, [localeAdapter, locale]);
 
+  const localStackState = useLocalStackState();
+  const localStackBlocking =
+    windowContext.kind === "main" && localStackState.phase !== "ready";
+
   return (
     <ThemeProvider>
-      {runtimeConfigResult.ok ? (
+      {localStackBlocking ? (
+        <LocalStackOverlay
+          state={localStackState}
+          onRetry={() => void window.localStackAPI.retry()}
+          onSkip={() => void window.localStackAPI.skip()}
+        />
+      ) : runtimeConfigResult.ok ? (
         <CoreProvider
           apiBaseUrl={runtimeConfigResult.config.apiUrl}
           wsUrl={runtimeConfigResult.config.wsUrl}

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
@@ -1,6 +1,14 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { LocalStackOverlay } from "./local-stack-overlay";
+import type { LocalStackState } from "../../../shared/local-stack";
+import { LocalStackOverlay, useLocalStackState } from "./local-stack-overlay";
 
 // This repo has no @testing-library/user-event dependency — interaction tests
 // use fireEvent (see src/renderer/src/components/route-error-page.test.tsx).
@@ -107,5 +115,103 @@ describe("LocalStackOverlay", () => {
       "data-status",
       "done",
     );
+  });
+});
+
+// useLocalStackState is the single mechanism implementing the "read then
+// subscribe" invariant: the bring-up starts before React mounts, so the hook
+// must read getState() on mount (not rely on onState alone) or it would sit
+// on "idle" forever. Stub window.localStackAPI directly rather than going
+// through the real preload bridge.
+function stubLocalStackAPI(overrides: {
+  getState: ReturnType<typeof vi.fn>;
+  onState: ReturnType<typeof vi.fn>;
+}) {
+  Object.defineProperty(window, "localStackAPI", {
+    configurable: true,
+    value: {
+      getState: overrides.getState,
+      onState: overrides.onState,
+      retry: vi.fn(),
+      skip: vi.fn(),
+    },
+  });
+}
+
+describe("useLocalStackState", () => {
+  it("calls getState() on mount and lands the resolved value in state", async () => {
+    const getState = vi
+      .fn()
+      .mockResolvedValue({ phase: "running", step: "engine" } as LocalStackState);
+    const onState = vi.fn(() => () => {});
+    stubLocalStackAPI({ getState, onState });
+
+    const { result } = renderHook(() => useLocalStackState());
+
+    expect(getState).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(result.current).toEqual({ phase: "running", step: "engine" }),
+    );
+  });
+
+  it("subscribes via onState, and a pushed state updates the returned state", async () => {
+    const getState = vi.fn().mockResolvedValue({ phase: "idle" } as LocalStackState);
+    let pushState: ((state: LocalStackState) => void) | undefined;
+    const onState = vi.fn((callback: (state: LocalStackState) => void) => {
+      pushState = callback;
+      return () => {};
+    });
+    stubLocalStackAPI({ getState, onState });
+
+    const { result } = renderHook(() => useLocalStackState());
+    await waitFor(() => expect(onState).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      pushState?.({ phase: "running", step: "probe" });
+    });
+
+    expect(result.current).toEqual({ phase: "running", step: "probe" });
+  });
+
+  it("calls the onState unsubscribe function on unmount", async () => {
+    const getState = vi.fn().mockResolvedValue({ phase: "idle" } as LocalStackState);
+    const unsubscribe = vi.fn();
+    const onState = vi.fn(() => unsubscribe);
+    stubLocalStackAPI({ getState, onState });
+
+    const { unmount } = renderHook(() => useLocalStackState());
+    await waitFor(() => expect(onState).toHaveBeenCalledTimes(1));
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  // The hook's `active` flag exists precisely for this: a slow initial
+  // getState() call that only resolves after the component is gone must not
+  // resurrect stale state or throw. Prove the guard by resolving it late.
+  it("ignores a getState() resolution that arrives after unmount", async () => {
+    let resolveGetState: ((state: LocalStackState) => void) | undefined;
+    const getState = vi.fn(
+      () =>
+        new Promise<LocalStackState>((resolve) => {
+          resolveGetState = resolve;
+        }),
+    );
+    const onState = vi.fn(() => () => {});
+    stubLocalStackAPI({ getState, onState });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result, unmount } = renderHook(() => useLocalStackState());
+    unmount();
+
+    await act(async () => {
+      resolveGetState?.({ phase: "ready" });
+      await Promise.resolve();
+    });
+
+    expect(result.current).toEqual({ phase: "idle" });
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
@@ -6,9 +6,13 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LocalStackState } from "../../../shared/local-stack";
-import { LocalStackOverlay, useLocalStackState } from "./local-stack-overlay";
+import {
+  LocalStackOverlay,
+  SKIP_VISIBLE_AFTER_MS,
+  useLocalStackState,
+} from "./local-stack-overlay";
 
 // This repo has no @testing-library/user-event dependency — interaction tests
 // use fireEvent (see src/renderer/src/components/route-error-page.test.tsx).
@@ -116,20 +120,99 @@ describe("LocalStackOverlay", () => {
       "done",
     );
   });
+
+  // Bounded worst case for a bring-up that hangs everywhere is roughly nine
+  // minutes (three 180s command timeouts plus the 90s backend poll). Without an
+  // escape hatch during `running` that is nine minutes of a window with no
+  // buttons and no keyboard way out.
+  describe("escape hatch while running", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("offers Continue anyway while running once the delay elapses", () => {
+      const onSkip = vi.fn();
+      render(
+        <LocalStackOverlay
+          state={{ phase: "running", step: "backend" }}
+          onRetry={() => {}}
+          onSkip={onSkip}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /continue anyway/i }),
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(SKIP_VISIBLE_AFTER_MS);
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /continue anyway/i }));
+      expect(onSkip).toHaveBeenCalledOnce();
+    });
+
+    // Retry stays failure-only: re-running a bring-up that is still in flight
+    // is what the main-process single-flight guard exists to prevent.
+    it("does not offer Retry while running", () => {
+      render(
+        <LocalStackOverlay
+          state={{ phase: "running", step: "backend" }}
+          onRetry={() => {}}
+          onSkip={() => {}}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(SKIP_VISIBLE_AFTER_MS);
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /retry/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // `idle` is what the renderer sees when main is up but the supervisor has
+    // not reported yet. It blocks exactly like `running`, so it needs the same
+    // way out.
+    it("offers Continue anyway from a stuck idle state too", () => {
+      render(
+        <LocalStackOverlay
+          state={{ phase: "idle" }}
+          onRetry={() => {}}
+          onSkip={() => {}}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(SKIP_VISIBLE_AFTER_MS);
+      });
+
+      expect(
+        screen.getByRole("button", { name: /continue anyway/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });
 
-// useLocalStackState is the single mechanism implementing the "read then
+// useLocalStackState implements the "seed synchronously, then read, then
 // subscribe" invariant: the bring-up starts before React mounts, so the hook
-// must read getState() on mount (not rely on onState alone) or it would sit
-// on "idle" forever. Stub window.localStackAPI directly rather than going
+// seeds from the preload's synchronous snapshot and still reads getState() on
+// mount (an event emitted between the snapshot and the subscription would
+// otherwise be lost). Stub window.localStackAPI directly rather than going
 // through the real preload bridge.
 function stubLocalStackAPI(overrides: {
   getState: ReturnType<typeof vi.fn>;
   onState: ReturnType<typeof vi.fn>;
+  initialState?: LocalStackState;
 }) {
   Object.defineProperty(window, "localStackAPI", {
     configurable: true,
     value: {
+      initialState: overrides.initialState ?? ({ phase: "idle" } as LocalStackState),
       getState: overrides.getState,
       onState: overrides.onState,
       retry: vi.fn(),
@@ -139,6 +222,37 @@ function stubLocalStackAPI(overrides: {
 }
 
 describe("useLocalStackState", () => {
+  // The first render decides whether App paints the overlay or mounts
+  // CoreProvider. Seeding from the preload snapshot is what keeps a SaaS build
+  // — where main resolved `ready` long before the window existed — from showing
+  // the startup overlay as its first visible frame.
+  it("seeds synchronously from the preload snapshot, before any IPC resolves", () => {
+    const getState = vi.fn(() => new Promise<LocalStackState>(() => {}));
+    const onState = vi.fn(() => () => {});
+    stubLocalStackAPI({
+      getState,
+      onState,
+      initialState: { phase: "ready" },
+    });
+
+    const { result } = renderHook(() => useLocalStackState());
+
+    expect(result.current).toEqual({ phase: "ready" });
+  });
+
+  // A rejected invoke (no handler registered, main torn down) must open the
+  // gate, not hold it shut: the failure mode it replaces is a button-less
+  // overlay with no timeout and no keyboard escape.
+  it("falls back to ready when getState() rejects", async () => {
+    const getState = vi.fn().mockRejectedValue(new Error("no handler"));
+    const onState = vi.fn(() => () => {});
+    stubLocalStackAPI({ getState, onState, initialState: { phase: "idle" } });
+
+    const { result } = renderHook(() => useLocalStackState());
+
+    await waitFor(() => expect(result.current).toEqual({ phase: "ready" }));
+  });
+
   it("calls getState() on mount and lands the resolved value in state", async () => {
     const getState = vi
       .fn()
@@ -187,9 +301,10 @@ describe("useLocalStackState", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  // The hook's `active` flag exists precisely for this: a slow initial
-  // getState() call that only resolves after the component is gone must not
-  // resurrect stale state or throw. Prove the guard by resolving it late.
+  // Documents the intent of the hook's `active` flag: a slow initial getState()
+  // that resolves after unmount must not resurrect stale state. This is not a
+  // regression guard — React 18 silently no-ops a post-unmount setState, so the
+  // assertions below hold with or without the flag.
   it("ignores a getState() resolution that arrives after unmount", async () => {
     let resolveGetState: ((state: LocalStackState) => void) | undefined;
     const getState = vi.fn(

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LocalStackOverlay } from "./local-stack-overlay";
+
+// This repo has no @testing-library/user-event dependency — interaction tests
+// use fireEvent (see src/renderer/src/components/route-error-page.test.tsx).
+
+describe("LocalStackOverlay", () => {
+  it("shows the current step while running", () => {
+    render(
+      <LocalStackOverlay
+        state={{ phase: "running", step: "engine" }}
+        onRetry={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(screen.getByText(/starting docker engine/i)).toBeInTheDocument();
+  });
+
+  it("marks earlier steps as done", () => {
+    render(
+      <LocalStackOverlay
+        state={{ phase: "running", step: "backend" }}
+        onRetry={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("step-engine")).toHaveAttribute(
+      "data-status",
+      "done",
+    );
+    expect(screen.getByTestId("step-backend")).toHaveAttribute(
+      "data-status",
+      "active",
+    );
+  });
+
+  it("shows the failure message and both actions on failure", () => {
+    const onRetry = vi.fn();
+    const onSkip = vi.fn();
+    render(
+      <LocalStackOverlay
+        state={{ phase: "failed", step: "containers", message: "compose exploded" }}
+        onRetry={onRetry}
+        onSkip={onSkip}
+      />,
+    );
+
+    expect(screen.getByText("compose exploded")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: /continue anyway/i }));
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it("marks the failed step so the user sees where it stopped", () => {
+    render(
+      <LocalStackOverlay
+        state={{ phase: "failed", step: "containers", message: "boom" }}
+        onRetry={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("step-containers")).toHaveAttribute(
+      "data-status",
+      "failed",
+    );
+  });
+
+  // A config-load failure happens before any bring-up step runs. It must land
+  // on the config row, not on probe — misattributing it sends the user
+  // debugging docker when the real problem is a typo in their JSON.
+  it("attributes a config failure to the config step, not probe", () => {
+    render(
+      <LocalStackOverlay
+        state={{
+          phase: "failed",
+          step: "config",
+          message: "local stack config: repoDir is required",
+        }}
+        onRetry={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("step-config")).toHaveAttribute(
+      "data-status",
+      "failed",
+    );
+    expect(screen.getByTestId("step-probe")).toHaveAttribute(
+      "data-status",
+      "pending",
+    );
+  });
+
+  // The happy path never emits a running:config event — config loading is
+  // instantaneous — so by the time probe is active, config must already read
+  // as done rather than being stuck pending.
+  it("shows config as done once probe is active", () => {
+    render(
+      <LocalStackOverlay
+        state={{ phase: "running", step: "probe" }}
+        onRetry={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("step-config")).toHaveAttribute(
+      "data-status",
+      "done",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  LOCAL_STACK_STEPS,
+  type LocalStackState,
+  type LocalStackStep,
+} from "../../../shared/local-stack";
+
+const STEP_LABELS: Record<LocalStackStep, string> = {
+  config: "Loading configuration",
+  probe: "Checking backend",
+  engine: "Starting Docker engine",
+  containers: "Starting containers",
+  backend: "Waiting for backend",
+};
+
+const STEPS = LOCAL_STACK_STEPS.map((key) => ({
+  key,
+  label: STEP_LABELS[key],
+}));
+
+type StepStatus = "pending" | "active" | "done" | "failed";
+
+function statusFor(
+  step: LocalStackStep,
+  state: LocalStackState,
+): StepStatus {
+  const order = STEPS.findIndex((s) => s.key === step);
+  if (state.phase === "ready") return "done";
+  if (state.phase === "idle") return "pending";
+
+  const currentIndex = STEPS.findIndex((s) => s.key === state.step);
+  if (state.phase === "failed") {
+    if (order === currentIndex) return "failed";
+    return order < currentIndex ? "done" : "pending";
+  }
+  if (order < currentIndex) return "done";
+  return order === currentIndex ? "active" : "pending";
+}
+
+/**
+ * Subscribes to supervisor state. Reads the current value on mount first: the
+ * bring-up starts as soon as the main process is ready, which is before React
+ * mounts, so a subscribe-only approach would miss the early transitions.
+ */
+export function useLocalStackState(): LocalStackState {
+  const [state, setState] = useState<LocalStackState>({ phase: "idle" });
+
+  useEffect(() => {
+    let active = true;
+    void window.localStackAPI.getState().then((s) => {
+      if (active) setState(s);
+    });
+    const unsubscribe = window.localStackAPI.onState(setState);
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return state;
+}
+
+export function LocalStackOverlay({
+  state,
+  onRetry,
+  onSkip,
+}: {
+  state: LocalStackState;
+  onRetry: () => void;
+  onSkip: () => void;
+}) {
+  const failed = state.phase === "failed";
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-background p-8 text-foreground">
+      <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm">
+        <h1 className="text-lg font-semibold">
+          {failed ? "Local stack failed to start" : "Starting local stack"}
+        </h1>
+
+        <ul className="mt-5 space-y-2">
+          {STEPS.map((step) => {
+            const status = statusFor(step.key, state);
+            return (
+              <li
+                key={step.key}
+                data-testid={`step-${step.key}`}
+                data-status={status}
+                className="flex items-center gap-3 text-sm"
+              >
+                <span
+                  aria-hidden
+                  className={
+                    status === "done"
+                      ? "size-2 rounded-full bg-primary"
+                      : status === "active"
+                        ? "size-2 animate-pulse rounded-full bg-primary"
+                        : status === "failed"
+                          ? "size-2 rounded-full bg-destructive"
+                          : "size-2 rounded-full bg-muted-foreground/30"
+                  }
+                />
+                <span
+                  className={
+                    status === "pending"
+                      ? "text-muted-foreground"
+                      : "text-foreground"
+                  }
+                >
+                  {step.label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+
+        {failed && (
+          <>
+            <pre className="mt-4 max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs text-muted-foreground">
+              {state.message}
+            </pre>
+            <div className="mt-4 flex gap-2">
+              <Button onClick={onRetry}>Retry</Button>
+              <Button variant="outline" onClick={onSkip}>
+                Continue anyway
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
@@ -39,19 +39,36 @@ function statusFor(
   return order === currentIndex ? "active" : "pending";
 }
 
+/** How long a bring-up may run before the overlay offers a way out. */
+export const SKIP_VISIBLE_AFTER_MS = 15_000;
+
 /**
- * Subscribes to supervisor state. Reads the current value on mount first: the
- * bring-up starts as soon as the main process is ready, which is before React
- * mounts, so a subscribe-only approach would miss the early transitions.
+ * Subscribes to supervisor state.
+ *
+ * The initial value comes from the synchronous preload read, not from an IPC
+ * round-trip: the whole app is gated on this state, so seeding with `idle`
+ * would paint the overlay as the first frame of every launch (including SaaS
+ * builds, which have nothing to bring up) and would serialize the CoreProvider
+ * mount behind an invoke. The async read still runs afterwards to close the
+ * window between the preload snapshot and the subscription, and falls back to
+ * `ready` if it rejects — a supervisor we cannot reach must never keep the gate
+ * closed.
  */
 export function useLocalStackState(): LocalStackState {
-  const [state, setState] = useState<LocalStackState>({ phase: "idle" });
+  const [state, setState] = useState<LocalStackState>(
+    () => window.localStackAPI.initialState ?? { phase: "ready" },
+  );
 
   useEffect(() => {
     let active = true;
-    void window.localStackAPI.getState().then((s) => {
-      if (active) setState(s);
-    });
+    window.localStackAPI
+      .getState()
+      .then((s) => {
+        if (active) setState(s);
+      })
+      .catch(() => {
+        if (active) setState({ phase: "ready" });
+      });
     const unsubscribe = window.localStackAPI.onState(setState);
     return () => {
       active = false;
@@ -72,6 +89,23 @@ export function LocalStackOverlay({
   onSkip: () => void;
 }) {
   const failed = state.phase === "failed";
+
+  // Escape hatch while the bring-up is still running. Worst case without it is
+  // colima status + colima start + compose up (180s each) plus the 90s backend
+  // poll — around nine minutes of a window with no buttons — and it is also
+  // what makes a supervisor that wedges mid-run survivable rather than terminal.
+  // Delayed rather than immediate so the common short bring-up doesn't invite
+  // the user to skip a stack that is seconds from ready.
+  const [escapeHatchVisible, setEscapeHatchVisible] = useState(false);
+  const running = state.phase === "running" || state.phase === "idle";
+  useEffect(() => {
+    if (!running) return undefined;
+    const timer = setTimeout(
+      () => setEscapeHatchVisible(true),
+      SKIP_VISIBLE_AFTER_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [running]);
 
   return (
     <div className="flex h-screen flex-col">
@@ -118,7 +152,7 @@ export function LocalStackOverlay({
             })}
           </ul>
 
-          {failed && (
+          {failed ? (
             <>
               <pre className="mt-4 max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs text-muted-foreground">
                 {state.message}
@@ -130,6 +164,14 @@ export function LocalStackOverlay({
                 </Button>
               </div>
             </>
+          ) : (
+            escapeHatchVisible && (
+              <div className="mt-4 flex gap-2">
+                <Button variant="outline" onClick={onSkip}>
+                  Continue anyway
+                </Button>
+              </div>
+            )
           )}
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
+++ b/apps/desktop/src/renderer/src/components/local-stack-overlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Button } from "@multica/ui/components/ui/button";
+import { DragStrip } from "@multica/views/platform";
 import {
   LOCAL_STACK_STEPS,
   type LocalStackState,
@@ -73,61 +74,64 @@ export function LocalStackOverlay({
   const failed = state.phase === "failed";
 
   return (
-    <div className="flex h-screen items-center justify-center bg-background p-8 text-foreground">
-      <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm">
-        <h1 className="text-lg font-semibold">
-          {failed ? "Local stack failed to start" : "Starting local stack"}
-        </h1>
+    <div className="flex h-screen flex-col">
+      <DragStrip />
+      <div className="flex flex-1 items-center justify-center bg-background p-8 text-foreground">
+        <div className="w-full max-w-md rounded-lg border bg-card p-6 shadow-sm">
+          <h1 className="text-lg font-semibold">
+            {failed ? "Local stack failed to start" : "Starting local stack"}
+          </h1>
 
-        <ul className="mt-5 space-y-2">
-          {STEPS.map((step) => {
-            const status = statusFor(step.key, state);
-            return (
-              <li
-                key={step.key}
-                data-testid={`step-${step.key}`}
-                data-status={status}
-                className="flex items-center gap-3 text-sm"
-              >
-                <span
-                  aria-hidden
-                  className={
-                    status === "done"
-                      ? "size-2 rounded-full bg-primary"
-                      : status === "active"
-                        ? "size-2 animate-pulse rounded-full bg-primary"
-                        : status === "failed"
-                          ? "size-2 rounded-full bg-destructive"
-                          : "size-2 rounded-full bg-muted-foreground/30"
-                  }
-                />
-                <span
-                  className={
-                    status === "pending"
-                      ? "text-muted-foreground"
-                      : "text-foreground"
-                  }
+          <ul className="mt-5 space-y-2">
+            {STEPS.map((step) => {
+              const status = statusFor(step.key, state);
+              return (
+                <li
+                  key={step.key}
+                  data-testid={`step-${step.key}`}
+                  data-status={status}
+                  className="flex items-center gap-3 text-sm"
                 >
-                  {step.label}
-                </span>
-              </li>
-            );
-          })}
-        </ul>
+                  <span
+                    aria-hidden
+                    className={
+                      status === "done"
+                        ? "size-2 rounded-full bg-primary"
+                        : status === "active"
+                          ? "size-2 animate-pulse rounded-full bg-primary"
+                          : status === "failed"
+                            ? "size-2 rounded-full bg-destructive"
+                            : "size-2 rounded-full bg-muted-foreground/30"
+                    }
+                  />
+                  <span
+                    className={
+                      status === "pending"
+                        ? "text-muted-foreground"
+                        : "text-foreground"
+                    }
+                  >
+                    {step.label}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
 
-        {failed && (
-          <>
-            <pre className="mt-4 max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs text-muted-foreground">
-              {state.message}
-            </pre>
-            <div className="mt-4 flex gap-2">
-              <Button onClick={onRetry}>Retry</Button>
-              <Button variant="outline" onClick={onSkip}>
-                Continue anyway
-              </Button>
-            </div>
-          </>
-        )}
+          {failed && (
+            <>
+              <pre className="mt-4 max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                {state.message}
+              </pre>
+              <div className="mt-4 flex gap-2">
+                <Button onClick={onRetry}>Retry</Button>
+                <Button variant="outline" onClick={onSkip}>
+                  Continue anyway
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/shared/local-stack.ts
+++ b/apps/desktop/src/shared/local-stack.ts
@@ -2,10 +2,16 @@
 // Shared between main (produces state), preload (bridges it), and renderer
 // (renders it). Kept free of node/electron imports for that reason.
 
-export type LocalStackStep = "probe" | "engine" | "containers" | "backend";
+export type LocalStackStep =
+  | "config"
+  | "probe"
+  | "engine"
+  | "containers"
+  | "backend";
 
 /** Bring-up order; also the display order in the startup overlay. */
 export const LOCAL_STACK_STEPS: readonly LocalStackStep[] = [
+  "config",
   "probe",
   "engine",
   "containers",

--- a/apps/desktop/src/shared/local-stack.ts
+++ b/apps/desktop/src/shared/local-stack.ts
@@ -1,0 +1,19 @@
+// src/shared/local-stack.ts
+// Shared between main (produces state), preload (bridges it), and renderer
+// (renders it). Kept free of node/electron imports for that reason.
+
+export type LocalStackStep = "probe" | "engine" | "containers" | "backend";
+
+/** Bring-up order; also the display order in the startup overlay. */
+export const LOCAL_STACK_STEPS: readonly LocalStackStep[] = [
+  "probe",
+  "engine",
+  "containers",
+  "backend",
+] as const;
+
+export type LocalStackState =
+  | { phase: "idle" }
+  | { phase: "running"; step: LocalStackStep }
+  | { phase: "ready" }
+  | { phase: "failed"; step: LocalStackStep; message: string };

--- a/multica-start.sh
+++ b/multica-start.sh
@@ -21,8 +21,14 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="docker-compose.selfhost.yml"
 COLIMA_CPU=2
 COLIMA_MEM=4
-FRONTEND_URL="http://localhost:3000"
-BACKEND_URL="http://localhost:8080"
+# Both ports are read from the environment and exported so `docker compose`
+# picks them up — an environment variable outranks the same key in .env.
+# Override either one when a default collides with another local service.
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+export BACKEND_PORT FRONTEND_PORT
+FRONTEND_URL="http://localhost:${FRONTEND_PORT}"
+BACKEND_URL="http://localhost:${BACKEND_PORT}"
 
 # ---- Helpers ---------------------------------------------------------------
 c_green() { printf '\033[32m%s\033[0m\n' "$*"; }

--- a/multica-start.sh
+++ b/multica-start.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# multica-start.sh — bring up the local self-hosted Multica stack.
+#
+# Order: colima (Docker engine) -> server containers (postgres/backend/frontend)
+# -> local daemon. Every step checks whether its component is already running and
+# skips it, so the script is idempotent and safe to re-run.
+#
+# Usage:
+#   ./multica-start.sh            # start everything
+#   ./multica-start.sh --code     # start, then print the latest login code from the backend log
+#   ./multica-start.sh --logs     # start, then follow the backend log
+#
+set -euo pipefail
+
+# ---- Configuration ---------------------------------------------------------
+# The repo is the directory this script lives in, so a clone anywhere works
+# without editing anything. Resolve it before any `cd` so a relative invocation
+# (./multica-start.sh) and an absolute one behave the same.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="docker-compose.selfhost.yml"
+COLIMA_CPU=2
+COLIMA_MEM=4
+FRONTEND_URL="http://localhost:3000"
+BACKEND_URL="http://localhost:8080"
+
+# ---- Helpers ---------------------------------------------------------------
+c_green() { printf '\033[32m%s\033[0m\n' "$*"; }
+c_blue()  { printf '\033[34m%s\033[0m\n' "$*"; }
+c_yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+c_red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+step()    { c_blue "▶ $*"; }
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+# ---- Preflight -------------------------------------------------------------
+for bin in colima docker multica; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    c_red "✗ Missing command: $bin — install it first"; exit 1
+  fi
+done
+if ! docker compose version >/dev/null 2>&1; then
+  c_red "✗ 'docker compose' is unavailable — install the Docker Compose plugin"; exit 1
+fi
+if [ ! -f "$REPO_DIR/$COMPOSE_FILE" ]; then
+  c_red "✗ $REPO_DIR/$COMPOSE_FILE not found — is this script still at the repo root?"; exit 1
+fi
+cd "$REPO_DIR"
+
+# ---- 1. colima (Docker engine) ---------------------------------------------
+step "Checking the Docker engine (colima)..."
+if docker info >/dev/null 2>&1; then
+  c_green "  ✓ Docker daemon already running"
+else
+  c_yellow "  colima is not running, starting it (${COLIMA_CPU}C/${COLIMA_MEM}G)..."
+  colima start --cpu "$COLIMA_CPU" --memory "$COLIMA_MEM"
+  # Wait for the daemon to answer (up to 60s).
+  for i in $(seq 1 30); do
+    docker info >/dev/null 2>&1 && break
+    sleep 2
+  done
+  docker info >/dev/null 2>&1 || { c_red "✗ Docker daemon did not come up in time"; exit 1; }
+  c_green "  ✓ colima ready"
+fi
+
+# ---- 2. Server containers --------------------------------------------------
+step "Checking server containers..."
+running=$(compose ps --services --filter status=running 2>/dev/null | sort -u | tr '\n' ' ')
+if echo "$running" | grep -q postgres && echo "$running" | grep -q backend && echo "$running" | grep -q frontend; then
+  c_green "  ✓ postgres / backend / frontend all running"
+else
+  c_yellow "  Starting the server stack (docker compose up -d)..."
+  compose up -d
+fi
+
+# Wait for the backend to answer (up to 60s).
+step "Waiting for the backend..."
+for i in $(seq 1 30); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "$BACKEND_URL/api/config" 2>/dev/null || echo 000)
+  [ "$code" = "200" ] && break
+  sleep 2
+done
+if [ "${code:-000}" = "200" ]; then
+  c_green "  ✓ Backend ready ($BACKEND_URL)"
+else
+  # Do not guess the cause — a migration in progress, a DB auth failure and a
+  # port conflict all look identical from out here. Show the log instead.
+  c_red "  ✗ Backend did not return 200 within 60s. Last log lines:"
+  compose logs backend --tail 8 2>&1 | sed 's/^/    /' || true
+fi
+
+# ---- 3. Local daemon -------------------------------------------------------
+step "Checking the local daemon..."
+# `multica daemon status` exits 0 even when the daemon is stopped, so the
+# output has to be matched — the exit code carries no signal here.
+if multica daemon status 2>/dev/null | grep -q 'running'; then
+  c_green "  ✓ Daemon already running"
+else
+  c_yellow "  Starting the daemon..."
+  multica daemon start
+fi
+
+# ---- Summary ---------------------------------------------------------------
+echo
+c_green "✓ Local Multica stack is up"
+echo "  Frontend: $FRONTEND_URL"
+echo "  Backend:  $BACKEND_URL"
+multica daemon status 2>/dev/null | sed 's/^/  /' || true
+
+# ---- Optional: print the login code / follow logs --------------------------
+case "${1:-}" in
+  --code)
+    echo
+    step "Latest login code (from the backend log):"
+    logs=$(compose logs backend 2>&1) || true
+    if printf '%s' "$logs" | grep -q 'error from daemon in stream'; then
+      # When the Docker data disk hits an I/O error the log file cannot be read
+      # at all. That is a different failure from "no code has been sent yet" and
+      # must be reported separately, otherwise it reads as the latter.
+      c_red "  ✗ Could not read the backend log — Docker data disk error:"
+      printf '%s\n' "$logs" | grep 'error from daemon in stream' | tail -1 | sed 's/^/    /'
+      c_yellow "  Recover with: ./multica-stop.sh; colima stop; colima start; ./multica-start.sh"
+    elif code_line=$(printf '%s\n' "$logs" | grep '\[DEV\] Verification' | tail -1) \
+      && [ -n "$code_line" ]; then
+      printf '%s\n' "$code_line" | sed 's/^/  /'
+    else
+      c_yellow "  No code yet — enter your email at $FRONTEND_URL to trigger one, then re-run --code"
+    fi
+    ;;
+  --logs)
+    echo; step "Following the backend log (Ctrl-C to exit)..."
+    compose logs -f backend
+    ;;
+esac

--- a/multica-stop.sh
+++ b/multica-stop.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# multica-stop.sh — stop the local self-hosted Multica stack.
+#
+# Order: local daemon -> server containers (postgres/backend/frontend). colima
+# (the Docker engine) is left running by default because other projects may share
+# it; pass --all to stop it too. Components that are already stopped are skipped,
+# so the script is idempotent.
+#
+# Usage:
+#   ./multica-stop.sh          # stop the daemon + server containers (keep colima)
+#   ./multica-stop.sh --all    # also stop colima (the Docker engine)
+#
+set -euo pipefail
+
+# ---- Configuration (mirrors multica-start.sh) ------------------------------
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="docker-compose.selfhost.yml"
+
+# ---- Helpers ---------------------------------------------------------------
+c_green() { printf '\033[32m%s\033[0m\n' "$*"; }
+c_blue()  { printf '\033[34m%s\033[0m\n' "$*"; }
+c_yellow(){ printf '\033[33m%s\033[0m\n' "$*"; }
+c_red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+step()    { c_blue "▶ $*"; }
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+STOP_ALL=false
+[ "${1:-}" = "--all" ] && STOP_ALL=true
+
+# ---- Preflight -------------------------------------------------------------
+if [ ! -f "$REPO_DIR/$COMPOSE_FILE" ]; then
+  c_red "✗ $REPO_DIR/$COMPOSE_FILE not found — is this script still at the repo root?"; exit 1
+fi
+cd "$REPO_DIR"
+
+# ---- 1. Local daemon -------------------------------------------------------
+step "Stopping the local daemon..."
+if command -v multica >/dev/null 2>&1 && multica daemon status >/dev/null 2>&1; then
+  multica daemon stop
+  c_green "  ✓ Daemon stopped"
+else
+  c_yellow "  Daemon not running, skipping"
+fi
+
+# ---- 2. Server containers --------------------------------------------------
+step "Stopping server containers..."
+if docker info >/dev/null 2>&1; then
+  running=$(compose ps --services --filter status=running 2>/dev/null | tr '\n' ' ')
+  if [ -n "${running// /}" ]; then
+    compose down
+    c_green "  ✓ postgres / backend / frontend stopped (volumes kept)"
+  else
+    c_yellow "  Server containers not running, skipping"
+  fi
+else
+  c_yellow "  Docker engine not running — treating server containers as stopped"
+fi
+
+# ---- 3. colima (optional) --------------------------------------------------
+if $STOP_ALL; then
+  step "Stopping colima (the Docker engine)..."
+  if command -v colima >/dev/null 2>&1 && colima status >/dev/null 2>&1; then
+    colima stop
+    c_green "  ✓ colima stopped"
+  else
+    c_yellow "  colima not running, skipping"
+  fi
+else
+  c_yellow "▶ Leaving colima (the Docker engine) running — re-run with --all to stop it too"
+fi
+
+echo
+c_green "✓ Local Multica stack stopped"


### PR DESCRIPTION
## Summary

Launching the desktop app against a self-hosted stack means bringing that stack up by hand first — colima, then `docker compose up -d`, then waiting for the backend. This adds an opt-in supervisor that does it, with a startup overlay showing which step is running.

Opt-in and off by default: the supervisor reads `~/.multica/desktop-local-stack.json` and a missing file is the "disabled" signal, so behavior is unchanged for everyone who does not create it.

```json
{ "repoDir": "/path/to/checkout", "composeFile": "docker-compose.selfhost.yml", "backendPort": 8080 }
```

## Bring-up order

The order is load-bearing, not cosmetic: the daemon connects to the backend API as soon as it starts and login cannot succeed before the backend answers.

1. Probe the backend first — with the stack left running between launches this is the common case and costs one request.
2. colima, if the Docker engine is not answering.
3. `docker compose up -d`.
4. Poll the backend until healthy (90s ceiling).

## Fail-open

A supervisor that can wedge the app shut is worse than no supervisor. The gate fails open: any step that errors surfaces in the overlay with the failure text and the user can dismiss it and continue to the normal window. `local-stack-supervisor.test.ts` covers the escape paths, including a window destroyed mid-bring-up.

## Notes for review

- `app.setName(app.getName())` replaces the hardcoded `app.setName("Multica")`. Hardcoding overrode electron-builder's `productName`, so a differently-branded build (a local self-host package, for instance) silently shared userData and the single-instance lock with the official app. For official builds the two are identical.
- `multica-start.sh` / `multica-stop.sh` are the shell equivalent for people not using the desktop app. Both are idempotent, derive the repo directory from the script's own location, and read `BACKEND_PORT` / `FRONTEND_PORT` from the environment with the compose file's defaults (8080 / 3000), exporting them so `docker compose` inherits the same values.
- The start script carries three fixes found while recovering from a colima data-disk I/O failure, each noted in its commit: `multica daemon status` exits 0 even when stopped so the exit-code check never started the daemon; `--code` reported "no code yet" when the log was merely unreadable; and the readiness timeout guessed "probably still migrating", hiding a Postgres auth failure for 60s.
- `DEFAULT_BACKEND_PORT` matches the compose file's own `${BACKEND_PORT:-8080}` rather than assuming a moved port. Installs that relocated the backend set `backendPort` in the config file — the supervisor tests use 8081 as the fixture value precisely to prove the override path works.

## Verification

- `pnpm vitest run` in `apps/desktop` — 58 files, 567 tests pass, 49 of them the new local-stack suites (config loader, state machine, supervisor, overlay).
- `pnpm typecheck` — 7/7 tasks pass.
- `pnpm lint` — 0 errors (28 pre-existing warnings in `packages/views`, untouched here).
- `bash -n` on both scripts; repo-directory derivation verified from a different working directory and via an absolute invocation.