### PR TITLE
MUL-6644 fix(realtime): stamp comment:created broadcasts with the real UTC offset

### DIFF
--- a/server/internal/service/comment_event_fields_test.go
+++ b/server/internal/service/comment_event_fields_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func commentAt(created time.Time) db.Comment {
+	return db.Comment{
+		AuthorType: "system",
+		Content:    "task failed",
+		Type:       "system",
+		CreatedAt:  pgtype.Timestamptz{Time: created, Valid: true},
+	}
+}
+
+// A comment:created broadcast must carry the SAME created_at string the REST
+// timeline returns for that comment. pgx decodes timestamptz into the process
+// location, so formatting with a literal "Z" suffix published local wall-clock
+// digits under a UTC label: on an Asia/Shanghai deployment every WS-delivered
+// agent/system comment landed 8 hours from its real instant, then jumped back
+// into place once a refetch replaced it with the REST value.
+func TestCommentEventFieldsCreatedAtCarriesRealOffset(t *testing.T) {
+	shanghai := time.FixedZone("CST", 8*60*60)
+	created := time.Date(2026, 8, 24, 17, 7, 5, 0, shanghai)
+
+	got, _ := commentEventFields(commentAt(created))["created_at"].(string)
+	if want := "2026-08-24T17:07:05+08:00"; got != want {
+		t.Fatalf("created_at = %q, want %q", got, want)
+	}
+	parsed, err := time.Parse(time.RFC3339, got)
+	if err != nil {
+		t.Fatalf("parse created_at %q: %v", got, err)
+	}
+	if !parsed.Equal(created) {
+		t.Fatalf("created_at %q decodes to %s, want %s", got, parsed.UTC(), created.UTC())
+	}
+}
+
+// The overwhelmingly common deployment runs the server process in UTC, where
+// the old literal-"Z" format was already correct. Pin that those clients see a
+// byte-identical payload so the fix carries no migration for them.
+func TestCommentEventFieldsCreatedAtUTCIsUnchanged(t *testing.T) {
+	created := time.Date(2026, 8, 24, 9, 7, 5, 0, time.UTC)
+
+	got, _ := commentEventFields(commentAt(created))["created_at"].(string)
+	if want := "2026-08-24T09:07:05Z"; got != want {
+		t.Fatalf("created_at = %q, want %q", got, want)
+	}
+}
+
+// An unset timestamp must not render as a zero-value instant that would sort
+// to the beginning of every timeline.
+func TestCommentEventFieldsCreatedAtInvalidIsEmpty(t *testing.T) {
+	got, ok := commentEventFields(db.Comment{})["created_at"].(string)
+	if !ok || got != "" {
+		t.Fatalf("created_at = %q (string=%v), want empty string", got, ok)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -5508,17 +5508,7 @@ func (s *TaskService) ensureDelegatedFailureRecoveryComment(ctx context.Context,
 			ActorType:   "system",
 			ActorID:     "",
 			Payload: map[string]any{
-				"comment": map[string]any{
-					"id":             util.UUIDToString(target.comment.ID),
-					"issue_id":       util.UUIDToString(target.comment.IssueID),
-					"author_type":    target.comment.AuthorType,
-					"author_id":      util.UUIDToString(target.comment.AuthorID),
-					"content":        target.comment.Content,
-					"type":           target.comment.Type,
-					"parent_id":      util.UUIDToPtr(target.comment.ParentID),
-					"source_task_id": util.UUIDToPtr(target.comment.SourceTaskID),
-					"created_at":     target.comment.CreatedAt.Time.Format("2006-01-02T15:04:05Z"),
-				},
+				"comment":      commentEventFields(target.comment),
 				"issue_title":  target.issue.Title,
 				"issue_status": target.issue.Status,
 			},
@@ -5658,17 +5648,7 @@ func (s *TaskService) exhaustDelegatedFailureRecovery(ctx context.Context, targe
 			ActorType:   "system",
 			ActorID:     "",
 			Payload: map[string]any{
-				"comment": map[string]any{
-					"id":             util.UUIDToString(exhaustedComment.ID),
-					"issue_id":       util.UUIDToString(exhaustedComment.IssueID),
-					"author_type":    exhaustedComment.AuthorType,
-					"author_id":      util.UUIDToString(exhaustedComment.AuthorID),
-					"content":        exhaustedComment.Content,
-					"type":           exhaustedComment.Type,
-					"parent_id":      util.UUIDToPtr(exhaustedComment.ParentID),
-					"source_task_id": util.UUIDToPtr(exhaustedComment.SourceTaskID),
-					"created_at":     exhaustedComment.CreatedAt.Time.Format("2006-01-02T15:04:05Z"),
-				},
+				"comment":      commentEventFields(exhaustedComment),
 				"issue_title":  target.issue.Title,
 				"issue_status": target.issue.Status,
 			},
@@ -6410,6 +6390,34 @@ func (s *TaskService) getIssuePrefix(workspaceID pgtype.UUID) string {
 	return ws.IssuePrefix
 }
 
+// commentEventFields renders the `comment` object carried by comment:created
+// broadcasts published outside the HTTP handler (agent replies, delegated
+// failure recovery, recovery exhaustion).
+//
+// created_at goes through util.TimestampToString — the SAME helper the REST
+// CommentResponse uses — so the timestamp a client receives over WS is
+// byte-identical to the one it gets when it refetches that comment. These
+// payloads used to format the time with a literal "Z" suffix instead, which
+// is not Go's Z07:00 offset token: pgx decodes timestamptz into the process
+// location (pgtype/timestamptz.go, no ScanLocation configured), so on a
+// deployment whose process TZ is not UTC the broadcast stamped local
+// wall-clock digits with a UTC label. Clients then placed the entry a whole
+// offset away from its real instant and moved it again once a refetch
+// replaced the value — visible as timeline entries jumping position.
+func commentEventFields(c db.Comment) map[string]any {
+	return map[string]any{
+		"id":             util.UUIDToString(c.ID),
+		"issue_id":       util.UUIDToString(c.IssueID),
+		"author_type":    c.AuthorType,
+		"author_id":      util.UUIDToString(c.AuthorID),
+		"content":        c.Content,
+		"type":           c.Type,
+		"parent_id":      util.UUIDToPtr(c.ParentID),
+		"source_task_id": util.UUIDToPtr(c.SourceTaskID),
+		"created_at":     util.TimestampToString(c.CreatedAt),
+	}
+}
+
 func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID pgtype.UUID, content, commentType string, parentID, sourceTaskID pgtype.UUID) {
 	if content == "" {
 		return
@@ -6447,24 +6455,15 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	}
 	comment := created.Comment()
 	s.CancelDeferredEscalationsForIssueAgent(ctx, issueID, agentID)
+	commentFields := commentEventFields(comment)
+	commentFields["revision"] = comment.Revision
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventCommentCreated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
 		ActorType:   "agent",
 		ActorID:     util.UUIDToString(agentID),
 		Payload: map[string]any{
-			"comment": map[string]any{
-				"id":             util.UUIDToString(comment.ID),
-				"issue_id":       util.UUIDToString(comment.IssueID),
-				"author_type":    comment.AuthorType,
-				"author_id":      util.UUIDToString(comment.AuthorID),
-				"content":        comment.Content,
-				"type":           comment.Type,
-				"parent_id":      util.UUIDToPtr(comment.ParentID),
-				"source_task_id": util.UUIDToPtr(comment.SourceTaskID),
-				"created_at":     comment.CreatedAt.Time.Format("2006-01-02T15:04:05Z"),
-				"revision":       comment.Revision,
-			},
+			"comment":        commentFields,
 			"issue_title":    issue.Title,
 			"issue_status":   issue.Status,
 			"issue_revision": created.IssueRevision,


### PR DESCRIPTION
## What does this PR do?

The three `comment:created` broadcasts published from `TaskService` — agent replies, delegated failure recovery, and recovery exhaustion — formatted `created_at` with `Format("2006-01-02T15:04:05Z")`. That trailing `Z` is a **literal**, not Go's `Z07:00` offset token, and pgx decodes `timestamptz` into the process location (no `ScanLocation` is configured). So on any deployment whose server process TZ is not UTC, those broadcasts published local wall-clock digits under a UTC label.

Two consequences for clients:

1. The entry lands a whole offset away from its real instant, then **moves again** once a refetch replaces the value with the REST rendering (`util.TimestampToString`, which emits the real offset). Self-hosted instances are the likely victims — official images run UTC, a from-source host usually does not.
2. `sortTimelineEntriesAsc` (`packages/core/issues/timeline-sort.ts`) compares `created_at` as a **string**, so mixing `…05Z` and `…05+08:00` in one cache breaks its ordering key outright.

The fix renders all three through `util.TimestampToString` — the same helper the REST `CommentResponse` uses — behind one shared `commentEventFields` renderer, so a comment's `created_at` is byte-identical over WS and over HTTP. Every other `created_at` payload in the codebase already used this helper; these three were the only outliers.

It also closes a latent case: the old format rendered an *unset* timestamp as `0001-01-01T00:00:00Z`, which would sort to the top of every timeline. `util.TimestampToString` returns `""`.

**On a UTC process the emitted string is unchanged**, which is why this needs no client coordination or rollout sequencing.

## Related Issue

Related to #7506 (question 3 in that report: *"是否所有事件类型都以服务端 UTC 打戳？"* — insert-side yes, `comment.created_at` is `DEFAULT now()` and never client-supplied; the serialization side was not). This does **not** fix the threading behavior #7506 leads with — #7519 covers that.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/internal/service/task.go`: add `commentEventFields`, the shared renderer for `comment:created` payloads published outside the HTTP handler; route all three publish sites through it. The agent-comment site keeps its extra `revision` field.
- `server/internal/service/comment_event_fields_test.go`: DB-free regression coverage — a non-UTC instant must serialize with its real offset and round-trip to the same instant; a UTC instant must stay byte-identical to today's output; an unset timestamp must render `""` rather than year 0001.

## How to Test

1. `cd server && go test ./internal/service -run TestCommentEventFields -v` — 3 passing.
2. Revert just the `created_at` line inside `commentEventFields` to `c.CreatedAt.Time.Format("2006-01-02T15:04:05Z")` and re-run: the offset test fails with `created_at = "2026-08-24T17:07:05Z", want "2026-08-24T17:07:05+08:00"` (the 8-hour lie) and the unset-timestamp test fails with `"0001-01-01T00:00:00Z"`.
3. Full package against a migrated database: `go test ./internal/service` and `go test ./internal/handler` — both `ok`. This covers the delegated-failure-recovery and task-failure suites that exercise all three changed publish paths.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks

Low. The only behavioral change is on non-UTC server processes, where the emitted string moves from wrong to correct; UTC processes emit the identical bytes they do today. `RFC3339` parses in every client that already handles the REST field, and no field was added, removed, or renamed. No coordinated deploy needed — old and new servers can serve old and new clients in any combination.

Out of scope, worth separate follow-ups:

- `util.TimestampToString` is second-precision while the DB orders on microseconds, so same-second entries rely on the UUIDv7 id tie-break rather than a real ordering contract. `util.TimestampToNanoPtr` exists for exactly this and its own doc comment says new ordering fields should use it.
- The web timeline sorts timestamps by string comparison rather than by parsed instant, which is only safe while every producer agrees on one format.

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:** Found while reviewing #7506 — the report's evidence ruled out comment-data disorder, so I traced the serialization path instead of the insert path, compared every `created_at` payload builder in the server against the REST renderer, and confirmed pgx's decode location in `pgtype/timestamptz.go`. Fix is the smallest one that makes the three outliers match the established helper; the regression test is DB-free so it runs without a database.
