### PR TITLE
fix(billing): prefill first Checkout email

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1810,9 +1810,6 @@ export class ApiClient {
         body: JSON.stringify({
           interval: data.interval,
           idempotency_key: data.idempotencyKey,
-          ...(data.customerEmail
-            ? { customer_email: data.customerEmail }
-            : {}),
         }),
         extraHeaders: {
           "Content-Type": "application/json",

--- a/packages/core/types/billing.ts
+++ b/packages/core/types/billing.ts
@@ -267,7 +267,6 @@ export interface WorkspaceSubscriptionPrices {
 export interface CreateWorkspaceSubscriptionCheckoutRequest {
   interval: WorkspaceSubscriptionInterval;
   idempotencyKey: string;
-  customerEmail?: string;
 }
 
 export interface CreateWorkspaceSubscriptionCheckoutResponse {

--- a/server/internal/handler/cloud_billing.go
+++ b/server/internal/handler/cloud_billing.go
@@ -229,7 +229,11 @@ func (h *Handler) CreateCloudWorkspaceSubscriptionCheckout(w http.ResponseWriter
 	if !ok {
 		return
 	}
-	user, err := h.Queries.GetUser(r.Context(), parseUUID(userID))
+	payerUserID, ok := parseUUIDOrBadRequest(w, userID, "user id")
+	if !ok {
+		return
+	}
+	user, err := h.Queries.GetUser(r.Context(), payerUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve checkout payer")
 		return

--- a/server/internal/handler/cloud_billing.go
+++ b/server/internal/handler/cloud_billing.go
@@ -54,7 +54,6 @@ const maxCloudSubscriptionSeats = 10_000
 type cloudSubscriptionCheckoutRequest struct {
 	Interval       string `json:"interval"`
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
-	CustomerEmail  string `json:"customer_email,omitempty"`
 }
 
 // This is an intentional allowlist: additive cloud fields are not forwarded
@@ -205,8 +204,9 @@ func (h *Handler) GetCloudWorkspaceSubscriptionPrices(w http.ResponseWriter, r *
 }
 
 // CreateCloudWorkspaceSubscriptionCheckout injects the middleware-resolved
-// workspace into the upstream body. A caller cannot use a valid role in one
-// workspace to smuggle a different workspace_id through JSON.
+// workspace and authenticated user's stored email into the upstream body. A
+// caller cannot smuggle a different workspace or Stripe payer identity through
+// JSON; Cloud remains authoritative for the price, quantity, and Checkout.
 func (h *Handler) CreateCloudWorkspaceSubscriptionCheckout(w http.ResponseWriter, r *http.Request) {
 	workspaceID, userID, ok := h.requireCloudSubscriptionWorkspace(w, r, "owner", "admin")
 	if !ok {
@@ -229,11 +229,21 @@ func (h *Handler) CreateCloudWorkspaceSubscriptionCheckout(w http.ResponseWriter
 	if !ok {
 		return
 	}
+	user, err := h.Queries.GetUser(r.Context(), parseUUID(userID))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve checkout payer")
+		return
+	}
+	customerEmail := strings.TrimSpace(user.Email)
+	if customerEmail == "" {
+		writeError(w, http.StatusInternalServerError, "checkout payer email is unavailable")
+		return
+	}
 	upstreamBody, err := json.Marshal(cloudSubscriptionCheckoutUpstreamRequest{
 		WorkspaceID:    workspaceID,
 		Interval:       in.Interval,
 		IdempotencyKey: idempotencyKey,
-		CustomerEmail:  in.CustomerEmail,
+		CustomerEmail:  customerEmail,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to build subscription request")

--- a/server/internal/handler/cloud_billing_test.go
+++ b/server/internal/handler/cloud_billing_test.go
@@ -441,6 +441,52 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutFailsWhenPayerCannotBeResolved(
 	}
 }
 
+func TestCreateCloudWorkspaceSubscriptionCheckoutRejectsInvalidPayerID(t *testing.T) {
+	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, true)
+	proxy := &fakeCloudRuntimeProxy{enabled: true}
+	useCloudRuntimeProxy(t, proxy)
+
+	req := newRequest(http.MethodPost, "/api/cloud-subscriptions/checkout-sessions", map[string]any{
+		"interval":        "month",
+		"idempotency_key": "checkout-request-invalid-payer",
+	})
+	req.Header.Set("X-User-ID", "not-a-uuid")
+	req = withCloudSubscriptionWorkspace(req, "owner")
+	w := httptest.NewRecorder()
+	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "invalid user id") {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if proxy.called {
+		t.Fatal("upstream must not be called with an invalid payer id")
+	}
+}
+
+func TestCreateCloudWorkspaceSubscriptionCheckoutRejectsEmptyPayerEmail(t *testing.T) {
+	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, true)
+	proxy := &fakeCloudRuntimeProxy{enabled: true}
+	useCloudRuntimeProxy(t, proxy)
+	emptyEmailUserID := dbfx.User(t, "Empty Checkout Email", "   ")
+	dbfx.Member(t, testWorkspaceID, emptyEmailUserID, "owner")
+
+	req := newRequest(http.MethodPost, "/api/cloud-subscriptions/checkout-sessions", map[string]any{
+		"interval":        "month",
+		"idempotency_key": "checkout-request-empty-email",
+	})
+	req.Header.Set("X-User-ID", emptyEmailUserID)
+	req = withCloudSubscriptionWorkspace(req, "owner")
+	w := httptest.NewRecorder()
+	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+
+	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "checkout payer email is unavailable") {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if proxy.called {
+		t.Fatal("upstream must not be called without a payer email")
+	}
+}
+
 func TestCreateCloudWorkspaceSubscriptionCheckoutAcceptsHeaderIdempotencyKey(t *testing.T) {
 	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, true)
 	proxy := &fakeCloudRuntimeProxy{

--- a/server/internal/handler/cloud_billing_test.go
+++ b/server/internal/handler/cloud_billing_test.go
@@ -376,7 +376,7 @@ func TestCloudWorkspaceSubscriptionReadAndWritesUseScopedPaths(t *testing.T) {
 	}
 }
 
-func TestCreateCloudWorkspaceSubscriptionCheckoutInjectsAuthoritativeWorkspace(t *testing.T) {
+func TestCreateCloudWorkspaceSubscriptionCheckoutInjectsAuthoritativeWorkspaceAndEmail(t *testing.T) {
 	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, true)
 	proxy := &fakeCloudRuntimeProxy{
 		enabled: true,
@@ -391,7 +391,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutInjectsAuthoritativeWorkspace(t
 		"workspace_id":    "00000000-0000-0000-0000-000000000001",
 		"interval":        "year",
 		"idempotency_key": "checkout-request-1",
-		"customer_email":  "payer@example.com",
+		"customer_email":  "attacker@example.com",
 	})
 	req.Header.Set(idempotencyKeyHeader, "checkout-header-1")
 	req = withCloudSubscriptionWorkspace(req, "owner")
@@ -411,11 +411,33 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutInjectsAuthoritativeWorkspace(t
 	if body.WorkspaceID != testWorkspaceID {
 		t.Fatalf("upstream workspace_id = %q, want middleware workspace %q", body.WorkspaceID, testWorkspaceID)
 	}
-	if body.Interval != "year" || body.IdempotencyKey != "checkout-request-1" || body.CustomerEmail != "payer@example.com" {
+	if body.Interval != "year" || body.IdempotencyKey != "checkout-request-1" || body.CustomerEmail != handlerTestEmail {
 		t.Fatalf("upstream body = %+v", body)
 	}
 	if got := proxy.req.Headers.Get(idempotencyKeyHeader); got != "checkout-header-1" {
 		t.Fatalf("upstream idempotency key = %q", got)
+	}
+}
+
+func TestCreateCloudWorkspaceSubscriptionCheckoutFailsWhenPayerCannotBeResolved(t *testing.T) {
+	withFeatureFlag(t, testHandler, featureflags.BillingWorkspaceSubscriptions, true)
+	proxy := &fakeCloudRuntimeProxy{enabled: true}
+	useCloudRuntimeProxy(t, proxy)
+
+	req := newRequest(http.MethodPost, "/api/cloud-subscriptions/checkout-sessions", map[string]any{
+		"interval":        "month",
+		"idempotency_key": "checkout-request-missing-payer",
+	})
+	req.Header.Set("X-User-ID", "00000000-0000-0000-0000-000000000099")
+	req = withCloudSubscriptionWorkspace(req, "owner")
+	w := httptest.NewRecorder()
+	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+
+	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "failed to resolve checkout payer") {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if proxy.called {
+		t.Fatal("upstream must not be called without an authoritative payer email")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Prefills Stripe Checkout with the authenticated Multica account email even when the workspace has never created a Stripe Customer.

The browser continues to send only the billing interval and idempotency key. The Multica server resolves the authenticated user from the database, injects the stored email into the trusted Cloud request, and Cloud continues to own Checkout Session creation, prices, quantities, and subscription behavior.

Follow-up to multica#7528 and multica-cloud#55.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Resolve the Checkout payer email from the authenticated user row in the Multica server proxy.
- Ignore any client-supplied customer_email value so the browser cannot select a different Stripe payer identity.
- Remove customerEmail from the workspace-subscription frontend request type and serializer.
- Fail before calling Cloud if the authenticated payer cannot be resolved.
- Add handler regression coverage for authoritative email injection and the missing-payer path.

## How to Test

1. Use a workspace with no existing Stripe Customer and start Upgrade to Pro.
2. Verify the Stripe Checkout email is prefilled from the signed-in Multica account.
3. Verify an existing Stripe Customer is still reused by Cloud.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Validation

- make test
- pnpm typecheck
- pnpm lint
- pnpm test: 397 views files and 4,749 views tests passed on clean rerun
- Cloud subscription and Stripe client package tests

## Risk notes

A valid authenticated Multica user without a resolvable stored email now receives an internal error instead of falling back to manual Stripe email entry. This fails closed and prevents a client-selected billing identity.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Traced the browser, Multica proxy, Cloud subscription service, and Stripe Checkout Session parameters; kept billing authority in Cloud while moving the identity email to the trusted server boundary; added spoofing and failure regression coverage.