### PR TITLE
MUL-6745 fix(views): align version-conflict actions with their corresponding previews

### DIFF
--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -556,21 +556,26 @@ function CommentRevisionConflict({
       localLabel={t(($) => $.revision.local_version)}
       serverValue={serverContent}
       localValue={localContent}
-      actions={(
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={saving}
-            onClick={onKeepLocal}
-          >
-            {t(($) => $.revision.keep_local)}
-          </Button>
-          <Button type="button" size="sm" variant="ghost" onClick={onUseServer}>
-            {t(($) => $.revision.use_server)}
-          </Button>
-        </div>
+      serverAction={(
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onUseServer}
+        >
+          {t(($) => $.revision.use_server)}
+        </Button>
+      )}
+      localAction={(
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={saving}
+          onClick={onKeepLocal}
+        >
+          {t(($) => $.revision.keep_local)}
+        </Button>
       )}
     />
   );

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2950,44 +2950,44 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               localLabel={t(($) => $.revision.local_version)}
               serverValue={issue.title}
               localValue={titleConflictDraft}
-              actions={(
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      const draft = titleConflictDraft.trim();
-                      if (!draft) return;
-                      handleUpdateField(
-                        { title: draft, title_base: issue.title },
-                        {
-                          onSuccess: (serverIssue) => {
-                            setTitleConflictDraft(null);
-                            titleBaseRef.current = serverIssue.title;
-                          },
+              serverAction={(
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    // Local-only: the server already holds this title, so
+                    // discarding writes nothing. The remount is what puts it
+                    // back into the editor (see titleResetToken).
+                    setTitleConflictDraft(null);
+                    titleBaseRef.current = issue.title;
+                    setTitleResetToken((token) => token + 1);
+                  }}
+                >
+                  {t(($) => $.revision.use_server)}
+                </Button>
+              )}
+              localAction={(
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    const draft = titleConflictDraft.trim();
+                    if (!draft) return;
+                    handleUpdateField(
+                      { title: draft, title_base: issue.title },
+                      {
+                        onSuccess: (serverIssue) => {
+                          setTitleConflictDraft(null);
+                          titleBaseRef.current = serverIssue.title;
                         },
-                      );
-                    }}
-                  >
-                    {t(($) => $.revision.keep_local)}
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => {
-                      // Local-only: the server already holds this title, so
-                      // discarding writes nothing. The remount is what puts it
-                      // back into the editor (see titleResetToken).
-                      setTitleConflictDraft(null);
-                      titleBaseRef.current = issue.title;
-                      setTitleResetToken((token) => token + 1);
-                    }}
-                  >
-                    {t(($) => $.revision.use_server)}
-                  </Button>
-                </div>
+                      },
+                    );
+                  }}
+                >
+                  {t(($) => $.revision.keep_local)}
+                </Button>
               )}
             />
           ) : null}
@@ -3102,52 +3102,52 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 localLabel={t(($) => $.revision.local_version)}
                 serverValue={issue.description || ""}
                 localValue={descriptionConflictDraft}
-                actions={(
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => {
-                        handleUpdateField(
-                          {
-                            description: descriptionConflictDraft,
-                            description_base: issue.description || "",
-                            attachment_ids:
-                              descriptionAttachmentIdsRef.current.length > 0
-                                ? descriptionAttachmentIdsRef.current
-                                : undefined,
+                serverAction={(
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      // The editor is dirty — that is why this conflict
+                      // exists — so the `value` prop cannot land: ContentEditor
+                      // deliberately refuses to clobber unsaved bytes.
+                      // adoptContent is the explicit "take this content"
+                      // channel and applies without emitting an update, so
+                      // discarding never writes.
+                      descEditorRef.current?.adoptContent(issue.description || "");
+                      descriptionAttachmentIdsRef.current = [];
+                      pendingDescriptionSaveRef.current = null;
+                      setDescriptionConflictDraft(null);
+                    }}
+                  >
+                    {t(($) => $.revision.use_server)}
+                  </Button>
+                )}
+                localAction={(
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      handleUpdateField(
+                        {
+                          description: descriptionConflictDraft,
+                          description_base: issue.description || "",
+                          attachment_ids:
+                            descriptionAttachmentIdsRef.current.length > 0
+                              ? descriptionAttachmentIdsRef.current
+                              : undefined,
+                        },
+                        {
+                          onSuccess: () => {
+                            setDescriptionConflictDraft(null);
                           },
-                          {
-                            onSuccess: () => {
-                              setDescriptionConflictDraft(null);
-                            },
-                          },
-                        );
-                      }}
-                    >
-                      {t(($) => $.revision.keep_local)}
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => {
-                        // The editor is dirty — that is why this conflict
-                        // exists — so the `value` prop cannot land: ContentEditor
-                        // deliberately refuses to clobber unsaved bytes.
-                        // adoptContent is the explicit "take this content"
-                        // channel and applies without emitting an update, so
-                        // discarding never writes.
-                        descEditorRef.current?.adoptContent(issue.description || "");
-                        descriptionAttachmentIdsRef.current = [];
-                        pendingDescriptionSaveRef.current = null;
-                        setDescriptionConflictDraft(null);
-                      }}
-                    >
-                      {t(($) => $.revision.use_server)}
-                    </Button>
-                  </div>
+                        },
+                      );
+                    }}
+                  >
+                    {t(($) => $.revision.keep_local)}
+                  </Button>
                 )}
               />
             ) : null}

--- a/packages/views/issues/components/revision-conflict-compare.test.tsx
+++ b/packages/views/issues/components/revision-conflict-compare.test.tsx
@@ -62,4 +62,32 @@ describe("RevisionConflictCompare", () => {
     );
     expect(container.querySelector("[class*='line-clamp']")).toBeNull();
   });
+
+  it("puts each action in the column of the preview it applies to", () => {
+    const { container } = render(
+      <RevisionConflictCompare
+        title="Compare both versions"
+        serverLabel="Latest server version"
+        localLabel="Your local version"
+        serverValue="server"
+        localValue="local"
+        serverAction={<button type="button">Use the latest version</button>}
+        localAction={<button type="button">Keep my version</button>}
+      />,
+    );
+
+    // The mismatch reported in #7624 was "keep my version" sitting under the
+    // server preview, so assert the side each action lands on — not just that
+    // both rendered.
+    const actions = container.querySelector(
+      "[data-revision-conflict-actions]",
+    );
+    expect(actions).not.toBeNull();
+    const [serverCell, localCell] = Array.from(actions!.children);
+    expect(serverCell).toHaveTextContent("Use the latest version");
+    expect(localCell).toHaveTextContent("Keep my version");
+    // Same two-column grid as the labels and the diff rows, so the pairing
+    // survives every window width.
+    expect(actions).toHaveClass("grid", "grid-cols-2");
+  });
 });

--- a/packages/views/issues/components/revision-conflict-compare.tsx
+++ b/packages/views/issues/components/revision-conflict-compare.tsx
@@ -9,7 +9,13 @@ interface RevisionConflictCompareProps {
   serverValue: string;
   localValue: string;
   footer?: ReactNode;
-  actions?: ReactNode;
+  // One action per side, rendered in its own column of the same two-column
+  // grid as the labels and the diff. A single shared action row read as
+  // "keep my version" sitting under the SERVER preview it discards (#7624);
+  // the column is what makes each action point at its own pane, and it holds
+  // at every width because the diff itself never stacks.
+  serverAction?: ReactNode;
+  localAction?: ReactNode;
   className?: string;
 }
 
@@ -101,7 +107,8 @@ export function RevisionConflictCompare({
   serverValue,
   localValue,
   footer,
-  actions,
+  serverAction,
+  localAction,
   className,
 }: RevisionConflictCompareProps) {
   const rows = revisionConflictRows(serverValue, localValue);
@@ -135,11 +142,21 @@ export function RevisionConflictCompare({
             </div>
           ))}
         </div>
+        {serverAction || localAction ? (
+          <div
+            data-revision-conflict-actions
+            className="grid grid-cols-2 border-t bg-muted/40"
+          >
+            {/* px-3 matches the label cells above, so each button's left
+                edge lands on the same vertical line as its column header. */}
+            <div className="min-w-0 px-3 py-2">{serverAction}</div>
+            <div className="min-w-0 border-l px-3 py-2">{localAction}</div>
+          </div>
+        ) : null}
       </div>
       {footer ? (
         <div className="mt-2 text-muted-foreground">{footer}</div>
       ) : null}
-      {actions ? <div className="mt-2">{actions}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
Closes #7624

## What

The concurrent-edit conflict block showed the server version in the left pane and the local version in the right pane, but rendered both actions in a single row under the left edge of the box. That put **Keep my version** under the *server* preview it discards, and **Use the latest version** to its right — the spatial pairing was inverted, exactly as reported.

## Change

`RevisionConflictCompare` no longer takes one freeform `actions` node. It takes `serverAction` and `localAction`, and renders them in the same two-column grid already used by the pane labels and the diff rows — one action per column, inside the bordered box as a footer strip that mirrors the header.

- Each action now sits under the preview it applies to.
- The diff itself never stacks, so the pairing holds at every window width (checked at 420px).
- Action cells use `px-3` to match the label cells, so each button's left edge lands on the same vertical line as its column header.
- Both buttons are `outline` now. They are peer choices under equal-weight panes, and the discard-my-edits side should not read as the quieter one.

Labels are unchanged. Under its own column, `使用最新版本` / `保留我的版本` is already unambiguous, so the relabel the issue suggested as an alternative isn't needed and would churn every locale.

All three call sites are updated: issue title conflict, issue description conflict, and comment conflict.

## Verification

- `packages/views` full suite: 405 files / 4810 tests pass.
- `tsc --noEmit` and `eslint` clean on `packages/views`.
- New test in `revision-conflict-compare.test.tsx` asserts which column each action lands in, so the inversion can't come back silently.
- Rendered the component in a throwaway route and screenshotted before/after in light and dark, plus a 420px-wide case. The scratch route is not part of this diff.
