### PR TITLE
MUL-6682 [WS-2018] Archive Codex task threads after persistence

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -384,6 +384,13 @@ type Daemon struct {
 	// went away is a few bytes, not a leak worth a lifecycle.
 	registerSerial sync.Map
 
+	// codexConversationSerial holds one mutex per stable Codex conversation.
+	// A terminal callback wakes successor tasks before the old daemon handler
+	// receives its HTTP response; holding this lock through post-persistence
+	// archive prevents that successor from unarchiving/resuming the same thread
+	// while its predecessor is still moving the rollout.
+	codexConversationSerial sync.Map
+
 	// agentsAvailable holds the current built-in agent CLI availability set —
 	// the same shape as cfg.Agents, which it supersedes as the read path.
 	//
@@ -5020,6 +5027,38 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	}
 	provider := rt.Provider
 
+	if provider == "codex" {
+		conversation := execenv.TaskContextForEnv{
+			IssueID:       task.IssueID,
+			ChatSessionID: task.ChatSessionID,
+			AgentID:       task.AgentID,
+		}
+		lockKey := execenv.CodexSessionStorePath(d.cfg.Profile, conversation)
+		if lockKey == "" {
+			// Tasks without a stable issue/chat conversation cannot be resumed
+			// by another task, but retaining a task-local key keeps the locking
+			// rule total and avoids a global mutex.
+			lockKey = "task:" + task.ID
+		}
+		lockAny, _ := d.codexConversationSerial.LoadOrStore(lockKey, &sync.Mutex{})
+		conversationLock := lockAny.(*sync.Mutex)
+		conversationLock.Lock()
+		defer conversationLock.Unlock()
+
+		// Keep both halves of a local-directory conversation store out of the
+		// existing GC until archive/unarchive and their process cleanup finish.
+		for _, store := range []string{
+			execenv.CodexSessionStorePath(d.cfg.Profile, conversation),
+			execenv.CodexArchivedSessionStorePath(d.cfg.Profile, conversation),
+		} {
+			if store == "" {
+				continue
+			}
+			d.markActiveStore(store)
+			defer d.unmarkActiveStore(store)
+		}
+	}
+
 	// Task-scoped logger with short ID for readable concurrent logs.
 	taskLog := d.logger.With("task", shortID(task.ID))
 	agentName := "agent"
@@ -5142,6 +5181,8 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		}
 		if ackErr := d.client.AckTaskCancelled(ctx, task.ID, ack); ackErr != nil {
 			taskLog.Warn("cancel ack failed; server sweeper will finalize", "error", ackErr)
+		} else {
+			d.archiveCodexTaskThreads(ctx, provider, task, result, taskLog)
 		}
 		return
 	default:
@@ -5166,6 +5207,8 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 			failureReason:  taskRunFailureReason(err),
 		}); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
+		} else {
+			d.archiveCodexTaskThreads(ctx, provider, task, result, taskLog)
 		}
 		return
 	}
@@ -5191,11 +5234,15 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		// them.
 		if ackErr := d.client.AckTaskCancelled(ctx, task.ID, TaskCancelAck{BranchName: result.BranchName, DurableWorkDir: result.DurableWorkDir}); ackErr != nil {
 			taskLog.Warn("cancel ack failed; server sweeper will finalize", "error", ackErr)
+		} else {
+			d.archiveCodexTaskThreads(ctx, provider, task, result, taskLog)
 		}
 		return
 	}
 
-	d.reportTaskResult(ctx, task.ID, result, taskLog)
+	if d.reportTaskResult(ctx, task.ID, result, taskLog) {
+		d.archiveCodexTaskThreads(ctx, provider, task, result, taskLog)
+	}
 
 	// Write GC metadata after the task finishes so the periodic GC loop
 	// can look up the parent record (issue / chat session / autopilot run /
@@ -5473,7 +5520,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 // the agent may have built a real session before getting stuck, and we want
 // the next chat turn to resume there rather than start over and "forget"
 // the conversation.
-func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result TaskResult, taskLog *slog.Logger) {
+func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result TaskResult, taskLog *slog.Logger) bool {
 	switch result.Status {
 	case "completed":
 		taskLog.Info("task completed", "status", result.Status)
@@ -5489,7 +5536,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			retiredSessionID:      result.RetiredSessionID,
 		})
 		if err == nil {
-			return
+			return true
 		}
 		// CompleteTask retries transient errors internally. A transient
 		// error reaching us here means the schedule was exhausted while
@@ -5504,7 +5551,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 		// left is a concrete failure.
 		if isTransientError(err) {
 			taskLog.Error("complete task failed after retries; leaving task in running rather than falling back to fail", "error", err)
-			return
+			return false
 		}
 		taskLog.Error("complete task rejected by server, falling back to fail", "error", err)
 		// MUL-2946: this fallback fires when a server-side complete
@@ -5532,7 +5579,9 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			retiredSessionID:      result.RetiredSessionID,
 		}); failErr != nil {
 			taskLog.Error("fail task fallback also failed", "error", failErr)
+			return false
 		}
+		return true
 	default:
 		failureReason := result.FailureReason
 		if failureReason == "" {
@@ -5570,7 +5619,51 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			retiredSessionID:      result.RetiredSessionID,
 		}); err != nil {
 			taskLog.Error("report failed task failed", "error", err)
+			return false
 		}
+		return true
+	}
+	return false
+}
+
+const codexTaskArchiveTimeout = 20 * time.Second
+
+// archiveCodexTaskThreads is the sole post-persistence archive boundary. The
+// caller invokes it only after /complete, /fail or /cancel-ack returned
+// success. A transient or rejected terminal callback leaves the task running
+// and must leave its threads active for recovery.
+//
+// Archive is best-effort by contract: the server result is already durable, so
+// an RPC failure is structured operational evidence and never another task
+// status transition. One shared deadline bounds all retry-created roots and
+// their process cleanup below the daemon's task-drain window.
+func (d *Daemon) archiveCodexTaskThreads(parent context.Context, provider string, task Task, result TaskResult, taskLog *slog.Logger) {
+	if provider != "codex" || result.CodexArchiveThread == nil || len(result.CodexArchiveThreadIDs) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), codexTaskArchiveTimeout)
+	defer cancel()
+	for _, threadID := range mergeCodexThreadIDs(result.CodexArchiveThreadIDs) {
+		started := time.Now()
+		if err := result.CodexArchiveThread(ctx, threadID); err != nil {
+			taskLog.Warn("codex task thread archive failed",
+				"task_id", task.ID,
+				"runtime_id", task.RuntimeID,
+				"thread_id", threadID,
+				"latency", time.Since(started).Round(time.Millisecond).String(),
+				"error", err,
+			)
+			if ctx.Err() != nil {
+				return
+			}
+			continue
+		}
+		taskLog.Info("codex task thread archived",
+			"task_id", task.ID,
+			"runtime_id", task.RuntimeID,
+			"thread_id", threadID,
+			"latency", time.Since(started).Round(time.Millisecond).String(),
+		)
 	}
 }
 
@@ -5884,11 +5977,19 @@ func gateCodexResumeToRolloutPresence(task *Task, taskCtx *execenv.TaskContextFo
 	if provider != "codex" || task.PriorSessionID == "" || codexHome == "" {
 		return
 	}
-	if execenv.CodexResumeRolloutPresent(codexHome, task.PriorSessionID) {
+	if execenv.CodexResumeRolloutPresent(codexHome, task.PriorSessionID) ||
+		execenv.CodexArchivedRolloutPresent(codexHome, task.PriorSessionID) {
 		return
 	}
 	taskLog.Warn("dropping prior codex session: rollout not present in task CODEX_HOME; starting a fresh thread",
 		"session_id", task.PriorSessionID, "codex_home", codexHome)
+	markCodexResumeUnavailable(task, taskCtx)
+}
+
+func markCodexResumeUnavailable(task *Task, taskCtx *execenv.TaskContextForEnv) {
+	if task == nil || taskCtx == nil {
+		return
+	}
 	task.PriorSessionID = ""
 	taskCtx.PriorSessionResumed = false
 	// The user expected this run to continue the prior conversation; surface the
@@ -5936,6 +6037,25 @@ func codexSessionResumable(codexHome, sessionID string, wait time.Duration) bool
 		}
 		time.Sleep(codexRolloutPollInterval)
 	}
+}
+
+func mergeCodexThreadIDs(groups ...[]string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, group := range groups {
+		for _, id := range group {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // waitCodexRolloutPresent blocks until sessionID's rollout appears in codexHome's
@@ -7584,6 +7704,63 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		execOpts.SystemPrompt = runtimeBrief
 	}
 
+	// thread/archive makes the task disappear from Codex Desktop by moving its
+	// rollout to archived_sessions. Before a later Multica task resumes the
+	// persisted pointer, restore it through the official inverse RPC. The
+	// archived_sessions view is stable across local-directory task homes (see
+	// execenv.prepareCodexArchivedSessionsDir), so this preserves the existing
+	// cross-task continuity contract instead of turning archive into deletion.
+	//
+	// Keep the exact backend and ExecOptions for handleTask's post-persistence
+	// archive. ThreadIDs is sampled in the defer, after all internal and daemon
+	// fresh-session retries have finished, so intermediate roots are not leaked.
+	if lifecycle, ok := backend.(agent.CodexThreadLifecycle); ok {
+		var preUnarchived []string
+		if execOpts.ResumeSessionID != "" && execenv.CodexArchivedRolloutPresent(env.CodexHome, execOpts.ResumeSessionID) {
+			priorThreadID := execOpts.ResumeSessionID
+			unarchiveErr := lifecycle.UnarchiveThread(ctx, priorThreadID, execOpts)
+			active := execenv.CodexResumeRolloutPresent(env.CodexHome, priorThreadID)
+			if unarchiveErr == nil && active {
+				preUnarchived = append(preUnarchived, priorThreadID)
+				taskLog.Info("codex archived thread restored for resume", "thread_id", priorThreadID)
+			} else if active {
+				// An idempotent race (or an older runtime reporting an error after
+				// moving the rollout) is safe when the filesystem proves the thread
+				// is active. The conversation lock in handleTask prevents another
+				// local task from entering this window concurrently.
+				preUnarchived = append(preUnarchived, priorThreadID)
+				taskLog.Info("codex thread already active after unarchive response", "thread_id", priorThreadID)
+			} else {
+				taskLog.Warn("codex thread unarchive failed; starting a fresh thread",
+					"thread_id", priorThreadID, "error", unarchiveErr)
+				markCodexResumeUnavailable(&task, &taskCtx)
+				execOpts.ResumeSessionID = ""
+				execOpts.ResumeExpected = false
+				execOpts.ResumeContinuityNotice = ""
+				if freshBrief, briefErr := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx); briefErr != nil {
+					taskLog.Warn("execenv: re-inject runtime config after unarchive failure failed (non-fatal)", "error", briefErr)
+				} else {
+					runtimeBrief = freshBrief
+					if providerNeedsInlineSystemPrompt(provider) {
+						execOpts.SystemPrompt = runtimeBrief
+					}
+				}
+				prompt = BuildPrompt(task, provider, promptOptions...)
+			}
+		}
+		defer func() {
+			ids := mergeCodexThreadIDs(preUnarchived, lifecycle.ThreadIDs())
+			if len(ids) == 0 {
+				return
+			}
+			opts := execOpts
+			taskResult.CodexArchiveThreadIDs = ids
+			taskResult.CodexArchiveThread = func(archiveCtx context.Context, threadID string) error {
+				return lifecycle.ArchiveThread(archiveCtx, threadID, opts)
+			}
+		}()
+	}
+
 	// A quick-actions refresh task from a server that predates server-side
 	// generation (MUL-5573). This daemon no longer has a suggestion pass to run
 	// it with, and it must NOT fall through to the ordinary chat path below:
@@ -8726,6 +8903,15 @@ func (d *Daemon) markActiveStore(store string) {
 	}
 	d.activeStoresMu.Lock()
 	defer d.activeStoresMu.Unlock()
+	if d.activeStores == nil {
+		d.activeStores = make(map[string]int)
+	}
+	if d.deletingStores == nil {
+		d.deletingStores = make(map[string]bool)
+	}
+	if d.activeStoresCond == nil {
+		d.activeStoresCond = sync.NewCond(&d.activeStoresMu)
+	}
 	for d.deletingStores[store] {
 		d.activeStoresCond.Wait()
 	}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1687,6 +1687,14 @@ func TestGateCodexResumeToRolloutPresence(t *testing.T) {
 	if err := os.WriteFile(present, []byte("{}"), 0o644); err != nil {
 		t.Fatalf("write rollout: %v", err)
 	}
+	archived := filepath.Join(codexHome, "archived_sessions",
+		"rollout-2026-07-13T00-00-00-archived-session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(archived), 0o755); err != nil {
+		t.Fatalf("mkdir archived sessions: %v", err)
+	}
+	if err := os.WriteFile(archived, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write archived rollout: %v", err)
+	}
 
 	tests := []struct {
 		name        string
@@ -1696,6 +1704,7 @@ func TestGateCodexResumeToRolloutPresence(t *testing.T) {
 		wantSession string
 	}{
 		{name: "rollout present keeps resume", provider: "codex", sessionID: "present-session", codexHome: codexHome, wantSession: "present-session"},
+		{name: "archived rollout stays eligible for unarchive", provider: "codex", sessionID: "archived-session", codexHome: codexHome, wantSession: "archived-session"},
 		{name: "rollout absent drops resume", provider: "codex", sessionID: "gone-session", codexHome: codexHome, wantSession: ""},
 		{name: "non-codex provider is a no-op", provider: "claude", sessionID: "present-session", codexHome: codexHome, wantSession: "present-session"},
 		{name: "empty codex home is a no-op", provider: "codex", sessionID: "present-session", codexHome: "", wantSession: "present-session"},
@@ -4379,6 +4388,181 @@ func TestReportTaskResult_CancelledParentStillRunsPermanentFailureFallback(t *te
 	}
 	if got := failCalls.Load(); got != 1 {
 		t.Fatalf("fallback fail calls = %d, want 1", got)
+	}
+}
+
+func TestHandleTaskArchivesCodexOnlyAfterTerminalPersistence(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	tests := []struct {
+		name           string
+		result         TaskResult
+		runErr         error
+		archiveErr     error
+		statusResponse string
+		wantTerminal   string
+	}{
+		{
+			name:           "completion",
+			result:         TaskResult{Status: "completed"},
+			statusResponse: "running",
+			wantTerminal:   "complete",
+		},
+		{
+			name:           "archive failure does not overwrite completion",
+			result:         TaskResult{Status: "completed"},
+			archiveErr:     errors.New("archive unavailable"),
+			statusResponse: "running",
+			wantTerminal:   "complete",
+		},
+		{
+			name:           "failure result",
+			result:         TaskResult{Status: "blocked", Comment: "provider failed"},
+			statusResponse: "running",
+			wantTerminal:   "fail",
+		},
+		{
+			name:         "runner error",
+			result:       TaskResult{},
+			runErr:       errors.New("runner crashed"),
+			wantTerminal: "fail",
+		},
+		{
+			name:           "post-run cancellation",
+			result:         TaskResult{Status: "completed"},
+			statusResponse: "cancelled",
+			wantTerminal:   "cancel-ack",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var events []string
+			record := func(event string) {
+				mu.Lock()
+				events = append(events, event)
+				mu.Unlock()
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/status"):
+					status := tc.statusResponse
+					if status == "" {
+						status = "running"
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprintf(w, `{"status":%q}`, status)
+				case strings.HasSuffix(r.URL.Path, "/complete"):
+					record("complete")
+					w.WriteHeader(http.StatusOK)
+				case strings.HasSuffix(r.URL.Path, "/fail"):
+					record("fail")
+					w.WriteHeader(http.StatusOK)
+				case strings.HasSuffix(r.URL.Path, "/cancel-ack"):
+					record("cancel-ack")
+					w.WriteHeader(http.StatusOK)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			result := tc.result
+			result.CodexArchiveThreadIDs = []string{"thr-task", "thr-task"}
+			result.CodexArchiveThread = func(_ context.Context, id string) error {
+				record("archive:" + id)
+				return tc.archiveErr
+			}
+			d := &Daemon{
+				client:             NewClient(srv.URL),
+				logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+				workspaces:         make(map[string]*workspaceState),
+				runtimeIndex:       map[string]Runtime{"rt-codex": {ID: "rt-codex", Provider: "codex"}},
+				cancelPollInterval: time.Hour,
+				activeStores:       make(map[string]int),
+				deletingStores:     make(map[string]bool),
+			}
+			d.activeStoresCond = sync.NewCond(&d.activeStoresMu)
+			d.runner = taskRunnerFunc(func(_ context.Context, _ Task, _ string, _ int, _ *slog.Logger) (TaskResult, error) {
+				return result, tc.runErr
+			})
+			d.handleTask(context.Background(), Task{
+				ID:        "task-codex",
+				RuntimeID: "rt-codex",
+				IssueID:   "issue-codex",
+				AgentID:   "agent-codex",
+				Agent:     &AgentData{Name: "Codex"},
+			}, 0)
+
+			mu.Lock()
+			got := append([]string(nil), events...)
+			mu.Unlock()
+			want := []string{tc.wantTerminal, "archive:thr-task"}
+			if !slices.Equal(got, want) {
+				t.Fatalf("event order = %v, want terminal persistence before one deduplicated archive %v", got, want)
+			}
+		})
+	}
+}
+
+func TestHandleTaskDoesNotArchiveWhenTerminalPersistenceFails(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	var archives atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/status"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		case strings.HasSuffix(r.URL.Path, "/fail"):
+			w.WriteHeader(http.StatusBadRequest)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{
+		client:             NewClient(srv.URL),
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:         make(map[string]*workspaceState),
+		runtimeIndex:       map[string]Runtime{"rt-codex": {ID: "rt-codex", Provider: "codex"}},
+		cancelPollInterval: time.Hour,
+		activeStores:       make(map[string]int),
+		deletingStores:     make(map[string]bool),
+	}
+	d.activeStoresCond = sync.NewCond(&d.activeStoresMu)
+	d.runner = taskRunnerFunc(func(_ context.Context, _ Task, _ string, _ int, _ *slog.Logger) (TaskResult, error) {
+		return TaskResult{
+			CodexArchiveThreadIDs: []string{"thr-no-persist"},
+			CodexArchiveThread: func(context.Context, string) error {
+				archives.Add(1)
+				return nil
+			},
+		}, errors.New("runner crashed")
+	})
+	d.handleTask(context.Background(), Task{
+		ID:        "task-codex-fail",
+		RuntimeID: "rt-codex",
+		IssueID:   "issue-codex-fail",
+		AgentID:   "agent-codex",
+		Agent:     &AgentData{Name: "Codex"},
+	}, 0)
+	if got := archives.Load(); got != 0 {
+		t.Fatalf("archive calls = %d, want 0 when /fail persistence was rejected", got)
+	}
+}
+
+func TestArchiveCodexTaskThreadsIgnoresNonCodexProvider(t *testing.T) {
+	var calls atomic.Int32
+	result := TaskResult{
+		CodexArchiveThreadIDs: []string{"thr-wrong-provider"},
+		CodexArchiveThread: func(context.Context, string) error {
+			calls.Add(1)
+			return nil
+		},
+	}
+	(&Daemon{}).archiveCodexTaskThreads(context.Background(), "claude", Task{}, result, slog.Default())
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("non-Codex archive calls = %d, want 0", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -212,6 +212,15 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	if err := prepareCodexSessionsDir(codexHome, sharedHome, opts, logger); err != nil {
 		logger.Warn("execenv: codex-home sessions dir prepare failed", "error", err)
 	}
+	// thread/archive moves a rollout out of sessions/ and into
+	// archived_sessions/. Local-directory tasks receive a fresh CODEX_HOME for
+	// every task ID, so point that directory at a stable per-conversation store
+	// as well; otherwise archiving would make the server-persisted session
+	// impossible to unarchive on the next task. Managed tasks reuse their env
+	// root and keep the directory local, matching prepareCodexSessionsDir.
+	if err := prepareCodexArchivedSessionsDir(codexHome, sharedHome, opts); err != nil {
+		logger.Warn("execenv: codex-home archived sessions dir prepare failed", "error", err)
+	}
 
 	// Symlink shared files (auth).
 	for _, name := range codexSymlinkedFiles {
@@ -359,6 +368,8 @@ var codexSessionStateGlobs = []string{
 // user's own thread list.
 const codexSessionStoreRoot = "multica-sessions"
 
+const codexArchivedStoreSuffix = "__archived"
+
 // codexSessionStoreDir returns the persistent, per-(agent, issue) Codex sessions
 // store for key, rooted on the shared Codex home's volume. It survives across
 // task IDs (unlike the task-scoped envRoot the GC reclaims) and holds only that
@@ -368,6 +379,19 @@ func codexSessionStoreDir(sharedHome, key string) string {
 		return ""
 	}
 	return filepath.Join(sharedHome, codexSessionStoreRoot, key)
+}
+
+// codexArchivedSessionStoreDir is the persistent archive half of a
+// per-conversation store. It deliberately lives under the existing
+// multica-sessions root with a reserved suffix: the existing session-store GC
+// then applies the same profile isolation, retention and reservation protocol
+// without introducing a second cleanup loop.
+func codexArchivedSessionStoreDir(sharedHome, key string) string {
+	store := codexSessionStoreDir(sharedHome, key)
+	if store == "" {
+		return ""
+	}
+	return store + codexArchivedStoreSuffix
 }
 
 // codexSessionStoreNamespace maps a daemon's profile to the directory segment
@@ -629,6 +653,33 @@ func prepareCodexSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions
 	return os.MkdirAll(dst, 0o755)
 }
 
+// prepareCodexArchivedSessionsDir preserves archive/resume continuity across
+// task IDs. Local-directory tasks cannot reuse their task CODEX_HOME, so their
+// archived_sessions directory is linked to the per-conversation archive store.
+// Managed tasks reuse the same env root and retain a local directory, avoiding
+// an unbounded cross-volume move when Codex archives a large rollout.
+func prepareCodexArchivedSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions) error {
+	dst := filepath.Join(codexHome, "archived_sessions")
+	if !opts.IsLocalDirectory || opts.SessionStoreKey == "" {
+		return os.MkdirAll(dst, 0o755)
+	}
+	// Do not destroy archives produced by the temporary pre-producer helper in
+	// an already-existing local directory. New task homes have no destination
+	// yet and take the stable link below; a non-empty legacy directory stays
+	// readable in place and can be recovered manually.
+	if fi, err := os.Lstat(dst); err == nil && fi.Mode()&os.ModeSymlink == 0 {
+		entries, readErr := os.ReadDir(dst)
+		if readErr != nil {
+			return readErr
+		}
+		if len(entries) > 0 {
+			return nil
+		}
+	}
+	storeDir := codexArchivedSessionStoreDir(sharedHome, opts.SessionStoreKey)
+	return ensureCodexSessionsLink(dst, storeDir)
+}
+
 // linkCodexSessionsToStore points codex-home/sessions (dst) at the per-issue
 // store (storeDir) via an idempotent directory link — a symlink on Unix, a
 // junction on Windows — both of which cross filesystem volumes without special
@@ -687,6 +738,16 @@ func CodexSessionStorePath(profile string, task TaskContextForEnv) string {
 		return ""
 	}
 	return codexSessionStoreDir(resolveSharedCodexHome(), key)
+}
+
+// CodexArchivedSessionStorePath returns the persistent archived-rollout store
+// for the same conversation key as CodexSessionStorePath.
+func CodexArchivedSessionStorePath(profile string, task TaskContextForEnv) string {
+	key := codexSessionStoreKey(profile, task)
+	if key == "" {
+		return ""
+	}
+	return codexArchivedSessionStoreDir(resolveSharedCodexHome(), key)
 }
 
 // sameCodexPath reports whether two filesystem paths refer to the same location,
@@ -784,6 +845,17 @@ func CodexResumeRolloutPresent(codexHome, sessionID string) bool {
 		return false
 	}
 	return len(findCodexRollouts(filepath.Join(codexHome, "sessions"), sessionID)) > 0
+}
+
+// CodexArchivedRolloutPresent reports whether thread/archive moved the target
+// rollout into this task's archived_sessions view. The daemon uses it to keep a
+// persisted resume pointer eligible long enough to call official
+// thread/unarchive before the next thread/resume.
+func CodexArchivedRolloutPresent(codexHome, sessionID string) bool {
+	if codexHome == "" || sessionID == "" {
+		return false
+	}
+	return len(findCodexRollouts(filepath.Join(codexHome, "archived_sessions"), sessionID)) > 0
 }
 
 // exposeResumeRollout links sessionID's rollout(s) out of the shared sessions

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -689,6 +689,54 @@ func TestPruneCodexSessionStores_RemovesEmptyAgentDir(t *testing.T) {
 	assertAbsent(t, filepath.Join(storeRoot, "agent-lonely"))
 }
 
+func TestPrepareCodexArchivedSessionsPersistsAcrossLocalTaskHomes(t *testing.T) {
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+	key := codexSessionStoreKey("", TaskContextForEnv{AgentID: "agent-1", IssueID: "issue-1"})
+	sessionID := "thr-archived-resume"
+
+	firstHome := filepath.Join(t.TempDir(), "codex-home-a")
+	if err := prepareCodexHomeWithOpts(firstHome, CodexHomeOptions{
+		GOOS:             "linux",
+		IsLocalDirectory: true,
+		SessionStoreKey:  key,
+	}, testLogger()); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := seedRolloutAt(t, filepath.Join(firstHome, "archived_sessions", "rollout-2026-08-25T00-00-00-"+sessionID+".jsonl"), 32)
+	if !CodexArchivedRolloutPresent(firstHome, sessionID) {
+		t.Fatal("first task home cannot see archived rollout")
+	}
+
+	secondHome := filepath.Join(t.TempDir(), "codex-home-b")
+	if err := prepareCodexHomeWithOpts(secondHome, CodexHomeOptions{
+		GOOS:             "linux",
+		IsLocalDirectory: true,
+		SessionStoreKey:  key,
+		ResumeSessionID:  sessionID,
+	}, testLogger()); err != nil {
+		t.Fatal(err)
+	}
+	if !CodexArchivedRolloutPresent(secondHome, sessionID) {
+		t.Fatal("archived rollout did not survive into the next local task home")
+	}
+	wantStore := codexArchivedSessionStoreDir(sharedHome, key)
+	gotTarget, err := filepath.EvalSymlinks(filepath.Join(secondHome, "archived_sessions"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTarget, err := filepath.EvalSymlinks(wantStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameCodexPath(gotTarget, wantTarget) {
+		t.Fatalf("archived_sessions target = %s, want %s", gotTarget, wantTarget)
+	}
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("archive written through first task link was lost: %v", err)
+	}
+}
+
 // chtimesTree sets the atime/mtime of every entry under root to ts.
 func chtimesTree(t *testing.T, root string, ts time.Time) {
 	t.Helper()

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3042,8 +3042,8 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 		t.Fatalf("prepareCodexHome failed: %v", err)
 	}
 
-	// Directory should contain task-local sessions, the model-cache config
-	// binding, and auto-generated config.toml.
+	// Directory should contain task-local active/archived sessions, the
+	// model-cache config binding, and auto-generated config.toml.
 	entries, err := os.ReadDir(codexHome)
 	if err != nil {
 		t.Fatalf("failed to read codex-home: %v", err)
@@ -3055,6 +3055,9 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	if !entryNames["sessions"] {
 		t.Error("expected sessions directory")
 	}
+	if !entryNames["archived_sessions"] {
+		t.Error("expected archived_sessions directory")
+	}
 	if !entryNames["config.toml"] {
 		t.Error("expected config.toml (auto-generated for network access)")
 	}
@@ -3065,7 +3068,7 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 		t.Error("expected models cache config binding")
 	}
 	for name := range entryNames {
-		if name != "sessions" && name != "config.toml" && name != "plugins" && name != codexModelsCacheBindingFile {
+		if name != "sessions" && name != "archived_sessions" && name != "config.toml" && name != "plugins" && name != codexModelsCacheBindingFile {
 			t.Errorf("unexpected entry: %s", name)
 		}
 	}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
@@ -316,8 +317,14 @@ type TaskResult struct {
 	// abandoned as unresumable (GH #6066). Forwarded on every terminal path,
 	// including the completed one: a fresh-session retry that SUCCEEDS is
 	// precisely when the abandoned id would otherwise stay selectable.
-	RetiredSessionID string           `json:"-"`
-	Usage            []TaskUsageEntry `json:"usage,omitempty"` // per-model token usage
+	RetiredSessionID string `json:"-"`
+	// CodexArchiveThread and CodexArchiveThreadIDs are producer-internal
+	// lifecycle metadata. The backend supplies exact task-owned thread IDs;
+	// handleTask invokes the callback only after the server accepted a terminal
+	// complete/fail/cancel persistence boundary. They never cross the task API.
+	CodexArchiveThread    func(context.Context, string) error `json:"-"`
+	CodexArchiveThreadIDs []string                            `json:"-"`
+	Usage                 []TaskUsageEntry                    `json:"usage,omitempty"` // per-model token usage
 }
 
 // PluginHookTool is one agent-trigger plugin hook, as the agent will see it.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -22,6 +22,23 @@ type Backend interface {
 	Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error)
 }
 
+// CodexThreadLifecycle is implemented only by the Codex app-server backend.
+// It gives the daemon a provider-owned way to move a task thread out of the
+// active Desktop list after the task's terminal callback is durable, and to
+// restore an archived rollout before a later task resumes it.
+//
+// The daemon must use ThreadIDs rather than deriving archive targets from a
+// task's resume pointer: Codex may create more than one real thread across its
+// bounded startup/fresh-session retries, while Result.SessionID carries only
+// the final one. Lifecycle RPCs receive the same ExecOptions as Execute so the
+// one-shot app-server uses the exact runtime args and CODEX_HOME that own the
+// thread.
+type CodexThreadLifecycle interface {
+	ArchiveThread(ctx context.Context, threadID string, opts ExecOptions) error
+	UnarchiveThread(ctx context.Context, threadID string, opts ExecOptions) error
+	ThreadIDs() []string
+}
+
 // ExecOptions configures a single execution.
 type ExecOptions struct {
 	Cwd   string

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -258,6 +258,41 @@ func (o *codexFirstItemWaitObservation) snapshot() (time.Duration, string, codex
 // and communicating via JSON-RPC 2.0 over stdin/stdout.
 type codexBackend struct {
 	cfg Config
+
+	threadIDsMu sync.Mutex
+	threadIDs   []string
+}
+
+const maxCodexArchiveTargets = 8
+
+func (b *codexBackend) recordThreadID(threadID string) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return
+	}
+	b.threadIDsMu.Lock()
+	defer b.threadIDsMu.Unlock()
+	for _, existing := range b.threadIDs {
+		if existing == threadID {
+			return
+		}
+	}
+	// A normal task can create at most four roots today (two internal Codex
+	// attempts across the daemon's one fresh-session retry). Keep a defensive
+	// cap so a custom protocol-compatible runtime cannot grow task memory or
+	// post-terminal work without bound.
+	if len(b.threadIDs) < maxCodexArchiveTargets {
+		b.threadIDs = append(b.threadIDs, threadID)
+	}
+}
+
+// ThreadIDs returns every thread this backend positively observed in a
+// successful thread/start or thread/resume response. It never guesses from a
+// prior session id or a state database row.
+func (b *codexBackend) ThreadIDs() []string {
+	b.threadIDsMu.Lock()
+	defer b.threadIDsMu.Unlock()
+	return append([]string(nil), b.threadIDs...)
 }
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
@@ -1440,6 +1475,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			return
 		}
 		c.threadID = threadID
+		b.recordThreadID(threadID)
 		if resumed {
 			b.cfg.Logger.Info("codex thread resumed", "thread_id", threadID)
 		} else {
@@ -2167,6 +2203,10 @@ type codexClient struct {
 	// suppressing an initialize retry after observed activity) without letting
 	// filtered history mutate current-turn output or lifecycle state.
 	onDiscardedNotification func(method string, params map[string]any)
+	// rejectServerRequests makes the one-shot archive/unarchive client
+	// read-only. The execution client intentionally auto-approves tools in
+	// daemon mode; a lifecycle process must never inherit that authority.
+	rejectServerRequests bool
 
 	notificationProtocol string // "unknown", "legacy", "raw"
 	turnStarted          bool
@@ -2287,7 +2327,7 @@ func (e *codexHandshakeTimeoutError) Unwrap() error {
 
 func isCodexHandshakeRPC(method string) bool {
 	switch method {
-	case "initialize", "thread/start", "thread/resume", "thread/name/set", "turn/start":
+	case "initialize", "thread/start", "thread/resume", "thread/name/set", "turn/start", "thread/archive", "thread/unarchive":
 		return true
 	default:
 		return false
@@ -2555,6 +2595,10 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 
 	var method string
 	_ = json.Unmarshal(raw["method"], &method)
+	if c.rejectServerRequests {
+		c.respondError(id, -32601, "server requests are disabled during codex thread lifecycle")
+		return
+	}
 
 	// Auto-approve all exec/patch requests in daemon mode
 	switch method {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -3706,7 +3706,7 @@ func TestCodexExecuteRetriesAfterModelCatalogRefreshFailure(t *testing.T) {
 		`  echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-warm","turn":{"id":"turn-warm","status":"completed"}}}'`+"\n"+
 		`fi`+"\n")
 
-	result, messages := executeFakeCodexCollectingMessages(t, fakePath, ExecOptions{
+	result, messages, backend := executeFakeCodexCollectingMessagesWithBackend(t, fakePath, Config{Logger: slog.Default()}, ExecOptions{
 		Timeout:                   20 * time.Second,
 		SemanticInactivityTimeout: 100 * time.Millisecond,
 	}, 20*time.Second)
@@ -3726,6 +3726,9 @@ func TestCodexExecuteRetriesAfterModelCatalogRefreshFailure(t *testing.T) {
 		if msg.SessionID == "thr-cold" {
 			t.Fatalf("discarded attempt leaked a session pin for thr-cold: %+v", msg)
 		}
+	}
+	if got, want := backend.(CodexThreadLifecycle).ThreadIDs(), []string{"thr-cold", "thr-warm"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("archive targets = %v, want every successful retry-created thread %v", got, want)
 	}
 }
 
@@ -3769,7 +3772,7 @@ func TestCodexExecuteRetryAfterCatalogFailureStartsFreshThreadForResume(t *testi
 		`  echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-fresh","turn":{"id":"turn-fresh","status":"completed"}}}'`+"\n"+
 		`fi`+"\n")
 
-	result, _ := executeFakeCodexCollectingMessages(t, fakePath, ExecOptions{
+	result, _, backend := executeFakeCodexCollectingMessagesWithBackend(t, fakePath, Config{Logger: slog.Default()}, ExecOptions{
 		ResumeSessionID: "thr-prior",
 		ResumeExpected:  true,
 		// Supplied by the daemon since MUL-5722: this package no longer holds
@@ -3785,6 +3788,9 @@ func TestCodexExecuteRetryAfterCatalogFailureStartsFreshThreadForResume(t *testi
 	}
 	if result.SessionID != "thr-fresh" {
 		t.Fatalf("expected the retry to land on a fresh thread, got %q", result.SessionID)
+	}
+	if got, want := backend.(CodexThreadLifecycle).ThreadIDs(), []string{"thr-prior", "thr-fresh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("resume archive targets = %v, want resumed and fresh retry roots %v", got, want)
 	}
 	dir := filepath.Dir(fakePath)
 	first, err := os.ReadFile(filepath.Join(dir, "rpc-1.log"))
@@ -4025,6 +4031,12 @@ func executeFakeCodexCollectingMessages(t *testing.T, fakePath string, opts Exec
 
 func executeFakeCodexCollectingMessagesWithConfig(t *testing.T, fakePath string, cfg Config, opts ExecOptions, budget time.Duration) (Result, []Message) {
 	t.Helper()
+	result, messages, _ := executeFakeCodexCollectingMessagesWithBackend(t, fakePath, cfg, opts, budget)
+	return result, messages
+}
+
+func executeFakeCodexCollectingMessagesWithBackend(t *testing.T, fakePath string, cfg Config, opts ExecOptions, budget time.Duration) (Result, []Message, Backend) {
+	t.Helper()
 	cfg.ExecutablePath = fakePath
 	backend, err := New("codex", cfg)
 	if err != nil {
@@ -4055,10 +4067,10 @@ func executeFakeCodexCollectingMessagesWithConfig(t *testing.T, fakePath string,
 		mu.Lock()
 		collected := append([]Message(nil), messages...)
 		mu.Unlock()
-		return result, collected
+		return result, collected, backend
 	case <-time.After(budget):
 		t.Fatal("timeout waiting for result")
-		return Result{}, nil
+		return Result{}, nil, backend
 	}
 }
 

--- a/server/pkg/agent/codex_thread_lifecycle.go
+++ b/server/pkg/agent/codex_thread_lifecycle.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	codexThreadLifecycleTimeout = 15 * time.Second
+	codexLifecycleCleanupGrace  = 3 * time.Second
+)
+
+func (b *codexBackend) ArchiveThread(ctx context.Context, threadID string, opts ExecOptions) error {
+	return b.runThreadLifecycleRPC(ctx, "thread/archive", threadID, opts)
+}
+
+func (b *codexBackend) UnarchiveThread(ctx context.Context, threadID string, opts ExecOptions) error {
+	return b.runThreadLifecycleRPC(ctx, "thread/unarchive", threadID, opts)
+}
+
+// runThreadLifecycleRPC starts a bounded, archive-only app-server. The task's
+// execution app-server is deliberately gone before the daemon persists the
+// terminal result, so reusing it would invert the required ordering. This
+// one-shot process reuses the exact runtime command, launch prefix, effective
+// args, environment and CODEX_HOME, but never starts a turn or handles a tool.
+func (b *codexBackend) runThreadLifecycleRPC(parent context.Context, method, threadID string, opts ExecOptions) error {
+	if method != "thread/archive" && method != "thread/unarchive" {
+		return fmt.Errorf("unsupported codex thread lifecycle method")
+	}
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return fmt.Errorf("codex thread lifecycle requires a thread id")
+	}
+
+	ctx, cancel := context.WithTimeout(parent, codexThreadLifecycleTimeout)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return codexThreadLifecycleError(method, err)
+	}
+
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "codex"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return fmt.Errorf("codex thread lifecycle executable unavailable")
+	}
+
+	codexHome := strings.TrimSpace(b.cfg.Env["CODEX_HOME"])
+	if codexHome != "" {
+		if err := ensureCodexMcpConfig(filepath.Join(codexHome, "config.toml"), opts.McpConfig, b.cfg.Logger); err != nil {
+			return fmt.Errorf("codex thread lifecycle config unavailable")
+		}
+	} else if hasManagedCodexMcpConfig(opts.McpConfig) {
+		return fmt.Errorf("codex thread lifecycle CODEX_HOME unavailable")
+	}
+
+	runtimeCmd := b.cfg.commandAt(execPath)
+	if codexHome != "" {
+		opts.ExtraArgs = filterCodexShellEnvConfigOverrides(opts.ExtraArgs, b.cfg.Logger)
+		opts.CustomArgs = filterCodexShellEnvConfigOverrides(opts.CustomArgs, b.cfg.Logger)
+		runtimeCmd = runtimeCmd.withFilteredPrefix(func(prefix []string) []string {
+			return filterCodexShellEnvConfigOverrides(prefix, b.cfg.Logger)
+		})
+	}
+	if hasManagedCodexMcpConfig(opts.McpConfig) {
+		runtimeCmd = runtimeCmd.withFilteredPrefix(func(prefix []string) []string {
+			return filterCodexCustomConfigOverrides(prefix, b.cfg.Logger)
+		})
+	}
+	if opts.ServiceTier == codexFastServiceTier {
+		runtimeCmd = runtimeCmd.withFilteredPrefix(func(prefix []string) []string {
+			return stripCodexFastModeConflicts(prefix, b.cfg.Logger)
+		})
+	}
+
+	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
+	cmd := runtimeCmd.exec(ctx, codexArgs...)
+	hideAgentWindow(cmd)
+	cmd.WaitDelay = codexLifecycleCleanupGrace
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+	b.cfg.logAgentCommand(cmd, newAgentCommandLogArgs(codexArgs, trustAgentCommandPositional(0, "app-server")))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("codex thread lifecycle stdout unavailable")
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("codex thread lifecycle stdin unavailable")
+	}
+	// Archive failures are operational metadata, not provider diagnostics.
+	// Discard stderr so credentials or config values echoed by a custom runtime
+	// can never cross into the daemon's structured warning.
+	cmd.Stderr = io.Discard
+
+	if err := startOwnedProcessTree(cmd, b.cfg.Logger); err != nil {
+		return fmt.Errorf("codex thread lifecycle process start failed")
+	}
+
+	client := &codexClient{
+		cfg:                  b.cfg,
+		stdin:                stdin,
+		pending:              make(map[int]*pendingRPC),
+		processDone:          make(chan struct{}),
+		handshakeTimeout:     codexThreadLifecycleTimeout,
+		pid:                  cmd.Process.Pid,
+		rejectServerRequests: true,
+	}
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := newAgentStreamScanner(stdout)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line != "" {
+				client.handleLine(line)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			client.markProcessExited(fmt.Errorf("%w: stream read failed", errCodexProcessExited))
+			return
+		}
+		client.markProcessExited(errCodexProcessExited)
+	}()
+
+	// Exactly one Wait owns the process. Cleanup first gives stdin EOF a short
+	// graceful chance, then cancels/kills the whole process group and waits
+	// within a fixed post-RPC grace. The lifecycle RPC's 15 s deadline plus this
+	// grace stays below the daemon's 30 s task-drain window.
+	defer func() {
+		_ = stdin.Close()
+		graceTimer := time.NewTimer(codexLifecycleCleanupGrace / 3)
+		select {
+		case <-readerDone:
+			if !graceTimer.Stop() {
+				select {
+				case <-graceTimer.C:
+				default:
+				}
+			}
+		case <-graceTimer.C:
+			cancel()
+			signalProcessGroup(cmd, syscall.SIGKILL)
+		}
+
+		waitDone := make(chan struct{})
+		go func() {
+			_ = cmd.Wait()
+			close(waitDone)
+		}()
+		waitTimer := time.NewTimer(codexLifecycleCleanupGrace)
+		select {
+		case <-waitDone:
+			if !waitTimer.Stop() {
+				select {
+				case <-waitTimer.C:
+				default:
+				}
+			}
+		case <-waitTimer.C:
+			cancel()
+			signalProcessGroup(cmd, syscall.SIGKILL)
+			<-waitDone
+		}
+		releaseProcessGroup(cmd)
+	}()
+
+	if _, err := client.request(ctx, "initialize", map[string]any{
+		"clientInfo": map[string]any{
+			"name":    "multica-agent-sdk",
+			"title":   "Multica Agent SDK",
+			"version": "0.2.0",
+		},
+		"capabilities": map[string]any{"experimentalApi": true},
+	}); err != nil {
+		return codexThreadLifecycleError("initialize", err)
+	}
+	client.notify("initialized")
+	if _, err := client.request(ctx, method, map[string]any{"threadId": threadID}); err != nil {
+		return codexThreadLifecycleError(method, err)
+	}
+	return nil
+}
+
+func codexThreadLifecycleError(phase string, err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		return fmt.Errorf("codex thread lifecycle %s timed out", phase)
+	case errors.Is(err, errCodexProcessExited):
+		return fmt.Errorf("codex thread lifecycle %s process exited", phase)
+	default:
+		// Do not include raw JSON-RPC/provider text. It can be emitted by a
+		// custom runtime and may contain auth or configuration material.
+		return fmt.Errorf("codex thread lifecycle %s rejected", phase)
+	}
+}

--- a/server/pkg/agent/codex_thread_lifecycle_test.go
+++ b/server/pkg/agent/codex_thread_lifecycle_test.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCodexThreadLifecycleRPCUsesOfficialShapeAndRuntimeIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requestLog := filepath.Join(t.TempDir(), "requests.jsonl")
+	identityLog := filepath.Join(t.TempDir(), "identity.txt")
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`printf '%s\n' "$CODEX_HOME" > "$LIFECYCLE_IDENTITY_LOG"`+"\n"+
+		`printf '%s\n' "$@" >> "$LIFECYCLE_IDENTITY_LOG"`+"\n"+
+		`IFS= read -r line; printf '%s\n' "$line" >> "$LIFECYCLE_REQUEST_LOG"`+"\n"+
+		`printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`IFS= read -r line; printf '%s\n' "$line" >> "$LIFECYCLE_REQUEST_LOG"`+"\n"+
+		`IFS= read -r line; printf '%s\n' "$line" >> "$LIFECYCLE_REQUEST_LOG"`+"\n"+
+		`printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'`+"\n")
+
+	backendAny, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		LaunchPrefix:   []string{"profile-prefix"},
+		Env: map[string]string{
+			"CODEX_HOME":             home,
+			"LIFECYCLE_REQUEST_LOG":  requestLog,
+			"LIFECYCLE_IDENTITY_LOG": identityLog,
+		},
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, ok := backendAny.(CodexThreadLifecycle)
+	if !ok {
+		t.Fatal("codex backend does not implement CodexThreadLifecycle")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := lifecycle.ArchiveThread(ctx, "thr-owned", ExecOptions{Cwd: t.TempDir()}); err != nil {
+		t.Fatalf("ArchiveThread: %v", err)
+	}
+	if err := lifecycle.UnarchiveThread(ctx, "thr-owned", ExecOptions{Cwd: t.TempDir()}); err != nil {
+		t.Fatalf("UnarchiveThread: %v", err)
+	}
+
+	raw, err := os.ReadFile(requestLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 6 {
+		t.Fatalf("request lines = %d, want archive and unarchive handshakes: %q", len(lines), raw)
+	}
+	var initialize, initialized, archive struct {
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &initialize); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &initialized); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(lines[2]), &archive); err != nil {
+		t.Fatal(err)
+	}
+	if initialize.Method != "initialize" || initialized.Method != "initialized" || archive.Method != "thread/archive" {
+		t.Fatalf("method sequence = %q, %q, %q", initialize.Method, initialized.Method, archive.Method)
+	}
+	if got := archive.Params["threadId"]; got != "thr-owned" {
+		t.Fatalf("thread/archive threadId = %v, want thr-owned", got)
+	}
+	var unarchive struct {
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(lines[5]), &unarchive); err != nil {
+		t.Fatal(err)
+	}
+	if unarchive.Method != "thread/unarchive" || unarchive.Params["threadId"] != "thr-owned" {
+		t.Fatalf("thread/unarchive request = %+v", unarchive)
+	}
+
+	identity, err := os.ReadFile(identityLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identityLines := strings.Split(strings.TrimSpace(string(identity)), "\n")
+	if len(identityLines) < 2 || identityLines[0] != home || identityLines[1] != "profile-prefix" {
+		t.Fatalf("lifecycle runtime identity = %q, want CODEX_HOME then launch prefix", identity)
+	}
+}
+
+func TestCodexThreadIDsDeduplicatesAndCapsTargets(t *testing.T) {
+	b := &codexBackend{}
+	b.recordThreadID("thr-a")
+	b.recordThreadID("thr-a")
+	for i := 0; i < maxCodexArchiveTargets+3; i++ {
+		b.recordThreadID(string(rune('b' + i)))
+	}
+	ids := b.ThreadIDs()
+	if len(ids) != maxCodexArchiveTargets {
+		t.Fatalf("ThreadIDs len = %d, want cap %d: %v", len(ids), maxCodexArchiveTargets, ids)
+	}
+	if ids[0] != "thr-a" {
+		t.Fatalf("first thread id = %q, want deduplicated thr-a", ids[0])
+	}
+	ids[0] = "mutated"
+	if b.ThreadIDs()[0] != "thr-a" {
+		t.Fatal("ThreadIDs exposed backend storage")
+	}
+}
+
+func TestCodexThreadLifecycleRPCBoundsAndReapsProcessTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script process-group fixture is POSIX-only")
+	}
+	childPIDFile := filepath.Join(t.TempDir(), "child.pid")
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`sleep 30 & child=$!`+"\n"+
+		`printf '%s\n' "$child" > "$LIFECYCLE_CHILD_PID"`+"\n"+
+		`IFS= read -r line`+"\n"+
+		`wait "$child"`+"\n")
+	backendAny, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"LIFECYCLE_CHILD_PID": childPIDFile},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := backendAny.(CodexThreadLifecycle)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err = lifecycle.ArchiveThread(ctx, "thr-timeout", ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("ArchiveThread error = %v, want bounded timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("lifecycle timeout took %s, want bounded cleanup", elapsed)
+	}
+
+	rawPID, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatalf("fake app-server did not spawn child: %v", readErr)
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(rawPID)))
+	if convErr != nil {
+		t.Fatal(convErr)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		process, _ := os.FindProcess(pid)
+		alive := process != nil && process.Signal(syscall.Signal(0)) == nil
+		if !alive {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("lifecycle descendant pid %d survived process-group cleanup", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestCodexThreadLifecycleRPCDoesNotExposeProviderError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	const secret = "SECRET_PROVIDER_DIAGNOSTIC"
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`IFS= read -r line`+"\n"+
+		`printf '%s\n' '{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"`+secret+`"}}'`+"\n")
+	backendAny, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = backendAny.(CodexThreadLifecycle).ArchiveThread(context.Background(), "thr-secret", ExecOptions{})
+	if err == nil {
+		t.Fatal("ArchiveThread unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("lifecycle error exposed provider text: %v", err)
+	}
+}
+
+func TestCodexThreadLifecycleClientRejectsServerToolRequests(t *testing.T) {
+	stdin := &fakeStdin{}
+	client := &codexClient{
+		cfg:                  Config{Logger: slog.Default()},
+		stdin:                stdin,
+		pending:              make(map[int]*pendingRPC),
+		processDone:          make(chan struct{}),
+		rejectServerRequests: true,
+	}
+	client.handleLine(`{"jsonrpc":"2.0","id":41,"method":"item/commandExecution/requestApproval","params":{}}`)
+	lines := stdin.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("lifecycle approval responses = %d, want one explicit rejection", len(lines))
+	}
+	var response struct {
+		ID    int `json:"id"`
+		Error struct {
+			Code int `json:"code"`
+		} `json:"error"`
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.ID != 41 || response.Error.Code != -32601 || response.Result != nil {
+		t.Fatalf("lifecycle server request response = %s, want JSON-RPC rejection", lines[0])
+	}
+}


### PR DESCRIPTION
## Summary

- capture every task-owned Codex thread returned by successful start/resume attempts and archive them only after `/complete`, `/fail`, or `/cancel-ack` is durable
- run official `initialize` → `initialized` → `thread/archive` / `thread/unarchive` RPCs in a bounded one-shot app-server with the exact task runtime identity; archive failures are structured-log-only and never overwrite the task result
- preserve resume continuity with a per-conversation archived rollout store and serialize same-conversation run/persist/archive transitions to close the successor wake race

## Verification

- `go test ./pkg/agent -run '^TestCodex' -count=1`
- `env -u MULTICA_TASK_CONFIG_ROOT -u OPENCLAW_STATE_DIR -u CODEX_HOME go test ./internal/daemon/execenv ./internal/daemon -count=1`
- real Codex CLI 0.149.0 copied-rollout canary across two fresh `CODEX_HOME`s: archive moved the rollout and wrote `archived=1`; unarchive from the second home moved it back and wrote `archived=0`
- `git diff --check`

Package-wide `./pkg/agent` runs on this host also hit existing 5-second initialization flakes in unrelated Kiro/Qwen/Qoder/Traecli/Kimi tests; the exact failed cases all passed when rerun in isolation.

## Rollout

- run the acceptance canary through a deployed Multica task and verify its exact task-owned row in that task's `state_5.sqlite`, plus the independently persisted issue status/comment
- remove the external `archive-current-thread.js` prompt instruction as a required path after deployment; retain the helper only for manual recovery

Closes WS-2018.
