### PR TITLE
MUL-6582: add schedule-pulse example plugin

### DIFF
--- a/examples/plugins/schedule-pulse/README.md
+++ b/examples/plugins/schedule-pulse/README.md
@@ -1,0 +1,48 @@
+# Schedule Pulse
+
+A real scheduled plugin, not a log line. Multica POSTs the plugin's own HTTPS
+endpoint every five minutes. The handler records each unique `delivery_id` in
+workspace storage **before** it answers, so a retry of the same planned wake
+does not look like a second pulse.
+
+The issue panel reads that storage row. After install you should see the count
+go up about once every five minutes, not on every HTTP attempt.
+
+## What it verifies
+
+| Host behavior | What this plugin does |
+| --- | --- |
+| Durable schedule trigger | Declares `triggers: ["schedule"]` and a five-minute cron |
+| At-least-once delivery | Persists `delivery_id` first; a retry with the same id returns `{duplicate: true}` |
+| Plugin actor | Writes as the installation through the callback token, into `storage:workspace` |
+| Consent | `net:pulse.example.com` is the only outbound host; schedule is not a data scope |
+
+It does not create issues. That is a later Plugin Action API, not this trigger.
+
+## Running the handler
+
+```bash
+MULTICA_SIGNING_SECRET=whsec_… node server/handler.mjs
+```
+
+The signing secret is shown once, next to the install token, when an admin
+rotates the plugin's token in workspace settings.
+
+Point `transport.url` at this process and declare the matching `net:` scope.
+Local development also needs:
+
+```bash
+export MULTICA_PLUGIN_DEV_ORIGINS=https://localhost:8787
+```
+
+Without that opt-in the host refuses a private address.
+
+## Why storage, not a log
+
+A log line cannot prove idempotency. The panel shows `count`, `delivery_id`,
+`planned_at`, and `attempt`. If the host retries the same plan, `attempt`
+changes and `count` does not.
+
+The callback token is revoked when this HTTP request returns. All storage
+writes happen before the 200. Work that must continue after the response
+should use the standing `mpi_` install token instead.

--- a/examples/plugins/schedule-pulse/multica.plugin.json
+++ b/examples/plugins/schedule-pulse/multica.plugin.json
@@ -1,0 +1,48 @@
+{
+  "manifest_version": 1,
+  "key": "ai.multica.schedule-pulse",
+  "name": "Schedule Pulse",
+  "description": "A scheduled Hook that Multica wakes every five minutes. Each unique delivery is recorded once in workspace storage, including when the host retries.",
+  "version": "1.0.0",
+  "author": {
+    "name": "multica",
+    "url": "https://multica.ai"
+  },
+  "scopes": [
+    "storage:workspace",
+    "net:pulse.example.com"
+  ],
+  "contributes": {
+    "surfaces": [
+      {
+        "key": "pulse",
+        "type": "issue_panel",
+        "name": "Schedule pulse",
+        "entry": "ui/main.js",
+        "platforms": [
+          "web",
+          "desktop"
+        ]
+      }
+    ],
+    "hooks": [
+      {
+        "key": "pulse",
+        "name": "Schedule pulse",
+        "description": "Records one workspace-storage pulse per planned delivery. Retries of the same delivery_id do not increment the count.",
+        "triggers": [
+          "schedule"
+        ],
+        "schedule": {
+          "cron": "*/5 * * * *",
+          "timezone": "UTC"
+        },
+        "transport": {
+          "type": "http",
+          "url": "https://pulse.example.com/hooks/pulse"
+        },
+        "timeout_ms": 8000
+      }
+    ]
+  }
+}

--- a/examples/plugins/schedule-pulse/server/handler.mjs
+++ b/examples/plugins/schedule-pulse/server/handler.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Schedule Pulse handler — the plugin author's side of a durable scheduled Hook.
+ *
+ * Run:
+ *   MULTICA_SIGNING_SECRET=whsec_... node handler.mjs
+ */
+
+import { createServer as createHTTPServer } from "node:http";
+import { createServer as createHTTPSServer } from "node:https";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const PORT = Number(process.env.PORT ?? 8787);
+const SIGNING_SECRET = process.env.MULTICA_SIGNING_SECRET ?? "";
+const TOLERANCE_SECONDS = 5 * 60;
+const PULSE_KEY = "last_pulse";
+
+if (!SIGNING_SECRET) {
+  console.error("MULTICA_SIGNING_SECRET is required. Rotate the plugin token in Multica to obtain it.");
+  process.exit(1);
+}
+
+const seenSignatures = new Map();
+
+function rememberSignature(signature, now) {
+  for (const [seen, at] of seenSignatures) {
+    if (now - at > TOLERANCE_SECONDS * 1000) seenSignatures.delete(seen);
+  }
+  if (seenSignatures.has(signature)) return false;
+  seenSignatures.set(signature, now);
+  return true;
+}
+
+function verify(rawBody, headers) {
+  const timestamp = headers["x-multica-timestamp"];
+  const presented = String(headers["x-multica-signature"] ?? "").replace(/^v1=/, "");
+  if (!timestamp || !presented) return "missing signature headers";
+
+  const drift = Math.abs(Math.floor(Date.now() / 1000) - Number(timestamp));
+  if (!Number.isFinite(drift) || drift > TOLERANCE_SECONDS) return "timestamp outside the accepted window";
+
+  const secret = Buffer.from(SIGNING_SECRET.replace(/^whsec_/, ""), "hex");
+  const expected = createHmac("sha256", secret)
+    .update(timestamp)
+    .update(".")
+    .update(rawBody)
+    .digest("hex");
+
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const presentedBytes = Buffer.from(presented, "utf8");
+  if (expectedBytes.length !== presentedBytes.length) return "signature does not match";
+  if (!timingSafeEqual(expectedBytes, presentedBytes)) return "signature does not match";
+  if (!rememberSignature(presented, Date.now())) return "this request was already delivered";
+  return null;
+}
+
+async function callback(body, method, path, payload) {
+  const response = await fetch(`${body.callback_url}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${body.callback_token}`,
+    },
+    body: payload === undefined ? undefined : JSON.stringify(payload),
+  });
+  const text = await response.text();
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Multica answered ${response.status}: ${text}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+async function loadPulse(body) {
+  const stored = await callback(body, "GET", `/storage/workspace/${PULSE_KEY}`);
+  if (!stored?.value) return { count: 0, delivery_id: "" };
+  try {
+    return JSON.parse(stored.value);
+  } catch {
+    return { count: 0, delivery_id: "" };
+  }
+}
+
+const tlsCert = process.env.MULTICA_HOOK_TLS_CERT;
+const tlsKey = process.env.MULTICA_HOOK_TLS_KEY;
+const createServer = tlsCert && tlsKey
+  ? (handler) => createHTTPSServer({ cert: readFileSync(tlsCert), key: readFileSync(tlsKey) }, handler)
+  : createHTTPServer;
+
+const server = createServer((request, response) => {
+  if (request.method !== "POST" || request.url !== "/hooks/pulse") {
+    response.writeHead(404).end();
+    return;
+  }
+
+  const chunks = [];
+  request.on("data", (chunk) => chunks.push(chunk));
+  request.on("end", async () => {
+    const rawBody = Buffer.concat(chunks);
+    const failure = verify(rawBody, request.headers);
+    if (failure) {
+      console.warn(`rejected: ${failure}`);
+      response.writeHead(401, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: failure }));
+      return;
+    }
+
+    const body = JSON.parse(rawBody.toString("utf8"));
+    if (body.hook_key !== "pulse" || body.trigger !== "schedule") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ skipped: "not a scheduled pulse" }));
+      return;
+    }
+    if (!body.delivery_id) {
+      response.writeHead(400, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "scheduled delivery is missing delivery_id" }));
+      return;
+    }
+
+    try {
+      const previous = await loadPulse(body);
+      if (previous.delivery_id === body.delivery_id) {
+        console.log(`duplicate delivery ${body.delivery_id} attempt ${body.attempt}`);
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ duplicate: true, delivery_id: body.delivery_id, count: previous.count }));
+        return;
+      }
+
+      const pulse = {
+        delivery_id: body.delivery_id,
+        count: (previous.count ?? 0) + 1,
+        last_planned_at: body.schedule?.planned_at ?? "",
+        last_occurred_at: body.occurred_at ?? "",
+        last_attempt: body.attempt ?? 1,
+      };
+      await callback(body, "PUT", `/storage/workspace/${PULSE_KEY}`, { value: JSON.stringify(pulse) });
+      console.log(`pulse ${pulse.count} delivery ${pulse.delivery_id} attempt ${pulse.last_attempt}`);
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ accepted: true, ...pulse }));
+    } catch (error) {
+      console.error(error);
+      response.writeHead(502, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "pulse failed" }));
+    }
+  });
+});
+
+server.listen(PORT, () => console.log(`schedule pulse listening on ${tlsCert ? "https" : "http"}://127.0.0.1:${PORT}`));

--- a/examples/plugins/schedule-pulse/ui/main.js
+++ b/examples/plugins/schedule-pulse/ui/main.js
@@ -1,0 +1,67 @@
+// Schedule Pulse — reads the workspace-storage row the scheduled Hook writes.
+//
+// Plain ES module, no build step. The surface has no credential; it talks to
+// Multica only through the host bridge.
+
+const pending = new Map();
+const port = globalThis.__multicaPluginBridgePortV2;
+let sequence = 0;
+
+if (!(port instanceof MessagePort)) throw new Error("Multica surface bridge is unavailable");
+delete globalThis.__multicaPluginBridgePortV2;
+port.onmessage = (message) => {
+  const payload = message.data;
+  if (payload?.kind === "theme") return applyTheme(payload.theme);
+  const entry = pending.get(payload?.id);
+  if (!entry) return;
+  pending.delete(payload.id);
+  if (payload.ok) entry.resolve(payload.data);
+  else entry.reject(new Error(payload.error));
+};
+port.start();
+start();
+
+function applyTheme(theme) {
+  for (const [name, value] of Object.entries(theme ?? {})) {
+    document.documentElement.style.setProperty(name, value);
+  }
+}
+
+function call(method, path, body) {
+  const id = `r${++sequence}`;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    port.postMessage({ id, kind: "action", method, path, body });
+  });
+}
+
+function resize() {
+  port.postMessage({ id: `resize${Date.now()}`, kind: "ui.resize", height: document.body.scrollHeight + 16 });
+}
+
+async function start() {
+  const root = document.getElementById("root");
+  root.innerHTML = `
+    <div style="padding:12px 14px; display:grid; gap:8px">
+      <div style="font-weight:600">Schedule pulse</div>
+      <div id="status" style="color:var(--muted-foreground)">Loading…</div>
+      <dl id="pulse" style="display:none; margin:0; grid-template-columns:auto 1fr; gap:4px 12px"></dl>
+    </div>`;
+
+  const status = root.querySelector("#status");
+  const list = root.querySelector("#pulse");
+  try {
+    const stored = await call("GET", "/storage/workspace/last_pulse");
+    const pulse = JSON.parse(stored.value);
+    status.textContent = "Multica has woken this plugin on a durable five-minute schedule.";
+    list.style.display = "grid";
+    list.innerHTML = `
+      <dt style="color:var(--muted-foreground)">Count</dt><dd style="margin:0">${pulse.count ?? 0}</dd>
+      <dt style="color:var(--muted-foreground)">Delivery</dt><dd style="margin:0; overflow-wrap:anywhere">${pulse.delivery_id ?? "—"}</dd>
+      <dt style="color:var(--muted-foreground)">Planned</dt><dd style="margin:0">${pulse.last_planned_at ?? "—"}</dd>
+      <dt style="color:var(--muted-foreground)">Attempt</dt><dd style="margin:0">${pulse.last_attempt ?? "—"}</dd>`;
+  } catch {
+    status.textContent = "No pulse yet. After install, Multica calls this plugin every five minutes and writes the first delivery here.";
+  }
+  resize();
+}

--- a/server/cmd/server/plugin_schedule_pulse_example_test.go
+++ b/server/cmd/server/plugin_schedule_pulse_example_test.go
@@ -1,0 +1,380 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/featureflags"
+	"github.com/multica-ai/multica/server/internal/scheduler"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+	"github.com/multica-ai/multica/server/pkg/plugincontract"
+)
+
+type schedulePulseState struct {
+	DeliveryID     string `json:"delivery_id"`
+	Count          int    `json:"count"`
+	LastPlannedAt  string `json:"last_planned_at"`
+	LastOccurredAt string `json:"last_occurred_at"`
+	LastAttempt    int    `json:"last_attempt"`
+}
+
+type schedulePulseHookBody struct {
+	DeliveryID   string `json:"delivery_id"`
+	InvocationID string `json:"invocation_id"`
+	Attempt      int    `json:"attempt"`
+	Trigger      string `json:"trigger"`
+	HookKey      string `json:"hook_key"`
+	OccurredAt   string `json:"occurred_at"`
+	CallbackURL  string `json:"callback_url"`
+	Callback     string `json:"callback_token"`
+	Schedule     struct {
+		PlannedAt string `json:"planned_at"`
+	} `json:"schedule"`
+}
+
+func schedulePulseExampleDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test file")
+	}
+	dir := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "examples", "plugins", "schedule-pulse")
+	if _, err := os.Stat(filepath.Join(dir, plugincontract.ManifestFilename)); err != nil {
+		t.Fatalf("the schedule-pulse example is missing: %v", err)
+	}
+	return dir
+}
+
+// TestSchedulePulseExampleManifestDrivesDurableRetry is the author-facing
+// proof for MUL-6582: the shipped example plugin, not a fixture, is installed
+// and woken by two scheduler replicas. The first HTTP attempt writes workspace
+// storage and then drops the connection; the retry keeps the same delivery_id
+// and does not increment the pulse count.
+func TestSchedulePulseExampleManifestDrivesDurableRetry(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+
+	var (
+		mu            sync.Mutex
+		hookCalls     int
+		signingSecret string
+		callbacks     = service.NewCallbackTokens()
+	)
+
+	plugins := service.NewPluginService(queries, testPool)
+	provider := featureflag.NewStaticProvider()
+	provider.Set(featureflags.PluginsV1, featureflag.Rule{Default: true})
+	plugins.FeatureFlags = featureflag.NewService(provider)
+	plugins.DeploymentKey = []byte("0123456789abcdef0123456789abcdef")
+	plugins.Callbacks = callbacks
+
+	action := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		grant, err := callbacks.Resolve(token)
+		if err != nil || grant.Trigger != plugincontract.TriggerSchedule || grant.Actor.Type != "plugin" {
+			http.Error(w, "callback grant", http.StatusUnauthorized)
+			return
+		}
+		scopeID, err := service.ResolveStorageScope(service.PluginStorageWorkspace, grant.WorkspaceID, pgtype.UUID{})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		key := strings.TrimPrefix(r.URL.Path, "/storage/workspace/")
+		switch {
+		case r.Method == http.MethodGet:
+			value, getErr := plugins.GetStorageValue(r.Context(), grant.InstallationID, service.PluginStorageWorkspace, scopeID, key)
+			if getErr != nil {
+				var pluginErr *service.PluginError
+				if errors.As(getErr, &pluginErr) && pluginErr.Kind == service.PluginErrorNotFound {
+					http.Error(w, pluginErr.Message, http.StatusNotFound)
+					return
+				}
+				http.Error(w, getErr.Error(), http.StatusBadGateway)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"value": value})
+		case r.Method == http.MethodPut:
+			var payload struct {
+				Value string `json:"value"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, "json", http.StatusBadRequest)
+				return
+			}
+			if err := plugins.SetStorageValue(r.Context(), grant.InstallationID, service.PluginStorageWorkspace, scopeID, key, payload.Value); err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(action.Close)
+	plugins.CallbackBaseURL = action.URL
+
+	endpoint := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/hooks/pulse" {
+			http.NotFound(w, r)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		secret := signingSecret
+		mu.Unlock()
+		if err := service.VerifyHookSignature(
+			secret,
+			r.Header.Get("X-Multica-Timestamp"),
+			raw,
+			r.Header.Get("X-Multica-Signature"),
+			time.Now(),
+		); err != nil {
+			http.Error(w, "signature", http.StatusUnauthorized)
+			return
+		}
+		var body schedulePulseHookBody
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, "json", http.StatusBadRequest)
+			return
+		}
+		if body.HookKey != "pulse" || body.Trigger != plugincontract.TriggerSchedule || body.DeliveryID == "" {
+			http.Error(w, "not a scheduled pulse", http.StatusBadRequest)
+			return
+		}
+		req, err := http.NewRequest(http.MethodGet, body.CallbackURL+"/storage/workspace/last_pulse", nil)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+body.Callback)
+		stored, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		storedBody, _ := io.ReadAll(stored.Body)
+		_ = stored.Body.Close()
+		previous := schedulePulseState{}
+		if stored.StatusCode == http.StatusOK {
+			var wrapped struct {
+				Value string `json:"value"`
+			}
+			if err := json.Unmarshal(storedBody, &wrapped); err == nil {
+				_ = json.Unmarshal([]byte(wrapped.Value), &previous)
+			}
+		} else if stored.StatusCode != http.StatusNotFound {
+			http.Error(w, "storage get", http.StatusBadGateway)
+			return
+		}
+
+		mu.Lock()
+		hookCalls++
+		attemptIndex := hookCalls
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if previous.DeliveryID == body.DeliveryID {
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"duplicate":true,"delivery_id":%q,"count":%d}`, body.DeliveryID, previous.Count)))
+			return
+		}
+		pulse := schedulePulseState{
+			DeliveryID:     body.DeliveryID,
+			Count:          previous.Count + 1,
+			LastPlannedAt:  body.Schedule.PlannedAt,
+			LastOccurredAt: body.OccurredAt,
+			LastAttempt:    body.Attempt,
+		}
+		encoded, _ := json.Marshal(pulse)
+		put, err := http.NewRequest(http.MethodPut, body.CallbackURL+"/storage/workspace/last_pulse", strings.NewReader(fmt.Sprintf(`{"value":%s}`, strconvQuote(string(encoded)))))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		put.Header.Set("Authorization", "Bearer "+body.Callback)
+		put.Header.Set("Content-Type", "application/json")
+		putResp, err := http.DefaultClient.Do(put)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		_ = putResp.Body.Close()
+		if putResp.StatusCode != http.StatusNoContent {
+			http.Error(w, "storage put", http.StatusBadGateway)
+			return
+		}
+		if attemptIndex == 1 {
+			connection, _, hijackErr := w.(http.Hijacker).Hijack()
+			if hijackErr != nil {
+				http.Error(w, "hijack", http.StatusInternalServerError)
+				return
+			}
+			_ = connection.Close()
+			return
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"accepted":true,"delivery_id":%q,"count":%d}`, pulse.DeliveryID, pulse.Count)))
+	}))
+	t.Cleanup(endpoint.Close)
+
+	parsedEndpoint, err := url.Parse(endpoint.URL)
+	if err != nil {
+		t.Fatalf("parse endpoint: %v", err)
+	}
+	_, port, err := net.SplitHostPort(parsedEndpoint.Host)
+	if err != nil {
+		t.Fatalf("split endpoint: %v", err)
+	}
+	hookOrigin := "https://pulse.example.com:" + port
+	client := endpoint.Client()
+	transport := client.Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, endpoint.Listener.Addr().String())
+	}
+	client.Transport = transport
+	plugins.DevOrigins = []string{hookOrigin}
+	plugins.HookClient = client
+
+	raw, err := os.ReadFile(filepath.Join(schedulePulseExampleDir(t), plugincontract.ManifestFilename))
+	if err != nil {
+		t.Fatalf("read example manifest: %v", err)
+	}
+	rewritten := strings.ReplaceAll(string(raw), "https://pulse.example.com", hookOrigin)
+	manifest, canonical, err := plugincontract.ParseManifest([]byte(rewritten))
+	if err != nil {
+		t.Fatalf("example manifest does not parse: %v", err)
+	}
+	if err := manifest.CheckCapabilities(plugincontract.HostCapabilities()); err != nil {
+		t.Fatalf("example cannot install on this host: %v", err)
+	}
+	grantedScopes, _ := json.Marshal(manifest.Scopes)
+	installation, err := queries.CreatePluginInstallation(ctx, db.CreatePluginInstallationParams{
+		WorkspaceID:      parseUUID(testWorkspaceID),
+		PluginKey:        manifest.Key,
+		PackageVersionID: pgtype.UUID{Bytes: uuid.New(), Valid: true},
+		Version:          manifest.Version,
+		Manifest:         canonical,
+		GrantedScopes:    grantedScopes,
+		InstalledBy:      parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("create plugin installation: %v", err)
+	}
+	derivedSigningSecret, err := plugins.HookSigningSecret(installation.ID)
+	if err != nil {
+		t.Fatalf("derive signing secret: %v", err)
+	}
+	mu.Lock()
+	signingSecret = derivedSigningSecret
+	mu.Unlock()
+	scheduleRow, err := queries.CreatePluginHookSchedule(ctx, db.CreatePluginHookScheduleParams{
+		InstallationID: installation.ID,
+		WorkspaceID:    installation.WorkspaceID,
+		HookKey:        "pulse",
+		CronExpression: "*/5 * * * *",
+		Timezone:       "UTC",
+		Enabled:        true,
+	})
+	if err != nil {
+		t.Fatalf("create plugin schedule: %v", err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`UPDATE plugin_hook_schedule SET activated_at = now() - interval '6 minutes' WHERE id = $1`,
+		scheduleRow.ID,
+	); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+	scopeID := util.UUIDToString(scheduleRow.ID) + ":" + util.UUIDToString(scheduleRow.Generation)
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = testPool.Exec(cleanupCtx,
+			`DELETE FROM sys_cron_executions WHERE job_name = $1 AND scope_id = $2`,
+			scheduler.JobNamePluginHookScheduleDispatch, scopeID,
+		)
+		_ = queries.DeletePluginHookSchedulesByInstallation(cleanupCtx, installation.ID)
+		_ = queries.DeletePluginStorageByInstallation(cleanupCtx, installation.ID)
+		_ = queries.DeletePluginInvocationsByInstallation(cleanupCtx, installation.ID)
+		_ = queries.DeletePluginInstallation(cleanupCtx, installation.ID)
+	})
+
+	managerA := scheduler.NewManager(testPool, scheduler.Options{RunnerID: "schedule-pulse-a"})
+	managerB := scheduler.NewManager(testPool, scheduler.Options{RunnerID: "schedule-pulse-b"})
+	for _, manager := range []*scheduler.Manager{managerA, managerB} {
+		if err := manager.Register(scheduler.PluginHookScheduleDispatchJob(queries, plugins)); err != nil {
+			t.Fatalf("register plugin schedule job: %v", err)
+		}
+	}
+	runManagersTogether(t, ctx, managerA, managerB)
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sys_cron_executions
+		SET next_retry_at = now() - interval '1 second'
+		WHERE job_name = $1 AND scope_kind = $2 AND scope_id = $3
+	`, scheduler.JobNamePluginHookScheduleDispatch, scheduler.ScopeKindPluginHookSchedule, scopeID); err != nil {
+		t.Fatalf("make retry due: %v", err)
+	}
+	runManagersTogether(t, ctx, managerA, managerB)
+
+	var status string
+	var attempt int
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, attempt
+		FROM sys_cron_executions
+		WHERE job_name = $1 AND scope_kind = $2 AND scope_id = $3
+	`, scheduler.JobNamePluginHookScheduleDispatch, scheduler.ScopeKindPluginHookSchedule, scopeID).Scan(&status, &attempt); err != nil {
+		t.Fatalf("load execution: %v", err)
+	}
+	if status != "SUCCESS" || attempt != 2 {
+		t.Fatalf("execution = %s attempt %d, want SUCCESS attempt 2", status, attempt)
+	}
+
+	mu.Lock()
+	calls := hookCalls
+	mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("hook calls=%d, want 2", calls)
+	}
+
+	scopeIDUUID, err := service.ResolveStorageScope(service.PluginStorageWorkspace, installation.WorkspaceID, pgtype.UUID{})
+	if err != nil {
+		t.Fatalf("resolve storage scope: %v", err)
+	}
+	value, err := plugins.GetStorageValue(ctx, installation.ID, service.PluginStorageWorkspace, scopeIDUUID, "last_pulse")
+	if err != nil {
+		t.Fatalf("read pulse storage: %v", err)
+	}
+	var pulse schedulePulseState
+	if err := json.Unmarshal([]byte(value), &pulse); err != nil {
+		t.Fatalf("decode pulse storage: %v", err)
+	}
+	if pulse.Count != 1 || pulse.DeliveryID == "" {
+		t.Fatalf("pulse storage = %+v, want count 1 with a delivery_id", pulse)
+	}
+}
+
+func strconvQuote(s string) string {
+	encoded, _ := json.Marshal(s)
+	return string(encoded)
+}


### PR DESCRIPTION
Follow-up to #7448. Adds a real scheduled plugin that Multica can install and wake every five minutes.

**What it is**
- `examples/plugins/schedule-pulse`: manifest with a `schedule` trigger, HMAC-verifying handler, workspace-storage pulse, and a panel that shows the last delivery.
- Each unique `delivery_id` is written once. A retry of the same planned wake returns `{duplicate: true}` and does not increment the count.

**Verification**
`TestSchedulePulseExampleManifestDrivesDurableRetry` installs this example manifest (not a fixture), runs two scheduler replicas, drops the first HTTP response after storage is written, and asserts the retry keeps the same `delivery_id` with `count == 1`.

Does not add issue create, Discord logic, or `Closes MUL-6582` — that belongs on #7448.