### PR TITLE
MUL-6701: fix(email): split SMTP envelope from the From: header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,8 +233,11 @@ RESEND_FROM_EMAIL=noreply@multica.ai
 # Option B: SMTP relay (for self-hosted / on-premise deployments)
 #   Takes priority over Resend when SMTP_HOST is set.
 #   Supports unauthenticated relay (leave SMTP_USERNAME empty) and authenticated SMTP.
-#   SMTP_FROM_EMAIL is the envelope/header sender for SMTP. If unset, SMTP
-#     falls back to RESEND_FROM_EMAIL for backwards compatibility.
+#   SMTP_FROM_EMAIL is the sender for SMTP. Accepts a bare address or a full
+#     mailbox with a display name, e.g. 'Example Team <noreply@example.com>'.
+#     The display name is used for the From: header only — the SMTP envelope
+#     always receives the bare address, which is what relays require. If unset,
+#     SMTP falls back to RESEND_FROM_EMAIL for backwards compatibility.
 #   Set SMTP_TLS_INSECURE=true only for private CA or self-signed certificates.
 #   SMTP_TLS controls the TLS mode:
 #     - unset / "starttls" (default): plaintext connect, upgrade via STARTTLS.

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -93,7 +93,7 @@ Kubernetes で shutdown hold を設定する場合、`terminationGracePeriodSeco
 | `SMTP_PORT` | `25` | よく使う値: 25、587、465 |
 | `SMTP_USERNAME` | 空 | ユーザー名。匿名 relay では空のまま |
 | `SMTP_PASSWORD` | 空 | パスワード |
-| `SMTP_FROM_EMAIL` | `RESEND_FROM_EMAIL` にフォールバック | Envelope From とメールの From |
+| `SMTP_FROM_EMAIL` | `RESEND_FROM_EMAIL` にフォールバック | 送信者アドレス。ベアアドレスまたは `Display Name <user@example.com>` を指定できます。表示名はメールの `From:` ヘッダーにのみ使われ、SMTP エンベロープには含まれません |
 | `SMTP_TLS` | `starttls` | `implicit`、`smtps`、`ssl` は暗黙的 TLS を意味します。465 では自動的に有効 |
 | `SMTP_TLS_INSECURE` | `false` | 証明書検証をスキップ。信頼できる内部ネットワーク専用 |
 | `SMTP_EHLO_NAME` | ホスト名 | 厳格な relay が要求する EHLO/FQDN |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -93,7 +93,7 @@ Kubernetes에서 shutdown hold를 설정하면 `terminationGracePeriodSeconds`�
 | `SMTP_PORT` | `25` | 일반적인 값: 25, 587, 465 |
 | `SMTP_USERNAME` | 비어 있음 | 사용자 이름. 익명 relay에서는 비워 둠 |
 | `SMTP_PASSWORD` | 비어 있음 | 비밀번호 |
-| `SMTP_FROM_EMAIL` | `RESEND_FROM_EMAIL`로 fallback | Envelope From과 이메일 From |
+| `SMTP_FROM_EMAIL` | `RESEND_FROM_EMAIL`로 fallback | 발신자 주소. 순수 주소 또는 `Display Name <user@example.com>` 형식을 지원하며, 표시 이름은 메일 `From:` 헤더에만 사용되고 SMTP envelope에는 포함되지 않습니다 |
 | `SMTP_TLS` | `starttls` | `implicit`, `smtps`, `ssl`은 암시적 TLS를 의미하며 465에서는 자동 활성화 |
 | `SMTP_TLS_INSECURE` | `false` | 인증서 검증 건너뛰기. 신뢰할 수 있는 내부 네트워크에서만 사용 |
 | `SMTP_EHLO_NAME` | host 이름 | 엄격한 relay에서 요구하는 EHLO/FQDN |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -93,7 +93,7 @@ SMTP takes priority over Resend whenever `SMTP_HOST` is non-empty.
 | `SMTP_PORT` | `25` | Common values: 25, 587, 465 |
 | `SMTP_USERNAME` | empty | Username; leave empty for anonymous relays |
 | `SMTP_PASSWORD` | empty | Password |
-| `SMTP_FROM_EMAIL` | falls back to `RESEND_FROM_EMAIL` | Envelope From and message From |
+| `SMTP_FROM_EMAIL` | falls back to `RESEND_FROM_EMAIL` | Sender address. Accepts a bare address or `Display Name <user@example.com>`; the display name is used for the `From:` header only, never the SMTP envelope |
 | `SMTP_TLS` | `starttls` | `implicit`, `smtps`, or `ssl` means implicit TLS; port 465 enables it automatically |
 | `SMTP_TLS_INSECURE` | `false` | Skips certificate verification; trusted internal networks only |
 | `SMTP_EHLO_NAME` | hostname | EHLO/FQDN required by strict relays |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -93,7 +93,7 @@ MULTICA_PUBLIC_URL=https://api.multica.example.com
 | `SMTP_PORT` | `25` | 常见值：25、587、465 |
 | `SMTP_USERNAME` | 空 | 用户名；匿名 relay 留空 |
 | `SMTP_PASSWORD` | 空 | 密码 |
-| `SMTP_FROM_EMAIL` | 回退到 `RESEND_FROM_EMAIL` | Envelope From 与邮件 From |
+| `SMTP_FROM_EMAIL` | 回退到 `RESEND_FROM_EMAIL` | 发件人地址。可填裸地址或 `Display Name <user@example.com>`；显示名仅用于邮件 `From:` 头，不会进入 SMTP envelope |
 | `SMTP_TLS` | `starttls` | `implicit`、`smtps` 或 `ssl` 表示隐式 TLS；465 会自动启用 |
 | `SMTP_TLS_INSECURE` | `false` | 跳过证书校验，仅用于可信内网 |
 | `SMTP_EHLO_NAME` | 主机名 | 严格 relay 要求的 EHLO/FQDN |

--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -1,13 +1,16 @@
 package service
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"html"
 	"mime"
 	"mime/quotedprintable"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"os"
 	"strings"
@@ -125,6 +128,52 @@ func resolveFromEmail(smtpHost string) string {
 	return resendFrom
 }
 
+// parseFromEmail splits a configured sender into the two forms the SMTP path
+// needs. They are documented as one value, but the envelope (RFC 5321
+// Reverse-path — addr-spec only) and the From: header (RFC 5322 mailbox — may
+// carry a display name) have different grammars. Using the raw value for both
+// turns `"Team" <a@b.com>` into MAIL FROM:<"Team" <a@b.com>>, nested angle
+// brackets that strict relays reject outright.
+//
+// Values that do not parse — a bare local part such as "root", which some local
+// MTAs accept — are passed through unchanged so deployments that work today keep
+// working. ok=false lets the caller warn about it once at startup instead.
+func parseFromEmail(raw string) (address, header string, ok bool) {
+	addr, err := mail.ParseAddress(strings.TrimSpace(raw))
+	if err != nil {
+		return raw, raw, false
+	}
+	// Only switch to the angle-addr form when there is a display name to carry.
+	// A bare address then stays byte-identical to what we sent before, so the
+	// deployments that are not currently broken see no change on the wire.
+	if addr.Name == "" {
+		return addr.Address, addr.Address, true
+	}
+	// Address.String() also RFC 2047-encodes a non-ASCII display name, matching
+	// how Subject: is already handled.
+	return addr.Address, addr.String(), true
+}
+
+// newMessageID builds a unique Message-ID rooted at the sender's own domain.
+// Deriving it from the relay hostname instead produced IDs like
+// <...@smtp.gmail.com> — a domain the sender does not own, which receiving
+// providers are entitled to distrust or dedupe away.
+//
+// fallbackDomain covers senders whose address has no parseable domain; dropping
+// the header is not an option, since RFC 5322 makes Date mandatory and
+// Message-ID a SHOULD, and a plain RFC 5321 relay must not add them for us.
+func newMessageID(fromAddress, fallbackDomain string) string {
+	domain := fallbackDomain
+	if at := strings.LastIndex(fromAddress, "@"); at >= 0 && at+1 < len(fromAddress) {
+		domain = fromAddress[at+1:]
+	}
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("<%d@%s>", time.Now().UnixNano(), domain)
+	}
+	return fmt.Sprintf("<%s@%s>", hex.EncodeToString(buf[:]), domain)
+}
+
 func (s *EmailService) openSMTPClient() (*smtp.Client, error) {
 	addr := net.JoinHostPort(s.smtpHost, s.smtpPort)
 
@@ -231,6 +280,11 @@ func NewEmailService() *EmailService {
 			tlsLabel = "implicit-tls"
 		}
 		fmt.Printf("EmailService: SMTP relay %s:%s (%s) from=%s\n", smtpHost, smtpPort, tlsLabel, from)
+		// Surface a malformed sender at startup rather than on the first send,
+		// where it only shows up as a relay-side syntax error.
+		if _, _, ok := parseFromEmail(from); from != "" && !ok {
+			fmt.Printf("EmailService: SMTP_FROM_EMAIL=%q is not a valid RFC 5322 address; sending it verbatim as both envelope and From: header. Use `Display Name <user@example.com>` or a bare address if the relay rejects it.\n", from)
+		}
 	case client != nil:
 		fmt.Printf("EmailService: Resend API from=%s\n", from)
 	default:
@@ -290,7 +344,8 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 	// non-ASCII workspace/inviter names crossing strict or older SMTP hops.
 	has8Bit, _ := c.Extension("8BITMIME")
 	encodedSubject := mime.QEncoding.Encode("utf-8", subject)
-	msgID := fmt.Sprintf("<%d@%s>", time.Now().UnixNano(), s.smtpHost)
+	fromAddress, fromHeader, _ := parseFromEmail(s.fromEmail)
+	msgID := newMessageID(fromAddress, s.smtpHost)
 
 	var bodyBytes []byte
 	var cte string
@@ -306,7 +361,8 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 		cte = "quoted-printable"
 	}
 
-	if err = c.Mail(s.fromEmail); err != nil {
+	// Envelope takes the addr-spec; the From: header below takes the full mailbox.
+	if err = c.Mail(fromAddress); err != nil {
 		return fmt.Errorf("smtp MAIL FROM: %w", err)
 	}
 	if err = c.Rcpt(to); err != nil {
@@ -316,7 +372,7 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 	if err != nil {
 		return fmt.Errorf("smtp DATA: %w", err)
 	}
-	headers := "From: " + s.fromEmail + "\r\n" +
+	headers := "From: " + fromHeader + "\r\n" +
 		"To: " + to + "\r\n" +
 		"Subject: " + encodedSubject + "\r\n" +
 		"Date: " + time.Now().UTC().Format(time.RFC1123Z) + "\r\n" +

--- a/server/internal/service/email_test.go
+++ b/server/internal/service/email_test.go
@@ -511,6 +511,12 @@ type testSMTPServer struct {
 	ExpectedPass string
 	// If true, advertise STARTTLS in EHLO
 	AdvertiseSTARTTLS bool
+
+	// ReceivedMailFrom captures the raw MAIL FROM command line, and ReceivedData
+	// the complete DATA payload, so tests can assert on the envelope and the
+	// message headers independently — they have different grammars.
+	ReceivedMailFrom chan string
+	ReceivedData     chan string
 }
 
 func startTestSMTPServer(t *testing.T, cfg testSMTPServer) (*testSMTPServer, func()) {
@@ -521,6 +527,12 @@ func startTestSMTPServer(t *testing.T, cfg testSMTPServer) (*testSMTPServer, fun
 	}
 	cfg.Listener = l
 	cfg.Addr = l.Addr().String()
+	if cfg.ReceivedMailFrom == nil {
+		cfg.ReceivedMailFrom = make(chan string, 4)
+	}
+	if cfg.ReceivedData == nil {
+		cfg.ReceivedData = make(chan string, 4)
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -608,6 +620,10 @@ func (s *testSMTPServer) handleConn(conn net.Conn) {
 			}
 
 		case strings.HasPrefix(upper, "MAIL FROM:"):
+			select {
+			case s.ReceivedMailFrom <- line:
+			default:
+			}
 			writeLine("250 OK")
 
 		case strings.HasPrefix(upper, "RCPT TO:"):
@@ -616,11 +632,17 @@ func (s *testSMTPServer) handleConn(conn net.Conn) {
 		case upper == "DATA":
 			writeLine("354 Start mail input; end with <CRLF>.<CRLF>")
 			// Read until line containing only "."
+			var dataLines []string
 			for {
 				dataLine := readLine()
 				if dataLine == "." {
 					break
 				}
+				dataLines = append(dataLines, dataLine)
+			}
+			select {
+			case s.ReceivedData <- strings.Join(dataLines, "\r\n"):
+			default:
 			}
 			writeLine("250 OK")
 
@@ -726,5 +748,220 @@ func TestSendSMTP_LoginAuthRejectsUnencryptedRemote(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unencrypted connection") {
 		t.Errorf("expected 'unencrypted connection' error, got: %v", err)
+	}
+}
+
+// --- SMTP sender: envelope vs From: header (GH #7568) ---
+
+func TestParseFromEmail(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantAddress string
+		wantHeader  string
+		wantOK      bool
+	}{
+		{
+			name:        "bare address stays byte-identical",
+			raw:         "sender@example.com",
+			wantAddress: "sender@example.com",
+			wantHeader:  "sender@example.com",
+			wantOK:      true,
+		},
+		{
+			name:        "quoted display name splits into two forms",
+			raw:         `"Example Team" <sender@example.com>`,
+			wantAddress: "sender@example.com",
+			wantHeader:  `"Example Team" <sender@example.com>`,
+			wantOK:      true,
+		},
+		{
+			name:        "unquoted display name is normalized",
+			raw:         "Example Team <sender@example.com>",
+			wantAddress: "sender@example.com",
+			wantHeader:  `"Example Team" <sender@example.com>`,
+			wantOK:      true,
+		},
+		{
+			name:        "non-ASCII display name is RFC 2047 encoded",
+			raw:         "多利卡 <verify@multica.ai>",
+			wantAddress: "verify@multica.ai",
+			wantHeader:  "=?utf-8?q?=E5=A4=9A=E5=88=A9=E5=8D=A1?= <verify@multica.ai>",
+			wantOK:      true,
+		},
+		{
+			name:        "surrounding whitespace is trimmed",
+			raw:         "  sender@example.com  ",
+			wantAddress: "sender@example.com",
+			wantHeader:  "sender@example.com",
+			wantOK:      true,
+		},
+		{
+			name:        "internal hostname without a dot is accepted",
+			raw:         "noreply@mail-internal",
+			wantAddress: "noreply@mail-internal",
+			wantHeader:  "noreply@mail-internal",
+			wantOK:      true,
+		},
+		{
+			// Some local MTAs accept a bare local part. It cannot be parsed, so it
+			// is passed through rather than turned into a hard startup failure.
+			name:        "bare local part passes through unparsed",
+			raw:         "root",
+			wantAddress: "root",
+			wantHeader:  "root",
+			wantOK:      false,
+		},
+		{
+			// The value is operator-controlled, but parsing means a CRLF payload can
+			// no longer reach the header block verbatim.
+			name:        "CRLF header injection is rejected",
+			raw:         "Team <sender@example.com>\r\nBcc: evil@example.com",
+			wantAddress: "Team <sender@example.com>\r\nBcc: evil@example.com",
+			wantHeader:  "Team <sender@example.com>\r\nBcc: evil@example.com",
+			wantOK:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, header, ok := parseFromEmail(tt.raw)
+			if address != tt.wantAddress {
+				t.Errorf("address = %q, want %q", address, tt.wantAddress)
+			}
+			if header != tt.wantHeader {
+				t.Errorf("header = %q, want %q", header, tt.wantHeader)
+			}
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+// sendViaTestServer runs one sendSMTP against a capturing mock relay and returns
+// the MAIL FROM command line and the DATA payload.
+func sendViaTestServer(t *testing.T, fromEmail string) (mailFrom, data string) {
+	t.Helper()
+	srv, cleanup := startTestSMTPServer(t, testSMTPServer{})
+	defer cleanup()
+	host, port, _ := net.SplitHostPort(srv.Addr)
+
+	s := &EmailService{
+		fromEmail: fromEmail,
+		smtpHost:  host,
+		smtpPort:  port,
+	}
+	if err := s.sendSMTP("to@example.com", "Test Subject", "<p>Hello</p>"); err != nil {
+		t.Fatalf("sendSMTP failed: %v", err)
+	}
+	return <-srv.ReceivedMailFrom, <-srv.ReceivedData
+}
+
+func TestSendSMTP_DisplayNameSplitsEnvelopeAndHeader(t *testing.T) {
+	mailFrom, data := sendViaTestServer(t, `"Example Team" <sender@example.com>`)
+
+	// The envelope must carry the addr-spec only. Before the fix this was
+	// MAIL FROM:<"Example Team" <sender@example.com>>, which strict relays reject.
+	if !strings.HasPrefix(mailFrom, "MAIL FROM:<sender@example.com>") {
+		t.Errorf("envelope = %q, want addr-spec only", mailFrom)
+	}
+	if strings.Contains(mailFrom, "Example Team") {
+		t.Errorf("envelope must not carry the display name, got %q", mailFrom)
+	}
+
+	// The header keeps the full mailbox.
+	if !strings.Contains(data, "From: \"Example Team\" <sender@example.com>\r\n") {
+		t.Errorf("From: header missing the display name, got:\n%s", data)
+	}
+}
+
+func TestSendSMTP_NonASCIIDisplayNameIsEncoded(t *testing.T) {
+	_, data := sendViaTestServer(t, "多利卡 <verify@multica.ai>")
+
+	if !strings.Contains(data, "From: =?utf-8?q?=E5=A4=9A=E5=88=A9=E5=8D=A1?= <verify@multica.ai>\r\n") {
+		t.Errorf("From: header not RFC 2047 encoded, got:\n%s", data)
+	}
+	if strings.Contains(data, "From: 多利卡") {
+		t.Errorf("raw UTF-8 leaked into the From: header:\n%s", data)
+	}
+}
+
+// Bare addresses are the configurations that are not broken today, so the bytes
+// on the wire must not change for them.
+func TestSendSMTP_BareAddressWireFormatUnchanged(t *testing.T) {
+	mailFrom, data := sendViaTestServer(t, "sender@example.com")
+
+	if !strings.HasPrefix(mailFrom, "MAIL FROM:<sender@example.com>") {
+		t.Errorf("envelope = %q", mailFrom)
+	}
+	if !strings.Contains(data, "From: sender@example.com\r\n") {
+		t.Errorf("From: header should stay a bare address, got:\n%s", data)
+	}
+}
+
+func TestSendSMTP_UnparseableFromIsPassedThrough(t *testing.T) {
+	mailFrom, data := sendViaTestServer(t, "root")
+
+	if !strings.HasPrefix(mailFrom, "MAIL FROM:<root>") {
+		t.Errorf("envelope = %q, want the value passed through unchanged", mailFrom)
+	}
+	if !strings.Contains(data, "From: root\r\n") {
+		t.Errorf("From: header = unexpected, got:\n%s", data)
+	}
+}
+
+// --- Message-ID provenance (MUL-6225 / GH #7014) ---
+
+func TestSendSMTP_MessageIDUsesSenderDomainNotRelayHost(t *testing.T) {
+	_, data := sendViaTestServer(t, `"Example Team" <sender@example.com>`)
+
+	var msgID string
+	for _, line := range strings.Split(data, "\r\n") {
+		if strings.HasPrefix(line, "Message-ID: ") {
+			msgID = strings.TrimPrefix(line, "Message-ID: ")
+			break
+		}
+	}
+	if msgID == "" {
+		// RFC 5322 makes Date mandatory and Message-ID a SHOULD, and a plain
+		// RFC 5321 relay must not add them on our behalf.
+		t.Fatalf("Message-ID header is missing:\n%s", data)
+	}
+	if !strings.HasSuffix(msgID, "@example.com>") {
+		t.Errorf("Message-ID = %q, want it rooted at the sender's domain", msgID)
+	}
+	// 127.0.0.1 is the relay host in this test; it must not appear in the ID.
+	if strings.Contains(msgID, "127.0.0.1") {
+		t.Errorf("Message-ID = %q, must not be rooted at the relay hostname", msgID)
+	}
+	if !strings.Contains(data, "Date: ") {
+		t.Errorf("Date header is mandatory under RFC 5322, missing from:\n%s", data)
+	}
+}
+
+func TestSendSMTP_MessageIDIsUniquePerSend(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 3; i++ {
+		_, data := sendViaTestServer(t, "sender@example.com")
+		for _, line := range strings.Split(data, "\r\n") {
+			if strings.HasPrefix(line, "Message-ID: ") {
+				id := strings.TrimPrefix(line, "Message-ID: ")
+				if seen[id] {
+					t.Fatalf("duplicate Message-ID across sends: %q", id)
+				}
+				seen[id] = true
+			}
+		}
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 distinct Message-IDs, got %d", len(seen))
+	}
+}
+
+func TestNewMessageID_FallsBackWhenSenderHasNoDomain(t *testing.T) {
+	id := newMessageID("root", "relay.internal")
+	if !strings.HasSuffix(id, "@relay.internal>") {
+		t.Errorf("newMessageID = %q, want the fallback domain", id)
 	}
 }

--- a/server/internal/service/email_test.go
+++ b/server/internal/service/email_test.go
@@ -813,9 +813,11 @@ func TestParseFromEmail(t *testing.T) {
 			wantOK:      false,
 		},
 		{
-			// The value is operator-controlled, but parsing means a CRLF payload can
-			// no longer reach the header block verbatim.
-			name:        "CRLF header injection is rejected",
+			// Note this is a pass-through, not a sanitization: parseFromEmail
+			// returns unparseable input verbatim. Such a value never reaches the
+			// header block because net/smtp.Client.Mail rejects CR/LF before the
+			// envelope is sent — see TestSendSMTP_CRLFInSenderAbortsBeforeData.
+			name:        "CRLF payload passes through unparsed",
 			raw:         "Team <sender@example.com>\r\nBcc: evil@example.com",
 			wantAddress: "Team <sender@example.com>\r\nBcc: evil@example.com",
 			wantHeader:  "Team <sender@example.com>\r\nBcc: evil@example.com",
@@ -908,6 +910,35 @@ func TestSendSMTP_UnparseableFromIsPassedThrough(t *testing.T) {
 	}
 	if !strings.Contains(data, "From: root\r\n") {
 		t.Errorf("From: header = unexpected, got:\n%s", data)
+	}
+}
+
+// The configured sender is operator-controlled, so this is defense in depth
+// rather than a user-facing trust boundary. parseFromEmail does NOT sanitize —
+// it returns an unparseable value verbatim. What actually stops a CRLF payload
+// is net/smtp.Client.Mail, which rejects CR/LF before the envelope goes out, so
+// the send aborts at MAIL FROM and nothing reaches the header block.
+func TestSendSMTP_CRLFInSenderAbortsBeforeData(t *testing.T) {
+	srv, cleanup := startTestSMTPServer(t, testSMTPServer{})
+	defer cleanup()
+	host, port, _ := net.SplitHostPort(srv.Addr)
+
+	s := &EmailService{
+		fromEmail: "Team <sender@example.com>\r\nBcc: evil@example.com",
+		smtpHost:  host,
+		smtpPort:  port,
+	}
+	err := s.sendSMTP("to@example.com", "Test Subject", "<p>Hello</p>")
+	if err == nil {
+		t.Fatal("expected sendSMTP to reject a CR/LF sender")
+	}
+	if !strings.Contains(err.Error(), "MAIL FROM") {
+		t.Errorf("expected the failure at MAIL FROM, got: %v", err)
+	}
+	select {
+	case data := <-srv.ReceivedData:
+		t.Fatalf("no message should have been delivered, got:\n%s", data)
+	default:
 	}
 }
 


### PR DESCRIPTION
Fixes #7568.

## Problem

`SMTP_FROM_EMAIL` is documented as one value, but it is used verbatim in two places with **different grammars**:

- the SMTP envelope (RFC 5321 `Reverse-path`) — accepts an `addr-spec` only
- the `From:` header (RFC 5322 `mailbox`) — accepts a display name

So any value carrying a display name produced:

```
MAIL FROM:<"Example Team" <sender@example.com>> BODY=8BITMIME
```

Nested angle brackets. Strict relays reject it outright, which stops **all** mail on that deployment — verification codes and invitations both route through `sendSMTP`.

Thanks to @xiaoyaner0201 for the report: it pinned the exact lines, included a relay response table, and ruled out charset as a factor by testing ASCII display names.

### The blast radius is wider than "operator set a display name"

`resolveFromEmail` falls back to `RESEND_FROM_EMAIL` when `SMTP_HOST` is set and `SMTP_FROM_EMAIL` is not — a documented contract. And a display name is precisely what `RESEND_FROM_EMAIL` was meant to carry (see #343, closed with *"User will configure RESEND_FROM_EMAIL directly"* — true for Resend, whose API takes a mailbox string).

A deployment migrating from Resend to SMTP therefore breaks **without `SMTP_FROM_EMAIL` ever being set**, and the culprit is a variable whose name says `RESEND`.

## Fix

Parse the sender once, give each role the form it requires:

```go
addr, err := mail.ParseAddress(strings.TrimSpace(raw))
// envelope → addr.Address      header → addr.String()
```

`Address.String()` also RFC 2047-encodes a non-ASCII display name, matching how `Subject:` is already handled at `email.go:292`.

## Also folded in: Message-ID provenance (MUL-6225 / #7014)

#7014 has been sitting on *changes requested* for ~10 days. It touches the same header literal, and the fix asked for there — derive `Message-ID` from **the sender's own domain** — needs the parsed sender address this PR introduces, so doing them separately would mean one blocking the other.

Implemented as reviewed there: **keep both headers**, and build the ID as `<{crypto-random}@{sender domain}>` instead of `<{UnixNano}@{relay host}>`. The old value looked like `<...@smtp.gmail.com>` — a domain the sender does not own, which a receiving provider is entitled to distrust or dedupe away.

`Date` and `Message-ID` both stay present. RFC 5322 makes `Date` mandatory and `Message-ID` a SHOULD, and with `SMTP_PORT` defaulting to `25` and auth skipped when `SMTP_USERNAME` is empty, this path is routinely a plain RFC 5321 relay that must not add them for us.

## Backward compatibility

The deployments that are **not** broken today are bare-address ones, so they get zero wire change:

| `SMTP_FROM_EMAIL` | envelope | `From:` header |
|---|---|---|
| `sender@example.com` | `<sender@example.com>` | `sender@example.com` *(unchanged)* |
| `"Example Team" <sender@example.com>` | `<sender@example.com>` | `"Example Team" <sender@example.com>` |
| `多利卡 <verify@multica.ai>` | `<verify@multica.ai>` | `=?utf-8?q?...?= <verify@multica.ai>` |
| `root` | `<root>` | `root` *(unchanged, + startup warning)* |

Two deliberate choices:

- **The angle-addr form is only used when a display name is present.** `addr.String()` would rewrite `From: sender@example.com` into `From: <sender@example.com>` for every existing deployment. Both are valid, but there is no reason to change bytes for the configurations that currently work.
- **Unparseable values pass through instead of failing hard.** `mail.ParseAddress("root")` errors, but a bare local part is accepted by some local MTAs. A hard startup failure would turn "sends today" into "broken after upgrade", so it warns at startup and sends verbatim. (`noreply@localhost` and `noreply@mail-internal` parse fine.)

Validation moved to startup, so a malformed value surfaces before the first send instead of as a relay-side syntax error.

## Note on CRLF in the sender (correcting an earlier claim in this description)

An earlier revision of this description claimed the parse "closes a header-injection hole". That was wrong about the mechanism, and the test name has been corrected along with it.

`parseFromEmail` does **not** sanitize — it returns unparseable input verbatim, and the send path ignores its `ok` return. What actually stops a CRLF payload is `net/smtp.Client.Mail`, which calls `validateLine` and rejects CR/LF before the envelope is sent, so the send aborts at `MAIL FROM` and nothing reaches the header block. That was already true before this PR.

`TestSendSMTP_CRLFInSenderAbortsBeforeData` now pins that behavior where it actually lives, and the table case is named `CRLF payload passes through unparsed` to describe what the parser really does. No security claim is being made for this change.

## Testing

`go test ./internal/service/ -race` passes; full package green.

Added 8 tests. Verified they **fail against the pre-fix code** — the envelope assertion reproduces the reporter's captured bytes exactly:

```
email_test.go:867: envelope = "MAIL FROM:<\"Example Team\" <sender@example.com>>", want addr-spec only
email_test.go:932: Message-ID = "<178...@127.0.0.1>", want it rooted at the sender's domain
```

- `TestParseFromEmail` — 8 cases: bare, quoted/unquoted/non-ASCII display names, whitespace, dotless internal hostname, bare local part, CRLF pass-through
- `TestSendSMTP_DisplayNameSplitsEnvelopeAndHeader` — the reported bug
- `TestSendSMTP_NonASCIIDisplayNameIsEncoded`
- `TestSendSMTP_BareAddressWireFormatUnchanged` — pins the no-change guarantee (passes pre-fix, by design)
- `TestSendSMTP_UnparseableFromIsPassedThrough`
- `TestSendSMTP_MessageIDUsesSenderDomainNotRelayHost` — also asserts `Date` survives
- `TestSendSMTP_MessageIDIsUniquePerSend`
- `TestSendSMTP_CRLFInSenderAbortsBeforeData` — records that the CR/LF guarantee comes from `net/smtp`, not from this parser

The mock relay now captures the `MAIL FROM` line and the `DATA` payload separately, so envelope and headers can be asserted independently.

Docs updated: `environment-variables.mdx` (en/zh/ja/ko) described the value as "Envelope From and message From", which was the source of the conflation, plus `.env.example`.

