### PR TITLE
MUL-6748: shrink ScheduleEditor DOM coverage

### DIFF
--- a/packages/views/autopilots/components/schedule-editor/number-field.test.tsx
+++ b/packages/views/autopilots/components/schedule-editor/number-field.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NumberField } from "./number-field";
+
+describe("NumberField", () => {
+  it("keeps both digits while committing complete in-range values", () => {
+    const onCommit = vi.fn();
+    render(<NumberField value={15} min={1} max={31} ariaLabel="Day" onCommit={onCommit} />);
+    const input = screen.getByLabelText("Day");
+    fireEvent.change(input, { target: { value: "1" } });
+    fireEvent.change(input, { target: { value: "18" } });
+    expect(input).toHaveValue(18);
+    expect(onCommit.mock.calls).toEqual([[1], [18]]);
+  });
+
+  it("restores empty text and clamps out-of-range text on blur", () => {
+    const restore = vi.fn();
+    const clamp = vi.fn();
+    render(
+      <>
+        <NumberField value={15} min={1} max={31} ariaLabel="Restore" onCommit={restore} />
+        <NumberField value={6} min={1} max={23} ariaLabel="Clamp" onCommit={clamp} />
+      </>,
+    );
+    const restoreInput = screen.getByLabelText("Restore");
+    fireEvent.change(restoreInput, { target: { value: "" } });
+    fireEvent.blur(restoreInput);
+    expect(restoreInput).toHaveValue(15);
+    expect(restore).not.toHaveBeenCalled();
+
+    const clampInput = screen.getByLabelText("Clamp");
+    fireEvent.change(clampInput, { target: { value: "24" } });
+    fireEvent.blur(clampInput);
+    expect(clampInput).toHaveValue(23);
+    expect(clamp).toHaveBeenLastCalledWith(23);
+  });
+
+  it.each([
+    ["0", "ArrowUp", 1],
+    ["40", "ArrowDown", 31],
+    ["31", "ArrowUp", 1],
+    ["1", "ArrowDown", 31],
+  ])("steps %s with %s to %i", (typed, key, expected) => {
+    const onCommit = vi.fn();
+    render(<NumberField value={15} min={1} max={31} ariaLabel="Day" onCommit={onCommit} />);
+    const input = screen.getByLabelText("Day");
+    fireEvent.change(input, { target: { value: typed } });
+    fireEvent.keyDown(input, { key });
+    expect(input).toHaveValue(expected);
+    expect(onCommit).toHaveBeenLastCalledWith(expected);
+  });
+});

--- a/packages/views/autopilots/components/schedule-editor/number-field.tsx
+++ b/packages/views/autopilots/components/schedule-editor/number-field.tsx
@@ -1,0 +1,82 @@
+import {
+  useRef,
+  useState,
+  type ComponentProps,
+  type ComponentType,
+} from "react";
+import { Input } from "@multica/ui/components/ui/input";
+
+/**
+ * A number field that keeps transient text separate from its committed value.
+ * Clearing is allowed while typing; blur restores an empty field or clamps an
+ * out-of-range value. This lets a two-digit entry pass through an invalid first
+ * digit without committing a schedule the user never chose.
+ */
+export function NumberField({
+  value,
+  min,
+  max,
+  onCommit,
+  className,
+  ariaLabel,
+  autoFocus,
+  component: Field = Input,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  onCommit: (value: number) => void;
+  className?: string;
+  ariaLabel: string;
+  autoFocus?: boolean;
+  component?: ComponentType<ComponentProps<"input">>;
+}) {
+  const [text, setText] = useState(String(value));
+  const lastValueRef = useRef(value);
+  if (lastValueRef.current !== value) {
+    lastValueRef.current = value;
+    setText(String(value));
+  }
+
+  return (
+    <Field
+      type="number"
+      aria-label={ariaLabel}
+      // Caller-gated: focus only when a user action revealed the field.
+      autoFocus={autoFocus}
+      min={min}
+      max={max}
+      value={text}
+      onChange={(event) => {
+        setText(event.target.value);
+        const next = Number.parseInt(event.target.value, 10);
+        if (!Number.isNaN(next) && next >= min && next <= max) onCommit(next);
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+        event.preventDefault();
+        const typed = Number.parseInt(text, 10);
+        // Values already outside the range land on the bound they overshot.
+        // Values at a bound wrap, matching the time fields in this editor.
+        const stepped =
+          Number.isNaN(typed) || (typed >= min && typed <= max)
+            ? (Number.isNaN(typed) ? value : typed) + (event.key === "ArrowUp" ? 1 : -1)
+            : Math.min(max, Math.max(min, typed));
+        const wrapped = stepped > max ? min : stepped < min ? max : stepped;
+        setText(String(wrapped));
+        if (wrapped !== lastValueRef.current) onCommit(wrapped);
+      }}
+      onBlur={() => {
+        const typed = Number.parseInt(text, 10);
+        if (Number.isNaN(typed)) {
+          setText(String(lastValueRef.current));
+          return;
+        }
+        const clamped = Math.min(max, Math.max(min, typed));
+        setText(String(clamped));
+        if (clamped !== lastValueRef.current) onCommit(clamped);
+      }}
+      className={className}
+    />
+  );
+}

--- a/packages/views/autopilots/components/schedule-editor/preview-state.test.ts
+++ b/packages/views/autopilots/components/schedule-editor/preview-state.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { getSchedulePreviewState, type PreviewQueryStatus } from "./preview-state";
+
+const base = {
+  advanced: false,
+  current: true,
+  status: "pending" as PreviewQueryStatus,
+  nextRuns: null,
+  rejected: false,
+  accepted: false,
+  hasShownRuns: false,
+};
+
+describe("getSchedulePreviewState", () => {
+  it("maps query verdicts to the canonical preview surfaces", () => {
+    const cases = [
+      ["pending", {}, { body: "pending", busy: false }],
+      ["accepted runs", { status: "success", nextRuns: ["future"], hasShownRuns: true }, { body: "runs", settled: true, busy: false }],
+      ["stale runs", { current: false, hasShownRuns: true }, { body: "runs", settled: false, busy: true }],
+      ["accepted empty", { status: "success", nextRuns: [] }, { body: "empty", settled: true }],
+      ["unreadable response", { status: "success" }, { body: "unavailable", unavailable: true }],
+      ["transport failure", { status: "error" }, { body: "unavailable", unavailable: true }],
+      ["rejection", { status: "error", rejected: true }, { body: "hidden", unavailable: false }],
+      ["accepted advanced", { advanced: true, accepted: true }, { advancedNotice: "accepted" }],
+      ["unverified advanced", { advanced: true, status: "error" }, { advancedNotice: "unavailable" }],
+      ["checking advanced", { advanced: true }, { advancedNotice: "checking" }],
+    ] as const;
+
+    for (const [name, input, expected] of cases) {
+      expect(getSchedulePreviewState({ ...base, ...input }), name).toMatchObject(expected);
+    }
+  });
+});

--- a/packages/views/autopilots/components/schedule-editor/preview-state.test.ts
+++ b/packages/views/autopilots/components/schedule-editor/preview-state.test.ts
@@ -1,35 +1,73 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
-import { getSchedulePreviewState, type PreviewQueryStatus } from "./preview-state";
+import { getSchedulePreviewState } from "./preview-state";
+
+type PreviewInput = Parameters<typeof getSchedulePreviewState>[0];
+type PreviewState = ReturnType<typeof getSchedulePreviewState>;
+type PreviewCase = readonly [string, Partial<PreviewInput>, PreviewState];
 
 const base = {
   advanced: false,
   current: true,
-  status: "pending" as PreviewQueryStatus,
+  status: "pending",
   nextRuns: null,
   rejected: false,
   accepted: false,
   hasShownRuns: false,
-};
+} satisfies PreviewInput;
+
+const state = (body: PreviewState["body"], overrides: Partial<PreviewState> = {}): PreviewState => ({
+  advancedNotice: null,
+  body,
+  busy: false,
+  settled: false,
+  unavailable: false,
+  ...overrides,
+});
+
+const cases = [
+  ["pending", {}, state("pending")],
+  [
+    "accepted",
+    {
+      advanced: true,
+      status: "success",
+      nextRuns: ["future"],
+      accepted: true,
+      hasShownRuns: true,
+    },
+    state("runs", { advancedNotice: "accepted", settled: true }),
+  ],
+  [
+    "empty",
+    { advanced: true, status: "success", nextRuns: [], accepted: true },
+    state("empty", { advancedNotice: "accepted", settled: true }),
+  ],
+  // Rejection details are normalized before this behavior-free state helper.
+  ["invalid cron", { status: "error", rejected: true }, state("hidden")],
+  ["invalid timezone", { advanced: true, status: "error", rejected: true }, state("hidden")],
+  [
+    "unavailable",
+    { advanced: true, status: "error" },
+    state("unavailable", { advancedNotice: "unavailable", unavailable: true }),
+  ],
+  ["unknown rejection", { advanced: true, status: "error", rejected: true }, state("hidden")],
+  ["stale runs", { current: false, hasShownRuns: true }, state("runs", { busy: true })],
+  [
+    "unreadable success response",
+    { advanced: true, status: "success" },
+    state("unavailable", { advancedNotice: "unavailable", unavailable: true }),
+  ],
+  [
+    "advanced validation still checking",
+    { advanced: true },
+    state("pending", { advancedNotice: "checking" }),
+  ],
+] satisfies PreviewCase[];
 
 describe("getSchedulePreviewState", () => {
-  it("maps query verdicts to the canonical preview surfaces", () => {
-    const cases = [
-      ["pending", {}, { body: "pending", busy: false }],
-      ["accepted runs", { status: "success", nextRuns: ["future"], hasShownRuns: true }, { body: "runs", settled: true, busy: false }],
-      ["stale runs", { current: false, hasShownRuns: true }, { body: "runs", settled: false, busy: true }],
-      ["accepted empty", { status: "success", nextRuns: [] }, { body: "empty", settled: true }],
-      ["unreadable response", { status: "success" }, { body: "unavailable", unavailable: true }],
-      ["transport failure", { status: "error" }, { body: "unavailable", unavailable: true }],
-      ["rejection", { status: "error", rejected: true }, { body: "hidden", unavailable: false }],
-      ["accepted advanced", { advanced: true, accepted: true }, { advancedNotice: "accepted" }],
-      ["unverified advanced", { advanced: true, status: "error" }, { advancedNotice: "unavailable" }],
-      ["checking advanced", { advanced: true }, { advancedNotice: "checking" }],
-    ] as const;
-
-    for (const [name, input, expected] of cases) {
-      expect(getSchedulePreviewState({ ...base, ...input }), name).toMatchObject(expected);
-    }
+  it.each(cases)("maps %s to the canonical preview surfaces", (_name, input, expected) => {
+    expect(getSchedulePreviewState({ ...base, ...input })).toEqual(expected);
   });
 });

--- a/packages/views/autopilots/components/schedule-editor/preview-state.ts
+++ b/packages/views/autopilots/components/schedule-editor/preview-state.ts
@@ -1,0 +1,61 @@
+export type PreviewQueryStatus = "pending" | "success" | "error";
+export type AdvancedNotice = "accepted" | "unavailable" | "checking" | null;
+export type PreviewBody = "hidden" | "unavailable" | "runs" | "empty" | "pending";
+
+export interface SchedulePreviewState {
+  advancedNotice: AdvancedNotice;
+  body: PreviewBody;
+  busy: boolean;
+  settled: boolean;
+  unavailable: boolean;
+}
+
+/** Decide which preview surfaces are trustworthy for the current schedule. */
+export function getSchedulePreviewState({
+  advanced,
+  current,
+  status,
+  nextRuns,
+  rejected,
+  accepted,
+  hasShownRuns,
+}: {
+  advanced: boolean;
+  current: boolean;
+  status: PreviewQueryStatus;
+  nextRuns: readonly string[] | null;
+  rejected: boolean;
+  accepted: boolean;
+  hasShownRuns: boolean;
+}): SchedulePreviewState {
+  const settled = current && status === "success" && nextRuns !== null;
+  const unavailable =
+    current &&
+    ((status === "error" && !rejected) || (status === "success" && nextRuns === null));
+  const showsRuns = !rejected && !unavailable && hasShownRuns;
+  const body: PreviewBody = rejected
+    ? "hidden"
+    : unavailable
+      ? "unavailable"
+      : showsRuns
+        ? "runs"
+        : settled
+          ? "empty"
+          : "pending";
+  const advancedNotice: AdvancedNotice =
+    !advanced || rejected
+      ? null
+      : accepted
+        ? "accepted"
+        : unavailable
+          ? "unavailable"
+          : "checking";
+
+  return {
+    advancedNotice,
+    body,
+    busy: showsRuns && !settled,
+    settled,
+    unavailable,
+  };
+}

--- a/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
+++ b/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
@@ -299,6 +299,7 @@ describe("ScheduleEditor", () => {
   it("restores weekly and monthly values after switching day kinds", async () => {
     renderEditor(cron("0 9 * * 2,4,6"));
     await choose("Day pattern", "Day of month");
+    expect(screen.queryByText(/are skipped/)).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Day of month"), { target: { value: "30" } });
     await choose("Day pattern", "Every day");
     await choose("Day pattern", "Days of week");

--- a/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
+++ b/packages/views/autopilots/components/schedule-editor/schedule-editor.test.tsx
@@ -1,95 +1,48 @@
 import { useState } from "react";
-import { describe, it, expect, vi } from "vitest";
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ApiError } from "@multica/core/api";
-import type { SupportedLocale } from "@multica/core/i18n";
 import { renderWithI18n } from "../../../test/i18n";
 import { ScheduleEditor } from "./schedule-editor";
 import type { ScheduleConfig } from "./model";
 import { cronFields, parseCron, toCron } from "./cron-mapping";
 
-// The heaviest interaction cases drive several async userEvent steps through
-// Base UI dropdowns; fast locally, but a loaded CI runner can push a single one
-// past the default 5s cap. Raise the ceiling without slowing the fast cases.
 vi.setConfig({ testTimeout: 15_000 });
 
-// The preview is server-owned; the editor must never approximate it. The mock
-// stands in for the cron-preview endpoint: it 400s on anything that isn't a
-// 5-field expression (mirroring the robfig parser's contract) and can be told
-// to fail at the transport level, which must NOT read as "your cron is wrong".
-const previewFailure = {
-  transport: false,
-  unreadable: false,
-  badTimezone: false,
-  // A 400 whose code the editor does not know. The endpoint only ever sends
-  // invalid_cron and invalid_timezone today, but a rejection it cannot classify
-  // must still reach the user with the server's own words attached.
-  unknownCode: false,
-  // Every run already in the past, so the editor's "the list has expired,
-  // refresh it" effect fires. Two schedules sharing a next-run instant is the
-  // norm, not a coincidence — anything firing at tomorrow 09:00 does.
-  expired: false,
+const previewMode: { value: "ok" | "transport" | "timezone" | "expired" } = {
+  value: "ok",
 };
-// Every expression the editor actually asked the server about, in order. The
-// expired-preview refresh is an *extra* fetch on top of the first one, so its
-// absence for a given expression is visible as a missing entry here.
 const previewCalls: string[] = [];
 
 vi.mock("@multica/core/autopilots/queries", () => ({
   cronPreviewOptions: (
     wsId: string,
     expr: string,
-    tz: string,
+    timezone: string,
     options?: { enabled?: boolean },
   ) => ({
-    queryKey: [
-      "autopilots",
-      wsId,
-      "cron-preview",
-      expr,
-      tz,
-      previewFailure.transport,
-      previewFailure.unreadable,
-      previewFailure.badTimezone,
-      previewFailure.unknownCode,
-      previewFailure.expired,
-    ],
+    queryKey: ["autopilots", wsId, "cron-preview", expr, timezone, previewMode.value],
     queryFn: async () => {
       previewCalls.push(expr);
-      if (previewFailure.expired) {
-        // A shared instant, deliberately: the guard must tell the two
-        // expressions apart, and it cannot do that from the timestamp alone.
-        return { next_runs: ["2020-01-01T00:00:00Z"] };
-      }
-      if (previewFailure.transport) {
+      if (previewMode.value === "expired") return { next_runs: ["2020-01-01T00:00:00Z"] };
+      if (previewMode.value === "transport") {
         throw new ApiError("API error: 500 Internal Server Error", 500, "Internal Server Error");
       }
-      if (previewFailure.badTimezone) {
-        throw new ApiError(`invalid timezone "${tz}"`, 400, "Bad Request", {
-          error: `invalid timezone "${tz}"`,
+      if (previewMode.value === "timezone") {
+        throw new ApiError(`invalid timezone "${timezone}"`, 400, "Bad Request", {
+          error: `invalid timezone "${timezone}"`,
           code: "invalid_timezone",
         });
       }
-      if (previewFailure.unknownCode) {
-        throw new ApiError("schedule rejected by policy", 400, "Bad Request", {
-          error: "schedule rejected by policy",
-          code: "some_future_code",
-        });
-      }
-      // The server reads a TZ=/CRON_TZ= prefix off the expression itself
-      // (case-sensitively, up to the first literal space) and validates the
-      // embedded zone before the fields — the guarded no-space shape and an
-      // unknown zone are both invalid_cron, since they are part of the string.
+
       let fields = expr;
       if (fields.startsWith("TZ=") || fields.startsWith("CRON_TZ=")) {
         const space = fields.indexOf(" ");
-        const zone = space === -1 ? null : fields.slice(fields.indexOf("=") + 1, space);
-        // "asia/shanghai" mirrors a dev server on a case-insensitive filesystem,
-        // where LoadLocation takes the lowercase spelling too.
-        if (zone === null || !["UTC", "Asia/Tokyo", "Asia/Shanghai", "asia/shanghai", "Local", ""].includes(zone)) {
-          throw new ApiError(`parse cron: provided bad location ${zone ?? expr}`, 400, "Bad Request", {
+        const zone = space < 0 ? null : fields.slice(fields.indexOf("=") + 1, space);
+        if (zone === null || !["UTC", "Asia/Tokyo", "Asia/Shanghai", "Local"].includes(zone)) {
+          throw new ApiError("parse cron: provided bad location", 400, "Bad Request", {
             error: "parse cron: provided bad location",
             code: "invalid_cron",
           });
@@ -102,12 +55,9 @@ vi.mock("@multica/core/autopilots/queries", () => ({
           code: "invalid_cron",
         });
       }
-      // A response the schema could not read degrades to null — distinct from
-      // an empty list, which means "this expression never fires".
-      if (previewFailure.unreadable) return { next_runs: null };
       if (fields === "0 0 30 2 *") return { next_runs: [] };
       return {
-        next_runs: ["2126-07-14T01:00:00Z", "2126-07-14T03:00:00Z", "2126-07-14T05:00:00Z"],
+        next_runs: ["2126-07-14T01:00:00Z", "2126-07-14T03:00:00Z"],
       };
     },
     enabled: options?.enabled ?? true,
@@ -116,8 +66,8 @@ vi.mock("@multica/core/autopilots/queries", () => ({
 }));
 
 vi.mock("../pickers/timezone-picker", () => ({
-  TimezonePicker: ({ value, onChange }: { value: string; onChange: (tz: string) => void }) => (
-    <select data-testid="timezone-picker" value={value} onChange={(e) => onChange(e.target.value)}>
+  TimezonePicker: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <select data-testid="timezone-picker" value={value} onChange={(event) => onChange(event.target.value)}>
       <option value="UTC">UTC</option>
       <option value="Asia/Shanghai">Asia/Shanghai</option>
     </select>
@@ -156,981 +106,323 @@ function Harness({
   );
 }
 
-function renderEditor(
-  initial: ScheduleConfig,
-  opts?: { onChange?: () => void; disabled?: boolean; locale?: SupportedLocale },
-) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function renderEditor(initial: ScheduleConfig, options?: { onChange?: () => void; disabled?: boolean }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return renderWithI18n(
-    <QueryClientProvider client={qc}>
-      <Harness initial={initial} onChange={opts?.onChange} disabled={opts?.disabled} />
+    <QueryClientProvider client={queryClient}>
+      <Harness initial={initial} onChange={options?.onChange} disabled={options?.disabled} />
     </QueryClientProvider>,
-    opts?.locale === undefined ? undefined : { locale: opts.locale },
   );
 }
 
-const cron = (expr: string) => parseCron(expr, "UTC");
+const cron = (expression: string) => parseCron(expression, "UTC");
 const cronOut = () => screen.getByTestId("cron-out").textContent;
 const wireOut = () => screen.getByTestId("wire-out").textContent;
 
-// The cron expression is read-only until clicked, but already an input in
-// advanced-only mode, so only click it open when the field isn't mounted yet.
 async function openCronInput(): Promise<HTMLElement> {
   if (screen.queryByRole("textbox", { name: "Cron" }) === null) {
-    const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /click to edit/ }));
+    await userEvent.setup().click(screen.getByRole("button", { name: /click to edit/ }));
   }
   return screen.getByRole("textbox", { name: "Cron" });
 }
 
-async function editCronText(expr: string) {
+async function editCronText(expression: string) {
   const input = await openCronInput();
-  fireEvent.change(input, { target: { value: expr } });
+  fireEvent.change(input, { target: { value: expression } });
   fireEvent.blur(input);
 }
 
+async function choose(label: string, option: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText(label));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
 describe("ScheduleEditor", () => {
-  // Parsing/serialization, descriptions, state transitions, and rejection
-  // classification are canonical in the sibling .test.ts suites. This file
-  // only keeps DOM wiring, accessibility, and integration-specific behavior.
-  it("renders the three form blocks and the cron readback", () => {
-    renderEditor(cron("0 9-21 * * *"));
+  // Pure parsing, transitions, preview decisions, and number-field boundaries
+  // are canonical in sibling .test.ts/.test.tsx suites. This suite owns DOM
+  // wiring, accessibility, and integration-specific regressions only.
+  it("renders the editor without changing an untouched schedule", async () => {
+    const onChange = vi.fn();
+    renderEditor(cron("0 9-21 * * *"), { onChange });
     expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.getByText("Days")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
-    // The cron expression lives in the result panel below the form, shown as a
-    // click-to-edit readback rather than a labelled field.
     expect(screen.getByRole("button", { name: /click to edit/ })).toBeInTheDocument();
-  });
-
-  it("never fires onChange on mount (untouched save sends no update)", async () => {
-    const onChange = vi.fn();
-    renderEditor(cron("0 9-21 * * *"), { onChange });
     await waitFor(() => expect(screen.getByText("Next runs")).toBeInTheDocument());
     expect(onChange).not.toHaveBeenCalled();
-    expect(cronOut()).toBe("0 9-21 * * *");
   });
 
-  it("edits interval, window and day chips in sequence on one schedule", async () => {
+  it("wires interval, window, and day edits into one schedule", async () => {
     const user = userEvent.setup();
-    // The three dimensions are written by two handlers that each overwrite the
-    // whole config (`{...value, time | days, raw: null}`). Editing them one at a
-    // time from a trivial baseline never shows one clobbering another.
     renderEditor(cron("0 9-21/2 * * 2-4"));
-
     fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "3" } });
-    expect(cronOut()).toBe("0 9-21/3 * * 2-4");
-
     await user.click(screen.getByLabelText("Window end hour"));
     await user.keyboard("18");
-    expect(cronOut()).toBe("0 9-18/3 * * 2-4");
-
     await user.click(screen.getByRole("button", { name: "Monday" }));
-    expect(cronOut()).toBe("0 9-18/3 * * 1-4");
-
     await user.click(screen.getByLabelText("Window start hour"));
     await user.keyboard("10");
     expect(cronOut()).toBe("0 10-18/3 * * 1-4");
   });
 
-  // Stepping off a bound wraps; stepping from OUTSIDE the range lands on the
-  // bound that was overshot. Clamping before stepping instead of after made the
-  // bounds themselves unreachable from a mistyped number.
-  it.each([
-    ["0", "ArrowUp", "0 9 1 * *"],
-    ["0", "ArrowDown", "0 9 1 * *"],
-    ["40", "ArrowDown", "0 9 31 * *"],
-    ["40", "ArrowUp", "0 9 31 * *"],
-  ])("steps a mistyped day-of-month %s back onto the bound it overshot", (typed, key, expected) => {
-    renderEditor(cron("0 9 15 * *"));
-    const box = screen.getByRole("spinbutton");
-    fireEvent.change(box, { target: { value: typed } });
-    fireEvent.keyDown(box, { key });
-    expect(cronOut()).toBe(expected);
-  });
-
-  it.each([
-    ["31", "ArrowUp", "0 9 1 * *"],
-    ["1", "ArrowDown", "0 9 31 * *"],
-  ])("still wraps the day-of-month at %s", (typed, key, expected) => {
-    renderEditor(cron("0 9 15 * *"));
-    const box = screen.getByRole("spinbutton");
-    fireEvent.change(box, { target: { value: typed } });
-    fireEvent.keyDown(box, { key });
-    expect(cronOut()).toBe(expected);
-  });
-
-  it("hydrates structured controls from cron text", async () => {
+  it("hydrates the structured controls from committed cron text", async () => {
     renderEditor(cron("0 9 * * *"));
     await editCronText("0 9-21/2 * * 2-4");
     expect(cronOut()).toBe("0 9-21/2 * * 2-4");
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("null");
     expect(screen.getByRole("button", { name: "Tuesday", pressed: true })).toBeInTheDocument();
   });
 
-  it("enters advanced-only mode for unrepresentable expressions and recovers", async () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    // The notice waits for the server to take the expression — until then all the
-    // editor knows is that it cannot parse it, which is also true of a typo.
-    await waitFor(() =>
-      expect(screen.getByText(/visual editor can't represent/)).toBeInTheDocument(),
-    );
-    expect(screen.getByTestId("raw-out").textContent).toBe("0 9 1,15 * *");
+  it("preserves structured values under advanced text and recovers them", async () => {
+    renderEditor(cron("0 17 * * 1"));
+    await editCronText("0 9 1,15 * *");
+    await waitFor(() => expect(screen.getByText(/visual editor can't represent/)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "At a time" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Monday", pressed: true })).toBeInTheDocument();
+    expect(screen.getByLabelText("Hour")).toHaveValue("17");
 
     await editCronText("0 9 * * *");
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
-    expect(screen.queryByText(/visual editor can't represent/)).not.toBeInTheDocument();
-  });
-
-  it("changes the timezone of a structured schedule without touching the expression", async () => {
-    renderEditor(cron("0 9-21/2 * * 2-4"));
-    // The zone has to change on a *settled* preview, or "not settled yet" and
-    // "re-querying for the new zone" are the same state and prove nothing.
-    const line = await waitFor(() => {
-      const el = screen.getByText("Next runs").closest("div");
-      expect(el).toHaveAttribute("aria-busy", "false");
-      return el;
-    });
-
-    fireEvent.change(screen.getByTestId("timezone-picker"), {
-      target: { value: "Asia/Shanghai" },
-    });
-    expect(screen.getByTestId("tz-out").textContent).toBe("Asia/Shanghai");
-    // The timezone is orthogonal to the expression: it is the one control that
-    // must move the schedule without rewriting a single cron field.
-    expect(cronOut()).toBe("0 9-21/2 * * 2-4");
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
-    // The preview is the server's answer for a cron AND a zone, so a new zone
-    // must re-ask: 09:00 in Shanghai is not 09:00 in UTC. A preview keyed on the
-    // expression alone would still read settled here, having never noticed.
-    expect(line).toHaveAttribute("aria-busy", "true");
-    await waitFor(() => expect(line).toHaveAttribute("aria-busy", "false"));
-  });
-
-  it("keeps the timezone editable in advanced-only mode and preserves raw", () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    fireEvent.change(screen.getByTestId("timezone-picker"), {
-      target: { value: "Asia/Shanghai" },
-    });
-    expect(screen.getByTestId("tz-out").textContent).toBe("Asia/Shanghai");
-    expect(screen.getByTestId("raw-out").textContent).toBe("0 9 1,15 * *");
-  });
-
-  it("shows the server error inline for an invalid expression", async () => {
-    renderEditor(cron("0 9 * * *"));
-    await editCronText("@daily");
-    await waitFor(() => expect(screen.getByText(/expected exactly 5 fields/)).toBeInTheDocument());
-    expect(screen.getByTestId("valid-out").textContent).toBe("false");
-    expect(screen.queryByText(/visual editor can't represent/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Checking this expression/)).not.toBeInTheDocument();
-    expect(screen.queryByText("Next runs")).not.toBeInTheDocument();
-  });
-
-  it("does not accept an emptied cron expression", async () => {
-    renderEditor(cron("0 9 * * 1-5"));
-    await editCronText("   ");
-    // Snaps back to the model instead of writing "" into raw and letting the
-    // dialog submit an empty cron_expression.
-    expect(screen.getByTestId("cron-out").textContent).toBe("0 9 * * 1-5");
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
-  });
-
-  it("does not reinterpret the cron text while the user is still typing", async () => {
-    renderEditor(cron("0 9 * * *"));
-    const input = await openCronInput();
-    fireEvent.change(input, { target: { value: "0 9 * *" } });
-    // Half-typed text must not flip the editor into advanced-only mode; the
-    // model only changes on blur/Enter.
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("null");
     expect(screen.getByRole("button", { name: "At a time" })).toBeEnabled();
   });
 
-  it("validates the cron text on blur, not on every keystroke", async () => {
-    renderEditor(cron("0 9 * * *"));
-    const input = await openCronInput();
-    fireEvent.change(input, { target: { value: "0 9 * *" } });
-    // The half-typed expression would be rejected by the server, but it is not
-    // the user's answer yet — nothing is sent and nothing is flagged.
-    await waitFor(() => expect(screen.getByText("Next runs")).toBeInTheDocument());
-    expect(screen.queryByText(/isn't valid/)).not.toBeInTheDocument();
-
-    fireEvent.blur(input);
-    await waitFor(() => expect(screen.getByText(/isn't valid/)).toBeInTheDocument());
+  it("re-queries a timezone edit without rewriting cron fields", async () => {
+    renderEditor(cron("0 9-21/2 * * 2-4"));
+    const preview = await waitFor(() => {
+      const line = screen.getByText("Next runs").closest("div");
+      expect(line).toHaveAttribute("aria-busy", "false");
+      return line;
+    });
+    fireEvent.change(screen.getByTestId("timezone-picker"), {
+      target: { value: "Asia/Shanghai" },
+    });
+    expect(cronOut()).toBe("0 9-21/2 * * 2-4");
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("null");
+    expect(preview).toHaveAttribute("aria-busy", "true");
+    await waitFor(() => expect(preview).toHaveAttribute("aria-busy", "false"));
   });
 
-  it("commits the cron text on Enter", async () => {
+  it("shows a server rejection inline and blocks saving", async () => {
+    renderEditor(cron("0 9 * * *"));
+    await editCronText("@daily");
+    await waitFor(() => expect(screen.getByText(/expected exactly 5 fields/)).toBeInTheDocument());
+    expect(screen.getByTestId("valid-out")).toHaveTextContent("false");
+    expect(screen.queryByText("Next runs")).not.toBeInTheDocument();
+    expect(screen.queryByText(/visual editor can't represent/)).not.toBeInTheDocument();
+  });
+
+  it("commits cron only on Enter or blur and ignores an empty commit", async () => {
     renderEditor(cron("0 9 * * *"));
     const input = await openCronInput();
-    fireEvent.change(input, { target: { value: "0 9-21/2 * * 2-4" } });
+    fireEvent.change(input, { target: { value: "0 18 * * *" } });
+    expect(cronOut()).toBe("0 9 * * *");
     fireEvent.keyDown(input, { key: "Enter" });
-    expect(screen.getByTestId("cron-out").textContent).toBe("0 9-21/2 * * 2-4");
+    expect(cronOut()).toBe("0 18 * * *");
+    expect(input).toHaveFocus();
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+    expect(cronOut()).toBe("0 18 * * *");
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("null");
   });
 
-  it("disables the structured controls in advanced-only mode, not just greys them", () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    // pointer-events-none alone would still let a keyboard user activate these
-    // and silently overwrite the hand-written expression.
-    expect(screen.getByRole("button", { name: "At a time" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "At an interval" })).toBeDisabled();
-    expect(screen.getByLabelText("Hour")).toBeDisabled();
-  });
-
-  it("disables every schedule control when the editor is locked", async () => {
+  it("locks every editor control while retaining the read-only preview", async () => {
     renderEditor(cron("0 9 * * 1-5"), { disabled: true });
     expect(screen.getByRole("button", { name: "At a time" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Monday" })).toBeDisabled();
-    // Locked: the cron row cannot even be opened for editing.
     expect(screen.getByRole("button", { name: /click to edit/ })).toBeDisabled();
-    expect(screen.queryByRole("textbox", { name: "Cron" })).not.toBeInTheDocument();
-  });
-
-  it("still shows next runs when the editor is locked", async () => {
-    renderEditor(cron("0 9 * * 1-5"), { disabled: true });
     await waitFor(() => expect(screen.getByText("Next runs")).toBeInTheDocument());
   });
 
-  it("focuses the interval when the time switches to an interval", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9 * * *"));
-    await user.click(screen.getByRole("button", { name: "At an interval" }));
-    // The switch reveals a fresh field; the caret lands in it so the step can be
-    // typed without a second click.
-    expect(screen.getByLabelText("Interval")).toHaveFocus();
-  });
-
-  it("focuses the hour when the time switches back to a fixed time", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 */2 * * *"));
-    await user.click(screen.getByRole("button", { name: "At a time" }));
-    expect(screen.getByLabelText("Hour")).toHaveFocus();
-  });
-
-  it("focuses the step when the interval unit switches", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 */2 * * *"));
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    // The step stays mounted across the unit switch, so this is an imperative
-    // focus, not autoFocus — the caret returns to the number to retype it.
-    expect(screen.getByLabelText("Interval")).toHaveFocus();
-  });
-
-  it("focuses the day box when the day pattern switches to monthly", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9 * * *"));
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Day of month" }));
-    expect(screen.getByLabelText("Day of month")).toHaveFocus();
-  });
-
-  it("does not steal focus on first render, even when a field is already shown", async () => {
-    // The gate is a user switch, not the field's presence: a schedule that opens
-    // already monthly must not pull focus (and the panel's scroll) on mount.
-    renderEditor(cron("0 9 14 * *"));
-    expect(screen.getByLabelText("Day of month")).not.toHaveFocus();
-  });
-
-  it("names every control, so none is announced as a bare box", async () => {
+  it("names controls and focuses fields revealed by mode switches", async () => {
     const user = userEvent.setup();
     renderEditor(cron("0 9 * * *"));
     expect(screen.getByLabelText("Hour")).toBeInTheDocument();
     expect(screen.getByLabelText("Minute")).toBeInTheDocument();
-    expect(screen.getByLabelText("Day pattern")).toBeInTheDocument();
-
     await user.click(screen.getByRole("button", { name: "At an interval" }));
-    expect(screen.getByLabelText("Interval")).toBeInTheDocument();
-    expect(screen.getByLabelText("Interval unit")).toBeInTheDocument();
-    // The window is on screen from the moment the interval is, all-day included.
+    expect(screen.getByLabelText("Interval")).toHaveFocus();
     expect(screen.getByLabelText("Window start hour")).toBeInTheDocument();
-    expect(screen.getByLabelText("Window end hour")).toBeInTheDocument();
-
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Day of month" }));
-    expect(screen.getByLabelText("Day of month")).toBeInTheDocument();
+    await choose("Interval unit", "minutes");
+    expect(screen.getByLabelText("Interval")).toHaveFocus();
+    await choose("Day pattern", "Day of month");
+    expect(screen.getByLabelText("Day of month")).toHaveFocus();
   });
 
-  it("labels every select trigger with its option's text, not its raw value", async () => {
+  it("does not steal focus from a field already shown on first render", () => {
+    renderEditor(cron("0 9 14 * *"));
+    expect(screen.getByLabelText("Day of month")).not.toHaveFocus();
+  });
+
+  it("groups compound controls and renders human-readable select labels", () => {
     renderEditor(cron("*/15 9-21 * * *"));
-    // Base UI falls back to the raw value, which would read as "every" and
-    // "minutes" — the enum members, not the labels the user picked.
-    const triggers = screen.getAllByRole("combobox").map((el) => el.textContent ?? "");
-    expect(triggers.some((text) => text.startsWith("Every day"))).toBe(true);
-    expect(triggers.some((text) => text.startsWith("minutes"))).toBe(true);
+    const step = screen.getByLabelText("Interval");
+    const unit = screen.getByLabelText("Interval unit");
+    expect(step.closest("[data-slot=input-group]")).toContainElement(unit);
+    const start = screen.getByLabelText("Window start hour");
+    expect(start.closest("[data-slot=input-group]")).toContainElement(
+      screen.getByLabelText("Window end hour"),
+    );
+    const labels = screen.getAllByRole("combobox").map((element) => element.textContent ?? "");
+    expect(labels.some((label) => label.startsWith("Every day"))).toBe(true);
+    expect(labels.some((label) => label.startsWith("minutes"))).toBe(true);
   });
 
-  it("edits both ends of a minute-step window in place, with no minute segment", async () => {
+  it("edits an hour-only window for a minute interval", async () => {
     const user = userEvent.setup();
     renderEditor(cron("*/15 9-21 * * *"));
-    const startHour = screen.getByLabelText("Window start hour");
-    const endHour = screen.getByLabelText("Window end hour");
-    // A minute-step window is hour-granular: the bounds carry no minute, so the
-    // minute segment is not rendered at all — not shown greyed-out.
-    expect(screen.queryByLabelText("Window start minute")).toBeNull();
-    expect(screen.queryByLabelText("Window end minute")).toBeNull();
-    await user.click(startHour!);
+    expect(screen.queryByLabelText("Window start minute")).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Window start hour"));
     await user.keyboard("10");
-    expect(cronOut()).toBe("*/15 10-21 * * *");
-    await user.click(endHour!);
+    await user.click(screen.getByLabelText("Window end hour"));
     await user.keyboard("18");
     expect(cronOut()).toBe("*/15 10-18 * * *");
   });
 
-  it("restores the interval and its window after a round trip through fixed time", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-21/3 * * 1-5"));
-    await user.click(screen.getByRole("button", { name: "At a time" }));
-    await user.click(screen.getByRole("button", { name: "At an interval" }));
-    // Step, unit and window are as much user input as the hour is; rebuilding
-    // the pattern from defaults would silently turn "every 3h, 9-21" into
-    // "every hour, all day".
-    expect(screen.getByTestId("cron-out").textContent).toBe("0 9-21/3 * * 1-5");
-  });
-
-  it("reports a transport failure as an unavailable preview, not an invalid cron", async () => {
-    previewFailure.transport = true;
-    try {
-      renderEditor(cron("0 9 * * *"));
-      await waitFor(() => expect(screen.getByText(/Next runs unavailable/)).toBeInTheDocument());
-      expect(screen.queryByText(/500 Internal Server Error/)).not.toBeInTheDocument();
-      expect(screen.getByTestId("valid-out").textContent).toBe("true");
-    } finally {
-      previewFailure.transport = false;
-    }
-  });
-
-  it("types the window end two digits at a time without clamping mid-keystroke", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-21 * * *"));
-    const endHour = screen.getByLabelText("Window end hour");
-    await user.click(endHour!);
-    // The intermediate "01" is below the start hour. Clamping it there would
-    // leave TimeInput building the second digit from a value it never showed.
-    await user.keyboard("12");
-    expect(cronOut()).toBe("0 9-12 * * *");
-  });
-
-  it("never lets the window end fall below its start, not even mid-edit", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-21 * * *"));
-    const endHour = screen.getByLabelText("Window end hour");
-    await user.click(endHour!);
-    await user.keyboard("08");
-    // A window that ends before it starts has no cron form. The two ends
-    // constrain each other while typing, so it is never displayed or submitted —
-    // no error at save time.
-    expect(endHour).toHaveValue("09");
-    expect(cronOut()).toBe("0 9-9 * * *");
-  });
-
-  it("draws the interval and its unit in one box, lit by whichever holds focus", async () => {
-    renderEditor(cron("0 */3 * * *"));
-    const step = screen.getByLabelText("Interval");
-    const unit = screen.getByLabelText("Interval unit");
-    // "Every 3 hours" is one setting: the step and the unit share a box, rather
-    // than sitting in two that happen to be next to each other.
-    const box = step.closest("[data-slot=input-group]");
-    expect(box).not.toBeNull();
-    expect(box).toContainElement(unit);
-    // The box lights its border from the control inside it that has focus, and it
-    // knows them by this slot. A trigger that kept its own would leave the box
-    // dark while the select it holds is the very thing focused.
-    expect(step).toHaveAttribute("data-slot", "input-group-control");
-    expect(unit).toHaveAttribute("data-slot", "input-group-control");
-  });
-
-  it("draws the window's two ends in one box", async () => {
-    renderEditor(cron("0 9-21/3 * * *"));
-    const start = screen.getByLabelText("Window start hour");
-    // A window is one value with two ends, so it reads as one control rather than
-    // two fields that happen to sit next to each other.
-    const box = start.closest("[data-slot=input-group]");
-    expect(box).not.toBeNull();
-    expect(box).toContainElement(screen.getByLabelText("Window end hour"));
-    // The segments, not their wrapper, are what the box lights its border from:
-    // they are what gets focused.
-    expect(start).toHaveAttribute("data-slot", "input-group-control");
-  });
-
-  // The window is a dimension of the schedule, not a mode of the editor: it is on
-  // screen for every interval, and narrowing it is one edit — not a mode switch
-  // followed by one.
-  it("shows the day's bounds for an all-day interval, at either unit", async () => {
+  it("narrows an always-visible all-day window in one edit", async () => {
     const user = userEvent.setup();
     renderEditor(cron("15 */3 * * *"));
-    // The hours unit carries the firing minute at both ends.
     expect(screen.getByLabelText("Window start hour")).toHaveValue("00");
     expect(screen.getByLabelText("Window start minute")).toHaveValue("15");
     expect(screen.getByLabelText("Window end hour")).toHaveValue("23");
-    expect(screen.getByLabelText("Window end minute")).toHaveValue("15");
-
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    // A minute-step window is hour-granular: the bounds are the whole hours.
-    expect(screen.getByLabelText("Window start hour")).toHaveValue("00");
-    expect(screen.getByLabelText("Window end hour")).toHaveValue("23");
-  });
-
-  it("narrows an all-day interval by editing the bound, with nothing to click first", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 */3 * * *"));
     await user.click(screen.getByLabelText("Window start hour"));
     await user.keyboard("09");
-    // One edit, no mode switch.
-    expect(cronOut()).toBe("0 9-23/3 * * *");
+    expect(cronOut()).toBe("15 9-23/3 * * *");
   });
 
-  it("clears the window end to the end of the day, not onto its start", async () => {
+  it("restores interval settings after a round trip through fixed time", async () => {
     const user = userEvent.setup();
-    renderEditor(cron("0 9-15 * * *"));
-    await user.click(screen.getByLabelText("Window end hour"));
-    await user.keyboard("{Backspace}");
-    // The end's floor is wherever the start sits, but that is not its neutral
-    // value: clearing it opens the window to the end of the day.
-    expect(cronOut()).toBe("0 9-23 * * *");
-  });
-
-  it("clears the window start to midnight", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-23 * * *"));
-    await user.click(screen.getByLabelText("Window start hour"));
-    await user.keyboard("{Backspace}");
-    // Both bounds cleared is the whole day — which is all day, not a 00-23 window.
-    expect(cronOut()).toBe("0 * * * *");
-  });
-
-  it("moves the shared firing minute when the window end's minute is edited", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-21 * * *"));
-    const endMinute = screen.getByLabelText("Window end minute");
-    await user.click(endMinute!);
-    await user.keyboard("30");
-    // cron keeps one minute for both ends of the range, so the start moves too.
-    expect(cronOut()).toBe("30 9-21 * * *");
-  });
-
-  // The all-day variant of this round-trip is the same wiring with a strictly
-  // weaker assertion; clampWindow's own unit round-trip matrix is in
-  // transitions.test.ts.
-  it("keeps the firing minute across a unit round-trip with a time window", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("30 9-21/2 * * *"));
-    await user.click(screen.getAllByRole("combobox")[0]!);
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    await user.click(screen.getAllByRole("combobox")[0]!);
-    await user.click(await screen.findByRole("option", { name: "hours" }));
-    // The window carries the firing minute in cron, so the unit toggle must not
-    // strand it: `minute`, not the window text, is the source of truth.
-    expect(cronOut()).toBe("30 9-21/2 * * *");
-  });
-
-  it("keeps both typed digits when the window start's minute is edited", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("1 9-21/2 * * *"));
-    const startMinute = screen.getByLabelText("Window start minute");
-    await user.click(startMinute!);
-    // The second keystroke must build on the first one, not on the minute the
-    // model held before it — a stale minute would snap "12" back to "01".
-    await user.keyboard("12");
-    expect(cronOut()).toBe("12 9-21/2 * * *");
-  });
-
-  it("never leaves a cleared number box sitting over a stale model value", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("*/15 * * * *"));
-    const interval = screen.getByRole("spinbutton");
-    await user.clear(interval);
-    // While the box is empty the model keeps the last valid value, but the box
-    // must not stay empty over it once the user leaves the field.
-    expect(cronOut()).toBe("*/15 * * * *");
-    fireEvent.blur(interval);
-    expect(interval).toHaveValue(15);
-  });
-
-  it("clamps an out-of-range number into the field's bounds on blur", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 */6 * * *"));
-    const interval = screen.getByRole("spinbutton");
-    await user.clear(interval);
-    await user.type(interval, "24");
-    // The digits arrive one at a time, so the box passes through "2" — a value
-    // the user never chose. Leaving the field must land on the bound they were
-    // reaching for, not on the first digit they happened to type.
-    fireEvent.blur(interval);
-    expect(interval).toHaveValue(23);
-    expect(cronOut()).toBe("0 */23 * * *");
-  });
-
-  it("gives the weekday selection back after a trip through another day kind", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9 * * 2,4,6"));
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Every day" }));
-    expect(cronOut()).toBe("0 9 * * *");
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Days of week" }));
-    // Rebuilt from defaults, a glance at another kind would save the autopilot
-    // to Monday — a day the user never picked.
-    expect(cronOut()).toBe("0 9 * * 2,4,6");
-  });
-
-  it("warns that short months are skipped for days 29-31, and only there", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9 15 * *"));
-    expect(screen.queryByText(/are skipped/)).not.toBeInTheDocument();
-    const day = screen.getByLabelText("Day of month");
-    await user.clear(day);
-    await user.type(day, "31");
-    expect(screen.getByText("Months without day 31 are skipped.")).toBeInTheDocument();
-  });
-
-  it("gives the day of month back after a trip through another day kind", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9 25 * *"));
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Every day" }));
-    await user.click(screen.getByLabelText("Day pattern"));
-    await user.click(await screen.findByRole("option", { name: "Day of month" }));
-    expect(cronOut()).toBe("0 9 25 * *");
-  });
-
-  it("gives the window end back when the start stops overrunning it", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-15/2 * * *"));
-    const startHour = screen.getByLabelText("Window start hour");
-    await user.click(startHour);
-    await user.keyboard("22");
-    // A window cannot run backwards, so the end is dragged along…
-    expect(cronOut()).toBe("0 22-22/2 * * *");
-    await user.click(startHour);
-    await user.keyboard("09");
-    // …but it is the user's 15:00, not a value the drag invented: keeping 22
-    // here would nearly double how often the autopilot runs.
-    expect(cronOut()).toBe("0 9-15/2 * * *");
-  });
-
-  it("takes a window typed into the cron box as the end to hold, not the old one", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-15/2 * * *"));
-    await editCronText("0 8-20/2 * * *");
-    const startHour = screen.getByLabelText("Window start hour");
-    await user.click(startHour);
-    await user.keyboard("09");
-    // The end the user just typed into the cron box is the current intent; an
-    // anchor left over from before it would quietly cut the window back to 15:00.
-    expect(cronOut()).toBe("0 9-20/2 * * *");
-  });
-
-  it("keeps the window when a fixed time later than its end is carried back", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-15/3 * * *"));
+    renderEditor(cron("30 9-21/3 * * 1-5"));
     await user.click(screen.getByRole("button", { name: "At a time" }));
-    const hour = screen.getByLabelText("Hour");
-    await user.click(hour);
-    await user.keyboard("22");
     await user.click(screen.getByRole("button", { name: "At an interval" }));
-    // Rebasing the window onto 22:00 would drag its end up and hand back the
-    // single hour 22:00–22:00 — the window the anchor exists to preserve.
-    expect(cronOut()).toBe("0 9-15/3 * * *");
+    expect(cronOut()).toBe("30 9-21/3 * * 1-5");
   });
 
-  it("holds the dragged-open window's anchor across an interval unit switch", async () => {
+  it("restores weekly and monthly values after switching day kinds", async () => {
+    renderEditor(cron("0 9 * * 2,4,6"));
+    await choose("Day pattern", "Day of month");
+    fireEvent.change(screen.getByLabelText("Day of month"), { target: { value: "30" } });
+    await choose("Day pattern", "Every day");
+    await choose("Day pattern", "Days of week");
+    expect(cronOut()).toBe("0 9 * * 2,4,6");
+    await choose("Day pattern", "Day of month");
+    expect(screen.getByLabelText("Day of month")).toHaveValue(30);
+    expect(screen.getByText("Months without day 30 are skipped.")).toBeInTheDocument();
+  });
+
+  it("restores a dragged window end but keeps an end explicitly typed after a drag", async () => {
     const user = userEvent.setup();
     renderEditor(cron("0 9-15/2 * * *"));
-    await user.click(screen.getByLabelText("Window start hour"));
+    const start = screen.getByLabelText("Window start hour");
+    await user.click(start);
     await user.keyboard("22");
-    expect(cronOut()).toBe("0 22-22/2 * * *");
-    // A unit switch rewrites the end from 22:00 to 22:59 without the user asking
-    // for anything — it must not be read as "22 is what I want".
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "hours" }));
-    await user.click(screen.getByLabelText("Window start hour"));
+    await user.click(start);
     await user.keyboard("09");
     expect(cronOut()).toBe("0 9-15/2 * * *");
-  });
 
-  it("takes an end typed right after a drag as the new end", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("0 9-15/2 * * *"));
-    await user.click(screen.getByLabelText("Window start hour"));
+    await user.click(start);
     await user.keyboard("22");
-    // The drag already produced 22; typing 22 into the end field means the user
-    // wants it — the start must not hand back the old 15 afterwards.
     await user.click(screen.getByLabelText("Window end hour"));
     await user.keyboard("22");
-    await user.click(screen.getByLabelText("Window start hour"));
+    await user.click(start);
     await user.keyboard("09");
     expect(cronOut()).toBe("0 9-22/2 * * *");
   });
 
-  it("gives the step back after a trip through the other interval unit", async () => {
-    const user = userEvent.setup();
-    renderEditor(cron("*/45 * * * *"));
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "hours" }));
-    // 45 hours has no meaning, so the step is clamped on the way there…
-    expect(cronOut()).toBe("0 */23 * * *");
-    await user.click(screen.getByLabelText("Interval unit"));
-    await user.click(await screen.findByRole("option", { name: "minutes" }));
-    // …but keeping the 23 on the way back would double how often it runs.
-    expect(cronOut()).toBe("*/45 * * * *");
-  });
-
-  it("keeps the structured schedule under an expression it cannot represent", async () => {
-    renderEditor(cron("0 17 * * 1"));
-    await editCronText("0 9 1,15 * *");
-    expect(screen.getByTestId("raw-out").textContent).toBe("0 9 1,15 * *");
-    // The greyed controls must still show the schedule the user had, not the
-    // 09:00/every-day defaults parseCron falls back to — that schedule is what
-    // they return to the moment the expression is structurable again.
-    expect(screen.getByRole("button", { name: "Monday", pressed: true })).toBeInTheDocument();
-    expect(screen.getByLabelText("Hour")).toHaveValue("17");
-  });
-
-  it("closes the cron field when a blur brings the expression back into the model", async () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    const input = screen.getByRole("textbox", { name: "Cron" });
-    fireEvent.change(input, { target: { value: "0 9 * * *" } });
-    fireEvent.blur(input);
-    // The field is only open because the expression was advanced-only; once it
-    // isn't, the panel goes back to its readback.
-    expect(screen.getByRole("button", { name: /click to edit/ })).toBeInTheDocument();
-  });
-
-  it("keeps the cron field open and focused when Enter leaves advanced-only mode", async () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    const input = screen.getByRole("textbox", { name: "Cron" });
-    input.focus();
-    fireEvent.change(input, { target: { value: "0 9 15 * *" } });
-    fireEvent.keyDown(input, { key: "Enter" });
-    // The expression is structurable again, so the field would collapse back to
-    // its readback — under the hands of the keyboard user still typing in it.
-    expect(screen.getByTestId("raw-out").textContent).toBe("null");
-    expect(screen.getByRole("textbox", { name: "Cron" })).toHaveFocus();
-  });
-
-  it("marks the previous expression's next runs as pending instead of removing the row", async () => {
+  it("keeps stale next runs mounted and marks them busy during an edit", async () => {
     renderEditor(cron("0 9 * * *"));
     const line = await waitFor(() => screen.getByText("Next runs").closest("div"));
     expect(line).not.toBeNull();
-
     await editCronText("0 18 * * *");
-    // The description updates instantly while the preview is still the cached
-    // 09:00 answer. The row stays mounted so it does not blink out on every
-    // edit, but it must not read as this schedule's answer until it catches up.
-    expect(screen.getByText(/At 18:00/)).toBeInTheDocument();
     expect(screen.getByText("Next runs").closest("div")).toBe(line);
     expect(line).toHaveAttribute("aria-busy", "true");
-
-    // Once the preview catches up, the same element carries the new text.
     await waitFor(() => expect(line).toHaveAttribute("aria-busy", "false"));
-    expect(screen.getByText("Next runs").closest("div")).toBe(line);
   });
 
-  it("refreshes an expired preview per expression, not per run instant", async () => {
-    previewFailure.expired = true;
+  it("refreshes an expired preview once for each expression", async () => {
+    previewMode.value = "expired";
     previewCalls.length = 0;
     try {
       renderEditor(cron("0 9 * * *"));
-      // The first run has already passed, so the cached list is stale and the
-      // editor asks again — once, then it stops: a client clock ahead of the
-      // server must not turn this into a refetch on every tick.
-      await waitFor(() =>
-        expect(previewCalls.filter((e) => e === "TZ=UTC 0 9 * * *")).toHaveLength(2),
-      );
-
+      await waitFor(() => expect(previewCalls.filter((value) => value.includes("0 9 * * *"))).toHaveLength(2));
       await editCronText("0 9 * * 1-5");
-      // A different schedule that happens to share that same passed instant. A
-      // guard keyed on the instant alone would count the refresh it did for the
-      // previous expression as having covered this one, and leave it showing a
-      // run in the past for as long as the dialog stays open.
-      await waitFor(() =>
-        expect(previewCalls.filter((e) => e === "TZ=UTC 0 9 * * 1-5")).toHaveLength(2),
-      );
-      // Still exactly one refresh each — the guard holds within an expression.
-      expect(previewCalls.filter((e) => e === "TZ=UTC 0 9 * * *")).toHaveLength(2);
+      await waitFor(() => expect(previewCalls.filter((value) => value.includes("0 9 * * 1-5"))).toHaveLength(2));
     } finally {
-      previewFailure.expired = false;
+      previewMode.value = "ok";
       previewCalls.length = 0;
     }
   });
 
-  it("blames the timezone, not the cron, when the server rejects the zone", async () => {
-    previewFailure.badTimezone = true;
-    try {
-      renderEditor(cron("0 9 * * *"));
-      await waitFor(() =>
-        expect(screen.getByText(/timezone isn't recognized/)).toBeInTheDocument(),
-      );
-      expect(screen.queryByText("This cron expression isn't valid.")).not.toBeInTheDocument();
-    } finally {
-      previewFailure.badTimezone = false;
-    }
-  });
-
-  // The model cannot tell an expression that is beyond the controls from one that
-  // is plain wrong — both land in `raw`. Only the server can, so every notice
-  // below is about what the server said, not about what the model could parse.
-
-  it("does not call an unverified expression too advanced for the controls", async () => {
-    previewFailure.transport = true;
+  it("treats an unavailable advanced preview as unverified but still saveable", async () => {
+    previewMode.value = "transport";
     try {
       renderEditor(cron("0 9 1,15 * *"));
-      await waitFor(() =>
-        expect(screen.getByText(/server couldn't be reached/)).toBeInTheDocument(),
-      );
-      // The claim it must not make: with the preview endpoint down, "the server
-      // takes this, the controls just can't show it" is an answer nobody gave.
+      await waitFor(() => expect(screen.getByText(/server couldn't be reached/)).toBeInTheDocument());
+      expect(screen.getByText(/Next runs unavailable/)).toBeInTheDocument();
       expect(screen.queryByText(/visual editor can't represent/)).not.toBeInTheDocument();
-      // Saving stays open all the same — the write path validates the cron of its
-      // own accord, so a preview outage must not block a schedule the server would
-      // have taken.
-      expect(screen.getByTestId("valid-out").textContent).toBe("true");
+      expect(screen.getByTestId("valid-out")).toHaveTextContent("true");
     } finally {
-      previewFailure.transport = false;
+      previewMode.value = "ok";
     }
   });
 
-  it("does not call an unreadable preview too advanced for the controls", async () => {
-    previewFailure.unreadable = true;
-    try {
-      renderEditor(cron("0 9 1,15 * *"));
-      await waitFor(() =>
-        expect(screen.getByText(/server couldn't be reached/)).toBeInTheDocument(),
-      );
-      expect(screen.queryByText(/visual editor can't represent/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/no upcoming runs/)).not.toBeInTheDocument();
-    } finally {
-      previewFailure.unreadable = false;
-    }
-  });
-
-  it("says the expression is still being checked before the server has answered", async () => {
-    renderEditor(cron("0 9 1,15 * *"));
-    // The round trip is a whole debounce and a request away, and an invalid cron
-    // is indistinguishable from an unrepresentable one until it lands.
-    expect(screen.getByText(/Checking this expression/)).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByText(/visual editor can't represent/)).toBeInTheDocument(),
-    );
-    expect(screen.queryByText(/Checking this expression/)).not.toBeInTheDocument();
-  });
-
-  it("calls an accepted expression advanced even when it has no upcoming runs", async () => {
-    // 29 Feb is both beyond the controls (a month is pinned) and firing nowhere in
-    // the preview window. An empty list is still an answer: the server took it.
+  it("accepts an advanced expression with no upcoming runs", async () => {
     renderEditor(cron("0 0 30 2 *"));
-    await waitFor(() =>
-      expect(screen.getByText(/visual editor can't represent/)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/visual editor can't represent/)).toBeInTheDocument());
     expect(screen.getByText(/no upcoming runs/)).toBeInTheDocument();
   });
 
-  it("surfaces a rejection whose code it does not know, with the server's reason", async () => {
-    previewFailure.unknownCode = true;
+  it("attributes a timezone rejection to the picker rather than the cron", async () => {
+    previewMode.value = "timezone";
     try {
       renderEditor(cron("0 9 * * *"));
-      // An unclassifiable 400 is still a refusal: it blocks the save and carries
-      // the server's own words, rather than being swallowed as an outage.
-      await waitFor(() => expect(screen.getByText(/rejected by policy/)).toBeInTheDocument());
-      expect(screen.getByTestId("valid-out").textContent).toBe("false");
-      expect(screen.getByText("This cron expression isn't valid.")).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText(/timezone isn't recognized/)).toBeInTheDocument());
+      expect(screen.queryByText("This cron expression isn't valid.")).not.toBeInTheDocument();
     } finally {
-      previewFailure.unknownCode = false;
+      previewMode.value = "ok";
     }
   });
 
-  // Every numeric field in the panel is a wheel, not a slider: stepping off one
-  // end of its range comes out at the other. A field that stopped dead at its
-  // bound would leave a keyboard user pressing a key that does nothing, and make
-  // 23:00 → 00:00 a mouse-only move.
-  describe("keyboard stepping wraps within each field's range", () => {
-    it("wraps the fixed time's hour and minute", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 23 * * *"));
-      await user.click(screen.getByLabelText("Hour"));
-      await user.keyboard("{ArrowUp}");
-      expect(cronOut()).toBe("0 0 * * *");
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("0 23 * * *");
-
-      await user.click(screen.getByLabelText("Minute"));
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("59 23 * * *");
-      await user.keyboard("{ArrowUp}");
-      expect(cronOut()).toBe("0 23 * * *");
-    });
-
-    it("wraps the firing minute an all-day interval carries in its window start", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 */2 * * *"));
-      await user.click(screen.getByLabelText("Window start minute"));
-      await user.keyboard("{ArrowDown}");
-      // Still all day — only the minute moved, so the schedule keeps its "*/2".
-      expect(cronOut()).toBe("59 */2 * * *");
-    });
-
-    it("wraps the interval step within the unit's range", async () => {
-      const user = userEvent.setup();
-      // The step starts at 1, which is its minimum — not 0, so its wrap-around
-      // lands on the unit's max rather than on some shared 0.
-      renderEditor(cron("0 * * * *"));
-      await user.click(screen.getByLabelText("Interval"));
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("0 */23 * * *");
-      await user.keyboard("{ArrowUp}");
-      expect(cronOut()).toBe("0 * * * *");
-
-      // Minutes carry a different ceiling, and the wrap must follow it.
-      await user.click(screen.getByLabelText("Interval unit"));
-      await user.click(await screen.findByRole("option", { name: "minutes" }));
-      await user.click(screen.getByLabelText("Interval"));
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("*/59 * * * *");
-    });
-
-    it("wraps the day of month", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 9 31 * *"));
-      const day = screen.getByLabelText("Day of month");
-      await user.click(day);
-      await user.keyboard("{ArrowUp}");
-      expect(cronOut()).toBe("0 9 1 * *");
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("0 9 31 * *");
-    });
-
-    it("wraps the window end within the range its start leaves it", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 9-15/2 * * *"));
-      const end = screen.getByLabelText("Window end hour");
-      await user.click(end);
-      // Pull the end down onto the start, so the next step is off the bottom of
-      // its range. (Typed, not parsed: "9-9/2" reads back as a fixed 9:00.)
-      await user.keyboard("09");
-      expect(cronOut()).toBe("0 9-9/2 * * *");
-      // A completed pair hands focus on to the minute; the hour is where the
-      // stepping is being tested.
-      await user.click(end);
-      // The end can never precede the start, so its range is 9–23: stepping
-      // below 9 comes out at 23, not at 8 (which has no cron form) and not stuck
-      // on 9 (which is the same key doing nothing).
-      await user.keyboard("{ArrowDown}");
-      expect(cronOut()).toBe("0 9-23/2 * * *");
-      await user.keyboard("{ArrowUp}");
-      expect(cronOut()).toBe("0 9-9/2 * * *");
-    });
-
-    it("keeps an out-of-range end unreachable by typing, too", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 9-15/2 * * *"));
-      await user.click(screen.getByLabelText("Window end hour"));
-      // 08 is before the start: the field holds it at the start hour rather than
-      // wrapping a half-typed number round to 23.
-      await user.keyboard("08");
-      expect(cronOut()).toBe("0 9-9/2 * * *");
-    });
-
-    it("still types a two-digit end whose first digit alone is out of range", async () => {
-      const user = userEvent.setup();
-      renderEditor(cron("0 9-15/2 * * *"));
-      await user.click(screen.getByLabelText("Window end hour"));
-      // The "1" of 18 is below the 9 the field starts at. Clamping it for display
-      // must not overwrite the digit being typed — the pair still has to land as 18.
-      await user.keyboard("18");
-      expect(cronOut()).toBe("0 9-18/2 * * *");
-    });
+  it("promotes an accepted typed timezone prefix into the picker", async () => {
+    renderEditor(cron("0 9 * * *"));
+    await editCronText("CRON_TZ=Asia/Tokyo 30 9 * * 1-5");
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("CRON_TZ=Asia/Tokyo");
+    await waitFor(() => expect(screen.getByTestId("tz-out")).toHaveTextContent("Asia/Tokyo"));
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("null");
+    expect(cronOut()).toBe("30 9 * * 1-5");
   });
 
-  describe("timezone prefix extraction", () => {
-    // Extraction rewrites two controls the user is looking at — the zone lands
-    // in the picker, the cron box loses the prefix — so a TYPED prefix waits
-    // for the server: the text commits verbatim first, and only the preview's
-    // 200 for that exact text promotes it to the extracted pair.
-    it("moves a typed CRON_TZ= prefix into the picker once the server accepts it", async () => {
-      renderEditor(cron("0 9 * * *"));
-      await editCronText("CRON_TZ=Asia/Tokyo 30 9 * * 1-5");
-      // Before the verdict: verbatim, both controls untouched.
-      expect(screen.getByTestId("raw-out").textContent).toBe("CRON_TZ=Asia/Tokyo 30 9 * * 1-5");
-      expect(screen.getByTestId("tz-out").textContent).toBe("UTC");
-      // The 200 lands both rewrites at once.
-      await waitFor(() =>
-        expect(screen.getByTestId("tz-out").textContent).toBe("Asia/Tokyo"),
-      );
-      expect(screen.getByTestId("raw-out").textContent).toBe("null");
-      expect(cronOut()).toBe("30 9 * * 1-5");
-    });
-
-    it("never promotes an expression the server rejected", async () => {
-      renderEditor(cron("0 9 * * *"));
-      await editCronText("TZ=Europe/Berlin 0 9 * * *");
-      // The mock's server knows no Berlin; the browser does. The text must
-      // stay exactly as typed, under the server's own error — the picker never
-      // shows a zone the server refused.
-      await waitFor(() =>
-        expect(screen.getByText("This cron expression isn't valid.")).toBeInTheDocument(),
-      );
-      expect(screen.getByTestId("raw-out").textContent).toBe("TZ=Europe/Berlin 0 9 * * *");
-      expect(screen.getByTestId("tz-out").textContent).toBe("UTC");
-    });
-
+  it("keeps a rejected typed timezone prefix verbatim", async () => {
+    renderEditor(cron("0 9 * * *"));
+    await editCronText("TZ=Europe/Berlin 0 9 * * *");
+    await waitFor(() => expect(screen.getByText("This cron expression isn't valid.")).toBeInTheDocument());
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("TZ=Europe/Berlin 0 9 * * *");
+    expect(screen.getByTestId("tz-out")).toHaveTextContent("UTC");
   });
 
-  describe("timezone prefix as the wire form", () => {
-    // The expression that leaves the editor — for the preview and for saving —
-    // always carries the timezone as a TZ= prefix, so the cron string and the
-    // timezone column can never disagree about which zone governs the schedule.
-    it("serialises the picker's zone into the expression it validates and saves", async () => {
-      renderEditor(cron("0 9 * * *"));
-      expect(wireOut()).toBe("TZ=UTC 0 9 * * *");
-      previewCalls.length = 0;
-      fireEvent.change(screen.getByTestId("timezone-picker"), {
-        target: { value: "Asia/Shanghai" },
-      });
-      // The prefix follows the picker; the fields do not move.
-      expect(wireOut()).toBe("TZ=Asia/Shanghai 0 9 * * *");
-      expect(cronOut()).toBe("0 9 * * *");
-      // And the preview judges the prefixed pair, not the bare fields.
-      await waitFor(() =>
-        expect(previewCalls).toContain("TZ=Asia/Shanghai 0 9 * * *"),
-      );
-    });
+  it("uses a fixed timezone segment in the wire form without stealing focus", async () => {
+    renderEditor(cron("0 9 * * *"));
+    expect(wireOut()).toBe("TZ=UTC 0 9 * * *");
+    const input = await openCronInput();
+    input.focus();
+    expect(input).toHaveValue("0 9 * * *");
+    expect(fireEvent.mouseDown(screen.getByText("TZ=UTC"))).toBe(false);
+    expect(input).toHaveFocus();
 
-    it("draws the prefix as a fixed segment, outside the editable text", async () => {
-      renderEditor(cron("0 9 * * *"));
-      const input = await openCronInput();
-      // The zone is not characters in the field — it cannot be half-deleted
-      // into the no-space shape robfig panics on.
-      expect((input as HTMLInputElement).value).toBe("0 9 * * *");
-      expect(screen.getByText("TZ=UTC")).toBeInTheDocument();
+    previewCalls.length = 0;
+    fireEvent.change(screen.getByTestId("timezone-picker"), {
+      target: { value: "Asia/Shanghai" },
     });
+    expect(wireOut()).toBe("TZ=Asia/Shanghai 0 9 * * *");
+    await waitFor(() => expect(previewCalls).toContain("TZ=Asia/Shanghai 0 9 * * *"));
+  });
 
-    it("keeps focus in the field when the fixed segment is clicked", async () => {
-      renderEditor(cron("0 9 * * *"));
-      await openCronInput();
-      // The browser moves focus on mousedown, before the addon's click-to-focus
-      // can run — and blurring the input is what closes the field. The segment
-      // must swallow the mousedown (fireEvent returns false when the default
-      // was prevented) so focus never leaves.
-      expect(fireEvent.mouseDown(screen.getByText("TZ=UTC"))).toBe(false);
-    });
-
-    it("yields the fixed segment while a typed prefix awaits the verdict", async () => {
-      renderEditor(cron("0 9 * * *"));
-      await editCronText("TZ=Local 0 9 * * *");
-      // The committed text carries its own prefix; drawing the picker's next
-      // to it would read as an expression carrying both. It also must not be
-      // stacked onto the wire form — robfig strips ONE prefix and would read
-      // the second as a field.
-      await waitFor(() => expect(screen.getByText("Next runs")).toBeInTheDocument());
-      expect(screen.getByTestId("raw-out").textContent).toBe("TZ=Local 0 9 * * *");
-      expect(screen.getByTestId("tz-out").textContent).toBe("UTC");
-      expect(wireOut()).toBe("TZ=Local 0 9 * * *");
-      const input = await openCronInput();
-      expect((input as HTMLInputElement).value).toBe("TZ=Local 0 9 * * *");
-      expect(screen.queryByText("TZ=UTC")).not.toBeInTheDocument();
-    });
-
+  it("does not add a second prefix while a typed prefix awaits promotion", async () => {
+    renderEditor(cron("0 9 * * *"));
+    await editCronText("TZ=Local 0 9 * * *");
+    await waitFor(() => expect(screen.getByText("Next runs")).toBeInTheDocument());
+    expect(screen.getByTestId("raw-out")).toHaveTextContent("TZ=Local 0 9 * * *");
+    expect(wireOut()).toBe("TZ=Local 0 9 * * *");
+    const input = await openCronInput();
+    expect(input).toHaveValue("TZ=Local 0 9 * * *");
+    expect(screen.queryByText("TZ=UTC")).not.toBeInTheDocument();
   });
 });

--- a/packages/views/autopilots/components/schedule-editor/schedule-editor.tsx
+++ b/packages/views/autopilots/components/schedule-editor/schedule-editor.tsx
@@ -6,14 +6,11 @@ import {
   useMemo,
   useRef,
   useState,
-  type ComponentProps,
-  type ComponentType,
   type ReactNode,
 } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Clock, Pencil } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
-import { Input } from "@multica/ui/components/ui/input";
 import {
   InputGroup,
   InputGroupAddon,
@@ -49,6 +46,8 @@ import {
 } from "./cron-mapping";
 import { classifyScheduleRejection } from "./validate";
 import { useDescribeSchedule } from "./describe";
+import { NumberField } from "./number-field";
+import { getSchedulePreviewState } from "./preview-state";
 import {
   clampWindow,
   defaultAtTime,
@@ -138,91 +137,6 @@ function ScheduleField({
           handing its 8px to the visible control and inflating the block. */}
       <div className="flex min-w-0 flex-col gap-2">{children}</div>
     </fieldset>
-  );
-}
-
-/** Number field whose DOM text and model value cannot drift apart: clearing it
- *  is allowed while typing, and blur reconciles the box with the model —
- *  clamping an out-of-range number into the field's bounds, and snapping back to
- *  the committed value when the box holds no number at all. Without the clamp,
- *  typing "24" into a 1–23 field would commit the 2 of the first keystroke and
- *  then reject the pair, leaving "every 2 hours" — a schedule the user never
- *  chose — behind. */
-function NumberField({
-  value,
-  min,
-  max,
-  onCommit,
-  className,
-  ariaLabel,
-  autoFocus,
-  // The box this field is drawn in. Standing alone it brings its own; inside an
-  // InputGroup the group owns the border, the ring and the focus slot, and
-  // InputGroupInput is the same field with all three given up.
-  component: Field = Input,
-}: {
-  value: number;
-  min: number;
-  max: number;
-  onCommit: (value: number) => void;
-  className?: string;
-  ariaLabel: string;
-  autoFocus?: boolean;
-  component?: ComponentType<ComponentProps<"input">>;
-}) {
-  const [text, setText] = useState(String(value));
-  const lastValueRef = useRef(value);
-  if (lastValueRef.current !== value) {
-    lastValueRef.current = value;
-    setText(String(value));
-  }
-  return (
-    <Field
-      type="number"
-      aria-label={ariaLabel}
-      // Caller-gated: set only when the user just revealed this field, never on
-      // first mount.
-      autoFocus={autoFocus}
-      min={min}
-      max={max}
-      value={text}
-      onChange={(e) => {
-        setText(e.target.value);
-        const n = parseInt(e.target.value, 10);
-        if (!Number.isNaN(n) && n >= min && n <= max) onCommit(n);
-      }}
-      // The native stepper stops dead at the bounds; every other field in this
-      // panel wraps, so these do too. Stepping off 31 gives day 1 back, not
-      // another press that does nothing.
-      onKeyDown={(e) => {
-        if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-        e.preventDefault();
-        const typed = parseInt(text, 10);
-        // An out-of-range box is not somewhere to step FROM — stepping is what
-        // brings it back in, and it lands on the bound it overshot. Clamping
-        // first and then stepping would step off that bound instead, so the
-        // bound itself could never be reached: in a 1-31 field, an arrow on a
-        // typed "0" gave 2, and one on "40" gave 30.
-        const stepped =
-          Number.isNaN(typed) || typed >= min && typed <= max
-            ? (Number.isNaN(typed) ? value : typed) + (e.key === "ArrowUp" ? 1 : -1)
-            : Math.min(max, Math.max(min, typed));
-        const wrapped = stepped > max ? min : stepped < min ? max : stepped;
-        setText(String(wrapped));
-        if (wrapped !== lastValueRef.current) onCommit(wrapped);
-      }}
-      onBlur={() => {
-        const n = parseInt(text, 10);
-        if (Number.isNaN(n)) {
-          setText(String(lastValueRef.current));
-          return;
-        }
-        const clamped = Math.min(max, Math.max(min, n));
-        setText(String(clamped));
-        if (clamped !== lastValueRef.current) onCommit(clamped);
-      }}
-      className={className}
-    />
   );
 }
 
@@ -446,11 +360,6 @@ export function ScheduleEditor({
   const rejection = liveRejection ?? verdict?.rejection ?? null;
   const scheduleRejection = rejection !== null ? classifyScheduleRejection(rejection) : null;
   const cronErrorDetail = scheduleRejection?.detail ?? null;
-  const previewUnavailable =
-    previewIsCurrent &&
-    ((preview.error !== null && cronErrorDetail === null) ||
-      (preview.isSuccess && nextRuns === null));
-
   // The preview arrives one round trip after every edit. Unmounting the line
   // while it is in flight makes it blink out and back on each keystroke, so the
   // last answer stays on screen and its text is replaced in place. It is dimmed
@@ -480,14 +389,15 @@ export function ScheduleEditor({
       at: Date.parse(iso),
     }));
   }, [shownPreview, i18n.language]);
-  const previewIsPending = !previewIsSettled;
-  // Busy/dimming only makes sense over the list: the unavailable message never
-  // settles, and dimming it forever would read as a permanent loading state.
-  const previewShowsList =
-    cronErrorDetail === null &&
-    !previewUnavailable &&
-    shownPreview !== null &&
-    shownPreview.runs.length > 0;
+  const previewState = getSchedulePreviewState({
+    advanced,
+    current: previewIsCurrent,
+    status: preview.isSuccess ? "success" : preview.error !== null ? "error" : "pending",
+    nextRuns,
+    rejected: cronErrorDetail !== null,
+    accepted: serverAccepted,
+    hasShownRuns: shownPreview !== null && shownPreview.runs.length > 0,
+  });
 
   // A malformed timestamp must degrade to "no countdown", never to NaN, so every
   // value is checked before it becomes a Date (see the list below).
@@ -796,9 +706,9 @@ export function ScheduleEditor({
             // a statement about the expression: the server took it and the
             // controls cannot show it; we could not ask; we have not asked yet.
             <p>
-              {serverAccepted
+              {previewState.advancedNotice === "accepted"
                 ? t(($) => $.schedule_editor.advanced_hint)
-                : previewUnavailable
+                : previewState.advancedNotice === "unavailable"
                   ? t(($) => $.schedule_editor.advanced_unverified)
                   : t(($) => $.schedule_editor.advanced_checking)}
             </p>
@@ -817,20 +727,20 @@ export function ScheduleEditor({
             instead of tearing the section down, so a re-render of the same
             schedule never flashes — it just dims and reports busy until the
             answer is current. */}
-        {cronErrorDetail === null && (
+        {previewState.body !== "hidden" && (
         <div
-          aria-busy={previewShowsList ? previewIsPending : undefined}
+          aria-busy={previewState.body === "runs" ? previewState.busy : undefined}
           className={cn(
             "mt-2.5 min-h-14 border-t border-border/60 pt-2.5 transition-opacity",
-            previewShowsList && previewIsPending && "opacity-50",
+            previewState.body === "runs" && previewState.busy && "opacity-50",
           )}
         >
           <p className="mb-1.5 font-medium text-foreground">
             {t(($) => $.schedule_editor.next_runs_label)}
           </p>
-          {previewUnavailable ? (
+          {previewState.body === "unavailable" ? (
             <p>{t(($) => $.schedule_editor.preview_unavailable)}</p>
-          ) : shownPreview !== null && shownPreview.runs.length > 0 ? (
+          ) : previewState.body === "runs" && shownPreview !== null ? (
             // A grid, not per-row flex: the localized dates are not fixed-width,
             // so only a shared column can line the countdowns up with each
             // other. max-content sizes that column to the widest date.
@@ -855,7 +765,7 @@ export function ScheduleEditor({
                 </li>
               ))}
             </ul>
-          ) : previewIsSettled ? (
+          ) : previewState.body === "empty" ? (
             // An empty list from a readable response: valid syntax, never fires.
             <p>{t(($) => $.schedule_editor.no_upcoming_runs)}</p>
           ) : null}


### PR DESCRIPTION
## Stack dependency

This PR is stacked on #7631 and should merge after it. Its base is the PR1 branch so this review shows only the PR2 delta.

## Summary

- extract `NumberField` into a focused component with direct boundary coverage
- extract preview rendering decisions into a pure state helper with a canonical table test
- reduce the full `ScheduleEditor` DOM suite from 77 tests to 25 integration, accessibility, and named-regression tests

## Impact

- focused schedule-editor coverage: 77 tests → 32 tests (25 DOM + 7 focused canonical tests)
- test code: 1,136 lines → 515 lines (net -621)
- complete PR2 diff: 418 additions / 986 deletions (net -568)
- no intended product behavior change

## Timing

- before: 77 DOM tests, 6.53s wall / 5.66s test time
- after: 32 tests across three focused files, 5.22s wall / 3.98s test time

## Validation

- targeted editor and canonical sibling suites: 367 tests passed
- full `@multica/views` suite: 406 files / 4,730 tests passed
- `pnpm typecheck`
- `pnpm lint` (existing warnings only; no errors)
- `pnpm build`
- `git diff --check`

This implements PR2 of MUL-6748 and intentionally does not close the overall issue.
