### PR TITLE
MUL-6560: WS-4075: honor run-only autopilot declared failures

### DIFF
--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -45,6 +45,16 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 			wantResult: "done",
 		},
 		{
+			name: "agent declared failure",
+			finalize: func(task db.AgentTaskQueue) {
+				if _, err := taskSvc.CompleteTask(ctx, task.ID, []byte(`{"output":"[MULTICA_AUTOPILOT_FAILED] budget_exceeded: no delivery receipt"}`), "", "", "", false, "", ""); err != nil {
+					t.Fatalf("CompleteTask: %v", err)
+				}
+			},
+			wantStatus: "failed",
+			wantReason: "task declared failure: budget_exceeded: no delivery receipt",
+		},
+		{
 			name: "failed",
 			finalize: func(task db.AgentTaskQueue) {
 				if _, err := taskSvc.FailTask(ctx, task.ID, "boom", "", "", "", "agent_error", false, "", ""); err != nil {

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"strings"
 	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 // TestClassifyTask pins the precedence rule on classifyTask. All four
@@ -210,6 +212,16 @@ func TestBriefOwnsAutopilotIssueCommandsGuard(t *testing.T) {
 	out := buildMetaSkillContent("claude", TaskContextForEnv{AutopilotRunID: "run-1"})
 	if !strings.Contains(out, AutopilotIssueCommandsGuard) {
 		t.Errorf("autopilot brief missing AutopilotIssueCommandsGuard — the per-turn prompt defers to this single emission point")
+	}
+}
+
+func TestBriefTeachesAutopilotDeclaredFailureMarker(t *testing.T) {
+	out := buildMetaSkillContent("claude", TaskContextForEnv{AutopilotRunID: "run-1"})
+	if !strings.Contains(out, protocol.AutopilotFailureMarker+" <short_reason_code>: <reason>") {
+		t.Fatalf("autopilot brief missing the declared-failure output contract")
+	}
+	if !strings.Contains(out, "makes the autopilot run `failed`") {
+		t.Fatalf("autopilot brief does not explain the marker's terminal effect")
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 // This file holds the runtime brief assembler — the post-MUL-3560 path
@@ -586,6 +587,7 @@ func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
 		fmt.Fprintf(b, "- Run `multica autopilot get %s --output json` if you need the full autopilot configuration\n", ctx.AutopilotID)
 	}
 	b.WriteString("- Complete the autopilot instructions directly\n")
+	fmt.Fprintf(b, "- If the run cannot satisfy its delivery contract, begin the final response with `%s <short_reason_code>: <reason>`. This explicit marker makes the autopilot run `failed`; writing failure prose without it is still a normally completed agent turn. Use it only for a terminal incomplete outcome, not for an acceptable degraded delivery.\n", protocol.AutopilotFailureMarker)
 	b.WriteString("- " + AutopilotIssueCommandsGuard + "\n\n")
 }
 

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1099,6 +1099,19 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 
 	switch task.Status {
 	case "completed":
+		if reason, declared := taskDeclaredFailureForAutopilotRun(task); declared {
+			updatedRun, err := s.failAutopilotRun(ctx, db.UpdateAutopilotRunFailedParams{
+				ID:            run.ID,
+				FailureReason: pgtype.Text{String: reason, Valid: true},
+			})
+			if err != nil {
+				slog.Warn("failed to record agent-declared autopilot failure", "run_id", util.UUIDToString(run.ID), "error", err)
+				return
+			}
+			s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
+			s.publishRunDone(wsID, updatedRun, "failed")
+			return
+		}
 		updatedRun, err := s.completeAutopilotRun(ctx, db.UpdateAutopilotRunCompletedParams{
 			ID:     run.ID,
 			Result: task.Result,
@@ -1125,6 +1138,58 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
 		s.publishRunDone(wsID, updatedRun, "failed")
 	}
+}
+
+// taskDeclaredFailureForAutopilotRun lets a run-only agent distinguish
+// "the provider turn returned normally" from "the automation delivered its
+// contract". Agent backends expose only a completed turn when the model exits
+// with a final answer, so without this explicit output protocol a fail-fast
+// budget/verification verdict is indistinguishable from successful delivery.
+//
+// The marker is the durable protocol. The two legacy prefixes preserve the
+// failure contracts already embedded in long-lived autopilot descriptions.
+// Only the first non-empty output line is considered, preventing a successful
+// report that quotes or discusses an earlier failure from being reclassified.
+func taskDeclaredFailureForAutopilotRun(task db.AgentTaskQueue) (string, bool) {
+	var payload protocol.TaskCompletedPayload
+	if err := json.Unmarshal(task.Result, &payload); err != nil {
+		return "", false
+	}
+
+	lines := strings.Split(strings.TrimSpace(payload.Output), "\n")
+	if len(lines) == 0 {
+		return "", false
+	}
+	first := strings.TrimSpace(lines[0])
+	if first == "" {
+		return "", false
+	}
+
+	if first == protocol.AutopilotFailureMarker {
+		for _, line := range lines[1:] {
+			if reason := strings.TrimSpace(line); reason != "" {
+				return "task declared failure: " + reason, true
+			}
+		}
+		return "task declared failure", true
+	}
+	for _, separator := range []string{" ", ":"} {
+		prefix := protocol.AutopilotFailureMarker + separator
+		if strings.HasPrefix(first, prefix) {
+			reason := strings.TrimSpace(strings.TrimPrefix(first, prefix))
+			if reason == "" {
+				return "task declared failure", true
+			}
+			return "task declared failure: " + reason, true
+		}
+	}
+
+	for _, prefix := range []string{"Run failed fast:", "Phase 4 verify FAILED:"} {
+		if strings.HasPrefix(first, prefix) {
+			return "task declared failure: " + first, true
+		}
+	}
+	return "", false
 }
 
 // SyncRunFromLinkedIssueTask fails a create_issue autopilot run when its

--- a/server/internal/service/autopilot_test.go
+++ b/server/internal/service/autopilot_test.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 func TestAutopilotErrorType(t *testing.T) {
@@ -59,6 +61,75 @@ func TestTaskFailureReasonForAutopilotRun(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := taskFailureReasonForAutopilotRun(tc.task); got != tc.want {
 				t.Fatalf("taskFailureReasonForAutopilotRun() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTaskDeclaredFailureForAutopilotRun(t *testing.T) {
+	result := func(output string) []byte {
+		data, err := json.Marshal(protocol.TaskCompletedPayload{Output: output})
+		if err != nil {
+			t.Fatalf("marshal task result: %v", err)
+		}
+		return data
+	}
+
+	cases := []struct {
+		name       string
+		result     []byte
+		wantReason string
+		want       bool
+	}{
+		{
+			name:       "marker and inline reason",
+			result:     result("[MULTICA_AUTOPILOT_FAILED] budget_exceeded: no delivery receipt"),
+			wantReason: "task declared failure: budget_exceeded: no delivery receipt",
+			want:       true,
+		},
+		{
+			name:       "marker and next-line reason",
+			result:     result("[MULTICA_AUTOPILOT_FAILED]\n\nverification_failed: main issue missing"),
+			wantReason: "task declared failure: verification_failed: main issue missing",
+			want:       true,
+		},
+		{
+			name:       "marker without reason",
+			result:     result("[MULTICA_AUTOPILOT_FAILED]"),
+			wantReason: "task declared failure",
+			want:       true,
+		},
+		{
+			name:       "legacy fail-fast contract",
+			result:     result("Run failed fast: the explicit token budget was exceeded\nNo issue was created."),
+			wantReason: "task declared failure: Run failed fast: the explicit token budget was exceeded",
+			want:       true,
+		},
+		{
+			name:       "legacy phase verification contract",
+			result:     result("Phase 4 verify FAILED: missing fresh main issue"),
+			wantReason: "task declared failure: Phase 4 verify FAILED: missing fresh main issue",
+			want:       true,
+		},
+		{
+			name:   "quoted failure later in successful output",
+			result: result("Delivery recovered and verified.\nPrevious attempt: Run failed fast: budget exceeded"),
+		},
+		{
+			name:   "ordinary completion",
+			result: result("Created and verified WS-123."),
+		},
+		{
+			name:   "malformed task result",
+			result: []byte(`{"output":`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReason, got := taskDeclaredFailureForAutopilotRun(db.AgentTaskQueue{Result: tc.result})
+			if got != tc.want || gotReason != tc.wantReason {
+				t.Fatalf("taskDeclaredFailureForAutopilotRun() = (%q, %v), want (%q, %v)", gotReason, got, tc.wantReason, tc.want)
 			}
 		})
 	}

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -31,6 +31,18 @@ Execution modes:
 - `run_only` creates an agent task directly. No issue is created; any durable
   report location has to come from other task context or instructions.
 
+A run-only provider turn can exit normally even when the automation contract
+failed. For a terminal incomplete outcome, begin the final response with:
+
+```text
+[MULTICA_AUTOPILOT_FAILED] <short_reason_code>: <reason>
+```
+
+The server records the autopilot run as `failed` and exposes the reason. Do not
+use the marker for an acceptable degraded delivery. Long-lived descriptions
+that begin the final output with `Run failed fast:` or `Phase 4 verify FAILED:`
+remain compatible, but new instructions should use the explicit marker.
+
 `issue-title-template` only supports `{{date}}`. Do not invent `{{trigger_id}}`, `{{branch}}`, or other variables.
 
 ## CLI

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -4,6 +4,8 @@
 - The CLI maps reads/writes to `/api/autopilots`, `/api/autopilots/{id}`, `/api/autopilots/{id}/trigger`, `/api/autopilots/{id}/runs`, and trigger subroutes. `autopilot get` nulls `webhook_token`, `webhook_path`, and `webhook_url` in normal JSON output and adds `has_webhook_token` plus `webhook_token_hint`; `--show-secrets` is an explicit JSON-only escape hatch that prints a credential-exposure warning to stderr.
 - `server/internal/service/autopilot.go` has `DispatchAutopilot`, synchronous delivery-idempotent `AdmitAutopilotWebhookDelivery`, and worker-side `DispatchAutopilotForWebhookDelivery`; it creates `autopilot_run` and switches on `execution_mode`.
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
+- `server/pkg/protocol/messages.go` defines `AutopilotFailureMarker`; `server/internal/daemon/execenv/runtime_config_sections.go` teaches it to run-only agents, and `taskDeclaredFailureForAutopilotRun` / `SyncRunFromTask` in `server/internal/service/autopilot.go` convert a marked completed task (plus the two documented legacy prefixes) into a failed run with `failure_reason`.
+- Migration `398_backfill_declared_autopilot_failures` corrects historical `completed` rows whose first non-empty output line used either legacy failure prefix; it deliberately ignores failures quoted later in an otherwise successful report.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.

--- a/server/migrations/398_backfill_declared_autopilot_failures.down.sql
+++ b/server/migrations/398_backfill_declared_autopilot_failures.down.sql
@@ -1,0 +1,4 @@
+-- Irreversible data correction: a failed automation must not become successful
+-- again merely because the server binary is rolled back. The task result keeps
+-- the original provider output for audit and future reclassification.
+SELECT 1;

--- a/server/migrations/398_backfill_declared_autopilot_failures.up.sql
+++ b/server/migrations/398_backfill_declared_autopilot_failures.up.sql
@@ -1,0 +1,15 @@
+-- A run-only provider turn can complete normally while its final output says
+-- the automation contract failed. Before the explicit failure marker existed,
+-- two fail-fast prefixes were already documented in durable autopilot prompts.
+-- Correct only rows whose first non-empty output line uses one of those exact
+-- prefixes; later quoted/discussed failures remain successful.
+UPDATE autopilot_run
+SET status = 'failed',
+    failure_reason = 'task declared failure: '
+        || split_part(ltrim(result ->> 'output', E' \n\r\t'), E'\n', 1)
+WHERE status = 'completed'
+  AND jsonb_typeof(result) = 'object'
+  AND (
+      split_part(ltrim(result ->> 'output', E' \n\r\t'), E'\n', 1) LIKE 'Run failed fast:%'
+      OR split_part(ltrim(result ->> 'output', E' \n\r\t'), E'\n', 1) LIKE 'Phase 4 verify FAILED:%'
+  );

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -135,6 +135,12 @@ type TaskProgressPayload struct {
 	Total   int    `json:"total,omitempty"`
 }
 
+// AutopilotFailureMarker is the first-line output marker a run-only agent uses
+// when its provider turn completed normally but the automation contract did
+// not. The autopilot task listener converts that declared outcome into a failed
+// autopilot_run with a visible failure_reason.
+const AutopilotFailureMarker = "[MULTICA_AUTOPILOT_FAILED]"
+
 // TaskCompletedPayload is sent from daemon to server when a task finishes.
 type TaskCompletedPayload struct {
 	TaskID string `json:"task_id"`


### PR DESCRIPTION
## Summary

- add an explicit `[MULTICA_AUTOPILOT_FAILED]` first-line protocol for run-only agents and convert declared failures into `autopilot_run.status=failed` with a visible reason
- preserve the existing `Run failed fast:` and `Phase 4 verify FAILED:` contracts, while avoiding false positives when successful reports quote those phrases later
- backfill historical misclassified runs and teach the runtime brief/built-in autopilot skill the new contract

## Verification

- `go test ./internal/service -run '^(TestTaskDeclaredFailureForAutopilotRun|TestTaskFailureReasonForAutopilotRun|TestAutopilotErrorType)$' -count=1`
- `go test ./internal/daemon/execenv -run '^(TestBriefTeachesAutopilotDeclaredFailureMarker|TestBriefOwnsAutopilotIssueCommandsGuard)$' -count=1`
- `go test ./cmd/server -run '^TestAutopilotRunOnlyTaskTerminalEventsUpdateRun$' -count=1`
- `go vet ./internal/service ./internal/daemon/execenv ./pkg/protocol ./cmd/server`
- migration 398 exercised against an isolated migrated PostgreSQL database with both legacy prefixes plus a negative quoted-failure control

Closes WS-4075
