### PR TITLE
feat: jitter retry schedules to prevent thundering herd

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -952,7 +953,14 @@ var skillBundleResolveRetrySchedule = []time.Duration{
 // retrySleep is the sleep used between retry attempts. Pulled into a package
 // variable so tests can swap in an instant sleep without rewriting the
 // caller's schedule.
+//
+// The ±20% jitter matters fleet-wide: without it, tasks watchdog-killed at
+// outage start re-fire in lockstep and re-cluster onto the provider exactly
+// as it recovers (thundering herd).
 var retrySleep = func(ctx context.Context, d time.Duration) error {
+	if jitterSpan := d / 5; jitterSpan > 0 {
+		d += time.Duration(rand.Int63n(int64(2*jitterSpan))) - jitterSpan // [-20%, +20%)
+	}
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -4727,16 +4728,22 @@ func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 // retryDelayForAttempt reports how long to defer the NEXT attempt after a
 // failure at failedAttempt. runtime_offline always gets a positive fire_at so
 // it waits for the health-gated promotion path. provider_network's final
-// attempt is deferred ~5s; every other retry remains immediate (zero delay →
-// the child is created 'queued', claimable at once). Callers pass the returned
-// delay to CreateRetryTask via fire_at.
+// attempt is deferred ~5s with ±20% jitter; every other retry remains
+// immediate (zero delay → the child is created 'queued', claimable at once).
+// Callers pass the returned delay to CreateRetryTask via fire_at. The jitter
+// keeps tasks that failed against the same provider blip from re-queuing in
+// lockstep onto the recovering upstream.
 func retryDelayForAttempt(reason string, failedAttempt int32) time.Duration {
 	if reason == string(taskfailure.ReasonRuntimeOffline) {
 		return runtimeOfflineRetryDeferral
 	}
 	if reason == string(taskfailure.ReasonAgentProviderNetwork) &&
 		failedAttempt >= providerNetworkMaxAttempts-1 {
-		return providerNetworkFinalRetryWait
+		base := providerNetworkFinalRetryWait
+		if span := base / 5; span > 0 {
+			base += time.Duration(rand.Int63n(int64(2*span))) - span
+		}
+		return base
 	}
 	return 0
 }

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -197,20 +197,22 @@ func TestProviderNetworkRetrySchedule(t *testing.T) {
 	}
 
 	// Backoff / deferral: runtime_offline always waits for health-gated
-	// promotion; provider_network only defers its final tier.
+	// promotion; provider_network only defers its final tier, now with ±20%
+	// jitter — assert a window instead of an exact value.
 	delayCases := []struct {
 		reason        string
 		failedAttempt int32
-		want          time.Duration
+		min, max      time.Duration
 	}{
-		{provNet, 1, 0}, // first failure → immediate retry
-		{provNet, 2, providerNetworkFinalRetryWait}, // second failure → 5s-deferred retry
-		{"runtime_offline", 1, runtimeOfflineRetryDeferral},
-		{"timeout", 2, 0}, // unrelated reason → never deferred
+		{provNet, 1, 0, 0},                             // first failure → immediate retry
+		{provNet, 2, 4 * time.Second, 6 * time.Second}, // second failure → 5s±20% deferred retry
+		{"runtime_offline", 1, runtimeOfflineRetryDeferral, runtimeOfflineRetryDeferral},
+		{"timeout", 2, 0, 0}, // unrelated reason → never deferred
 	}
 	for _, tc := range delayCases {
-		if got := retryDelayForAttempt(tc.reason, tc.failedAttempt); got != tc.want {
-			t.Errorf("retryDelayForAttempt(%q, %d) = %s, want %s", tc.reason, tc.failedAttempt, got, tc.want)
+		got := retryDelayForAttempt(tc.reason, tc.failedAttempt)
+		if got < tc.min || got > tc.max {
+			t.Errorf("retryDelayForAttempt(%q, %d) = %s, want within [%s, %s]", tc.reason, tc.failedAttempt, got, tc.min, tc.max)
 		}
 	}
 


### PR DESCRIPTION
Closes #7471

Both retry schedules were deterministic — daemon client backoff (4/8/16/32/64s) and the server-side deferred-retry `fire_at`. Tasks watchdog-killed by a provider blip re-fire in lockstep and re-cluster onto the upstream exactly as it recovers.

Adds ±20% jitter to:
- `retrySleep` (client.go)
- `retryDelayForAttempt`'s provider_network final-tier deferral (keeps the new runtime_offline health-gated deferral untouched)

Test updated to assert a [4s, 6s] window for the jittered tier instead of an exact value; runtime_offline case keeps its exact assertion.