### PR TITLE
MUL-6610: fix(web): proxy /health to the backend in the runtime rewrite

### DIFF
--- a/apps/web/config/runtime-urls.test.ts
+++ b/apps/web/config/runtime-urls.test.ts
@@ -283,6 +283,18 @@ describe("runtimeRewriteDestination", () => {
       }),
     ).toBe("http://backend:8080/health");
     expect(runtimeRewriteDestination("/health", {})).toBeUndefined();
+    // Probe variants stay unproxied: /healthz is the k8s alias and /readyz
+    // the deep check — both go to the backend directly in every topology.
+    expect(
+      runtimeRewriteDestination("/healthz", {
+        REMOTE_API_URL: "http://backend:8080",
+      }),
+    ).toBeUndefined();
+    expect(
+      runtimeRewriteDestination("/readyz", {
+        REMOTE_API_URL: "http://backend:8080",
+      }),
+    ).toBeUndefined();
   });
 
   it("maps websocket paths to the runtime API origin", () => {

--- a/apps/web/config/runtime-urls.test.ts
+++ b/apps/web/config/runtime-urls.test.ts
@@ -276,6 +276,15 @@ describe("runtimeRewriteDestination", () => {
     ).toBe("http://multica-docs:3000/docs/zh/agents");
   });
 
+  it("maps the CLI health probe to the runtime API origin", () => {
+    expect(
+      runtimeRewriteDestination("/health", {
+        REMOTE_API_URL: "http://backend:8080",
+      }),
+    ).toBe("http://backend:8080/health");
+    expect(runtimeRewriteDestination("/health", {})).toBeUndefined();
+  });
+
   it("maps websocket paths to the runtime API origin", () => {
     expect(
       runtimeRewriteDestination("/ws", {

--- a/apps/web/config/runtime-urls.ts
+++ b/apps/web/config/runtime-urls.ts
@@ -134,6 +134,14 @@ export function runtimeRewriteDestination(
   if (pathname === "/ws") {
     return appendPath(remoteApiUrl, "/ws");
   }
+  // `multica setup self-host` probes `{server-url}/health` and treats any
+  // non-200 as "Server not reachable". The backend serves it, but a
+  // same-origin reverse proxy that forwards everything to the web image left
+  // the probe 404ing at the Next.js router, so setup failed against a healthy
+  // stack. Proxy the exact path like /ws.
+  if (pathname === "/health") {
+    return appendPath(remoteApiUrl, "/health");
+  }
   if (isBackendAuthPath(pathname)) {
     return appendPath(remoteApiUrl, pathname);
   }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -79,6 +79,10 @@ const nextConfig: NextConfig = {
               destination: `${remoteApiUrl}/ws`,
             },
             {
+              source: "/health",
+              destination: `${remoteApiUrl}/health`,
+            },
+            {
               source: "/auth/:path*",
               destination: `${remoteApiUrl}/auth/:path*`,
             },

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -186,6 +186,21 @@ describe("proxy runtime upstream rewrites", () => {
     }
   });
 
+  it("rewrites the CLI health probe to the runtime API origin", () => {
+    const previous = process.env.REMOTE_API_URL;
+    process.env.REMOTE_API_URL = "http://backend:8080";
+    try {
+      const res = proxy(makeRequest("/health"));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-middleware-rewrite")).toBe(
+        "http://backend:8080/health",
+      );
+    } finally {
+      restoreEnv("REMOTE_API_URL", previous);
+    }
+  });
+
   it("rewrites Plugin API requests to the runtime API origin", () => {
     const previous = process.env.REMOTE_API_URL;
     process.env.REMOTE_API_URL = "http://backend:8080";


### PR DESCRIPTION
## Summary

- `multica setup self-host` probes `{server-url}/health` and needs a 200 (documented in the self-host quickstart). The backend serves the path, but the web image's runtime rewrite only covered `/docs`, `/v1`, `/api`, `/uploads`, `/ws` and `/auth`, so a same-origin reverse proxy that forwards everything to the web image left the probe 404ing at the Next.js router — the CLI then reports "Server not reachable" while the stack is healthy.
- Adds the exact `/health` path to `runtimeRewriteDestination` (production proxy.ts path) and to the `next.config.ts` dev rewrites, mirroring how `/ws` is handled.

Context: hit while deploying a single-origin self-host (one domain, one port — everything through the web image, with only `/ws` routed to the backend). Companion docs PR adds the explicit proxy route for older images and a single-origin example: #7466.

## Tests

- `go run`-free check: `pnpm vitest run config/runtime-urls.test.ts` — 33 passed, including the new case (`/health` maps to the runtime API origin; stays undefined with no upstream configured).
- `pnpm typecheck` in apps/web passes.
- Verified the failure mode against a live v0.4.32 deployment before the change: `curl http://127.0.0.1:13001/health` → 404 (frontend), `curl http://127.0.0.1:18090/health` → `{"status":"ok"}` (backend).

**Review notes** (pre-empting obvious questions):
- The proxy.ts matcher's catch-all pattern covers `/health` (verified against the matcher source; covered indirectly by the new proxy-level test).
- `health` is already a reserved workspace slug (`packages/core/paths/reserved-slugs.ts`), so proxying the exact path cannot collide with workspace routing.
- The next.config.ts entry is dev-parity only — in published images `remoteApiUrl` is unset at build time, so production effect comes entirely from proxy.ts (same as the existing `/ws`/`/api` entries).
- No infra depends on a frontend-served `/health`: the web image has no HEALTHCHECK, helm probes hit the backend service directly, and the selfhost scripts probe the backend port.