### PR TITLE
MUL-6552 docs(self-hosting): correct the PostgreSQL extension requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Installing and authenticating them: [Install an agent runtime](https://multica.a
                           ▼
    ┌──────────────┐   ┌──────────────┐   ┌──────────────────┐
    │   Next.js    │──>│  Go backend  │──>│   PostgreSQL     │
-   │   frontend   │<──│  (Chi + WS)  │<──│   (pgvector)     │
+   │   frontend   │<──│  (Chi + WS)  │<──│   (17)           │
    └──────────────┘   └──────┬───────┘   └──────────────────┘
                              │  tasks over WebSocket
                       ┌──────┴───────┐
@@ -214,7 +214,7 @@ Installing and authenticating them: [Install an agent runtime](https://multica.a
 | Desktop | Electron, sharing the web UI packages |
 | Mobile | Expo / React Native (iOS) |
 | Backend | Go (Chi router, sqlc, gorilla/websocket) |
-| Database | PostgreSQL 17 with pgvector |
+| Database | PostgreSQL 17 (`pgcrypto` + `pg_trgm`) |
 | Agent runtime | Local daemon executing any of the 23 agent CLIs above |
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -186,7 +186,7 @@ Multica 不自带模型。它驱动的是你本来就装好、登录好的那些
                           ▼
    ┌──────────────┐   ┌──────────────┐   ┌──────────────────┐
    │   Next.js    │──>│   Go 后端    │──>│   PostgreSQL     │
-   │    前端      │<──│  (Chi + WS)  │<──│   (pgvector)     │
+   │    前端      │<──│  (Chi + WS)  │<──│   (17)           │
    └──────────────┘   └──────┬───────┘   └──────────────────┘
                              │  通过 WebSocket 下发 task
                       ┌──────┴───────┐
@@ -205,7 +205,7 @@ Multica 不自带模型。它驱动的是你本来就装好、登录好的那些
 | 桌面端 | Electron，复用 Web 的 UI 包 |
 | 移动端 | Expo / React Native (iOS) |
 | 后端 | Go (Chi router, sqlc, gorilla/websocket) |
-| 数据库 | PostgreSQL 17 + pgvector |
+| 数据库 | PostgreSQL 17（`pgcrypto` + `pg_trgm`） |
 | 智能体运行时 | 本地守护进程拉起上面 23 种智能体 CLI 中的任意一个 |
 
 ---

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -8,7 +8,7 @@ Deploy Multica on your own infrastructure in minutes.
 |-----------|-------------|------------|
 | **Backend** | REST API + WebSocket server | Go (single binary) |
 | **Frontend** | Web application | Next.js 16 |
-| **Database** | Primary data store | PostgreSQL 17 with pgvector |
+| **Database** | Primary data store | PostgreSQL 17 (`pgcrypto` + `pg_trgm`) |
 
 Each user who runs AI agents locally also installs the **`multica` CLI** and runs the **agent daemon** on their own machine.
 

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -223,7 +223,37 @@ Agent-specific overrides:
 
 ## Database Setup
 
-Multica requires PostgreSQL 17 with the pgvector extension.
+Multica requires PostgreSQL 17. It does **not** use pgvector — no migration
+declares a `vector` column or runs `CREATE EXTENSION vector`. The bundled image
+is named `pgvector/pgvector:pg17` for historical reasons only; a stock
+PostgreSQL 17 is sufficient.
+
+Migrations reference four extensions:
+
+| Extension | Migration | Required |
+| --- | --- | --- |
+| `pgcrypto` | `001_init` | **Yes** — a bare `CREATE EXTENSION`; the migration fails without it |
+| `pg_trgm` | `137_search_index_pg_trgm_extension` | **Yes** — same, and the search indexes depend on it |
+| `pg_bigm` | `032_issue_search_index` | No — wrapped in `DO ... EXCEPTION`, skipped with a `NOTICE` when unavailable |
+| `pg_cron` | `076_task_usage_pgcron_extension` | No — same; the usage rollup runs in-process instead, see [Usage Dashboard Rollup](#usage-dashboard-rollup) |
+
+`pgcrypto` and `pg_trgm` ship with every standard PostgreSQL 17 build
+(`postgresql-contrib` on Debian/Ubuntu, bundled in Homebrew's `postgresql@17`
+and in the official `postgres:17` image), so neither hard requirement needs a
+custom image.
+
+`pg_bigm` is optional and only affects **CJK search quality** — bigram indexes
+are far more selective than trigram ones for Chinese, Japanese, and Korean text.
+Search works without it: migrations 138–142 install portable `pg_trgm` fallback
+indexes covering every column the search handlers touch. Installing `pg_bigm`
+does require a custom image or a source build — the bundled
+`pgvector/pgvector:pg17` image does not ship it either.
+
+> Because `pg_bigm` and `pg_cron` are installed conditionally, a row in
+> `schema_migrations` proves the migration ran, not that its objects exist. Run
+> `SELECT extname FROM pg_extension` to see what a database actually has. To
+> recover a missing comment-content search index, follow
+> `server/cmd/migrate/README.md`.
 
 ### Using Docker Compose (Recommended)
 
@@ -231,10 +261,12 @@ The `docker-compose.selfhost.yml` includes PostgreSQL. No separate setup needed.
 
 ### Using Your Own PostgreSQL
 
-If you prefer to use an existing PostgreSQL instance, ensure the pgvector extension is available:
+If you prefer to use an existing PostgreSQL instance, confirm the migration role
+can create the two required extensions:
 
 ```sql
-CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 ```
 
 Set `DATABASE_URL` in your `.env` and remove the `postgres` service from the compose file.
@@ -313,7 +345,7 @@ If you are upgrading from a binary that pre-dates MUL-2957 (or the auto-hook fai
 
 If you prefer to build and run services manually:
 
-**Prerequisites:** Go 1.26.6, Node.js 22, pnpm 10.28.2, PostgreSQL 17 with pgvector.
+**Prerequisites:** Go 1.26.6, Node.js 22, pnpm 10.28.2, PostgreSQL 17 — a stock install is enough, see [Database Setup](#database-setup).
 
 ```bash
 # Start your PostgreSQL (or use: docker compose up -d postgres)

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -86,7 +86,17 @@ Changes take effect after restarting the backend / compose stack. The web UI rea
 
 ### File Storage (Optional)
 
-For file uploads and attachments, configure S3 and (optionally) CloudFront:
+Uploads and attachments are written to local disk by default. Set `S3_BUCKET` to
+use S3-compatible object storage instead.
+
+#### Local disk (default)
+
+| Variable | Description |
+|----------|-------------|
+| `LOCAL_UPLOAD_DIR` | Directory attachments are written to (default: `./data/uploads`). The default is **relative to the backend's working directory** — `/app` in the bundled image, where the compose file mounts the `backend_uploads` volume. When running the binary manually it resolves against whatever directory you launched from, so set an absolute path; otherwise uploads land somewhere new each time the launch directory changes, and existing `attachment` rows point at files the server no longer looks for |
+| `LOCAL_UPLOAD_BASE_URL` | Optional absolute base for attachment URLs (e.g. `http://localhost:8080`). Leave empty to store `/uploads/...` paths that stay relative to the API origin |
+
+#### S3 / CloudFront
 
 | Variable | Description |
 |----------|-------------|

--- a/deploy/helm/multica/Chart.yaml
+++ b/deploy/helm/multica/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: multica
 description: |
   AI-native task management — like Linear, but with AI agents as first-class citizens.
-  Self-host the backend, frontend, and PostgreSQL (pgvector) on a Kubernetes cluster.
+  Self-host the backend, frontend, and PostgreSQL on a Kubernetes cluster.
 type: application
 version: 0.1.0
 appVersion: "latest"

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -48,7 +48,7 @@ images:
 existingSecret: multica-secrets
 
 # -----------------------------------------------------------------------------
-# PostgreSQL (pgvector)
+# PostgreSQL
 # -----------------------------------------------------------------------------
 postgres:
   # Set external.enabled=true to skip the built-in postgres Deployment/PVC and

--- a/server/internal/handler/search.go
+++ b/server/internal/handler/search.go
@@ -14,9 +14,9 @@ import (
 //
 // The two search handlers (SearchIssues, SearchProjects) run LOWER(col) LIKE
 // '%pattern%' queries whose fast path depends on pg_bigm / pg_trgm GIN
-// indexes (see migrations 032, 033, 036, 134). When those extensions are
+// indexes (see migrations 032, 033, 036, 137–142). When those extensions are
 // missing — as they were on every self-hosted deployment using the bundled
-// pgvector/pgvector:pg17 image before migration 134 shipped — Postgres
+// pgvector/pgvector:pg17 image before migration 137 shipped — Postgres
 // falls back to a Seq Scan on `issue` plus correlated Seq Scans on
 // `comment`. On workspaces with thousands of rows the query takes long
 // enough that the frontend Loader2 spinner appears to hang forever


### PR DESCRIPTION
## Summary

The self-hosting docs told operators Multica requires pgvector and instructed them to run `CREATE EXTENSION IF NOT EXISTS vector`. It does not, and on a stock PostgreSQL 17 that statement fails — so the instruction blocked the "use your own PostgreSQL" path it appeared in.

Re-lands the fix from #7409 (closed unmerged by its author) with one correction and some trimming. Original work by @sail-cn, preserved via `Co-authored-by`.

### 1. The pgvector requirement is not real

Across all 429 migrations there is no `vector` column, no `CREATE EXTENSION vector`, and no Go package importing a pgvector driver. There are exactly four `CREATE EXTENSION` statements:

| Extension | Migration | Required |
| --- | --- | --- |
| `pgcrypto` | `001_init` | Yes — bare `CREATE EXTENSION`, migration fails without it |
| `pg_trgm` | `137_search_index_pg_trgm_extension` | Yes — same |
| `pg_bigm` | `032_issue_search_index` | No — `DO ... EXCEPTION`, skipped with a `NOTICE` |
| `pg_cron` | `076_task_usage_pgcron_extension` | No — same |

Both hard requirements ship with any standard PostgreSQL 17 build, so no custom image is needed. The new section also records that a `schema_migrations` row does not prove a conditionally skipped object exists.

Mentions of the bundled image *name* are deliberately left alone — those describe which image the compose file pulls, which is still accurate. The Helm `Chart.yaml` description and `values.yaml` comment are updated because they present pgvector as part of the stack rather than as an image name.

**Correction vs #7409.** That PR stated that without `pg_bigm`, `/search` falls back to sequential scans on `issue` plus correlated scans on `comment`. That is no longer true: migrations 138–142 install portable `pg_trgm` fallback indexes covering every column both search handlers touch, and `371_comment_content_search_index_strategy` only drops the comment trigram fallback when the bigram index is valid and ready. The `search.go` comment describing seq scans is accurate because it is scoped to the state *before* migration 137 shipped; dropping that qualifier turns it into a false present-tense claim. This PR documents `pg_bigm` as what it is — a CJK search-quality improvement, not a correctness requirement.

### 2. Local disk storage was undocumented

The File Storage section covered only S3/CloudFront, yet local disk is what runs whenever `S3_BUCKET` is unset — every default install. `LOCAL_UPLOAD_DIR` / `LOCAL_UPLOAD_BASE_URL` are now documented, including that the `./data/uploads` default resolves against the **process working directory**. That is `/app` in the bundled image (where the volume is mounted) but the launch directory for a manually run binary, which scatters uploads and leaves `attachment` rows pointing where the server no longer looks.

### 3. Wrong migration number in a code comment

The comment on `searchStatementTimeout` credited migration 134 with installing the search extensions. `134_runtime_profile_add_qoder` widens a `protocol_family` CHECK constraint; the `pg_trgm` install is 137. The referenced index list is extended to 137–142, since 137 only installs the extension while 138–142 create the indexes.

## Verification

Docs plus one Go comment — no behavior change, so no tests were added.

- `gofmt -l server/internal/handler/search.go` — clean
- `go vet ./internal/handler/` — clean
- `go build ./...` — clean
- Every factual claim above re-verified against `main` at `fbbe6975`: `CREATE EXTENSION` grep over all 429 migrations, `vector` grep over the full migration set, `storage/local.go` default, `Dockerfile` `WORKDIR /app` vs the `backend_uploads` mount, and the `#usage-dashboard-rollup` anchor.
- README ASCII diagram box widths checked to confirm alignment is preserved.
