### PR TITLE
fix(pi): keep turn error when process exits 1 [MUL-6585]

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -429,7 +429,20 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			finalError = "execution cancelled"
 		} else if waitErr != nil && finalStatus == "completed" {
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("%s exited with error: %v", label, waitErr)
+			// Prefer the turn's provider message over the process exit code.
+			// Pi (and pi-print-clean-exit) exits 1 after stopReason=error, so
+			// Wait() wins this branch and used to drop lastTurnError. The
+			// classifier then saw only "exit status 1" and filed the run as
+			// non-retryable process_failure — even when the turn was a
+			// transient LiteLLM/OpenAI "Connection error." / "Request timed
+			// out." Keep the exit status as a suffix so a genuine crash is
+			// still visible (same shape as the OpenCode empty-step+exit
+			// composite).
+			if lastTurnError != "" {
+				finalError = fmt.Sprintf("%s; %s exited with error: %v", lastTurnError, label, waitErr)
+			} else {
+				finalError = fmt.Sprintf("%s exited with error: %v", label, waitErr)
+			}
 		} else if writeErr != nil && finalStatus == "completed" {
 			finalStatus = "failed"
 			finalError = fmt.Sprintf("%s prompt write failed: %v", label, writeErr)

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"runtime"
@@ -229,6 +230,13 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 // piEventStreamScript builds a sh script that prints each JSON event on
 // its own stdout line. Fixtures must not contain single quotes.
 func piEventStreamScript(events []string) string {
+	return piEventStreamScriptWithExit(events, 0)
+}
+
+// piEventStreamScriptWithExit is piEventStreamScript plus an explicit
+// process exit code. Real Pi (and pi-print-clean-exit) exits 1 after a
+// turn whose last assistant stopReason is "error".
+func piEventStreamScriptWithExit(events []string, exitCode int) string {
 	var b strings.Builder
 	b.WriteString("#!/bin/sh\n")
 	// Real Pi reads the piped prompt to EOF before emitting events, so the fake
@@ -241,6 +249,9 @@ func piEventStreamScript(events []string) string {
 		b.WriteString("printf '%s\\n' '")
 		b.WriteString(e)
 		b.WriteString("'\n")
+	}
+	if exitCode != 0 {
+		b.WriteString(fmt.Sprintf("exit %d\n", exitCode))
 	}
 	return b.String()
 }
@@ -390,6 +401,59 @@ func TestPiExecuteSucceedsWhenRetryFollowsTurnError(t *testing.T) {
 		}
 		if result.Output != "recovered" {
 			t.Fatalf("Output: got %q, want %q", result.Output, "recovered")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestPiExecuteKeepsTurnErrorWhenProcessExitsNonZero(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Real Pi (and pi-print-clean-exit) exits 1 after stopReason=error.
+	// Wait() used to win the completed-branch and drop lastTurnError, so
+	// the classifier only saw "exit status 1" (non-retryable
+	// process_failure). The provider message must survive so
+	// "Connection error." / "Request timed out." classify as
+	// provider_network.
+	events := []string{
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"turn_end","message":{"role":"assistant","content":[],"model":"test","usage":{"input":0,"output":0},"stopReason":"error","errorMessage":"Connection error."}}`,
+		`{"type":"agent_end","messages":[],"willRetry":false}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScriptWithExit(events, 1)))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Connection error.") {
+			t.Fatalf("Error: got %q, want it to carry the provider message", result.Error)
+		}
+		if !strings.Contains(result.Error, "exited with error") {
+			t.Fatalf("Error: got %q, want the process exit still visible as a suffix", result.Error)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -194,27 +194,26 @@ func Classify(rawError string) Reason {
 	//    the bare strings "Connection error." and "Request timed out." on
 	//    turn_end.errorMessage (then exits 1). Those used to fall through to
 	//    process_failure via "exit status 1" and terminate the task with no
-	//    retry (BHD-135). Matched here, before rule 13, so a composite
-	//    "Connection error.; pi exited with error: exit status 1" still
-	//    routes to the retryable provider_network bucket.
-	//    Mirror these substrings into the MUL-1949 offline backfill SQL.
-	case containsAny(lower,
-		"stream disconnected",
-		opencodeStreamEndedPrefix,
-		"connection closed",
-		"connection error",
-		"mid-response",
-		"error sending request",
-		"unable to connect",
-		"dial tcp",
-		"connection refused",
-		"connectionrefused",
-		"dns",
-		"i/o timeout",
-		"deadline exceeded",
-		"timeout exceeded while awaiting",
-		"request timed out",
-	):
+	//    retry (BHD-135). isPiProviderNetworkError matches only the exact bare
+	//    messages and the stable Pi/OMP exit composite, rather than treating
+	//    the same broad substrings from local tools or MCP servers as retryable.
+	//    Mirror these Pi message shapes into the MUL-1949 offline backfill SQL.
+	case isPiProviderNetworkError(lower),
+		containsAny(lower,
+			"stream disconnected",
+			opencodeStreamEndedPrefix,
+			"connection closed",
+			"mid-response",
+			"error sending request",
+			"unable to connect",
+			"dial tcp",
+			"connection refused",
+			"connectionrefused",
+			"dns",
+			"i/o timeout",
+			"deadline exceeded",
+			"timeout exceeded while awaiting",
+		):
 		return ReasonAgentProviderNetwork
 
 	// 8. Model not found / unavailable. The SQL uses `%model%not%found%`,
@@ -404,6 +403,17 @@ var legacyOpenclawCLITimeoutReasons = map[string]bool{
 	string(ReasonAgentUnknown):         true,
 	string(ReasonAgentProviderNetwork): true,
 	"agent_error":                      true,
+}
+
+func isPiProviderNetworkError(lower string) bool {
+	for _, message := range []string{"connection error.", "request timed out."} {
+		if lower == message ||
+			strings.HasPrefix(lower, message+"; pi exited with error: ") ||
+			strings.HasPrefix(lower, message+"; omp exited with error: ") {
+			return true
+		}
+	}
+	return false
 }
 
 // opencodeStreamEndedPrefix opens every failure the OpenCode terminal-signal

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -190,11 +190,19 @@ func Classify(rawError string) Reason {
 	//    matching rule 13 by accident) and agent_error.unknown respectively;
 	//    neither is on the retry allowlist, so a transient cut ended the task
 	//    outright and max_attempts never applied (#6522).
+	//    Pi's OpenAI-compatible SDK surfaces a dropped LiteLLM/OpenAI call as
+	//    the bare strings "Connection error." and "Request timed out." on
+	//    turn_end.errorMessage (then exits 1). Those used to fall through to
+	//    process_failure via "exit status 1" and terminate the task with no
+	//    retry (BHD-135). Matched here, before rule 13, so a composite
+	//    "Connection error.; pi exited with error: exit status 1" still
+	//    routes to the retryable provider_network bucket.
 	//    Mirror these substrings into the MUL-1949 offline backfill SQL.
 	case containsAny(lower,
 		"stream disconnected",
 		opencodeStreamEndedPrefix,
 		"connection closed",
+		"connection error",
 		"mid-response",
 		"error sending request",
 		"unable to connect",
@@ -205,6 +213,7 @@ func Classify(rawError string) Reason {
 		"i/o timeout",
 		"deadline exceeded",
 		"timeout exceeded while awaiting",
+		"request timed out",
 	):
 		return ReasonAgentProviderNetwork
 

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -121,6 +121,13 @@ func TestClassifyRules(t *testing.T) {
 		{"opencode continuation never started", "opencode stream ended without a terminal signal (last step required a continuation that never started)", ReasonAgentProviderNetwork},
 		{"opencode empty final step", "opencode stream ended on an empty step (no text, no tool call, no reported usage) — the provider produced nothing", ReasonAgentProviderNetwork},
 		{"opencode empty step with process exit appended", "opencode stream ended on an empty step (no text, no tool call, no reported usage) — the provider produced nothing; opencode exited with error: exit status 1", ReasonAgentProviderNetwork},
+		// BHD-135: Pi's OpenAI-compatible SDK wording for a dropped LiteLLM
+		// call. Bare strings, then the same strings glued to "exit status 1"
+		// after pi-print-clean-exit forces a non-zero wrap-up.
+		{"pi connection error", "Connection error.", ReasonAgentProviderNetwork},
+		{"pi connection error with exit status wins over process failure", "Connection error.; pi exited with error: exit status 1", ReasonAgentProviderNetwork},
+		{"pi request timed out", "Request timed out.", ReasonAgentProviderNetwork},
+		{"pi request timed out with exit status wins over process failure", "Request timed out.; pi exited with error: exit status 1", ReasonAgentProviderNetwork},
 
 		// 8. Model not found / unavailable.
 		{"model not found", "Error: model claude-3-opus-99 not found", ReasonAgentModelNotFoundOrUnavailable},

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -128,6 +128,7 @@ func TestClassifyRules(t *testing.T) {
 		{"pi connection error with exit status wins over process failure", "Connection error.; pi exited with error: exit status 1", ReasonAgentProviderNetwork},
 		{"pi request timed out", "Request timed out.", ReasonAgentProviderNetwork},
 		{"pi request timed out with exit status wins over process failure", "Request timed out.; pi exited with error: exit status 1", ReasonAgentProviderNetwork},
+		{"omp connection error with exit status wins over process failure", "Connection error.; omp exited with error: exit status 1", ReasonAgentProviderNetwork},
 
 		// 8. Model not found / unavailable.
 		{"model not found", "Error: model claude-3-opus-99 not found", ReasonAgentModelNotFoundOrUnavailable},
@@ -165,6 +166,12 @@ func TestClassifyRules(t *testing.T) {
 		// 14. Catchall.
 		{"unrecognized", "the agent gave up for reasons unknown", ReasonAgentUnknown},
 		{"sentence with no marker", "Hello world.", ReasonAgentUnknown},
+		// Pi's two short provider messages must not become broad substring
+		// matches: local tool and MCP failures are deterministic and retrying
+		// them only repeats the same failure.
+		{"local tool connection error is not provider network", "local tool connection error while opening its database", ReasonAgentUnknown},
+		{"mcp request timeout is not provider network", "MCP server request timed out while loading configuration", ReasonAgentUnknown},
+		{"local connection error with exit remains process failure", "MCP server connection error; agent exited with error: exit status 1", ReasonAgentProcessFailure},
 
 		// 15. Digit-boundary regression: 3-digit HTTP status codes must NOT
 		//     match when embedded in a longer number. Before the fix these


### PR DESCRIPTION
## Summary

Pi (and the local `pi-print-clean-exit` extension) exits 1 after a turn whose last assistant `stopReason` is `error`. The pi backend then overwrote `lastTurnError` with `pi exited with error: exit status 1`, so `taskfailure.Classify` filed a LiteLLM/OpenAI `Connection error.` / `Request timed out.` as **non-retryable** `agent_error.process_failure`.

That is the same class of bug as MUL-4910 / #6522: a transient provider drop becomes a terminal failure with no session resume.

## What changed

1. `pkg/agent/pi.go` — if Wait() is non-zero **and** the last turn carried `errorMessage`, keep that message and append the exit status (same composite shape as OpenCode empty-step + exit).
2. `pkg/taskfailure/classify.go` — classify only the exact Pi/OMP `Connection error.` and `Request timed out.` messages, plus their stable process-exit composites, as `provider_network`. Broad substring matches are intentionally avoided so deterministic local tool or MCP failures do not receive provider retries.

## Evidence (local, 2026-08-23)

Four `bhd-main2:cli-pi` tasks all ended `agent_error.process_failure` / `pi exited with error: exit status 1` while the runtime was **online**. Pi session JSONL last assistant:

| Task | Issue | errorMessage |
|---|---|---|
| `01a02ccd-4428-…` | BHD-113 | `Connection error.` (after posting the explore comment) |
| `01a02cdc-250e-…` | BHD-115 | `Request timed out.` |
| `01a02ce2-9c7e-…` | BHD-118 | `Request timed out.` |
| `01a028fe-df43-…` | BHD-19 | `Request timed out.` |

Daemon: `agent result detail … agent_error="pi exited with error: exit status 1"` — `lastTurnError` was dropped.

This is **not** a wrap-up-after-success false fail. BHD-113 posted a comment, then the *next* completion died. BHD-118 died mid-RED-tests. Auto-retry does not apply to `process_failure`.

## Tests

```text
go test ./pkg/agent -count=1 -run 'TestPiExecute'
go test ./pkg/taskfailure -count=1
go vet ./pkg/agent/ ./pkg/taskfailure/
```

Coverage includes the non-zero Pi exit regression, the exact bare and Pi/OMP composite provider errors, and negative cases proving that local tool or MCP errors containing the same phrases are not classified as retryable provider failures.

The matching MUL-1949 offline-backfill update is tracked separately in MUL-6628 because that SQL is maintained outside this repository.
