### PR TITLE
MUL-6583: fix archived inbox group counts

### DIFF
--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -152,8 +152,9 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 // unbounded archive never rides along with the main list.
 //
 // The query drops any issue that also has an active row, keeping this list and
-// the main inbox mutually exclusive per issue group, and caps the response at
-// 200 rows — see the query comment for both.
+// the main inbox mutually exclusive per issue group. It selects at most 200
+// groups and returns only each group's newest row plus its optional comment
+// anchor — see the query comment for both the bound and the grouping contract.
 func (h *Handler) ListArchivedInbox(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+func inboxRequest(method, path, workspaceID string) *http.Request {
+	return testutil.WithHeaders(
+		testutil.JSONRequest(method, path, nil),
+		"X-User-ID", testUserID,
+		"X-Workspace-ID", workspaceID,
+	)
+}
+
+func inboxWorkspaceHandler(handler http.HandlerFunc) http.HandlerFunc {
+	return middleware.RequireWorkspaceMember(testHandler.Queries)(handler).ServeHTTP
+}
+
+func TestListArchivedInboxLimitsIssueGroupsNotRows(t *testing.T) {
+	workspaceID := dbfx.Workspace(t, "Archived inbox groups", "archived-groups-"+uuid.NewString())
+	dbfx.Member(t, workspaceID, testUserID, "owner")
+	noisyIssueID := dbfx.Issue(t, "Noisy archived issue", testutil.Cols{"workspace_id": workspaceID})
+	olderIssueID := dbfx.Issue(t, "Older archived issue", testutil.Cols{"workspace_id": workspaceID})
+
+	base := time.Now().UTC().Add(-time.Minute)
+	for i := 0; i < 200; i++ {
+		cols := testutil.Cols{
+			"workspace_id":   workspaceID,
+			"recipient_type": "member",
+			"recipient_id":   testUserID,
+			"type":           "status_changed",
+			"severity":       "info",
+			"issue_id":       noisyIssueID,
+			"title":          fmt.Sprintf("noisy-%03d", i),
+			"archived":       true,
+			"created_at":     base.Add(-time.Duration(i) * time.Millisecond),
+		}
+		if i == 199 {
+			// The bounded response keeps this row as the group's comment anchor,
+			// even though the newest status row is the one the UI renders.
+			cols["details"] = testutil.Raw(`'{"comment_id":"comment-1"}'::jsonb`)
+		}
+		dbfx.Insert(t, "inbox_item", cols)
+	}
+	dbfx.Insert(t, "inbox_item", testutil.Cols{
+		"workspace_id":   workspaceID,
+		"recipient_type": "member",
+		"recipient_id":   testUserID,
+		"type":           "new_comment",
+		"severity":       "info",
+		"issue_id":       olderIssueID,
+		"title":          "older-group",
+		"archived":       true,
+		"created_at":     base.Add(-time.Hour),
+	})
+
+	var items []InboxItemResponse
+	testutil.Call(t, inboxWorkspaceHandler(testHandler.ListArchivedInbox),
+		inboxRequest(http.MethodGet, "/api/inbox/archived", workspaceID)).
+		Want(http.StatusOK).
+		JSON(&items)
+
+	var noisyRows int
+	var sawNoisyNewest, sawCommentAnchor, sawOlderGroup bool
+	for _, item := range items {
+		switch {
+		case item.IssueID != nil && *item.IssueID == noisyIssueID:
+			noisyRows++
+			sawNoisyNewest = sawNoisyNewest || item.Title == "noisy-000"
+			sawCommentAnchor = sawCommentAnchor || strings.Contains(string(item.Details), `"comment_id":"comment-1"`)
+		case item.IssueID != nil && *item.IssueID == olderIssueID:
+			sawOlderGroup = true
+		}
+	}
+	if noisyRows != 2 || !sawNoisyNewest || !sawCommentAnchor {
+		t.Fatalf("noisy group rows = %d, newest=%v anchor=%v; items=%+v",
+			noisyRows, sawNoisyNewest, sawCommentAnchor, items)
+	}
+	if !sawOlderGroup {
+		t.Fatal("raw-row limit let one issue hide another archived issue group")
+	}
+}
+
+func TestArchiveAllReadInboxUsesNewestIssueRow(t *testing.T) {
+	workspaceID := dbfx.Workspace(t, "Archive read groups", "archive-read-"+uuid.NewString())
+	dbfx.Member(t, workspaceID, testUserID, "owner")
+	readIssueID := dbfx.Issue(t, "Newest row is read", testutil.Cols{"workspace_id": workspaceID})
+	unreadIssueID := dbfx.Issue(t, "Newest row is unread", testutil.Cols{"workspace_id": workspaceID})
+
+	insert := func(issueID, title string, read bool, createdAt testutil.Raw) {
+		t.Helper()
+		dbfx.Insert(t, "inbox_item", testutil.Cols{
+			"workspace_id":   workspaceID,
+			"recipient_type": "member",
+			"recipient_id":   testUserID,
+			"type":           "status_changed",
+			"severity":       "info",
+			"issue_id":       issueID,
+			"title":          title,
+			"read":           read,
+			"archived":       false,
+			"created_at":     createdAt,
+		})
+	}
+	insert(readIssueID, "older unread", false, "now() - interval '2 minutes'")
+	insert(readIssueID, "newest read", true, "now() - interval '1 minute'")
+	insert(unreadIssueID, "older read", true, "now() - interval '2 minutes'")
+	insert(unreadIssueID, "newest unread", false, "now() - interval '1 minute'")
+
+	testutil.Call(t, inboxWorkspaceHandler(testHandler.ArchiveAllReadInbox),
+		inboxRequest(http.MethodPost, "/api/inbox/archive-all-read", workspaceID)).
+		Want(http.StatusOK)
+
+	if got := dbfx.Count(t,
+		"SELECT count(*) FROM inbox_item WHERE issue_id = $1 AND archived = true", readIssueID); got != 2 {
+		t.Fatalf("archived rows in read issue = %d, want the whole two-row group", got)
+	}
+	if got := dbfx.Count(t,
+		"SELECT count(*) FROM inbox_item WHERE issue_id = $1 AND archived = true", unreadIssueID); got != 0 {
+		t.Fatalf("archived rows in unread issue = %d, want the whole group untouched", got)
+	}
+}

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -378,8 +378,10 @@ func (q *Queries) GetInboxItemInWorkspace(ctx context.Context, arg GetInboxItemI
 
 const listArchivedInboxItems = `-- name: ListArchivedInboxItems :many
 WITH eligible_archived AS MATERIALIZED (
-    SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-           COALESCE(i.issue_id, i.id) AS group_id
+    SELECT i.id,
+           COALESCE(i.issue_id, i.id) AS group_id,
+           i.created_at,
+           i.details
     FROM inbox_item i
     WHERE i.workspace_id = $1
       AND i.recipient_type = $2
@@ -471,6 +473,8 @@ type ListArchivedInboxItemsRow struct {
 // renders plus, when different, the newest row carrying a comment anchor. The
 // client already merges those two rows while deduplicating, preserving direct
 // comment landing without sending every historical notification in the group.
+// Keep the materialized working set narrow: full row data is joined only for
+// the final selected ids, not copied for every archived notification scanned.
 func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedInboxItemsParams) ([]ListArchivedInboxItemsRow, error) {
 	rows, err := q.db.Query(ctx, listArchivedInboxItems, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
 	if err != nil {

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -30,8 +30,28 @@ func (q *Queries) ArchiveAllInbox(ctx context.Context, arg ArchiveAllInboxParams
 }
 
 const archiveAllReadInbox = `-- name: ArchiveAllReadInbox :execrows
-UPDATE inbox_item SET archived = true
-WHERE workspace_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND read = true AND archived = false
+WITH newest_groups AS (
+    SELECT DISTINCT ON (COALESCE(i.issue_id, i.id))
+           COALESCE(i.issue_id, i.id) AS group_id,
+           i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = 'member'
+      AND i.recipient_id = $2
+      AND i.archived = false
+    ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+), read_groups AS (
+    SELECT group_id
+    FROM newest_groups
+    WHERE read = true
+)
+UPDATE inbox_item i SET archived = true
+FROM read_groups selected
+WHERE i.workspace_id = $1
+  AND i.recipient_type = 'member'
+  AND i.recipient_id = $2
+  AND i.archived = false
+  AND COALESCE(i.issue_id, i.id) = selected.group_id
 `
 
 type ArchiveAllReadInboxParams struct {
@@ -39,6 +59,11 @@ type ArchiveAllReadInboxParams struct {
 	RecipientID pgtype.UUID `json:"recipient_id"`
 }
 
+// "Read" is the state of the one issue row the inbox renders: the newest
+// active notification in that issue group. Archive every row in groups whose
+// newest row is read, and leave an unread group wholly untouched. Updating raw
+// read rows instead makes an older unread sibling reappear after the newest
+// row is archived (and can archive an older read sibling under an unread row).
 func (q *Queries) ArchiveAllReadInbox(ctx context.Context, arg ArchiveAllReadInboxParams) (int64, error) {
 	result, err := q.db.Exec(ctx, archiveAllReadInbox, arg.WorkspaceID, arg.RecipientID)
 	if err != nil {
@@ -352,22 +377,54 @@ func (q *Queries) GetInboxItemInWorkspace(ctx context.Context, arg GetInboxItemI
 }
 
 const listArchivedInboxItems = `-- name: ListArchivedInboxItems :many
+WITH eligible_archived AS MATERIALIZED (
+    SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
+           COALESCE(i.issue_id, i.id) AS group_id
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = $2
+      AND i.recipient_id = $3
+      AND i.archived = true
+      AND (i.issue_id IS NULL OR NOT EXISTS (
+          SELECT 1
+          FROM inbox_item active
+          WHERE active.workspace_id = i.workspace_id
+            AND active.recipient_type = i.recipient_type
+            AND active.recipient_id = i.recipient_id
+            AND active.issue_id = i.issue_id
+            AND active.archived = false
+      ))
+), newest_groups AS (
+    SELECT DISTINCT ON (group_id)
+           group_id,
+           id AS newest_id,
+           created_at AS newest_created_at
+    FROM eligible_archived
+    ORDER BY group_id, created_at DESC, id DESC
+), limited_groups AS (
+    SELECT group_id, newest_id
+    FROM newest_groups
+    ORDER BY newest_created_at DESC, newest_id DESC
+    LIMIT 200
+), comment_anchors AS (
+    SELECT DISTINCT ON (archived.group_id)
+           archived.group_id,
+           archived.id
+    FROM eligible_archived archived
+    JOIN limited_groups selected USING (group_id)
+    WHERE NULLIF(archived.details->>'comment_id', '') IS NOT NULL
+    ORDER BY archived.group_id, archived.created_at DESC, archived.id DESC
+), selected_ids AS (
+    SELECT newest_id AS id FROM limited_groups
+    UNION
+    SELECT id FROM comment_anchors
+)
 SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
        iss.status as issue_status
 FROM inbox_item i
+JOIN selected_ids selected ON selected.id = i.id
 LEFT JOIN issue iss ON iss.id = i.issue_id
-WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = true
-  AND (i.issue_id IS NULL OR NOT EXISTS (
-      SELECT 1
-      FROM inbox_item active
-      WHERE active.workspace_id = i.workspace_id
-        AND active.recipient_type = i.recipient_type
-        AND active.recipient_id = i.recipient_id
-        AND active.issue_id = i.issue_id
-        AND active.archived = false
-  ))
-ORDER BY i.created_at DESC
-LIMIT 200
+ORDER BY i.created_at DESC, i.id DESC
 `
 
 type ListArchivedInboxItemsParams struct {
@@ -407,9 +464,13 @@ type ListArchivedInboxItemsRow struct {
 // the other's cache being loaded. Items without an issue_id group on their own
 // id and can never have an active sibling, hence the IS NULL short-circuit.
 //
-// LIMIT bounds the response while the archive grows without end (v1 ships no
-// pagination). Rows are newest-first, so truncation drops the OLDEST rows and
-// can never hide a group's newest row — the one the deduplicated UI renders.
+// LIMIT applies to ISSUE GROUPS, not raw notification rows. Applying it after
+// the final SELECT lets one noisy issue consume all 200 rows and hide other
+// archived issues, which makes both the visible list and its count too small.
+// The response stays bounded at two rows per group: the newest row the UI
+// renders plus, when different, the newest row carrying a comment anchor. The
+// client already merges those two rows while deduplicating, preserving direct
+// comment landing without sending every historical notification in the group.
 func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedInboxItemsParams) ([]ListArchivedInboxItemsRow, error) {
 	rows, err := q.db.Query(ctx, listArchivedInboxItems, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
 	if err != nil {

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -19,25 +19,61 @@ ORDER BY i.created_at DESC;
 -- the other's cache being loaded. Items without an issue_id group on their own
 -- id and can never have an active sibling, hence the IS NULL short-circuit.
 --
--- LIMIT bounds the response while the archive grows without end (v1 ships no
--- pagination). Rows are newest-first, so truncation drops the OLDEST rows and
--- can never hide a group's newest row — the one the deduplicated UI renders.
+-- LIMIT applies to ISSUE GROUPS, not raw notification rows. Applying it after
+-- the final SELECT lets one noisy issue consume all 200 rows and hide other
+-- archived issues, which makes both the visible list and its count too small.
+-- The response stays bounded at two rows per group: the newest row the UI
+-- renders plus, when different, the newest row carrying a comment anchor. The
+-- client already merges those two rows while deduplicating, preserving direct
+-- comment landing without sending every historical notification in the group.
+WITH eligible_archived AS MATERIALIZED (
+    SELECT i.*,
+           COALESCE(i.issue_id, i.id) AS group_id
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = $2
+      AND i.recipient_id = $3
+      AND i.archived = true
+      AND (i.issue_id IS NULL OR NOT EXISTS (
+          SELECT 1
+          FROM inbox_item active
+          WHERE active.workspace_id = i.workspace_id
+            AND active.recipient_type = i.recipient_type
+            AND active.recipient_id = i.recipient_id
+            AND active.issue_id = i.issue_id
+            AND active.archived = false
+      ))
+), newest_groups AS (
+    SELECT DISTINCT ON (group_id)
+           group_id,
+           id AS newest_id,
+           created_at AS newest_created_at
+    FROM eligible_archived
+    ORDER BY group_id, created_at DESC, id DESC
+), limited_groups AS (
+    SELECT group_id, newest_id
+    FROM newest_groups
+    ORDER BY newest_created_at DESC, newest_id DESC
+    LIMIT 200
+), comment_anchors AS (
+    SELECT DISTINCT ON (archived.group_id)
+           archived.group_id,
+           archived.id
+    FROM eligible_archived archived
+    JOIN limited_groups selected USING (group_id)
+    WHERE NULLIF(archived.details->>'comment_id', '') IS NOT NULL
+    ORDER BY archived.group_id, archived.created_at DESC, archived.id DESC
+), selected_ids AS (
+    SELECT newest_id AS id FROM limited_groups
+    UNION
+    SELECT id FROM comment_anchors
+)
 SELECT i.*,
        iss.status as issue_status
 FROM inbox_item i
+JOIN selected_ids selected ON selected.id = i.id
 LEFT JOIN issue iss ON iss.id = i.issue_id
-WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = true
-  AND (i.issue_id IS NULL OR NOT EXISTS (
-      SELECT 1
-      FROM inbox_item active
-      WHERE active.workspace_id = i.workspace_id
-        AND active.recipient_type = i.recipient_type
-        AND active.recipient_id = i.recipient_id
-        AND active.issue_id = i.issue_id
-        AND active.archived = false
-  ))
-ORDER BY i.created_at DESC
-LIMIT 200;
+ORDER BY i.created_at DESC, i.id DESC;
 
 -- name: GetInboxItem :one
 SELECT * FROM inbox_item
@@ -138,8 +174,33 @@ UPDATE inbox_item SET archived = true
 WHERE workspace_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND archived = false;
 
 -- name: ArchiveAllReadInbox :execrows
-UPDATE inbox_item SET archived = true
-WHERE workspace_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND read = true AND archived = false;
+-- "Read" is the state of the one issue row the inbox renders: the newest
+-- active notification in that issue group. Archive every row in groups whose
+-- newest row is read, and leave an unread group wholly untouched. Updating raw
+-- read rows instead makes an older unread sibling reappear after the newest
+-- row is archived (and can archive an older read sibling under an unread row).
+WITH newest_groups AS (
+    SELECT DISTINCT ON (COALESCE(i.issue_id, i.id))
+           COALESCE(i.issue_id, i.id) AS group_id,
+           i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = 'member'
+      AND i.recipient_id = $2
+      AND i.archived = false
+    ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+), read_groups AS (
+    SELECT group_id
+    FROM newest_groups
+    WHERE read = true
+)
+UPDATE inbox_item i SET archived = true
+FROM read_groups selected
+WHERE i.workspace_id = $1
+  AND i.recipient_type = 'member'
+  AND i.recipient_id = $2
+  AND i.archived = false
+  AND COALESCE(i.issue_id, i.id) = selected.group_id;
 
 -- name: ArchiveCompletedInbox :execrows
 UPDATE inbox_item i SET archived = true

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -26,9 +26,13 @@ ORDER BY i.created_at DESC;
 -- renders plus, when different, the newest row carrying a comment anchor. The
 -- client already merges those two rows while deduplicating, preserving direct
 -- comment landing without sending every historical notification in the group.
+-- Keep the materialized working set narrow: full row data is joined only for
+-- the final selected ids, not copied for every archived notification scanned.
 WITH eligible_archived AS MATERIALIZED (
-    SELECT i.*,
-           COALESCE(i.issue_id, i.id) AS group_id
+    SELECT i.id,
+           COALESCE(i.issue_id, i.id) AS group_id,
+           i.created_at,
+           i.details
     FROM inbox_item i
     WHERE i.workspace_id = $1
       AND i.recipient_type = $2


### PR DESCRIPTION
## Summary

- apply the archived inbox limit after selecting issue groups, so one noisy issue cannot hide other archived issues or shrink the displayed archive count
- keep the newest notification and optional comment anchor for each selected group while preserving the existing array response contract
- make “archive all read” use the newest active row’s read state and archive or retain the whole issue group consistently
- add database-backed regressions for both failure modes

## Verification

- `go test ./internal/handler -count=1`
- `go test ./cmd/server -run 'Test(ArchivedInboxThroughRouter|ArchivedInboxExcludesIssuesWithActiveItems|UnarchiveInboxPreservesUnread)$' -count=1`
- `make sqlc`

Closes MUL-6583
