### PR TITLE
MUL-6632: add status and priority filters to Inbox

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -773,6 +773,60 @@ describe("ApiClient notification preferences", () => {
   });
 });
 
+describe("ApiClient Inbox response schemas", () => {
+  const legacyRow = {
+    id: "inbox-1",
+    workspace_id: "ws-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: "issue-1",
+    title: "Legacy Inbox row",
+    body: null,
+    read: false,
+    archived: false,
+    created_at: "2026-08-24T00:00:00Z",
+  };
+
+  it("schema-parses the main Inbox and preserves omitted legacy projections", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify([legacyRow]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const result = await new ApiClient("https://api.example.test").listInbox();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toHaveProperty("issue_status");
+    expect(result[0]).not.toHaveProperty("issue_priority");
+  });
+
+  it("falls back safely when the main Inbox projection is wrong-typed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify([{ ...legacyRow, issue_priority: 3 }]),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    await expect(
+      new ApiClient("https://api.example.test").listInbox(),
+    ).resolves.toEqual([]);
+  });
+});
+
 describe("ApiClient", () => {
   it("preserves HTTP status on failed requests", async () => {
     vi.stubGlobal(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -2306,7 +2306,10 @@ export class ApiClient {
 
   // Inbox
   async listInbox(): Promise<InboxItem[]> {
-    return this.fetch("/api/inbox");
+    const raw = await this.fetch<unknown>("/api/inbox");
+    return parseWithFallback(raw, InboxItemListSchema, EMPTY_INBOX_ITEMS, {
+      endpoint: "GET /api/inbox",
+    });
   }
 
   async markInboxRead(id: string): Promise<InboxItem> {

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -1066,13 +1066,23 @@ describe("InboxItemListSchema", () => {
 
   it("parses a well-formed archived list and tolerates extra fields", () => {
     const parsed = parseWithFallback(
-      [row({ issue_status: "in_progress", details: { comment_id: "c-1" }, future_field: 1 })],
+      [row({
+        issue_status: "in_progress",
+        issue_priority: "high",
+        details: { comment_id: "c-1" },
+        future_field: 1,
+      })],
       InboxItemListSchema,
       EMPTY_INBOX_ITEMS,
       ENDPOINT,
     );
     expect(parsed).toHaveLength(1);
-    expect(parsed[0]).toMatchObject({ id: "inbox-1", archived: true });
+    expect(parsed[0]).toMatchObject({
+      id: "inbox-1",
+      archived: true,
+      issue_status: "in_progress",
+      issue_priority: "high",
+    });
   });
 
   it("keeps a notification type this client doesn't know yet", () => {
@@ -1094,6 +1104,17 @@ describe("InboxItemListSchema", () => {
     expect(
       parseWithFallback([withoutOptionals], InboxItemListSchema, EMPTY_INBOX_ITEMS, ENDPOINT),
     ).toHaveLength(1);
+  });
+
+  it("returns the empty fallback when an issue projection is wrong-typed", () => {
+    expect(
+      parseWithFallback(
+        [row({ issue_priority: 3 })],
+        InboxItemListSchema,
+        EMPTY_INBOX_ITEMS,
+        ENDPOINT,
+      ),
+    ).toBe(EMPTY_INBOX_ITEMS);
   });
 
   it("returns the empty fallback for a non-array body", () => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -2197,14 +2197,15 @@ export const InboxUnreadSummarySchema = z.array(
 export const EMPTY_INBOX_UNREAD_SUMMARY: InboxWorkspaceUnread[] = [];
 
 // ---------------------------------------------------------------------------
-// Archived inbox items (`/api/inbox/archived` GET).
+// Inbox items (`/api/inbox` and `/api/inbox/archived` GET).
 // Lenient per the usual rules: `severity` / `type` / `recipient_type` stay
 // `z.string()` so a notification kind this client doesn't know yet still
 // parses and renders (the UI's type-label lookup already tolerates unknown
 // kinds). Nullable optional fields are declared optional as well, since older
 // rows can omit them entirely. On malformed JSON parseWithFallback returns the
-// empty list — the archived view then reads as empty rather than white-
-// screening the inbox.
+// empty list — the affected view then reads as empty rather than white-
+// screening the inbox. Both endpoints share this boundary because they return
+// the same row shape and both feed the status/priority filter UI.
 // ---------------------------------------------------------------------------
 
 export const InboxItemListSchema = z.array(

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -2219,6 +2219,8 @@ export const InboxItemListSchema = z.array(
       issue_id: z.string().nullish(),
       title: z.string(),
       body: z.string().nullish(),
+      issue_status: z.string().nullish(),
+      issue_priority: z.string().nullish(),
       read: z.boolean(),
       archived: z.boolean(),
       created_at: z.string(),

--- a/packages/core/inbox/filter-store.test.ts
+++ b/packages/core/inbox/filter-store.test.ts
@@ -5,7 +5,9 @@ import type { InboxItem } from "../types";
 import {
   EMPTY_INBOX_FILTERS,
   filterInboxItems,
+  inboxFiltersForPrioritySupport,
   inboxFilterCount,
+  inboxPriorityFilterSupport,
   useInboxFilterStore,
 } from "./filter-store";
 
@@ -67,6 +69,32 @@ describe("filterInboxItems", () => {
       ),
     ).toEqual(["todo-high", "done-high"]);
   });
+
+  it("does not apply a priority condition until the projection is supported", () => {
+    const filters = { statuses: ["todo"], priorities: ["high"] } as const;
+
+    expect(inboxFiltersForPrioritySupport(filters, "unknown")).toEqual({
+      statuses: ["todo"],
+      priorities: [],
+    });
+    expect(inboxFiltersForPrioritySupport(filters, "unsupported")).toEqual({
+      statuses: ["todo"],
+      priorities: [],
+    });
+    expect(inboxFiltersForPrioritySupport(filters, "supported")).toBe(filters);
+  });
+});
+
+describe("inboxPriorityFilterSupport", () => {
+  it("distinguishes an omitted legacy projection from a supported null", () => {
+    expect(inboxPriorityFilterSupport([])).toBe("unknown");
+    expect(inboxPriorityFilterSupport([item("system", null, null)])).toBe(
+      "supported",
+    );
+    expect(inboxPriorityFilterSupport([item("legacy", "todo", undefined)])).toBe(
+      "unsupported",
+    );
+  });
 });
 
 describe("useInboxFilterStore", () => {
@@ -86,5 +114,18 @@ describe("useInboxFilterStore", () => {
     useInboxFilterStore.getState().clearFilters("ws-1");
     expect(useInboxFilterStore.getState().filtersByWorkspace["ws-1"]).toBeUndefined();
     expect(useInboxFilterStore.getState().filtersByWorkspace["ws-2"]).toBeDefined();
+  });
+
+  it("clears only the unsupported priority dimension", () => {
+    const store = useInboxFilterStore.getState();
+    store.toggleStatusFilter("ws-1", "todo");
+    store.togglePriorityFilter("ws-1", "high");
+
+    useInboxFilterStore.getState().clearPriorityFilters("ws-1");
+
+    expect(useInboxFilterStore.getState().filtersByWorkspace["ws-1"]).toEqual({
+      statuses: ["todo"],
+      priorities: [],
+    });
   });
 });

--- a/packages/core/inbox/filter-store.test.ts
+++ b/packages/core/inbox/filter-store.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { InboxItem } from "../types";
+import {
+  EMPTY_INBOX_FILTERS,
+  filterInboxItems,
+  inboxFilterCount,
+  useInboxFilterStore,
+} from "./filter-store";
+
+function item(
+  id: string,
+  issueStatus: InboxItem["issue_status"],
+  issuePriority: InboxItem["issue_priority"],
+): InboxItem {
+  return {
+    id,
+    workspace_id: "ws-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: null,
+    actor_id: null,
+    type: "mentioned",
+    severity: "info",
+    issue_id: issueStatus == null ? null : `issue-${id}`,
+    title: id,
+    body: null,
+    issue_status: issueStatus,
+    issue_priority: issuePriority,
+    read: false,
+    archived: false,
+    created_at: "2026-08-24T00:00:00Z",
+    details: null,
+  };
+}
+
+const ITEMS = [
+  item("todo-high", "todo", "high"),
+  item("todo-low", "todo", "low"),
+  item("done-high", "done", "high"),
+  item("system", null, null),
+];
+
+beforeEach(() => {
+  useInboxFilterStore.setState({ filtersByWorkspace: {} });
+});
+
+describe("filterInboxItems", () => {
+  it("keeps the original reference when no filter is active", () => {
+    expect(filterInboxItems(ITEMS, EMPTY_INBOX_FILTERS)).toBe(ITEMS);
+  });
+
+  it("uses OR within a dimension and AND between dimensions", () => {
+    expect(
+      filterInboxItems(ITEMS, {
+        statuses: ["todo", "done"],
+        priorities: ["high"],
+      }).map((candidate) => candidate.id),
+    ).toEqual(["todo-high", "done-high"]);
+  });
+
+  it("excludes notifications without an issue when an issue filter is active", () => {
+    expect(
+      filterInboxItems(ITEMS, { statuses: [], priorities: ["high"] }).map(
+        (candidate) => candidate.id,
+      ),
+    ).toEqual(["todo-high", "done-high"]);
+  });
+});
+
+describe("useInboxFilterStore", () => {
+  it("keeps filters isolated by workspace and clears one workspace only", () => {
+    const store = useInboxFilterStore.getState();
+    store.toggleStatusFilter("ws-1", "todo");
+    store.togglePriorityFilter("ws-2", "urgent");
+
+    expect(useInboxFilterStore.getState().filtersByWorkspace).toMatchObject({
+      "ws-1": { statuses: ["todo"], priorities: [] },
+      "ws-2": { statuses: [], priorities: ["urgent"] },
+    });
+    expect(
+      inboxFilterCount(useInboxFilterStore.getState().filtersByWorkspace["ws-1"]!),
+    ).toBe(1);
+
+    useInboxFilterStore.getState().clearFilters("ws-1");
+    expect(useInboxFilterStore.getState().filtersByWorkspace["ws-1"]).toBeUndefined();
+    expect(useInboxFilterStore.getState().filtersByWorkspace["ws-2"]).toBeDefined();
+  });
+});

--- a/packages/core/inbox/filter-store.ts
+++ b/packages/core/inbox/filter-store.ts
@@ -6,6 +6,11 @@ export interface InboxFilters {
   readonly priorities: readonly IssuePriority[];
 }
 
+export type InboxPriorityFilterSupport =
+  | "unknown"
+  | "supported"
+  | "unsupported";
+
 export const EMPTY_INBOX_FILTERS: InboxFilters = Object.freeze({
   statuses: Object.freeze([]),
   priorities: Object.freeze([]),
@@ -15,6 +20,7 @@ interface InboxFilterState {
   filtersByWorkspace: Record<string, InboxFilters>;
   toggleStatusFilter: (wsId: string, status: IssueStatus) => void;
   togglePriorityFilter: (wsId: string, priority: IssuePriority) => void;
+  clearPriorityFilters: (wsId: string) => void;
   clearFilters: (wsId: string) => void;
 }
 
@@ -52,6 +58,22 @@ export const useInboxFilterStore = create<InboxFilterState>()((set) => ({
         },
       };
     }),
+  clearPriorityFilters: (wsId) =>
+    set((state) => {
+      const current = state.filtersByWorkspace[wsId];
+      if (!current || current.priorities.length === 0) return state;
+      if (current.statuses.length === 0) {
+        const { [wsId]: _removed, ...filtersByWorkspace } =
+          state.filtersByWorkspace;
+        return { filtersByWorkspace };
+      }
+      return {
+        filtersByWorkspace: {
+          ...state.filtersByWorkspace,
+          [wsId]: { ...current, priorities: [] },
+        },
+      };
+    }),
   clearFilters: (wsId) =>
     set((state) => {
       if (!state.filtersByWorkspace[wsId]) return state;
@@ -67,6 +89,35 @@ export function useInboxFilters(wsId: string): InboxFilters {
     useInboxFilterStore((state) => state.filtersByWorkspace[wsId]) ??
     EMPTY_INBOX_FILTERS
   );
+}
+
+/**
+ * Capability inferred from the parsed response, not from a version string.
+ *
+ * The new backend always serializes `issue_priority` for every Inbox row
+ * (including `null` for notifications without an issue). An older backend
+ * omits it. Requiring every returned row to carry a defined value also keeps a
+ * priority cache patch from making a mixed rolling-deploy response look fully
+ * supported.
+ */
+export function inboxPriorityFilterSupport(
+  items: readonly InboxItem[],
+): InboxPriorityFilterSupport {
+  if (items.length === 0) return "unknown";
+  return items.every((item) => item.issue_priority !== undefined)
+    ? "supported"
+    : "unsupported";
+}
+
+/** Ignore a stale priority selection until the backend capability is proven. */
+export function inboxFiltersForPrioritySupport(
+  filters: InboxFilters,
+  support: InboxPriorityFilterSupport,
+): InboxFilters {
+  if (support === "supported" || filters.priorities.length === 0) {
+    return filters;
+  }
+  return { statuses: filters.statuses, priorities: [] };
 }
 
 /** OR within a dimension, AND between status and priority dimensions. */

--- a/packages/core/inbox/filter-store.ts
+++ b/packages/core/inbox/filter-store.ts
@@ -1,0 +1,94 @@
+import { create } from "zustand";
+import type { InboxItem, IssuePriority, IssueStatus } from "../types";
+
+export interface InboxFilters {
+  readonly statuses: readonly IssueStatus[];
+  readonly priorities: readonly IssuePriority[];
+}
+
+export const EMPTY_INBOX_FILTERS: InboxFilters = Object.freeze({
+  statuses: Object.freeze([]),
+  priorities: Object.freeze([]),
+});
+
+interface InboxFilterState {
+  filtersByWorkspace: Record<string, InboxFilters>;
+  toggleStatusFilter: (wsId: string, status: IssueStatus) => void;
+  togglePriorityFilter: (wsId: string, priority: IssuePriority) => void;
+  clearFilters: (wsId: string) => void;
+}
+
+function toggleValue<T extends string>(values: readonly T[], value: T): T[] {
+  return values.includes(value)
+    ? values.filter((candidate) => candidate !== value)
+    : [...values, value];
+}
+
+export const useInboxFilterStore = create<InboxFilterState>()((set) => ({
+  filtersByWorkspace: {},
+  toggleStatusFilter: (wsId, status) =>
+    set((state) => {
+      const current = state.filtersByWorkspace[wsId] ?? EMPTY_INBOX_FILTERS;
+      return {
+        filtersByWorkspace: {
+          ...state.filtersByWorkspace,
+          [wsId]: {
+            ...current,
+            statuses: toggleValue(current.statuses, status),
+          },
+        },
+      };
+    }),
+  togglePriorityFilter: (wsId, priority) =>
+    set((state) => {
+      const current = state.filtersByWorkspace[wsId] ?? EMPTY_INBOX_FILTERS;
+      return {
+        filtersByWorkspace: {
+          ...state.filtersByWorkspace,
+          [wsId]: {
+            ...current,
+            priorities: toggleValue(current.priorities, priority),
+          },
+        },
+      };
+    }),
+  clearFilters: (wsId) =>
+    set((state) => {
+      if (!state.filtersByWorkspace[wsId]) return state;
+      const { [wsId]: _removed, ...filtersByWorkspace } =
+        state.filtersByWorkspace;
+      return { filtersByWorkspace };
+    }),
+}));
+
+/** Workspace-isolated filter state with a stable empty fallback. */
+export function useInboxFilters(wsId: string): InboxFilters {
+  return (
+    useInboxFilterStore((state) => state.filtersByWorkspace[wsId]) ??
+    EMPTY_INBOX_FILTERS
+  );
+}
+
+/** OR within a dimension, AND between status and priority dimensions. */
+export function filterInboxItems(
+  items: InboxItem[],
+  filters: InboxFilters,
+): InboxItem[] {
+  if (filters.statuses.length === 0 && filters.priorities.length === 0) {
+    return items;
+  }
+
+  const statuses = new Set(filters.statuses);
+  const priorities = new Set(filters.priorities);
+  return items.filter(
+    (item) =>
+      (statuses.size === 0 ||
+        (item.issue_status != null && statuses.has(item.issue_status))) &&
+      (priorities.size === 0 ||
+        (item.issue_priority != null && priorities.has(item.issue_priority))),
+  );
+}
+
+export function inboxFilterCount(filters: InboxFilters): number {
+  return filters.statuses.length + filters.priorities.length;
+}

--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -5,6 +5,7 @@ import {
   onInboxIssueDeleted,
   onInboxIssueStatusChanged,
   onInboxSummaryInvalidate,
+  patchInboxIssueProjection,
 } from "./ws-updaters";
 import { inboxKeys } from "./queries";
 import type { InboxItem } from "../types";
@@ -153,5 +154,33 @@ describe("onInboxIssueStatusChanged", () => {
     expect(
       qc.getQueryData<InboxItem[]>(inboxKeys.archived(wsId))?.[0]?.issue_status,
     ).toBe("done");
+  });
+});
+
+describe("patchInboxIssueProjection", () => {
+  it("patches priority in both active and archived issue rows", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), [
+      makeItem("i1", "issue-a", { issue_priority: "low" }),
+      makeItem("i2", "issue-b", { issue_priority: "low" }),
+    ]);
+    qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), [
+      makeItem("a1", "issue-a", {
+        archived: true,
+        issue_priority: "low",
+      }),
+    ]);
+
+    patchInboxIssueProjection(qc, wsId, "issue-a", { priority: "urgent" });
+
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))?.map((item) =>
+        item.issue_priority,
+      ),
+    ).toEqual(["urgent", "low"]);
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.archived(wsId))?.[0]
+        ?.issue_priority,
+    ).toBe("urgent");
   });
 });

--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -183,4 +183,17 @@ describe("patchInboxIssueProjection", () => {
         ?.issue_priority,
     ).toBe("urgent");
   });
+
+  it("does not manufacture priority capability for legacy Inbox rows", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), [
+      makeItem("legacy", "issue-a"),
+    ]);
+
+    patchInboxIssueProjection(qc, wsId, "issue-a", { priority: "urgent" });
+
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))?.[0],
+    ).not.toHaveProperty("issue_priority");
+  });
 });

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { inboxKeys } from "./queries";
-import type { InboxItem, IssueStatus } from "../types";
+import type { InboxItem, IssuePriority, IssueStatus } from "../types";
 
 export function onInboxNew(
   qc: QueryClient,
@@ -17,17 +17,42 @@ export function onInboxNew(
   qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
 }
 
+export function patchInboxIssueProjection(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  patch: { status?: IssueStatus; priority?: IssuePriority },
+) {
+  const project = (old: InboxItem[] | undefined) => {
+    if (!old) return old;
+    let changed = false;
+    const next = old.map((item) => {
+      if (item.issue_id !== issueId) return item;
+      changed = true;
+      return {
+        ...item,
+        ...(patch.status !== undefined
+          ? { issue_status: patch.status }
+          : {}),
+        ...(patch.priority !== undefined
+          ? { issue_priority: patch.priority }
+          : {}),
+      };
+    });
+    return changed ? next : old;
+  };
+  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), project);
+  // Archived rows expose the same issue fields and filter controls.
+  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), project);
+}
+
 export function patchInboxIssueStatus(
   qc: QueryClient,
   wsId: string,
   issueId: string,
   status: IssueStatus,
 ) {
-  const patch = (old: InboxItem[] | undefined) =>
-    old?.map((i) => (i.issue_id === issueId ? { ...i, issue_status: status } : i));
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), patch);
-  // Archived rows render the same status icon, so they need the same patch.
-  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), patch);
+  patchInboxIssueProjection(qc, wsId, issueId, { status });
 }
 
 export function onInboxIssueStatusChanged(

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -34,7 +34,10 @@ export function patchInboxIssueProjection(
         ...(patch.status !== undefined
           ? { issue_status: patch.status }
           : {}),
-        ...(patch.priority !== undefined
+        // Do not manufacture the projection on data returned by an older
+        // backend. Capability detection relies on `undefined` continuing to
+        // mean "this endpoint version does not provide issue_priority".
+        ...(patch.priority !== undefined && item.issue_priority !== undefined
           ? { issue_priority: patch.priority }
           : {}),
       };

--- a/packages/core/issues/cache-coordinator.test.ts
+++ b/packages/core/issues/cache-coordinator.test.ts
@@ -437,6 +437,65 @@ describe("applyIssueChange", () => {
     expect(staleHashes).not.toContain(hashKey(wsKey));
   });
 
+  it("priority change patches and rolls back both Inbox projections", () => {
+    const active = {
+      id: "inbox-active",
+      workspace_id: WS_ID,
+      recipient_type: "member" as const,
+      recipient_id: "me",
+      actor_type: "member" as const,
+      actor_id: "bob",
+      type: "priority_changed" as const,
+      severity: "info" as const,
+      issue_id: "issue-1",
+      title: "Inbox",
+      body: null,
+      issue_status: "todo" as const,
+      issue_priority: "low" as const,
+      read: false,
+      archived: false,
+      created_at: "2025-01-01T00:00:00Z",
+      details: null,
+    } satisfies InboxItem;
+    const archived = {
+      ...active,
+      id: "inbox-archived",
+      archived: true,
+    } satisfies InboxItem;
+    qc.setQueryData<InboxItem[]>(inboxKeys.list(WS_ID), [active]);
+    qc.setQueryData<InboxItem[]>(inboxKeys.archived(WS_ID), [archived]);
+
+    const result = applyIssueChange(
+      qc,
+      WS_ID,
+      "issue-1",
+      { priority: "urgent" },
+      {
+        changed: issueChangedDims({ priority: "urgent" }, issue()),
+        baseIssue: issue(),
+      },
+    );
+
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.list(WS_ID))?.[0]
+        ?.issue_priority,
+    ).toBe("urgent");
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.archived(WS_ID))?.[0]
+        ?.issue_priority,
+    ).toBe("urgent");
+
+    rollbackIssueChange(qc, WS_ID, "issue-1", result);
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.list(WS_ID))?.[0]
+        ?.issue_priority,
+    ).toBe("low");
+    expect(
+      qc.getQueryData<InboxItem[]>(inboxKeys.archived(WS_ID))?.[0]
+        ?.issue_priority,
+    ).toBe("low");
+  });
+
   it("off-window leave: decrements the old status bucket total without a refetch", () => {
     // The card is beyond My-Assigned's loaded window; reassigning it to bob
     // means the list's todo total counted it and must lose one.

--- a/packages/core/issues/cache-coordinator.ts
+++ b/packages/core/issues/cache-coordinator.ts
@@ -12,7 +12,7 @@ import {
   type MyIssuesFilter,
 } from "./queries";
 import { inboxKeys } from "../inbox/queries";
-import { patchInboxIssueStatus } from "../inbox/ws-updaters";
+import { patchInboxIssueProjection } from "../inbox/ws-updaters";
 import { projectKeys } from "../projects/queries";
 import {
   decrementBucketTotal,
@@ -75,7 +75,7 @@ export type IssueTableRowCache = IssueTableRowsResponse;
  * uncommitted state and stomp the optimistic patch), the WS path invalidates
  * immediately (the server already committed).
  *
- * The detail cache and the Inbox `issue_status` projection are patched in the
+ * The detail cache and the Inbox issue projections are patched in the
  * same pass. Aggregate projections that cannot be recomputed from one entity
  * (assignee-grouped boards, Gantt, project metrics) go through
  * {@link invalidateIssueDerivatives}.
@@ -89,6 +89,7 @@ export interface IssueCacheChangeResult {
   prevTableRows: [QueryKey, IssueTableRowCache][];
   prevDetail: Issue | undefined;
   prevInboxList: InboxItem[] | undefined;
+  prevArchivedInboxList: InboxItem[] | undefined;
   /** Loaded list keys whose server result may have drifted (membership
    *  unknown, possible enter/leave beyond the loaded window, bucket-count
    *  drift). Invalidate on settle (mutation) or immediately (WS). */
@@ -529,12 +530,20 @@ export function applyIssueChange(
     if (!prevIssue) prevIssue = prevDetail;
   }
 
-  // Inbox rows carry an `issue_status` display snapshot; the issue's status
-  // is the real state, so the projection follows every status write.
+  // Inbox rows carry issue status/priority snapshots used by presentation and
+  // filtering. The issue is the real state, so both projections follow every
+  // write immediately.
   let prevInboxList: InboxItem[] | undefined;
-  if (patch.status !== undefined) {
+  let prevArchivedInboxList: InboxItem[] | undefined;
+  if (patch.status !== undefined || patch.priority !== undefined) {
     prevInboxList = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-    if (prevInboxList) patchInboxIssueStatus(qc, wsId, id, patch.status);
+    prevArchivedInboxList = qc.getQueryData<InboxItem[]>(
+      inboxKeys.archived(wsId),
+    );
+    patchInboxIssueProjection(qc, wsId, id, {
+      status: patch.status,
+      priority: patch.priority,
+    });
   }
 
   return {
@@ -543,6 +552,7 @@ export function applyIssueChange(
     prevTableRows,
     prevDetail,
     prevInboxList,
+    prevArchivedInboxList,
     staleKeys,
     prevIssue,
   };
@@ -561,6 +571,7 @@ export function rollbackIssueChange(
     | "prevTableRows"
     | "prevDetail"
     | "prevInboxList"
+    | "prevArchivedInboxList"
   >,
 ) {
   for (const [key, snapshot] of result.prevLists) {
@@ -577,6 +588,12 @@ export function rollbackIssueChange(
   }
   if (result.prevInboxList !== undefined) {
     qc.setQueryData(inboxKeys.list(wsId), result.prevInboxList);
+  }
+  if (result.prevArchivedInboxList !== undefined) {
+    qc.setQueryData(
+      inboxKeys.archived(wsId),
+      result.prevArchivedInboxList,
+    );
   }
 }
 

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -138,8 +138,8 @@ export function useUpdateIssue() {
       qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined) {
-        qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      if (patch.status !== undefined || patch.priority !== undefined) {
+        qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
       }
       const prevDetail = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
       // The coordinator owns the cross-cache rules: surgical patch/rebucket
@@ -437,8 +437,8 @@ export function useBatchUpdateIssues() {
       await qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined) {
-        await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      if (patch.status !== undefined || patch.priority !== undefined) {
+        await qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
       }
 
       // Run every issue through the coordinator — the same rules table the
@@ -455,6 +455,7 @@ export function useBatchUpdateIssues() {
       >();
       const prevDetailById = new Map<string, Issue>();
       let prevInboxList: InboxItem[] | undefined;
+      let prevArchivedInboxList: InboxItem[] | undefined;
       const staleKeys: QueryKey[] = [];
       for (const id of ids) {
         const base = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
@@ -481,6 +482,12 @@ export function useBatchUpdateIssues() {
         if (change.prevDetail) prevDetailById.set(id, change.prevDetail);
         if (prevInboxList === undefined && change.prevInboxList !== undefined) {
           prevInboxList = change.prevInboxList;
+        }
+        if (
+          prevArchivedInboxList === undefined &&
+          change.prevArchivedInboxList !== undefined
+        ) {
+          prevArchivedInboxList = change.prevArchivedInboxList;
         }
         staleKeys.push(...change.staleKeys);
       }
@@ -510,6 +517,7 @@ export function useBatchUpdateIssues() {
         prevTableRows: [...prevTableRowByHash.values()],
         prevDetailById,
         prevInboxList,
+        prevArchivedInboxList,
         staleKeys,
         prevChildren,
         affectedParentIds,
@@ -538,6 +546,12 @@ export function useBatchUpdateIssues() {
       }
       if (ctx?.prevInboxList !== undefined) {
         qc.setQueryData(inboxKeys.list(wsId), ctx.prevInboxList);
+      }
+      if (ctx?.prevArchivedInboxList !== undefined) {
+        qc.setQueryData(
+          inboxKeys.archived(wsId),
+          ctx.prevArchivedInboxList,
+        );
       }
       if (ctx?.prevChildren) {
         for (const [parentId, snapshot] of ctx.prevChildren) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "./inbox": "./inbox/index.ts",
     "./inbox/queries": "./inbox/queries.ts",
     "./inbox/mutations": "./inbox/mutations.ts",
+    "./inbox/filter-store": "./inbox/filter-store.ts",
     "./inbox/ws-updaters": "./inbox/ws-updaters.ts",
     "./notification-preferences": "./notification-preferences/index.ts",
     "./notification-preferences/queries": "./notification-preferences/queries.ts",

--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -1,4 +1,4 @@
-import type { IssueStatus } from "./issue";
+import type { IssuePriority, IssueStatus } from "./issue";
 
 export type InboxSeverity = "action_required" | "attention" | "info";
 
@@ -50,6 +50,12 @@ export interface InboxItem {
   title: string;
   body: string | null;
   issue_status: IssueStatus | null;
+  /**
+   * Current priority of the linked issue. Optional so an installed Desktop
+   * client remains compatible with an older backend that predates this Inbox
+   * projection; null also covers notifications without a linked issue.
+   */
+  issue_priority?: IssuePriority | null;
   read: boolean;
   archived: boolean;
   created_at: string;

--- a/packages/views/inbox/components/inbox-filter-menu.test.tsx
+++ b/packages/views/inbox/components/inbox-filter-menu.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setApiInstance } from "@multica/core/api";
+import type { ApiClient } from "@multica/core/api/client";
+import { STATUS_ORDER } from "@multica/core/issues/config";
+import { useInboxFilterStore } from "@multica/core/inbox/filter-store";
+import type { InboxItem, IssueStatusEntry } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { InboxFilterMenu } from "./inbox-filter-menu";
+
+function statusEntry(category: (typeof STATUS_ORDER)[number]): IssueStatusEntry {
+  return {
+    id: `status-${category}`,
+    workspace_id: "ws-1",
+    key: category,
+    name: category,
+    description: "",
+    category,
+    color: "#888888",
+    is_system: true,
+    position: 0,
+    archived_at: null,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function item(
+  id: string,
+  issueStatus: InboxItem["issue_status"],
+  issuePriority: InboxItem["issue_priority"],
+): InboxItem {
+  return {
+    id,
+    workspace_id: "ws-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: null,
+    actor_id: null,
+    type: "mentioned",
+    severity: "info",
+    issue_id: `issue-${id}`,
+    title: id,
+    body: null,
+    issue_status: issueStatus,
+    issue_priority: issuePriority,
+    read: false,
+    archived: false,
+    created_at: "2026-08-24T00:00:00Z",
+    details: null,
+  };
+}
+
+const ITEMS = [
+  item("todo-high", "todo", "high"),
+  item("done-low", "done", "low"),
+];
+
+function renderMenu() {
+  setApiInstance({
+    listIssueStatuses: async () => ({
+      statuses: STATUS_ORDER.map(statusEntry),
+      categories: [],
+      total: STATUS_ORDER.length,
+    }),
+  } as unknown as ApiClient);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  return renderWithI18n(
+    <QueryClientProvider client={queryClient}>
+      <InboxFilterMenu wsId="ws-1" items={ITEMS} />
+    </QueryClientProvider>,
+  );
+}
+
+async function openSubmenu(name: "Status" | "Priority") {
+  fireEvent.click(screen.getByRole("button", { name: "Filter inbox" }));
+  const trigger = await screen.findByRole("menuitem", {
+    name: new RegExp(`^${name}`),
+  });
+  fireEvent.click(trigger);
+}
+
+beforeEach(() => {
+  useInboxFilterStore.setState({ filtersByWorkspace: {} });
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+describe("InboxFilterMenu", () => {
+  it("selects a status and exposes the active count on the trigger", async () => {
+    renderMenu();
+    await openSubmenu("Status");
+    const todo = await screen.findByRole("menuitemcheckbox", {
+      name: /Todo.*1 notification/,
+    });
+
+    fireEvent.click(todo);
+
+    expect(
+      useInboxFilterStore.getState().filtersByWorkspace["ws-1"]?.statuses,
+    ).toEqual(["todo"]);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "1 active filter" }),
+      ).toHaveTextContent("1"),
+    );
+  });
+
+  it("selects a priority", async () => {
+    renderMenu();
+    await openSubmenu("Priority");
+    const high = await screen.findByRole("menuitemcheckbox", {
+      name: /High.*1 notification/,
+    });
+
+    fireEvent.click(high);
+
+    expect(
+      useInboxFilterStore.getState().filtersByWorkspace["ws-1"]?.priorities,
+    ).toEqual(["high"]);
+  });
+
+  it("clears every active filter from the root menu", async () => {
+    const store = useInboxFilterStore.getState();
+    store.toggleStatusFilter("ws-1", "todo");
+    store.togglePriorityFilter("ws-1", "high");
+    renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: "2 active filters" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Clear filters" }));
+
+    expect(
+      useInboxFilterStore.getState().filtersByWorkspace["ws-1"],
+    ).toBeUndefined();
+  });
+});

--- a/packages/views/inbox/components/inbox-filter-menu.test.tsx
+++ b/packages/views/inbox/components/inbox-filter-menu.test.tsx
@@ -11,7 +11,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { setApiInstance } from "@multica/core/api";
 import type { ApiClient } from "@multica/core/api/client";
 import { STATUS_ORDER } from "@multica/core/issues/config";
-import { useInboxFilterStore } from "@multica/core/inbox/filter-store";
+import {
+  type InboxPriorityFilterSupport,
+  useInboxFilterStore,
+} from "@multica/core/inbox/filter-store";
 import type { InboxItem, IssueStatusEntry } from "@multica/core/types";
 import { renderWithI18n } from "../../test/i18n";
 import { InboxFilterMenu } from "./inbox-filter-menu";
@@ -64,7 +67,13 @@ const ITEMS = [
   item("done-low", "done", "low"),
 ];
 
-function renderMenu() {
+function renderMenu({
+  items = ITEMS,
+  priorityFilterSupport = "supported",
+}: {
+  items?: InboxItem[];
+  priorityFilterSupport?: InboxPriorityFilterSupport;
+} = {}) {
   setApiInstance({
     listIssueStatuses: async () => ({
       statuses: STATUS_ORDER.map(statusEntry),
@@ -77,7 +86,11 @@ function renderMenu() {
   });
   return renderWithI18n(
     <QueryClientProvider client={queryClient}>
-      <InboxFilterMenu wsId="ws-1" items={ITEMS} />
+      <InboxFilterMenu
+        wsId="ws-1"
+        items={items}
+        priorityFilterSupport={priorityFilterSupport}
+      />
     </QueryClientProvider>,
   );
 }
@@ -145,5 +158,23 @@ describe("InboxFilterMenu", () => {
     expect(
       useInboxFilterStore.getState().filtersByWorkspace["ws-1"],
     ).toBeUndefined();
+  });
+
+  it("hides priority and clears its filter for a legacy response", async () => {
+    useInboxFilterStore.getState().togglePriorityFilter("ws-1", "high");
+    renderMenu({
+      items: [item("legacy", "todo", undefined)],
+      priorityFilterSupport: "unsupported",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter inbox" }));
+    expect(
+      screen.queryByRole("menuitem", { name: /^Priority/ }),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(
+        useInboxFilterStore.getState().filtersByWorkspace["ws-1"],
+      ).toBeUndefined(),
+    );
   });
 });

--- a/packages/views/inbox/components/inbox-filter-menu.tsx
+++ b/packages/views/inbox/components/inbox-filter-menu.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useMemo } from "react";
+import { CircleDot, Filter, RotateCcw, SignalHigh } from "lucide-react";
+import { PRIORITY_DISPLAY_ORDER } from "@multica/core/issues/config";
+import {
+  filterInboxItems,
+  inboxFilterCount,
+  useInboxFilters,
+  useInboxFilterStore,
+} from "@multica/core/inbox/filter-store";
+import type { InboxItem } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@multica/ui/components/ui/dropdown-menu";
+import { cn } from "@multica/ui/lib/utils";
+import { PriorityIcon } from "../../issues/components/priority-icon";
+import { StatusIcon } from "../../issues/components/status-icon";
+import { useStatusOptions } from "../../issues/utils/status-options";
+import { useT } from "../../i18n";
+
+function statusCounts(items: InboxItem[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    if (item.issue_status == null) continue;
+    counts.set(item.issue_status, (counts.get(item.issue_status) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function priorityCounts(items: InboxItem[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    if (item.issue_priority == null) continue;
+    counts.set(
+      item.issue_priority,
+      (counts.get(item.issue_priority) ?? 0) + 1,
+    );
+  }
+  return counts;
+}
+
+/** Priority/status facets for the deduplicated list currently on screen. */
+export function InboxFilterMenu({
+  wsId,
+  items,
+}: {
+  wsId: string;
+  items: InboxItem[];
+}) {
+  const { t } = useT("inbox");
+  const { t: tIssues } = useT("issues");
+  const filters = useInboxFilters(wsId);
+  const toggleStatus = useInboxFilterStore((state) => state.toggleStatusFilter);
+  const togglePriority = useInboxFilterStore(
+    (state) => state.togglePriorityFilter,
+  );
+  const clearFilters = useInboxFilterStore((state) => state.clearFilters);
+  const statusOptions = useStatusOptions(wsId);
+  const activeCount = inboxFilterCount(filters);
+
+  // Counts are faceted: a status count respects the active priority filter
+  // (and vice versa) while ignoring its own dimension, so every number says
+  // how many rows selecting that value can actually reveal.
+  const statusFacetItems = useMemo(
+    () =>
+      filterInboxItems(items, {
+        statuses: [],
+        priorities: filters.priorities,
+      }),
+    [items, filters.priorities],
+  );
+  const priorityFacetItems = useMemo(
+    () =>
+      filterInboxItems(items, {
+        statuses: filters.statuses,
+        priorities: [],
+      }),
+    [items, filters.statuses],
+  );
+  const statuses = useMemo(
+    () => statusCounts(statusFacetItems),
+    [statusFacetItems],
+  );
+  const priorities = useMemo(
+    () => priorityCounts(priorityFacetItems),
+    [priorityFacetItems],
+  );
+  const triggerLabel =
+    activeCount > 0
+      ? t(($) => $.filters.active_count, { count: activeCount })
+      : t(($) => $.filters.tooltip);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant={activeCount > 0 ? "default" : "ghost"}
+            size="icon-sm"
+            aria-label={triggerLabel}
+            title={triggerLabel}
+            className={cn(
+              "text-muted-foreground",
+              activeCount > 0 &&
+                "w-auto gap-1 bg-brand px-2 text-white hover:bg-brand/90",
+            )}
+          />
+        }
+      >
+        <Filter className="size-4" />
+        {activeCount > 0 && (
+          <span className="text-caption tabular-nums">{activeCount}</span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-auto min-w-44">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <CircleDot className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.status)}</span>
+            {filters.statuses.length > 0 && (
+              <span className="text-caption font-medium text-primary">
+                {filters.statuses.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-48">
+            {statusOptions.map((option) => {
+              const checked = filters.statuses.includes(option.key);
+              const count = statuses.get(option.key) ?? 0;
+              return (
+                <DropdownMenuCheckboxItem
+                  key={option.key}
+                  checked={checked}
+                  onCheckedChange={() => toggleStatus(wsId, option.key)}
+                >
+                  <StatusIcon
+                    status={option.key}
+                    category={option.category}
+                    color={option.color}
+                    className="size-3.5"
+                  />
+                  <span className="flex-1">{option.label}</span>
+                  {count > 0 && (
+                    <span className="text-caption text-muted-foreground">
+                      {t(($) => $.filters.notification_count, { count })}
+                    </span>
+                  )}
+                </DropdownMenuCheckboxItem>
+              );
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <SignalHigh className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.priority)}</span>
+            {filters.priorities.length > 0 && (
+              <span className="text-caption font-medium text-primary">
+                {filters.priorities.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-44">
+            {PRIORITY_DISPLAY_ORDER.map((priority) => {
+              const checked = filters.priorities.includes(priority);
+              const count = priorities.get(priority) ?? 0;
+              return (
+                <DropdownMenuCheckboxItem
+                  key={priority}
+                  checked={checked}
+                  onCheckedChange={() => togglePriority(wsId, priority)}
+                >
+                  <PriorityIcon priority={priority} />
+                  <span className="flex-1">
+                    {tIssues(($) => $.priority[priority])}
+                  </span>
+                  {count > 0 && (
+                    <span className="text-caption text-muted-foreground">
+                      {t(($) => $.filters.notification_count, { count })}
+                    </span>
+                  )}
+                </DropdownMenuCheckboxItem>
+              );
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        {activeCount > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => clearFilters(wsId)}>
+              <RotateCcw className="size-3.5" />
+              {t(($) => $.filters.clear)}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/views/inbox/components/inbox-filter-menu.tsx
+++ b/packages/views/inbox/components/inbox-filter-menu.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { CircleDot, Filter, RotateCcw, SignalHigh } from "lucide-react";
 import { PRIORITY_DISPLAY_ORDER } from "@multica/core/issues/config";
 import {
   filterInboxItems,
+  inboxFiltersForPrioritySupport,
   inboxFilterCount,
+  type InboxPriorityFilterSupport,
   useInboxFilters,
   useInboxFilterStore,
 } from "@multica/core/inbox/filter-store";
@@ -53,9 +55,11 @@ function priorityCounts(items: InboxItem[]): Map<string, number> {
 export function InboxFilterMenu({
   wsId,
   items,
+  priorityFilterSupport,
 }: {
   wsId: string;
   items: InboxItem[];
+  priorityFilterSupport: InboxPriorityFilterSupport;
 }) {
   const { t } = useT("inbox");
   const { t: tIssues } = useT("issues");
@@ -65,8 +69,44 @@ export function InboxFilterMenu({
     (state) => state.togglePriorityFilter,
   );
   const clearFilters = useInboxFilterStore((state) => state.clearFilters);
-  const statusOptions = useStatusOptions(wsId);
-  const activeCount = inboxFilterCount(filters);
+  const clearPriorityFilters = useInboxFilterStore(
+    (state) => state.clearPriorityFilters,
+  );
+  const inboxStatusKeys = useMemo(
+    () => [
+      ...new Set(
+        items.flatMap((item) =>
+          item.issue_status == null ? [] : [item.issue_status],
+        ),
+      ),
+    ],
+    [items],
+  );
+  const statusOptions = useStatusOptions(wsId, inboxStatusKeys);
+  const effectiveFilters = useMemo(
+    () => inboxFiltersForPrioritySupport(filters, priorityFilterSupport),
+    [filters, priorityFilterSupport],
+  );
+  const activeCount = inboxFilterCount(effectiveFilters);
+  const priorityFilteringSupported = priorityFilterSupport === "supported";
+
+  // A workspace can retain filters while its backend changes (Desktop server
+  // switch, self-hosted downgrade, or rolling deployment). Remove a priority
+  // selection only once incompatibility is confirmed; "unknown" simply keeps
+  // it dormant while an empty list gives us no capability evidence.
+  useEffect(() => {
+    if (
+      priorityFilterSupport === "unsupported" &&
+      filters.priorities.length > 0
+    ) {
+      clearPriorityFilters(wsId);
+    }
+  }, [
+    clearPriorityFilters,
+    filters.priorities.length,
+    priorityFilterSupport,
+    wsId,
+  ]);
 
   // Counts are faceted: a status count respects the active priority filter
   // (and vice versa) while ignoring its own dimension, so every number says
@@ -75,17 +115,17 @@ export function InboxFilterMenu({
     () =>
       filterInboxItems(items, {
         statuses: [],
-        priorities: filters.priorities,
+        priorities: effectiveFilters.priorities,
       }),
-    [items, filters.priorities],
+    [items, effectiveFilters.priorities],
   );
   const priorityFacetItems = useMemo(
     () =>
       filterInboxItems(items, {
-        statuses: filters.statuses,
+        statuses: effectiveFilters.statuses,
         priorities: [],
       }),
-    [items, filters.statuses],
+    [items, effectiveFilters.statuses],
   );
   const statuses = useMemo(
     () => statusCounts(statusFacetItems),
@@ -127,15 +167,15 @@ export function InboxFilterMenu({
           <DropdownMenuSubTrigger>
             <CircleDot className="size-3.5" />
             <span className="flex-1">{t(($) => $.filters.status)}</span>
-            {filters.statuses.length > 0 && (
+            {effectiveFilters.statuses.length > 0 && (
               <span className="text-caption font-medium text-primary">
-                {filters.statuses.length}
+                {effectiveFilters.statuses.length}
               </span>
             )}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-auto min-w-48">
             {statusOptions.map((option) => {
-              const checked = filters.statuses.includes(option.key);
+              const checked = effectiveFilters.statuses.includes(option.key);
               const count = statuses.get(option.key) ?? 0;
               return (
                 <DropdownMenuCheckboxItem
@@ -161,40 +201,42 @@ export function InboxFilterMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
 
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <SignalHigh className="size-3.5" />
-            <span className="flex-1">{t(($) => $.filters.priority)}</span>
-            {filters.priorities.length > 0 && (
-              <span className="text-caption font-medium text-primary">
-                {filters.priorities.length}
-              </span>
-            )}
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="w-auto min-w-44">
-            {PRIORITY_DISPLAY_ORDER.map((priority) => {
-              const checked = filters.priorities.includes(priority);
-              const count = priorities.get(priority) ?? 0;
-              return (
-                <DropdownMenuCheckboxItem
-                  key={priority}
-                  checked={checked}
-                  onCheckedChange={() => togglePriority(wsId, priority)}
-                >
-                  <PriorityIcon priority={priority} />
-                  <span className="flex-1">
-                    {tIssues(($) => $.priority[priority])}
-                  </span>
-                  {count > 0 && (
-                    <span className="text-caption text-muted-foreground">
-                      {t(($) => $.filters.notification_count, { count })}
+        {priorityFilteringSupported ? (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <SignalHigh className="size-3.5" />
+              <span className="flex-1">{t(($) => $.filters.priority)}</span>
+              {effectiveFilters.priorities.length > 0 ? (
+                <span className="text-caption font-medium text-primary">
+                  {effectiveFilters.priorities.length}
+                </span>
+              ) : null}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-auto min-w-44">
+              {PRIORITY_DISPLAY_ORDER.map((priority) => {
+                const checked = effectiveFilters.priorities.includes(priority);
+                const count = priorities.get(priority) ?? 0;
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={priority}
+                    checked={checked}
+                    onCheckedChange={() => togglePriority(wsId, priority)}
+                  >
+                    <PriorityIcon priority={priority} />
+                    <span className="flex-1">
+                      {tIssues(($) => $.priority[priority])}
                     </span>
-                  )}
-                </DropdownMenuCheckboxItem>
-              );
-            })}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
+                    {count > 0 ? (
+                      <span className="text-caption text-muted-foreground">
+                        {t(($) => $.filters.notification_count, { count })}
+                      </span>
+                    ) : null}
+                  </DropdownMenuCheckboxItem>
+                );
+              })}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ) : null}
 
         {activeCount > 0 && (
           <>

--- a/packages/views/inbox/components/inbox-list.tsx
+++ b/packages/views/inbox/components/inbox-list.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Archive, ChevronRight, Inbox } from "lucide-react";
 import { isEditableShortcutTarget } from "@multica/core/shortcuts";
@@ -47,6 +54,8 @@ export function InboxList({
   onSelect,
   onAction,
   onOpenArchived,
+  emptyLabel,
+  emptyAction,
 }: {
   items: InboxItem[];
   view: InboxView;
@@ -57,6 +66,8 @@ export function InboxList({
   onSelect: (item: InboxItem) => void;
   onAction: (id: string) => void;
   onOpenArchived: () => void;
+  emptyLabel?: string;
+  emptyAction?: ReactNode;
 }) {
   const { t } = useT("inbox");
   // Virtuoso's `customScrollParent` wants the actual HTMLElement, not a ref.
@@ -176,10 +187,12 @@ export function InboxList({
         <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
           <Inbox className="mb-3 h-8 w-8 text-faint-foreground" />
           <p className="text-body">
-            {isArchivedView
-              ? t(($) => $.list.archived_empty)
-              : t(($) => $.list.empty)}
+            {emptyLabel ??
+              (isArchivedView
+                ? t(($) => $.list.archived_empty)
+                : t(($) => $.list.empty))}
           </p>
+          {emptyAction && <div className="mt-3">{emptyAction}</div>}
         </div>
         {/* Still offer the archive when the main list is empty — that is
             exactly when a user goes looking for what they filed away. */}

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -292,6 +292,23 @@ describe("InboxPage", () => {
     expect(screen.getByTestId("row")).toHaveTextContent("todo-high");
   });
 
+  it("ignores a priority filter when a legacy response omits the projection", () => {
+    reset();
+    const legacyItem = item({
+      id: "legacy-todo",
+      issue_status: "todo",
+    });
+    delete legacyItem.issue_priority;
+    listData.active = [legacyItem];
+    useInboxFilterStore
+      .getState()
+      .togglePriorityFilter("workspace-1", "urgent");
+
+    render(<InboxPage />);
+
+    expect(screen.getByTestId("row")).toHaveTextContent("legacy-todo");
+  });
+
   it("renders the archived list when the URL asks for it", () => {
     // ?view=archived is what makes a refresh, a back/forward step, or a mobile
     // detail-back land in the archive instead of the main inbox.

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import type { InboxItem } from "@multica/core/types";
+import { useInboxFilterStore } from "@multica/core/inbox/filter-store";
 import { InboxPage } from "./inbox-page";
 
 vi.mock("sonner", () => ({
@@ -133,10 +134,14 @@ vi.mock("./inbox-list", () => ({
     items,
     view,
     onSelect,
+    emptyLabel,
+    emptyAction,
   }: {
     items: InboxItem[];
     view: string;
     onSelect: (item: InboxItem) => void;
+    emptyLabel?: string;
+    emptyAction?: React.ReactNode;
   }) => (
     <div data-testid="list" data-view={view}>
       {items.map((i) => (
@@ -144,8 +149,13 @@ vi.mock("./inbox-list", () => ({
           {i.id}
         </button>
       ))}
+      {items.length === 0 && emptyLabel && <p>{emptyLabel}</p>}
+      {items.length === 0 && emptyAction}
     </div>
   ),
+}));
+vi.mock("./inbox-filter-menu", () => ({
+  InboxFilterMenu: () => <button type="button">Filter inbox</button>,
 }));
 vi.mock("./inbox-list-item", () => ({ useTimeAgo: () => vi.fn() }));
 
@@ -185,6 +195,7 @@ function item(overrides: Partial<InboxItem> = {}): InboxItem {
     title: "Issue title",
     body: null,
     issue_status: null,
+    issue_priority: null,
     read: true,
     archived: false,
     created_at: "2026-06-15T08:00:00Z",
@@ -208,6 +219,7 @@ function reset() {
   rowActions = null;
   issueDetailProps.length = 0;
   layout.width = PHONE;
+  useInboxFilterStore.setState({ filtersByWorkspace: {} });
 }
 
 describe("InboxPage", () => {
@@ -231,6 +243,53 @@ describe("InboxPage", () => {
 
     expect(screen.getByTestId("list").dataset.view).toBe("inbox");
     expect(screen.getByTestId("row").textContent).toBe("active-1");
+  });
+
+  it("filters the list by status and priority together", () => {
+    reset();
+    listData.active = [
+      item({
+        id: "todo-high",
+        issue_id: "issue-1",
+        issue_status: "todo",
+        issue_priority: "high",
+      }),
+      item({
+        id: "done-low",
+        issue_id: "issue-2",
+        issue_status: "done",
+        issue_priority: "low",
+      }),
+      item({ id: "system", issue_id: null }),
+    ];
+    const filters = useInboxFilterStore.getState();
+    filters.toggleStatusFilter("workspace-1", "done");
+    filters.togglePriorityFilter("workspace-1", "low");
+
+    render(<InboxPage />);
+
+    expect(screen.getAllByTestId("row")).toHaveLength(1);
+    expect(screen.getByTestId("row")).toHaveTextContent("done-low");
+  });
+
+  it("offers to clear filters when they hide every notification", () => {
+    reset();
+    listData.active = [
+      item({
+        id: "todo-high",
+        issue_status: "todo",
+        issue_priority: "high",
+      }),
+    ];
+    useInboxFilterStore
+      .getState()
+      .togglePriorityFilter("workspace-1", "urgent");
+
+    render(<InboxPage />);
+
+    expect(screen.queryByTestId("row")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Inbox" }));
+    expect(screen.getByTestId("row")).toHaveTextContent("todo-high");
   });
 
   it("renders the archived list when the URL asks for it", () => {

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -38,6 +38,12 @@ import {
   useArchiveAllReadInbox,
   useArchiveCompletedInbox,
 } from "@multica/core/inbox/mutations";
+import {
+  filterInboxItems,
+  inboxFilterCount,
+  useInboxFilters,
+  useInboxFilterStore,
+} from "@multica/core/inbox/filter-store";
 
 import { IssueDetail, issueHighlightMementoKey } from "../../issues/components";
 import { useViewStateWriter } from "../../platform";
@@ -76,6 +82,7 @@ import { cn } from "@multica/ui/lib/utils";
 import { PAGE_GUTTER, PageHeader } from "../../layout/page-header";
 import { useTimeAgo } from "./inbox-list-item";
 import { InboxList } from "./inbox-list";
+import { InboxFilterMenu } from "./inbox-filter-menu";
 import { InboxContextMenuProvider } from "./inbox-context-menu";
 import { ARCHIVED_VIEW_PARAM, type InboxView } from "./inbox-view";
 import { useTypeLabels } from "./inbox-detail-label";
@@ -123,10 +130,21 @@ export function InboxPage() {
   );
 
   const isArchivedView = view === "archived";
-  const visibleItems = isArchivedView ? archivedItems : items;
+  const viewItems = isArchivedView ? archivedItems : items;
+  const filters = useInboxFilters(wsId);
+  const clearFilters = useInboxFilterStore((state) => state.clearFilters);
+  const visibleItems = useMemo(
+    () => filterInboxItems(viewItems, filters),
+    [viewItems, filters],
+  );
+  const hasActiveFilters = inboxFilterCount(filters) > 0;
 
   const selected =
     visibleItems.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+  const selectedInView =
+    viewItems.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+  const selectionFilteredOut =
+    selectedKey.length > 0 && selectedInView !== null && selected === null;
 
   // What the DETAIL pane shows, one React transition behind the click.
   //
@@ -188,6 +206,13 @@ export function InboxPage() {
   // an inline arrow here would rebuild (and remount) the entry every render.
   const openArchived = useCallback(() => setView("archived"), [setView]);
 
+  // Applying a filter can remove the open row from the list. Clear that local
+  // selection instead of treating it as a broken deep link and redirecting to
+  // the issue page; the notification still exists, it is simply filtered out.
+  useEffect(() => {
+    if (selectionFilteredOut) setSelectedKey("");
+  }, [selectionFilteredOut, setSelectedKey]);
+
   // Whether the list currently on screen has finished its first load. The
   // fallback and drain effects below both key on this, and getting it wrong in
   // the archived view means acting on an empty list that simply hasn't arrived.
@@ -203,12 +228,21 @@ export function InboxPage() {
     if (viewLoading) return;
     if (!selectedKey) return;
     if (selected) return;
+    if (selectionFilteredOut) return;
     if (lastResolvedKeyRef.current === selectedKey) {
       setSelectedKey("");
       return;
     }
     replace(wsPaths.issueDetail(selectedKey));
-  }, [viewLoading, selectedKey, selected, replace, wsPaths, setSelectedKey]);
+  }, [
+    viewLoading,
+    selectedKey,
+    selected,
+    selectionFilteredOut,
+    replace,
+    wsPaths,
+    setSelectedKey,
+  ]);
 
   // Never strand the user on an empty archive: when the last archived issue is
   // restored (or a new notification revives it into the main inbox), fall back
@@ -359,7 +393,7 @@ export function InboxPage() {
 
   // Toasts live in these shared handlers so every archive surface confirms alike.
   const handleArchive = (id: string) => {
-    advanceSelectionPast(id, items);
+    advanceSelectionPast(id, visibleItems);
     archiveMutation.mutate(id, {
       onSuccess: () => toast.success(t(($) => $.toasts.archived)),
       onError: (err) =>
@@ -372,7 +406,7 @@ export function InboxPage() {
   };
 
   const handleUnarchive = (id: string) => {
-    advanceSelectionPast(id, archivedItems);
+    advanceSelectionPast(id, visibleItems);
     unarchiveMutation.mutate(id, {
       onSuccess: () => toast.success(t(($) => $.toasts.unarchived)),
       onError: (err) =>
@@ -473,6 +507,7 @@ export function InboxPage() {
           />
         )}
       </div>
+      <InboxFilterMenu wsId={wsId} items={viewItems} />
       {/* Batch actions are main-view only. Every entry archives from the MAIN
           inbox, so offering them while the archived list is on screen reads as
           "archive all of these" and does the opposite of what it looks like. */}
@@ -554,6 +589,22 @@ export function InboxPage() {
         onSelect={handleSelect}
         onAction={isArchivedView ? handleUnarchive : handleArchive}
         onOpenArchived={openArchived}
+        emptyLabel={
+          hasActiveFilters && viewItems.length > 0 && visibleItems.length === 0
+            ? t(($) => $.filters.empty)
+            : undefined
+        }
+        emptyAction={
+          hasActiveFilters && viewItems.length > 0 && visibleItems.length === 0 ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => clearFilters(wsId)}
+            >
+              {t(($) => $.filters.clear)}
+            </Button>
+          ) : undefined
+        }
       />
     </InboxContextMenuProvider>
   );

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -40,7 +40,9 @@ import {
 } from "@multica/core/inbox/mutations";
 import {
   filterInboxItems,
+  inboxFiltersForPrioritySupport,
   inboxFilterCount,
+  inboxPriorityFilterSupport,
   useInboxFilters,
   useInboxFilterStore,
 } from "@multica/core/inbox/filter-store";
@@ -133,11 +135,23 @@ export function InboxPage() {
   const viewItems = isArchivedView ? archivedItems : items;
   const filters = useInboxFilters(wsId);
   const clearFilters = useInboxFilterStore((state) => state.clearFilters);
-  const visibleItems = useMemo(
-    () => filterInboxItems(viewItems, filters),
-    [viewItems, filters],
+  // Active and archived endpoints return the same row contract and are both
+  // already loaded on this page. Requiring the combined response to expose the
+  // projection prevents one pod in a rolling deploy from advertising a
+  // capability the other pod does not have yet.
+  const priorityFilterSupport = useMemo(
+    () => inboxPriorityFilterSupport([...rawItems, ...rawArchivedItems]),
+    [rawItems, rawArchivedItems],
   );
-  const hasActiveFilters = inboxFilterCount(filters) > 0;
+  const effectiveFilters = useMemo(
+    () => inboxFiltersForPrioritySupport(filters, priorityFilterSupport),
+    [filters, priorityFilterSupport],
+  );
+  const visibleItems = useMemo(
+    () => filterInboxItems(viewItems, effectiveFilters),
+    [viewItems, effectiveFilters],
+  );
+  const hasActiveFilters = inboxFilterCount(effectiveFilters) > 0;
 
   const selected =
     visibleItems.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
@@ -507,7 +521,11 @@ export function InboxPage() {
           />
         )}
       </div>
-      <InboxFilterMenu wsId={wsId} items={viewItems} />
+      <InboxFilterMenu
+        wsId={wsId}
+        items={viewItems}
+        priorityFilterSupport={priorityFilterSupport}
+      />
       {/* Batch actions are main-view only. Every entry archives from the MAIN
           inbox, so offering them while the archived list is on screen reads as
           "archive all of these" and does the opposite of what it looks like. */}

--- a/packages/views/issues/utils/status-options.test.tsx
+++ b/packages/views/issues/utils/status-options.test.tsx
@@ -118,6 +118,22 @@ describe("useStatusOptions", () => {
     expect(result.current.map((o) => o.key)).not.toContain("qa");
   });
 
+  it("lets a read-only filter include an archived status still in use", () => {
+    catalogEntries = [
+      ...BUILT_INS,
+      entry({
+        key: "qa",
+        name: "QA",
+        archived_at: "2026-01-01T00:00:00Z",
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useStatusOptions("workspace-1", ["qa"]),
+    );
+
+    expect(result.current.map((o) => o.key)).toContain("qa");
+  });
+
   // Built-ins keep their semantic token color; a hex here would override it.
   it("carries a color for custom statuses only", () => {
     catalogEntries = [...BUILT_INS, entry({ key: "qa", name: "QA", color: "#ff0000" })];

--- a/packages/views/issues/utils/status-options.ts
+++ b/packages/views/issues/utils/status-options.ts
@@ -28,23 +28,41 @@ export interface StatusOption {
  * — a status offered in one and missing from the other is exactly how an issue
  * becomes unfindable.
  *
- * Archived statuses are excluded: archiving retires a status from future
- * assignment. Issues already on one keep it, and `useStatusLabel` still names
- * it, because the catalog query keeps archived rows.
+ * Archived statuses are excluded by default: archiving retires a status from
+ * future assignment. A read-only filter can opt specific current keys back in
+ * through `includeArchivedKeys`, so existing issues remain findable without a
+ * picker offering a retired value for assignment.
  */
-export function useStatusOptions(wsId: string): StatusOption[] {
-  const { activeStatuses } = useIssueStatuses(wsId);
+const NO_ARCHIVED_STATUS_KEYS: readonly IssueStatus[] = [];
+
+export function useStatusOptions(
+  wsId: string,
+  includeArchivedKeys: readonly IssueStatus[] = NO_ARCHIVED_STATUS_KEYS,
+): StatusOption[] {
+  const { statuses } = useIssueStatuses(wsId);
   const labelOf = useStatusLabel(wsId);
 
   return useMemo(
-    () =>
-      ALL_STATUSES.flatMap((category) => {
-        const entries = activeStatuses.filter((e) => e.category === category);
+    () => {
+      const includedArchived = new Set(includeArchivedKeys);
+      return ALL_STATUSES.flatMap((category) => {
+        const entries = statuses.filter(
+          (entry) =>
+            entry.category === category &&
+            (!entry.archived_at || includedArchived.has(entry.key)),
+        );
         // No catalog row for this category: the fetch is still in flight, or
         // this workspace predates the seed. Offer the built-in, whose key IS
         // the category, so a lifecycle step is never missing.
         if (entries.length === 0) {
-          return [{ key: category as IssueStatus, category, label: labelOf(category), color: null }];
+          return [
+            {
+              key: category as IssueStatus,
+              category,
+              label: labelOf(category),
+              color: null,
+            },
+          ];
         }
         return entries.map((e) => ({
           key: e.key as IssueStatus,
@@ -52,7 +70,8 @@ export function useStatusOptions(wsId: string): StatusOption[] {
           label: labelOf(e.key),
           color: issueStatusColor(e),
         }));
-      }),
-    [activeStatuses, labelOf],
+      });
+    },
+    [includeArchivedKeys, labelOf, statuses],
   );
 }

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -9,6 +9,17 @@
     "archive_all_read": "Archive all read",
     "archive_completed": "Archive completed"
   },
+  "filters": {
+    "tooltip": "Filter inbox",
+    "active_count_one": "{{count}} active filter",
+    "active_count_other": "{{count}} active filters",
+    "status": "Status",
+    "priority": "Priority",
+    "notification_count_one": "{{count}} notification",
+    "notification_count_other": "{{count}} notifications",
+    "clear": "Clear filters",
+    "empty": "No notifications match your filters"
+  },
   "context_menu": {
     "mark_read": "Mark as read",
     "mark_unread": "Mark as unread",

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -9,6 +9,15 @@
     "archive_all_read": "既読の項目をすべてアーカイブ",
     "archive_completed": "完了した項目をアーカイブ"
   },
+  "filters": {
+    "tooltip": "インボックスを絞り込む",
+    "active_count_other": "{{count}} 件のフィルター",
+    "status": "ステータス",
+    "priority": "優先度",
+    "notification_count_other": "{{count}} 件の通知",
+    "clear": "フィルターをクリア",
+    "empty": "フィルターに一致する通知はありません"
+  },
   "context_menu": {
     "mark_read": "既読にする",
     "mark_unread": "未読にする",

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -9,6 +9,15 @@
     "archive_all_read": "읽은 항목 모두 보관",
     "archive_completed": "완료된 항목 보관"
   },
+  "filters": {
+    "tooltip": "인박스 필터",
+    "active_count_other": "필터 {{count}}개 적용됨",
+    "status": "상태",
+    "priority": "우선순위",
+    "notification_count_other": "알림 {{count}}개",
+    "clear": "필터 지우기",
+    "empty": "필터와 일치하는 알림이 없습니다"
+  },
   "context_menu": {
     "mark_read": "읽음으로 표시",
     "mark_unread": "읽지 않음으로 표시",

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -9,6 +9,15 @@
     "archive_all_read": "归档全部已读",
     "archive_completed": "归档已完成"
   },
+  "filters": {
+    "tooltip": "筛选收件箱",
+    "active_count_other": "{{count}} 个筛选条件",
+    "status": "状态",
+    "priority": "优先级",
+    "notification_count_other": "{{count}} 条通知",
+    "clear": "清除筛选",
+    "empty": "没有符合筛选条件的通知"
+  },
   "context_menu": {
     "mark_read": "标为已读",
     "mark_unread": "标为未读",

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -29,6 +29,7 @@ type InboxItemResponse struct {
 	Archived      bool            `json:"archived"`
 	CreatedAt     string          `json:"created_at"`
 	IssueStatus   *string         `json:"issue_status"`
+	IssuePriority *string         `json:"issue_priority"`
 	ActorType     *string         `json:"actor_type"`
 	ActorID       *string         `json:"actor_id"`
 	Details       json.RawMessage `json:"details"`
@@ -69,6 +70,7 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 		Archived:      r.Archived,
 		CreatedAt:     timestampToString(r.CreatedAt),
 		IssueStatus:   textToPtr(r.IssueStatus),
+		IssuePriority: textToPtr(r.IssuePriority),
 		ActorType:     textToPtr(r.ActorType),
 		ActorID:       uuidToPtr(r.ActorID),
 		Details:       json.RawMessage(r.Details),
@@ -76,7 +78,7 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 }
 
 // ListArchivedInboxItemsRow carries the same columns as ListInboxItemsRow (both
-// queries select `inbox_item.*` plus the joined issue status), so the archived
+// queries select `inbox_item.*` plus the joined issue projections), so the archived
 // row converts to the active one and reuses its mapper. If either query's
 // column list drifts, this conversion stops compiling — which is the point.
 func archivedInboxRowToResponse(r db.ListArchivedInboxItemsRow) InboxItemResponse {
@@ -91,6 +93,8 @@ func (h *Handler) enrichInboxResponse(ctx context.Context, resp InboxItemRespons
 	if err == nil {
 		s := issue.Status
 		resp.IssueStatus = &s
+		p := issue.Priority
+		resp.IssuePriority = &p
 	}
 	return resp
 }

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -24,6 +24,41 @@ func inboxWorkspaceHandler(handler http.HandlerFunc) http.HandlerFunc {
 	return middleware.RequireWorkspaceMember(testHandler.Queries)(handler).ServeHTTP
 }
 
+func TestListInboxProjectsCurrentIssueStatusAndPriority(t *testing.T) {
+	workspaceID := dbfx.Workspace(t, "Inbox filter projections", "inbox-filter-"+uuid.NewString())
+	dbfx.Member(t, workspaceID, testUserID, "owner")
+	issueID := dbfx.Issue(t, "Filtered issue", testutil.Cols{
+		"workspace_id": workspaceID,
+		"status":       "in_review",
+		"priority":     "high",
+	})
+	dbfx.Insert(t, "inbox_item", testutil.Cols{
+		"workspace_id":   workspaceID,
+		"recipient_type": "member",
+		"recipient_id":   testUserID,
+		"type":           "status_changed",
+		"severity":       "info",
+		"issue_id":       issueID,
+		"title":          "Projected issue",
+	})
+
+	var items []InboxItemResponse
+	testutil.Call(t, inboxWorkspaceHandler(testHandler.ListInbox),
+		inboxRequest(http.MethodGet, "/api/inbox", workspaceID)).
+		Want(http.StatusOK).
+		JSON(&items)
+
+	if len(items) != 1 {
+		t.Fatalf("inbox items = %d, want 1: %+v", len(items), items)
+	}
+	if items[0].IssueStatus == nil || *items[0].IssueStatus != "in_review" {
+		t.Errorf("issue_status = %v, want in_review", items[0].IssueStatus)
+	}
+	if items[0].IssuePriority == nil || *items[0].IssuePriority != "high" {
+		t.Errorf("issue_priority = %v, want high", items[0].IssuePriority)
+	}
+}
+
 func TestListArchivedInboxLimitsIssueGroupsNotRows(t *testing.T) {
 	workspaceID := dbfx.Workspace(t, "Archived inbox groups", "archived-groups-"+uuid.NewString())
 	dbfx.Member(t, workspaceID, testUserID, "owner")

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -422,7 +422,8 @@ WITH eligible_archived AS MATERIALIZED (
     SELECT id FROM comment_anchors
 )
 SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-       iss.status as issue_status
+       iss.status AS issue_status,
+       iss.priority AS issue_priority
 FROM inbox_item i
 JOIN selected_ids selected ON selected.id = i.id
 LEFT JOIN issue iss ON iss.id = i.issue_id
@@ -452,6 +453,7 @@ type ListArchivedInboxItemsRow struct {
 	ActorID       pgtype.UUID        `json:"actor_id"`
 	Details       []byte             `json:"details"`
 	IssueStatus   pgtype.Text        `json:"issue_status"`
+	IssuePriority pgtype.Text        `json:"issue_priority"`
 }
 
 // Archived counterpart of ListInboxItems, backing the inbox's "Archived"
@@ -501,6 +503,7 @@ func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedIn
 			&i.ActorID,
 			&i.Details,
 			&i.IssueStatus,
+			&i.IssuePriority,
 		); err != nil {
 			return nil, err
 		}
@@ -514,7 +517,8 @@ func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedIn
 
 const listInboxItems = `-- name: ListInboxItems :many
 SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-       iss.status as issue_status
+       iss.status AS issue_status,
+       iss.priority AS issue_priority
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
@@ -544,6 +548,7 @@ type ListInboxItemsRow struct {
 	ActorID       pgtype.UUID        `json:"actor_id"`
 	Details       []byte             `json:"details"`
 	IssueStatus   pgtype.Text        `json:"issue_status"`
+	IssuePriority pgtype.Text        `json:"issue_priority"`
 }
 
 func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) ([]ListInboxItemsRow, error) {
@@ -572,6 +577,7 @@ func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) 
 			&i.ActorID,
 			&i.Details,
 			&i.IssueStatus,
+			&i.IssuePriority,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -1,6 +1,7 @@
 -- name: ListInboxItems :many
 SELECT i.*,
-       iss.status as issue_status
+       iss.status AS issue_status,
+       iss.priority AS issue_priority
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
@@ -73,7 +74,8 @@ WITH eligible_archived AS MATERIALIZED (
     SELECT id FROM comment_anchors
 )
 SELECT i.*,
-       iss.status as issue_status
+       iss.status AS issue_status,
+       iss.priority AS issue_priority
 FROM inbox_item i
 JOIN selected_ids selected ON selected.id = i.id
 LEFT JOIN issue iss ON iss.id = i.issue_id


### PR DESCRIPTION
## Summary

- add workspace-scoped Inbox filters for issue status and priority, including custom statuses, faceted notification counts, active-filter state, and a clearable no-match state
- project issue priority through the active and archived Inbox APIs and keep both status and priority snapshots synchronized across optimistic updates and realtime cache changes
- cover the filter store, menu interactions, Inbox page behavior, API schema, cache rollback, and backend projection; add Inbox filter copy for all supported locales

## Testing

- `make sqlc`
- `pnpm --filter @multica/core test` (1,602 tests)
- `pnpm --filter @multica/views test` (4,672 tests)
- `pnpm typecheck`
- `pnpm --filter @multica/core lint`
- `pnpm --filter @multica/views lint` (0 errors; existing warnings only)
- `go test ./internal/handler -run TestListInboxProjectsCurrentIssueStatusAndPriority -count=1`
- Desktop local-dev smoke test: API and renderer reached ready state

`make test` also completed the full `server/internal/handler` package successfully, but its CLI/daemon suites reject the daemon-managed task marker and injected temp/home paths in this agent environment.

Closes MUL-6632
