### PR TITLE
MUL-6618 feat(issues): show time in status on the issue sidebar

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -79,6 +79,7 @@ import type {
   CreateRuntimeLocalSkillImportRequest,
   RuntimeLocalSkillImportRequest,
   TimelineEntry,
+  StatusDurations,
   AssigneeFrequencyEntry,
   TaskMessagePayload,
   Attachment,
@@ -279,6 +280,7 @@ import {
   EMPTY_SQUAD,
   EMPTY_SQUAD_LIST,
   EMPTY_SQUAD_MEMBER_STATUS_LIST,
+  EMPTY_STATUS_DURATIONS,
   EMPTY_TIMELINE_ENTRIES,
   EMPTY_USER,
   EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE,
@@ -310,6 +312,7 @@ import {
   SquadListSchema,
   SquadMemberStatusListResponseSchema,
   SubscribersListSchema,
+  StatusDurationsSchema,
   TimelineEntriesSchema,
   UserSchema,
   WebhookDeliveryResponseSchema,
@@ -1218,6 +1221,24 @@ export class ApiClient {
     );
     return parseWithFallback(raw, TimelineEntriesSchema, EMPTY_TIMELINE_ENTRIES, {
       endpoint: "GET /api/issues/:id/timeline",
+    });
+  }
+
+  /**
+   * "Time in status" aggregate for one issue.
+   *
+   * Deliberately a separate request rather than something derived from
+   * `listTimeline`: the timeline caps at the newest 2000 entries and discards
+   * the OLDEST rows first, which are exactly the ones a duration aggregate
+   * needs. Deriving it client-side would produce a confidently wrong number on
+   * any issue busy enough to hit the cap.
+   */
+  async getIssueStatusDurations(issueId: string): Promise<StatusDurations> {
+    const raw = await this.fetch<unknown>(
+      `/api/issues/${issueId}/status-durations`,
+    );
+    return parseWithFallback(raw, StatusDurationsSchema, EMPTY_STATUS_DURATIONS, {
+      endpoint: "GET /api/issues/:id/status-durations",
     });
   }
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -79,6 +79,7 @@ import type {
   ShareLinkInfo,
   Skill,
   Squad,
+  StatusDurations,
   TimelineEntry,
   User,
   WebhookDelivery,
@@ -909,6 +910,38 @@ const TimelineEntrySchema = z.object({
 export const TimelineEntriesSchema = z.array(TimelineEntrySchema);
 
 export const EMPTY_TIMELINE_ENTRIES: TimelineEntry[] = [];
+
+// /status-durations returns the "time in status" aggregate for one issue:
+// total residency per status, summed over repeat visits, ordered by first
+// entry so the list reads as the issue's history top-to-bottom.
+//
+// `status` is a bare status key, not a validated enum: the workspace status
+// catalog is user-extensible and keys survive archival, so the aggregate can
+// legitimately name a status this client's catalog no longer offers. The
+// renderer falls back to the raw key rather than dropping the row.
+export const StatusDurationEntrySchema = z.object({
+  status: z.string(),
+  seconds: z.number(),
+  current: z.boolean().default(false),
+}).loose();
+
+export const StatusDurationsSchema = z.object({
+  entries: z.array(StatusDurationEntrySchema).default([]),
+  // Server clock at the moment the open segment was closed off. The live
+  // ticker adds its own elapsed time to this rather than to the client clock,
+  // so a skewed client cannot make the current status count backwards.
+  computed_at: z.string().default(""),
+  // True when nothing was ever logged for this issue, so the whole lifetime
+  // sits in one synthetic bucket. Surfaced so the UI can hedge its wording
+  // instead of presenting a reconstruction as measured history.
+  partial: z.boolean().default(false),
+}).loose();
+
+export const EMPTY_STATUS_DURATIONS: StatusDurations = {
+  entries: [],
+  computed_at: "",
+  partial: false,
+};
 
 const OptionalStringSchema = z.preprocess(
   (value) => (typeof value === "string" ? value : undefined),

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -165,6 +165,10 @@ export const issueKeys = {
     [...issueKeys.subscribersAll(), issueId] as const,
   usageAll: () => ["issues", "usage"] as const,
   usage: (issueId: string) => [...issueKeys.usageAll(), issueId] as const,
+  statusDurationsAll: () => ["issues", "status-durations"] as const,
+  /** "Time in status" aggregate — hover-only, fetched lazily. */
+  statusDurations: (issueId: string) =>
+    [...issueKeys.statusDurationsAll(), issueId] as const,
   attachmentsAll: () => ["issues", "attachments"] as const,
   /** Issue-level attachments — used by the description editor so its
    *  inline file-card / image NodeViews can re-sign download URLs at
@@ -598,6 +602,30 @@ export function issueUsageOptions(issueId: string) {
   return queryOptions({
     queryKey: issueKeys.usage(issueId),
     queryFn: () => api.getIssueUsage(issueId),
+  });
+}
+
+/**
+ * "Time in status" aggregate for the issue-detail status hover.
+ *
+ * Laziness comes from WHERE this is consumed, not from an `enabled` flag: the
+ * hover card's body only mounts while the card is open, so no request happens
+ * until a user actually points at the status row (same pattern as
+ * IssueHoverCard).
+ *
+ * The finite `staleTime` overrides the app-wide `staleTime: Infinity` default
+ * on purpose. Every other per-issue cache here is invalidated by a WS event
+ * when its data changes, but this one also goes stale *with no event at all* —
+ * the current status's duration grows on wall-clock time. Without this, a card
+ * re-opened an hour later would render a number frozen at whenever the issue
+ * was first opened. The open segment is ticked client-side while a card is
+ * up; this is what re-anchors it to the server between hovers.
+ */
+export function issueStatusDurationsOptions(issueId: string) {
+  return queryOptions({
+    queryKey: issueKeys.statusDurations(issueId),
+    queryFn: () => api.getIssueStatusDurations(issueId),
+    staleTime: 60_000,
   });
 }
 

--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -116,11 +116,11 @@ describe("useRealtimeSync — ws instance change", () => {
     rerender({ ws: ws2 });
 
     // Should have called invalidateQueries for all workspace-scoped keys
-    // (16 workspace-scoped [incl. property definitions] + 6 per-issue
+    // (16 workspace-scoped [incl. property definitions] + 7 per-issue
     // prefixes + the workspace working-agents projection + 5 per-chat
     // prefixes + 1 workspaceKeys.list() + 1 cross-workspace inbox unread
-    // summary = 31 calls)
-    expect(invalidateSpy).toHaveBeenCalledTimes(31);
+    // summary = 32 calls)
+    expect(invalidateSpy).toHaveBeenCalledTimes(32);
   });
 
   it("does not re-invalidate when rerendered with the same ws instance", () => {

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -677,6 +677,7 @@ function invalidateWorkspaceScopedQueries(qc: QueryClient): void {
   qc.invalidateQueries({ queryKey: issueKeys.reactionsAll() });
   qc.invalidateQueries({ queryKey: issueKeys.subscribersAll() });
   qc.invalidateQueries({ queryKey: issueKeys.usageAll() });
+  qc.invalidateQueries({ queryKey: issueKeys.statusDurationsAll() });
   qc.invalidateQueries({ queryKey: issueKeys.attachmentsAll() });
   qc.invalidateQueries({ queryKey: issueKeys.tasksAll() });
   // Per-chat-session caches are also keyed without wsId, so the
@@ -1003,6 +1004,17 @@ export function useRealtimeSync(
         if (issue.status) {
           onInboxIssueStatusChanged(qc, wsId, issue.id, issue.status);
         }
+      }
+      // A transition closes the previously-open segment and opens a new one,
+      // so every row of the cached aggregate can move. `refetchType: "none"`
+      // keeps this cheap: the data is only ever read behind a hover, so
+      // marking it stale is enough — the next hover refetches, and an issue
+      // nobody is pointing at costs nothing.
+      if (payload.status_changed) {
+        qc.invalidateQueries({
+          queryKey: issueKeys.statusDurations(issue.id),
+          refetchType: "none",
+        });
       }
     });
 

--- a/packages/core/types/activity.ts
+++ b/packages/core/types/activity.ts
@@ -7,6 +7,27 @@ export interface AssigneeFrequencyEntry {
   frequency: number;
 }
 
+/**
+ * Total wall-clock time an issue has spent on one status, summed across every
+ * visit to it. Backs the "time in status" hover on the issue detail sidebar.
+ */
+export interface StatusDurationEntry {
+  /** Raw status key. May name a status archived out of the workspace catalog. */
+  status: string;
+  seconds: number;
+  /** The status the issue sits on now — its `seconds` is still growing. */
+  current: boolean;
+}
+
+export interface StatusDurations {
+  /** Ordered by first entry into each status, oldest first. */
+  entries: StatusDurationEntry[];
+  /** Server clock when the open segment was closed off, RFC3339. */
+  computed_at: string;
+  /** True when no transitions were ever logged, so this is a single bucket. */
+  partial: boolean;
+}
+
 export interface TimelineEntry {
   type: "activity" | "comment";
   id: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -131,6 +131,8 @@ export {
 export type {
   TimelineEntry,
   AssigneeFrequencyEntry,
+  StatusDurationEntry,
+  StatusDurations,
 } from "./activity";
 export type { IssueSubscriber } from "./subscriber";
 export type * from "./events";

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -69,6 +69,7 @@ import { toast } from "sonner";
 import { errorCode } from "@multica/core/api";
 import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, StagePicker, StartDatePicker, DueDatePicker, AssigneePicker, LabelPicker } from ".";
 import { maxSiblingStage } from "./pickers/stage-picker";
+import { StatusDurationHover } from "./status-duration-hover";
 import { CustomPropertyValueEditor, CustomPropertyValueDisplay } from "./pickers/custom-property-picker";
 import { Switch } from "@multica/ui/components/ui/switch";
 import { IssueActionsDropdown, useIssueActions, IssueActionsContextMenu, IssueContextMenuProvider } from "../actions";
@@ -1177,6 +1178,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [isMobile]);
   const sidebarOpen = isMobile ? mobileSidebarOpen : desktopSidebarOpen;
   const [propertiesOpen, setPropertiesOpen] = useState(true);
+  // Controlled only so the "time in status" hover can stand down while the
+  // picker popover is up — two layers anchored to the same row read as a bug.
+  const [statusPickerOpen, setStatusPickerOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(true);
   const [parentIssueOpen, setParentIssueOpen] = useState(true);
   const [pullRequestsOpen, setPullRequestsOpen] = useState(true);
@@ -2304,7 +2308,19 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         {propertiesOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
           {/* Core props — always rendered. */}
           <PropRow label={t(($) => $.detail.prop_status)}>
-            <StatusPicker status={issue.status} onUpdate={handleUpdateField} align="start" />
+            <StatusDurationHover
+              issueId={issue.id}
+              wsId={wsId}
+              disabled={statusPickerOpen}
+            >
+              <StatusPicker
+                status={issue.status}
+                onUpdate={handleUpdateField}
+                align="start"
+                open={statusPickerOpen}
+                onOpenChange={setStatusPickerOpen}
+              />
+            </StatusDurationHover>
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_assignee)}>
             <AssigneePicker assigneeType={issue.assignee_type} assigneeId={issue.assignee_id} onUpdate={handleUpdateField} align="start" />

--- a/packages/views/issues/components/status-duration-hover.test.tsx
+++ b/packages/views/issues/components/status-duration-hover.test.tsx
@@ -1,0 +1,320 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+import { renderWithI18n } from "../../test/i18n";
+import { StatusDurationBody, StatusDurationHover } from "./status-duration-hover";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@multica/core/issue-statuses/hooks", () => ({
+  // The catalog resolves custom keys to human names. Stubbed so the suite can
+  // assert the fallback path (an archived key the catalog no longer knows)
+  // without standing up a real workspace catalog.
+  useIssueStatuses: () => ({
+    statuses: [],
+    activeStatuses: [],
+    categoryOf: (key: string) => key,
+    colorOf: () => null,
+    labelOf: (key: string) => key,
+    entryOf: (key: string) =>
+      key === "code_review" ? { name: "Code Review" } : undefined,
+    inCategory: () => [],
+    isLoaded: true,
+  }),
+}));
+
+vi.mock("./status-icon", () => ({
+  StatusIcon: ({ status }: { status: string }) => (
+    <svg data-testid="status-icon" data-status={status} />
+  ),
+}));
+
+vi.mock("@multica/core/issues/queries", () => ({
+  issueStatusDurationsOptions: (issueId: string) => ({
+    queryKey: ["status-durations", issueId],
+  }),
+}));
+
+const mockUseQuery = vi.mocked(useQuery);
+
+type Entry = { status: string; seconds: number; current: boolean };
+
+function mockDurations(
+  state:
+    | { phase: "pending" }
+    | { phase: "error" }
+    | {
+        phase: "success";
+        entries: Entry[];
+        partial?: boolean;
+        computedAt?: string;
+      },
+): void {
+  mockUseQuery.mockImplementation(
+    () =>
+      ({
+        data:
+          state.phase === "success"
+            ? {
+                entries: state.entries,
+                partial: state.partial ?? false,
+                computed_at: state.computedAt ?? new Date().toISOString(),
+              }
+            : undefined,
+        isPending: state.phase === "pending",
+        isError: state.phase === "error",
+      }) as unknown as ReturnType<typeof useQuery>,
+  );
+}
+
+function renderBody(): void {
+  renderWithI18n(<StatusDurationBody issueId="issue-1" wsId="workspace-1" />);
+}
+
+/** The duration cells, in render order. */
+function durations(): string[] {
+  return screen
+    .getAllByTestId("status-icon")
+    .map((icon) => icon.parentElement?.lastElementChild?.textContent ?? "");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("StatusDurationBody", () => {
+  it("renders one row per status with a compact duration", () => {
+    mockDurations({
+      phase: "success",
+      entries: [
+        { status: "backlog", seconds: 9, current: false },
+        { status: "in_progress", seconds: 56 * 60, current: false },
+        { status: "code_review", seconds: 11 * 86400, current: true },
+      ],
+    });
+    renderBody();
+
+    expect(screen.getAllByTestId("status-icon")).toHaveLength(3);
+    expect(durations()).toEqual(["9s", "56min", "11d"]);
+  });
+
+  it("preserves server order, which is chronological rather than by size", () => {
+    // The list has to read as the issue's history top-to-bottom. Re-sorting by
+    // duration client-side would make rows jump as the current one grows.
+    mockDurations({
+      phase: "success",
+      entries: [
+        { status: "backlog", seconds: 9, current: false },
+        { status: "in_progress", seconds: 11 * 86400, current: false },
+        { status: "code_review", seconds: 60, current: true },
+      ],
+    });
+    renderBody();
+
+    expect(
+      screen.getAllByTestId("status-icon").map((i) => i.dataset.status),
+    ).toEqual(["backlog", "in_progress", "code_review"]);
+  });
+
+  it("resolves catalog names and falls back to the raw key for unknown ones", () => {
+    // A status can be archived out of the catalog while issues that visited it
+    // still report time against it. The row must survive with its raw key
+    // rather than rendering blank.
+    mockDurations({
+      phase: "success",
+      entries: [
+        { status: "code_review", seconds: 60, current: false },
+        { status: "retired_status", seconds: 60, current: true },
+      ],
+    });
+    renderBody();
+
+    expect(screen.getByText("Code Review")).toBeTruthy();
+    expect(screen.getByText("retired_status")).toBeTruthy();
+  });
+
+  it("shows a skeleton while pending and never translation keys", () => {
+    mockDurations({ phase: "pending" });
+    renderBody();
+
+    expect(screen.getByTestId("status-duration-skeleton")).toBeTruthy();
+    expect(screen.queryByText(/status_duration/)).toBeNull();
+  });
+
+  it("degrades to one message for both error and empty responses", () => {
+    mockDurations({ phase: "error" });
+    const { unmount } = renderWithI18n(
+      <StatusDurationBody issueId="issue-1" wsId="workspace-1" />,
+    );
+    expect(screen.getByText("No status history yet")).toBeTruthy();
+    unmount();
+
+    mockDurations({ phase: "success", entries: [] });
+    renderBody();
+    expect(screen.getByText("No status history yet")).toBeTruthy();
+  });
+
+  it("notes when the aggregate is a reconstruction rather than recorded history", () => {
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "backlog", seconds: 120, current: true }],
+      partial: true,
+    });
+    renderBody();
+
+    expect(
+      screen.getByText(
+        "No transitions recorded — showing time since the issue was created.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("omits the note when real history exists", () => {
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "backlog", seconds: 120, current: true }],
+      partial: false,
+    });
+    renderBody();
+
+    expect(screen.queryByText(/No transitions recorded/)).toBeNull();
+  });
+
+  it("adds request-latency drift to the current status only", () => {
+    // The server closed the open segment 30s before this render. The current
+    // row must already account for that on first paint; closed segments are
+    // final and must not move.
+    const computedAt = new Date(Date.now() - 30_000).toISOString();
+    mockDurations({
+      phase: "success",
+      entries: [
+        { status: "backlog", seconds: 100, current: false },
+        { status: "code_review", seconds: 100, current: true },
+      ],
+      computedAt,
+    });
+    renderBody();
+
+    expect(durations()).toEqual(["1min", "2min"]);
+  });
+
+  it("discards an implausible clock skew instead of adding it", () => {
+    // A client clock hours behind the server would otherwise credit the
+    // current status with hours it never held.
+    const computedAt = new Date(Date.now() - 6 * 3600 * 1000).toISOString();
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "code_review", seconds: 60, current: true }],
+      computedAt,
+    });
+    renderBody();
+
+    expect(durations()).toEqual(["1min"]);
+  });
+
+  it("ignores a client clock ahead of the server rather than going backwards", () => {
+    const computedAt = new Date(Date.now() + 60_000).toISOString();
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "code_review", seconds: 120, current: true }],
+      computedAt,
+    });
+    renderBody();
+
+    expect(durations()).toEqual(["2min"]);
+  });
+
+  it("survives a malformed computed_at", () => {
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "code_review", seconds: 120, current: true }],
+      computedAt: "not-a-date",
+    });
+    renderBody();
+
+    expect(durations()).toEqual(["2min"]);
+  });
+
+  it("localizes units", () => {
+    mockDurations({
+      phase: "success",
+      entries: [
+        { status: "backlog", seconds: 9, current: false },
+        { status: "code_review", seconds: 11 * 86400, current: true },
+      ],
+    });
+    renderWithI18n(<StatusDurationBody issueId="issue-1" wsId="workspace-1" />, {
+      locale: "zh-Hans",
+    });
+
+    expect(durations()).toEqual(["9 秒", "11 天"]);
+  });
+});
+
+describe("StatusDurationHover trigger", () => {
+  function renderHover(disabled = false) {
+    return renderWithI18n(
+      <StatusDurationHover
+        issueId="issue-1"
+        wsId="workspace-1"
+        disabled={disabled}
+        delay={0}
+      >
+        <button type="button">Code Review</button>
+      </StatusDurationHover>,
+    );
+  }
+
+  it("renders its children as the trigger", () => {
+    mockDurations({ phase: "success", entries: [] });
+    renderHover();
+
+    expect(screen.getByRole("button", { name: "Code Review" })).toBeTruthy();
+  });
+
+  it("does not fetch until the card is opened", () => {
+    // The whole laziness claim: mounting an issue detail must not cost a
+    // status-durations request. Base UI only mounts the popup subtree (where
+    // the query lives) once the card opens, so a closed card issues nothing.
+    mockDurations({ phase: "success", entries: [] });
+    renderHover();
+
+    expect(mockUseQuery).not.toHaveBeenCalled();
+  });
+
+  it("fetches and renders rows once hovered", async () => {
+    const user = userEvent.setup();
+    mockDurations({
+      phase: "success",
+      entries: [{ status: "code_review", seconds: 11 * 86400, current: true }],
+    });
+    renderHover();
+
+    await user.hover(screen.getByRole("button", { name: "Code Review" }));
+
+    await screen.findByText("Time in status");
+    expect(mockUseQuery).toHaveBeenCalled();
+    expect(screen.getByText("11d")).toBeTruthy();
+  });
+
+  it("stays shut while the status picker owns the row", async () => {
+    // Two layers anchored to the same row read as a glitch, and a user who
+    // just clicked to CHANGE the status is not asking how long it has been
+    // there. Nothing should be fetched either.
+    const user = userEvent.setup();
+    mockDurations({ phase: "success", entries: [] });
+    renderHover(true);
+
+    await user.hover(screen.getByRole("button", { name: "Code Review" }));
+
+    expect(screen.queryByText("Time in status")).toBeNull();
+    expect(mockUseQuery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/components/status-duration-hover.tsx
+++ b/packages/views/issues/components/status-duration-hover.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@multica/ui/components/ui/hover-card";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
+import { issueStatusDurationsOptions } from "@multica/core/issues/queries";
+import type { StatusDurationEntry } from "@multica/core/types";
+import { StatusIcon } from "./status-icon";
+import { useT } from "../../i18n";
+import { useStatusLabel } from "../utils/status-label";
+import { statusDurationParts } from "../utils/status-duration";
+
+/**
+ * Latency between the server closing off the open segment and this client
+ * rendering it is seconds at worst. A larger gap means the two clocks
+ * disagree, not that time passed, so the drift correction is discarded rather
+ * than trusted — better to under-report the live segment by a few seconds than
+ * to add hours of clock skew to it.
+ */
+const MAX_TRUSTED_DRIFT_SECONDS = 300;
+
+/**
+ * Ticks once a second so the current status's duration counts up while the
+ * card is open. The interval exists only while the card is mounted — Base UI
+ * tears the portalled popup down on close — so a closed card costs nothing.
+ *
+ * Returns elapsed milliseconds since mount rather than a wall-clock instant,
+ * so the figure advances at the right RATE even on a client whose clock is
+ * wrong; absolute skew is handled separately and defensively below.
+ */
+function useElapsedSinceOpen(): number {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const startedAt = Date.now();
+    const id = setInterval(() => setElapsed(Date.now() - startedAt), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return elapsed;
+}
+
+/** One status row: glyph, label, duration. */
+function StatusDurationRow({
+  entry,
+  extraSeconds,
+  wsId,
+}: {
+  entry: StatusDurationEntry;
+  /** Live seconds to add — non-zero only for the current status. */
+  extraSeconds: number;
+  wsId: string;
+}) {
+  const { t } = useT("issues");
+  const { categoryOf, colorOf } = useIssueStatuses(wsId);
+  const labelOf = useStatusLabel(wsId);
+
+  const { value, unit } = statusDurationParts(entry.seconds + extraSeconds);
+
+  return (
+    <div className="flex items-center gap-2">
+      <StatusIcon
+        status={entry.status}
+        category={categoryOf(entry.status)}
+        color={colorOf(entry.status)}
+        className="h-3.5 w-3.5 shrink-0"
+      />
+      {/* The current status is the one the sidebar row already shows;
+          everything above it is history. Muting the past rows makes that
+          reading order obvious without spending a second column on it. */}
+      <span
+        className={`min-w-0 flex-1 truncate ${
+          entry.current ? "text-foreground" : "text-muted-foreground"
+        }`}
+      >
+        {labelOf(entry.status)}
+      </span>
+      <span className="shrink-0 tabular-nums text-muted-foreground">
+        {t(($) => $.status_duration[unit], { count: value })}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * "Time in status" hover card for the issue-detail sidebar status row.
+ *
+ * Shows how long the issue has spent on each status it has passed through,
+ * summed across repeat visits and ordered by first entry, so the list reads as
+ * the issue's history from the top down.
+ *
+ * Like IssueHoverCard, the query lives in the BODY, not here: Base UI mounts
+ * the popup subtree only while the card is open, so this component adds no
+ * request until a user actually points at the row. Hoisting the query up would
+ * fire one per mounted issue detail.
+ */
+export function StatusDurationHover({
+  issueId,
+  wsId,
+  children,
+  disabled = false,
+  delay,
+}: {
+  issueId: string;
+  wsId: string;
+  children: ReactNode;
+  /**
+   * Suppresses the card while the status picker popover is open. Two layers
+   * anchored to the same element read as a glitch, and a user who just clicked
+   * to CHANGE the status is no longer asking how long it has been there.
+   */
+  disabled?: boolean;
+  /**
+   * Open-delay override in milliseconds, for tests. Production passes nothing
+   * and gets Base UI's default, matching every other hover card in the app.
+   */
+  delay?: number;
+}) {
+  const { t } = useT("issues");
+  const [open, setOpen] = useState(false);
+
+  // Driving `open` rather than unmounting the HoverCard on `disabled` keeps
+  // the trigger's DOM node stable, so the picker anchored inside it does not
+  // lose its position mid-interaction.
+  const isOpen = open && !disabled;
+
+  // Clear the latched hover when the picker takes over, not just mask it.
+  // Masking alone makes the card flash back on when the picker closes: the
+  // pointer is wherever the chosen option was, so `open` is still true from
+  // the hover that preceded the click. Reopening should require a fresh hover.
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
+
+  return (
+    <HoverCard open={isOpen} onOpenChange={setOpen}>
+      {/* A real box, not `display: contents`. The positioner anchors to the
+          trigger's bounding rect, and a `contents` element has none — the card
+          renders pinned to the viewport corner instead of beside the row.
+          `flex min-w-0` keeps it transparent to the surrounding layout: it is a
+          flex item in PropRow's value cell and passes the truncation budget
+          straight through to the picker inside. */}
+      <HoverCardTrigger
+        delay={delay}
+        render={<span className="flex min-w-0 items-center" />}
+      >
+        {children}
+      </HoverCardTrigger>
+      <HoverCardContent side="left" align="start" className="w-60">
+        <div className="mb-2 text-caption font-medium">
+          {t(($) => $.status_duration.title)}
+        </div>
+        <StatusDurationBody issueId={issueId} wsId={wsId} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+/**
+ * Card body — mounted only while the card is open, which is what makes the
+ * fetch lazy. Exported so tests can render it directly instead of driving real
+ * pointer hover through a portal.
+ */
+export function StatusDurationBody({
+  issueId,
+  wsId,
+}: {
+  issueId: string;
+  wsId: string;
+}) {
+  const { t } = useT("issues");
+  const elapsedMs = useElapsedSinceOpen();
+  const { data, isPending, isError } = useQuery(
+    issueStatusDurationsOptions(issueId),
+  );
+
+  const computedAt = data?.computed_at;
+
+  // Seconds to add to the current status on FIRST paint, so the figure already
+  // accounts for request latency instead of restarting from the server's
+  // snapshot. Recomputed only when a new response arrives.
+  const driftSeconds = useMemo(() => {
+    if (!computedAt) return 0;
+    const computed = new Date(computedAt).getTime();
+    if (!Number.isFinite(computed)) return 0;
+    const drift = Math.floor((Date.now() - computed) / 1000);
+    if (drift < 0 || drift > MAX_TRUSTED_DRIFT_SECONDS) return 0;
+    return drift;
+  }, [computedAt]);
+
+  if (isPending) {
+    return (
+      <div
+        data-testid="status-duration-skeleton"
+        className="flex flex-col gap-1.5"
+      >
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-4/5" />
+      </div>
+    );
+  }
+
+  // One terminal state for every way the aggregate can fail to arrive: an
+  // error after retries, or a response with nothing in it.
+  if (isError || !data || data.entries.length === 0) {
+    return (
+      <p className="text-caption text-muted-foreground">
+        {t(($) => $.status_duration.unavailable)}
+      </p>
+    );
+  }
+
+  // The ticker advances only the CURRENT status — past segments are closed and
+  // their totals are final.
+  const liveExtra = driftSeconds + Math.floor(elapsedMs / 1000);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5 text-caption">
+        {data.entries.map((entry) => (
+          <StatusDurationRow
+            key={entry.status}
+            entry={entry}
+            extraSeconds={entry.current ? liveExtra : 0}
+            wsId={wsId}
+          />
+        ))}
+      </div>
+      {/* Says so when the numbers are a reconstruction rather than recorded
+          history, instead of presenting the two as the same thing. */}
+      {data.partial && (
+        <p className="text-micro text-muted-foreground">
+          {t(($) => $.status_duration.partial_note)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/views/issues/utils/status-duration.test.ts
+++ b/packages/views/issues/utils/status-duration.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { statusDurationParts } from "./status-duration";
+
+describe("statusDurationParts", () => {
+  it("picks the largest unit that yields a whole value", () => {
+    expect(statusDurationParts(9)).toEqual({ value: 9, unit: "seconds" });
+    expect(statusDurationParts(56 * 60)).toEqual({ value: 56, unit: "minutes" });
+    expect(statusDurationParts(3 * 3600)).toEqual({ value: 3, unit: "hours" });
+    expect(statusDurationParts(11 * 86400)).toEqual({ value: 11, unit: "days" });
+  });
+
+  it("truncates rather than rounds, so time that has not elapsed is never credited", () => {
+    // The whole point of a coarse unit is that it must not overstate. 59
+    // minutes reading "1h" would let a status claim time it never held.
+    expect(statusDurationParts(59 * 60 + 59)).toEqual({
+      value: 59,
+      unit: "minutes",
+    });
+    expect(statusDurationParts(23 * 3600 + 3599)).toEqual({
+      value: 23,
+      unit: "hours",
+    });
+  });
+
+  it("switches unit exactly at each boundary", () => {
+    expect(statusDurationParts(59)).toEqual({ value: 59, unit: "seconds" });
+    expect(statusDurationParts(60)).toEqual({ value: 1, unit: "minutes" });
+    expect(statusDurationParts(3599)).toEqual({ value: 59, unit: "minutes" });
+    expect(statusDurationParts(3600)).toEqual({ value: 1, unit: "hours" });
+    expect(statusDurationParts(86399)).toEqual({ value: 23, unit: "hours" });
+    expect(statusDurationParts(86400)).toEqual({ value: 1, unit: "days" });
+  });
+
+  it("clamps corrupt input to 0s instead of rendering it", () => {
+    // A negative or NaN duration means a bad timestamp upstream. "0s" is a
+    // sane thing to show a user; "-3s" or "NaNd" is not.
+    for (const bad of [-1, -10_000, Number.NaN, Number.POSITIVE_INFINITY * 0]) {
+      expect(statusDurationParts(bad)).toEqual({ value: 0, unit: "seconds" });
+    }
+    expect(statusDurationParts(0)).toEqual({ value: 0, unit: "seconds" });
+  });
+
+  it("keeps a sub-second visit visible as 0s rather than dropping it", () => {
+    // The row exists because the issue really passed through that status.
+    expect(statusDurationParts(0.4)).toEqual({ value: 0, unit: "seconds" });
+  });
+
+  it("does not overflow into a larger unit for very long durations", () => {
+    expect(statusDurationParts(365 * 86400)).toEqual({
+      value: 365,
+      unit: "days",
+    });
+  });
+});

--- a/packages/views/issues/utils/status-duration.ts
+++ b/packages/views/issues/utils/status-duration.ts
@@ -1,0 +1,46 @@
+/**
+ * Compact single-unit duration formatting for the "time in status" hover.
+ *
+ * Deliberately different from the two-unit formatters elsewhere in the app
+ * (`formatDuration` in dashboard/utils.ts renders "2d 3h"; the agent-activity
+ * card renders "1h 03m"). Those describe ONE running thing, where the second
+ * unit is the precision a user is actually watching. This list describes
+ * several statuses side by side, and its job is comparison — "most of the time
+ * went to code review" — not precision. A column of "11d 4h" / "56m 12s" /
+ * "9s" makes that comparison harder to eyeball than "11d" / "56min" / "9s",
+ * and the extra digits are noise at the scale that matters here.
+ *
+ * Truncates rather than rounds, so a status is never credited with time that
+ * has not elapsed: 59 minutes reads "59min", not "1h".
+ */
+
+/** The unit a duration renders in — the key half of the i18n lookup. */
+export type StatusDurationUnit = "seconds" | "minutes" | "hours" | "days";
+
+export interface StatusDurationParts {
+  value: number;
+  unit: StatusDurationUnit;
+}
+
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Splits a second count into the largest unit that yields a value >= 1.
+ *
+ * Returned as parts rather than a finished string so the caller can render the
+ * suffix through i18n. CJK locales do not use the Latin "min"/"d" abbreviations,
+ * and a hardcoded suffix here would be untranslatable.
+ */
+export function statusDurationParts(seconds: number): StatusDurationParts {
+  // Negative or non-finite input means a corrupt timestamp upstream. Clamp to
+  // zero: "0s" is a sane thing to show, "-3s" or "NaNd" is not.
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return { value: 0, unit: "seconds" };
+  }
+  if (seconds < MINUTE) return { value: Math.floor(seconds), unit: "seconds" };
+  if (seconds < HOUR) return { value: Math.floor(seconds / MINUTE), unit: "minutes" };
+  if (seconds < DAY) return { value: Math.floor(seconds / HOUR), unit: "hours" };
+  return { value: Math.floor(seconds / DAY), unit: "days" };
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -488,6 +488,15 @@
   "reply": {
     "placeholder": "Leave a reply..."
   },
+  "status_duration": {
+    "title": "Time in status",
+    "unavailable": "No status history yet",
+    "partial_note": "No transitions recorded — showing time since the issue was created.",
+    "seconds": "{{count}}s",
+    "minutes": "{{count}}min",
+    "hours": "{{count}}h",
+    "days": "{{count}}d"
+  },
   "agent_activity": {
     "hover_header_one": "{{count}} agent working",
     "hover_header_other": "{{count}} agents working",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -473,6 +473,15 @@
   "reply": {
     "placeholder": "返信を残す..."
   },
+  "status_duration": {
+    "title": "ステータス別の経過時間",
+    "unavailable": "ステータスの変更履歴がありません",
+    "partial_note": "変更履歴がないため、作成からの経過時間を表示しています。",
+    "seconds": "{{count}} 秒",
+    "minutes": "{{count}} 分",
+    "hours": "{{count}} 時間",
+    "days": "{{count}} 日"
+  },
   "agent_activity": {
     "hover_header_other": "作業中のエージェント {{count}} 件",
     "hover_header_tasks_other": "実行中の作業 {{count}} 件",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -473,6 +473,15 @@
   "reply": {
     "placeholder": "답글 남기기..."
   },
+  "status_duration": {
+    "title": "상태별 소요 시간",
+    "unavailable": "상태 변경 기록이 없습니다",
+    "partial_note": "변경 기록이 없어 이슈 생성 이후 경과 시간을 표시합니다.",
+    "seconds": "{{count}}초",
+    "minutes": "{{count}}분",
+    "hours": "{{count}}시간",
+    "days": "{{count}}일"
+  },
   "agent_activity": {
     "hover_header_other": "작업 중인 에이전트 {{count}}개",
     "hover_header_tasks_other": "실행 중인 작업 {{count}}개",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -473,6 +473,15 @@
   "reply": {
     "placeholder": "回复..."
   },
+  "status_duration": {
+    "title": "各状态耗时",
+    "unavailable": "暂无状态变更记录",
+    "partial_note": "没有状态变更记录，显示的是任务创建至今的时长。",
+    "seconds": "{{count}} 秒",
+    "minutes": "{{count}} 分钟",
+    "hours": "{{count}} 小时",
+    "days": "{{count}} 天"
+  },
   "agent_activity": {
     "hover_header_other": "{{count}} 个智能体工作中",
     "hover_header_tasks_other": "{{count}} 个 task 工作中",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1804,6 +1804,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Post("/comments", h.CreateComment)
 					r.Get("/comments", h.ListComments)
 					r.Get("/timeline", h.ListTimeline)
+					r.Get("/status-durations", h.GetIssueStatusDurations)
 					r.Get("/subscribers", h.ListIssueSubscribers)
 					r.Post("/subscribe", h.SubscribeToIssue)
 					r.Post("/unsubscribe", h.UnsubscribeFromIssue)

--- a/server/internal/handler/issue_status_duration.go
+++ b/server/internal/handler/issue_status_duration.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// StatusDurationEntry is the total wall-clock time an issue has spent on one
+// status, summed across every visit to it.
+//
+// Seconds rather than millis: the UI renders a single coarse unit ("9s",
+// "56min", "11d") and the underlying activity timestamps are only meaningful to
+// about the second anyway, so millisecond precision would be false precision.
+type StatusDurationEntry struct {
+	Status  string `json:"status"`
+	Seconds int64  `json:"seconds"`
+	// Current marks the status the issue sits on right now. Its Seconds keeps
+	// growing, so the client can label it as still-running rather than final.
+	Current bool `json:"current"`
+}
+
+// StatusDurationsResponse is the "time in status" aggregate for one issue.
+type StatusDurationsResponse struct {
+	Entries []StatusDurationEntry `json:"entries"`
+	// ComputedAt is the instant the open (current) segment was closed off for
+	// this response. Clients that tick the live segment locally add
+	// now-ComputedAt rather than guessing at request latency.
+	ComputedAt string `json:"computed_at"`
+	// Partial is true when the issue predates status-change logging, so the
+	// aggregate is a single synthetic bucket rather than reconstructed history.
+	Partial bool `json:"partial"`
+}
+
+// statusChange is the storage-independent shape aggregateStatusDurations works
+// on, so the aggregation can be unit-tested without a database.
+type statusChange struct {
+	From string
+	To   string
+	At   time.Time
+}
+
+// aggregateStatusDurations reconstructs per-status residency from an issue's
+// ordered status-change history.
+//
+// The model is a partition of [createdAt, now] into half-open segments. Each
+// change closes the running segment and opens the next one:
+//
+//	created ──seg0──▶ change1 ──seg1──▶ change2 ──seg2──▶ now
+//
+// Attribution rules, and why each is what it is:
+//
+//   - Segment 0 belongs to changes[0].From, not to any stored "initial status"
+//     column — there isn't one. The first transition's `from` is the only
+//     record of what the issue was created as, and it is exact.
+//   - The final open segment is attributed to currentStatus (the issue row),
+//     NOT to the last change's `To`. Activity rows are written by a
+//     best-effort async event-bus listener, so a status write can land in the
+//     issue row without ever producing an activity. When the two disagree we
+//     know an unlogged transition happened at an unknown instant; the tail is
+//     given to the issue row so the status the user is looking at never reads
+//     as "0s", and the last logged status is still listed (at zero) so the
+//     transition is not erased from the history. Either choice misplaces the
+//     same amount of time, so the tiebreak is which one reads correctly.
+//   - Ordering of the result is by FIRST time each status was entered, so the
+//     list reads as the issue's life story top-to-bottom and stays stable as
+//     durations grow. Sorting by duration instead would make rows jump around
+//     between renders.
+//
+// Repeat visits to the same status accumulate into one row: the question the
+// UI answers is "how long in code review", not "how long in the third visit to
+// code review".
+//
+// Returns partial=true when there is no recorded history at all, in which case
+// the entire lifetime is attributed to the current status. That covers issues
+// created before status-change logging existed as well as issues that have
+// genuinely never moved; the two are indistinguishable from here, and the
+// single-bucket answer is correct for the second and the best available
+// approximation for the first.
+func aggregateStatusDurations(
+	createdAt time.Time,
+	currentStatus string,
+	changes []statusChange,
+	now time.Time,
+) ([]StatusDurationEntry, bool) {
+	partial := len(changes) == 0
+
+	// Phase 1 — lay the lifetime out as (status, start) boundaries. Building the
+	// full list before folding it keeps the "what was held when" question
+	// separate from the "how long" arithmetic; an earlier version fused the two
+	// and silently dropped the last logged status.
+	type segment struct {
+		status string
+		start  time.Time
+	}
+	var segments []segment
+	if len(changes) == 0 {
+		segments = append(segments, segment{currentStatus, createdAt})
+	} else {
+		// The first transition's `from` is the only surviving record of what
+		// the issue was created as.
+		segments = append(segments, segment{changes[0].From, createdAt})
+		for _, c := range changes {
+			segments = append(segments, segment{c.To, c.At})
+		}
+		// An unlogged transition: hand the open tail to the issue row, leaving
+		// the last logged status present but zero-length.
+		if last := segments[len(segments)-1]; last.status != currentStatus {
+			segments = append(segments, segment{currentStatus, last.start})
+		}
+	}
+
+	// Phase 2 — fold adjacent boundaries into per-status totals.
+	totals := map[string]int64{}
+	order := []string{}
+
+	cursor := createdAt
+	for i, seg := range segments {
+		// A clock skew or backdated row can order a boundary before its
+		// predecessor. Clamp the cursor forward rather than subtracting, so one
+		// bad timestamp costs a zero-length segment instead of a negative
+		// contribution that eats real time from another status.
+		start := seg.start
+		if start.Before(cursor) {
+			start = cursor
+		}
+		cursor = start
+
+		end := now
+		if i+1 < len(segments) {
+			end = segments[i+1].start
+			if end.Before(cursor) {
+				end = cursor
+			}
+		}
+
+		if seg.status == "" {
+			// A transition with no recorded endpoint. Dropping it is better than
+			// inventing a bucket keyed on "": the UI has no label to render.
+			cursor = end
+			continue
+		}
+		if _, seen := totals[seg.status]; !seen {
+			order = append(order, seg.status)
+			totals[seg.status] = 0
+		}
+		if d := end.Sub(start); d > 0 {
+			totals[seg.status] += int64(d / time.Second)
+		}
+		cursor = end
+	}
+
+	entries := make([]StatusDurationEntry, 0, len(order))
+	for _, status := range order {
+		entries = append(entries, StatusDurationEntry{
+			Status:  status,
+			Seconds: totals[status],
+			Current: status == currentStatus,
+		})
+	}
+	return entries, partial
+}
+
+// GetIssueStatusDurations returns how long an issue has spent in each status,
+// aggregated across repeat visits and ordered by first entry.
+//
+// Backed by a dedicated uncapped query rather than the issue timeline: see
+// ListStatusChangesForIssue for why the timeline's newest-N cap makes it
+// unusable as a source for this aggregate.
+func (h *Handler) GetIssueStatusDurations(w http.ResponseWriter, r *http.Request) {
+	issue, ok := h.loadIssueForUser(w, r, chi.URLParam(r, "id"))
+	if !ok {
+		return
+	}
+
+	rows, err := h.Queries.ListStatusChangesForIssue(r.Context(), issue.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list status changes")
+		return
+	}
+
+	changes := make([]statusChange, 0, len(rows))
+	for _, row := range rows {
+		if !row.CreatedAt.Valid {
+			continue
+		}
+		changes = append(changes, statusChange{
+			From: row.FromStatus,
+			To:   row.ToStatus,
+			At:   row.CreatedAt.Time,
+		})
+	}
+
+	createdAt := issue.CreatedAt.Time
+	now := time.Now().UTC()
+	// An issue with no valid created_at cannot anchor segment 0. Falling back
+	// to `now` yields zero-length segments rather than a lifetime measured
+	// from the zero time (year 1), which would render as ~2000y.
+	if !issue.CreatedAt.Valid {
+		createdAt = now
+	}
+
+	entries, partial := aggregateStatusDurations(createdAt, issue.Status, changes, now)
+
+	writeJSON(w, http.StatusOK, StatusDurationsResponse{
+		Entries:    entries,
+		ComputedAt: now.Format(time.RFC3339),
+		Partial:    partial,
+	})
+}

--- a/server/internal/handler/issue_status_duration_test.go
+++ b/server/internal/handler/issue_status_duration_test.go
@@ -1,0 +1,367 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// base is an arbitrary fixed instant; every case builds offsets from it so the
+// expected numbers are readable as "N units after creation".
+var base = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func at(d time.Duration) time.Time { return base.Add(d) }
+
+// got maps entries to a compact status->seconds view for assertions that do not
+// care about order.
+func got(entries []StatusDurationEntry) map[string]int64 {
+	out := map[string]int64{}
+	for _, e := range entries {
+		out[e.Status] = e.Seconds
+	}
+	return out
+}
+
+func order(entries []StatusDurationEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Status
+	}
+	return out
+}
+
+// TestAggregate_LinearScreenshotShape reproduces the canonical case: an issue
+// created in backlog, moved through an implementation status, now sitting in
+// review. It pins all three attribution rules at once — segment 0 comes from
+// the first change's `from`, interior segments from each change's `to`, and the
+// open tail from the issue's current status.
+func TestAggregate_LinearScreenshotShape(t *testing.T) {
+	changes := []statusChange{
+		{From: "backlog", To: "implement", At: at(9 * time.Second)},
+		{From: "implement", To: "code_review", At: at(9*time.Second + 56*time.Minute)},
+	}
+	now := at(9*time.Second + 56*time.Minute + 11*24*time.Hour)
+
+	entries, partial := aggregateStatusDurations(base, "code_review", changes, now)
+	if partial {
+		t.Fatal("partial = true, want false when history exists")
+	}
+
+	want := map[string]int64{
+		"backlog":     9,
+		"implement":   56 * 60,
+		"code_review": 11 * 24 * 3600,
+	}
+	for status, seconds := range want {
+		if g := got(entries)[status]; g != seconds {
+			t.Errorf("%s = %ds, want %ds", status, g, seconds)
+		}
+	}
+
+	// Ordering is by first entry, so the list reads chronologically.
+	wantOrder := []string{"backlog", "implement", "code_review"}
+	for i, status := range order(entries) {
+		if status != wantOrder[i] {
+			t.Fatalf("order = %v, want %v", order(entries), wantOrder)
+		}
+	}
+
+	for _, e := range entries {
+		if (e.Status == "code_review") != e.Current {
+			t.Errorf("%s current = %v, want %v", e.Status, e.Current, e.Status == "code_review")
+		}
+	}
+}
+
+// TestAggregate_RepeatVisitsAccumulate is the reason the result is a map keyed
+// by status rather than a list of segments: bouncing between review and
+// implement must sum into one row per status, not four rows.
+func TestAggregate_RepeatVisitsAccumulate(t *testing.T) {
+	changes := []statusChange{
+		{From: "todo", To: "review", At: at(1 * time.Hour)},  // todo: 1h
+		{From: "review", To: "todo", At: at(3 * time.Hour)},  // review: 2h
+		{From: "todo", To: "review", At: at(4 * time.Hour)},  // todo: +1h
+		{From: "review", To: "todo", At: at(10 * time.Hour)}, // review: +6h
+	}
+	now := at(12 * time.Hour) // todo: +2h
+
+	entries, _ := aggregateStatusDurations(base, "todo", changes, now)
+
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2 (one row per distinct status)", len(entries))
+	}
+	if g := got(entries)["todo"]; g != int64(4*time.Hour/time.Second) {
+		t.Errorf("todo = %ds, want %ds", g, int64(4*time.Hour/time.Second))
+	}
+	if g := got(entries)["review"]; g != int64(8*time.Hour/time.Second) {
+		t.Errorf("review = %ds, want %ds", g, int64(8*time.Hour/time.Second))
+	}
+}
+
+// TestAggregate_NoHistory covers issues that predate status-change logging and
+// issues that have simply never moved. Both must report the whole lifetime on
+// the current status, flagged partial so the UI can hedge its wording.
+func TestAggregate_NoHistory(t *testing.T) {
+	now := at(5 * time.Hour)
+
+	entries, partial := aggregateStatusDurations(base, "backlog", nil, now)
+
+	if !partial {
+		t.Error("partial = false, want true when there is no recorded history")
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].Status != "backlog" || entries[0].Seconds != int64(5*time.Hour/time.Second) {
+		t.Errorf("entry = %+v, want backlog for the full lifetime", entries[0])
+	}
+	if !entries[0].Current {
+		t.Error("the only entry must be marked current")
+	}
+}
+
+// TestAggregate_TailUsesIssueRowNotLastActivity pins the deliberate disagreement
+// rule. The activity listener is a best-effort async subscriber, so the issue
+// row can hold a status that never produced an activity row. The status the
+// user is looking at must be the one the tail is attributed to.
+func TestAggregate_TailUsesIssueRowNotLastActivity(t *testing.T) {
+	changes := []statusChange{
+		{From: "todo", To: "review", At: at(1 * time.Hour)},
+	}
+	now := at(3 * time.Hour)
+
+	// Issue row says "done" even though no activity recorded the review->done move.
+	entries, _ := aggregateStatusDurations(base, "done", changes, now)
+
+	if g := got(entries)["done"]; g != int64(2*time.Hour/time.Second) {
+		t.Errorf("done = %ds, want the full open tail (%ds)", g, int64(2*time.Hour/time.Second))
+	}
+	if _, ok := got(entries)["review"]; !ok {
+		t.Error("review must still appear with a zero-length segment, not vanish")
+	}
+	for _, e := range entries {
+		if e.Status == "review" && e.Current {
+			t.Error("review must not be marked current when the issue row says done")
+		}
+	}
+}
+
+// TestAggregate_BackdatedRowsNeverGoNegative guards the clamp. A clock skew
+// between writers can order a row before its predecessor; that must cost one
+// zero-length segment, never a negative contribution that eats real time from
+// another status.
+func TestAggregate_BackdatedRowsNeverGoNegative(t *testing.T) {
+	changes := []statusChange{
+		{From: "todo", To: "review", At: at(2 * time.Hour)},
+		// Backdated: lands before the previous change.
+		{From: "review", To: "done", At: at(1 * time.Hour)},
+	}
+	now := at(4 * time.Hour)
+
+	entries, _ := aggregateStatusDurations(base, "done", changes, now)
+
+	for _, e := range entries {
+		if e.Seconds < 0 {
+			t.Errorf("%s = %ds, want no negative durations", e.Status, e.Seconds)
+		}
+	}
+	if g := got(entries)["todo"]; g != int64(2*time.Hour/time.Second) {
+		t.Errorf("todo = %ds, want 2h preserved despite the backdated successor", g)
+	}
+	if g := got(entries)["done"]; g != int64(2*time.Hour/time.Second) {
+		t.Errorf("done = %ds, want 2h", g)
+	}
+}
+
+// TestAggregate_EmptyStatusSegmentsAreDropped covers activity rows whose details
+// lack an endpoint. There is no label to render for "", so such a segment must
+// not create a bucket.
+func TestAggregate_EmptyStatusSegmentsAreDropped(t *testing.T) {
+	changes := []statusChange{
+		{From: "", To: "review", At: at(1 * time.Hour)},
+	}
+	now := at(2 * time.Hour)
+
+	entries, _ := aggregateStatusDurations(base, "review", changes, now)
+
+	for _, e := range entries {
+		if e.Status == "" {
+			t.Fatal("an empty status key must never become a row")
+		}
+	}
+	if len(entries) != 1 || entries[0].Status != "review" {
+		t.Fatalf("entries = %+v, want only the review row", entries)
+	}
+}
+
+// TestAggregate_SubSecondSegmentsRoundToZeroButStillListed keeps a status the
+// issue genuinely passed through visible even when it held it only briefly.
+// Dropping it would hide a real transition; the row reads as "0s".
+func TestAggregate_SubSecondSegmentsRoundToZeroButStillListed(t *testing.T) {
+	changes := []statusChange{
+		{From: "todo", To: "triage", At: at(500 * time.Millisecond)},
+		{From: "triage", To: "done", At: at(900 * time.Millisecond)},
+	}
+	now := at(time.Hour)
+
+	entries, _ := aggregateStatusDurations(base, "done", changes, now)
+
+	if len(entries) != 3 {
+		t.Fatalf("len(entries) = %d, want 3 including the sub-second visit", len(entries))
+	}
+	if g := got(entries)["triage"]; g != 0 {
+		t.Errorf("triage = %ds, want 0 (rounded down but present)", g)
+	}
+}
+
+// ── endpoint tests ────────────────────────────────────────────────────────────
+//
+// The pure tests above cover the arithmetic. These cover the wiring the pure
+// tests cannot see: the SQL projection (jsonb -> from/to), row ordering, the
+// created_at anchor coming off the issue row, and workspace scoping.
+
+// fetchStatusDurations calls the endpoint and returns the decoded body.
+func fetchStatusDurations(t *testing.T, issueID string) (StatusDurationsResponse, int) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/"+issueID+"/status-durations", nil)
+	req = withURLParam(req, "id", issueID)
+	testHandler.GetIssueStatusDurations(w, req)
+	var resp StatusDurationsResponse
+	if w.Code == http.StatusOK {
+		json.NewDecoder(w.Body).Decode(&resp)
+	}
+	return resp, w.Code
+}
+
+// seedStatusChange inserts one status_changed activity at an explicit instant.
+func seedStatusChange(t *testing.T, issueID, from, to string, at time.Time) {
+	t.Helper()
+	_, err := testPool.Exec(context.Background(), `
+		INSERT INTO activity_log (workspace_id, issue_id, actor_type, actor_id, action, details, created_at)
+		VALUES ($1, $2, 'member', $3, 'status_changed',
+		        jsonb_build_object('from', $4::text, 'to', $5::text), $6)
+	`, testWorkspaceID, issueID, testUserID, from, to, at)
+	if err != nil {
+		t.Fatalf("seed status change %s->%s: %v", from, to, err)
+	}
+}
+
+// TestGetIssueStatusDurations_AggregatesSeededHistory drives the whole path:
+// real jsonb rows in, aggregated durations out.
+func TestGetIssueStatusDurations_AggregatesSeededHistory(t *testing.T) {
+	issueID := createIssueForTimeline(t, "Status durations aggregate")
+
+	// Anchor creation far enough back that every segment is comfortably
+	// measurable in whole seconds.
+	created := time.Now().UTC().Add(-10 * time.Hour)
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE issue SET created_at = $1, status = 'in_review' WHERE id = $2`, created, issueID); err != nil {
+		t.Fatalf("backdate issue: %v", err)
+	}
+
+	seedStatusChange(t, issueID, "todo", "in_progress", created.Add(2*time.Hour))
+	seedStatusChange(t, issueID, "in_progress", "in_review", created.Add(5*time.Hour))
+
+	resp, status := fetchStatusDurations(t, issueID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if resp.Partial {
+		t.Error("partial = true, want false when history exists")
+	}
+	if len(resp.Entries) != 3 {
+		t.Fatalf("entries = %+v, want 3 rows", resp.Entries)
+	}
+
+	// Ordered by first entry, so the list reads chronologically.
+	wantOrder := []string{"todo", "in_progress", "in_review"}
+	for i, e := range resp.Entries {
+		if e.Status != wantOrder[i] {
+			t.Fatalf("order = %v, want %v", order(resp.Entries), wantOrder)
+		}
+	}
+
+	// Closed segments are exact. The open one is compared with slack because
+	// it runs to time.Now() inside the handler.
+	if s := got(resp.Entries)["todo"]; s != int64(2*time.Hour/time.Second) {
+		t.Errorf("todo = %ds, want 7200", s)
+	}
+	if s := got(resp.Entries)["in_progress"]; s != int64(3*time.Hour/time.Second) {
+		t.Errorf("in_progress = %ds, want 10800", s)
+	}
+	if s := got(resp.Entries)["in_review"]; s < int64(5*time.Hour/time.Second)-30 {
+		t.Errorf("in_review = %ds, want ~18000 (the open segment)", s)
+	}
+
+	if resp.Entries[2].Status != "in_review" || !resp.Entries[2].Current {
+		t.Error("the issue row's status must be the one flagged current")
+	}
+	if resp.ComputedAt == "" {
+		t.Error("computed_at must be set so clients can tick the open segment")
+	}
+}
+
+// TestGetIssueStatusDurations_NoHistoryIsPartial covers issues predating
+// status-change logging: one synthetic bucket for the whole lifetime.
+func TestGetIssueStatusDurations_NoHistoryIsPartial(t *testing.T) {
+	issueID := createIssueForTimeline(t, "Status durations no history")
+	created := time.Now().UTC().Add(-3 * time.Hour)
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE issue SET created_at = $1 WHERE id = $2`, created, issueID); err != nil {
+		t.Fatalf("backdate issue: %v", err)
+	}
+
+	resp, status := fetchStatusDurations(t, issueID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !resp.Partial {
+		t.Error("partial = false, want true when nothing was ever logged")
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].Status != "todo" {
+		t.Fatalf("entries = %+v, want a single todo row", resp.Entries)
+	}
+	if s := resp.Entries[0].Seconds; s < int64(3*time.Hour/time.Second)-30 {
+		t.Errorf("seconds = %d, want ~10800 (the full lifetime)", s)
+	}
+}
+
+// TestGetIssueStatusDurations_IgnoresNonStatusActivity proves the SQL filter
+// bites. Issue timelines are dominated by other action kinds; if the filter
+// were dropped, their rows would be read as transitions with empty endpoints.
+func TestGetIssueStatusDurations_IgnoresNonStatusActivity(t *testing.T) {
+	issueID := createIssueForTimeline(t, "Status durations filter")
+	created := time.Now().UTC().Add(-4 * time.Hour)
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE issue SET created_at = $1 WHERE id = $2`, created, issueID); err != nil {
+		t.Fatalf("backdate issue: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO activity_log (workspace_id, issue_id, actor_type, actor_id, action, details, created_at)
+		VALUES ($1, $2, 'member', $3, 'priority_changed', '{"from":"low","to":"high"}'::jsonb, $4)
+	`, testWorkspaceID, issueID, testUserID, created.Add(time.Hour)); err != nil {
+		t.Fatalf("seed priority activity: %v", err)
+	}
+
+	resp, status := fetchStatusDurations(t, issueID)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !resp.Partial || len(resp.Entries) != 1 {
+		t.Fatalf("entries = %+v (partial=%v), want the priority change to be invisible here",
+			resp.Entries, resp.Partial)
+	}
+}
+
+// TestGetIssueStatusDurations_CrossWorkspaceReturns404 keeps the endpoint from
+// becoming a read hole into other workspaces' issue history.
+func TestGetIssueStatusDurations_CrossWorkspaceReturns404(t *testing.T) {
+	_, status := fetchStatusDurations(t, "00000000-0000-0000-0000-000000000000")
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for an issue this user cannot see", status)
+	}
+}

--- a/server/pkg/db/generated/activity.sql.go
+++ b/server/pkg/db/generated/activity.sql.go
@@ -204,3 +204,58 @@ func (q *Queries) ListActivitiesForIssue(ctx context.Context, arg ListActivities
 	}
 	return items, nil
 }
+
+const listStatusChangesForIssue = `-- name: ListStatusChangesForIssue :many
+SELECT COALESCE(details->>'from', '')::text AS from_status,
+       COALESCE(details->>'to', '')::text   AS to_status,
+       created_at
+FROM activity_log
+WHERE issue_id = $1
+  AND action = 'status_changed'
+ORDER BY created_at ASC, id ASC
+`
+
+type ListStatusChangesForIssueRow struct {
+	FromStatus string             `json:"from_status"`
+	ToStatus   string             `json:"to_status"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+}
+
+// Every status transition for an issue, oldest first, for the "time in status"
+// aggregate.
+//
+// This deliberately does NOT reuse ListActivitiesForIssue. That query caps at
+// the NEWEST N rows, and on a machine-paced issue the cap bites (MUL-5492) —
+// the rows it discards are the oldest ones, which are exactly the ones a
+// duration aggregate needs to attribute the early part of the lifetime. A
+// truncated timeline renders as "some history is missing"; a truncated
+// aggregate renders as a confidently wrong number.
+//
+// Uncapped is safe here because the filter is one action out of ~10 logged
+// kinds: status transitions are human/agent-paced (tens per issue), not
+// autosave-paced. idx_activity_log_issue_keyset (migration 068) serves the
+// issue_id lookup via a backward scan; `action` is filtered on the heap rows
+// that scan already touches, so no new index is needed.
+// The ::text casts exist only so sqlc infers `string` instead of `interface{}`
+// for the JSON extractions. COALESCE keeps a missing key from arriving as a
+// NULL that every call site would have to unwrap: "" already means "unknown"
+// in the aggregation below.
+func (q *Queries) ListStatusChangesForIssue(ctx context.Context, issueID pgtype.UUID) ([]ListStatusChangesForIssueRow, error) {
+	rows, err := q.db.Query(ctx, listStatusChangesForIssue, issueID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListStatusChangesForIssueRow{}
+	for rows.Next() {
+		var i ListStatusChangesForIssueRow
+		if err := rows.Scan(&i.FromStatus, &i.ToStatus, &i.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/server/pkg/db/queries/activity.sql
+++ b/server/pkg/db/queries/activity.sql
@@ -22,6 +22,34 @@ SELECT * FROM (
 ) AS recent
 ORDER BY created_at ASC, id ASC;
 
+-- name: ListStatusChangesForIssue :many
+-- Every status transition for an issue, oldest first, for the "time in status"
+-- aggregate.
+--
+-- This deliberately does NOT reuse ListActivitiesForIssue. That query caps at
+-- the NEWEST N rows, and on a machine-paced issue the cap bites (MUL-5492) —
+-- the rows it discards are the oldest ones, which are exactly the ones a
+-- duration aggregate needs to attribute the early part of the lifetime. A
+-- truncated timeline renders as "some history is missing"; a truncated
+-- aggregate renders as a confidently wrong number.
+--
+-- Uncapped is safe here because the filter is one action out of ~10 logged
+-- kinds: status transitions are human/agent-paced (tens per issue), not
+-- autosave-paced. idx_activity_log_issue_keyset (migration 068) serves the
+-- issue_id lookup via a backward scan; `action` is filtered on the heap rows
+-- that scan already touches, so no new index is needed.
+-- The ::text casts exist only so sqlc infers `string` instead of `interface{}`
+-- for the JSON extractions. COALESCE keeps a missing key from arriving as a
+-- NULL that every call site would have to unwrap: "" already means "unknown"
+-- in the aggregation below.
+SELECT COALESCE(details->>'from', '')::text AS from_status,
+       COALESCE(details->>'to', '')::text   AS to_status,
+       created_at
+FROM activity_log
+WHERE issue_id = $1
+  AND action = 'status_changed'
+ORDER BY created_at ASC, id ASC;
+
 -- name: GetActivity :one
 SELECT * FROM activity_log
 WHERE id = $1;


### PR DESCRIPTION
## What does this PR do?

Hovering the **Status** property in the issue detail sidebar now shows how long the issue has spent in each status, accumulated across repeat visits.

![Time in status hover card](https://raw.githubusercontent.com/t2o2/multica/046d5bd96706ccc48143aed178022b20b0f20aa4/pr/status-duration-hover.png)

The interesting decision is where the numbers come from. The obvious move is to reuse `GET /api/issues/{id}/timeline` and fold the transitions on the client — no new endpoint, no new query. That is wrong here: `/timeline` caps its response at 2000 entries and truncates the **oldest** rows first, which are exactly the rows a lifetime aggregate depends on. On a long-lived issue the card would quietly under-report, and a plausible-looking wrong duration is worse than no duration at all. So this adds `GET /api/issues/{id}/status-durations`, backed by an uncapped query filtered to `status_changed`.

That query needs no migration: the existing `idx_activity_log_issue_keyset (issue_id, created_at DESC, id DESC)` from migration 068 already serves it via a backward scan, and the `action` filter lands on heap rows the scan has touched anyway.

Aggregation is server-side and pure, which keeps three attribution rules honest and testable:

- **The first segment takes its status from the first change's `from`.** There is no stored initial-status column, so that field is the only surviving record of where the issue started.
- **The trailing segment is attributed to `issue.status`, not to the last activity's `to`.** The activity listener is a best-effort async event-bus subscriber and can miss a write, so the issue row is the more trustworthy source for *now*. When the two disagree the last logged status is still emitted at zero seconds, so its transition is not erased from the list. This one was found by a failing test and forced a rewrite from incremental folding to an explicit two-phase segment list.
- **Entries stay in first-visit chronological order.** Sorting by magnitude would make rows jump around as the live segment grows; chronological order lets the list read as the issue's history.

Backdated or clock-skewed rows clamp the cursor forward rather than subtracting, which costs one zero-length segment instead of letting a single bad timestamp contribute negative time. Issues predating status activity logging have no transitions at all, so the response sets `partial: true` and the card hedges its wording instead of presenting one full-lifetime bucket as fact.

## Related Issue

Closes #7482

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

**Server**

- `server/pkg/db/queries/activity.sql` — add `ListStatusChangesForIssue`, uncapped and filtered to `action = 'status_changed'`. `COALESCE(details->>'from','')::text` casts so sqlc emits `string` rather than `interface{}`.
- `server/pkg/db/generated/activity.sql.go` — regenerated via `make sqlc`.
- `server/internal/handler/issue_status_duration.go` — `GetIssueStatusDurations` (authorised through `h.loadIssueForUser`) plus the pure `aggregateStatusDurations(createdAt, currentStatus, changes, now)`.
- `server/cmd/server/router.go` — mount `GET /status-durations` alongside `/timeline`.

**Core**

- `packages/core/types/activity.ts`, `types/index.ts` — `StatusDurationEntry`, `StatusDurations`.
- `packages/core/api/schemas.ts` — matching zod schemas and `EMPTY_STATUS_DURATIONS`.
- `packages/core/api/client.ts` — `getIssueStatusDurations(issueId)` via `parseWithFallback`.
- `packages/core/issues/queries.ts` — `issueStatusDurationsOptions` and the `issueKeys.statusDurations*` key factories, `staleTime: 60_000`.
- `packages/core/realtime/use-realtime-sync.ts` — invalidate on `issue:updated` when `payload.status_changed`, with `refetchType: "none"` so a background issue does not refetch; added to the reconnect-recovery block too.

**Views**

- `packages/views/issues/components/status-duration-hover.tsx` — `StatusDurationHover` trigger plus `StatusDurationBody`. The query lives in the body so nothing is fetched until the popup actually opens, matching `IssueHoverCard`.
- `packages/views/issues/utils/status-duration.ts` — `statusDurationParts(seconds)` returns `{ value, unit }` and truncates rather than rounds.
- `packages/views/issues/components/issue-detail.tsx` — wrap the sidebar `StatusPicker`, suppressing the card while the picker owns the row.
- `packages/views/locales/{en,ja,ko,zh-Hans}/issues.json` — `status_duration` block. Parts are returned rather than a formatted string so unit suffixes go through i18n for CJK.

## How to Test

1. Open any issue that has moved between statuses at least once, then hover the **Status** row in the right-hand properties sidebar. The card lists each status with its accumulated time, oldest first.
2. Move the issue through `In Progress → In Review → In Progress`. Confirm `In Progress` shows a single row holding the combined time, not two rows.
3. Leave the card open on the current status and watch the last row tick upward live.
4. Click the status row. The picker opens and the hover card stands down rather than overlapping it.
5. Backend directly:

   ```bash
   curl -s "localhost:8080/api/issues/$ID/status-durations?workspace_id=$WS" \
     -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
   ```

   ```json
   {
     "entries": [
       { "status": "backlog",     "seconds": 9,      "current": false },
       { "status": "in_progress", "seconds": 3360,   "current": false },
       { "status": "in_review",   "seconds": 950631, "current": true  }
     ],
     "computed_at": "2026-08-23T21:57:33Z",
     "partial": false
   }
   ```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Notes on the checklist, so the ticks are not taken for more than they are worth:

- **Verification run:** 11 Go tests (7 pure aggregation, 4 endpoint) against a real Postgres; the full `internal/handler` package passes at 3127 to rule out contamination from the regenerated `activity.sql.go`; 250 Vitest specs including locale parity across all four locales; `pnpm typecheck` 7/7; `eslint` clean on every touched file and across all six packages.
- **Docs / landing copy:** no new runtime, coding tool, or UI tab, so there was nothing to sync. No user-facing docs page describes the properties sidebar at this level of detail.
- **Chinese copy:** the `zh-Hans` strings are status/duration labels only. Checked against the glossary; no `task` / `issue` / `skill` terminology is involved.
- **Screenshot:** the image above is the real rendered card, not a mockup.

## Risks

- The card is only as complete as `activity_log`. Issues predating status logging return `partial: true`; the UI hedges rather than presenting a single bucket as the whole truth.
- The live ticker anchors on `computed_at` and adds observed drift on first paint, capped by `MAX_TRUSTED_DRIFT_SECONDS = 300`, and counts using elapsed-since-mount so a client with a skewed clock still ticks at the right rate.
- Scope is deliberately the issue detail sidebar. Board and table rows can adopt `StatusDurationHover` unchanged when wanted; that is not in this PR.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Asked for a Linear-style "time in status" hover, with a reference screenshot of Linear's card as the visual target, and instructions to follow the repo conventions in `apps/docs/content/docs/developers/conventions.mdx`.

Two moments are worth reporting because both changed the code:

1. **A failing test rewrote the aggregation.** The first implementation folded durations incrementally and trusted the last activity's `to` for the current status. A test asserting that the issue row wins when the two disagree failed, which exposed that the activity listener is best-effort and can miss writes. The fold was replaced with an explicit two-phase segment list.

2. **jsdom passed while the feature was visibly broken.** All component tests were green, but a real browser check against a seeded workspace showed the card rendering pinned to the top-left corner of the viewport, over the sidebar. The trigger used `display: contents` — required so the wrapper does not break `PropRow`'s subgrid — but an element with `display: contents` generates no box, so the positioner had no anchor rect. jsdom asserts text, not geometry, so it could never have caught this. Fixed with a real but layout-transparent `flex min-w-0 items-center` box and re-verified in the browser; the screenshot above is that verification.
