### PR TITLE
MUL-6580: add right sidebar toggle shortcut

### DIFF
--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -93,6 +93,16 @@ describe("keyboard shortcut definitions", () => {
     expect(action.allowInEditable).toBe(true);
   });
 
+  it("pairs the left and right sidebar toggles without a default conflict", () => {
+    expect(SHORTCUT_ACTION_BY_ID.toggleSidebar.defaultShortcut).toEqual(
+      createShortcutChord("B", { primary: true }),
+    );
+    expect(SHORTCUT_ACTION_BY_ID.toggleRightSidebar.defaultShortcut).toEqual(
+      createShortcutChord("B", { primary: true, shift: true }),
+    );
+    expect(SHORTCUT_ACTION_BY_ID.toggleRightSidebar.allowInEditable).toBe(false);
+  });
+
   it("keeps the inbox archive key out of editable controls", () => {
     const action = SHORTCUT_ACTION_BY_ID.archiveInboxItem;
     expect(action.defaultShortcut).toEqual(createShortcutChord("E"));

--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -93,12 +93,12 @@ describe("keyboard shortcut definitions", () => {
     expect(action.allowInEditable).toBe(true);
   });
 
-  it("pairs the left and right sidebar toggles without a default conflict", () => {
+  it("assigns distinct defaults to the left and right sidebar toggles", () => {
     expect(SHORTCUT_ACTION_BY_ID.toggleSidebar.defaultShortcut).toEqual(
       createShortcutChord("B", { primary: true }),
     );
     expect(SHORTCUT_ACTION_BY_ID.toggleRightSidebar.defaultShortcut).toEqual(
-      createShortcutChord("B", { primary: true, shift: true }),
+      createShortcutChord("/", { primary: true }),
     );
     expect(SHORTCUT_ACTION_BY_ID.toggleRightSidebar.allowInEditable).toBe(false);
   });

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -9,6 +9,7 @@ export type ShortcutActionId =
   | "openSearch"
   | "createIssue"
   | "toggleSidebar"
+  | "toggleRightSidebar"
   | "toggleChat"
   | "findInIssue"
   | "openThreadNav"
@@ -80,6 +81,14 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
   { id: "openSearch", category: "general", defaultShortcut: primary("K"), allowInEditable: true },
   { id: "createIssue", category: "general", defaultShortcut: createShortcutChord("C"), allowInEditable: false },
   { id: "toggleSidebar", category: "general", defaultShortcut: primary("B"), allowInEditable: false },
+  // Keep the two sidebars on one mnemonic: Shift selects the secondary,
+  // right-hand panel while preserving the established Mod+B left toggle.
+  {
+    id: "toggleRightSidebar",
+    category: "general",
+    defaultShortcut: createShortcutChord("B", { primary: true, shift: true }),
+    allowInEditable: false,
+  },
   // Mod+J follows the "toggle a docked panel" convention, and is one of the few
   // letters this module's own policy leaves free on every platform and runtime:
   // it is neither app-owned (PRIMARY_RESERVED_KEYS) nor browser-owned

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -81,12 +81,10 @@ export const SHORTCUT_ACTIONS: readonly ShortcutActionDefinition[] = [
   { id: "openSearch", category: "general", defaultShortcut: primary("K"), allowInEditable: true },
   { id: "createIssue", category: "general", defaultShortcut: createShortcutChord("C"), allowInEditable: false },
   { id: "toggleSidebar", category: "general", defaultShortcut: primary("B"), allowInEditable: false },
-  // Keep the two sidebars on one mnemonic: Shift selects the secondary,
-  // right-hand panel while preserving the established Mod+B left toggle.
   {
     id: "toggleRightSidebar",
     category: "general",
-    defaultShortcut: createShortcutChord("B", { primary: true, shift: true }),
+    defaultShortcut: primary("/"),
     allowInEditable: false,
   },
   // Mod+J follows the "toggle a docked panel" convention, and is one of the few

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -143,6 +143,7 @@ import {
   getAnimatedRightSidebarInitialOpen,
   rightSidebarPanelMotionProps,
   useAnimatedRightSidebarState,
+  useRightSidebarShortcut,
 } from "../../layout/animated-right-sidebar";
 
 /**
@@ -1241,8 +1242,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const consumedHighlightRef = useRef(consumedHighlightId);
   consumedHighlightRef.current = consumedHighlightId;
   const writeViewState = useViewStateWriter();
+  const rightSidebarShortcutTargetRef = useRef<HTMLDivElement | null>(null);
   const attachScrollContainer = useCallback(
     (el: HTMLDivElement | null) => {
+      rightSidebarShortcutTargetRef.current = el;
       setScrollContainerEl(el);
       restoreScrollRef(el);
     },
@@ -2193,6 +2196,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       else panel.collapse();
     });
   }, [beginDesktopSidebarToggle, isMobile, sidebarRef]);
+
+  useRightSidebarShortcut(rightSidebarShortcutTargetRef, handleToggleSidebar);
 
   useIssueDetailScrollRestore({
     restoreKey: `${wsId}:${id}`,

--- a/packages/views/layout/animated-right-sidebar.test.tsx
+++ b/packages/views/layout/animated-right-sidebar.test.tsx
@@ -82,7 +82,7 @@ describe("animated right sidebar state", () => {
 });
 
 describe("right sidebar shortcut", () => {
-  it("toggles the visible detail sidebar on Mod+Shift+B", () => {
+  it("toggles the visible detail sidebar on Mod+/", () => {
     configureShortcutPlatform("macos");
     const onToggle = vi.fn();
     const target = document.createElement("div");
@@ -94,9 +94,8 @@ describe("right sidebar shortcut", () => {
       useRightSidebarShortcut(targetRef, onToggle),
     );
     const event = new KeyboardEvent("keydown", {
-      key: "b",
+      key: "/",
       metaKey: true,
-      shiftKey: true,
       cancelable: true,
     });
 
@@ -116,9 +115,8 @@ describe("right sidebar shortcut", () => {
       useRightSidebarShortcut(targetRef, onToggle),
     );
     const event = new KeyboardEvent("keydown", {
-      key: "b",
+      key: "/",
       metaKey: true,
-      shiftKey: true,
       cancelable: true,
     });
 

--- a/packages/views/layout/animated-right-sidebar.test.tsx
+++ b/packages/views/layout/animated-right-sidebar.test.tsx
@@ -1,10 +1,20 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  configureShortcutPlatform,
+  useShortcutStore,
+} from "@multica/core/shortcuts";
 
 import {
   getAnimatedRightSidebarInitialOpen,
   useAnimatedRightSidebarState,
+  useRightSidebarShortcut,
 } from "./animated-right-sidebar";
+
+afterEach(() => {
+  configureShortcutPlatform(null);
+  useShortcutStore.getState().resetAll();
+});
 
 describe("animated right sidebar state", () => {
   it("uses a restored collapsed layout before falling back to the default", () => {
@@ -68,5 +78,54 @@ describe("animated right sidebar state", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("right sidebar shortcut", () => {
+  it("toggles the visible detail sidebar on Mod+Shift+B", () => {
+    configureShortcutPlatform("macos");
+    const onToggle = vi.fn();
+    const target = document.createElement("div");
+    vi.spyOn(target, "getClientRects").mockReturnValue(
+      [{}] as unknown as DOMRectList,
+    );
+    const targetRef = { current: target };
+    const { unmount } = renderHook(() =>
+      useRightSidebarShortcut(targetRef, onToggle),
+    );
+    const event = new KeyboardEvent("keydown", {
+      key: "b",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    document.dispatchEvent(event);
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+    unmount();
+  });
+
+  it("leaves the shortcut unclaimed when its detail page is hidden", () => {
+    configureShortcutPlatform("macos");
+    const onToggle = vi.fn();
+    const target = document.createElement("div");
+    const targetRef = { current: target };
+    const { unmount } = renderHook(() =>
+      useRightSidebarShortcut(targetRef, onToggle),
+    );
+    const event = new KeyboardEvent("keydown", {
+      key: "b",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    document.dispatchEvent(event);
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    unmount();
   });
 });

--- a/packages/views/layout/animated-right-sidebar.tsx
+++ b/packages/views/layout/animated-right-sidebar.tsx
@@ -1,8 +1,21 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { motion } from "motion/react";
 import type { Layout, PanelSize } from "react-resizable-panels";
+import {
+  isEditableShortcutTarget,
+  shortcutMatchesEvent,
+  useShortcut,
+} from "@multica/core/shortcuts";
+import { isImeComposing } from "@multica/core/utils";
 import { cn } from "@multica/ui/lib/utils";
 
 export const rightSidebarPanelMotionProps = {
@@ -79,6 +92,31 @@ export function useAnimatedRightSidebarState(initialOpen: boolean) {
   }, []);
 
   return { open, visualOpen, motionEnabled, beginToggle, handleResize };
+}
+
+/** Toggle the right sidebar only for the visible detail page that owns it. */
+export function useRightSidebarShortcut(
+  targetRef: RefObject<HTMLElement | null>,
+  onToggle: () => void,
+) {
+  const shortcut = useShortcut("toggleRightSidebar");
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat || isImeComposing(event)) return;
+      if (isEditableShortcutTarget(event.target)) return;
+      if (!shortcutMatchesEvent(shortcut, event)) return;
+
+      const target = targetRef.current;
+      if (!target || target.getClientRects().length === 0) return;
+
+      event.preventDefault();
+      onToggle();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onToggle, shortcut, targetRef]);
 }
 
 export function AnimatedRightSidebar({

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -360,7 +360,7 @@
       "hint_jump": "jump",
       "hint_close": "close"
     },
-    "sidebar_tooltip": "Toggle sidebar",
+    "sidebar_tooltip": "Toggle right sidebar",
     "find": {
       "placeholder": "Find in issue...",
       "count": "{{current}}/{{total}}",

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -62,7 +62,7 @@
     "icon_tooltip": "Change icon",
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
-    "sidebar_tooltip": "Toggle sidebar",
+    "sidebar_tooltip": "Toggle right sidebar",
     "copy_link": "Copy link",
     "delete_action": "Delete project",
     "section_properties": "Properties",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -168,8 +168,12 @@
         "description": "Open your preferred issue creation flow."
       },
       "toggleSidebar": {
-        "label": "Toggle sidebar",
-        "description": "Show or hide the main sidebar."
+        "label": "Toggle left sidebar",
+        "description": "Show or hide the left sidebar."
+      },
+      "toggleRightSidebar": {
+        "label": "Toggle right sidebar",
+        "description": "Show or hide the right sidebar when the current page has one."
       },
       "toggleChat": {
         "label": "Toggle chat window",

--- a/packages/views/locales/en/ui.json
+++ b/packages/views/locales/en/ui.json
@@ -1,6 +1,6 @@
 {
   "attach_file": "Attach file",
-  "toggle_sidebar": "Toggle Sidebar",
+  "toggle_sidebar": "Toggle left sidebar",
   "copy_code": "Copy code",
   "plain_text": "plain text"
 }

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -355,7 +355,7 @@
       "hint_jump": "移動",
       "hint_close": "閉じる"
     },
-    "sidebar_tooltip": "サイドバーの開閉",
+    "sidebar_tooltip": "右サイドバーの開閉",
     "find": {
       "placeholder": "タスク内を検索...",
       "count": "{{current}}/{{total}}",

--- a/packages/views/locales/ja/projects.json
+++ b/packages/views/locales/ja/projects.json
@@ -61,7 +61,7 @@
     "icon_tooltip": "アイコンを変更",
     "pin_tooltip": "サイドバーに固定",
     "unpin_tooltip": "サイドバーの固定を解除",
-    "sidebar_tooltip": "サイドバーの開閉",
+    "sidebar_tooltip": "右サイドバーの開閉",
     "copy_link": "リンクをコピー",
     "delete_action": "プロジェクトを削除",
     "section_properties": "プロパティ",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -168,8 +168,12 @@
         "description": "優先するタスク作成フローを開きます。"
       },
       "toggleSidebar": {
-        "label": "サイドバーを切り替え",
-        "description": "メインサイドバーの表示を切り替えます。"
+        "label": "左サイドバーを切り替え",
+        "description": "左サイドバーの表示を切り替えます。"
+      },
+      "toggleRightSidebar": {
+        "label": "右サイドバーを切り替え",
+        "description": "現在のページに右サイドバーがある場合、その表示を切り替えます。"
       },
       "toggleChat": {
         "label": "チャットウィンドウを切り替え",

--- a/packages/views/locales/ja/ui.json
+++ b/packages/views/locales/ja/ui.json
@@ -1,6 +1,6 @@
 {
   "attach_file": "ファイルを添付",
-  "toggle_sidebar": "サイドバーの開閉",
+  "toggle_sidebar": "左サイドバーの開閉",
   "copy_code": "コードをコピー",
   "plain_text": "プレーンテキスト"
 }

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -355,7 +355,7 @@
       "hint_jump": "이동",
       "hint_close": "닫기"
     },
-    "sidebar_tooltip": "사이드바 열기/닫기",
+    "sidebar_tooltip": "오른쪽 사이드바 열기/닫기",
     "find": {
       "placeholder": "태스크에서 찾기...",
       "count": "{{current}}/{{total}}",

--- a/packages/views/locales/ko/projects.json
+++ b/packages/views/locales/ko/projects.json
@@ -61,7 +61,7 @@
     "icon_tooltip": "아이콘 변경",
     "pin_tooltip": "사이드바에 고정",
     "unpin_tooltip": "사이드바 고정 해제",
-    "sidebar_tooltip": "사이드바 열기/닫기",
+    "sidebar_tooltip": "오른쪽 사이드바 열기/닫기",
     "copy_link": "링크 복사",
     "delete_action": "프로젝트 삭제",
     "section_properties": "속성",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -168,8 +168,12 @@
         "description": "선호하는 태스크 만들기 흐름을 엽니다."
       },
       "toggleSidebar": {
-        "label": "사이드바 전환",
-        "description": "기본 사이드바를 표시하거나 숨깁니다."
+        "label": "왼쪽 사이드바 전환",
+        "description": "왼쪽 사이드바를 표시하거나 숨깁니다."
+      },
+      "toggleRightSidebar": {
+        "label": "오른쪽 사이드바 전환",
+        "description": "현재 페이지에 오른쪽 사이드바가 있으면 표시하거나 숨깁니다."
       },
       "toggleChat": {
         "label": "채팅 창 전환",

--- a/packages/views/locales/ko/ui.json
+++ b/packages/views/locales/ko/ui.json
@@ -1,6 +1,6 @@
 {
   "attach_file": "파일 첨부",
-  "toggle_sidebar": "사이드바 열기/닫기",
+  "toggle_sidebar": "왼쪽 사이드바 열기/닫기",
   "copy_code": "코드 복사",
   "plain_text": "일반 텍스트"
 }

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -353,7 +353,7 @@
       "hint_jump": "跳转",
       "hint_close": "关闭"
     },
-    "sidebar_tooltip": "切换侧边栏",
+    "sidebar_tooltip": "切换右侧边栏",
     "find": {
       "placeholder": "在任务中查找...",
       "count": "{{current}}/{{total}}",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -61,7 +61,7 @@
     "icon_tooltip": "更换图标",
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
-    "sidebar_tooltip": "切换侧边栏",
+    "sidebar_tooltip": "切换右侧边栏",
     "copy_link": "复制链接",
     "delete_action": "删除项目",
     "section_properties": "属性",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -168,8 +168,12 @@
         "description": "打开你常用的任务创建流程。"
       },
       "toggleSidebar": {
-        "label": "显示或隐藏侧边栏",
-        "description": "切换主侧边栏的显示状态。"
+        "label": "显示或隐藏左侧边栏",
+        "description": "切换左侧边栏的显示状态。"
+      },
+      "toggleRightSidebar": {
+        "label": "显示或隐藏右侧边栏",
+        "description": "当前页面有右侧边栏时，切换其显示状态。"
       },
       "toggleChat": {
         "label": "显示或隐藏聊天窗",

--- a/packages/views/locales/zh-Hans/ui.json
+++ b/packages/views/locales/zh-Hans/ui.json
@@ -1,6 +1,6 @@
 {
   "attach_file": "添加附件",
-  "toggle_sidebar": "切换侧边栏",
+  "toggle_sidebar": "切换左侧边栏",
   "copy_code": "复制代码",
   "plain_text": "纯文本"
 }

--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -240,6 +240,7 @@ vi.mock("../../layout/animated-right-sidebar", () => ({
   ),
   getAnimatedRightSidebarInitialOpen: () => true,
   rightSidebarPanelMotionProps: {},
+  useRightSidebarShortcut: vi.fn(),
   useAnimatedRightSidebarState: () => ({
     open: true,
     visualOpen: true,

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -58,6 +58,7 @@ import {
   getAnimatedRightSidebarInitialOpen,
   rightSidebarPanelMotionProps,
   useAnimatedRightSidebarState,
+  useRightSidebarShortcut,
 } from "../../layout/animated-right-sidebar";
 import {
   AlertDialog,
@@ -155,6 +156,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     id: "multica_project_detail_layout",
   });
   const sidebarRef = usePanelRef();
+  const rightSidebarShortcutTargetRef = useRef<HTMLDivElement | null>(null);
   const desktopSidebarInitialOpen = getAnimatedRightSidebarInitialOpen(
     true,
     defaultLayout,
@@ -194,6 +196,8 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       else panel.collapse();
     });
   }, [beginDesktopSidebarToggle, isMobile, sidebarRef]);
+
+  useRightSidebarShortcut(rightSidebarShortcutTargetRef, handleToggleSidebar);
 
   // Lead popover
   const [leadOpen, setLeadOpen] = useState(false);
@@ -473,7 +477,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     <>
     <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
       <ResizablePanel id="content" minSize="50%">
-        <div className="flex h-full flex-col">
+        <div ref={rightSidebarShortcutTargetRef} className="flex h-full flex-col">
           <BreadcrumbHeader
             segments={[{ href: wsPaths.projects(), label: t(($) => $.detail.breadcrumb_fallback) }]}
             leaf={<span className="truncate font-medium text-foreground">{project.title}</span>}

--- a/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
+++ b/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
@@ -21,6 +21,24 @@ describe("KeyboardShortcutsTab", () => {
     useShortcutStore.getState().resetAll();
   });
 
+  it("shows distinct left and right sidebar actions", () => {
+    renderWithI18n(<KeyboardShortcutsTab />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Change shortcut for Toggle left sidebar",
+      }),
+    ).toBeInTheDocument();
+    const rightSidebarRecorder = screen.getByRole("button", {
+      name: "Change shortcut for Toggle right sidebar",
+    });
+    expect(within(rightSidebarRecorder).getByTitle("Ctrl")).toHaveTextContent(
+      "Ctrl",
+    );
+    expect(within(rightSidebarRecorder).getByTitle("Shift")).toBeInTheDocument();
+    expect(within(rightSidebarRecorder).getByTitle("B")).toHaveTextContent("B");
+  });
+
   it("records a shortcut and applies it immediately", () => {
     renderWithI18n(<KeyboardShortcutsTab />);
     const recorder = screen.getByRole("button", {

--- a/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
+++ b/packages/views/settings/components/keyboard-shortcuts-tab.test.tsx
@@ -35,8 +35,7 @@ describe("KeyboardShortcutsTab", () => {
     expect(within(rightSidebarRecorder).getByTitle("Ctrl")).toHaveTextContent(
       "Ctrl",
     );
-    expect(within(rightSidebarRecorder).getByTitle("Shift")).toBeInTheDocument();
-    expect(within(rightSidebarRecorder).getByTitle("B")).toHaveTextContent("B");
+    expect(within(rightSidebarRecorder).getByTitle("/")).toHaveTextContent("/");
   });
 
   it("records a shortcut and applies it immediately", () => {

--- a/packages/views/settings/components/settings-page.test.tsx
+++ b/packages/views/settings/components/settings-page.test.tsx
@@ -63,7 +63,7 @@ function NavStateProbe() {
 }
 
 function trigger() {
-  return screen.getByRole("button", { name: "Toggle Sidebar" });
+  return screen.getByRole("button", { name: "Toggle left sidebar" });
 }
 
 beforeEach(() => {
@@ -110,7 +110,7 @@ describe("SettingsPage nav trigger", () => {
     renderWithI18n(<SettingsPage />);
 
     expect(
-      screen.queryByRole("button", { name: "Toggle Sidebar" }),
+      screen.queryByRole("button", { name: "Toggle left sidebar" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- add a configurable `Mod+/` action for the visible issue or project right sidebar
- rename the existing `Mod+B` action and left-sidebar accessibility copy to "Toggle left sidebar"
- clarify right-sidebar tooltips and shortcut labels in all supported locales

## Testing

- `pnpm typecheck`
- `pnpm exec vitest run shortcuts/definitions.test.ts` in `packages/core`
- focused Views shortcut, settings, issue-detail, and project-detail suites (92 tests)
- changed-file ESLint and locale JSON validation

Closes MUL-6580
