### PR TITLE
MUL-6654: fix(daemon): stage task-local multica CLI, add sandbox PATH fallbacks for Codex (ALL-219)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -165,6 +166,68 @@ func taskMulticaEnvironment(task Task, agentName, token, configRoot, workspacesR
 		"TMP":                  tempDir,
 		"TEMP":                 tempDir,
 	}
+}
+
+type windowsPowerShellPathDeps struct {
+	UserHomeDir  func() (string, error)
+	LocalAppData string
+	UserPath     string
+	Lstat        func(string) (os.FileInfo, error)
+}
+
+// preferWindowsCodexPowerShell prepends a verified PowerShell directory for
+// Codex tasks. The desktop daemon can outlive a user PATH update, leaving its
+// inherited PATH pointed at the zero-byte WindowsApps execution alias.
+func preferWindowsCodexPowerShell(provider, goos, path string, deps windowsPowerShellPathDeps) string {
+	if provider != "codex" || goos != "windows" {
+		return path
+	}
+	if deps.UserHomeDir == nil || deps.Lstat == nil {
+		return path
+	}
+	home, err := deps.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return path
+	}
+
+	candidates := make([]string, 0, 8)
+	for _, dir := range strings.Split(deps.UserPath, ";") {
+		if dir = strings.TrimSpace(dir); dir != "" {
+			candidates = append(candidates, dir)
+		}
+	}
+	localAppData := strings.TrimSpace(deps.LocalAppData)
+	if localAppData == "" {
+		localAppData = filepath.Join(home, "AppData", "Local")
+	}
+	candidates = append(candidates,
+		filepath.Join(localAppData, "Programs", "PowerShell", "7"),
+		filepath.Join(home, ".cache", "codex-runtimes", "codex-primary-runtime", "dependencies", "native", "powershell"),
+	)
+
+	for _, dir := range candidates {
+		dir = filepath.Clean(dir)
+		info, err := deps.Lstat(filepath.Join(dir, "pwsh.exe"))
+		// WindowsApps aliases are reparse points or zero-byte placeholders. A
+		// regular, non-empty file is the minimum safe contract for the child.
+		if err != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+			continue
+		}
+		if path == "" {
+			return dir
+		}
+		return dir + ";" + path
+	}
+	return path
+}
+
+func windowsCodexPowerShellPath(provider, goos, path string) string {
+	return preferWindowsCodexPowerShell(provider, goos, path, windowsPowerShellPathDeps{
+		UserHomeDir:  os.UserHomeDir,
+		LocalAppData: os.Getenv("LOCALAPPDATA"),
+		UserPath:     windowsUserPath(),
+		Lstat:        os.Lstat,
+	})
 }
 
 // taskRunner executes a single agent task and returns the result.
@@ -7353,14 +7416,26 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			}
 		}
 	}
+	// Stage a task-local copy because provider sandboxes may not be able to
+	// access the daemon's install directory (especially on Windows).
+	selfBin, err := resolveSelfExecutable()
+	if err != nil {
+		return TaskResult{}, fmt.Errorf("resolve multica CLI executable: %w", err)
+	}
+	taskCLIPath, err := stageTaskCLI(selfBin, taskTempDir)
+	if err != nil {
+		return TaskResult{}, fmt.Errorf("stage multica CLI executable: %w", err)
+	}
+
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
-	// inherit the daemon's PATH. Prepend the directory of the running
-	// multica binary so that `multica` commands in the agent always resolve.
-	if selfBin, err := resolveSelfExecutable(); err == nil {
-		binDir := filepath.Dir(selfBin)
-		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
-	}
+	// inherit the daemon's PATH. Prepend the task-local copy so that `multica`
+	// commands in the agent always resolve within the sandbox.
+	agentEnv["PATH"] = filepath.Dir(taskCLIPath) + string(os.PathListSeparator) + os.Getenv("PATH")
+	agentEnv["PATH"] = windowsCodexPowerShellPath(provider, runtime.GOOS, agentEnv["PATH"])
+	// PATH can still be filtered by a provider sandbox or shell policy. Expose
+	// the task-local executable explicitly for deterministic fallback commands.
+	agentEnv["MULTICA_CLI_PATH"] = taskCLIPath
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {
@@ -8930,6 +9005,46 @@ func socketSafeTempBaseDir() string {
 		}
 	}
 	return os.TempDir()
+}
+
+func stageTaskCLI(sourcePath, taskTempDir string) (string, error) {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return "", errors.New("source executable path is empty")
+	}
+	taskTempDir = strings.TrimSpace(taskTempDir)
+	if taskTempDir == "" {
+		return "", errors.New("task temp dir is empty")
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("stat source executable: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("source executable is not a regular file: %s", sourcePath)
+	}
+	if err := os.MkdirAll(taskTempDir, 0o700); err != nil {
+		return "", fmt.Errorf("create task temp dir: %w", err)
+	}
+	targetPath := filepath.Join(taskTempDir, filepath.Base(sourcePath))
+	in, err := os.Open(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("open source executable: %w", err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return "", fmt.Errorf("create staged executable: %w", err)
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return "", fmt.Errorf("copy executable: %w", copyErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("close staged executable: %w", closeErr)
+	}
+	return targetPath, nil
 }
 
 // isBlockedEnvKey returns true if the key must not be overridden by user-

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -59,6 +59,38 @@ func TestNormalizeServerBaseURL(t *testing.T) {
 	}
 }
 
+func TestStageTaskCLI_CopiesExecutableIntoTaskTempDir(t *testing.T) {
+	t.Parallel()
+	source := filepath.Join(t.TempDir(), "multica.exe")
+	want := []byte("fake executable")
+	if err := os.WriteFile(source, want, 0o755); err != nil {
+		t.Fatalf("write source executable: %v", err)
+	}
+	taskTempDir := t.TempDir()
+	staged, err := stageTaskCLI(source, taskTempDir)
+	if err != nil {
+		t.Fatalf("stageTaskCLI: %v", err)
+	}
+	if filepath.Dir(staged) != taskTempDir {
+		t.Fatalf("staged path = %q, want under %q", staged, taskTempDir)
+	}
+	got, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatalf("read staged executable: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("staged contents = %q, want %q", got, want)
+	}
+}
+
+func TestStageTaskCLI_ReportsMissingSource(t *testing.T) {
+	t.Parallel()
+	_, err := stageTaskCLI(filepath.Join(t.TempDir(), "missing-multica"), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "stat source executable") {
+		t.Fatalf("stageTaskCLI error = %v, want explicit source stat failure", err)
+	}
+}
+
 func TestTriggerRestart_BrewLinuxCellarDeleted(t *testing.T) {
 	originalIsBrewInstall := isBrewInstall
 	originalGetBrewPrefix := getBrewPrefix
@@ -581,6 +613,59 @@ func TestTaskMulticaEnvironmentIncludesPrivateConfigRoot(t *testing.T) {
 	}
 	if env["MULTICA_TOKEN"] != fakeToken {
 		t.Fatal("custom env replaced task-scoped token")
+	}
+}
+
+func TestPreferWindowsCodexPowerShellPrefersRealUserPathOverWindowsAppsAlias(t *testing.T) {
+	aliasDir := t.TempDir()
+	realDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(aliasDir, "pwsh.exe"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "pwsh.exe"), []byte("real pwsh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := preferWindowsCodexPowerShell("codex", "windows", `C:\\task\\bin;C:\\WindowsApps`, windowsPowerShellPathDeps{
+		UserHomeDir:  func() (string, error) { return t.TempDir(), nil },
+		UserPath:     aliasDir + ";" + realDir,
+		Lstat:        os.Lstat,
+		LocalAppData: t.TempDir(),
+	})
+	if want := realDir + `;C:\\task\\bin;C:\\WindowsApps`; got != want {
+		t.Fatalf("PATH = %q, want %q", got, want)
+	}
+}
+
+func TestPreferWindowsCodexPowerShellKeepsPathWithoutRealPowerShell(t *testing.T) {
+	aliasDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(aliasDir, "pwsh.exe"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := `C:\\task\\bin;C:\\WindowsApps`
+	got := preferWindowsCodexPowerShell("codex", "windows", path, windowsPowerShellPathDeps{
+		UserHomeDir:  func() (string, error) { return t.TempDir(), nil },
+		UserPath:     aliasDir,
+		Lstat:        os.Lstat,
+		LocalAppData: t.TempDir(),
+	})
+	if got != path {
+		t.Fatalf("PATH = %q, want unchanged %q", got, path)
+	}
+}
+
+func TestPreferWindowsCodexPowerShellLeavesOtherProvidersUntouched(t *testing.T) {
+	called := false
+	path := `C:\\task\\bin;C:\\WindowsApps`
+	got := preferWindowsCodexPowerShell("claude", "windows", path, windowsPowerShellPathDeps{
+		UserHomeDir: func() (string, error) {
+			called = true
+			return "", nil
+		},
+		Lstat: os.Lstat,
+	})
+	if got != path || called {
+		t.Fatalf("non-Codex provider changed PATH or consulted the filesystem: path=%q called=%v", got, called)
 	}
 }
 

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -612,7 +612,7 @@ func buildChatPrompt(task Task) string {
 				fmt.Fprintf(&b, "- id=%s filename=%q\n", a.ID, a.Filename)
 			}
 		}
-		b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it.\n")
+		b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it. If the `multica` command is not found, use the task-provided absolute CLI path instead: PowerShell `& $env:MULTICA_CLI_PATH attachment download <id>`; POSIX shells `\"$MULTICA_CLI_PATH\" attachment download <id>`. Do not conclude that the attachment is unavailable until both forms have been tried.\n")
 		b.WriteString("When creating an issue that should preserve one of these attachments, pass `--attachment-id <id>` to `multica issue create` in addition to keeping the attachment markdown inline.\n")
 	}
 	// Outbound attachments: how the agent puts an image/file INTO its reply.

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -489,6 +489,8 @@ func TestBuildChatPromptAttachmentIDsCanBeBoundToCreatedIssues(t *testing.T) {
 		"Attachments on this message:",
 		"id=019ec09d-6222-722b-bdfa-427b105d80be",
 		"multica attachment download <id>",
+		"$env:MULTICA_CLI_PATH attachment download <id>",
+		"$MULTICA_CLI_PATH\" attachment download <id>",
 		"--attachment-id <id>",
 	} {
 		if !strings.Contains(out, want) {

--- a/server/internal/daemon/windows_user_path_other.go
+++ b/server/internal/daemon/windows_user_path_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package daemon
+
+func windowsUserPath() string { return "" }

--- a/server/internal/daemon/windows_user_path_windows.go
+++ b/server/internal/daemon/windows_user_path_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package daemon
+
+import "golang.org/x/sys/windows/registry"
+
+func windowsUserPath() string {
+	key, err := registry.OpenKey(registry.CURRENT_USER, `Environment`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer key.Close()
+	path, _, err := key.GetStringValue("Path")
+	if err != nil {
+		return ""
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

Upstreams three local daemon patches (ALL-219) that fix real Codex sandbox failures on the desktop build. All three were previously uncommitted working-tree changes on an old release branch; this PR re-applies them on a clean v0.4.33 baseline.

### 1. `stageTaskCLI` — task-local CLI staging

`server/internal/daemon/daemon.go`

Provider sandboxes (Codex on Windows) can be unable to read the daemon's install directory. `runTask` now copies the running multica executable into the task temp dir and prepends that directory to the agent `PATH`, so `multica` commands resolve inside the sandbox.

- `stageTaskCLI` function: `server/internal/daemon/daemon.go:9010`
- `runTask` staging call: `server/internal/daemon/daemon.go:7425`

### 2. `MULTICA_CLI_PATH` — explicit fallback env var

`server/internal/daemon/daemon.go` sets `agentEnv["MULTICA_CLI_PATH"]` to the staged executable path (`server/internal/daemon/daemon.go:7438`) for deterministic fallback when a sandbox filters `PATH`.

`server/internal/daemon/prompt.go` instructs agents to use the absolute CLI path when `multica` is not on `PATH` (`server/internal/daemon/prompt.go:615`).

### 3. `preferWindowsCodexPowerShell` — real PowerShell over WindowsApps alias

The desktop daemon can outlive a user PATH update, leaving its inherited PATH pointed at the zero-byte WindowsApps execution alias for `pwsh.exe`. `windowsCodexPowerShellPath` prepends a verified real PowerShell directory for Codex tasks.

- `preferWindowsCodexPowerShell`: `server/internal/daemon/daemon.go:181`
- `windowsUserPath` (reads user PATH from registry, Windows only): `server/internal/daemon/windows_user_path_windows.go:7`

## Tests

- `TestStageTaskCLI_CopiesExecutableIntoTaskTempDir`
- `TestStageTaskCLI_ReportsMissingSource`
- `TestPreferWindowsCodexPowerShellPrefersRealUserPathOverWindowsAppsAlias`
- `TestPreferWindowsCodexPowerShellKeepsPathWithoutRealPowerShell`
- `TestPreferWindowsCodexPowerShellLeavesOtherProvidersUntouched`
- `TestBuildChatPromptAttachmentIDsCanBeBoundToCreatedIssues` (extended for `MULTICA_CLI_PATH` guidance)

## Verification

```
go build ./cmd/multica        # exit 0
go test ./internal/daemon/ -run 'PreferWindows|TaskCLI' -v   # 5/5 PASS
go test ./internal/daemon/ -run 'TestBuildChatPromptAttachmentIDsCanBeBoundToCreatedIssues' -v  # PASS
```

## Notes

- Patch semantics are preserved exactly as deployed; nothing was deleted or rewritten.
- The PR contains only the six files tied to these three patches — none of the unrelated working-tree changes from the old release branch.
