### PR TITLE
MUL-6550 fix(issues): re-rank an issue when its status moves it to a new column

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -250,6 +250,7 @@ var concurrentIndexCleanups = map[string]string{
 	"395_plugin_package_version_package_index":                  "idx_plugin_package_version_package",
 	"396_plugin_package_file_path_index":                        "idx_plugin_package_file_path",
 	"397_plugin_installation_package_version_index":             "idx_plugin_installation_package_version",
+	"398_issue_workspace_status_position_index":                 "idx_issue_workspace_status_position",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -237,7 +237,9 @@ var issueReorderCmd = &cobra.Command{
 		"  --top          move it to the top of its column\n" +
 		"  --bottom       move it to the bottom of its column\n\n" +
 		"Reorder stays inside the issue's current column. To move an issue to a\n" +
-		"different column, change its status first with `multica issue status`.",
+		"different column, change its status first with `multica issue status`,\n" +
+		"which lands it at the top of the destination column — no follow-up\n" +
+		"reorder needed.",
 	Args: exactArgs(1),
 	RunE: runIssueReorder,
 }

--- a/server/internal/handler/issue_status_position_test.go
+++ b/server/internal/handler/issue_status_position_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// position ranks an issue inside its own (workspace, status) column, so the
+// value is meaningless once the status moves the issue to a different column.
+// Carrying it over put agent-completed work below every hand-dragged issue in
+// Done — the column an agent writes to and never drags in. These tests pin the
+// re-ranking to the two queries that can change a status.
+
+// destinationMin reads the current top of a column so assertions stay valid
+// against a shared test workspace other suites have left rows in.
+func destinationMin(t *testing.T, status string) float64 {
+	t.Helper()
+	var min float64
+	dbfx.QueryRow(t,
+		`SELECT COALESCE(MIN(position), 0) FROM issue WHERE workspace_id = $1 AND status = $2`,
+		testWorkspaceID, status).Scan(&min)
+	return min
+}
+
+func issuePosition(t *testing.T, issueID string) float64 {
+	t.Helper()
+	var pos float64
+	dbfx.QueryRow(t, `SELECT position FROM issue WHERE id = $1`, issueID).Scan(&pos)
+	return pos
+}
+
+// TestUpdateIssueStatusRanksAboveDestinationColumn reproduces the reported
+// board state: a Done column ordered by hand, and an issue arriving from Todo
+// carrying the -1 that made it the top of Todo. -1 is above nothing in Done.
+func TestUpdateIssueStatusRanksAboveDestinationColumn(t *testing.T) {
+	for _, pos := range []float64{-57.75, -20, -7.25} {
+		dbfx.Issue(t, "status-position hand-dragged done issue", testutil.Cols{
+			"status":   "done",
+			"position": pos,
+		})
+	}
+	moving := dbfx.Issue(t, "status-position moving issue", testutil.Cols{
+		"status":   "todo",
+		"position": -1.0,
+	})
+
+	before := destinationMin(t, "done")
+
+	var updated IssueResponse
+	testutil.Call(t, testHandler.UpdateIssue, testutil.WithURLParams(
+		newRequest(http.MethodPut, "/api/issues/"+moving, map[string]any{"status": "done"}),
+		"id", moving,
+	)).Want(http.StatusOK).JSON(&updated)
+
+	if updated.Position >= before {
+		t.Errorf("position after move = %v, want above the Done column top (%v)", updated.Position, before)
+	}
+	if updated.Position >= -57.75 {
+		t.Errorf("position after move = %v, want above the hand-dragged issues (-57.75 and lower)", updated.Position)
+	}
+}
+
+// TestUpdateIssueStatusKeepsExplicitPosition covers cross-column drag-and-drop,
+// which sends status and position together and means the slot it dropped on.
+func TestUpdateIssueStatusKeepsExplicitPosition(t *testing.T) {
+	dbfx.Issue(t, "status-position explicit destination issue", testutil.Cols{
+		"status":   "done",
+		"position": -1000.0,
+	})
+	moving := dbfx.Issue(t, "status-position explicit moving issue", testutil.Cols{
+		"status":   "todo",
+		"position": -1.0,
+	})
+
+	const dropped = -12.5
+	var updated IssueResponse
+	testutil.Call(t, testHandler.UpdateIssue, testutil.WithURLParams(
+		newRequest(http.MethodPut, "/api/issues/"+moving, map[string]any{
+			"status":   "done",
+			"position": dropped,
+		}),
+		"id", moving,
+	)).Want(http.StatusOK).JSON(&updated)
+
+	if updated.Position != dropped {
+		t.Errorf("position after drag = %v, want the dropped slot %v", updated.Position, dropped)
+	}
+}
+
+// TestUpdateIssueWithoutStatusChangeKeepsPosition guards the other direction:
+// editing an issue in place must not shuffle the column it is already in.
+func TestUpdateIssueWithoutStatusChangeKeepsPosition(t *testing.T) {
+	issueID := dbfx.Issue(t, "status-position untouched issue", testutil.Cols{
+		"status":   "todo",
+		"position": -3.5,
+	})
+
+	var updated IssueResponse
+	testutil.Call(t, testHandler.UpdateIssue, testutil.WithURLParams(
+		newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+			"title":  "status-position untouched issue, retitled",
+			"status": "todo",
+		}),
+		"id", issueID,
+	)).Want(http.StatusOK).JSON(&updated)
+
+	if updated.Position != -3.5 {
+		t.Errorf("position after in-place edit = %v, want it left at -3.5", updated.Position)
+	}
+}
+
+// TestUpdateIssueStatusQueryRanksAboveDestinationColumn covers the query GitHub
+// sync and agent task completion call directly, bypassing the UpdateIssue
+// handler. Agents close issues through this path and never drag anything, so
+// leaving it out would leave the reported bug in place for its main victim.
+func TestUpdateIssueStatusQueryRanksAboveDestinationColumn(t *testing.T) {
+	dbfx.Issue(t, "direct status-position destination issue", testutil.Cols{
+		"status":   "done",
+		"position": -1000.0,
+	})
+	moving := dbfx.Issue(t, "direct status-position moving issue", testutil.Cols{
+		"status":   "todo",
+		"position": -1.0,
+	})
+
+	before := destinationMin(t, "done")
+
+	updated, err := testHandler.Queries.UpdateIssueStatus(context.Background(), db.UpdateIssueStatusParams{
+		ID:          parseUUID(moving),
+		Status:      "done",
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("UpdateIssueStatus: %v", err)
+	}
+	if updated.Position >= before {
+		t.Errorf("position after move = %v, want above the Done column top (%v)", updated.Position, before)
+	}
+}
+
+// TestUpdateIssueStatusQueryNoopKeepsPosition pins the same-status write: a
+// re-delivered GitHub webhook or a repeated completion must not walk the issue
+// further up its own column on every call.
+func TestUpdateIssueStatusQueryNoopKeepsPosition(t *testing.T) {
+	issueID := dbfx.Issue(t, "direct status-position noop issue", testutil.Cols{
+		"status":   "done",
+		"position": -4.25,
+	})
+
+	if _, err := testHandler.Queries.UpdateIssueStatus(context.Background(), db.UpdateIssueStatusParams{
+		ID:          parseUUID(issueID),
+		Status:      "done",
+		WorkspaceID: parseUUID(testWorkspaceID),
+	}); err != nil {
+		t.Fatalf("UpdateIssueStatus: %v", err)
+	}
+
+	if got := issuePosition(t, issueID); got != -4.25 {
+		t.Errorf("position after same-status write = %v, want it left at -4.25", got)
+	}
+}

--- a/server/internal/issueposition/position.go
+++ b/server/internal/issueposition/position.go
@@ -14,6 +14,10 @@ type queryRower interface {
 
 // NextTopPosition returns a position that sorts before every existing issue in
 // the workspace/status column when manual sorting orders by position ASC.
+//
+// UpdateIssue and UpdateIssueStatus in queries/issue.sql inline the same
+// MIN(position) - 1 policy to re-rank an issue whose status moves it to a
+// different column. Change them together.
 func NextTopPosition(ctx context.Context, q queryRower, workspaceID pgtype.UUID, status string) (float64, error) {
 	var minPos float64
 	if err := q.QueryRow(ctx,

--- a/server/migrations/398_issue_workspace_status_position_index.down.sql
+++ b/server/migrations/398_issue_workspace_status_position_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_workspace_status_position;

--- a/server/migrations/398_issue_workspace_status_position_index.up.sql
+++ b/server/migrations/398_issue_workspace_status_position_index.up.sql
@@ -1,0 +1,8 @@
+-- Re-ranking an issue into a new column reads MIN(position) for the
+-- destination (workspace_id, status). idx_issue_status stops at
+-- (workspace_id, status), so that min costs a heap fetch per issue in the
+-- column -- paid on every status change, most often against Done, the column
+-- that grows without bound. Carrying position in the index makes it an
+-- index-only min. New-issue creation takes the same min and benefits equally.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_workspace_status_position
+    ON issue (workspace_id, status, position);

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -1554,7 +1554,34 @@ WITH candidate AS (
         COALESCE($5::text, i.priority) AS next_priority,
         $6::text AS next_assignee_type,
         $7::uuid AS next_assignee_id,
-        COALESCE($8::double precision, i.position) AS next_position,
+        CASE
+            -- An explicit position wins. Cross-column drag-and-drop sends
+            -- status and position together and means the slot it dropped on.
+            WHEN $8::double precision IS NOT NULL
+                THEN $8::double precision
+            -- position ranks an issue *within* its (workspace, status)
+            -- column, so it stops meaning anything the moment the column
+            -- changes: the value that put the issue on top of Todo lands it
+            -- below every hand-dragged issue in Done. Re-rank to the top of
+            -- the destination, the same policy new issues get from
+            -- NextTopPosition. Keep the two in sync.
+            --
+            -- Two status changes running at once can read the same MIN and
+            -- claim one slot. Every position-ordered query carries a unique
+            -- final key (created_at DESC, id DESC), so a tie leaves the
+            -- relative order of simultaneous moves arbitrary but never
+            -- unstable across pages. Creation avoids the tie by computing its
+            -- min under the workspace counter lock; a status change holds no
+            -- such lock and is not worth taking one for.
+            WHEN i.status IS DISTINCT FROM COALESCE($4::text, i.status)
+                THEN (
+                    SELECT COALESCE(MIN(target.position), 0) - 1
+                    FROM issue AS target
+                    WHERE target.workspace_id = i.workspace_id
+                      AND target.status = $4::text
+                )
+            ELSE i.position
+        END AS next_position,
         $9::date AS next_start_date,
         $10::date AS next_due_date,
         $11::uuid AS next_parent_issue_id,
@@ -1677,15 +1704,21 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 }
 
 const updateIssueStatus = `-- name: UpdateIssueStatus :one
-UPDATE issue SET
+UPDATE issue AS i SET
     status = $2,
-    revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
-    last_activity_at = CASE WHEN status IS DISTINCT FROM $2
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
+    position = CASE WHEN i.status IS DISTINCT FROM $2 THEN (
+        SELECT COALESCE(MIN(target.position), 0) - 1
+        FROM issue AS target
+        WHERE target.workspace_id = i.workspace_id
+          AND target.status = $2
+    ) ELSE i.position END,
+    revision = i.revision + CASE WHEN i.status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
+    last_activity_at = CASE WHEN i.status IS DISTINCT FROM $2
+        THEN GREATEST(COALESCE(i.last_activity_at, i.updated_at), now())
+        ELSE i.last_activity_at
     END,
     updated_at = now()
-WHERE id = $1 AND workspace_id = $3
+WHERE i.id = $1 AND i.workspace_id = $3
 RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage, properties, revision, last_activity_at
 `
 
@@ -1696,6 +1729,10 @@ type UpdateIssueStatusParams struct {
 }
 
 // Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
+// Repositioning lives here rather than in the callers (GitHub sync, agent task
+// completion) so a status write cannot land without one: an issue carrying its
+// old column's rank into a new column is the bug this guards against. See the
+// next_position CASE in UpdateIssue for the policy.
 func (q *Queries) UpdateIssueStatus(ctx context.Context, arg UpdateIssueStatusParams) (Issue, error) {
 	row := q.db.QueryRow(ctx, updateIssueStatus, arg.ID, arg.Status, arg.WorkspaceID)
 	var i Issue

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -154,7 +154,34 @@ WITH candidate AS (
         COALESCE(sqlc.narg('priority')::text, i.priority) AS next_priority,
         sqlc.narg('assignee_type')::text AS next_assignee_type,
         sqlc.narg('assignee_id')::uuid AS next_assignee_id,
-        COALESCE(sqlc.narg('position')::double precision, i.position) AS next_position,
+        CASE
+            -- An explicit position wins. Cross-column drag-and-drop sends
+            -- status and position together and means the slot it dropped on.
+            WHEN sqlc.narg('position')::double precision IS NOT NULL
+                THEN sqlc.narg('position')::double precision
+            -- position ranks an issue *within* its (workspace, status)
+            -- column, so it stops meaning anything the moment the column
+            -- changes: the value that put the issue on top of Todo lands it
+            -- below every hand-dragged issue in Done. Re-rank to the top of
+            -- the destination, the same policy new issues get from
+            -- NextTopPosition. Keep the two in sync.
+            --
+            -- Two status changes running at once can read the same MIN and
+            -- claim one slot. Every position-ordered query carries a unique
+            -- final key (created_at DESC, id DESC), so a tie leaves the
+            -- relative order of simultaneous moves arbitrary but never
+            -- unstable across pages. Creation avoids the tie by computing its
+            -- min under the workspace counter lock; a status change holds no
+            -- such lock and is not worth taking one for.
+            WHEN i.status IS DISTINCT FROM COALESCE(sqlc.narg('status')::text, i.status)
+                THEN (
+                    SELECT COALESCE(MIN(target.position), 0) - 1
+                    FROM issue AS target
+                    WHERE target.workspace_id = i.workspace_id
+                      AND target.status = sqlc.narg('status')::text
+                )
+            ELSE i.position
+        END AS next_position,
         sqlc.narg('start_date')::date AS next_start_date,
         sqlc.narg('due_date')::date AS next_due_date,
         sqlc.narg('parent_issue_id')::uuid AS next_parent_issue_id,
@@ -209,15 +236,25 @@ RETURNING i.*;
 
 -- name: UpdateIssueStatus :one
 -- Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
-UPDATE issue SET
+-- Repositioning lives here rather than in the callers (GitHub sync, agent task
+-- completion) so a status write cannot land without one: an issue carrying its
+-- old column's rank into a new column is the bug this guards against. See the
+-- next_position CASE in UpdateIssue for the policy.
+UPDATE issue AS i SET
     status = $2,
-    revision = revision + CASE WHEN status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
-    last_activity_at = CASE WHEN status IS DISTINCT FROM $2
-        THEN GREATEST(COALESCE(last_activity_at, updated_at), now())
-        ELSE last_activity_at
+    position = CASE WHEN i.status IS DISTINCT FROM $2 THEN (
+        SELECT COALESCE(MIN(target.position), 0) - 1
+        FROM issue AS target
+        WHERE target.workspace_id = i.workspace_id
+          AND target.status = $2
+    ) ELSE i.position END,
+    revision = i.revision + CASE WHEN i.status IS DISTINCT FROM $2 THEN 1 ELSE 0 END,
+    last_activity_at = CASE WHEN i.status IS DISTINCT FROM $2
+        THEN GREATEST(COALESCE(i.last_activity_at, i.updated_at), now())
+        ELSE i.last_activity_at
     END,
     updated_at = now()
-WHERE id = $1 AND workspace_id = $3
+WHERE i.id = $1 AND i.workspace_id = $3
 RETURNING *;
 
 -- name: CreateIssueWithOrigin :one


### PR DESCRIPTION
## What does this PR do?

`position` ranks an issue **inside its own `(workspace, status)` column**, but a status change carried the old column's value over unchanged. The value that puts an issue on top of Todo is roughly zero; in a Done column ordered by hand (`-57.75 … -7.25`) that same value sorts below everything. So work an agent had just completed sank into the middle of a long Done column and read as "the task disappeared from the board."

The reporter described this as `position` staying at a default of `-1`. Worth correcting, because it changes what the fix has to do: the column default is `0` (`001_init.up.sql`), and `-1` is what `NextTopPosition` computes for a *new* issue in an empty-ish Todo. That also explains the reported "62 of 211 done issues all at exactly `-1`": each issue takes `-1` on creation in Todo, carries it into Done, Todo's `MIN` falls back to `0`, and the next one takes `-1` again. Nothing is failing to assign a position — the rank is just being read against the wrong column.

So the fix is to **re-rank on arrival**, not to fill in a missing value.

## Related Issue

Closes #7410

Same root cause as #7419 from @mameikagou, whose diagnosis and `MIN(position) - 1` approach this follows; opening this separately to add the missing migration-hook registration, the index, and the extra guard tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `UpdateIssue` and `UpdateIssueStatus` re-rank to the top of the destination column when the status changes, reusing the `MIN(position) - 1` policy new issues already get from `NextTopPosition`.
- An explicit `position` still wins, so cross-column drag-and-drop keeps the slot it dropped on. A same-status write leaves `position` alone.
- Both queries are covered, not just the handler: agents close issues through `UpdateIssueStatus` (agent task completion, GitHub sync) and never drag anything, so they are the main victim of this bug.
- New index `(workspace_id, status, position)`. The re-rank reads `MIN(position)` for the destination column; `idx_issue_status` stops at `(workspace_id, status)`, so that min costs a heap fetch per issue in the column — paid on every completion, against Done, the column that grows without bound. Issue creation takes the same min and benefits equally.
- `multica issue reorder --help` no longer implies a follow-up reorder is needed after a status change.

## Behavior change worth flagging

Moving an issue *back* (`done → todo`) now also lands it at the top of the destination, so a round trip no longer restores its former manual slot. This is consistent with how newly created issues enter a column, and the alternative — remembering a per-column position per issue — is a much larger change for a rarer case. Called out here so it is a decision rather than a side effect.

Concurrency is unchanged in kind: two simultaneous status changes can read the same `MIN` and claim one slot. Ordering stays deterministic because every position-ordered query carries a unique final key (`created_at DESC, id DESC`), so a tie only leaves the relative order of simultaneous moves arbitrary, never unstable across pages. Creation avoids the tie by computing its min under the workspace counter lock; a status change holds no such lock and taking one for this did not seem worth the contention. Documented in the SQL.

## Out of scope

The two smaller items at the end of #7410 are deliberately not here:

1. **Tied positions making offset pagination unsafe** — does not reproduce on `main`. `ListIssues` already orders by `i.position ASC, i.created_at DESC, i.id DESC`, a unique total order (`#5454`). What remains is the ordinary offset-pagination race — rows moving across page boundaries while agents mutate them mid-scroll — which a tiebreaker cannot fix and keyset pagination would.
2. **Sorting by issue number** — confirmed missing from both the API sort whitelist and the CLI, but it is a feature, not part of this bug.

## How to Test

1. `cd server && go test ./internal/handler -run 'TestUpdateIssueStatus|TestUpdateIssueWithoutStatusChange|TestCreateIssuePosition' -count=1`
2. `cd server && go test ./internal/handler ./cmd/migrate -count=1`

`TestUpdateIssueStatusRanksAboveDestinationColumn` and `TestUpdateIssueStatusQueryRanksAboveDestinationColumn` were confirmed to fail without the query change, reporting exactly the symptom from the report (`position after move = -1`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Verification

`go test ./internal/handler` and `go test ./cmd/migrate` pass. The rest of `go test ./...` is unchanged from `main` in this environment: `cmd/multica`, `internal/cli`, `internal/daemon` and `internal/daemon/execenv` fail identically before and after this change (ambient agent environment variables the local checkout cannot avoid). No frontend files are touched, so the TypeScript suites were not run.
