### PR TITLE
fix(autopilot): mutex gate prevents concurrent scheduled runs (ALL-206)

### DIFF
--- a/server/cmd/server/autopilot_mutex_gate_test.go
+++ b/server/cmd/server/autopilot_mutex_gate_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/dispatch"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestAutopilotMutexGateSkipsOverlappingSlot is the ALL-206 regression for the
+// scheduler mutex/lease gate: while an autopilot still has an in-flight run
+// (autopilot_run.status IN ('pending','issue_created','running') — the exact set
+// of the partial index idx_autopilot_run_status from migration 042), the next
+// scheduled slot MUST NOT start a second concurrent run. It is recorded as a
+// `skipped` run with a clear failure_reason instead.
+func TestAutopilotMutexGateSkipsOverlappingSlot(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap := createAutopilotForMutexTest(t, ctx, queries, "ALL-206 mutex in-flight", agentID)
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Slot 1 dispatches normally and leaves a run in flight (running + task).
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil {
+		t.Fatalf("slot 1 returned nil run")
+	}
+	if first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = status %q, task_id valid %v; want running with task", first.Status, first.TaskID.Valid)
+	}
+
+	// Slot 2 is the very next occurrence while slot 1 is still in flight: the
+	// mutex gate must skip it instead of starting a concurrent run.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil {
+		t.Fatalf("slot 2 returned nil run")
+	}
+	if second.Status != "skipped" {
+		t.Fatalf("slot 2 run status = %q, want skipped", second.Status)
+	}
+	if !second.FailureReason.Valid || !strings.Contains(second.FailureReason.String, "previous run still in flight") {
+		t.Fatalf("slot 2 failure_reason = %q, want it to mention the in-flight predecessor", second.FailureReason.String)
+	}
+	if second.TaskID.Valid {
+		t.Fatalf("skipped run must not be linked to a task, got task_id=%s", util.UUIDToString(second.TaskID))
+	}
+
+	// The manual "run now" surface reports the same typed admission code so the
+	// HTTP handler can return it to the clicking member.
+	manualRun, code, err := autopilotSvc.DispatchAutopilotManual(ctx, ap, trigger.ID, nil, parseUUID(testUserID))
+	if err != nil {
+		t.Fatalf("DispatchAutopilotManual while in flight: %v", err)
+	}
+	if code != dispatch.ReasonAlreadyActive {
+		t.Fatalf("manual dispatch reason code = %q, want %q", code, dispatch.ReasonAlreadyActive)
+	}
+	if manualRun == nil || manualRun.Status != "skipped" {
+		t.Fatalf("manual dispatch while in flight = %+v, want skipped run", manualRun)
+	}
+
+	// Never created a concurrent task: slot 1's task is the only one across slot
+	// 1, slot 2 and the manual call.
+	var taskCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		 WHERE autopilot_run_id IN (SELECT id FROM autopilot_run WHERE autopilot_id = $1)
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if taskCount != 1 {
+		t.Fatalf("expected exactly 1 task (slot 1), got %d — an overlapping slot must not dispatch", taskCount)
+	}
+}
+
+// TestAutopilotMutexGateAllowsDispatchAfterTerminal is the counterpart ALL-206
+// regression: once the previous run reaches a terminal state (here completed,
+// the same flip the task listener applies), the next scheduled slot MUST
+// dispatch normally. The mutex gate is per-autopilot, never global.
+func TestAutopilotMutexGateAllowsDispatchAfterTerminal(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap := createAutopilotForMutexTest(t, ctx, queries, "ALL-206 mutex terminal", agentID)
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+
+	// Close out slot 1 the way the task listener (SyncRunFromTask) does: the run
+	// flips to completed once its queued task finishes.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE id = $1`, first.ID); err != nil {
+		t.Fatalf("close slot 1 run: %v", err)
+	}
+
+	// The next occurrence must now dispatch normally — a fresh run and task, not
+	// a mutex skip.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil {
+		t.Fatalf("slot 2 returned nil run")
+	}
+	if second.Status != "running" || !second.TaskID.Valid {
+		t.Fatalf("slot 2 run = status %q, task_id valid %v; want normal running dispatch", second.Status, second.TaskID.Valid)
+	}
+	if second.FailureReason.Valid {
+		t.Fatalf("slot 2 run must not carry a failure_reason, got %q", second.FailureReason.String)
+	}
+
+	// Exactly two tasks — one per dispatched slot: no loss, no duplication.
+	var taskCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		 WHERE autopilot_run_id IN (SELECT id FROM autopilot_run WHERE autopilot_id = $1)
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if taskCount != 2 {
+		t.Fatalf("expected exactly 2 tasks (one per slot), got %d", taskCount)
+	}
+}
+
+// createAutopilotForMutexTest seeds an active run_only autopilot assigned to the
+// fixture agent. Deleting the autopilot cascades to its triggers and runs
+// (migration 042), so a single DELETE is the whole cleanup.
+func createAutopilotForMutexTest(t *testing.T, ctx context.Context, queries *db.Queries, title, agentID string) db.Autopilot {
+	t.Helper()
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              title,
+		Description:        pgtype.Text{String: "ALL-206 mutex gate test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+			t.Logf("cleanup autopilot: %v", err)
+		}
+	})
+	return ap
+}
+
+// createTriggerForMutexTest seeds an enabled schedule trigger on the autopilot.
+func createTriggerForMutexTest(t *testing.T, ctx context.Context, queries *db.Queries, ap db.Autopilot) db.AutopilotTrigger {
+	t.Helper()
+	trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+		AutopilotID:    ap.ID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+	return trigger
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1268,6 +1268,27 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 //     agent assignee being missing is now a real condition the gate must
 //     handle (previously cascade-deleted).
 func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopilot, actorUserID pgtype.UUID) (string, dispatch.ReasonCode, bool) {
+	// Mutex / lease gate (ALL-206): never dispatch a new slot while the
+	// autopilot still has an in-flight run. The in-flight statuses
+	// (pending / issue_created / running) mirror the partial index
+	// idx_autopilot_run_status from migration 042 — a scheduled run that
+	// outlives its slot interval used to let the next slot start a second
+	// concurrent run for the same autopilot. When one is in flight the new
+	// slot is recorded as skipped (with a clear failure_reason) instead of
+	// creating a concurrent run.
+	prior, err := s.Queries.GetAutopilotRunInFlight(ctx, ap.ID)
+	if err == nil {
+		return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		// Transient DB error — fail-open so the next scheduler tick gets a
+		// chance to succeed, consistent with the rest of the admission gate.
+		slog.Warn("autopilot admission: failed to check for in-flight run",
+			"autopilot_id", util.UUIDToString(ap.ID),
+			"error", err,
+		)
+		return "", "", false
+	}
 	if !ap.AssigneeID.Valid {
 		return "autopilot has no assignee", dispatch.ReasonTargetUnavailable, true
 	}

--- a/server/internal/service/autopilot_quota_test.go
+++ b/server/internal/service/autopilot_quota_test.go
@@ -605,6 +605,15 @@ func TestAutopilotQuotaSchedulePersistsSkippedRun(t *testing.T) {
 		pool.Exec(context.Background(), `DELETE FROM autopilot_quota_period WHERE workspace_id = $1`, workspaceID)
 	})
 
+	// seedRunOnlyAutopilot leaves a `running` run for the fixture. The ALL-206
+	// mutex gate would short-circuit the dispatch on that in-flight run, so
+	// close it out first — this test exercises the quota gate in isolation.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE autopilot_id = $1`,
+		util.MustParseUUID(autopilotIDString)); err != nil {
+		t.Fatalf("close seeded in-flight run: %v", err)
+	}
+
 	start := time.Now().UTC().Truncate(time.Second)
 	end := start.Add(13 * time.Hour)
 	limit := 0

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -924,6 +924,45 @@ func (q *Queries) GetAutopilotRunByWebhookDelivery(ctx context.Context, webhookD
 	return i, err
 }
 
+const getAutopilotRunInFlight = `-- name: GetAutopilotRunInFlight :one
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, quota_reservation_id, reason_code FROM autopilot_run
+WHERE autopilot_id = $1
+  AND status IN ('pending', 'issue_created', 'running')
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+// Mutex gate for the scheduler: returns the most recent run that has not yet
+// reached a terminal state. The status list mirrors the partial index
+// idx_autopilot_run_status (migration 042), which is also the authoritative
+// definition of "in flight". Returns no rows when the autopilot is free to
+// dispatch a new run.
+func (q *Queries) GetAutopilotRunInFlight(ctx context.Context, autopilotID pgtype.UUID) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getAutopilotRunInFlight, autopilotID)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
+		&i.WebhookDeliveryID,
+		&i.QuotaReservationID,
+		&i.ReasonCode,
+	)
+	return i, err
+}
+
 const getAutopilotTaskByRun = `-- name: GetAutopilotTaskByRun :one
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
 WHERE autopilot_run_id = $1

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -399,6 +399,18 @@ WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 
+-- name: GetAutopilotRunInFlight :one
+-- Mutex gate for the scheduler: returns the most recent run that has not yet
+-- reached a terminal state. The status list mirrors the partial index
+-- idx_autopilot_run_status (migration 042), which is also the authoritative
+-- definition of "in flight". Returns no rows when the autopilot is free to
+-- dispatch a new run.
+SELECT * FROM autopilot_run
+WHERE autopilot_id = $1
+  AND status IN ('pending', 'issue_created', 'running')
+ORDER BY created_at DESC
+LIMIT 1;
+
 -- name: UpdateAutopilotRunIssueCreated :one
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2


### PR DESCRIPTION
## Autopilot scheduler mutex / lease gate (ALL-206)

### Problem

The Autopilot scheduler (cron → `DispatchAutopilotForPlan`) did not check
whether an autopilot already had an in-flight run before dispatching a new
slot. A run that outlived its slot interval let the next slot start a **second
concurrent run for the same autopilot**, duplicating the autopilot's side
effect (a second task/issue on the same schedule).

### Fix

A single admission gate in `shouldSkipDispatch` (`server/internal/service/autopilot.go`)
— the pre-flight choke point shared by every dispatch entry point
(schedule `DispatchAutopilotForPlan`, manual `DispatchAutopilotManual`,
webhook `AdmitAutopilotWebhookDelivery`, API):

- New sqlc query `GetAutopilotRunInFlight` returns the most recent
  `autopilot_run` that has not reached a terminal state. The in-flight status
  set (`pending`, `issue_created`, `running`) mirrors the partial index
  `idx_autopilot_run_status` from migration 042, which is the authoritative
  definition of "in flight".
- When a run is in flight, the slot is recorded as `skipped` with
  `failure_reason = "previous run still in flight (<run_id>)"` and the typed
  reason code `dispatch.ReasonAlreadyActive` — a concurrent run is never
  created.
- Transient DB errors fail open (log + proceed), consistent with the rest of
  the admission gate, so a hiccup never silently swallows a scheduled run.

```go
// server/internal/service/autopilot.go
prior, err := s.Queries.GetAutopilotRunInFlight(ctx, ap.ID)
if err == nil {
    return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
}
if !errors.Is(err, pgx.ErrNoRows) {
    slog.Warn("autopilot admission: failed to check for in-flight run",
        "autopilot_id", util.UUIDToString(ap.ID), "error", err)
    return "", "", false // fail open
}
```

```sql
-- server/pkg/db/queries/autopilot.sql
-- name: GetAutopilotRunInFlight :one
SELECT * FROM autopilot_run
WHERE autopilot_id = $1
  AND status IN ('pending', 'issue_created', 'running')
ORDER BY created_at DESC
LIMIT 1;
```

### Regression tests

`server/cmd/server/autopilot_mutex_gate_test.go` (real-DB integration, same
pattern as `autopilot_dispatch_for_plan_test.go`, no new dependencies):

- `TestAutopilotMutexGateSkipsOverlappingSlot` — slot 1 dispatches and is
  `running`; the very next slot while slot 1 is still in flight is recorded as
  `skipped` with a `failure_reason` naming the predecessor, carries no task,
  and the manual "run now" surface returns `ReasonAlreadyActive`. Task count
  across all three attempts is exactly 1 (no concurrent task).
- `TestAutopilotMutexGateAllowsDispatchAfterTerminal` — after slot 1 reaches
  `completed` (the same flip the task listener applies), the next slot
  dispatches normally (`running` + task, no `failure_reason`). Task count is
  exactly 2.

### Out of scope, documented

**Trigger label mismatch** (`label: "guardian-60m"` vs
`cron_expression: "0 */2 * * *"`, trigger `17a136da-9539-4fbc-859c-31023d1430a8`):
this trigger is **not** created or seeded by this repository — no code, seed,
or migration references the trigger id or the `guardian-60m` label (verified by
repo-wide search and against a fresh migrated DB). It is owner-only production
runtime configuration, so it cannot be fixed in this PR. Owner action: update
the trigger's `label` in the production DB to match its actual 2-hour cadence,
or rename the autopilot if "every 60 minutes" was the intent.

### Long-run protection (recommendations, not in this PR)

The mutex gate prevents *overlap*, but a single run that consistently outlives
its slot interval will now be skipped every time — operators should add, as
follow-ups:

1. **Hard cap**: a maximum `autopilot_run` lifetime (e.g. N × slot interval)
   after which the scheduler marks the run `failed`/`skipped` and force-releases
   the slot, instead of skipping forever.
2. **Sharding / job splitting**: for autopilots whose workload legitimately
   exceeds the slot interval, split the unit of work so one run completes within
   one interval (align the cron expression to the real expected duration).
3. **Alerting**: surface `failure_reason = "previous run still in flight (...)"`
   skips in the autopilot health/pause monitor — sustained skips indicate a
   slot interval that is too short for the workload, not just a one-off overlap.
