### PR TITLE
fix(issues): position status changes at column top

### DIFF
--- a/server/internal/handler/issue_create_position_test.go
+++ b/server/internal/handler/issue_create_position_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -59,6 +60,86 @@ func TestCreateIssuePositionTopOfColumn(t *testing.T) {
 	}
 	if pos3 >= pos2 {
 		t.Errorf("third issue position (%v) should be less than second (%v)", pos3, pos2)
+	}
+}
+
+func TestUpdateIssueStatusPositionTopOfColumn(t *testing.T) {
+	movingID := dbfx.Issue(t, "status-position moving issue", testutil.Cols{
+		"status":   "todo",
+		"priority": "low",
+		"position": 0.0,
+	})
+	dbfx.Issue(t, "status-position destination issue", testutil.Cols{
+		"status":   "done",
+		"priority": "low",
+		"position": -1000.0,
+	})
+
+	var destinationMin float64
+	dbfx.QueryRow(t,
+		`SELECT MIN(position) FROM issue WHERE workspace_id = $1 AND status = 'done'`,
+		testWorkspaceID).Scan(&destinationMin)
+
+	var updated IssueResponse
+	req := testutil.WithURLParams(newRequest(http.MethodPut, "/api/issues/"+movingID,
+		map[string]any{"status": "done"}), "id", movingID)
+	testutil.Call(t, testHandler.UpdateIssue, req).
+		Want(http.StatusOK).JSON(&updated)
+
+	if updated.Status != "done" {
+		t.Fatalf("updated status = %q, want done", updated.Status)
+	}
+	if updated.Position >= destinationMin {
+		t.Fatalf("updated position = %v, want below destination minimum %v", updated.Position, destinationMin)
+	}
+}
+
+func TestUpdateIssueStatusKeepsExplicitPosition(t *testing.T) {
+	movingID := dbfx.Issue(t, "status-position explicit issue", testutil.Cols{
+		"status":   "todo",
+		"priority": "low",
+		"position": 0.0,
+	})
+
+	const explicitPosition = 42.5
+	var updated IssueResponse
+	req := testutil.WithURLParams(newRequest(http.MethodPut, "/api/issues/"+movingID,
+		map[string]any{"status": "done", "position": explicitPosition}), "id", movingID)
+	testutil.Call(t, testHandler.UpdateIssue, req).
+		Want(http.StatusOK).JSON(&updated)
+
+	if updated.Position != explicitPosition {
+		t.Fatalf("updated position = %v, want explicit position %v", updated.Position, explicitPosition)
+	}
+}
+
+func TestDirectUpdateIssueStatusPositionTopOfColumn(t *testing.T) {
+	movingID := dbfx.Issue(t, "direct status-position moving issue", testutil.Cols{
+		"status":   "todo",
+		"priority": "low",
+		"position": 0.0,
+	})
+	dbfx.Issue(t, "direct status-position destination issue", testutil.Cols{
+		"status":   "done",
+		"priority": "low",
+		"position": -1000.0,
+	})
+
+	var destinationMin float64
+	dbfx.QueryRow(t,
+		`SELECT MIN(position) FROM issue WHERE workspace_id = $1 AND status = 'done'`,
+		testWorkspaceID).Scan(&destinationMin)
+
+	updated, err := testHandler.Queries.UpdateIssueStatus(context.Background(), db.UpdateIssueStatusParams{
+		ID:          parseUUID(movingID),
+		Status:      "done",
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("UpdateIssueStatus: %v", err)
+	}
+	if updated.Position >= destinationMin {
+		t.Fatalf("updated position = %v, want below destination minimum %v", updated.Position, destinationMin)
 	}
 }
 

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -1690,23 +1690,23 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 }
 
 const updateIssueStatus = `-- name: UpdateIssueStatus :one
-UPDATE issue SET
+UPDATE issue AS i SET
     status = $2,
-    position = CASE WHEN status IS DISTINCT FROM $2 THEN (
+    position = CASE WHEN i.status IS DISTINCT FROM $2 THEN (
         SELECT COALESCE(MIN(target.position), 0) - 1
         FROM issue AS target
-        WHERE target.workspace_id = issue.workspace_id
+        WHERE target.workspace_id = i.workspace_id
           AND target.status = $2
-          AND target.id <> issue.id
-    ) ELSE position END,
-    revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
-    last_activity_at = CASE WHEN status IS DISTINCT FROM $2
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
+          AND target.id <> i.id
+    ) ELSE i.position END,
+    revision = i.revision + CASE WHEN i.status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
+    last_activity_at = CASE WHEN i.status IS DISTINCT FROM $2
+        THEN GREATEST(COALESCE(i.last_activity_at, i.updated_at), now())
+        ELSE i.last_activity_at
     END,
     updated_at = now()
-WHERE id = $1 AND workspace_id = $3
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage, properties, revision, last_activity_at
+WHERE i.id = $1 AND i.workspace_id = $3
+RETURNING i.id, i.workspace_id, i.title, i.description, i.status, i.priority, i.assignee_type, i.assignee_id, i.creator_type, i.creator_id, i.parent_issue_id, i.acceptance_criteria, i.context_refs, i.position, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.origin_type, i.origin_id, i.first_executed_at, i.start_date, i.metadata, i.stage, i.properties, i.revision, i.last_activity_at
 `
 
 type UpdateIssueStatusParams struct {

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -1554,7 +1554,20 @@ WITH candidate AS (
         COALESCE($5::text, i.priority) AS next_priority,
         $6::text AS next_assignee_type,
         $7::uuid AS next_assignee_id,
-        COALESCE($8::double precision, i.position) AS next_position,
+        CASE
+            WHEN $8::double precision IS NOT NULL
+                THEN $8::double precision
+            WHEN $4::text IS NOT NULL
+                 AND i.status IS DISTINCT FROM $4::text
+                THEN (
+                    SELECT COALESCE(MIN(target.position), 0) - 1
+                    FROM issue AS target
+                    WHERE target.workspace_id = i.workspace_id
+                      AND target.status = $4::text
+                      AND target.id <> i.id
+                )
+            ELSE i.position
+        END AS next_position,
         $9::date AS next_start_date,
         $10::date AS next_due_date,
         $11::uuid AS next_parent_issue_id,
@@ -1679,6 +1692,13 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 const updateIssueStatus = `-- name: UpdateIssueStatus :one
 UPDATE issue SET
     status = $2,
+    position = CASE WHEN status IS DISTINCT FROM $2 THEN (
+        SELECT COALESCE(MIN(target.position), 0) - 1
+        FROM issue AS target
+        WHERE target.workspace_id = issue.workspace_id
+          AND target.status = $2
+          AND target.id <> issue.id
+    ) ELSE position END,
     revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
     last_activity_at = CASE WHEN status IS DISTINCT FROM $2
         THEN GREATEST(COALESCE(last_activity_at, updated_at), now())

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -154,7 +154,20 @@ WITH candidate AS (
         COALESCE(sqlc.narg('priority')::text, i.priority) AS next_priority,
         sqlc.narg('assignee_type')::text AS next_assignee_type,
         sqlc.narg('assignee_id')::uuid AS next_assignee_id,
-        COALESCE(sqlc.narg('position')::double precision, i.position) AS next_position,
+        CASE
+            WHEN sqlc.narg('position')::double precision IS NOT NULL
+                THEN sqlc.narg('position')::double precision
+            WHEN sqlc.narg('status')::text IS NOT NULL
+                 AND i.status IS DISTINCT FROM sqlc.narg('status')::text
+                THEN (
+                    SELECT COALESCE(MIN(target.position), 0) - 1
+                    FROM issue AS target
+                    WHERE target.workspace_id = i.workspace_id
+                      AND target.status = sqlc.narg('status')::text
+                      AND target.id <> i.id
+                )
+            ELSE i.position
+        END AS next_position,
         sqlc.narg('start_date')::date AS next_start_date,
         sqlc.narg('due_date')::date AS next_due_date,
         sqlc.narg('parent_issue_id')::uuid AS next_parent_issue_id,
@@ -211,6 +224,13 @@ RETURNING i.*;
 -- Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
 UPDATE issue SET
     status = $2,
+    position = CASE WHEN status IS DISTINCT FROM $2 THEN (
+        SELECT COALESCE(MIN(target.position), 0) - 1
+        FROM issue AS target
+        WHERE target.workspace_id = issue.workspace_id
+          AND target.status = $2
+          AND target.id <> issue.id
+    ) ELSE position END,
     revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
     last_activity_at = CASE WHEN status IS DISTINCT FROM $2
         THEN GREATEST(COALESCE(last_activity_at, updated_at), now())

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -222,23 +222,23 @@ RETURNING i.*;
 
 -- name: UpdateIssueStatus :one
 -- Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
-UPDATE issue SET
+UPDATE issue AS i SET
     status = $2,
-    position = CASE WHEN status IS DISTINCT FROM $2 THEN (
+    position = CASE WHEN i.status IS DISTINCT FROM $2 THEN (
         SELECT COALESCE(MIN(target.position), 0) - 1
         FROM issue AS target
-        WHERE target.workspace_id = issue.workspace_id
+        WHERE target.workspace_id = i.workspace_id
           AND target.status = $2
-          AND target.id <> issue.id
-    ) ELSE position END,
-    revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
-    last_activity_at = CASE WHEN status IS DISTINCT FROM $2
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
+          AND target.id <> i.id
+    ) ELSE i.position END,
+    revision = i.revision + CASE WHEN i.status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
+    last_activity_at = CASE WHEN i.status IS DISTINCT FROM $2
+        THEN GREATEST(COALESCE(i.last_activity_at, i.updated_at), now())
+        ELSE i.last_activity_at
     END,
     updated_at = now()
-WHERE id = $1 AND workspace_id = $3
-RETURNING *;
+WHERE i.id = $1 AND i.workspace_id = $3
+RETURNING i.*;
 
 -- name: CreateIssueWithOrigin :one
 INSERT INTO issue (


### PR DESCRIPTION
## What does this PR do?

Status changes through the API/CLI kept the issue's old position, which could bury newly completed work below manually ordered issues.

The board already orders positions ascending and new issues use `MIN(position) - 1`. This applies the same policy to both status-update queries while preserving an explicitly supplied position.

Risk: concurrent status changes can still choose the same position, matching the repository's existing best-effort ordering behavior and secondary sort fallback.

## Related Issue

Closes #7410

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Reposition issues at the top of the destination column when their status changes.
- Preserve explicit positions supplied with the status update.
- Cover both `UpdateIssue` and direct `UpdateIssueStatus` paths with database-backed tests.

## How to Test

1. `go test ./internal/handler -run 'Test(UpdateIssueStatusPositionTopOfColumn|UpdateIssueStatusKeepsExplicitPosition|DirectUpdateIssueStatusPositionTopOfColumn)$' -count=1`
2. `go test ./internal/handler -count=1`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Reproduce #7410 on current main, trace both status-update paths, reuse the existing `MIN(position) - 1` ordering policy, and add database-backed regression tests using the repository fixtures.
