### PR TITLE
feat(lark): push inbox notifications to a bound member's Lark DM (delivery)

### DIFF
--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -296,7 +296,21 @@ type SendTextParams struct {
 	// ReplyTarget threads the text reply back into a Lark topic; see
 	// ReplyTarget. Empty keeps the chat-level send.
 	ReplyTarget ReplyTarget
+	// ReceiveIDType tells Lark how to read ChatID. Empty means chat_id —
+	// the historical chat-level send. ReceiveIDOpenID addresses a person
+	// instead, which is how the inbox push reaches a bound member without
+	// a pre-existing chat. Ignored when ReplyTarget is set, since a reply
+	// is addressed by message id.
+	ReceiveIDType ReceiveIDType
 }
+
+// ReceiveIDType is Lark's receive_id_type query parameter: it selects
+// which identifier namespace receive_id is read in.
+type ReceiveIDType string
+
+// ReceiveIDOpenID addresses a single user by their per-app open_id. The
+// bot opens (or reuses) a 1:1 conversation with that person.
+const ReceiveIDOpenID ReceiveIDType = "open_id"
 
 // SendMarkdownCardParams is the input shape for posting an agent
 // reply as a Lark interactive card with a markdown body element.
@@ -316,6 +330,10 @@ type SendMarkdownCardParams struct {
 	// ReplyTarget threads the card reply back into a Lark topic; see
 	// ReplyTarget. Empty keeps the chat-level send.
 	ReplyTarget ReplyTarget
+	// ReceiveIDType tells Lark how to read ChatID; see the field of the
+	// same name on SendTextParams. Empty means chat_id. Ignored when
+	// ReplyTarget is set.
+	ReceiveIDType ReceiveIDType
 }
 
 // BindingPromptParams carries the data needed to render and send the

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -323,7 +323,7 @@ func (c *httpAPIClient) doAuthedJSON(ctx context.Context, creds InstallationCred
 // goes to the chat-level send endpoint keyed by receive_id=chat_id, the
 // historical behavior. Body is map[string]any (not map[string]string)
 // because reply_in_thread is a bool.
-func outboundMessageRequest(chatID ChatID, msgType, content string, target ReplyTarget) (string, map[string]any) {
+func outboundMessageRequest(chatID ChatID, msgType, content string, target ReplyTarget, receiveIDType ReceiveIDType) (string, map[string]any) {
 	if target.IsSet() {
 		return "/open-apis/im/v1/messages/" + url.PathEscape(target.MessageID) + "/reply", map[string]any{
 			"msg_type":        msgType,
@@ -332,7 +332,15 @@ func outboundMessageRequest(chatID ChatID, msgType, content string, target Reply
 		}
 	}
 	q := url.Values{}
-	q.Set("receive_id_type", "chat_id")
+	// receive_id_type selects how Lark reads receive_id. Empty keeps the
+	// historical chat-level send; the inbox push sets open_id so the bot
+	// opens a 1:1 conversation with the bound member instead of needing a
+	// chat to already exist.
+	idType := string(receiveIDType)
+	if idType == "" {
+		idType = "chat_id"
+	}
+	q.Set("receive_id_type", idType)
 	return "/open-apis/im/v1/messages?" + q.Encode(), map[string]any{
 		"receive_id": string(chatID),
 		"msg_type":   msgType,
@@ -350,7 +358,7 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	if p.CardJSON == "" {
 		return "", errors.New("lark http client: missing card json")
 	}
-	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "interactive", p.CardJSON, p.ReplyTarget, "")
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -390,7 +398,7 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode text content: %w", err)
 	}
-	path, body := outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.ReplyTarget, p.ReceiveIDType)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
@@ -432,24 +440,29 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 	if p.Markdown == "" {
 		return "", errors.New("lark http client: missing markdown body")
 	}
+	// update_multi is declared on every markdown card: Lark refuses to
+	// apply PatchInteractiveCard to a card that did not declare itself
+	// updatable AT SEND TIME, and the refusal is silent (see the same
+	// note on defaultRenderer.Render). Declaring it keeps every sent
+	// card patchable later; for cards that are never patched it is inert.
+	cfg := map[string]any{"update_multi": true}
+	if p.Summary != "" {
+		cfg["summary"] = map[string]any{"content": p.Summary}
+	}
 	card := map[string]any{
 		"schema": "2.0",
+		"config": cfg,
 		"body": map[string]any{
 			"elements": []any{
 				map[string]any{"tag": "markdown", "content": p.Markdown},
 			},
 		},
 	}
-	if p.Summary != "" {
-		card["config"] = map[string]any{
-			"summary": map[string]any{"content": p.Summary},
-		}
-	}
 	cardBytes, err := json.Marshal(card)
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode markdown card: %w", err)
 	}
-	path, body := outboundMessageRequest(p.ChatID, "interactive", string(cardBytes), p.ReplyTarget)
+	path, body := outboundMessageRequest(p.ChatID, "interactive", string(cardBytes), p.ReplyTarget, p.ReceiveIDType)
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`

--- a/server/internal/integrations/lark/inbox_message.go
+++ b/server/internal/integrations/lark/inbox_message.go
@@ -1,0 +1,254 @@
+package lark
+
+// inbox_message.go — the card body the Lark bot pushes on inbox:new. Kept
+// in its own file so the outbound Patcher stays focused on delivery and this
+// module owns the wording + link building. Mirrors the WeCom smart-bot inbox
+// path (internal/integrations/wecom/inbox_message.go); the presentation
+// differs deliberately: the notification lands in the same conversation as
+// the agent's chat replies, which are schema-2.0 markdown cards carrying
+// their full body — so this card renders the body verbatim too, instead of
+// WeCom's flattened plain text. A squeezed excerpt next to fully-rendered
+// reply cards reads as a different, worse product.
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// inboxTitleMaxRunes bounds the header line; titles are one line by
+	// nature and 120 runes is beyond any real one.
+	inboxTitleMaxRunes = 120
+	// inboxBodyMaxRunes is a safety valve, not a presentation choice: the
+	// body ships verbatim, and only a pathological one is cut — on a line
+	// boundary, with the full text still one click away.
+	inboxBodyMaxRunes = 3000
+)
+
+// inboxTypeLabels are the Chinese display names used in the notification
+// preamble. Kept locally so lark does not reach into cmd/server for it;
+// the lists agree with wecom's by convention.
+var inboxTypeLabels = map[string]string{
+	"issue_assigned":     "任务指派",
+	"mentioned":          "提及你",
+	"status_changed":     "状态变更",
+	"comment_added":      "新评论",
+	"new_comment":        "新评论",
+	"reaction_added":     "表情反应",
+	"task_failed":        "任务失败",
+	"unassigned":         "取消指派",
+	"assignee_changed":   "指派人变更",
+	"priority_changed":   "优先级变更",
+	"due_date_changed":   "截止日期变更",
+	"start_date_changed": "开始日期变更",
+}
+
+func inboxTypeLabel(t string) string {
+	if label, ok := inboxTypeLabels[t]; ok {
+		return label
+	}
+	return "新消息"
+}
+
+// inboxAppURL resolves the frontend origin used to build the detail link.
+// Priority: LARK_APP_URL → MULTICA_APP_URL → FRONTEND_ORIGIN.
+//
+// Unlike the WeCom path this accepts http:// as well. That guard exists
+// there to keep a misconfigured env from putting an http link in front of a
+// user; here it would instead silence the link for every self-hosted
+// deployment served over plain http on an internal network, which is the
+// common shape for this integration. The value is operator-set, never
+// member-authored, and the message says where it points.
+func inboxAppURL() string {
+	for _, name := range []string{"LARK_APP_URL", "MULTICA_APP_URL", "FRONTEND_ORIGIN"} {
+		v := strings.TrimSpace(os.Getenv(name))
+		if v == "" {
+			continue
+		}
+		if !strings.HasPrefix(v, "https://") && !strings.HasPrefix(v, "http://") {
+			continue
+		}
+		return strings.TrimRight(v, "/")
+	}
+	return ""
+}
+
+// buildInboxCard builds the markdown card body and the chat-list summary
+// line from an inbox_item map. Card shape:
+//
+//	**【{type}】{title}**
+//	{body, verbatim markdown}
+//	[查看详情]({appURL}/{slug|workspaceID}/inbox?issue={issueID})
+//
+// The body renders exactly as the agent-reply cards in the same chat do.
+// The link line is omitted entirely when no appURL is configured — better a
+// link-less card than a broken link. The summary is what Lark shows in the
+// chat list and the OS notification banner.
+func buildInboxCard(item map[string]any, workspaceID, slug string) (markdown, summary string) {
+	parts, ok := buildInboxParts(item, workspaceID, slug)
+	if !ok {
+		return "", ""
+	}
+	return composeInboxCard(parts.header, parts.body, nil, parts.link), parts.summary
+}
+
+// inboxCardParts are the composable pieces of one notification; a
+// standalone card is header + body + link, and the blocks parameter of
+// composeInboxCard leaves room for stitching follow-up events into the
+// same card.
+type inboxCardParts struct {
+	label   string
+	header  string // **【label】title**
+	body    string
+	link    string
+	summary string
+}
+
+func buildInboxParts(item map[string]any, workspaceID, slug string) (inboxCardParts, bool) {
+	title, _ := item["title"].(string)
+	typeStr, _ := item["type"].(string)
+	if title == "" && typeStr == "" {
+		return inboxCardParts{}, false
+	}
+	label := inboxTypeLabel(typeStr)
+	// The title is the one member-authored field spliced into the bot's own
+	// bold line, where "[x](url)" would render as a link the bot appears to
+	// vouch for. Separating "](" is sufficient — markdown only forms a link
+	// when the two are adjacent. The body is NOT rewritten: it renders
+	// verbatim like the agent-reply cards beside it, links included.
+	title = breakLinkAdjacency(title)
+	title = truncateRunesEllipsis(title, inboxTitleMaxRunes)
+	return inboxCardParts{
+		label:   label,
+		header:  "**【" + label + "】" + title + "**",
+		body:    clampBody(strings.TrimSpace(inboxItemBody(item))),
+		link:    inboxItemLink(item, workspaceID, slug),
+		summary: "【" + label + "】" + title,
+	}, true
+}
+
+// composeInboxCard renders the card markdown: the first event's header and
+// body, any follow-up blocks separated by rules, and one 查看详情
+// line at the bottom.
+// Every seam is a blank line: markdown folds a single newline into the
+// previous paragraph, and a line directly above "---" turns into a setext
+// heading — the title-and-description-as-one-giant-bold-block bug.
+func composeInboxCard(header, body string, blocks []string, link string) string {
+	var b strings.Builder
+	b.WriteString(header)
+	if body != "" {
+		b.WriteString("\n\n")
+		b.WriteString(body)
+	}
+	for _, blk := range blocks {
+		b.WriteString("\n\n---\n\n")
+		b.WriteString(blk)
+	}
+	if link != "" {
+		b.WriteString("\n\n[查看详情](")
+		b.WriteString(link)
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// clampBody cuts a pathologically long body on a line boundary and closes
+// an unbalanced code fence so the cut cannot swallow the rest of the card
+// into a code block. Anything cut is still one click away.
+func clampBody(s string) string {
+	if utf8.RuneCountInString(s) <= inboxBodyMaxRunes {
+		return s
+	}
+	runes := []rune(s)
+	cut := string(runes[:inboxBodyMaxRunes])
+	if i := strings.LastIndexByte(cut, '\n'); i > 0 {
+		cut = cut[:i]
+	}
+	if strings.Count(cut, "```")%2 == 1 {
+		cut += "\n```"
+	}
+	return cut + "\n……(已截断,完整内容见下方链接)"
+}
+
+// breakLinkAdjacency inserts a space between "](" pairs so member-authored
+// text cannot form a markdown link inside the bot's own header line.
+// CommonMark requires the link text to be followed immediately by "(" —
+// separation is enough, and every character stays visible.
+func breakLinkAdjacency(s string) string {
+	return strings.ReplaceAll(s, "](", "] (")
+}
+
+// inboxItemBody extracts the body string from an inbox_item map. Body may
+// arrive as *string (nil-able JSON field), string, or be missing.
+func inboxItemBody(item map[string]any) string {
+	switch v := item["body"].(type) {
+	case *string:
+		if v != nil {
+			return *v
+		}
+	case string:
+		return v
+	}
+	return ""
+}
+
+// inboxItemLink builds the {appURL}/{slug|wsUUID}/inbox?issue={issueID}
+// deep link. Returns "" when no appURL is configured — the caller drops the
+// whole link line on that signal.
+func inboxItemLink(item map[string]any, workspaceID, slug string) string {
+	appURL := inboxAppURL()
+	if appURL == "" {
+		return ""
+	}
+	seg := slug
+	if seg == "" {
+		seg = workspaceID
+	}
+	var b strings.Builder
+	b.WriteString(appURL)
+	b.WriteString("/")
+	b.WriteString(url.PathEscape(seg))
+	b.WriteString("/inbox")
+	// Optional ?issue=... — chat-only inbox items have no issue.
+	if issueID := inboxItemIssueID(item); issueID != "" {
+		b.WriteString("?issue=")
+		b.WriteString(url.QueryEscape(issueID))
+	}
+	return b.String()
+}
+
+// inboxItemIssueID extracts issue_id when present. Chat-type notifications
+// have none and return "", which drops the query param.
+func inboxItemIssueID(item map[string]any) string {
+	switch v := item["issue_id"].(type) {
+	case *string:
+		if v != nil {
+			return *v
+		}
+	case string:
+		return v
+	}
+	return ""
+}
+
+// truncateRunesEllipsis trims s to at most maxRunes runes, appending "…"
+// when anything was cut. Rune-based rather than byte-based so truncation
+// never splits a Chinese character.
+func truncateRunesEllipsis(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	i := 0
+	for pos := range s {
+		if i == maxRunes {
+			return s[:pos] + "…"
+		}
+		i++
+	}
+	return s
+}

--- a/server/internal/integrations/lark/inbox_push.go
+++ b/server/internal/integrations/lark/inbox_push.go
@@ -1,0 +1,190 @@
+package lark
+
+// inbox_push.go — delivery of inbox:new notifications to a member's Lark
+// DM. Mirrors the WeCom smart-bot path (internal/integrations/wecom/
+// outbound.go handleInboxNew): a member who has bound their Lark account
+// gets the notification pushed to them; everyone else just sees it in the
+// in-app inbox as before. Every miss is a no-op, never an error to the
+// publisher — the inbox item is already written by the time we run.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// inboxPushTimeout bounds one delivery, so a Lark outage cannot pin the
+// delivery goroutine (and its DB connection) indefinitely.
+const inboxPushTimeout = 10 * time.Second
+
+// handleInboxNew is the inbox:new subscriber. It delivers to the bound
+// member's Lark DM and is a no-op on every miss: a non-member recipient
+// (agents get nothing over chat channels), no Lark binding, a missing
+// installation, or a send failure. Notification preferences are already
+// applied upstream — a muted type never produces an inbox item, so
+// nothing is re-checked here.
+//
+// Delivery is fire-and-forget on a goroutine. Bus delivery is synchronous
+// and inbox:new is published on user-facing write paths (adding a comment,
+// changing a status), so an outbound Lark HTTP call here would add its
+// latency to those API responses — up to inboxPushTimeout per bound
+// recipient when Lark is slow. The WeCom equivalent delivers inline, but
+// its send is an in-process handoff to an already-connected WS sender;
+// this one leaves the building.
+func (p *Patcher) handleInboxNew(e events.Event) {
+	payload, ok := e.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+	item, ok := payload["item"].(map[string]any)
+	if !ok {
+		return
+	}
+	if rt, _ := item["recipient_type"].(string); rt != "member" {
+		return
+	}
+	recipientIDStr, _ := item["recipient_id"].(string)
+	workspaceIDStr, _ := item["workspace_id"].(string)
+	if recipientIDStr == "" || workspaceIDStr == "" {
+		return
+	}
+
+	go func() {
+		// The bus recovers panics in synchronous handlers; a goroutine
+		// escapes that net, so it carries its own.
+		defer func() {
+			if r := recover(); r != nil {
+				p.cfg.Logger.Error("lark inbox push: panic recovered", "recovered", r)
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), inboxPushTimeout)
+		defer cancel()
+		p.tryDeliverInbox(ctx, item, recipientIDStr, workspaceIDStr)
+	}()
+}
+
+// tryDeliverInbox is the delivery core. Reports whether the bot pushed the
+// notification; the bool is for tests and logging, not for the caller's
+// control flow.
+func (p *Patcher) tryDeliverInbox(ctx context.Context, item map[string]any, recipientIDStr, workspaceIDStr string) bool {
+	log := p.cfg.Logger
+	recipientID, err := util.ParseUUID(recipientIDStr)
+	if err != nil || !recipientID.Valid {
+		return false
+	}
+	workspaceID, err := util.ParseUUID(workspaceIDStr)
+	if err != nil || !workspaceID.Valid {
+		return false
+	}
+
+	binding, err := p.queries.FindChannelBindingForMember(ctx, db.FindChannelBindingForMemberParams{
+		WorkspaceID:   workspaceID,
+		MulticaUserID: recipientID,
+		// The binding rows this platform writes carry channel_type
+		// "feishu" (channel_store.go), not "lark" — the package name and
+		// the stored value differ.
+		ChannelType: channelTypeFeishu,
+	})
+	if err != nil {
+		// No binding is the ordinary case for an unbound member, not a
+		// fault: they keep receiving the notification in-app.
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.WarnContext(ctx, "lark inbox push: lookup member binding failed",
+				"error", err, "workspace_id", workspaceIDStr, "recipient_id", recipientIDStr)
+		}
+		return false
+	}
+
+	inst, err := p.queries.GetLarkInstallation(ctx, binding.InstallationID)
+	if err != nil {
+		log.WarnContext(ctx, "lark inbox push: load installation failed",
+			"error", err, "recipient_id", recipientIDStr)
+		return false
+	}
+	creds, err := p.installationCredentials(inst)
+	if err != nil {
+		log.WarnContext(ctx, "lark inbox push: resolve credentials failed",
+			"error", err, "recipient_id", recipientIDStr)
+		return false
+	}
+
+	// Best-effort slug for a readable link; the workspace UUID stands in
+	// when the lookup fails.
+	slug := ""
+	if ws, err := p.queries.GetWorkspace(ctx, workspaceID); err == nil {
+		slug = ws.Slug
+	}
+	item = p.backfillAssignmentBody(ctx, item)
+	parts, ok := buildInboxParts(item, workspaceIDStr, slug)
+	if !ok {
+		return false
+	}
+
+	// A markdown card rather than plain text: notification bodies are
+	// member/agent-authored markdown, and msg_type=text shows the syntax
+	// literally while a bare URL is the only link form it can carry. The
+	// binding's channel_user_id is the member's per-app open_id, so the
+	// send addresses the person and Lark opens the 1:1 chat itself.
+	if _, err := p.client.SendMarkdownCard(ctx, SendMarkdownCardParams{
+		InstallationID: creds,
+		ChatID:         ChatID(binding.ChannelUserID),
+		Markdown:       composeInboxCard(parts.header, parts.body, nil, parts.link),
+		Summary:        parts.summary,
+		ReceiveIDType:  ReceiveIDOpenID,
+	}); err != nil {
+		log.WarnContext(ctx, "lark inbox push: send failed",
+			"error", err, "recipient_open_id", binding.ChannelUserID)
+		return false
+	}
+	log.DebugContext(ctx, "lark inbox push: delivered",
+		"recipient_id", recipientIDStr, "inbox_type", item["type"])
+	return true
+}
+
+// descriptionBackfillTypes are the notification types whose inbox item
+// carries no body (cmd/server/notification_listeners.go passes "" for
+// them) while the issue's description is exactly what the recipient needs
+// to decide whether to act. Status flips and reactions stay body-less: a
+// description repeated on every transition is spam, not signal.
+var descriptionBackfillTypes = map[string]bool{
+	"issue_assigned":   true,
+	"assignee_changed": true,
+}
+
+// backfillAssignmentBody fills a body-less assignment notification with the
+// issue's description. It works on a copy — the item map is shared with the
+// event's other subscribers and this runs on the delivery goroutine.
+// Best-effort: any miss returns the item unchanged and the card simply has
+// no body, which is what it had anyway.
+func (p *Patcher) backfillAssignmentBody(ctx context.Context, item map[string]any) map[string]any {
+	if inboxItemBody(item) != "" {
+		return item
+	}
+	if t, _ := item["type"].(string); !descriptionBackfillTypes[t] {
+		return item
+	}
+	issueID := inboxItemIssueID(item)
+	if issueID == "" {
+		return item
+	}
+	iu, err := util.ParseUUID(issueID)
+	if err != nil || !iu.Valid {
+		return item
+	}
+	iss, err := p.queries.GetIssue(ctx, iu)
+	if err != nil || !iss.Description.Valid || strings.TrimSpace(iss.Description.String) == "" {
+		return item
+	}
+	clone := make(map[string]any, len(item)+1)
+	for k, v := range item {
+		clone[k] = v
+	}
+	clone["body"] = iss.Description.String
+	return clone
+}

--- a/server/internal/integrations/lark/inbox_push_test.go
+++ b/server/internal/integrations/lark/inbox_push_test.go
@@ -1,0 +1,316 @@
+package lark
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	testInboxRecipientID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+	testInboxWorkspaceID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+	testInboxIssueID     = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+)
+
+// inboxItem builds an inbox_item map shaped like the one notifyDirect
+// publishes on inbox:new.
+func inboxItem(overrides map[string]any) map[string]any {
+	item := map[string]any{
+		"recipient_type": "member",
+		"recipient_id":   testInboxRecipientID,
+		"workspace_id":   testInboxWorkspaceID,
+		"type":           "issue_assigned",
+		"title":          "Fix the login redirect",
+		"body":           "assigned to you",
+		"issue_id":       testInboxIssueID,
+	}
+	for k, v := range overrides {
+		if v == nil {
+			delete(item, k)
+			continue
+		}
+		item[k] = v
+	}
+	return item
+}
+
+func inboxEvent(overrides map[string]any) events.Event {
+	return events.Event{
+		Type:        protocol.EventInboxNew,
+		WorkspaceID: testInboxWorkspaceID,
+		Payload:     map[string]any{"item": inboxItem(overrides)},
+	}
+}
+
+// deliver runs the synchronous delivery core the async handler wraps.
+func deliver(t *testing.T, p *Patcher, item map[string]any) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rid, _ := item["recipient_id"].(string)
+	wid, _ := item["workspace_id"].(string)
+	return p.tryDeliverInbox(ctx, item, rid, wid)
+}
+
+// withBoundMember wires the fake queries so the recipient has a Lark
+// binding and the workspace resolves to a slug.
+func withBoundMember(t *testing.T, q *fakePatcherQueries) {
+	t.Helper()
+	q.memberBinding = db.ChannelUserBinding{
+		InstallationID: uuidFromString(t, "1111aaaa-1111-1111-1111-111111111111"),
+		MulticaUserID:  uuidFromString(t, testInboxRecipientID),
+		ChannelType:    channelTypeFeishu,
+		ChannelUserID:  "ou_member_open_id",
+	}
+	q.workspace = db.Workspace{Slug: "acme"}
+}
+
+func TestInboxPushDeliversCardToBoundMemberByOpenID(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+
+	if !deliver(t, p, inboxItem(nil)) {
+		t.Fatal("expected delivery to succeed")
+	}
+	if len(api.mdCardSent) != 1 {
+		t.Fatalf("expected 1 markdown card send, got %d", len(api.mdCardSent))
+	}
+	sent := api.mdCardSent[0]
+	// Addressing the person, not a chat: this is what lets the bot open
+	// the 1:1 conversation itself.
+	if sent.ReceiveIDType != ReceiveIDOpenID {
+		t.Errorf("ReceiveIDType: got %q, want %q", sent.ReceiveIDType, ReceiveIDOpenID)
+	}
+	if sent.ChatID != "ou_member_open_id" {
+		t.Errorf("ChatID: got %q, want the binding's open_id", sent.ChatID)
+	}
+	if sent.ReplyTarget.IsSet() {
+		t.Error("inbox push must not thread into a reply target")
+	}
+	for _, want := range []string{"**【任务指派】Fix the login redirect**", "assigned to you",
+		"[查看详情](https://multica.example.com/acme/inbox?issue=" + testInboxIssueID + ")"} {
+		if !strings.Contains(sent.Markdown, want) {
+			t.Errorf("Markdown missing %q; got:\n%s", want, sent.Markdown)
+		}
+	}
+	if sent.Summary != "【任务指派】Fix the login redirect" {
+		t.Errorf("Summary: got %q", sent.Summary)
+	}
+}
+
+// TestInboxPushHandlerDeliversAsync pins the bus-facing wiring: the
+// registered handler parses the event and delivery lands without the
+// caller waiting on it.
+func TestInboxPushHandlerDeliversAsync(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+
+	p.handleInboxNew(inboxEvent(nil))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		api.mu.Lock()
+		n := len(api.mdCardSent)
+		api.mu.Unlock()
+		if n == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("async delivery never landed")
+}
+
+func TestInboxPushSkipsUnboundMember(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	// No binding row: the ordinary case for a member who never linked
+	// their Lark account. They still get the in-app inbox item.
+	q.memberBindingErr = pgx.ErrNoRows
+
+	if deliver(t, p, inboxItem(nil)) {
+		t.Fatal("expected no delivery for an unbound member")
+	}
+	if len(api.mdCardSent) != 0 {
+		t.Fatalf("expected no send for an unbound member, got %d", len(api.mdCardSent))
+	}
+}
+
+func TestInboxPushHandlerSkipsAgentRecipient(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+
+	// The handler filters non-member recipients before it ever spawns the
+	// delivery goroutine, so asserting right after it returns is not racy.
+	p.handleInboxNew(inboxEvent(map[string]any{"recipient_type": "agent"}))
+
+	if len(api.mdCardSent) != 0 {
+		t.Fatalf("agents receive nothing over chat channels, got %d sends", len(api.mdCardSent))
+	}
+}
+
+func TestInboxPushHandlerSurvivesMalformedPayload(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+
+	// Each of these returns before the goroutine spawn, so the immediate
+	// assertion below cannot race a delivery.
+	p.handleInboxNew(events.Event{Type: protocol.EventInboxNew, Payload: "not-a-map"})
+	p.handleInboxNew(events.Event{Type: protocol.EventInboxNew, Payload: map[string]any{}})
+	p.handleInboxNew(inboxEvent(map[string]any{"recipient_id": ""}))
+
+	if len(api.mdCardSent) != 0 {
+		t.Fatalf("expected no send on malformed payloads, got %d", len(api.mdCardSent))
+	}
+}
+
+func TestInboxCardOmitsLinkWithoutAppURL(t *testing.T) {
+	// No LARK_APP_URL / MULTICA_APP_URL / FRONTEND_ORIGIN configured.
+	t.Setenv("LARK_APP_URL", "")
+	t.Setenv("MULTICA_APP_URL", "")
+	t.Setenv("FRONTEND_ORIGIN", "")
+
+	md, _ := buildInboxCard(inboxItem(nil), testInboxWorkspaceID, "acme")
+	// A link-less card beats one carrying a broken link.
+	if strings.Contains(md, "查看详情") || strings.Contains(md, "/inbox") {
+		t.Errorf("expected no link line; got:\n%s", md)
+	}
+	if !strings.Contains(md, "Fix the login redirect") {
+		t.Error("title must survive when the link is dropped")
+	}
+}
+
+func TestInboxCardAcceptsHTTPAppURL(t *testing.T) {
+	// Self-hosted deployments on an internal network commonly serve plain
+	// http; silencing the link there would cost the notification its whole
+	// point. This is the one place this path diverges from the WeCom one.
+	t.Setenv("LARK_APP_URL", "http://multica.internal")
+	link := inboxItemLink(map[string]any{"issue_id": testInboxIssueID}, testInboxWorkspaceID, "acme")
+	if link != "http://multica.internal/acme/inbox?issue="+testInboxIssueID {
+		t.Errorf("got %q", link)
+	}
+}
+
+func TestInboxCardFallsBackToWorkspaceIDWithoutSlug(t *testing.T) {
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+	link := inboxItemLink(map[string]any{}, testInboxWorkspaceID, "")
+	if link != "https://multica.example.com/"+testInboxWorkspaceID+"/inbox" {
+		t.Errorf("got %q", link)
+	}
+	// A chat-only item has no issue_id, so no query param either.
+	if strings.Contains(link, "?issue=") {
+		t.Errorf("expected no issue param; got %q", link)
+	}
+}
+
+func TestInboxCardRendersBodyVerbatim(t *testing.T) {
+	// The notification lands in the same conversation as the agent's chat
+	// replies, which are markdown cards carrying their full body. The
+	// inbox card must match: nothing stripped, nothing summarized.
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+	body := "## 发布报告\n\n- **结果**: ✅成功\n- **版本**: `89bcd8fa` → `687f5eb7`\n\n```\n==> 当前版本: 89bcd8fa\n```\n\n详见 [MR 链接](https://git.example/mr/22)。"
+	md, _ := buildInboxCard(inboxItem(map[string]any{"type": "new_comment", "body": body}), testInboxWorkspaceID, "acme")
+
+	if !strings.Contains(md, body) {
+		t.Errorf("body must ship verbatim; got:\n%s", md)
+	}
+	if !strings.HasPrefix(md, "**【新评论】Fix the login redirect**\n\n") {
+		t.Errorf("header line malformed; got prefix:\n%s", md[:60])
+	}
+	if !strings.HasSuffix(md, "[查看详情](https://multica.example.com/acme/inbox?issue="+testInboxIssueID+")") {
+		t.Errorf("link line malformed; got:\n%s", md)
+	}
+}
+
+func TestInboxCardClampsPathologicalBodyOnLineBoundary(t *testing.T) {
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+	// A body over the safety valve, with an open code fence right at the
+	// cut: the clamp must cut on a line boundary, close the fence so the
+	// rest of the card cannot be swallowed into a code block, and keep
+	// the link line intact.
+	body := strings.Repeat("正文行。\n", 300) + "```\n" + strings.Repeat("log line\n", 200)
+	md, _ := buildInboxCard(inboxItem(map[string]any{
+		"title": strings.Repeat("标", 500),
+		"body":  body,
+	}), testInboxWorkspaceID, "acme")
+
+	lines := strings.Split(md, "\n")
+	if n := len([]rune(lines[0])); n > inboxTitleMaxRunes+20 {
+		t.Errorf("title line is %d runes", n)
+	}
+	if strings.Count(md, "```")%2 != 0 {
+		t.Errorf("clamp left an unbalanced code fence:\n…%s", md[len(md)-120:])
+	}
+	if !strings.Contains(md, "已截断") {
+		t.Error("a cut body must say so")
+	}
+	if !strings.HasSuffix(md, "/inbox?issue="+testInboxIssueID+")") {
+		t.Error("link must survive truncation — it is the whole affordance")
+	}
+}
+
+func TestInboxCardBreaksTitleLinksButKeepsBodyLinks(t *testing.T) {
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+	md, _ := buildInboxCard(inboxItem(map[string]any{
+		"title": "[click here](http://evil.example)",
+		"body":  "详见 [MR](https://git.example/mr/22)",
+	}), testInboxWorkspaceID, "acme")
+
+	// The title is spliced into the bot's own bold line, so its link
+	// syntax must not survive there…
+	if strings.Contains(md, "](http://evil.example") {
+		t.Errorf("member-authored title link survived into the header:\n%s", md)
+	}
+	// …while the body renders verbatim like the agent-reply cards beside
+	// it, links included, and the card's own link renders too.
+	if !strings.Contains(md, "[MR](https://git.example/mr/22)") {
+		t.Errorf("body links must be preserved:\n%s", md)
+	}
+	if !strings.Contains(md, "[查看详情](https://multica.example.com/") {
+		t.Errorf("the card's own link must still render:\n%s", md)
+	}
+}
+
+func TestInboxPushBackfillsDescriptionForAssignment(t *testing.T) {
+	// Upstream passes body="" for issue_assigned (notification_listeners.go),
+	// yet the description is exactly what the recipient needs to decide
+	// whether to act. The push fetches it.
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+	t.Setenv("LARK_APP_URL", "https://multica.example.com")
+	q.issue = db.Issue{Description: pgtype.Text{String: "## 目标\n完成登录重定向修复", Valid: true}}
+
+	if !deliver(t, p, inboxItem(map[string]any{"body": nil})) {
+		t.Fatal("expected delivery to succeed")
+	}
+	if got := api.mdCardSent[0].Markdown; !strings.Contains(got, "完成登录重定向修复") {
+		t.Errorf("assignment card must carry the issue description; got:\n%s", got)
+	}
+}
+
+func TestInboxPushDoesNotBackfillStatusChanges(t *testing.T) {
+	// A description repeated on every status flip is spam, not signal.
+	p, q, api := newTestPatcher(t)
+	withBoundMember(t, q)
+	q.issue = db.Issue{Description: pgtype.Text{String: "must not appear", Valid: true}}
+
+	if !deliver(t, p, inboxItem(map[string]any{"type": "status_changed", "body": nil})) {
+		t.Fatal("expected delivery to succeed")
+	}
+	if got := api.mdCardSent[0].Markdown; strings.Contains(got, "must not appear") {
+		t.Errorf("status_changed must stay body-less; got:\n%s", got)
+	}
+}
+
+func TestInboxCardUsesFallbackLabelForUnknownType(t *testing.T) {
+	_, summary := buildInboxCard(inboxItem(map[string]any{"type": "some_future_type"}), testInboxWorkspaceID, "acme")
+	if !strings.HasPrefix(summary, "【新消息】") {
+		t.Errorf("unknown types need a readable fallback label; got %q", summary)
+	}
+}

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -152,6 +152,13 @@ type PatcherQueries interface {
 	GetLarkOutboundCardByTask(ctx context.Context, taskID pgtype.UUID) (OutboundCardMessage, error)
 	CreateLarkOutboundCardMessage(ctx context.Context, arg CreateOutboundCardMessageParams) (OutboundCardMessage, error)
 	UpdateLarkOutboundCardStatus(ctx context.Context, arg UpdateOutboundCardStatusParams) error
+
+	// Used by the inbox:new push (inbox_push.go) to find the bound member
+	// to deliver to, build a readable link, and backfill the issue
+	// description into body-less assignment notifications.
+	FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error)
+	GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error)
+	GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error)
 }
 
 // CredentialsResolver decrypts an installation's app_secret for the
@@ -286,6 +293,9 @@ func (p *Patcher) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventTaskFailed, p.handleEvent)
 	bus.Subscribe(protocol.EventChatDone, p.handleEvent)
 	bus.Subscribe(protocol.EventTaskCancelled, p.handleEvent)
+	// Inbox notifications delivered to a member's Lark DM when they have
+	// bound their account; a no-op for everyone else. See inbox_push.go.
+	bus.Subscribe(protocol.EventInboxNew, p.handleInboxNew)
 }
 
 func (p *Patcher) handleEvent(e events.Event) {

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -34,6 +34,27 @@ type fakePatcherQueries struct {
 	created             []CreateOutboundCardMessageParams
 	createReturn        OutboundCardMessage
 	statusUpdates       []UpdateOutboundCardStatusParams
+	memberBinding       db.ChannelUserBinding
+	memberBindingErr    error
+	workspace           db.Workspace
+	workspaceErr        error
+	issue               db.Issue
+	issueErr            error
+}
+
+func (f *fakePatcherQueries) FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error) {
+	if f.memberBindingErr != nil {
+		return db.ChannelUserBinding{}, f.memberBindingErr
+	}
+	return f.memberBinding, nil
+}
+
+func (f *fakePatcherQueries) GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error) {
+	return f.workspace, f.workspaceErr
+}
+
+func (f *fakePatcherQueries) GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error) {
+	return f.issue, f.issueErr
 }
 
 func (f *fakePatcherQueries) GetAgentTask(ctx context.Context, id pgtype.UUID) (db.AgentTaskQueue, error) {


### PR DESCRIPTION
WeCom's smart bot already pushes `inbox:new` to a member who has linked their account (`internal/integrations/wecom`); Lark had no equivalent, so a Lark-bound member only discovered assignments, mentions, comments and status changes the next time they opened the app.

This adds the Lark side: the outbound Patcher subscribes to `inbox:new` and delivers to the member's DM when they have a binding row, addressing them by open_id so Lark opens the 1:1 conversation itself (`SendTextParams` and `SendMarkdownCardParams` gain `ReceiveIDType`; empty keeps existing callers on chat_id). Every miss — agent recipient, unbound member, missing installation, send failure — is a no-op and the in-app inbox is unaffected. Notification preferences need no second check: a muted type never produces an inbox item.

The notification is a schema-2.0 markdown card, not plain text: bodies are member/agent-authored markdown and land in the same conversation as the agent's reply cards, so both render the same way — bold 【type】title header, body verbatim, one 查看详情 link. Assignment-family notifications arrive body-less upstream (`notifyDirect` passes `""`), so the push backfills the issue description — it is exactly what the recipient needs to decide whether to act, and only for that family: repeating it on every status flip would be spam.

**Scope**: this is the delivery half of #7136, re-cut for reviewability (−250 lines, none of the locking/patching subtleties). A follow-up PR adds per-issue aggregation — folding an event burst into one growing card via card patching — which is why every markdown card already declares `update_multi` at send time and `composeInboxCard` accepts follow-up blocks.

**Why binding-by-member rather than per-installation**: `FindChannelBindingForMember` deliberately keys on (member, channel_type), matching the WeCom precedent — the bot is the pipe, the inbox is member-scoped. A workspace-level notification bot would be a cleaner home but is an installation-model change, out of scope here.

Verified end-to-end on a self-hosted deployment: assignment, mention, comment and status-change notifications land in the bound member's Feishu DM as individual cards.
