### PR TITLE
MUL-6721: perf(runtime): restore HOT heartbeats and index the stale-task sweep

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -293,6 +293,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"371_comment_content_search_index_strategy":             "idx_comment_content_trgm",
 	"375_drop_issue_last_activity_index":                    "idx_issue_workspace_last_activity",
 	"391_drop_agent_task_queue_dispatched_prepare_index":    "idx_agent_task_queue_dispatched_prepare",
+	"432_drop_agent_runtime_last_seen_at_index":             "idx_agent_runtime_last_seen_at",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -506,18 +506,33 @@ func gcRuntime(ctx context.Context, txStarter runtimeGCTxStarter, queries *db.Qu
 // edge where a runtime row lingers online-with-stale-heartbeat past the
 // wall clock (MUL-4107).
 func sweepStaleTasks(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus, reconnectGrace time.Duration) {
-	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
+	// Dispatched and running tasks are failed by two separate statements rather
+	// than one OR'd UPDATE so each can use its own partial index; an OR across
+	// idx_agent_task_queue_dispatched_reclaim_v2 and
+	// idx_agent_task_queue_running_started_at cannot be combined by the planner
+	// and forced a full sequential scan every tick (GH #7389).
+	dispatched, err := queries.FailStaleDispatchedTasks(ctx, db.FailStaleDispatchedTasksParams{
 		DispatchTimeoutSecs: dispatchTimeoutSeconds,
-		RunningTimeoutSecs:  runningTimeoutSeconds,
 		// Reuse the runtime stale window so the running-task backstop
 		// exactly matches what sweepStaleRuntimes considers "not alive".
 		RuntimeStaleSecs:          staleThresholdSeconds,
 		RuntimeReconnectGraceSecs: reconnectGrace.Seconds(),
 	})
 	if err != nil {
-		slog.Warn("task sweeper: failed to clean up stale tasks", "error", err)
+		slog.Warn("task sweeper: failed to clean up stale dispatched tasks", "error", err)
 		return
 	}
+
+	running, err := queries.FailStaleRunningTasks(ctx, db.FailStaleRunningTasksParams{
+		RunningTimeoutSecs:        runningTimeoutSeconds,
+		RuntimeReconnectGraceSecs: reconnectGrace.Seconds(),
+	})
+	if err != nil {
+		slog.Warn("task sweeper: failed to clean up stale running tasks", "error", err)
+		return
+	}
+
+	failedTasks := append(dispatched, running...)
 	if len(failedTasks) == 0 {
 		return
 	}

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -12,6 +12,38 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+// failStaleTasksParams mirrors the fields of the former single FailStaleTasks
+// query. Tests use it to exercise both the dispatched and running paths with
+// one call, matching how sweepStaleTasks fans out to the two split queries.
+type failStaleTasksParams struct {
+	DispatchTimeoutSecs       float64
+	RunningTimeoutSecs        float64
+	RuntimeStaleSecs          float64
+	RuntimeReconnectGraceSecs float64
+}
+
+// failStaleTasks runs both split queries and returns their combined result, so
+// existing tests keep asserting on the union of dispatched + running failures
+// exactly as the pre-split FailStaleTasks statement did.
+func failStaleTasks(ctx context.Context, q *db.Queries, p failStaleTasksParams) ([]db.AgentTaskQueue, error) {
+	dispatched, err := q.FailStaleDispatchedTasks(ctx, db.FailStaleDispatchedTasksParams{
+		DispatchTimeoutSecs:       p.DispatchTimeoutSecs,
+		RuntimeStaleSecs:          p.RuntimeStaleSecs,
+		RuntimeReconnectGraceSecs: p.RuntimeReconnectGraceSecs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	running, err := q.FailStaleRunningTasks(ctx, db.FailStaleRunningTasksParams{
+		RunningTimeoutSecs:        p.RunningTimeoutSecs,
+		RuntimeReconnectGraceSecs: p.RuntimeReconnectGraceSecs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return append(dispatched, running...), nil
+}
+
 // setupSweeperTestFixture creates an issue and a task in the given status with
 // timestamps old enough to trigger the sweeper. Returns (issueID, agentID, taskID).
 func setupSweeperTestFixture(t *testing.T, taskStatus string) (string, string, string) {
@@ -267,7 +299,7 @@ func TestSweepStaleTasksBroadcastsWithWorkspaceID(t *testing.T) {
 	})
 
 	// Use very short timeouts to trigger the sweep on our test task
-	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0, // 1 second — our task is 3 hours old
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -361,7 +393,7 @@ func TestSweepStaleTasksReconcileAgentStatus(t *testing.T) {
 	})
 
 	// Fail stale tasks with short timeout
-	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -424,7 +456,7 @@ func TestSweepDispatchedStaleTask(t *testing.T) {
 	})
 
 	// Fail stale tasks — dispatch timeout of 1 second (our task is 10 minutes old)
-	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), queries, failStaleTasksParams{
 		DispatchTimeoutSecs: 1.0,
 		RunningTimeoutSecs:  9000.0,
 		// RuntimeStaleSecs only affects the running branch — irrelevant for
@@ -495,7 +527,7 @@ func TestSweepDispatchedTaskWaitsThroughReconnectGrace(t *testing.T) {
 	t.Cleanup(func() { cleanupSweeperFixture(t, issueID, agentID) })
 	setAgentRuntimeOffline(t, agentID, 10*time.Minute)
 
-	failedTasks, err := db.New(testPool).FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), db.New(testPool), failStaleTasksParams{
 		DispatchTimeoutSecs:       1.0,
 		RunningTimeoutSecs:        9000.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -537,7 +569,7 @@ func TestSweepRunningTaskSkippedWhenRuntimeFresh(t *testing.T) {
 	// Task started_at is 3h ago; RunningTimeoutSecs=1s would kill on wall clock
 	// alone — but the runtime is proving liveness, so the sweeper must skip it.
 	queries := db.New(testPool)
-	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -573,7 +605,7 @@ func TestSweepRunningTaskWaitsThroughReconnectGrace(t *testing.T) {
 	t.Cleanup(func() { cleanupSweeperFixture(t, issueID, agentID) })
 	setAgentRuntimeOffline(t, agentID, 10*time.Minute)
 
-	failedTasks, err := db.New(testPool).FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), db.New(testPool), failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -610,7 +642,7 @@ func TestSweepRunningTaskKilledBeyondReconnectGrace(t *testing.T) {
 	ageOutAgentRuntime(t, agentID, defaultRuntimeReconnectGrace+time.Hour)
 
 	queries := db.New(testPool)
-	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(context.Background(), queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -863,7 +895,7 @@ func TestSweepResetsInProgressIssueToTodo(t *testing.T) {
 	ageOutAgentRuntime(t, agentID, defaultRuntimeReconnectGrace+time.Hour)
 
 	// Fail the stale task (running timeout of 1 second — our task is 3 hours old).
-	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(ctx, queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,
@@ -952,7 +984,7 @@ func TestSweepDoesNotResetIssueAlreadyInReview(t *testing.T) {
 	// Runtime must be stale for the running-task wall clock to fire (MUL-4107).
 	ageOutAgentRuntime(t, agentID, defaultRuntimeReconnectGrace+time.Hour)
 
-	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
+	failedTasks, err := failStaleTasks(ctx, queries, failStaleTasksParams{
 		DispatchTimeoutSecs:       300.0,
 		RunningTimeoutSecs:        1.0,
 		RuntimeStaleSecs:          staleThresholdSeconds,

--- a/server/migrations/432_drop_agent_runtime_last_seen_at_index.down.sql
+++ b/server/migrations/432_drop_agent_runtime_last_seen_at_index.down.sql
@@ -1,0 +1,4 @@
+-- Recreate the plain btree index on agent_runtime.last_seen_at (migration 115).
+-- Single-statement CONCURRENTLY per repo convention.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_runtime_last_seen_at
+    ON agent_runtime (last_seen_at);

--- a/server/migrations/432_drop_agent_runtime_last_seen_at_index.up.sql
+++ b/server/migrations/432_drop_agent_runtime_last_seen_at_index.up.sql
@@ -1,0 +1,19 @@
+-- Drop the plain btree index on agent_runtime.last_seen_at (migration 115).
+--
+-- The heartbeat hot path (TouchAgentRuntimesLastSeenBatch) updates only
+-- last_seen_at and deliberately leaves updated_at untouched to keep the row
+-- HOT-eligible. That intent never held: HOT requires that no indexed column
+-- change, and this index puts last_seen_at itself under an index, so every
+-- batch flush was non-HOT and rewrote all of the table's indexes. At fleet
+-- scale that drove continuous write amplification and autovacuum churn
+-- (MUL / GH #7389).
+--
+-- Removing this index restores HOT updates on the heartbeat path. The two
+-- sampler reads it used to serve (runtime_online, runtime_heartbeat_age) run
+-- at most a few times a minute behind an 8s cache against a table of ~18k
+-- rows, so a sequential scan of the now-compact table is an acceptable trade
+-- for eliminating the write-path cost.
+--
+-- Single-statement CONCURRENTLY per repo convention: DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction or multi-command string.
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_runtime_last_seen_at;

--- a/server/migrations/433_agent_runtime_fillfactor.down.sql
+++ b/server/migrations/433_agent_runtime_fillfactor.down.sql
@@ -1,0 +1,2 @@
+-- Restore the default fillfactor (100) on agent_runtime.
+ALTER TABLE agent_runtime SET (fillfactor = 100);

--- a/server/migrations/433_agent_runtime_fillfactor.up.sql
+++ b/server/migrations/433_agent_runtime_fillfactor.up.sql
@@ -1,0 +1,7 @@
+-- Lower fillfactor on agent_runtime so heartbeat updates keep free space on
+-- each heap page for HOT chains. With migration 432 removing the last_seen_at
+-- index, the heartbeat UPDATE is HOT-eligible; leaving ~10% free space per page
+-- lets the new row version stay on the same page instead of forcing a non-HOT
+-- placement once a page fills. Existing pages adopt the setting as they are
+-- updated or rewritten; no rewrite is forced here.
+ALTER TABLE agent_runtime SET (fillfactor = 90);

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3763,98 +3763,186 @@ func (q *Queries) FailExpiredRuntimeReconnectRetries(ctx context.Context, arg Fa
 	return items, nil
 }
 
-const failStaleTasks = `-- name: FailStaleTasks :many
+const failStaleDispatchedTasks = `-- name: FailStaleDispatchedTasks :many
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout',
     prepare_lease_expires_at = NULL
-WHERE (
-    status = 'dispatched'
-    AND dispatched_at < now() - make_interval(secs => $1::double precision)
-    AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
-    AND (
-      runtime_id IS NULL
-      OR NOT EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-      )
-      OR EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-          AND (
-            (
-              r.status = 'online'
-              AND COALESCE(r.last_seen_at, r.updated_at) >=
-                  now() - make_interval(secs => $2::double precision)
-            )
-            OR COALESCE(r.last_seen_at, r.updated_at) <
-               now() - make_interval(secs => $3::double precision)
-          )
-      )
+WHERE status = 'dispatched'
+  AND started_at IS NULL
+  AND dispatched_at < now() - make_interval(secs => $1::double precision)
+  AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
+  AND (
+    runtime_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
     )
-  )
-   OR (
-    status = 'running'
-    AND started_at < now() - make_interval(secs => $4::double precision)
-    AND (
-      runtime_id IS NULL
-      OR NOT EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-          AND COALESCE(r.last_seen_at, r.updated_at) >=
-              now() - make_interval(secs => $3::double precision)
-      )
+    OR EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
+        AND (
+          (
+            r.status = 'online'
+            AND COALESCE(r.last_seen_at, r.updated_at) >=
+                now() - make_interval(secs => $2::double precision)
+          )
+          OR COALESCE(r.last_seen_at, r.updated_at) <
+             now() - make_interval(secs => $3::double precision)
+        )
     )
   )
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
 `
 
-type FailStaleTasksParams struct {
+type FailStaleDispatchedTasksParams struct {
 	DispatchTimeoutSecs       float64 `json:"dispatch_timeout_secs"`
 	RuntimeStaleSecs          float64 `json:"runtime_stale_secs"`
 	RuntimeReconnectGraceSecs float64 `json:"runtime_reconnect_grace_secs"`
-	RunningTimeoutSecs        float64 `json:"running_timeout_secs"`
 }
 
-// Fails tasks stuck in dispatched/running beyond the given thresholds.
+// Fails tasks stuck in 'dispatched' beyond the dispatch deadline. Split out of
+// the former single-statement FailStaleTasks (which OR'd dispatched and running
+// in one UPDATE) so each status can use its own partial index instead of
+// forcing a full sequential scan of agent_task_queue: an OR across two
+// different partial indexes cannot be combined by the planner (GH #7389).
 //
-// Each branch pairs a wall-clock deadline with a task-appropriate liveness
-// signal, so the sweeper only kills tasks whose owning daemon is no longer
-// proving it is alive:
-//
-//   - Dispatched: `prepare_lease_expires_at` is refreshed every 15s by the
-//     daemon between claim and StartTask (see startTaskPrepareLeaseExtender).
-//     A live lease excludes the row. An expired lease may fail immediately on
-//     a healthy runtime, but a disconnected runtime gets the same reconnect
-//     grace as a running task.
-//
-//   - Running: no per-task lease is renewed once StartTask fires, so we key
-//     off the daemon-wide heartbeat instead — `agent_runtime.last_seen_at`,
-//     which the daemon bumps every ~15s while it is up. A running task is not
-//     killed until that heartbeat has been absent for the full reconnect
-//     grace, even when its own wall-clock timeout elapsed earlier. This keeps
-//     healthy multi-hour work alive through a network partition.
+// `prepare_lease_expires_at` is refreshed every 15s by the daemon between claim
+// and StartTask (see startTaskPrepareLeaseExtender). A live lease excludes the
+// row. An expired lease may fail immediately on a healthy runtime, but a
+// disconnected runtime gets the same reconnect grace as a running task.
 //
 // The daemon-dead case is recovered immediately when that daemon restarts via
 // RecoverOrphanedTasksForRuntime. Until then, this query and
 // FailTasksForOfflineRuntimes share the same bounded reconnect grace.
 //
-// runtime_id IS NULL: a running row with no runtime is by definition not
-// proving liveness, so the wall clock is allowed to fire — same shape as
-// the legacy pure-wall-clock behavior for that (rare / historical) case.
+// started_at IS NULL is load-bearing in two ways: a dispatched row has not yet
+// started, so it is always true here and never narrows the result; and stating
+// it explicitly lets the predicate match the partial index
+// idx_agent_task_queue_dispatched_reclaim_v2
+// (WHERE status = 'dispatched' AND started_at IS NULL).
+func (q *Queries) FailStaleDispatchedTasks(ctx context.Context, arg FailStaleDispatchedTasksParams) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, failStaleDispatchedTasks, arg.DispatchTimeoutSecs, arg.RuntimeStaleSecs, arg.RuntimeReconnectGraceSecs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+			&i.RuntimeMcpOverlay,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+			&i.OriginatorUserID,
+			&i.RuntimeConnectedApps,
+			&i.CoalescedCommentIds,
+			&i.DeliveredCommentIds,
+			&i.ChatInputTaskID,
+			&i.ChatFinalizeDeferredAt,
+			&i.OriginatorSource,
+			&i.DelegatedFromTaskID,
+			&i.RetryOfTaskID,
+			&i.RerunOfTaskID,
+			&i.RuleVersionID,
+			&i.TriggerEvidenceKind,
+			&i.TriggerEvidenceRefID,
+			&i.AccountableUserID,
+			&i.SessionRolloutMissing,
+			&i.RetiredSessionID,
+			&i.QuickActionsDisabled,
+			&i.RegenerateQuickActionsFor,
+			&i.BranchName,
+			&i.DurableWorkDir,
+			&i.ChannelContextRevision,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const failStaleRunningTasks = `-- name: FailStaleRunningTasks :many
+UPDATE agent_task_queue
+SET status = 'failed', completed_at = now(), error = 'task timed out',
+    failure_reason = 'timeout',
+    prepare_lease_expires_at = NULL
+WHERE status = 'running'
+  AND started_at < now() - make_interval(secs => $1::double precision)
+  AND (
+    runtime_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
+        AND COALESCE(r.last_seen_at, r.updated_at) >=
+            now() - make_interval(secs => $2::double precision)
+    )
+  )
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
+`
+
+type FailStaleRunningTasksParams struct {
+	RunningTimeoutSecs        float64 `json:"running_timeout_secs"`
+	RuntimeReconnectGraceSecs float64 `json:"runtime_reconnect_grace_secs"`
+}
+
+// Fails tasks stuck in 'running' beyond the running deadline. Split out of the
+// former single-statement FailStaleTasks so this branch can use the partial
+// index idx_agent_task_queue_running_started_at (WHERE status = 'running')
+// instead of a full sequential scan (GH #7389).
 //
-// waiting_local_directory rows are intentionally excluded: the daemon owns
-// the wait (with its own ctx-driven timeout) and a legitimate queue ahead
-// of this task can exceed the dispatch / running timeouts without being
-// "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
-// those rows at restart.
-func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) ([]AgentTaskQueue, error) {
-	rows, err := q.db.Query(ctx, failStaleTasks,
-		arg.DispatchTimeoutSecs,
-		arg.RuntimeStaleSecs,
-		arg.RuntimeReconnectGraceSecs,
-		arg.RunningTimeoutSecs,
-	)
+// No per-task lease is renewed once StartTask fires, so we key off the
+// daemon-wide heartbeat instead — `agent_runtime.last_seen_at`, which the
+// daemon bumps every ~15s while it is up. A running task is not killed until
+// that heartbeat has been absent for the full reconnect grace, even when its
+// own wall-clock timeout elapsed earlier. This keeps healthy multi-hour work
+// alive through a network partition.
+//
+// runtime_id IS NULL: a running row with no runtime is by definition not
+// proving liveness, so the wall clock is allowed to fire — same shape as the
+// legacy pure-wall-clock behavior for that (rare / historical) case.
+//
+// waiting_local_directory rows are intentionally excluded (in both this and the
+// dispatched query): the daemon owns the wait (with its own ctx-driven timeout)
+// and a legitimate queue ahead of this task can exceed the dispatch / running
+// timeouts without being "stuck". If the daemon dies,
+// RecoverOrphanedTasksForRuntime reclaims those rows at restart.
+func (q *Queries) FailStaleRunningTasks(ctx context.Context, arg FailStaleRunningTasksParams) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, failStaleRunningTasks, arg.RunningTimeoutSecs, arg.RuntimeReconnectGraceSecs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1317,79 +1317,92 @@ SET status = 'failed',
 WHERE runtime_id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
 RETURNING *;
 
--- name: FailStaleTasks :many
--- Fails tasks stuck in dispatched/running beyond the given thresholds.
+-- name: FailStaleDispatchedTasks :many
+-- Fails tasks stuck in 'dispatched' beyond the dispatch deadline. Split out of
+-- the former single-statement FailStaleTasks (which OR'd dispatched and running
+-- in one UPDATE) so each status can use its own partial index instead of
+-- forcing a full sequential scan of agent_task_queue: an OR across two
+-- different partial indexes cannot be combined by the planner (GH #7389).
 --
--- Each branch pairs a wall-clock deadline with a task-appropriate liveness
--- signal, so the sweeper only kills tasks whose owning daemon is no longer
--- proving it is alive:
---
---   * Dispatched: `prepare_lease_expires_at` is refreshed every 15s by the
---     daemon between claim and StartTask (see startTaskPrepareLeaseExtender).
---     A live lease excludes the row. An expired lease may fail immediately on
---     a healthy runtime, but a disconnected runtime gets the same reconnect
---     grace as a running task.
---
---   * Running: no per-task lease is renewed once StartTask fires, so we key
---     off the daemon-wide heartbeat instead — `agent_runtime.last_seen_at`,
---     which the daemon bumps every ~15s while it is up. A running task is not
---     killed until that heartbeat has been absent for the full reconnect
---     grace, even when its own wall-clock timeout elapsed earlier. This keeps
---     healthy multi-hour work alive through a network partition.
+-- `prepare_lease_expires_at` is refreshed every 15s by the daemon between claim
+-- and StartTask (see startTaskPrepareLeaseExtender). A live lease excludes the
+-- row. An expired lease may fail immediately on a healthy runtime, but a
+-- disconnected runtime gets the same reconnect grace as a running task.
 --
 -- The daemon-dead case is recovered immediately when that daemon restarts via
 -- RecoverOrphanedTasksForRuntime. Until then, this query and
 -- FailTasksForOfflineRuntimes share the same bounded reconnect grace.
 --
--- runtime_id IS NULL: a running row with no runtime is by definition not
--- proving liveness, so the wall clock is allowed to fire — same shape as
--- the legacy pure-wall-clock behavior for that (rare / historical) case.
---
--- waiting_local_directory rows are intentionally excluded: the daemon owns
--- the wait (with its own ctx-driven timeout) and a legitimate queue ahead
--- of this task can exceed the dispatch / running timeouts without being
--- "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
--- those rows at restart.
+-- started_at IS NULL is load-bearing in two ways: a dispatched row has not yet
+-- started, so it is always true here and never narrows the result; and stating
+-- it explicitly lets the predicate match the partial index
+-- idx_agent_task_queue_dispatched_reclaim_v2
+-- (WHERE status = 'dispatched' AND started_at IS NULL).
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout',
     prepare_lease_expires_at = NULL
-WHERE (
-    status = 'dispatched'
-    AND dispatched_at < now() - make_interval(secs => @dispatch_timeout_secs::double precision)
-    AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
-    AND (
-      runtime_id IS NULL
-      OR NOT EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-      )
-      OR EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-          AND (
-            (
-              r.status = 'online'
-              AND COALESCE(r.last_seen_at, r.updated_at) >=
-                  now() - make_interval(secs => @runtime_stale_secs::double precision)
-            )
-            OR COALESCE(r.last_seen_at, r.updated_at) <
-               now() - make_interval(secs => @runtime_reconnect_grace_secs::double precision)
+WHERE status = 'dispatched'
+  AND started_at IS NULL
+  AND dispatched_at < now() - make_interval(secs => @dispatch_timeout_secs::double precision)
+  AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
+  AND (
+    runtime_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
+    )
+    OR EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
+        AND (
+          (
+            r.status = 'online'
+            AND COALESCE(r.last_seen_at, r.updated_at) >=
+                now() - make_interval(secs => @runtime_stale_secs::double precision)
           )
-      )
+          OR COALESCE(r.last_seen_at, r.updated_at) <
+             now() - make_interval(secs => @runtime_reconnect_grace_secs::double precision)
+        )
     )
   )
-   OR (
-    status = 'running'
-    AND started_at < now() - make_interval(secs => @running_timeout_secs::double precision)
-    AND (
-      runtime_id IS NULL
-      OR NOT EXISTS (
-        SELECT 1 FROM agent_runtime r
-        WHERE r.id = agent_task_queue.runtime_id
-          AND COALESCE(r.last_seen_at, r.updated_at) >=
-              now() - make_interval(secs => @runtime_reconnect_grace_secs::double precision)
-      )
+RETURNING *;
+
+-- name: FailStaleRunningTasks :many
+-- Fails tasks stuck in 'running' beyond the running deadline. Split out of the
+-- former single-statement FailStaleTasks so this branch can use the partial
+-- index idx_agent_task_queue_running_started_at (WHERE status = 'running')
+-- instead of a full sequential scan (GH #7389).
+--
+-- No per-task lease is renewed once StartTask fires, so we key off the
+-- daemon-wide heartbeat instead — `agent_runtime.last_seen_at`, which the
+-- daemon bumps every ~15s while it is up. A running task is not killed until
+-- that heartbeat has been absent for the full reconnect grace, even when its
+-- own wall-clock timeout elapsed earlier. This keeps healthy multi-hour work
+-- alive through a network partition.
+--
+-- runtime_id IS NULL: a running row with no runtime is by definition not
+-- proving liveness, so the wall clock is allowed to fire — same shape as the
+-- legacy pure-wall-clock behavior for that (rare / historical) case.
+--
+-- waiting_local_directory rows are intentionally excluded (in both this and the
+-- dispatched query): the daemon owns the wait (with its own ctx-driven timeout)
+-- and a legitimate queue ahead of this task can exceed the dispatch / running
+-- timeouts without being "stuck". If the daemon dies,
+-- RecoverOrphanedTasksForRuntime reclaims those rows at restart.
+UPDATE agent_task_queue
+SET status = 'failed', completed_at = now(), error = 'task timed out',
+    failure_reason = 'timeout',
+    prepare_lease_expires_at = NULL
+WHERE status = 'running'
+  AND started_at < now() - make_interval(secs => @running_timeout_secs::double precision)
+  AND (
+    runtime_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM agent_runtime r
+      WHERE r.id = agent_task_queue.runtime_id
+        AND COALESCE(r.last_seen_at, r.updated_at) >=
+            now() - make_interval(secs => @runtime_reconnect_grace_secs::double precision)
     )
   )
 RETURNING *;


### PR DESCRIPTION
## What does this PR do?

At fleet scale the `agent_runtime` heartbeat path and the stale-task sweep were the two biggest DB hot spots described in #7389.

**Write amplification.** The batch heartbeat updates only `last_seen_at` and deliberately leaves `updated_at` untouched to keep the row HOT-eligible. That intent never held: migration 115 put a btree index directly on `last_seen_at`, and HOT requires that *no indexed column* change. So every batch flush was non-HOT and rewrote all of the table's indexes, driving continuous write amplification and autovacuum churn on an otherwise tiny table.

**Sequential scans.** `FailStaleTasks` OR'd the `dispatched` and `running` branches in one `UPDATE`. The planner cannot combine the two status-specific partial indexes across an `OR`, so every sweep tick fell back to a full sequential scan of `agent_task_queue`.

This PR fixes both without dropping the `last_seen_at` column or adding a compatibility shim — the column stays, only the index is removed, so there is no multi-version migration dance.

## Related Issue

Closes #7389

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/migrations/432_drop_agent_runtime_last_seen_at_index.{up,down}.sql` — drop `idx_agent_runtime_last_seen_at` (`CREATE INDEX CONCURRENTLY` on rollback). Single-statement per repo convention.
- `server/migrations/433_agent_runtime_fillfactor.{up,down}.sql` — lower `agent_runtime` fillfactor to 90 so heartbeat updates keep page space for HOT chains.
- `server/cmd/migrate/main.go` — register `432` in `concurrentDownIndexCleanups` (its down direction rebuilds the index).
- `server/pkg/db/queries/agent.sql` — split `FailStaleTasks` into `FailStaleDispatchedTasks` (adds `started_at IS NULL` so it matches `idx_agent_task_queue_dispatched_reclaim_v2`) and `FailStaleRunningTasks` (matches `idx_agent_task_queue_running_started_at`).
- `server/pkg/db/generated/agent.sql.go` — regenerated via `make sqlc`.
- `server/cmd/server/runtime_sweeper.go` — `sweepStaleTasks` now runs both queries and unions the results.
- `server/cmd/server/runtime_sweeper_test.go` — test helper that runs both split queries so existing assertions keep testing the union.

## How to Test

Verified on a fresh `pgvector/pgvector:pg17` instance:

1. `go run ./cmd/migrate up` applies cleanly through `433`; after `432`, `last_seen_at` is referenced by **zero** indexes (`SELECT ... FROM pg_index ...`).
2. HOT recovery under a heartbeat workload (150k updates over 5000 online rows, VACUUM between ticks): **0% HOT with the index present → ~72% HOT after removal** on the real migrated schema (`pg_stat_user_tables.n_tup_hot_upd / n_tup_upd`).
3. `EXPLAIN` on the split queries: each uses its partial index (Index Scan) instead of the previous full Seq Scan; `FailStaleTasks` OR version was ~11.6ms → ~0.33ms for the two split statements on 200k rows.
4. `go build ./...`, `gofmt`, `go vet`, `go test ./cmd/migrate/...` (incl. `TestEveryConcurrentUpBuildHasCleanup`), and DB-backed `go test ./cmd/server/... ./pkg/taskfailure/...` all pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — backend only)
- [x] I have updated relevant documentation to reflect my changes (none required)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx (N/A — no product copy)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Thinking path

Started from #7389's two root causes → confirmed both still present in `runtime.sql` / `agent.sql` against the current `main` → measured on pg17 that any index on `last_seen_at` (including a `(status, last_seen_at)` composite) forces HOT to 0%, so the fix is removal, not a replacement index → confirmed dropping the column is unnecessary (the index, not the column, breaks HOT), which keeps this to two migrations with no multi-version compatibility work → split the OR'd sweep query so each branch hits its existing partial index.

### Risk notes

- Dropping `idx_agent_runtime_last_seen_at` makes the two sampler reads (`runtime_online`, `runtime_heartbeat_age`) scan the table. On a compact ~18k-row table behind an 8s cache this is sub-2ms and acceptable; a covering index cannot be reintroduced without re-breaking HOT.
- `FailStaleDispatchedTasks` adds `started_at IS NULL`. A `dispatched` row has not started, so this never narrows results in practice; it is required for the partial-index match.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Used Claude Code to triage #7389 against a local checkout, reproduce the write-amplification and seq-scan behavior on a local PostgreSQL 17 instance (measuring HOT ratios and `EXPLAIN` plans before/after), design the minimal fix (drop the index rather than the column to avoid a multi-version migration), and implement + verify the migrations, query split, and tests.
