### PR TITLE
MUL-6638: pin the outbound header set of both server HTTP clients

### DIFF
--- a/server/internal/cli/wire_headers_test.go
+++ b/server/internal/cli/wire_headers_test.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file is a characterization (snapshot) test of the CLI client's
+// OUTBOUND header set, one case per exported method that reaches the Multica
+// server. It asserts the FULL set — not "contains X" — so that any refactor
+// which moves header construction into a shared transport layer (MUL-6638)
+// has to keep the wire bytes identical, and any accidental addition or
+// omission fails here instead of at a server-side capability gate.
+//
+// Two entries below deliberately record a gap rather than a contract:
+// HealthCheck and DownloadFile-with-an-absolute-URL send no identity headers
+// at all. They are pinned as-is so the difference stays visible; changing
+// them is a wire-contract decision, not a refactor side effect.
+
+// wireHeaderKeys is the set of request headers this snapshot tracks: every
+// Multica protocol header plus the transport headers whose presence is part
+// of the contract. Anything outside this list (Host, User-Agent, Accept-
+// Encoding, Content-Length) is set by net/http, not by our client code.
+var wireHeaderKeys = []string{
+	"Authorization",
+	"Content-Type",
+	"If-None-Match",
+	"X-Agent-ID",
+	"X-Client-Capabilities",
+	"X-Client-OS",
+	"X-Client-Platform",
+	"X-Client-Version",
+	"X-Task-ID",
+	"X-Workspace-ID",
+}
+
+// captureWireHeaders renders the tracked headers of r as a stable, comparable
+// string. A multipart Content-Type is collapsed to its media type because the
+// boundary is random per request.
+func captureWireHeaders(r *http.Request) string {
+	var parts []string
+	for _, key := range wireHeaderKeys {
+		values, ok := r.Header[http.CanonicalHeaderKey(key)]
+		if !ok {
+			continue
+		}
+		joined := strings.Join(values, "|")
+		if key == "Content-Type" && strings.HasPrefix(joined, "multipart/form-data") {
+			joined = "multipart/form-data"
+		}
+		parts = append(parts, key+": "+joined)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
+}
+
+// wireHeadersTestClient is the fully-populated client every case below shares:
+// every optional field is set so an omitted header is a real omission and not
+// an unset input.
+func wireHeadersTestClient(baseURL string) *APIClient {
+	c := NewAPIClient(baseURL, "ws-1", "tok-1")
+	c.AgentID = "agent-1"
+	c.TaskID = "task-1"
+	c.Platform = "cli-test"
+	c.Version = "9.9.9"
+	c.OS = "linux"
+	return c
+}
+
+// fullWireHeaders is the header set every authenticated CLI request currently
+// carries. Written out longhand (not composed from the client fields) so the
+// expectation is a literal snapshot of the wire, readable without running the
+// code.
+const authWireHeader = "Authorization: Bearer tok-1"
+
+const protocolWireHeaders = `X-Agent-ID: agent-1
+X-Client-Capabilities: stable_attachment_urls
+X-Client-OS: linux
+X-Client-Platform: cli-test
+X-Client-Version: 9.9.9
+X-Task-ID: task-1
+X-Workspace-ID: ws-1`
+
+// The three variants differ only in Content-Type; captureWireHeaders sorts by
+// header name, so Content-Type lands between Authorization and the X-* block.
+const (
+	fullWireHeaders      = authWireHeader + "\n" + protocolWireHeaders
+	jsonBodyWireHeaders  = authWireHeader + "\nContent-Type: application/json\n" + protocolWireHeaders
+	multipartWireHeaders = authWireHeader + "\nContent-Type: multipart/form-data\n" + protocolWireHeaders
+)
+
+func TestAPIClientOutboundHeaderSnapshot(t *testing.T) {
+	// A response body that satisfies every decoder used below: an attachment
+	// response, a plain object, and an opaque byte payload all read cleanly
+	// from it.
+	const responseBody = `{"id":"att-1","url":"/u","download_url":"/d","markdown_url":"/m","filename":"f.txt"}`
+
+	cases := []struct {
+		name string
+		want string
+		call func(ctx context.Context, c *APIClient) error
+	}{
+		{
+			name: "GetJSON",
+			want: fullWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.GetJSON(ctx, "/api/test", nil)
+			},
+		},
+		{
+			name: "GetJSONWithHeaders",
+			want: fullWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.GetJSONWithHeaders(ctx, "/api/test", nil)
+				return err
+			},
+		},
+		{
+			name: "DeleteJSON",
+			want: fullWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.DeleteJSON(ctx, "/api/test")
+			},
+		},
+		{
+			name: "DeleteJSONWithBody",
+			want: jsonBodyWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.DeleteJSONWithBody(ctx, "/api/test", map[string]string{"k": "v"})
+			},
+		},
+		{
+			name: "PostJSON",
+			want: jsonBodyWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.PostJSON(ctx, "/api/test", map[string]string{"k": "v"}, nil)
+			},
+		},
+		{
+			name: "PutJSON",
+			want: jsonBodyWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.PutJSON(ctx, "/api/test", map[string]string{"k": "v"}, nil)
+			},
+		},
+		{
+			name: "PatchJSON",
+			want: jsonBodyWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.PatchJSON(ctx, "/api/test", map[string]string{"k": "v"}, nil)
+			},
+		},
+		{
+			name: "UploadFile",
+			want: multipartWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.UploadFile(ctx, []byte("x"), "f.txt", "issue-1")
+				return err
+			},
+		},
+		{
+			name: "UploadChatAttachment",
+			want: multipartWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.UploadChatAttachment(ctx, []byte("x"), "f.txt", "task-1")
+				return err
+			},
+		},
+		{
+			name: "UploadFileWithURL",
+			want: multipartWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				_, _, err := c.UploadFileWithURL(ctx, []byte("x"), "f.txt")
+				return err
+			},
+		},
+		{
+			name: "ImportSkillFile",
+			want: multipartWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.ImportSkillFile(ctx, []byte("x"), "s.skill", "skip", nil)
+			},
+		},
+		{
+			name: "UploadPrivatePlugin",
+			want: multipartWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				return c.UploadPrivatePlugin(ctx, "/api/plugins/private", []byte("x"), "p.zip", nil)
+			},
+		},
+		{
+			// A server-relative download_url is resolved against BaseURL and
+			// gets the full header set — this is the path that fetches an
+			// attachment from the Multica server itself.
+			name: "DownloadFile relative URL",
+			want: fullWireHeaders,
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.DownloadFile(ctx, "/api/attachments/att-1/download")
+				return err
+			},
+		},
+		{
+			// Characterized gap #1: an absolute URL is assumed to be a signed
+			// third-party (S3/CloudFront) URL, so NO headers are attached —
+			// deliberately, to avoid disturbing the query-string signature.
+			// A shared transport must preserve this carve-out; attaching
+			// operator-configured extra headers here would leak a ZTN
+			// credential to the object store.
+			name: "DownloadFile absolute URL sends no client headers",
+			want: "",
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.DownloadFile(ctx, c.BaseURL+"/signed/object?sig=abc")
+				return err
+			},
+		},
+		{
+			// Characterized gap #2: HealthCheck skips setHeaders entirely, so
+			// /health is the one CLI request that carries neither auth nor
+			// identity. Behind a header-injecting reverse proxy or ZTN this
+			// request cannot authenticate, which is why `multica setup`'s
+			// reachability probe misreads such deployments (MUL-6638).
+			name: "HealthCheck sends no client headers",
+			want: "",
+			call: func(ctx context.Context, c *APIClient) error {
+				_, err := c.HealthCheck(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var requests int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				got = captureWireHeaders(r)
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, responseBody)
+			}))
+			defer srv.Close()
+
+			if err := tc.call(context.Background(), wireHeadersTestClient(srv.URL)); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if requests != 1 {
+				t.Fatalf("%s: server saw %d requests, want 1", tc.name, requests)
+			}
+			if got != tc.want {
+				t.Errorf("%s outbound headers changed.\ngot:\n%s\nwant:\n%s", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAPIClientIdentityHeadersOmittedWhenUnset pins the other half of the
+// contract: an unset field must omit its header rather than send an empty
+// value, because the server distinguishes "absent" from "empty" for the
+// capability and attribution headers.
+func TestAPIClientIdentityHeadersOmittedWhenUnset(t *testing.T) {
+	origPlatform, origVersion, origOS := ClientPlatform, ClientVersion, ClientOS
+	ClientPlatform, ClientVersion, ClientOS = "", "", ""
+	t.Cleanup(func() {
+		ClientPlatform, ClientVersion, ClientOS = origPlatform, origVersion, origOS
+	})
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = captureWireHeaders(r)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	// No token, workspace, agent, task, or identity overrides: only the
+	// always-on capability header should survive.
+	if err := NewAPIClient(srv.URL, "", "").GetJSON(context.Background(), "/api/test", nil); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	const want = "X-Client-Capabilities: stable_attachment_urls"
+	if got != want {
+		t.Errorf("outbound headers = %q, want %q", got, want)
+	}
+}

--- a/server/internal/daemon/wire_headers_test.go
+++ b/server/internal/daemon/wire_headers_test.go
@@ -1,0 +1,283 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// This file is a characterization (snapshot) test of the daemon's OUTBOUND
+// header set — on every HTTP request helper AND on the wakeup WebSocket
+// handshake. It asserts the FULL set rather than "contains X", so a refactor
+// that moves header construction into a transport layer shared with
+// internal/cli (MUL-6638) cannot silently change the wire, and the HTTP and WS
+// paths cannot drift apart unnoticed.
+//
+// The WS case matters most: the server derives claim-time capability gating
+// from the handshake headers, and before this test the handshake header set
+// had no coverage at all.
+
+// daemonWireHeaderKeys is the set of request headers this snapshot tracks.
+// Everything else on the wire (Host, User-Agent, Content-Length, the
+// Sec-WebSocket-* handshake headers) is set by net/http or gorilla, not by
+// daemon code.
+var daemonWireHeaderKeys = []string{
+	"Authorization",
+	"Content-Type",
+	"If-None-Match",
+	"X-Client-Capabilities",
+	"X-Client-OS",
+	"X-Client-Platform",
+	"X-Client-Version",
+}
+
+func captureDaemonWireHeaders(h http.Header) string {
+	var parts []string
+	for _, key := range daemonWireHeaderKeys {
+		values, ok := h[http.CanonicalHeaderKey(key)]
+		if !ok {
+			continue
+		}
+		parts = append(parts, key+": "+strings.Join(values, "|"))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
+}
+
+// daemonCapabilitiesSnapshot is the exact X-Client-Capabilities value, in
+// order. The server reads this header to gate skill bundles, coalesced
+// comments, local worktrees and WS RPC, so both its contents and the fact
+// that it is one comma-joined value are part of the protocol.
+const daemonCapabilitiesSnapshot = "skill-bundles-v1,coalesced-comments-v1,execution-manifest-v1,agent-skill-v1,remote-mcp-v1,local-worktree-v1,rpc-v1"
+
+// TestDaemonCapabilityHeaderValueSnapshot pins the literal header value.
+// daemonClientCapabilities() is assembled from constants, so this is the only
+// place a reorder or a dropped entry becomes visible as a wire change.
+func TestDaemonCapabilityHeaderValueSnapshot(t *testing.T) {
+	if got := daemonClientCapabilities(); got != daemonCapabilitiesSnapshot {
+		t.Errorf("daemonClientCapabilities() = %q, want %q\nChanging this value changes server-side gating for every daemon request and WS claim.", got, daemonCapabilitiesSnapshot)
+	}
+}
+
+func daemonWireHeadersWant(contentType string) string {
+	parts := []string{
+		"Authorization: Bearer tok-1",
+		"X-Client-Capabilities: " + daemonCapabilitiesSnapshot,
+		"X-Client-OS: " + normalizeGOOS(runtime.GOOS),
+		"X-Client-Platform: daemon",
+		"X-Client-Version: 9.9.9",
+	}
+	if contentType != "" {
+		parts = append(parts, "Content-Type: "+contentType)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
+}
+
+func TestDaemonClientOutboundHeaderSnapshot(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+		call func(ctx context.Context, c *Client) error
+	}{
+		{
+			name: "postJSON",
+			want: daemonWireHeadersWant("application/json"),
+			call: func(ctx context.Context, c *Client) error {
+				return c.postJSON(ctx, "/api/daemon/test", map[string]any{}, nil)
+			},
+		},
+		{
+			// The skill-bundle download runs on a second http.Client with a
+			// different timeout regime; it must still carry the same headers.
+			// Any transport-level policy added later (redirect handling,
+			// operator-configured extra headers) has to reach both clients.
+			name: "postJSON via bundleClient",
+			want: daemonWireHeadersWant("application/json"),
+			call: func(ctx context.Context, c *Client) error {
+				return c.postJSONVia(ctx, c.bundleClient, "/api/daemon/bundle", map[string]any{}, nil)
+			},
+		},
+		{
+			name: "getJSON",
+			want: daemonWireHeadersWant(""),
+			call: func(ctx context.Context, c *Client) error {
+				return c.getJSON(ctx, "/api/daemon/test", nil)
+			},
+		},
+		{
+			// A task-scoped token replaces the client's PAT and nothing else.
+			name: "getJSONWithToken",
+			want: strings.Replace(daemonWireHeadersWant(""), "Bearer tok-1", "Bearer mat_task", 1),
+			call: func(ctx context.Context, c *Client) error {
+				return c.getJSONWithToken(ctx, "/api/daemon/test", "mat_task", nil)
+			},
+		},
+		{
+			name: "postJSONWithToken",
+			want: strings.Replace(daemonWireHeadersWant("application/json"), "Bearer tok-1", "Bearer mat_task", 1),
+			call: func(ctx context.Context, c *Client) error {
+				return c.postJSONWithToken(ctx, "/api/daemon/test", "mat_task", map[string]any{}, nil)
+			},
+		},
+		{
+			// ListWorkspaces builds its request by hand instead of going
+			// through getJSON, which is exactly the kind of copy that drifts.
+			name: "ListWorkspaces",
+			want: daemonWireHeadersWant(""),
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.ListWorkspaces(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var requests int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				got = captureDaemonWireHeaders(r.Header)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL)
+			c.SetToken("tok-1")
+			c.SetVersion("9.9.9")
+
+			if err := tc.call(context.Background(), c); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if requests != 1 {
+				t.Fatalf("%s: server saw %d requests, want 1", tc.name, requests)
+			}
+			if got != tc.want {
+				t.Errorf("%s outbound headers changed.\ngot:\n%s\nwant:\n%s", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDaemonClientListWorkspacesSendsConditionalHeader pins the one
+// request-specific header the daemon adds on top of the shared set: a cached
+// ETag is replayed as If-None-Match. A shared transport must not overwrite
+// per-request headers a caller already set.
+func TestDaemonClientListWorkspacesSendsConditionalHeader(t *testing.T) {
+	var second string
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("ETag", `"ws-etag-1"`)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		second = captureDaemonWireHeaders(r.Header)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.SetToken("tok-1")
+	c.SetVersion("9.9.9")
+
+	for i := 0; i < 2; i++ {
+		if _, err := c.ListWorkspaces(context.Background()); err != nil {
+			t.Fatalf("ListWorkspaces #%d: %v", i+1, err)
+		}
+	}
+
+	want := daemonWireHeadersWant("")
+	want = strings.Join(append(strings.Split(want, "\n"), `If-None-Match: "ws-etag-1"`), "\n")
+	wantLines := strings.Split(want, "\n")
+	sort.Strings(wantLines)
+	want = strings.Join(wantLines, "\n")
+
+	if second != want {
+		t.Errorf("conditional ListWorkspaces headers changed.\ngot:\n%s\nwant:\n%s", second, want)
+	}
+}
+
+// TestTaskWakeupHandshakeHeaderSnapshot pins the wakeup WebSocket handshake
+// header set and, by comparing it to the HTTP set, the invariant that the two
+// paths advertise the same identity and capabilities. The WS path builds its
+// headers in wakeup.go rather than through Client.setIdentityHeaders, so this
+// is the drift the snapshot exists to catch.
+func TestTaskWakeupHandshakeHeaderSnapshot(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	handshake := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case handshake <- captureDaemonWireHeaders(r.Header):
+		default:
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Close immediately: the assertion is about the handshake, so the
+		// connection only needs to exist long enough to be established.
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	d := New(Config{
+		ServerBaseURL:  srv.URL,
+		WorkspacesRoot: t.TempDir(),
+		CLIVersion:     "9.9.9",
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d.client.SetToken("tok-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _ = d.runTaskWakeupConnection(ctx, []string{"runtime-1"}, make(chan taskWakeup, 1), make(chan struct{}))
+
+	select {
+	case got := <-handshake:
+		// The handshake carries no Content-Type (no body) and no
+		// If-None-Match, so the expected set is the daemon's bodyless HTTP
+		// set verbatim.
+		if want := daemonWireHeadersWant(""); got != want {
+			t.Errorf("wakeup WS handshake headers changed.\ngot:\n%s\nwant:\n%s\nThe WS handshake must advertise the same identity and capabilities as the HTTP control plane.", got, want)
+		}
+	default:
+		t.Fatal("wakeup WS handshake never reached the server")
+	}
+}
+
+// TestDaemonRequestErrorMatchesCLIShape documents, in executable form, that
+// daemon.requestError and cli.HTTPError render the same message for the same
+// failure — the duplication MUL-6638 proposes to collapse into one shared
+// error type. Kept as a test rather than a comment so a change to either
+// side's formatting is caught while the two types still coexist.
+func TestDaemonRequestErrorMatchesCLIShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("  already claimed\n"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	err := c.postJSON(context.Background(), "/api/daemon/test", map[string]any{}, nil)
+	if err == nil {
+		t.Fatal("postJSON: expected an error for a 409 response")
+	}
+	const want = "POST /api/daemon/test returned 409: already claimed"
+	if err.Error() != want {
+		t.Errorf("requestError.Error() = %q, want %q", err.Error(), want)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Pins the **complete outbound header set** of every path the `multica` binary uses to reach the Multica server, as characterization (snapshot) tests. Tests only — no production code is touched.

This is step 0 of the transport consolidation assessed in MUL-6638. The binary today has two independent server clients (`cli.APIClient`, `daemon.Client`) plus a hand-built WebSocket dial that re-implements the identity headers a third time. Before any of that construction moves into a shared layer, the current wire needs to be nailed down — otherwise the refactor's only safety net is code review.

Two concrete gaps this closes:

- The **wakeup WebSocket handshake header set had no test coverage at all** (`internal/daemon/wakeup_test.go` never asserted a header), even though the server derives claim-time capability gating from those headers.
- The existing HTTP tests assert *individual* headers ("contains `X-Client-Platform`"), so an accidentally **dropped** header passes, and only shows up as a server-side gate flipping off.

## Related Issue

Refs MUL-6638 (assessment of whether `cli.APIClient` and `daemon.Client` can be merged). Adjacent to #7492 / #7493, which adds operator-configured extra headers to the daemon path — the same headers that a shared transport should attach in one place.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

**`server/internal/cli/wire_headers_test.go`** (new)

- `TestAPIClientOutboundHeaderSnapshot` — 15 cases, one per `APIClient` method that reaches the server (`GetJSON`, `GetJSONWithHeaders`, `DeleteJSON`, `DeleteJSONWithBody`, `PostJSON`, `PutJSON`, `PatchJSON`, `UploadFile`, `UploadChatAttachment`, `UploadFileWithURL`, `ImportSkillFile`, `UploadPrivatePlugin`, `DownloadFile` relative + absolute, `HealthCheck`). Each asserts the full tracked header set as one comparable string, so an addition *or* an omission fails.
- Two cases record a **deliberate carve-out** rather than a contract, with the reasoning inline: `HealthCheck` skips `setHeaders` entirely, and `DownloadFile` with an absolute URL attaches nothing so a CloudFront signature is not disturbed. Both must survive a refactor — in particular, attaching operator-configured extra headers to the absolute-URL download would leak a ZTN credential to the object store.
- `TestAPIClientIdentityHeadersOmittedWhenUnset` — pins the other half: an unset field omits its header rather than sending an empty value, which the server distinguishes.

**`server/internal/daemon/wire_headers_test.go`** (new)

- `TestDaemonClientOutboundHeaderSnapshot` — `postJSON`, `getJSON`, `getJSONWithToken`, `postJSONWithToken`, hand-rolled `ListWorkspaces`, and `postJSONVia` over the second `bundleClient` (a distinct `http.Client`, so any transport-level policy added later has to reach both).
- `TestDaemonClientListWorkspacesSendsConditionalHeader` — the cached ETag is replayed as `If-None-Match`; a shared transport must not clobber per-request headers a caller already set.
- `TestTaskWakeupHandshakeHeaderSnapshot` — first coverage of the wakeup WS handshake, asserted against the daemon's bodyless HTTP set so HTTP and WS cannot drift apart.
- `TestDaemonCapabilityHeaderValueSnapshot` — literal snapshot of `X-Client-Capabilities`. The value is assembled from constants, so this is the only place a reorder or dropped entry surfaces as a wire change.
- `TestDaemonRequestErrorMatchesCLIShape` — executable evidence that `daemon.requestError` and `cli.HTTPError` already render identically for the same failure, which is the duplication MUL-6638 proposes to collapse.

## How to Test

```
cd server
go vet ./internal/cli/ ./internal/daemon/
go test -count=1 -run 'TestAPIClientOutboundHeaderSnapshot|TestAPIClientIdentityHeadersOmittedWhenUnset' ./internal/cli/
go test -count=1 -run 'TestDaemonCapabilityHeaderValueSnapshot|TestDaemonClientOutboundHeaderSnapshot|TestDaemonClientListWorkspacesSendsConditionalHeader|TestTaskWakeupHandshakeHeaderSnapshot|TestDaemonRequestErrorMatchesCLIShape' ./internal/daemon/
```

All pass. To see the net worth: delete `X-Client-Capabilities` from `daemon.setIdentityHeaders` or from the header block in `wakeup.go` and re-run — the snapshot fails with a printed diff, where the previous tests stayed green for the WS case.

## Checklist

- [x] I have included a thinking path that traces from project context to this change — MUL-6638 asks whether the two clients can be merged; the answer needs a migration-safety story, and "assert the header set before moving it" is the cheapest one. Scope stayed at tests deliberately so it can merge independently of the shared-transport work and of #7493.
- [x] I have run tests locally and they pass. Pre-existing, environment-induced failures in `internal/cli` (`TestCLIConfig_BackwardCompat_*`, `TestCLIConfig_OpenClaw*`, `TestCLIConfig_ProfileCommandOverrides_*`) and `internal/daemon` (`TestPrepareReasonixTaskStateHome`, `TestPrepareDshTaskSessionRoot`, `TestEnsureDaemonID_*`, `TestLegacyDaemonUUIDs_ScansProfileDirs`, `TestLoadConfig_BackendOverrides_BackwardCompat_NoConfigFile`) reproduce identically with these two files removed — they read the ambient agent-runtime `HOME` / config root. Same set #7493 documented.
- [x] I have added or updated tests where applicable — that is the whole change.
- [ ] If this change affects the UI, I have included before/after screenshots — N/A.
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs — N/A.
- [ ] If this PR touches Chinese product copy — N/A.
- [x] I have considered and documented any risks above. Risk is close to nil: no production code, no new dependencies. The one judgement call is pinning today's two carve-outs (`HealthCheck`, absolute-URL `DownloadFile`) as expectations; both are commented as characterized behavior, so intentionally changing them means editing the expectation in the same commit — which is the point.
- [x] I will address all reviewer comments before requesting merge.

## AI Disclosure

**AI tool used:** Kiro CLI (claude-opus-5) via the Multica agent runtime, working MUL-6638.

**Prompt/approach:** Read both clients end to end (`internal/cli/client.go`, `internal/daemon/client.go`), the WS dial in `internal/daemon/wakeup.go`, and every other outbound-HTTP construction site in `cmd/multica` / `internal/cli` / `internal/daemon` to enumerate the server-facing paths. Confirmed existing coverage asserted single headers and that the WS handshake had none, then wrote the snapshots to cover each path exactly once. Verified the pre-existing test failures reproduce without these files before attributing them to the environment.
