### PR TITLE
fix(selfhost): derive frontend URL defaults from FRONTEND_PORT, pass RATE_LIMIT_TRUSTED_PROXIES through

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -66,7 +66,7 @@ services:
       PORT: "8080"
       METRICS_ADDR: ${METRICS_ADDR:-}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET must be set to a strong random value — generate one with 'openssl rand -hex 32'}
-      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://localhost:3000}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://localhost:${FRONTEND_PORT:-3000}}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-noreply@multica.ai}
@@ -80,7 +80,7 @@ services:
       SMTP_EHLO_NAME: ${SMTP_EHLO_NAME:-}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:3000/auth/callback}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-${FRONTEND_ORIGIN:-http://localhost:${FRONTEND_PORT:-3000}}/auth/callback}
       S3_BUCKET: ${S3_BUCKET:-}
       S3_REGION: ${S3_REGION:-us-west-2}
       AWS_ENDPOINT_URL: ${AWS_ENDPOINT_URL:-}
@@ -95,7 +95,7 @@ services:
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       APP_ENV: ${APP_ENV:-production}
       MULTICA_DEV_VERIFICATION_CODE: ${MULTICA_DEV_VERIFICATION_CODE:-}
-      MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
+      MULTICA_APP_URL: ${MULTICA_APP_URL:-${FRONTEND_ORIGIN:-http://localhost:${FRONTEND_PORT:-3000}}}
       MULTICA_DATABASE_STARTUP_TIMEOUT: ${MULTICA_DATABASE_STARTUP_TIMEOUT:-3m}
       MULTICA_DATABASE_CONNECT_TIMEOUT: ${MULTICA_DATABASE_CONNECT_TIMEOUT:-5s}
       MULTICA_SHUTDOWN_HOLD_DURATION: ${MULTICA_SHUTDOWN_HOLD_DURATION:-}
@@ -146,6 +146,11 @@ services:
       # Empty default = headers ignored, RemoteAddr used. Set e.g.
       # "127.0.0.1/32" when running behind a same-host reverse proxy.
       MULTICA_TRUSTED_PROXIES: ${MULTICA_TRUSTED_PROXIES:-}
+      # Same-host proxy CIDRs for the auth rate limiter (separate list from
+      # MULTICA_TRUSTED_PROXIES above — see the Rate limiting section of
+      # .env.example). Without this passthrough the value documented as
+      # REQUIRED behind a reverse proxy never reached the backend.
+      RATE_LIMIT_TRUSTED_PROXIES: ${RATE_LIMIT_TRUSTED_PROXIES:-}
       # Server-side LLM layer, backing internal helpers such as chat title
       # generation. Both the API key and the base URL empty = layer disabled,
       # and callers fall back silently rather than failing. MULTICA_LLM_MAX_RETRIES


### PR DESCRIPTION
## Summary

- The self-host compose defaults for `FRONTEND_ORIGIN`, `GOOGLE_REDIRECT_URI` and `MULTICA_APP_URL` hardcoded `http://localhost:3000`. Changing `FRONTEND_PORT` without also overriding all three left the backend with a stale origin: CORS rejections, a wrong `daemon_server_url` in `/api/config`, and a broken OAuth redirect URI. They now derive from `FRONTEND_PORT` via nested interpolation, mirroring the derived references already documented in `.env.example` (compose >= 2.24 resolves those inside `.env` itself; older versions leave them literal — refs #6146).
- `RATE_LIMIT_TRUSTED_PROXIES` is documented in `.env.example` as REQUIRED behind a reverse proxy, but the compose file never passed it to the backend (`server/cmd/server/router.go` reads it), so setting it in `.env` was a no-op.

## Tests

- `docker compose -f docker-compose.selfhost.yml config` renders for all four scenarios:
  - no overrides → `http://localhost:3000` everywhere (unchanged behavior)
  - `FRONTEND_PORT=13001` only → all three URLs follow the port
  - `FRONTEND_PORT=13001 FRONTEND_ORIGIN=https://multica.example.com:6433` → `MULTICA_APP_URL` and `GOOGLE_REDIRECT_URI` follow `FRONTEND_ORIGIN`
  - `RATE_LIMIT_TRUSTED_PROXIES=127.0.0.1/32` → present in the backend environment
- Same render check with the values coming from a `.env` file (the #6146 reproduction path) instead of shell env.

**Caveat for #6146 (why this is refs, not Fixes):** the derived YAML defaults only take effect when `FRONTEND_ORIGIN` / `MULTICA_APP_URL` / `GOOGLE_REDIRECT_URI` are unset in `.env` (e.g. commented out). A `.env` copied verbatim from `.env.example` keeps those lines set, so on Docker Compose < 2.24 they still resolve to literal `${FRONTEND_PORT}` strings and override the defaults. Nested defaults in the compose file itself have been supported since Compose V2 GA (the file already relies on them for the backend port chain).