### PR TITLE
fix(daemon): scale skill bundle timeout for slow links

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3340,7 +3340,8 @@ func (d *Daemon) resolveSkillBundle(ctx context.Context, task *Task, ref SkillRe
 
 const (
 	// skillBundleResolveMinTimeout floors the per-skill resolve deadline so a
-	// tiny bundle still tolerates connection setup and round-trip latency.
+	// tiny bundle still tolerates connection setup, proxy negotiation, and
+	// first-byte latency before any response body transfer budget is added.
 	skillBundleResolveMinTimeout = 30 * time.Second
 	// skillBundleResolveMaxTimeout caps it so a wedged download cannot pin a
 	// task in prepare indefinitely.
@@ -3348,24 +3349,26 @@ const (
 	// skillBundleResolveMinThroughput is the pessimistic floor throughput
 	// (bytes/sec) used to scale the deadline to bundle size — deliberately low
 	// to cover slow, jittery links rather than ideal bandwidth.
-	skillBundleResolveMinThroughput = 50 * 1024
+	skillBundleResolveMinThroughput = 10 * 1024
 )
 
 // skillBundleResolveTimeout returns the deadline budget for downloading a
-// bundle of the given size: at least skillBundleResolveMinTimeout, scaled up at
-// skillBundleResolveMinThroughput, and capped at skillBundleResolveMaxTimeout.
+// bundle of the given size: a connection/first-byte allowance plus a body
+// transfer allowance at skillBundleResolveMinThroughput, capped at
+// skillBundleResolveMaxTimeout.
 func skillBundleResolveTimeout(sizeBytes int64) time.Duration {
 	if sizeBytes <= 0 {
 		return skillBundleResolveMinTimeout
 	}
-	scaled := time.Duration(sizeBytes/skillBundleResolveMinThroughput) * time.Second
-	if scaled < skillBundleResolveMinTimeout {
-		return skillBundleResolveMinTimeout
-	}
-	if scaled > skillBundleResolveMaxTimeout {
+	maxTransferSeconds := int64((skillBundleResolveMaxTimeout - skillBundleResolveMinTimeout) / time.Second)
+	if maxTransferSeconds <= 0 || sizeBytes >= maxTransferSeconds*skillBundleResolveMinThroughput {
 		return skillBundleResolveMaxTimeout
 	}
-	return scaled
+	transferSeconds := sizeBytes / skillBundleResolveMinThroughput
+	if sizeBytes%skillBundleResolveMinThroughput != 0 {
+		transferSeconds++
+	}
+	return skillBundleResolveMinTimeout + time.Duration(transferSeconds)*time.Second
 }
 
 func (d *Daemon) startTaskPrepareLeaseExtender(ctx context.Context, task Task, taskLog *slog.Logger) func() {

--- a/server/internal/daemon/skill_bundle_resolve_test.go
+++ b/server/internal/daemon/skill_bundle_resolve_test.go
@@ -18,8 +18,9 @@ func TestSkillBundleResolveTimeout(t *testing.T) {
 	}{
 		{"zero size floors to min", 0, skillBundleResolveMinTimeout},
 		{"negative size floors to min", -5, skillBundleResolveMinTimeout},
-		{"tiny bundle floors to min", 1024, skillBundleResolveMinTimeout},
-		{"scales with size above the floor", 2 * 1024 * 1024, 40 * time.Second},
+		{"tiny bundle adds one second of body budget", 1024, 31 * time.Second},
+		{"reported one megabyte bundle gets slow-link budget", 1101426, 138 * time.Second},
+		{"scales with size above the floor", 2 * 1024 * 1024, 235 * time.Second},
 		{"huge bundle caps at max", 100 * 1024 * 1024, skillBundleResolveMaxTimeout},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What does this PR do?

<!-- multica-auto-bugfix -->

Adjusts daemon skill-bundle resolve deadlines so medium-sized bundles on slow links no longer behave like fixed 30s downloads.

The previous formula used `max(30s, size / 50KiB/s)`, so the reported ~1.1 MB bundle still got only the 30s floor. The new formula keeps the 30s connection/proxy/first-byte allowance, adds `ceil(size / 10KiB/s)` body-transfer budget, and preserves the existing 5m cap.

## Related Issue

Closes #7386

Multica issue: ZIC-198

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: change skill-bundle timeout calculation to add slow-link body-transfer budget on top of the first-byte allowance.
- `server/internal/daemon/skill_bundle_resolve_test.go`: update the timeout table with the reported ~1.1 MB case and the new scaled expectations.

## How to Test

1. `cd server && go test ./internal/daemon -run 'TestSkillBundle|TestEnsureTaskSkillBundles|TestResolveSkillBundle|TestTransferStats|TestFormatBytes' -count=1`
2. `cd server && go test ./internal/daemon -count=1`
3. `make check-worktree` exited 0 locally, but printed that Docker was unavailable while checking PostgreSQL, so the daemon Go package test is the meaningful local validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
I traced the daemon skill-bundle resolve path from the reported GitHub issue, verified the existing per-skill retry/cache behavior, and made the timeout budget cover slow body transfer for the reported medium-sized bundle while preserving the existing cap and diagnostics.

## Screenshots (optional)

N/A
