### PR TITLE
fix(execenv): write .gc_meta.json / .managed_env.json atomically

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5215,6 +5215,12 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 			}
 			if err := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); err != nil {
 				taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
+				// One immediate retry: a dir that silently loses its meta
+				// falls to the 72h orphan-by-mtime path instead of
+				// parent-driven cleanup, pinning disk for days.
+				if retryErr := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); retryErr != nil {
+					taskLog.Error("write gc meta retry failed; dir will age out via mtime TTL", "error", retryErr)
+				}
 			}
 		}
 	}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -1057,7 +1057,9 @@ func WriteGCMeta(envRoot string, meta GCMeta, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("marshal gc meta: %w", err)
 	}
-	return os.WriteFile(filepath.Join(envRoot, gcMetaFile), data, 0o644)
+	// Atomic tmp+rename: a torn .gc_meta.json unmarshal-errors on read and is
+	// treated as "no meta", dropping the dir into the 72h orphan-by-mtime path.
+	return writeFileAtomic(filepath.Join(envRoot, gcMetaFile), data, 0o644)
 }
 
 // ReadGCMeta reads GC metadata from a task directory root. Pre-v2 meta files
@@ -1120,7 +1122,9 @@ func WriteManagedEnvProvenance(envRoot string, p ManagedEnvProvenance) error {
 	if err != nil {
 		return fmt.Errorf("marshal managed env provenance: %w", err)
 	}
-	return os.WriteFile(filepath.Join(envRoot, managedEnvProvenanceFile), data, 0o644)
+	// Atomic tmp+rename: a torn provenance file fails closed on read (no
+	// reuse), silently dropping session continuity — the MUL-4886 bug class.
+	return writeFileAtomic(filepath.Join(envRoot, managedEnvProvenanceFile), data, 0o644)
 }
 
 // ReadManagedEnvProvenance reads the Prepare-time reuse-eligibility marker from


### PR DESCRIPTION
Closes #7469

Route both metadata writers through the existing `writeFileAtomic` (tmp+rename) helper instead of plain `os.WriteFile`, and add one immediate retry when the finalize-time `.gc_meta.json` write fails (previously Warn-only, silently dropping the dir into the 72h orphan-by-mtime path).

- Torn provenance file = fail-closed on read → session continuity dropped (MUL-4886 bug class) — now impossible.
- Torn GC meta = unmarshal error → treated as no-meta → 72h orphan path — now impossible.
- Retry escalation turns transient write failures into a non-event with an Error log if it still fails.

No behavior change on the happy path; same file modes.