### PR TITLE
chore: add verify-multica skill and pstack model seats

### DIFF
--- a/.cursor/rules/pstack-models.mdc
+++ b/.cursor/rules/pstack-models.mdc
@@ -1,0 +1,25 @@
+---
+description: pstack per-role model choices (overrides skill defaults)
+alwaysApply: true
+---
+# pstack model configuration. One line per role. Delete a line to fall back to the skill default.
+# `inherit-parent` or `auto` as a value: the role runs on the parent chat model (omit Task `model`). Alias entries in a panel list still count toward its fan-out.
+# Repo copy so cloud agents see the same seats. Local /setup-pstack still writes ~/.cursor/rules/pstack-models.mdc.
+feature, refactoring: cursor-grok-4.6-xhigh-fast
+bug-fix: gpt-5.6-sol-max
+perf-issue: gpt-5.6-sol-max
+hillclimb: gpt-5.6-sol-max
+judgment and prose: claude-opus-5-thinking-max
+hardest tasks: claude-fable-5-thinking-max
+how explorer: cursor-grok-4.6-xhigh-fast
+how explainer: claude-fable-5-thinking-max
+how critics: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh-fast, kimi-k3-max
+why investigators: cursor-grok-4.6-xhigh-fast
+why synthesizer: claude-fable-5-thinking-max
+reflect tooling: gpt-5.6-sol-max
+reflect judgment, divergent, synthesizer: claude-fable-5-thinking-max
+arena runners: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh-fast, kimi-k3-max
+arena cross-judge pool: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh-fast, kimi-k3-max
+swarm workers: cursor-grok-4.6-xhigh-fast
+architect runners: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh-fast, kimi-k3-max
+interrogate reviewers: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh-fast, kimi-k3-max

--- a/.cursor/skills/verify-multica/SKILL.md
+++ b/.cursor/skills/verify-multica/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: verify-multica
+description: Drive this checkout's Multica web app the way a user does — launch, doctor identity, sign in with the local email code, exercise issues — and capture proof. Use for live UI verification, proving a change works, or when a PR asks for a live box.
+---
+
+# Verify Multica (web)
+
+Primary surface is the **web app** in this checkout (`apps/web`, Next.js). Desktop (Electron), mobile (Expo), the Go API, and `make cli` exist; do not treat those as this skill's drive target unless a mapped feature says so.
+
+You are writing proof for a later reader. Drive the real UI. Do not call internal setters, `TestApiClient`, or test-only endpoints to claim a user-facing feature works. API/DB reads are allowed as a *second* view of a mutation you already performed in the UI.
+
+## Launch
+
+On PATH you need `go` (module is 1.26), `docker` (Compose starts the shared local Postgres), `node` 22, and `pnpm`. Check with `.cursor/skills/verify-multica/control-multica prereqs`.
+
+From the repo root, or via the helper (preferred):
+
+```bash
+.cursor/skills/verify-multica/control-multica launch
+```
+
+That is `make up C=api,web` when this checkout is not already healthy. Ready when `control-multica doctor` exits 0.
+
+- Web origin and API port come from `make status --json` (`frontend_port`, `backend_port`). Defaults on a fresh main checkout are often `http://localhost:3000` and `http://localhost:8080`. Worktrees differ. Never hardcode another checkout's ports.
+- Local sign-in (non-production): email `dev@localhost` (or `MULTICA_DEV_EMAIL`) and code `888888` (or `MULTICA_DEV_VERIFICATION_CODE` from `.env` / `.env.worktree`). `control-multica urls` prints the pair this environment is using.
+- Two checkouts can run side by side. `make up` allocates ports and a database name per directory. If `/health` answers on this checkout's API port with a pid or commit that is not ours, **stop**. Do not reuse, kill, or drive it.
+- `make down` stops this environment and keeps the database. `make destroy` drops the database — never use it for verification cleanup.
+
+If this run called `launch` and doctor failed, run `control-multica cleanup` before retrying so ports are not stranded.
+
+## Doctor
+
+Run first whenever anything looks off:
+
+```bash
+.cursor/skills/verify-multica/control-multica doctor
+```
+
+It is read-only. It must show all of:
+
+- `make status --json` `dir` equals this repo root
+- `components.api.state` and `components.web.state` are `running`
+- `GET http://localhost:<backend_port>/health` returns JSON whose `commit` equals `git rev-parse --short HEAD`
+- `GET http://localhost:<frontend_port>` succeeds
+
+If doctor fails, do not drive. Launch or fix identity first.
+
+## Drive
+
+Harness: the Cursor browser tools against **this checkout's** web URL from `control-multica urls`. Prefer ARIA roles and accessible names. Do not click by coordinates.
+
+Existing Playwright specs under `e2e/` are a regression suite, not a substitute for this skill. They often inject `multica_token` via `TestApiClient` and skip the email-code path. Use them only when a feature file says a scripted replay is allowed *in addition* to the user path.
+
+Stable handles from this repo:
+
+| Control | Handle |
+|---|---|
+| Login title | text `Sign in to Multica` |
+| Email | role `textbox`, name `Email` (placeholder `you@example.com`) |
+| Send code | role `button`, name `Continue` (disabled while email is empty) |
+| Code step | heading `Check your email`; six-digit OTP at `[data-slot="input-otp"]` (hidden textbox; typing six digits submits) |
+| Issues home | `/{workspaceSlug}/issues`; role `button`, name `New Issue` |
+| Sidebar | role `link`, name `Inbox` / `Issues` (exact) / `Agents` / `Settings` (exact) |
+| Create issue | role `textbox`, name `Issue title`; role `button`, name `Create Issue` |
+| Agent vs manual create | role `button`, name `Switch to Manual` / `Switch to Agent` |
+| Create toast | text `Issue created`; role `button`, name `View issue` |
+| Issue detail | text `Properties`; comment shell `[data-testid="comment-composer-shell"]` |
+| Comment editor | `.ProseMirror` with placeholder `Leave a comment...`; submit `ControlOrMeta+Enter` |
+| Workspace menu | role `button` matching the workspace name; menuitem `Log out` |
+
+Read `.cursor/skills/verify-multica/features/README.md` and the matching feature file before driving. A proof that uses one convenient entry point is incomplete when the map lists others.
+
+Start from `/login` or `/{slug}/issues` as the feature file says. Do not paste `localStorage.multica_token` unless the feature's preconditions explicitly allow a seeded session *after* the user path has already been proven in this run.
+
+## Evidence
+
+Write proof under `.cursor/skills/verify-multica/artifacts/<feature-id>/`. Create the directory with:
+
+```bash
+.cursor/skills/verify-multica/control-multica artifacts <feature-id>
+```
+
+Standards:
+
+- Exercise the real user path (email → code → UI), not an injected token, unless the feature file is documenting a second view.
+- Capture the **action** and the **resulting state**, not only the last screen. For a mutation, take a screenshot or ARIA snapshot before and after, and a second user-facing read (reload, reopen, or a different page that must show the same value).
+- Verify side effects that the user would notice: URL, document title, toast, list row, issue heading, comment body. A 200 from `POST /api/issues` is not enough.
+- Mocks only at a production boundary the product already isolates (the settings Composio test is an example of that boundary — do not copy the pattern onto issue create).
+- Name every artifact with the feature ID and entry point. Example: `artifacts/sign-in/email-step.png`, `artifacts/sign-in/after-code.aria.yml`.
+
+Browser: screenshot + accessibility snapshot with Multica identity visible (login title, workspace name, or `Issues \| Multica` / `Inbox \| Multica` document title). CLI/API second views: command, stdout, stderr, exit code.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-multica/control-multica cleanup
+```
+
+- Tears down only an environment **this helper launched** (`launched=1` in `.run-state`). If doctor reused an already-running checkout, cleanup leaves it running.
+- Uses `make down` (keeps DB). Never `make destroy`. Never `kill` by process name (`multica`, `next`, `node`).
+- Removes `.run-state` only. **Does not delete `artifacts/`.** If cleanup ate the proof, the run failed.
+
+Issue titles created during a run may stay in the shared local DB. Prefix them `verify-` plus a timestamp so a later run can ignore them. Do not delete the user's existing issues.
+
+## Helpers
+
+`control-multica` lives next to this file and is executable.
+
+```bash
+.cursor/skills/verify-multica/control-multica prereqs
+.cursor/skills/verify-multica/control-multica launch
+.cursor/skills/verify-multica/control-multica doctor
+.cursor/skills/verify-multica/control-multica urls
+.cursor/skills/verify-multica/control-multica artifacts sign-in
+.cursor/skills/verify-multica/control-multica cleanup
+```
+
+## Other surfaces (out of scope unless mapped)
+
+- Desktop: `make up C=desktop`. Not this skill's default harness.
+- Mobile: read `apps/mobile/CLAUDE.md` first. Separate stack.
+- API-only: `GET /health` is for doctor, not product proof.

--- a/.cursor/skills/verify-multica/control-multica
+++ b/.cursor/skills/verify-multica/control-multica
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Drive this Multica checkout's local web environment for verification.
+# See SKILL.md. Never kill by process name. Never run make destroy.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE_FILE="$SCRIPT_DIR/.run-state"
+ARTIFACTS_DIR="$SCRIPT_DIR/artifacts"
+
+repo_root() {
+  local dir="$SCRIPT_DIR"
+  while [ "$dir" != / ]; do
+    if [ -f "$dir/Makefile" ] && [ -f "$dir/scripts/dev-env.sh" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo "control-multica: could not find the Multica repo root above $SCRIPT_DIR" >&2
+  exit 1
+}
+
+REPO_ROOT="$(repo_root)"
+cd "$REPO_ROOT"
+
+die() { echo "control-multica: $*" >&2; exit 1; }
+
+status_json() {
+  make status ARGS=--json
+}
+
+field() {
+  # field <json> <python expr on obj>
+  python3 -c 'import json,sys; obj=json.loads(sys.argv[1]); '"$2"'' "$1"
+}
+
+load_status() {
+  STATUS_JSON="$(status_json)" || die "make status --json failed. This checkout may have no registered environment. Run: $0 launch"
+}
+
+urls_from_status() {
+  load_status
+  BACKEND_PORT="$(field "$STATUS_JSON" 'print(obj["backend_port"])')"
+  FRONTEND_PORT="$(field "$STATUS_JSON" 'print(obj["frontend_port"])')"
+  API_STATE="$(field "$STATUS_JSON" 'print(obj["components"]["api"]["state"])')"
+  WEB_STATE="$(field "$STATUS_JSON" 'print(obj["components"]["web"]["state"])')"
+  API_DETAIL="$(field "$STATUS_JSON" 'print(obj["components"]["api"]["detail"])')"
+  WEB_ADDR="$(field "$STATUS_JSON" 'print(obj["components"]["web"]["address"])')"
+  API_ADDR="$(field "$STATUS_JSON" 'print(obj["components"]["api"]["address"])')"
+  ENV_DIR="$(field "$STATUS_JSON" 'print(obj["dir"])')"
+  ENV_NAME="$(field "$STATUS_JSON" 'print(obj["name"])')"
+  WEB_URL="http://localhost:${FRONTEND_PORT}"
+  API_URL="http://localhost:${BACKEND_PORT}"
+}
+
+expected_commit() {
+  git -C "$REPO_ROOT" rev-parse --short HEAD
+}
+
+dev_email() {
+  printf '%s\n' "${MULTICA_DEV_EMAIL:-dev@localhost}"
+}
+
+dev_code() {
+  if [ -f "$REPO_ROOT/.env.worktree" ]; then
+    # shellcheck disable=SC1091
+    code="$(grep -E '^MULTICA_DEV_VERIFICATION_CODE=' "$REPO_ROOT/.env.worktree" | tail -n1 | cut -d= -f2- || true)"
+    if [ -n "$code" ]; then
+      printf '%s\n' "$code"
+      return
+    fi
+  fi
+  if [ -f "$REPO_ROOT/.env" ]; then
+    # shellcheck disable=SC1091
+    code="$(grep -E '^MULTICA_DEV_VERIFICATION_CODE=' "$REPO_ROOT/.env" | tail -n1 | cut -d= -f2- || true)"
+    if [ -n "$code" ]; then
+      printf '%s\n' "$code"
+      return
+    fi
+  fi
+  printf '%s\n' "${MULTICA_DEV_VERIFICATION_CODE:-888888}"
+}
+
+write_state() {
+  mkdir -p "$(dirname "$STATE_FILE")"
+  cat >"$STATE_FILE" <<EOF
+launched=$1
+pid=$$
+repo=$REPO_ROOT
+started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+}
+
+read_launched() {
+  [ -f "$STATE_FILE" ] || { printf '0\n'; return; }
+  grep -E '^launched=' "$STATE_FILE" | cut -d= -f2
+}
+
+cmd_urls() {
+  urls_from_status
+  cat <<EOF
+env		$ENV_NAME
+dir		$ENV_DIR
+web		$WEB_URL
+api		$API_URL
+health		$API_URL/health
+sign-in		$(dev_email)  ·  code $(dev_code)
+artifacts	$ARTIFACTS_DIR
+EOF
+}
+
+cmd_doctor() {
+  urls_from_status
+
+  if [ "$ENV_DIR" != "$REPO_ROOT" ]; then
+    die "make status dir is $ENV_DIR, not this checkout ($REPO_ROOT). Refuse to drive another environment."
+  fi
+
+  if [ "$API_STATE" != running ]; then
+    die "api is '$API_STATE' (want running). Address: ${API_ADDR:--}. Run: $0 launch"
+  fi
+  if [ "$WEB_STATE" != running ]; then
+    die "web is '$WEB_STATE' (want running). Address: ${WEB_ADDR:--}. Run: $0 launch"
+  fi
+
+  local health expected health_commit
+  health="$(curl -sf --max-time 3 "$API_URL/health")" \
+    || die "GET $API_URL/health failed. The listener is not this checkout's API."
+  expected="$(expected_commit)"
+  health_commit="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("commit",""))' "$health")"
+  if [ "$health_commit" != "$expected" ]; then
+    die "/health commit is '$health_commit', this checkout is '$expected'. Refuse to drive a stale or foreign API. $API_DETAIL"
+  fi
+
+  curl -sf --max-time 15 "$WEB_URL" >/dev/null \
+    || die "GET $WEB_URL failed."
+
+  echo "control-multica doctor: ok"
+  echo "  env     $ENV_NAME"
+  echo "  web     $WEB_URL  ($WEB_STATE)"
+  echo "  api     $API_URL  commit $health_commit  $API_DETAIL"
+  echo "  sign-in $(dev_email) / $(dev_code)"
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing on PATH: $1 (install it, then retry launch)"
+}
+
+cmd_prereqs() {
+  need_cmd go
+  need_cmd docker
+  need_cmd node
+  need_cmd pnpm
+  echo "control-multica prereqs: ok (go docker node pnpm)"
+}
+
+cmd_launch() {
+  cmd_prereqs
+  # Subshell so doctor's `exit 1` cannot abort launch before `make up`.
+  if (cmd_doctor) >/dev/null 2>&1; then
+    if [ ! -f "$STATE_FILE" ]; then
+      write_state 0
+    fi
+    echo "control-multica launch: reused this checkout's already-running environment"
+    cmd_doctor
+    return 0
+  fi
+
+  echo "control-multica launch: make up C=api,web"
+  make up C=api,web
+  write_state 1
+  cmd_doctor
+}
+
+cmd_cleanup() {
+  local launched
+  launched="$(read_launched)"
+  if [ "$launched" = 1 ]; then
+    echo "control-multica cleanup: make down (keeps the database; leaves $ARTIFACTS_DIR)"
+    make down
+  else
+    echo "control-multica cleanup: did not start this environment; leaving it running"
+  fi
+  rm -f "$STATE_FILE"
+  echo "control-multica cleanup: proof artifacts remain in $ARTIFACTS_DIR"
+}
+
+cmd_artifacts() {
+  local feature="${1:-}"
+  [ -n "$feature" ] || die "usage: $0 artifacts <feature-id>"
+  local dir="$ARTIFACTS_DIR/$feature"
+  mkdir -p "$dir"
+  printf '%s\n' "$dir"
+}
+
+usage() {
+  cat <<EOF
+usage: control-multica <command>
+
+  launch      Start this checkout with make up C=api,web, or reuse it if doctor already passes
+  prereqs     Read-only: go, docker, node, pnpm on PATH
+  doctor      Read-only: this checkout owns api+web, /health commit matches HEAD, web answers
+  urls        Print web, api, local sign-in email/code, artifacts dir
+  artifacts <feature-id>
+              Create and print artifacts/<feature-id>
+  cleanup     make down only if this run launched the env. Never destroy. Never delete artifacts
+
+Run from any directory. All commands bind to the repo that contains this script.
+EOF
+}
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  launch) cmd_launch "$@" ;;
+  doctor) cmd_doctor "$@" ;;
+  prereqs) cmd_prereqs "$@" ;;
+  urls) cmd_urls "$@" ;;
+  artifacts) cmd_artifacts "$@" ;;
+  cleanup) cmd_cleanup "$@" ;;
+  -h|--help|help|"") usage ;;
+  *) die "unknown command: $cmd" ;;
+esac

--- a/.cursor/skills/verify-multica/features/README.md
+++ b/.cursor/skills/verify-multica/features/README.md
@@ -1,0 +1,49 @@
+# Multica web verification map
+
+This directory is the maintained source for verifying user-facing behavior of the Multica **web** app in this checkout. Read the index before driving, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- `control-multica prereqs` exits 0 (`go`, `docker`, `node`, `pnpm` on PATH).
+- This checkout's environment is healthy. Run `.cursor/skills/verify-multica/control-multica doctor` and require matching `dir`, running `api` + `web`, and `/health` commit equal to `git rev-parse --short HEAD`.
+- Web URL is the `web` line from `control-multica urls`. Never drive `localhost:3000` unless doctor printed that port for **this** repo.
+- Local sign-in uses the email/code pair from `control-multica urls` (`dev@localhost` / `888888` unless the env file overrides them). `APP_ENV` must not be `production` or the fixed code is ignored.
+- Never drive an instance doctor did not accept.
+- Playwright `e2e/` may be running against the same origin. Prefer a dedicated browser tab. Do not share a page Playwright is mid-test on.
+
+## Driving conventions
+
+- Start every recipe from the baseline unless its preconditions say otherwise.
+- Prefer ARIA roles and accessible names. Stable test ids in this repo are rare; `comment-composer-shell` is one.
+- Treat every command as literal. Keep quoted names unchanged.
+- Browser actions go through the Cursor browser tools against the doctor URL.
+- After a mutation, reopen or reload before calling it persisted.
+- Prefix created issue titles with `verify-` and a timestamp. Do not delete unrelated issues on cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes an ARIA snapshot and a screenshot with Multica identity visible (login copy, workspace name, or document title `… | Multica`).
+- Mutation proof includes a second user-facing read of the stored value.
+- Record the feature ID and entry point on every artifact.
+- Report an unreachable path with the attempted action and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with the browser` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact handle and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [Sign in](./sign-in.md) covers the email + code path, already-signed-in bounce, and logout.
+- [Create an issue](./create-issue.md) covers opening the composer, switching to manual, saving, cancelling, and reopening.
+- [Issue detail](./issue-detail.md) covers opening an issue from the list and reading title, properties, and document title.
+- [Comments](./comments.md) covers leaving a comment on an issue and seeing it in activity.
+- [Sidebar navigation](./sidebar-navigation.md) covers Inbox, Issues, Agents, and Settings from the signed-in shell.

--- a/.cursor/skills/verify-multica/features/comments.md
+++ b/.cursor/skills/verify-multica/features/comments.md
@@ -1,0 +1,35 @@
+# Comments
+
+Comments lets a user leave a note on an issue and see it in the issue's activity. An empty composer cannot send.
+
+## Sub-features
+
+- `comment-open` activates the composer from its idle shell.
+- `comment-submit` publishes a non-empty comment with `ControlOrMeta+Enter`.
+- `comment-visible` shows the new comment body on the same issue page.
+- `comment-empty` keeps send disabled while the composer has no text.
+
+## How to get to it (user POV)
+
+- Open any issue detail page and use the comment composer at the bottom of the thread.
+
+## Driving it with the browser
+
+Preconditions:
+
+- `control-multica doctor` exits 0.
+- Signed in on an issue detail URL (`/{slug}/issues/{id}`) with `Properties` visible. Use an issue created in this run (`verify-…`) when possible.
+
+- **See shell.** `[data-testid="comment-composer-shell"]` is visible. The send control (arrow-up button in that composer) is disabled while empty.
+- **Activate.** Choose the shell. A `.ProseMirror` editor with placeholder `Leave a comment...` is focused.
+- **Type.** Enter `verify-comment-<timestamp>`.
+- **Send.** Press `ControlOrMeta+Enter`. The page shows `verify-comment-<timestamp>` in the activity/thread, not only inside the editor.
+- **Confirm persistence.** Reload the same issue URL. The comment body is still visible after `Properties` appears.
+- **Proof.** Save `{artifacts}/comments/before.png` (shell visible, empty), `{artifacts}/comments/after.png` (body visible in the thread), and an ARIA snapshot that includes the comment text.
+
+## Gotchas
+
+- The composer is a static shell until clicked. Typing before activating it does not count.
+- Submit is `ControlOrMeta+Enter`, not a required click on the arrow. Either path is valid; record which you used.
+- A string that exists only in the still-focused editor is not published. Reload or blur and read the thread.
+- Do not insert the comment with `POST /api/issues/{id}/comments` and call this feature proven.

--- a/.cursor/skills/verify-multica/features/create-issue.md
+++ b/.cursor/skills/verify-multica/features/create-issue.md
@@ -1,0 +1,40 @@
+# Create an issue
+
+Create issue lets a signed-in user open a composer from the issues home, switch to manual fields, save a titled issue, cancel a draft, and reopen the saved issue from a second view.
+
+## Sub-features
+
+- `create-open` opens the composer from the issues-page `New Issue` button.
+- `create-manual` switches the composer from agent mode to manual fields when needed.
+- `create-save` persists a title and shows `Issue created`.
+- `create-open-result` opens the new issue from the toast.
+- `create-cancel` dismisses an unfinished composer with Escape.
+
+## How to get to it (user POV)
+
+- Choose `New Issue` on `/{slug}/issues`.
+- Use the command palette command `New Issue` (search).
+
+## Driving it with the browser
+
+Preconditions:
+
+- `control-multica doctor` exits 0.
+- You are signed in and on `/{slug}/issues` with a visible `New Issue` button. If you landed on onboarding, finish or use an already-onboarded local user (`dev@localhost` after a prior `make up` login) before this feature.
+- No need to pre-create rows. Use a fresh title `verify-create-<timestamp>`.
+
+- **Open composer.** Choose the button `New Issue`. A dialog appears.
+- **Switch to manual.** If there is no textbox named `Issue title`, choose `Switch to Manual`. The textbox `Issue title` is visible and `Create Issue` is present (disabled or not ready until the title is non-empty).
+- **Enter title.** Fill `Issue title` with `verify-create-<timestamp>`. `Create Issue` becomes ready.
+- **Save.** Choose `Create Issue`. A notification region shows `Issue created` and the title you typed.
+- **Open result.** Choose `View issue`. The URL matches `/{slug}/issues/{id}` and `Properties` is visible. The heading or title area shows `verify-create-<timestamp>`.
+- **Confirm persistence.** Go to `/{slug}/issues` (sidebar link `Issues`, exact). The new title is visible on the board or list. If the board is showing and the card is not in view, switch to `List`.
+- **Cancel draft.** Choose `New Issue` again, switch to manual if needed, type `verify-discard-<timestamp>`, press `Escape`. The title textbox is gone. `New Issue` is visible again. The issues view has no `verify-discard-<timestamp>` row.
+- **Proof.** Save `{artifacts}/create-issue/composer.png` (Issue title visible), `{artifacts}/create-issue/toast.png` (`Issue created` + title), `{artifacts}/create-issue/detail.png` (Properties + title), and an ARIA snapshot of the issues list that includes the saved title.
+
+## Gotchas
+
+- The composer often opens in **agent** mode first. Manual fields (`Issue title`, `Create Issue`) appear only after `Switch to Manual`. A missing title field is not a product failure until you have switched.
+- Toast text `Issue created` alone is insufficient. Reopen from `View issue` or the list.
+- The command-palette entry is a second path. If you skip it, say so; do not mark it verified.
+- Do not create the issue through `POST /api/issues` or `TestApiClient` and call this feature proven.

--- a/.cursor/skills/verify-multica/features/issue-detail.md
+++ b/.cursor/skills/verify-multica/features/issue-detail.md
@@ -1,0 +1,37 @@
+# Issue detail
+
+Issue detail shows a saved issue's title, properties, and a back path to the issues list. The browser tab names the issue so several open issues stay distinguishable.
+
+## Sub-features
+
+- `detail-open-list` opens an issue from the issues list or board.
+- `detail-properties` shows the `Properties` region.
+- `detail-title` shows the issue title and sets `document.title` to `{identifier}: {title} | Multica`.
+- `detail-back` returns to the issues list via the Issues breadcrumb or sidebar.
+
+## How to get to it (user POV)
+
+- Choose an issue title or card on `/{slug}/issues`.
+- Open `/{slug}/issues/{id}` directly (reload, bookmark, toast `View issue`).
+
+## Driving it with the browser
+
+Preconditions:
+
+- `control-multica doctor` exits 0.
+- Signed in on `/{slug}/issues`.
+- At least one issue exists. If the workspace is empty, create one with [create-issue](./create-issue.md) first (user path), or this feature is blocked.
+
+- **Find a row.** On `/{slug}/issues`, locate a visible issue title. Board columns include `Backlog`, `Todo`, `In Progress`. List view is the `List` control if cards are collapsed.
+- **Open from list.** Choose the issue's link (href ends with `/issues/{id}`). The URL matches `/{slug}/issues/{id}`.
+- **Read properties.** Text `Properties` is visible. The issue title from the list is visible on the page.
+- **Read tab title.** `document.title` is `{identifier}: {title} | Multica` (identifier looks like `ABC-123`).
+- **Back to list.** Choose the breadcrumb or sidebar link `Issues` (exact). The URL matches `/{slug}/issues` and `New Issue` is visible.
+- **Direct URL.** Open the same `/{slug}/issues/{id}` again. Properties and title still match.
+- **Proof.** Save `{artifacts}/issue-detail/open.png` (Properties + title), `{artifacts}/issue-detail/open.aria.yml`, and record the observed `document.title`.
+
+## Gotchas
+
+- Board cards can be off-screen. Switch to `List` before declaring the issue missing.
+- Title-only screenshots that omit `Properties` do not prove you are on the detail page (the list also shows titles).
+- Creating the issue via API and only opening the URL proves navigation, not create. That is allowed here if create-issue was already proven or is out of scope for this run — say which.

--- a/.cursor/skills/verify-multica/features/sidebar-navigation.md
+++ b/.cursor/skills/verify-multica/features/sidebar-navigation.md
@@ -1,0 +1,33 @@
+# Sidebar navigation
+
+Sidebar navigation moves a signed-in user between Inbox, Issues, Agents, and Settings. Each destination updates the URL and the browser tab title.
+
+## Sub-features
+
+- `nav-inbox` opens Inbox (`/{slug}/inbox`, title `Inbox | Multica`).
+- `nav-issues` opens Issues (`/{slug}/issues`, title `Issues | Multica`).
+- `nav-agents` opens Agents (`/{slug}/agents`, title `Agents | Multica`).
+- `nav-settings` opens Settings (`/{slug}/settings`) with tabs `General` and `Members`.
+
+## How to get to it (user POV)
+
+- Choose the matching sidebar link while signed in to a workspace.
+
+## Driving it with the browser
+
+Preconditions:
+
+- `control-multica doctor` exits 0.
+- Signed in. Any workspace-scoped page is fine (`/{slug}/issues` is the usual start).
+
+- **Inbox.** Choose link `Inbox`. URL matches `/inbox`. Visible text includes `Inbox`. Document title is `Inbox | Multica`.
+- **Agents.** Choose link `Agents`. URL matches `/agents`. Visible text includes `Agents`. Document title is `Agents | Multica`.
+- **Issues.** Choose link `Issues` (exact — not `My issues`). URL matches `/issues`. `New Issue` is visible. Document title is `Issues | Multica`.
+- **Settings.** Choose link `Settings` (exact). URL matches `/settings`. Tabs `General` and `Members` are visible.
+- **Proof.** Save one screenshot per destination under `{artifacts}/sidebar-navigation/` (`inbox.png`, `agents.png`, `issues.png`, `settings.png`) with the sidebar selection and page heading visible. Record each URL and document title.
+
+## Gotchas
+
+- `Issues` vs `My issues` are different links. The exact name `Issues` is the board/list home.
+- `Settings` vs other settings-adjacent items: use the exact sidebar link, then assert `/settings` and the `General` tab.
+- A URL change without the matching document title is incomplete proof (tab titles are how several open destinations stay distinguishable).

--- a/.cursor/skills/verify-multica/features/sign-in.md
+++ b/.cursor/skills/verify-multica/features/sign-in.md
@@ -1,0 +1,43 @@
+# Sign in
+
+Sign in lets a user request a six-digit email code, enter it, and land in Multica (onboarding or their workspace). An already-signed-in user who opens `/login` is sent onward. Log out returns them to the login screen.
+
+## Sub-features
+
+- `signin-email` shows the email form and keeps Continue disabled until an email is entered.
+- `signin-code` sends a code and shows the OTP step for that email.
+- `signin-accept` accepts the local development code and leaves `/login`.
+- `signin-session` sends an already-authenticated visit away from `/login`.
+- `signin-logout` returns a signed-in user to `/login`.
+
+## How to get to it (user POV)
+
+- Open `/login` in the web app.
+- Open a workspace URL while signed out; the app redirects to `/login`.
+- Choose `Log out` in the workspace switcher menu.
+
+## Driving it with the browser
+
+Preconditions:
+
+- `control-multica doctor` exits 0.
+- Web URL is the `web` line from `control-multica urls`.
+- Sign-in pair is the `sign-in` line from `urls` (typically `dev@localhost` / `888888`).
+- Use a browser profile that does not already have `multica_token` unless you are proving `signin-session`.
+
+- **Open login.** Go to `{web}/login`. The page shows `Sign in to Multica` and a textbox named `Email`. The button `Continue` is disabled.
+- **Enter email.** Fill the `Email` textbox with the urls email. `Continue` becomes enabled.
+- **Send code.** Choose `Continue`. The heading becomes `Check your email` and the description includes the address you typed.
+- **Enter code.** Focus `[data-slot="input-otp"]` (hidden textbox) and type the six-digit urls code. The form submits when the sixth digit is entered. Do not look for a separate submit button.
+- **Landed.** The URL is no longer `/login`. First-time users see `Continue on web` (onboarding). A user who has already onboarded in this database lands on `/{slug}/issues` with a `New Issue` button, or another post-auth destination. Document title contains `Multica`.
+- **Session bounce.** While still signed in, go to `{web}/login` again. The app leaves `/login` without asking for a new code.
+- **Log out.** From a workspace page, open the workspace-name button in the sidebar, choose menuitem `Log out`. The URL is `/login` and `Sign in to Multica` is visible.
+- **Proof.** Save `{artifacts}/sign-in/email-step.png` (title visible), `{artifacts}/sign-in/code-step.png` (email visible in the description), `{artifacts}/sign-in/after-login.png` plus an ARIA snapshot of the landed page. The after-login artifacts must not show the email form.
+
+## Gotchas
+
+- The OTP widget is one hidden textbox, not six separately named fields. Type the whole code into that textbox.
+- `888888` works only when `APP_ENV` is not `production`. Doctor does not check this; a rejected code with copy `Invalid or expired code` means the environment is not using the local override.
+- `dev@localhost` is shared across runs of this checkout. It may already be onboarded. That does not fail sign-in; it changes the landing page. Record which landing you got.
+- Injecting `localStorage.multica_token` proves session restore, not sign-in. Do not use it for `signin-email` / `signin-code` / `signin-accept`.
+- Google sign-in (`Continue with Google`) needs OAuth client config. Skip it unless this checkout's env has `GOOGLE_CLIENT_ID` and you intend to complete the real Google UI.

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ data/
 # Python (agent tooling)
 __pycache__/
 *.pyc
+
+# verify-multica run state and proof artifacts (skill files stay tracked)
+.cursor/skills/verify-multica/artifacts/
+.cursor/skills/verify-multica/.run-state


### PR DESCRIPTION
## Summary
- Add a project-local `verify-multica` skill so agents can launch, doctor, and drive this checkout’s web app instead of a shared instance.
- Commit pstack per-role model seats in `.cursor/rules/pstack-models.mdc` so cloud agents see the same mapping (Kimi on critics / arena / architect / interrogate panels).
- Ignore verification run state and proof artifacts; keep the skill files tracked.

## Test plan
- [ ] Confirm `.cursor/skills/verify-multica/control-multica` is executable and `prereqs` / `doctor` / `urls` behave as documented when this checkout’s env is up.
- [ ] Confirm `.cursor/rules/pstack-models.mdc` is always-applied in a new local chat and present in a cloud agent clone of this branch.
- [ ] Confirm `.cursor/settings.json` was not committed.


Made with [Cursor](https://cursor.com)