### PR TITLE
feat(daemon): durable outbox for terminal task reports

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -361,6 +361,11 @@ type Daemon struct {
 	skillCache *SkillBundleCache
 	logger     *slog.Logger
 
+	// outbox durably journals terminal reports whose send failed, replaying
+	// them on the next healthy heartbeat (GAP-14). Nil-safe: every use goes
+	// through methods that tolerate a disabled outbox.
+	outbox *reportOutbox
+
 	mu           sync.Mutex
 	workspaces   map[string]*workspaceState
 	runtimeIndex map[string]Runtime // runtimeID -> Runtime for provider lookups
@@ -646,6 +651,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		reconcile:                 newReconcileBroadcaster(),
 		workspaceChanges:          newWorkspaceChangeSignal(),
 		wsRPC:                     newWSRPCClient(wsRPCResponseGrace),
+		outbox:                    newReportOutbox(cfg.Profile, logger),
 	}
 	d.activeEnvRootsCond = sync.NewCond(&d.activeEnvRootsMu)
 	d.activeStoresCond = sync.NewCond(&d.activeStoresMu)
@@ -3888,6 +3894,7 @@ func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) bool {
 	// relies on.
 	if d.wsHeartbeatRecentlyAcked(rid) {
 		d.logger.Debug("heartbeat: skipping HTTP tick, WS recently acked", "runtime_id", rid)
+		d.maybeDrainOutbox()
 		return false
 	}
 	d.logger.Debug("heartbeat: HTTP tick", "runtime_id", rid)
@@ -3915,7 +3922,18 @@ func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) bool {
 		return false
 	}
 	d.handleHeartbeatActions(ctx, rid, resp)
+	d.maybeDrainOutbox()
 	return false
+}
+
+// maybeDrainOutbox replays journaled terminal reports when a heartbeat proves
+// the server is reachable. Non-blocking: the actual drain runs single-flight
+// in its own goroutine and no-ops on an empty journal.
+func (d *Daemon) maybeDrainOutbox() {
+	if d.outbox == nil || !d.outbox.pending() {
+		return
+	}
+	go d.outbox.drain(d.sendTerminalReport)
 }
 
 // handleHeartbeatActions dispatches the pending-action set returned by either
@@ -5572,10 +5590,30 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 // parent deadlines: daemon shutdown cancels the root context before pollLoop's
 // 30-second drain, but terminal callbacks must still use that remaining window.
 // The explicit timeout keeps this detached work bounded during normal runs.
+//
+// On delivery failure the report is journaled in the outbox (GAP-14) and
+// replayed on the next healthy heartbeat — without it, exhausted retries
+// leave the task row `running` forever on a heartbeating runtime.
 func (d *Daemon) reportTerminalTask(parentCtx context.Context, report terminalTaskReport) error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(parentCtx), terminalTaskReportTimeout)
 	defer cancel()
 
+	err := d.sendTerminalReport(ctx, report)
+	if err != nil {
+		if enqErr := d.outbox.enqueue(report.kind, report); enqErr != nil {
+			d.logger.Error("terminal report AND outbox journal write failed; result at risk",
+				"task_id", report.taskID, "report_error", err, "journal_error", enqErr)
+		} else {
+			d.logger.Warn("terminal report failed; queued in outbox for replay",
+				"task_id", report.taskID, "error", err)
+		}
+	}
+	return err
+}
+
+// sendTerminalReport performs one terminal callback against the server. Used
+// both by the live report path and by outbox replay.
+func (d *Daemon) sendTerminalReport(ctx context.Context, report terminalTaskReport) error {
 	switch report.kind {
 	case terminalTaskReportComplete:
 		return d.client.CompleteTask(ctx, report.taskID, report.output, report.branchName, report.sessionID, report.workDir, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir)

--- a/server/internal/daemon/outbox.go
+++ b/server/internal/daemon/outbox.go
@@ -1,0 +1,261 @@
+package daemon
+
+// Durable terminal-report outbox (GAP-14, fork issue #15).
+//
+// CompleteTask/FailTask retry six times over ~124s and then give up. The task
+// row stays `running` forever: FailStaleTasks explicitly spares tasks on
+// runtimes that keep heartbeating (MUL-4107), so only a daemon restart or the
+// runtime going offline recovers them — the finished work is invisible until
+// then. The comment at the old daemon.go:185 insertion point already planned
+// this outbox; reportTerminalTask is the single choke point it waits for.
+//
+// Shape: append-only JSONL journal under the Multica profile dir (survives env
+// GC, scoped per profile like hermes-state). Every failed terminal send is
+// appended; every healthy heartbeat drains the journal back through the same
+// client calls. The server's complete/fail handlers are idempotent on already-
+// terminal tasks, so replay after a partial recovery is harmless.
+//
+// Deliberate ceiling: entries older than pendingReportMaxAge are dropped with
+// a warning during drain. By then the server has reconciled the task through
+// another path (retry child, manual close) or the report is permanently
+// rejected; replaying forever would churn every heartbeat.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+const (
+	pendingReportsFile = "pending_reports.jsonl"
+
+	// Reports older than this are dropped at drain time.
+	pendingReportMaxAge = 24 * time.Hour
+)
+
+// terminalReportPayload mirrors terminalTaskReport for JSON. The struct keeps
+// unexported fields, so the outbox owns an explicit wire shape instead of
+// exporting the core type's fields.
+type terminalReportPayload struct {
+	TaskID                string `json:"task_id"`
+	Output                string `json:"output,omitempty"`
+	BranchName            string `json:"branch_name,omitempty"`
+	ErrorMessage          string `json:"error_message,omitempty"`
+	SessionID             string `json:"session_id,omitempty"`
+	WorkDir               string `json:"work_dir,omitempty"`
+	FailureReason         string `json:"failure_reason,omitempty"`
+	SessionRolloutMissing bool   `json:"session_rollout_missing,omitempty"`
+	RetiredSessionID      string `json:"retired_session_id,omitempty"`
+}
+
+type pendingReport struct {
+	Kind     terminalTaskReportKind `json:"kind"`
+	Report   terminalReportPayload  `json:"report"`
+	QueuedAt time.Time              `json:"queued_at"`
+}
+
+func newPendingReport(kind terminalTaskReportKind, r terminalTaskReport, now time.Time) pendingReport {
+	return pendingReport{
+		Kind: kind,
+		Report: terminalReportPayload{
+			TaskID:                r.taskID,
+			Output:                r.output,
+			BranchName:            r.branchName,
+			ErrorMessage:          r.errorMessage,
+			SessionID:             r.sessionID,
+			WorkDir:               r.workDir,
+			FailureReason:         r.failureReason,
+			SessionRolloutMissing: r.sessionRolloutMissing,
+			RetiredSessionID:      r.retiredSessionID,
+		},
+		QueuedAt: now.UTC(),
+	}
+}
+
+func (p pendingReport) terminalTaskReport() terminalTaskReport {
+	return terminalTaskReport{
+		kind:                  p.Kind,
+		taskID:                p.Report.TaskID,
+		output:                p.Report.Output,
+		branchName:            p.Report.BranchName,
+		errorMessage:          p.Report.ErrorMessage,
+		sessionID:             p.Report.SessionID,
+		workDir:               p.Report.WorkDir,
+		failureReason:         p.Report.FailureReason,
+		sessionRolloutMissing: p.Report.SessionRolloutMissing,
+		retiredSessionID:      p.Report.RetiredSessionID,
+	}
+}
+
+// reportOutbox persists terminal reports that could not be delivered and
+// replays them once the server is reachable again. A nil path disables the
+// outbox (profile dir unresolvable): sends then behave exactly as before.
+type reportOutbox struct {
+	path     string // empty = disabled
+	logger   *slog.Logger
+	mu       sync.Mutex
+	draining atomic.Bool
+}
+
+func newReportOutbox(profile string, logger *slog.Logger) *reportOutbox {
+	dir, err := cli.ProfileDir(profile)
+	if err != nil {
+		logger.Warn("terminal-report outbox disabled: cannot resolve profile dir", "error", err)
+		return &reportOutbox{logger: logger}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logger.Warn("terminal-report outbox disabled: cannot create profile dir", "dir", dir, "error", err)
+		return &reportOutbox{logger: logger}
+	}
+	return &reportOutbox{path: filepath.Join(dir, pendingReportsFile), logger: logger}
+}
+
+// enqueue appends one failed terminal send to the journal. Best-effort: a
+// journal write failure must never mask or delay the original report error.
+func (o *reportOutbox) enqueue(kind terminalTaskReportKind, r terminalTaskReport) error {
+	if o == nil || o.path == "" {
+		return nil
+	}
+	line, err := json.Marshal(newPendingReport(kind, r, time.Now()))
+	if err != nil {
+		return fmt.Errorf("marshal pending report: %w", err)
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	f, err := os.OpenFile(o.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open pending reports journal: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("append pending report: %w", err)
+	}
+	return nil
+}
+
+// pending reports whether the journal holds undelivered reports. Cheap stat;
+// safe to call from every heartbeat tick.
+func (o *reportOutbox) pending() bool {
+	if o == nil || o.path == "" {
+		return false
+	}
+	fi, err := os.Stat(o.path)
+	return err == nil && fi.Size() > 0
+}
+
+// drain replays every queued report through send. Successful and expired
+// entries are removed; failures stay queued for the next drain. Single-flight:
+// concurrent heartbeats collapse into one running drain.
+func (o *reportOutbox) drain(send func(context.Context, terminalTaskReport) error) {
+	if o == nil || o.path == "" {
+		return
+	}
+	if !o.draining.CompareAndSwap(false, true) {
+		return
+	}
+	defer o.draining.Store(false)
+
+	o.mu.Lock()
+	raw, err := os.ReadFile(o.path)
+	o.mu.Unlock()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			o.logger.Warn("read pending reports journal failed", "error", err)
+		}
+		return
+	}
+
+	var kept []pendingReport
+	dropped := 0
+	for _, line := range bytesLines(raw) {
+		var pr pendingReport
+		if err := json.Unmarshal(line, &pr); err != nil {
+			// Torn line (crash between write syscalls). Drop it: the entry
+			// was never acknowledged by our own enqueue, and the task will
+			// surface through stale-task sweeps if it was truly lost.
+			o.logger.Warn("dropping corrupt pending report line", "error", err)
+			dropped++
+			continue
+		}
+		if time.Since(pr.QueuedAt) > pendingReportMaxAge {
+			o.logger.Warn("dropping expired pending report",
+				"task_id", pr.Report.TaskID, "age", time.Since(pr.QueuedAt).Round(time.Minute))
+			dropped++
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), terminalTaskReportTimeout)
+		err := send(ctx, pr.terminalTaskReport())
+		cancel()
+		if err != nil {
+			kept = append(kept, pr)
+			continue
+		}
+		o.logger.Info("replayed pending terminal report", "task_id", pr.Report.TaskID, "kind", pr.Kind)
+	}
+	if len(kept) == len(bytesLines(raw)) && dropped == 0 {
+		return // nothing changed; leave the file untouched
+	}
+	o.rewrite(kept)
+}
+
+// rewrite replaces the journal with the still-undelivered entries, atomically.
+func (o *reportOutbox) rewrite(kept []pendingReport) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if len(kept) == 0 {
+		if err := os.Remove(o.path); err != nil && !os.IsNotExist(err) {
+			o.logger.Warn("remove pending reports journal failed", "error", err)
+		}
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(o.path), ".pending-reports-*")
+	if err != nil {
+		o.logger.Warn("rewrite pending reports journal failed", "error", err)
+		return
+	}
+	tmpName := tmp.Name()
+	for _, pr := range kept {
+		line, err := json.Marshal(pr)
+		if err != nil {
+			continue // already-validated shape; unreachable in practice
+		}
+		if _, err := tmp.Write(append(line, '\n')); err != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			o.logger.Warn("rewrite pending reports journal failed", "error", err)
+			return
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		o.logger.Warn("rewrite pending reports journal failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpName, o.path); err != nil {
+		os.Remove(tmpName)
+		o.logger.Warn("rewrite pending reports journal failed", "error", err)
+	}
+}
+
+// bytesLines splits raw JSONL content into non-empty lines.
+func bytesLines(raw []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i := 0; i <= len(raw); i++ {
+		if i == len(raw) || raw[i] == '\n' {
+			if i > start {
+				lines = append(lines, raw[start:i])
+			}
+			start = i + 1
+		}
+	}
+	return lines
+}

--- a/server/internal/daemon/outbox_test.go
+++ b/server/internal/daemon/outbox_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+func newTestOutbox(t *testing.T) *reportOutbox {
+	t.Helper()
+	t.Setenv(cli.TaskConfigRootEnv, t.TempDir())
+	o := newReportOutbox("test-profile", slog.Default())
+	if o.path == "" {
+		t.Fatal("outbox disabled in test env")
+	}
+	return o
+}
+
+func sampleReport(id string) terminalTaskReport {
+	return terminalTaskReport{
+		kind:          terminalTaskReportFail,
+		taskID:        id,
+		errorMessage:  "boom",
+		failureReason: "provider_network",
+	}
+}
+
+func TestOutboxDrainSuccessRemovesJournal(t *testing.T) {
+	o := newTestOutbox(t)
+	r := sampleReport("t1")
+	if err := o.enqueue(r.kind, r); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if !o.pending() {
+		t.Fatal("expected pending after enqueue")
+	}
+
+	var sent []terminalTaskReport
+	o.drain(func(_ context.Context, r terminalTaskReport) error {
+		sent = append(sent, r)
+		return nil
+	})
+
+	if len(sent) != 1 || sent[0].taskID != "t1" || sent[0].failureReason != "provider_network" {
+		t.Fatalf("unexpected replay: %+v", sent)
+	}
+	if o.pending() {
+		t.Fatal("journal should be removed after full success")
+	}
+}
+
+func TestOutboxKeepsFailedDropsCorruptAndExpired(t *testing.T) {
+	o := newTestOutbox(t)
+	good := sampleReport("keep-me")
+	if err := o.enqueue(good.kind, good); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	expired := pendingReport{
+		Kind:     terminalTaskReportComplete,
+		Report:   terminalReportPayload{TaskID: "old"},
+		QueuedAt: time.Now().Add(-25 * time.Hour),
+	}
+	goodLine, err := json.Marshal(newPendingReport(good.kind, good, time.Now()))
+	if err != nil {
+		t.Fatalf("marshal good: %v", err)
+	}
+	expLine, err := json.Marshal(expired)
+	if err != nil {
+		t.Fatalf("marshal expired: %v", err)
+	}
+	content := append([]byte("{not json\n"), goodLine...)
+	content = append(append(content, '\n'), expLine...)
+	content = append(content, '\n')
+	if err := os.WriteFile(o.path, content, 0o600); err != nil {
+		t.Fatalf("seed journal: %v", err)
+	}
+
+	var sent []string
+	o.drain(func(_ context.Context, r terminalTaskReport) error {
+		if r.taskID == "keep-me" {
+			return errors.New("server still down")
+		}
+		sent = append(sent, r.taskID)
+		return nil
+	})
+
+	raw, err := os.ReadFile(o.path)
+	if err != nil {
+		t.Fatalf("journal missing but an entry should remain: %v", err)
+	}
+	lines := bytesLines(raw)
+	if len(lines) != 1 || sent != nil {
+		t.Fatalf("want exactly the failed entry kept and nothing replayed, got lines=%d sent=%v", len(lines), sent)
+	}
+}
+
+func TestOutboxNilSafe(t *testing.T) {
+	var nilBox *reportOutbox
+	if nilBox.pending() {
+		t.Fatal("nil outbox must not report pending")
+	}
+	if err := nilBox.enqueue(terminalTaskReportComplete, sampleReport("x")); err != nil {
+		t.Fatalf("nil-safe enqueue: %v", err)
+	}
+	nilBox.drain(func(context.Context, terminalTaskReport) error { return nil })
+}
+
+func TestBytesLines(t *testing.T) {
+	got := bytesLines([]byte("a\n\nb\n"))
+	if len(got) != 2 || string(got[0]) != "a" || string(got[1]) != "b" {
+		t.Fatalf("unexpected split: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #7470

Adds a durable journal for terminal reports (CompleteTask/FailTask) whose send exhausts the existing retry budget, plus replay whenever a heartbeat proves the server reachable.

**Problem recap:** agent finishes during a >6min server/DB outage → retries exhausted → result dropped → task stuck `running` forever on a heartbeating runtime (`FailStaleTasks` spares online runtimes). Worse variant: DB partition flips runtime offline → live tasks failed + auto-retried while the original still runs; late report hits idempotent-already-terminal and work is discarded.

**Design:**
- `reportTerminalTask` remains the single insertion point; on failure it appends a JSONL entry to `<ProfileDir>/pending_reports.jsonl` (profile-scoped like hermes-state, survives env GC).
- Healthy heartbeat triggers single-flight drain through the same client calls. Server complete/fail are idempotent on already-terminal tasks → replay after partial recovery is harmless.
- Entries expire after 24h with a warning (by then retry children / manual close have reconciled); corrupt lines dropped.
- Outbox degrades to disabled (current behavior) if profile dir unresolvable — nil-safe throughout.
- New daemon field + heartbeat hook; no claim/worktree/session changes.

**Tests:** enqueue→drain-success removes journal; failed-send entry retained while corrupt+expired dropped; nil-safety; line splitter. Full daemon suite green.