### PR TITLE
MUL-6658 fix(cli): tell a rejected task token to stop, not to sign in again (#7522)

### DIFF
--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -61,11 +61,22 @@ type APIClient struct {
 	OS       string
 }
 
+// TaskTokenPrefix marks a task-scoped agent token, as minted by
+// internal/auth.NewAgentTaskToken. The server revokes these the moment the
+// task reaches a terminal state, so a 401 on one is a normal end-of-task
+// signal rather than an expired login.
+const TaskTokenPrefix = "mat_"
+
 type HTTPError struct {
 	Method     string
 	Path       string
 	StatusCode int
 	Body       string
+	// TaskScoped records that the request carried a task-scoped `mat_` token
+	// rather than a member credential. It changes nothing about the request;
+	// it only lets FormatError tell a 401 that means "your login expired" from
+	// a 401 that means "this task is over" (GH #7522).
+	TaskScoped bool
 }
 
 func (e *HTTPError) Error() string {
@@ -77,13 +88,17 @@ func (e *HTTPError) Error() string {
 // >= 400 responses through this so the top-level FormatError / ExitCodeFor can
 // classify the failure via errors.As(err, **HTTPError) regardless of which
 // HTTP verb the command used.
-func newHTTPError(method, path string, resp *http.Response) *HTTPError {
+//
+// It is a method so the error can record which kind of credential the request
+// used; nothing else about the client is read.
+func (c *APIClient) newHTTPError(method, path string, resp *http.Response) *HTTPError {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	return &HTTPError{
 		Method:     method,
 		Path:       path,
 		StatusCode: resp.StatusCode,
 		Body:       strings.TrimSpace(string(data)),
+		TaskScoped: strings.HasPrefix(c.Token, TaskTokenPrefix),
 	}
 }
 
@@ -236,7 +251,7 @@ func (c *APIClient) GetJSON(ctx context.Context, path string, out any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodGet, path, resp)
+		return c.newHTTPError(http.MethodGet, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -262,7 +277,7 @@ func (c *APIClient) GetJSONWithHeaders(ctx context.Context, path string, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, newHTTPError(http.MethodGet, path, resp)
+		return nil, c.newHTTPError(http.MethodGet, path, resp)
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -293,7 +308,7 @@ func (c *APIClient) DeleteJSONResponse(ctx context.Context, path string, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodDelete, path, resp)
+		return c.newHTTPError(http.MethodDelete, path, resp)
 	}
 	if out != nil {
 		return json.NewDecoder(resp.Body).Decode(out)
@@ -322,7 +337,7 @@ func (c *APIClient) DeleteJSONWithBody(ctx context.Context, path string, body an
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodDelete, path, resp)
+		return c.newHTTPError(http.MethodDelete, path, resp)
 	}
 	return nil
 }
@@ -349,7 +364,7 @@ func (c *APIClient) PostJSON(ctx context.Context, path string, body any, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodPost, path, resp)
+		return c.newHTTPError(http.MethodPost, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -379,7 +394,7 @@ func (c *APIClient) PutJSON(ctx context.Context, path string, body any, out any)
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodPut, path, resp)
+		return c.newHTTPError(http.MethodPut, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -409,7 +424,7 @@ func (c *APIClient) PatchJSON(ctx context.Context, path string, body any, out an
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodPatch, path, resp)
+		return c.newHTTPError(http.MethodPatch, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -470,7 +485,7 @@ func (c *APIClient) UploadFile(ctx context.Context, fileData []byte, filename st
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return "", newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return "", c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result map[string]any
@@ -535,7 +550,7 @@ func (c *APIClient) UploadChatAttachment(ctx context.Context, fileData []byte, f
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return AttachmentResponse{}, newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return AttachmentResponse{}, c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result AttachmentResponse
@@ -595,7 +610,7 @@ func (c *APIClient) UploadFileWithURL(ctx context.Context, fileData []byte, file
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return "", "", newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return "", "", c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result AttachmentResponse
@@ -661,7 +676,7 @@ func (c *APIClient) ImportSkillFile(ctx context.Context, fileData []byte, filena
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodPost, "/api/skills/import", resp)
+		return c.newHTTPError(http.MethodPost, "/api/skills/import", resp)
 	}
 	if out == nil {
 		return nil
@@ -699,7 +714,7 @@ func (c *APIClient) UploadPrivatePlugin(ctx context.Context, path string, archiv
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return newHTTPError(http.MethodPost, path, resp)
+		return c.newHTTPError(http.MethodPost, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -742,7 +757,7 @@ func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byt
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, newHTTPError(http.MethodGet, downloadURL, resp)
+		return nil, c.newHTTPError(http.MethodGet, downloadURL, resp)
 	}
 
 	const maxDownloadSize = 100 << 20 // 100 MB

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -72,10 +72,10 @@ type HTTPError struct {
 	Path       string
 	StatusCode int
 	Body       string
-	// TaskScoped records that the request carried a task-scoped `mat_` token
-	// rather than a member credential. It changes nothing about the request;
-	// it only lets FormatError tell a 401 that means "your login expired" from
-	// a 401 that means "this task is over" (GH #7522).
+	// TaskScoped records that the failing request actually carried a
+	// task-scoped `mat_` token. It changes nothing about the request; it only
+	// lets FormatError tell a 401 that means "your login expired" from one
+	// that means "this task token is finished" (GH #7522).
 	TaskScoped bool
 }
 
@@ -88,18 +88,32 @@ func (e *HTTPError) Error() string {
 // >= 400 responses through this so the top-level FormatError / ExitCodeFor can
 // classify the failure via errors.As(err, **HTTPError) regardless of which
 // HTTP verb the command used.
-//
-// It is a method so the error can record which kind of credential the request
-// used; nothing else about the client is read.
-func (c *APIClient) newHTTPError(method, path string, resp *http.Response) *HTTPError {
+func newHTTPError(method, path string, resp *http.Response) *HTTPError {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	return &HTTPError{
 		Method:     method,
 		Path:       path,
 		StatusCode: resp.StatusCode,
 		Body:       strings.TrimSpace(string(data)),
-		TaskScoped: strings.HasPrefix(c.Token, TaskTokenPrefix),
+		TaskScoped: requestUsedTaskToken(resp),
 	}
+}
+
+// requestUsedTaskToken reports whether the request that produced resp actually
+// sent a task token.
+//
+// Reading the client's own Token field would be wrong twice over. DownloadFile
+// deliberately sends no Authorization header for an absolute signed URL, so a
+// 401 from object storage would be reported as a finished task purely because
+// the client happened to hold a `mat_` token. And Go strips Authorization
+// across a cross-host redirect, so the request that was sent is not always the
+// one the caller built. resp.Request is the request that actually went out,
+// after redirects, which is the only thing this claim can honestly rest on.
+func requestUsedTaskToken(resp *http.Response) bool {
+	if resp == nil || resp.Request == nil {
+		return false
+	}
+	return strings.HasPrefix(resp.Request.Header.Get("Authorization"), "Bearer "+TaskTokenPrefix)
 }
 
 // defaultHTTPTimeout is the per-request timeout for the CLI's HTTP client.
@@ -251,7 +265,7 @@ func (c *APIClient) GetJSON(ctx context.Context, path string, out any) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodGet, path, resp)
+		return newHTTPError(http.MethodGet, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -277,7 +291,7 @@ func (c *APIClient) GetJSONWithHeaders(ctx context.Context, path string, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, c.newHTTPError(http.MethodGet, path, resp)
+		return nil, newHTTPError(http.MethodGet, path, resp)
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -308,7 +322,7 @@ func (c *APIClient) DeleteJSONResponse(ctx context.Context, path string, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodDelete, path, resp)
+		return newHTTPError(http.MethodDelete, path, resp)
 	}
 	if out != nil {
 		return json.NewDecoder(resp.Body).Decode(out)
@@ -337,7 +351,7 @@ func (c *APIClient) DeleteJSONWithBody(ctx context.Context, path string, body an
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodDelete, path, resp)
+		return newHTTPError(http.MethodDelete, path, resp)
 	}
 	return nil
 }
@@ -364,7 +378,7 @@ func (c *APIClient) PostJSON(ctx context.Context, path string, body any, out any
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodPost, path, resp)
+		return newHTTPError(http.MethodPost, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -394,7 +408,7 @@ func (c *APIClient) PutJSON(ctx context.Context, path string, body any, out any)
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodPut, path, resp)
+		return newHTTPError(http.MethodPut, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -424,7 +438,7 @@ func (c *APIClient) PatchJSON(ctx context.Context, path string, body any, out an
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodPatch, path, resp)
+		return newHTTPError(http.MethodPatch, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -485,7 +499,7 @@ func (c *APIClient) UploadFile(ctx context.Context, fileData []byte, filename st
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return "", c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return "", newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result map[string]any
@@ -550,7 +564,7 @@ func (c *APIClient) UploadChatAttachment(ctx context.Context, fileData []byte, f
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return AttachmentResponse{}, c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return AttachmentResponse{}, newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result AttachmentResponse
@@ -610,7 +624,7 @@ func (c *APIClient) UploadFileWithURL(ctx context.Context, fileData []byte, file
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return "", "", c.newHTTPError(http.MethodPost, "/api/upload-file", resp)
+		return "", "", newHTTPError(http.MethodPost, "/api/upload-file", resp)
 	}
 
 	var result AttachmentResponse
@@ -676,7 +690,7 @@ func (c *APIClient) ImportSkillFile(ctx context.Context, fileData []byte, filena
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodPost, "/api/skills/import", resp)
+		return newHTTPError(http.MethodPost, "/api/skills/import", resp)
 	}
 	if out == nil {
 		return nil
@@ -714,7 +728,7 @@ func (c *APIClient) UploadPrivatePlugin(ctx context.Context, path string, archiv
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return c.newHTTPError(http.MethodPost, path, resp)
+		return newHTTPError(http.MethodPost, path, resp)
 	}
 	if out == nil {
 		return nil
@@ -757,7 +771,7 @@ func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byt
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, c.newHTTPError(http.MethodGet, downloadURL, resp)
+		return nil, newHTTPError(http.MethodGet, downloadURL, resp)
 	}
 
 	const maxDownloadSize = 100 << 20 // 100 MB
@@ -784,6 +798,7 @@ func (c *APIClient) HealthCheck(ctx context.Context) (string, error) {
 			Path:       "/health",
 			StatusCode: resp.StatusCode,
 			Body:       strings.TrimSpace(string(data)),
+			TaskScoped: requestUsedTaskToken(resp),
 		}
 	}
 	return strings.TrimSpace(string(data)), nil

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -62,9 +62,12 @@ type APIClient struct {
 }
 
 // TaskTokenPrefix marks a task-scoped agent token, as minted by
-// internal/auth.NewAgentTaskToken. The server revokes these the moment the
-// task reaches a terminal state, so a 401 on one is a normal end-of-task
-// signal rather than an expired login.
+// internal/auth.NewAgentTaskToken. A 401 on one is not the "your login
+// expired" that a 401 on a member credential is: the token belongs to a single
+// run and there is no sign-in that brings it back. Why it was rejected is not
+// something the CLI can see — a terminal task is the usual cause, but a
+// malformed token, one sent to the wrong server, and one dropped by an
+// unrelated cleanup all look identical from here.
 const TaskTokenPrefix = "mat_"
 
 type HTTPError struct {
@@ -74,8 +77,8 @@ type HTTPError struct {
 	Body       string
 	// TaskScoped records that the failing request actually carried a
 	// task-scoped `mat_` token. It changes nothing about the request; it only
-	// lets FormatError tell a 401 that means "your login expired" from one
-	// that means "this task token is finished" (GH #7522).
+	// lets FormatError tell a 401 worth signing in again for from one where
+	// the right move is to stop (GH #7522).
 	TaskScoped bool
 }
 
@@ -104,8 +107,8 @@ func newHTTPError(method, path string, resp *http.Response) *HTTPError {
 //
 // Reading the client's own Token field would be wrong twice over. DownloadFile
 // deliberately sends no Authorization header for an absolute signed URL, so a
-// 401 from object storage would be reported as a finished task purely because
-// the client happened to hold a `mat_` token. And Go strips Authorization
+// 401 from object storage would be reported as a rejected task token purely
+// because the client happened to hold a `mat_` token. And Go strips Authorization
 // across a cross-host redirect, so the request that was sent is not always the
 // one the caller built. resp.Request is the request that actually went out,
 // after redirects, which is the only thing this claim can honestly rest on.

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -568,7 +568,7 @@ func TestSetHeaders_AdvertisesStableAttachmentURLs(t *testing.T) {
 // Reading the client's Token field instead is wrong in a way a hand-built
 // HTTPError cannot show: DownloadFile deliberately sends no Authorization
 // header for an absolute signed URL, so a 401 from object storage would be
-// reported to an agent as "your task token is finished, stop" purely because
+// reported to an agent as "your task token was rejected, stop" purely because
 // the client happened to hold one.
 func TestHTTPErrorTaskScopedFollowsTheRequestNotTheClient(t *testing.T) {
 	var sawAuth []string

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -561,3 +561,67 @@ func TestSetHeaders_AdvertisesStableAttachmentURLs(t *testing.T) {
 		}
 	})
 }
+
+// TestHTTPErrorTaskScopedFollowsTheRequestNotTheClient wires the credential
+// claim to what actually went out on the wire.
+//
+// Reading the client's Token field instead is wrong in a way a hand-built
+// HTTPError cannot show: DownloadFile deliberately sends no Authorization
+// header for an absolute signed URL, so a 401 from object storage would be
+// reported to an agent as "your task token is finished, stop" purely because
+// the client happened to hold one.
+func TestHTTPErrorTaskScopedFollowsTheRequestNotTheClient(t *testing.T) {
+	var sawAuth []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = append(sawAuth, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthorized"}`)
+	}))
+	defer srv.Close()
+
+	taskClient := NewAPIClient(srv.URL, "ws-1", TaskTokenPrefix+"0123456789abcdef")
+
+	t.Run("api call sends the task token", func(t *testing.T) {
+		err := taskClient.GetJSON(context.Background(), "/api/me", &struct{}{})
+		var httpErr *HTTPError
+		if !errors.As(err, &httpErr) {
+			t.Fatalf("err = %v, want an *HTTPError", err)
+		}
+		if !httpErr.TaskScoped {
+			t.Error("a 401 on a request that carried the task token must be marked task-scoped")
+		}
+		if got := FormatError(err, false); !strings.Contains(got, "task token") {
+			t.Errorf("message did not use the task-token copy: %q", got)
+		}
+	})
+
+	t.Run("signed absolute URL sends no credential at all", func(t *testing.T) {
+		before := len(sawAuth)
+		_, err := taskClient.DownloadFile(context.Background(), srv.URL+"/signed-object?sig=abc")
+		var httpErr *HTTPError
+		if !errors.As(err, &httpErr) {
+			t.Fatalf("err = %v, want an *HTTPError", err)
+		}
+		if auth := sawAuth[before]; auth != "" {
+			t.Fatalf("DownloadFile sent %q on an absolute URL; the test no longer covers the unauthenticated path", auth)
+		}
+		if httpErr.TaskScoped {
+			t.Error("a 401 from an unauthenticated signed URL must not be reported as a rejected task token")
+		}
+		if got := FormatError(err, false); strings.Contains(got, "task token") {
+			t.Errorf("storage 401 got the task-token copy: %q", got)
+		}
+	})
+
+	t.Run("member token is never task-scoped", func(t *testing.T) {
+		memberClient := NewAPIClient(srv.URL, "ws-1", "mul_0123456789abcdef")
+		err := memberClient.GetJSON(context.Background(), "/api/me", &struct{}{})
+		var httpErr *HTTPError
+		if !errors.As(err, &httpErr) {
+			t.Fatalf("err = %v, want an *HTTPError", err)
+		}
+		if httpErr.TaskScoped {
+			t.Error("a member credential must not be reported as a task token")
+		}
+	})
+}

--- a/server/internal/cli/errors.go
+++ b/server/internal/cli/errors.go
@@ -33,12 +33,17 @@ const (
 
 	// HTTP status layer.
 	KindAuthRequired // 401
-	KindForbidden    // 403
-	KindNotFound     // 404
-	KindConflict     // 409
-	KindValidation   // 400 / 422
-	KindRateLimited  // 429
-	KindServerError  // 5xx
+	// KindTaskTokenRevoked is a 401 on a task-scoped token. HTTPError.Kind()
+	// never returns it — the status code alone cannot tell the two apart — so
+	// it is selected in userMessage, where the credential kind is known. Exit
+	// classification is unchanged: it is still an auth failure.
+	KindTaskTokenRevoked
+	KindForbidden   // 403
+	KindNotFound    // 404
+	KindConflict    // 409
+	KindValidation  // 400 / 422
+	KindRateLimited // 429
+	KindServerError // 5xx
 
 	// Anything we could not classify.
 	KindUnknown
@@ -80,6 +85,8 @@ func (k ErrorKind) String() string {
 		return "network_offline"
 	case KindAuthRequired:
 		return "auth_required"
+	case KindTaskTokenRevoked:
+		return "task_token_revoked"
 	case KindForbidden:
 		return "forbidden"
 	case KindNotFound:
@@ -307,6 +314,10 @@ var kindMessages = map[ErrorKind][2]string{
 		"Your session has expired or you are not signed in. Run `multica login` to sign in again. On a self-hosted or non-OAuth setup, ask your administrator for valid credentials.",
 		"登录已过期或尚未登录。请运行 `multica login` 重新登录。自托管或非 OAuth 场景请联系管理员获取有效凭证。",
 	},
+	KindTaskTokenRevoked: {
+		"This task's token has been revoked because the task reached a terminal state (it finished, was cancelled, or timed out). This is expected, and it means the work is over. Do not retry with another credential: a profile or member token would run whatever follows as that person rather than as this task.",
+		"该任务的令牌已被吊销，因为任务已进入终态（已完成、被取消或超时）。这是预期行为，说明这项工作已经结束。请不要换用其他凭证重试：使用 profile 或成员令牌会让后续操作以该成员的身份执行，而不是以本任务的身份执行。",
+	},
 	KindForbidden: {
 		"You do not have permission to access this resource. Check that you are in the right workspace, or ask an administrator to grant access.",
 		"无权访问该资源。请确认当前 workspace 是否正确，或联系管理员授予权限。",
@@ -407,6 +418,15 @@ func userMessage(err error, lang Language) string {
 	var httpErr *HTTPError
 	if errors.As(err, &httpErr) {
 		kind := httpErr.Kind()
+		// A 401 on a task-scoped token is the task ending, not a login
+		// problem. The generic copy below tells the reader to sign in again or
+		// ask an administrator for valid credentials — advice an autonomous
+		// agent can act on, and did: after its token was revoked mid-run, one
+		// read the daemon owner's profile PAT and kept working under the
+		// member's identity (GH #7522).
+		if kind == KindAuthRequired && httpErr.TaskScoped {
+			return messageFor(KindTaskTokenRevoked, lang)
+		}
 		// Validation and conflict errors carry a useful server-provided
 		// message; surface it instead of the generic line. A body we cannot
 		// recognize still falls back to the template, so this never dumps a

--- a/server/internal/cli/errors.go
+++ b/server/internal/cli/errors.go
@@ -33,11 +33,11 @@ const (
 
 	// HTTP status layer.
 	KindAuthRequired // 401
-	// KindTaskTokenRevoked is a 401 on a task-scoped token. HTTPError.Kind()
+	// KindTaskTokenRejected is a 401 on a task-scoped token. HTTPError.Kind()
 	// never returns it — the status code alone cannot tell the two apart — so
-	// it is selected in userMessage, where the credential kind is known. Exit
-	// classification is unchanged: it is still an auth failure.
-	KindTaskTokenRevoked
+	// it is selected in userMessage, where the credential the request actually
+	// sent is known. Exit classification is unchanged: still an auth failure.
+	KindTaskTokenRejected
 	KindForbidden   // 403
 	KindNotFound    // 404
 	KindConflict    // 409
@@ -85,8 +85,8 @@ func (k ErrorKind) String() string {
 		return "network_offline"
 	case KindAuthRequired:
 		return "auth_required"
-	case KindTaskTokenRevoked:
-		return "task_token_revoked"
+	case KindTaskTokenRejected:
+		return "task_token_rejected"
 	case KindForbidden:
 		return "forbidden"
 	case KindNotFound:
@@ -314,9 +314,9 @@ var kindMessages = map[ErrorKind][2]string{
 		"Your session has expired or you are not signed in. Run `multica login` to sign in again. On a self-hosted or non-OAuth setup, ask your administrator for valid credentials.",
 		"登录已过期或尚未登录。请运行 `multica login` 重新登录。自托管或非 OAuth 场景请联系管理员获取有效凭证。",
 	},
-	KindTaskTokenRevoked: {
-		"This task's token has been revoked because the task reached a terminal state (it finished, was cancelled, or timed out). This is expected, and it means the work is over. Do not retry with another credential: a profile or member token would run whatever follows as that person rather than as this task.",
-		"该任务的令牌已被吊销，因为任务已进入终态（已完成、被取消或超时）。这是预期行为，说明这项工作已经结束。请不要换用其他凭证重试：使用 profile 或成员令牌会让后续操作以该成员的身份执行，而不是以本任务的身份执行。",
+	KindTaskTokenRejected: {
+		"This task token was rejected and is no longer usable. Stop here: do not retry, and do not fall back to a profile or member credential, because anything done with one would run as that person rather than as this task. Only the runtime that started this task can supply a valid task token.",
+		"这个 task token 已被拒绝，不再可用。请到此为止：不要重试，也不要改用 profile 或成员凭证 —— 用它们执行的任何操作都会以那个成员的身份运行，而不是以这次 task 的身份运行。只有启动这次 task 的运行时才能提供有效的 task token。",
 	},
 	KindForbidden: {
 		"You do not have permission to access this resource. Check that you are in the right workspace, or ask an administrator to grant access.",
@@ -418,14 +418,20 @@ func userMessage(err error, lang Language) string {
 	var httpErr *HTTPError
 	if errors.As(err, &httpErr) {
 		kind := httpErr.Kind()
-		// A 401 on a task-scoped token is the task ending, not a login
-		// problem. The generic copy below tells the reader to sign in again or
-		// ask an administrator for valid credentials — advice an autonomous
-		// agent can act on, and did: after its token was revoked mid-run, one
-		// read the daemon owner's profile PAT and kept working under the
-		// member's identity (GH #7522).
+		// A 401 on a task token is not a login problem, and the generic copy
+		// below is the wrong instruction for whoever reads it: it says to sign
+		// in again or ask an administrator for valid credentials. An
+		// autonomous agent can act on that, and one did — after its task token
+		// stopped working mid-run it read the daemon owner's profile PAT and
+		// kept going under the member's identity (GH #7522).
+		//
+		// What the copy must not do is guess *why*. The usual cause is the
+		// task reaching a terminal state, but the same 401 covers a malformed
+		// token, one sent to the wrong server, and one dropped by an unrelated
+		// cleanup. "Stop" is true in every one of those cases; "the task
+		// finished" is not.
 		if kind == KindAuthRequired && httpErr.TaskScoped {
-			return messageFor(KindTaskTokenRevoked, lang)
+			return messageFor(KindTaskTokenRejected, lang)
 		}
 		// Validation and conflict errors carry a useful server-provided
 		// message; surface it instead of the generic line. A body we cannot

--- a/server/internal/cli/errors_test.go
+++ b/server/internal/cli/errors_test.go
@@ -81,8 +81,8 @@ func TestFormatErrorAllKinds(t *testing.T) {
 	withLang(t, "") // default English
 	allKinds := []ErrorKind{
 		KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS, KindNetworkOffline,
-		KindAuthRequired, KindForbidden, KindNotFound, KindConflict, KindValidation,
-		KindRateLimited, KindServerError, KindUnknown,
+		KindAuthRequired, KindTaskTokenRevoked, KindForbidden, KindNotFound, KindConflict,
+		KindValidation, KindRateLimited, KindServerError, KindUnknown,
 	}
 	for _, lang := range []Language{LangEN, LangZH} {
 		for _, k := range allKinds {
@@ -375,19 +375,20 @@ func withLang(t *testing.T, lang string) {
 
 func TestErrorKindString(t *testing.T) {
 	cases := map[ErrorKind]string{
-		KindNetworkTimeout: "network_timeout",
-		KindNetworkDNS:     "network_dns",
-		KindNetworkRefused: "network_refused",
-		KindNetworkTLS:     "network_tls",
-		KindNetworkOffline: "network_offline",
-		KindAuthRequired:   "auth_required",
-		KindForbidden:      "forbidden",
-		KindNotFound:       "not_found",
-		KindConflict:       "conflict",
-		KindValidation:     "validation",
-		KindRateLimited:    "rate_limited",
-		KindServerError:    "server_error",
-		KindUnknown:        "unknown",
+		KindNetworkTimeout:   "network_timeout",
+		KindNetworkDNS:       "network_dns",
+		KindNetworkRefused:   "network_refused",
+		KindNetworkTLS:       "network_tls",
+		KindNetworkOffline:   "network_offline",
+		KindAuthRequired:     "auth_required",
+		KindTaskTokenRevoked: "task_token_revoked",
+		KindForbidden:        "forbidden",
+		KindNotFound:         "not_found",
+		KindConflict:         "conflict",
+		KindValidation:       "validation",
+		KindRateLimited:      "rate_limited",
+		KindServerError:      "server_error",
+		KindUnknown:          "unknown",
 	}
 	seen := map[string]ErrorKind{}
 	for k, want := range cases {
@@ -402,6 +403,56 @@ func TestErrorKindString(t *testing.T) {
 	// Out-of-range value gets a stable fallback rather than an empty string.
 	if got := ErrorKind(999).String(); got != "ErrorKind(999)" {
 		t.Errorf("unexpected fallback String(): %q", got)
+	}
+}
+
+// TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential is GH #7522 in
+// one assertion. The generic 401 copy tells the reader to run `multica login`
+// or ask an administrator for valid credentials. That is right for a person
+// and wrong for an agent: after its task token was revoked mid-run, one read
+// the daemon owner's profile PAT and kept working under the member's identity.
+// A 401 on a task-scoped token has to read as "this task is over", never as
+// "find a working credential".
+func TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T) {
+	httpErr := &HTTPError{Method: "GET", Path: "/api/me", StatusCode: 401, TaskScoped: true}
+
+	for _, tc := range []struct {
+		lang    string
+		want    []string
+		refuted []string
+	}{
+		{"en_US.UTF-8",
+			[]string{"revoked", "terminal state", "Do not retry with another credential"},
+			[]string{"multica login", "administrator"}},
+		{"zh_CN.UTF-8",
+			[]string{"吊销", "终态", "不要换用其他凭证"},
+			[]string{"multica login", "管理员"}},
+	} {
+		withLang(t, tc.lang)
+		got := FormatError(httpErr, false)
+		for _, sub := range tc.want {
+			if !strings.Contains(got, sub) {
+				t.Errorf("%s: %q missing %q", tc.lang, got, sub)
+			}
+		}
+		for _, sub := range tc.refuted {
+			if strings.Contains(got, sub) {
+				t.Errorf("%s: a revoked task token must not be told to find another credential, got %q (contains %q)",
+					tc.lang, got, sub)
+			}
+		}
+	}
+
+	// A member 401 is unchanged: that really is an expired login.
+	withLang(t, "en_US.UTF-8")
+	member := FormatError(&HTTPError{Method: "GET", Path: "/api/me", StatusCode: 401}, false)
+	if !strings.Contains(member, "multica login") {
+		t.Errorf("a member 401 should still point at sign-in, got %q", member)
+	}
+
+	// Exit classification is unchanged — still an auth failure.
+	if got := ExitCodeFor(httpErr); got != ExitAuth {
+		t.Errorf("ExitCodeFor(revoked task token) = %d, want %d", got, ExitAuth)
 	}
 }
 

--- a/server/internal/cli/errors_test.go
+++ b/server/internal/cli/errors_test.go
@@ -81,7 +81,7 @@ func TestFormatErrorAllKinds(t *testing.T) {
 	withLang(t, "") // default English
 	allKinds := []ErrorKind{
 		KindNetworkTimeout, KindNetworkDNS, KindNetworkRefused, KindNetworkTLS, KindNetworkOffline,
-		KindAuthRequired, KindTaskTokenRevoked, KindForbidden, KindNotFound, KindConflict,
+		KindAuthRequired, KindTaskTokenRejected, KindForbidden, KindNotFound, KindConflict,
 		KindValidation, KindRateLimited, KindServerError, KindUnknown,
 	}
 	for _, lang := range []Language{LangEN, LangZH} {
@@ -375,20 +375,20 @@ func withLang(t *testing.T, lang string) {
 
 func TestErrorKindString(t *testing.T) {
 	cases := map[ErrorKind]string{
-		KindNetworkTimeout:   "network_timeout",
-		KindNetworkDNS:       "network_dns",
-		KindNetworkRefused:   "network_refused",
-		KindNetworkTLS:       "network_tls",
-		KindNetworkOffline:   "network_offline",
-		KindAuthRequired:     "auth_required",
-		KindTaskTokenRevoked: "task_token_revoked",
-		KindForbidden:        "forbidden",
-		KindNotFound:         "not_found",
-		KindConflict:         "conflict",
-		KindValidation:       "validation",
-		KindRateLimited:      "rate_limited",
-		KindServerError:      "server_error",
-		KindUnknown:          "unknown",
+		KindNetworkTimeout:    "network_timeout",
+		KindNetworkDNS:        "network_dns",
+		KindNetworkRefused:    "network_refused",
+		KindNetworkTLS:        "network_tls",
+		KindNetworkOffline:    "network_offline",
+		KindAuthRequired:      "auth_required",
+		KindTaskTokenRejected: "task_token_rejected",
+		KindForbidden:         "forbidden",
+		KindNotFound:          "not_found",
+		KindConflict:          "conflict",
+		KindValidation:        "validation",
+		KindRateLimited:       "rate_limited",
+		KindServerError:       "server_error",
+		KindUnknown:           "unknown",
 	}
 	seen := map[string]ErrorKind{}
 	for k, want := range cases {
@@ -406,14 +406,23 @@ func TestErrorKindString(t *testing.T) {
 	}
 }
 
-// TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential is GH #7522 in
-// one assertion. The generic 401 copy tells the reader to run `multica login`
-// or ask an administrator for valid credentials. That is right for a person
-// and wrong for an agent: after its task token was revoked mid-run, one read
-// the daemon owner's profile PAT and kept working under the member's identity.
-// A 401 on a task-scoped token has to read as "this task is over", never as
-// "find a working credential".
-func TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T) {
+// TestFormatErrorRejectedTaskTokenDoesNotSuggestAnotherCredential is GH #7522
+// in one assertion. The generic 401 copy tells the reader to run `multica
+// login` or ask an administrator for valid credentials. That is right for a
+// person and wrong for an agent: after its task token stopped working mid-run,
+// one read the daemon owner's profile PAT and kept working under the member's
+// identity. A 401 on a task token has to read as "stop", never as "find a
+// working credential".
+//
+// It must also not guess why the token was rejected. A terminal task is the
+// usual cause, but the same 401 covers a malformed token, one sent to the wrong
+// server, and one dropped by an unrelated cleanup — so a message that asserts
+// the task finished is a claim the CLI cannot make.
+//
+// The wiring — which requests are marked task-scoped in the first place — is
+// covered by TestHTTPErrorTaskScopedFollowsTheRequestNotTheClient, which drives
+// a real client instead of hand-building the error.
+func TestFormatErrorRejectedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T) {
 	httpErr := &HTTPError{Method: "GET", Path: "/api/me", StatusCode: 401, TaskScoped: true}
 
 	for _, tc := range []struct {
@@ -422,11 +431,13 @@ func TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T
 		refuted []string
 	}{
 		{"en_US.UTF-8",
-			[]string{"revoked", "terminal state", "Do not retry with another credential"},
-			[]string{"multica login", "administrator"}},
+			[]string{"rejected", "no longer usable", "Stop here", "do not retry",
+				"do not fall back to a profile or member credential"},
+			// No sign-in advice, and no claim about a cause it cannot verify.
+			[]string{"multica login", "administrator", "cancelled", "finished", "terminal state"}},
 		{"zh_CN.UTF-8",
-			[]string{"吊销", "终态", "不要换用其他凭证"},
-			[]string{"multica login", "管理员"}},
+			[]string{"已被拒绝", "不再可用", "不要重试", "不要改用 profile 或成员凭证"},
+			[]string{"multica login", "管理员", "已完成", "被取消", "终态"}},
 	} {
 		withLang(t, tc.lang)
 		got := FormatError(httpErr, false)
@@ -437,10 +448,21 @@ func TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T
 		}
 		for _, sub := range tc.refuted {
 			if strings.Contains(got, sub) {
-				t.Errorf("%s: a revoked task token must not be told to find another credential, got %q (contains %q)",
-					tc.lang, got, sub)
+				t.Errorf("%s: %q must not contain %q", tc.lang, got, sub)
 			}
 		}
+	}
+
+	// Glossary: an agent execution is `task` in Chinese; 任务 is the product
+	// entity a user files (an issue). Writing this message with 任务 would say
+	// the user's issue was rejected. See conventions.zh.mdx.
+	withLang(t, "zh_CN.UTF-8")
+	zh := FormatError(httpErr, false)
+	if strings.Contains(zh, "任务") {
+		t.Errorf("zh copy used 任务 for an agent execution; it must stay `task`: %q", zh)
+	}
+	if !strings.Contains(zh, "task") {
+		t.Errorf("zh copy dropped the `task` term entirely: %q", zh)
 	}
 
 	// A member 401 is unchanged: that really is an expired login.
@@ -452,7 +474,7 @@ func TestFormatErrorRevokedTaskTokenDoesNotSuggestAnotherCredential(t *testing.T
 
 	// Exit classification is unchanged — still an auth failure.
 	if got := ExitCodeFor(httpErr); got != ExitAuth {
-		t.Errorf("ExitCodeFor(revoked task token) = %d, want %d", got, ExitAuth)
+		t.Errorf("ExitCodeFor(rejected task token) = %d, want %d", got, ExitAuth)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #7531, from the same incident (#7522). Defence in depth, not the fix — cancellation failing to terminate the process tree is the fix.

## The problem

The CLI's generic 401 copy is:

> Your session has expired or you are not signed in. Run `multica login` to sign in again. On a self-hosted or non-OAuth setup, ask your administrator for valid credentials.

That is right for a person and actively harmful for an agent. A task's `mat_` token stops working the moment the task reaches a terminal state, so **every** call an orphaned agent makes after its task is cancelled receives this message. For an autonomous agent, error copy is a control surface: this one reads as an instruction to go find a working credential, and in #7522 one did — it read the daemon owner's profile PAT out of `~/.multica/profiles/<profile>/config.json` and kept working under the member's identity for 40 minutes.

## The change

A 401 on a task-scoped token now says the token was rejected and to stop:

> This task token was rejected and is no longer usable. Stop here: do not retry, and do not fall back to a profile or member credential, because anything done with one would run as that person rather than as this task. Only the runtime that started this task can supply a valid task token.

Localized in both EN and ZH, like every other kind in the table.

**It deliberately does not say why.** A terminal task is the usual cause, but the same 401 covers a malformed token, one sent to the wrong server, and one dropped by an unrelated cleanup. "Stop, and do not fall back to another credential" is true in all of those; "the task finished" is a claim the CLI cannot make.

**The claim follows the request, not the client.** `HTTPError.TaskScoped` is derived from `resp.Request` — the request that actually went out. Reading the client's own `Token` field would be wrong twice over: `DownloadFile` deliberately sends no `Authorization` header for an absolute signed URL, so a 401 from object storage would be reported as a rejected task token purely because the client happened to hold one; and Go strips `Authorization` across a cross-host redirect, so the request that was sent is not always the one the caller built.

Deliberately unchanged:
- **Exit classification.** A rejected task token is still `ExitAuth`. `HTTPError.Kind()` still returns `KindAuthRequired`; `KindTaskTokenRejected` is a message-table key selected in `userMessage`, where the credential the request actually sent is known.
- **The member 401.** An expired login still gets the sign-in copy, asserted in the test.

## What this does and does not buy

It removes the *motive*, not the *capability*. An agent that decides on its own to read a profile token can still do so — per MUL-5578, task subprocesses run with the daemon user's real HOME and full filesystem access, and the `mat_` boundary is a convention rather than an OS boundary. The point is that Multica should not be the thing suggesting it.

## Testing

- `TestHTTPErrorTaskScopedFollowsTheRequestNotTheClient` drives a real client against an `httptest` server returning 401 and covers all three paths: an API call (marked), an unauthenticated signed URL through `DownloadFile` (not marked), and a member credential (not marked). Verified to fail if the claim moves back to client state.
- `TestFormatErrorRejectedTaskTokenDoesNotSuggestAnotherCredential` asserts, in both languages, that the message appears **and** that `multica login` / administrator guidance does not — plus that it names no cause, that a member 401 is untouched, and that the exit code is still `ExitAuth`.
- A glossary assertion fails if 任务 reappears in this message. Per `conventions.zh.mdx`, an agent execution stays lowercase `task` in Chinese; 任务 is the product entity a user files, so the original wording said the user's *issue* was rejected.
- Existing `TestFormatErrorAllKinds` and `TestErrorKindString` extended to cover the new kind.
- `go test ./internal/cli/`: four `TestCLIConfig_*` failures reproduce identically on a clean `main` on this machine (they read a real `~/.multica`); unrelated to this change.
