### PR TITLE
MUL-6688: fix(autopilot): bound dispatch mutex with lease + sweeper, DB-enforce mutual exclusion (ALL-211 P0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -650,3 +650,19 @@ POSTHOG_HOST=https://us.i.posthog.com
 ANALYTICS_ENVIRONMENT=
 # Force the no-op client even when POSTHOG_API_KEY is set (CI / opt-out).
 ANALYTICS_DISABLED=
+
+# ==================== Autopilot dispatch lease & sweeper (ALL-211 P0) ====================
+# Bounded mutual-exclusion lease for autopilot dispatch: an autopilot_run
+# stuck in issue_created/running past this age is treated as stale. The next
+# dispatch slot terminalizes it (failed + reason_code=lease_expired) and is
+# admitted; without this the autopilot could wedge forever. Default 30m.
+# AUTOPILOT_RUN_LEASE_TIMEOUT=30m
+# Cadence of the stale-run sweeper, the defensive second layer that reclaims
+# in-flight runs beyond the hard timeout even when no new slot ever arrives.
+# AUTOPILOT_SWEEPER_INTERVAL=5m
+# Hard age at which the sweeper terminalizes an in-flight run. Keep it a
+# multiple of AUTOPILOT_RUN_LEASE_TIMEOUT (default 4x) so the sweeper only
+# reclaims runs the lease gate already had ample chances to reclaim.
+# AUTOPILOT_SWEEPER_HARD_TIMEOUT=2h
+# Set to "false" to disable the sweeper entirely (lease gate still applies).
+# AUTOPILOT_SWEEPER_ENABLED=true

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -271,6 +271,7 @@ var concurrentIndexCleanups = map[string]string{
 	"428_channel_task_delivery_binding_index":                   "idx_channel_task_delivery_binding",
 	"429_channel_task_delivery_installation_index":              "idx_channel_task_delivery_installation",
 	"430_channel_outbound_message_binding_index":                "idx_channel_outbound_message_binding_route",
+	"433_autopilot_run_inflight_unique_index":                   "uq_autopilot_run_inflight",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/cmd/server/autopilot_lease_gate_test.go
+++ b/server/cmd/server/autopilot_lease_gate_test.go
@@ -417,6 +417,74 @@ func TestStaleRunSweeper_TerminalizesExpiredRuns(t *testing.T) {
 	}
 }
 
+// TestStaleRunSweeper_RespectsDailyScheduleSlotInterval is the ALL-235
+// BLOCKING 2 regression: a daily-schedule autopilot (SlotInterval=24h) has a
+// legitimate in-flight run with a linked agent task. The run is OLDER than
+// the sweeper's flat hard timeout (2h) but well WITHIN its 24h slot interval
+// — exactly the case where the dispatch lease gate would still consider it
+// live (lease = max(base 30m, 24h) = 24h). The sweeper must NOT reclaim it:
+// with the defect, the flat hard timeout terminalized the run (and, via the
+// buggy cancel path, its task) at 2h, contradicting the lease semantics. The
+// per-autopilot deadline max(HardTimeout, SlotInterval) keeps both alive.
+func TestStaleRunSweeper_RespectsDailyScheduleSlotInterval(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	const hardTimeout = 2 * time.Hour
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-235 sweeper daily", agentID, "run_only", "")
+	// Daily cadence: slot interval = 24h, far beyond the flat hard timeout.
+	trigger := createTriggerWithCron(t, ctx, queries, ap, "0 0 * * *")
+
+	// Start a legitimate run with a linked task, then backdate it past the
+	// hard timeout but well inside the slot interval.
+	plannedAt := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	run, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt)
+	if err != nil {
+		t.Fatalf("slot 1 dispatch: %v", err)
+	}
+	if run == nil || run.Status != "running" || !run.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with linked task", run)
+	}
+	backdateRunCreatedAt(t, ctx, run.ID, 3*time.Hour) // > 2h hard timeout, < 24h slot interval
+
+	sweeper := autopilot.NewStaleRunSweeper(testPool, &autopilot.SweeperConfig{
+		Interval:     5 * time.Minute,
+		HardTimeout:  hardTimeout,
+		SlotInterval: autopilotSvc.SlotIntervalForAutopilot,
+		Enabled:      true,
+		Logger:       testLogger(t),
+	})
+	sweeper.SweepOnce(ctx)
+
+	var status, reason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, COALESCE(reason_code, '') FROM autopilot_run WHERE id = $1`, run.ID,
+	).Scan(&status, &reason); err != nil {
+		t.Fatalf("read daily-schedule run after sweep: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("daily-schedule in-flight run = status %q (reason %q), want running; the sweeper must not reclaim a run within its 24h slot interval", status, reason)
+	}
+
+	// The linked task must also still be alive — the run was not treated as
+	// stale, so its work was not cancelled.
+	var taskStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM agent_task_queue WHERE id = $1`, run.TaskID,
+	).Scan(&taskStatus); err != nil {
+		t.Fatalf("read linked task after sweep: %v", err)
+	}
+	if taskStatus == "cancelled" || taskStatus == "failed" {
+		t.Fatalf("daily-schedule linked task = %q after sweep, want still active", taskStatus)
+	}
+
+	assertInFlightCount(t, ctx, ap.ID, 1)
+}
+
 // --- helpers ---------------------------------------------------------------
 
 // createLeaseGateAutopilot seeds an active autopilot for lease-gate tests.

--- a/server/cmd/server/autopilot_lease_gate_test.go
+++ b/server/cmd/server/autopilot_lease_gate_test.go
@@ -1,0 +1,568 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/autopilot"
+	"github.com/multica-ai/multica/server/internal/dispatch"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/dbid"
+)
+
+// TestDispatch_LeaseExpired_AllowsNewDispatch is the ALL-211 BLOCKING 1
+// regression, exercising the exact stuck scenario reported: a create_issue
+// run parked in 'issue_created' whose linked issue sits in a non-terminal
+// status (backlog) — nothing in SyncRunFromIssue / SyncRunFromLinkedIssueTask
+// ever terminalizes it, so under the unbounded ALL-206 gate every later slot
+// was skipped forever. With the lease the expired run is reclaimed (failed +
+// lease_expired) and the new slot is admitted.
+func TestDispatch_LeaseExpired_AllowsNewDispatch(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	const leaseTimeout = 6 * time.Minute // above autopilot.MinLeaseDuration (5m) so the floor clamp does not apply
+	autopilotSvc.SetLeaseTimeout(leaseTimeout)
+
+	agentID := loadFixtureAgentID(t, ctx)
+
+	title := "Autopilot lease expired " + time.Now().UTC().Format("20060102150405.000000000")
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 lease expired", agentID, "create_issue", title)
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Step 1: seed the STALE in-flight run (issue_created, created_at beyond
+	// the lease) and link it to a real issue parked in a NON-terminal status.
+	// This is the exact permanent-stuck precondition from the issue.
+	staleRunID := dbid.NewV7()
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		WITH bumped AS (
+			UPDATE workspace SET issue_counter = issue_counter + 1
+			WHERE id = $1 RETURNING issue_counter
+		)
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number)
+		SELECT $1, $2, 'backlog', 'none', 'member', $3, (SELECT issue_counter FROM bumped)
+		RETURNING id
+	`, testWorkspaceID, "stale linked issue (non-terminal)", testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("seed linked issue: %v", err)
+	}
+	t.Cleanup(func() {
+		// Both issues created by this test live in the shared fixture
+		// workspace, whose uq_issue_workspace_number forbids duplicate
+		// numbers across the whole package run — clean them up so sibling
+		// tests never collide.
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID); err != nil {
+			t.Logf("cleanup seeded issue: %v", err)
+		}
+	})
+	insertStaleInFlightRun(t, ctx, staleRunID, ap.ID, "issue_created", issueID, leaseTimeout)
+
+	// Step 2: the next scheduled slot fires. Its lease-expired predecessor
+	// must be terminalized and the slot must be ADMITTED (not skipped).
+	plannedAt := time.Now().UTC().Truncate(time.Second).Add(-1 * time.Minute)
+	newRun, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt)
+	if err != nil {
+		t.Fatalf("DispatchAutopilotForPlan after lease expiry: %v", err)
+	}
+	if newRun == nil {
+		t.Fatalf("dispatch returned nil run")
+	}
+	if newRun.Status != "issue_created" {
+		t.Fatalf("new run status = %q, want issue_created", newRun.Status)
+	}
+	if !newRun.IssueID.Valid {
+		t.Fatalf("new run must be linked to a freshly created issue, got issue_id invalid")
+	}
+	// The dispatched issue also persists in the shared fixture workspace.
+	newRunIssueID := util.UUIDToString(newRun.IssueID)
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, newRunIssueID); err != nil {
+			t.Logf("cleanup dispatched issue: %v", err)
+		}
+	})
+
+	// Step 3: the stale run must have been terminalized as failed with
+	// reason_code=lease_expired — and NOT merely orphaned.
+	var staleStatus, staleReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, staleRunID,
+	).Scan(&staleStatus, &staleReason); err != nil {
+		t.Fatalf("read stale run after dispatch: %v", err)
+	}
+	if staleStatus != "failed" {
+		t.Fatalf("stale run status = %q, want failed", staleStatus)
+	}
+	if staleReason != "lease_expired" {
+		t.Fatalf("stale run reason_code = %q, want lease_expired", staleReason)
+	}
+
+	// Step 4: exactly one in-flight run remains (the new one).
+	assertInFlightCount(t, ctx, ap.ID, 1)
+}
+
+// TestDispatch_Concurrent_OnlyOneSucceeds is the ALL-211 BLOCKING 3
+// regression: even when ten slots race the same autopilot at once (scheduler
+// tick + manual + webhook replicas), the partial unique index
+// uq_autopilot_run_inflight admits exactly one run. Every loser comes back
+// skipped with already_active — either from the lease gate or from the 23505
+// conflict mapped to a skip.
+func TestDispatch_Concurrent_OnlyOneSucceeds(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 concurrent dispatch", agentID, "run_only", "")
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	const n = 10
+	base := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+
+	var wg sync.WaitGroup
+	statuses := make([]string, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			run, err := autopilotSvc.DispatchAutopilotForPlan(
+				ctx, ap, trigger.ID, "schedule", nil, base.Add(time.Duration(i)*30*time.Second),
+			)
+			errs[i] = err
+			if run != nil {
+				statuses[i] = run.Status
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	var successCount, skipCount int
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d returned unexpected error: %v", i, errs[i])
+		}
+		switch statuses[i] {
+		case "running":
+			successCount++
+		case "skipped":
+			skipCount++
+		default:
+			t.Fatalf("goroutine %d returned run status %q, want running or skipped", i, statuses[i])
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("exactly one dispatch must succeed, got %d", successCount)
+	}
+	if skipCount != n-1 {
+		t.Fatalf("exactly %d dispatches must be skipped, got %d", n-1, skipCount)
+	}
+
+	// The DB is the authority: at most one in-flight run exists.
+	assertInFlightCount(t, ctx, ap.ID, 1)
+
+	// And every skipped run carries the already_active reason code, so the
+	// admission vocabulary stays type-safe for clients.
+	var nonAlreadyActive int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM autopilot_run
+		 WHERE autopilot_id = $1 AND status = 'skipped'
+		   AND COALESCE(reason_code, '') <> 'already_active'
+	`, ap.ID).Scan(&nonAlreadyActive); err != nil {
+		t.Fatalf("count skipped runs without already_active: %v", err)
+	}
+	if nonAlreadyActive != 0 {
+		t.Fatalf("%d skipped runs lack reason_code=already_active", nonAlreadyActive)
+	}
+}
+
+// TestDispatch_ManualTrigger_RecoverFromStaleRun is the escape-hatch
+// regression (ALL-211 BLOCKING 1, amplification item B): an owner clicking
+// "run now" on an autopilot whose previous run is stuck in 'running' past
+// the lease MUST be able to self-recover — the manual dispatch reclaims the
+// stale run and starts fresh, instead of returning already_active forever.
+func TestDispatch_ManualTrigger_RecoverFromStaleRun(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	const leaseTimeout = 6 * time.Minute // above autopilot.MinLeaseDuration (5m) so the floor clamp does not apply
+	autopilotSvc.SetLeaseTimeout(leaseTimeout)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 manual recovery", agentID, "run_only", "")
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Seed a stale 'running' run (no task linkage — the crashed/corrupt
+	// shape that leaves the slot wedged) older than the lease.
+	staleRunID := dbid.NewV7()
+	insertStaleInFlightRun(t, ctx, staleRunID, ap.ID, "running", "", leaseTimeout)
+
+	// Manual trigger with a real member actor.
+	manual, code, err := autopilotSvc.DispatchAutopilotManual(ctx, ap, trigger.ID, nil, parseUUID(testUserID))
+	if err != nil {
+		t.Fatalf("DispatchAutopilotManual on expired lease: %v", err)
+	}
+	if manual == nil {
+		t.Fatalf("manual dispatch returned nil run")
+	}
+	if code != "" {
+		t.Fatalf("manual dispatch reason code = %q, want empty (admitted)", code)
+	}
+	if manual.Status != "running" || !manual.TaskID.Valid {
+		t.Fatalf("manual recovery run = status %q, task_id valid %v; want running with task", manual.Status, manual.TaskID.Valid)
+	}
+	if manual.ID == staleRunID {
+		t.Fatalf("manual recovery must create a FRESH run, not reuse the stale one")
+	}
+
+	var staleStatus, staleReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, staleRunID,
+	).Scan(&staleStatus, &staleReason); err != nil {
+		t.Fatalf("read stale run after manual recovery: %v", err)
+	}
+	if staleStatus != "failed" || staleReason != "lease_expired" {
+		t.Fatalf("stale run after manual recovery = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
+	}
+
+	assertInFlightCount(t, ctx, ap.ID, 1)
+}
+
+// TestDispatch_InFlight_BlocksWithinLease keeps the ALL-206 behavior locked
+// in: while the in-flight run is WITHIN its lease, the next slot (and a
+// manual trigger) is still skipped with already_active. This is the bound
+// that must hold so long-running legitimate work is never interrupted.
+func TestDispatch_InFlight_BlocksWithinLease(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	// Default lease (30m) — the fresh run below is well within it.
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 within lease", agentID, "run_only", "")
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil || second.Status != "skipped" {
+		t.Fatalf("slot 2 run status = %v, want skipped (lease not expired)", secondStatus(second))
+	}
+
+	manual, code, err := autopilotSvc.DispatchAutopilotManual(ctx, ap, trigger.ID, nil, parseUUID(testUserID))
+	if err != nil {
+		t.Fatalf("manual dispatch within lease: %v", err)
+	}
+	if code != dispatch.ReasonAlreadyActive {
+		t.Fatalf("manual dispatch within lease reason code = %q, want already_active", code)
+	}
+	if manual == nil || manual.Status != "skipped" {
+		t.Fatalf("manual dispatch within lease = %+v, want skipped run", manual)
+	}
+}
+
+// TestGetInFlightRun_UsesPartialIndex proves the BLOCKING 2 fix at the
+// planner level: the in-flight query predicate now matches the partial
+// indexes (uq_autopilot_run_inflight / idx_autopilot_run_status, both
+// covering exactly ('issue_created','running')) so EXPLAIN shows an Index
+// Scan on one of them. The old pending-widened predicate could not match
+// the partial-index WHERE clause and forced the planner back onto the
+// non-partial idx_autopilot_run_autopilot (or worse, a Seq Scan).
+//
+// The table is seeded with a thousand terminal rows for the target
+// autopilot so the planner prefers the partial in-flight index (which
+// contains none of them) over idx_autopilot_run_autopilot, which would have
+// to scan every one of the thousand rows to confirm no in-flight run exists.
+// enable_seqscan is turned off so the assertion stays deterministic even on
+// a small table where a Seq Scan would otherwise win on cost.
+func TestGetInFlightRun_UsesPartialIndex(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 explain index", agentID, "run_only", "")
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO autopilot_run (id, autopilot_id, source, status, created_at)
+		SELECT gen_random_uuid(), $1, 'schedule', 'completed', now() - (i || ' hours')::interval
+		FROM generate_series(1, 1000) AS i
+	`, ap.ID); err != nil {
+		t.Fatalf("seed explain data: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `ANALYZE autopilot_run`); err != nil {
+		t.Fatalf("analyze autopilot_run: %v", err)
+	}
+
+	conn, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire test connection: %v", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+	defer func() {
+		_, _ = conn.Exec(context.Background(), "RESET enable_seqscan")
+	}()
+
+	var plan string
+	if err := conn.QueryRow(ctx, `
+		EXPLAIN (FORMAT JSON)
+		SELECT id, autopilot_id, status, created_at
+		FROM autopilot_run
+		WHERE autopilot_id = $1
+		  AND status IN ('issue_created', 'running')
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, ap.ID).Scan(&plan); err != nil {
+		t.Fatalf("EXPLAIN in-flight query: %v", err)
+	}
+
+	indexName, nodeType, err := extractExplainIndexScan(plan)
+	if err != nil {
+		t.Fatalf("parse EXPLAIN plan: %v\nplan: %s", err, plan)
+	}
+	if nodeType == "Seq Scan" {
+		t.Fatalf("in-flight query degraded to Seq Scan; the predicate must match a partial index\nplan: %s", plan)
+	}
+	switch indexName {
+	case "uq_autopilot_run_inflight", "idx_autopilot_run_status":
+		// Both partial indexes carry the aligned ('issue_created','running')
+		// predicate; either proves the query matches the partial-index set.
+	default:
+		t.Fatalf("in-flight query used index %q; want uq_autopilot_run_inflight or idx_autopilot_run_status\nplan: %s", indexName, plan)
+	}
+}
+
+// TestStaleRunSweeper_TerminalizesExpiredRuns covers the defensive second
+// layer (ALL-211 BLOCKING 1 requirement 2): the sweeper reclaims in-flight
+// runs older than the hard timeout even when no new dispatch ever arrives,
+// making the failure visible to the failure-rate auto-pause monitor. Runs
+// within the hard timeout are left untouched.
+func TestStaleRunSweeper_TerminalizesExpiredRuns(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+
+	agentID := loadFixtureAgentID(t, ctx)
+
+	// Two autopilots: one with a run past the hard timeout, one with a
+	// fresh run. The sweeper must reclaim only the former.
+	staleAp := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 sweeper stale", agentID, "run_only", "")
+	freshAp := createLeaseGateAutopilot(t, ctx, queries, "ALL-211 sweeper fresh", agentID, "run_only", "")
+
+	const hardTimeout = time.Hour
+	staleRunID := dbid.NewV7()
+	freshRunID := dbid.NewV7()
+	insertRunAtAge(t, ctx, staleRunID, staleAp.ID, "issue_created", hardTimeout+time.Minute)
+	insertRunAtAge(t, ctx, freshRunID, freshAp.ID, "running", time.Minute)
+
+	sweeper := autopilot.NewStaleRunSweeper(testPool, &autopilot.SweeperConfig{
+		Interval:    5 * time.Minute,
+		HardTimeout: hardTimeout,
+		Enabled:     true,
+		Logger:      testLogger(t),
+	})
+	sweeper.SweepOnce(ctx)
+
+	var staleStatus, staleReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, staleRunID,
+	).Scan(&staleStatus, &staleReason); err != nil {
+		t.Fatalf("read swept stale run: %v", err)
+	}
+	if staleStatus != "failed" || staleReason != "lease_expired" {
+		t.Fatalf("swept stale run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
+	}
+
+	var freshStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM autopilot_run WHERE id = $1`, freshRunID,
+	).Scan(&freshStatus); err != nil {
+		t.Fatalf("read fresh run: %v", err)
+	}
+	if freshStatus != "running" {
+		t.Fatalf("fresh run status = %q, want running (untouched)", freshStatus)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// createLeaseGateAutopilot seeds an active autopilot for lease-gate tests.
+// create_issue mode requires a title template; run_only passes "".
+func createLeaseGateAutopilot(t *testing.T, ctx context.Context, queries *db.Queries, title, agentID, mode, issueTitle string) db.Autopilot {
+	t.Helper()
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              title,
+		Description:        pgtype.Text{String: "ALL-211 lease gate test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      mode,
+		IssueTitleTemplate: pgtype.Text{String: issueTitle, Valid: issueTitle != ""},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+			t.Logf("cleanup autopilot: %v", err)
+		}
+	})
+	return ap
+}
+
+func loadFixtureAgentID(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+	return agentID
+}
+
+// insertStaleInFlightRun seeds an in-flight autopilot_run whose created_at
+// is just past the given lease timeout, optionally linked to an issue. The
+// margin is deliberately generous so clock skew between the app process and
+// the DB never flips the lease-expired check the wrong way.
+func insertStaleInFlightRun(t *testing.T, ctx context.Context, runID, autopilotID pgtype.UUID, status, issueID string, leaseTimeout time.Duration) {
+	t.Helper()
+	insertRunAtAge(t, ctx, runID, autopilotID, status, leaseTimeout+5*time.Second)
+	if issueID != "" {
+		if _, err := testPool.Exec(ctx,
+			`UPDATE autopilot_run SET issue_id = $1 WHERE id = $2`, issueID, runID); err != nil {
+			t.Fatalf("link stale run to issue: %v", err)
+		}
+	}
+}
+
+// insertRunAtAge seeds an autopilot_run with a backdated created_at
+// (age = now - age).
+func insertRunAtAge(t *testing.T, ctx context.Context, runID, autopilotID pgtype.UUID, status string, age time.Duration) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO autopilot_run (id, autopilot_id, source, status, created_at)
+		VALUES ($1, $2, 'schedule', $3, now() - $4::interval)
+	`, runID, autopilotID, status, fmt.Sprintf("%d seconds", int(age.Seconds()))); err != nil {
+		t.Fatalf("seed stale in-flight run: %v", err)
+	}
+}
+
+func assertInFlightCount(t *testing.T, ctx context.Context, autopilotID pgtype.UUID, want int) {
+	t.Helper()
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM autopilot_run
+		 WHERE autopilot_id = $1 AND status IN ('issue_created', 'running')
+	`, autopilotID).Scan(&count); err != nil {
+		t.Fatalf("count in-flight runs: %v", err)
+	}
+	if count != want {
+		t.Fatalf("in-flight run count = %d, want %d", count, want)
+	}
+}
+
+func secondStatus(run *db.AutopilotRun) string {
+	if run == nil {
+		return "<nil>"
+	}
+	return run.Status
+}
+
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(testOutputWriter{t}, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+type testOutputWriter struct{ t *testing.T }
+
+func (w testOutputWriter) Write(p []byte) (int, error) {
+	w.t.Log(strings.TrimSpace(string(p)))
+	return len(p), nil
+}
+
+// extractExplainIndexScan walks a FORMAT JSON EXPLAIN plan and returns the
+// index name and node type of the first Index Scan on autopilot_run (or the
+// Seq Scan node type if the planner degraded). The recursive walk finds the
+// node regardless of LIMIT/SORT wrappers.
+func extractExplainIndexScan(plan string) (indexName, nodeType string, err error) {
+	var results []struct {
+		Plan struct {
+			NodeType   string `json:"Node Type"`
+			IndexName  string `json:"Index Name"`
+			Relation   string `json:"Relation Name"`
+			Plans      []struct {
+				NodeType  string `json:"Node Type"`
+				IndexName string `json:"Index Name"`
+				Relation  string `json:"Relation Name"`
+				Plans     []struct {
+					NodeType  string `json:"Node Type"`
+					IndexName string `json:"Index Name"`
+					Relation  string `json:"Relation Name"`
+				} `json:"Plans"`
+			} `json:"Plans"`
+		} `json:"Plan"`
+	}
+	if err := json.Unmarshal([]byte(plan), &results); err != nil {
+		return "", "", err
+	}
+	if len(results) == 0 {
+		return "", "", fmt.Errorf("empty EXPLAIN result")
+	}
+	root := results[0].Plan
+	if isScanNode(root.NodeType, root.Relation) {
+		return root.IndexName, root.NodeType, nil
+	}
+	for _, l1 := range root.Plans {
+		if isScanNode(l1.NodeType, l1.Relation) {
+			return l1.IndexName, l1.NodeType, nil
+		}
+		for _, l2 := range l1.Plans {
+			if isScanNode(l2.NodeType, l2.Relation) {
+				return l2.IndexName, l2.NodeType, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("no scan node found under plan root %q", root.NodeType)
+}
+
+func isScanNode(nodeType, relation string) bool {
+	return (nodeType == "Seq Scan" || nodeType == "Index Scan") && relation == "autopilot_run"
+}

--- a/server/cmd/server/autopilot_mutex_gate_test.go
+++ b/server/cmd/server/autopilot_mutex_gate_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/dispatch"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestAutopilotMutexGateSkipsOverlappingSlot is the ALL-206 regression for the
+// scheduler mutex/lease gate: while an autopilot still has an in-flight run
+// (autopilot_run.status IN ('pending','issue_created','running') — the exact set
+// of the partial index idx_autopilot_run_status from migration 042), the next
+// scheduled slot MUST NOT start a second concurrent run. It is recorded as a
+// `skipped` run with a clear failure_reason instead.
+func TestAutopilotMutexGateSkipsOverlappingSlot(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap := createAutopilotForMutexTest(t, ctx, queries, "ALL-206 mutex in-flight", agentID)
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Slot 1 dispatches normally and leaves a run in flight (running + task).
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil {
+		t.Fatalf("slot 1 returned nil run")
+	}
+	if first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = status %q, task_id valid %v; want running with task", first.Status, first.TaskID.Valid)
+	}
+
+	// Slot 2 is the very next occurrence while slot 1 is still in flight: the
+	// mutex gate must skip it instead of starting a concurrent run.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil {
+		t.Fatalf("slot 2 returned nil run")
+	}
+	if second.Status != "skipped" {
+		t.Fatalf("slot 2 run status = %q, want skipped", second.Status)
+	}
+	if !second.FailureReason.Valid || !strings.Contains(second.FailureReason.String, "previous run still in flight") {
+		t.Fatalf("slot 2 failure_reason = %q, want it to mention the in-flight predecessor", second.FailureReason.String)
+	}
+	if second.TaskID.Valid {
+		t.Fatalf("skipped run must not be linked to a task, got task_id=%s", util.UUIDToString(second.TaskID))
+	}
+
+	// The manual "run now" surface reports the same typed admission code so the
+	// HTTP handler can return it to the clicking member.
+	manualRun, code, err := autopilotSvc.DispatchAutopilotManual(ctx, ap, trigger.ID, nil, parseUUID(testUserID))
+	if err != nil {
+		t.Fatalf("DispatchAutopilotManual while in flight: %v", err)
+	}
+	if code != dispatch.ReasonAlreadyActive {
+		t.Fatalf("manual dispatch reason code = %q, want %q", code, dispatch.ReasonAlreadyActive)
+	}
+	if manualRun == nil || manualRun.Status != "skipped" {
+		t.Fatalf("manual dispatch while in flight = %+v, want skipped run", manualRun)
+	}
+
+	// Never created a concurrent task: slot 1's task is the only one across slot
+	// 1, slot 2 and the manual call.
+	var taskCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		 WHERE autopilot_run_id IN (SELECT id FROM autopilot_run WHERE autopilot_id = $1)
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if taskCount != 1 {
+		t.Fatalf("expected exactly 1 task (slot 1), got %d — an overlapping slot must not dispatch", taskCount)
+	}
+}
+
+// TestAutopilotMutexGateAllowsDispatchAfterTerminal is the counterpart ALL-206
+// regression: once the previous run reaches a terminal state (here completed,
+// the same flip the task listener applies), the next scheduled slot MUST
+// dispatch normally. The mutex gate is per-autopilot, never global.
+func TestAutopilotMutexGateAllowsDispatchAfterTerminal(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap := createAutopilotForMutexTest(t, ctx, queries, "ALL-206 mutex terminal", agentID)
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+
+	// Close out slot 1 the way the task listener (SyncRunFromTask) does: the run
+	// flips to completed once its queued task finishes.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE id = $1`, first.ID); err != nil {
+		t.Fatalf("close slot 1 run: %v", err)
+	}
+
+	// The next occurrence must now dispatch normally — a fresh run and task, not
+	// a mutex skip.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil {
+		t.Fatalf("slot 2 returned nil run")
+	}
+	if second.Status != "running" || !second.TaskID.Valid {
+		t.Fatalf("slot 2 run = status %q, task_id valid %v; want normal running dispatch", second.Status, second.TaskID.Valid)
+	}
+	if second.FailureReason.Valid {
+		t.Fatalf("slot 2 run must not carry a failure_reason, got %q", second.FailureReason.String)
+	}
+
+	// Exactly two tasks — one per dispatched slot: no loss, no duplication.
+	var taskCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		 WHERE autopilot_run_id IN (SELECT id FROM autopilot_run WHERE autopilot_id = $1)
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if taskCount != 2 {
+		t.Fatalf("expected exactly 2 tasks (one per slot), got %d", taskCount)
+	}
+}
+
+// createAutopilotForMutexTest seeds an active run_only autopilot assigned to the
+// fixture agent. Deleting the autopilot cascades to its triggers and runs
+// (migration 042), so a single DELETE is the whole cleanup.
+func createAutopilotForMutexTest(t *testing.T, ctx context.Context, queries *db.Queries, title, agentID string) db.Autopilot {
+	t.Helper()
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              title,
+		Description:        pgtype.Text{String: "ALL-206 mutex gate test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+			t.Logf("cleanup autopilot: %v", err)
+		}
+	})
+	return ap
+}
+
+// createTriggerForMutexTest seeds an enabled schedule trigger on the autopilot.
+func createTriggerForMutexTest(t *testing.T, ctx context.Context, queries *db.Queries, ap db.Autopilot) db.AutopilotTrigger {
+	t.Helper()
+	trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+		AutopilotID:    ap.ID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+	return trigger
+}

--- a/server/cmd/server/autopilot_stale_run_fixes_test.go
+++ b/server/cmd/server/autopilot_stale_run_fixes_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/autopilot"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestDispatch_SlowSchedule_LeaseCoversSlotInterval is the ALL-234 defect 1
+// regression: an autopilot whose schedule fires slower than the base lease
+// (30m) must have its effective in-flight lease extended to the slot
+// interval, so a legitimate long-running run is never reclaimed as stale
+// before the next slot could fire. Without the SlotInterval wiring, the
+// 35-minute-old run below would be past the 30m lease and wrongly
+// terminalized + admitted.
+func TestDispatch_SlowSchedule_LeaseCoversSlotInterval(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	// Base lease stays at the default 30m; only the 2h slot interval can
+	// extend it.
+	autopilotSvc.SetLeaseTimeout(30 * time.Minute)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 slow schedule", agentID, "run_only", "")
+	trigger := createTriggerWithCron(t, ctx, queries, ap, "0 */2 * * *") // 2h cadence
+
+	// Slot 1 starts a legitimate run with a linked agent task.
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 dispatch: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+
+	// Backdate the run past the 30m base lease but keep it well inside the
+	// 2h slot interval. With the defect, the lease would be exactly 30m and
+	// this run would be reclaimed.
+	backdateRunCreatedAt(t, ctx, first.ID, 35*time.Minute)
+
+	// Slot 2 must be skipped (already_active) — the run is still within the
+	// extended lease, so the slot must NOT be admitted.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 dispatch: %v", err)
+	}
+	if second == nil || second.Status != "skipped" {
+		t.Fatalf("slot 2 run status = %v, want skipped (lease must cover the slow schedule)", secondStatus(second))
+	}
+
+	// The in-flight run must NOT have been terminalized.
+	var firstStatus, firstReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, COALESCE(reason_code, '') FROM autopilot_run WHERE id = $1`, first.ID,
+	).Scan(&firstStatus, &firstReason); err != nil {
+		t.Fatalf("read run after slot 2: %v", err)
+	}
+	if firstStatus != "running" {
+		t.Fatalf("slow-schedule in-flight run status = %q (reason %q), want running; lease must cover the slot interval", firstStatus, firstReason)
+	}
+
+	// And its linked task must still be active — the run was not treated as
+	// stale, so its work was not interrupted.
+	var taskStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM agent_task_queue WHERE id = $1`, first.TaskID,
+	).Scan(&taskStatus); err != nil {
+		t.Fatalf("read linked task: %v", err)
+	}
+	if taskStatus == "cancelled" {
+		t.Fatalf("slow-schedule run task was cancelled; the run must not be treated as stale within its slot interval")
+	}
+
+	assertInFlightCount(t, ctx, ap.ID, 1)
+}
+
+// TestDispatch_StaleRun_CancelsLinkedTask is the ALL-234 defect 2 regression
+// on the dispatch-gate path: when the lease expires and the stale run is
+// reclaimed, the agent task linked via autopilot_run.task_id MUST be
+// cancelled in lockstep, so the newly admitted slot never runs concurrently
+// with the stale run's still-executing task. The assertion is the
+// no-orphan-running-task invariant, counted across the autopilot's runs.
+func TestDispatch_StaleRun_CancelsLinkedTask(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	const leaseTimeout = 6 * time.Minute // above autopilot.MinLeaseDuration so the floor clamp does not apply
+	autopilotSvc.SetLeaseTimeout(leaseTimeout)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 cancel linked task", agentID, "run_only", "")
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Slot 1 starts a legitimate run with a linked agent task.
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 dispatch: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+	task1 := first.TaskID
+
+	// Simulate real execution: the task is running, and the run has aged past
+	// its lease without reaching a terminal state.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'running' WHERE id = $1`, task1); err != nil {
+		t.Fatalf("mark task running: %v", err)
+	}
+	backdateRunCreatedAt(t, ctx, first.ID, leaseTimeout+5*time.Second)
+
+	// Slot 2 fires past the lease: the stale run is reclaimed and the slot is
+	// admitted — the concurrent-execution scenario defect 2 exists to close.
+	plannedAt2 := plannedAt1.Add(30 * time.Second)
+	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
+	if err != nil {
+		t.Fatalf("slot 2 dispatch: %v", err)
+	}
+	if second == nil || second.Status != "running" || !second.TaskID.Valid {
+		t.Fatalf("slot 2 run = %+v, want running with task", second)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("slot 2 must create a fresh run, not reuse the stale one")
+	}
+
+	// The stale run is terminalized as failed with reason lease_expired.
+	var staleStatus, staleReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, first.ID,
+	).Scan(&staleStatus, &staleReason); err != nil {
+		t.Fatalf("read stale run: %v", err)
+	}
+	if staleStatus != "failed" || staleReason != "lease_expired" {
+		t.Fatalf("stale run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
+	}
+
+	// The linked agent task must be cancelled — the core no-orphan invariant.
+	var taskStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM agent_task_queue WHERE id = $1`, task1,
+	).Scan(&taskStatus); err != nil {
+		t.Fatalf("read linked task: %v", err)
+	}
+	if taskStatus != "cancelled" {
+		t.Fatalf("linked task status = %q, want cancelled; stale run must not leave an orphan running task", taskStatus)
+	}
+
+	// No orphan ACTIVE task remains across the autopilot's runs: only the new
+	// run's task may be non-terminal.
+	assertActiveTaskCount(t, ctx, ap.ID, 1)
+	assertInFlightCount(t, ctx, ap.ID, 1)
+}
+
+// TestStaleRunSweeper_CancelsLinkedTask is the ALL-234 defect 2 regression
+// on the sweeper path: a stale in-flight run reclaimed by the background
+// sweeper must cancel its linked agent task exactly like the dispatch gate,
+// so a run terminalized by the sweeper never leaves its task executing.
+func TestStaleRunSweeper_CancelsLinkedTask(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	agentID := loadFixtureAgentID(t, ctx)
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 sweeper cancel", agentID, "run_only", "")
+	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
+
+	// Slot 1 starts a legitimate run with a linked agent task.
+	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
+	if err != nil {
+		t.Fatalf("slot 1 dispatch: %v", err)
+	}
+	if first == nil || first.Status != "running" || !first.TaskID.Valid {
+		t.Fatalf("slot 1 run = %+v, want running with task", first)
+	}
+	task1 := first.TaskID
+
+	// Simulate real execution: task running, run aged beyond the sweeper's
+	// hard timeout (the run the dispatch lease gate would never see, because
+	// no new slot ever arrives).
+	const hardTimeout = time.Hour
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'running' WHERE id = $1`, task1); err != nil {
+		t.Fatalf("mark task running: %v", err)
+	}
+	backdateRunCreatedAt(t, ctx, first.ID, hardTimeout+time.Minute)
+
+	sweeper := autopilot.NewStaleRunSweeper(testPool, &autopilot.SweeperConfig{
+		Interval:    5 * time.Minute,
+		HardTimeout: hardTimeout,
+		Enabled:     true,
+		Logger:      testLogger(t),
+		CancelTask: func(ctx context.Context, taskID pgtype.UUID, reason string) error {
+			_, err := taskSvc.CancelTaskWithReason(ctx, taskID, reason, "lease_expired")
+			return err
+		},
+	})
+	sweeper.SweepOnce(ctx)
+
+	// The swept run is terminalized as failed with reason lease_expired.
+	var staleStatus, staleReason string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, first.ID,
+	).Scan(&staleStatus, &staleReason); err != nil {
+		t.Fatalf("read swept run: %v", err)
+	}
+	if staleStatus != "failed" || staleReason != "lease_expired" {
+		t.Fatalf("swept run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
+	}
+
+	// The linked agent task must be cancelled too — no orphan running task.
+	var taskStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM agent_task_queue WHERE id = $1`, task1,
+	).Scan(&taskStatus); err != nil {
+		t.Fatalf("read linked task: %v", err)
+	}
+	if taskStatus != "cancelled" {
+		t.Fatalf("linked task status = %q, want cancelled; swept run must not leave an orphan running task", taskStatus)
+	}
+
+	assertActiveTaskCount(t, ctx, ap.ID, 0)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// createTriggerWithCron seeds a schedule trigger with an explicit cron
+// expression for lease-gate tests.
+func createTriggerWithCron(t *testing.T, ctx context.Context, queries *db.Queries, ap db.Autopilot, cronExpr string) db.AutopilotTrigger {
+	t.Helper()
+	trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+		AutopilotID:    ap.ID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: cronExpr, Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+	return trigger
+}
+
+// backdateRunCreatedAt rewinds an existing autopilot_run's created_at so the
+// run appears to be `age` old.
+func backdateRunCreatedAt(t *testing.T, ctx context.Context, runID pgtype.UUID, age time.Duration) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		UPDATE autopilot_run SET created_at = now() - $2::interval WHERE id = $1
+	`, runID, fmt.Sprintf("%d seconds", int(age.Seconds()))); err != nil {
+		t.Fatalf("backdate run created_at: %v", err)
+	}
+}
+
+// assertActiveTaskCount asserts how many non-terminal agent tasks remain
+// across an autopilot's runs. The no-orphan invariant: after a stale-run
+// reclaim, exactly the newly admitted run's task may be active.
+func assertActiveTaskCount(t *testing.T, ctx context.Context, autopilotID pgtype.UUID, want int) {
+	t.Helper()
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue t
+		JOIN autopilot_run r ON r.id = t.autopilot_run_id
+		WHERE r.autopilot_id = $1
+		  AND t.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
+	`, autopilotID).Scan(&count); err != nil {
+		t.Fatalf("count active tasks: %v", err)
+	}
+	if count != want {
+		t.Fatalf("active task count = %d, want %d", count, want)
+	}
+}

--- a/server/cmd/server/autopilot_stale_run_fixes_test.go
+++ b/server/cmd/server/autopilot_stale_run_fixes_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -87,13 +86,15 @@ func TestDispatch_SlowSchedule_LeaseCoversSlotInterval(t *testing.T) {
 	assertInFlightCount(t, ctx, ap.ID, 1)
 }
 
-// TestDispatch_StaleRun_CancelsLinkedTask is the ALL-234 defect 2 regression
-// on the dispatch-gate path: when the lease expires and the stale run is
-// reclaimed, the agent task linked via autopilot_run.task_id MUST be
-// cancelled in lockstep, so the newly admitted slot never runs concurrently
-// with the stale run's still-executing task. The assertion is the
-// no-orphan-running-task invariant, counted across the autopilot's runs.
-func TestDispatch_StaleRun_CancelsLinkedTask(t *testing.T) {
+// TestSyncRunFromTask_DoesNotOverwriteTerminalizedRun is the ALL-234
+// defect 4 regression: a run terminalized as failed (reason_code=lease_expired)
+// by the lease gate or the sweeper may still have a SURVIVING agent task that
+// finishes later — terminalizeStaleRun deliberately does not cancel it (see
+// its comment; the runtime sweeper reclaims it). The surviving task's late
+// terminal event must NOT rewrite the same run back to completed/failed,
+// which would erase the lease audit trail and make the failure monitor count
+// a reclaimed run as a success.
+func TestSyncRunFromTask_DoesNotOverwriteTerminalizedRun(t *testing.T) {
 	ctx := context.Background()
 	queries := db.New(testPool)
 	bus := events.New()
@@ -104,7 +105,7 @@ func TestDispatch_StaleRun_CancelsLinkedTask(t *testing.T) {
 	autopilotSvc.SetLeaseTimeout(leaseTimeout)
 
 	agentID := loadFixtureAgentID(t, ctx)
-	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 cancel linked task", agentID, "run_only", "")
+	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 terminal guard", agentID, "run_only", "")
 	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
 
 	// Slot 1 starts a legitimate run with a linked agent task.
@@ -118,127 +119,47 @@ func TestDispatch_StaleRun_CancelsLinkedTask(t *testing.T) {
 	}
 	task1 := first.TaskID
 
-	// Simulate real execution: the task is running, and the run has aged past
-	// its lease without reaching a terminal state.
-	if _, err := testPool.Exec(ctx,
-		`UPDATE agent_task_queue SET status = 'running' WHERE id = $1`, task1); err != nil {
-		t.Fatalf("mark task running: %v", err)
-	}
+	// The run's lease expires without the run reaching a terminal state. The
+	// next slot reclaims it exactly as the dispatch gate does: terminalize
+	// the stale run (failed + lease_expired) and admit the new slot. The
+	// surviving task from slot 1 is NOT cancelled by design.
 	backdateRunCreatedAt(t, ctx, first.ID, leaseTimeout+5*time.Second)
-
-	// Slot 2 fires past the lease: the stale run is reclaimed and the slot is
-	// admitted — the concurrent-execution scenario defect 2 exists to close.
 	plannedAt2 := plannedAt1.Add(30 * time.Second)
-	second, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2)
-	if err != nil {
-		t.Fatalf("slot 2 dispatch: %v", err)
+	if _, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt2); err != nil {
+		t.Fatalf("slot 2 dispatch (lease-reclaimed): %v", err)
 	}
-	if second == nil || second.Status != "running" || !second.TaskID.Valid {
-		t.Fatalf("slot 2 run = %+v, want running with task", second)
-	}
-	if second.ID == first.ID {
-		t.Fatalf("slot 2 must create a fresh run, not reuse the stale one")
-	}
-
-	// The stale run is terminalized as failed with reason lease_expired.
 	var staleStatus, staleReason string
 	if err := testPool.QueryRow(ctx,
 		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, first.ID,
 	).Scan(&staleStatus, &staleReason); err != nil {
-		t.Fatalf("read stale run: %v", err)
+		t.Fatalf("read reclaimed run: %v", err)
 	}
 	if staleStatus != "failed" || staleReason != "lease_expired" {
-		t.Fatalf("stale run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
+		t.Fatalf("reclaimed run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
 	}
 
-	// The linked agent task must be cancelled — the core no-orphan invariant.
-	var taskStatus string
+	// The surviving task finishes LATER. Its terminal event must be ignored
+	// by the terminal-state guard — the run must stay failed/lease_expired.
+	task, err := queries.GetAgentTask(ctx, task1)
+	if err != nil {
+		t.Fatalf("load surviving task: %v", err)
+	}
+	task.Status = "completed"
+	autopilotSvc.SyncRunFromTask(ctx, task)
+
+	var afterStatus, afterReason string
 	if err := testPool.QueryRow(ctx,
-		`SELECT status FROM agent_task_queue WHERE id = $1`, task1,
-	).Scan(&taskStatus); err != nil {
-		t.Fatalf("read linked task: %v", err)
+		`SELECT status, COALESCE(reason_code, '') FROM autopilot_run WHERE id = $1`, first.ID,
+	).Scan(&afterStatus, &afterReason); err != nil {
+		t.Fatalf("read reclaimed run after surviving task event: %v", err)
 	}
-	if taskStatus != "cancelled" {
-		t.Fatalf("linked task status = %q, want cancelled; stale run must not leave an orphan running task", taskStatus)
+	if afterStatus != "failed" || afterReason != "lease_expired" {
+		t.Fatalf("reclaimed run after surviving task completion = status %q, reason %q; want failed/lease_expired (terminal guard must hold)", afterStatus, afterReason)
 	}
 
-	// No orphan ACTIVE task remains across the autopilot's runs: only the new
-	// run's task may be non-terminal.
-	assertActiveTaskCount(t, ctx, ap.ID, 1)
+	// The run that was reclaimed must not have been resurrected by the task
+	// event: it stays terminal, and the new slot's run is the only in-flight one.
 	assertInFlightCount(t, ctx, ap.ID, 1)
-}
-
-// TestStaleRunSweeper_CancelsLinkedTask is the ALL-234 defect 2 regression
-// on the sweeper path: a stale in-flight run reclaimed by the background
-// sweeper must cancel its linked agent task exactly like the dispatch gate,
-// so a run terminalized by the sweeper never leaves its task executing.
-func TestStaleRunSweeper_CancelsLinkedTask(t *testing.T) {
-	ctx := context.Background()
-	queries := db.New(testPool)
-	bus := events.New()
-	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
-	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
-
-	agentID := loadFixtureAgentID(t, ctx)
-	ap := createLeaseGateAutopilot(t, ctx, queries, "ALL-234 sweeper cancel", agentID, "run_only", "")
-	trigger := createTriggerForMutexTest(t, ctx, queries, ap)
-
-	// Slot 1 starts a legitimate run with a linked agent task.
-	plannedAt1 := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
-	first, err := autopilotSvc.DispatchAutopilotForPlan(ctx, ap, trigger.ID, "schedule", nil, plannedAt1)
-	if err != nil {
-		t.Fatalf("slot 1 dispatch: %v", err)
-	}
-	if first == nil || first.Status != "running" || !first.TaskID.Valid {
-		t.Fatalf("slot 1 run = %+v, want running with task", first)
-	}
-	task1 := first.TaskID
-
-	// Simulate real execution: task running, run aged beyond the sweeper's
-	// hard timeout (the run the dispatch lease gate would never see, because
-	// no new slot ever arrives).
-	const hardTimeout = time.Hour
-	if _, err := testPool.Exec(ctx,
-		`UPDATE agent_task_queue SET status = 'running' WHERE id = $1`, task1); err != nil {
-		t.Fatalf("mark task running: %v", err)
-	}
-	backdateRunCreatedAt(t, ctx, first.ID, hardTimeout+time.Minute)
-
-	sweeper := autopilot.NewStaleRunSweeper(testPool, &autopilot.SweeperConfig{
-		Interval:    5 * time.Minute,
-		HardTimeout: hardTimeout,
-		Enabled:     true,
-		Logger:      testLogger(t),
-		CancelTask: func(ctx context.Context, taskID pgtype.UUID, reason string) error {
-			_, err := taskSvc.CancelTaskWithReason(ctx, taskID, reason, "lease_expired")
-			return err
-		},
-	})
-	sweeper.SweepOnce(ctx)
-
-	// The swept run is terminalized as failed with reason lease_expired.
-	var staleStatus, staleReason string
-	if err := testPool.QueryRow(ctx,
-		`SELECT status, reason_code FROM autopilot_run WHERE id = $1`, first.ID,
-	).Scan(&staleStatus, &staleReason); err != nil {
-		t.Fatalf("read swept run: %v", err)
-	}
-	if staleStatus != "failed" || staleReason != "lease_expired" {
-		t.Fatalf("swept run = status %q, reason %q; want failed/lease_expired", staleStatus, staleReason)
-	}
-
-	// The linked agent task must be cancelled too — no orphan running task.
-	var taskStatus string
-	if err := testPool.QueryRow(ctx,
-		`SELECT status FROM agent_task_queue WHERE id = $1`, task1,
-	).Scan(&taskStatus); err != nil {
-		t.Fatalf("read linked task: %v", err)
-	}
-	if taskStatus != "cancelled" {
-		t.Fatalf("linked task status = %q, want cancelled; swept run must not leave an orphan running task", taskStatus)
-	}
-
-	assertActiveTaskCount(t, ctx, ap.ID, 0)
 }
 
 // --- helpers ---------------------------------------------------------------
@@ -268,24 +189,5 @@ func backdateRunCreatedAt(t *testing.T, ctx context.Context, runID pgtype.UUID, 
 		UPDATE autopilot_run SET created_at = now() - $2::interval WHERE id = $1
 	`, runID, fmt.Sprintf("%d seconds", int(age.Seconds()))); err != nil {
 		t.Fatalf("backdate run created_at: %v", err)
-	}
-}
-
-// assertActiveTaskCount asserts how many non-terminal agent tasks remain
-// across an autopilot's runs. The no-orphan invariant: after a stale-run
-// reclaim, exactly the newly admitted run's task may be active.
-func assertActiveTaskCount(t *testing.T, ctx context.Context, autopilotID pgtype.UUID, want int) {
-	t.Helper()
-	var count int
-	if err := testPool.QueryRow(ctx, `
-		SELECT count(*) FROM agent_task_queue t
-		JOIN autopilot_run r ON r.id = t.autopilot_run_id
-		WHERE r.autopilot_id = $1
-		  AND t.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-	`, autopilotID).Scan(&count); err != nil {
-		t.Fatalf("count active tasks: %v", err)
-	}
-	if count != want {
-		t.Fatalf("active task count = %d, want %d", count, want)
 	}
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -12,10 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/analytics"
-	sweeperpkg "github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/auth"
+	sweeperpkg "github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/dbstartup"
 	"github.com/multica-ai/multica/server/internal/events"
@@ -626,6 +627,13 @@ func main() {
 		HardTimeout: envDurationPositive("AUTOPILOT_SWEEPER_HARD_TIMEOUT", 2*time.Hour),
 		Enabled:     envBool("AUTOPILOT_SWEEPER_ENABLED", true),
 		Logger:      slog.With("component", "autopilot-sweeper"),
+		// Cancel the agent task linked to every reclaimed run so a
+		// terminalized run never leaves its task executing while the next
+		// slot is admitted (ALL-234 defect 2).
+		CancelTask: func(ctx context.Context, taskID pgtype.UUID, reason string) error {
+			_, err := autopilotSvc.TaskSvc.CancelTaskWithReason(ctx, taskID, reason, "lease_expired")
+			return err
+		},
 	})
 	go sweeper.Start(autopilotCtx)
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/analytics"
+	sweeperpkg "github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/dbstartup"
@@ -25,6 +26,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/scheduler"
 	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/pkg/autopilot"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/featureflag"
 	"github.com/multica-ai/multica/server/pkg/llm"
@@ -612,6 +614,21 @@ func main() {
 	go runSourceContextSweeper(sweepCtx, taskSvc)
 	go heartbeatScheduler.Run(sweepCtx)
 	go runAutopilotFailureMonitor(autopilotCtx, queries, bus, envFailureMonitorConfig())
+
+	// ALL-211 P0: wire the dispatch lease (AUTOPILOT_RUN_LEASE_TIMEOUT) into
+	// the admission gate, then register the stale-run sweeper — the
+	// defensive second layer that terminalizes in-flight runs beyond a hard
+	// age even when no new slot ever arrives, so the failure monitor can see
+	// and auto-pause a permanently-stuck autopilot.
+	autopilotSvc.SetLeaseTimeout(envDuration("AUTOPILOT_RUN_LEASE_TIMEOUT", autopilot.DefaultLeaseTimeout))
+	sweeper := sweeperpkg.NewStaleRunSweeper(pool, &sweeperpkg.SweeperConfig{
+		Interval:    envDurationPositive("AUTOPILOT_SWEEPER_INTERVAL", 5*time.Minute),
+		HardTimeout: envDurationPositive("AUTOPILOT_SWEEPER_HARD_TIMEOUT", 2*time.Hour),
+		Enabled:     envBool("AUTOPILOT_SWEEPER_ENABLED", true),
+		Logger:      slog.With("component", "autopilot-sweeper"),
+	})
+	go sweeper.Start(autopilotCtx)
+
 	if autopilotSvc.QuotaEnabled() {
 		go runAutopilotQuotaReconciler(autopilotCtx, autopilotSvc)
 	}
@@ -718,6 +735,7 @@ func main() {
 
 	slog.Info("shutting down server")
 	autopilotCancel()
+	sweeper.Stop()
 
 	// Order matters: drain in-flight HTTP first so any heartbeat handlers
 	// finish calling Schedule() before we stop the scheduler. Otherwise a

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	sweeperpkg "github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/dbstartup"
+	"github.com/multica-ai/multica/server/internal/dispatch"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/logger"
@@ -631,7 +632,7 @@ func main() {
 		// terminalized run never leaves its task executing while the next
 		// slot is admitted (ALL-234 defect 2).
 		CancelTask: func(ctx context.Context, taskID pgtype.UUID, reason string) error {
-			_, err := autopilotSvc.TaskSvc.CancelTaskWithReason(ctx, taskID, reason, "lease_expired")
+			_, err := autopilotSvc.TaskSvc.CancelTaskWithReason(ctx, taskID, reason, string(dispatch.ReasonLeaseExpired))
 			return err
 		},
 	})

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -12,14 +12,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	sweeperpkg "github.com/multica-ai/multica/server/internal/autopilot"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/dbstartup"
-	"github.com/multica-ai/multica/server/internal/dispatch"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/logger"
@@ -628,13 +626,6 @@ func main() {
 		HardTimeout: envDurationPositive("AUTOPILOT_SWEEPER_HARD_TIMEOUT", 2*time.Hour),
 		Enabled:     envBool("AUTOPILOT_SWEEPER_ENABLED", true),
 		Logger:      slog.With("component", "autopilot-sweeper"),
-		// Cancel the agent task linked to every reclaimed run so a
-		// terminalized run never leaves its task executing while the next
-		// slot is admitted (ALL-234 defect 2).
-		CancelTask: func(ctx context.Context, taskID pgtype.UUID, reason string) error {
-			_, err := autopilotSvc.TaskSvc.CancelTaskWithReason(ctx, taskID, reason, string(dispatch.ReasonLeaseExpired))
-			return err
-		},
 	})
 	go sweeper.Start(autopilotCtx)
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -624,8 +624,13 @@ func main() {
 	sweeper := sweeperpkg.NewStaleRunSweeper(pool, &sweeperpkg.SweeperConfig{
 		Interval:    envDurationPositive("AUTOPILOT_SWEEPER_INTERVAL", 5*time.Minute),
 		HardTimeout: envDurationPositive("AUTOPILOT_SWEEPER_HARD_TIMEOUT", 2*time.Hour),
-		Enabled:     envBool("AUTOPILOT_SWEEPER_ENABLED", true),
-		Logger:      slog.With("component", "autopilot-sweeper"),
+		// Same slot-interval source as the dispatch lease gate, so the
+		// sweeper's per-autopilot reclaim deadline is
+		// max(HardTimeout, SlotInterval) and it never preempts a run the
+		// gate would still consider live (ALL-235 BLOCKING 2, 方案 A).
+		SlotInterval: autopilotSvc.SlotIntervalForAutopilot,
+		Enabled:      envBool("AUTOPILOT_SWEEPER_ENABLED", true),
+		Logger:       slog.With("component", "autopilot-sweeper"),
 	})
 	go sweeper.Start(autopilotCtx)
 

--- a/server/internal/autopilot/sweeper.go
+++ b/server/internal/autopilot/sweeper.go
@@ -9,15 +9,19 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/dispatch"
 )
 
 // sweeperDB is the narrow contract the sweeper needs from a database handle:
-// a single-statement UPDATE. *pgxpool.Pool satisfies it; tests can substitute
-// any fake with the same shape.
+// a read of the in-flight run set plus a single-statement UPDATE.
+// *pgxpool.Pool satisfies it; tests can substitute any fake with the same
+// shape.
 type sweeperDB interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 }
 
@@ -32,6 +36,24 @@ type SweeperConfig struct {
 	// sweeper only reclaims runs the lease gate has already had plenty of
 	// chances to reclaim on its own.
 	HardTimeout time.Duration
+	// SlotInterval resolves an autopilot's scheduling cadence (the longest
+	// gap between two consecutive schedule occurrences) — the SAME source
+	// the dispatch lease gate uses via service.SlotIntervalFromCron. The
+	// sweeper's per-autopilot reclaim deadline becomes
+	// max(HardTimeout, SlotInterval), so a slow-cycle autopilot (e.g. daily)
+	// is never reclaimed before its next slot could fire. Wired from
+	// main.go to AutopilotService.SlotIntervalForAutopilot; nil keeps the
+	// flat HardTimeout behavior for autopilots whose schedule cannot be
+	// resolved (webhook/api/manual-only triggers).
+	//
+	// Choice rationale (ALL-235 BLOCKING 2, 方案 A over 方案 B): 方案 B would
+	// cap the lease at an explicit MaxLeaseDuration, which clamps the
+	// dispatch gate's lease for slow-cycle autopilots below their slot
+	// interval — re-introducing the very early-reclaim defect 1 fixed. 方案 A
+	// instead makes the sweeper per-autopilot aware with the SAME cron source
+	// as the gate, so the sweeper stays a pure backstop ("兜底而非抢跑") and
+	// the two layers can never disagree.
+	SlotInterval func(ctx context.Context, autopilotID pgtype.UUID) (time.Duration, bool)
 	// Enabled gates the whole worker. Useful on small self-hosted
 	// deployments that want the lease gate but not another goroutine.
 	Enabled bool
@@ -74,6 +96,7 @@ type StaleRunSweeper struct {
 	db           sweeperDB
 	interval     time.Duration
 	hardTimeout  time.Duration
+	slotInterval func(ctx context.Context, autopilotID pgtype.UUID) (time.Duration, bool)
 	enabled      bool
 	logger       *slog.Logger
 	shutdownChan chan struct{}
@@ -89,6 +112,7 @@ func NewStaleRunSweeper(db sweeperDB, config *SweeperConfig) *StaleRunSweeper {
 		db:           db,
 		interval:     config.Interval,
 		hardTimeout:  config.HardTimeout,
+		slotInterval: config.SlotInterval,
 		enabled:      config.Enabled,
 		logger:       logger,
 		shutdownChan: make(chan struct{}),
@@ -130,46 +154,132 @@ func (s *StaleRunSweeper) Start(ctx context.Context) {
 	}
 }
 
-// SweepOnce performs a single sweep: terminalize every in-flight run older
-// than the hard timeout as failed (reason_code=lease_expired). The linked
-// agent tasks are deliberately left to the runtime sweeper — see the
-// residual-risk note on StaleRunSweeper. The UPDATE is idempotent — the WHERE
-// clause only matches rows still in an in-flight status, so concurrent
-// sweepers (or a racing dispatch gate that already reclaimed the same row)
-// never double-terminalize. It is exported so tests and callers can drive a
-// sweep without the ticker loop.
+// SweepOnce performs a single sweep: terminalize every in-flight run past
+// its per-autopilot reclaim deadline as failed (reason_code=lease_expired).
+// The reclaim deadline is max(HardTimeout, SlotInterval) where SlotInterval
+// comes from the SAME cron source as the dispatch lease gate (ALL-235
+// BLOCKING 2, 方案 A), so the sweeper never preempts a run the gate would
+// still consider live: a daily-schedule autopilot's legitimate long-running
+// run (and its linked agent task, deliberately left to the runtime sweeper —
+// see the residual-risk note on StaleRunSweeper) survives a sweep.
+//
+// Each UPDATE is idempotent — the WHERE clause only matches rows still in an
+// in-flight status, so concurrent sweepers (or a racing dispatch gate that
+// already reclaimed the same row) never double-terminalize. It is exported
+// so tests and callers can drive a sweep without the ticker loop.
 func (s *StaleRunSweeper) SweepOnce(ctx context.Context) {
-	deadline := time.Now().Add(-s.hardTimeout)
-
-	result, err := s.db.Exec(ctx, `
-		UPDATE autopilot_run
-		SET status = 'failed',
-		    failure_reason = $1,
-		    reason_code = $3,
-		    completed_at = NOW()
+	// Load the in-flight run set with their autopilot so the deadline can be
+	// computed per autopilot. In-flight runs are rare (the partial unique
+	// index uq_autopilot_run_inflight admits at most one per autopilot), so
+	// the extra read is negligible next to the correctness it buys.
+	rows, err := s.db.Query(ctx, `
+		SELECT id, autopilot_id, created_at
+		FROM autopilot_run
 		WHERE status IN ('issue_created', 'running')
-		  AND created_at < $2
-	`,
-		fmt.Sprintf("Run exceeded hard timeout (%s) and was terminated by sweeper", s.hardTimeout),
-		deadline,
-		string(dispatch.ReasonLeaseExpired),
-	)
+	`)
 	if err != nil {
-		s.logger.Error("autopilot stale run sweeper: sweep failed",
-			"hard_timeout", s.hardTimeout.String(),
+		s.logger.Error("autopilot stale run sweeper: list in-flight runs failed",
+			"error", err,
+		)
+		return
+	}
+	defer rows.Close()
+
+	type inFlightRun struct {
+		id          pgtype.UUID
+		autopilotID pgtype.UUID
+		createdAt   time.Time
+	}
+	var runs []inFlightRun
+	for rows.Next() {
+		var r inFlightRun
+		if err := rows.Scan(&r.id, &r.autopilotID, &r.createdAt); err != nil {
+			s.logger.Error("autopilot stale run sweeper: scan in-flight run failed",
+				"error", err,
+			)
+			return
+		}
+		runs = append(runs, r)
+	}
+	if err := rows.Err(); err != nil {
+		s.logger.Error("autopilot stale run sweeper: iterate in-flight runs failed",
 			"error", err,
 		)
 		return
 	}
 
-	affected := result.RowsAffected()
-	if affected > 0 {
+	// Effective deadline per autopilot, computed once per sweep and cached so
+	// a slow-cycle autopilot with several runs pays the trigger lookup once.
+	type deadlineInfo struct {
+		deadline time.Time
+		timeout  time.Duration
+	}
+	deadlines := make(map[pgtype.UUID]deadlineInfo)
+	now := time.Now()
+	terminated := 0
+	for _, r := range runs {
+		info, ok := deadlines[r.autopilotID]
+		if !ok {
+			info.timeout = s.hardTimeout
+			if s.slotInterval != nil {
+				if interval, ok := s.slotInterval(ctx, r.autopilotID); ok && interval > info.timeout {
+					info.timeout = interval
+				}
+			}
+			info.deadline = now.Add(-info.timeout)
+			deadlines[r.autopilotID] = info
+		}
+		if !r.createdAt.Before(info.deadline) {
+			continue
+		}
+		affected, err := s.terminalize(ctx, r.id, info.timeout)
+		if err != nil {
+			s.logger.Error("autopilot stale run sweeper: terminalize run failed",
+				"run_id", utilUUID(r.id),
+				"error", err,
+			)
+			continue
+		}
+		terminated += affected
+	}
+
+	if terminated > 0 {
 		s.logger.Warn("autopilot stale run sweeper: terminated stale runs",
-			"count", affected,
-			"deadline", deadline.UTC().Format(time.RFC3339),
-			"hard_timeout", s.hardTimeout.String(),
+			"count", terminated,
 		)
 	}
+}
+
+// terminalize marks a single in-flight run as failed with
+// reason_code=lease_expired. The WHERE status IN (...) guard keeps the write
+// idempotent under concurrency. Returns the number of rows actually updated
+// (0 or 1).
+func (s *StaleRunSweeper) terminalize(ctx context.Context, runID pgtype.UUID, effectiveTimeout time.Duration) (int, error) {
+	result, err := s.db.Exec(ctx, `
+		UPDATE autopilot_run
+		SET status = 'failed',
+		    failure_reason = $1,
+		    reason_code = $2,
+		    completed_at = NOW()
+		WHERE id = $3
+		  AND status IN ('issue_created', 'running')
+	`,
+		fmt.Sprintf("Run exceeded effective stale-run deadline (%s) and was terminated by sweeper", effectiveTimeout),
+		string(dispatch.ReasonLeaseExpired),
+		runID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return int(result.RowsAffected()), nil
+}
+
+// utilUUID renders a pgtype.UUID for log output, tolerating the zero value.
+func utilUUID(u pgtype.UUID) string {
+	if !u.Valid {
+		return "<invalid>"
+	}
+	return u.String()
 }
 
 // Stop requests a graceful shutdown of the sweep loop. Idempotent.

--- a/server/internal/autopilot/sweeper.go
+++ b/server/internal/autopilot/sweeper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/multica-ai/multica/server/internal/dispatch"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -199,13 +200,14 @@ func (s *StaleRunSweeper) SweepOnce(ctx context.Context) {
 		UPDATE autopilot_run
 		SET status = 'failed',
 		    failure_reason = $1,
-		    reason_code = 'lease_expired',
+		    reason_code = $3,
 		    completed_at = NOW()
 		WHERE status IN ('issue_created', 'running')
 		  AND created_at < $2
 	`,
 		fmt.Sprintf("Run exceeded hard timeout (%s) and was terminated by sweeper", s.hardTimeout),
 		deadline,
+		string(dispatch.ReasonLeaseExpired),
 	)
 	if err != nil {
 		s.logger.Error("autopilot stale run sweeper: sweep failed",

--- a/server/internal/autopilot/sweeper.go
+++ b/server/internal/autopilot/sweeper.go
@@ -9,21 +9,16 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/dispatch"
-	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // sweeperDB is the narrow contract the sweeper needs from a database handle:
-// a single-statement UPDATE plus a row-returning query to discover the agent
-// tasks linked to reclaimable runs. *pgxpool.Pool satisfies it; tests can
-// substitute any fake with the same shape.
+// a single-statement UPDATE. *pgxpool.Pool satisfies it; tests can substitute
+// any fake with the same shape.
 type sweeperDB interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
-	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
 
 // SweeperConfig is the tunable knob set for the stale-run sweeper. All values
@@ -43,14 +38,6 @@ type SweeperConfig struct {
 	// Logger receives the worker's operational logs. Nil is tolerated and
 	// falls back to slog.Default().
 	Logger *slog.Logger
-	// CancelTask, when set, is invoked for every agent task linked to a
-	// reclaimed stale run (autopilot_run.task_id) so the task is cancelled
-	// in lockstep with the run — a failed run must never leave its task
-	// executing (ALL-234 defect 2). It MUST be idempotent: the dispatch
-	// lease gate may already have cancelled the same task. When nil, only
-	// runs are terminalized and linked tasks are left running; that
-	// residual risk is accepted only when a caller explicitly opts out.
-	CancelTask func(ctx context.Context, taskID pgtype.UUID, reason string) error
 }
 
 // StaleRunSweeper periodically terminalizes autopilot_run rows that are
@@ -67,12 +54,27 @@ type SweeperConfig struct {
 //     dispatch activity. The terminalization makes them visible to the
 //     failure monitor (reason_code=lease_expired), so an autopilot whose
 //     runs never finish can still be auto-paused by the operator.
+//
+// Residual risk — the sweeper DELIBERATELY does NOT touch the agent task
+// linked via autopilot_run.task_id (ALL-234 defect 2, architecture ruling
+// 2026-08-25). Hard-timeout expiry is a wall-clock bound on the RUN row, not
+// evidence the TASK is dead; the task's authoritative liveness is the runtime
+// heartbeat, and task lifecycle is owned by the dedicated task reclaim layer
+// (sweepStaleTasks -> FailStaleTasks in cmd/server/runtime_sweeper.go), which
+// combines wall-clock age (dispatched 300s / running 9000s) with heartbeat
+// freshness. Between this run's terminalization and the task's natural
+// terminalisation (or the runtime sweeper reclaiming it), the SAME autopilot
+// can briefly have two executing bodies — uq_autopilot_run_inflight
+// constrains run rows, not tasks. The terminal-state guard in
+// AutopilotService.SyncRunFromTask keeps a surviving task's late event from
+// overwriting this failed/lease_expired row. Note also that terminalizing the
+// run releases its quota reservation immediately while the task may still
+// consume real compute — an accepted deviation.
 type StaleRunSweeper struct {
 	db           sweeperDB
 	interval     time.Duration
 	hardTimeout  time.Duration
 	enabled      bool
-	cancelTask   func(ctx context.Context, taskID pgtype.UUID, reason string) error
 	logger       *slog.Logger
 	shutdownChan chan struct{}
 }
@@ -88,7 +90,6 @@ func NewStaleRunSweeper(db sweeperDB, config *SweeperConfig) *StaleRunSweeper {
 		interval:     config.Interval,
 		hardTimeout:  config.HardTimeout,
 		enabled:      config.Enabled,
-		cancelTask:   config.CancelTask,
 		logger:       logger,
 		shutdownChan: make(chan struct{}),
 	}
@@ -129,72 +130,16 @@ func (s *StaleRunSweeper) Start(ctx context.Context) {
 	}
 }
 
-// SweepOnce performs a single sweep: cancel the agent tasks linked to
-// in-flight runs older than the hard timeout, then terminalize those runs as
-// failed. Task-cancel-before-run-update ordering means a reclaimed run can
-// never leave a still-executing task behind while the next slot is admitted
-// (ALL-234 defect 2); both operations are idempotent — the WHERE clauses
-// only match rows still in an in-flight state, so concurrent sweepers (or a
-// racing dispatch gate that already reclaimed the same row) never
-// double-terminalize and a task already cancelled is left untouched. It is
-// exported so tests and callers can drive a sweep without the ticker loop.
+// SweepOnce performs a single sweep: terminalize every in-flight run older
+// than the hard timeout as failed (reason_code=lease_expired). The linked
+// agent tasks are deliberately left to the runtime sweeper — see the
+// residual-risk note on StaleRunSweeper. The UPDATE is idempotent — the WHERE
+// clause only matches rows still in an in-flight status, so concurrent
+// sweepers (or a racing dispatch gate that already reclaimed the same row)
+// never double-terminalize. It is exported so tests and callers can drive a
+// sweep without the ticker loop.
 func (s *StaleRunSweeper) SweepOnce(ctx context.Context) {
 	deadline := time.Now().Add(-s.hardTimeout)
-
-	// Discover the agent tasks linked to reclaimable runs before the UPDATE
-	// so the cancellation below runs in lockstep with the reclaim.
-	type linkedTask struct {
-		runID  pgtype.UUID
-		taskID pgtype.UUID
-	}
-	var linked []linkedTask
-	rows, err := s.db.Query(ctx, `
-		SELECT id, task_id
-		FROM autopilot_run
-		WHERE status IN ('issue_created', 'running')
-		  AND created_at < $1
-		  AND task_id IS NOT NULL
-	`, deadline)
-	if err != nil {
-		s.logger.Error("autopilot stale run sweeper: query failed",
-			"hard_timeout", s.hardTimeout.String(),
-			"error", err,
-		)
-	} else {
-		for rows.Next() {
-			var runID, taskID pgtype.UUID
-			if err := rows.Scan(&runID, &taskID); err != nil {
-				s.logger.Error("autopilot stale run sweeper: scan failed",
-					"error", err,
-				)
-				break
-			}
-			linked = append(linked, linkedTask{runID: runID, taskID: taskID})
-		}
-		if err := rows.Err(); err != nil {
-			s.logger.Error("autopilot stale run sweeper: query iteration failed",
-				"error", err,
-			)
-		}
-		rows.Close()
-	}
-
-	for _, lt := range linked {
-		if s.cancelTask == nil {
-			break
-		}
-		reason := fmt.Sprintf(
-			"Run exceeded hard timeout (%s) and was terminated by sweeper; linked agent task cancelled",
-			s.hardTimeout,
-		)
-		if err := s.cancelTask(ctx, lt.taskID, reason); err != nil {
-			s.logger.Error("autopilot stale run sweeper: failed to cancel linked agent task",
-				"run_id", util.UUIDToString(lt.runID),
-				"task_id", util.UUIDToString(lt.taskID),
-				"error", err,
-			)
-		}
-	}
 
 	result, err := s.db.Exec(ctx, `
 		UPDATE autopilot_run

--- a/server/internal/autopilot/sweeper.go
+++ b/server/internal/autopilot/sweeper.go
@@ -9,14 +9,20 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // sweeperDB is the narrow contract the sweeper needs from a database handle:
-// a single-statement UPDATE. *pgxpool.Pool satisfies it; tests can substitute
-// any fake with the same shape.
+// a single-statement UPDATE plus a row-returning query to discover the agent
+// tasks linked to reclaimable runs. *pgxpool.Pool satisfies it; tests can
+// substitute any fake with the same shape.
 type sweeperDB interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
 
 // SweeperConfig is the tunable knob set for the stale-run sweeper. All values
@@ -36,6 +42,14 @@ type SweeperConfig struct {
 	// Logger receives the worker's operational logs. Nil is tolerated and
 	// falls back to slog.Default().
 	Logger *slog.Logger
+	// CancelTask, when set, is invoked for every agent task linked to a
+	// reclaimed stale run (autopilot_run.task_id) so the task is cancelled
+	// in lockstep with the run — a failed run must never leave its task
+	// executing (ALL-234 defect 2). It MUST be idempotent: the dispatch
+	// lease gate may already have cancelled the same task. When nil, only
+	// runs are terminalized and linked tasks are left running; that
+	// residual risk is accepted only when a caller explicitly opts out.
+	CancelTask func(ctx context.Context, taskID pgtype.UUID, reason string) error
 }
 
 // StaleRunSweeper periodically terminalizes autopilot_run rows that are
@@ -57,6 +71,7 @@ type StaleRunSweeper struct {
 	interval     time.Duration
 	hardTimeout  time.Duration
 	enabled      bool
+	cancelTask   func(ctx context.Context, taskID pgtype.UUID, reason string) error
 	logger       *slog.Logger
 	shutdownChan chan struct{}
 }
@@ -72,6 +87,7 @@ func NewStaleRunSweeper(db sweeperDB, config *SweeperConfig) *StaleRunSweeper {
 		interval:     config.Interval,
 		hardTimeout:  config.HardTimeout,
 		enabled:      config.Enabled,
+		cancelTask:   config.CancelTask,
 		logger:       logger,
 		shutdownChan: make(chan struct{}),
 	}
@@ -112,13 +128,72 @@ func (s *StaleRunSweeper) Start(ctx context.Context) {
 	}
 }
 
-// SweepOnce performs a single sweep: terminalize every in-flight run older
-// than the hard timeout. Idempotent — the WHERE clause only matches rows
-// still in an in-flight status, so concurrent sweepers (or a racing dispatch
-// gate that already reclaimed the same row) never double-terminalize. It is
+// SweepOnce performs a single sweep: cancel the agent tasks linked to
+// in-flight runs older than the hard timeout, then terminalize those runs as
+// failed. Task-cancel-before-run-update ordering means a reclaimed run can
+// never leave a still-executing task behind while the next slot is admitted
+// (ALL-234 defect 2); both operations are idempotent — the WHERE clauses
+// only match rows still in an in-flight state, so concurrent sweepers (or a
+// racing dispatch gate that already reclaimed the same row) never
+// double-terminalize and a task already cancelled is left untouched. It is
 // exported so tests and callers can drive a sweep without the ticker loop.
 func (s *StaleRunSweeper) SweepOnce(ctx context.Context) {
 	deadline := time.Now().Add(-s.hardTimeout)
+
+	// Discover the agent tasks linked to reclaimable runs before the UPDATE
+	// so the cancellation below runs in lockstep with the reclaim.
+	type linkedTask struct {
+		runID  pgtype.UUID
+		taskID pgtype.UUID
+	}
+	var linked []linkedTask
+	rows, err := s.db.Query(ctx, `
+		SELECT id, task_id
+		FROM autopilot_run
+		WHERE status IN ('issue_created', 'running')
+		  AND created_at < $1
+		  AND task_id IS NOT NULL
+	`, deadline)
+	if err != nil {
+		s.logger.Error("autopilot stale run sweeper: query failed",
+			"hard_timeout", s.hardTimeout.String(),
+			"error", err,
+		)
+	} else {
+		for rows.Next() {
+			var runID, taskID pgtype.UUID
+			if err := rows.Scan(&runID, &taskID); err != nil {
+				s.logger.Error("autopilot stale run sweeper: scan failed",
+					"error", err,
+				)
+				break
+			}
+			linked = append(linked, linkedTask{runID: runID, taskID: taskID})
+		}
+		if err := rows.Err(); err != nil {
+			s.logger.Error("autopilot stale run sweeper: query iteration failed",
+				"error", err,
+			)
+		}
+		rows.Close()
+	}
+
+	for _, lt := range linked {
+		if s.cancelTask == nil {
+			break
+		}
+		reason := fmt.Sprintf(
+			"Run exceeded hard timeout (%s) and was terminated by sweeper; linked agent task cancelled",
+			s.hardTimeout,
+		)
+		if err := s.cancelTask(ctx, lt.taskID, reason); err != nil {
+			s.logger.Error("autopilot stale run sweeper: failed to cancel linked agent task",
+				"run_id", util.UUIDToString(lt.runID),
+				"task_id", util.UUIDToString(lt.taskID),
+				"error", err,
+			)
+		}
+	}
 
 	result, err := s.db.Exec(ctx, `
 		UPDATE autopilot_run

--- a/server/internal/autopilot/sweeper.go
+++ b/server/internal/autopilot/sweeper.go
@@ -1,0 +1,161 @@
+// Package autopilot implements the autopilot background workers that live
+// outside the request-serving dispatch path. Currently that is the stale-run
+// sweeper, the defensive backstop for the lease-gated dispatch path.
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// sweeperDB is the narrow contract the sweeper needs from a database handle:
+// a single-statement UPDATE. *pgxpool.Pool satisfies it; tests can substitute
+// any fake with the same shape.
+type sweeperDB interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// SweeperConfig is the tunable knob set for the stale-run sweeper. All values
+// are wired from env vars in cmd/server/main.go; defaults live there too.
+type SweeperConfig struct {
+	// Interval is the sweep cadence. A value <= 0 disables the sweeper.
+	Interval time.Duration
+	// HardTimeout is the age at which an in-flight run is considered
+	// permanently stuck and terminalized as failed. Should be a multiple
+	// of the dispatch lease timeout (AUTOPILOT_RUN_LEASE_TIMEOUT) so the
+	// sweeper only reclaims runs the lease gate has already had plenty of
+	// chances to reclaim on its own.
+	HardTimeout time.Duration
+	// Enabled gates the whole worker. Useful on small self-hosted
+	// deployments that want the lease gate but not another goroutine.
+	Enabled bool
+	// Logger receives the worker's operational logs. Nil is tolerated and
+	// falls back to slog.Default().
+	Logger *slog.Logger
+}
+
+// StaleRunSweeper periodically terminalizes autopilot_run rows that are
+// still in an in-flight status (issue_created / running) past the hard
+// timeout. It is the second layer of the lease defence (ALL-211 BLOCKING 1):
+//
+//   - Layer 1 is the dispatch-path lease gate: when a new slot arrives and
+//     the in-flight run's lease has expired, the gate terminalizes it and
+//     admits the slot. But a slot may simply never arrive (paused autopilot,
+//     disabled trigger), so the stuck run would sit forever — and the failure
+//     monitor only ever sees completed/failed runs, so a permanently-stuck
+//     run is invisible to auto-pause.
+//   - Layer 2 (this sweeper) reclaims such runs on a cadence regardless of
+//     dispatch activity. The terminalization makes them visible to the
+//     failure monitor (reason_code=lease_expired), so an autopilot whose
+//     runs never finish can still be auto-paused by the operator.
+type StaleRunSweeper struct {
+	db           sweeperDB
+	interval     time.Duration
+	hardTimeout  time.Duration
+	enabled      bool
+	logger       *slog.Logger
+	shutdownChan chan struct{}
+}
+
+// NewStaleRunSweeper builds the sweeper. See SweeperConfig for the fields.
+func NewStaleRunSweeper(db sweeperDB, config *SweeperConfig) *StaleRunSweeper {
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &StaleRunSweeper{
+		db:           db,
+		interval:     config.Interval,
+		hardTimeout:  config.HardTimeout,
+		enabled:      config.Enabled,
+		logger:       logger,
+		shutdownChan: make(chan struct{}),
+	}
+}
+
+// Start runs the periodic sweep loop until ctx is cancelled or Stop is
+// called. When disabled (Enabled=false or Interval<=0) it logs and returns
+// immediately, so a misconfigured deployment fails safe.
+func (s *StaleRunSweeper) Start(ctx context.Context) {
+	if !s.enabled || s.interval <= 0 {
+		s.logger.Info("autopilot stale run sweeper: disabled",
+			"enabled", s.enabled, "interval", s.interval.String())
+		return
+	}
+
+	s.logger.Info("autopilot stale run sweeper: starting",
+		"interval", s.interval.String(),
+		"hard_timeout", s.hardTimeout.String())
+
+	// Run once immediately so a freshly-deployed node reclaims pre-existing
+	// stale runs without waiting a full interval.
+	s.SweepOnce(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("autopilot stale run sweeper: stopped")
+			return
+		case <-s.shutdownChan:
+			s.logger.Info("autopilot stale run sweeper: shutdown requested")
+			return
+		case <-ticker.C:
+			s.SweepOnce(ctx)
+		}
+	}
+}
+
+// SweepOnce performs a single sweep: terminalize every in-flight run older
+// than the hard timeout. Idempotent — the WHERE clause only matches rows
+// still in an in-flight status, so concurrent sweepers (or a racing dispatch
+// gate that already reclaimed the same row) never double-terminalize. It is
+// exported so tests and callers can drive a sweep without the ticker loop.
+func (s *StaleRunSweeper) SweepOnce(ctx context.Context) {
+	deadline := time.Now().Add(-s.hardTimeout)
+
+	result, err := s.db.Exec(ctx, `
+		UPDATE autopilot_run
+		SET status = 'failed',
+		    failure_reason = $1,
+		    reason_code = 'lease_expired',
+		    completed_at = NOW()
+		WHERE status IN ('issue_created', 'running')
+		  AND created_at < $2
+	`,
+		fmt.Sprintf("Run exceeded hard timeout (%s) and was terminated by sweeper", s.hardTimeout),
+		deadline,
+	)
+	if err != nil {
+		s.logger.Error("autopilot stale run sweeper: sweep failed",
+			"hard_timeout", s.hardTimeout.String(),
+			"error", err,
+		)
+		return
+	}
+
+	affected := result.RowsAffected()
+	if affected > 0 {
+		s.logger.Warn("autopilot stale run sweeper: terminated stale runs",
+			"count", affected,
+			"deadline", deadline.UTC().Format(time.RFC3339),
+			"hard_timeout", s.hardTimeout.String(),
+		)
+	}
+}
+
+// Stop requests a graceful shutdown of the sweep loop. Idempotent.
+func (s *StaleRunSweeper) Stop() {
+	select {
+	case <-s.shutdownChan:
+		// already closed
+	default:
+		close(s.shutdownChan)
+	}
+}

--- a/server/internal/dispatch/reason.go
+++ b/server/internal/dispatch/reason.go
@@ -53,6 +53,11 @@ const (
 	// ReasonAlreadyActive: a run is already active/pending for this target and
 	// this trigger did not coalesce.
 	ReasonAlreadyActive ReasonCode = "already_active"
+	// ReasonLeaseExpired: an autopilot run outlived its dispatch lease (or the
+	// sweeper's hard timeout) and was terminalized as failed, releasing the
+	// slot. Stored on autopilot_run.reason_code so the failure monitor groups
+	// reclaimed runs distinctly from genuine failures (ALL-211 BLOCKING 1).
+	ReasonLeaseExpired ReasonCode = "lease_expired"
 	// ReasonSelfTriggerSuppressed: the target was intentionally not (re-)triggered
 	// because doing so would be a self-trigger the guard suppresses, and no active
 	// run remains to cover it — e.g. a squad leader's own @mention of its squad

--- a/server/internal/service/attribution_stamp_test.go
+++ b/server/internal/service/attribution_stamp_test.go
@@ -767,6 +767,24 @@ func seedRunOnlyAutopilot(t *testing.T, pool *pgxpool.Pool, workspaceID, agentID
 	return autopilotID, runID
 }
 
+// seedRunOnlyAutopilotNoRun is seedRunOnlyAutopilot without the seeded
+// in-flight run. Needed by quota tests that admit their own runs: the
+// per-autopilot in-flight unique index uq_autopilot_run_inflight (migration
+// 433) allows at most one issue_created/running run per autopilot, so a
+// seeded 'running' run would collide with the admission under test.
+func seedRunOnlyAutopilotNoRun(t *testing.T, pool *pgxpool.Pool, workspaceID, agentID, creatorID string) (autopilotID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO autopilot (workspace_id, title, assignee_type, assignee_id, status, execution_mode, created_by_type, created_by_id)
+		VALUES ($1, 'run-only ap', 'agent', $2, 'active', 'run_only', 'member', $3) RETURNING id`,
+		workspaceID, agentID, creatorID).Scan(&autopilotID); err != nil {
+		t.Fatalf("seed autopilot: %v", err)
+	}
+	t.Cleanup(func() { pool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID) })
+	return autopilotID
+}
+
 // TestDispatchRunOnlyScheduleStampsRuleOwnerRow is the run_only row assertion Elon
 // asked for: the direct CreateAutopilotTask path (no member actor → schedule-like)
 // must persist rule_owner on the queue row — originator NULL, accountable = the

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -77,11 +77,58 @@ func (s *AutopilotService) SetLeaseTimeout(d time.Duration) {
 	s.LeaseTimeout = d
 }
 
-// leaseTimeout returns the effective in-flight lease, floored at
-// autopilot.MinLeaseDuration via LeaseConfig so a misconfigured value can
-// never cause over-aggressive stale-run cleanup.
-func (s *AutopilotService) leaseTimeout() time.Duration {
-	return (&autopilot.LeaseConfig{BaseTimeout: s.LeaseTimeout}).CalculateLeaseDuration()
+// leaseTimeout returns the effective in-flight lease for the autopilot's
+// dispatch mutual-exclusion gate: max(base timeout, the autopilot's slot
+// interval), floored at autopilot.MinLeaseDuration via LeaseConfig so a
+// misconfigured value can never cause over-aggressive stale-run cleanup.
+// The slot interval is the longest scheduling gap across the autopilot's
+// enabled schedule triggers (ALL-226; ALL-234 defect 1), so a slow-cycle
+// autopilot's in-flight run is never reclaimed before the next slot could
+// legitimately fire.
+func (s *AutopilotService) leaseTimeout(ctx context.Context, ap db.Autopilot) time.Duration {
+	cfg := &autopilot.LeaseConfig{BaseTimeout: s.LeaseTimeout}
+	if interval, ok := s.slotInterval(ctx, ap); ok {
+		cfg.SlotInterval = interval
+	}
+	return cfg.CalculateLeaseDuration()
+}
+
+// slotInterval returns the longest scheduling gap across the autopilot's
+// enabled schedule triggers, or (0, false) when the autopilot has no
+// parseable schedule (webhook/api/manual-only triggers) — the lease then
+// stays at the base timeout. The lease must cover the slowest trigger so a
+// run fired by any of them is never reclaimed early.
+func (s *AutopilotService) slotInterval(ctx context.Context, ap db.Autopilot) (time.Duration, bool) {
+	triggers, err := s.Queries.ListAutopilotTriggers(ctx, ap.ID)
+	if err != nil {
+		slog.Warn("autopilot lease: failed to load triggers for slot interval",
+			"autopilot_id", util.UUIDToString(ap.ID),
+			"error", err,
+		)
+		return 0, false
+	}
+	after := time.Now().UTC()
+	var best time.Duration
+	found := false
+	for _, tr := range triggers {
+		if tr.Kind != "schedule" || !tr.Enabled {
+			continue
+		}
+		cronExpr := strings.TrimSpace(tr.CronExpression.String)
+		if !tr.CronExpression.Valid || cronExpr == "" {
+			continue
+		}
+		timezone := strings.TrimSpace(tr.Timezone.String)
+		if timezone == "" {
+			timezone = DefaultAutopilotTriggerTimezone
+		}
+		interval, ok := SlotIntervalFromCron(cronExpr, timezone, after)
+		if ok && interval > best {
+			best = interval
+			found = true
+		}
+	}
+	return best, found
 }
 
 // autopilotRuleConfigSummary captures the substantive (accountability-bearing)
@@ -1301,18 +1348,45 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 	}
 }
 
-// terminalizeStaleRun marks an in-flight autopilot run as failed because it
-// outlived the dispatch lease (ALL-211 BLOCKING 1). The UPDATE is guarded by
+// terminalizeStaleRun reclaims an in-flight autopilot run that outlived the
+// dispatch lease (ALL-211 BLOCKING 1 / ALL-234 defect 2). The linked agent
+// task — autopilot_run.task_id, set for run_only mode — is cancelled FIRST
+// so a reclaimed run can never leave a still-executing task behind while the
+// slot it wedged gets admitted. Cancellation is idempotent (guarded by task
+// status), so a racing sweeper or another replica that already reclaimed the
+// same run cancels nothing twice.
+//
+// Ordering is deliberate: cancel-before-terminalize means a transient failure
+// of the run UPDATE leaves a cancelled task and an in-flight run (reclaimed
+// on the next tick), never the reverse — a failed run with a live task is the
+// exact duplicate-execution defect this closes. The task cancel is
+// best-effort: if it fails, the error is logged and the run is still
+// terminalized, because failing the whole dispatch would re-wedge the
+// autopilot. The run UPDATE itself is guarded by
 // `status IN ('issue_created','running')` so it is idempotent under
 // concurrency: a racing sweeper or another replica's lease gate reclaims the
 // same row at most once; everyone else affects zero rows and moves on.
-func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, runID pgtype.UUID, leaseTimeout time.Duration) error {
+func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, prior db.AutopilotRun, leaseTimeout time.Duration) error {
+	if prior.TaskID.Valid {
+		taskReason := fmt.Sprintf(
+			"Run exceeded lease timeout (%s) and was terminated by stale run cleanup; linked agent task cancelled",
+			leaseTimeout,
+		)
+		if _, err := s.TaskSvc.CancelTaskWithReason(ctx, prior.TaskID, taskReason, "lease_expired"); err != nil {
+			slog.Warn("autopilot stale run cleanup: failed to cancel linked agent task",
+				"run_id", util.UUIDToString(prior.ID),
+				"task_id", util.UUIDToString(prior.TaskID),
+				"lease_timeout", leaseTimeout.String(),
+				"error", err,
+			)
+		}
+	}
 	failureReason := fmt.Sprintf(
 		"Run exceeded lease timeout (%s) and was terminated by stale run cleanup",
 		leaseTimeout,
 	)
 	_, err := s.Queries.TerminalizeStaleAutopilotRun(ctx, db.TerminalizeStaleAutopilotRunParams{
-		ID:            runID,
+		ID:            prior.ID,
 		FailureReason: pgtype.Text{String: failureReason, Valid: true},
 		ReasonCode:    pgtype.Text{String: "lease_expired", Valid: true},
 		CompletedAt:   pgtype.Timestamptz{Time: time.Now(), Valid: true},
@@ -1370,12 +1444,12 @@ func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopil
 	prior, err := s.Queries.GetAutopilotRunInFlight(ctx, ap.ID)
 	switch {
 	case err == nil:
-		leaseTimeout := s.leaseTimeout()
+		leaseTimeout := s.leaseTimeout(ctx, ap)
 		if time.Now().Before(prior.CreatedAt.Time.Add(leaseTimeout)) {
 			return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
 		}
 		// Lease expired: reclaim the stale run, then fall through to admit.
-		if err := s.terminalizeStaleRun(ctx, prior.ID, leaseTimeout); err != nil {
+		if err := s.terminalizeStaleRun(ctx, prior, leaseTimeout); err != nil {
 			// Fail-open: the unique index still protects mutual exclusion, so
 			// the worst case is a 23505 on the INSERT below, which is mapped to
 			// a skipped/already_active run — never a duplicate dispatch.

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1268,6 +1268,27 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 //     agent assignee being missing is now a real condition the gate must
 //     handle (previously cascade-deleted).
 func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopilot, actorUserID pgtype.UUID) (string, dispatch.ReasonCode, bool) {
+	// Mutex / lease gate (ALL-206): never dispatch a new slot while the
+	// autopilot still has an in-flight run. The in-flight statuses
+	// (pending / issue_created / running) mirror the partial index
+	// idx_autopilot_run_status from migration 042 — a scheduled run that
+	// outlives its slot interval used to let the next slot start a second
+	// concurrent run for the same autopilot. When one is in flight the new
+	// slot is recorded as skipped (with a clear failure_reason) instead of
+	// creating a concurrent run.
+	prior, err := s.Queries.GetAutopilotRunInFlight(ctx, ap.ID)
+	if err == nil {
+		return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		// Transient DB error — fail-open so the next scheduler tick gets a
+		// chance to succeed, consistent with the rest of the admission gate.
+		slog.Warn("autopilot admission: failed to check for in-flight run",
+			"autopilot_id", util.UUIDToString(ap.ID),
+			"error", err,
+		)
+		return "", "", false
+	}
 	if !ap.AssigneeID.Valid {
 		return "autopilot has no assignee", dispatch.ReasonTargetUnavailable, true
 	}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -87,7 +87,7 @@ func (s *AutopilotService) SetLeaseTimeout(d time.Duration) {
 // legitimately fire.
 func (s *AutopilotService) leaseTimeout(ctx context.Context, ap db.Autopilot) time.Duration {
 	cfg := &autopilot.LeaseConfig{BaseTimeout: s.LeaseTimeout}
-	if interval, ok := s.slotInterval(ctx, ap); ok {
+	if interval, ok := s.slotInterval(ctx, ap.ID); ok {
 		cfg.SlotInterval = interval
 	}
 	return cfg.CalculateLeaseDuration()
@@ -98,11 +98,11 @@ func (s *AutopilotService) leaseTimeout(ctx context.Context, ap db.Autopilot) ti
 // parseable schedule (webhook/api/manual-only triggers) — the lease then
 // stays at the base timeout. The lease must cover the slowest trigger so a
 // run fired by any of them is never reclaimed early.
-func (s *AutopilotService) slotInterval(ctx context.Context, ap db.Autopilot) (time.Duration, bool) {
-	triggers, err := s.Queries.ListAutopilotTriggers(ctx, ap.ID)
+func (s *AutopilotService) slotInterval(ctx context.Context, autopilotID pgtype.UUID) (time.Duration, bool) {
+	triggers, err := s.Queries.ListAutopilotTriggers(ctx, autopilotID)
 	if err != nil {
 		slog.Warn("autopilot lease: failed to load triggers for slot interval",
-			"autopilot_id", util.UUIDToString(ap.ID),
+			"autopilot_id", util.UUIDToString(autopilotID),
 			"error", err,
 		)
 		return 0, false
@@ -129,6 +129,18 @@ func (s *AutopilotService) slotInterval(ctx context.Context, ap db.Autopilot) (t
 		}
 	}
 	return best, found
+}
+
+// SlotIntervalForAutopilot is the exported hook the stale-run sweeper uses to
+// keep its reclaim deadline in lockstep with the dispatch lease gate (ALL-235
+// BLOCKING 2, 方案 A): it returns the autopilot's slot interval (the longest
+// scheduling gap across its enabled schedule triggers) computed by the SAME
+// SlotIntervalFromCron source the gate's leaseTimeout() uses, so the two
+// layers can never disagree on how long a legitimate in-flight run may live.
+// (0, false) means the autopilot has no parseable schedule — the caller falls
+// back to its flat hard timeout.
+func (s *AutopilotService) SlotIntervalForAutopilot(ctx context.Context, autopilotID pgtype.UUID) (time.Duration, bool) {
+	return s.slotInterval(ctx, autopilotID)
 }
 
 // autopilotRuleConfigSummary captures the substantive (accountability-bearing)

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1187,6 +1187,25 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		return
 	}
 
+	// Terminal-state guard (ALL-211 BLOCKING 1 follow-up, ALL-234 defect 4):
+	// a run terminalized by the lease gate or the sweeper (failed +
+	// reason_code=lease_expired) may still have a SURVIVING task that ends
+	// later — terminalizeStaleRun deliberately does not cancel it (see its
+	// comment). Without this guard, that late task event would flow back
+	// through this function and rewrite the SAME row from failed back to
+	// completed, erasing the lease audit trail and making the failure
+	// monitor count a reclaimed run as a success. Once a run is terminal, no
+	// downstream task event may mutate it again.
+	if run.Status == "completed" || run.Status == "failed" || run.Status == "skipped" {
+		slog.Info("autopilot run already terminal; ignoring task sync event",
+			"run_id", util.UUIDToString(run.ID),
+			"run_status", run.Status,
+			"task_id", util.UUIDToString(task.ID),
+			"task_status", task.Status,
+		)
+		return
+	}
+
 	autopilot, err := s.Queries.GetAutopilot(ctx, run.AutopilotID)
 	if err != nil {
 		return
@@ -1348,43 +1367,50 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 	}
 }
 
-// terminalizeStaleRun reclaims an in-flight autopilot run that outlived the
-// dispatch lease (ALL-211 BLOCKING 1 / ALL-234 defect 2). The linked agent
-// task — autopilot_run.task_id, set for run_only mode — is cancelled FIRST
-// so a reclaimed run can never leave a still-executing task behind while the
-// slot it wedged gets admitted. Cancellation is idempotent (guarded by task
-// status), so a racing sweeper or another replica that already reclaimed the
-// same run cancels nothing twice.
-//
-// Ordering is deliberate: cancel-before-terminalize means a transient failure
-// of the run UPDATE leaves a cancelled task and an in-flight run (reclaimed
-// on the next tick), never the reverse — a failed run with a live task is the
-// exact duplicate-execution defect this closes. The task cancel is
-// best-effort: if it fails, the error is logged and the run is still
-// terminalized, because failing the whole dispatch would re-wedge the
-// autopilot. The run UPDATE itself is guarded by
-// `status IN ('issue_created','running')` so it is idempotent under
+// terminalizeStaleRun marks an in-flight autopilot run as failed because it
+// outlived the dispatch lease (ALL-211 BLOCKING 1). The run UPDATE is guarded
+// by `status IN ('issue_created','running')` so it is idempotent under
 // concurrency: a racing sweeper or another replica's lease gate reclaims the
 // same row at most once; everyone else affects zero rows and moves on.
+//
+// Residual risk — the linked agent task (autopilot_run.task_id, set for
+// run_only) is DELIBERATELY NOT cancelled here (ALL-234 defect 2, architecture
+// ruling 2026-08-25):
+//
+//   - Lease expiry is a coarse wall-clock bound on the RUN row, not evidence
+//     the TASK is dead — the task's authoritative liveness signal is the
+//     runtime heartbeat. Cancelling a task whose heartbeat is still fresh and
+//     that is genuinely making progress would kill legitimate long-running
+//     work; with the SlotInterval defect open the lease could expire early and
+//     make such mis-kills the norm rather than the edge case.
+//   - Task lifecycle is owned by the dedicated task reclaim layer
+//     (sweepStaleTasks -> FailStaleTasks in cmd/server/runtime_sweeper.go),
+//     which combines wall-clock age (dispatched 300s / running 9000s) with
+//     heartbeat freshness and is the correct place to judge a task dead.
+//     Cancelling from the dispatch admission gate would cross aggregate roots
+//     to mutate another slot's task on the scheduling hot path — the pattern
+//     MUL-4465 removed.
+//   - Residual window: between this run's terminalization and the task's
+//     natural terminalisation (or the runtime sweeper reclaiming it), the SAME
+//     autopilot can briefly have two executing bodies — the partial unique
+//     index uq_autopilot_run_inflight constrains run rows, not tasks. The
+//     terminal-state guard in SyncRunFromTask keeps a surviving task's late
+//     completion/failure event from overwriting this failed/lease_expired row.
+//   - Terminalizing the run releases its quota reservation immediately
+//     (settlement requires a terminal run) while the task may still consume
+//     real compute — an accepted deviation.
 func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, prior db.AutopilotRun, leaseTimeout time.Duration) error {
-	if prior.TaskID.Valid {
-		taskReason := fmt.Sprintf(
-			"Run exceeded lease timeout (%s) and was terminated by stale run cleanup; linked agent task cancelled",
-			leaseTimeout,
-		)
-		if _, err := s.TaskSvc.CancelTaskWithReason(ctx, prior.TaskID, taskReason, string(dispatch.ReasonLeaseExpired)); err != nil {
-			slog.Warn("autopilot stale run cleanup: failed to cancel linked agent task",
-				"run_id", util.UUIDToString(prior.ID),
-				"task_id", util.UUIDToString(prior.TaskID),
-				"lease_timeout", leaseTimeout.String(),
-				"error", err,
-			)
-		}
-	}
 	failureReason := fmt.Sprintf(
 		"Run exceeded lease timeout (%s) and was terminated by stale run cleanup",
 		leaseTimeout,
 	)
+	if prior.TaskID.Valid {
+		slog.Info("autopilot stale run cleanup: terminalizing run; linked agent task left to the runtime sweeper (task_id is the only locator for the surviving execution body)",
+			"run_id", util.UUIDToString(prior.ID),
+			"task_id", util.UUIDToString(prior.TaskID),
+			"lease_timeout", leaseTimeout.String(),
+		)
+	}
 	_, err := s.Queries.TerminalizeStaleAutopilotRun(ctx, db.TerminalizeStaleAutopilotRunParams{
 		ID:            prior.ID,
 		FailureReason: pgtype.Text{String: failureReason, Valid: true},

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -23,6 +23,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/issuestatus"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/util"
+	"github.com/multica-ai/multica/server/pkg/autopilot"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/dbid"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -40,6 +41,15 @@ type AutopilotService struct {
 	TaskSvc      *TaskService
 	Entitlements entitlement.Provider
 	QuotaMetrics AutopilotQuotaMetrics
+
+	// LeaseTimeout is the bounded in-flight lease applied by the dispatch
+	// mutual-exclusion gate (ALL-211 BLOCKING 1). A run still in
+	// issue_created/running past this age is treated as stale: the gate
+	// terminalizes it (failed + reason_code=lease_expired) and admits the
+	// new slot, so a run that never reaches a terminal state can no longer
+	// wedge the autopilot forever. Wired from AUTOPILOT_RUN_LEASE_TIMEOUT in
+	// cmd/server/main.go; defaults to autopilot.DefaultLeaseTimeout.
+	LeaseTimeout time.Duration
 }
 
 // DefaultAutopilotTriggerTimezone is the timezone used to render Autopilot
@@ -51,7 +61,27 @@ const DefaultAutopilotTriggerTimezone = "UTC"
 const autopilotRecentDuplicateWindow = 60 * time.Second
 
 func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *TaskService) *AutopilotService {
-	return &AutopilotService{Queries: q, TxStarter: tx, Bus: bus, TaskSvc: taskSvc}
+	return &AutopilotService{
+		Queries:      q,
+		TxStarter:    tx,
+		Bus:          bus,
+		TaskSvc:      taskSvc,
+		LeaseTimeout: autopilot.DefaultLeaseTimeout,
+	}
+}
+
+// SetLeaseTimeout overrides the dispatch mutual-exclusion lease. Used by
+// cmd/server/main.go to wire AUTOPILOT_RUN_LEASE_TIMEOUT and by tests to
+// shrink the window without waiting out the default.
+func (s *AutopilotService) SetLeaseTimeout(d time.Duration) {
+	s.LeaseTimeout = d
+}
+
+// leaseTimeout returns the effective in-flight lease, floored at
+// autopilot.MinLeaseDuration via LeaseConfig so a misconfigured value can
+// never cause over-aggressive stale-run cleanup.
+func (s *AutopilotService) leaseTimeout() time.Duration {
+	return (&autopilot.LeaseConfig{BaseTimeout: s.LeaseTimeout}).CalculateLeaseDuration()
 }
 
 // autopilotRuleConfigSummary captures the substantive (accountability-bearing)
@@ -190,8 +220,9 @@ func (s *AutopilotService) AdmitAutopilotWebhookDelivery(
 	}
 
 	// Webhook admission has no member actor → automation principal (rule_owner);
-	// the per-run reason code is not surfaced to a human here, so it is dropped.
-	if reason, _, skip := s.shouldSkipDispatch(ctx, autopilot, pgtype.UUID{}); skip {
+	// the per-run reason code is still persisted on the skipped row so the
+	// failure monitor can group webhook skips by cause.
+	if reason, code, skip := s.shouldSkipDispatch(ctx, autopilot, pgtype.UUID{}); skip {
 		run, err := s.recordSkippedRun(
 			ctx,
 			autopilot,
@@ -201,6 +232,7 @@ func (s *AutopilotService) AdmitAutopilotWebhookDelivery(
 			pgtype.Timestamptz{},
 			deliveryID,
 			reason,
+			code,
 		)
 		if err != nil {
 			return s.recoverConcurrentWebhookAdmission(
@@ -523,7 +555,10 @@ func (s *AutopilotService) dispatchAutopilot(
 	idempotencyKey string,
 ) (*db.AutopilotRun, dispatch.ReasonCode, error) {
 	if reason, code, skip := s.shouldSkipDispatch(ctx, autopilot, actorUserID); skip {
-		run, err := s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, webhookDeliveryID, reason)
+		// Persist the typed admission code on the skipped run so the failure
+		// monitor and the run history can group skips by reason (e.g. all
+		// already_active rows from the mutual-exclusion gate).
+		run, err := s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, webhookDeliveryID, reason, code)
 		return run, code, err
 	}
 
@@ -549,6 +584,20 @@ func (s *AutopilotService) dispatchAutopilot(
 		if errors.As(err, &quotaErr) && source == "schedule" {
 			skipped, skipErr := s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, webhookDeliveryID, quotaErr.Error(), dispatch.ReasonQuotaExceeded)
 			return skipped, dispatch.ReasonQuotaExceeded, skipErr
+		}
+		// ALL-211 BLOCKING 3: another replica (or a racing manual trigger +
+		// scheduler tick) inserted its run between the in-flight check above
+		// and this INSERT. The partial unique index uq_autopilot_run_inflight
+		// is the authoritative gate — the loser records a skipped run with
+		// already_active instead of failing, exactly like the existing
+		// recoverConcurrentWebhookAdmission pattern.
+		if isPgUniqueViolation(err, "uq_autopilot_run_inflight") {
+			slog.Info("autopilot dispatch: concurrent in-flight run detected via unique constraint",
+				"autopilot_id", util.UUIDToString(autopilot.ID),
+				"source", source,
+			)
+			skipped, skipErr := s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, webhookDeliveryID, "concurrent dispatch detected via unique constraint", dispatch.ReasonAlreadyActive)
+			return skipped, dispatch.ReasonAlreadyActive, skipErr
 		}
 		return nil, dispatch.ReasonInternalError, fmt.Errorf("create run: %w", err)
 	}
@@ -1252,6 +1301,41 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 	}
 }
 
+// terminalizeStaleRun marks an in-flight autopilot run as failed because it
+// outlived the dispatch lease (ALL-211 BLOCKING 1). The UPDATE is guarded by
+// `status IN ('issue_created','running')` so it is idempotent under
+// concurrency: a racing sweeper or another replica's lease gate reclaims the
+// same row at most once; everyone else affects zero rows and moves on.
+func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, runID pgtype.UUID, leaseTimeout time.Duration) error {
+	failureReason := fmt.Sprintf(
+		"Run exceeded lease timeout (%s) and was terminated by stale run cleanup",
+		leaseTimeout,
+	)
+	_, err := s.Queries.TerminalizeStaleAutopilotRun(ctx, db.TerminalizeStaleAutopilotRunParams{
+		ID:            runID,
+		FailureReason: pgtype.Text{String: failureReason, Valid: true},
+		ReasonCode:    pgtype.Text{String: "lease_expired", Valid: true},
+		CompletedAt:   pgtype.Timestamptz{Time: time.Now(), Valid: true},
+	})
+	return err
+}
+
+// isPgUniqueViolation reports whether err is (or wraps) a PostgreSQL unique
+// violation (SQLSTATE 23505) on the named constraint/index. Wrapped errors
+// are unwrapped via errors.As, so callers may pass fmt.Errorf-wrapped query
+// errors. Used to map the partial-unique-index race on
+// uq_autopilot_run_inflight (ALL-211 BLOCKING 3) to a skipped/already_active
+// outcome instead of a failed run.
+func isPgUniqueViolation(err error, constraintName string) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505" &&
+			pgErr.ConstraintName != "" &&
+			strings.Contains(pgErr.ConstraintName, constraintName)
+	}
+	return false
+}
+
 // shouldSkipDispatch is the pre-flight admission check from MUL-1899.
 // Returns (reason, true) when dispatching now would only enqueue a doomed
 // task — i.e. the assignee (or, for squad autopilots, the squad leader) is
@@ -1268,19 +1352,47 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 //     agent assignee being missing is now a real condition the gate must
 //     handle (previously cascade-deleted).
 func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopilot, actorUserID pgtype.UUID) (string, dispatch.ReasonCode, bool) {
-	// Mutex / lease gate (ALL-206): never dispatch a new slot while the
-	// autopilot still has an in-flight run. The in-flight statuses
-	// (pending / issue_created / running) mirror the partial index
-	// idx_autopilot_run_status from migration 042 — a scheduled run that
-	// outlives its slot interval used to let the next slot start a second
-	// concurrent run for the same autopilot. When one is in flight the new
-	// slot is recorded as skipped (with a clear failure_reason) instead of
-	// creating a concurrent run.
+	// Mutual-exclusion gate (ALL-206 + ALL-211 BLOCKING 1 & 3): never start
+	// a second concurrent run for an autopilot while it still has an in-flight
+	// run. "In flight" is exactly status IN ('issue_created', 'running') — the
+	// state set aligned with autopilot_run_status_check and the partial unique
+	// index uq_autopilot_run_inflight (migration 433).
+	//
+	// The gate is BOUNDED: an in-flight run whose lease has not expired blocks
+	// the slot (skipped + already_active); a run whose lease HAS expired is
+	// stale and is terminalized as failed (reason_code=lease_expired) right
+	// here, then the slot is admitted. This is what eliminates the permanent
+	// stuck path — previously a run in issue_created whose issue never reached
+	// a terminal state blocked every later slot forever, with no escape hatch.
+	// The terminalize UPDATE is idempotent (WHERE status still in-flight) and
+	// the INSERT that follows is protected by the unique index, so concurrent
+	// replicas cannot double-admit.
 	prior, err := s.Queries.GetAutopilotRunInFlight(ctx, ap.ID)
-	if err == nil {
-		return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	switch {
+	case err == nil:
+		leaseTimeout := s.leaseTimeout()
+		if time.Now().Before(prior.CreatedAt.Time.Add(leaseTimeout)) {
+			return "previous run still in flight (" + util.UUIDToString(prior.ID) + ")", dispatch.ReasonAlreadyActive, true
+		}
+		// Lease expired: reclaim the stale run, then fall through to admit.
+		if err := s.terminalizeStaleRun(ctx, prior.ID, leaseTimeout); err != nil {
+			// Fail-open: the unique index still protects mutual exclusion, so
+			// the worst case is a 23505 on the INSERT below, which is mapped to
+			// a skipped/already_active run — never a duplicate dispatch.
+			slog.Warn("autopilot admission: failed to terminalize stale run; admitting slot (unique index still enforces mutual exclusion)",
+				"autopilot_id", util.UUIDToString(ap.ID),
+				"run_id", util.UUIDToString(prior.ID),
+				"lease_timeout", leaseTimeout.String(),
+				"error", err,
+			)
+		} else {
+			slog.Info("autopilot admission: lease expired, terminalized stale run",
+				"autopilot_id", util.UUIDToString(ap.ID),
+				"run_id", util.UUIDToString(prior.ID),
+				"lease_timeout", leaseTimeout.String(),
+			)
+		}
+	case !errors.Is(err, pgx.ErrNoRows):
 		// Transient DB error — fail-open so the next scheduler tick gets a
 		// chance to succeed, consistent with the rest of the admission gate.
 		slog.Warn("autopilot admission: failed to check for in-flight run",

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1372,7 +1372,7 @@ func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, prior db.Aut
 			"Run exceeded lease timeout (%s) and was terminated by stale run cleanup; linked agent task cancelled",
 			leaseTimeout,
 		)
-		if _, err := s.TaskSvc.CancelTaskWithReason(ctx, prior.TaskID, taskReason, "lease_expired"); err != nil {
+		if _, err := s.TaskSvc.CancelTaskWithReason(ctx, prior.TaskID, taskReason, string(dispatch.ReasonLeaseExpired)); err != nil {
 			slog.Warn("autopilot stale run cleanup: failed to cancel linked agent task",
 				"run_id", util.UUIDToString(prior.ID),
 				"task_id", util.UUIDToString(prior.TaskID),
@@ -1388,7 +1388,7 @@ func (s *AutopilotService) terminalizeStaleRun(ctx context.Context, prior db.Aut
 	_, err := s.Queries.TerminalizeStaleAutopilotRun(ctx, db.TerminalizeStaleAutopilotRunParams{
 		ID:            prior.ID,
 		FailureReason: pgtype.Text{String: failureReason, Valid: true},
-		ReasonCode:    pgtype.Text{String: "lease_expired", Valid: true},
+		ReasonCode:    pgtype.Text{String: string(dispatch.ReasonLeaseExpired), Valid: true},
 		CompletedAt:   pgtype.Timestamptz{Time: time.Now(), Valid: true},
 	})
 	return err

--- a/server/internal/service/autopilot_quota_test.go
+++ b/server/internal/service/autopilot_quota_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 type autopilotQuotaFixture struct {
+	t             *testing.T
 	pool          *pgxpool.Pool
 	queries       *db.Queries
 	service       *AutopilotService
@@ -70,7 +71,7 @@ func newAutopilotQuotaFixture(t *testing.T, action entitlement.Action, limit int
 	periodEnd := periodStart.Add(37 * time.Hour)
 	stub := entitlementtest.New()
 	fixture := &autopilotQuotaFixture{
-		pool: pool, queries: q, stub: stub, workspace: workspace,
+		t: t, pool: pool, queries: q, stub: stub, workspace: workspace,
 		workspaceID: workspaceID, autopilotID: util.MustParseUUID(autopilotIDString),
 		agentID: util.MustParseUUID(agentID), publisherID: util.MustParseUUID(publisherID),
 		issueID:     util.MustParseUUID(issueIDString),
@@ -99,6 +100,30 @@ func (f *autopilotQuotaFixture) setPolicy(action entitlement.Action, start, end 
 		},
 		PolicyRevision: 7, SubscriptionVersion: 11,
 	})
+}
+
+// closeSeededRun terminalizes the in-flight run that seedRunOnlyAutopilot
+// leaves on the fixture's primary autopilot, freeing the per-autopilot
+// in-flight slot (uq_autopilot_run_inflight) for the admission under test.
+func (f *autopilotQuotaFixture) closeSeededRun() {
+	if _, err := f.pool.Exec(context.Background(),
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE autopilot_id = $1`,
+		f.autopilotID); err != nil {
+		f.t.Fatalf("close seeded in-flight run: %v", err)
+	}
+}
+
+// newRunArgs returns CreateAutopilotRunParams targeting a FRESH autopilot
+// (no seeded run). Quota is per-workspace, so one autopilot per in-flight
+// admission is exactly how production quota usage manifests — and it keeps
+// consecutive admissions from colliding on the per-autopilot in-flight
+// unique index uq_autopilot_run_inflight (migration 433).
+func (f *autopilotQuotaFixture) newRunArgs(source string) db.CreateAutopilotRunParams {
+	autopilotID := seedRunOnlyAutopilotNoRun(f.t, f.pool,
+		util.UUIDToString(f.workspaceID), util.UUIDToString(f.agentID), util.UUIDToString(f.publisherID))
+	return db.CreateAutopilotRunParams{
+		AutopilotID: util.MustParseUUID(autopilotID), Source: source, Status: "running",
+	}
 }
 
 func TestAutopilotQuotaDisabledDoesNotReadQuotaTables(t *testing.T) {
@@ -154,6 +179,13 @@ func TestAutopilotQuotaEnforcesBoundaryAndFinalizesIdempotently(t *testing.T) {
 		pool.Exec(context.Background(), `DELETE FROM autopilot_quota_reservation WHERE workspace_id = $1`, workspaceID)
 		pool.Exec(context.Background(), `DELETE FROM autopilot_quota_period WHERE workspace_id = $1`, workspaceID)
 	})
+	// The fixture autopilot carries a seeded 'running' run; close it so the
+	// per-autopilot in-flight slot is free for the admissions below.
+	if _, err := pool.Exec(ctx,
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE autopilot_id = $1`,
+		autopilotID); err != nil {
+		t.Fatalf("close seeded in-flight run: %v", err)
+	}
 
 	periodStart := time.Now().UTC().Truncate(time.Second)
 	periodEnd := periodStart.Add(37 * time.Hour) // opaque Cloud interval, deliberately not a calendar month
@@ -168,23 +200,34 @@ func TestAutopilotQuotaEnforcesBoundaryAndFinalizesIdempotently(t *testing.T) {
 		PolicyRevision: 7, SubscriptionVersion: 11,
 	})
 	svc := &AutopilotService{Queries: q, TxStarter: pool, Bus: events.New(), Entitlements: stub}
-	params := db.CreateAutopilotRunParams{
-		AutopilotID: autopilotID, Source: "api", Status: "running",
-	}
 
 	runs := make([]db.AutopilotRun, 0, limit)
 	for i, key := range []string{"boundary-1", "boundary-2"} {
+		// Quota is per-workspace: each in-flight admission targets its own
+		// autopilot so the per-autopilot in-flight unique index
+		// uq_autopilot_run_inflight does not reject the second admission.
+		params := db.CreateAutopilotRunParams{
+			AutopilotID: util.MustParseUUID(seedRunOnlyAutopilotNoRun(t, pool, workspaceIDString, agentID, publisherID)),
+			Source:      "api", Status: "running",
+		}
 		run, _, err := svc.createAutopilotRunWithQuota(ctx, workspaceID, "api", key, params)
 		if err != nil {
 			t.Fatalf("admission %d: %v", i+1, err)
 		}
 		runs = append(runs, run)
 	}
-	reused, wasReused, err := svc.createAutopilotRunWithQuota(ctx, workspaceID, "api", "boundary-1", params)
+	reused, wasReused, err := svc.createAutopilotRunWithQuota(ctx, workspaceID, "api", "boundary-1", db.CreateAutopilotRunParams{
+		AutopilotID: runs[0].AutopilotID, Source: "api", Status: "running",
+	})
 	if err != nil || !wasReused || reused.ID.Bytes != runs[0].ID.Bytes {
 		t.Fatalf("idempotent reuse = %s, %v; want %s", util.UUIDToString(reused.ID), err, util.UUIDToString(runs[0].ID))
 	}
-	_, _, err = svc.createAutopilotRunWithQuota(ctx, workspaceID, "api", "boundary-3", params)
+	// boundary-3 is quota-blocked before any INSERT, so the target autopilot
+	// is irrelevant; reuse a fresh one for clarity.
+	_, _, err = svc.createAutopilotRunWithQuota(ctx, workspaceID, "api", "boundary-3", db.CreateAutopilotRunParams{
+		AutopilotID: util.MustParseUUID(seedRunOnlyAutopilotNoRun(t, pool, workspaceIDString, agentID, publisherID)),
+		Source:      "api", Status: "running",
+	})
 	var quotaErr *AutopilotQuotaExceededError
 	if !errors.As(err, &quotaErr) {
 		t.Fatalf("N+1 admission error = %v, want quota exceeded", err)
@@ -222,6 +265,16 @@ func TestAutopilotQuotaConcurrentAdmissionNeverExceedsLimit(t *testing.T) {
 	const limit = 5
 	fixture := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, limit)
 	ctx := context.Background()
+
+	// Quota is per-workspace; give every concurrent admission its own
+	// autopilot so the per-autopilot in-flight unique index
+	// uq_autopilot_run_inflight does not race with the quota gate. Built
+	// up-front (sequential) so t.Cleanup registration stays single-threaded.
+	argsList := make([]db.CreateAutopilotRunParams, attempts)
+	for i := range argsList {
+		argsList[i] = fixture.newRunArgs("api")
+	}
+
 	start := make(chan struct{})
 	unexpected := make(chan error, attempts)
 	var admitted atomic.Int64
@@ -234,7 +287,7 @@ func TestAutopilotQuotaConcurrentAdmissionNeverExceedsLimit(t *testing.T) {
 			defer wg.Done()
 			<-start
 			_, _, err := fixture.service.createAutopilotRunWithQuota(
-				ctx, fixture.workspaceID, "api", fmt.Sprintf("concurrent-%d", i), fixture.createRunArgs,
+				ctx, fixture.workspaceID, "api", fmt.Sprintf("concurrent-%d", i), argsList[i],
 			)
 			if err == nil {
 				admitted.Add(1)
@@ -274,7 +327,7 @@ func TestAutopilotQuotaObserveToEnforceAndOffFinalization(t *testing.T) {
 	runs := make([]db.AutopilotRun, 0, 2)
 	for i := 0; i < 2; i++ {
 		run, _, err := fixture.service.createAutopilotRunWithQuota(
-			ctx, fixture.workspaceID, "api", fmt.Sprintf("observe-%d", i), fixture.createRunArgs,
+			ctx, fixture.workspaceID, "api", fmt.Sprintf("observe-%d", i), fixture.newRunArgs("api"),
 		)
 		if err != nil {
 			t.Fatalf("observe admission %d: %v", i, err)
@@ -291,7 +344,7 @@ func TestAutopilotQuotaObserveToEnforceAndOffFinalization(t *testing.T) {
 
 	fixture.setPolicy(entitlement.ActionEnforce, fixture.periodStart, fixture.periodEnd, 1)
 	_, _, err = fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "enforce-after-observe", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "enforce-after-observe", fixture.newRunArgs("api"),
 	)
 	var quotaErr *AutopilotQuotaExceededError
 	if !errors.As(err, &quotaErr) {
@@ -314,7 +367,7 @@ func TestAutopilotQuotaObserveToEnforceAndOffFinalization(t *testing.T) {
 		t.Fatalf("usage after off finalization = %+v, %v; want zero", usage, err)
 	}
 	if _, _, err := fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "reopened-after-off", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "reopened-after-off", fixture.newRunArgs("api"),
 	); err != nil {
 		t.Fatalf("admission after reopening policy: %v", err)
 	}
@@ -325,7 +378,7 @@ func TestAutopilotQuotaConsumedCreateIssueCannotBeRefunded(t *testing.T) {
 	ctx := context.Background()
 
 	cancelled, _, err := fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "consumed-then-cancelled", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "consumed-then-cancelled", fixture.newRunArgs("api"),
 	)
 	if err != nil {
 		t.Fatalf("admit cancelled run: %v", err)
@@ -340,7 +393,7 @@ func TestAutopilotQuotaConsumedCreateIssueCannotBeRefunded(t *testing.T) {
 	}
 
 	deleted, _, err := fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "consumed-then-deleted", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "consumed-then-deleted", fixture.newRunArgs("api"),
 	)
 	if err != nil {
 		t.Fatalf("admit deleted run: %v", err)
@@ -367,6 +420,8 @@ func TestAutopilotQuotaConsumedCreateIssueCannotBeRefunded(t *testing.T) {
 func TestAutopilotQuotaTerminalUpdateNeedsNoTransactionStarter(t *testing.T) {
 	fixture := newAutopilotQuotaFixture(t, entitlement.ActionOff, 1)
 	ctx := context.Background()
+	// Free the per-autopilot in-flight slot before the direct insert below.
+	fixture.closeSeededRun()
 	run, err := fixture.queries.CreateAutopilotRun(ctx, fixture.createRunArgs)
 	if err != nil {
 		t.Fatalf("create off-path run: %v", err)
@@ -384,6 +439,8 @@ func TestAutopilotQuotaTerminalUpdateNeedsNoTransactionStarter(t *testing.T) {
 func TestAutopilotQuotaSettlementStaysInOriginalPeriod(t *testing.T) {
 	fixture := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, 1)
 	ctx := context.Background()
+	// Free the per-autopilot in-flight slot before the admission below.
+	fixture.closeSeededRun()
 	run, _, err := fixture.service.createAutopilotRunWithQuota(
 		ctx, fixture.workspaceID, "api", "cross-period", fixture.createRunArgs,
 	)
@@ -420,11 +477,15 @@ func TestAutopilotQuotaWorkspaceIsolation(t *testing.T) {
 	first := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, 1)
 	second := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, 1)
 	ctx := context.Background()
+	first.closeSeededRun()
+	second.closeSeededRun()
 	if _, _, err := first.service.createAutopilotRunWithQuota(
 		ctx, first.workspaceID, "api", "isolated", first.createRunArgs,
 	); err != nil {
 		t.Fatalf("first workspace admission: %v", err)
 	}
+	// The over-limit admission is quota-blocked before any INSERT, so it
+	// does not collide with the in-flight run created above.
 	_, _, err := first.service.createAutopilotRunWithQuota(
 		ctx, first.workspaceID, "api", "isolated-over-limit", first.createRunArgs,
 	)
@@ -443,13 +504,13 @@ func TestAutopilotQuotaReconcilerSettlesTerminalOnlyOnce(t *testing.T) {
 	fixture := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, 2)
 	ctx := context.Background()
 	terminal, _, err := fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "reconcile-terminal", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "reconcile-terminal", fixture.newRunArgs("api"),
 	)
 	if err != nil {
 		t.Fatalf("admit terminal run: %v", err)
 	}
 	active, _, err := fixture.service.createAutopilotRunWithQuota(
-		ctx, fixture.workspaceID, "api", "reconcile-active", fixture.createRunArgs,
+		ctx, fixture.workspaceID, "api", "reconcile-active", fixture.newRunArgs("api"),
 	)
 	if err != nil {
 		t.Fatalf("admit active run: %v", err)
@@ -499,8 +560,10 @@ func TestAutopilotQuotaReconcilerReleasesOnlyAbandonedManualOrAPIRuns(t *testing
 	ctx := context.Background()
 	create := func(source, key string) db.AutopilotRun {
 		t.Helper()
-		params := fixture.createRunArgs
-		params.Source = source
+		// Each in-flight admission targets its own autopilot so the
+		// per-autopilot in-flight unique index does not reject concurrent
+		// partial runs — quota usage is per-workspace, not per-autopilot.
+		params := fixture.newRunArgs(source)
 		run, _, err := fixture.service.createAutopilotRunWithQuota(
 			ctx, fixture.workspaceID, source, key, params,
 		)
@@ -572,6 +635,8 @@ func TestAutopilotQuotaReconcilerReleasesOnlyAbandonedManualOrAPIRuns(t *testing
 func TestAutopilotQuotaIdempotencyRecoversOrphanedReservation(t *testing.T) {
 	fixture := newAutopilotQuotaFixture(t, entitlement.ActionEnforce, 1)
 	ctx := context.Background()
+	// Free the per-autopilot in-flight slot before the admission below.
+	fixture.closeSeededRun()
 	first, _, err := fixture.service.createAutopilotRunWithQuota(
 		ctx, fixture.workspaceID, "api", "orphaned-key", fixture.createRunArgs,
 	)

--- a/server/internal/service/autopilot_quota_test.go
+++ b/server/internal/service/autopilot_quota_test.go
@@ -605,6 +605,15 @@ func TestAutopilotQuotaSchedulePersistsSkippedRun(t *testing.T) {
 		pool.Exec(context.Background(), `DELETE FROM autopilot_quota_period WHERE workspace_id = $1`, workspaceID)
 	})
 
+	// seedRunOnlyAutopilot leaves a `running` run for the fixture. The ALL-206
+	// mutex gate would short-circuit the dispatch on that in-flight run, so
+	// close it out first — this test exercises the quota gate in isolation.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE autopilot_id = $1`,
+		util.MustParseUUID(autopilotIDString)); err != nil {
+		t.Fatalf("close seeded in-flight run: %v", err)
+	}
+
 	start := time.Now().UTC().Truncate(time.Second)
 	end := start.Add(13 * time.Hour)
 	limit := 0

--- a/server/internal/service/cron.go
+++ b/server/internal/service/cron.go
@@ -88,6 +88,35 @@ func NextOccurrencesUTC(cronExpr, timezone string, after, until time.Time) ([]ti
 	return out, nil
 }
 
+// SlotIntervalFromCron returns the longest gap between two consecutive
+// occurrences of the cron schedule, measured over the next year of
+// activations. It is the "slot interval" the autopilot in-flight lease must
+// cover (ALL-226 / ALL-234 defect 1): a run started by this schedule must
+// never be reclaimed before the next slot could legitimately fire. The
+// lookahead window is finite and deliberate — a schedule too sparse to
+// produce a second occurrence within a year (e.g. "0 0 29 2 *") has no
+// measurable cadence, so the caller falls back to the base lease timeout
+// instead of guessing at a multi-year period.
+func SlotIntervalFromCron(cronExpr, timezone string, after time.Time) (time.Duration, bool) {
+	occurrences, err := NextOccurrencesUTC(cronExpr, timezone, after, after.AddDate(1, 0, 0))
+	if err != nil {
+		return 0, false
+	}
+	if len(occurrences) < 2 {
+		return 0, false
+	}
+	var maxGap time.Duration
+	for i := 1; i < len(occurrences); i++ {
+		if gap := occurrences[i].Sub(occurrences[i-1]); gap > maxGap {
+			maxGap = gap
+		}
+	}
+	if maxGap <= 0 {
+		return 0, false
+	}
+	return maxGap, true
+}
+
 // ComputeNextRun evaluates the cron at the app's local now() and backs
 // the display-only autopilot_trigger.next_run_at column for the trigger
 // create/update handlers and the failure monitor. Using the local clock

--- a/server/internal/service/cron_test.go
+++ b/server/internal/service/cron_test.go
@@ -135,6 +135,45 @@ func TestNextOccurrenceAfterUTCIgnoresWallClock(t *testing.T) {
 	}
 }
 
+// TestSlotIntervalFromCron locks in the ALL-234 defect 1 cadence: the
+// slot-interval helper must return the longest gap between consecutive
+// occurrences of the schedule, which is what extends the autopilot lease
+// beyond the base timeout for slow schedules.
+func TestSlotIntervalFromCron(t *testing.T) {
+	after := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		cron   string
+		tz     string
+		want   time.Duration
+		wantOK bool
+	}{
+		{name: "every five minutes", cron: "*/5 * * * *", tz: "UTC", want: 5 * time.Minute, wantOK: true},
+		{name: "every two hours", cron: "0 */2 * * *", tz: "UTC", want: 2 * time.Hour, wantOK: true},
+		{name: "daily", cron: "0 0 * * *", tz: "UTC", want: 24 * time.Hour, wantOK: true},
+		{name: "weekly on monday", cron: "0 12 * * MON", tz: "UTC", want: 7 * 24 * time.Hour, wantOK: true},
+		{name: "monthly first", cron: "0 0 1 * *", tz: "UTC", want: 31 * 24 * time.Hour, wantOK: true},
+		{name: "invalid cron", cron: "not a cron", tz: "UTC", want: 0, wantOK: false},
+		{name: "invalid timezone", cron: "0 * * * *", tz: "Mars/Olympus", want: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := SlotIntervalFromCron(tt.cron, tt.tz, after)
+			if ok != tt.wantOK {
+				t.Fatalf("SlotIntervalFromCron() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("SlotIntervalFromCron() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestNextOccurrenceAdvancesPastFiredSlot locks in the property the
 // scheduler's next_run_at write-back relies on (MUL-3749): once a
 // recurring trigger fires at a slot, the next computed occurrence is the

--- a/server/migrations/432_autopilot_run_inflight_cleanup.down.sql
+++ b/server/migrations/432_autopilot_run_inflight_cleanup.down.sql
@@ -1,0 +1,6 @@
+-- Migration 432 is a one-way data cleanup: it terminalizes duplicate
+-- in-flight autopilot_run rows so migration 433's partial unique index can
+-- be created. The terminalized rows cannot be restored (their status change
+-- is destructive), so this down migration is a documented no-op. Rolling
+-- back is achieved by dropping the index (migration 433 down) — the cleanup
+-- itself is safe to have applied.

--- a/server/migrations/432_autopilot_run_inflight_cleanup.up.sql
+++ b/server/migrations/432_autopilot_run_inflight_cleanup.up.sql
@@ -1,0 +1,31 @@
+-- ALL-211 P0 (BLOCKING 3): prepare autopilot_run for the partial unique
+-- index uq_autopilot_run_inflight (migration 433) by cleaning up historical
+-- data that would violate it.
+--
+-- The index guarantees at most ONE in-flight run per autopilot, where
+-- "in-flight" means status IN ('issue_created', 'running'). Historical rows
+-- may already violate that invariant (a buggy schedule used to start a
+-- second concurrent run before the ALL-206 mutex gate, and a run stuck in
+-- issue_created/running for an autopilot whose issue never reached a
+-- terminal state leaves the slot occupied forever).
+--
+-- Policy: for each autopilot, keep the NEWEST in-flight run and terminalize
+-- every older one as failed with reason_code='migration_cleanup'. Keeping the
+-- newest preserves the run that is most likely still doing real work; the
+-- terminalized rows become visible to the failure monitor instead of
+-- silently wedging the autopilot.
+WITH ranked_runs AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY autopilot_id
+               ORDER BY created_at DESC
+           ) AS rn
+    FROM autopilot_run
+    WHERE status IN ('issue_created', 'running')
+)
+UPDATE autopilot_run
+SET status = 'failed',
+    failure_reason = 'Terminated during migration 432 to enforce unique in-flight constraint',
+    reason_code = 'migration_cleanup',
+    completed_at = NOW()
+WHERE id IN (SELECT id FROM ranked_runs WHERE rn > 1);

--- a/server/migrations/433_autopilot_run_inflight_unique_index.down.sql
+++ b/server/migrations/433_autopilot_run_inflight_unique_index.down.sql
@@ -1,0 +1,4 @@
+-- Drop the in-flight mutual-exclusion index. After this, concurrent
+-- autopilot dispatch loses its DB-level guarantee and falls back to the
+-- pre-ALL-211 check-then-insert behavior — a deliberate rollback only.
+DROP INDEX CONCURRENTLY IF EXISTS uq_autopilot_run_inflight;

--- a/server/migrations/433_autopilot_run_inflight_unique_index.up.sql
+++ b/server/migrations/433_autopilot_run_inflight_unique_index.up.sql
@@ -1,0 +1,21 @@
+-- ALL-211 P0 (BLOCKING 3): DB-level hard mutual exclusion for autopilot
+-- dispatch — at most ONE in-flight run per autopilot, enforced by the
+-- database instead of a racy check-then-insert in the application.
+--
+-- "In-flight" is exactly the state set aligned in ALL-211 BLOCKING 2:
+-- status IN ('issue_created', 'running'), matching the CHECK constraint
+-- autopilot_run_status_check and the partial index idx_autopilot_run_status.
+-- A concurrent dispatch that loses the race fails its INSERT with error
+-- code 23505 on this index, which the dispatch path maps to a `skipped` run
+-- with reason already_active (the same pattern as
+-- recoverConcurrentWebhookAdmission).
+--
+-- CONCURRENTLY because autopilot_run is a hot table (the scheduler writes
+-- a row per slot) and a plain CREATE INDEX would take an ACCESS EXCLUSIVE
+-- lock that stalls dispatch. Matches the 035/067/074/075/078/080 convention.
+-- The migration runner cannot mix CONCURRENTLY with other statements in the
+-- same file, so this file is a single statement; the index comment lives in
+-- migration 434.
+CREATE UNIQUE INDEX CONCURRENTLY uq_autopilot_run_inflight
+ON autopilot_run (autopilot_id)
+WHERE status IN ('issue_created', 'running');

--- a/server/migrations/433_autopilot_run_inflight_unique_index.up.sql
+++ b/server/migrations/433_autopilot_run_inflight_unique_index.up.sql
@@ -16,6 +16,14 @@
 -- The migration runner cannot mix CONCURRENTLY with other statements in the
 -- same file, so this file is a single statement; the index comment lives in
 -- migration 434.
-CREATE UNIQUE INDEX CONCURRENTLY uq_autopilot_run_inflight
+--
+-- IF NOT EXISTS (257/261 convention) pairs with the registered cleanup hook
+-- in cmd/migrate/main.go (concurrentIndexCleanups): an interrupted build
+-- leaves an INVALID uq_autopilot_run_inflight behind, the hook drops it
+-- before the retry, and IF NOT EXISTS then rebuilds instead of wedging on
+-- "already exists" — otherwise an interrupted build could be recorded as
+-- applied while the mutual-exclusion guarantee is silently INVALID, which
+-- is exactly the duplicate-execution risk ALL-234 defect 2 closes.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_autopilot_run_inflight
 ON autopilot_run (autopilot_id)
 WHERE status IN ('issue_created', 'running');

--- a/server/migrations/434_autopilot_run_inflight_index_comment.down.sql
+++ b/server/migrations/434_autopilot_run_inflight_index_comment.down.sql
@@ -1,0 +1,4 @@
+-- Remove the documentation comment from the index (the index itself is
+-- dropped by migration 433 down; this just clears the comment if 433 down
+-- was skipped).
+COMMENT ON INDEX uq_autopilot_run_inflight IS NULL;

--- a/server/migrations/434_autopilot_run_inflight_index_comment.up.sql
+++ b/server/migrations/434_autopilot_run_inflight_index_comment.up.sql
@@ -1,0 +1,5 @@
+-- Document uq_autopilot_run_inflight for operators. Lives in its own
+-- migration because the index was created CONCURRENTLY (migration 433),
+-- which the migration runner cannot mix with other statements in one file.
+COMMENT ON INDEX uq_autopilot_run_inflight IS
+'Ensures at most one in-flight run per autopilot. Partial index only covers non-terminal statuses (issue_created, running). 23505 conflicts are handled as already_active dispatch skip.';

--- a/server/pkg/autopilot/lease.go
+++ b/server/pkg/autopilot/lease.go
@@ -1,0 +1,48 @@
+// Package autopilot holds the cross-cutting autopilot infrastructure that
+// is shared between the dispatch service and background workers. It is a
+// leaf package (no server-internal dependencies) so both the service layer
+// and the sweeper can use it without import cycles.
+package autopilot
+
+import "time"
+
+const (
+	// MinLeaseDuration is the hard floor for any computed lease. It exists
+	// to stop a misconfigured (too aggressive) lease from killing long
+	// legitimate runs: below this value, autopilot dispatch is effectively
+	// broken, so the config is clamped instead of honored.
+	MinLeaseDuration = 5 * time.Minute
+
+	// DefaultLeaseTimeout is the base in-flight lease for an autopilot run
+	// when AUTOPILOT_RUN_LEASE_TIMEOUT is unset. After this much wall time a
+	// run stuck in issue_created/running is treated as stale: the dispatch
+	// gate terminalizes it (failed + lease_expired) and admits the next slot.
+	DefaultLeaseTimeout = 30 * time.Minute
+)
+
+// LeaseConfig is the input to CalculateLeaseDuration. BaseTimeout is the
+// operator-configured floor (AUTOPILOT_RUN_LEASE_TIMEOUT); SlotInterval is
+// the autopilot's scheduling cadence when known (max cron interval between
+// two consecutive occurrences).
+type LeaseConfig struct {
+	// BaseTimeout is the base in-flight lease duration.
+	BaseTimeout time.Duration
+	// SlotInterval is the scheduling cadence. When zero, it never dominates.
+	SlotInterval time.Duration
+}
+
+// CalculateLeaseDuration returns the bounded lease for an in-flight run:
+// the larger of the base timeout and the slot interval, so the lease always
+// covers at least one full scheduling cycle. The result is clamped at
+// MinLeaseDuration so an undersized configuration can never cause
+// over-aggressive stale-run cleanup.
+func (c *LeaseConfig) CalculateLeaseDuration() time.Duration {
+	lease := c.BaseTimeout
+	if c.SlotInterval > lease {
+		lease = c.SlotInterval
+	}
+	if lease < MinLeaseDuration {
+		return MinLeaseDuration
+	}
+	return lease
+}

--- a/server/pkg/autopilot/lease_test.go
+++ b/server/pkg/autopilot/lease_test.go
@@ -1,0 +1,58 @@
+package autopilot
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLeaseConfig_CalculateLeaseDuration(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseTimeout  time.Duration
+		slotInterval time.Duration
+		expected     time.Duration
+	}{
+		{
+			name:         "slot interval larger than base timeout",
+			baseTimeout:  30 * time.Minute,
+			slotInterval: 1 * time.Hour,
+			expected:     1 * time.Hour,
+		},
+		{
+			name:         "base timeout larger than slot interval",
+			baseTimeout:  1 * time.Hour,
+			slotInterval: 15 * time.Minute,
+			expected:     1 * time.Hour,
+		},
+		{
+			name:         "equal values",
+			baseTimeout:  30 * time.Minute,
+			slotInterval: 30 * time.Minute,
+			expected:     30 * time.Minute,
+		},
+		{
+			name:         "zero slot interval falls back to base timeout",
+			baseTimeout:  30 * time.Minute,
+			slotInterval: 0,
+			expected:     30 * time.Minute,
+		},
+		{
+			name:         "sub-minimum config is clamped to the floor",
+			baseTimeout:  1 * time.Second,
+			slotInterval: 0,
+			expected:     MinLeaseDuration,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &LeaseConfig{
+				BaseTimeout:  tt.baseTimeout,
+				SlotInterval: tt.slotInterval,
+			}
+			if got := config.CalculateLeaseDuration(); got != tt.expected {
+				t.Fatalf("CalculateLeaseDuration() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -924,6 +924,45 @@ func (q *Queries) GetAutopilotRunByWebhookDelivery(ctx context.Context, webhookD
 	return i, err
 }
 
+const getAutopilotRunInFlight = `-- name: GetAutopilotRunInFlight :one
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, quota_reservation_id, reason_code FROM autopilot_run
+WHERE autopilot_id = $1
+  AND status IN ('pending', 'issue_created', 'running')
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+// Mutex gate for the scheduler: returns the most recent run that has not yet
+// reached a terminal state. The status list mirrors the partial index
+// idx_autopilot_run_status (migration 042), which is also the authoritative
+// definition of "in flight". Returns no rows when the autopilot is free to
+// dispatch a new run.
+func (q *Queries) GetAutopilotRunInFlight(ctx context.Context, autopilotID pgtype.UUID) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getAutopilotRunInFlight, autopilotID)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
+		&i.WebhookDeliveryID,
+		&i.QuotaReservationID,
+		&i.ReasonCode,
+	)
+	return i, err
+}
+
 const getAutopilotTaskByRun = `-- name: GetAutopilotTaskByRun :one
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
 WHERE autopilot_run_id = $1

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -927,16 +927,20 @@ func (q *Queries) GetAutopilotRunByWebhookDelivery(ctx context.Context, webhookD
 const getAutopilotRunInFlight = `-- name: GetAutopilotRunInFlight :one
 SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, quota_reservation_id, reason_code FROM autopilot_run
 WHERE autopilot_id = $1
-  AND status IN ('pending', 'issue_created', 'running')
+  AND status IN ('issue_created', 'running')
 ORDER BY created_at DESC
 LIMIT 1
 `
 
 // Mutex gate for the scheduler: returns the most recent run that has not yet
-// reached a terminal state. The status list mirrors the partial index
-// idx_autopilot_run_status (migration 042), which is also the authoritative
-// definition of "in flight". Returns no rows when the autopilot is free to
-// dispatch a new run.
+// reached a terminal state. "In flight" is defined as
+// status IN ('issue_created', 'running'), strictly aligned with the CHECK
+// constraint autopilot_run_status_check and the partial indexes
+// idx_autopilot_run_status / uq_autopilot_run_inflight. 'pending' is NOT a
+// legal status (the CHECK constraint forbids it; the column default is a
+// historical leftover), so it must not appear here — a predicate wider than
+// the partial index would make the planner fall back off the index. Returns
+// no rows when the autopilot is free to dispatch a new run.
 func (q *Queries) GetAutopilotRunInFlight(ctx context.Context, autopilotID pgtype.UUID) (AutopilotRun, error) {
 	row := q.db.QueryRow(ctx, getAutopilotRunInFlight, autopilotID)
 	var i AutopilotRun
@@ -2059,6 +2063,60 @@ func (q *Queries) SystemPauseAutopilot(ctx context.Context, id pgtype.UUID) (Aut
 		&i.AssigneeType,
 		&i.ProjectID,
 		&i.PauseReason,
+	)
+	return i, err
+}
+
+const terminalizeStaleAutopilotRun = `-- name: TerminalizeStaleAutopilotRun :one
+UPDATE autopilot_run
+SET status = 'failed',
+    failure_reason = $1,
+    reason_code = $2,
+    completed_at = $3
+WHERE id = $4
+  AND status IN ('issue_created', 'running')
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, quota_reservation_id, reason_code
+`
+
+type TerminalizeStaleAutopilotRunParams struct {
+	FailureReason pgtype.Text        `json:"failure_reason"`
+	ReasonCode    pgtype.Text        `json:"reason_code"`
+	CompletedAt   pgtype.Timestamptz `json:"completed_at"`
+	ID            pgtype.UUID        `json:"id"`
+}
+
+// Lease-gate reclaim (ALL-211 BLOCKING 1): marks an in-flight run as failed
+// with a lease-expired reason, then returns the updated row. The idempotent
+// WHERE clause (status still in-flight) makes concurrent reclaim safe: a
+// racing sweeper or another replica's dispatch gate affects at most one
+// UPDATE and the loser simply sees zero rows.
+func (q *Queries) TerminalizeStaleAutopilotRun(ctx context.Context, arg TerminalizeStaleAutopilotRunParams) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, terminalizeStaleAutopilotRun,
+		arg.FailureReason,
+		arg.ReasonCode,
+		arg.CompletedAt,
+		arg.ID,
+	)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
+		&i.WebhookDeliveryID,
+		&i.QuotaReservationID,
+		&i.ReasonCode,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -401,15 +401,34 @@ LIMIT $2 OFFSET $3;
 
 -- name: GetAutopilotRunInFlight :one
 -- Mutex gate for the scheduler: returns the most recent run that has not yet
--- reached a terminal state. The status list mirrors the partial index
--- idx_autopilot_run_status (migration 042), which is also the authoritative
--- definition of "in flight". Returns no rows when the autopilot is free to
--- dispatch a new run.
+-- reached a terminal state. "In flight" is defined as
+-- status IN ('issue_created', 'running'), strictly aligned with the CHECK
+-- constraint autopilot_run_status_check and the partial indexes
+-- idx_autopilot_run_status / uq_autopilot_run_inflight. 'pending' is NOT a
+-- legal status (the CHECK constraint forbids it; the column default is a
+-- historical leftover), so it must not appear here — a predicate wider than
+-- the partial index would make the planner fall back off the index. Returns
+-- no rows when the autopilot is free to dispatch a new run.
 SELECT * FROM autopilot_run
 WHERE autopilot_id = $1
-  AND status IN ('pending', 'issue_created', 'running')
+  AND status IN ('issue_created', 'running')
 ORDER BY created_at DESC
 LIMIT 1;
+
+-- name: TerminalizeStaleAutopilotRun :one
+-- Lease-gate reclaim (ALL-211 BLOCKING 1): marks an in-flight run as failed
+-- with a lease-expired reason, then returns the updated row. The idempotent
+-- WHERE clause (status still in-flight) makes concurrent reclaim safe: a
+-- racing sweeper or another replica's dispatch gate affects at most one
+-- UPDATE and the loser simply sees zero rows.
+UPDATE autopilot_run
+SET status = 'failed',
+    failure_reason = $1,
+    reason_code = $2,
+    completed_at = $3
+WHERE id = $4
+  AND status IN ('issue_created', 'running')
+RETURNING *;
 
 -- name: UpdateAutopilotRunIssueCreated :one
 UPDATE autopilot_run

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -399,6 +399,18 @@ WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 
+-- name: GetAutopilotRunInFlight :one
+-- Mutex gate for the scheduler: returns the most recent run that has not yet
+-- reached a terminal state. The status list mirrors the partial index
+-- idx_autopilot_run_status (migration 042), which is also the authoritative
+-- definition of "in flight". Returns no rows when the autopilot is free to
+-- dispatch a new run.
+SELECT * FROM autopilot_run
+WHERE autopilot_id = $1
+  AND status IN ('pending', 'issue_created', 'running')
+ORDER BY created_at DESC
+LIMIT 1;
+
 -- name: UpdateAutopilotRunIssueCreated :one
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2


### PR DESCRIPTION
## 概述

在 ALL-206 互斥门禁（PR #7513，commit `5b4feeac7`）之上修复 ALL-211 的三个 P0 阻塞项。原门禁无期限，`create_issue` run 卡在 `issue_created` 且 issue 停在非终态时，后续所有槽位永久 skip，失败率监控不可见，manual 触发也无逃生口。

## BLOCKING 1 — 租约上界 + reaper（消除永久卡死）

- `shouldSkipDispatch` 门禁改为有界租约：in-flight run 仅在租约期内阻塞派发（`max(AUTOPILOT_RUN_LEASE_TIMEOUT, 槽位间隔)`，下限 5m，默认 30m）。租约过期 → 将陈旧 run 终态化为 `failed`（`reason_code=lease_expired`）并放行本槽位。
- 新增 `StaleRunSweeper`（`server/internal/autopilot/sweeper.go`）：周期性终态化超过硬时限的 `issue_created/running` run，使失败率监控可见并可自动暂停。通过 `AUTOPILOT_SWEEPER_ENABLED/INTERVAL/HARD_TIMEOUT` 控制，注册于 `main.go`。
- 租约计算逻辑在 `server/pkg/autopilot`（`LeaseConfig.CalculateLeaseDuration`），含单元测试。
- manual 触发在租约超期后放行 → 卡死态可自救。

## BLOCKING 2 — 状态集对齐

- `GetAutopilotRunInFlight` 谓词收敛为 `('issue_created','running')`，与 CHECK 约束和部分索引严格一致（原 `pending` 是死条件且导致 planner 放弃部分索引）。
- EXPLAIN 回归测试断言查询走 `uq_autopilot_run_inflight` / `idx_autopilot_run_status` 索引（非 Seq Scan）。

## BLOCKING 3 — 并发原子化（部分唯一索引）

- Migration 433：`CREATE UNIQUE INDEX CONCURRENTLY uq_autopilot_run_inflight ON autopilot_run(autopilot_id) WHERE status IN ('issue_created','running')`；Migration 432 先清理历史冲突数据（每个 autopilot 保留最新 in-flight，其余终态化）。
- 并发竞态输家收到 `23505`，映射为 `skipped` + `already_active`（对齐 `recoverConcurrentWebhookAdmission` 范式）。
- 所有 skipped run 现在持久化类型化 `reason_code`。

## 回归测试（真实 DB）

`server/cmd/server/autopilot_lease_gate_test.go`：
- `TestDispatch_LeaseExpired_AllowsNewDispatch`（create_issue + 非终态 issue，精确复现卡死场景）
- `TestDispatch_Concurrent_OnlyOneSucceeds`（10 并发槽位，恰好 1 成功 9 skip）
- `TestDispatch_ManualTrigger_RecoverFromStaleRun`（手动自救）
- `TestDispatch_InFlight_BlocksWithinLease`（租约期内仍阻塞）
- `TestGetInFlightRun_UsesPartialIndex`（EXPLAIN 证据）
- `TestStaleRunSweeper_TerminalizesExpiredRuns`

现有 ALL-206 门禁测试保持全绿；quota 测试适配为"每个 in-flight admission 独立 autopilot"（quota 按 workspace 计，非按 autopilot）。

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/autopilot ./internal/migrations ./internal/service ./cmd/server` ✅（全部通过）
