### PR TITLE
fix(issue-status): derive a stable key for all-non-ASCII status names

### DIFF
--- a/server/internal/handler/issue_status_test.go
+++ b/server/internal/handler/issue_status_test.go
@@ -369,6 +369,28 @@ func TestCreateIssueStatusIsNotGatedOnRollout(t *testing.T) {
 	dbfx.Cleanup(t, `DELETE FROM issue_status WHERE id = $1`, parseUUID(created.ID))
 }
 
+// TestCreateIssueStatusFromNonASCIIName pins the #7627 fix: a display name with
+// no slug-able characters (e.g. `客户确认`) must create through the name-only
+// form, since the settings UI offers no explicit-key field. The derived key is
+// a valid ASCII schema identifier.
+func TestCreateIssueStatusFromNonASCIIName(t *testing.T) {
+	seedTestCatalog(t)
+
+	var created IssueStatusResponse
+	testutil.Call(t, testHandler.CreateIssueStatus,
+		newRequest(http.MethodPost, "/api/issue-statuses", map[string]any{
+			"name": "客户确认", "category": issuestatus.InReview, "color": "#123456",
+		})).Want(http.StatusCreated).JSON(&created)
+	dbfx.Cleanup(t, `DELETE FROM issue_status WHERE id = $1`, parseUUID(created.ID))
+
+	if created.Name != "客户确认" {
+		t.Errorf("stored name = %q, want the Unicode display name", created.Name)
+	}
+	if _, err := issuestatus.ValidateKey(created.Key); err != nil {
+		t.Errorf("derived key %q is not a valid status key: %v", created.Key, err)
+	}
+}
+
 // TestIssueWriteStoresCanonicalStatusKey guards the 500 found in review:
 // resolution is case- and whitespace-insensitive, so writing the caller's raw
 // string back would store a value the column's format constraint rejects.

--- a/server/internal/issuestatus/issuestatus.go
+++ b/server/internal/issuestatus/issuestatus.go
@@ -24,6 +24,8 @@ package issuestatus
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"regexp"
@@ -132,7 +134,15 @@ func ValidateKey(key string) (string, error) {
 }
 
 // SlugifyKey derives a candidate key from a display name, for callers that let
-// an admin type only a name. Returns an error when nothing usable survives.
+// an admin type only a name.
+//
+// Keys are ASCII schema-level identifiers (see conventions: `todo`,
+// `in_progress`), so a name in a non-Latin script slugifies to nothing. Rather
+// than reject it — the settings form offers no explicit-key field, so that left
+// entirely non-ASCII names uncreatable (#7627) — fall back to a stable
+// content-derived key. The fallback is deterministic in the name, so recreating
+// a status by the same name (e.g. after archiving) lands on the same key,
+// matching the behavior of the ASCII path.
 func SlugifyKey(name string) (string, error) {
 	var b strings.Builder
 	lastUnderscore := false
@@ -151,9 +161,19 @@ func SlugifyKey(name string) (string, error) {
 		slug = strings.Trim(slug[:32], "_")
 	}
 	if slug == "" {
-		return "", errors.New("cannot derive a status key from that name; provide one explicitly")
+		slug = fallbackKey(name)
 	}
 	return ValidateKey(slug)
+}
+
+// fallbackKey derives a stable ASCII key from a display name that carries no
+// slug-able characters. The hash is over the trimmed, lower-cased name so it is
+// deterministic and case-insensitive, matching the ASCII slug path; the
+// `status_` prefix guarantees the leading-letter requirement of keyPattern and
+// can never collide with a built-in key.
+func fallbackKey(name string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(name))))
+	return "status_" + hex.EncodeToString(sum[:])[:12]
 }
 
 // Ensure idempotently seeds a workspace's 7 built-in statuses. Safe to call

--- a/server/internal/issuestatus/issuestatus_test.go
+++ b/server/internal/issuestatus/issuestatus_test.go
@@ -263,8 +263,29 @@ func TestSlugifyKey(t *testing.T) {
 	if _, err := SlugifyKey("In Progress"); err == nil {
 		t.Error("a name slugifying to a built-in key should be rejected")
 	}
-	if _, err := SlugifyKey("客户"); err == nil {
-		t.Error("a name with no slug-able characters should be rejected")
+
+	// A name with no slug-able characters falls back to a stable content-derived
+	// key rather than being rejected: the settings form has no explicit-key
+	// field, so rejecting left entirely non-ASCII names uncreatable (#7627).
+	nonASCII, err := SlugifyKey("客户确认")
+	if err != nil {
+		t.Fatalf("SlugifyKey(non-ASCII) should fall back, got error: %v", err)
+	}
+	if !keyPattern.MatchString(nonASCII) {
+		t.Errorf("fallback key %q does not satisfy the storage pattern", nonASCII)
+	}
+	if IsBuiltIn(nonASCII) {
+		t.Errorf("fallback key %q collides with a built-in", nonASCII)
+	}
+	// Deterministic and case-insensitive, so recreating a status by the same
+	// name lands on the same key, matching the ASCII slug path.
+	again, _ := SlugifyKey("  客户确认  ")
+	if again != nonASCII {
+		t.Errorf("fallback key not stable across whitespace: %q vs %q", again, nonASCII)
+	}
+	// Distinct names yield distinct keys.
+	if other, _ := SlugifyKey("待审核"); other == nonASCII {
+		t.Errorf("distinct non-ASCII names collided on key %q", other)
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes #7627.

Creating a custom issue status from **Workspace Settings → Issue Statuses**
fails when the display name contains only non-ASCII characters (e.g. `客户确认`):

> cannot derive a status key from that name; provide one explicitly

`SlugifyKey` (`server/internal/issuestatus/issuestatus.go`) derives the
status key by keeping only `[a-z0-9]`, so an all-non-Latin name slugifies to
an empty string and is rejected. The settings form submits only
name/description/category/color and exposes **no explicit-key field**, so
there is no way to create such a status through the UI. This affects any name
written entirely in a non-Latin script, not just Chinese.

## Fix

Status keys are ASCII schema-level identifiers (per the conventions doc:
`todo`, `in_progress`), while the display name carries the localized text.
Rather than reject a name that slugifies to empty, derive a **stable
content-based fallback key**:

```
status_<sha256(lower(trim(name)))[:12]>
```

- **Deterministic & case-insensitive** — recreating a status by the same name
  (e.g. after archiving) lands on the same key, matching the existing ASCII
  slug path.
- The `status_` prefix satisfies the leading-letter rule of the key pattern
  and can never collide with a built-in key.
- **Server-only change** — keeps the deliberately thin settings form (one
  name field) intact; no frontend changes.

## Testing

- `go test ./internal/issuestatus/ ./internal/handler/` — green on a freshly
  migrated DB. New coverage:
  - `TestSlugifyKey`: non-ASCII name now yields a valid, stable, non-colliding key.
  - `TestCreateIssueStatusFromNonASCIIName`: `POST /api/issue-statuses` with
    `客户确认` returns **201** with a valid ASCII key.
- **End-to-end** (`make dev`, real HTTP → API → DB):
  - `客户确认` → 201, name preserved, key `status_7d11b1e1782e`.
  - `待审核` → distinct key `status_7bf25421c6df` (no collision).
  - Re-submitting `客户确认` → 409 (same key), confirming determinism.
  - Catalog list endpoint renders both custom statuses correctly.
