### PR TITLE
feat(skills): atomic batch upsert for skill supporting files

### DIFF
--- a/server/cmd/multica/cmd_skill.go
+++ b/server/cmd/multica/cmd_skill.go
@@ -105,6 +105,32 @@ var skillFilesDeleteCmd = &cobra.Command{
 	RunE:  runSkillFilesDelete,
 }
 
+var skillFilesBatchUpsertCmd = &cobra.Command{
+	Use:   "batch-upsert <skill-id>",
+	Short: "Atomically upsert several supporting files from a manifest",
+	Long: `Apply multiple supporting-file writes as one atomic partial update.
+
+Each manifest entry names a skill-relative path and the local file supplying
+its content. Optional expected_sha256 fields enable optimistic concurrency:
+when given, the current content on the server must match or the whole batch
+is rejected with a conflict and nothing is written.
+
+Manifest shape:
+  {
+    "files": [
+      {"path": "references/a.md", "file": "./local/a.md",
+       "expected_sha256": "<64-hex, optional>"},
+      {"path": "references/new.md", "file": "./local/new.md"}
+    ],
+    "expected_skill_sha256": "<64-hex, optional>",
+    "idempotency_key": "<opaque, optional>"
+  }
+
+Files omitted from the manifest are left untouched.`,
+	Args: exactArgs(1),
+	RunE: runSkillFilesBatchUpsert,
+}
+
 func init() {
 	skillCmd.AddCommand(skillListCmd)
 	skillCmd.AddCommand(skillGetCmd)
@@ -118,6 +144,7 @@ func init() {
 
 	skillFilesCmd.AddCommand(skillFilesListCmd)
 	skillFilesCmd.AddCommand(skillFilesUpsertCmd)
+	skillFilesCmd.AddCommand(skillFilesBatchUpsertCmd)
 	skillFilesCmd.AddCommand(skillFilesDeleteCmd)
 
 	// skill list
@@ -170,6 +197,10 @@ func init() {
 	skillFilesUpsertCmd.Flags().Bool("content-stdin", false, "Read file content from stdin. Mutually exclusive with --content and --content-file.")
 	skillFilesUpsertCmd.Flags().String("content-file", "", "Read file content from a UTF-8 file. Mutually exclusive with --content and --content-stdin.")
 	skillFilesUpsertCmd.Flags().String("output", "json", "Output format: table or json")
+
+	// skill files batch-upsert
+	skillFilesBatchUpsertCmd.Flags().String("manifest", "", "Path to a JSON manifest listing the files to upsert (required)")
+	skillFilesBatchUpsertCmd.Flags().String("output", "json", "Output format: table or json")
 }
 
 // ---------------------------------------------------------------------------
@@ -761,6 +792,102 @@ func runSkillFilesUpsert(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Skill file upserted: %s (%s)\n", strVal(result, "path"), strVal(result, "id"))
+	return nil
+}
+
+// skillFilesBatchManifestEntry is one manifest row: the skill-relative path to
+// write and the local file whose verbatim content becomes that file's body.
+type skillFilesBatchManifestEntry struct {
+	Path           string `json:"path"`
+	File           string `json:"file"`
+	ExpectedSHA256 string `json:"expected_sha256,omitempty"`
+}
+
+// skillFilesBatchManifest mirrors the batch endpoint's request envelope. The
+// files are rebuilt server-side (content read from disk here), so only the
+// concurrency fields pass through verbatim.
+type skillFilesBatchManifest struct {
+	Files               []skillFilesBatchManifestEntry `json:"files"`
+	ExpectedSkillSHA256 string                         `json:"expected_skill_sha256,omitempty"`
+	IdempotencyKey      string                         `json:"idempotency_key,omitempty"`
+}
+
+func runSkillFilesBatchUpsert(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	manifestPath, _ := cmd.Flags().GetString("manifest")
+	if manifestPath == "" {
+		return fmt.Errorf("--manifest is required")
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	var manifest skillFilesBatchManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return fmt.Errorf("parse manifest %s: %w", manifestPath, err)
+	}
+	if len(manifest.Files) == 0 {
+		return fmt.Errorf("manifest %s lists no files", manifestPath)
+	}
+
+	body := map[string]any{}
+	files := make([]map[string]any, 0, len(manifest.Files))
+	for i, entry := range manifest.Files {
+		if entry.Path == "" {
+			return fmt.Errorf("manifest entry %d is missing \"path\"", i+1)
+		}
+		if entry.File == "" {
+			return fmt.Errorf("manifest entry %d (%s) is missing \"file\"", i+1, entry.Path)
+		}
+		contentBytes, err := os.ReadFile(entry.File)
+		if err != nil {
+			return fmt.Errorf("read content for %s: %w", entry.Path, err)
+		}
+		fileBody := map[string]any{
+			"path":    entry.Path,
+			"content": string(contentBytes),
+		}
+		if entry.ExpectedSHA256 != "" {
+			fileBody["expected_sha256"] = entry.ExpectedSHA256
+		}
+		files = append(files, fileBody)
+	}
+	body["files"] = files
+	if manifest.ExpectedSkillSHA256 != "" {
+		body["expected_skill_sha256"] = manifest.ExpectedSkillSHA256
+	}
+	if manifest.IdempotencyKey != "" {
+		body["idempotency_key"] = manifest.IdempotencyKey
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PutJSON(ctx, "/api/skills/"+args[0]+"/files/batch", body, &result); err != nil {
+		return fmt.Errorf("batch upsert skill files: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	wroteFiles, _ := result["files"].([]any)
+	for _, rf := range wroteFiles {
+		f, ok := rf.(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Printf("Skill file upserted: %s (%s)\n", strVal(f, "path"), strVal(f, "id"))
+	}
+	if agg := strVal(result, "skill_files_sha256"); agg != "" {
+		fmt.Printf("Skill files sha256: %s\n", agg)
+	}
 	return nil
 }
 

--- a/server/cmd/multica/cmd_skill_batch_test.go
+++ b/server/cmd/multica/cmd_skill_batch_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newSkillFilesBatchUpsertTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "batch-upsert"}
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("manifest", "", "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+// writeBatchManifest marshals the manifest as JSON (so Windows path separators
+// in local file references are escaped correctly) and writes it to a temp file.
+func writeBatchManifest(t *testing.T, manifest map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	path := t.TempDir() + string(os.PathSeparator) + "manifest.json"
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+func writeBatchContentFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := t.TempDir() + string(os.PathSeparator) + name
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write content file %s: %v", name, err)
+	}
+	return path
+}
+
+func TestRunSkillFilesBatchUpsertSendsVerbatimUTF8Content(t *testing.T) {
+	var body map[string]any
+	srv := newSkillBodyCaptureServer(t, http.MethodPut, "/api/skills/skill-123/files/batch", &body)
+	defer srv.Close()
+	setSkillServerEnv(t, srv.URL)
+
+	contentA := "alpha body\nwith \"quotes\" and a literal \\n\n"
+	contentB := "# 中文指南\n这是逐字节读取的说明文字。\n"
+	pathA := writeBatchContentFile(t, "a.md", contentA)
+	pathB := writeBatchContentFile(t, "b.md", contentB)
+
+	manifestPath := writeBatchManifest(t, map[string]any{
+		"files": []any{
+			map[string]any{"path": "docs/a.md", "file": pathA},
+			map[string]any{"path": "notes/b.md", "file": pathB},
+		},
+	})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	if _, err := captureStdout(t, func() error { return runSkillFilesBatchUpsert(cmd, []string{"skill-123"}) }); err != nil {
+		t.Fatalf("runSkillFilesBatchUpsert: %v", err)
+	}
+
+	files, ok := body["files"].([]any)
+	if !ok {
+		t.Fatalf("body files missing or wrong type: %#v", body["files"])
+	}
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2", len(files))
+	}
+	fileA, ok := files[0].(map[string]any)
+	if !ok {
+		t.Fatalf("files[0] wrong type: %#v", files[0])
+	}
+	if fileA["path"] != "docs/a.md" {
+		t.Fatalf("files[0] path = %v, want docs/a.md", fileA["path"])
+	}
+	if fileA["content"] != contentA {
+		t.Fatalf("files[0] content = %q, want verbatim %q", fileA["content"], contentA)
+	}
+	if _, present := fileA["expected_sha256"]; present {
+		t.Fatalf("files[0] must omit expected_sha256 when not set: %#v", fileA)
+	}
+	fileB, ok := files[1].(map[string]any)
+	if !ok {
+		t.Fatalf("files[1] wrong type: %#v", files[1])
+	}
+	if fileB["path"] != "notes/b.md" {
+		t.Fatalf("files[1] path = %v, want notes/b.md", fileB["path"])
+	}
+	if fileB["content"] != contentB {
+		t.Fatalf("files[1] content = %q, want verbatim UTF-8 %q", fileB["content"], contentB)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertPassesConcurrencyFields(t *testing.T) {
+	var body map[string]any
+	srv := newSkillBodyCaptureServer(t, http.MethodPut, "/api/skills/skill-123/files/batch", &body)
+	defer srv.Close()
+	setSkillServerEnv(t, srv.URL)
+
+	wantEntrySHA := strings.Repeat("a", 64)
+	wantSkillSHA := strings.Repeat("b", 64)
+	wantIdempotencyKey := "idem-key-1"
+
+	pathA := writeBatchContentFile(t, "a.md", "content a\n")
+	pathB := writeBatchContentFile(t, "b.md", "content b\n")
+	manifestPath := writeBatchManifest(t, map[string]any{
+		"files": []any{
+			map[string]any{"path": "docs/a.md", "file": pathA, "expected_sha256": wantEntrySHA},
+			map[string]any{"path": "notes/b.md", "file": pathB},
+		},
+		"expected_skill_sha256": wantSkillSHA,
+		"idempotency_key":       wantIdempotencyKey,
+	})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	if _, err := captureStdout(t, func() error { return runSkillFilesBatchUpsert(cmd, []string{"skill-123"}) }); err != nil {
+		t.Fatalf("runSkillFilesBatchUpsert: %v", err)
+	}
+
+	if body["expected_skill_sha256"] != wantSkillSHA {
+		t.Fatalf("expected_skill_sha256 = %v, want %s", body["expected_skill_sha256"], wantSkillSHA)
+	}
+	if body["idempotency_key"] != wantIdempotencyKey {
+		t.Fatalf("idempotency_key = %v, want %s", body["idempotency_key"], wantIdempotencyKey)
+	}
+	files, ok := body["files"].([]any)
+	if !ok || len(files) != 2 {
+		t.Fatalf("body files missing or wrong length: %#v", body["files"])
+	}
+	fileA, ok := files[0].(map[string]any)
+	if !ok {
+		t.Fatalf("files[0] wrong type: %#v", files[0])
+	}
+	if fileA["expected_sha256"] != wantEntrySHA {
+		t.Fatalf("files[0] expected_sha256 = %v, want %s", fileA["expected_sha256"], wantEntrySHA)
+	}
+	fileB, ok := files[1].(map[string]any)
+	if !ok {
+		t.Fatalf("files[1] wrong type: %#v", files[1])
+	}
+	if _, present := fileB["expected_sha256"]; present {
+		t.Fatalf("files[1] must omit expected_sha256 when not set: %#v", fileB)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertMissingManifestFlag(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+	}))
+	defer srv.Close()
+	setSkillServerEnv(t, srv.URL)
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	err := runSkillFilesBatchUpsert(cmd, []string{"skill-123"})
+	if err == nil {
+		t.Fatal("expected missing --manifest to return an error")
+	}
+	if !strings.Contains(err.Error(), "--manifest is required") {
+		t.Fatalf("error = %v, want mention of --manifest is required", err)
+	}
+	if hits != 0 {
+		t.Fatalf("expected no HTTP request for a missing flag, got %d", hits)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertEmptyManifestListedNoFiles(t *testing.T) {
+	setSkillServerEnv(t, "http://127.0.0.1:1")
+
+	manifestPath := writeBatchManifest(t, map[string]any{"files": []any{}})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	err := runSkillFilesBatchUpsert(cmd, []string{"skill-123"})
+	if err == nil {
+		t.Fatal("expected empty manifest to return an error")
+	}
+	if !strings.Contains(err.Error(), "lists no files") {
+		t.Fatalf("error = %v, want mention of lists no files", err)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertEntryMissingFileField(t *testing.T) {
+	setSkillServerEnv(t, "http://127.0.0.1:1")
+
+	manifestPath := writeBatchManifest(t, map[string]any{
+		"files": []any{map[string]any{"path": "docs/a.md"}},
+	})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	err := runSkillFilesBatchUpsert(cmd, []string{"skill-123"})
+	if err == nil {
+		t.Fatal("expected entry without file to return an error")
+	}
+	if !strings.Contains(err.Error(), `missing "file"`) {
+		t.Fatalf("error = %v, want mention of missing \"file\"", err)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertConflictFromServer(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/api/skills/skill-123/files/batch" {
+			t.Fatalf("path = %q, want /api/skills/skill-123/files/batch", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "expected_skill_sha256 does not match current skill files",
+		})
+	}))
+	defer srv.Close()
+	setSkillServerEnv(t, srv.URL)
+
+	contentPath := writeBatchContentFile(t, "a.md", "conflicting body\n")
+	manifestPath := writeBatchManifest(t, map[string]any{
+		"files": []any{map[string]any{"path": "docs/a.md", "file": contentPath}},
+	})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	if _, err := captureStdout(t, func() error { return runSkillFilesBatchUpsert(cmd, []string{"skill-123"}) }); err == nil {
+		t.Fatal("expected 409 from server to return an error")
+	} else if !strings.Contains(err.Error(), "batch upsert skill files") {
+		t.Fatalf("error = %v, want wrap mentioning batch upsert skill files", err)
+	}
+	if hits != 1 {
+		t.Fatalf("server hit %d times, want exactly one PUT attempt", hits)
+	}
+}
+
+func TestRunSkillFilesBatchUpsertTableOutputPrintsPathsAndAggregate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files": []any{
+				map[string]any{"id": "f1", "path": "docs/SKILL.md"},
+				map[string]any{"id": "f2", "path": "notes/idea.md"},
+			},
+			"skill_files_sha256": strings.Repeat("c", 64),
+		})
+	}))
+	defer srv.Close()
+	setSkillServerEnv(t, srv.URL)
+
+	contentPath := writeBatchContentFile(t, "a.md", "table body\n")
+	manifestPath := writeBatchManifest(t, map[string]any{
+		"files": []any{map[string]any{"path": "docs/SKILL.md", "file": contentPath}},
+	})
+
+	cmd := newSkillFilesBatchUpsertTestCmd()
+	_ = cmd.Flags().Set("manifest", manifestPath)
+	_ = cmd.Flags().Set("output", "table")
+
+	out, err := captureStdout(t, func() error { return runSkillFilesBatchUpsert(cmd, []string{"skill-123"}) })
+	if err != nil {
+		t.Fatalf("runSkillFilesBatchUpsert: %v", err)
+	}
+	for _, want := range []string{"docs/SKILL.md", "notes/idea.md"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table output %q must contain upserted path %s", out, want)
+		}
+	}
+	wantAggregate := "Skill files sha256: " + strings.Repeat("c", 64)
+	if !strings.Contains(out, wantAggregate) {
+		t.Fatalf("table output %q must contain aggregate line %q", out, wantAggregate)
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -2084,6 +2084,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Delete("/labels/{labelId}", h.DetachLabelFromSkill)
 					r.Get("/files", h.ListSkillFiles)
 					r.Put("/files", h.UpsertSkillFile)
+					r.Put("/files/batch", h.UpsertSkillFilesBatch)
 					r.Delete("/files/{fileId}", h.DeleteSkillFile)
 				})
 			})

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -301,15 +302,22 @@ type AddAgentSkillsRequest struct {
 // --- Helpers ---
 
 // validateFilePath checks that a file path is safe (no traversal, no absolute paths).
+//
+// Separators are normalized to "/" first: filepath.IsAbs reports POSIX-style
+// absolute paths like "/etc/passwd" as relative when running on Windows,
+// which would let them through the check below.
 func validateFilePath(p string) bool {
 	if p == "" {
 		return false
 	}
-	if filepath.IsAbs(p) {
+	normalized := filepath.ToSlash(p)
+	if filepath.IsAbs(normalized) {
 		return false
 	}
-	cleaned := filepath.Clean(p)
-	if strings.HasPrefix(cleaned, "..") {
+	cleaned := filepath.Clean(normalized)
+	// On Windows Clean renders POSIX-absolute input with backslashes
+	// ("\etc\passwd"), so guard against both separators.
+	if strings.HasPrefix(cleaned, "..") || strings.HasPrefix(cleaned, "/") || strings.HasPrefix(cleaned, `\`) {
 		return false
 	}
 	return true
@@ -2501,6 +2509,250 @@ func (h *Handler) UpsertSkillFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, skillFileToResponse(sf))
+}
+
+// --- Batch upsert of supporting files (atomic, optimistic concurrency) ---
+
+// maxBatchUpsertFiles caps a single batch request. It exists so one caller
+// cannot force the server to build an unbounded transaction; real skill
+// packages ship far fewer files than this.
+const maxBatchUpsertFiles = 100
+
+// expectedSHA256Pattern accepts exactly a lowercase-or-uppercase hex SHA-256
+// digest. Values are normalized before this check runs.
+var expectedSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+type CreateSkillFileBatchEntry struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	// ExpectedSHA256, when non-empty, is the SHA-256 hex digest the current
+	// content of Path must match for the batch to apply. An empty value means
+	// create-or-overwrite unconditionally.
+	ExpectedSHA256 string `json:"expected_sha256,omitempty"`
+}
+
+type UpsertSkillFilesBatchRequest struct {
+	Files []CreateSkillFileBatchEntry `json:"files"`
+	// ExpectedSkillSHA256, when non-empty, is the aggregate hash over ALL
+	// supporting files currently on the skill (see skillFilesAggregateHash).
+	ExpectedSkillSHA256 string `json:"expected_skill_sha256,omitempty"`
+	// IdempotencyKey is echoed back verbatim and kept as a reserved field.
+	// The batch is already all-or-nothing inside one transaction and the
+	// underlying UPSERT is naturally idempotent, so no server-side key store
+	// is needed today.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+type UpsertSkillFilesBatchResponse struct {
+	Files            []SkillFileResponse `json:"files"`
+	SkillFilesSHA256 string              `json:"skill_files_sha256"`
+	IdempotencyKey   string              `json:"idempotency_key,omitempty"`
+}
+
+// skillFilesAggregateHash computes the deterministic aggregate digest over a
+// set of supporting files: every file ordered lexicographically by path,
+// contributing path + NUL + content + LF into one SHA-256 stream. Clients use
+// it as an optimistic-concurrency token for the whole file set via
+// expected_skill_sha256; the same definition must be used when recomputing
+// the post-write aggregate returned in the response.
+func skillFilesAggregateHash(files []db.SkillFile) string {
+	sorted := make([]db.SkillFile, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+	digest := sha256.New()
+	for _, f := range sorted {
+		digest.Write([]byte(f.Path))
+		digest.Write([]byte{0x00})
+		digest.Write([]byte(f.Content))
+		digest.Write([]byte{0x0A})
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+// UpsertSkillFilesBatch applies several supporting-file writes as one atomic
+// partial update guarded by optimistic concurrency checks. Unlike PUT /files
+// per call there are no intermediate observable states, and unlike the full
+// replacement semantics of the skill update endpoint, supporting files that
+// are absent from the request are left untouched. Any failed precondition —
+// a stale per-file expected_sha256 or a stale expected_skill_sha256 — rejects
+// the whole batch with 409 Conflict and performs zero writes.
+func (h *Handler) UpsertSkillFilesBatch(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	skill, ok := h.loadSkillForUser(w, r, id)
+	if !ok {
+		return
+	}
+	if !h.canManageSkill(w, r, skill) {
+		return
+	}
+
+	var req UpsertSkillFilesBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(req.Files) == 0 {
+		writeError(w, http.StatusBadRequest, "files must not be empty")
+		return
+	}
+	if len(req.Files) > maxBatchUpsertFiles {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("too many files in batch: %d (max %d)", len(req.Files), maxBatchUpsertFiles))
+		return
+	}
+	seenPaths := make(map[string]struct{}, len(req.Files))
+	for i := range req.Files {
+		f := &req.Files[i]
+		if !validateFilePath(f.Path) {
+			writeError(w, http.StatusBadRequest, "invalid file path: "+f.Path)
+			return
+		}
+		if skillpkg.IsReservedContentPath(f.Path) {
+			writeError(w, http.StatusBadRequest, "SKILL.md is reserved for the primary skill content")
+			return
+		}
+		if _, dup := seenPaths[f.Path]; dup {
+			writeError(w, http.StatusBadRequest, "duplicate file path in batch: "+f.Path)
+			return
+		}
+		seenPaths[f.Path] = struct{}{}
+		f.ExpectedSHA256 = strings.ToLower(strings.TrimSpace(f.ExpectedSHA256))
+		if f.ExpectedSHA256 != "" && !expectedSHA256Pattern.MatchString(f.ExpectedSHA256) {
+			writeError(w, http.StatusBadRequest,
+				"expected_sha256 for "+f.Path+" must be a 64-character hexadecimal SHA-256 digest")
+			return
+		}
+	}
+	req.ExpectedSkillSHA256 = strings.ToLower(strings.TrimSpace(req.ExpectedSkillSHA256))
+	if req.ExpectedSkillSHA256 != "" && !expectedSHA256Pattern.MatchString(req.ExpectedSkillSHA256) {
+		writeError(w, http.StatusBadRequest,
+			"expected_skill_sha256 must be a 64-character hexadecimal SHA-256 digest")
+		return
+	}
+	req.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	if len(req.IdempotencyKey) > 128 {
+		writeError(w, http.StatusBadRequest, "idempotency_key must be at most 128 characters")
+		return
+	}
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	// Serialize concurrent batches against the same skill: without this row
+	// lock two batches could both pass their preconditions against the same
+	// snapshot and then interleave their writes, defeating the whole point of
+	// the expected-hash checks. Locking the parent skill row is the cheapest
+	// correct serialization point (same pattern as the FOR UPDATE locks in
+	// workspace_delete.sql).
+	//
+	// Scope note: this lock guarantees ordering between batch writes and any
+	// other path that also touches the parent skill row (e.g. UpdateSkill's
+	// UPDATE skill). It does NOT by itself lock supporting-file writers that
+	// never lock the parent — the single-file UpsertSkillFile path is
+	// serialized instead by Postgres' implicit FOR KEY SHARE row lock that the
+	// skill_file.skill_id foreign key takes on the referenced skill row, which
+	// conflicts with this FOR UPDATE. If that implicit lock ever changes (for
+	// example a foreign key is dropped), the optimistic checks here would stop
+	// protecting against concurrent single-file writes, so keep this comment in
+	// sync with the migration that defines that constraint.
+	tag, err := tx.Exec(r.Context(), "SELECT id FROM skill WHERE id = $1 FOR UPDATE", skill.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to lock skill for update")
+		return
+	}
+	if tag.RowsAffected() == 0 {
+		// The skill was deleted after loadSkillForUser validated it (while we
+		// waited for the row lock or in the gap before this transaction began).
+		// Without this guard the writes below would fail on the foreign key and
+		// surface as a misleading 500 instead of a clean 404.
+		writeError(w, http.StatusNotFound, "skill not found")
+		return
+	}
+
+	existing, err := qtx.ListSkillFiles(r.Context(), skill.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list existing skill files")
+		return
+	}
+
+	// Aggregate precondition first: reject early when the file set as a whole
+	// has changed underneath the client.
+	if req.ExpectedSkillSHA256 != "" && skillFilesAggregateHash(existing) != req.ExpectedSkillSHA256 {
+		writeError(w, http.StatusConflict, "stale expected_skill_sha256: the skill's supporting files have changed")
+		return
+	}
+
+	existingByPath := make(map[string]db.SkillFile, len(existing))
+	for _, ef := range existing {
+		existingByPath[ef.Path] = ef
+	}
+	for i := range req.Files {
+		f := &req.Files[i]
+		if f.ExpectedSHA256 == "" {
+			continue // unconditional create-or-overwrite
+		}
+		cur, exists := existingByPath[f.Path]
+		if !exists || contentHash(cur.Content) != f.ExpectedSHA256 {
+			writeError(w, http.StatusConflict,
+				"stale expected_sha256 for "+f.Path+": current content does not match the provided digest")
+			return
+		}
+	}
+
+	fileResps := make([]SkillFileResponse, 0, len(req.Files))
+	for _, f := range req.Files {
+		content := sanitizeNullBytes(f.Content)
+		// Skip a no-op write: when the request already matches the stored
+		// content for this path, running the UPSERT would still refresh
+		// updated_at and emit a redundant write on identical replays. Skipping
+		// keeps idempotent retries free of side effects while the response
+		// still reports the file's current state.
+		if cur, ok := existingByPath[f.Path]; ok && cur.Content == content {
+			fileResps = append(fileResps, skillFileToResponse(cur))
+			continue
+		}
+		sf, err := qtx.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
+			SkillID: skill.ID,
+			Path:    sanitizeNullBytes(f.Path),
+			Content: content,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to upsert skill file: "+err.Error())
+			return
+		}
+		fileResps = append(fileResps, skillFileToResponse(sf))
+	}
+
+	// Re-read within the same transaction so the returned aggregate reflects
+	// the post-write state clients can pass back as their next
+	// expected_skill_sha256.
+	finalFiles, err := qtx.ListSkillFiles(r.Context(), skill.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to re-read skill files")
+		return
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit batch upsert")
+		return
+	}
+
+	resp := UpsertSkillFilesBatchResponse{
+		Files:            fileResps,
+		SkillFilesSHA256: skillFilesAggregateHash(finalFiles),
+		IdempotencyKey:   req.IdempotencyKey,
+	}
+	wsID := h.resolveWorkspaceID(r)
+	actorType, actorID := h.resolveActor(r, requestUserID(r), wsID)
+	h.publish(protocol.EventSkillUpdated, wsID, actorType, actorID, map[string]any{
+		"skill": SkillWithFilesResponse{SkillResponse: skillToResponse(skill), Files: resp.Files},
+	})
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *Handler) DeleteSkillFile(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/skill_files_batch_test.go
+++ b/server/internal/handler/skill_files_batch_test.go
@@ -1,0 +1,380 @@
+package handler
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// batchSkillNameSeq keeps generated fixture names unique within the process.
+var batchSkillNameSeq atomic.Int64
+
+// newBatchSkillFixture builds a skill with two supporting files so batch tests
+// can mix creates and updates while still leaving one file untouched to prove
+// the endpoint is partial, not full replacement.
+func newBatchSkillFixture(t *testing.T) string {
+	t.Helper()
+	skillID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         fmt.Sprintf("batch-upsert-fixture-%d", batchSkillNameSeq.Add(1)),
+		"content":      "# primary",
+		"created_by":   testUserID,
+	})
+	for path, body := range map[string]string{
+		"docs/existing.md": "existing-body\n",
+		"keep.md":          "keep-body\n",
+	} {
+		dbfx.Insert(t, "skill_file", testutil.Cols{
+			"skill_id": skillID,
+			"path":     path,
+			"content":  body,
+		})
+	}
+	return skillID
+}
+
+// batchUpsertRequest builds a PUT request against UpsertSkillFilesBatch.
+func batchUpsertRequest(t *testing.T, skillID string, body any) *http.Request {
+	t.Helper()
+	return withURLParam(newRequest(http.MethodPut, "/api/skills/"+skillID+"/files/batch", body), "id", skillID)
+}
+
+// entry is shorthand for building one files[] element in request bodies.
+type entry struct {
+	path           string
+	content        string
+	expectedSHA256 string // empty = unconditional
+}
+
+func entriesBody(es []entry, extra map[string]any) map[string]any {
+	files := make([]map[string]any, 0, len(es))
+	for _, e := range es {
+		f := map[string]any{"path": e.path, "content": e.content}
+		if e.expectedSHA256 != "" {
+			f["expected_sha256"] = e.expectedSHA256
+		}
+		files = append(files, f)
+	}
+	body := map[string]any{"files": files}
+	for k, v := range extra {
+		body[k] = v
+	}
+	return body
+}
+
+func sha256hex(s string) string { return contentHash(s) }
+
+// skillFilesAggregate mirrors the server-side aggregate definition over the
+// fixture's initial file set so guard tests can produce both matching and
+// stale tokens without another round trip.
+func skillFilesAggregate(files map[string]string) string {
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	for i := 0; i < len(paths); i++ {
+		for j := i + 1; j < len(paths); j++ {
+			if paths[j] < paths[i] {
+				paths[i], paths[j] = paths[j], paths[i]
+			}
+		}
+	}
+	digest := sha256.New()
+	for _, p := range paths {
+		digest.Write([]byte(p))
+		digest.Write([]byte{0x00})
+		digest.Write([]byte(files[p]))
+		digest.Write([]byte{0x0A})
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func batchFileContent(t *testing.T, skillID, path string) (string, bool) {
+	t.Helper()
+	var content string
+	err := testPool.QueryRow(context.Background(),
+		`SELECT content FROM skill_file WHERE skill_id = $1 AND path = $2`,
+		parseUUID(skillID), path).Scan(&content)
+	return content, err == nil
+}
+
+func assertUntouchedFiles(t *testing.T, skillID string) {
+	t.Helper()
+	// keep.md is never part of any batch in these tests: it surviving is what
+	// proves the endpoint is partial. docs/existing.md may or may not have
+	// been updated depending on the case.
+	if got, _ := batchFileContent(t, skillID, "keep.md"); got != "keep-body\n" {
+		t.Errorf("untouched file changed: %q", got)
+	}
+}
+
+func TestUpsertSkillFilesBatchAppliesMixedBatchAndLeavesUntouchedFiles(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	body := entriesBody([]entry{
+		{path: "docs/existing.md", content: "updated-body\n", expectedSHA256: sha256hex("existing-body\n")},
+		{path: "new.md", content: "brand-new\n"},
+	}, nil)
+
+	req := batchUpsertRequest(t, skillID, body)
+	var resp UpsertSkillFilesBatchResponse
+	testutil.Call(t, testHandler.UpsertSkillFilesBatch, req).Want(http.StatusOK).JSON(&resp)
+
+	if len(resp.Files) != 2 {
+		t.Fatalf("got %d files in response, want 2", len(resp.Files))
+	}
+	if got, _ := batchFileContent(t, skillID, "docs/existing.md"); got != "updated-body\n" {
+		t.Errorf("update not applied: %q", got)
+	}
+	gotNew, ok := batchFileContent(t, skillID, "new.md")
+	if !ok || gotNew != "brand-new\n" {
+		t.Errorf("create not applied: %q found=%v", gotNew, ok)
+	}
+	assertUntouchedFiles(t, skillID)
+
+	// The returned aggregate must be exactly what a client would hand back as
+	// its next expected_skill_sha256 — recompute it from the persisted state
+	// instead of trusting the handler's own inputs.
+	all := map[string]string{"keep.md": "keep-body\n"}
+	for _, f := range resp.Files {
+		all[f.Path] = f.Content
+	}
+	if want := skillFilesAggregate(all); resp.SkillFilesSHA256 != want {
+		t.Errorf("skill_files_sha256 = %q, want %q", resp.SkillFilesSHA256, want)
+	}
+
+	// A follow-up replay of the same writes — with expectations refreshed from
+	// the previous response, the way a real client retries — is idempotent:
+	// no extra rows, contents unchanged.
+	replayBody := entriesBody([]entry{
+		{path: "docs/existing.md", content: "updated-body\n", expectedSHA256: sha256hex("updated-body\n")},
+		{path: "new.md", content: "brand-new\n"},
+	}, nil)
+	replayReq := batchUpsertRequest(t, skillID, replayBody)
+	var replayResp UpsertSkillFilesBatchResponse
+	testutil.Call(t, testHandler.UpsertSkillFilesBatch, replayReq).Want(http.StatusOK).JSON(&replayResp)
+	if n := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID); n != 3 {
+		t.Errorf("after replay got %d files, want 3", n)
+	}
+	if replayResp.SkillFilesSHA256 != resp.SkillFilesSHA256 {
+		t.Errorf("replay aggregate = %q, want stable %q", replayResp.SkillFilesSHA256, resp.SkillFilesSHA256)
+	}
+}
+
+func TestUpsertSkillFilesBatchStalePerFileHashConflictsWithZeroWrites(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	before := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID)
+
+	// One entry carries a stale digest alongside an unconditional create: the
+	// whole batch must reject without applying either write.
+	body := entriesBody([]entry{
+		{path: "docs/existing.md", content: "should-not-land\n", expectedSHA256: strings.Repeat("ab", 32)},
+		{path: "sneaky-new.md", content: "nor-this\n"},
+	}, nil)
+
+	res := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body))
+	if res.Code != http.StatusConflict {
+		t.Fatalf("expected 409 conflict, got %d: %s", res.Code, res.Text())
+	}
+
+	if after := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID); after != before {
+		t.Fatalf("conflict wrote rows: count before=%d after=%d", before, after)
+	}
+	if got, _ := batchFileContent(t, skillID, "docs/existing.md"); got != "existing-body\n" {
+		t.Errorf("conditional update landed despite conflict: %q", got)
+	}
+	if _, ok := batchFileContent(t, skillID, "sneaky-new.md"); ok {
+		t.Error("unconditional create landed despite conflict")
+	}
+	assertUntouchedFiles(t, skillID)
+}
+
+func TestUpsertSkillFilesBatchExpectedHashForMissingPathConflicts(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	body := entriesBody([]entry{
+		{path: "ghost.md", content: "x\n", expectedSHA256: strings.Repeat("cd", 32)},
+	}, nil)
+
+	res := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body))
+	if res.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for expected_sha256 on missing path, got %d: %s", res.Code, res.Text())
+	}
+	assertUntouchedFiles(t, skillID)
+}
+
+func TestUpsertSkillFilesBatchAggregateHashGuard(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	t.Run("stale aggregate rejects everything", func(t *testing.T) {
+		skillID := newBatchSkillFixture(t)
+		stale := skillFilesAggregate(map[string]string{
+			"docs/existing.md": "existing-body\n",
+			"keep.md":          "keep-body\n",
+			"gone.md":          "older-file-no-longer-present\n",
+		})
+		body := entriesBody([]entry{{path: "new.md", content: "n\n"}}, map[string]any{"expected_skill_sha256": stale})
+
+		res := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body))
+		if res.Code != http.StatusConflict {
+			t.Fatalf("expected 409 for stale aggregate, got %d: %s", res.Code, res.Text())
+		}
+		if _, ok := batchFileContent(t, skillID, "new.md"); ok {
+			t.Error("write landed despite stale aggregate guard")
+		}
+	})
+
+	t.Run("matching aggregate admits the batch", func(t *testing.T) {
+		skillID := newBatchSkillFixture(t)
+		current := skillFilesAggregate(map[string]string{
+			"docs/existing.md": "existing-body\n",
+			"keep.md":          "keep-body\n",
+		})
+		body := entriesBody([]entry{{path: "new.md", content: "n\n"}},
+			map[string]any{"expected_skill_sha256": current, "idempotency_key": "key-1"})
+
+		var resp UpsertSkillFilesBatchResponse
+		testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body)).
+			Want(http.StatusOK).JSON(&resp)
+		if resp.IdempotencyKey != "key-1" {
+			t.Errorf("idempotency_key echoed = %q, want key-1", resp.IdempotencyKey)
+		}
+	})
+}
+
+func TestUpsertSkillFilesBatchRejectsBadPathsAndPayloads(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{"reserved SKILL.md", entriesBody([]entry{{path: "SKILL.md", content: "override"}}, nil)},
+		{"traversal path", entriesBody([]entry{{path: "../evil.md", content: "x"}}, nil)},
+		{"absolute path", entriesBody([]entry{{path: "/etc/passwd", content: "x"}}, nil)},
+		{"duplicate paths", entriesBody([]entry{
+			{path: "dup.md", content: "a"}, {path: "dup.md", content: "b"},
+		}, nil)},
+		{"bad per-file hash", entriesBody([]entry{{path: "a.md", content: "a", expectedSHA256: "not-hex"}}, nil)},
+		{"bad aggregate hash", entriesBody([]entry{{path: "a.md", content: "a"}}, map[string]any{"expected_skill_sha256": "zz81"})},
+		{"empty files", map[string]any{"files": []any{}}},
+		{"idempotency key too long", entriesBody([]entry{{path: "a.md", content: "a"}},
+			map[string]any{"idempotency_key": strings.Repeat("k", 129)})},
+		{"oversized batch", func() map[string]any {
+			es := make([]entry, 0, maxBatchUpsertFiles+1)
+			for i := 0; i <= maxBatchUpsertFiles; i++ {
+				es = append(es, entry{path: fmt.Sprintf("f/%03d.md", i), content: "x"})
+			}
+			return entriesBody(es, nil)
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID)
+			res := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, tc.body))
+			if res.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", res.Code, res.Text())
+			}
+			if after := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID); after != before {
+				t.Errorf("rejected request wrote rows: before=%d after=%d", before, after)
+			}
+		})
+	}
+}
+
+func TestUpsertSkillFilesBatchNonCreatorMemberForbidden(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	otherUser := dbfx.User(t, "plain-member-batch", "plain-member-batch@example.com")
+	dbfx.Member(t, testWorkspaceID, otherUser, "member")
+
+	body := entriesBody([]entry{{path: "docs/existing.md", content: "hijack\n"}}, nil)
+	req := testutil.WithHeaders(batchUpsertRequest(t, skillID, body), "X-User-ID", otherUser)
+
+	res := testutil.Call(t, testHandler.UpsertSkillFilesBatch, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-creator member, got %d: %s", res.Code, res.Text())
+	}
+	assertUntouchedFiles(t, skillID)
+}
+
+func TestUpsertSkillFilesBatchUTF8RoundTrip(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	const cjk = "中文内容 🚀 带换行\n"
+	body := entriesBody([]entry{{path: "i18n/中文.md", content: cjk}}, nil)
+	var resp UpsertSkillFilesBatchResponse
+	testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body)).
+		Want(http.StatusOK).JSON(&resp)
+
+	got, ok := batchFileContent(t, skillID, "i18n/中文.md")
+	if !ok || got != cjk {
+		t.Errorf("UTF-8 round trip mismatch: got %q, want %q", got, cjk)
+	}
+}
+
+func TestUpsertSkillFilesBatchIdempotentReplayDoesNotBumpUpdatedAt(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+	skillID := newBatchSkillFixture(t)
+
+	body := entriesBody([]entry{{path: "docs/existing.md", content: "v1\n"}}, nil)
+	first := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first write: expected 200, got %d: %s", first.Code, first.Text())
+	}
+
+	// Capture the timestamp right after the first write.
+	var firstAt string
+	dbfx.QueryRow(t,
+		`SELECT updated_at::text FROM skill_file WHERE skill_id = $1 AND path = 'docs/existing.md'`,
+		parseUUID(skillID)).Scan(&firstAt)
+
+	// Replaying the identical payload must be a no-op: same content, so the
+	// handler should skip the UPSERT and leave updated_at untouched.
+	replay := testutil.Call(t, testHandler.UpsertSkillFilesBatch, batchUpsertRequest(t, skillID, body))
+	if replay.Code != http.StatusOK {
+		t.Fatalf("replay: expected 200, got %d: %s", replay.Code, replay.Text())
+	}
+
+	var afterAt string
+	dbfx.QueryRow(t,
+		`SELECT updated_at::text FROM skill_file WHERE skill_id = $1 AND path = 'docs/existing.md'`,
+		parseUUID(skillID)).Scan(&afterAt)
+
+	if afterAt != firstAt {
+		t.Errorf("idempotent replay bumped updated_at: before=%q after=%q", firstAt, afterAt)
+	}
+	if n := dbfx.Count(t, `SELECT count(*) FROM skill_file WHERE skill_id = $1`, skillID); n != 2 {
+		t.Errorf("after replay got %d files, want 2", n)
+	}
+}

--- a/server/internal/handler/skill_validate_path_test.go
+++ b/server/internal/handler/skill_validate_path_test.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestValidateFilePath covers the path-safety helper that every skill file
+// endpoint shares. Cross-platform cases (Windows-style absolute paths and
+// backslash-separated traversal) only hold on the platform whose filepath
+// semantics recognize them, so each is skipped where it does not apply.
+func TestValidateFilePath(t *testing.T) {
+	isWindows := runtime.GOOS == "windows"
+
+	cases := []struct {
+		name    string
+		path    string
+		want    bool
+		windows bool // when true, only assert want on Windows; skip elsewhere
+	}{
+		{"empty", "", false, false},
+		{"simple file", "a.md", true, false},
+		{"nested path", "sub/guide.md", true, false},
+		{"posix traversal", "../evil.md", false, false},
+		{"posix absolute", "/etc/passwd", false, false},
+		{"posix traversal deep", "../../etc/passwd", false, false},
+		{"traversal looking only", "..", false, false},
+		{"windows traversal", `..\evil.md`, false, false},
+		{"windows-led backslash", `\evil.md`, false, false},
+		{"windows absolute", `C:\windows\system32`, false, true},
+		{"unc share", `\\server\share\x.md`, false, true},
+		{"relative clean", "docs/../a.md", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.windows && !isWindows {
+				t.Skip("Windows path semantics only")
+			}
+			if got := validateFilePath(tc.path); got != tc.want {
+				t.Errorf("validateFilePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds an atomic batch upsert for a skill's supporting files. Today the single-file `PUT /api/skills/{id}/files` requires one round trip per file with no transaction or concurrency protection, and the skill-update `files[]` parameter is a full replacement (it deletes omitted files).

This PR adds `PUT /api/skills/{id}/files/batch`:

- Applies multiple supporting-file writes in **one transaction** as a **partial** update (files omitted from the request are left untouched).
- Guards writes with **optimistic concurrency**: an optional per-file `expected_sha256` and an optional aggregate `expected_skill_sha256`. Any stale precondition rejects the whole batch with `409 Conflict` and performs **zero writes**.
- Rows are written through the existing `UPSERT`, so a replay of the same payload is naturally idempotent; an identical-content entry is skipped so retries do not bump `updated_at`.
- Requires no schema migration: the `skill_file` table already has a `(skill_id, path)` unique key and no hash column.

Also adds a matching CLI subcommand and hardens `validateFilePath` against POSIX-style absolute paths / traversal on Windows.

## Related Issue

Closes #7443

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/skill.go`: new `UpsertSkillFilesBatch` handler with per-file and aggregate hash preconditions inside a transaction (parent row locked `FOR UPDATE` to serialize concurrent batches); new aggregate-hash helper `skillFilesAggregateHash`; hardened `validateFilePath` (normalizes separators, guards absolute/traversal on Windows).
- `server/cmd/server/router.go`: register `PUT /api/skills/{id}/files/batch`.
- `server/cmd/multica/cmd_skill.go`: new `multica skill files batch-upsert <skill-id> --manifest <file>` subcommand; reads local files verbatim (UTF-8 preserved) and sends a single request.
- Tests: `server/internal/handler/skill_files_batch_test.go`, `server/internal/handler/skill_validate_path_test.go`, `server/cmd/multica/cmd_skill_batch_test.go`.

## How to Test

1. CLI (no DB): `cd server && go test ./cmd/multica -run TestRunSkillFilesBatch`
2. Handler integration (needs Postgres; skipped if unreachable): `cd server && go test ./internal/handler -run TestUpsertSkillFilesBatch`
3. Build gate: `go build ./... && go vet ./cmd/multica ./internal/handler ./cmd/server`

Coverage includes: mixed create+update batch leaving untouched files intact; stale per-file hash -> 409 with zero writes; missing-path hash -> 409; aggregate hash match/stale; reserved `SKILL.md` / traversal / absolute / duplicate-path / empty-files / oversized batch -> 400; non-manager member -> 403; UTF-8 round trip; idempotent replay does not bump `updated_at`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI code changed)
- [ ] I have updated relevant documentation to reflect my changes (no doc change required)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (not applicable)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** AI-assisted (literate coding harness)

**Prompt / approach:**
Implemented against the issue's specification using the codebase's existing skill handler, transaction, and permission patterns. Design notes and known trade-offs are recorded in the pull request conversation for review.

## Risks / Notes

- `idempotency_key` is echoed back and treated as a reserved field; it is not stored server-side. The batch is already all-or-nothing within one transaction and the underlying UPSERT is idempotent, so no key store is needed today. If a stronger server-side dedup key is required, it can be added as a follow-up.
- The parent-row `FOR UPDATE` lock serializes batch-vs-batch and batch-vs-skill-update concurrency; single-file writes are serialized by the implicit foreign-key row lock on `skill_file.skill_id` (noted in a code comment).
