### PR TITLE
MUL-6542 fix(mobile): stabilize recycled markdown layout

### DIFF
--- a/apps/mobile/docs/markdown-rendering-adr.md
+++ b/apps/mobile/docs/markdown-rendering-adr.md
@@ -30,7 +30,7 @@ not a Multica problem.
 
 | Library | Path | Last release | Verdict for Multica |
 |---|---|---|---|
-| [`react-native-enriched-markdown`](https://github.com/software-mansion-labs/react-native-enriched-markdown) | A | v0.5.0 (Apr 2026) | **Selected for prose.** Expo officially recommends it in [Edit rich text](https://docs.expo.dev/guides/editing-richtext/) — A-tier endorsement. Software Mansion (same team as Reanimated / Gesture Handler) |
+| [`react-native-enriched-markdown`](https://github.com/software-mansion/enriched-markdown) | A | v0.6.0 (May 2026) | **Selected for prose.** Expo officially recommends it in [Edit rich text](https://docs.expo.dev/guides/editing-richtext/) — A-tier endorsement. Software Mansion (same team as Reanimated / Gesture Handler) |
 | [`react-native-streamdown`](https://github.com/software-mansion-labs/react-native-streamdown) | A + worklets | active 2026 | Not adopted. Built on enriched-markdown, optimised for AI streaming. Web/desktop don't use a streaming-specific renderer either, mobile streaming isn't currently a top product pain |
 | [`react-native-marked`](https://github.com/gmsgowtham/react-native-marked) | B | v8.1.0 (2026-05-14) | Not adopted. v7 removed `CustomToken`, v8 added "React component embedding" but no token-level customisation. Pure `<Text>` tree → would trigger nested-text bugs |
 | [`amilmohd155/react-native-markdown`](https://github.com/amilmohd155/react-native-markdown) | B | v0.8.5 (Jan 2026) | Not adopted. Same nested-`<Text>` constraint as `react-native-marked`. 14 ⭐, single maintainer, not production-validated |
@@ -106,9 +106,10 @@ enriched-markdown's `normalizeMarkdownStyle.js` carries a frozen table of
 ~30 hardcoded **light-mode** color defaults. Fields not explicitly
 overridden in `useMarkdownStyle()` use those hardcoded values and
 disappear (or render garishly) in dark mode. Every color field must be
-explicitly mapped to a `THEME[scheme]` token. **When upgrading
-enriched-markdown (v0.6+), re-audit `normalizeMarkdownStyle.js` for
-newly-added color fields** — they will also ship light-mode defaults.
+explicitly mapped to a `THEME[scheme]` token. Version 0.6.0 adds a transparent
+link background plus link-variant, superscript, and subscript defaults; none
+introduce a new opaque color. Re-audit `normalizeMarkdownStyle.js` on every
+upgrade because newly-added color fields may ship light-mode defaults.
 
 ---
 

--- a/apps/mobile/lib/markdown/code-block.tsx
+++ b/apps/mobile/lib/markdown/code-block.tsx
@@ -69,16 +69,26 @@ export function CodeBlock({ code, lang, selectable = true }: Props) {
   const { isDarkColorScheme } = useColorScheme();
   const theme = isDarkColorScheme ? SHIKI_THEME_DARK : SHIKI_THEME_LIGHT;
   const resolvedLang = resolveLang(lang);
-  const [lines, setLines] = useState<HighlightedLine[] | null>(null);
+  const [highlighted, setHighlighted] = useState<{
+    code: string;
+    lang: string;
+    theme: string;
+    lines: HighlightedLine[];
+  } | null>(null);
+  const lines =
+    highlighted?.code === code &&
+    highlighted.lang === resolvedLang &&
+    highlighted.theme === theme
+      ? highlighted.lines
+      : null;
 
   useEffect(() => {
-    if (!resolvedLang) {
-      setLines(null);
-      return;
-    }
+    if (!resolvedLang) return;
     let cancelled = false;
     void highlight(code, resolvedLang, theme).then((result) => {
-      if (!cancelled) setLines(result);
+      if (!cancelled && result) {
+        setHighlighted({ code, lang: resolvedLang, theme, lines: result });
+      }
     });
     return () => {
       cancelled = true;
@@ -88,7 +98,14 @@ export function CodeBlock({ code, lang, selectable = true }: Props) {
   return (
     <View className={CODE_BLOCK_CONTAINER_CLASS}>
       <CodeBlockHeader code={code} lang={lang} />
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      {/* RN's horizontal ScrollView defaults to flexGrow: 1. In a recycled,
+          self-sized chat bubble that lets the child outgrow the FlashList
+          cell instead of sizing to its code. */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={{ flexGrow: 0 }}
+      >
         {lines ? (
           <HighlightedCode lines={lines} selectable={selectable} />
         ) : (

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -63,7 +63,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
-    "react-native-enriched-markdown": "^0.5.0",
+    "react-native-enriched-markdown": "^0.6.0",
     "react-native-gesture-handler": "~2.30.1",
     "react-native-image-viewing": "^0.2.2",
     "react-native-keyboard-controller": "1.20.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,8 +462,8 @@ importers:
         specifier: 0.83.6
         version: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       react-native-enriched-markdown:
-        specifier: ^0.5.0
-        version: 0.5.0(@expo/config-plugins@55.0.9)(katex@0.16.45)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        specifier: ^0.6.0
+        version: 0.6.0(@expo/config-plugins@55.0.9)(katex@0.16.45)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-gesture-handler:
         specifier: ~2.30.1
         version: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -9269,8 +9269,8 @@ packages:
       react-native-svg:
         optional: true
 
-  react-native-enriched-markdown@0.5.0:
-    resolution: {integrity: sha512-CYihNlcg8IjsrVbmypDjFHsDF6Z6vYO0yraw6CkR30SDsg99J6fcBrOkyWOItO8PIDD21jw8yD1eYP/0LBOCdA==}
+  react-native-enriched-markdown@0.6.0:
+    resolution: {integrity: sha512-/ZkKZv9jGPAuc/oXevkf3MpVfcrG3pjHoVMyKzpJhGsmIXxeTRr2dlsIqo66k+Pa4JrChBg+HB6ImQ44Fg3wJw==}
     peerDependencies:
       '@expo/config-plugins': '>=50.0.0'
       katex: '>=0.16.0'
@@ -20902,7 +20902,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-enriched-markdown@0.5.0(@expo/config-plugins@55.0.9)(katex@0.16.45)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+  react-native-enriched-markdown@0.6.0(@expo/config-plugins@55.0.9)(katex@0.16.45)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)


### PR DESCRIPTION
## What does this PR do?

Fixes the iOS chat-bubble overlap at the two places where layout first becomes incorrect, rather than asking FlashList to relayout from a descendant `onLayout` observer.

The investigation separated all three Markdown paths:

- **Prose / tables:** `react-native-enriched-markdown` 0.5 reports an intrinsically measured width that Yoga can shrink and re-wrap after the height was calculated. Version 0.6 includes the upstream multiline-width fix ([#291](https://github.com/software-mansion/enriched-markdown/pull/291)), Fabric recycle reset ([#324](https://github.com/software-mansion/enriched-markdown/pull/324)), and pending-style measurement fix ([#343](https://github.com/software-mansion/enriched-markdown/pull/343)).
- **Code:** RN's horizontal `ScrollView` defaults to `flexGrow: 1`. In the vertical bubble this allowed the code descendant to measure at 762 pt while the FlashList cell remained 434 pt, so the cell's built-in `onLayout` never received the overflowing size. Setting `flexGrow: 0` makes the bubble and cell share the same geometry.
- **Images:** no source change is needed. Native measurement showed the cell and bubble both move from the 16:9 placeholder (332.67 pt) to the resolved 1:1 image (448 pt); FlashList's built-in path already catches this resize.

The previous bubble observer, exact-float predicate, `useLayoutState` side-effect trigger, and per-recycle full-list layout have all been removed. There is no new feedback loop or duplicate `layout()` call.

## Related Issue

Closes #7398

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Upgrade `react-native-enriched-markdown` from 0.5 to 0.6 for the upstream iOS intrinsic-measurement and Fabric recycling fixes.
- Prevent the horizontal code `ScrollView` from flex-growing beyond its self-sized parent.
- Key async Shiki results by code, resolved language, and theme so a recycled `CodeBlock` never displays the previous message's tokens while the current highlight is pending.
- Update the Markdown ADR's canonical package URL/version and re-audit the 0.6 theme defaults.

## How to Test

1. Build the native iOS app from source and open the temporary 160-row Markdown recycling harness.
2. Verify one-word, multiline prose, table, known/unknown-language code, combined table + async Shiki, and 1:1 image-ratio cases for both user and assistant boundaries.
3. Force 40 alternating top/bottom `scrollToIndex` jumps and verify recycled long bubbles remain equal to their FlashList cells with no overlap or blank bubble.

Measured results on iPhone 17 Pro / iOS 26.5:

| Path | Before | After |
|---|---:|---:|
| Static code | cell 434 pt / bubble 762 pt | cell 258 pt / bubble 258 pt |
| Table + async Shiki, initial | n/a | cell 438 pt / bubble 438 pt |
| Table + async Shiki, highlighted | n/a | cell 454 pt / bubble 454 pt |
| Resolved 1:1 image | placeholder 332.67 pt | cell 448 pt / bubble 448 pt |
| One-word `ok` | n/a | 47.67 x 40 pt |

The 16 pt Shiki change and 115.33 pt image change are both detected by FlashList's existing cell `onLayout -> validateItemSize -> layout()` path after the parent/child geometry is corrected.

Verification completed:

- `pnpm install --frozen-lockfile`
- `pnpm exec turbo typecheck lint test --filter=@multica/mobile --force` (4/4 tasks; 18 files / 113 tests; iOS runner assertions pass)
- `pnpm --dir apps/mobile exec eslint lib/markdown/code-block.tsx` (0 findings)
- Native Expo clean prebuild, CocoaPods install, and from-source iOS compile with `ReactNativeEnrichedMarkdown 0.6.0`
- 160-row native harness with 40 alternating recycle jumps, including valid GFM tables, known/unknown code, async Shiki, image-ratio changes, and assistant boundaries
- Light/dark appearance switching and a cold launch at iOS Accessibility Large; final measured rows remained separated after all 40 jumps
- `pnpm dlx expo-doctor apps/mobile` (17/20 checks; the 3 failures are pre-existing SDK/package-version diagnostics unrelated to this diff)
- `git diff --check`

The full mobile lint has 0 errors and 7 existing warnings, unchanged from `main`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The primary risk is the native dependency upgrade. It stays within the 0.x minor line supported by RN 0.83, its current JS API and Expo plugin usage remain compatible, the theme defaults were audited, and the pod compiled from source in the target simulator build.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Used Codex to inspect FlashList and React Native layout sources, compare enriched-markdown releases, instrument native cell/bubble measurements, build a focused recycling harness, review the patch, and run the repository verification commands. The harness and logging were removed before commit.

## Screenshots

**Before:** the code descendant outgrows the cell and paints across later rows.

![Before: code block overflowing its FlashList cell](https://raw.githubusercontent.com/iiwish/multica/b42af84d217f85256907bdf0856997ebe26f04ea/before-code-cell-overflow.png)

**After 24 forced recycling jumps (original evidence capture):** the long table/code bubble ends before the assistant boundary, while the one-word bubble stays tight. A second 160-row run completed 40 jumps in both appearances without overlap or blank bubbles.

![After: stable long and one-word bubbles after 24 recycling jumps](https://raw.githubusercontent.com/iiwish/multica/b42af84d217f85256907bdf0856997ebe26f04ea/after-24-recycle-jumps.png)
