### PR TITLE
MUL-6319: Fix duplicate scheduled scan issue titles

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -880,6 +880,40 @@ func TestCreateIssueRejectsActiveDuplicate(t *testing.T) {
 	}
 }
 
+func TestCreateIssueRejectsActiveDuplicateWithGeneratedTimestampSuffix(t *testing.T) {
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	var issueID string
+	defer func() {
+		testPool.Exec(ctx, `DELETE FROM issue WHERE workspace_id = $1 AND title LIKE $2`, testWorkspaceID, "LAS Jira scan duplicate guard "+suffix+"%")
+	}()
+
+	baseTitle := "LAS Jira scan duplicate guard " + suffix
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": baseTitle + " - 2026-08-18 00:50",
+	})
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
+	var original IssueResponse
+	w.JSON(&original)
+	issueID = original.ID
+
+	req = newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": baseTitle + " - 2026-08-18 01:00",
+	})
+	w = testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusConflict)
+	var conflict struct {
+		Code  string        `json:"code"`
+		Issue IssueResponse `json:"issue"`
+	}
+	w.JSON(&conflict)
+	if conflict.Code != "active_duplicate_issue" {
+		t.Fatalf("code = %q, want active_duplicate_issue", conflict.Code)
+	}
+	if conflict.Issue.ID != issueID {
+		t.Fatalf("conflict issue = %s, want original %s", conflict.Issue.ID, issueID)
+	}
+}
+
 func TestCreateIssueAllowsDuplicateAfterCancelled(t *testing.T) {
 	ctx := context.Background()
 	title := fmt.Sprintf("Cancelled duplicate guard %d", time.Now().UnixNano())

--- a/server/internal/issueguard/duplicate.go
+++ b/server/internal/issueguard/duplicate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -13,7 +14,10 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+var volatileTitleTimestampSuffix = regexp.MustCompile(`(?i)\s*(?:[-:|]\s*)?[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}[ T][0-9]{1,2}:[0-9]{2}(?::[0-9]{2})?\s*$`)
+
 func NormalizeTitle(title string) string {
+	title = volatileTitleTimestampSuffix.ReplaceAllString(title, "")
 	return strings.ToLower(strings.Join(strings.Fields(title), " "))
 }
 

--- a/server/internal/issueguard/duplicate_test.go
+++ b/server/internal/issueguard/duplicate_test.go
@@ -1,0 +1,40 @@
+package issueguard
+
+import "testing"
+
+func TestNormalizeTitleStripsGeneratedTimestampSuffix(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "hyphen date minute",
+			title: "LAS Jira manual issue scan - 2026-08-18 00:50",
+			want:  "las jira manual issue scan",
+		},
+		{
+			name:  "slash date seconds",
+			title: "LAS Jira manual issue scan | 2026/08/18 00:50:10",
+			want:  "las jira manual issue scan",
+		},
+		{
+			name:  "plain date is preserved",
+			title: "LAS Jira manual issue scan - 2026-08-18",
+			want:  "las jira manual issue scan - 2026-08-18",
+		},
+		{
+			name:  "internal timestamp is preserved",
+			title: "Review 2026-08-18 00:50 scan output",
+			want:  "review 2026-08-18 00:50 scan output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeTitle(tt.title); got != tt.want {
+				t.Fatalf("NormalizeTitle(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -446,7 +446,10 @@ WHERE workspace_id = $1
   AND issue_effective_status(workspace_id, status) NOT IN ('done', 'cancelled')
   AND project_id IS NOT DISTINCT FROM $2::uuid
   AND parent_issue_id IS NOT DISTINCT FROM $3::uuid
-  AND lower(btrim(regexp_replace(title, '[[:space:]]+', ' ', 'g'))) = $4
+  AND lower(btrim(regexp_replace(
+    regexp_replace(title, '[[:space:]]*([-:|][[:space:]]*)?[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}[ T][0-9]{1,2}:[0-9]{2}(:[0-9]{2})?[[:space:]]*$', ''),
+    '[[:space:]]+', ' ', 'g'
+  ))) = $4
 ORDER BY created_at ASC
 LIMIT 1
 `
@@ -506,7 +509,10 @@ WHERE i.workspace_id = $1
   AND i.origin_type = 'autopilot'
   AND i.origin_id = $2
   AND i.project_id IS NOT DISTINCT FROM $3::uuid
-  AND lower(btrim(regexp_replace(i.title, '[[:space:]]+', ' ', 'g'))) = $4
+  AND lower(btrim(regexp_replace(
+    regexp_replace(i.title, '[[:space:]]*([-:|][[:space:]]*)?[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}[ T][0-9]{1,2}:[0-9]{2}(:[0-9]{2})?[[:space:]]*$', ''),
+    '[[:space:]]+', ' ', 'g'
+  ))) = $4
   AND i.created_at >= $5::timestamptz
   AND EXISTS (
     SELECT 1

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -282,7 +282,10 @@ WHERE workspace_id = $1
   AND issue_effective_status(workspace_id, status) NOT IN ('done', 'cancelled')
   AND project_id IS NOT DISTINCT FROM sqlc.arg('project_id')::uuid
   AND parent_issue_id IS NOT DISTINCT FROM sqlc.arg('parent_issue_id')::uuid
-  AND lower(btrim(regexp_replace(title, '[[:space:]]+', ' ', 'g'))) = sqlc.arg('normalized_title')
+  AND lower(btrim(regexp_replace(
+    regexp_replace(title, '[[:space:]]*([-:|][[:space:]]*)?[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}[ T][0-9]{1,2}:[0-9]{2}(:[0-9]{2})?[[:space:]]*$', ''),
+    '[[:space:]]+', ' ', 'g'
+  ))) = sqlc.arg('normalized_title')
 ORDER BY created_at ASC
 LIMIT 1;
 
@@ -293,7 +296,10 @@ WHERE i.workspace_id = $1
   AND i.origin_type = 'autopilot'
   AND i.origin_id = $2
   AND i.project_id IS NOT DISTINCT FROM sqlc.arg('project_id')::uuid
-  AND lower(btrim(regexp_replace(i.title, '[[:space:]]+', ' ', 'g'))) = sqlc.arg('normalized_title')
+  AND lower(btrim(regexp_replace(
+    regexp_replace(i.title, '[[:space:]]*([-:|][[:space:]]*)?[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}[ T][0-9]{1,2}:[0-9]{2}(:[0-9]{2})?[[:space:]]*$', ''),
+    '[[:space:]]+', ' ', 'g'
+  ))) = sqlc.arg('normalized_title')
   AND i.created_at >= sqlc.arg('created_after')::timestamptz
   AND EXISTS (
     SELECT 1


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Scheduled scan workflows often create follow-up issues whose titles end with a generated run timestamp, for example `LAS Jira scan - 2026-08-18 00:50`. Those suffixes made otherwise identical active issues look unique to the duplicate guard, so every scheduled scan could create another task instead of reusing the existing consolidated issue.

This updates issue-title duplicate normalization to ignore trailing generated `YYYY-MM-DD HH:MM[:SS]` / `YYYY/MM/DD HH:MM[:SS]` suffixes, and applies the same normalization in the SQL duplicate lookups.

## Related Issue

Closes #7109

Multica issue: ZIC-200

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/issueguard/duplicate.go` to strip generated trailing date-time suffixes from duplicate keys.
- Updated `server/pkg/db/queries/issue.sql` and regenerated `server/pkg/db/generated/issue.sql.go` so DB-side duplicate lookups use the same canonicalization.
- Added focused coverage for normalizer behavior and active duplicate rejection across different generated scan timestamps.

## How to Test

1. `cd server && go test ./internal/issueguard ./internal/handler -run 'TestNormalizeTitleStripsGeneratedTimestampSuffix|TestCreateIssueRejectsActiveDuplicate|TestCreateIssueRejectsActiveDuplicateWithGeneratedTimestampSuffix|TestCreateIssueAllowsDuplicateAfterCancelled|TestCreateIssueAllowsDuplicateAfterDone|TestTriggerAutopilotAllowsActiveDuplicateIssue|TestScheduledAutopilotAllowsActiveDuplicateIssue' -count=1`
2. `make check-worktree` exited 0. It emitted a local Docker daemon warning during the PostgreSQL probe, then reported `All checks passed`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Investigated the scheduled Jira scan screenshots, traced scheduled autopilot dispatch and agent-created issue duplicate handling, then added a narrow duplicate-key normalization for generated trailing run timestamps with focused regression coverage.

## Screenshots (optional)

N/A; backend duplicate guard change.
