### PR TITLE
MUL-6551 fix(i18n): separate task failure labels from raw diagnostics

### DIFF
--- a/packages/views/agents/agents-i18n-parity.test.ts
+++ b/packages/views/agents/agents-i18n-parity.test.ts
@@ -5,6 +5,8 @@ import zhHans from "../locales/zh-Hans/agents.json";
 import ja from "../locales/ja/agents.json";
 import ko from "../locales/ko/agents.json";
 import { FAILURE_REASON_I18N_KEYS } from "./components/tabs/task-failure";
+import { taskStatusConfig } from "./config";
+import { availabilityConfig, workloadConfig } from "./presence";
 
 const LOCALES = { en, "zh-Hans": zhHans, ja, ko } as const;
 
@@ -30,6 +32,89 @@ describe("task failure reason i18n parity across all 4 locales", () => {
         expect(typeof label, `${name}: ${key} is not a string`).toBe("string");
         expect(label.length, `${name}: ${key} is empty`).toBeGreaterThan(0);
       }
+    }
+  });
+});
+
+/**
+ * #7411: hardcoded English label tables living inside the translated package.
+ * The visual configs must stay visual — the moment one of them carries a
+ * human-readable string again, that string is untranslatable by construction
+ * and no parity test over the JSON bundles can see it. So assert the absence
+ * of the field itself, at the only place that can still notice.
+ */
+describe("visual config tables carry no human-readable labels", () => {
+  const tables: Record<string, Record<string, object>> = {
+    taskStatusConfig,
+    availabilityConfig,
+    workloadConfig,
+  };
+
+  it("exposes no `label` field on any visual entry", () => {
+    for (const [tableName, table] of Object.entries(tables)) {
+      for (const [key, visual] of Object.entries(table)) {
+        expect(
+          Object.keys(visual),
+          `${tableName}.${key} must not carry a label — use the agents locale bundle`,
+        ).not.toContain("label");
+      }
+    }
+  });
+
+  it("keeps every availability and workload value translated in all 4 locales", () => {
+    for (const [name, locale] of Object.entries(LOCALES)) {
+      for (const key of Object.keys(availabilityConfig)) {
+        const value = (locale.availability as Record<string, string>)[key];
+        expect(value, `${name}: availability.${key} missing`).toBeDefined();
+        expect(value!.length, `${name}: availability.${key} empty`).toBeGreaterThan(0);
+      }
+      for (const key of Object.keys(workloadConfig)) {
+        const value = (locale.workload as Record<string, string>)[key];
+        expect(value, `${name}: workload.${key} missing`).toBeDefined();
+        expect(value!.length, `${name}: workload.${key} empty`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("interpolates the presence status aria-label in all 4 locales", () => {
+    for (const [name, locale] of Object.entries(LOCALES)) {
+      const phrase = locale.presence_status_aria;
+      expect(typeof phrase, `${name}: presence_status_aria missing`).toBe("string");
+      expect(
+        phrase.includes("{{status}}"),
+        `${name}: presence_status_aria lost {{status}}`,
+      ).toBe(true);
+      // The prefix is part of the accessible name, so it must be translated
+      // too — an English "Status:" in front of a localized word is the same
+      // bug in a smaller box.
+      if (name !== "en") {
+        expect(
+          phrase.toLowerCase().includes("status:"),
+          `${name}: presence_status_aria still carries the English prefix`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+/**
+ * The transcript's Run details separates two audiences: `details_reason` heads
+ * the localized `failure_reason` label, `details_diagnostics` heads the raw
+ * English text the server persisted. Both headings must exist everywhere, and
+ * they must not collapse into the same word — that would undo the distinction
+ * the UI is making (#7411).
+ */
+describe("failure reason vs raw diagnostics headings", () => {
+  it("ships both headings, distinct, in all 4 locales", () => {
+    for (const [name, locale] of Object.entries(LOCALES)) {
+      const reason = locale.transcript.details_reason;
+      const diagnostics = locale.transcript.details_diagnostics;
+      expect(typeof reason, `${name}: details_reason missing`).toBe("string");
+      expect(typeof diagnostics, `${name}: details_diagnostics missing`).toBe("string");
+      expect(diagnostics.length, `${name}: details_diagnostics empty`).toBeGreaterThan(0);
+      expect(diagnostics, `${name}: diagnostics heading duplicates the reason heading`).not.toBe(
+        reason,
+      );
     }
   });
 });

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -682,11 +682,13 @@ function TaskRow({
           {failureLabel && (
             <>
               <Sep />
-              {/* Hover reveals the actionable text ("upgrade the daemon on
-                  that machine", "work preserved at …"), not just the bucket. */}
-              <span className="text-destructive" title={task.error ?? undefined}>
-                {failureLabel}
-              </span>
+              {/* The localized reason is the whole user-facing explanation
+                  here. The raw `task.error` used to ride along as this
+                  element's `title`, which put untranslated English (and
+                  absolute paths) in front of every non-English workspace
+                  (#7411); the full diagnostic lives in the transcript's Run
+                  details instead. */}
+              <span className="text-destructive">{failureLabel}</span>
             </>
           )}
           {/* Accountable member (MUL-4302 §9): whose behalf this run is on.

--- a/packages/views/agents/config.ts
+++ b/packages/views/agents/config.ts
@@ -6,11 +6,16 @@ import {
   Play,
 } from "lucide-react";
 
-export const taskStatusConfig: Record<string, { label: string; icon: typeof CheckCircle2; color: string }> = {
-  queued: { label: "Queued", icon: Clock, color: "text-muted-foreground" },
-  dispatched: { label: "Dispatched", icon: Play, color: "text-info" },
-  running: { label: "Running", icon: Loader2, color: "text-brand" },
-  completed: { label: "Completed", icon: CheckCircle2, color: "text-success" },
-  failed: { label: "Failed", icon: XCircle, color: "text-destructive" },
-  cancelled: { label: "Cancelled", icon: XCircle, color: "text-muted-foreground" },
+// Visual-only mapping for a task status: icon + tone. Deliberately carries no
+// `label` — the human-readable status word comes from `taskStatusLabel(status, t)`
+// against the `agents` locale bundle. A `label` here would be a second,
+// untranslatable source of the same string sitting inside a translated package,
+// which is exactly the drift #7411 reported.
+export const taskStatusConfig: Record<string, { icon: typeof CheckCircle2; color: string }> = {
+  queued: { icon: Clock, color: "text-muted-foreground" },
+  dispatched: { icon: Play, color: "text-info" },
+  running: { icon: Loader2, color: "text-brand" },
+  completed: { icon: CheckCircle2, color: "text-success" },
+  failed: { icon: XCircle, color: "text-destructive" },
+  cancelled: { icon: XCircle, color: "text-muted-foreground" },
 };

--- a/packages/views/agents/presence.ts
+++ b/packages/views/agents/presence.ts
@@ -34,8 +34,11 @@ import type { AgentAvailability, Workload } from "@multica/core/agents";
 // — those are historical context, surfaced via Recent Work + Inbox, not
 // list-level summary state.
 
+// Visual-only: dot/text tone + icon. The human-readable word comes from the
+// `agents` locale bundle (`availability.*` / `workload.*`), never from here —
+// a `label` field inside a translated package is a second, untranslatable
+// source of the same string (#7411).
 export interface AvailabilityVisual {
-  label: string;
   // Background fill for the dot indicator.
   dotClass: string;
   // Foreground colour for the label text alongside the dot.
@@ -46,28 +49,25 @@ export interface AvailabilityVisual {
 
 export const availabilityConfig: Record<AgentAvailability, AvailabilityVisual> = {
   online: {
-    label: "Online",
     dotClass: "bg-success",
     textClass: "text-success",
     icon: CircleDot,
   },
   unstable: {
-    label: "Unstable",
     dotClass: "bg-warning",
     textClass: "text-warning",
     icon: PlugZap,
   },
   offline: {
-    label: "Offline",
     dotClass: "bg-muted-foreground/40",
     textClass: "text-muted-foreground",
     icon: CircleSlash,
   },
   // Lifecycle state, not a runtime state — a retired agent. Gray like
-  // offline (it can't take work) but labelled distinctly so the user reads
-  // "this agent is archived", not "temporarily unreachable".
+  // offline (it can't take work) but labelled distinctly (via
+  // `availability.archived`) so the user reads "this agent is archived", not
+  // "temporarily unreachable".
   archived: {
-    label: "Archived",
     dotClass: "bg-muted-foreground/40",
     textClass: "text-muted-foreground",
     icon: Archive,
@@ -83,7 +83,6 @@ export const availabilityOrder: AgentAvailability[] = [
 ];
 
 export interface WorkloadVisual {
-  label: string;
   // Foreground colour for icon + label text.
   textClass: string;
   // Icon used inline.
@@ -92,7 +91,6 @@ export interface WorkloadVisual {
 
 export const workloadConfig: Record<Workload, WorkloadVisual> = {
   working: {
-    label: "Working",
     textClass: "text-brand",
     icon: Loader2,
   },
@@ -100,12 +98,10 @@ export const workloadConfig: Record<Workload, WorkloadVisual> = {
     // Amber chip: nothing running but tasks waiting. On an offline runtime
     // this is the "stuck" signal we explicitly surface (replacing the old
     // misleading "Running 0/N +Mq" copy).
-    label: "Queued",
     textClass: "text-warning",
     icon: Clock,
   },
   idle: {
-    label: "Idle",
     textClass: "text-muted-foreground",
     icon: AlertCircle,
   },

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -16,6 +16,7 @@ import { AgentLivePeekCard } from "../agents/components/agent-live-peek-card";
 import { MemberProfileCard } from "../members/member-profile-card";
 import { SquadProfileCard } from "../squads/components/squad-profile-card";
 import { availabilityConfig } from "../agents/presence";
+import { useT } from "../i18n";
 import {
   resolveClickIntent,
   useIntentNavigate,
@@ -217,15 +218,22 @@ function ActorAvatarProfileLink({
 export function AgentStatusDot({ agentId, size }: { agentId: string; size?: AvatarSize }) {
   const ws = useCurrentWorkspace();
   const detail = useAgentPresenceDetail(ws?.id, agentId);
+  const { t } = useT("agents");
   if (detail === "loading") return null;
 
-  const { dotClass, label } = availabilityConfig[detail.availability];
+  const { dotClass } = availabilityConfig[detail.availability];
   const px = size ? AVATAR_SIZE_PX[size] : 24;
   const dotSize = px >= 24 ? "h-1.5 w-1.5" : "h-1 w-1";
 
   return (
     <span
-      aria-label={`Status: ${label}`}
+      // The dot is the only presence signal on this avatar, so the aria-label
+      // is the whole accessible payload — it has to be translated, prefix
+      // included. It used to read `Status: ${availabilityConfig[...].label}`,
+      // which was English in every locale (#7411).
+      aria-label={t(($) => $.presence_status_aria, {
+        status: t(($) => $.availability[detail.availability]),
+      })}
       className={`absolute bottom-0 right-0 rounded-full ring-1 ring-background ${dotClass} ${dotSize}`}
     />
   );

--- a/packages/views/common/agent-status-dot-i18n.test.tsx
+++ b/packages/views/common/agent-status-dot-i18n.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+/**
+ * The presence dot's accessible name (#7411).
+ *
+ * `AgentStatusDot` renders a coloured dot and nothing else, so its
+ * `aria-label` is the entire payload for a screen-reader user — colour is not
+ * available to them. That label used to be built as `Status: ${label}` from
+ * `availabilityConfig`, a table of English strings sitting inside the
+ * translated package: a Chinese workspace announced "Status: Offline". Both
+ * halves — the prefix and the state word — now come from the `agents` bundle.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import type { AgentAvailability } from "@multica/core/agents";
+import { renderWithI18n } from "../test/i18n";
+
+const presence = vi.hoisted(() => ({
+  availability: "offline" as AgentAvailability,
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: () => "Ada Lovelace",
+    getActorInitials: () => "AL",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    memberDetail: (id: string) => `/acme/members/${id}`,
+    agentDetail: (id: string) => `/acme/agents/${id}`,
+    squadDetail: (id: string) => `/acme/squads/${id}`,
+  }),
+  useCurrentWorkspace: () => ({ id: "ws1", slug: "acme" }),
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  useAgentPresenceDetail: () => ({
+    availability: presence.availability,
+    workload: null,
+  }),
+}));
+
+vi.mock("../agents/components/agent-profile-card", () => ({
+  AgentProfileCard: () => null,
+}));
+vi.mock("../agents/components/agent-live-peek-card", () => ({
+  AgentLivePeekCard: () => null,
+}));
+vi.mock("../members/member-profile-card", () => ({
+  MemberProfileCard: () => null,
+}));
+vi.mock("../squads/components/squad-profile-card", () => ({
+  SquadProfileCard: () => null,
+}));
+
+import { AgentStatusDot } from "./actor-avatar";
+
+describe("AgentStatusDot accessible name", () => {
+  it("names the status in English by default", () => {
+    presence.availability = "offline";
+    renderWithI18n(<AgentStatusDot agentId="agent-1" />);
+
+    expect(screen.getByLabelText("Status: Offline")).toBeInTheDocument();
+  });
+
+  it("names the status in the active locale, prefix included", () => {
+    presence.availability = "offline";
+    renderWithI18n(<AgentStatusDot agentId="agent-1" />, { locale: "zh-Hans" });
+
+    expect(screen.getByLabelText("状态：离线")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Status:/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Offline/)).not.toBeInTheDocument();
+  });
+
+  it("covers every availability value the visual config knows", () => {
+    // `archived` is a lifecycle state the dot also renders; it was in the same
+    // English table, so it needs the same coverage as the runtime states.
+    for (const [availability, expected] of [
+      ["online", "状态：在线"],
+      ["unstable", "状态：不稳定"],
+      ["offline", "状态：离线"],
+      ["archived", "状态：已归档"],
+    ] as const) {
+      presence.availability = availability;
+      const { unmount } = renderWithI18n(<AgentStatusDot agentId="agent-1" />, {
+        locale: "zh-Hans",
+      });
+      expect(screen.getByLabelText(expected)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -797,8 +797,9 @@ describe("AgentTranscriptDialog — delivered branch", () => {
 });
 
 // A server-cancelled run (worktree claim gate, preserved-work delivery) must
-// explain itself: the reason rides the status badge and the full persisted
-// error is readable in Run details. A user's own cancel stays a plain
+// explain itself: the localized reason rides the status badge and heads the
+// "Reason" row in Run details, while the raw persisted diagnostic sits under
+// its own "Technical details" heading. A user's own cancel stays a plain
 // "Cancelled" — they know why they clicked.
 describe("AgentTranscriptDialog — cancel reason", () => {
   const gateError = "worktree mode needs daemon version 0.4.24 or newer on that machine";
@@ -843,5 +844,80 @@ describe("AgentTranscriptDialog — cancel reason", () => {
 
     expect(screen.getByText("Cancelled")).toBeInTheDocument();
     expect(screen.queryByText(/Local directory error/)).not.toBeInTheDocument();
+  });
+
+  // #7411: the status badge used to carry the raw English error as its
+  // `title`. Hovering a translated pill and getting English prose (with an
+  // absolute path in it) is exactly the leak this issue reported.
+  it("keeps the raw diagnostic off the status badge tooltip", () => {
+    renderDialog(items, {
+      locale: "zh-Hans",
+      task: {
+        ...baseTask,
+        status: "cancelled",
+        error: gateError,
+        failure_reason: "local_directory_error",
+      },
+    });
+
+    expect(screen.queryByTitle(gateError)).not.toBeInTheDocument();
+  });
+});
+
+// The two audiences of a failure, kept apart in Run details: the localized
+// reason answers "what happened" for the person who ran the task, the raw
+// persisted text answers "what exactly did the runner say" for whoever
+// debugs it. Merging them is what made #7411 unfixable by translation alone.
+describe("AgentTranscriptDialog — reason vs raw diagnostics", () => {
+  const rawError =
+    "opencode stream ended on an empty step (no text, no tool call, no reported usage)";
+
+  it("heads the localized reason and the raw text with different labels", async () => {
+    renderDialog(items, {
+      task: {
+        ...baseTask,
+        status: "failed",
+        error: rawError,
+        failure_reason: "agent_error.provider_network",
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Run details" }));
+
+    expect(screen.getByText("Reason")).toBeInTheDocument();
+    expect(screen.getByText("Network error reaching provider")).toBeInTheDocument();
+    expect(screen.getByText("Technical details")).toBeInTheDocument();
+    expect(screen.getByText(rawError)).toBeInTheDocument();
+  });
+
+  it("translates both headings and the reason, leaving the raw text verbatim", async () => {
+    renderDialog(items, {
+      locale: "zh-Hans",
+      task: {
+        ...baseTask,
+        status: "failed",
+        error: rawError,
+        failure_reason: "agent_error.provider_network",
+      },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "运行详情" }));
+
+    expect(screen.getByText("原始诊断")).toBeInTheDocument();
+    expect(screen.queryByText("Technical details")).not.toBeInTheDocument();
+    // The diagnostic itself is not translated — it is the runner's own output.
+    // Keeping it readable is the point; presenting it as the reason is not.
+    expect(screen.getByText(rawError)).toBeInTheDocument();
+  });
+
+  it("shows no diagnostics section for a run that persisted no error", async () => {
+    renderDialog(items, {
+      task: { ...baseTask, status: "completed", error: null },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Run details" }));
+
+    expect(screen.queryByText("Technical details")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reason")).not.toBeInTheDocument();
   });
 });

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -42,7 +42,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { ActorAvatar } from "../actor-avatar";
 import { AttributionBadge } from "../../issues/components/attribution-badge";
-import { cancelReasonLabel } from "../../agents/components/tabs/task-failure";
+import { cancelReasonLabel, failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { RichContent } from "../../rich-content";
 import { api } from "@multica/core/api";
 import {
@@ -715,10 +715,13 @@ export function AgentTranscriptDialog({
         // A server-cancelled run (worktree claim gate, preserved-work
         // delivery) carries a persisted reason the user must act on; surface
         // it on the badge instead of a bare "Cancelled". User-initiated
-        // cancels have no reason and keep the plain label.
+        // cancels have no reason and keep the plain label. The badge carries
+        // no `title`: the raw `task.error` behind it is untranslated
+        // operator prose (#7411) and belongs in Run details, not in hover
+        // text on a status pill.
         const cancelReason = cancelReasonLabel(task, t);
         return (
-          <span className={cn(base, "bg-muted text-muted-foreground")} title={task.error ?? undefined}>
+          <span className={cn(base, "bg-muted text-muted-foreground")}>
             <XCircle className="h-3 w-3" />
             {cancelReason
               ? `${t(($) => $.transcript.status_cancelled)} · ${cancelReason}`
@@ -785,10 +788,23 @@ export function AgentTranscriptDialog({
   // this figure, same as on the other usage surfaces.
   useCustomPricingStore((s) => s.pricings);
   const usage = summarizeTaskUsage(task.usage);
+  // Two separate things, deliberately not one string (#7411):
+  //   • `reasonLabel` — the localized reason, derived from the stable
+  //     `failure_reason` enum. This is the user-facing explanation.
+  //   • `task.error` — the raw diagnostic the server/daemon persisted, in
+  //     English, for classification and logs. Kept readable (it is how you
+  //     find "which worktree holds my preserved work" and "which machine
+  //     needs upgrading") but labelled as a technical detail rather than
+  //     presented as the reason, and never merged into the localized text.
+  const reasonLabel =
+    task.status === "failed"
+      ? failureReasonLabel(task.failure_reason, t)
+      : cancelReasonLabel(task, t);
   const hasRunDetails =
     !!runtimeInfo ||
     !!workdirCopyTarget?.relativePath ||
     !!task.branch_name ||
+    !!reasonLabel ||
     !!task.error ||
     !!createdLabel ||
     !!startedLabel ||
@@ -936,14 +952,13 @@ export function AgentTranscriptDialog({
                           copyTitle={t(($) => $.transcript.copy_branch)}
                         />
                       )}
-                      {/* The full persisted error, for failed AND
-                          server-cancelled runs — this is where "which
-                          worktree holds my preserved work" and "which
-                          machine needs upgrading" are actually readable. */}
-                      {task.error && (
+                      {/* The localized reason, from the stable
+                          `failure_reason` enum — this is the explanation, and
+                          it reads in the user's language. */}
+                      {reasonLabel && (
                         <RunDetailRow
                           label={t(($) => $.transcript.details_reason)}
-                          value={task.error}
+                          value={reasonLabel}
                         />
                       )}
                       {createdLabel && (
@@ -954,6 +969,23 @@ export function AgentTranscriptDialog({
                       )}
                       {completedLabel && (
                         <RunDetailRow label={t(($) => $.transcript.details_completed)} value={completedLabel} />
+                      )}
+                      {/* The raw persisted diagnostic, last and behind its own
+                          divider. It is English prose written by the server
+                          and daemon for logs and classification, so it is
+                          labelled "Technical details" — a translated heading
+                          over untranslated content — rather than shown as the
+                          run's reason (#7411). Still the place where "which
+                          worktree holds my preserved work" is readable. */}
+                      {task.error && (
+                        <>
+                          <div className="my-2 h-px bg-border" />
+                          <RunDetailRow
+                            label={t(($) => $.transcript.details_diagnostics)}
+                            value={task.error}
+                            mono
+                          />
+                        </>
                       )}
                       {usage && (
                         <>

--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -228,7 +228,7 @@ describe("TaskCommentCoverage", () => {
 });
 
 describe("execution log failure reasons", () => {
-  it("renders a failed run's reason in the active locale", () => {
+  function failedLogClient() {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -240,9 +240,12 @@ describe("execution log failure reasons", () => {
         failure_reason: "agent_error.provider_quota_limit",
       }),
     ]);
+    return queryClient;
+  }
 
+  it("renders a failed run's reason in the active locale", () => {
     renderWithI18n(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={failedLogClient()}>
         <ExecutionLogSection issueId="issue-1" />
       </QueryClientProvider>,
       { locale: "zh-Hans" },
@@ -253,6 +256,24 @@ describe("execution log failure reasons", () => {
     expect(
       screen.queryByText(/Provider quota exhausted/),
     ).not.toBeInTheDocument();
+  });
+
+  // #7411: the raw `task.error` is English prose the server writes for logs
+  // and classification. It used to be concatenated into the status tooltip,
+  // which put untranslated text — and absolute worktree paths — in front of
+  // every non-English workspace. The localized reason is the whole hover text
+  // now; the raw diagnostic lives in the transcript's Run details.
+  it("keeps the raw server error out of the status tooltip", () => {
+    renderWithI18n(
+      <QueryClientProvider client={failedLogClient()}>
+        <ExecutionLogSection issueId="issue-1" />
+      </QueryClientProvider>,
+      { locale: "zh-Hans" },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "显示历史运行（1）" }));
+    expect(screen.queryByTitle(/provider returned 402/)).not.toBeInTheDocument();
+    expect(screen.getByTitle("提供商配额已用尽")).toBeInTheDocument();
   });
 });
 

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -440,10 +440,14 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
     task.status === "failed"
       ? failureReasonLabel(task.failure_reason, tAgents)
       : cancelReasonLabel(task, tAgents);
-  // Hovering the status mark reveals the actionable text ("upgrade the daemon
-  // on that machine", "work preserved at …"), not just the reason bucket.
-  const statusTitle =
-    failureLabel && task.error ? `${failureLabel}: ${task.error}` : (failureLabel ?? label);
+  // Hovering the status mark reveals the localized reason, never the raw
+  // `task.error`. That field is operator-facing English prose the daemon and
+  // server write for classification and logs (#7411) — pasting it into a
+  // tooltip made every non-English workspace read English at the exact moment
+  // something broke, and dragged absolute worktree paths and machine names
+  // into hover text and screenshots. The full diagnostic stays one click away
+  // in the transcript's Run details.
+  const statusTitle = failureLabel ?? label;
 
   // What this run cost, in the slot the relative timestamp used to hold.
   //

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -34,6 +34,7 @@
     "queued": "Queued",
     "idle": "Idle"
   },
+  "presence_status_aria": "Status: {{status}}",
   "archived": {
     "active_link": "Active agents",
     "title": "Archived agents"
@@ -846,6 +847,7 @@
     "usage_chip_title": "Tokens and estimated cost for this run",
     "details_branch": "Branch",
     "details_reason": "Reason",
+    "details_diagnostics": "Technical details",
     "copy_branch": "Copy branch name",
     "lane_model": "Model",
     "lane_tool": "Tools",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -34,6 +34,7 @@
     "queued": "待機中",
     "idle": "アイドル"
   },
+  "presence_status_aria": "ステータス: {{status}}",
   "archived": {
     "active_link": "アクティブなエージェント",
     "title": "アーカイブ済みエージェント"
@@ -725,6 +726,7 @@
     "usage_chip_title": "この実行のトークンと推定費用",
     "details_branch": "ブランチ",
     "details_reason": "理由",
+    "details_diagnostics": "技術的な詳細",
     "copy_branch": "ブランチ名をコピー",
     "lane_model": "モデル",
     "lane_tool": "ツール",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -34,6 +34,7 @@
     "queued": "대기 중",
     "idle": "유휴"
   },
+  "presence_status_aria": "상태: {{status}}",
   "archived": {
     "active_link": "활성 에이전트",
     "title": "보관된 에이전트"
@@ -733,6 +734,7 @@
     "usage_chip_title": "이 실행의 토큰 및 예상 비용",
     "details_branch": "브랜치",
     "details_reason": "사유",
+    "details_diagnostics": "기술 세부 정보",
     "copy_branch": "브랜치 이름 복사",
     "lane_model": "모델",
     "lane_tool": "도구",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -34,6 +34,7 @@
     "queued": "排队中",
     "idle": "空闲"
   },
+  "presence_status_aria": "状态：{{status}}",
   "archived": {
     "active_link": "活跃智能体",
     "title": "已归档智能体"
@@ -832,6 +833,7 @@
     "usage_chip_title": "这次运行消耗的 token 与估算费用",
     "details_branch": "分支",
     "details_reason": "原因",
+    "details_diagnostics": "原始诊断",
     "copy_branch": "复制分支名",
     "lane_model": "模型",
     "lane_tool": "工具",


### PR DESCRIPTION
## Background

`#7459` (MUL-6565) localized the `failure_reason` labels, which fixed item 1 of #7411. Item 2 was untouched: the raw `task.error` the server and daemon persist was still concatenated into the text a user reads.

The result on `main` before this PR — a translated reason followed by an English sentence:

```
提供商配额已用尽: API Error: 529 Overloaded. This is a server-side issue…
```

That is not a missing translation. `task.error` is free-form English written by the runner for logs and for `taskfailure.Classify` to match on; it cannot be localized by any client. Merging it into the localized reason also dragged absolute worktree paths and machine names into hover text and screenshots.

## What this changes

Splits the two by audience, entirely in the web/desktop layer.

**The localized reason is the whole user-facing explanation.** The raw `task.error` is removed from:

- `issues/components/execution-log-section.tsx` — the past-run status tooltip
- `agents/components/tabs/activity-tab.tsx` — the agent activity row's failure tooltip
- `common/task-transcript/agent-transcript-dialog.tsx` — the cancelled status badge's `title`

**The transcript's Run details now labels both, separately.** `Reason` heads the localized label derived from the stable `failure_reason` enum; the raw text moves to its own `Technical details` row at the end, behind a divider — a translated heading over untranslated content. This is still where "which worktree holds my preserved work" and "which machine needs upgrading" are readable, which was the original justification for showing it at all.

**Finishes the two label tables `#7459` left inside the translated package.**

- `agents/config.ts` — `taskStatusConfig.label` was dead code. The only importer reads `icon` and `color`; the status word already comes from `taskStatusLabel(status, t)`. Field removed.
- `agents/presence.ts` — `availabilityConfig` / `workloadConfig` carried English `label` strings whose only reader was `AgentStatusDot`'s `aria-label={`Status: ${label}`}`. That dot renders no text, so the aria-label is the entire payload for a screen-reader user, and it announced `Status: Offline` in a Chinese workspace. It now reads through the existing `availability.*` keys plus a new `presence_status_aria`, and both visual configs carry no copy at all.

New keys in all four shipped locales (`en`, `zh-Hans`, `ja`, `ko`): `presence_status_aria`, `transcript.details_diagnostics`.

## What this deliberately does not do

- **No `failure_detail {code, params}` field.** `agent_task_queue.error` is `taskfailure.Classify`'s input — dozens of `containsAny` rules match its prose — so it keeps its exact current meaning. A second failure taxonomy with a persistence and API contract, mixed-version compatibility, and an arbitrary `params` map is not something this PR needs to answer #7411's user-visible half. If a follow-up finds information users must see that the existing structured fields (`failure_reason`, `runtime_id`, `relative_work_dir`, `relative_durable_work_dir`, `branch_name`) cannot express, that deserves its own design with an allowlisted, strongly-typed shape and leak tests.
- **No French locale.** #7411's title says "five shipped locales", but `packages/core/i18n/types.ts` ships four — `en | zh-Hans | ko | ja` — and there is no `locales/fr/` directory. French is open PR #7141, which needs a rebase past #7459 and the new `task_failure.reasons` keys.
- **No mobile change.** `apps/mobile` is English-only by design (no i18n library) and keeps its own mirrored tables, which have drifted 9 reasons behind the web enum. That is a separate follow-up and does not block the web/desktop fix.
- **No server or schema change.** No migration, no protocol version, no client/server release ordering requirement.

## Testing

- `agents/agents-i18n-parity.test.ts` — asserts no visual config entry exposes a `label` field (the only place a re-introduced hardcoded string is visible, since a parity test over the JSON bundles cannot see it); asserts every `availability` / `workload` value is translated in all four locales; asserts `presence_status_aria` keeps its `{{status}}` token and that no non-English locale still carries the English `Status:` prefix; asserts `details_reason` and `details_diagnostics` both exist and are distinct per locale.
- `common/agent-status-dot-i18n.test.tsx` (new) — asserts the presence dot's accessible name in English and in Chinese, prefix included, across every availability value including `archived`.
- `issues/components/execution-log-section.test.tsx` — asserts the raw error is absent from the status tooltip while the localized reason is present.
- `common/task-transcript/agent-transcript-dialog.test.tsx` — asserts the raw diagnostic is off the badge tooltip, that both headings render with their correct values in English and Chinese, that the raw text stays verbatim, and that a clean run shows neither section.

Locally: `packages/views` `tsc --noEmit` clean, `eslint .` 0 errors, and `pnpm typecheck` green across all 7 packages. `vitest run` in `packages/views` is 4665 passed / 1 failed, the failure being `layout/sidebar-resize.test.tsx`, which fails identically on a clean checkout of `main` in this environment (a `localStorage` sandbox issue, unrelated to this change).

Refs #7411
