### PR TITLE
MUL-6697: enforce runtime access on task claims

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1707,8 +1707,8 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 		resp, deliveredCommentIDs, _, _, failure := h.buildClaimedTaskResponse(r, &task, rt, uuidToString(task.RuntimeID), rtWorkspaceID)
 		if failure != nil {
 			// Builder rejected this task (workspace isolation / chat-input);
-			// it has already cancelled the task where the failure requires it.
-			// Skip it — non-cancelling failures leave the task dispatched for
+			// it has already settled the task where the failure requires it.
+			// Skip it — non-settling failures leave the task dispatched for
 			// the reclaim path.
 			continue
 		}
@@ -2092,6 +2092,10 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	}
 	if runtime.Visibility == "private" && runtime.OwnerID.Valid &&
 		(!agent.OwnerID.Valid || agent.OwnerID != runtime.OwnerID) {
+		userMessage := "This private runtime cannot run the assigned agent because the agent and runtime have different owners."
+		if !agent.OwnerID.Valid {
+			userMessage = "This private runtime cannot run the assigned agent because the agent has no owner."
+		}
 		slog.Warn("daemon claim: private runtime no longer permits task agent; refusing dispatch",
 			"task_id", uuidToString(task.ID),
 			"agent_id", uuidToString(task.AgentID),
@@ -2100,7 +2104,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		)
 		return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, h.failClaimedTaskBeforeLaunch(
 			r.Context(), task,
-			"This private runtime cannot run the assigned agent because the agent has no matching owner.",
+			userMessage,
 			taskfailure.ReasonInvalidTaskIdentity,
 			"error_runtime_access_denied", http.StatusForbidden, "private runtime does not permit task agent",
 		)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2072,6 +2072,39 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			message: "failed to load task agent",
 		}
 	}
+	// The SQL claim narrows candidates and repeats the access predicate before
+	// changing task state, but Agent mutations do not stay locked through HTTP
+	// response assembly. Recheck the freshly loaded Agent here so a rebind or
+	// owner change that committed after the claim cannot reach the daemon.
+	if agent.RuntimeID != task.RuntimeID {
+		slog.Warn("daemon claim: agent runtime changed before delivery; refusing dispatch",
+			"task_id", uuidToString(task.ID),
+			"agent_id", uuidToString(task.AgentID),
+			"task_runtime_id", uuidToString(task.RuntimeID),
+			"agent_runtime_id", uuidToString(agent.RuntimeID),
+		)
+		return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, h.failClaimedTaskBeforeLaunch(
+			r.Context(), task,
+			"The agent moved to another runtime before this task could start. Retry the task to run it on the agent's current runtime.",
+			taskfailure.ReasonInvalidTaskIdentity,
+			"error_agent_runtime_changed", http.StatusConflict, "agent runtime changed before task delivery",
+		)
+	}
+	if runtime.Visibility == "private" && runtime.OwnerID.Valid &&
+		(!agent.OwnerID.Valid || agent.OwnerID != runtime.OwnerID) {
+		slog.Warn("daemon claim: private runtime no longer permits task agent; refusing dispatch",
+			"task_id", uuidToString(task.ID),
+			"agent_id", uuidToString(task.AgentID),
+			"runtime_id", runtimeID,
+			"agent_owner_valid", agent.OwnerID.Valid,
+		)
+		return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, h.failClaimedTaskBeforeLaunch(
+			r.Context(), task,
+			"This private runtime cannot run the assigned agent because the agent has no matching owner.",
+			taskfailure.ReasonInvalidTaskIdentity,
+			"error_runtime_access_denied", http.StatusForbidden, "private runtime does not permit task agent",
+		)
+	}
 	useSkillRefs := requestHasClientCapability(r, protocol.DaemonCapabilitySkillBundlesV1)
 	var customEnv map[string]string
 	if agent.CustomEnv != nil {

--- a/server/internal/handler/daemon_runtime_access_test.go
+++ b/server/internal/handler/daemon_runtime_access_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
@@ -38,8 +39,64 @@ func TestClaimTaskByRuntime_OwnerlessAgentOnPrivateRuntimeFailsExplicitly(t *tes
 	if status != "failed" {
 		t.Fatalf("task status = %q, want failed", status)
 	}
-	if !strings.Contains(errorMessage, "agent has no matching owner") {
-		t.Fatalf("task error = %q, want actionable owner mismatch", errorMessage)
+	if !strings.Contains(errorMessage, "agent has no owner") {
+		t.Fatalf("task error = %q, want actionable missing-owner error", errorMessage)
+	}
+	if failureReason != taskfailure.ReasonInvalidTaskIdentity.String() {
+		t.Fatalf("failure_reason = %q, want %q", failureReason, taskfailure.ReasonInvalidTaskIdentity)
+	}
+}
+
+func TestBuildClaimedTaskResponseRejectsAgentOwnerChangedAfterClaim(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	newOwnerID := dbfx.User(t, "Claim owner mismatch", "claim-owner-mismatch-"+uuid.NewString()+"@example.com")
+	dbfx.Member(t, testWorkspaceID, newOwnerID, "member")
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Claim then change owner runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Claim then change owner agent")
+	taskID := seedQueuedIssueTask(t, ctx, agentID, runtimeID, issueID)
+
+	task, err := testHandler.TaskService.ClaimTaskForRuntime(ctx, parseUUID(runtimeID))
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if task == nil || uuidToString(task.ID) != taskID {
+		t.Fatalf("claimed task = %+v, want %s", task, taskID)
+	}
+	dbfx.Exec(t, `UPDATE agent SET owner_id = $1 WHERE id = $2`, newOwnerID, agentID)
+
+	runtime, err := testHandler.Queries.GetAgentRuntimeForWorkspace(ctx, db.GetAgentRuntimeForWorkspaceParams{
+		ID:          parseUUID(runtimeID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("load runtime: %v", err)
+	}
+	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
+		testWorkspaceID, "claim-then-owner-change")
+	_, _, _, _, failure := testHandler.buildClaimedTaskResponse(
+		req, task, runtime, runtimeID, testWorkspaceID,
+	)
+	if failure == nil || failure.status != http.StatusForbidden || failure.outcome != "error_runtime_access_denied" {
+		t.Fatalf("failure = %+v, want runtime-access forbidden", failure)
+	}
+
+	var status, errorMessage, failureReason string
+	dbfx.QueryRow(t, `
+		SELECT status, error, failure_reason
+		FROM agent_task_queue
+		WHERE id = $1
+	`, taskID).Scan(&status, &errorMessage, &failureReason)
+	if status != "failed" {
+		t.Fatalf("task status = %q, want failed", status)
+	}
+	if !strings.Contains(errorMessage, "agent and runtime have different owners") {
+		t.Fatalf("task error = %q, want actionable owner-mismatch error", errorMessage)
+	}
+	if strings.Contains(errorMessage, "agent has no owner") {
+		t.Fatalf("task error = %q, must not describe a non-null owner as missing", errorMessage)
 	}
 	if failureReason != taskfailure.ReasonInvalidTaskIdentity.String() {
 		t.Fatalf("failure_reason = %q, want %q", failureReason, taskfailure.ReasonInvalidTaskIdentity)

--- a/server/internal/handler/daemon_runtime_access_test.go
+++ b/server/internal/handler/daemon_runtime_access_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+func TestClaimTaskByRuntime_OwnerlessAgentOnPrivateRuntimeFailsExplicitly(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Ownerless agent private runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Ownerless private agent")
+	dbfx.Exec(t, `UPDATE agent SET owner_id = NULL WHERE id = $1`, agentID)
+	taskID := seedQueuedIssueTask(t, ctx, agentID, runtimeID, issueID)
+
+	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
+		testWorkspaceID, "ownerless-agent-claim")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusForbidden)
+	if !strings.Contains(w.Body.String(), "private runtime does not permit task agent") {
+		t.Fatalf("ClaimTaskByRuntime body = %q, want explicit private-runtime access error", w.Body.String())
+	}
+
+	var status, errorMessage, failureReason string
+	dbfx.QueryRow(t, `
+		SELECT status, error, failure_reason
+		FROM agent_task_queue
+		WHERE id = $1
+	`, taskID).Scan(&status, &errorMessage, &failureReason)
+	if status != "failed" {
+		t.Fatalf("task status = %q, want failed", status)
+	}
+	if !strings.Contains(errorMessage, "agent has no matching owner") {
+		t.Fatalf("task error = %q, want actionable owner mismatch", errorMessage)
+	}
+	if failureReason != taskfailure.ReasonInvalidTaskIdentity.String() {
+		t.Fatalf("failure_reason = %q, want %q", failureReason, taskfailure.ReasonInvalidTaskIdentity)
+	}
+}
+
+func TestBuildClaimedTaskResponseRejectsAgentReboundAfterClaim(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	oldRuntimeID := createClaimReclaimRuntime(t, ctx, "Claim then rebind old runtime")
+	newRuntimeID := createClaimReclaimRuntime(t, ctx, "Claim then rebind new runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, oldRuntimeID, "Claim then rebind agent")
+	taskID := seedQueuedIssueTask(t, ctx, agentID, oldRuntimeID, issueID)
+
+	task, err := testHandler.TaskService.ClaimTaskForRuntime(ctx, parseUUID(oldRuntimeID))
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if task == nil || uuidToString(task.ID) != taskID {
+		t.Fatalf("claimed task = %+v, want %s", task, taskID)
+	}
+	dbfx.Exec(t, `UPDATE agent SET runtime_id = $1 WHERE id = $2`, newRuntimeID, agentID)
+
+	runtime, err := testHandler.Queries.GetAgentRuntimeForWorkspace(ctx, db.GetAgentRuntimeForWorkspaceParams{
+		ID:          parseUUID(oldRuntimeID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("load old runtime: %v", err)
+	}
+	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+oldRuntimeID+"/tasks/claim", nil,
+		testWorkspaceID, "claim-then-rebind")
+	_, _, _, _, failure := testHandler.buildClaimedTaskResponse(
+		req, task, runtime, oldRuntimeID, testWorkspaceID,
+	)
+	if failure == nil || failure.status != http.StatusConflict || failure.outcome != "error_agent_runtime_changed" {
+		t.Fatalf("failure = %+v, want runtime-changed conflict", failure)
+	}
+
+	var status, errorMessage, failureReason string
+	dbfx.QueryRow(t, `
+		SELECT status, error, failure_reason
+		FROM agent_task_queue
+		WHERE id = $1
+	`, taskID).Scan(&status, &errorMessage, &failureReason)
+	if status != "failed" {
+		t.Fatalf("task status = %q, want failed", status)
+	}
+	if !strings.Contains(errorMessage, "moved to another runtime") {
+		t.Fatalf("task error = %q, want actionable rebind error", errorMessage)
+	}
+	if failureReason != taskfailure.ReasonInvalidTaskIdentity.String() {
+		t.Fatalf("failure_reason = %q, want %q", failureReason, taskfailure.ReasonInvalidTaskIdentity)
+	}
+}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2723,11 +2723,11 @@ func createRuntimeGuardAgent(t *testing.T, ctx context.Context) (agentID, runtim
 	dbfx.QueryRow(t, `
 		INSERT INTO agent (
 			workspace_id, name, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks
+			runtime_id, visibility, max_concurrent_tasks, owner_id
 		)
-		VALUES ($1, $2, 'local', '{}'::jsonb, $3, 'workspace', 3)
+		VALUES ($1, $2, 'local', '{}'::jsonb, $3, 'workspace', 3, $4)
 		RETURNING id
-	`, testWorkspaceID, "Runtime Guard Agent "+t.Name(), runtimeID).Scan(&agentID)
+	`, testWorkspaceID, "Runtime Guard Agent "+t.Name(), runtimeID, testUserID).Scan(&agentID)
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
 
 	return agentID, runtimeID, daemonID

--- a/server/internal/service/runtime_claim_access_test.go
+++ b/server/internal/service/runtime_claim_access_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -98,10 +99,12 @@ func TestRuntimeAccessGatesQueuedTaskClaims(t *testing.T) {
 		visibility      string
 		sameOwner       bool
 		matchingBinding bool
+		ownerlessAgent  bool
 		wantClaim       bool
 	}{
 		{name: "private runtime rejects foreign agent", visibility: "private", wantClaim: false, matchingBinding: true},
 		{name: "private runtime accepts owner agent", visibility: "private", sameOwner: true, matchingBinding: true, wantClaim: true},
+		{name: "private runtime routes ownerless agent to handler", visibility: "private", sameOwner: true, matchingBinding: true, ownerlessAgent: true, wantClaim: true},
 		{name: "public runtime accepts foreign agent", visibility: "public", wantClaim: true, matchingBinding: true},
 		{name: "task runtime must match agent binding", visibility: "public", wantClaim: false, matchingBinding: false},
 	}
@@ -109,6 +112,11 @@ func TestRuntimeAccessGatesQueuedTaskClaims(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fixture := newRuntimeClaimAccessFixture(t, tt.visibility, tt.sameOwner, tt.matchingBinding, "queued")
+			if tt.ownerlessAgent {
+				if _, err := fixture.pool.Exec(ctx, `UPDATE agent SET owner_id = NULL WHERE id = $1`, fixture.agentID); err != nil {
+					t.Fatalf("clear agent owner: %v", err)
+				}
+			}
 			q := db.New(fixture.pool)
 
 			candidates, err := q.ListQueuedClaimCandidatesByRuntime(ctx, fixture.runtimeID)
@@ -167,10 +175,12 @@ func TestRuntimeAccessGatesStaleDispatchReclaim(t *testing.T) {
 		visibility      string
 		sameOwner       bool
 		matchingBinding bool
+		ownerlessAgent  bool
 		wantReclaim     bool
 	}{
 		{name: "private runtime rejects foreign agent", visibility: "private", wantReclaim: false, matchingBinding: true},
 		{name: "private runtime accepts owner agent", visibility: "private", sameOwner: true, matchingBinding: true, wantReclaim: true},
+		{name: "private runtime routes ownerless agent to handler", visibility: "private", sameOwner: true, matchingBinding: true, ownerlessAgent: true, wantReclaim: true},
 		{name: "public runtime accepts foreign agent", visibility: "public", wantReclaim: true, matchingBinding: true},
 		{name: "task runtime must match agent binding", visibility: "public", wantReclaim: false, matchingBinding: false},
 	}
@@ -178,6 +188,11 @@ func TestRuntimeAccessGatesStaleDispatchReclaim(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fixture := newRuntimeClaimAccessFixture(t, tt.visibility, tt.sameOwner, tt.matchingBinding, "dispatched")
+			if tt.ownerlessAgent {
+				if _, err := fixture.pool.Exec(ctx, `UPDATE agent SET owner_id = NULL WHERE id = $1`, fixture.agentID); err != nil {
+					t.Fatalf("clear agent owner: %v", err)
+				}
+			}
 			q := db.New(fixture.pool)
 			params := db.ReclaimStaleDispatchedTaskForRuntimeParams{
 				RuntimeID:         fixture.runtimeID,
@@ -232,7 +247,7 @@ func TestRuntimeAccessGatesStaleDispatchReclaim(t *testing.T) {
 func TestClaimTaskRejectsMismatchedAgentRuntime(t *testing.T) {
 	ctx := context.Background()
 	fixture := newRuntimeClaimAccessFixture(t, "public", false, false, "queued")
-	svc := NewTaskService(db.New(fixture.pool), fixture.pool, nil, nil)
+	svc := NewTaskService(db.New(fixture.pool), fixture.pool, nil, events.New())
 
 	claimed, err := svc.claimTask(ctx, fixture.agentID, fixture.runtimeID)
 	if err != nil {
@@ -248,5 +263,22 @@ func TestClaimTaskRejectsMismatchedAgentRuntime(t *testing.T) {
 	}
 	if status != "queued" {
 		t.Fatalf("task status = %q, want queued", status)
+	}
+}
+
+func TestClaimTaskUsesCurrentAgentRuntimeWhenRuntimeIDIsOmitted(t *testing.T) {
+	ctx := context.Background()
+	fixture := newRuntimeClaimAccessFixture(t, "public", true, true, "queued")
+	svc := NewTaskService(db.New(fixture.pool), fixture.pool, nil, events.New())
+
+	claimed, err := svc.ClaimTask(ctx, fixture.agentID)
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("ClaimTask returned nil, want task from the agent's current runtime")
+	}
+	if util.UUIDToString(claimed.ID) != fixture.taskID {
+		t.Fatalf("claimed task = %s, want %s", util.UUIDToString(claimed.ID), fixture.taskID)
 	}
 }

--- a/server/internal/service/runtime_claim_access_test.go
+++ b/server/internal/service/runtime_claim_access_test.go
@@ -1,0 +1,252 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type runtimeClaimAccessFixture struct {
+	pool      *pgxpool.Pool
+	agentID   pgtype.UUID
+	runtimeID pgtype.UUID
+	taskID    string
+}
+
+func newRuntimeClaimAccessFixture(
+	t *testing.T,
+	visibility string,
+	sameOwner bool,
+	matchingBinding bool,
+	taskStatus string,
+) runtimeClaimAccessFixture {
+	t.Helper()
+
+	pool := newResolveOriginatorPool(t)
+	bootstrap := testutil.New(pool, "", "")
+	suffix := time.Now().UnixNano()
+	runtimeOwnerID := bootstrap.User(t,
+		fmt.Sprintf("runtime-owner-%d", suffix),
+		fmt.Sprintf("runtime-owner-%d@example.com", suffix),
+	)
+	agentOwnerID := runtimeOwnerID
+	if !sameOwner {
+		agentOwnerID = bootstrap.User(t,
+			fmt.Sprintf("agent-owner-%d", suffix),
+			fmt.Sprintf("agent-owner-%d@example.com", suffix),
+		)
+	}
+	workspaceID := bootstrap.Workspace(t,
+		fmt.Sprintf("runtime-claim-access-%d", suffix),
+		fmt.Sprintf("runtime-claim-access-%d", suffix),
+	)
+
+	fx := testutil.New(pool, workspaceID, runtimeOwnerID)
+	fx.Member(t, workspaceID, runtimeOwnerID, "owner")
+	if agentOwnerID != runtimeOwnerID {
+		fx.Member(t, workspaceID, agentOwnerID, "member")
+	}
+	taskRuntimeID := fx.Runtime(t, "task-runtime", testutil.Cols{
+		"visibility": visibility,
+		"owner_id":   runtimeOwnerID,
+	})
+	boundRuntimeID := taskRuntimeID
+	if !matchingBinding {
+		boundRuntimeID = fx.Runtime(t, "agent-runtime", testutil.Cols{
+			"visibility": "public",
+			"owner_id":   runtimeOwnerID,
+		})
+	}
+	agentID := fx.Agent(t, "claim-agent", boundRuntimeID, testutil.Cols{
+		"owner_id":             agentOwnerID,
+		"max_concurrent_tasks": 5,
+	})
+	issueID := fx.Issue(t, "runtime claim access")
+	taskCols := testutil.Cols{
+		"runtime_id": taskRuntimeID,
+		"issue_id":   issueID,
+		"status":     taskStatus,
+	}
+	if taskStatus == "dispatched" {
+		taskCols["dispatched_at"] = testutil.Raw("now() - interval '10 minutes'")
+		taskCols["prepare_lease_expires_at"] = testutil.Raw("now() - interval '1 minute'")
+	}
+	taskID := fx.Task(t, agentID, taskCols)
+
+	return runtimeClaimAccessFixture{
+		pool:      pool,
+		agentID:   util.MustParseUUID(agentID),
+		runtimeID: util.MustParseUUID(taskRuntimeID),
+		taskID:    taskID,
+	}
+}
+
+func TestRuntimeAccessGatesQueuedTaskClaims(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		visibility      string
+		sameOwner       bool
+		matchingBinding bool
+		wantClaim       bool
+	}{
+		{name: "private runtime rejects foreign agent", visibility: "private", wantClaim: false, matchingBinding: true},
+		{name: "private runtime accepts owner agent", visibility: "private", sameOwner: true, matchingBinding: true, wantClaim: true},
+		{name: "public runtime accepts foreign agent", visibility: "public", wantClaim: true, matchingBinding: true},
+		{name: "task runtime must match agent binding", visibility: "public", wantClaim: false, matchingBinding: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newRuntimeClaimAccessFixture(t, tt.visibility, tt.sameOwner, tt.matchingBinding, "queued")
+			q := db.New(fixture.pool)
+
+			candidates, err := q.ListQueuedClaimCandidatesByRuntime(ctx, fixture.runtimeID)
+			if err != nil {
+				t.Fatalf("list singular candidates: %v", err)
+			}
+			batchCandidates, err := q.ListQueuedClaimCandidatesByRuntimes(ctx, []pgtype.UUID{fixture.runtimeID})
+			if err != nil {
+				t.Fatalf("list batch candidates: %v", err)
+			}
+			wantCandidates := 0
+			if tt.wantClaim {
+				wantCandidates = 1
+			}
+			if len(candidates) != wantCandidates {
+				t.Fatalf("singular candidates = %d, want %d", len(candidates), wantCandidates)
+			}
+			if len(batchCandidates) != wantCandidates {
+				t.Fatalf("batch candidates = %d, want %d", len(batchCandidates), wantCandidates)
+			}
+
+			claimed, err := q.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
+				AgentID:          fixture.agentID,
+				RuntimeID:        fixture.runtimeID,
+				PrepareLeaseSecs: 60,
+				RuntimeStaleSecs: RuntimeClaimFreshnessSeconds,
+			})
+			if !tt.wantClaim {
+				if !errors.Is(err, pgx.ErrNoRows) {
+					t.Fatalf("claim error = %v, want no rows", err)
+				}
+				var status string
+				if err := fixture.pool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, fixture.taskID).Scan(&status); err != nil {
+					t.Fatalf("read task status: %v", err)
+				}
+				if status != "queued" {
+					t.Fatalf("task status = %q, want queued", status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("claim: %v", err)
+			}
+			if util.UUIDToString(claimed.ID) != fixture.taskID {
+				t.Fatalf("claimed task = %s, want %s", util.UUIDToString(claimed.ID), fixture.taskID)
+			}
+		})
+	}
+}
+
+func TestRuntimeAccessGatesStaleDispatchReclaim(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		visibility      string
+		sameOwner       bool
+		matchingBinding bool
+		wantReclaim     bool
+	}{
+		{name: "private runtime rejects foreign agent", visibility: "private", wantReclaim: false, matchingBinding: true},
+		{name: "private runtime accepts owner agent", visibility: "private", sameOwner: true, matchingBinding: true, wantReclaim: true},
+		{name: "public runtime accepts foreign agent", visibility: "public", wantReclaim: true, matchingBinding: true},
+		{name: "task runtime must match agent binding", visibility: "public", wantReclaim: false, matchingBinding: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newRuntimeClaimAccessFixture(t, tt.visibility, tt.sameOwner, tt.matchingBinding, "dispatched")
+			q := db.New(fixture.pool)
+			params := db.ReclaimStaleDispatchedTaskForRuntimeParams{
+				RuntimeID:         fixture.runtimeID,
+				PrepareLeaseSecs:  60,
+				ClaimRecoverySecs: 30,
+				RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
+			}
+			reclaimed, err := q.ReclaimStaleDispatchedTaskForRuntime(ctx, params)
+			if !tt.wantReclaim {
+				if !errors.Is(err, pgx.ErrNoRows) {
+					t.Fatalf("singular reclaim error = %v, want no rows", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("singular reclaim: %v", err)
+				}
+				if util.UUIDToString(reclaimed.ID) != fixture.taskID {
+					t.Fatalf("singular reclaimed task = %s, want %s", util.UUIDToString(reclaimed.ID), fixture.taskID)
+				}
+			}
+
+			// Restore the stale generation so the batch path evaluates the same gate.
+			if _, err := fixture.pool.Exec(ctx, `
+				UPDATE agent_task_queue
+				SET dispatched_at = now() - interval '10 minutes',
+				    prepare_lease_expires_at = now() - interval '1 minute'
+				WHERE id = $1
+			`, fixture.taskID); err != nil {
+				t.Fatalf("reset stale dispatch: %v", err)
+			}
+			batch, err := q.ReclaimStaleDispatchedTasksForRuntimes(ctx, db.ReclaimStaleDispatchedTasksForRuntimesParams{
+				RuntimeIds:        []pgtype.UUID{fixture.runtimeID},
+				PrepareLeaseSecs:  60,
+				ClaimRecoverySecs: 30,
+				RuntimeStaleSecs:  RuntimeClaimFreshnessSeconds,
+				MaxTasks:          10,
+			})
+			if err != nil {
+				t.Fatalf("batch reclaim: %v", err)
+			}
+			wantBatch := 0
+			if tt.wantReclaim {
+				wantBatch = 1
+			}
+			if len(batch) != wantBatch {
+				t.Fatalf("batch reclaimed %d tasks, want %d", len(batch), wantBatch)
+			}
+		})
+	}
+}
+
+func TestClaimTaskRejectsMismatchedAgentRuntime(t *testing.T) {
+	ctx := context.Background()
+	fixture := newRuntimeClaimAccessFixture(t, "public", false, false, "queued")
+	svc := NewTaskService(db.New(fixture.pool), fixture.pool, nil, nil)
+
+	claimed, err := svc.claimTask(ctx, fixture.agentID, fixture.runtimeID)
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("claimed mismatched task %s", util.UUIDToString(claimed.ID))
+	}
+
+	var status string
+	if err := fixture.pool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, fixture.taskID).Scan(&status); err != nil {
+		t.Fatalf("read task status: %v", err)
+	}
+	if status != "queued" {
+		t.Fatalf("task status = %q, want queued", status)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3374,6 +3374,13 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 			outcome = "no_runtime"
 			return nil
 		}
+		// A daemon may still hold a stale candidate after the agent is rebound.
+		// Reject it before doing capacity work; ClaimAgentTask repeats this fence
+		// atomically so a concurrent rebind cannot dispatch the stale task.
+		if runtimeID.Valid && agent.RuntimeID != runtimeID {
+			outcome = "runtime_mismatch"
+			return nil
+		}
 
 		t0 = time.Now()
 		running, err := qtx.CountRunningTasks(ctx, agentID)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3375,8 +3375,10 @@ func (s *TaskService) claimTask(ctx context.Context, agentID, runtimeID pgtype.U
 			return nil
 		}
 		// A daemon may still hold a stale candidate after the agent is rebound.
-		// Reject it before doing capacity work; ClaimAgentTask repeats this fence
-		// atomically so a concurrent rebind cannot dispatch the stale task.
+		// Reject it before doing capacity work. ClaimAgentTask repeats the fence
+		// before its state transition; the claim handler then rechecks the freshly
+		// loaded Agent before returning any payload. Runtime mutation teardown is
+		// responsible for serializing and settling the remaining queued rows.
 		if runtimeID.Valid && agent.RuntimeID != runtimeID {
 			outcome = "runtime_mismatch"
 			return nil

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1583,15 +1583,20 @@ WHERE id = (
           WHERE a.id = atq.agent_id
             -- A task's persisted runtime is not authority after an agent rebind.
             AND a.runtime_id = atq.runtime_id
-            -- Private runtimes only execute their owner's agents. An ownerless
-            -- private runtime remains claimable only so the handler can cancel
-            -- it through the existing missing-owner path before daemon delivery.
+            -- Private runtimes only execute their owner's agents. Ownerless
+            -- runtime/agent rows remain claimable only so the handler can
+            -- settle them explicitly before daemon delivery; filtering them
+            -- here would leave every task silently queued until the TTL.
             -- Public runtimes remain shareable across agent owners.
             AND (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'
@@ -5809,6 +5814,7 @@ SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatc
 WHERE atq.runtime_id = $1
   AND atq.status = 'queued'
   AND EXISTS (
+      -- Keep this authorization fence in sync with ClaimAgentTask.
       SELECT 1
       FROM agent a
       JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -5818,7 +5824,11 @@ WHERE atq.runtime_id = $1
             r.visibility = 'public'
             OR (
                 r.visibility = 'private'
-                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                AND (
+                    r.owner_id IS NULL
+                    OR a.owner_id IS NULL
+                    OR r.owner_id = a.owner_id
+                )
             )
         )
   )
@@ -5913,6 +5923,7 @@ SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatc
 WHERE atq.runtime_id = ANY($1::uuid[])
   AND atq.status = 'queued'
   AND EXISTS (
+      -- Keep this authorization fence in sync with ClaimAgentTask.
       SELECT 1
       FROM agent a
       JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -5922,7 +5933,11 @@ WHERE atq.runtime_id = ANY($1::uuid[])
             r.visibility = 'public'
             OR (
                 r.visibility = 'private'
-                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                AND (
+                    r.owner_id IS NULL
+                    OR a.owner_id IS NULL
+                    OR r.owner_id = a.owner_id
+                )
             )
         )
   )
@@ -7314,6 +7329,7 @@ WHERE id = (
       AND atq.dispatched_at < now() - make_interval(secs => $3::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
+          -- Keep this authorization fence in sync with ClaimAgentTask.
           SELECT 1
           FROM agent a
           JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -7323,7 +7339,11 @@ WHERE id = (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'
@@ -7428,6 +7448,7 @@ WHERE id IN (
       AND atq.dispatched_at < now() - make_interval(secs => $3::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
+          -- Keep this authorization fence in sync with ClaimAgentTask.
           SELECT 1
           FROM agent a
           JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -7437,7 +7458,11 @@ WHERE id IN (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1577,8 +1577,23 @@ WHERE id = (
       AND atq.runtime_id = $3
       AND atq.status = 'queued'
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            -- A task's persisted runtime is not authority after an agent rebind.
+            AND a.runtime_id = atq.runtime_id
+            -- Private runtimes only execute their owner's agents. An ownerless
+            -- private runtime remains claimable only so the handler can cancel
+            -- it through the existing missing-owner path before daemon delivery.
+            -- Public runtimes remain shareable across agent owners.
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => $4::double precision)
@@ -5790,12 +5805,27 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+WHERE atq.runtime_id = $1
+  AND atq.status = 'queued'
+  AND EXISTS (
+      SELECT 1
+      FROM agent a
+      JOIN agent_runtime r ON r.id = atq.runtime_id
+      WHERE a.id = atq.agent_id
+        AND a.runtime_id = atq.runtime_id
+        AND (
+            r.visibility = 'public'
+            OR (
+                r.visibility = 'private'
+                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+            )
+        )
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC
 `
 
-// Returns rows the runtime can attempt to claim. Status is restricted to
+// Returns rows the runtime is authorized to attempt to claim. Status is restricted to
 // 'queued' (in contrast to ListPendingTasksByRuntime which also includes
 // 'dispatched') because dispatched rows are by definition already owned
 // and cannot be re-claimed — including them in the candidate list pads
@@ -5879,9 +5909,24 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 }
 
 const listQueuedClaimCandidatesByRuntimes = `-- name: ListQueuedClaimCandidatesByRuntimes :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
-WHERE runtime_id = ANY($1::uuid[]) AND status = 'queued'
-ORDER BY priority DESC, created_at ASC
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.runtime_mcp_overlay, atq.escalation_for_task_id, atq.fire_at, atq.originator_user_id, atq.runtime_connected_apps, atq.coalesced_comment_ids, atq.delivered_comment_ids, atq.chat_input_task_id, atq.chat_finalize_deferred_at, atq.originator_source, atq.delegated_from_task_id, atq.retry_of_task_id, atq.rerun_of_task_id, atq.rule_version_id, atq.trigger_evidence_kind, atq.trigger_evidence_ref_id, atq.accountable_user_id, atq.session_rollout_missing, atq.retired_session_id, atq.quick_actions_disabled, atq.regenerate_quick_actions_for, atq.branch_name, atq.durable_work_dir, atq.channel_context_revision FROM agent_task_queue atq
+WHERE atq.runtime_id = ANY($1::uuid[])
+  AND atq.status = 'queued'
+  AND EXISTS (
+      SELECT 1
+      FROM agent a
+      JOIN agent_runtime r ON r.id = atq.runtime_id
+      WHERE a.id = atq.agent_id
+        AND a.runtime_id = atq.runtime_id
+        AND (
+            r.visibility = 'public'
+            OR (
+                r.visibility = 'private'
+                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+            )
+        )
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC
 `
 
 // Batch variant of ListQueuedClaimCandidatesByRuntime (MUL-4257): returns
@@ -7269,8 +7314,18 @@ WHERE id = (
       AND atq.dispatched_at < now() - make_interval(secs => $3::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            AND a.runtime_id = atq.runtime_id
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => $4::double precision)
@@ -7373,8 +7428,18 @@ WHERE id IN (
       AND atq.dispatched_at < now() - make_interval(secs => $3::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            AND a.runtime_id = atq.runtime_id
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => $4::double precision)

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -788,8 +788,23 @@ WHERE id = (
       AND atq.runtime_id = @runtime_id
       AND atq.status = 'queued'
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            -- A task's persisted runtime is not authority after an agent rebind.
+            AND a.runtime_id = atq.runtime_id
+            -- Private runtimes only execute their owner's agents. An ownerless
+            -- private runtime remains claimable only so the handler can cancel
+            -- it through the existing missing-owner path before daemon delivery.
+            -- Public runtimes remain shareable across agent owners.
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => @runtime_stale_secs::double precision)
@@ -877,8 +892,18 @@ WHERE id = (
       AND atq.dispatched_at < now() - make_interval(secs => @claim_recovery_secs::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            AND a.runtime_id = atq.runtime_id
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => @runtime_stale_secs::double precision)
@@ -908,8 +933,18 @@ WHERE id IN (
       AND atq.dispatched_at < now() - make_interval(secs => @claim_recovery_secs::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
-          SELECT 1 FROM agent_runtime r
-          WHERE r.id = atq.runtime_id
+          SELECT 1
+          FROM agent a
+          JOIN agent_runtime r ON r.id = atq.runtime_id
+          WHERE a.id = atq.agent_id
+            AND a.runtime_id = atq.runtime_id
+            AND (
+                r.visibility = 'public'
+                OR (
+                    r.visibility = 'private'
+                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                )
+            )
             AND r.status = 'online'
             AND COALESCE(r.last_seen_at, r.updated_at) >=
                 now() - make_interval(secs => @runtime_stale_secs::double precision)
@@ -2023,7 +2058,7 @@ WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC;
 
 -- name: ListQueuedClaimCandidatesByRuntime :many
--- Returns rows the runtime can attempt to claim. Status is restricted to
+-- Returns rows the runtime is authorized to attempt to claim. Status is restricted to
 -- 'queued' (in contrast to ListPendingTasksByRuntime which also includes
 -- 'dispatched') because dispatched rows are by definition already owned
 -- and cannot be re-claimed — including them in the candidate list pads
@@ -2031,9 +2066,24 @@ ORDER BY priority DESC, created_at ASC;
 -- ClaimAgentTask, wasting CPU and a SELECT every poll cycle when the
 -- runtime is busy on a long-running task. Backed by the partial index
 -- idx_agent_task_queue_claim_candidates so the warm path is cheap.
-SELECT * FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC;
+SELECT atq.* FROM agent_task_queue atq
+WHERE atq.runtime_id = $1
+  AND atq.status = 'queued'
+  AND EXISTS (
+      SELECT 1
+      FROM agent a
+      JOIN agent_runtime r ON r.id = atq.runtime_id
+      WHERE a.id = atq.agent_id
+        AND a.runtime_id = atq.runtime_id
+        AND (
+            r.visibility = 'public'
+            OR (
+                r.visibility = 'private'
+                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+            )
+        )
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC;
 
 -- name: CancelSupersededDeferredRetriesForRuntimes :many
 -- Cancels deferred auto-retry rows that a newer active task has already
@@ -2138,9 +2188,24 @@ RETURNING *;
 -- a sort step (each runtime's slice is index-ordered, but merging several
 -- runtimes' rows into one priority/FIFO order is not). The per-machine
 -- candidate set is small, so this is cheap in practice.
-SELECT * FROM agent_task_queue
-WHERE runtime_id = ANY(@runtime_ids::uuid[]) AND status = 'queued'
-ORDER BY priority DESC, created_at ASC;
+SELECT atq.* FROM agent_task_queue atq
+WHERE atq.runtime_id = ANY(@runtime_ids::uuid[])
+  AND atq.status = 'queued'
+  AND EXISTS (
+      SELECT 1
+      FROM agent a
+      JOIN agent_runtime r ON r.id = atq.runtime_id
+      WHERE a.id = atq.agent_id
+        AND a.runtime_id = atq.runtime_id
+        AND (
+            r.visibility = 'public'
+            OR (
+                r.visibility = 'private'
+                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+            )
+        )
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC;
 
 -- name: PromoteDueDeferredTasksForRuntimes :many
 -- Batch variant of PromoteDueDeferredTasksForRuntime (MUL-4257): promotes all

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -794,15 +794,20 @@ WHERE id = (
           WHERE a.id = atq.agent_id
             -- A task's persisted runtime is not authority after an agent rebind.
             AND a.runtime_id = atq.runtime_id
-            -- Private runtimes only execute their owner's agents. An ownerless
-            -- private runtime remains claimable only so the handler can cancel
-            -- it through the existing missing-owner path before daemon delivery.
+            -- Private runtimes only execute their owner's agents. Ownerless
+            -- runtime/agent rows remain claimable only so the handler can
+            -- settle them explicitly before daemon delivery; filtering them
+            -- here would leave every task silently queued until the TTL.
             -- Public runtimes remain shareable across agent owners.
             AND (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'
@@ -892,6 +897,7 @@ WHERE id = (
       AND atq.dispatched_at < now() - make_interval(secs => @claim_recovery_secs::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
+          -- Keep this authorization fence in sync with ClaimAgentTask.
           SELECT 1
           FROM agent a
           JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -901,7 +907,11 @@ WHERE id = (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'
@@ -933,6 +943,7 @@ WHERE id IN (
       AND atq.dispatched_at < now() - make_interval(secs => @claim_recovery_secs::double precision)
       AND (atq.prepare_lease_expires_at IS NULL OR atq.prepare_lease_expires_at < now())
       AND EXISTS (
+          -- Keep this authorization fence in sync with ClaimAgentTask.
           SELECT 1
           FROM agent a
           JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -942,7 +953,11 @@ WHERE id IN (
                 r.visibility = 'public'
                 OR (
                     r.visibility = 'private'
-                    AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                    AND (
+                        r.owner_id IS NULL
+                        OR a.owner_id IS NULL
+                        OR r.owner_id = a.owner_id
+                    )
                 )
             )
             AND r.status = 'online'
@@ -2070,6 +2085,7 @@ SELECT atq.* FROM agent_task_queue atq
 WHERE atq.runtime_id = $1
   AND atq.status = 'queued'
   AND EXISTS (
+      -- Keep this authorization fence in sync with ClaimAgentTask.
       SELECT 1
       FROM agent a
       JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -2079,7 +2095,11 @@ WHERE atq.runtime_id = $1
             r.visibility = 'public'
             OR (
                 r.visibility = 'private'
-                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                AND (
+                    r.owner_id IS NULL
+                    OR a.owner_id IS NULL
+                    OR r.owner_id = a.owner_id
+                )
             )
         )
   )
@@ -2192,6 +2212,7 @@ SELECT atq.* FROM agent_task_queue atq
 WHERE atq.runtime_id = ANY(@runtime_ids::uuid[])
   AND atq.status = 'queued'
   AND EXISTS (
+      -- Keep this authorization fence in sync with ClaimAgentTask.
       SELECT 1
       FROM agent a
       JOIN agent_runtime r ON r.id = atq.runtime_id
@@ -2201,7 +2222,11 @@ WHERE atq.runtime_id = ANY(@runtime_ids::uuid[])
             r.visibility = 'public'
             OR (
                 r.visibility = 'private'
-                AND (r.owner_id IS NULL OR r.owner_id = a.owner_id)
+                AND (
+                    r.owner_id IS NULL
+                    OR a.owner_id IS NULL
+                    OR r.owner_id = a.owner_id
+                )
             )
         )
   )


### PR DESCRIPTION
## What does this PR do?

This is the first, independently deployable fix for the runtime visibility gap tracked by MUL-6697 / #7567.

Task delivery now revalidates the relationship that authorizes execution instead of trusting the `runtime_id` persisted when the task was queued:

- the Agent must still be bound to the task's Runtime;
- a private Runtime only delivers tasks for Agents owned by the Runtime owner;
- a public Runtime remains shareable across Agent owners.

The check is applied to singular and batch candidate selection, queued-task claim, and singular and batch stale-dispatch reclaim. Candidate filtering keeps known unauthorized rows out of hot polling, while the state-changing claim repeats the predicate. Response assembly then rechecks the freshly loaded Agent before returning a payload, covering an Agent rebind or owner change that commits after the claim.

Ownerless rows have explicit server-side settlement paths instead of silently waiting for the queue TTL:

- an ownerless Runtime retains the existing pre-delivery cancellation path because no scoped task token can be minted;
- an ownerless Agent on a private Runtime is allowed through the SQL selector only so response assembly can fail it with an actionable error before daemon delivery.

This PR deliberately does not bulk-settle queued rows during Runtime visibility mutations or ordinary Agent rebinds. Both mutation-side cleanup cases are explicitly follow-up PR scope, together with Agent unbinding, Autopilot pausing, and the visibility confirmation UI. Until that follow-up lands, stale rebind rows remain non-deliverable and may stay queued until the existing sweeper expires them; only a claim already in flight when the rebind commits is settled immediately by the response-assembly recheck. This is safe from unauthorized execution but is an acknowledged UX gap.

## Related Issue

Related to #7567. This PR is stage one and must not close the issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Reject stale Runtime candidates in `TaskService.claimTask` before capacity work, with comments limited to the guarantees the current lock protocol actually provides.
- Enforce Agent binding and private Runtime ownership in queued claim and stale reclaim SQL, for singular and batch paths.
- Route ownerless private-Runtime Agents to an explicit pre-delivery failure instead of filtering them into a two-hour silent queue expiry.
- Recheck the fresh Agent during claim response assembly so a post-claim rebind or owner change cannot be delivered to the daemon.
- Add concise synchronization comments to every duplicated SQL authorization predicate.
- Add database-backed coverage for private owner/foreign-owner/ownerless Agents, public sharing, stale Agent bindings, singular/batch reclaim, the omitted-runtime `ClaimTask` wrapper, post-claim rebind rejection, and the existing ownerless Runtime cancellation paths.

## How to Test

Using a newly created and fully migrated isolated database:

1. `env DATABASE_URL='<isolated-db>' go test ./internal/service -count=1`
2. `env DATABASE_URL='<isolated-db>' go test ./internal/handler -count=1`
3. `env DATABASE_URL='<isolated-db>' go test -race ./internal/service -run 'TestRuntimeAccessGatesQueuedTaskClaims|TestRuntimeAccessGatesStaleDispatchReclaim|TestClaimTaskRejectsMismatchedAgentRuntime|TestClaimTaskUsesCurrentAgentRuntimeWhenRuntimeIDIsOmitted' -count=1`
4. `env DATABASE_URL='<isolated-db>' go test -race ./internal/handler -run 'TestClaimTaskByRuntime_(OwnerlessAgentOnPrivateRuntimeFailsExplicitly|MissingRuntimeOwnerCancelsAndRejects)|TestClaimTasksByRuntime_CancelsTaskWhenRuntimeOwnerMissing|TestBuildClaimedTaskResponseRejectsAgentReboundAfterClaim' -count=1`
5. `go vet ./internal/service ./internal/handler ./pkg/db/generated`

All commands above pass locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex (Multica agent)

**Prompt / approach:** Confirm the claim/reclaim authorization gap against current `main`, isolate the first deployable server-side fix, enforce the invariant at candidate, state-changing SQL, and pre-delivery response boundaries, and add database-backed regression coverage before updating the PR.

## Screenshots (optional)

Not applicable; this PR has no UI changes.
