### PR TITLE
MUL-6557: fix(daemon): fail closed on cross-project task-root reuse

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1799,10 +1800,16 @@ func runDaemonDiskUsage(cmd *cobra.Command, _ []string) error {
 	}
 	// Resolve before --top trims the slice: the batch endpoint costs the same
 	// either way, and the JSON consumer sees statuses for everything it gets.
-	// Skipped in a task: the fetcher authenticates with the Owner profile's
-	// stored token, which a task must not borrow, so the column stays blank.
-	if !taskContext && diskUsageNeedsParentStatus(byWorkspace, output) {
-		fillDiskUsageParentStatuses(cmd, profile, &report)
+	// Outside a task this uses the Owner profile token. Inside a task it uses
+	// the injected task token against the ordinary issue API — never the
+	// Owner profile — so STATUS can name the real issue without borrowing
+	// the runtime owner's credential.
+	if diskUsageNeedsParentStatus(byWorkspace, output) {
+		if taskContext {
+			fillDiskUsageParentStatusesWithTaskToken(cmd, &report)
+		} else {
+			fillDiskUsageParentStatuses(cmd, profile, &report)
+		}
 	}
 
 	if top > 0 {
@@ -1881,6 +1888,44 @@ func diskUsageNeedsParentStatus(byWorkspace bool, output string) bool {
 // diagnostic that has to keep working when the machine is offline or logged
 // out. When statuses can't be resolved the column simply stays blank, and the
 // reason goes to stderr so `--output json` stdout stays machine-readable.
+func fillDiskUsageParentStatusesWithTaskToken(cmd *cobra.Command, report *daemon.DiskUsageReport) {
+	token := strings.TrimSpace(os.Getenv("MULTICA_TOKEN"))
+	serverURL := strings.TrimSpace(os.Getenv("MULTICA_SERVER_URL"))
+	workspaceID := strings.TrimSpace(os.Getenv("MULTICA_WORKSPACE_ID"))
+	if token == "" || serverURL == "" {
+		return
+	}
+	baseURL, err := daemon.NormalizeServerBaseURL(serverURL)
+	if err != nil {
+		return
+	}
+	api := cli.NewAPIClient(baseURL, workspaceID, token)
+	fetch := func(ctx context.Context, _ string, issueIDs []string) (map[string]string, error) {
+		statuses := make(map[string]string, len(issueIDs))
+		var firstErr error
+		for _, id := range issueIDs {
+			var issue struct {
+				Status string `json:"status"`
+			}
+			if err := api.GetJSON(ctx, "/api/issues/"+url.PathEscape(id), &issue); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			if issue.Status != "" {
+				statuses[id] = issue.Status
+			}
+		}
+		return statuses, firstErr
+	}
+	ctx, cancel := cli.APIContext(cmd.Context())
+	defer cancel()
+	if err := daemon.ResolveParentStatuses(ctx, report, fetch); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not resolve issue statuses, STATUS column may be blank: %v\n", err)
+	}
+}
+
 func fillDiskUsageParentStatuses(cmd *cobra.Command, profile string, report *daemon.DiskUsageReport) {
 	fetch := newParentStatusFetcher(cmd, profile)
 	if fetch == nil {
@@ -2066,8 +2111,16 @@ func printDiskUsageTaskTable(w io.Writer, report daemon.DiskUsageReport) {
 	for _, task := range report.Tasks {
 		displayedSize += task.SizeBytes
 		displayedArtifact += task.ArtifactSizeBytes
+		identity := task.TaskID
+		if identity == "" {
+			identity = task.IssueID
+		}
+		if identity == "" {
+			identity = task.ParentID
+		}
 		rows = append(rows, []string{
 			task.WorkspaceShort + "/" + task.TaskShort,
+			emptyDash(identity),
 			task.Kind,
 			emptyDash(task.ParentStatus),
 			formatAge(task.AgeSeconds),
@@ -2075,7 +2128,7 @@ func printDiskUsageTaskTable(w io.Writer, report daemon.DiskUsageReport) {
 			formatBytes(task.ArtifactSizeBytes),
 		})
 	}
-	cli.PrintTable(w, []string{"PATH", "KIND", "STATUS", "AGE", "SIZE", "ARTIFACTS"}, rows)
+	cli.PrintTable(w, []string{"PATH", "ID", "KIND", "STATUS", "AGE", "SIZE", "ARTIFACTS"}, rows)
 
 	if len(report.Tasks) < report.TotalTaskCount {
 		// Report-wide totals stay anchored to the full scan; the displayed

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5851,6 +5851,10 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 	if marker.ManagedBy != execenv.TaskContextMarkerManagedBy || marker.AgentID != task.AgentID {
 		return "", false
 	}
+	repoURLs := execenv.BindingRepoURLs(convertReposForEnv(task.Repos), convertProjectResourcesForEnv(task.ProjectResources))
+	if !execenv.ProvenanceMatchesBinding(prov, task.ProjectID, repoURLs) {
+		return "", false
+	}
 	if task.IssueID != "" {
 		if prov.IssueID != task.IssueID || marker.IssueID != task.IssueID {
 			return "", false

--- a/server/internal/daemon/diskusage.go
+++ b/server/internal/daemon/diskusage.go
@@ -23,6 +23,9 @@ type TaskDiskUsage struct {
 	WorkspaceID       string `json:"workspace_id"`
 	WorkspaceShort    string `json:"workspace_short"`
 	TaskShort         string `json:"task_short"`
+	TaskID            string `json:"task_id,omitempty"`
+	IssueID           string `json:"issue_id,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
 	Path              string `json:"path"`
 	Kind              string `json:"kind"`
 	ParentID          string `json:"parent_id,omitempty"`
@@ -312,11 +315,33 @@ func buildTaskUsage(taskDir, wsID, taskShort string, matcher artifactMatcher) Ta
 		Kind:           DiskUsageKindUnknown,
 	}
 
+	ident := execenv.ReadTaskDirIdentity(taskDir)
+	usage.TaskID = ident.TaskID
+	usage.IssueID = ident.IssueID
+	usage.ProjectID = ident.ProjectID
+	if ident.Kind != "" {
+		usage.Kind = string(ident.Kind)
+	}
+	switch ident.Kind {
+	case execenv.GCKindIssue:
+		usage.ParentID = ident.IssueID
+	case execenv.GCKindChat:
+		usage.ParentID = ident.ChatSessionID
+	case execenv.GCKindAutopilotRun:
+		// Autopilot run id is only in gc_meta; identity() does not carry it.
+	case execenv.GCKindQuickCreate:
+		usage.ParentID = ident.TaskID
+	}
+
 	metaPresent := false
 	if meta, err := execenv.ReadGCMeta(taskDir); err == nil && meta != nil {
 		metaPresent = true
-		usage.Kind = string(meta.Kind)
-		usage.ParentID = parentIDForMeta(meta)
+		if usage.Kind == DiskUsageKindUnknown {
+			usage.Kind = string(meta.Kind)
+		}
+		if usage.ParentID == "" {
+			usage.ParentID = parentIDForMeta(meta)
+		}
 		if !meta.CompletedAt.IsZero() {
 			usage.AgeSeconds = int64(time.Since(meta.CompletedAt).Seconds())
 		} else if age, ok := gcMetaFileAge(taskDir); ok {

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -721,3 +721,55 @@ func TestScanDiskUsage_SkipsDaemonInternalDotDirs(t *testing.T) {
 		t.Errorf("total_size_bytes = %d, want 1000 (skill cache excluded)", report.TotalSizeBytes)
 	}
 }
+
+// TestScanDiskUsage_PrefersLiveIdentityOverStaleGCMeta is the APEX-1692
+// attribution case: a prefix-collided or reused env root can still have the
+// previous occupant's .gc_meta.json while Prepare has already rewritten the
+// task marker and provenance. Disk-usage must report the live issue, not the
+// leftover parent id.
+func TestScanDiskUsage_PrefersLiveIdentityOverStaleGCMeta(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	wsID := "d21747ad-7e06-4378-9a81-cd6271b37bec"
+	taskDir := filepath.Join(root, wsID, "01a02554")
+	writeFile(t, filepath.Join(taskDir, "workdir/notes.md"), 100)
+	mustWriteMeta(t, taskDir, execenv.GCMeta{
+		Kind:        execenv.GCKindIssue,
+		IssueID:     "01a02554-9a14-7ea7-86bf-63ad1dbace8d",
+		WorkspaceID: wsID,
+		CompletedAt: time.Now().Add(-time.Hour),
+	})
+	if err := os.WriteFile(filepath.Join(taskDir, ".task_owner"), []byte("01a02554-9110-75ad-9f58-3c51f673ee8f\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := execenv.WriteManagedEnvProvenance(taskDir, execenv.ManagedEnvProvenance{
+		WorkspaceID: wsID,
+		IssueID:     "01a02554-9110-75ad-9f58-3c51f673ee8f",
+		AgentID:     "agent-cc",
+		ProjectID:   "949398e5-2e0e-4584-8d3c-98c0439c79c4",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := ScanDiskUsage(root, nil)
+	if err != nil {
+		t.Fatalf("ScanDiskUsage: %v", err)
+	}
+	if len(report.Tasks) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1", len(report.Tasks))
+	}
+	got := report.Tasks[0]
+	if got.TaskID != "01a02554-9110-75ad-9f58-3c51f673ee8f" {
+		t.Errorf("task_id = %q, want the live owner", got.TaskID)
+	}
+	if got.IssueID != "01a02554-9110-75ad-9f58-3c51f673ee8f" {
+		t.Errorf("issue_id = %q, want the live Command Center issue, not the leftover HBP gc_meta", got.IssueID)
+	}
+	if got.ParentID != got.IssueID {
+		t.Errorf("parent_id = %q, want live issue %q", got.ParentID, got.IssueID)
+	}
+	if got.ProjectID != "949398e5-2e0e-4584-8d3c-98c0439c79c4" {
+		t.Errorf("project_id = %q", got.ProjectID)
+	}
+}

--- a/server/internal/daemon/execenv/binding.go
+++ b/server/internal/daemon/execenv/binding.go
@@ -1,0 +1,92 @@
+package execenv
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// BindingRepoURLs returns the canonical repository URLs a task is bound to:
+// workspace repos plus github_repo project resources. Order is sorted and
+// de-duplicated so two tasks that bind the same set compare equal.
+func BindingRepoURLs(repos []RepoContextForEnv, resources []ProjectResourceForEnv) []string {
+	seen := map[string]struct{}{}
+	var urls []string
+	add := func(raw string) {
+		u := canonicalizeRepoURL(raw)
+		if u == "" {
+			return
+		}
+		if _, ok := seen[u]; ok {
+			return
+		}
+		seen[u] = struct{}{}
+		urls = append(urls, u)
+	}
+	for _, repo := range repos {
+		add(repo.URL)
+	}
+	for _, res := range resources {
+		if !strings.EqualFold(strings.TrimSpace(res.ResourceType), "github_repo") {
+			continue
+		}
+		add(githubRepoURL(res.ResourceRef))
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+func githubRepoURL(ref json.RawMessage) string {
+	if len(ref) == 0 {
+		return ""
+	}
+	var parsed struct {
+		URL string `json:"url"`
+	}
+	if json.Unmarshal(ref, &parsed) != nil {
+		return ""
+	}
+	return parsed.URL
+}
+
+func canonicalizeRepoURL(raw string) string {
+	u := strings.TrimSpace(strings.ToLower(raw))
+	u = strings.TrimSuffix(u, ".git")
+	u = strings.TrimRight(u, "/")
+	return u
+}
+
+// ProvenanceMatchesBinding reports whether a managed-env provenance file is
+// safe to reuse for a task with this project and repository binding.
+//
+// Empty provenance project/repo fields are treated as "not yet recorded"
+// (files written before this check existed) and do not fail the match — a
+// follow-up on an older env root would otherwise start fresh on every
+// machine that has not recycled the directory. Once both sides have a
+// value, a mismatch fails closed.
+func ProvenanceMatchesBinding(p *ManagedEnvProvenance, projectID string, repoURLs []string) bool {
+	if p == nil {
+		return false
+	}
+	wantProject := strings.TrimSpace(projectID)
+	gotProject := strings.TrimSpace(p.ProjectID)
+	if gotProject != "" && gotProject != wantProject {
+		return false
+	}
+	if len(p.RepoURLs) == 0 {
+		return true
+	}
+	want := append([]string(nil), repoURLs...)
+	sort.Strings(want)
+	got := append([]string(nil), p.RepoURLs...)
+	sort.Strings(got)
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if canonicalizeRepoURL(got[i]) != canonicalizeRepoURL(want[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -148,6 +148,18 @@ func writeWorkspacesRootMarkerAtomic(path string, data []byte) error {
 // cloud-mode tasks whose envRoot is wiped wholesale by the GC loop — may
 // pass nil to skip the bookkeeping entirely.
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
+	return writeContextFilesWithMode(workDir, provider, ctx, manifest, false)
+}
+
+// writeContextFilesRefreshing overwrites daemon-owned sidecars (issue context,
+// project resources) that a previous occupant of this workdir left behind.
+// Used on managed Prepare/Reuse only — local_directory still refuses to
+// clobber a user-owned file at the same path.
+func writeContextFilesRefreshing(workDir, provider string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
+	return writeContextFilesWithMode(workDir, provider, ctx, manifest, true)
+}
+
+func writeContextFilesWithMode(workDir, provider string, ctx TaskContextForEnv, manifest *sidecarManifest, overwriteSidecars bool) error {
 	if err := writeTaskContextMarker(workDir, ctx, manifest); err != nil {
 		return err
 	}
@@ -159,15 +171,13 @@ func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest
 
 	content := renderIssueContext(provider, ctx)
 	path := filepath.Join(contextDir, "issue_context.md")
-	if err := recordWriteFile(path, []byte(content), 0o644, manifest); err != nil {
-		// A pre-existing path means the user already owns
-		// .agent_context/issue_context.md — either they created it
-		// themselves or it survived from a crashed prior run we can't
-		// safely distinguish from intentional content. Refusing the
-		// write is the correct call: the runtime brief (CLAUDE.md /
-		// AGENTS.md) already carries every fact this file
-		// would, so the agent runs fine without the sidecar copy.
-		// Anything else is a real failure.
+	if err := writeSidecarFile(path, []byte(content), 0o644, manifest, overwriteSidecars); err != nil {
+		// A pre-existing path on the local_directory path means the user
+		// already owns .agent_context/issue_context.md. Refusing the write
+		// is the correct call there: the runtime brief already carries
+		// every fact this file would. Managed env roots overwrite instead,
+		// so a leftover brief from another issue cannot be served to this
+		// run. Anything else is a real failure.
 		if !errors.Is(err, errPathPreExists) {
 			return fmt.Errorf("write issue_context.md: %w", err)
 		}
@@ -196,7 +206,7 @@ func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest
 	// block task startup. Missing resources surface as the agent simply not
 	// seeing the file, which matches the "scoped, not dumped" design (the
 	// meta skill content always lists what the agent should expect).
-	if err := writeProjectResources(workDir, ctx, manifest); err != nil {
+	if err := writeProjectResources(workDir, ctx, manifest, overwriteSidecars); err != nil {
 		// Caller logs warnings; avoid noisy returns for non-fatal context.
 		return fmt.Errorf("write project resources: %w", err)
 	}
@@ -285,7 +295,7 @@ func (p ProjectResourceForEnv) MarshalJSON() ([]byte, error) {
 // manifest, when non-nil, is populated with the .multica/project chain
 // of created directories and the resources.json file so CleanupSidecars
 // can undo them on local_directory teardown.
-func writeProjectResources(workDir string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
+func writeProjectResources(workDir string, ctx TaskContextForEnv, manifest *sidecarManifest, overwrite bool) error {
 	if ctx.ProjectID == "" && len(ctx.ProjectResources) == 0 {
 		return nil
 	}
@@ -307,15 +317,42 @@ func writeProjectResources(workDir string, ctx TaskContextForEnv, manifest *side
 	if err != nil {
 		return err
 	}
-	if err := recordWriteFile(filepath.Join(dir, "resources.json"), data, 0o644, manifest); err != nil {
-		// .multica/project/resources.json is Multica-owned and a
-		// pre-existing path is almost certainly user content the
-		// manifest must not destroy. The runtime brief already lists
-		// every project resource so the agent runs fine without the
-		// JSON sidecar — collision degrades to brief-only mode.
+	if err := writeSidecarFile(filepath.Join(dir, "resources.json"), data, 0o644, manifest, overwrite); err != nil {
+		// .multica/project/resources.json is Multica-owned. On a
+		// local_directory path a pre-existing file is treated as user
+		// content the manifest must not destroy. Managed env roots
+		// overwrite, so a leftover House Builder Pro resource file
+		// cannot be handed to a Command Center run. The runtime brief
+		// already lists every project resource, so a refused write on
+		// the local_directory path degrades to brief-only mode.
 		if !errors.Is(err, errPathPreExists) {
 			return err
 		}
+	}
+	return nil
+}
+
+// writeSidecarFile writes a daemon sidecar. When overwrite is false it
+// preserves a pre-existing path (local_directory user content). When
+// overwrite is true it replaces a regular file so a leftover occupant
+// cannot leak another issue's context into this run.
+func writeSidecarFile(path string, data []byte, perm os.FileMode, manifest *sidecarManifest, overwrite bool) error {
+	err := recordWriteFile(path, data, perm, manifest)
+	if err == nil || !overwrite || !errors.Is(err, errPathPreExists) {
+		return err
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return err
+	}
+	if writeErr := os.WriteFile(path, data, perm); writeErr != nil {
+		return fmt.Errorf("refresh sidecar %s: %w", path, writeErr)
+	}
+	if manifest != nil {
+		manifest.Files = append(manifest.Files, path)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -544,7 +545,15 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		}()
 	}
 
-	if err := writeContextFiles(workDir, params.Provider, params.Task, manifest); err != nil {
+	writeCtx := writeContextFiles
+	if params.LocalWorkDir == "" {
+		// Managed env roots are daemon-owned. A leftover sidecar from a
+		// previous occupant of this path (shared ULID prefix, crashed
+		// prepare, missing sidecar manifest) must not survive as the
+		// new task's issue/project context.
+		writeCtx = writeContextFilesRefreshing
+	}
+	if err := writeCtx(workDir, params.Provider, params.Task, manifest); err != nil {
 		return nil, fmt.Errorf("execenv: write context files: %w", err)
 	}
 
@@ -563,6 +572,8 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 			IssueID:       params.Task.IssueID,
 			ChatSessionID: params.Task.ChatSessionID,
 			AgentID:       params.Task.AgentID,
+			ProjectID:     params.Task.ProjectID,
+			RepoURLs:      BindingRepoURLs(params.Task.Repos, params.Task.ProjectResources),
 		}); err != nil && logger != nil {
 			logger.Warn("execenv: write managed env provenance failed (non-fatal); a follow-up may start a fresh session", "error", err)
 		}
@@ -836,7 +847,11 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// legacy local_directory Reuse fallback — skip the persist in that
 	// case to avoid creating a stray manifest at the filesystem root.
 	manifest := &sidecarManifest{}
-	if err := writeContextFiles(params.WorkDir, params.Provider, params.Task, manifest); err != nil {
+	writeCtx := writeContextFiles
+	if !params.LocalDirectory {
+		writeCtx = writeContextFilesRefreshing
+	}
+	if err := writeCtx(params.WorkDir, params.Provider, params.Task, manifest); err != nil {
 		logger.Warn("execenv: refresh context files failed", "error", err)
 	}
 
@@ -1105,6 +1120,13 @@ type ManagedEnvProvenance struct {
 	IssueID       string `json:"issue_id,omitempty"`
 	ChatSessionID string `json:"chat_session_id,omitempty"`
 	AgentID       string `json:"agent_id"`
+	// ProjectID and RepoURLs bind the env root to the project and repositories
+	// the task was prepared with. shouldReusePriorWorkdir fails closed when a
+	// follow-up's binding disagrees, so a Command Center run cannot inherit a
+	// House Builder Pro worktree (or the reverse) merely because two issue
+	// ids shared a truncated directory name.
+	ProjectID string   `json:"project_id,omitempty"`
+	RepoURLs  []string `json:"repo_urls,omitempty"`
 }
 
 // WriteManagedEnvProvenance persists the reuse-eligibility marker at the env
@@ -1381,7 +1403,7 @@ func claimEnvRoot(envRoot, taskID string) (lockFile *os.File, reset bool, err er
 		// lock it would still be holding.
 		return lockFile, true, nil
 	case owner != "":
-		return nil, false, fmt.Errorf("env root %s belongs to task %s; refusing to reset it for task %s", envRoot, owner, taskID)
+		return adoptQuarantinedEnvRoot(envRoot, taskID, owner, lockFile)
 	}
 
 	// No owner recorded. Either the directory is new, or a crash tore the
@@ -1392,12 +1414,66 @@ func claimEnvRoot(envRoot, taskID string) (lockFile *os.File, reset bool, err er
 		return nil, false, fmt.Errorf("inspect env root %s: %w", envRoot, err)
 	}
 	if hasWork {
-		return nil, false, fmt.Errorf("env root %s already holds files but names no owning task; refusing to delete it", envRoot)
+		return adoptQuarantinedEnvRoot(envRoot, taskID, "unowned", lockFile)
 	}
 	if err := writeEnvRootOwner(envRoot, taskID); err != nil {
 		return nil, false, err
 	}
 	return lockFile, false, nil
+}
+
+// adoptQuarantinedEnvRoot moves a foreign or unowned env root aside and
+// returns a freshly claimed empty directory at the original path. The
+// occupant is preserved so a later human or GC pass can inspect it; the
+// incoming task never sees those files.
+func adoptQuarantinedEnvRoot(envRoot, taskID, owner string, lockFile *os.File) (*os.File, bool, error) {
+	// Rename while still holding the lock so a concurrent claimant cannot
+	// observe the original path unowned between unlock and rename. The lock
+	// inode moves with the directory; release it after the rename.
+	quarantined, err := quarantineEnvRoot(envRoot, owner)
+	if err != nil {
+		return nil, false, fmt.Errorf("env root %s belongs to task %s; quarantine failed: %w", envRoot, owner, err)
+	}
+	releaseLockFile(lockFile)
+	if err := os.MkdirAll(envRoot, 0o755); err != nil {
+		return nil, false, fmt.Errorf("recreate env root %s after quarantining %s: %w", envRoot, quarantined, err)
+	}
+	lock, err := openLockFile(filepath.Join(envRoot, envRootLockFile))
+	if err != nil {
+		return nil, false, fmt.Errorf("open env root lock for %s after quarantine: %w", envRoot, err)
+	}
+	locked, err := lockFileExclusiveNonBlocking(lock)
+	if err != nil {
+		lock.Close()
+		return nil, false, fmt.Errorf("lock env root %s after quarantine: %w", envRoot, err)
+	}
+	if !locked {
+		lock.Close()
+		return nil, false, fmt.Errorf("env root %s is held after quarantine; refusing to reset it for task %s", envRoot, taskID)
+	}
+	if err := writeEnvRootOwner(envRoot, taskID); err != nil {
+		releaseLockFile(lock)
+		return nil, false, err
+	}
+	return lock, false, nil
+}
+
+// quarantineEnvRoot renames envRoot to a sibling directory that cannot collide
+// with PredictRootDir for any task id. The lock inode lives inside the
+// directory and moves with it; the caller releases that lock after the rename.
+func quarantineEnvRoot(envRoot, owner string) (string, error) {
+	parent := filepath.Dir(envRoot)
+	base := filepath.Base(envRoot)
+	ownerKey := taskKey(owner)
+	if ownerKey == "" {
+		ownerKey = "unknown"
+	}
+	name := base + ".quarantine-" + ownerKey + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	dest := filepath.Join(parent, name)
+	if err := os.Rename(envRoot, dest); err != nil {
+		return "", err
+	}
+	return dest, nil
 }
 
 // ReleaseLock drops the env root's execution lock. The daemon defers this for

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -368,7 +368,7 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 func TestWriteProjectResourcesSkippedWhenNone(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := writeProjectResources(dir, TaskContextForEnv{}, nil); err != nil {
+	if err := writeProjectResources(dir, TaskContextForEnv{}, nil, false); err != nil {
 		t.Fatalf("writeProjectResources: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".multica", "project", "resources.json")); !os.IsNotExist(err) {
@@ -6271,20 +6271,21 @@ func TestTaskKeyReadsTheRandomTail(t *testing.T) {
 	}
 }
 
-// TestPrepareRefusesEnvRootOwnedByAnotherTask covers the guard that makes the
-// os.RemoveAll in Prepare safe. taskKey makes a shared env root improbable but
-// not impossible, and the cost of being wrong is deleting a running task's
-// work — so a foreign owner must stop Prepare rather than be overwritten.
-func TestPrepareRefusesEnvRootOwnedByAnotherTask(t *testing.T) {
+// TestPrepareQuarantinesEnvRootOwnedByAnotherTask covers the guard that makes
+// the os.RemoveAll in Prepare safe. taskKey makes a shared env root improbable
+// but not impossible; when the path is already owned by another task the
+// occupant is renamed aside so its files never appear in the incoming run.
+func TestPrepareQuarantinesEnvRootOwnedByAnotherTask(t *testing.T) {
 	t.Parallel()
 	workspacesRoot := t.TempDir()
 	const taskID = "01a01ec0-e69d-7000-8000-0123456789ab"
+	const otherID = "11111111-2222-3333-4444-555555555555"
 
 	envRoot := PredictRootDir(workspacesRoot, "ws-owned", taskID)
 	if err := os.MkdirAll(filepath.Join(envRoot, "workdir"), 0o755); err != nil {
 		t.Fatalf("seed env root: %v", err)
 	}
-	if err := writeEnvRootOwner(envRoot, "11111111-2222-3333-4444-555555555555"); err != nil {
+	if err := writeEnvRootOwner(envRoot, otherID); err != nil {
 		t.Fatalf("seed owner: %v", err)
 	}
 	survivor := filepath.Join(envRoot, "workdir", "other-task-work.txt")
@@ -6292,21 +6293,41 @@ func TestPrepareRefusesEnvRootOwnedByAnotherTask(t *testing.T) {
 		t.Fatalf("seed work: %v", err)
 	}
 
-	_, err := Prepare(PrepareParams{
+	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-owned",
 		TaskID:         taskID,
 		AgentName:      "Intruder",
 		Task:           TaskContextForEnv{IssueID: taskID},
 	}, testLogger())
-	if err == nil {
-		t.Fatal("Prepare accepted an env root owned by another task")
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
 	}
-	if !strings.Contains(err.Error(), "belongs to task") {
-		t.Fatalf("error = %v, want it to name the owning task", err)
+	defer env.Cleanup(true)
+
+	if _, statErr := os.Stat(survivor); !os.IsNotExist(statErr) {
+		t.Fatalf("incoming run still sees the other task's work at %s: %v", survivor, statErr)
 	}
-	if _, statErr := os.Stat(survivor); statErr != nil {
-		t.Fatalf("Prepare deleted the other task's work despite failing: %v", statErr)
+	entries, err := os.ReadDir(filepath.Dir(envRoot))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if !strings.Contains(e.Name(), ".quarantine-") {
+			continue
+		}
+		found = true
+		got, readErr := os.ReadFile(filepath.Join(filepath.Dir(envRoot), e.Name(), "workdir", "other-task-work.txt"))
+		if readErr != nil {
+			t.Fatalf("quarantined work missing: %v", readErr)
+		}
+		if string(got) != "keep me" {
+			t.Fatalf("quarantined work = %q", got)
+		}
+	}
+	if !found {
+		t.Fatal("expected a .quarantine-* sibling of the env root")
 	}
 }
 
@@ -6424,14 +6445,14 @@ func TestPrepareConcurrentSameKeyTasksClaimExclusively(t *testing.T) {
 	}
 }
 
-// TestClaimEnvRootRefusesUnownedDirectoryWithContent covers the other way the
-// marker can be missing: a directory that holds files but names no task. The
-// marker is written before any content, so this is not a shape Prepare
-// produces — and guessing that it is abandoned would mean deleting work whose
-// owner we could not identify.
-func TestClaimEnvRootRefusesUnownedDirectoryWithContent(t *testing.T) {
+// TestClaimEnvRootQuarantinesUnownedDirectoryWithContent covers the other way
+// the marker can be missing: a directory that holds files but names no task.
+// Guessing it is abandoned would delete work whose owner we could not identify,
+// so the occupant is renamed aside and the incoming task gets an empty root.
+func TestClaimEnvRootQuarantinesUnownedDirectoryWithContent(t *testing.T) {
 	t.Parallel()
-	envRoot := filepath.Join(t.TempDir(), "ws", "0123456789ab")
+	parent := t.TempDir()
+	envRoot := filepath.Join(parent, "0123456789ab")
 	if err := os.MkdirAll(filepath.Join(envRoot, "workdir"), 0o755); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -6439,13 +6460,39 @@ func TestClaimEnvRootRefusesUnownedDirectoryWithContent(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	if _, _, err := claimEnvRoot(envRoot, "aaaaaaaa-1111-2222-3333-0123456789ab"); err == nil {
-		t.Fatal("claimEnvRoot took a directory holding files with no owner")
-	} else if !strings.Contains(err.Error(), "names no owning task") {
-		t.Fatalf("error = %v, want it to explain the missing owner", err)
+	lock, reset, err := claimEnvRoot(envRoot, "aaaaaaaa-1111-2222-3333-0123456789ab")
+	if err != nil {
+		t.Fatalf("claimEnvRoot: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(envRoot, "workdir", "work.txt")); err != nil {
-		t.Fatalf("claimEnvRoot deleted the content it refused to claim: %v", err)
+	if reset {
+		t.Fatal("fresh claim after quarantine should not ask to reset")
+	}
+	if lock != nil {
+		releaseLockFile(lock)
+	}
+	if _, err := os.Stat(filepath.Join(envRoot, "workdir", "work.txt")); !os.IsNotExist(err) {
+		t.Fatal("incoming claim still sees the unowned work")
+	}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if !strings.Contains(e.Name(), ".quarantine-") {
+			continue
+		}
+		found = true
+		got, readErr := os.ReadFile(filepath.Join(parent, e.Name(), "workdir", "work.txt"))
+		if readErr != nil {
+			t.Fatalf("quarantined work missing: %v", readErr)
+		}
+		if string(got) != "x" {
+			t.Fatalf("quarantined work = %q", got)
+		}
+	}
+	if !found {
+		t.Fatal("expected a .quarantine-* sibling preserving the unowned work")
 	}
 }
 

--- a/server/internal/daemon/execenv/identity.go
+++ b/server/internal/daemon/execenv/identity.go
@@ -1,0 +1,102 @@
+package execenv
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TaskDirIdentity is the full unique binding of a daemon env root, assembled
+// from live Prepare-time files first and completion-time .gc_meta.json last.
+// A reused or prefix-collided directory can leave a stale gc_meta from a
+// previous occupant; the marker and provenance written at Prepare win.
+type TaskDirIdentity struct {
+	TaskID        string
+	IssueID       string
+	ChatSessionID string
+	AgentID       string
+	ProjectID     string
+	WorkspaceID   string
+	Kind          GCMetaKind
+}
+
+// ReadTaskDirIdentity inspects envRoot without following the directory name.
+// Missing files are ignored; an unreadable owner marker is ignored the same
+// way disk-usage already treats a missing gc_meta — present on disk, but no
+// parent record we can lock onto.
+func ReadTaskDirIdentity(envRoot string) TaskDirIdentity {
+	var id TaskDirIdentity
+	if owner, err := readEnvRootOwner(envRoot); err == nil {
+		id.TaskID = strings.TrimSpace(owner)
+	}
+	if prov, err := ReadManagedEnvProvenance(envRoot); err == nil && prov != nil &&
+		prov.ManagedBy == ManagedEnvProvenanceManagedBy {
+		if id.WorkspaceID == "" {
+			id.WorkspaceID = strings.TrimSpace(prov.WorkspaceID)
+		}
+		id.IssueID = firstNonEmpty(id.IssueID, prov.IssueID)
+		id.ChatSessionID = firstNonEmpty(id.ChatSessionID, prov.ChatSessionID)
+		id.AgentID = firstNonEmpty(id.AgentID, prov.AgentID)
+		id.ProjectID = firstNonEmpty(id.ProjectID, prov.ProjectID)
+	}
+	if marker := readTaskContextMarkerFile(filepath.Join(envRoot, "workdir")); marker != nil {
+		id.IssueID = firstNonEmpty(id.IssueID, marker.IssueID)
+		id.ChatSessionID = firstNonEmpty(id.ChatSessionID, marker.ChatSessionID)
+		id.AgentID = firstNonEmpty(id.AgentID, marker.AgentID)
+	}
+	if projectID := readProjectID(filepath.Join(envRoot, "workdir")); projectID != "" {
+		id.ProjectID = firstNonEmpty(id.ProjectID, projectID)
+	}
+	if id.IssueID != "" {
+		id.Kind = GCKindIssue
+	} else if id.ChatSessionID != "" {
+		id.Kind = GCKindChat
+	}
+	if meta, err := ReadGCMeta(envRoot); err == nil && meta != nil {
+		id.WorkspaceID = firstNonEmpty(id.WorkspaceID, meta.WorkspaceID)
+		id.TaskID = firstNonEmpty(id.TaskID, strings.TrimSpace(meta.TaskID))
+		if id.Kind == "" {
+			id.Kind = meta.Kind
+		}
+		// gc_meta is last: only fill ids the live files did not already name.
+		id.IssueID = firstNonEmpty(id.IssueID, meta.IssueID)
+		id.ChatSessionID = firstNonEmpty(id.ChatSessionID, meta.ChatSessionID)
+	}
+	return id
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func readTaskContextMarkerFile(workDir string) *taskContextMarkerFile {
+	data, err := os.ReadFile(filepath.Join(workDir, TaskContextMarkerRelPath))
+	if err != nil {
+		return nil
+	}
+	var marker taskContextMarkerFile
+	if json.Unmarshal(data, &marker) != nil || marker.ManagedBy != TaskContextMarkerManagedBy {
+		return nil
+	}
+	return &marker
+}
+
+func readProjectID(workDir string) string {
+	data, err := os.ReadFile(filepath.Join(workDir, ".multica", "project", "resources.json"))
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		ProjectID string `json:"project_id"`
+	}
+	if json.Unmarshal(data, &parsed) != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.ProjectID)
+}

--- a/server/internal/daemon/execenv/task_root_collision_test.go
+++ b/server/internal/daemon/execenv/task_root_collision_test.go
@@ -1,0 +1,195 @@
+package execenv
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// APEX-1692 / APEX-1684 vs APEX-1685: two issues created ~2s apart share the
+// first eight UUIDv7 characters. They belong to different projects.
+const (
+	apex1684IssueID = "01a02554-9110-75ad-9f58-3c51f673ee8f"
+	apex1685IssueID = "01a02554-9a14-7ea7-86bf-63ad1dbace8d"
+	commandCenterID = "949398e5-2e0e-4584-8d3c-98c0439c79c4"
+	houseBuilderID  = "63be9f70-ea4d-435b-a099-3c53b4cba706"
+)
+
+func TestPredictRootDirDistinctForAPEX1684And1685(t *testing.T) {
+	t.Parallel()
+	a := PredictRootDir("/root", "ws", apex1684IssueID)
+	b := PredictRootDir("/root", "ws", apex1685IssueID)
+	if a == b {
+		t.Fatalf("APEX-1684 and APEX-1685 share env root %q", a)
+	}
+	if strings.HasSuffix(a, "01a02554") || strings.HasSuffix(b, "01a02554") {
+		t.Fatalf("env root still uses the shared 8-char prefix: %q %q", a, b)
+	}
+}
+
+func TestPrepareDistinctRootsAndContextsForSharedPrefixCrossProject(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	envCC, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-collision",
+		TaskID:         apex1684IssueID,
+		AgentName:      "Codex Studio",
+		Task: TaskContextForEnv{
+			IssueID:   apex1684IssueID,
+			AgentID:   "agent-cc",
+			ProjectID: commandCenterID,
+			ProjectResources: []ProjectResourceForEnv{{
+				ID:           "res-cc",
+				ResourceType: "github_repo",
+				ResourceRef:  json.RawMessage(`{"url":"https://github.com/apexagi-app/command-center.git"}`),
+			}},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare Command Center: %v", err)
+	}
+	defer envCC.Cleanup(true)
+
+	envHBP, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-collision",
+		TaskID:         apex1685IssueID,
+		AgentName:      "Grok HBP",
+		Task: TaskContextForEnv{
+			IssueID:   apex1685IssueID,
+			AgentID:   "agent-hbp",
+			ProjectID: houseBuilderID,
+			ProjectResources: []ProjectResourceForEnv{{
+				ID:           "res-hbp",
+				ResourceType: "github_repo",
+				ResourceRef:  json.RawMessage(`{"url":"https://github.com/example/housebuilderpro.git"}`),
+			}},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare House Builder Pro: %v", err)
+	}
+	defer envHBP.Cleanup(true)
+
+	if envCC.RootDir == envHBP.RootDir {
+		t.Fatalf("both projects share env root %q", envCC.RootDir)
+	}
+
+	assertIssueAndProject(t, envCC.WorkDir, apex1684IssueID, commandCenterID, "command-center")
+	assertIssueAndProject(t, envHBP.WorkDir, apex1685IssueID, houseBuilderID, "housebuilderpro")
+
+	ccProv, err := ReadManagedEnvProvenance(envCC.RootDir)
+	if err != nil {
+		t.Fatalf("cc provenance: %v", err)
+	}
+	hbpProv, err := ReadManagedEnvProvenance(envHBP.RootDir)
+	if err != nil {
+		t.Fatalf("hbp provenance: %v", err)
+	}
+	if ProvenanceMatchesBinding(ccProv, houseBuilderID, BindingRepoURLs(nil, []ProjectResourceForEnv{{
+		ResourceType: "github_repo",
+		ResourceRef:  json.RawMessage(`{"url":"https://github.com/example/housebuilderpro.git"}`),
+	}})) {
+		t.Fatal("Command Center provenance matched a House Builder Pro binding")
+	}
+	if ProvenanceMatchesBinding(hbpProv, commandCenterID, BindingRepoURLs(nil, []ProjectResourceForEnv{{
+		ResourceType: "github_repo",
+		ResourceRef:  json.RawMessage(`{"url":"https://github.com/apexagi-app/command-center.git"}`),
+	}})) {
+		t.Fatal("House Builder Pro provenance matched a Command Center binding")
+	}
+}
+
+func TestWriteContextFilesRefreshingReplacesCrossProjectLeftovers(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(workDir, ".agent_context"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, ".multica", "project"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".agent_context", "issue_context.md"), []byte("# Task Assignment\n\n**Issue ID:** "+apex1685IssueID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleResources := `{"project_id":"` + houseBuilderID + `","project_title":"House Builder Pro","resources":[]}`
+	if err := os.WriteFile(filepath.Join(workDir, ".multica", "project", "resources.json"), []byte(staleResources), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeContextFilesRefreshing(workDir, "codex", TaskContextForEnv{
+		IssueID:      apex1684IssueID,
+		AgentID:      "agent-cc",
+		ProjectID:    commandCenterID,
+		ProjectTitle: "Command Center",
+		ProjectResources: []ProjectResourceForEnv{{
+			ID:           "res-cc",
+			ResourceType: "github_repo",
+			ResourceRef:  json.RawMessage(`{"url":"https://github.com/apexagi-app/command-center.git"}`),
+		}},
+	}, &sidecarManifest{})
+	if err != nil {
+		t.Fatalf("writeContextFilesRefreshing: %v", err)
+	}
+
+	assertIssueAndProject(t, workDir, apex1684IssueID, commandCenterID, "command-center")
+}
+
+func TestProvenanceMatchesBinding(t *testing.T) {
+	t.Parallel()
+	p := &ManagedEnvProvenance{
+		ProjectID: commandCenterID,
+		RepoURLs:  []string{"https://github.com/apexagi-app/command-center"},
+	}
+	cc := BindingRepoURLs(nil, []ProjectResourceForEnv{{
+		ResourceType: "github_repo",
+		ResourceRef:  json.RawMessage(`{"url":"https://github.com/apexagi-app/command-center.git"}`),
+	}})
+	hbp := BindingRepoURLs(nil, []ProjectResourceForEnv{{
+		ResourceType: "github_repo",
+		ResourceRef:  json.RawMessage(`{"url":"https://github.com/example/housebuilderpro.git"}`),
+	}})
+	if !ProvenanceMatchesBinding(p, commandCenterID, cc) {
+		t.Fatal("same project and repo should match")
+	}
+	if ProvenanceMatchesBinding(p, houseBuilderID, hbp) {
+		t.Fatal("cross-project binding must fail closed")
+	}
+	legacy := &ManagedEnvProvenance{ProjectID: ""}
+	if !ProvenanceMatchesBinding(legacy, commandCenterID, cc) {
+		t.Fatal("legacy provenance without project must still be reusable")
+	}
+}
+
+func assertIssueAndProject(t *testing.T, workDir, issueID, projectID, repoNeedle string) {
+	t.Helper()
+	ctxBytes, err := os.ReadFile(filepath.Join(workDir, ".agent_context", "issue_context.md"))
+	if err != nil {
+		t.Fatalf("issue_context.md: %v", err)
+	}
+	if !strings.Contains(string(ctxBytes), issueID) {
+		t.Fatalf("issue_context.md does not name %s:\n%s", issueID, ctxBytes)
+	}
+	resBytes, err := os.ReadFile(filepath.Join(workDir, ".multica", "project", "resources.json"))
+	if err != nil {
+		t.Fatalf("resources.json: %v", err)
+	}
+	if !strings.Contains(string(resBytes), projectID) {
+		t.Fatalf("resources.json does not name project %s:\n%s", projectID, resBytes)
+	}
+	if !strings.Contains(string(resBytes), repoNeedle) {
+		t.Fatalf("resources.json does not name repo %s:\n%s", repoNeedle, resBytes)
+	}
+	markerBytes, err := os.ReadFile(filepath.Join(workDir, TaskContextMarkerRelPath))
+	if err != nil {
+		t.Fatalf("daemon_task_context.json: %v", err)
+	}
+	if !strings.Contains(string(markerBytes), issueID) {
+		t.Fatalf("task context marker does not name %s:\n%s", issueID, markerBytes)
+	}
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -782,6 +782,10 @@ func isAgentTaskTerminal(status string) bool {
 // cleanTaskDir removes a task directory, logs the reclaimed bytes, and returns
 // that count for the cycle summary. A failed removal reports zero reclaimed.
 func (d *Daemon) cleanTaskDir(taskDir string) int64 {
+	if reason := taskDirCustodyHold(context.Background(), taskDir); reason != "" {
+		d.logger.Info("gc: retaining task dir; unique git work present", "dir", taskDir, "reason", reason)
+		return 0
+	}
 	bytes := dirSize(taskDir)
 	if err := os.RemoveAll(taskDir); err != nil {
 		d.logger.Warn("gc: remove task dir failed", "dir", taskDir, "error", err)

--- a/server/internal/daemon/gc_custody.go
+++ b/server/internal/daemon/gc_custody.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// taskDirCustodyHold reports why a completed task directory must not be
+// deleted. Unique commits (present locally, on no remote-tracking ref) and
+// uncommitted/untracked files are sole copies; APEX-832 forbids deleting
+// those. An empty reason means the tree is regenerable from remotes.
+func taskDirCustodyHold(ctx context.Context, taskDir string) string {
+	workDir := filepath.Join(taskDir, "workdir")
+	info, err := os.Stat(workDir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	var hold string
+	_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || hold != "" {
+			return nil
+		}
+		if !d.IsDir() && d.Name() != ".git" {
+			return nil
+		}
+		if d.Name() != ".git" {
+			return nil
+		}
+		repo := filepath.Dir(path)
+		if reason := gitRepoCustodyHold(ctx, repo); reason != "" {
+			hold = reason
+			return filepath.SkipAll
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return hold
+}
+
+func gitRepoCustodyHold(ctx context.Context, repo string) string {
+	out, err := runGitGCCommandContext(ctx, repo, "status", "--porcelain")
+	if err != nil {
+		// A checkout we cannot interrogate might still hold unique work.
+		return "git status failed in " + repo
+	}
+	if strings.TrimSpace(out) != "" {
+		return "uncommitted or untracked files in " + repo
+	}
+	out, err = runGitGCCommandContext(ctx, repo, "rev-list", "--all", "--not", "--remotes", "--max-count=1")
+	if err != nil {
+		return "git rev-list failed in " + repo
+	}
+	if strings.TrimSpace(out) != "" {
+		return "commits not on any remote-tracking ref in " + repo
+	}
+	return ""
+}

--- a/server/internal/daemon/gc_custody_test.go
+++ b/server/internal/daemon/gc_custody_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanTaskDirRetainsUniqueCommits(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for custody checks")
+	}
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "unique-git", nil)
+	repo := filepath.Join(taskDir, "workdir", "command-center")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "custody@example.com")
+	runGit(t, repo, "config", "user.name", "Custody")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("unique\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "sole copy")
+
+	if got := d.cleanTaskDir(taskDir); got != 0 {
+		t.Fatalf("cleanTaskDir reclaimed %d bytes of a repo with unique commits", got)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "README.md")); err != nil {
+		t.Fatalf("unique work was deleted: %v", err)
+	}
+}
+
+func TestCleanTaskDirReclaimsCleanClone(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for custody checks")
+	}
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "clean-git", nil)
+	remote := t.TempDir()
+	runGit(t, remote, "init", "--bare")
+
+	repo := filepath.Join(taskDir, "workdir", "command-center")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "custody@example.com")
+	runGit(t, repo, "config", "user.name", "Custody")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("tracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "on remote")
+	runGit(t, repo, "remote", "add", "origin", remote)
+	runGit(t, repo, "push", "-u", "origin", "HEAD")
+
+	if got := d.cleanTaskDir(taskDir); got == 0 {
+		t.Fatal("cleanTaskDir retained a regenerable clone")
+	}
+	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+		t.Fatalf("regenerable task dir still present: %v", err)
+	}
+}
+
+func TestTaskDirCustodyHoldUntracked(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for custody checks")
+	}
+	taskDir := t.TempDir()
+	repo := filepath.Join(taskDir, "workdir", "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "custody@example.com")
+	runGit(t, repo, "config", "user.name", "Custody")
+	if err := os.WriteFile(filepath.Join(repo, "committed.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "base")
+	if err := os.WriteFile(filepath.Join(repo, "scratch.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := taskDirCustodyHold(context.Background(), taskDir); got == "" {
+		t.Fatal("expected a hold for untracked files")
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -202,6 +202,39 @@ func TestShouldReusePriorWorkdirSquadLeaderRejectsMismatchedProvenanceOwner(t *t
 // TestShouldReusePriorWorkdirSquadLeaderRejectsMismatchedTaskMarker keeps its
 // original intent — a marker for another agent must be refused — now with a
 // matching provenance in place so the check reaches the marker comparison.
+func TestShouldReusePriorWorkdirRejectsCrossProjectBinding(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "ws-leader", "12345678", "workdir")
+	writeLeaderTaskMarker(t, workDir, "agent-leader", "issue-leader")
+	envRoot := filepath.Dir(workDir)
+	if err := os.MkdirAll(envRoot, 0o755); err != nil {
+		t.Fatalf("mkdir env root: %v", err)
+	}
+	if err := execenv.WriteManagedEnvProvenance(envRoot, execenv.ManagedEnvProvenance{
+		WorkspaceID: "ws-leader",
+		IssueID:     "issue-leader",
+		AgentID:     "agent-leader",
+		ProjectID:   "63be9f70-ea4d-435b-a099-3c53b4cba706",
+		RepoURLs:    []string{"https://github.com/example/housebuilderpro"},
+	}); err != nil {
+		t.Fatalf("write provenance: %v", err)
+	}
+
+	task := leaderReuseTestTask("task-cross-project")
+	task.ProjectID = "949398e5-2e0e-4584-8d3c-98c0439c79c4"
+	task.ProjectResources = []ProjectResourceData{{
+		ID:           "res-cc",
+		ResourceType: "github_repo",
+		ResourceRef:  []byte(`{"url":"https://github.com/apexagi-app/command-center.git"}`),
+	}}
+	task.PriorWorkDir = workDir
+	if _, ok := shouldReusePriorWorkdir(task, nil, root); ok {
+		t.Fatal("reused a House Builder Pro env root for a Command Center task")
+	}
+}
+
 func TestShouldReusePriorWorkdirSquadLeaderRejectsMismatchedTaskMarker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Two issues created about two seconds apart can share the first eight characters of a UUIDv7 (`01a02554-…`). On daemon versions that truncated the env-root segment to that prefix, a Command Center run and a House Builder Pro run were mapped onto one directory: the incoming task saw the other issue's context, project resources, and worktree.

`taskKey` (random tail + exclusive claim) already shipped in v0.4.32 (#7347 / #7326). This PR closes the remaining fail-closed gaps so that collision cannot still leak another project's files, and so disk-usage and GC can tell the two tasks apart.

## What changed

- **Binding:** `.managed_env.json` now records `project_id` and canonical repo URLs. `shouldReusePriorWorkdir` fails closed when they disagree (legacy empty fields still reuse).
- **Sidecars:** managed Prepare/Reuse overwrite daemon-owned `issue_context.md` and `.multica/project/resources.json`. Local-directory user files are still refused.
- **Quarantine:** a foreign or unowned env root is renamed to a `.quarantine-*` sibling before the incoming task is given an empty directory at the original path. Occupant files are never exposed to the new run.
- **Disk-usage:** reports full `task_id` / `issue_id` / `project_id` from live provenance/marker/owner, not a leftover `.gc_meta.json`. The table has an ID column. Inside a managed task, STATUS is filled with the task token against `/api/issues/{id}` — never the Owner profile.
- **GC:** `cleanTaskDir` retains a completed env root that still has uncommitted files or commits on no remote-tracking ref (APEX-832 custody). Regenerable clones are still reclaimed.

## Tests

- `TestPredictRootDirDistinctForAPEX1684And1685` and `TestPrepareDistinctRootsAndContextsForSharedPrefixCrossProject` using the live APEX-1684 / APEX-1685 ids.
- Refresh leftover HBP `resources.json` / `issue_context.md` into Command Center files.
- Quarantine of a foreign-owned and an unowned occupied root.
- Disk-usage prefers live identity over stale gc_meta.
- Reuse rejects a House Builder Pro provenance for a Command Center task.
- GC retains unique commits and untracked files; reclaims a clone whose commits are on `origin`.

Verified locally:

```
go test ./internal/daemon/execenv/ -count=1
go test ./internal/daemon/ -count=1 -run 'TestShouldReusePriorWorkdir|TestScanDiskUsage|TestCleanTaskDir|TestTaskDirCustody|TestRunTaskSquadLeader'
go test ./cmd/multica/ -count=1 -run 'TestRunDaemonDiskUsage|TestPrintRepoCache|TestDiskUsage'
go test ./internal/handler/ -count=1 -run 'TestTaskDirSegment'
```

## Out of scope

- Does not update a running daemon (Studio is still on 0.4.31; this host is 0.4.29). The collision fix in 0.4.32 plus this PR needs a daemon upgrade to take effect on those machines.
- Does not delete or rewrite the live APEX-1684 / APEX-1685 trees.
- Does not retire the APEX-1614 Command Center checkout on Mac Studio (that host is not this runtime). GC will reclaim it once the issue is terminal, TTL has passed, and the tree has no unique git work.
- Does not touch APEX-11.

Fixes the remaining APEX-1692 gaps on top of #7326 / #7347.
