### PR TITLE
fix(runtime): classify storage exhaustion (MUL-6589)

### DIFF
--- a/packages/core/dashboard/failure-class.test.ts
+++ b/packages/core/dashboard/failure-class.test.ts
@@ -18,6 +18,7 @@ describe("failureClassOf", () => {
     // MUL-5370: the run never reached the model provider, so this belongs
     // with the substrate failures an operator fixes by checking the daemon.
     expect(failureClassOf("skill_bundle_unavailable")).toBe("runtime");
+    expect(failureClassOf("runtime_storage_exhausted")).toBe("runtime");
     expect(failureClassOf("agent_error.process_failure")).toBe("agent");
     // MUL-5722: the daemon and the provider are both healthy — codex could
     // not hand its own stored thread back — so this reads as an agent-side

--- a/packages/core/dashboard/failure-class.ts
+++ b/packages/core/dashboard/failure-class.ts
@@ -70,6 +70,7 @@ const REASON_CLASS: Record<string, FailureClass> = {
   // fix is on the host running the daemon — a faster CLI or a raised timeout —
   // not with the model provider, which was never contacted.
   runtime_cli_timeout: "runtime",
+  runtime_storage_exhausted: "runtime",
 
   // The agent process itself produced the failure.
   "agent_error.process_failure": "agent",

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5254,6 +5254,9 @@ func taskRunFailureReason(err error) string {
 	if errors.Is(err, execenv.ErrOpenclawCLITimeout) {
 		return taskfailure.ReasonRuntimeCLITimeout.String()
 	}
+	if execenv.IsStorageExhausted(err) {
+		return taskfailure.ReasonRuntimeStorageExhausted.String()
+	}
 	return taskfailure.Classify(err.Error()).String()
 }
 

--- a/server/internal/daemon/execenv/isolation.go
+++ b/server/internal/daemon/execenv/isolation.go
@@ -67,7 +67,18 @@ type preparationResponse struct {
 
 // preparationErrorKindOpenclawCLITimeout marks a helper failure caused by the
 // local openclaw CLI missing its deadline (ErrOpenclawCLITimeout).
-const preparationErrorKindOpenclawCLITimeout = "openclaw_cli_timeout"
+const (
+	preparationErrorKindOpenclawCLITimeout = "openclaw_cli_timeout"
+	preparationErrorKindStorageExhausted   = "storage_exhausted"
+)
+
+// ErrStorageExhausted preserves a platform disk-full failure across the
+// preparation helper's JSON boundary.
+var ErrStorageExhausted = errors.New("storage exhausted")
+
+func IsStorageExhausted(err error) bool {
+	return errors.Is(err, ErrStorageExhausted) || isPlatformStorageExhausted(err)
+}
 
 // preparationKindError re-attaches a sentinel to an error that crossed the
 // helper boundary as text, so the daemon's classifier sees the same
@@ -87,6 +98,9 @@ func preparationErrorKind(err error) string {
 	if errors.Is(err, ErrOpenclawCLITimeout) {
 		return preparationErrorKindOpenclawCLITimeout
 	}
+	if IsStorageExhausted(err) {
+		return preparationErrorKindStorageExhausted
+	}
 	return ""
 }
 
@@ -97,6 +111,8 @@ func rehydratePreparationError(message, kind string) error {
 	switch kind {
 	case preparationErrorKindOpenclawCLITimeout:
 		return &preparationKindError{msg: message, kind: ErrOpenclawCLITimeout}
+	case preparationErrorKindStorageExhausted:
+		return &preparationKindError{msg: message, kind: ErrStorageExhausted}
 	default:
 		return errors.New(message)
 	}

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -259,6 +259,19 @@ func TestRehydratePreparationErrorUnknownKind(t *testing.T) {
 	}
 }
 
+func TestPreparationErrorKindRoundTripsStorageExhaustion(t *testing.T) {
+	err := fmt.Errorf("mkdir task workspace: %w", ErrStorageExhausted)
+	kind := preparationErrorKind(err)
+	if kind != "storage_exhausted" {
+		t.Fatalf("preparationErrorKind = %q, want storage_exhausted", kind)
+	}
+
+	rehydrated := rehydratePreparationError(err.Error(), kind)
+	if !IsStorageExhausted(rehydrated) {
+		t.Errorf("storage exhaustion sentinel did not survive helper boundary: %v", rehydrated)
+	}
+}
+
 // TestPrepareIsolatedKeepsTheClaimWithTheParent is the production-path
 // regression. Every real daemon prepares through PrepareIsolated, and the
 // helper is a short-lived child process: a lock taken inside it is released by

--- a/server/internal/daemon/execenv/isolation_unix.go
+++ b/server/internal/daemon/execenv/isolation_unix.go
@@ -11,6 +11,8 @@ import (
 
 type preparationProcessController struct{}
 
+func isPlatformStorageExhausted(err error) bool { return errors.Is(err, syscall.ENOSPC) }
+
 func newPreparationProcessController(cmd *exec.Cmd) (*preparationProcessController, error) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/server/internal/daemon/execenv/isolation_unix_test.go
+++ b/server/internal/daemon/execenv/isolation_unix_test.go
@@ -83,3 +83,9 @@ func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 		t.Fatalf("retry environment = %#v, want the predicted root", env)
 	}
 }
+
+func TestUnixStorageExhaustionError(t *testing.T) {
+	if !IsStorageExhausted(syscall.ENOSPC) {
+		t.Error("ENOSPC must be classified as storage exhaustion")
+	}
+}

--- a/server/internal/daemon/execenv/isolation_windows.go
+++ b/server/internal/daemon/execenv/isolation_windows.go
@@ -3,6 +3,7 @@
 package execenv
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"time"
@@ -13,6 +14,11 @@ import (
 
 type preparationProcessController struct {
 	job windows.Handle
+}
+
+func isPlatformStorageExhausted(err error) bool {
+	return errors.Is(err, windows.ERROR_DISK_FULL) ||
+		errors.Is(err, windows.ERROR_HANDLE_DISK_FULL)
 }
 
 // jobObjectBasicAccountingInformation mirrors JOBOBJECT_BASIC_ACCOUNTING_INFORMATION.

--- a/server/internal/daemon/execenv/isolation_windows_test.go
+++ b/server/internal/daemon/execenv/isolation_windows_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -138,5 +140,13 @@ func TestPrepareIsolated_WindowsKillsDescendantBeforeRetry(t *testing.T) {
 	}
 	if env == nil || env.RootDir != PredictRootDir(params.WorkspacesRoot, params.WorkspaceID, params.TaskID) {
 		t.Fatalf("retry environment = %#v, want the predicted root", env)
+	}
+}
+
+func TestWindowsStorageExhaustionErrors(t *testing.T) {
+	for _, err := range []error{windows.ERROR_DISK_FULL, windows.ERROR_HANDLE_DISK_FULL} {
+		if !IsStorageExhausted(err) {
+			t.Errorf("IsStorageExhausted(%v) = false, want true", err)
+		}
 	}
 }

--- a/server/internal/daemon/runtime_storage_exhausted_test.go
+++ b/server/internal/daemon/runtime_storage_exhausted_test.go
@@ -1,0 +1,20 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+func TestTaskRunFailureReasonLabelsStorageExhaustion(t *testing.T) {
+	err := fmt.Errorf(
+		"prepare execution environment: execenv: mkdir /data/workspaces/82be3a30-d4ec-401e-8ea0-8b564565ebaf: %w",
+		execenv.ErrStorageExhausted,
+	)
+
+	if got, want := taskRunFailureReason(err), taskfailure.ReasonRuntimeStorageExhausted.String(); got != want {
+		t.Errorf("taskRunFailureReason = %q, want %q", got, want)
+	}
+}

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -445,7 +445,11 @@ func NormalizeDaemonReason(reason, rawError string) Reason {
 	storageError := strings.ToLower(strings.TrimSpace(rawError))
 	if legacyStorageExhaustedReasons[reason] &&
 		strings.HasPrefix(storageError, "prepare execution environment:") &&
-		strings.Contains(storageError, "no space left on device") {
+		containsAny(storageError,
+			"no space left on device",
+			"the disk is full",
+			"there is not enough space on the disk",
+		) {
 		return ReasonRuntimeStorageExhausted
 	}
 	if legacySkillBundleReasons[reason] &&

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -397,6 +397,12 @@ var legacyOpenclawCLITimeoutReasons = map[string]bool{
 	"agent_error":                      true,
 }
 
+var legacyStorageExhaustedReasons = map[string]bool{
+	string(ReasonAgentProviderAuthOrAccess): true,
+	string(ReasonAgentUnknown):              true,
+	"agent_error":                           true,
+}
+
 // opencodeStreamEndedPrefix opens every failure the OpenCode terminal-signal
 // guard raises (pkg/agent/opencode.go). Exactly one code path emits it, and it
 // is a PREFIX of the whole error rather than a phrase somewhere inside it, so
@@ -436,6 +442,12 @@ var legacyOpencodeStreamEndedReasons = map[string]bool{
 // can be deleted once no daemon old enough to produce its wire shape is still
 // reporting.
 func NormalizeDaemonReason(reason, rawError string) Reason {
+	storageError := strings.ToLower(strings.TrimSpace(rawError))
+	if legacyStorageExhaustedReasons[reason] &&
+		strings.HasPrefix(storageError, "prepare execution environment:") &&
+		strings.Contains(storageError, "no space left on device") {
+		return ReasonRuntimeStorageExhausted
+	}
 	if legacySkillBundleReasons[reason] &&
 		strings.HasPrefix(strings.TrimSpace(rawError), legacySkillBundlePrefix) {
 		return ReasonSkillBundleUnavailable

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -445,16 +445,19 @@ func TestNormalizeDaemonReason_UpgradedReasonIsPlatformSide(t *testing.T) {
 }
 
 func TestNormalizeDaemonReasonUpgradesLegacyStorageExhaustion(t *testing.T) {
-	raw := "prepare execution environment: execenv: mkdir " +
-		"/workspaces/task: no space left on device"
-
-	for _, legacy := range []string{
-		ReasonAgentProviderAuthOrAccess.String(),
-		ReasonAgentUnknown.String(),
-		"agent_error",
+	for _, raw := range []string{
+		"prepare execution environment: execenv: mkdir /workspaces/task: no space left on device",
+		"prepare execution environment: execenv: mkdir C:\\workspaces\\task: The disk is full.",
+		"prepare execution environment: execenv: mkdir C:\\workspaces\\task: There is not enough space on the disk.",
 	} {
-		if got := NormalizeDaemonReason(legacy, raw); got != ReasonRuntimeStorageExhausted {
-			t.Errorf("NormalizeDaemonReason(%q, storage exhaustion) = %q, want %q", legacy, got, ReasonRuntimeStorageExhausted)
+		for _, legacy := range []string{
+			ReasonAgentProviderAuthOrAccess.String(),
+			ReasonAgentUnknown.String(),
+			"agent_error",
+		} {
+			if got := NormalizeDaemonReason(legacy, raw); got != ReasonRuntimeStorageExhausted {
+				t.Errorf("NormalizeDaemonReason(%q, %q) = %q, want %q", legacy, raw, got, ReasonRuntimeStorageExhausted)
+			}
 		}
 	}
 }

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -444,6 +444,30 @@ func TestNormalizeDaemonReason_UpgradedReasonIsPlatformSide(t *testing.T) {
 	}
 }
 
+func TestNormalizeDaemonReasonUpgradesLegacyStorageExhaustion(t *testing.T) {
+	raw := "prepare execution environment: execenv: mkdir " +
+		"/workspaces/task: no space left on device"
+
+	for _, legacy := range []string{
+		ReasonAgentProviderAuthOrAccess.String(),
+		ReasonAgentUnknown.String(),
+		"agent_error",
+	} {
+		if got := NormalizeDaemonReason(legacy, raw); got != ReasonRuntimeStorageExhausted {
+			t.Errorf("NormalizeDaemonReason(%q, storage exhaustion) = %q, want %q", legacy, got, ReasonRuntimeStorageExhausted)
+		}
+	}
+}
+
+func TestNormalizeDaemonReasonLeavesAgentStorageMessageAlone(t *testing.T) {
+	reason := ReasonAgentProviderAuthOrAccess.String()
+	raw := "agent execution failed: remote tool: no space left on device"
+
+	if got := NormalizeDaemonReason(reason, raw); got.String() != reason {
+		t.Errorf("NormalizeDaemonReason(%q, agent failure) = %q, want unchanged", reason, got)
+	}
+}
+
 // TestProviderUnconfigured pins the predicate the daemon uses to decide whether
 // a failure is worth annotating with the HERMES_HOME it actually read (GH
 // #6872). The wrapped fixture is the shape the error really arrives in — the

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -26,7 +26,8 @@
 //     queued_expired, runtime_offline, runtime_reconnect_timeout,
 //     runtime_recovery, timeout, iteration_limit, agent_blocked,
 //     api_invalid_request, skill_bundle_unavailable,
-//     runtime_cli_timeout, invalid_task_identity, issue_window_restricted
+//     runtime_cli_timeout, runtime_storage_exhausted, invalid_task_identity,
+//     issue_window_restricted
 //
 //   - 14 agent-side values (with `agent_error.` prefix) produced by
 //     Classify(rawError) when the agent process surfaced an error string.
@@ -131,6 +132,11 @@ const (
 	// taskRunFailureReason in daemon/daemon.go.
 	ReasonRuntimeCLITimeout Reason = "runtime_cli_timeout"
 
+	// ReasonRuntimeStorageExhausted: the runtime host ran out of local storage
+	// while preparing the task environment. The agent process was never launched.
+	// Written by taskRunFailureReason in daemon/daemon.go.
+	ReasonRuntimeStorageExhausted Reason = "runtime_storage_exhausted"
+
 	// ReasonInvalidTaskIdentity: the daemon refused a claimed task because
 	// the task row's authoritative agent_id was absent or disagreed with the
 	// nested agent payload. The agent process is never launched. This is
@@ -219,7 +225,7 @@ const (
 	ReasonAgentUnknown Reason = "agent_error.unknown"
 )
 
-// allReasons is the canonical ordered list of the 26 reasons. Order is
+// allReasons is the canonical ordered list of the 27 reasons. Order is
 // stable so callers (e.g. Prometheus collectors that pre-warm series via
 // AllReasons) can build deterministic label sets across restarts.
 //
@@ -240,6 +246,7 @@ var allReasons = []Reason{
 	ReasonAPIInvalidRequest,
 	ReasonSkillBundleUnavailable,
 	ReasonRuntimeCLITimeout,
+	ReasonRuntimeStorageExhausted,
 	ReasonInvalidTaskIdentity,
 	ReasonIssueWindowRestricted,
 

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -29,6 +29,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonAPIInvalidRequest, "api_invalid_request"},
 		{ReasonSkillBundleUnavailable, "skill_bundle_unavailable"},
 		{ReasonRuntimeCLITimeout, "runtime_cli_timeout"},
+		{ReasonRuntimeStorageExhausted, "runtime_storage_exhausted"},
 		{ReasonInvalidTaskIdentity, "invalid_task_identity"},
 		{ReasonIssueWindowRestricted, "issue_window_restricted"},
 		// Agent-side.
@@ -48,7 +49,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonAgentUnknown, "agent_error.unknown"},
 	}
 
-	if got, want := len(cases), 26; got != want {
+	if got, want := len(cases), 27; got != want {
 		t.Fatalf("constant count = %d, want %d (canonical taxonomy size)", got, want)
 	}
 
@@ -78,6 +79,7 @@ func TestIsAgentError(t *testing.T) {
 		ReasonAPIInvalidRequest,
 		ReasonSkillBundleUnavailable,
 		ReasonRuntimeCLITimeout,
+		ReasonRuntimeStorageExhausted,
 		ReasonInvalidTaskIdentity,
 		ReasonIssueWindowRestricted,
 	}
@@ -120,8 +122,8 @@ func TestAllReasonsContents(t *testing.T) {
 	t.Parallel()
 
 	got := AllReasons()
-	if len(got) != 26 {
-		t.Fatalf("AllReasons() returned %d entries, want 26", len(got))
+	if len(got) != 27 {
+		t.Fatalf("AllReasons() returned %d entries, want 27", len(got))
 	}
 
 	seen := make(map[Reason]bool, len(got))
@@ -138,8 +140,8 @@ func TestAllReasonsContents(t *testing.T) {
 		}
 	}
 
-	if platformCount != 12 {
-		t.Errorf("AllReasons(): platform-side count = %d, want 12", platformCount)
+	if platformCount != 13 {
+		t.Errorf("AllReasons(): platform-side count = %d, want 13", platformCount)
 	}
 	if agentCount != 14 {
 		t.Errorf("AllReasons(): agent-side count = %d, want 14", agentCount)
@@ -154,7 +156,8 @@ func TestAllReasonsContents(t *testing.T) {
 		ReasonRuntimeRecovery,
 		ReasonTimeout, ReasonIterationLimit, ReasonAgentBlocked,
 		ReasonAPIInvalidRequest, ReasonSkillBundleUnavailable,
-		ReasonRuntimeCLITimeout, ReasonInvalidTaskIdentity, ReasonIssueWindowRestricted,
+		ReasonRuntimeCLITimeout, ReasonRuntimeStorageExhausted, ReasonInvalidTaskIdentity,
+		ReasonIssueWindowRestricted,
 		ReasonAgentProviderAuthOrAccess, ReasonAgentProviderQuotaLimit,
 		ReasonAgentProviderCapacityOrRateLimit, ReasonAgentProviderServerError,
 		ReasonAgentProviderNetwork, ReasonAgentProcessFailure,


### PR DESCRIPTION
## Summary

- classify task-environment disk exhaustion as `runtime_storage_exhausted` before provider error parsing
- preserve the classification across the preparation-helper boundary
- recognize native Unix and Windows disk-full errors
- normalize legacy Linux and Windows daemon disk-full wire shapes without rewriting unrelated agent errors
- show the new reason as a runtime failure in the dashboard

## Root cause

An execution-environment path contained a UUID segment such as `-401e-`. When the host returned `no space left on device`, the generic provider classifier matched `401` inside that path and persisted `agent_error.provider_auth_or_access`, even though the agent process never started.

## Verification

- `go test ./pkg/taskfailure ./internal/daemon/execenv ./internal/daemon ./internal/service`
- `go vet ./pkg/taskfailure ./internal/daemon/execenv ./internal/daemon ./internal/service`
- Linux and Windows AMD64 daemon test binaries compile
- `pnpm --filter @multica/core exec vitest run dashboard/failure-class.test.ts` — 4 tests passed
- `pnpm --filter @multica/core typecheck`
- targeted ESLint and `git diff --check`

## Scope

No retry policy, dependency, localized copy, or historical backfill is added. Existing rows are unchanged; this PR corrects future failures and mixed-version Linux and Windows daemon reports.
