### PR TITLE
BHI-15092: pilot agent-approval-check on Multica

### DIFF
--- a/.github/agent-approval-check-pilot.md
+++ b/.github/agent-approval-check-pilot.md
@@ -1,0 +1,34 @@
+# Agent approval check pilot
+
+This repository is piloting Anthropic's `agent-approval-check` in observation mode.
+
+## What counts as agent-authored
+
+The check marks a PR as agent-authored when either of these signals appears:
+
+- a commit or `Co-authored-by` trailer uses one of the configured agent emails
+- the PR author or an `APPROVED` review matches one of the configured agent bot logins
+
+Human-only PRs are unaffected. During the pilot we are **not** making this a required branch protection check.
+
+## Identities included in this pilot
+
+See `.github/agent-identities.yaml` for the source of truth. The first-pass map covers:
+
+- `multica-agent` / `github@multica.ai`
+- `claude[bot]`, `claude-code[bot]`, `noreply@anthropic.com`
+- `openai-codex[bot]`, `noreply@openai.com`, `codex@openai.com`
+- `hermes-seaeye[bot]`, `hermes@nousresearch.com`
+
+## Promote-to-required follow-up
+
+Promote `agent-approval-check` to a required status only after reviewing a sample of real PRs for both error classes:
+
+1. **False positives**: human-only PRs incorrectly flagged as agent-authored.
+2. **False negatives**: agent-authored PRs that bypass the check because the emitted login or email is missing from the map.
+
+Promotion bar for this repo:
+
+- zero human-only false positives in the observation sample
+- no missed `multica-agent`, Claude, Codex, or Hermes-authored PRs in the same sample
+- native GitHub review requirements remain enabled alongside this check

--- a/.github/agent-identities.yaml
+++ b/.github/agent-identities.yaml
@@ -1,0 +1,41 @@
+---
+# Pilot identity map for anthropics/claude-code-action/agent-approval-check.
+#
+# Detection rule summary:
+# - commit/co-author emails in agent_emails mark a PR as agent-authored
+# - PR/review actors in agent_app_logins also mark agent activity
+# - approvals from excluded_approver_logins never count toward the required total
+#
+# Source notes:
+# - multica-agent / github@multica.ai were observed in recent multica PR commits
+#   such as #5018, #5150, and #6233
+# - Claude identities come from Anthropic's agent-approval-check docs
+# - Codex identities come from public OpenAI Codex commit attribution examples
+# - Hermes currently shows up upstream as Hermes Agent <hermes@nousresearch.com>
+#   and hermes-seaeye[bot]; if BHirst standardizes a noreply identity later,
+#   update this file to match the real emitted trailer/login
+agent_emails:
+  - github@multica.ai
+  - noreply@anthropic.com
+  - noreply@openai.com
+  - codex@openai.com
+  - hermes@nousresearch.com
+
+agent_app_logins:
+  - multica-agent
+  - claude[bot]
+  - claude-code[bot]
+  - openai-codex[bot]
+  - hermes-seaeye[bot]
+
+excluded_approver_logins:
+  - multica-agent
+  - claude[bot]
+  - claude-code[bot]
+  - openai-codex[bot]
+  - hermes-seaeye[bot]
+
+protected_bases:
+  multica-ai/multica:
+    exact: [main]
+    prefixes: []

--- a/.github/workflows/agent-approval-check.yml
+++ b/.github/workflows/agent-approval-check.yml
@@ -1,0 +1,31 @@
+name: agent-approval-check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  check:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base-branch policy
+        uses: actions/checkout@v6
+        with:
+          # Keep policy on the trusted base branch. Never read agent identities
+          # from the PR head.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Run agent approval check
+        uses: anthropics/claude-code-action/agent-approval-check@main
+        with:
+          required_approvals: 1
+          config_file: .github/agent-identities.yaml


### PR DESCRIPTION
## What does this PR do?

Pilots Anthropic's `agent-approval-check` on the Multica repo in observation mode.

This adds a dedicated workflow plus a base-branch config file so we can measure how well the check identifies agent-authored PRs without making it a required branch protection gate yet.

## Related Issue

BHI-15092

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- added `.github/workflows/agent-approval-check.yml` to run `anthropics/claude-code-action/agent-approval-check` on `pull_request_target` and `/approve` issue comments
- set `required_approvals: 1` for the pilot
- checked out the trusted base branch before reading `config_file`, so PR heads cannot edit their own identity policy
- added `.github/agent-identities.yaml` with an explicit first-pass identity map for Multica, Claude / Claude Code, Codex, and Hermes
- added `.github/agent-approval-check-pilot.md` documenting the detection rules, included identities, and the criteria for promoting the check to required later

## How to Test

1. Run `ruby -e 'require "yaml"; [".github/workflows/agent-approval-check.yml", ".github/agent-identities.yaml"].each { |p| YAML.load_file(p); puts "OK #{p}" }'`
2. Open an agent-authored PR or add an agent-authored commit trailer that matches `.github/agent-identities.yaml`
3. Confirm the workflow posts an `agent-approval-check` status, while human-only PRs remain unaffected during the pilot because the check is not yet a required branch protection gate

## Pilot detection details

The check treats a PR as agent-authored when either signal appears:

- a commit or `Co-authored-by` trailer uses one of the configured agent emails
- the PR author or an `APPROVED` review matches one of the configured bot logins

Identity map included in this pilot:

- `multica-agent` / `github@multica.ai`, observed in recent multica PR commits such as #5018, #5150, and #6233
- `claude[bot]`, `claude-code[bot]`, `noreply@anthropic.com`
- `openai-codex[bot]`, `noreply@openai.com`, `codex@openai.com`
- `hermes-seaeye[bot]`, `hermes@nousresearch.com`

## Promote-to-required follow-up

Do not make this check required until we review a real sample for both:

- false positives, human-only PRs flagged as agent-authored
- false negatives, agent-authored PRs whose emitted login or email is missing from the map

Promotion bar proposed in this PR:

- zero human-only false positives in the observation sample
- no missed Multica, Claude, Codex, or Hermes agent-authored PRs in the same sample
- native GitHub review requirements stay in place alongside this check

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Test note: `pnpm test` currently fails in the existing `@multica/views` suite on `packages/views/settings/components/billing-tab.test.tsx` date assertions (`Feb 15, 2030` / `Apr 1, 2030` expectations). This PR only adds GitHub workflow and documentation files and does not touch the billing codepath.

## AI Disclosure

**AI tool used:** Hermes Agent

**Prompt / approach:**

Implemented the smallest repo-local pilot: inspect existing CI conventions, verify Anthropic's `agent-approval-check` config-file threat model, build an explicit identity map from recent Multica agent-authored commits plus documented Claude/Codex/Hermes identities, validate the new YAML files locally, and document the promote-to-required criteria in-repo.
