### PR TITLE
MUL-6644 / ZIC-201: Fix failed task recovery comment threading

### DIFF
--- a/server/internal/service/delegated_failure_recovery_test.go
+++ b/server/internal/service/delegated_failure_recovery_test.go
@@ -15,15 +15,16 @@ import (
 )
 
 type delegatedFailureFixture struct {
-	pool        *pgxpool.Pool
-	workspaceID string
-	userID      string
-	issueID     string
-	workerIssue string
-	runtimeID   string
-	coordinator string
-	worker      string
-	sourceTask  string
+	pool          *pgxpool.Pool
+	workspaceID   string
+	userID        string
+	issueID       string
+	workerIssue   string
+	runtimeID     string
+	coordinator   string
+	worker        string
+	sourceTrigger string
+	sourceTask    string
 }
 
 func seedDelegatedFailureFixture(t *testing.T) (*delegatedFailureFixture, *TaskService) {
@@ -60,27 +61,36 @@ func seedDelegatedFailureFixture(t *testing.T) (*delegatedFailureFixture, *TaskS
 		t.Fatalf("seed worker issue: %v", err)
 	}
 
+	var sourceTriggerID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
+		VALUES ($1, $2, 'member', $3, 'coordinate delegated work')
+		RETURNING id`, workspaceID, issueID, userID).Scan(&sourceTriggerID); err != nil {
+		t.Fatalf("seed source trigger comment: %v", err)
+	}
+
 	var sourceTaskID string
 	if err := pool.QueryRow(ctx, `
 		INSERT INTO agent_task_queue (
 			agent_id, runtime_id, issue_id, status, priority,
-			originator_user_id, accountable_user_id, originator_source
+			trigger_comment_id, originator_user_id, accountable_user_id, originator_source
 		)
-		VALUES ($1, $2, $3, 'completed', 0, $4, $4, 'direct_human')
-		RETURNING id`, coordinatorID, runtimeID, issueID, userID).Scan(&sourceTaskID); err != nil {
+		VALUES ($1, $2, $3, 'completed', 0, $4, $5, $5, 'direct_human')
+		RETURNING id`, coordinatorID, runtimeID, issueID, sourceTriggerID, userID).Scan(&sourceTaskID); err != nil {
 		t.Fatalf("seed source task: %v", err)
 	}
 
 	return &delegatedFailureFixture{
-		pool:        pool,
-		workspaceID: workspaceID,
-		userID:      userID,
-		issueID:     issueID,
-		workerIssue: workerIssueID,
-		runtimeID:   runtimeID,
-		coordinator: coordinatorID,
-		worker:      workerID,
-		sourceTask:  sourceTaskID,
+		pool:          pool,
+		workspaceID:   workspaceID,
+		userID:        userID,
+		issueID:       issueID,
+		workerIssue:   workerIssueID,
+		runtimeID:     runtimeID,
+		coordinator:   coordinatorID,
+		worker:        workerID,
+		sourceTrigger: sourceTriggerID,
+		sourceTask:    sourceTaskID,
 	}, NewTaskService(db.New(pool), pool, nil, events.New())
 }
 
@@ -139,15 +149,18 @@ func TestFailTaskFinalDelegatedFailureWakesCoordinatorOnce(t *testing.T) {
 	}
 
 	var commentCount int
-	var content string
+	var content, parentID string
 	if err := f.pool.QueryRow(ctx, `
-		SELECT count(*), COALESCE(max(content), '') FROM comment
+		SELECT count(*), COALESCE(max(content), ''), COALESCE(max(parent_id::text), '') FROM comment
 		WHERE issue_id = $1 AND author_type = 'system' AND type = 'progress_update' AND source_task_id = $2`, f.issueID, failedID).
-		Scan(&commentCount, &content); err != nil {
+		Scan(&commentCount, &content, &parentID); err != nil {
 		t.Fatalf("read recovery comment: %v", err)
 	}
 	if commentCount != 1 {
 		t.Fatalf("recovery comment count = %d, want 1", commentCount)
+	}
+	if parentID != f.sourceTrigger {
+		t.Fatalf("recovery comment parent_id = %q, want source trigger %s", parentID, f.sourceTrigger)
 	}
 	if strings.Contains(content, secret) || !strings.Contains(content, "[REDACTED API KEY]") {
 		t.Fatalf("recovery comment did not redact error: %q", content)
@@ -509,16 +522,19 @@ func TestDelegatedFailureRecoveryStopsAfterBoundedUndeliveredAttempts(t *testing
 	}
 
 	var exhaustionComments int
-	var exhaustionContent string
+	var exhaustionContent, exhaustionParentID string
 	if err := f.pool.QueryRow(ctx, `
-		SELECT count(*), COALESCE(max(content), '')
+		SELECT count(*), COALESCE(max(content), ''), COALESCE(max(parent_id::text), '')
 		FROM comment
 		WHERE issue_id = $1 AND author_type = 'system' AND type = 'system' AND source_task_id = $2`, f.issueID, failedID).
-		Scan(&exhaustionComments, &exhaustionContent); err != nil {
+		Scan(&exhaustionComments, &exhaustionContent, &exhaustionParentID); err != nil {
 		t.Fatalf("read exhaustion comment: %v", err)
 	}
 	if exhaustionComments != 1 || !strings.Contains(exhaustionContent, "stopped after 3") {
 		t.Fatalf("exhaustion comment = count %d content %q, want one visible bounded-stop explanation", exhaustionComments, exhaustionContent)
+	}
+	if exhaustionParentID != f.sourceTrigger {
+		t.Fatalf("exhaustion comment parent_id = %q, want source trigger %s", exhaustionParentID, f.sourceTrigger)
 	}
 	var inboxItems int
 	var inboxSeverity, inboxBody string

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5487,6 +5487,7 @@ func (s *TaskService) ensureDelegatedFailureRecoveryComment(ctx context.Context,
 			AuthorID:     pgtype.UUID{Valid: true},
 			Content:      delegatedFailureRecoveryContent(target.failed, target.source),
 			Type:         delegatedFailureRecoveryCommentType,
+			ParentID:     target.source.TriggerCommentID,
 			SourceTaskID: failed.ID,
 		})
 		if err != nil {
@@ -5593,6 +5594,7 @@ func (s *TaskService) exhaustDelegatedFailureRecovery(ctx context.Context, targe
 			AuthorID:     pgtype.UUID{Valid: true},
 			Content:      delegatedFailureRecoveryExhaustionContent(target),
 			Type:         "system",
+			ParentID:     target.source.TriggerCommentID,
 			SourceTaskID: target.failed.ID,
 		})
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent timeline threading for delayed delegated task failure recovery comments. The platform-authored recovery and exhaustion comments now mount under the source coordinator task's trigger comment when one exists, matching the user-visible threading strategy used for ordinary task failure comments.

<!-- multica-auto-bugfix -->

## Related Issue

Refs #7506 — deliberately a non-closing reference.

#7506 reports two separate defects and this PR fixes one of them: recovery and exhaustion comments mounting as roots while ordinary failure comments mount under the triggering comment. The report's other finding — `comment:created` WS broadcasts stamping process-local time with a literal `Z` — is fixed separately in #7523. The issue's headline symptom (a late reply rendering inside an old thread, so it appears above newer entries) is a threaded-rendering property that neither PR changes, so #7506 must stay open after this merges.

Multica issue: ZIC-201

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/service/task.go`: set `parent_id` for delegated failure recovery and recovery-exhaustion comments from the source coordinator task's trigger comment.
- `server/internal/service/delegated_failure_recovery_test.go`: seed a real source trigger comment and assert both recovery comment types preserve that thread mount.

## How to Test

1. `go test ./internal/service -run 'Test(FailTaskFinalDelegatedFailureWakesCoordinatorOnce|DelegatedFailureRecoveryStopsAfterBoundedUndeliveredAttempts|HandleFailedTasksFinalDelegatedFailureWakesCoordinator|PendingDelegatedFailureSweep|TaskFailed)'`
2. `go test ./internal/service`
3. `make check-worktree` was attempted; it returned success but printed `Cannot connect to the Docker daemon` during the PostgreSQL check, so the Go service tests above are the meaningful local verification. Reviewer re-ran `go test ./internal/service -count=1` against a freshly migrated PostgreSQL: the package passes, and dropping either `ParentID:` line makes the two new assertions fail, so the added coverage is not vacuous.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Investigated GitHub #7506 from the Multica OSS contribution workflow, traced timeline ordering to comment-backed failure recovery rows, made the smallest backend threading fix, and added regression coverage around delegated failure recovery and exhaustion comments.

## Screenshots (optional)

N/A

