### PR TITLE
MUL-6591: prevent transaction timeline label overlap

### DIFF
--- a/packages/views/common/task-transcript/build-steps.test.ts
+++ b/packages/views/common/task-transcript/build-steps.test.ts
@@ -237,6 +237,16 @@ describe("timelineTicks", () => {
   it("returns nothing for a run with no length", () => {
     expect(timelineTicks(0)).toEqual([]);
   });
+
+  it("omits a round tick that would crowd the exact run end", () => {
+    expect(timelineTicks(2 * 60_000 + 2_000, 6)).toEqual([
+      0,
+      30_000,
+      60_000,
+      90_000,
+      122_000,
+    ]);
+  });
 });
 
 describe("laneSegmentPosition", () => {

--- a/packages/views/common/task-transcript/build-steps.ts
+++ b/packages/views/common/task-transcript/build-steps.ts
@@ -354,6 +354,16 @@ export function timelineTicks(totalMs: number, maxTicks = 6): number[] {
   const interval = steps.find((step) => totalMs / step <= maxTicks) ?? steps[steps.length - 1]!;
   const ticks: number[] = [];
   for (let at = 0; at < totalMs; at += interval) ticks.push(at);
+  const lastRoundTick = ticks[ticks.length - 1];
+  // The exact run end is more useful than a nearby round tick. Keeping both
+  // makes labels such as `2m` and `2m 2s` occupy the same right-edge pixels.
+  if (
+    lastRoundTick !== undefined &&
+    lastRoundTick > 0 &&
+    totalMs - lastRoundTick < interval / 2
+  ) {
+    ticks.pop();
+  }
   ticks.push(totalMs);
   return ticks;
 }


### PR DESCRIPTION
## Summary

- keep the exact run-end tick while dropping a nearby round tick that would collide with it
- preserve the zero origin and regular tick density at every zoom level
- add a regression case for the reported `2m` / `2m 2s` overlap

## Verification

- `pnpm --filter @multica/views exec vitest run common/task-transcript/build-steps.test.ts` — 27 passed
- `pnpm --filter @multica/views typecheck` — passed
- ESLint on the two changed files — passed
- local `api,web` named environment — verified the exact `2m 2s` label renders with zero conflicting `2m` labels; screenshot attached to MUL-6591
- full `@multica/views` suite — 4,633 passed; 7 unrelated UI tests failed across six existing suites

Closes MUL-6591
