### PR TITLE
MUL-6681 fix(autopilots): show and keep Project for run_only autopilots

### DIFF
--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -898,28 +898,30 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
                   {t(($) => $.execution_mode[autopilot.execution_mode as AutopilotExecutionMode])}
                 </div>
               </div>
-              {autopilot.execution_mode === "create_issue" && (
-                <div>
-                  <label className="text-caption text-muted-foreground">{t(($) => $.detail.field_project)}</label>
-                  <div className="mt-1 min-w-0">
-                    {!autopilot.project_id ? (
-                      <span className="text-muted-foreground">{t(($) => $.detail.no_project)}</span>
-                    ) : projectLoading ? (
-                      <Skeleton className="h-5 w-32" />
-                    ) : project ? (
-                      <AppLink
-                        href={wsPaths.projectDetail(project.id)}
-                        className="inline-flex max-w-full items-center gap-1.5 text-foreground hover:underline"
-                      >
-                        <ProjectIcon project={project} size="md" />
-                        <span className="truncate">{project.title}</span>
-                      </AppLink>
-                    ) : (
-                      <span className="text-muted-foreground">{t(($) => $.detail.project_unavailable)}</span>
-                    )}
-                  </div>
+              {/* Shown for BOTH output modes (MUL-6681): a run_only autopilot's
+                  project decides its execution environment (repository /
+                  local_directory, and therefore worktree isolation), so an
+                  operator debugging a run needs to see it here. */}
+              <div>
+                <label className="text-caption text-muted-foreground">{t(($) => $.detail.field_project)}</label>
+                <div className="mt-1 min-w-0">
+                  {!autopilot.project_id ? (
+                    <span className="text-muted-foreground">{t(($) => $.detail.no_project)}</span>
+                  ) : projectLoading ? (
+                    <Skeleton className="h-5 w-32" />
+                  ) : project ? (
+                    <AppLink
+                      href={wsPaths.projectDetail(project.id)}
+                      className="inline-flex max-w-full items-center gap-1.5 text-foreground hover:underline"
+                    >
+                      <ProjectIcon project={project} size="md" />
+                      <span className="truncate">{project.title}</span>
+                    </AppLink>
+                  ) : (
+                    <span className="text-muted-foreground">{t(($) => $.detail.project_unavailable)}</span>
+                  )}
                 </div>
-              )}
+              </div>
               {autopilot.execution_mode === "create_issue" && (
                 <div className="col-span-2">
                   <label className="text-caption text-muted-foreground">

--- a/packages/views/autopilots/components/autopilot-dialog.project.test.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.project.test.tsx
@@ -1,0 +1,238 @@
+import { useImperativeHandle, useRef, useState } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AutopilotExecutionMode } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+
+// Regression cover for MUL-6681 (GH #7550): the dialog rendered the Project
+// section only for create_issue autopilots and sent `project_id: null` for
+// run_only ones. A run_only autopilot could therefore never be bound to a
+// project from the UI, and editing anything else on one — a title, a cron —
+// silently cleared a binding made via the CLI. That binding is not cosmetic:
+// it is the only project context a run_only task has, so losing it drops the
+// run out of its project's worktree and into a bare workdir.
+
+const mockCreateAutopilot = vi.hoisted(() => vi.fn());
+const mockUpdateAutopilot = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-test" }));
+vi.mock("@multica/core/paths", () => ({ useCurrentWorkspace: () => ({ name: "Acme" }) }));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: (wsId: string) => ({
+    queryKey: ["agents", wsId],
+    queryFn: async () => [
+      {
+        id: "agent-1",
+        name: "Scout",
+        description: "Researches things",
+        archived_at: null,
+        runtime_id: "runtime-1",
+      },
+    ],
+  }),
+  squadListOptions: (wsId: string) => ({
+    queryKey: ["squads", wsId],
+    queryFn: async () => [],
+  }),
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: (wsId: string) => ({
+    queryKey: ["projects", wsId],
+    queryFn: async () => [{ id: "proj-1", title: "Fleet", icon: null }],
+  }),
+}));
+
+vi.mock("@multica/core/autopilots/queries", () => ({
+  cronPreviewOptions: (wsId: string, expr: string, tz: string) => ({
+    queryKey: ["cron-preview", wsId, expr, tz],
+    queryFn: async () => ({ next_runs: ["2126-07-14T01:00:00Z"] }),
+    retry: false,
+  }),
+}));
+
+vi.mock("@multica/core/autopilots/mutations", () => ({
+  useCreateAutopilot: () => ({ mutateAsync: mockCreateAutopilot }),
+  useCreateAutopilotTrigger: () => ({ mutateAsync: vi.fn().mockResolvedValue({ id: "trg-new" }) }),
+  useUpdateAutopilot: () => ({ mutateAsync: mockUpdateAutopilot }),
+  useUpdateAutopilotTrigger: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("../../editor", () => ({
+  TitleEditor: ({ ref, defaultValue, placeholder, onChange, onSubmit }: any) => {
+    const [value, setValue] = useState(defaultValue ?? "");
+    const inputRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => ({
+      getText: () => value,
+      focus: () => inputRef.current?.focus(),
+      focusAtCoords: () => inputRef.current?.focus(),
+    }));
+    return (
+      <input
+        ref={inputRef}
+        aria-label="title"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange?.(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onSubmit?.();
+        }}
+      />
+    );
+  },
+  ContentEditor: ({ placeholder }: any) => <textarea aria-label="runbook" placeholder={placeholder} />,
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: ({ actorId }: { actorId: string }) => <span data-testid="actor-avatar">{actorId}</span>,
+}));
+
+vi.mock("./subscriber-multi-select", () => ({
+  SubscriberMultiSelect: () => <div data-testid="subscriber-multi-select" />,
+}));
+
+// Stand-in picker: renders the dialog's own trigger (so the selected project
+// title is asserted against the real markup) plus a button that reports a
+// selection, which is how the create-mode test binds a project.
+vi.mock("../../projects/components/project-picker", () => ({
+  ProjectPicker: ({
+    triggerRender,
+    onUpdate,
+  }: {
+    triggerRender: React.ReactElement;
+    onUpdate: (updates: { project_id: string | null }) => void;
+  }) => (
+    <div>
+      {triggerRender}
+      <button type="button" onClick={() => onUpdate({ project_id: "proj-1" })}>
+        pick Fleet
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("./pickers/timezone-picker", () => ({
+  TimezonePicker: ({ value }: { value: string }) => <div data-testid="timezone-picker">{value}</div>,
+}));
+
+import { AutopilotDialog } from "./autopilot-dialog";
+
+const AUTOPILOT_ID = "ap-1";
+
+function renderEditDialog(mode: AutopilotExecutionMode, projectId: string | null) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderWithI18n(
+    <QueryClientProvider client={qc}>
+      <AutopilotDialog
+        mode="edit"
+        open
+        onOpenChange={vi.fn()}
+        autopilotId={AUTOPILOT_ID}
+        initial={{
+          title: "Push fleet repo to GitHub",
+          description: "",
+          project_id: projectId,
+          assignee_type: "agent",
+          assignee_id: "agent-1",
+          execution_mode: mode,
+          subscriber_user_ids: [],
+        }}
+        triggers={[]}
+        collaborators={[]}
+        canManageAccess={false}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function renderCreateDialog() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderWithI18n(
+    <QueryClientProvider client={qc}>
+      <AutopilotDialog
+        mode="create"
+        open
+        onOpenChange={vi.fn()}
+        initial={{
+          assignee_type: "agent",
+          assignee_id: "agent-1",
+          execution_mode: "run_only",
+        }}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+const saveButton = () => screen.getByRole("button", { name: "Save" });
+
+describe("AutopilotDialog project section", () => {
+  beforeEach(() => {
+    mockCreateAutopilot.mockReset().mockResolvedValue({ id: AUTOPILOT_ID });
+    mockUpdateAutopilot.mockReset().mockResolvedValue({ id: AUTOPILOT_ID });
+  });
+
+  it("offers the project picker to a run_only autopilot", async () => {
+    renderEditDialog("run_only", "proj-1");
+
+    expect(screen.getByText("Project")).toBeInTheDocument();
+    // The bound project reads back instead of the empty-state label.
+    expect(await screen.findByText("Fleet")).toBeInTheDocument();
+    expect(screen.queryByText("No project")).not.toBeInTheDocument();
+  });
+
+  it("says the project also decides where runs execute", () => {
+    renderEditDialog("run_only", null);
+
+    expect(
+      screen.getByText("Also sets where runs execute — the project's repository or local directory"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a run_only autopilot's project on save instead of clearing it", async () => {
+    const user = userEvent.setup();
+    renderEditDialog("run_only", "proj-1");
+
+    await user.type(screen.getByLabelText("title"), " v2");
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockUpdateAutopilot).toHaveBeenCalledTimes(1));
+    expect(mockUpdateAutopilot.mock.calls[0]?.[0]).toMatchObject({
+      id: AUTOPILOT_ID,
+      execution_mode: "run_only",
+      project_id: "proj-1",
+    });
+  });
+
+  it("keeps a create_issue autopilot's project on save", async () => {
+    const user = userEvent.setup();
+    renderEditDialog("create_issue", "proj-1");
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockUpdateAutopilot).toHaveBeenCalledTimes(1));
+    expect(mockUpdateAutopilot.mock.calls[0]?.[0]).toMatchObject({ project_id: "proj-1" });
+  });
+
+  it("binds a project chosen while creating a run_only autopilot", async () => {
+    const user = userEvent.setup();
+    renderCreateDialog();
+
+    await user.type(screen.getByLabelText("title"), "Push fleet repo to GitHub");
+    await user.click(screen.getByRole("button", { name: "pick Fleet" }));
+    await user.click(screen.getByRole("button", { name: "Create autopilot" }));
+
+    await waitFor(() => expect(mockCreateAutopilot).toHaveBeenCalledTimes(1));
+    expect(mockCreateAutopilot.mock.calls[0]?.[0]).toMatchObject({
+      execution_mode: "run_only",
+      project_id: "proj-1",
+    });
+  });
+});

--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -315,7 +315,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
         const autopilot = await createAutopilot.mutateAsync({
           title: title.trim(),
           description: description.trim() || undefined,
-          project_id: executionMode === "create_issue" ? projectId : null,
+          project_id: projectId,
           assignee_type: assigneeType,
           assignee_id: assigneeId,
           execution_mode: executionMode,
@@ -368,7 +368,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
           id: props.autopilotId,
           title: title.trim(),
           description: description.trim() || null,
-          project_id: executionMode === "create_issue" ? projectId : null,
+          project_id: projectId,
           assignee_type: assigneeType,
           assignee_id: assigneeId,
           execution_mode: executionMode,
@@ -621,13 +621,19 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
 
             <OutputModeSection mode={executionMode} onChange={setExecutionMode} />
 
-            {executionMode === "create_issue" && (
-              <ProjectSection
-                projectId={projectId}
-                selectedProject={selectedProject}
-                onChange={setProjectId}
-              />
-            )}
+            {/* Shown for BOTH output modes (MUL-6681). The project is not only
+                issue routing: for a run_only autopilot it is the ONLY source of
+                project context the daemon has (there is no issue to inherit it
+                from), so it decides whether the run gets the project's
+                repository / local_directory — and with it worktree isolation —
+                or a bare workdir. Hiding it here left run_only autopilots with
+                no way to bind one, and the save below used to send null for
+                run_only, silently clearing a binding made via the CLI. */}
+            <ProjectSection
+              projectId={projectId}
+              selectedProject={selectedProject}
+              onChange={setProjectId}
+            />
 
             {executionMode === "create_issue" && (
               <SubscribersSection
@@ -902,6 +908,9 @@ function ProjectSection({
   return (
     <div>
       <SectionLabel>{t(($) => $.dialog.section_project)}</SectionLabel>
+      <p className="mb-2 text-micro text-muted-foreground">
+        {t(($) => $.dialog.project_hint)}
+      </p>
       <ProjectPicker
         projectId={projectId}
         onUpdate={(updates) => onChange(updates.project_id ?? null)}

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -285,6 +285,7 @@
     "select_agent": "Select agent",
     "select_assignee": "Select agent or squad",
     "section_project": "Project",
+    "project_hint": "Also sets where runs execute — the project's repository or local directory",
     "no_project": "No project",
     "section_output_mode": "Output mode",
     "section_subscribers": "Subscribers",

--- a/packages/views/locales/ja/autopilots.json
+++ b/packages/views/locales/ja/autopilots.json
@@ -285,6 +285,7 @@
     "select_agent": "エージェントを選択",
     "select_assignee": "エージェントまたはスクワッドを選択",
     "section_project": "プロジェクト",
+    "project_hint": "実行環境も決まります — このプロジェクトのリポジトリまたはローカルディレクトリ",
     "no_project": "プロジェクトなし",
     "section_subscribers": "購読者",
     "subscribers_hint": "このオートパイロットが作成するすべてのタスクを自動で購読します",

--- a/packages/views/locales/ko/autopilots.json
+++ b/packages/views/locales/ko/autopilots.json
@@ -285,6 +285,7 @@
     "select_agent": "에이전트 선택",
     "select_assignee": "에이전트 또는 스쿼드 선택",
     "section_project": "프로젝트",
+    "project_hint": "실행 환경도 결정합니다 — 해당 프로젝트의 저장소 또는 로컬 디렉터리",
     "no_project": "프로젝트 없음",
     "section_subscribers": "구독자",
     "subscribers_hint": "이 오토파일럿이 만드는 모든 태스크를 자동으로 구독합니다",

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -285,6 +285,7 @@
     "select_agent": "选择智能体",
     "select_assignee": "选择智能体或小队",
     "section_project": "关联项目",
+    "project_hint": "同时决定运行时的执行环境 —— 该项目的仓库或本地目录",
     "no_project": "不关联项目",
     "section_output_mode": "输出模式",
     "section_subscribers": "订阅者",


### PR DESCRIPTION
Fixes #7550.

## What's wrong

The autopilot dialog rendered the **Project** section only for `create_issue` autopilots, and sent `project_id: null` for `run_only` ones on **both create and update**. Two consequences:

1. A `run_only` autopilot can never be bound to a project from the web UI — there is no control to do it.
2. Worse, and not in the original report: because the PATCH handler treats a present `project_id: null` as "clear it" (`server/internal/handler/autopilot.go:893`), editing *anything else* on a `run_only` autopilot — its title, its cron — silently wiped a binding made via the CLI. The detail page also hid the field, so nothing on either surface showed what had happened.

The binding is not issue routing alone. A `run_only` task has no issue to inherit project context from, so the daemon hydrates it from `autopilot.project_id` (`server/internal/handler/daemon.go:2832`). Unbound, the run does not get the project's repository or `local_directory`, and therefore no worktree isolation: instead of a git worktree that is removed when the run ends, it gets a bare workdir reclaimed only on the next GC sweep — 2h by default (`server/internal/daemon/config.go:69`). That is the directory accumulation the reporter measured.

## What this changes

- Render the Project section in the dialog for both output modes, and persist whatever is selected instead of nulling it by mode.
- Show the Project field on the detail page for both modes, so an operator debugging a run can see the binding.
- Add a hint under the field stating that it also selects where runs execute (the project's repository or local directory), translated for all four locales — the reporter's point that the field reads as issue-only is fair.

Subscribers stay `create_issue`-only: they genuinely only affect issues the autopilot creates.

No API or schema change — the backend already stored and used `project_id` for `run_only`; only the UI disagreed.

## Verification

New `packages/views/autopilots/components/autopilot-dialog.project.test.tsx` covers the picker being offered to a `run_only` autopilot, the hint, project preservation on save in both modes, and binding a project while creating a `run_only` autopilot. Four of its five cases fail against `main` and pass with this change; the fifth (`create_issue` preservation) passes both ways and is there as a guard against fixing this by breaking the other mode.

- `pnpm -C packages/views vitest run` — 399 files, 4763 tests, all pass (includes the locale parity test for the new key)
- `turbo typecheck --filter=@multica/views --filter=@multica/web` — clean
- `turbo lint --filter=@multica/views` — 0 errors, no new warnings
