### PR TITLE
MUL-6748: collapse execenv assertion scaffolding

### DIFF
--- a/server/cmd/rewrite-test-assertions/main.go
+++ b/server/cmd/rewrite-test-assertions/main.go
@@ -1,0 +1,354 @@
+// Command rewrite-test-assertions folds one-call testing failure blocks into
+// testutil.OnFailure while preserving the original testing call verbatim.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/imports"
+)
+
+const testutilImportPath = "github.com/multica-ai/multica/server/internal/testutil"
+
+type stats struct {
+	blocks      int
+	files       int
+	handwritten int
+}
+
+type sourceEdit struct {
+	start       int
+	end         int
+	replacement string
+}
+
+func main() {
+	write := flag.Bool("w", false, "rewrite files in place")
+	check := flag.Bool("check", false, "fail when a file would be rewritten")
+	maxHandwritten := flag.Int("max-handwritten", -1, "fail when more than this many hand-written assertion blocks remain")
+	flag.Parse()
+	if *write && *check {
+		fmt.Fprintln(os.Stderr, "-w and -check are mutually exclusive")
+		os.Exit(2)
+	}
+	if flag.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: rewrite-test-assertions [-w|-check] [-max-handwritten N] <file-or-directory>...")
+		os.Exit(2)
+	}
+
+	result, err := rewritePaths(flag.Args(), *write)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if *check && result.blocks > 0 {
+		fmt.Fprintf(os.Stderr, "%d collapsible assertion blocks remain in %d files\n", result.blocks, result.files)
+		os.Exit(1)
+	}
+	if *maxHandwritten >= 0 && result.handwritten > *maxHandwritten {
+		fmt.Fprintf(os.Stderr, "%d hand-written assertion blocks exceed maximum %d\n", result.handwritten, *maxHandwritten)
+		os.Exit(1)
+	}
+	verb := "found"
+	if *write {
+		verb = "rewrote"
+	}
+	fmt.Printf(
+		"%s %d collapsible assertion blocks in %d files; %d hand-written blocks total\n",
+		verb,
+		result.blocks,
+		result.files,
+		result.handwritten,
+	)
+}
+
+func rewritePaths(paths []string, write bool) (stats, error) {
+	files, err := collectTestFiles(paths)
+	if err != nil {
+		return stats{}, err
+	}
+	var result stats
+	for _, path := range files {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return stats{}, fmt.Errorf("read %s: %w", path, err)
+		}
+		rewritten, blocks, handwritten, err := rewriteSource(path, source)
+		if err != nil {
+			return stats{}, err
+		}
+		remaining := handwritten
+		if write {
+			remaining -= blocks
+		}
+		result.handwritten += remaining
+		if blocks == 0 {
+			continue
+		}
+		result.blocks += blocks
+		result.files++
+		if !write {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return stats{}, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, rewritten, info.Mode().Perm()); err != nil {
+			return stats{}, fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return result, nil
+}
+
+func collectTestFiles(paths []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	for _, root := range paths {
+		info, err := os.Stat(root)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", root, err)
+		}
+		if !info.IsDir() {
+			if strings.HasSuffix(root, "_test.go") {
+				seen[filepath.Clean(root)] = struct{}{}
+			}
+			continue
+		}
+		err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if path != root && (entry.Name() == "vendor" || strings.HasPrefix(entry.Name(), ".")) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(entry.Name(), "_test.go") {
+				seen[filepath.Clean(path)] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walk %s: %w", root, err)
+		}
+	}
+	files := make([]string, 0, len(seen))
+	for path := range seen {
+		files = append(files, path)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func rewriteSource(filename string, source []byte) ([]byte, int, int, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, source, parser.ParseComments)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("parse %s: %w", filename, err)
+	}
+	handwritten := countHandwrittenAssertions(file)
+	alias, imported, err := importAlias(file)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("inspect imports in %s: %w", filename, err)
+	}
+	if !imported {
+		alias = unusedAlias(file, "testassert")
+	}
+
+	var edits []sourceEdit
+	astutil.Apply(file, func(cursor *astutil.Cursor) bool {
+		node := cursor.Node()
+		statement, ok := collapsibleAssertion(file, node)
+		if !ok {
+			return true
+		}
+		ifStatement := node.(*ast.IfStmt)
+		if parent, ok := cursor.Parent().(*ast.IfStmt); ok && parent.Else == ifStatement {
+			return false
+		}
+		receiver := statement.X.(*ast.CallExpr).Fun.(*ast.SelectorExpr).X.(*ast.Ident)
+		replacement := fmt.Sprintf(
+			"%s.OnFailure(%s, %s, func() { %s })",
+			alias,
+			receiver.Name,
+			sourceSlice(fset, source, ifStatement.Cond),
+			sourceSlice(fset, source, statement.X),
+		)
+		if _, parseErr := parser.ParseExpr(replacement); parseErr != nil {
+			err = fmt.Errorf("build replacement in %s: %w", filename, parseErr)
+			return false
+		}
+		edits = append(edits, sourceEdit{
+			start:       fset.PositionFor(ifStatement.Pos(), false).Offset,
+			end:         fset.PositionFor(ifStatement.End(), false).Offset,
+			replacement: replacement,
+		})
+		return false
+	}, nil)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if len(edits) == 0 {
+		return source, 0, handwritten, nil
+	}
+
+	var rewritten strings.Builder
+	last := 0
+	for _, edit := range edits {
+		rewritten.Write(source[last:edit.start])
+		rewritten.WriteString(edit.replacement)
+		last = edit.end
+	}
+	rewritten.Write(source[last:])
+	formatted, err := format.Source([]byte(rewritten.String()))
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("format %s: %w", filename, err)
+	}
+	if imported {
+		return formatted, len(edits), handwritten, nil
+	}
+
+	fset = token.NewFileSet()
+	file, err = parser.ParseFile(fset, filename, formatted, parser.ParseComments)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("parse rewritten %s: %w", filename, err)
+	}
+	if !astutil.AddNamedImport(fset, file, alias, testutilImportPath) {
+		return nil, 0, 0, fmt.Errorf("add %s import to %s", testutilImportPath, filename)
+	}
+	withImport, err := nodeBytes(fset, file)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("render %s: %w", filename, err)
+	}
+	formatted, err = imports.Process(filename, withImport, nil)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("format %s: %w", filename, err)
+	}
+	return formatted, len(edits), handwritten, nil
+}
+
+func sourceSlice(fset *token.FileSet, source []byte, node ast.Node) string {
+	start := fset.PositionFor(node.Pos(), false).Offset
+	end := fset.PositionFor(node.End(), false).Offset
+	return string(source[start:end])
+}
+
+func collapsibleAssertion(file *ast.File, node ast.Node) (*ast.ExprStmt, bool) {
+	statement, ok := node.(*ast.IfStmt)
+	if !ok || statement.Init != nil || statement.Else != nil || len(statement.Body.List) != 1 {
+		return nil, false
+	}
+	for _, comment := range file.Comments {
+		if comment.Pos() > statement.Body.Lbrace && comment.End() < statement.Body.Rbrace {
+			return nil, false
+		}
+	}
+	return assertionStatement(statement)
+}
+
+func countHandwrittenAssertions(file *ast.File) int {
+	count := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		statement, ok := node.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		if _, ok := assertionStatement(statement); ok {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func assertionStatement(statement *ast.IfStmt) (*ast.ExprStmt, bool) {
+	if len(statement.Body.List) != 1 {
+		return nil, false
+	}
+	expression, ok := statement.Body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return nil, false
+	}
+	call, ok := expression.X.(*ast.CallExpr)
+	if !ok {
+		return nil, false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !isTestingFailure(selector.Sel.Name) {
+		return nil, false
+	}
+	receiver, ok := selector.X.(*ast.Ident)
+	if !ok || (receiver.Name != "t" && receiver.Name != "tb") {
+		return nil, false
+	}
+	return expression, true
+}
+
+func isTestingFailure(name string) bool {
+	switch name {
+	case "Fatal", "Fatalf", "Error", "Errorf":
+		return true
+	default:
+		return false
+	}
+}
+
+func importAlias(file *ast.File) (string, bool, error) {
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			return "", false, err
+		}
+		if path != testutilImportPath {
+			continue
+		}
+		if spec.Name == nil {
+			return "testutil", true, nil
+		}
+		if spec.Name.Name == "." || spec.Name.Name == "_" {
+			return "", false, fmt.Errorf("unsupported import name %q", spec.Name.Name)
+		}
+		return spec.Name.Name, true, nil
+	}
+	return "", false, nil
+}
+
+func unusedAlias(file *ast.File, base string) string {
+	used := map[string]struct{}{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		if identifier, ok := node.(*ast.Ident); ok {
+			used[identifier.Name] = struct{}{}
+		}
+		return true
+	})
+	for suffix := 1; ; suffix++ {
+		candidate := base
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s%d", base, suffix)
+		}
+		if _, exists := used[candidate]; !exists {
+			return candidate
+		}
+	}
+}
+
+func nodeBytes(fset *token.FileSet, node ast.Node) ([]byte, error) {
+	var output strings.Builder
+	if err := format.Node(&output, fset, node); err != nil {
+		return nil, err
+	}
+	return []byte(output.String()), nil
+}

--- a/server/cmd/rewrite-test-assertions/main_test.go
+++ b/server/cmd/rewrite-test-assertions/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"go/format"
+	"path/filepath"
+	"testing"
+)
+
+func TestExecenvAssertionsStayCollapsed(t *testing.T) {
+	t.Parallel()
+
+	result, err := rewritePaths([]string{
+		filepath.Join("..", "..", "internal", "daemon", "execenv"),
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.blocks != 0 {
+		t.Fatalf("execenv has %d collapsible assertion blocks in %d files; run go run ./cmd/rewrite-test-assertions -w ./internal/daemon/execenv", result.blocks, result.files)
+	}
+	const maxHandwritten = 1236
+	if result.handwritten > maxHandwritten {
+		t.Fatalf("execenv has %d hand-written assertion blocks, maximum is %d", result.handwritten, maxHandwritten)
+	}
+}
+
+func TestRewriteSourcePreservesTestingMethodAndLazyArguments(t *testing.T) {
+	t.Parallel()
+
+	input := `package sample
+import "testing"
+func test(t *testing.T, got, want int, err error) {
+	if got != want {
+		t.Fatalf("got %d, want %d", got, want)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got == 0 {
+		t.Fatal(expensiveMessage())
+	}
+	if got < 0 {
+		t.Error("negative")
+	}
+}
+`
+	want := `package sample
+import (
+	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
+)
+func test(t *testing.T, got, want int, err error) {
+	testassert.OnFailure(t, got != want, func() { t.Fatalf("got %d, want %d", got, want) })
+	testassert.OnFailure(t, err != nil, func() { t.Errorf("unexpected error: %v", err) })
+	testassert.OnFailure(t, got == 0, func() { t.Fatal(expensiveMessage()) })
+	testassert.OnFailure(t, got < 0, func() { t.Error("negative") })
+}
+`
+	assertRewrite(t, input, want, 4)
+}
+
+func TestRewriteSourceUsesExistingImportAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	input := `package sample
+import (
+	"testing"
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+func test(t *testing.T, failed bool) {
+	if failed {
+		t.Fatal("failed")
+	}
+}
+`
+	want := `package sample
+import (
+	"testing"
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+func test(t *testing.T, failed bool) {
+	testutil.OnFailure(t, failed, func() { t.Fatal("failed") })
+}
+`
+	rewritten := assertRewrite(t, input, want, 1)
+	again, blocks, handwritten, err := rewriteSource("sample_test.go", rewritten)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocks != 0 {
+		t.Fatalf("second rewrite found %d blocks", blocks)
+	}
+	if string(again) != string(rewritten) {
+		t.Fatal("second rewrite changed the source")
+	}
+	if handwritten != 0 {
+		t.Fatalf("second rewrite found %d hand-written blocks", handwritten)
+	}
+}
+
+func TestRewriteSourceSkipsScopesAndCommentsItCannotPreserve(t *testing.T) {
+	t.Parallel()
+
+	input := `package sample
+import "testing"
+func test(t *testing.T, failed bool) {
+	if got := compute(); got != 0 {
+		t.Fatalf("got %d", got)
+	}
+	if failed {
+		// This explanation belongs to the failure.
+		t.Error("failed")
+	}
+	if failed {
+		t.Error("failed")
+	} else {
+		work()
+	}
+	if ready {
+		work()
+	} else if failed {
+		t.Fatal("failed")
+	}
+}
+`
+	assertRewrite(t, input, input, 0)
+}
+
+func assertRewrite(t *testing.T, input, want string, wantBlocks int) []byte {
+	t.Helper()
+	rewritten, blocks, handwritten, err := rewriteSource("sample_test.go", []byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocks != wantBlocks {
+		t.Fatalf("blocks = %d, want %d", blocks, wantBlocks)
+	}
+	if handwritten < blocks {
+		t.Fatalf("hand-written blocks = %d, want at least %d", handwritten, blocks)
+	}
+	wantFormatted := []byte(want)
+	if wantBlocks > 0 {
+		wantFormatted, err = format.Source(wantFormatted)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if string(rewritten) != string(wantFormatted) {
+		t.Fatalf("rewrite mismatch\ngot:\n%s\nwant:\n%s", rewritten, wantFormatted)
+	}
+	return rewritten
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/yuin/goldmark v1.8.4
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/tools v0.48.0
 	google.golang.org/protobuf v1.36.8
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -76,7 +77,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/tools v0.48.0 // indirect
 	golang.org/x/vuln v1.6.0 // indirect
 )
 

--- a/server/internal/daemon/execenv/codex_home_link_test.go
+++ b/server/internal/daemon/execenv/codex_home_link_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestEnsureSymlink_SkipsWhenSourceMissing(t *testing.T) {
@@ -40,12 +42,10 @@ func TestEnsureSymlink_ReplacesStaleRegularFile(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
-	}
-	if string(data) != "new" {
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read dst: %v", err) })
+	testassert.OnFailure(t, string(data) != "new", func() {
 		t.Errorf("dst content = %q, want %q (file should be re-linked/re-copied from src)", data, "new")
-	}
+	})
 }
 
 func TestEnsureSymlink_RefreshesAfterCopyFallbackThenSrcChange(t *testing.T) {
@@ -70,12 +70,8 @@ func TestEnsureSymlink_RefreshesAfterCopyFallbackThenSrcChange(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
-	}
-	if string(data) != `{"refresh_token":"v2"}` {
-		t.Errorf("dst content after refresh = %q, want v2 contents", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read dst: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"refresh_token":"v2"}`, func() { t.Errorf("dst content after refresh = %q, want v2 contents", data) })
 }
 
 func TestCreateDirLink(t *testing.T) {
@@ -93,12 +89,8 @@ func TestCreateDirLink(t *testing.T) {
 
 	// Should be able to read files through the link.
 	data, err := os.ReadFile(filepath.Join(dst, "test.txt"))
-	if err != nil {
-		t.Fatalf("read through link: %v", err)
-	}
-	if string(data) != "hello" {
-		t.Errorf("content = %q, want %q", data, "hello")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read through link: %v", err) })
+	testassert.OnFailure(t, string(data) != "hello", func() { t.Errorf("content = %q, want %q", data, "hello") })
 }
 
 func TestCreateFileLink(t *testing.T) {
@@ -114,12 +106,8 @@ func TestCreateFileLink(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read link: %v", err)
-	}
-	if string(data) != `{"key":"value"}` {
-		t.Errorf("content = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read link: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"key":"value"}`, func() { t.Errorf("content = %q", data) })
 }
 
 func TestCopyFile(t *testing.T) {
@@ -135,13 +123,9 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	data, _ := os.ReadFile(dst)
-	if string(data) != "content" {
-		t.Errorf("content = %q", data)
-	}
+	testassert.OnFailure(t, string(data) != "content", func() { t.Errorf("content = %q", data) })
 
 	// Verify it's a copy, not a symlink.
 	fi, _ := os.Lstat(dst)
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("expected regular file, not symlink")
-	}
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("expected regular file, not symlink") })
 }

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // seedFakeRollout writes a fake Codex rollout for sessionID under
@@ -61,19 +63,11 @@ func TestPrepareCodexSessionsDir_FreshCreatesEmptyLocalDir(t *testing.T) {
 
 	sessions := filepath.Join(codexHome, "sessions")
 	fi, err := os.Lstat(sessions)
-	if err != nil {
-		t.Fatalf("sessions not created: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("fresh sessions must be a real dir, not a symlink")
-	}
-	if !fi.IsDir() {
-		t.Error("fresh sessions must be a directory")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions not created: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("fresh sessions must be a real dir, not a symlink") })
+	testassert.OnFailure(t, !fi.IsDir(), func() { t.Error("fresh sessions must be a directory") })
 	entries, _ := os.ReadDir(sessions)
-	if len(entries) != 0 {
-		t.Errorf("fresh sessions must be empty, has %d entries", len(entries))
-	}
+	testassert.OnFailure(t, len(entries) != 0, func() { t.Errorf("fresh sessions must be empty, has %d entries", len(entries)) })
 }
 
 func TestPrepareCodexSessionsDir_RealDirIsAuthoritative(t *testing.T) {
@@ -98,9 +92,7 @@ func TestPrepareCodexSessionsDir_RealDirIsAuthoritative(t *testing.T) {
 		t.Errorf("task-local rollout must be preserved, got err=%v data=%q", err, data)
 	}
 	fi, _ := os.Lstat(filepath.Join(codexHome, "sessions"))
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("authoritative sessions must remain a real dir")
-	}
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("authoritative sessions must remain a real dir") })
 }
 
 func TestPrepareCodexSessionsDir_MigratesLegacySymlinkNoResume(t *testing.T) {
@@ -126,17 +118,13 @@ func TestPrepareCodexSessionsDir_MigratesLegacySymlinkNoResume(t *testing.T) {
 
 	sessions := filepath.Join(codexHome, "sessions")
 	fi, err := os.Lstat(sessions)
-	if err != nil {
-		t.Fatalf("sessions missing after migration: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("legacy symlink must be replaced with a real dir")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions missing after migration: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("legacy symlink must be replaced with a real dir") })
 	// No resume requested -> none of the global history is pulled in.
 	entries, _ := os.ReadDir(sessions)
-	if len(entries) != 0 {
+	testassert.OnFailure(t, len(entries) != 0, func() {
 		t.Errorf("non-resume migration must yield an empty sessions dir, has %d entries", len(entries))
-	}
+	})
 	// The global history itself must be left intact.
 	if _, err := os.Stat(filepath.Join(sharedSessions, "2026", "07", "13", "rollout-2026-07-13T00-00-00-other-session-a.jsonl")); err != nil {
 		t.Errorf("shared history must not be deleted: %v", err)
@@ -163,9 +151,7 @@ func TestPrepareCodexSessionsDir_MigrateWithResumeRoutesThroughStore(t *testing.
 
 	key := filepath.Join("agent-1", "issue-1")
 	err := prepareCodexSessionsDir(codexHome, sharedHome, CodexHomeOptions{ResumeSessionID: resumeID, SessionStoreKey: key}, testLogger())
-	if err != nil {
-		t.Fatalf("prepareCodexSessionsDir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCodexSessionsDir: %v", err) })
 
 	// sessions/ is now a directory link to the per-issue store on the shared
 	// volume — the cross-volume-safe exposure (a same-volume hard link into the
@@ -175,15 +161,11 @@ func TestPrepareCodexSessionsDir_MigrateWithResumeRoutesThroughStore(t *testing.
 
 	// The resume rollout is present in the task home (through the link) and
 	// materialised as a zero-copy hard link from the shared history.
-	if !CodexResumeRolloutPresent(codexHome, resumeID) {
-		t.Fatal("resume rollout must be visible in the task CODEX_HOME after migration")
-	}
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(codexHome, resumeID), func() { t.Fatal("resume rollout must be visible in the task CODEX_HOME after migration") })
 	stored := filepath.Join(codexSessionStoreDir(sharedHome, key), "2026", "07", "13", filepath.Base(resumeSrc))
 	assertZeroCopyLink(t, resumeSrc, stored)
 	// The unrelated session must NOT be pulled in.
-	if CodexResumeRolloutPresent(codexHome, "unrelated-session") {
-		t.Error("unrelated shared history must not be exposed to the task")
-	}
+	testassert.OnFailure(t, CodexResumeRolloutPresent(codexHome, "unrelated-session"), func() { t.Error("unrelated shared history must not be exposed to the task") })
 	// Stale state dropped so Codex rebuilds from the scoped store.
 	assertAbsent(t, filepath.Join(codexHome, "state_5.sqlite"))
 }
@@ -316,16 +298,10 @@ func TestCodexResumeRolloutPresent(t *testing.T) {
 	seedRolloutAt(t, filepath.Join(sessions, "rollout-2026-07-13T00-00-00-flat.jsonl.zst"), 8)
 
 	for _, id := range []string{"nested", "flat"} {
-		if !CodexResumeRolloutPresent(codexHome, id) {
-			t.Errorf("expected rollout %q to be found", id)
-		}
+		testassert.OnFailure(t, !CodexResumeRolloutPresent(codexHome, id), func() { t.Errorf("expected rollout %q to be found", id) })
 	}
-	if CodexResumeRolloutPresent(codexHome, "absent") {
-		t.Error("absent session must not be reported present")
-	}
-	if CodexResumeRolloutPresent("", "nested") || CodexResumeRolloutPresent(codexHome, "") {
-		t.Error("empty codexHome/sessionID must be reported absent")
-	}
+	testassert.OnFailure(t, CodexResumeRolloutPresent(codexHome, "absent"), func() { t.Error("absent session must not be reported present") })
+	testassert.OnFailure(t, CodexResumeRolloutPresent("", "nested") || CodexResumeRolloutPresent(codexHome, ""), func() { t.Error("empty codexHome/sessionID must be reported absent") })
 }
 
 func TestPrepareCodexSessionsDir_LocalDirectoryUsesPerIssueStore(t *testing.T) {
@@ -351,12 +327,10 @@ func TestPrepareCodexSessionsDir_LocalDirectoryUsesPerIssueStore(t *testing.T) {
 	// The store holds only this issue's history — the machine's global rollouts
 	// are invisible, so `initialize` never enumerates them (the MUL-4424 stall).
 	entries, _ := os.ReadDir(sessions)
-	if len(entries) != 0 {
+	testassert.OnFailure(t, len(entries) != 0, func() {
 		t.Errorf("per-issue store must start empty, has %d entries (whole-history leak?)", len(entries))
-	}
-	if CodexResumeRolloutPresent(codexHome, "other-a") {
-		t.Error("machine-global history must not be visible to a local_directory task")
-	}
+	})
+	testassert.OnFailure(t, CodexResumeRolloutPresent(codexHome, "other-a"), func() { t.Error("machine-global history must not be visible to a local_directory task") })
 }
 
 // With no stable per-issue key (e.g. a non-issue task), a local_directory task
@@ -377,15 +351,9 @@ func TestPrepareCodexSessionsDir_LocalDirectoryNoKeyFallsBackToEmptyDir(t *testi
 	}
 	sessions := filepath.Join(codexHome, "sessions")
 	fi, err := os.Lstat(sessions)
-	if err != nil {
-		t.Fatalf("sessions not created: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("no-key local_directory must not link the shared history")
-	}
-	if CodexResumeRolloutPresent(codexHome, "other") {
-		t.Error("machine-global history must not be visible")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions not created: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("no-key local_directory must not link the shared history") })
+	testassert.OnFailure(t, CodexResumeRolloutPresent(codexHome, "other"), func() { t.Error("machine-global history must not be visible") })
 }
 
 // Two consecutive local_directory tasks share one project dir but get a fresh
@@ -421,9 +389,9 @@ func TestPrepareCodexSessionsDir_LocalDirectoryResumeAcrossTaskIDs(t *testing.T)
 
 	// The round-2 home must resolve the round-1 rollout through the shared store —
 	// otherwise the daemon would silently drop the conversation.
-	if !CodexResumeRolloutPresent(home2, sessionID) {
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(home2, sessionID), func() {
 		t.Fatal("round-2 local_directory task cannot see round-1 rollout — context would be silently lost")
-	}
+	})
 }
 
 // A managed home migrated on a prior reuse already links the per-issue store; a
@@ -455,9 +423,7 @@ func TestPrepareCodexSessionsDir_ReusedStoreLinkIsAuthoritative(t *testing.T) {
 	}
 
 	assertSessionsLinkedToStore(t, filepath.Join(codexHome, "sessions"), storeDir)
-	if !CodexResumeRolloutPresent(codexHome, sessionID) {
-		t.Error("existing store rollout must remain resumable after reuse")
-	}
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(codexHome, sessionID), func() { t.Error("existing store rollout must remain resumable after reuse") })
 }
 
 // PruneCodexSessionStores must reclaim per-issue stores idle past retention,
@@ -483,12 +449,8 @@ func TestPruneCodexSessionStores(t *testing.T) {
 	chtimesTree(t, staleStore, now.Add(-30*24*time.Hour))
 
 	removed, bytes := PruneCodexSessionStores("", retention, now, nil, testLogger())
-	if removed != 1 {
-		t.Fatalf("removed = %d, want 1 (only the store idle past retention)", removed)
-	}
-	if bytes <= 0 {
-		t.Errorf("bytesFreed = %d, want > 0", bytes)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("removed = %d, want 1 (only the store idle past retention)", removed) })
+	testassert.OnFailure(t, bytes <= 0, func() { t.Errorf("bytesFreed = %d, want > 0", bytes) })
 	// The stale store is gone; the fresh one and the other agent's store survive
 	// (per-issue isolation), and agent-1 stays because issue-fresh remains.
 	assertAbsent(t, staleStore)
@@ -525,18 +487,14 @@ func TestPruneCodexSessionStores_ReopenedStoreNotReclaimed(t *testing.T) {
 	if err := linkCodexSessionsToStore(filepath.Join(codexHome, "sessions"), storeDir, filepath.Join(home, "sessions"), sessionID, testLogger()); err != nil {
 		t.Fatalf("linkCodexSessionsToStore: %v", err)
 	}
-	if !CodexResumeRolloutPresent(codexHome, sessionID) {
-		t.Fatal("resume rollout must be visible after remount")
-	}
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(codexHome, sessionID), func() { t.Fatal("resume rollout must be visible after remount") })
 
 	// A GC cycle now — before the resumed turn writes anything — must keep it.
 	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 (a just-reopened store must survive GC)", removed)
 	}
 	assertPresent(t, storeDir)
-	if !CodexResumeRolloutPresent(codexHome, sessionID) {
-		t.Error("resume rollout must still be present after GC")
-	}
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(codexHome, sessionID), func() { t.Error("resume rollout must still be present after GC") })
 }
 
 // TestPruneCodexSessionStores_ActiveStoreNotReclaimed proves the reservation
@@ -616,9 +574,7 @@ func TestCodexSessionStoreNamespaceInjective(t *testing.T) {
 		}
 	}
 	// Deterministic for a fixed profile.
-	if codexSessionStoreNamespace("staging") != codexSessionStoreNamespace("staging") {
-		t.Error("namespace must be deterministic for a fixed profile")
-	}
+	testassert.OnFailure(t, codexSessionStoreNamespace("staging") != codexSessionStoreNamespace("staging"), func() { t.Error("namespace must be deterministic for a fixed profile") })
 }
 
 // TestCodexSessionStoreNamespace_FitsDirectorySegment guards Elon's round-8
@@ -631,9 +587,9 @@ func TestCodexSessionStoreNamespace_FitsDirectorySegment(t *testing.T) {
 	base := t.TempDir()
 	for _, profile := range []string{"", "staging", strings.Repeat("a", 127), strings.Repeat("z", 255)} {
 		ns := codexSessionStoreNamespace(profile)
-		if len(ns) > 255 {
+		testassert.OnFailure(t, len(ns) > 255, func() {
 			t.Errorf("profile (len %d) -> namespace (len %d) exceeds the 255-byte single-segment limit", len(profile), len(ns))
-		}
+		})
 		if err := os.MkdirAll(filepath.Join(base, ns), 0o755); err != nil {
 			t.Errorf("namespace for profile (len %d) could not be created: %v", len(profile), err)
 		}
@@ -698,9 +654,7 @@ func chtimesTree(t *testing.T, root string, ts time.Time) {
 		}
 		return os.Chtimes(path, ts, ts)
 	})
-	if err != nil {
-		t.Fatalf("chtimes tree %s: %v", root, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("chtimes tree %s: %v", root, err) })
 }
 
 func seedRolloutAt(t *testing.T, path string, size int) string {
@@ -724,28 +678,18 @@ func seedRolloutAt(t *testing.T, path string, size int) string {
 func assertSessionsLinkedToStore(t *testing.T, sessions, storeDir string) {
 	t.Helper()
 	fi, err := os.Lstat(sessions)
-	if err != nil {
-		t.Fatalf("sessions link missing: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions link missing: %v", err) })
 	if runtime.GOOS != "windows" {
-		if fi.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("sessions must link the per-issue store, got mode %v", fi.Mode())
-		}
+		testassert.OnFailure(t, fi.Mode()&os.ModeSymlink == 0, func() { t.Fatalf("sessions must link the per-issue store, got mode %v", fi.Mode()) })
 		if target, _ := os.Readlink(sessions); filepath.Clean(target) != filepath.Clean(storeDir) {
 			t.Errorf("sessions link target = %q, want store %q", target, storeDir)
 		}
 	}
 	realSessions, err := filepath.EvalSymlinks(sessions)
-	if err != nil {
-		t.Fatalf("eval sessions link: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("eval sessions link: %v", err) })
 	realStore, err := filepath.EvalSymlinks(storeDir)
-	if err != nil {
-		t.Fatalf("eval store: %v", err)
-	}
-	if realSessions != realStore {
-		t.Errorf("sessions resolves to %q, want store %q", realSessions, realStore)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("eval store: %v", err) })
+	testassert.OnFailure(t, realSessions != realStore, func() { t.Errorf("sessions resolves to %q, want store %q", realSessions, realStore) })
 }
 
 // assertZeroCopyLink verifies dst resolves to the same inode as src — a hard
@@ -753,16 +697,10 @@ func assertSessionsLinkedToStore(t *testing.T, sessions, storeDir string) {
 func assertZeroCopyLink(t *testing.T, src, dst string) {
 	t.Helper()
 	si, err := os.Stat(src)
-	if err != nil {
-		t.Fatalf("stat src %s: %v", src, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat src %s: %v", src, err) })
 	di, err := os.Stat(dst)
-	if err != nil {
-		t.Fatalf("stat dst %s: %v", dst, err)
-	}
-	if !os.SameFile(si, di) {
-		t.Errorf("%s is a copy of %s, expected a zero-copy hard/sym link", dst, src)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat dst %s: %v", dst, err) })
+	testassert.OnFailure(t, !os.SameFile(si, di), func() { t.Errorf("%s is a copy of %s, expected a zero-copy hard/sym link", dst, src) })
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/server/internal/daemon/execenv/codex_memory_test.go
+++ b/server/internal/daemon/execenv/codex_memory_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // requireMemoryDisabled asserts that the parsed config has Codex memory
@@ -14,35 +16,21 @@ func requireMemoryDisabled(t *testing.T, parsed map[string]any) {
 	t.Helper()
 
 	features, ok := parsed["features"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected `features` table in parsed config, got: %#v", parsed["features"])
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected `features` table in parsed config, got: %#v", parsed["features"]) })
 	v, ok := features["memories"].(bool)
-	if !ok {
-		t.Fatalf("expected features.memories to be a bool, got: %#v", features["memories"])
-	}
-	if v {
-		t.Errorf("expected features.memories = false, got true")
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected features.memories to be a bool, got: %#v", features["memories"]) })
+	testassert.OnFailure(t, v, func() { t.Errorf("expected features.memories = false, got true") })
 
 	memories, ok := parsed["memories"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected `memories` table in parsed config, got: %#v", parsed["memories"])
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected `memories` table in parsed config, got: %#v", parsed["memories"]) })
 	gen, ok := memories["generate_memories"].(bool)
-	if !ok {
+	testassert.OnFailure(t, !ok, func() {
 		t.Fatalf("expected memories.generate_memories to be a bool, got: %#v", memories["generate_memories"])
-	}
-	if gen {
-		t.Errorf("expected memories.generate_memories = false, got true")
-	}
+	})
+	testassert.OnFailure(t, gen, func() { t.Errorf("expected memories.generate_memories = false, got true") })
 	use, ok := memories["use_memories"].(bool)
-	if !ok {
-		t.Fatalf("expected memories.use_memories to be a bool, got: %#v", memories["use_memories"])
-	}
-	if use {
-		t.Errorf("expected memories.use_memories = false, got true")
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected memories.use_memories to be a bool, got: %#v", memories["use_memories"]) })
+	testassert.OnFailure(t, use, func() { t.Errorf("expected memories.use_memories = false, got true") })
 }
 
 func TestStripUserMemoryDirectives(t *testing.T) {
@@ -150,9 +138,9 @@ model = "o3"
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := stripUserMemoryDirectives(tt.in)
-			if got != tt.want {
+			testassert.OnFailure(t, got != tt.want, func() {
 				t.Errorf("stripUserMemoryDirectives mismatch\n--- got ---\n%s\n--- want ---\n%s", got, tt.want)
-			}
+			})
 		})
 	}
 }
@@ -168,9 +156,7 @@ func TestEnsureCodexMemoryConfigEmptyFile(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read result: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read result: %v", err) })
 	got := string(data)
 	for _, want := range []string{
 		"features.memories = false",
@@ -181,9 +167,7 @@ func TestEnsureCodexMemoryConfigEmptyFile(t *testing.T) {
 		multicaMemoryConfigBeginMarker,
 		multicaMemoryConfigEndMarker,
 	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("expected %q in output, got:\n%s", want, got)
-		}
+		testassert.OnFailure(t, !strings.Contains(got, want), func() { t.Errorf("expected %q in output, got:\n%s", want, got) })
 	}
 	requireMemoryDisabled(t, parseTOML(t, got))
 }
@@ -216,13 +200,9 @@ model = "o3"
 		"memories.generate_memories = true",
 		"memories.use_memories = true",
 	} {
-		if strings.Contains(got, banned) {
-			t.Errorf("expected user %q stripped, got:\n%s", banned, got)
-		}
+		testassert.OnFailure(t, strings.Contains(got, banned), func() { t.Errorf("expected user %q stripped, got:\n%s", banned, got) })
 	}
-	if !strings.Contains(got, `[profiles.default]`) || !strings.Contains(got, `model = "o3"`) {
-		t.Errorf("expected unrelated content preserved, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, `[profiles.default]`) || !strings.Contains(got, `model = "o3"`), func() { t.Errorf("expected unrelated content preserved, got:\n%s", got) })
 	requireMemoryDisabled(t, parseTOML(t, got))
 }
 
@@ -252,26 +232,16 @@ model = "o3"
 	// User's `memories = true` inside [features] must be gone.
 	// Managed override must be INSIDE [features], not as a root dotted key
 	// (which would redefine the table and break the strict TOML parser).
-	if strings.Contains(got, "memories = true") {
-		t.Errorf("expected user memories = true to be stripped, got:\n%s", got)
-	}
-	if strings.Contains(got, "features.memories = false") {
+	testassert.OnFailure(t, strings.Contains(got, "memories = true"), func() { t.Errorf("expected user memories = true to be stripped, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "features.memories = false"), func() {
 		t.Errorf("managed memory-feature block must NOT use root dotted-key form when [features] table exists (would redefine the table); got:\n%s", got)
-	}
-	if !strings.Contains(got, "[features]") {
-		t.Errorf("expected [features] header preserved, got:\n%s", got)
-	}
-	if !strings.Contains(got, "experimental_thinking = true") {
-		t.Errorf("expected sibling features.* keys preserved, got:\n%s", got)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(got, "[features]"), func() { t.Errorf("expected [features] header preserved, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "experimental_thinking = true"), func() { t.Errorf("expected sibling features.* keys preserved, got:\n%s", got) })
 
 	// memory-config side still root-form because no [memories] table existed.
-	if !strings.Contains(got, "memories.generate_memories = false") {
-		t.Errorf("expected memories.generate_memories = false at root, got:\n%s", got)
-	}
-	if !strings.Contains(got, "memories.use_memories = false") {
-		t.Errorf("expected memories.use_memories = false at root, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "memories.generate_memories = false"), func() { t.Errorf("expected memories.generate_memories = false at root, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "memories.use_memories = false"), func() { t.Errorf("expected memories.use_memories = false at root, got:\n%s", got) })
 
 	requireMemoryDisabled(t, parseTOML(t, got))
 }
@@ -300,23 +270,15 @@ model = "o3"
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
 
-	if strings.Contains(got, "generate_memories = true") {
-		t.Errorf("expected user generate_memories = true to be stripped, got:\n%s", got)
-	}
-	if strings.Contains(got, "use_memories = true") {
-		t.Errorf("expected user use_memories = true to be stripped, got:\n%s", got)
-	}
-	if strings.Contains(got, "memories.generate_memories = false") {
+	testassert.OnFailure(t, strings.Contains(got, "generate_memories = true"), func() { t.Errorf("expected user generate_memories = true to be stripped, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "use_memories = true"), func() { t.Errorf("expected user use_memories = true to be stripped, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "memories.generate_memories = false"), func() {
 		t.Errorf("managed memory-config block must NOT use root dotted-key form when [memories] table exists (would redefine the table); got:\n%s", got)
-	}
-	if !strings.Contains(got, `storage_path = "/somewhere"`) {
-		t.Errorf("expected sibling memories.* keys preserved, got:\n%s", got)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(got, `storage_path = "/somewhere"`), func() { t.Errorf("expected sibling memories.* keys preserved, got:\n%s", got) })
 
 	// memory-feature side still root-form because no [features] table existed.
-	if !strings.Contains(got, "features.memories = false") {
-		t.Errorf("expected features.memories = false at root, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "features.memories = false"), func() { t.Errorf("expected features.memories = false at root, got:\n%s", got) })
 
 	requireMemoryDisabled(t, parseTOML(t, got))
 }
@@ -347,20 +309,16 @@ storage_path = "/somewhere"
 	got := string(data)
 
 	// No root dotted-key forms when both tables exist.
-	if strings.Contains(got, "features.memories = false") {
+	testassert.OnFailure(t, strings.Contains(got, "features.memories = false"), func() {
 		t.Errorf("managed block must NOT use root dotted-key form when [features] table exists; got:\n%s", got)
-	}
-	if strings.Contains(got, "memories.generate_memories = false") {
+	})
+	testassert.OnFailure(t, strings.Contains(got, "memories.generate_memories = false"), func() {
 		t.Errorf("managed block must NOT use root dotted-key form when [memories] table exists; got:\n%s", got)
-	}
+	})
 
 	// User content preserved.
-	if !strings.Contains(got, "experimental_thinking = true") {
-		t.Errorf("expected experimental_thinking preserved, got:\n%s", got)
-	}
-	if !strings.Contains(got, `storage_path = "/somewhere"`) {
-		t.Errorf("expected storage_path preserved, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "experimental_thinking = true"), func() { t.Errorf("expected experimental_thinking preserved, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, `storage_path = "/somewhere"`), func() { t.Errorf("expected storage_path preserved, got:\n%s", got) })
 
 	requireMemoryDisabled(t, parseTOML(t, got))
 }
@@ -386,9 +344,7 @@ thinking = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if !strings.Contains(got, "features.memories = false") {
-		t.Errorf("expected root dotted-key form when only sub-tables exist, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "features.memories = false"), func() { t.Errorf("expected root dotted-key form when only sub-tables exist, got:\n%s", got) })
 
 	parsed := parseTOML(t, got)
 	requireMemoryDisabled(t, parsed)
@@ -447,12 +403,8 @@ use_memories = true
 			second, _ := os.ReadFile(configPath)
 			infoSecond, _ := os.Stat(configPath)
 
-			if string(first) != string(second) {
-				t.Errorf("expected idempotent rewrite\n--- first ---\n%s\n--- second ---\n%s", first, second)
-			}
-			if !infoSecond.ModTime().Equal(infoFirst.ModTime()) {
-				t.Errorf("expected no rewrite on second pass (file was touched)")
-			}
+			testassert.OnFailure(t, string(first) != string(second), func() { t.Errorf("expected idempotent rewrite\n--- first ---\n%s\n--- second ---\n%s", first, second) })
+			testassert.OnFailure(t, !infoSecond.ModTime().Equal(infoFirst.ModTime()), func() { t.Errorf("expected no rewrite on second pass (file was touched)") })
 			requireMemoryDisabled(t, parseTOML(t, string(second)))
 		})
 	}
@@ -477,18 +429,16 @@ features.memories = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if got != original {
+	testassert.OnFailure(t, got != original, func() {
 		t.Errorf("expected file untouched when escape hatch set\n--- got ---\n%s\n--- want ---\n%s", got, original)
-	}
+	})
 }
 
 func TestCodexMemoryEnabledTruthy(t *testing.T) {
 	for _, v := range []string{"1", "true", "TRUE", "yes", "On"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(MulticaCodexMemoryEnv, v)
-			if !codexMemoryEnabled() {
-				t.Errorf("expected %q to be truthy", v)
-			}
+			testassert.OnFailure(t, !codexMemoryEnabled(), func() { t.Errorf("expected %q to be truthy", v) })
 		})
 	}
 }
@@ -497,9 +447,7 @@ func TestCodexMemoryEnabledFalsy(t *testing.T) {
 	for _, v := range []string{"", "0", "false", "no", "off", "anything else"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(MulticaCodexMemoryEnv, v)
-			if codexMemoryEnabled() {
-				t.Errorf("expected %q to be falsy", v)
-			}
+			testassert.OnFailure(t, codexMemoryEnabled(), func() { t.Errorf("expected %q to be falsy", v) })
 		})
 	}
 }
@@ -536,16 +484,10 @@ features.multi_agent = true
 		multicaMemoryFeatureBeginMarker,
 		multicaMemoryConfigBeginMarker,
 	} {
-		if !strings.Contains(got, marker) {
-			t.Errorf("expected marker %q in combined output, got:\n%s", marker, got)
-		}
+		testassert.OnFailure(t, !strings.Contains(got, marker), func() { t.Errorf("expected marker %q in combined output, got:\n%s", marker, got) })
 	}
-	if strings.Contains(got, "features.memories = true") {
-		t.Errorf("expected user features.memories = true stripped, got:\n%s", got)
-	}
-	if strings.Contains(got, "features.multi_agent = true") {
-		t.Errorf("expected user features.multi_agent = true stripped, got:\n%s", got)
-	}
+	testassert.OnFailure(t, strings.Contains(got, "features.memories = true"), func() { t.Errorf("expected user features.memories = true stripped, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "features.multi_agent = true"), func() { t.Errorf("expected user features.multi_agent = true stripped, got:\n%s", got) })
 
 	// File must parse as valid TOML with everything disabled.
 	parsed := parseTOML(t, got)
@@ -563,9 +505,9 @@ features.multi_agent = true
 		t.Fatalf("ensureCodexMemoryConfig (rerun) failed: %v", err)
 	}
 	dataAfter, _ := os.ReadFile(configPath)
-	if string(dataAfter) != got {
+	testassert.OnFailure(t, string(dataAfter) != got, func() {
 		t.Errorf("expected idempotent combined rewrite\n--- first ---\n%s\n--- second ---\n%s", got, dataAfter)
-	}
+	})
 }
 
 // Regression: when the user's config has a `[features]` table, naively

--- a/server/internal/daemon/execenv/codex_multi_agent_test.go
+++ b/server/internal/daemon/execenv/codex_multi_agent_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -26,16 +27,10 @@ func parseTOML(t *testing.T, content string) map[string]any {
 func requireMultiAgentDisabled(t *testing.T, parsed map[string]any) {
 	t.Helper()
 	features, ok := parsed["features"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected `features` table in parsed config, got: %#v", parsed["features"])
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected `features` table in parsed config, got: %#v", parsed["features"]) })
 	v, ok := features["multi_agent"].(bool)
-	if !ok {
-		t.Fatalf("expected features.multi_agent to be a bool, got: %#v", features["multi_agent"])
-	}
-	if v {
-		t.Errorf("expected features.multi_agent = false, got true")
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected features.multi_agent to be a bool, got: %#v", features["multi_agent"]) })
+	testassert.OnFailure(t, v, func() { t.Errorf("expected features.multi_agent = false, got true") })
 }
 
 func TestStripUserMultiAgentDirectives(t *testing.T) {
@@ -160,9 +155,9 @@ something_else = "keep"
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := stripUserMultiAgentDirectives(tt.in)
-			if got != tt.want {
+			testassert.OnFailure(t, got != tt.want, func() {
 				t.Errorf("stripUserMultiAgentDirectives mismatch\n--- got ---\n%s\n--- want ---\n%s", got, tt.want)
-			}
+			})
 		})
 	}
 }
@@ -178,19 +173,11 @@ func TestEnsureCodexMultiAgentConfigEmptyFile(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read result: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read result: %v", err) })
 	got := string(data)
-	if !strings.Contains(got, "features.multi_agent = false") {
-		t.Errorf("expected managed block to set features.multi_agent = false at root, got:\n%s", got)
-	}
-	if !strings.Contains(got, multicaMultiAgentBeginMarker) {
-		t.Errorf("expected begin marker, got:\n%s", got)
-	}
-	if !strings.Contains(got, multicaMultiAgentEndMarker) {
-		t.Errorf("expected end marker, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "features.multi_agent = false"), func() { t.Errorf("expected managed block to set features.multi_agent = false at root, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, multicaMultiAgentBeginMarker), func() { t.Errorf("expected begin marker, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, multicaMultiAgentEndMarker), func() { t.Errorf("expected end marker, got:\n%s", got) })
 	requireMultiAgentDisabled(t, parseTOML(t, got))
 }
 
@@ -215,15 +202,9 @@ model = "o3"
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if strings.Contains(got, "features.multi_agent = true") {
-		t.Errorf("expected user features.multi_agent = true to be stripped, got:\n%s", got)
-	}
-	if !strings.Contains(got, "features.multi_agent = false") {
-		t.Errorf("expected managed features.multi_agent = false at root, got:\n%s", got)
-	}
-	if !strings.Contains(got, `[profiles.default]`) || !strings.Contains(got, `model = "o3"`) {
-		t.Errorf("expected unrelated content preserved, got:\n%s", got)
-	}
+	testassert.OnFailure(t, strings.Contains(got, "features.multi_agent = true"), func() { t.Errorf("expected user features.multi_agent = true to be stripped, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "features.multi_agent = false"), func() { t.Errorf("expected managed features.multi_agent = false at root, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, `[profiles.default]`) || !strings.Contains(got, `model = "o3"`), func() { t.Errorf("expected unrelated content preserved, got:\n%s", got) })
 	requireMultiAgentDisabled(t, parseTOML(t, got))
 }
 
@@ -245,9 +226,7 @@ features . multi_agent = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if strings.Contains(got, "features . multi_agent = true") {
-		t.Errorf("expected user features . multi_agent = true to be stripped, got:\n%s", got)
-	}
+	testassert.OnFailure(t, strings.Contains(got, "features . multi_agent = true"), func() { t.Errorf("expected user features . multi_agent = true to be stripped, got:\n%s", got) })
 	requireMultiAgentDisabled(t, parseTOML(t, got))
 }
 
@@ -277,18 +256,12 @@ model = "o3"
 	// User's `multi_agent = true` must be gone, our managed `multi_agent = false`
 	// must be inside the [features] table (NOT at the root as a dotted key,
 	// which would redefine the table and break the strict TOML parser).
-	if strings.Contains(got, "multi_agent = true") {
-		t.Errorf("expected user multi_agent = true to be stripped, got:\n%s", got)
-	}
-	if strings.Contains(got, "features.multi_agent = false") {
+	testassert.OnFailure(t, strings.Contains(got, "multi_agent = true"), func() { t.Errorf("expected user multi_agent = true to be stripped, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "features.multi_agent = false"), func() {
 		t.Errorf("managed block must NOT use root dotted-key form when [features] table exists (would redefine the table); got:\n%s", got)
-	}
-	if !strings.Contains(got, "[features]") {
-		t.Errorf("expected [features] header preserved, got:\n%s", got)
-	}
-	if !strings.Contains(got, "experimental_thinking = true") {
-		t.Errorf("expected sibling features.* keys preserved, got:\n%s", got)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(got, "[features]"), func() { t.Errorf("expected [features] header preserved, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "experimental_thinking = true"), func() { t.Errorf("expected sibling features.* keys preserved, got:\n%s", got) })
 
 	// Output must parse as valid TOML and have features.multi_agent = false.
 	requireMultiAgentDisabled(t, parseTOML(t, got))
@@ -323,12 +296,10 @@ experimental_thinking = true
 
 			data, _ := os.ReadFile(configPath)
 			got := string(data)
-			if strings.Contains(got, "features.multi_agent = false") {
+			testassert.OnFailure(t, strings.Contains(got, "features.multi_agent = false"), func() {
 				t.Errorf("managed block must NOT use root dotted-key form when [features] table exists; got:\n%s", got)
-			}
-			if strings.Contains(got, "multi_agent = true") {
-				t.Errorf("expected user multi_agent = true to be stripped, got:\n%s", got)
-			}
+			})
+			testassert.OnFailure(t, strings.Contains(got, "multi_agent = true"), func() { t.Errorf("expected user multi_agent = true to be stripped, got:\n%s", got) })
 
 			parsed := parseTOML(t, got)
 			requireMultiAgentDisabled(t, parsed)
@@ -380,9 +351,7 @@ thinking = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if !strings.Contains(got, "features.multi_agent = false") {
-		t.Errorf("expected root dotted-key form when only sub-tables exist, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "features.multi_agent = false"), func() { t.Errorf("expected root dotted-key form when only sub-tables exist, got:\n%s", got) })
 
 	parsed := parseTOML(t, got)
 	requireMultiAgentDisabled(t, parsed)
@@ -432,12 +401,8 @@ model = "o3"
 			second, _ := os.ReadFile(configPath)
 			infoSecond, _ := os.Stat(configPath)
 
-			if string(first) != string(second) {
-				t.Errorf("expected idempotent rewrite\n--- first ---\n%s\n--- second ---\n%s", first, second)
-			}
-			if !infoSecond.ModTime().Equal(infoFirst.ModTime()) {
-				t.Errorf("expected no rewrite on second pass (file was touched)")
-			}
+			testassert.OnFailure(t, string(first) != string(second), func() { t.Errorf("expected idempotent rewrite\n--- first ---\n%s\n--- second ---\n%s", first, second) })
+			testassert.OnFailure(t, !infoSecond.ModTime().Equal(infoFirst.ModTime()), func() { t.Errorf("expected no rewrite on second pass (file was touched)") })
 			// Final output must parse as valid TOML.
 			requireMultiAgentDisabled(t, parseTOML(t, string(second)))
 		})
@@ -463,18 +428,16 @@ features.multi_agent = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if got != original {
+	testassert.OnFailure(t, got != original, func() {
 		t.Errorf("expected file untouched when escape hatch set\n--- got ---\n%s\n--- want ---\n%s", got, original)
-	}
+	})
 }
 
 func TestCodexMultiAgentEnabledTruthy(t *testing.T) {
 	for _, v := range []string{"1", "true", "TRUE", "yes", "On"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(MulticaCodexMultiAgentEnv, v)
-			if !codexMultiAgentEnabled() {
-				t.Errorf("expected %q to be truthy", v)
-			}
+			testassert.OnFailure(t, !codexMultiAgentEnabled(), func() { t.Errorf("expected %q to be truthy", v) })
 		})
 	}
 }
@@ -483,9 +446,7 @@ func TestCodexMultiAgentEnabledFalsy(t *testing.T) {
 	for _, v := range []string{"", "0", "false", "no", "off", "anything else"} {
 		t.Run(v, func(t *testing.T) {
 			t.Setenv(MulticaCodexMultiAgentEnv, v)
-			if codexMultiAgentEnabled() {
-				t.Errorf("expected %q to be falsy", v)
-			}
+			testassert.OnFailure(t, codexMultiAgentEnabled(), func() { t.Errorf("expected %q to be falsy", v) })
 		})
 	}
 }
@@ -512,15 +473,9 @@ features.multi_agent = true
 
 	data, _ := os.ReadFile(configPath)
 	got := string(data)
-	if !strings.Contains(got, multicaManagedBeginMarker) {
-		t.Errorf("expected sandbox managed block, got:\n%s", got)
-	}
-	if !strings.Contains(got, multicaMultiAgentBeginMarker) {
-		t.Errorf("expected multi-agent managed block, got:\n%s", got)
-	}
-	if strings.Contains(got, "features.multi_agent = true") {
-		t.Errorf("expected user features.multi_agent = true to be stripped, got:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, multicaManagedBeginMarker), func() { t.Errorf("expected sandbox managed block, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, multicaMultiAgentBeginMarker), func() { t.Errorf("expected multi-agent managed block, got:\n%s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "features.multi_agent = true"), func() { t.Errorf("expected user features.multi_agent = true to be stripped, got:\n%s", got) })
 
 	// File must parse as valid TOML and have multi_agent disabled.
 	requireMultiAgentDisabled(t, parseTOML(t, got))
@@ -533,9 +488,9 @@ features.multi_agent = true
 		t.Fatalf("ensureCodexMultiAgentConfig (rerun) failed: %v", err)
 	}
 	dataAfter, _ := os.ReadFile(configPath)
-	if string(dataAfter) != got {
+	testassert.OnFailure(t, string(dataAfter) != got, func() {
 		t.Errorf("expected idempotent combined rewrite\n--- first ---\n%s\n--- second ---\n%s", got, dataAfter)
-	}
+	})
 }
 
 // Regression for PR #1845 review: when the user's config has a `[features]`

--- a/server/internal/daemon/execenv/codex_real_home_test.go
+++ b/server/internal/daemon/execenv/codex_real_home_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Codex tasks keep the daemon user's real HOME on every platform. Earlier
@@ -34,9 +36,7 @@ func TestPrepareCodexKeepsRealHomeAndScopesOnlyCodexHome(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "real-home-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if _, err := os.Lstat(filepath.Join(env.RootDir, legacyTaskHomeDirName)); !os.IsNotExist(err) {
@@ -73,9 +73,7 @@ func TestPrepareCodexLocalDirectoryChatKeepsRolloutAcrossTaskIDs(t *testing.T) {
 		LocalWorkDir:   localWorkDir,
 		Task:           task,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("first Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first Prepare failed: %v", err) })
 	sessionID := "019fe3de-56a2-7792-8913-ee53664dfa0e"
 	seedRolloutAt(t, filepath.Join(first.CodexHome, "sessions", "2026", "08", "09", "rollout-2026-08-09T09-13-47-"+sessionID+".jsonl"), 32)
 	if err := first.Cleanup(true); err != nil {
@@ -92,15 +90,11 @@ func TestPrepareCodexLocalDirectoryChatKeepsRolloutAcrossTaskIDs(t *testing.T) {
 		LocalWorkDir:   localWorkDir,
 		Task:           task,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("second Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("second Prepare failed: %v", err) })
 	defer second.Cleanup(true)
 
 	// Then: the prior rollout is visible, so the daemon can resume the chat.
-	if !CodexResumeRolloutPresent(second.CodexHome, sessionID) {
-		t.Fatal("follow-up direct chat cannot see the prior rollout; context would be dropped")
-	}
+	testassert.OnFailure(t, !CodexResumeRolloutPresent(second.CodexHome, sessionID), func() { t.Fatal("follow-up direct chat cannot see the prior rollout; context would be dropped") })
 }
 
 func TestCodexSessionStoreKeyUsesChatSessionIDWhenIssueAbsent(t *testing.T) {
@@ -116,15 +110,9 @@ func TestCodexSessionStoreKeyUsesChatSessionIDWhenIssueAbsent(t *testing.T) {
 	keyB := codexSessionStoreKey("", TaskContextForEnv{AgentID: agentID, ChatSessionID: chatB})
 
 	// Then: the key is stable for one chat and isolated from another chat.
-	if keyA == "" {
-		t.Fatal("direct chat must have a persistent Codex session-store key")
-	}
-	if keyA != keyAAgain {
-		t.Fatalf("same chat produced unstable keys: %q and %q", keyA, keyAAgain)
-	}
-	if keyA == keyB {
-		t.Fatalf("different chats share one Codex session-store key: %q", keyA)
-	}
+	testassert.OnFailure(t, keyA == "", func() { t.Fatal("direct chat must have a persistent Codex session-store key") })
+	testassert.OnFailure(t, keyA != keyAAgain, func() { t.Fatalf("same chat produced unstable keys: %q and %q", keyA, keyAAgain) })
+	testassert.OnFailure(t, keyA == keyB, func() { t.Fatalf("different chats share one Codex session-store key: %q", keyA) })
 }
 
 // TestReuseCodexToleratesLegacyTaskHome covers an env root prepared by an older
@@ -144,9 +132,7 @@ func TestReuseCodexToleratesLegacyTaskHome(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "legacy-home-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// Simulate what an older daemon left behind.
@@ -163,10 +149,6 @@ func TestReuseCodexToleratesLegacyTaskHome(t *testing.T) {
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "legacy-home-test"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil on an env root carrying a legacy task home")
-	}
-	if reused.CodexHome == "" {
-		t.Error("expected CodexHome to be restored on reuse")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil on an env root carrying a legacy task home") })
+	testassert.OnFailure(t, reused.CodexHome == "", func() { t.Error("expected CodexHome to be restored on reuse") })
 }

--- a/server/internal/daemon/execenv/codex_shell_env_test.go
+++ b/server/internal/daemon/execenv/codex_shell_env_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -75,9 +76,7 @@ func TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames(t *testing.T) 
 		"SystemRoot",
 		"USERPROFILE",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(got, want), func() { t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want) })
 }
 
 func TestCodexShellEnvAllowlistOnlyAuthorizesExplicitCustomSecrets(t *testing.T) {
@@ -111,9 +110,7 @@ func TestCodexShellEnvAllowlistOnlyAuthorizesExplicitCustomSecrets(t *testing.T)
 		"x_secret",
 		"Y_KEY",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(got, want), func() { t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want) })
 }
 
 func TestEnsureCodexShellEnvPolicyConfigReplacesAllLegalPolicyForms(t *testing.T) {
@@ -215,34 +212,22 @@ foo = true
 				t.Fatalf("EnsureCodexShellEnvPolicyConfig: %v", err)
 			}
 			data, err := os.ReadFile(configPath)
-			if err != nil {
-				t.Fatalf("read config.toml: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read config.toml: %v", err) })
 			s := string(data)
 			assertValidToml(t, s)
 			for _, want := range tt.kept {
-				if !strings.Contains(s, want) {
-					t.Errorf("lost unrelated content %q:\n%s", want, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("lost unrelated content %q:\n%s", want, s) })
 			}
 			for _, unwanted := range tt.removed {
-				if strings.Contains(s, unwanted) {
-					t.Errorf("stale policy content %q remains:\n%s", unwanted, s)
-				}
+				testassert.OnFailure(t, strings.Contains(s, unwanted), func() { t.Errorf("stale policy content %q remains:\n%s", unwanted, s) })
 			}
-			if strings.Contains(s, `"MULTICA_*"`) {
-				t.Fatalf("managed policy must not use a MULTICA_* wildcard:\n%s", s)
-			}
+			testassert.OnFailure(t, strings.Contains(s, `"MULTICA_*"`), func() { t.Fatalf("managed policy must not use a MULTICA_* wildcard:\n%s", s) })
 			if n := strings.Count(s, "[shell_environment_policy]"); n != 1 {
 				t.Fatalf("expected exactly one managed policy table, got %d:\n%s", n, s)
 			}
 			policy := parsedShellEnvPolicy(t, s)
-			if policy.Inherit != "all" || !policy.IgnoreDefaultExcludes {
-				t.Fatalf("unexpected managed policy: %#v", policy)
-			}
-			if !reflect.DeepEqual(policy.IncludeOnly, includeOnly) {
-				t.Fatalf("include_only = %#v, want %#v", policy.IncludeOnly, includeOnly)
-			}
+			testassert.OnFailure(t, policy.Inherit != "all" || !policy.IgnoreDefaultExcludes, func() { t.Fatalf("unexpected managed policy: %#v", policy) })
+			testassert.OnFailure(t, !reflect.DeepEqual(policy.IncludeOnly, includeOnly), func() { t.Fatalf("include_only = %#v, want %#v", policy.IncludeOnly, includeOnly) })
 		})
 	}
 }
@@ -259,12 +244,8 @@ func TestEnsureCodexShellEnvPolicyConfigRejectsInvalidInputWithoutWriting(t *tes
 		t.Fatal("expected malformed input to fail")
 	}
 	got, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read config.toml: %v", err)
-	}
-	if !reflect.DeepEqual(got, existing) {
-		t.Fatalf("invalid input was modified: got %q, want %q", got, existing)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read config.toml: %v", err) })
+	testassert.OnFailure(t, !reflect.DeepEqual(got, existing), func() { t.Fatalf("invalid input was modified: got %q, want %q", got, existing) })
 }
 
 func TestEnsureCodexShellEnvPolicyConfigIsIdempotent(t *testing.T) {
@@ -279,9 +260,7 @@ func TestEnsureCodexShellEnvPolicyConfigIsIdempotent(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read config.toml: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read config.toml: %v", err) })
 	s := string(data)
 	assertValidToml(t, s)
 	if n := strings.Count(s, multicaShellEnvBeginMarker); n != 1 {

--- a/server/internal/daemon/execenv/codex_skill_strip_test.go
+++ b/server/internal/daemon/execenv/codex_skill_strip_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestStripSkillsConfigEntries(t *testing.T) {
@@ -109,9 +111,9 @@ enabled = false
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := stripSkillsConfigEntries(tt.in)
-			if got != tt.want {
+			testassert.OnFailure(t, got != tt.want, func() {
 				t.Errorf("stripSkillsConfigEntries result mismatch\n--- got ---\n%s\n--- want ---\n%s", got, tt.want)
-			}
+			})
 		})
 	}
 }
@@ -143,19 +145,11 @@ model = "o3"
 	}
 
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read result: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read result: %v", err) })
 	got := string(data)
-	if strings.Contains(got, "[[skills.config]]") {
-		t.Errorf("expected all [[skills.config]] entries to be removed, got:\n%s", got)
-	}
-	if !strings.Contains(got, `[profiles.default]`) {
-		t.Errorf("unrelated tables should be preserved, got:\n%s", got)
-	}
-	if !strings.Contains(got, `model = "o3"`) {
-		t.Errorf("top-level keys should be preserved, got:\n%s", got)
-	}
+	testassert.OnFailure(t, strings.Contains(got, "[[skills.config]]"), func() { t.Errorf("expected all [[skills.config]] entries to be removed, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, `[profiles.default]`), func() { t.Errorf("unrelated tables should be preserved, got:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, `model = "o3"`), func() { t.Errorf("top-level keys should be preserved, got:\n%s", got) })
 }
 
 func TestSanitizeCopiedCodexConfigNoop(t *testing.T) {
@@ -168,25 +162,17 @@ func TestSanitizeCopiedCodexConfigNoop(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 	infoBefore, err := os.Stat(configPath)
-	if err != nil {
-		t.Fatalf("stat before: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat before: %v", err) })
 
 	if err := sanitizeCopiedCodexConfig(configPath); err != nil {
 		t.Fatalf("sanitizeCopiedCodexConfig failed: %v", err)
 	}
 
 	infoAfter, err := os.Stat(configPath)
-	if err != nil {
-		t.Fatalf("stat after: %v", err)
-	}
-	if !infoAfter.ModTime().Equal(infoBefore.ModTime()) {
-		t.Errorf("file should not be rewritten when there is nothing to strip")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat after: %v", err) })
+	testassert.OnFailure(t, !infoAfter.ModTime().Equal(infoBefore.ModTime()), func() { t.Errorf("file should not be rewritten when there is nothing to strip") })
 	data, _ := os.ReadFile(configPath)
-	if string(data) != original {
-		t.Errorf("content drifted: got %q, want %q", data, original)
-	}
+	testassert.OnFailure(t, string(data) != original, func() { t.Errorf("content drifted: got %q, want %q", data, original) })
 }
 
 func TestSanitizeCopiedCodexConfigMissingFile(t *testing.T) {

--- a/server/internal/daemon/execenv/codex_user_skills_test.go
+++ b/server/internal/daemon/execenv/codex_user_skills_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // User skills reach the per-task CODEX_HOME as links, not copies (MUL-6000).
@@ -28,12 +30,8 @@ func writeUserSkill(t *testing.T, dir, body string) {
 func assertIsLink(t *testing.T, path string) {
 	t.Helper()
 	fi, err := os.Lstat(path)
-	if err != nil {
-		t.Fatalf("lstat %s: %v", path, err)
-	}
-	if fi.Mode()&(os.ModeSymlink|os.ModeIrregular) == 0 {
-		t.Fatalf("%s is a real directory (mode %v), want a link", path, fi.Mode())
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat %s: %v", path, err) })
+	testassert.OnFailure(t, fi.Mode()&(os.ModeSymlink|os.ModeIrregular) == 0, func() { t.Fatalf("%s is a real directory (mode %v), want a link", path, fi.Mode()) })
 }
 
 func TestSeedUserCodexSkillsLinksInsteadOfCopying(t *testing.T) {
@@ -52,12 +50,8 @@ func TestSeedUserCodexSkillsLinksInsteadOfCopying(t *testing.T) {
 	assertIsLink(t, dst)
 
 	body, err := os.ReadFile(filepath.Join(dst, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read seeded SKILL.md: %v", err)
-	}
-	if string(body) != "alpha v1" {
-		t.Errorf("seeded SKILL.md = %q, want %q", body, "alpha v1")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read seeded SKILL.md: %v", err) })
+	testassert.OnFailure(t, string(body) != "alpha v1", func() { t.Errorf("seeded SKILL.md = %q, want %q", body, "alpha v1") })
 
 	// The decisive proof it is not a copy: content added to the user's real
 	// skill directory after seeding is visible through the per-task path.
@@ -94,27 +88,17 @@ func TestSeedUserCodexSkillsResolvesInstallerSymlink(t *testing.T) {
 	dst := filepath.Join(codexHome, "skills", "lark-base")
 	assertIsLink(t, dst)
 	body, err := os.ReadFile(filepath.Join(dst, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("symlink-installed skill unreadable through the per-task link: %v", err)
-	}
-	if string(body) != "lark-base v1" {
-		t.Errorf("SKILL.md = %q, want %q", body, "lark-base v1")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("symlink-installed skill unreadable through the per-task link: %v", err) })
+	testassert.OnFailure(t, string(body) != "lark-base v1", func() { t.Errorf("SKILL.md = %q, want %q", body, "lark-base v1") })
 
 	// The per-task link must point at the real directory, not at the
 	// installer's own link, so it stays valid if the installer re-points it.
 	if runtime.GOOS != "windows" {
 		target, err := os.Readlink(dst)
-		if err != nil {
-			t.Fatalf("readlink %s: %v", dst, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("readlink %s: %v", dst, err) })
 		want, err := filepath.EvalSymlinks(realSkill)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if target != want {
-			t.Errorf("link target = %q, want the resolved skill dir %q", target, want)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatal(err) })
+		testassert.OnFailure(t, target != want, func() { t.Errorf("link target = %q, want the resolved skill dir %q", target, want) })
 	}
 }
 
@@ -208,12 +192,8 @@ func TestHydrateCodexSkillsNeverWritesThroughAUserSkillLink(t *testing.T) {
 	}
 
 	body, err := os.ReadFile(filepath.Join(userSkill, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read user skill: %v", err)
-	}
-	if string(body) != "user version" {
-		t.Fatalf("workspace skill was written through the link into the user's skill dir: %q", body)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read user skill: %v", err) })
+	testassert.OnFailure(t, string(body) != "user version", func() { t.Fatalf("workspace skill was written through the link into the user's skill dir: %q", body) })
 	if _, err := os.Stat(filepath.Join(skillsDir, "alpha-multica", "SKILL.md")); err != nil {
 		t.Errorf("colliding workspace skill did not land in a sibling dir: %v", err)
 	}

--- a/server/internal/daemon/execenv/codex_user_skills_windows_test.go
+++ b/server/internal/daemon/execenv/codex_user_skills_windows_test.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // On Windows createDirLink falls back to a directory junction (mklink /J) when
@@ -41,11 +43,7 @@ func TestHydrateCodexSkillsWipeKeepsJunctionTarget(t *testing.T) {
 	}
 
 	body, err := os.ReadFile(filepath.Join(userSkill, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("the skills wipe reached through the junction: %v", err)
-	}
-	if string(body) != "alpha v1" {
-		t.Errorf("user SKILL.md = %q, want %q", body, "alpha v1")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("the skills wipe reached through the junction: %v", err) })
+	testassert.OnFailure(t, string(body) != "alpha v1", func() { t.Errorf("user SKILL.md = %q, want %q", body, "alpha v1") })
 	assertIsLink(t, junction)
 }

--- a/server/internal/daemon/execenv/codex_windows_sandbox_integration_test.go
+++ b/server/internal/daemon/execenv/codex_windows_sandbox_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
@@ -38,9 +39,7 @@ func TestWindowsSandboxHonorsShellQuotedCustomArg(t *testing.T) {
 			norm := agent.NormalizeCodexLaunchArgs(nil, tc.raw, nil, testLogger())
 			missing := filepath.Join(t.TempDir(), "config.toml")
 			state := resolveWindowsSandboxState(missing, nil, sharedConfigAbsent, norm, testLogger())
-			if state != windowsSandboxNative {
-				t.Fatalf("normalized %v -> state %v, want native", norm, state)
-			}
+			testassert.OnFailure(t, state != windowsSandboxNative, func() { t.Fatalf("normalized %v -> state %v, want native", norm, state) })
 			if p := codexSandboxPolicyForWindows(state); p.Mode != "workspace-write" {
 				t.Fatalf("policy mode = %q, want workspace-write (isolation preserved)", p.Mode)
 			}

--- a/server/internal/daemon/execenv/context_marker_test.go
+++ b/server/internal/daemon/execenv/context_marker_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestEnsureWorkspacesRootMarker covers the root-level daemon marker that
@@ -21,18 +23,14 @@ func TestEnsureWorkspacesRootMarker(t *testing.T) {
 			t.Fatalf("EnsureWorkspacesRootMarker: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(root, TaskContextMarkerRelPath))
-		if err != nil {
-			t.Fatalf("read root marker: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read root marker: %v", err) })
 		var marker struct {
 			ManagedBy string `json:"managed_by"`
 		}
 		if err := json.Unmarshal(data, &marker); err != nil {
 			t.Fatalf("unmarshal root marker: %v\n%s", err, string(data))
 		}
-		if marker.ManagedBy != TaskContextMarkerManagedBy {
-			t.Fatalf("managed_by = %q, want %q", marker.ManagedBy, TaskContextMarkerManagedBy)
-		}
+		testassert.OnFailure(t, marker.ManagedBy != TaskContextMarkerManagedBy, func() { t.Fatalf("managed_by = %q, want %q", marker.ManagedBy, TaskContextMarkerManagedBy) })
 	})
 
 	t.Run("is idempotent when a matching marker exists", func(t *testing.T) {
@@ -59,12 +57,8 @@ func TestEnsureWorkspacesRootMarker(t *testing.T) {
 			t.Fatal("expected error for foreign file at marker path, got nil")
 		}
 		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("re-read foreign file: %v", err)
-		}
-		if string(data) != string(foreign) {
-			t.Fatalf("foreign file was clobbered: %s", string(data))
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("re-read foreign file: %v", err) })
+		testassert.OnFailure(t, string(data) != string(foreign), func() { t.Fatalf("foreign file was clobbered: %s", string(data)) })
 	})
 
 	t.Run("self-heals a corrupt marker from a torn write", func(t *testing.T) {
@@ -85,18 +79,16 @@ func TestEnsureWorkspacesRootMarker(t *testing.T) {
 				t.Fatalf("reclaim corrupt marker %q: unexpected error %v", corrupt, err)
 			}
 			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read reclaimed marker: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read reclaimed marker: %v", err) })
 			var marker struct {
 				ManagedBy string `json:"managed_by"`
 			}
 			if err := json.Unmarshal(data, &marker); err != nil {
 				t.Fatalf("reclaimed marker not valid JSON for input %q: %v\n%s", corrupt, err, string(data))
 			}
-			if marker.ManagedBy != TaskContextMarkerManagedBy {
+			testassert.OnFailure(t, marker.ManagedBy != TaskContextMarkerManagedBy, func() {
 				t.Fatalf("managed_by = %q, want %q (input %q)", marker.ManagedBy, TaskContextMarkerManagedBy, corrupt)
-			}
+			})
 		}
 	})
 
@@ -121,18 +113,12 @@ func TestPrepare_WritesWorkspacesRootMarker(t *testing.T) {
 			IssueID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	data, err := os.ReadFile(filepath.Join(root, TaskContextMarkerRelPath))
-	if err != nil {
-		t.Fatalf("read root marker after Prepare: %v", err)
-	}
-	if !strings.Contains(string(data), TaskContextMarkerManagedBy) {
-		t.Fatalf("root marker missing managed_by discriminator: %s", string(data))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read root marker after Prepare: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), TaskContextMarkerManagedBy), func() { t.Fatalf("root marker missing managed_by discriminator: %s", string(data)) })
 }
 
 // TestReuse_SelfHealsWorkspacesRootMarker verifies the root marker is restored
@@ -147,9 +133,7 @@ func TestReuse_SelfHealsWorkspacesRootMarker(t *testing.T) {
 		AgentName:      "Reuse Agent",
 		Task:           TaskContextForEnv{IssueID: "b2c3d4e5-f6a7-8901-bcde-f23456789012"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	rootMarker := filepath.Join(root, TaskContextMarkerRelPath)
@@ -162,9 +146,7 @@ func TestReuse_SelfHealsWorkspacesRootMarker(t *testing.T) {
 		WorkDir:        env.WorkDir,
 		Task:           TaskContextForEnv{IssueID: "b2c3d4e5-f6a7-8901-bcde-f23456789012"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil for an existing workdir")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil for an existing workdir") })
 	if _, err := os.Stat(rootMarker); err != nil {
 		t.Fatalf("Reuse did not restore the root marker: %v", err)
 	}

--- a/server/internal/daemon/execenv/cursor_mcp_test.go
+++ b/server/internal/daemon/execenv/cursor_mcp_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestCursorMcpApprovalKeyMatchesCursorAgent(t *testing.T) {
@@ -14,13 +16,9 @@ func TestCursorMcpApprovalKeyMatchesCursorAgent(t *testing.T) {
 	keys, err := cursorMcpApprovalKeys("/tmp/work", map[string]json.RawMessage{
 		"fetch": json.RawMessage(`{"command":"uvx","args":["mcp-server-fetch"]}`),
 	})
-	if err != nil {
-		t.Fatalf("cursorMcpApprovalKeys: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("cursorMcpApprovalKeys: %v", err) })
 	want := []string{"fetch-b3a6127d3cbd8e52"}
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("approval keys = %v, want %v", keys, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(keys, want), func() { t.Fatalf("approval keys = %v, want %v", keys, want) })
 }
 
 func TestCursorMcpApprovalKeyMatchesCursorAgentWithReorderedStdioConfig(t *testing.T) {
@@ -29,13 +27,9 @@ func TestCursorMcpApprovalKeyMatchesCursorAgentWithReorderedStdioConfig(t *testi
 	keys, err := cursorMcpApprovalKeys("/tmp/work", map[string]json.RawMessage{
 		"fetch": json.RawMessage(`{ "args": [ "mcp-server-fetch" ], "command": "uvx", "env": { "TOKEN": "x" } }`),
 	})
-	if err != nil {
-		t.Fatalf("cursorMcpApprovalKeys: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("cursorMcpApprovalKeys: %v", err) })
 	want := []string{"fetch-4c7232835349773b"}
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("approval keys = %v, want %v", keys, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(keys, want), func() { t.Fatalf("approval keys = %v, want %v", keys, want) })
 }
 
 func TestCursorMcpApprovalKeyMatchesJSONStringifyWithHTMLCharacters(t *testing.T) {
@@ -44,13 +38,9 @@ func TestCursorMcpApprovalKeyMatchesJSONStringifyWithHTMLCharacters(t *testing.T
 	keys, err := cursorMcpApprovalKeys("/tmp/work", map[string]json.RawMessage{
 		"fetch": json.RawMessage(`{"command":"uvx","args":["mcp"],"env":{"URL":"https://x.test?a=1&b=2"}}`),
 	})
-	if err != nil {
-		t.Fatalf("cursorMcpApprovalKeys: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("cursorMcpApprovalKeys: %v", err) })
 	want := []string{"fetch-37ab92a3e088d73a"}
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("approval keys = %v, want %v", keys, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(keys, want), func() { t.Fatalf("approval keys = %v, want %v", keys, want) })
 }
 
 func TestCursorMcpApprovalKeyMatchesCursorAgentWithStdioTypeAndCwd(t *testing.T) {
@@ -59,14 +49,10 @@ func TestCursorMcpApprovalKeyMatchesCursorAgentWithStdioTypeAndCwd(t *testing.T)
 	keys, err := cursorMcpApprovalKeys("/private/tmp/work", map[string]json.RawMessage{
 		"withtypecwd": json.RawMessage(`{"enabled":true,"cwd":"/tmp/probe","timeout":30,"args":["mcp"],"command":"uvx","type":"stdio"}`),
 	})
-	if err != nil {
-		t.Fatalf("cursorMcpApprovalKeys: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("cursorMcpApprovalKeys: %v", err) })
 	// Captured from cursor-agent 2026.08.04-aaa8809 via mcp enable.
 	want := []string{"withtypecwd-ba71d2f70913528e"}
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("approval keys = %v, want %v", keys, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(keys, want), func() { t.Fatalf("approval keys = %v, want %v", keys, want) })
 }
 
 func TestCursorMcpApprovalKeyMatchesCursorAgentForRemoteServer(t *testing.T) {
@@ -75,14 +61,10 @@ func TestCursorMcpApprovalKeyMatchesCursorAgentForRemoteServer(t *testing.T) {
 	keys, err := cursorMcpApprovalKeys("/private/tmp/work", map[string]json.RawMessage{
 		"remote": json.RawMessage(`{"enabled":true,"headers":{"Authorization":"Bearer x"},"timeout":30,"url":"https://mcp.example.com","type":"http"}`),
 	})
-	if err != nil {
-		t.Fatalf("cursorMcpApprovalKeys: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("cursorMcpApprovalKeys: %v", err) })
 	// Captured from cursor-agent 2026.08.04-aaa8809 via mcp enable.
 	want := []string{"remote-abc2ffe78532b37e"}
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("approval keys = %v, want %v", keys, want)
-	}
+	testassert.OnFailure(t, !reflect.DeepEqual(keys, want), func() { t.Fatalf("approval keys = %v, want %v", keys, want) })
 }
 
 func TestPrepareCursorMcpConfigWritesProjectConfigAndApprovals(t *testing.T) {
@@ -102,24 +84,16 @@ func TestPrepareCursorMcpConfigWritesProjectConfigAndApprovals(t *testing.T) {
 	}`)
 
 	cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, mcpConfig, "", manifest)
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig: %v", err)
-	}
-	if cursorDataDir != filepath.Join(envRoot, "cursor-data") {
-		t.Fatalf("CursorDataDir = %q, want envRoot/cursor-data", cursorDataDir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig: %v", err) })
+	testassert.OnFailure(t, cursorDataDir != filepath.Join(envRoot, "cursor-data"), func() { t.Fatalf("CursorDataDir = %q, want envRoot/cursor-data", cursorDataDir) })
 
 	rawConfig, err := os.ReadFile(filepath.Join(workDir, ".cursor", "mcp.json"))
-	if err != nil {
-		t.Fatalf("read .cursor/mcp.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read .cursor/mcp.json: %v", err) })
 	var cfg cursorMcpConfigFile
 	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
 		t.Fatalf("unmarshal .cursor/mcp.json: %v\n%s", err, rawConfig)
 	}
-	if len(cfg.McpServers) != 2 {
-		t.Fatalf("mcpServers length = %d, want 2: %s", len(cfg.McpServers), rawConfig)
-	}
+	testassert.OnFailure(t, len(cfg.McpServers) != 2, func() { t.Fatalf("mcpServers length = %d, want 2: %s", len(cfg.McpServers), rawConfig) })
 	if mode := filePerm(t, filepath.Join(workDir, ".cursor", "mcp.json")); mode != 0o600 {
 		t.Fatalf(".cursor/mcp.json mode = %#o, want 0600", mode)
 	}
@@ -127,29 +101,21 @@ func TestPrepareCursorMcpConfigWritesProjectConfigAndApprovals(t *testing.T) {
 	projectRoot := cursorProjectRoot(workDir)
 	projectDataDir := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot))
 	rawApprovals, err := os.ReadFile(filepath.Join(projectDataDir, "mcp-approvals.json"))
-	if err != nil {
-		t.Fatalf("read mcp-approvals.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read mcp-approvals.json: %v", err) })
 	var approvals []string
 	if err := json.Unmarshal(rawApprovals, &approvals); err != nil {
 		t.Fatalf("unmarshal mcp-approvals.json: %v\n%s", err, rawApprovals)
 	}
 	wantApprovals, err := cursorMcpApprovalKeys(projectRoot, cfg.McpServers)
-	if err != nil {
-		t.Fatalf("expected approvals: %v", err)
-	}
-	if !reflect.DeepEqual(approvals, wantApprovals) {
-		t.Fatalf("approvals = %v, want %v", approvals, wantApprovals)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("expected approvals: %v", err) })
+	testassert.OnFailure(t, !reflect.DeepEqual(approvals, wantApprovals), func() { t.Fatalf("approvals = %v, want %v", approvals, wantApprovals) })
 	if mode := filePerm(t, filepath.Join(projectDataDir, "mcp-approvals.json")); mode != 0o600 {
 		t.Fatalf("mcp-approvals.json mode = %#o, want 0600", mode)
 	}
 	if _, err := os.Stat(filepath.Join(projectDataDir, cursorWorkspaceTrustedFile)); err != nil {
 		t.Fatalf("workspace trust file missing: %v", err)
 	}
-	if len(manifest.Files) == 0 {
-		t.Fatal("manifest did not record .cursor/mcp.json")
-	}
+	testassert.OnFailure(t, len(manifest.Files) == 0, func() { t.Fatal("manifest did not record .cursor/mcp.json") })
 }
 
 func TestPrepareCursorMcpConfigManagedEmptySet(t *testing.T) {
@@ -161,24 +127,16 @@ func TestPrepareCursorMcpConfigManagedEmptySet(t *testing.T) {
 		t.Fatalf("mkdir workDir: %v", err)
 	}
 	cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, json.RawMessage(`{"mcpServers":{}}`), "", &sidecarManifest{})
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig: %v", err)
-	}
-	if cursorDataDir == "" {
-		t.Fatal("managed empty mcp_config should still isolate CursorDataDir")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig: %v", err) })
+	testassert.OnFailure(t, cursorDataDir == "", func() { t.Fatal("managed empty mcp_config should still isolate CursorDataDir") })
 	projectRoot := cursorProjectRoot(workDir)
 	rawApprovals, err := os.ReadFile(filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot), "mcp-approvals.json"))
-	if err != nil {
-		t.Fatalf("read mcp-approvals.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read mcp-approvals.json: %v", err) })
 	var approvals []string
 	if err := json.Unmarshal(rawApprovals, &approvals); err != nil {
 		t.Fatalf("unmarshal approvals: %v", err)
 	}
-	if len(approvals) != 0 {
-		t.Fatalf("approvals length = %d, want 0: %v", len(approvals), approvals)
-	}
+	testassert.OnFailure(t, len(approvals) != 0, func() { t.Fatalf("approvals length = %d, want 0: %v", len(approvals), approvals) })
 }
 
 func TestPrepareCursorMcpConfigSeedsExplicitAuthSource(t *testing.T) {
@@ -199,18 +157,12 @@ func TestPrepareCursorMcpConfigSeedsExplicitAuthSource(t *testing.T) {
 	}
 
 	cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}`), sourceProjectDir, &sidecarManifest{})
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig: %v", err) })
 	projectRoot := cursorProjectRoot(workDir)
 	targetAuth := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot), cursorMcpAuthFile)
 	data, err := os.ReadFile(targetAuth)
-	if err != nil {
-		t.Fatalf("read seeded auth: %v", err)
-	}
-	if string(data) != `{"tokens":{"fetch":"secret"}}` {
-		t.Fatalf("seeded auth = %s", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read seeded auth: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"tokens":{"fetch":"secret"}}`, func() { t.Fatalf("seeded auth = %s", data) })
 }
 
 func TestPrepareCursorMcpConfigRemovesPriorAuthOnOptOut(t *testing.T) {
@@ -232,9 +184,7 @@ func TestPrepareCursorMcpConfigRemovesPriorAuthOnOptOut(t *testing.T) {
 	mcpConfig := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}`)
 
 	cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, mcpConfig, sourceProjectDir, nil)
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig with auth source: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig with auth source: %v", err) })
 	projectRoot := cursorProjectRoot(workDir)
 	targetAuth := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot), cursorMcpAuthFile)
 	if _, err := os.Stat(targetAuth); err != nil {
@@ -242,9 +192,7 @@ func TestPrepareCursorMcpConfigRemovesPriorAuthOnOptOut(t *testing.T) {
 	}
 
 	cursorDataDir, err = prepareCursorMcpConfig(envRoot, workDir, mcpConfig, "", nil)
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig without auth source: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig without auth source: %v", err) })
 	targetAuth = filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot), cursorMcpAuthFile)
 	if _, err := os.Stat(targetAuth); !os.IsNotExist(err) {
 		t.Fatalf("auth file should be removed after opt-out, stat err=%v", err)
@@ -265,9 +213,7 @@ func TestPrepareCursorMcpConfigRejectsArbitraryAuthSourceFile(t *testing.T) {
 	}
 
 	_, err := prepareCursorMcpConfig(envRoot, workDir, json.RawMessage(`{"mcpServers":{}}`), source, &sidecarManifest{})
-	if err == nil {
-		t.Fatal("expected non-mcp-auth source file to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected non-mcp-auth source file to fail") })
 }
 
 func TestPrepareCursorMcpConfigNilDoesNotTakeOwnership(t *testing.T) {
@@ -279,12 +225,8 @@ func TestPrepareCursorMcpConfigNilDoesNotTakeOwnership(t *testing.T) {
 		t.Fatalf("mkdir workDir: %v", err)
 	}
 	cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, nil, "", &sidecarManifest{})
-	if err != nil {
-		t.Fatalf("prepareCursorMcpConfig: %v", err)
-	}
-	if cursorDataDir != "" {
-		t.Fatalf("CursorDataDir = %q, want empty", cursorDataDir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareCursorMcpConfig: %v", err) })
+	testassert.OnFailure(t, cursorDataDir != "", func() { t.Fatalf("CursorDataDir = %q, want empty", cursorDataDir) })
 	if _, err := os.Stat(filepath.Join(workDir, ".cursor", "mcp.json")); !os.IsNotExist(err) {
 		t.Fatalf(".cursor/mcp.json should not exist, stat err=%v", err)
 	}
@@ -299,16 +241,12 @@ func TestPrepareCursorMcpConfigRejectsMalformedConfig(t *testing.T) {
 		t.Fatalf("mkdir workDir: %v", err)
 	}
 	_, err := prepareCursorMcpConfig(envRoot, workDir, json.RawMessage(`{"mcpServers":{"bad":42}}`), "", &sidecarManifest{})
-	if err == nil {
-		t.Fatal("expected malformed server config to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected malformed server config to fail") })
 }
 
 func filePerm(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat %s: %v", path, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat %s: %v", path, err) })
 	return info.Mode().Perm()
 }

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func testLogger() *slog.Logger {
@@ -50,9 +52,7 @@ func TestPredictRootDir(t *testing.T) {
 		IssueIdentifier: "MUL-6063",
 	})
 	want := filepath.Join("/root", "asset-feed-a548b2390cb2", "mul-6063-b659c34a1dc3")
-	if got != want {
-		t.Errorf("PredictRootDir = %q, want %q", got, want)
-	}
+	testassert.OnFailure(t, got != want, func() { t.Errorf("PredictRootDir = %q, want %q", got, want) })
 	if got := PredictRootDir(RootDirParams{WorkspaceID: "ws", TaskID: "task"}); got != "" {
 		t.Errorf("expected empty when workspaces root missing, got %q", got)
 	}
@@ -75,9 +75,7 @@ func TestResolveRootDirFreezesReadableNamesBeforePrepare(t *testing.T) {
 	}
 
 	first, err := ResolveRootDir(base)
-	if err != nil {
-		t.Fatalf("resolve fallback root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve fallback root: %v", err) })
 	if _, err := os.Stat(first); !os.IsNotExist(err) {
 		t.Fatalf("ResolveRootDir should freeze identity before creating the env root; stat err = %v", err)
 	}
@@ -86,23 +84,15 @@ func TestResolveRootDirFreezesReadableNamesBeforePrepare(t *testing.T) {
 	enriched.WorkspaceSlug = "Asset Feed"
 	enriched.IssueIdentifier = "MUL-6063"
 	second, err := ResolveRootDir(enriched)
-	if err != nil {
-		t.Fatalf("resolve enriched root: %v", err)
-	}
-	if second != first {
-		t.Fatalf("same task moved from %q to %q when readable fields arrived", first, second)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve enriched root: %v", err) })
+	testassert.OnFailure(t, second != first, func() { t.Fatalf("same task moved from %q to %q when readable fields arrived", first, second) })
 
 	renamed := enriched
 	renamed.WorkspaceSlug = "Renamed Workspace"
 	renamed.IssueIdentifier = "NEW-6063"
 	third, err := ResolveRootDir(renamed)
-	if err != nil {
-		t.Fatalf("resolve renamed root: %v", err)
-	}
-	if third != first {
-		t.Fatalf("same task moved from %q to %q after workspace/issue rename", first, third)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve renamed root: %v", err) })
+	testassert.OnFailure(t, third != first, func() { t.Fatalf("same task moved from %q to %q after workspace/issue rename", first, third) })
 
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot:  renamed.WorkspacesRoot,
@@ -113,24 +103,16 @@ func TestResolveRootDirFreezesReadableNamesBeforePrepare(t *testing.T) {
 		AgentName:       "Stable Root",
 		Task:            TaskContextForEnv{IssueID: "issue-stable-root"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare after pre-StartTask reclaim: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare after pre-StartTask reclaim: %v", err) })
 	defer env.Cleanup(true)
-	if env.RootDir != first {
-		t.Fatalf("Prepare root = %q, want frozen root %q", env.RootDir, first)
-	}
+	testassert.OnFailure(t, env.RootDir != first, func() { t.Fatalf("Prepare root = %q, want frozen root %q", env.RootDir, first) })
 
 	liveRename := renamed
 	liveRename.WorkspaceSlug = "Renamed Again"
 	liveRename.IssueIdentifier = "NEXT-6063"
 	afterPrepare, err := ResolveRootDir(liveRename)
-	if err != nil {
-		t.Fatalf("resolve after live rename: %v", err)
-	}
-	if afterPrepare != first {
-		t.Fatalf("live task moved from %q to %q after issue prefix changed", first, afterPrepare)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve after live rename: %v", err) })
+	testassert.OnFailure(t, afterPrepare != first, func() { t.Fatalf("live task moved from %q to %q after issue prefix changed", first, afterPrepare) })
 }
 
 func TestResolveRootDirAdoptsExistingOwnedRootBeforeIndex(t *testing.T) {
@@ -162,12 +144,8 @@ func TestResolveRootDirAdoptsExistingOwnedRootBeforeIndex(t *testing.T) {
 		TaskID:          taskID,
 		IssueIdentifier: "NEW-6063",
 	})
-	if err != nil {
-		t.Fatalf("resolve renamed existing root: %v", err)
-	}
-	if resolved != original {
-		t.Fatalf("existing owned root %q was orphaned in favor of %q", original, resolved)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve renamed existing root: %v", err) })
+	testassert.OnFailure(t, resolved != original, func() { t.Fatalf("existing owned root %q was orphaned in favor of %q", original, resolved) })
 }
 
 func TestResolveRootDirAdoptsRootWithInterruptedOwnerTemp(t *testing.T) {
@@ -200,12 +178,8 @@ func TestResolveRootDirAdoptsRootWithInterruptedOwnerTemp(t *testing.T) {
 		TaskID:          taskID,
 		IssueIdentifier: "NEW-6063",
 	})
-	if err != nil {
-		t.Fatalf("resolve root with interrupted owner temp: %v", err)
-	}
-	if resolved != original {
-		t.Fatalf("recoverable root %q was orphaned in favor of %q", original, resolved)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve root with interrupted owner temp: %v", err) })
+	testassert.OnFailure(t, resolved != original, func() { t.Fatalf("recoverable root %q was orphaned in favor of %q", original, resolved) })
 	if _, err := os.Stat(tempOwner); err != nil {
 		t.Fatalf("resolution unexpectedly mutated the candidate root: %v", err)
 	}
@@ -246,13 +220,9 @@ func TestResolveRootDirConcurrentFirstClaimsChooseOnePhysicalRoot(t *testing.T) 
 	wg.Wait()
 
 	for i, err := range errs {
-		if err != nil {
-			t.Fatalf("resolve %d: %v", i, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve %d: %v", i, err) })
 	}
-	if paths[0] != paths[1] {
-		t.Fatalf("concurrent claims chose two roots: %q and %q", paths[0], paths[1])
-	}
+	testassert.OnFailure(t, paths[0] != paths[1], func() { t.Fatalf("concurrent claims chose two roots: %q and %q", paths[0], paths[1]) })
 }
 
 func TestRemoveRootDirRecordKeepsSharedIndexParent(t *testing.T) {
@@ -264,9 +234,7 @@ func TestRemoveRootDirRecordKeepsSharedIndexParent(t *testing.T) {
 		TaskID:         "5c57b65b-ee7a-4603-a72d-b659c34a1dc3",
 	}
 	envRoot, err := ResolveRootDir(params)
-	if err != nil {
-		t.Fatalf("ResolveRootDir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ResolveRootDir: %v", err) })
 	if err := RemoveRootDirRecord(params.WorkspacesRoot, envRoot, EnvRootOwner{
 		WorkspaceID: params.WorkspaceID,
 		TaskID:      params.TaskID,
@@ -274,12 +242,8 @@ func TestRemoveRootDirRecordKeepsSharedIndexParent(t *testing.T) {
 		t.Fatalf("RemoveRootDirRecord: %v", err)
 	}
 	indexInfo, err := os.Stat(filepath.Join(params.WorkspacesRoot, taskRootIndexDir))
-	if err != nil {
-		t.Fatalf("shared task root index was removed: %v", err)
-	}
-	if !indexInfo.IsDir() {
-		t.Fatal("shared task root index is not a directory")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("shared task root index was removed: %v", err) })
+	testassert.OnFailure(t, !indexInfo.IsDir(), func() { t.Fatal("shared task root index is not a directory") })
 }
 
 func TestPruneTaskRootIndexBoundsAbandonedEntries(t *testing.T) {
@@ -300,9 +264,7 @@ func TestPruneTaskRootIndexBoundsAbandonedEntries(t *testing.T) {
 	var materializedRoot string
 	for _, params := range []RootDirParams{terminal, running, materialized, recent} {
 		resolved, err := ResolveRootDir(params)
-		if err != nil {
-			t.Fatalf("ResolveRootDir(%s): %v", params.TaskID, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("ResolveRootDir(%s): %v", params.TaskID, err) })
 		if params.TaskID == materialized.TaskID {
 			materializedRoot = resolved
 		}
@@ -334,12 +296,8 @@ func TestPruneTaskRootIndexBoundsAbandonedEntries(t *testing.T) {
 	removed, err := PruneTaskRootIndex(root, 0, now, func(_, taskID string) bool {
 		return taskID == terminal.TaskID || taskID == materialized.TaskID || taskID == recent.TaskID
 	})
-	if err != nil {
-		t.Fatalf("PruneTaskRootIndex: %v", err)
-	}
-	if removed != 2 {
-		t.Fatalf("removed = %d, want terminal record plus stale pending entry", removed)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PruneTaskRootIndex: %v", err) })
+	testassert.OnFailure(t, removed != 2, func() { t.Fatalf("removed = %d, want terminal record plus stale pending entry", removed) })
 	for _, removedPath := range []string{taskRootRecordDir(terminal), stalePending} {
 		if _, err := os.Stat(removedPath); !os.IsNotExist(err) {
 			t.Fatalf("stale entry %s still exists: %v", removedPath, err)
@@ -412,17 +370,11 @@ func TestPredictRootDirWorstCaseLabelsStayWithinWindowsBudget(t *testing.T) {
 		IssueIdentifier: strings.Repeat("issue", 20),
 	})
 	rel, err := filepath.Rel("/root", root)
-	if err != nil {
-		t.Fatalf("relative env root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("relative env root: %v", err) })
 	parts := strings.Split(rel, string(filepath.Separator))
-	if len(parts) != 2 {
-		t.Fatalf("relative env root = %q, want exactly two segments", rel)
-	}
+	testassert.OnFailure(t, len(parts) != 2, func() { t.Fatalf("relative env root = %q, want exactly two segments", rel) })
 	for _, part := range parts {
-		if len(part) > readablePathSegmentMax {
-			t.Fatalf("path segment %q has length %d, want <= %d", part, len(part), readablePathSegmentMax)
-		}
+		testassert.OnFailure(t, len(part) > readablePathSegmentMax, func() { t.Fatalf("path segment %q has length %d, want <= %d", part, len(part), readablePathSegmentMax) })
 	}
 	// main's opaque layout spent 36 + 1 + 12 characters below WorkspacesRoot.
 	// The readable layout must not consume a larger Windows path budget.
@@ -487,9 +439,7 @@ func TestPrepareDirectoryMode(t *testing.T) {
 			},
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// Verify directory structure.
@@ -499,34 +449,22 @@ func TestPrepareDirectoryMode(t *testing.T) {
 			t.Fatalf("expected %s to exist", path)
 		}
 	}
-	if env.MulticaConfigRoot != filepath.Join(env.RootDir, "multica-config") {
-		t.Fatalf("MulticaConfigRoot = %q, want task-local config directory", env.MulticaConfigRoot)
-	}
+	testassert.OnFailure(t, env.MulticaConfigRoot != filepath.Join(env.RootDir, "multica-config"), func() { t.Fatalf("MulticaConfigRoot = %q, want task-local config directory", env.MulticaConfigRoot) })
 	info, err := os.Stat(env.MulticaConfigRoot)
-	if err != nil {
-		t.Fatalf("stat MulticaConfigRoot: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat MulticaConfigRoot: %v", err) })
 	if got := info.Mode().Perm(); got != 0o700 {
 		t.Fatalf("MulticaConfigRoot mode = %o, want 700", got)
 	}
 
 	// Verify context file contains issue ID and CLI hints.
 	content, err := os.ReadFile(filepath.Join(env.WorkDir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read issue_context.md: %v", err)
-	}
-	if !strings.Contains(string(content), "a1b2c3d4-e5f6-7890-abcd-ef1234567890") {
-		t.Fatalf("issue_context.md missing the issue id")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read issue_context.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(content), "a1b2c3d4-e5f6-7890-abcd-ef1234567890"), func() { t.Fatalf("issue_context.md missing the issue id") })
 	// The skill list lives in the runtime brief only (MUL-5529).
-	if strings.Contains(string(content), "code-review") {
-		t.Fatalf("issue_context.md should no longer carry a skill list:\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Contains(string(content), "code-review"), func() { t.Fatalf("issue_context.md should no longer carry a skill list:\n%s", content) })
 
 	markerContent, err := os.ReadFile(filepath.Join(env.WorkDir, TaskContextMarkerRelPath))
-	if err != nil {
-		t.Fatalf("failed to read task context marker: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read task context marker: %v", err) })
 	var marker struct {
 		ManagedBy string `json:"managed_by"`
 		IssueID   string `json:"issue_id"`
@@ -534,21 +472,13 @@ func TestPrepareDirectoryMode(t *testing.T) {
 	if err := json.Unmarshal(markerContent, &marker); err != nil {
 		t.Fatalf("task context marker unmarshal: %v\n%s", err, string(markerContent))
 	}
-	if marker.ManagedBy != TaskContextMarkerManagedBy {
-		t.Fatalf("marker managed_by = %q, want %q", marker.ManagedBy, TaskContextMarkerManagedBy)
-	}
-	if marker.IssueID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
-		t.Fatalf("marker issue_id = %q, want issue id", marker.IssueID)
-	}
+	testassert.OnFailure(t, marker.ManagedBy != TaskContextMarkerManagedBy, func() { t.Fatalf("marker managed_by = %q, want %q", marker.ManagedBy, TaskContextMarkerManagedBy) })
+	testassert.OnFailure(t, marker.IssueID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890", func() { t.Fatalf("marker issue_id = %q, want issue id", marker.IssueID) })
 
 	// Verify skill files.
 	skillContent, err := os.ReadFile(filepath.Join(env.WorkDir, ".agent_context", "skills", "code-review", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillContent), "Be concise.") {
-		t.Fatal("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillContent), "Be concise."), func() { t.Fatal("SKILL.md missing content") })
 }
 
 func TestPrepareWithProjectResources(t *testing.T) {
@@ -576,17 +506,13 @@ func TestPrepareWithProjectResources(t *testing.T) {
 		Provider:       "claude",
 		Task:           taskCtx,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// resources.json should exist and decode back to what we wrote.
 	resourcesPath := filepath.Join(env.WorkDir, ".multica", "project", "resources.json")
 	raw, err := os.ReadFile(resourcesPath)
-	if err != nil {
-		t.Fatalf("failed to read resources.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read resources.json: %v", err) })
 	var got struct {
 		ProjectID          string `json:"project_id"`
 		ProjectTitle       string `json:"project_title"`
@@ -600,27 +526,19 @@ func TestPrepareWithProjectResources(t *testing.T) {
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("resources.json unmarshal: %v\n%s", err, string(raw))
 	}
-	if got.ProjectID != taskCtx.ProjectID {
-		t.Errorf("resources.json project_id = %q, want %q", got.ProjectID, taskCtx.ProjectID)
-	}
-	if got.ProjectTitle != taskCtx.ProjectTitle {
-		t.Errorf("resources.json project_title = %q, want %q", got.ProjectTitle, taskCtx.ProjectTitle)
-	}
-	if got.ProjectDescription != taskCtx.ProjectDescription {
+	testassert.OnFailure(t, got.ProjectID != taskCtx.ProjectID, func() { t.Errorf("resources.json project_id = %q, want %q", got.ProjectID, taskCtx.ProjectID) })
+	testassert.OnFailure(t, got.ProjectTitle != taskCtx.ProjectTitle, func() { t.Errorf("resources.json project_title = %q, want %q", got.ProjectTitle, taskCtx.ProjectTitle) })
+	testassert.OnFailure(t, got.ProjectDescription != taskCtx.ProjectDescription, func() {
 		t.Errorf("resources.json project_description = %q, want %q", got.ProjectDescription, taskCtx.ProjectDescription)
-	}
-	if len(got.Resources) != 1 || got.Resources[0].ResourceType != "github_repo" {
-		t.Fatalf("resources.json resources mismatch: %+v", got.Resources)
-	}
+	})
+	testassert.OnFailure(t, len(got.Resources) != 1 || got.Resources[0].ResourceType != "github_repo", func() { t.Fatalf("resources.json resources mismatch: %+v", got.Resources) })
 
 	// CLAUDE.md should mention the project context block.
 	if _, err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
 		t.Fatalf("InjectRuntimeConfig: %v", err)
 	}
 	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(content)
 	for _, want := range []string{
 		"## Project Context",
@@ -632,9 +550,7 @@ func TestPrepareWithProjectResources(t *testing.T) {
 		"default branch hint: `main`",
 		".multica/project/resources.json",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("CLAUDE.md missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("CLAUDE.md missing %q", want) })
 	}
 }
 
@@ -670,9 +586,7 @@ func TestChatProjectContextInjectedIntoRuntimeBrief(t *testing.T) {
 				t.Fatalf("InjectRuntimeConfig: %v", err)
 			}
 			content, err := os.ReadFile(filepath.Join(dir, tc.filename))
-			if err != nil {
-				t.Fatalf("read %s: %v", tc.filename, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", tc.filename, err) })
 			s := string(content)
 			for _, want := range []string{
 				"## Project Context",
@@ -680,18 +594,14 @@ func TestChatProjectContextInjectedIntoRuntimeBrief(t *testing.T) {
 				"Use the beta repository and follow the beta rollout plan.",
 				"https://github.com/org/beta",
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s missing chat project context %q", tc.filename, want)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s missing chat project context %q", tc.filename, want) })
 			}
 			for _, banned := range []string{
 				"This issue belongs to",
 				"## Issue Metadata",
 				"## Sub-issue Creation",
 			} {
-				if strings.Contains(s, banned) {
-					t.Errorf("%s chat brief contains issue-only text %q", tc.filename, banned)
-				}
+				testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("%s chat brief contains issue-only text %q", tc.filename, banned) })
 			}
 		})
 	}
@@ -727,16 +637,10 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig: %v", err)
 	}
 	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(content)
-	if !strings.Contains(s, "https://github.com/org/project-repo") {
-		t.Errorf("CLAUDE.md missing project repo URL")
-	}
-	if strings.Contains(s, "https://github.com/org/workspace-repo") {
-		t.Errorf("CLAUDE.md should not contain workspace repo when project has its own")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "https://github.com/org/project-repo"), func() { t.Errorf("CLAUDE.md missing project repo URL") })
+	testassert.OnFailure(t, strings.Contains(s, "https://github.com/org/workspace-repo"), func() { t.Errorf("CLAUDE.md should not contain workspace repo when project has its own") })
 }
 
 func TestWriteProjectResourcesSkippedWhenNone(t *testing.T) {
@@ -769,9 +673,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 		Provider:       "claude",
 		Task:           taskCtx,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// Inject runtime config (done separately in daemon, replicate here).
@@ -781,21 +683,15 @@ func TestPrepareWithRepoContext(t *testing.T) {
 
 	// Workdir should be empty (no pre-created repo dirs).
 	entries, err := os.ReadDir(env.WorkDir)
-	if err != nil {
-		t.Fatalf("failed to read workdir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read workdir: %v", err) })
 	for _, e := range entries {
 		name := e.Name()
-		if name != ".agent_context" && name != ".multica" && name != "CLAUDE.md" && name != ".claude" {
-			t.Errorf("unexpected entry in workdir: %s", name)
-		}
+		testassert.OnFailure(t, name != ".agent_context" && name != ".multica" && name != "CLAUDE.md" && name != ".claude", func() { t.Errorf("unexpected entry in workdir: %s", name) })
 	}
 
 	// CLAUDE.md should contain repo info.
 	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("failed to read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read CLAUDE.md: %v", err) })
 	s := string(content)
 	for _, want := range []string{
 		"multica repo checkout",
@@ -803,9 +699,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 		"[--ref <branch-or-sha>]",
 		"https://github.com/org/frontend",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("CLAUDE.md missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("CLAUDE.md missing %q", want) })
 	}
 }
 
@@ -831,41 +725,27 @@ func TestWriteContextFiles(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "test-issue-id-1234") {
-		t.Errorf("content missing %q", "test-issue-id-1234")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "test-issue-id-1234"), func() { t.Errorf("content missing %q", "test-issue-id-1234") })
 
 	// Issue details should NOT be in the context file (agent fetches via CLI).
 	//
 	// Nor the skill list: nothing ever read this copy, and the runtime brief
 	// carries the same names-only index (MUL-5529).
 	for _, absent := range []string{"## Description", "## Workspace Context", "## Agent Skills", "go-conventions"} {
-		if strings.Contains(s, absent) {
-			t.Errorf("content should NOT contain %q", absent)
-		}
+		testassert.OnFailure(t, strings.Contains(s, absent), func() { t.Errorf("content should NOT contain %q", absent) })
 	}
 
 	// Verify skill directory and files.
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 
 	supportFile, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 }
 
 func TestWriteContextFilesOmitsSkillsWhenEmpty(t *testing.T) {
@@ -881,17 +761,11 @@ func TestWriteContextFilesOmitsSkillsWhenEmpty(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "minimal-issue-id") {
-		t.Error("expected issue ID to be present")
-	}
-	if strings.Contains(s, "## Agent Skills") {
-		t.Error("expected skills section to be omitted when no skills")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "minimal-issue-id"), func() { t.Error("expected issue ID to be present") })
+	testassert.OnFailure(t, strings.Contains(s, "## Agent Skills"), func() { t.Error("expected skills section to be omitted when no skills") })
 }
 
 func TestWriteContextFilesAutopilotRunOnly(t *testing.T) {
@@ -911,9 +785,7 @@ func TestWriteContextFilesAutopilotRunOnly(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("failed to read: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read: %v", err) })
 
 	s := string(content)
 	for _, want := range []string{
@@ -924,13 +796,9 @@ func TestWriteContextFilesAutopilotRunOnly(t *testing.T) {
 		"multica autopilot get autopilot-1 --output json",
 		"no assigned issue",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("autopilot context missing %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("autopilot context missing %q\n---\n%s", want, s) })
 	}
-	if strings.Contains(s, "Run `multica issue get") {
-		t.Errorf("autopilot context should not contain issue get workflow\n---\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, "Run `multica issue get"), func() { t.Errorf("autopilot context should not contain issue get workflow\n---\n%s", s) })
 }
 
 func TestWriteContextFilesClaudeNativeSkills(t *testing.T) {
@@ -956,21 +824,13 @@ func TestWriteContextFilesClaudeNativeSkills(t *testing.T) {
 
 	// Skills should be in .claude/skills/ (native discovery), NOT .agent_context/skills/.
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .claude/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .claude/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 
 	// Supporting files should also be under .claude/skills/.
 	supportFile, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 
 	// .agent_context/skills/ should NOT exist for Claude.
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
@@ -1014,21 +874,13 @@ func TestWriteContextFilesCodebuddyNativeSkills(t *testing.T) {
 	// Skills should be in .codebuddy/skills/ (native discovery), NOT
 	// .claude/skills/ and NOT .agent_context/skills/.
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".codebuddy", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .codebuddy/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .codebuddy/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 
 	// Supporting files should also be under .codebuddy/skills/.
 	supportFile, err := os.ReadFile(filepath.Join(dir, ".codebuddy", "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 
 	// .claude/skills/ must NOT exist — this is the exact regression this
 	// test guards against.
@@ -1072,9 +924,7 @@ func TestReuseRefreshesSkillsWithoutDuplicating(t *testing.T) {
 		Provider:       "claude",
 		Task:           task,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	skillsDir := filepath.Join(env.WorkDir, ".claude", "skills")
@@ -1091,26 +941,20 @@ func TestReuseRefreshesSkillsWithoutDuplicating(t *testing.T) {
 	}
 
 	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		t.Fatalf("read skills dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skills dir: %v", err) })
 	var names []string
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	if len(names) != 1 || names[0] != "issue-review" {
+	testassert.OnFailure(t, len(names) != 1 || names[0] != "issue-review", func() {
 		t.Fatalf("after re-dispatch the skills dir = %v, want exactly [issue-review] with no -multica duplicates", names)
-	}
+	})
 
 	// The surviving skill keeps its natural slug in frontmatter, so the agent
 	// invokes `issue-review` and not a suffixed copy.
 	body, err := os.ReadFile(filepath.Join(skillsDir, "issue-review", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(body), "name: issue-review") {
-		t.Errorf("SKILL.md frontmatter should pin name: issue-review; got:\n%s", body)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(body), "name: issue-review"), func() { t.Errorf("SKILL.md frontmatter should pin name: issue-review; got:\n%s", body) })
 }
 
 // TestReuseReclaimsManagedSkillDirWithStrayAgentFile covers the edge case the
@@ -1138,9 +982,7 @@ func TestReuseReclaimsManagedSkillDirWithStrayAgentFile(t *testing.T) {
 		Provider:       "claude",
 		Task:           task,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	skillsDir := filepath.Join(env.WorkDir, ".claude", "skills")
@@ -1160,16 +1002,14 @@ func TestReuseReclaimsManagedSkillDirWithStrayAgentFile(t *testing.T) {
 	}
 
 	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		t.Fatalf("read skills dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skills dir: %v", err) })
 	var names []string
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	if len(names) != 1 || names[0] != "issue-review" {
+	testassert.OnFailure(t, len(names) != 1 || names[0] != "issue-review", func() {
 		t.Fatalf("after reuse with a stray agent file the skills dir = %v, want exactly [issue-review] with no -multica duplicate", names)
-	}
+	})
 
 	// The managed skill dir is platform-owned: reclaiming it drops the agent's
 	// stray scratch (matching the Codex path) and re-creates a clean SKILL.md.
@@ -1239,26 +1079,18 @@ func TestReuseSkillRefreshIsCanonicalAcrossProviders(t *testing.T) {
 			}
 
 			entries, err := os.ReadDir(skillsDir)
-			if err != nil {
-				t.Fatalf("read skills dir: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skills dir: %v", err) })
 			var names []string
 			for _, e := range entries {
 				names = append(names, e.Name())
 			}
-			if len(names) != 1 || names[0] != "issue-review" {
-				t.Fatalf("skills dir = %v, want exactly [issue-review]", names)
-			}
+			testassert.OnFailure(t, len(names) != 1 || names[0] != "issue-review", func() { t.Fatalf("skills dir = %v, want exactly [issue-review]", names) })
 			if _, err := os.Stat(stray); !os.IsNotExist(err) {
 				t.Errorf("stray agent file should be reclaimed; stat err = %v", err)
 			}
 			body, err := os.ReadFile(filepath.Join(skillsDir, "issue-review", "SKILL.md"))
-			if err != nil {
-				t.Fatalf("read refreshed SKILL.md: %v", err)
-			}
-			if !strings.Contains(string(body), "v2") {
-				t.Errorf("SKILL.md should carry refreshed content v2; got:\n%s", body)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read refreshed SKILL.md: %v", err) })
+			testassert.OnFailure(t, !strings.Contains(string(body), "v2"), func() { t.Errorf("SKILL.md should carry refreshed content v2; got:\n%s", body) })
 		})
 	}
 }
@@ -1283,9 +1115,7 @@ func TestCleanupPreservesLogs(t *testing.T) {
 		AgentName:      "Preserve Test",
 		Task:           TaskContextForEnv{IssueID: "preserve-test-id"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 
 	// Write something to logs/.
 	os.WriteFile(filepath.Join(env.RootDir, "logs", "test.log"), []byte("log data"), 0o644)
@@ -1326,9 +1156,7 @@ func TestInjectRuntimeConfigClaude(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("failed to read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read CLAUDE.md: %v", err) })
 
 	s := string(content)
 	for _, want := range []string{
@@ -1342,16 +1170,12 @@ func TestInjectRuntimeConfigClaude(t *testing.T) {
 		"pr-review",
 		"discovered automatically",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("CLAUDE.md missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("CLAUDE.md missing %q", want) })
 	}
 	// The display names must not leak into the listing — a model that reads
 	// "PR Review" and invokes it by that name gets nothing.
 	for _, absent := range []string{"Go Conventions", "PR Review"} {
-		if strings.Contains(s, absent) {
-			t.Errorf("CLAUDE.md lists display name %q instead of its slug", absent)
-		}
+		testassert.OnFailure(t, strings.Contains(s, absent), func() { t.Errorf("CLAUDE.md lists display name %q instead of its slug", absent) })
 	}
 }
 
@@ -1377,9 +1201,7 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				t.Fatalf("InjectRuntimeConfig failed: %v", err)
 			}
 			data, err := os.ReadFile(filepath.Join(dir, tc.file))
-			if err != nil {
-				t.Fatalf("read %s: %v", tc.file, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", tc.file, err) })
 			s := string(data)
 			for _, want := range []string{
 				"## Background Task Safety",
@@ -1417,9 +1239,7 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				"URL, logs, and stop instructions",
 				"survival as best-effort, not guaranteed",
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s) })
 			}
 			// Exactly one exception: substring pins cannot see a duplicated
 			// "The one exception" clause (a second, wider-scope copy slipped
@@ -1429,15 +1249,13 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 			}
 			// `gh run watch` may only appear as a banned command, never as
 			// the section's example of how to wait properly.
-			if strings.Contains(s, "e.g. `gh run watch`") {
-				t.Errorf("%s should not suggest waiting for external GitHub CI\n---\n%s", tc.file, s)
-			}
+			testassert.OnFailure(t, strings.Contains(s, "e.g. `gh run watch`"), func() { t.Errorf("%s should not suggest waiting for external GitHub CI\n---\n%s", tc.file, s) })
 			// MUL-5274 review: with the persistent-service exception in the
 			// list, a "The rules above ..." scoping sentence would sweep in
 			// work that is precisely no longer run-owned after handoff.
-			if strings.Contains(s, "The rules above") {
+			testassert.OnFailure(t, strings.Contains(s, "The rules above"), func() {
 				t.Errorf("%s must not reintroduce the ambiguous \"The rules above\" scoping sentence\n---\n%s", tc.file, s)
-			}
+			})
 		})
 	}
 }
@@ -1451,9 +1269,7 @@ func TestInjectRuntimeConfigAvailableCommandsCoreOnly(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
 	for _, want := range []string{
@@ -1473,31 +1289,23 @@ func TestInjectRuntimeConfigAvailableCommandsCoreOnly(t *testing.T) {
 		"multica issue comment add <issue-id>",
 		"multica issue comment add --help",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("AGENTS.md missing core command/help text %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("AGENTS.md missing core command/help text %q\n---\n%s", want, s) })
 	}
 
 	// Squad maintenance is squad-leader surface and is gated on that (MUL-5442):
 	// an agent leading no squad has no squad whose roles it could change.
-	if strings.Contains(s, "### Squad maintenance") {
-		t.Errorf("non-leader brief must not carry the squad maintenance block\n---\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, "### Squad maintenance"), func() { t.Errorf("non-leader brief must not carry the squad maintenance block\n---\n%s", s) })
 	leaderDir := t.TempDir()
 	if _, err := InjectRuntimeConfig(leaderDir, "codex", TaskContextForEnv{IssueID: "issue-1", IsSquadLeader: true}); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	leader, err := os.ReadFile(filepath.Join(leaderDir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read leader AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read leader AGENTS.md: %v", err) })
 	for _, want := range []string{
 		"### Squad maintenance",
 		"multica squad member set-role <squad-id>",
 	} {
-		if !strings.Contains(string(leader), want) {
-			t.Errorf("squad-leader AGENTS.md missing %q\n---\n%s", want, leader)
-		}
+		testassert.OnFailure(t, !strings.Contains(string(leader), want), func() { t.Errorf("squad-leader AGENTS.md missing %q\n---\n%s", want, leader) })
 	}
 
 	for _, banned := range []string{
@@ -1525,9 +1333,7 @@ func TestInjectRuntimeConfigAvailableCommandsCoreOnly(t *testing.T) {
 		"multica issue comment delete",
 		"multica label create",
 	} {
-		if strings.Contains(s, banned) {
-			t.Errorf("AGENTS.md should not inject non-core command %q\n---\n%s", banned, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("AGENTS.md should not inject non-core command %q\n---\n%s", banned, s) })
 	}
 }
 
@@ -1545,18 +1351,12 @@ func TestInjectRuntimeConfigCodex(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
 }
 
 func TestInjectRuntimeConfigNoSkills(t *testing.T) {
@@ -1570,17 +1370,11 @@ func TestInjectRuntimeConfigNoSkills(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("failed to read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read CLAUDE.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "multica issue get") {
-		t.Error("should reference multica CLI even without skills")
-	}
-	if strings.Contains(s, "## Skills") {
-		t.Error("should not have Skills section when there are no skills")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "multica issue get"), func() { t.Error("should reference multica CLI even without skills") })
+	testassert.OnFailure(t, strings.Contains(s, "## Skills"), func() { t.Error("should not have Skills section when there are no skills") })
 }
 
 func TestWriteContextFilesCopilotNativeSkills(t *testing.T) {
@@ -1606,21 +1400,13 @@ func TestWriteContextFilesCopilotNativeSkills(t *testing.T) {
 
 	// Copilot CLI natively discovers project-level skills from .github/skills/.
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".github", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .github/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .github/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 
 	// Supporting files should also be under .github/skills/.
 	supportFile, err := os.ReadFile(filepath.Join(dir, ".github", "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 
 	// .agent_context/skills/ should NOT exist for Copilot.
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
@@ -1657,13 +1443,9 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 
 	// Skills should be in .opencode/skills/ (native discovery).
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .opencode/skills/go-conventions/SKILL.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .opencode/skills/go-conventions/SKILL.md: %v", err) })
 	body := string(skillMd)
-	if !strings.Contains(body, "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, !strings.Contains(body, "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	// OpenCode (and every other runtime) silently drops SKILL.md without a
 	// parseable frontmatter `name`. The synthesized frontmatter must lead
 	// with `name:` matching the parent directory slug and carry the
@@ -1675,21 +1457,13 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 	if len(prefix) > 120 {
 		prefix = prefix[:120]
 	}
-	if !strings.HasPrefix(body, "---\nname: go-conventions\n") {
-		t.Errorf("SKILL.md missing synthesized frontmatter name; got: %q", prefix)
-	}
-	if !strings.Contains(body, `description: "Follow our internal Go style."`) {
-		t.Errorf("SKILL.md missing synthesized quoted description; got: %q", prefix)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(body, "---\nname: go-conventions\n"), func() { t.Errorf("SKILL.md missing synthesized frontmatter name; got: %q", prefix) })
+	testassert.OnFailure(t, !strings.Contains(body, `description: "Follow our internal Go style."`), func() { t.Errorf("SKILL.md missing synthesized quoted description; got: %q", prefix) })
 
 	// Supporting files should also be under .opencode/skills/.
 	supportFile, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 
 	// .agent_context/skills/ should NOT exist for OpenCode.
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
@@ -1732,16 +1506,14 @@ func TestWriteContextFilesForcesSkillFrontmatterNameToSlug(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "display-name", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read SKILL.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read SKILL.md: %v", err) })
 
 	// name matches the directory it was written into, so both routing
 	// conventions resolve to the same skill.
 	want := "---\nname: display-name\ndescription: imported as-is\ncustom-key: keep me\n---\n\nbody"
-	if string(skillMd) != want {
+	testassert.OnFailure(t, string(skillMd) != want, func() {
 		t.Errorf("frontmatter name was not normalized to the slug; got:\n%s\nwant:\n%s", skillMd, want)
-	}
+	})
 }
 
 // The directory-name == frontmatter-name invariant must survive collision
@@ -1777,22 +1549,16 @@ func TestWriteContextFilesFrontmatterNameFollowsCollisionSlug(t *testing.T) {
 
 	// The user's directory is untouched.
 	got, err := os.ReadFile(filepath.Join(userSkill, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read user SKILL.md: %v", err)
-	}
-	if string(got) != userContent {
-		t.Errorf("user skill was overwritten; got:\n%s", got)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read user SKILL.md: %v", err) })
+	testassert.OnFailure(t, string(got) != userContent, func() { t.Errorf("user skill was overwritten; got:\n%s", got) })
 
 	// Multica's copy landed at the fallback slug and names itself after it.
 	moved, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "review-multica", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read relocated SKILL.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read relocated SKILL.md: %v", err) })
 	want := "---\nname: review-multica\n---\n\nmultica body"
-	if string(moved) != want {
+	testassert.OnFailure(t, string(moved) != want, func() {
 		t.Errorf("frontmatter name did not follow the collision slug; got:\n%s\nwant:\n%s", moved, want)
-	}
+	})
 }
 
 // The name rewrite must not disturb neighbouring keys, including a nested
@@ -1818,16 +1584,12 @@ func TestWriteContextFilesLeavesNestedFrontmatterNameAlone(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "nested", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read SKILL.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read SKILL.md: %v", err) })
 
 	// The block has no top-level name, so one is injected; `metadata.name`
 	// stays put.
 	want := "---\nname: nested\nmetadata:\n  name: inner\n---\n\nbody"
-	if string(skillMd) != want {
-		t.Errorf("nested name handling is wrong; got:\n%s\nwant:\n%s", skillMd, want)
-	}
+	testassert.OnFailure(t, string(skillMd) != want, func() { t.Errorf("nested name handling is wrong; got:\n%s\nwant:\n%s", skillMd, want) })
 }
 
 // Some upstream skills (GitHub imports, Skills.sh) ship a frontmatter block
@@ -1857,14 +1619,10 @@ func TestWriteContextFilesInjectsNameIntoNamelessFrontmatter(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".opencode", "skills", "review-prs", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read SKILL.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read SKILL.md: %v", err) })
 	got := string(skillMd)
 	want := "---\nname: review-prs\ndescription: Review pull requests\n---\n\nbody"
-	if got != want {
-		t.Errorf("SKILL.md was not patched correctly;\n got: %q\nwant: %q", got, want)
-	}
+	testassert.OnFailure(t, got != want, func() { t.Errorf("SKILL.md was not patched correctly;\n got: %q\nwant: %q", got, want) })
 }
 
 // OpenClaw's native skill scanner reads {workspaceDir}/skills/. The daemon
@@ -1895,20 +1653,12 @@ func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 
 	supportFile, err := os.ReadFile(filepath.Join(dir, "skills", "go-conventions", "templates", "example.go"))
-	if err != nil {
-		t.Fatalf("failed to read supporting file: %v", err)
-	}
-	if string(supportFile) != "package main" {
-		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read supporting file: %v", err) })
+	testassert.OnFailure(t, string(supportFile) != "package main", func() { t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main") })
 
 	// The pre-MUL-2219 fallback path must NOT be written: openclaw never scans it.
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
@@ -1935,12 +1685,8 @@ func TestWriteContextFilesKiroNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".kiro", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .kiro/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .kiro/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Kiro provider")
 	}
@@ -1962,12 +1708,8 @@ func TestWriteContextFilesQoderNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".qoder", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .qoder/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .qoder/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Qoder provider")
 	}
@@ -1989,12 +1731,8 @@ func TestWriteContextFilesQoderCNNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".qoder", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .qoder/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .qoder/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Qoder CN provider")
 	}
@@ -2016,12 +1754,8 @@ func TestWriteContextFilesQwenNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".qwen", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .qwen/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .qwen/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
 		t.Error("expected .agent_context/skills/ to NOT exist for Qwen provider")
 	}
@@ -2042,21 +1776,13 @@ func TestInjectRuntimeConfigOpencode(t *testing.T) {
 
 	// OpenCode uses AGENTS.md (same as codex).
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md missing native skill discovery hint")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md missing native skill discovery hint") })
 
 	// CLAUDE.md should NOT exist.
 	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
@@ -2078,21 +1804,13 @@ func TestInjectRuntimeConfigKiro(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md missing native skill discovery hint")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md missing native skill discovery hint") })
 }
 
 func TestInjectRuntimeConfigQoder(t *testing.T) {
@@ -2109,21 +1827,13 @@ func TestInjectRuntimeConfigQoder(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md missing native skill discovery hint")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md missing native skill discovery hint") })
 }
 
 func TestInjectRuntimeConfigQoderCN(t *testing.T) {
@@ -2140,12 +1850,8 @@ func TestInjectRuntimeConfigQoderCN(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
-	if !strings.Contains(string(content), "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(content), "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 }
 
 // TestInjectRuntimeConfigAntigravity pins that AGENTS.md for Antigravity
@@ -2165,24 +1871,14 @@ func TestInjectRuntimeConfigAntigravity(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md for Antigravity should advertise native skill discovery")
-	}
-	if strings.Contains(s, ".agent_context/skills/") {
-		t.Error("AGENTS.md for Antigravity must not reference the .agent_context/skills/ fallback")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md for Antigravity should advertise native skill discovery") })
+	testassert.OnFailure(t, strings.Contains(s, ".agent_context/skills/"), func() { t.Error("AGENTS.md for Antigravity must not reference the .agent_context/skills/ fallback") })
 }
 
 // TestInjectRuntimeConfigDim verifies that the runtime brief is delivered to
@@ -2202,20 +1898,12 @@ func TestInjectRuntimeConfigDim(t *testing.T) {
 	}
 
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md for Dim should advertise native skill discovery")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md for Dim should advertise native skill discovery") })
 }
 
 // TestWriteContextFilesAntigravityNativeSkills pins that skills for the
@@ -2237,12 +1925,8 @@ func TestWriteContextFilesAntigravityNativeSkills(t *testing.T) {
 	}
 
 	skillMd, err := os.ReadFile(filepath.Join(dir, ".agents", "skills", "go-conventions", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("failed to read .agents/skills/go-conventions/SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
-		t.Error("SKILL.md missing content")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read .agents/skills/go-conventions/SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(skillMd), "Follow Go conventions."), func() { t.Error("SKILL.md missing content") })
 	// The fallback path must NOT be written — Antigravity's scanner reads
 	// .agents/skills/, not .agent_context/skills/.
 	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
@@ -2268,9 +1952,7 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 		Provider:       "opencode",
 		Task:           taskCtx,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if _, err := InjectRuntimeConfig(env.WorkDir, "opencode", taskCtx); err != nil {
@@ -2279,29 +1961,21 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 
 	// Workdir should only contain expected entries.
 	entries, err := os.ReadDir(env.WorkDir)
-	if err != nil {
-		t.Fatalf("failed to read workdir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read workdir: %v", err) })
 	for _, e := range entries {
 		name := e.Name()
-		if name != ".agent_context" && name != ".multica" && name != "AGENTS.md" {
-			t.Errorf("unexpected entry in workdir: %s", name)
-		}
+		testassert.OnFailure(t, name != ".agent_context" && name != ".multica" && name != "AGENTS.md", func() { t.Errorf("unexpected entry in workdir: %s", name) })
 	}
 
 	// AGENTS.md should contain repo info.
 	content, err := os.ReadFile(filepath.Join(env.WorkDir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 	s := string(content)
 	for _, want := range []string{
 		"multica repo checkout",
 		"https://github.com/org/backend",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("AGENTS.md missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("AGENTS.md missing %q", want) })
 	}
 }
 
@@ -2333,9 +2007,7 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 				t.Fatalf("InjectRuntimeConfig failed: %v", err)
 			}
 			data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-			if err != nil {
-				t.Fatalf("read CLAUDE.md: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 			s := string(data)
 
 			// The workflow must contain an explicit `multica issue comment add`
@@ -2348,9 +2020,7 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 				"mandatory",
 			}
 			for _, want := range mustContain {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s: CLAUDE.md missing %q\n---\n%s", tc.name, want, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s: CLAUDE.md missing %q\n---\n%s", tc.name, want, s) })
 			}
 
 			// The Output section must carry a hard warning that terminal/log
@@ -2360,9 +2030,7 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 				"Final results MUST be delivered via `multica issue comment add`",
 				"does NOT see your terminal output",
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s: Output warning missing %q", tc.name, want)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s: Output warning missing %q", tc.name, want) })
 			}
 		})
 	}
@@ -2395,9 +2063,7 @@ func TestInjectRuntimeConfigCommentGuardrailIsProviderAgnostic(t *testing.T) {
 					configFile = "AGENTS.md"
 				}
 				data, err := os.ReadFile(filepath.Join(dir, configFile))
-				if err != nil {
-					t.Fatalf("read %s: %v", configFile, err)
-				}
+				testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", configFile, err) })
 				s := string(data)
 
 				// Available Commands lists all three input modes as available.
@@ -2406,9 +2072,7 @@ func TestInjectRuntimeConfigCommentGuardrailIsProviderAgnostic(t *testing.T) {
 					"--content-stdin",
 					"--content-file <path>",
 				} {
-					if !strings.Contains(s, want) {
-						t.Errorf("%s missing flag mention %q\n---\n%s", configFile, want, s)
-					}
+					testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s missing flag mention %q\n---\n%s", configFile, want, s) })
 				}
 
 				// The provider-agnostic guardrail must now reach non-Codex
@@ -2418,9 +2082,7 @@ func TestInjectRuntimeConfigCommentGuardrailIsProviderAgnostic(t *testing.T) {
 					"## Comment Formatting",
 					"Never use inline `--content` for agent-authored comments",
 				} {
-					if !strings.Contains(s, want) {
-						t.Errorf("%s missing provider-agnostic comment guardrail %q\n---\n%s", configFile, want, s)
-					}
+					testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s missing provider-agnostic comment guardrail %q\n---\n%s", configFile, want, s) })
 				}
 
 				// The legacy over-broad mandate (#1795 / #1851) must NOT
@@ -2431,9 +2093,9 @@ func TestInjectRuntimeConfigCommentGuardrailIsProviderAgnostic(t *testing.T) {
 					"Agent-authored comments should always pipe content via stdin",
 					"use `--description-stdin` and pipe a HEREDOC",
 				} {
-					if strings.Contains(s, banned) {
+					testassert.OnFailure(t, strings.Contains(s, banned), func() {
 						t.Errorf("%s reintroduces over-broad legacy mandate %q for provider %s\n---\n%s", configFile, banned, provider, s)
-					}
+					})
 				}
 			})
 		}
@@ -2471,9 +2133,7 @@ func TestInjectRuntimeConfigLinuxCommentFormattingEmphasizesFile(t *testing.T) {
 				fileName = "AGENTS.md"
 			}
 			data, err := os.ReadFile(filepath.Join(dir, fileName))
-			if err != nil {
-				t.Fatalf("read %s: %v", fileName, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", fileName, err) })
 			s := string(data)
 
 			// Assert inside the section slice: "#4182" also appears in
@@ -2482,9 +2142,7 @@ func TestInjectRuntimeConfigLinuxCommentFormattingEmphasizesFile(t *testing.T) {
 			// Match the HEADING at line start — Available Commands references
 			// "## Comment Formatting" inline earlier in the file.
 			cfStart := strings.Index(s, "\n## Comment Formatting\n")
-			if cfStart < 0 {
-				t.Fatalf("%s missing ## Comment Formatting section\n---\n%s", fileName, s)
-			}
+			testassert.OnFailure(t, cfStart < 0, func() { t.Fatalf("%s missing ## Comment Formatting section\n---\n%s", fileName, s) })
 			cf := s[cfStart+1:]
 			if next := strings.Index(cf[3:], "\n## "); next >= 0 {
 				cf = cf[:next+3]
@@ -2499,9 +2157,7 @@ func TestInjectRuntimeConfigLinuxCommentFormattingEmphasizesFile(t *testing.T) {
 				"rm ./reply.md",
 				"do not rely on `\\n` escapes",
 			} {
-				if !strings.Contains(cf, want) {
-					t.Errorf("%s Comment Formatting section missing %q\n---\n%s", fileName, want, cf)
-				}
+				testassert.OnFailure(t, !strings.Contains(cf, want), func() { t.Errorf("%s Comment Formatting section missing %q\n---\n%s", fileName, want, cf) })
 			}
 
 			// The previous mandate (#1795 / #1851 / MUL-2904) must NOT remain.
@@ -2510,9 +2166,7 @@ func TestInjectRuntimeConfigLinuxCommentFormattingEmphasizesFile(t *testing.T) {
 				"<<'COMMENT'",
 				"Codex-Specific Comment Formatting",
 			} {
-				if strings.Contains(s, banned) {
-					t.Errorf("%s still carries pre-#4182 stdin mandate %q\n---\n%s", fileName, banned, s)
-				}
+				testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("%s still carries pre-#4182 stdin mandate %q\n---\n%s", fileName, banned, s) })
 			}
 		})
 	}
@@ -2535,9 +2189,7 @@ func TestInjectRuntimeConfigCodexWindowsUsesContentFile(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read AGENTS.md: %v", err) })
 	s := string(data)
 	for _, want := range []string{
 		"On Windows, **always write the comment body to a UTF-8 file",
@@ -2545,16 +2197,12 @@ func TestInjectRuntimeConfigCodexWindowsUsesContentFile(t *testing.T) {
 		"--content-file",
 		"may replace non-ASCII characters with `?`",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("AGENTS.md missing Codex/Windows file-first guidance %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("AGENTS.md missing Codex/Windows file-first guidance %q\n---\n%s", want, s) })
 	}
 	for _, banned := range []string{
 		"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
 	} {
-		if strings.Contains(s, banned) {
-			t.Errorf("AGENTS.md still carries Codex stdin mandate %q on Windows\n---\n%s", banned, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("AGENTS.md still carries Codex stdin mandate %q on Windows\n---\n%s", banned, s) })
 	}
 }
 
@@ -2567,9 +2215,7 @@ func TestInjectRuntimeConfigQuickCreateOutputPrefixAgnostic(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read AGENTS.md: %v", err) })
 	s := string(data)
 
 	for _, want := range []string{
@@ -2578,16 +2224,12 @@ func TestInjectRuntimeConfigQuickCreateOutputPrefixAgnostic(t *testing.T) {
 		"identifier` from JSON output",
 		"never assume a workspace issue prefix",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("quick-create runtime config missing %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("quick-create runtime config missing %q\n---\n%s", want, s) })
 	}
 	for _, absent := range []string{
 		"Created MUL-<n>",
 	} {
-		if strings.Contains(s, absent) {
-			t.Errorf("quick-create runtime config should not contain %q\n---\n%s", absent, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, absent), func() { t.Errorf("quick-create runtime config should not contain %q\n---\n%s", absent, s) })
 	}
 }
 
@@ -2607,9 +2249,7 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read AGENTS.md: %v", err) })
 	s := string(data)
 
 	for _, want := range []string{
@@ -2619,18 +2259,14 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 		"multica autopilot get autopilot-1 --output json",
 		"Your final assistant output is captured automatically as the autopilot run result",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("autopilot runtime config missing %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("autopilot runtime config missing %q\n---\n%s", want, s) })
 	}
 
 	for _, absent := range []string{
 		"Run `multica issue get",
 		"Final results MUST be delivered via `multica issue comment add`",
 	} {
-		if strings.Contains(s, absent) {
-			t.Errorf("autopilot runtime config should not contain %q\n---\n%s", absent, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, absent), func() { t.Errorf("autopilot runtime config should not contain %q\n---\n%s", absent, s) })
 	}
 }
 
@@ -2645,9 +2281,7 @@ func TestInjectRuntimeConfigUnknownProvider(t *testing.T) {
 
 	// No files should be created.
 	entries, _ := os.ReadDir(dir)
-	if len(entries) != 0 {
-		t.Fatalf("expected empty dir for unknown provider, got %d entries", len(entries))
-	}
+	testassert.OnFailure(t, len(entries) != 0, func() { t.Fatalf("expected empty dir for unknown provider, got %d entries", len(entries)) })
 }
 
 func TestInjectRuntimeConfigHermes(t *testing.T) {
@@ -2665,28 +2299,18 @@ func TestInjectRuntimeConfigHermes(t *testing.T) {
 
 	// Hermes uses AGENTS.md.
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("failed to read AGENTS.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read AGENTS.md: %v", err) })
 
 	s := string(content)
-	if !strings.Contains(s, "Multica Agent Runtime") {
-		t.Error("AGENTS.md missing meta skill header")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "Multica Agent Runtime"), func() { t.Error("AGENTS.md missing meta skill header") })
 	// Listed by on-disk slug rather than the display name (MUL-5529).
-	if !strings.Contains(s, "coding") {
-		t.Error("AGENTS.md missing skill name")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "coding"), func() { t.Error("AGENTS.md missing skill name") })
 	// Hermes now discovers skills from the daemon-seeded per-task
 	// HERMES_HOME/skills (see hermes_home.go), so AGENTS.md must use the
 	// "discovered automatically" framing and must NOT point the agent at the
 	// old .agent_context/skills/ fallback it never read (issue #5242).
-	if !strings.Contains(s, "discovered automatically") {
-		t.Error("AGENTS.md for Hermes should describe skills as discovered automatically")
-	}
-	if strings.Contains(s, ".agent_context/skills/") {
-		t.Error("AGENTS.md for Hermes should not reference the .agent_context/skills/ fallback path")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "discovered automatically"), func() { t.Error("AGENTS.md for Hermes should describe skills as discovered automatically") })
+	testassert.OnFailure(t, strings.Contains(s, ".agent_context/skills/"), func() { t.Error("AGENTS.md for Hermes should not reference the .agent_context/skills/ fallback path") })
 
 	// CLAUDE.md should NOT exist.
 	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
@@ -2764,92 +2388,58 @@ func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 	// shared home (MUL-4424). A fresh home gets an empty local dir.
 	sessionsPath := filepath.Join(codexHome, "sessions")
 	fi, err := os.Lstat(sessionsPath)
-	if err != nil {
-		t.Fatalf("sessions not found: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("sessions should be a task-local directory, not a symlink into the shared home")
-	}
-	if !fi.IsDir() {
-		t.Error("sessions should be a directory")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions not found: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("sessions should be a task-local directory, not a symlink into the shared home") })
+	testassert.OnFailure(t, !fi.IsDir(), func() { t.Error("sessions should be a directory") })
 
 	// auth.json should be a symlink.
 	authPath := filepath.Join(codexHome, "auth.json")
 	fi, err = os.Lstat(authPath)
-	if err != nil {
-		t.Fatalf("auth.json not found: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("auth.json not found: %v", err) })
 	authIsLink := fi.Mode()&os.ModeSymlink != 0
-	if !authIsLink && runtime.GOOS != "windows" {
-		t.Error("auth.json should be a symlink")
-	}
+	testassert.OnFailure(t, !authIsLink && runtime.GOOS != "windows", func() { t.Error("auth.json should be a symlink") })
 	if authIsLink {
 		target, _ := os.Readlink(authPath)
-		if target != filepath.Join(sharedHome, "auth.json") {
+		testassert.OnFailure(t, target != filepath.Join(sharedHome, "auth.json"), func() {
 			t.Errorf("auth.json symlink target = %q, want %q", target, filepath.Join(sharedHome, "auth.json"))
-		}
+		})
 	}
 	// Verify content is accessible through symlink.
 	data, _ := os.ReadFile(authPath)
-	if string(data) != `{"token":"secret"}` {
-		t.Errorf("auth.json content = %q", data)
-	}
+	testassert.OnFailure(t, string(data) != `{"token":"secret"}`, func() { t.Errorf("auth.json content = %q", data) })
 
 	// config.json should be a copy (not symlink).
 	configPath := filepath.Join(codexHome, "config.json")
 	fi, err = os.Lstat(configPath)
-	if err != nil {
-		t.Fatalf("config.json not found: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("config.json should be a copy, not a symlink")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("config.json not found: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("config.json should be a copy, not a symlink") })
 	data, _ = os.ReadFile(configPath)
-	if string(data) != `{"model":"o3"}` {
-		t.Errorf("config.json content = %q", data)
-	}
+	testassert.OnFailure(t, string(data) != `{"model":"o3"}`, func() { t.Errorf("config.json content = %q", data) })
 
 	// config.toml should be copied and have the managed sandbox block prepended.
 	data, _ = os.ReadFile(filepath.Join(codexHome, "config.toml"))
 	tomlStr := string(data)
-	if !strings.Contains(tomlStr, `model = "o3"`) {
-		t.Errorf("config.toml missing original model setting, got: %q", tomlStr)
-	}
-	if !strings.Contains(tomlStr, "sandbox_mode = ") {
-		t.Errorf("config.toml missing managed sandbox_mode, got: %q", tomlStr)
-	}
+	testassert.OnFailure(t, !strings.Contains(tomlStr, `model = "o3"`), func() { t.Errorf("config.toml missing original model setting, got: %q", tomlStr) })
+	testassert.OnFailure(t, !strings.Contains(tomlStr, "sandbox_mode = "), func() { t.Errorf("config.toml missing managed sandbox_mode, got: %q", tomlStr) })
 
 	// instructions.md should be copied.
 	data, _ = os.ReadFile(filepath.Join(codexHome, "instructions.md"))
-	if string(data) != "Be helpful." {
-		t.Errorf("instructions.md content = %q", data)
-	}
+	testassert.OnFailure(t, string(data) != "Be helpful.", func() { t.Errorf("instructions.md content = %q", data) })
 
 	// models_cache.json is a task-local snapshot so Codex can skip a cold model
 	// catalog refresh without letting a task mutate the user's shared cache.
 	modelsCachePath := filepath.Join(codexHome, "models_cache.json")
 	fi, err = os.Lstat(modelsCachePath)
-	if err != nil {
-		t.Fatalf("models_cache.json not found: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("models_cache.json should be copied, not symlinked")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("models_cache.json not found: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("models_cache.json should be copied, not symlinked") })
 	data, _ = os.ReadFile(modelsCachePath)
-	if string(data) != `{"models":["gpt-test"]}` {
-		t.Errorf("models_cache.json content = %q", data)
-	}
+	testassert.OnFailure(t, string(data) != `{"models":["gpt-test"]}`, func() { t.Errorf("models_cache.json content = %q", data) })
 
 	// plugin cache should be exposed at the same relative path in codex-home.
 	pluginSkillPath := filepath.Join(codexHome, "plugins", "cache", "superpowers", "SKILL.md")
 	data, err = os.ReadFile(pluginSkillPath)
-	if err != nil {
-		t.Fatalf("plugin cache skill not exposed: %v", err)
-	}
-	if string(data) != "Use superpowers." {
-		t.Errorf("plugin cache skill content = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("plugin cache skill not exposed: %v", err) })
+	testassert.OnFailure(t, string(data) != "Use superpowers.", func() { t.Errorf("plugin cache skill content = %q", data) })
 
 	// Marketplace checkouts contain executable plugin code and must not be
 	// linked into a task home where one task could mutate another task's state.
@@ -2877,12 +2467,8 @@ func TestPrepareCodexHomeCopiesRelativeModelCatalog(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "cc-switch-model-catalog.json"))
-	if err != nil {
-		t.Fatalf("read per-task model catalog: %v", err)
-	}
-	if string(data) != `{"models":[{"model":"deepseek-v4-flash"}]}` {
-		t.Errorf("per-task model catalog = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task model catalog: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"models":[{"model":"deepseek-v4-flash"}]}`, func() { t.Errorf("per-task model catalog = %q", data) })
 }
 
 func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
@@ -2896,13 +2482,9 @@ func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
 	err := prepareCodexHome(codexHome, testLogger())
-	if err == nil {
-		t.Fatal("expected prepareCodexHome to fail for missing model catalog")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepareCodexHome to fail for missing model catalog") })
 	for _, want := range []string{"model_catalog_json", "missing-catalog.json", filepath.Join(sharedHome, "missing-catalog.json")} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q missing %q", err, want)
-		}
+		testassert.OnFailure(t, !strings.Contains(err.Error(), want), func() { t.Fatalf("error %q missing %q", err, want) })
 	}
 }
 
@@ -2928,12 +2510,8 @@ func TestPrepareCodexHomeCopiesRelativeModelInstructionsFile(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "gpt-unrestricted.md"))
-	if err != nil {
-		t.Fatalf("read per-task instructions: %v", err)
-	}
-	if string(data) != "Be direct." {
-		t.Errorf("per-task instructions = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task instructions: %v", err) })
+	testassert.OnFailure(t, string(data) != "Be direct.", func() { t.Errorf("per-task instructions = %q", data) })
 
 	// The copy must be isolated: a task editing its instructions cannot reach
 	// back into the user's real Codex home.
@@ -2941,12 +2519,8 @@ func TestPrepareCodexHomeCopiesRelativeModelInstructionsFile(t *testing.T) {
 		t.Fatalf("rewrite per-task instructions: %v", err)
 	}
 	shared, err := os.ReadFile(filepath.Join(sharedHome, "gpt-unrestricted.md"))
-	if err != nil {
-		t.Fatalf("read shared instructions: %v", err)
-	}
-	if string(shared) != "Be direct." {
-		t.Errorf("shared instructions mutated by task: %q", shared)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read shared instructions: %v", err) })
+	testassert.OnFailure(t, string(shared) != "Be direct.", func() { t.Errorf("shared instructions mutated by task: %q", shared) })
 }
 
 // A nested reference must land at the same relative location inside the task
@@ -2974,12 +2548,8 @@ func TestPrepareCodexHomeCopiesNestedDeprecatedInstructionsFile(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, rel))
-	if err != nil {
-		t.Fatalf("read per-task instructions: %v", err)
-	}
-	if string(data) != "Nested." {
-		t.Errorf("per-task instructions = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task instructions: %v", err) })
+	testassert.OnFailure(t, string(data) != "Nested.", func() { t.Errorf("per-task instructions = %q", data) })
 }
 
 // A missing source must fail while preparing the environment, with a diagnostic
@@ -2996,13 +2566,9 @@ func TestPrepareCodexHomeReportsMissingModelInstructionsFile(t *testing.T) {
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
 	err := prepareCodexHome(codexHome, testLogger())
-	if err == nil {
-		t.Fatal("expected prepareCodexHome to fail for missing model instructions file")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepareCodexHome to fail for missing model instructions file") })
 	for _, want := range []string{"model_instructions_file", "missing-instructions.md", filepath.Join(sharedHome, "missing-instructions.md")} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q missing %q", err, want)
-		}
+		testassert.OnFailure(t, !strings.Contains(err.Error(), want), func() { t.Fatalf("error %q missing %q", err, want) })
 	}
 }
 
@@ -3027,12 +2593,8 @@ func TestPrepareCodexHomeRejectsEscapingModelInstructionsFile(t *testing.T) {
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
 	err := prepareCodexHome(codexHome, testLogger())
-	if err == nil {
-		t.Fatal("expected prepareCodexHome to reject an escaping model instructions path")
-	}
-	if !strings.Contains(err.Error(), "model_instructions_file") {
-		t.Fatalf("error %q does not name the offending key", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepareCodexHome to reject an escaping model instructions path") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "model_instructions_file"), func() { t.Fatalf("error %q does not name the offending key", err) })
 	if _, statErr := os.Stat(filepath.Join(filepath.Dir(codexHome), "secrets.md")); !os.IsNotExist(statErr) {
 		t.Fatalf("escaping source was materialised outside the task home: %v", statErr)
 	}
@@ -3065,12 +2627,8 @@ func TestPrepareCodexHomeRefreshesModelInstructionsFileOnReuse(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "instructions-override.md"))
-	if err != nil {
-		t.Fatalf("read per-task instructions: %v", err)
-	}
-	if string(data) != "second" {
-		t.Errorf("per-task instructions = %q, want the refreshed source", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task instructions: %v", err) })
+	testassert.OnFailure(t, string(data) != "second", func() { t.Errorf("per-task instructions = %q, want the refreshed source", data) })
 }
 
 // A reused task home is writable by the task that ran in it, so an intermediate
@@ -3113,20 +2671,12 @@ func TestPrepareCodexHomeRefusesSymlinkedInstructionsParentOnReuse(t *testing.T)
 	}
 
 	err := prepareCodexHome(codexHome, testLogger())
-	if err == nil {
-		t.Fatal("expected prepareCodexHome to refuse writing through a symlinked parent")
-	}
-	if !strings.Contains(err.Error(), "model_instructions_file") {
-		t.Fatalf("error %q does not name the offending key", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepareCodexHome to refuse writing through a symlinked parent") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "model_instructions_file"), func() { t.Fatalf("error %q does not name the offending key", err) })
 
 	data, readErr := os.ReadFile(sentinel)
-	if readErr != nil {
-		t.Fatalf("sentinel outside the task home was removed: %v", readErr)
-	}
-	if string(data) != "outside the task home" {
-		t.Errorf("sentinel outside the task home was overwritten: %q", data)
-	}
+	testassert.OnFailure(t, readErr != nil, func() { t.Fatalf("sentinel outside the task home was removed: %v", readErr) })
+	testassert.OnFailure(t, string(data) != "outside the task home", func() { t.Errorf("sentinel outside the task home was overwritten: %q", data) })
 }
 
 // The destination file itself can also be a symlink on reuse. Removing it must
@@ -3166,26 +2716,14 @@ func TestPrepareCodexHomeReplacesSymlinkedInstructionsCopyOnReuse(t *testing.T) 
 	}
 
 	data, err := os.ReadFile(sentinel)
-	if err != nil {
-		t.Fatalf("sentinel outside the task home was removed: %v", err)
-	}
-	if string(data) != "outside the task home" {
-		t.Errorf("sentinel outside the task home was overwritten: %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sentinel outside the task home was removed: %v", err) })
+	testassert.OnFailure(t, string(data) != "outside the task home", func() { t.Errorf("sentinel outside the task home was overwritten: %q", data) })
 	info, err := os.Lstat(taskCopy)
-	if err != nil {
-		t.Fatalf("lstat task copy: %v", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		t.Error("task copy is still a symlink")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat task copy: %v", err) })
+	testassert.OnFailure(t, info.Mode()&os.ModeSymlink != 0, func() { t.Error("task copy is still a symlink") })
 	copied, err := os.ReadFile(taskCopy)
-	if err != nil {
-		t.Fatalf("read task copy: %v", err)
-	}
-	if string(copied) != "from shared home" {
-		t.Errorf("task copy = %q", copied)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read task copy: %v", err) })
+	testassert.OnFailure(t, string(copied) != "from shared home", func() { t.Errorf("task copy = %q", copied) })
 }
 
 // Repointing the key provisions the new target; the previous copy stays behind
@@ -3221,19 +2759,11 @@ func TestPrepareCodexHomeLeavesRepointedInstructionsCopyBehind(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "new.md"))
-	if err != nil {
-		t.Fatalf("read repointed instructions: %v", err)
-	}
-	if string(data) != "new" {
-		t.Errorf("repointed instructions = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read repointed instructions: %v", err) })
+	testassert.OnFailure(t, string(data) != "new", func() { t.Errorf("repointed instructions = %q", data) })
 	config, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read per-task config.toml: %v", err)
-	}
-	if !strings.Contains(string(config), `model_instructions_file = "new.md"`) {
-		t.Errorf("per-task config.toml still points at the old target: %s", config)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task config.toml: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(config), `model_instructions_file = "new.md"`), func() { t.Errorf("per-task config.toml still points at the old target: %s", config) })
 	if _, err := os.Stat(filepath.Join(codexHome, "old.md")); err != nil {
 		t.Errorf("unreferenced old copy unexpectedly cleaned up: %v", err)
 	}
@@ -3253,9 +2783,7 @@ func TestVerifyCodexHomeRootRejectsSwappedDirectory(t *testing.T) {
 		t.Fatalf("create codex home: %v", err)
 	}
 	root, err := os.OpenRoot(codexHome)
-	if err != nil {
-		t.Fatalf("open codex home root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("open codex home root: %v", err) })
 	defer root.Close()
 
 	// Same path, different directory — what a swap looks like after the open.
@@ -3267,12 +2795,8 @@ func TestVerifyCodexHomeRootRejectsSwappedDirectory(t *testing.T) {
 	}
 
 	err = verifyCodexHomeRoot(root, codexHome, "model_instructions_file")
-	if err == nil {
-		t.Fatal("expected verifyCodexHomeRoot to reject a swapped codex home")
-	}
-	if !strings.Contains(err.Error(), "replaced") {
-		t.Fatalf("error %q does not report the replacement", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected verifyCodexHomeRoot to reject a swapped codex home") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "replaced"), func() { t.Fatalf("error %q does not report the replacement", err) })
 }
 
 func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
@@ -3284,9 +2808,7 @@ func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
 		t.Fatalf("create codex home: %v", err)
 	}
 	root, err := os.OpenRoot(codexHome)
-	if err != nil {
-		t.Fatalf("open codex home root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("open codex home root: %v", err) })
 	defer root.Close()
 
 	outside := t.TempDir()
@@ -3298,12 +2820,8 @@ func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
 	}
 
 	err = verifyCodexHomeRoot(root, codexHome, "model_instructions_file")
-	if err == nil {
-		t.Fatal("expected verifyCodexHomeRoot to reject a symlinked codex home")
-	}
-	if !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("error %q does not report the symlink", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected verifyCodexHomeRoot to reject a symlinked codex home") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "symlink"), func() { t.Fatalf("error %q does not report the symlink", err) })
 }
 
 // End to end, scoped to the write this change owns: when the task home is
@@ -3337,20 +2855,12 @@ func TestPrepareCodexHomeRefusesReferencedFileWriteThroughSymlinkedCodexHome(t *
 	}
 
 	err := prepareCodexHome(codexHome, testLogger())
-	if err == nil {
-		t.Fatal("expected prepareCodexHome to refuse a symlinked codex home")
-	}
-	if !strings.Contains(err.Error(), "model_instructions_file") {
-		t.Fatalf("error %q does not name the offending key", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepareCodexHome to refuse a symlinked codex home") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "model_instructions_file"), func() { t.Fatalf("error %q does not name the offending key", err) })
 
 	data, readErr := os.ReadFile(sentinel)
-	if readErr != nil {
-		t.Fatalf("sentinel outside the task home was removed: %v", readErr)
-	}
-	if string(data) != "outside the task home" {
-		t.Errorf("sentinel outside the task home was overwritten: %q", data)
-	}
+	testassert.OnFailure(t, readErr != nil, func() { t.Fatalf("sentinel outside the task home was removed: %v", readErr) })
+	testassert.OnFailure(t, string(data) != "outside the task home", func() { t.Errorf("sentinel outside the task home was overwritten: %q", data) })
 }
 
 // Regression test for #1753 — Codex Desktop writes plugin-backed
@@ -3386,22 +2896,14 @@ model = "o3"
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read per-task config.toml: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task config.toml: %v", err) })
 	tomlStr := string(data)
-	if strings.Contains(tomlStr, "[[skills.config]]") {
+	testassert.OnFailure(t, strings.Contains(tomlStr, "[[skills.config]]"), func() {
 		t.Errorf("per-task config.toml should not inherit [[skills.config]] entries, got:\n%s", tomlStr)
-	}
-	if strings.Contains(tomlStr, "superpowers:brainstorming") {
-		t.Errorf("per-task config.toml should not retain plugin skill names, got:\n%s", tomlStr)
-	}
-	if !strings.Contains(tomlStr, `model = "o3"`) {
-		t.Errorf("top-level keys should be preserved, got:\n%s", tomlStr)
-	}
-	if !strings.Contains(tomlStr, "[profiles.default]") {
-		t.Errorf("unrelated tables should be preserved, got:\n%s", tomlStr)
-	}
+	})
+	testassert.OnFailure(t, strings.Contains(tomlStr, "superpowers:brainstorming"), func() { t.Errorf("per-task config.toml should not retain plugin skill names, got:\n%s", tomlStr) })
+	testassert.OnFailure(t, !strings.Contains(tomlStr, `model = "o3"`), func() { t.Errorf("top-level keys should be preserved, got:\n%s", tomlStr) })
+	testassert.OnFailure(t, !strings.Contains(tomlStr, "[profiles.default]"), func() { t.Errorf("unrelated tables should be preserved, got:\n%s", tomlStr) })
 }
 
 func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
@@ -3419,43 +2921,25 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	// Directory should contain task-local sessions, the model-cache config
 	// binding, and auto-generated config.toml.
 	entries, err := os.ReadDir(codexHome)
-	if err != nil {
-		t.Fatalf("failed to read codex-home: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read codex-home: %v", err) })
 	entryNames := make(map[string]bool, len(entries))
 	for _, e := range entries {
 		entryNames[e.Name()] = true
 	}
-	if !entryNames["sessions"] {
-		t.Error("expected sessions directory")
-	}
-	if !entryNames["config.toml"] {
-		t.Error("expected config.toml (auto-generated for network access)")
-	}
-	if !entryNames["plugins"] {
-		t.Error("expected plugins directory for plugin cache exposure")
-	}
-	if !entryNames[codexModelsCacheBindingFile] {
-		t.Error("expected models cache config binding")
-	}
+	testassert.OnFailure(t, !entryNames["sessions"], func() { t.Error("expected sessions directory") })
+	testassert.OnFailure(t, !entryNames["config.toml"], func() { t.Error("expected config.toml (auto-generated for network access)") })
+	testassert.OnFailure(t, !entryNames["plugins"], func() { t.Error("expected plugins directory for plugin cache exposure") })
+	testassert.OnFailure(t, !entryNames[codexModelsCacheBindingFile], func() { t.Error("expected models cache config binding") })
 	for name := range entryNames {
-		if name != "sessions" && name != "config.toml" && name != "plugins" && name != codexModelsCacheBindingFile {
-			t.Errorf("unexpected entry: %s", name)
-		}
+		testassert.OnFailure(t, name != "sessions" && name != "config.toml" && name != "plugins" && name != codexModelsCacheBindingFile, func() { t.Errorf("unexpected entry: %s", name) })
 	}
 	// sessions should be a real, task-local directory — not a symlink into the
 	// shared home (MUL-4424).
 	sessionsPath := filepath.Join(codexHome, "sessions")
 	fi, err := os.Lstat(sessionsPath)
-	if err != nil {
-		t.Fatalf("sessions not found: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("sessions should be a task-local directory, not a symlink")
-	}
-	if !fi.IsDir() {
-		t.Error("sessions should be a directory")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("sessions not found: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Error("sessions should be a task-local directory, not a symlink") })
+	testassert.OnFailure(t, !fi.IsDir(), func() { t.Error("sessions should be a directory") })
 	if _, err := os.Stat(filepath.Join(codexHome, "plugins", "cache")); err != nil {
 		t.Fatalf("missing shared plugin cache exposure should still be tolerated and created: %v", err)
 	}
@@ -3498,12 +2982,8 @@ func TestPrepareCodexHome_RefreshesStaleAuthCopyOnReuse(t *testing.T) {
 	// After Reuse, dst should mirror the current shared source — either as a
 	// fresh symlink (preferred) or as a fresh copy (Windows fallback).
 	data, err := os.ReadFile(stalePath)
-	if err != nil {
-		t.Fatalf("read auth.json: %v", err)
-	}
-	if string(data) != `{"refresh_token":"v2"}` {
-		t.Errorf("auth.json content = %q, want refreshed v2 contents", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read auth.json: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"refresh_token":"v2"}`, func() { t.Errorf("auth.json content = %q, want refreshed v2 contents", data) })
 }
 
 // Regression for MUL-2646: when the user updates `~/.codex/config.toml`
@@ -3566,19 +3046,13 @@ env_key = "NEW_API_KEY"
 
 	// config.toml must reflect the new provider/URL/env_key.
 	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read per-task config.toml: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task config.toml: %v", err) })
 	s := string(data)
 	for _, want := range []string{`model_provider = "new-provider"`, "https://new.example.com", "NEW_API_KEY"} {
-		if !strings.Contains(s, want) {
-			t.Errorf("per-task config.toml missing %q after refresh, got:\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("per-task config.toml missing %q after refresh, got:\n%s", want, s) })
 	}
 	for _, bad := range []string{"old-provider", "https://old.example.com", "OLD_API_KEY"} {
-		if strings.Contains(s, bad) {
-			t.Errorf("per-task config.toml still contains stale %q after refresh, got:\n%s", bad, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, bad), func() { t.Errorf("per-task config.toml still contains stale %q after refresh, got:\n%s", bad, s) })
 	}
 	// Daemon-managed sandbox / multi-agent / memory blocks must all be
 	// re-applied on top of the fresh copy — PR correctness depends on it.
@@ -3588,28 +3062,18 @@ env_key = "NEW_API_KEY"
 		multicaMemoryFeatureBeginMarker,
 		multicaMemoryConfigBeginMarker,
 	} {
-		if !strings.Contains(s, marker) {
-			t.Errorf("daemon-managed marker %q missing after refresh, got:\n%s", marker, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, marker), func() { t.Errorf("daemon-managed marker %q missing after refresh, got:\n%s", marker, s) })
 	}
 
 	// config.json must reflect the new model.
 	data, err = os.ReadFile(filepath.Join(codexHome, "config.json"))
-	if err != nil {
-		t.Fatalf("read per-task config.json: %v", err)
-	}
-	if string(data) != `{"model":"new-model"}` {
-		t.Errorf("per-task config.json content = %q, want refreshed contents", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task config.json: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"model":"new-model"}`, func() { t.Errorf("per-task config.json content = %q, want refreshed contents", data) })
 
 	// instructions.md must reflect the new content.
 	data, err = os.ReadFile(filepath.Join(codexHome, "instructions.md"))
-	if err != nil {
-		t.Fatalf("read per-task instructions.md: %v", err)
-	}
-	if string(data) != "new instructions" {
-		t.Errorf("per-task instructions.md content = %q, want refreshed contents", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task instructions.md: %v", err) })
+	testassert.OnFailure(t, string(data) != "new instructions", func() { t.Errorf("per-task instructions.md content = %q, want refreshed contents", data) })
 }
 
 // Regression for MUL-2646 (deletion arm): when the user removes a file from
@@ -3679,14 +3143,12 @@ env_key = "OLD_API_KEY"
 	// but it must contain only the daemon-managed blocks — no stale user
 	// provider/URL/env_key.
 	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read per-task config.toml after shared removal: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read per-task config.toml after shared removal: %v", err) })
 	s := string(data)
 	for _, bad := range []string{"old-provider", "https://old.example.com", "OLD_API_KEY"} {
-		if strings.Contains(s, bad) {
+		testassert.OnFailure(t, strings.Contains(s, bad), func() {
 			t.Errorf("per-task config.toml still contains stale %q after shared source removed, got:\n%s", bad, s)
-		}
+		})
 	}
 	for _, marker := range []string{
 		multicaManagedBeginMarker,
@@ -3694,9 +3156,7 @@ env_key = "OLD_API_KEY"
 		multicaMemoryFeatureBeginMarker,
 		multicaMemoryConfigBeginMarker,
 	} {
-		if !strings.Contains(s, marker) {
-			t.Errorf("daemon-managed marker %q missing after shared source removed, got:\n%s", marker, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, marker), func() { t.Errorf("daemon-managed marker %q missing after shared source removed, got:\n%s", marker, s) })
 	}
 }
 
@@ -3711,22 +3171,16 @@ func TestEnsureCodexSandboxConfigCreatesDefaultLinux(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("failed to read config.toml: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("failed to read config.toml: %v", err) })
 	s := string(data)
-	if !strings.Contains(s, multicaManagedBeginMarker) || !strings.Contains(s, multicaManagedEndMarker) {
-		t.Errorf("missing managed block markers, got:\n%s", s)
-	}
-	if !strings.Contains(s, `sandbox_mode = "danger-full-access"`) {
-		t.Error("missing sandbox_mode")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, multicaManagedBeginMarker) || !strings.Contains(s, multicaManagedEndMarker), func() { t.Errorf("missing managed block markers, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, `sandbox_mode = "danger-full-access"`), func() { t.Error("missing sandbox_mode") })
 	// Linux tasks run unsandboxed on the daemon user's real HOME, so nothing
 	// under sandbox_workspace_write applies — neither the table header nor the
 	// dotted-key form should be emitted (MUL-5578).
-	if strings.Contains(s, "sandbox_workspace_write") {
+	testassert.OnFailure(t, strings.Contains(s, "sandbox_workspace_write"), func() {
 		t.Errorf("must not emit any sandbox_workspace_write key under danger-full-access, got:\n%s", s)
-	}
+	})
 }
 
 func TestEnsureCodexSandboxConfigDarwinFallsBack(t *testing.T) {
@@ -3740,12 +3194,8 @@ func TestEnsureCodexSandboxConfigDarwinFallsBack(t *testing.T) {
 	}
 
 	s, _ := os.ReadFile(configPath)
-	if !strings.Contains(string(s), `sandbox_mode = "danger-full-access"`) {
-		t.Errorf("expected danger-full-access fallback on macOS, got:\n%s", s)
-	}
-	if strings.Contains(string(s), "[sandbox_workspace_write]") {
-		t.Errorf("should not emit workspace-write section on macOS fallback, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(string(s), `sandbox_mode = "danger-full-access"`), func() { t.Errorf("expected danger-full-access fallback on macOS, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(string(s), "[sandbox_workspace_write]"), func() { t.Errorf("should not emit workspace-write section on macOS fallback, got:\n%s", s) })
 }
 
 // TestEnsureCodexSandboxConfigWindowsFallsBack pins MUL-4957: when a Windows
@@ -3765,12 +3215,8 @@ func TestEnsureCodexSandboxConfigWindowsFallsBack(t *testing.T) {
 	}
 
 	s, _ := os.ReadFile(configPath)
-	if !strings.Contains(string(s), `sandbox_mode = "danger-full-access"`) {
-		t.Errorf("expected danger-full-access fallback on windows, got:\n%s", s)
-	}
-	if strings.Contains(string(s), "sandbox_workspace_write") {
-		t.Errorf("should not emit any workspace-write keys on windows fallback, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(string(s), `sandbox_mode = "danger-full-access"`), func() { t.Errorf("expected danger-full-access fallback on windows, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(string(s), "sandbox_workspace_write"), func() { t.Errorf("should not emit any workspace-write keys on windows fallback, got:\n%s", s) })
 }
 
 // TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox pins the MUL-4957
@@ -3793,9 +3239,7 @@ func TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox(t *testing.T) {
 			}
 
 			winState := resolveWindowsSandboxState(configPath, nil, sharedConfigPresent, nil, testLogger())
-			if winState != windowsSandboxNative {
-				t.Fatalf("resolveWindowsSandboxState = %v, want native", winState)
-			}
+			testassert.OnFailure(t, winState != windowsSandboxNative, func() { t.Fatalf("resolveWindowsSandboxState = %v, want native", winState) })
 			policy := codexSandboxPolicyForConfig("windows", "0.144.5", winState)
 			if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
 				t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
@@ -3803,19 +3247,13 @@ func TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox(t *testing.T) {
 
 			data, _ := os.ReadFile(configPath)
 			s := string(data)
-			if !strings.Contains(s, `sandbox_mode = "workspace-write"`) {
-				t.Errorf("expected workspace-write kept for user-configured windows.sandbox, got:\n%s", s)
-			}
-			if strings.Contains(s, "danger-full-access") {
+			testassert.OnFailure(t, !strings.Contains(s, `sandbox_mode = "workspace-write"`), func() { t.Errorf("expected workspace-write kept for user-configured windows.sandbox, got:\n%s", s) })
+			testassert.OnFailure(t, strings.Contains(s, "danger-full-access"), func() {
 				t.Errorf("must not downgrade a user-configured windows.sandbox to danger-full-access, got:\n%s", s)
-			}
-			if !strings.Contains(s, "network_access = true") {
-				t.Errorf("expected network_access = true under workspace-write, got:\n%s", s)
-			}
+			})
+			testassert.OnFailure(t, !strings.Contains(s, "network_access = true"), func() { t.Errorf("expected network_access = true under workspace-write, got:\n%s", s) })
 			// The user's explicit opt-in must survive verbatim.
-			if !strings.Contains(s, `sandbox = "`+mode+`"`) {
-				t.Errorf("user windows.sandbox = %q must be preserved, got:\n%s", mode, s)
-			}
+			testassert.OnFailure(t, !strings.Contains(s, `sandbox = "`+mode+`"`), func() { t.Errorf("user windows.sandbox = %q must be preserved, got:\n%s", mode, s) })
 		})
 	}
 }
@@ -3855,15 +3293,9 @@ approval_policy = "on-failure"
 
 	data, _ := os.ReadFile(configPath)
 	s := string(data)
-	if !strings.Contains(s, `model = "o3"`) {
-		t.Error("lost existing model setting")
-	}
-	if !strings.Contains(s, "approval_policy") {
-		t.Error("lost existing approval_policy")
-	}
-	if !strings.Contains(s, `sandbox_mode = "danger-full-access"`) {
-		t.Error("missing managed sandbox_mode")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, `model = "o3"`), func() { t.Error("lost existing model setting") })
+	testassert.OnFailure(t, !strings.Contains(s, "approval_policy"), func() { t.Error("lost existing approval_policy") })
+	testassert.OnFailure(t, !strings.Contains(s, `sandbox_mode = "danger-full-access"`), func() { t.Error("missing managed sandbox_mode") })
 }
 
 func TestEnsureCodexSandboxConfigStripsLegacyInlineDirectives(t *testing.T) {
@@ -3890,19 +3322,11 @@ network_access = true
 
 	data, _ := os.ReadFile(configPath)
 	s := string(data)
-	if !strings.Contains(s, `model = "o3"`) {
-		t.Error("should have preserved unrelated user config")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, `model = "o3"`), func() { t.Error("should have preserved unrelated user config") })
 	// Inline sandbox_mode and [sandbox_workspace_write] should be stripped.
-	if strings.Count(s, "sandbox_mode") != 1 {
-		t.Errorf("expected exactly one sandbox_mode line (inside managed block), got:\n%s", s)
-	}
-	if strings.Contains(s, "[sandbox_workspace_write]") {
-		t.Errorf("darwin fallback should not retain workspace-write section:\n%s", s)
-	}
-	if !strings.Contains(s, `sandbox_mode = "danger-full-access"`) {
-		t.Errorf("expected danger-full-access on macOS, got:\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Count(s, "sandbox_mode") != 1, func() { t.Errorf("expected exactly one sandbox_mode line (inside managed block), got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "[sandbox_workspace_write]"), func() { t.Errorf("darwin fallback should not retain workspace-write section:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, `sandbox_mode = "danger-full-access"`), func() { t.Errorf("expected danger-full-access on macOS, got:\n%s", s) })
 }
 
 func TestEnsureCodexSandboxConfigHoistsAboveUserTables(t *testing.T) {
@@ -3933,22 +3357,16 @@ trust = "always"
 	beginIdx := strings.Index(s, multicaManagedBeginMarker)
 	endIdx := strings.Index(s, multicaManagedEndMarker)
 	tableIdx := strings.Index(s, "[permissions.multica]")
-	if beginIdx < 0 || endIdx < 0 || tableIdx < 0 {
-		t.Fatalf("expected managed block and user table to both be present, got:\n%s", s)
-	}
+	testassert.OnFailure(t, beginIdx < 0 || endIdx < 0 || tableIdx < 0, func() { t.Fatalf("expected managed block and user table to both be present, got:\n%s", s) })
 	// The entire managed block must sit before the user's table header so
 	// that sandbox_mode and sandbox_workspace_write.network_access are
 	// parsed at the TOML root.
-	if !(beginIdx < endIdx && endIdx < tableIdx) {
+	testassert.OnFailure(t, !(beginIdx < endIdx && endIdx < tableIdx), func() {
 		t.Errorf("managed block must be hoisted above [permissions.multica]; got begin=%d end=%d table=%d:\n%s", beginIdx, endIdx, tableIdx, s)
-	}
+	})
 	// User content must be preserved verbatim.
-	if !strings.Contains(s, `model = "o3"`) {
-		t.Error("lost user top-level key")
-	}
-	if !strings.Contains(s, `trust = "always"`) {
-		t.Error("lost user permissions.multica content")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, `model = "o3"`), func() { t.Error("lost user top-level key") })
+	testassert.OnFailure(t, !strings.Contains(s, `trust = "always"`), func() { t.Error("lost user permissions.multica content") })
 
 	// Running again must be idempotent even when the preceding content ends
 	// inside a table.
@@ -3956,9 +3374,7 @@ trust = "always"
 		t.Fatalf("second pass: %v", err)
 	}
 	data2, _ := os.ReadFile(configPath)
-	if string(data2) != s {
-		t.Errorf("second pass should be idempotent:\n--- first ---\n%s\n--- second ---\n%s", s, data2)
-	}
+	testassert.OnFailure(t, string(data2) != s, func() { t.Errorf("second pass should be idempotent:\n--- first ---\n%s\n--- second ---\n%s", s, data2) })
 	if n := strings.Count(string(data2), multicaManagedBeginMarker); n != 1 {
 		t.Errorf("expected exactly one managed block after idempotent rewrite, got %d", n)
 	}
@@ -3996,17 +3412,11 @@ network_access = true
 
 	beginIdx := strings.Index(s, multicaManagedBeginMarker)
 	tableIdx := strings.Index(s, "[permissions.multica]")
-	if beginIdx < 0 || tableIdx < 0 || beginIdx > tableIdx {
-		t.Errorf("expected managed block to be hoisted above [permissions.multica], got:\n%s", s)
-	}
-	if strings.Count(s, multicaManagedBeginMarker) != 1 {
-		t.Errorf("expected exactly one managed block, got:\n%s", s)
-	}
+	testassert.OnFailure(t, beginIdx < 0 || tableIdx < 0 || beginIdx > tableIdx, func() { t.Errorf("expected managed block to be hoisted above [permissions.multica], got:\n%s", s) })
+	testassert.OnFailure(t, strings.Count(s, multicaManagedBeginMarker) != 1, func() { t.Errorf("expected exactly one managed block, got:\n%s", s) })
 	// The old inline `[sandbox_workspace_write]` header must be gone — the
 	// new block uses dotted-key form only.
-	if strings.Contains(s, "[sandbox_workspace_write]") {
-		t.Errorf("managed block must not emit [sandbox_workspace_write] table header, got:\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, "[sandbox_workspace_write]"), func() { t.Errorf("managed block must not emit [sandbox_workspace_write] table header, got:\n%s", s) })
 }
 
 func TestCodexSandboxPolicyFor(t *testing.T) {
@@ -4035,18 +3445,10 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := codexSandboxPolicyFor(tc.goos, tc.version)
-			if p.Mode != tc.wantMode {
-				t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode)
-			}
-			if p.NetworkAccess != tc.wantNet {
-				t.Errorf("network_access = %v, want %v", p.NetworkAccess, tc.wantNet)
-			}
-			if p.Reason == "" {
-				t.Error("expected non-empty Reason")
-			}
-			if (p.Hint != "") != tc.wantHint {
-				t.Errorf("hint present = %v, want %v (hint=%q)", p.Hint != "", tc.wantHint, p.Hint)
-			}
+			testassert.OnFailure(t, p.Mode != tc.wantMode, func() { t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode) })
+			testassert.OnFailure(t, p.NetworkAccess != tc.wantNet, func() { t.Errorf("network_access = %v, want %v", p.NetworkAccess, tc.wantNet) })
+			testassert.OnFailure(t, p.Reason == "", func() { t.Error("expected non-empty Reason") })
+			testassert.OnFailure(t, (p.Hint != "") != tc.wantHint, func() { t.Errorf("hint present = %v, want %v (hint=%q)", p.Hint != "", tc.wantHint, p.Hint) })
 		})
 	}
 }
@@ -4073,15 +3475,9 @@ func TestCodexSandboxPolicyForConfig(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := codexSandboxPolicyForConfig(tc.goos, "0.144.5", tc.winState)
-			if p.Mode != tc.wantMode {
-				t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode)
-			}
-			if p.NetworkAccess != tc.wantNet {
-				t.Errorf("network_access = %v, want %v", p.NetworkAccess, tc.wantNet)
-			}
-			if p.Reason == "" {
-				t.Error("expected non-empty Reason")
-			}
+			testassert.OnFailure(t, p.Mode != tc.wantMode, func() { t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode) })
+			testassert.OnFailure(t, p.NetworkAccess != tc.wantNet, func() { t.Errorf("network_access = %v, want %v", p.NetworkAccess, tc.wantNet) })
+			testassert.OnFailure(t, p.Reason == "", func() { t.Error("expected non-empty Reason") })
 		})
 	}
 }
@@ -4305,21 +3701,15 @@ func TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails(t *testing.T) {
 	})
 
 	err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "windows", CodexVersion: "0.144.5"}, testLogger())
-	if err == nil {
+	testassert.OnFailure(t, err == nil, func() {
 		t.Fatal("expected prepareCodexHomeWithOpts to fail closed when the sandbox block cannot be written, got nil")
-	}
-	if !strings.Contains(err.Error(), "sandbox config") {
-		t.Errorf("expected a sandbox-config error, got: %v", err)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "sandbox config"), func() { t.Errorf("expected a sandbox-config error, got: %v", err) })
 	// The stale danger-full-access is still on disk — proving the task would
 	// have launched unsandboxed had prepare reported success.
 	data, readErr := os.ReadFile(configPath)
-	if readErr != nil {
-		t.Fatalf("read config: %v", readErr)
-	}
-	if !strings.Contains(string(data), `sandbox_mode = "danger-full-access"`) {
-		t.Fatalf("expected the stale danger-full-access to remain (write failed), got:\n%s", data)
-	}
+	testassert.OnFailure(t, readErr != nil, func() { t.Fatalf("read config: %v", readErr) })
+	testassert.OnFailure(t, !strings.Contains(string(data), `sandbox_mode = "danger-full-access"`), func() { t.Fatalf("expected the stale danger-full-access to remain (write failed), got:\n%s", data) })
 }
 
 // TestPrepareCodexHomeWritesManagedSandboxBlock checks that preparing a codex
@@ -4340,21 +3730,15 @@ func TestPrepareCodexHomeWritesManagedSandboxBlock(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("config.toml not created: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("config.toml not created: %v", err) })
 	s := string(data)
-	if !strings.Contains(s, multicaManagedBeginMarker) {
-		t.Errorf("config.toml missing managed block, got:\n%s", s)
-	}
-	if !strings.Contains(s, `sandbox_mode = "danger-full-access"`) {
-		t.Errorf("config.toml missing danger-full-access sandbox_mode, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(s, multicaManagedBeginMarker), func() { t.Errorf("config.toml missing managed block, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, `sandbox_mode = "danger-full-access"`), func() { t.Errorf("config.toml missing danger-full-access sandbox_mode, got:\n%s", s) })
 	// Nothing under sandbox_workspace_write applies when the filesystem is not
 	// sandboxed; emitting it would imply containment that does not exist.
-	if strings.Contains(s, "sandbox_workspace_write") {
+	testassert.OnFailure(t, strings.Contains(s, "sandbox_workspace_write"), func() {
 		t.Errorf("config.toml must not emit sandbox_workspace_write under danger-full-access, got:\n%s", s)
-	}
+	})
 }
 
 func TestReuseRestoresCodexHome(t *testing.T) {
@@ -4374,26 +3758,18 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
-	if env.CodexHome == "" {
-		t.Fatal("expected CodexHome to be set after Prepare")
-	}
+	testassert.OnFailure(t, env.CodexHome == "", func() { t.Fatal("expected CodexHome to be set after Prepare") })
 
 	// Reuse should restore CodexHome.
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-test"}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
-	if reused.CodexHome == "" {
-		t.Fatal("expected CodexHome to be restored after Reuse")
-	}
-	if reused.MulticaConfigRoot != filepath.Join(reused.RootDir, "multica-config") {
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
+	testassert.OnFailure(t, reused.CodexHome == "", func() { t.Fatal("expected CodexHome to be restored after Reuse") })
+	testassert.OnFailure(t, reused.MulticaConfigRoot != filepath.Join(reused.RootDir, "multica-config"), func() {
 		t.Fatalf("MulticaConfigRoot = %q, want restored task-local config directory", reused.MulticaConfigRoot)
-	}
+	})
 	if info, err := os.Stat(reused.MulticaConfigRoot); err != nil {
 		t.Fatalf("stat restored MulticaConfigRoot: %v", err)
 	} else if got := info.Mode().Perm(); got != 0o700 {
@@ -4403,12 +3779,8 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	// Verify config.toml has a managed block (exact mode depends on host
 	// platform; either workspace-write or danger-full-access is valid).
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("config.toml not found in reused CodexHome: %v", err)
-	}
-	if !strings.Contains(string(data), multicaManagedBeginMarker) {
-		t.Error("reused config.toml missing multica-managed block")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("config.toml not found in reused CodexHome: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), multicaManagedBeginMarker), func() { t.Error("reused config.toml missing multica-managed block") })
 }
 
 func TestReuseRestoresCodexPluginCache(t *testing.T) {
@@ -4433,9 +3805,7 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-plugin-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if err := os.RemoveAll(filepath.Join(env.CodexHome, "plugins")); err != nil {
@@ -4443,17 +3813,11 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 	}
 
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-plugin-test"}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "plugins", "cache", "superpowers", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("reused codex plugin cache not restored: %v", err)
-	}
-	if string(data) != "Use superpowers." {
-		t.Errorf("reused plugin cache skill content = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("reused codex plugin cache not restored: %v", err) })
+	testassert.OnFailure(t, string(data) != "Use superpowers.", func() { t.Errorf("reused plugin cache skill content = %q", data) })
 }
 
 func TestReusePreservesTaskLocalModelsCacheWhenSharedMissing(t *testing.T) {
@@ -4470,9 +3834,7 @@ func TestReusePreservesTaskLocalModelsCacheWhenSharedMissing(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-missing"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	modelsCache := filepath.Join(env.CodexHome, "models_cache.json")
@@ -4485,17 +3847,11 @@ func TestReusePreservesTaskLocalModelsCacheWhenSharedMissing(t *testing.T) {
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-missing"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "models_cache.json"))
-	if err != nil {
-		t.Fatalf("task-local models cache removed on reuse: %v", err)
-	}
-	if string(data) != `{"source":"task"}` {
-		t.Fatalf("task-local models cache = %q, want task-generated cache", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("task-local models cache removed on reuse: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"source":"task"}`, func() { t.Fatalf("task-local models cache = %q, want task-generated cache", data) })
 }
 
 func TestReusePreservesTaskLocalModelsCacheOverStaleSharedSnapshot(t *testing.T) {
@@ -4515,9 +3871,7 @@ func TestReusePreservesTaskLocalModelsCacheOverStaleSharedSnapshot(t *testing.T)
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-stale"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	modelsCache := filepath.Join(env.CodexHome, "models_cache.json")
@@ -4530,17 +3884,11 @@ func TestReusePreservesTaskLocalModelsCacheOverStaleSharedSnapshot(t *testing.T)
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-stale"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "models_cache.json"))
-	if err != nil {
-		t.Fatalf("read reused task-local models cache: %v", err)
-	}
-	if string(data) != `{"source":"task"}` {
-		t.Fatalf("task-local models cache = %q, want refreshed task cache", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read reused task-local models cache: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"source":"task"}`, func() { t.Fatalf("task-local models cache = %q, want refreshed task cache", data) })
 }
 
 func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testing.T) {
@@ -4565,9 +3913,7 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	modelsCache := filepath.Join(env.CodexHome, "models_cache.json")
@@ -4588,39 +3934,27 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 	if _, err := os.Lstat(modelsCache); !os.IsNotExist(err) {
 		t.Fatalf("provider A models cache survived provider change: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "config.toml"))
-	if err != nil {
-		t.Fatalf("read provider B task config: %v", err)
-	}
-	if !strings.Contains(string(data), `model_provider = "provider-b"`) {
-		t.Fatalf("task config did not switch to provider B: %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read provider B task config: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), `model_provider = "provider-b"`), func() { t.Fatalf("task config did not switch to provider B: %q", data) })
 
 	// Once Codex refreshes the cache for provider B, another reuse with the
 	// unchanged binding must preserve it over the shared snapshot.
 	if err := os.WriteFile(modelsCache, []byte(`{"source":"task-b"}`), 0o644); err != nil {
 		t.Fatalf("write provider B task cache: %v", err)
 	}
-	if Reuse(ReuseParams{
+	testassert.OnFailure(t, Reuse(ReuseParams{
 		WorkDir:  env.WorkDir,
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
-	}, testLogger()) == nil {
-		t.Fatal("second Reuse returned nil")
-	}
+	}, testLogger()) == nil, func() { t.Fatal("second Reuse returned nil") })
 	data, err = os.ReadFile(modelsCache)
-	if err != nil {
-		t.Fatalf("read provider B task cache: %v", err)
-	}
-	if string(data) != `{"source":"task-b"}` {
-		t.Fatalf("provider B task cache = %q, want task-refreshed cache", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read provider B task cache: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"source":"task-b"}`, func() { t.Fatalf("provider B task cache = %q, want task-refreshed cache", data) })
 }
 
 func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.T) {
@@ -4647,9 +3981,7 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-model-catalog-change"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	modelsCache := filepath.Join(env.CodexHome, "models_cache.json")
@@ -4665,19 +3997,13 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-catalog-change"},
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 	if _, err := os.Lstat(modelsCache); !os.IsNotExist(err) {
 		t.Fatalf("models cache survived model catalog change: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "catalog.json"))
-	if err != nil {
-		t.Fatalf("read refreshed task model catalog: %v", err)
-	}
-	if string(data) != `{"models":[{"slug":"model-b"}]}` {
-		t.Fatalf("task model catalog = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read refreshed task model catalog: %v", err) })
+	testassert.OnFailure(t, string(data) != `{"models":[{"slug":"model-b"}]}`, func() { t.Fatalf("task model catalog = %q", data) })
 }
 
 func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
@@ -4697,9 +4023,7 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	modelsCache := filepath.Join(env.CodexHome, "models_cache.json")
@@ -4710,13 +4034,11 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 		t.Fatalf("remove cache binding to simulate pre-fix home: %v", err)
 	}
 
-	if Reuse(ReuseParams{
+	testassert.OnFailure(t, Reuse(ReuseParams{
 		WorkDir:  env.WorkDir,
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
-	}, testLogger()) == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	}, testLogger()) == nil, func() { t.Fatal("Reuse returned nil") })
 	if _, err := os.Lstat(modelsCache); !os.IsNotExist(err) {
 		t.Fatalf("unbound legacy cache survived reuse: %v", err)
 	}
@@ -4729,13 +4051,11 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sharedHome, "models_cache.json"), []byte(`{"source":"shared"}`), 0o644); err != nil {
 		t.Fatalf("write shared cache: %v", err)
 	}
-	if Reuse(ReuseParams{
+	testassert.OnFailure(t, Reuse(ReuseParams{
 		WorkDir:  env.WorkDir,
 		Provider: "codex",
 		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
-	}, testLogger()) == nil {
-		t.Fatal("second Reuse returned nil")
-	}
+	}, testLogger()) == nil, func() { t.Fatal("second Reuse returned nil") })
 	if _, err := os.Lstat(modelsCache); !os.IsNotExist(err) {
 		t.Fatalf("shared cache seeded into existing unbound home: %v", err)
 	}
@@ -4756,9 +4076,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-skill-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if err := os.RemoveAll(filepath.Join(env.CodexHome, "skills")); err != nil {
@@ -4775,24 +4093,14 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 			},
 		},
 	}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "writing", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("missing reused codex workspace skill: %v", err)
-	}
-	if !strings.Contains(string(data), "Write clearly.") {
-		t.Errorf("skill content = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("missing reused codex workspace skill: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), "Write clearly."), func() { t.Errorf("skill content = %q", data) })
 	example, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "writing", "examples", "example.md"))
-	if err != nil {
-		t.Fatalf("missing reused codex workspace skill support file: %v", err)
-	}
-	if string(example) != "Example" {
-		t.Errorf("support file content = %q", example)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("missing reused codex workspace skill support file: %v", err) })
+	testassert.OnFailure(t, string(example) != "Example", func() { t.Errorf("support file content = %q", example) })
 }
 
 func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
@@ -4819,9 +4127,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 			},
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
@@ -4834,24 +4140,14 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 			},
 		},
 	}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "writing", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("missing reused codex workspace skill: %v", err)
-	}
-	if !strings.Contains(string(data), "Updated writing guidance.") {
-		t.Errorf("skill content = %q", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("missing reused codex workspace skill: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), "Updated writing guidance."), func() { t.Errorf("skill content = %q", data) })
 	example, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "writing", "examples", "example.md"))
-	if err != nil {
-		t.Fatalf("missing reused codex workspace skill support file: %v", err)
-	}
-	if string(example) != "Updated example" {
-		t.Errorf("support file content = %q", example)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("missing reused codex workspace skill support file: %v", err) })
+	testassert.OnFailure(t, string(example) != "Updated example", func() { t.Errorf("support file content = %q", example) })
 }
 
 // TestPrepareCodexSeedsUserSkills covers the fix for #1922: skills the user
@@ -4894,9 +4190,7 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "user-skills-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "summarize", "SKILL.md")); err != nil {
@@ -4953,18 +4247,12 @@ func TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict(t *testing.T) {
 			},
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "writing", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("workspace skill not written: %v", err)
-	}
-	if !strings.Contains(string(data), "workspace writing") {
-		t.Errorf("SKILL.md = %q, want workspace content", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("workspace skill not written: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), "workspace writing"), func() { t.Errorf("SKILL.md = %q, want workspace content", data) })
 	// The user's stale support file must not leak through — seeding is
 	// skipped entirely for names that workspace skills claim.
 	if _, err := os.Stat(filepath.Join(env.CodexHome, "skills", "writing", "drafts", "stale.md")); !os.IsNotExist(err) {
@@ -4989,9 +4277,7 @@ func TestPrepareCodexNoUserSkillsDir(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "no-user-skills-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 	if _, err := os.Stat(filepath.Join(env.CodexHome, "skills")); !os.IsNotExist(err) {
 		t.Errorf("skills dir should not exist when neither user nor workspace skills are present, err=%v", err)
@@ -5037,9 +4323,7 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "symlinked-skills-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	dst := filepath.Join(env.CodexHome, "skills", "lark-mail")
@@ -5047,23 +4331,13 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 		t.Fatalf("seeded skill missing: %v", err)
 	}
 	target, err := os.Readlink(dst)
-	if err != nil {
-		t.Fatalf("seeded skill should be a link into the installer dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("seeded skill should be a link into the installer dir: %v", err) })
 	wantTarget, err := filepath.EvalSymlinks(installerRoot)
-	if err != nil {
-		t.Fatalf("resolve installer dir: %v", err)
-	}
-	if target != wantTarget {
-		t.Errorf("link target = %q, want the resolved installer dir %q", target, wantTarget)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve installer dir: %v", err) })
+	testassert.OnFailure(t, target != wantTarget, func() { t.Errorf("link target = %q, want the resolved installer dir %q", target, wantTarget) })
 	data, err := os.ReadFile(filepath.Join(dst, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("seeded SKILL.md missing: %v", err)
-	}
-	if string(data) != "lark" {
-		t.Errorf("seeded SKILL.md = %q, want %q", data, "lark")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("seeded SKILL.md missing: %v", err) })
+	testassert.OnFailure(t, string(data) != "lark", func() { t.Errorf("seeded SKILL.md = %q, want %q", data, "lark") })
 }
 
 // TestReuseSeedsUserSkillUpdates ensures that user-skill edits between two
@@ -5091,9 +4365,7 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "user-skill-reuse-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if err := os.WriteFile(filepath.Join(userSkill, "SKILL.md"), []byte("v2"), 0o644); err != nil {
@@ -5103,16 +4375,10 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "user-skill-reuse-test",
 	}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "summarize", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("user skill not refreshed on reuse: %v", err)
-	}
-	if string(data) != "v2" {
-		t.Errorf("after Reuse, user skill content = %q, want %q", data, "v2")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("user skill not refreshed on reuse: %v", err) })
+	testassert.OnFailure(t, string(data) != "v2", func() { t.Errorf("after Reuse, user skill content = %q, want %q", data, "v2") })
 }
 
 // TestReuseClearsUserSkillResidueOnWorkspaceConflict locks in the fix for
@@ -5145,9 +4411,7 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-conflict-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// Round 1 had no workspace skill, so the user version should be present.
@@ -5161,17 +4425,11 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 			{Name: "Writing", Content: "workspace writing"},
 		},
 	}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 
 	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "skills", "writing", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("workspace SKILL.md missing after reuse: %v", err)
-	}
-	if !strings.Contains(string(data), "workspace writing") {
-		t.Errorf("SKILL.md = %q, want workspace content", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("workspace SKILL.md missing after reuse: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(data), "workspace writing"), func() { t.Errorf("SKILL.md = %q, want workspace content", data) })
 	if _, err := os.Stat(filepath.Join(reused.CodexHome, "skills", "writing", "drafts", "stale.md")); !os.IsNotExist(err) {
 		t.Errorf("round-1 user support file leaked into round-2 workspace skill dir, err=%v", err)
 	}
@@ -5203,9 +4461,7 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-remove-test"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if _, err := os.Stat(filepath.Join(env.CodexHome, "skills", "deprecated", "SKILL.md")); err != nil {
@@ -5220,9 +4476,7 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-remove-test",
 	}}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 	if _, err := os.Stat(filepath.Join(reused.CodexHome, "skills", "deprecated")); !os.IsNotExist(err) {
 		t.Errorf("removed user skill still present in per-task home after reuse, err=%v", err)
 	}
@@ -5251,13 +4505,9 @@ func TestEnsureSymlinkRepairsBrokenLink(t *testing.T) {
 
 	// Should now point to src.
 	target, _ := os.Readlink(dst)
-	if target != src {
-		t.Errorf("symlink target = %q, want %q", target, src)
-	}
+	testassert.OnFailure(t, target != src, func() { t.Errorf("symlink target = %q, want %q", target, src) })
 	data, _ := os.ReadFile(dst)
-	if string(data) != "real" {
-		t.Errorf("content = %q, want %q", data, "real")
-	}
+	testassert.OnFailure(t, string(data) != "real", func() { t.Errorf("content = %q, want %q", data, "real") })
 }
 
 func TestWriteReadGCMeta(t *testing.T) {
@@ -5276,22 +4526,12 @@ func TestWriteReadGCMeta(t *testing.T) {
 	}
 
 	meta, err := ReadGCMeta(dir)
-	if err != nil {
-		t.Fatalf("ReadGCMeta: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ReadGCMeta: %v", err) })
 
-	if meta.Kind != GCKindIssue {
-		t.Errorf("Kind = %q, want %q", meta.Kind, GCKindIssue)
-	}
-	if meta.IssueID != issueID {
-		t.Errorf("IssueID = %q, want %q", meta.IssueID, issueID)
-	}
-	if meta.WorkspaceID != wsID {
-		t.Errorf("WorkspaceID = %q, want %q", meta.WorkspaceID, wsID)
-	}
-	if meta.CompletedAt.IsZero() {
-		t.Error("CompletedAt should not be zero")
-	}
+	testassert.OnFailure(t, meta.Kind != GCKindIssue, func() { t.Errorf("Kind = %q, want %q", meta.Kind, GCKindIssue) })
+	testassert.OnFailure(t, meta.IssueID != issueID, func() { t.Errorf("IssueID = %q, want %q", meta.IssueID, issueID) })
+	testassert.OnFailure(t, meta.WorkspaceID != wsID, func() { t.Errorf("WorkspaceID = %q, want %q", meta.WorkspaceID, wsID) })
+	testassert.OnFailure(t, meta.CompletedAt.IsZero(), func() { t.Error("CompletedAt should not be zero") })
 }
 
 func TestWriteGCMeta_EmptyRoot(t *testing.T) {
@@ -5324,15 +4564,9 @@ func TestReadGCMeta_LegacyFileDefaultsToIssueKind(t *testing.T) {
 		t.Fatal(err)
 	}
 	meta, err := ReadGCMeta(dir)
-	if err != nil {
-		t.Fatalf("ReadGCMeta: %v", err)
-	}
-	if meta.Kind != GCKindIssue {
-		t.Fatalf("legacy kind: want %q, got %q", GCKindIssue, meta.Kind)
-	}
-	if meta.IssueID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
-		t.Fatalf("legacy issue_id: got %q", meta.IssueID)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ReadGCMeta: %v", err) })
+	testassert.OnFailure(t, meta.Kind != GCKindIssue, func() { t.Fatalf("legacy kind: want %q, got %q", GCKindIssue, meta.Kind) })
+	testassert.OnFailure(t, meta.IssueID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890", func() { t.Fatalf("legacy issue_id: got %q", meta.IssueID) })
 }
 
 // New v2 meta files for chat / autopilot / quick-create round-trip without
@@ -5357,12 +4591,8 @@ func TestWriteReadGCMeta_KindRoundTrip(t *testing.T) {
 				t.Fatalf("WriteGCMeta: %v", err)
 			}
 			got, err := ReadGCMeta(dir)
-			if err != nil {
-				t.Fatalf("ReadGCMeta: %v", err)
-			}
-			if got.Kind != tc.want {
-				t.Fatalf("Kind: want %q, got %q", tc.want, got.Kind)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("ReadGCMeta: %v", err) })
+			testassert.OnFailure(t, got.Kind != tc.want, func() { t.Fatalf("Kind: want %q, got %q", tc.want, got.Kind) })
 		})
 	}
 }
@@ -5371,9 +4601,7 @@ func TestReadGCMeta_NoFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	_, err := ReadGCMeta(dir)
-	if err == nil {
-		t.Fatal("expected error for missing file")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected error for missing file") })
 }
 
 // TestInjectRuntimeConfigMentionLoopHardening locks in the mention-loop
@@ -5398,9 +4626,7 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			t.Fatalf("InjectRuntimeConfig failed: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-		if err != nil {
-			t.Fatalf("read CLAUDE.md: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 		return string(data)
 	}
 
@@ -5431,17 +4657,13 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			"a missed mention costs one follow-up ask, a stray one costs a run",
 			"Silence ends conversations",
 		} {
-			if !strings.Contains(s, want) {
-				t.Errorf("Mentions section missing %q\n---\n%s", want, s)
-			}
+			testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("Mentions section missing %q\n---\n%s", want, s) })
 		}
 		// Neither the bare prescription (MUL-6417) nor the overreach that
 		// replaced it may come back: "never how someone finds out" was false
 		// for non-followers and suppressed legitimate human escalation.
 		for _, banned := range []string{"Default: NO mention", "never how someone finds out"} {
-			if strings.Contains(s, banned) {
-				t.Errorf("Mentions section carries retired wording %q\n---\n%s", banned, s)
-			}
+			testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("Mentions section carries retired wording %q\n---\n%s", banned, s) })
 		}
 	})
 
@@ -5450,9 +4672,9 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 		s := readClaudeMD(t, assignmentCtx)
 		// The old footer said "**always** use the mention format" which models
 		// over-generalized to agent/member mentions. Guard against regression.
-		if strings.Contains(s, "**always** use the mention format") {
+		testassert.OnFailure(t, strings.Contains(s, "**always** use the mention format"), func() {
 			t.Errorf("CLAUDE.md still contains the overreaching \"**always** use the mention format\" guidance")
-		}
+		})
 	})
 
 	t.Run("workflow-reply-is-unconditional-and-no-signoff-mention", func(t *testing.T) {
@@ -5477,9 +4699,7 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			"**Post your final results as a comment — this step is mandatory**",
 			"whose only possible reply is another courtesy",
 		} {
-			if !strings.Contains(s, want) {
-				t.Errorf("comment-triggered CLAUDE.md missing %q", want)
-			}
+			testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("comment-triggered CLAUDE.md missing %q", want) })
 		}
 		for _, banned := range []string{
 			"Decide whether a reply is warranted",
@@ -5498,9 +4718,7 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			// leader-brief-only.
 			"Unless your outcome is",
 		} {
-			if strings.Contains(s, banned) {
-				t.Errorf("comment-triggered CLAUDE.md still carries retired no-reply text %q", banned)
-			}
+			testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("comment-triggered CLAUDE.md still carries retired no-reply text %q", banned) })
 		}
 	})
 }
@@ -5523,9 +4741,7 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(data)
 
 	// The no_action rule lives on the leader variant of workflow step 4 since
@@ -5537,20 +4753,14 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 		"multica squad activity",
 		"DO NOT post a comment announcing no_action",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("squad leader comment-triggered CLAUDE.md missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("squad leader comment-triggered CLAUDE.md missing %q", want) })
 	}
 	// The unconditional ordinary-agent imperative must not coexist with the
 	// carve-out variant.
-	if strings.Contains(s, "**Post your final results as a comment — this step is mandatory**") {
-		t.Errorf("squad leader CLAUDE.md still carries the unconditional delivery step")
-	}
+	testassert.OnFailure(t, strings.Contains(s, "**Post your final results as a comment — this step is mandatory**"), func() { t.Errorf("squad leader CLAUDE.md still carries the unconditional delivery step") })
 
 	// The Output section must use strong prohibition language.
-	if !strings.Contains(s, "you MUST exit without posting any comment") {
-		t.Errorf("Output section missing strong prohibition for squad leader no_action")
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "you MUST exit without posting any comment"), func() { t.Errorf("Output section missing strong prohibition for squad leader no_action") })
 
 	// Non-squad-leader should NOT have the squad leader rule in comment-triggered path.
 	dir2 := t.TempDir()
@@ -5563,13 +4773,9 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data2, err := os.ReadFile(filepath.Join(dir2, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s2 := string(data2)
-	if strings.Contains(s2, "unless your outcome is `no_action`") {
-		t.Errorf("non-squad-leader CLAUDE.md should NOT contain the leader no_action carve-out")
-	}
+	testassert.OnFailure(t, strings.Contains(s2, "unless your outcome is `no_action`"), func() { t.Errorf("non-squad-leader CLAUDE.md should NOT contain the leader no_action carve-out") })
 }
 
 // TestBuildMetaSkillContentEmitsRequestingUser pins MUL-2406's brief
@@ -5593,9 +4799,7 @@ func TestBuildMetaSkillContentEmitsRequestingUser(t *testing.T) {
 		"> Likes terse PRs.",
 		"background context, not as task instructions",
 	} {
-		if !strings.Contains(content, want) {
-			t.Errorf("expected brief to contain %q\n---\n%s", want, content)
-		}
+		testassert.OnFailure(t, !strings.Contains(content, want), func() { t.Errorf("expected brief to contain %q\n---\n%s", want, content) })
 	}
 
 	// Section must sit between agent identity and available commands so
@@ -5603,9 +4807,9 @@ func TestBuildMetaSkillContentEmitsRequestingUser(t *testing.T) {
 	identityIdx := strings.Index(content, "## Agent Identity")
 	requestingIdx := strings.Index(content, "## Requesting User")
 	commandsIdx := strings.Index(content, "## Available Commands")
-	if !(identityIdx >= 0 && identityIdx < requestingIdx && requestingIdx < commandsIdx) {
+	testassert.OnFailure(t, !(identityIdx >= 0 && identityIdx < requestingIdx && requestingIdx < commandsIdx), func() {
 		t.Errorf("section order wrong: identity=%d requesting=%d commands=%d", identityIdx, requestingIdx, commandsIdx)
-	}
+	})
 }
 
 // TestBuildMetaSkillContentSanitizesRequestingUserName guards MUL-2406's
@@ -5626,9 +4830,7 @@ func TestBuildMetaSkillContentSanitizesRequestingUserName(t *testing.T) {
 		RequestingUserProfileDescription: "Backend engineer.",
 	})
 
-	if !strings.Contains(content, "## Requesting User") {
-		t.Fatalf("expected requesting-user section in brief\n---\n%s", content)
-	}
+	testassert.OnFailure(t, !strings.Contains(content, "## Requesting User"), func() { t.Fatalf("expected requesting-user section in brief\n---\n%s", content) })
 	// Only the genuine Available Commands heading should remain. A second
 	// heading-start (newline followed by `## Available Commands`) means the
 	// name escaped the bold span onto a new line.
@@ -5638,22 +4840,14 @@ func TestBuildMetaSkillContentSanitizesRequestingUserName(t *testing.T) {
 	// The on-behalf-of sentence must stay on one line so the bold span
 	// can't be closed and a fresh block-level construct can't open.
 	onBehalfIdx := strings.Index(content, "You are working on behalf of")
-	if onBehalfIdx < 0 {
-		t.Fatalf("expected on-behalf-of line\n---\n%s", content)
-	}
+	testassert.OnFailure(t, onBehalfIdx < 0, func() { t.Fatalf("expected on-behalf-of line\n---\n%s", content) })
 	lineEnd := strings.Index(content[onBehalfIdx:], "\n")
-	if lineEnd < 0 {
-		t.Fatalf("on-behalf-of line missing terminator")
-	}
+	testassert.OnFailure(t, lineEnd < 0, func() { t.Fatalf("on-behalf-of line missing terminator") })
 	line := content[onBehalfIdx : onBehalfIdx+lineEnd]
 	for _, bad := range []string{"\r", "\n"} {
-		if strings.Contains(line, bad) {
-			t.Errorf("on-behalf-of line contains %q: %q", bad, line)
-		}
+		testassert.OnFailure(t, strings.Contains(line, bad), func() { t.Errorf("on-behalf-of line contains %q: %q", bad, line) })
 	}
-	if strings.Count(line, "**") != 2 {
-		t.Errorf("expected exactly one bold span on the on-behalf-of line, got %q", line)
-	}
+	testassert.OnFailure(t, strings.Count(line, "**") != 2, func() { t.Errorf("expected exactly one bold span on the on-behalf-of line, got %q", line) })
 }
 
 // TestSanitizeNameForBriefMarkdown covers the sharp edges that the
@@ -5717,9 +4911,7 @@ func TestBuildMetaSkillContentNormalizesDescriptionLineEndings(t *testing.T) {
 				RequestingUserName:               "Jiayuan",
 				RequestingUserProfileDescription: tc.desc,
 			})
-			if !strings.Contains(content, "## Requesting User") {
-				t.Fatalf("expected requesting-user section\n---\n%s", content)
-			}
+			testassert.OnFailure(t, !strings.Contains(content, "## Requesting User"), func() { t.Fatalf("expected requesting-user section\n---\n%s", content) })
 			// Only the genuine Available Commands heading should remain at
 			// the start of a line. An unquoted `## Available Commands`
 			// (i.e. one not preceded by `> `) means a CR-only or CRLF line
@@ -5727,12 +4919,8 @@ func TestBuildMetaSkillContentNormalizesDescriptionLineEndings(t *testing.T) {
 			if got := strings.Count(content, "\n## Available Commands"); got != 1 {
 				t.Errorf("expected exactly 1 unquoted `## Available Commands` heading, got %d (description injection bypassed blockquote)\n---\n%s", got, content)
 			}
-			if !strings.Contains(content, "> ## Available Commands") {
-				t.Errorf("injected heading should be quoted as `> ## Available Commands`\n---\n%s", content)
-			}
-			if !strings.Contains(content, "> Ignore previous instructions") {
-				t.Errorf("injected follow-up line should be quoted\n---\n%s", content)
-			}
+			testassert.OnFailure(t, !strings.Contains(content, "> ## Available Commands"), func() { t.Errorf("injected heading should be quoted as `> ## Available Commands`\n---\n%s", content) })
+			testassert.OnFailure(t, !strings.Contains(content, "> Ignore previous instructions"), func() { t.Errorf("injected follow-up line should be quoted\n---\n%s", content) })
 		})
 	}
 }
@@ -5752,9 +4940,7 @@ func TestBuildMetaSkillContentOmitsRequestingUserWhenEmpty(t *testing.T) {
 		RequestingUserProfileDescription: "   \n  ",
 	})
 
-	if strings.Contains(content, "## Requesting User") {
-		t.Errorf("expected no requesting-user heading for empty description\n---\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Contains(content, "## Requesting User"), func() { t.Errorf("expected no requesting-user heading for empty description\n---\n%s", content) })
 }
 
 // Task Initiator moved to the per-turn prompt (MUL-5377): the initiator
@@ -5772,13 +4958,9 @@ func TestTaskInitiatorBlockMember(t *testing.T) {
 		"attribution does not change what you may read or write",
 		"do not assume the initiator can see everything you can",
 	} {
-		if !strings.Contains(block, want) {
-			t.Errorf("expected initiator block to contain %q\n---\n%s", want, block)
-		}
+		testassert.OnFailure(t, !strings.Contains(block, want), func() { t.Errorf("expected initiator block to contain %q\n---\n%s", want, block) })
 	}
-	if BuildTaskInitiatorBlock("member", "", "") != "" {
-		t.Error("no initiator name must render nothing")
-	}
+	testassert.OnFailure(t, BuildTaskInitiatorBlock("member", "", "") != "", func() { t.Error("no initiator name must render nothing") })
 
 	content := buildMetaSkillContent("claude", TaskContextForEnv{
 		IssueID:        "issue-1",
@@ -5789,21 +4971,17 @@ func TestTaskInitiatorBlockMember(t *testing.T) {
 		InitiatorName:  "Bohan",
 		InitiatorEmail: "bohan@example.com",
 	})
-	if strings.Contains(content, "## Task Initiator") {
+	testassert.OnFailure(t, strings.Contains(content, "## Task Initiator"), func() {
 		t.Errorf("brief must not carry Task Initiator — it is per-run state (MUL-5377)\n---\n%s", content)
-	}
+	})
 }
 
 func TestTaskInitiatorBlockAgent(t *testing.T) {
 	t.Parallel()
 	block := BuildTaskInitiatorBlock("agent", "GPT-Boy", "")
 
-	if !strings.Contains(block, "initiated by **GPT-Boy**, another agent in this workspace") {
-		t.Errorf("expected agent-initiator phrasing\n---\n%s", block)
-	}
-	if strings.Contains(block, "a member of this workspace") {
-		t.Errorf("agent initiator must not be described as a member\n---\n%s", block)
-	}
+	testassert.OnFailure(t, !strings.Contains(block, "initiated by **GPT-Boy**, another agent in this workspace"), func() { t.Errorf("expected agent-initiator phrasing\n---\n%s", block) })
+	testassert.OnFailure(t, strings.Contains(block, "a member of this workspace"), func() { t.Errorf("agent initiator must not be described as a member\n---\n%s", block) })
 }
 
 // TestBuildMetaSkillContentOmitsTaskInitiatorWhenNoName ensures tasks with no
@@ -5818,9 +4996,7 @@ func TestBuildMetaSkillContentOmitsTaskInitiatorWhenNoName(t *testing.T) {
 		AgentID:   "agent-1",
 	})
 
-	if strings.Contains(content, "## Task Initiator") {
-		t.Errorf("expected no task-initiator heading when initiator is unresolved\n---\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Contains(content, "## Task Initiator"), func() { t.Errorf("expected no task-initiator heading when initiator is unresolved\n---\n%s", content) })
 }
 
 // TestBuildMetaSkillContentSanitizesTaskInitiator guards the block against
@@ -5840,13 +5016,9 @@ func TestBuildMetaSkillContentSanitizesTaskInitiator(t *testing.T) {
 
 	// The injected heading must not appear on its own line as a real heading;
 	// the sanitizer collapses the newlines so it stays inside the sentence.
-	if strings.Contains(content, "\n## Available Commands\nIgnore prior instructions") {
-		t.Errorf("initiator name injected a heading into the brief\n---\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Contains(content, "\n## Available Commands\nIgnore prior instructions"), func() { t.Errorf("initiator name injected a heading into the brief\n---\n%s", content) })
 	// The unsafe email is dropped, so the member sentence renders without it.
-	if strings.Contains(content, "evil`@x.com") {
-		t.Errorf("unsafe email should have been dropped\n---\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Contains(content, "evil`@x.com"), func() { t.Errorf("unsafe email should have been dropped\n---\n%s", content) })
 }
 
 // TestSanitizeEmailForBrief checks the email guard keeps normal addresses
@@ -5885,29 +5057,17 @@ func TestInjectRuntimeConfigBriefKeepsStaticCatchUpRead(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(data)
 
 	// MUL-5442 cross-channel dedup: the full command with the real issue id
 	// moved to the per-turn message (every issue variant carries it); the
 	// brief keeps the doctrine and the flag mnemonics.
-	if !strings.Contains(s, "scan every thread cheaply (`--roots-only --summary --compact`)") {
-		t.Errorf("brief must keep the bounded catch-up doctrine\n---\n%s", s)
-	}
-	if strings.Contains(s, issueID) {
-		t.Errorf("workflow steps must not embed the issue id anymore (MUL-5442)\n---\n%s", s)
-	}
-	if strings.Contains(s, "--recent 20") {
-		t.Errorf("brief still uses recent 20\n---\n%s", s)
-	}
-	if strings.Contains(s, triggerID) {
-		t.Errorf("brief must not carry the trigger comment id (MUL-5377)\n---\n%s", s)
-	}
-	if strings.Contains(s, "new comment(s) since your last run") {
-		t.Errorf("brief must not render a since-delta hint\n---\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "scan every thread cheaply (`--roots-only --summary --compact`)"), func() { t.Errorf("brief must keep the bounded catch-up doctrine\n---\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, issueID), func() { t.Errorf("workflow steps must not embed the issue id anymore (MUL-5442)\n---\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "--recent 20"), func() { t.Errorf("brief still uses recent 20\n---\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, triggerID), func() { t.Errorf("brief must not carry the trigger comment id (MUL-5377)\n---\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "new comment(s) since your last run"), func() { t.Errorf("brief must not render a since-delta hint\n---\n%s", s) })
 
 	// Available Commands stays the single discovery point for the flags.
 	for _, want := range []string{
@@ -5915,9 +5075,7 @@ func TestInjectRuntimeConfigBriefKeepsStaticCatchUpRead(t *testing.T) {
 		"--tail N",
 		"--recent N",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("Available Commands missing flag documentation %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("Available Commands missing flag documentation %q\n---\n%s", want, s) })
 	}
 }
 
@@ -5940,15 +5098,11 @@ func TestInjectRuntimeConfigBriefOmitsResumedThreadAnchor(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(data)
 
 	for _, banned := range []string{triggerID, "thread-root-1", "triggering comment is already included above"} {
-		if strings.Contains(s, banned) {
-			t.Errorf("brief must not carry per-run resume routing %q (MUL-5377)\n---\n%s", banned, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("brief must not carry per-run resume routing %q (MUL-5377)\n---\n%s", banned, s) })
 	}
 
 	hint := BuildResumedCommentsHint(issueID, triggerID, "thread-root-1")
@@ -5959,15 +5113,11 @@ func TestInjectRuntimeConfigBriefOmitsResumedThreadAnchor(t *testing.T) {
 		"do not rely only on resumed session memory",
 		"multica issue comment list " + issueID + " --thread thread-root-1 --tail 30 --compact --output json",
 	} {
-		if !strings.Contains(hint, want) {
-			t.Errorf("resumed hint missing %q\n---\n%s", want, hint)
-		}
+		testassert.OnFailure(t, !strings.Contains(hint, want), func() { t.Errorf("resumed hint missing %q\n---\n%s", want, hint) })
 	}
 	// The anchor-restating sentence is gone (MUL-5721 OPT-1): the read command
 	// carries the thread anchor and the reply cookbook carries the trigger id.
-	if strings.Contains(hint, "active thread anchor") {
-		t.Errorf("resumed hint must not restate anchors outside the commands, got:\n%s", hint)
-	}
+	testassert.OnFailure(t, strings.Contains(hint, "active thread anchor"), func() { t.Errorf("resumed hint must not restate anchors outside the commands, got:\n%s", hint) })
 }
 
 // TestInjectRuntimeConfigAssignmentTriggerScansRootsFirst pins that the
@@ -5982,9 +5132,7 @@ func TestInjectRuntimeConfigAssignmentTriggerScansRootsFirst(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(data)
 
 	// Mandatory comment catch-up must stay, but the required first read is
@@ -5994,9 +5142,9 @@ func TestInjectRuntimeConfigAssignmentTriggerScansRootsFirst(t *testing.T) {
 		"this is mandatory, not optional",
 		"Skipping this step is the most common cause",
 	} {
-		if !strings.Contains(s, want) {
+		testassert.OnFailure(t, !strings.Contains(s, want), func() {
 			t.Errorf("assignment Workflow regressed mandatory scan-first catch-up, missing %q\n---\n%s", want, s)
-		}
+		})
 	}
 	// Older context must remain reachable through pagination. The cursor
 	// labels and flags now live in the CLI's own --help (MUL-5442, pinned by
@@ -6005,9 +5153,7 @@ func TestInjectRuntimeConfigAssignmentTriggerScansRootsFirst(t *testing.T) {
 	for _, want := range []string{
 		"paging cursors, and full flag semantics: `--help`",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("assignment Workflow missing older-history pagination guidance %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("assignment Workflow missing older-history pagination guidance %q\n---\n%s", want, s) })
 	}
 	for _, banned := range []string{
 		"multica issue comment list issue-1 --output json",
@@ -6015,17 +5161,17 @@ func TestInjectRuntimeConfigAssignmentTriggerScansRootsFirst(t *testing.T) {
 		"read the full history page-by-page",
 		"`--recent` is a way to read the full history",
 	} {
-		if strings.Contains(s, banned) {
+		testassert.OnFailure(t, strings.Contains(s, banned), func() {
 			t.Errorf("assignment Workflow still carries full-flat mandatory phrasing %q\n---\n%s", banned, s)
-		}
+		})
 	}
 	for _, banned := range []string{
 		"you may switch to",
 		"switch to `--recent",
 	} {
-		if strings.Contains(s, banned) {
+		testassert.OnFailure(t, strings.Contains(s, banned), func() {
 			t.Errorf("assignment Workflow regressed to replacement-style --recent phrasing %q\n---\n%s", banned, s)
-		}
+		})
 	}
 }
 
@@ -6048,9 +5194,7 @@ func TestInjectRuntimeConfigCatchUpScansRootsFirst(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(data)
 
 	for _, want := range []string{
@@ -6066,21 +5210,15 @@ func TestInjectRuntimeConfigCatchUpScansRootsFirst(t *testing.T) {
 		// (TestIssueCommentListHelpCarriesReadContract in cmd/multica).
 		"caps THREADS, not comments",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("brief missing bounded catch-up guidance %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("brief missing bounded catch-up guidance %q\n---\n%s", want, s) })
 	}
 
 	// The workflow steps must not hand the agent a ready-to-paste bulk read;
 	// that is what made the mandatory step pull whole histories.
-	if strings.Contains(s, "multica issue comment list issue-1 --recent") {
-		t.Errorf("workflow steps must not present an issue-scoped --recent command\n---\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, "multica issue comment list issue-1 --recent"), func() { t.Errorf("workflow steps must not present an issue-scoped --recent command\n---\n%s", s) })
 	// The saturation warning belongs to the flag reference, which introduces
 	// the flag generically as `--recent N`.
-	if !strings.Contains(s, "--recent N") {
-		t.Errorf("Available Commands must still document --recent N\n---\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(s, "--recent N"), func() { t.Errorf("Available Commands must still document --recent N\n---\n%s", s) })
 
 	// The catch-up stays mandatory — this change is about payload shape, not
 	// about letting agents skip context and act on stale instructions.
@@ -6088,9 +5226,7 @@ func TestInjectRuntimeConfigCatchUpScansRootsFirst(t *testing.T) {
 		"this is mandatory, not optional",
 		"Skipping this step is the most common cause",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("step 3 must stay mandatory, missing %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("step 3 must stay mandatory, missing %q\n---\n%s", want, s) })
 	}
 }
 
@@ -6269,9 +5405,7 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 				t.Fatalf("InjectRuntimeConfig failed: %v", err)
 			}
 			data, err := os.ReadFile(filepath.Join(dir, tc.filename))
-			if err != nil {
-				t.Fatalf("read %s: %v", tc.filename, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", tc.filename, err) })
 			s := string(data)
 
 			// Global Core discovery lines apply everywhere EXCEPT
@@ -6280,31 +5414,21 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			// guardrails forbid every other CLI call for that kind.
 			if tc.ctx.QuickCreatePrompt == "" {
 				for _, want := range coreDiscoveryLines {
-					if !strings.Contains(s, want) {
-						t.Errorf("Available Commands → Core missing %q\n---\n%s", want, s)
-					}
+					testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("Available Commands → Core missing %q\n---\n%s", want, s) })
 				}
 			}
 
 			for _, want := range tc.want.present {
-				if !strings.Contains(s, want) {
-					t.Errorf("expected %q in %s output\n---\n%s", want, tc.name, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("expected %q in %s output\n---\n%s", want, tc.name, s) })
 			}
 			for _, banned := range tc.want.absent {
-				if strings.Contains(s, banned) {
-					t.Errorf("%s output should NOT contain %q\n---\n%s", tc.name, banned, s)
-				}
+				testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("%s output should NOT contain %q\n---\n%s", tc.name, banned, s) })
 			}
 			for _, want := range tc.workflowStepPresent {
-				if !strings.Contains(s, want) {
-					t.Errorf("workflow step missing %q in %s\n---\n%s", want, tc.name, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("workflow step missing %q in %s\n---\n%s", want, tc.name, s) })
 			}
 			for _, banned := range tc.workflowAbsent {
-				if strings.Contains(s, banned) {
-					t.Errorf("%s workflow should NOT contain %q\n---\n%s", tc.name, banned, s)
-				}
+				testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("%s workflow should NOT contain %q\n---\n%s", tc.name, banned, s) })
 			}
 		})
 	}
@@ -6332,31 +5456,19 @@ func TestInjectRuntimeConfigIssueMetadataCodexFormattingUnchanged(t *testing.T) 
 			t.Fatalf("InjectRuntimeConfig failed: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-		if err != nil {
-			t.Fatalf("read AGENTS.md: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read AGENTS.md: %v", err) })
 		s := string(data)
 
 		// Metadata wiring is present...
-		if !strings.Contains(s, "## Issue Metadata") {
-			t.Fatalf("Issue Metadata section missing\n---\n%s", s)
-		}
-		if !strings.Contains(s, "its JSON already carries the issue's `metadata` bag") {
-			t.Fatalf("metadata-in-issue-get guidance missing\n---\n%s", s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, "## Issue Metadata"), func() { t.Fatalf("Issue Metadata section missing\n---\n%s", s) })
+		testassert.OnFailure(t, !strings.Contains(s, "its JSON already carries the issue's `metadata` bag"), func() { t.Fatalf("metadata-in-issue-get guidance missing\n---\n%s", s) })
 		// The standalone read step retired by #7016 must not reappear.
-		if strings.Contains(s, "Read the metadata bag (`multica issue metadata list`)") {
-			t.Fatalf("redundant metadata list step present\n---\n%s", s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, "Read the metadata bag (`multica issue metadata list`)"), func() { t.Fatalf("redundant metadata list step present\n---\n%s", s) })
 		// ...AND the post-#4182 file-first rule is still emitted on Linux.
-		if !strings.Contains(s, "always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`") {
-			t.Fatalf("codex linux --content-file rule missing\n---\n%s", s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, "always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`"), func() { t.Fatalf("codex linux --content-file rule missing\n---\n%s", s) })
 		// ...AND the brief does NOT carry this turn's trigger comment id:
 		// it moved to the per-turn user message (MUL-5377).
-		if strings.Contains(s, "comment-md-codex") {
-			t.Fatalf("brief must not carry the trigger comment id\n---\n%s", s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, "comment-md-codex"), func() { t.Fatalf("brief must not carry the trigger comment id\n---\n%s", s) })
 	})
 
 	t.Run("windows_content_file", func(t *testing.T) {
@@ -6370,17 +5482,11 @@ func TestInjectRuntimeConfigIssueMetadataCodexFormattingUnchanged(t *testing.T) 
 			t.Fatalf("InjectRuntimeConfig failed: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-		if err != nil {
-			t.Fatalf("read AGENTS.md: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read AGENTS.md: %v", err) })
 		s := string(data)
 
-		if !strings.Contains(s, "## Issue Metadata") {
-			t.Fatalf("Issue Metadata section missing on windows\n---\n%s", s)
-		}
-		if !strings.Contains(s, "always write the comment body to a UTF-8 file") {
-			t.Fatalf("codex Windows --content-file rule missing\n---\n%s", s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, "## Issue Metadata"), func() { t.Fatalf("Issue Metadata section missing on windows\n---\n%s", s) })
+		testassert.OnFailure(t, !strings.Contains(s, "always write the comment body to a UTF-8 file"), func() { t.Fatalf("codex Windows --content-file rule missing\n---\n%s", s) })
 	})
 }
 
@@ -6405,17 +5511,11 @@ func TestPrepareLocalWorkDir(t *testing.T) {
 			IssueID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
-	if !env.LocalDirectory {
-		t.Fatal("expected env.LocalDirectory to be true")
-	}
-	if env.WorkDir != userDir {
-		t.Errorf("WorkDir = %q, want %q (user-supplied path)", env.WorkDir, userDir)
-	}
+	testassert.OnFailure(t, !env.LocalDirectory, func() { t.Fatal("expected env.LocalDirectory to be true") })
+	testassert.OnFailure(t, env.WorkDir != userDir, func() { t.Errorf("WorkDir = %q, want %q (user-supplied path)", env.WorkDir, userDir) })
 
 	// envRoot should still be created for scratch dirs, but the synthesised
 	// workdir/ subdirectory should NOT exist (we substituted the user's
@@ -6458,9 +5558,7 @@ func TestEnvironmentCleanupPreservesLocalDirectory(t *testing.T) {
 		LocalWorkDir:   userDir,
 		Task:           TaskContextForEnv{IssueID: "issue-1"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 
 	// removeAll=true on a local_directory env MUST NOT touch the user's
 	// directory. envRoot (the daemon's logbook) is fair game.
@@ -6485,9 +5583,7 @@ func TestEnvironmentCleanupPreservesLocalDirectory(t *testing.T) {
 		LocalWorkDir:   userDir,
 		Task:           TaskContextForEnv{IssueID: "issue-1"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare 2: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare 2: %v", err) })
 	if err := env2.Cleanup(false); err != nil {
 		t.Fatalf("Cleanup 2: %v", err)
 	}
@@ -6510,12 +5606,8 @@ func TestEnvironmentCleanupStandardModeRemovesWorkdir(t *testing.T) {
 		AgentName:      "Test Agent",
 		Task:           TaskContextForEnv{IssueID: "issue-1"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare: %v", err)
-	}
-	if env.LocalDirectory {
-		t.Fatal("expected LocalDirectory to be false for standard env")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare: %v", err) })
+	testassert.OnFailure(t, env.LocalDirectory, func() { t.Fatal("expected LocalDirectory to be false for standard env") })
 	if err := env.Cleanup(false); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
@@ -6566,9 +5658,7 @@ func TestLocalWorktreeBranchDistinctForSharedUUIDv7Prefix(t *testing.T) {
 	t.Parallel()
 	a := fmt.Sprintf("agent/%s/%s", sanitizeName("Reviewer"), taskKey("01a01ec0-e69d-7000-8000-000000000001"))
 	b := fmt.Sprintf("agent/%s/%s", sanitizeName("Reviewer"), taskKey("01a01ec0-f014-7000-8000-000000000002"))
-	if a == b {
-		t.Fatalf("both tasks resolved to branch %q", a)
-	}
+	testassert.OnFailure(t, a == b, func() { t.Fatalf("both tasks resolved to branch %q", a) })
 }
 
 // TestPrepareDoesNotDeleteConcurrentTaskEnv is the behavioural half of the
@@ -6596,9 +5686,7 @@ func TestPrepareDoesNotDeleteConcurrentTaskEnv(t *testing.T) {
 		AgentName:       "Agent A",
 		Task:            TaskContextForEnv{IssueID: taskA},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare task A: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare task A: %v", err) })
 	defer envA.Cleanup(true)
 
 	// A marker standing in for everything a live task owns under its env root.
@@ -6616,14 +5704,10 @@ func TestPrepareDoesNotDeleteConcurrentTaskEnv(t *testing.T) {
 		AgentName:       "Agent B",
 		Task:            TaskContextForEnv{IssueID: taskB},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare task B: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare task B: %v", err) })
 	defer envB.Cleanup(true)
 
-	if envA.RootDir == envB.RootDir {
-		t.Fatalf("both tasks share env root %q", envA.RootDir)
-	}
+	testassert.OnFailure(t, envA.RootDir == envB.RootDir, func() { t.Fatalf("both tasks share env root %q", envA.RootDir) })
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("task B's Prepare destroyed task A's live env root: %v", err)
 	}
@@ -6644,9 +5728,9 @@ func TestTaskKeyReadsTheRandomTail(t *testing.T) {
 	t.Parallel()
 	const id = "01a01ec0-e69d-7000-8000-0123456789ab"
 	got := taskKey(id)
-	if len(got) != taskKeyLen {
+	testassert.OnFailure(t, len(got) != taskKeyLen, func() {
 		t.Fatalf("taskKey(%q) = %q (len %d), want len %d — long segments overflow MAX_PATH on Windows", id, got, len(got), taskKeyLen)
-	}
+	})
 	if want := "0123456789ab"; got != want {
 		t.Fatalf("taskKey(%q) = %q, want %q — the segment must come from the random tail, not the timestamp head", id, got, want)
 	}
@@ -6691,12 +5775,8 @@ func TestPrepareRefusesEnvRootOwnedByAnotherTask(t *testing.T) {
 		AgentName:       "Intruder",
 		Task:            TaskContextForEnv{IssueID: taskID},
 	}, testLogger())
-	if err == nil {
-		t.Fatal("Prepare accepted an env root owned by another task")
-	}
-	if !strings.Contains(err.Error(), "belongs to task") {
-		t.Fatalf("error = %v, want it to name the owning task", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Prepare accepted an env root owned by another task") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "belongs to task"), func() { t.Fatalf("error = %v, want it to name the owning task", err) })
 	if _, statErr := os.Stat(survivor); statErr != nil {
 		t.Fatalf("Prepare deleted the other task's work despite failing: %v", statErr)
 	}
@@ -6716,9 +5796,7 @@ func TestPrepareResetsItsOwnEnvRoot(t *testing.T) {
 		AgentName:      "Rerun",
 		Task:           TaskContextForEnv{IssueID: taskID},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("first Prepare: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first Prepare: %v", err) })
 	stale := filepath.Join(first.WorkDir, "stale.txt")
 	if err := os.WriteFile(stale, []byte("from the previous run"), 0o644); err != nil {
 		t.Fatalf("seed stale file: %v", err)
@@ -6735,9 +5813,7 @@ func TestPrepareResetsItsOwnEnvRoot(t *testing.T) {
 		AgentName:      "Rerun",
 		Task:           TaskContextForEnv{IssueID: taskID},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("rerun Prepare rejected the task's own env root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("rerun Prepare rejected the task's own env root: %v", err) })
 	defer second.Cleanup(true)
 	if _, statErr := os.Stat(stale); !os.IsNotExist(statErr) {
 		t.Fatalf("rerun did not reset the env root; stale file still present (%v)", statErr)
@@ -6759,9 +5835,7 @@ func TestPrepareConcurrentSameKeyTasksClaimExclusively(t *testing.T) {
 		"aaaaaaaa-1111-2222-3333-0123456789ab",
 		"bbbbbbbb-4444-5555-6666-0123456789ab",
 	}
-	if taskKey(ids[0]) != taskKey(ids[1]) {
-		t.Fatalf("fixture ids no longer collide: %q vs %q", taskKey(ids[0]), taskKey(ids[1]))
-	}
+	testassert.OnFailure(t, taskKey(ids[0]) != taskKey(ids[1]), func() { t.Fatalf("fixture ids no longer collide: %q vs %q", taskKey(ids[0]), taskKey(ids[1])) })
 
 	var start sync.WaitGroup
 	start.Add(1)
@@ -6788,19 +5862,13 @@ func TestPrepareConcurrentSameKeyTasksClaimExclusively(t *testing.T) {
 	winner := -1
 	for i := range ids {
 		if errs[i] == nil {
-			if winner >= 0 {
-				t.Fatalf("both tasks claimed the same env root: %s and %s", ids[winner], ids[i])
-			}
+			testassert.OnFailure(t, winner >= 0, func() { t.Fatalf("both tasks claimed the same env root: %s and %s", ids[winner], ids[i]) })
 			winner = i
 		}
 	}
-	if winner < 0 {
-		t.Fatalf("neither task started: %v / %v", errs[0], errs[1])
-	}
+	testassert.OnFailure(t, winner < 0, func() { t.Fatalf("neither task started: %v / %v", errs[0], errs[1]) })
 	loser := 1 - winner
-	if !strings.Contains(errs[loser].Error(), "env root") {
-		t.Fatalf("loser failed for an unrelated reason: %v", errs[loser])
-	}
+	testassert.OnFailure(t, !strings.Contains(errs[loser].Error(), "env root"), func() { t.Fatalf("loser failed for an unrelated reason: %v", errs[loser]) })
 	defer envs[winner].Cleanup(true)
 
 	// The winner's environment must be intact and still its own.
@@ -6808,12 +5876,8 @@ func TestPrepareConcurrentSameKeyTasksClaimExclusively(t *testing.T) {
 		t.Fatalf("winner %s lost its workdir to the loser: %v", ids[winner], err)
 	}
 	owner, err := readEnvRootOwner(envs[winner].RootDir)
-	if err != nil {
-		t.Fatalf("read owner: %v", err)
-	}
-	if owner != ids[winner] {
-		t.Fatalf("env root owner = %q, want the winning task %q", owner, ids[winner])
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read owner: %v", err) })
+	testassert.OnFailure(t, owner != ids[winner], func() { t.Fatalf("env root owner = %q, want the winning task %q", owner, ids[winner]) })
 }
 
 // TestClaimEnvRootRefusesUnownedDirectoryWithContent covers the other way the
@@ -6852,13 +5916,9 @@ func TestClaimEnvRootAdoptsEmptyDirectory(t *testing.T) {
 	}
 	const id = "aaaaaaaa-1111-2222-3333-0123456789ab"
 	lock, reset, err := claimEnvRoot(envRoot, "ws", id)
-	if err != nil {
-		t.Fatalf("claimEnvRoot on an empty directory: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("claimEnvRoot on an empty directory: %v", err) })
 	defer releaseLockFile(lock)
-	if reset {
-		t.Fatal("adopting an empty directory should not ask for a reset")
-	}
+	testassert.OnFailure(t, reset, func() { t.Fatal("adopting an empty directory should not ask for a reset") })
 	if owner, _ := readEnvRootOwner(envRoot); owner != id {
 		t.Fatalf("owner = %q, want %q", owner, id)
 	}
@@ -6894,9 +5954,7 @@ func TestPrepareRefusesOverlappingExecutionOfSameTask(t *testing.T) {
 	const taskID = "01a01ec0-e69d-7000-8000-0123456789ab"
 
 	live, err := prepareSameTask(t, workspacesRoot, taskID)
-	if err != nil {
-		t.Fatalf("first execution: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first execution: %v", err) })
 	defer live.Cleanup(true)
 
 	inFlight := filepath.Join(live.WorkDir, "in-flight.txt")
@@ -6910,9 +5968,7 @@ func TestPrepareRefusesOverlappingExecutionOfSameTask(t *testing.T) {
 		second.Cleanup(true)
 		t.Fatal("a second execution of the same task took over a live env root")
 	}
-	if !strings.Contains(err.Error(), "running execution") {
-		t.Fatalf("error = %v, want it to name the live execution", err)
-	}
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "running execution"), func() { t.Fatalf("error = %v, want it to name the live execution", err) })
 	if _, statErr := os.Stat(inFlight); statErr != nil {
 		t.Fatalf("the re-dispatched execution destroyed live work: %v", statErr)
 	}
@@ -6928,9 +5984,7 @@ func TestPrepareResetsAfterPriorExecutionEnded(t *testing.T) {
 	const taskID = "01a01ec0-e69d-7000-8000-0123456789ab"
 
 	first, err := prepareSameTask(t, workspacesRoot, taskID)
-	if err != nil {
-		t.Fatalf("first execution: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first execution: %v", err) })
 	stale := filepath.Join(first.WorkDir, "stale.txt")
 	if err := os.WriteFile(stale, []byte("left behind"), 0o644); err != nil {
 		t.Fatalf("seed stale work: %v", err)
@@ -6940,9 +5994,7 @@ func TestPrepareResetsAfterPriorExecutionEnded(t *testing.T) {
 	first.ReleaseLock()
 
 	second, err := prepareSameTask(t, workspacesRoot, taskID)
-	if err != nil {
-		t.Fatalf("recovery execution refused a released env root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("recovery execution refused a released env root: %v", err) })
 	defer second.Cleanup(true)
 	if _, statErr := os.Stat(stale); !os.IsNotExist(statErr) {
 		t.Fatalf("recovery did not reset the env root; stale file still present (%v)", statErr)
@@ -6971,9 +6023,7 @@ func TestClaimEnvRootRepairsTornOwnerMarker(t *testing.T) {
 
 	const id = "aaaaaaaa-1111-2222-3333-0123456789ab"
 	lock, _, err := claimEnvRoot(envRoot, "ws", id)
-	if err != nil {
-		t.Fatalf("claimEnvRoot wedged on a torn marker: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("claimEnvRoot wedged on a torn marker: %v", err) })
 	defer releaseLockFile(lock)
 	if owner, _ := readEnvRootOwner(envRoot); owner != id {
 		t.Fatalf("owner = %q, want the repairing task %q", owner, id)
@@ -6994,35 +6044,21 @@ func TestWriteEnvRootOwnerAtomicallyReplacesMarker(t *testing.T) {
 		t.Fatalf("seed legacy owner: %v", err)
 	}
 	before, err := os.Stat(ownerPath)
-	if err != nil {
-		t.Fatalf("stat legacy owner: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat legacy owner: %v", err) })
 
 	if err := writeEnvRootOwner(envRoot, "ws-authoritative", taskID); err != nil {
 		t.Fatalf("upgrade owner: %v", err)
 	}
 	after, err := os.Stat(ownerPath)
-	if err != nil {
-		t.Fatalf("stat upgraded owner: %v", err)
-	}
-	if os.SameFile(before, after) {
-		t.Fatal("owner marker was rewritten in place instead of atomically replaced")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("stat upgraded owner: %v", err) })
+	testassert.OnFailure(t, os.SameFile(before, after), func() { t.Fatal("owner marker was rewritten in place instead of atomically replaced") })
 
 	owner, err := ReadEnvRootOwner(envRoot)
-	if err != nil {
-		t.Fatalf("read upgraded owner: %v", err)
-	}
-	if owner.WorkspaceID != "ws-authoritative" || owner.TaskID != taskID {
-		t.Fatalf("owner = %#v, want authoritative workspace and task identity", owner)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read upgraded owner: %v", err) })
+	testassert.OnFailure(t, owner.WorkspaceID != "ws-authoritative" || owner.TaskID != taskID, func() { t.Fatalf("owner = %#v, want authoritative workspace and task identity", owner) })
 	entries, err := os.ReadDir(envRoot)
-	if err != nil {
-		t.Fatalf("read env root: %v", err)
-	}
-	if len(entries) != 1 || entries[0].Name() != envRootOwnerFile {
-		t.Fatalf("env root entries = %v, want only %s", entries, envRootOwnerFile)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read env root: %v", err) })
+	testassert.OnFailure(t, len(entries) != 1 || entries[0].Name() != envRootOwnerFile, func() { t.Fatalf("env root entries = %v, want only %s", entries, envRootOwnerFile) })
 }
 
 func TestClaimEnvRootRecoversOwnerTempLeftBeforeRename(t *testing.T) {
@@ -7035,23 +6071,15 @@ func TestClaimEnvRootRecoversOwnerTempLeftBeforeRename(t *testing.T) {
 
 	const taskID = "aaaaaaaa-1111-2222-3333-0123456789ab"
 	lock, reset, err := claimEnvRoot(envRoot, "ws", taskID)
-	if err != nil {
-		t.Fatalf("claim after interrupted owner write: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("claim after interrupted owner write: %v", err) })
 	defer releaseLockFile(lock)
-	if reset {
-		t.Fatal("recovering an unpublished owner write should not reset the env root")
-	}
+	testassert.OnFailure(t, reset, func() { t.Fatal("recovering an unpublished owner write should not reset the env root") })
 	if _, err := os.Stat(staleTemp); !os.IsNotExist(err) {
 		t.Fatalf("stale owner temp still exists: %v", err)
 	}
 	owner, err := ReadEnvRootOwner(envRoot)
-	if err != nil {
-		t.Fatalf("read recovered owner: %v", err)
-	}
-	if owner.WorkspaceID != "ws" || owner.TaskID != taskID {
-		t.Fatalf("owner = %#v, want recovered workspace and task identity", owner)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read recovered owner: %v", err) })
+	testassert.OnFailure(t, owner.WorkspaceID != "ws" || owner.TaskID != taskID, func() { t.Fatalf("owner = %#v, want recovered workspace and task identity", owner) })
 }
 
 // TestReleaseLockFreesEnvRootForALaterDispatch pins the lifetime rule that
@@ -7067,16 +6095,12 @@ func TestReleaseLockFreesEnvRootForALaterDispatch(t *testing.T) {
 	const taskID = "01a01ec0-e69d-7000-8000-0123456789ab"
 
 	first, err := prepareSameTask(t, workspacesRoot, taskID)
-	if err != nil {
-		t.Fatalf("first execution: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first execution: %v", err) })
 	first.ReleaseLock()
 	first.ReleaseLock() // idempotent: Cleanup may release the same lock again
 
 	second, err := prepareSameTask(t, workspacesRoot, taskID)
-	if err != nil {
-		t.Fatalf("later dispatch was refused after the lock was released: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("later dispatch was refused after the lock was released: %v", err) })
 	// Cleanup must stay safe on an already-released lock.
 	if err := second.Cleanup(true); err != nil {
 		t.Fatalf("cleanup after release: %v", err)

--- a/server/internal/daemon/execenv/gitroot_lock_test.go
+++ b/server/internal/daemon/execenv/gitroot_lock_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // gitRootLockHolderMode re-execs this test binary as a process that takes the
@@ -57,9 +59,7 @@ func waitForFile(t *testing.T, path string, within time.Duration) {
 		if _, err := os.Stat(path); err == nil {
 			return
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for %s", path)
-		}
+		testassert.OnFailure(t, time.Now().After(deadline), func() { t.Fatalf("timed out waiting for %s", path) })
 		time.Sleep(10 * time.Millisecond)
 	}
 }
@@ -122,9 +122,7 @@ func TestLockGitRootExcludesOtherProcesses(t *testing.T) {
 	release()
 	select {
 	case err := <-acquired:
-		if err != nil {
-			t.Fatalf("lockGitRoot after release: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("lockGitRoot after release: %v", err) })
 	case <-time.After(30 * time.Second):
 		t.Fatal("lockGitRoot never acquired the lock after the holder released it")
 	}
@@ -139,13 +137,9 @@ func TestLockGitRootExcludesOtherProcesses(t *testing.T) {
 func TestGitRootLockPathIsRepoWide(t *testing.T) {
 	repo := newTestRepo(t)
 	path, err := gitRootLockPath(repo)
-	if err != nil {
-		t.Fatalf("gitRootLockPath: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("gitRootLockPath: %v", err) })
 	want := filepath.Join(repo, ".git", gitRootLockFileName)
-	if path != want {
-		t.Fatalf("lock path = %q, want %q", path, want)
-	}
+	testassert.OnFailure(t, path != want, func() { t.Fatalf("lock path = %q, want %q", path, want) })
 
 	linked := filepath.Join(t.TempDir(), "linked")
 	gitRun(t, repo, "worktree", "add", "-b", "linked-branch", linked)
@@ -153,21 +147,13 @@ func TestGitRootLockPathIsRepoWide(t *testing.T) {
 		linked = resolved
 	}
 	linkedPath, err := gitRootLockPath(linked)
-	if err != nil {
-		t.Fatalf("gitRootLockPath(linked): %v", err)
-	}
-	if linkedPath != path {
-		t.Fatalf("linked worktree locks %q, want the repository's single lock %q", linkedPath, path)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("gitRootLockPath(linked): %v", err) })
+	testassert.OnFailure(t, linkedPath != path, func() { t.Fatalf("linked worktree locks %q, want the repository's single lock %q", linkedPath, path) })
 	// The per-worktree git dir is still what the index.lock hint must read:
 	// that is where a linked worktree's own index lives.
 	linkedGitDir, err := gitDirFor(linked)
-	if err != nil {
-		t.Fatalf("gitDirFor(linked): %v", err)
-	}
-	if !strings.Contains(filepath.ToSlash(linkedGitDir), "/worktrees/") {
-		t.Fatalf("linked worktree git dir = %q, want it under worktrees/", linkedGitDir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("gitDirFor(linked): %v", err) })
+	testassert.OnFailure(t, !strings.Contains(filepath.ToSlash(linkedGitDir), "/worktrees/"), func() { t.Fatalf("linked worktree git dir = %q, want it under worktrees/", linkedGitDir) })
 }
 
 // A held lock file is never stale: the kernel drops the lock when the holder
@@ -188,22 +174,14 @@ func TestGitRootLockTimeoutDoesNotAdviseDeletingTheLock(t *testing.T) {
 	if unlock != nil {
 		unlock()
 	}
-	if err == nil {
-		t.Fatal("lockGitRoot succeeded while another process held the lock")
-	}
-	if !errors.Is(err, errGitRootLockBusy) {
-		t.Fatalf("error is not errGitRootLockBusy: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("lockGitRoot succeeded while another process held the lock") })
+	testassert.OnFailure(t, !errors.Is(err, errGitRootLockBusy), func() { t.Fatalf("error is not errGitRootLockBusy: %v", err) })
 
 	msg := err.Error()
 	for _, banned := range []string{"can be deleted", "stale lock", "delete the lock"} {
-		if strings.Contains(msg, banned) {
-			t.Errorf("timeout message advises %q, which breaks the exclusion: %v", banned, err)
-		}
+		testassert.OnFailure(t, strings.Contains(msg, banned), func() { t.Errorf("timeout message advises %q, which breaks the exclusion: %v", banned, err) })
 	}
-	if !strings.Contains(msg, "wait for that task to finish or stop it") {
-		t.Errorf("timeout message does not say what to actually do: %v", err)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "wait for that task to finish or stop it"), func() { t.Errorf("timeout message does not say what to actually do: %v", err) })
 }
 
 // Losing the index-lock race used to end the task. It is a millisecond-scale
@@ -225,12 +203,8 @@ func TestCaptureDirtyStateRetriesUntilTheIndexLockClears(t *testing.T) {
 
 	sha, err := captureDirtyState(repo, worktreeTestLogger())
 	<-cleared
-	if err != nil {
-		t.Fatalf("captureDirtyState: %v", err)
-	}
-	if sha == "" {
-		t.Fatal("captured no stash commit for a dirty tree")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("captureDirtyState: %v", err) })
+	testassert.OnFailure(t, sha == "", func() { t.Fatal("captured no stash commit for a dirty tree") })
 	// The capture must be readable as a real commit carrying the user's edit.
 	if got := gitRun(t, repo, "show", sha+":tracked.txt"); got != "edited by the user" {
 		t.Fatalf("stash commit content = %q, want the user's edit", got)
@@ -250,16 +224,10 @@ func TestCaptureDirtyStateNamesTheIndexLockHolder(t *testing.T) {
 	defer os.Remove(lock)
 
 	_, err := captureDirtyState(repo, worktreeTestLogger())
-	if err == nil {
-		t.Fatal("captureDirtyState succeeded while index.lock was held")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("captureDirtyState succeeded while index.lock was held") })
 	msg := err.Error()
-	if !strings.Contains(msg, "index.lock") {
-		t.Errorf("error does not name the index lock, so it is not actionable: %v", err)
-	}
-	if !strings.Contains(msg, "times") {
-		t.Errorf("error does not report that the capture was retried: %v", err)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "index.lock"), func() { t.Errorf("error does not name the index lock, so it is not actionable: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(msg, "times"), func() { t.Errorf("error does not report that the capture was retried: %v", err) })
 }
 
 // Every failure through runGitStdout used to arrive as "exit status 1": stderr
@@ -267,12 +235,8 @@ func TestCaptureDirtyStateNamesTheIndexLockHolder(t *testing.T) {
 func TestRunGitSurfacesStderrInTheError(t *testing.T) {
 	repo := newTestRepo(t)
 	_, err := runGitTrimmed(repo, "rev-parse", "--verify", "definitely-not-a-ref")
-	if err == nil {
-		t.Fatal("rev-parse of a bogus ref succeeded")
-	}
-	if !strings.Contains(err.Error(), "fatal:") {
-		t.Errorf("error dropped git's stderr: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("rev-parse of a bogus ref succeeded") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "fatal:"), func() { t.Errorf("error dropped git's stderr: %v", err) })
 }
 
 // The production shape: two tasks on one local_directory, each preparing in
@@ -315,16 +279,10 @@ func TestConcurrentIsolatedPreparesOnOneRepo(t *testing.T) {
 	branches := map[string]bool{}
 	for range taskIDs {
 		got := <-results
-		if got.err != nil {
-			t.Fatalf("concurrent PrepareIsolated failed: %v", got.err)
-		}
+		testassert.OnFailure(t, got.err != nil, func() { t.Fatalf("concurrent PrepareIsolated failed: %v", got.err) })
 		wt := got.env.LocalWorktree
-		if wt == nil {
-			t.Fatal("prepared environment has no worktree")
-		}
-		if branches[wt.Branch] {
-			t.Fatalf("two concurrent tasks landed on branch %q", wt.Branch)
-		}
+		testassert.OnFailure(t, wt == nil, func() { t.Fatal("prepared environment has no worktree") })
+		testassert.OnFailure(t, branches[wt.Branch], func() { t.Fatalf("two concurrent tasks landed on branch %q", wt.Branch) })
 		branches[wt.Branch] = true
 		// Each task must see the user's uncommitted state, which is precisely
 		// what the lost capture would have silently replaced with a clean HEAD.

--- a/server/internal/daemon/execenv/handoff_context_test.go
+++ b/server/internal/daemon/execenv/handoff_context_test.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestRenderIssueContext_HandoffNote verifies the handoff note lands in
@@ -12,22 +14,14 @@ func TestRenderIssueContext_HandoffNote(t *testing.T) {
 	note := "Scope to the auth module only."
 	md := renderIssueContext("claude", TaskContextForEnv{IssueID: "issue-1", HandoffNote: note})
 
-	if !strings.Contains(md, "## Handoff Note") {
-		t.Fatalf("expected Handoff Note section:\n%s", md)
-	}
-	if !strings.Contains(md, note) {
-		t.Fatalf("handoff note text missing:\n%s", md)
-	}
-	if !strings.Contains(md, "**Trigger:** New Assignment") {
-		t.Fatalf("handoff note must render under the assignment trigger:\n%s", md)
-	}
+	testassert.OnFailure(t, !strings.Contains(md, "## Handoff Note"), func() { t.Fatalf("expected Handoff Note section:\n%s", md) })
+	testassert.OnFailure(t, !strings.Contains(md, note), func() { t.Fatalf("handoff note text missing:\n%s", md) })
+	testassert.OnFailure(t, !strings.Contains(md, "**Trigger:** New Assignment"), func() { t.Fatalf("handoff note must render under the assignment trigger:\n%s", md) })
 }
 
 // TestRenderIssueContext_NoHandoffNote keeps the assignment context clean when
 // no note is present.
 func TestRenderIssueContext_NoHandoffNote(t *testing.T) {
 	md := renderIssueContext("claude", TaskContextForEnv{IssueID: "issue-1"})
-	if strings.Contains(md, "## Handoff Note") {
-		t.Fatalf("unexpected Handoff Note section when no note set:\n%s", md)
-	}
+	testassert.OnFailure(t, strings.Contains(md, "## Handoff Note"), func() { t.Fatalf("unexpected Handoff Note section when no note set:\n%s", md) })
 }

--- a/server/internal/daemon/execenv/hermes_home_config_warn_test.go
+++ b/server/internal/daemon/execenv/hermes_home_config_warn_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // captureLogger returns a logger writing into buf, for asserting on the
@@ -39,22 +41,14 @@ func TestHermesOverlayWarnsWhenSourceHomeCarriesNoConfig(t *testing.T) {
 		}
 
 		out := logs.String()
-		if !strings.Contains(out, "hermes source home does not exist") {
-			t.Errorf("missing source home must be warned about, got:\n%s", out)
-		}
-		if !strings.Contains(out, missing) {
-			t.Errorf("the warning must name the resolved source home %q, got:\n%s", missing, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, "hermes source home does not exist"), func() { t.Errorf("missing source home must be warned about, got:\n%s", out) })
+		testassert.OnFailure(t, !strings.Contains(out, missing), func() { t.Errorf("the warning must name the resolved source home %q, got:\n%s", missing, out) })
 
 		// The derived config is what the child actually reads: no provider,
 		// which is exactly why Hermes then refuses to start.
 		data, err := os.ReadFile(filepath.Join(hermesHome, "config.yaml"))
-		if err != nil {
-			t.Fatalf("overlay config.yaml unreadable: %v", err)
-		}
-		if strings.Contains(string(data), "provider:") {
-			t.Errorf("nothing to inherit, so the derived config should carry no provider, got:\n%s", data)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("overlay config.yaml unreadable: %v", err) })
+		testassert.OnFailure(t, strings.Contains(string(data), "provider:"), func() { t.Errorf("nothing to inherit, so the derived config should carry no provider, got:\n%s", data) })
 	})
 
 	t.Run("source home exists but has no config.yaml", func(t *testing.T) {
@@ -71,15 +65,9 @@ func TestHermesOverlayWarnsWhenSourceHomeCarriesNoConfig(t *testing.T) {
 		}
 
 		out := logs.String()
-		if !strings.Contains(out, "has no config.yaml") {
-			t.Errorf("a config-less source home must be warned about, got:\n%s", out)
-		}
-		if strings.Contains(out, "does not exist") {
-			t.Errorf("the home DOES exist; the two cases must not be conflated, got:\n%s", out)
-		}
-		if !strings.Contains(out, sharedHome) {
-			t.Errorf("the warning must name the resolved source home %q, got:\n%s", sharedHome, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, "has no config.yaml"), func() { t.Errorf("a config-less source home must be warned about, got:\n%s", out) })
+		testassert.OnFailure(t, strings.Contains(out, "does not exist"), func() { t.Errorf("the home DOES exist; the two cases must not be conflated, got:\n%s", out) })
+		testassert.OnFailure(t, !strings.Contains(out, sharedHome), func() { t.Errorf("the warning must name the resolved source home %q, got:\n%s", sharedHome, out) })
 	})
 }
 
@@ -103,13 +91,9 @@ func TestHermesOverlayKeepsProviderAndStaysQuiet(t *testing.T) {
 	}
 
 	data, err := os.ReadFile(filepath.Join(hermesHome, "config.yaml"))
-	if err != nil {
-		t.Fatalf("overlay config.yaml unreadable: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("overlay config.yaml unreadable: %v", err) })
 	for _, want := range []string{"provider: custom:9router", "name: 9router", "api_key: sk-test"} {
-		if !strings.Contains(string(data), want) {
-			t.Errorf("derived config dropped %q, got:\n%s", want, data)
-		}
+		testassert.OnFailure(t, !strings.Contains(string(data), want), func() { t.Errorf("derived config dropped %q, got:\n%s", want, data) })
 	}
 	if out := logs.String(); strings.Contains(out, "source home") {
 		t.Errorf("a healthy source home must not warn, got:\n%s", out)

--- a/server/internal/daemon/execenv/hermes_home_test.go
+++ b/server/internal/daemon/execenv/hermes_home_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -13,9 +14,7 @@ import (
 func hermesExternalDirs(t *testing.T, configPath string) []string {
 	t.Helper()
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read derived config: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read derived config: %v", err) })
 	var parsed struct {
 		Skills struct {
 			ExternalDirs []string `yaml:"external_dirs"`
@@ -32,9 +31,7 @@ func hermesExternalDirs(t *testing.T, configPath string) []string {
 func hermesMemoryProvider(t *testing.T, configPath string) (string, bool) {
 	t.Helper()
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read derived config: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read derived config: %v", err) })
 	var parsed struct {
 		Memory struct {
 			Provider *string `yaml:"provider"`
@@ -71,12 +68,8 @@ func TestPrepareHermesHomeOverlay(t *testing.T) {
 
 	for _, name := range []string{"auth.json", "plugins", "oauth_state.json"} {
 		fi, err := os.Lstat(filepath.Join(hermesHome, name))
-		if err != nil {
-			t.Fatalf("%s not mirrored into overlay: %v", name, err)
-		}
-		if fi.Mode()&os.ModeSymlink == 0 {
-			t.Errorf("%s should be a symlink into the shared home", name)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("%s not mirrored into overlay: %v", name, err) })
+		testassert.OnFailure(t, fi.Mode()&os.ModeSymlink == 0, func() { t.Errorf("%s should be a symlink into the shared home", name) })
 	}
 
 	// .env is overlay-owned/derived (not symlinked): it preserves the source's
@@ -134,12 +127,8 @@ func TestHermesDisablesExternalMemoryProvider(t *testing.T) {
 	}
 
 	got, ok := hermesMemoryProvider(t, filepath.Join(hermesHome, "config.yaml"))
-	if !ok {
-		t.Fatal("memory.provider should be present and explicitly disabled")
-	}
-	if got != "" {
-		t.Errorf("memory.provider = %q, want \"\" (external backend disabled)", got)
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatal("memory.provider should be present and explicitly disabled") })
+	testassert.OnFailure(t, got != "", func() { t.Errorf("memory.provider = %q, want \"\" (external backend disabled)", got) })
 	if data, _ := os.ReadFile(filepath.Join(hermesHome, "config.yaml")); !strings.Contains(string(data), "memory_enabled: true") {
 		t.Error("built-in memory settings should be preserved")
 	}
@@ -167,9 +156,7 @@ func TestHermesDerivedConfigRebasesRelativeExternalDirs(t *testing.T) {
 		"/opt/shared/skills",
 		filepath.Join(sharedHome, "skills"),
 	}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Errorf("external_dirs =\n%v\nwant\n%v", got, want)
-	}
+	testassert.OnFailure(t, strings.Join(got, "\n") != strings.Join(want, "\n"), func() { t.Errorf("external_dirs =\n%v\nwant\n%v", got, want) })
 }
 
 // TestHermesExternalDirsExpandsSanitizedEnv verifies a ${VAR} present in the
@@ -195,9 +182,7 @@ func TestHermesExternalDirsExpandsSanitizedEnv(t *testing.T) {
 		"${MYSTERY_VAR}/x",  // unknown var preserved verbatim, NOT absolutized
 		filepath.Join(sharedHome, "skills"),
 	}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Errorf("external_dirs =\n%v\nwant\n%v", got, want)
-	}
+	testassert.OnFailure(t, strings.Join(got, "\n") != strings.Join(want, "\n"), func() { t.Errorf("external_dirs =\n%v\nwant\n%v", got, want) })
 }
 
 // TestHermesBoundSkillKeepsNaturalSlug asserts a bound skill sharing a name with
@@ -216,12 +201,8 @@ func TestHermesBoundSkillKeepsNaturalSlug(t *testing.T) {
 	}
 
 	body, err := os.ReadFile(filepath.Join(hermesHome, "skills", "review-helper", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read bound skill: %v", err)
-	}
-	if strings.Contains(string(body), "USER VERSION") || !strings.Contains(string(body), "WORKSPACE VERSION") {
-		t.Errorf("bound skill should keep natural slug with its own content, got: %q", body)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read bound skill: %v", err) })
+	testassert.OnFailure(t, strings.Contains(string(body), "USER VERSION") || !strings.Contains(string(body), "WORKSPACE VERSION"), func() { t.Errorf("bound skill should keep natural slug with its own content, got: %q", body) })
 	if data, _ := os.ReadFile(userSkill); string(data) != "USER VERSION" {
 		t.Errorf("user's shared skill was modified: %q", data)
 	}
@@ -295,9 +276,7 @@ func TestHermesOverlayKeepsSessionDatabaseTaskLocal(t *testing.T) {
 	}
 	for _, name := range stateFiles {
 		data, err := os.ReadFile(filepath.Join(hermesHome, name))
-		if err != nil {
-			t.Fatalf("read task-local %s after reuse: %v", name, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read task-local %s after reuse: %v", name, err) })
 		if got, want := string(data), "TASK "+name; got != want {
 			t.Errorf("task-local %s after reuse = %q, want %q", name, got, want)
 		}
@@ -338,9 +317,7 @@ func TestHermesOverlayMigratesLegacySessionDatabase(t *testing.T) {
 			t.Errorf("legacy overlay %s should be removed during migration: %v", name, err)
 		}
 		data, err := os.ReadFile(filepath.Join(sharedHome, name))
-		if err != nil {
-			t.Fatalf("read host %s after migration: %v", name, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read host %s after migration: %v", name, err) })
 		if got, want := string(data), "HOST "+name; got != want {
 			t.Errorf("host %s changed during migration: got %q, want %q", name, got, want)
 		}
@@ -442,9 +419,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		t.Parallel()
 		base := t.TempDir()
 		res := ResolveHermesProfile(base, "", false, false)
-		if res.Err != nil || res.SourceHome != base || res.MustExist {
-			t.Fatalf("got %+v, want SourceHome=%q MustExist=false Err=nil", res, base)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != base || res.MustExist, func() { t.Fatalf("got %+v, want SourceHome=%q MustExist=false Err=nil", res, base) })
 	})
 
 	// The review's blocker 1: a sticky active_profile must be SELECTED as the
@@ -455,9 +430,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		mustWrite(t, filepath.Join(root, "active_profile"), "coder\n")
 		res := ResolveHermesProfile(root, "", false, false)
 		want := filepath.Join(root, "profiles", "coder")
-		if res.Err != nil || res.SourceHome != want || !res.MustExist {
-			t.Fatalf("sticky: got %+v, want SourceHome=%q MustExist=true", res, want)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != want || !res.MustExist, func() { t.Fatalf("sticky: got %+v, want SourceHome=%q MustExist=true", res, want) })
 	})
 
 	t.Run("sticky default is ignored", func(t *testing.T) {
@@ -465,9 +438,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		root := t.TempDir()
 		mustWrite(t, filepath.Join(root, "active_profile"), "default\n")
 		res := ResolveHermesProfile(root, "", false, false)
-		if res.Err != nil || res.SourceHome != root || res.MustExist {
-			t.Fatalf("sticky default: got %+v, want SourceHome=%q MustExist=false", res, root)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != root || res.MustExist, func() { t.Fatalf("sticky default: got %+v, want SourceHome=%q MustExist=false", res, root) })
 	})
 
 	t.Run("already-profile-scoped home with no flag is trusted", func(t *testing.T) {
@@ -477,9 +448,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		// A sticky at the root must NOT override an explicit profile-scoped home.
 		mustWrite(t, filepath.Join(root, "active_profile"), "research\n")
 		res := ResolveHermesProfile(scoped, "", false, false)
-		if res.Err != nil || res.SourceHome != scoped || !res.MustExist {
-			t.Fatalf("profile-scoped: got %+v, want SourceHome=%q MustExist=true", res, scoped)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != scoped || !res.MustExist, func() { t.Fatalf("profile-scoped: got %+v, want SourceHome=%q MustExist=true", res, scoped) })
 	})
 
 	t.Run("-p default from a profile-scoped home re-roots to the root", func(t *testing.T) {
@@ -487,9 +456,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		root := t.TempDir()
 		scoped := filepath.Join(root, "profiles", "coder")
 		res := ResolveHermesProfile(scoped, "default", true, false)
-		if res.Err != nil || res.SourceHome != root || res.MustExist {
-			t.Fatalf("-p default: got %+v, want SourceHome=%q MustExist=false", res, root)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != root || res.MustExist, func() { t.Fatalf("-p default: got %+v, want SourceHome=%q MustExist=false", res, root) })
 	})
 
 	t.Run("-p sibling from a profile-scoped home is a sibling, not nested", func(t *testing.T) {
@@ -498,9 +465,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		scoped := filepath.Join(root, "profiles", "coder")
 		res := ResolveHermesProfile(scoped, "research", true, false)
 		want := filepath.Join(root, "profiles", "research")
-		if res.Err != nil || res.SourceHome != want || !res.MustExist {
-			t.Fatalf("-p sibling: got %+v, want SourceHome=%q MustExist=true", res, want)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != want || !res.MustExist, func() { t.Fatalf("-p sibling: got %+v, want SourceHome=%q MustExist=true", res, want) })
 	})
 
 	t.Run("explicit named profile resolves under the root", func(t *testing.T) {
@@ -508,9 +473,7 @@ func TestResolveHermesProfile(t *testing.T) {
 		root := t.TempDir()
 		res := ResolveHermesProfile(root, "research", true, false)
 		want := filepath.Join(root, "profiles", "research")
-		if res.Err != nil || res.SourceHome != want || !res.MustExist {
-			t.Fatalf("named: got %+v, want SourceHome=%q MustExist=true", res, want)
-		}
+		testassert.OnFailure(t, res.Err != nil || res.SourceHome != want || !res.MustExist, func() { t.Fatalf("named: got %+v, want SourceHome=%q MustExist=true", res, want) })
 	})
 
 	t.Run("reserved names fail closed", func(t *testing.T) {
@@ -563,9 +526,7 @@ func TestHermesExternalDirsExpandsAgainstSelectedProfileHome(t *testing.T) {
 		filepath.Join(profileHome, "profile-skills"),
 		filepath.Join(profileHome, "skills"),
 	}
-	if strings.Join(got, "\n") != strings.Join(want, "\n") {
-		t.Errorf("external_dirs =\n%v\nwant\n%v", got, want)
-	}
+	testassert.OnFailure(t, strings.Join(got, "\n") != strings.Join(want, "\n"), func() { t.Errorf("external_dirs =\n%v\nwant\n%v", got, want) })
 }
 
 // TestHermesOverlayEnvPinsHomeAfterDotenvOverride is the review's blocker 1: a
@@ -594,12 +555,10 @@ func TestHermesOverlayEnvPinsHomeAfterDotenvOverride(t *testing.T) {
 	}
 
 	env := applyDotenvOverride(t, envPath)
-	if env["HERMES_HOME"] != hermesHome {
+	testassert.OnFailure(t, env["HERMES_HOME"] != hermesHome, func() {
 		t.Errorf("after override=True dotenv load HERMES_HOME = %q, want the overlay %q", env["HERMES_HOME"], hermesHome)
-	}
-	if env["ANTHROPIC_API_KEY"] != "sk-source" {
-		t.Errorf("source credential dropped: ANTHROPIC_API_KEY = %q", env["ANTHROPIC_API_KEY"])
-	}
+	})
+	testassert.OnFailure(t, env["ANTHROPIC_API_KEY"] != "sk-source", func() { t.Errorf("source credential dropped: ANTHROPIC_API_KEY = %q", env["ANTHROPIC_API_KEY"]) })
 	// HERMES_HOME pinned to the overlay ⇒ skill discovery and memory use the
 	// overlay's own dirs.
 	if _, err := os.Stat(filepath.Join(hermesHome, "skills", "review-helper", "SKILL.md")); err != nil {
@@ -622,9 +581,9 @@ func TestHermesOverlayEnvCreatedWhenSourceHasNone(t *testing.T) {
 		t.Fatalf("prepareHermesHome failed: %v", err)
 	}
 	env := applyDotenvOverride(t, filepath.Join(hermesHome, ".env"))
-	if env["HERMES_HOME"] != hermesHome {
+	testassert.OnFailure(t, env["HERMES_HOME"] != hermesHome, func() {
 		t.Errorf("overlay .env must exist and pin HERMES_HOME even with no source .env; got %q", env["HERMES_HOME"])
-	}
+	})
 }
 
 // applyDotenvOverride replays python-dotenv's single-file override=True load over
@@ -633,9 +592,7 @@ func TestHermesOverlayEnvCreatedWhenSourceHasNone(t *testing.T) {
 func applyDotenvOverride(t *testing.T, path string) map[string]string {
 	t.Helper()
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read overlay .env: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read overlay .env: %v", err) })
 	env := map[string]string{}
 	for _, line := range strings.Split(string(data), "\n") {
 		s := strings.TrimSpace(line)
@@ -677,9 +634,7 @@ func TestHermesRootFromHomeResolvesSymlinks(t *testing.T) {
 	}
 
 	root := hermesRootFromHomeFor(link, native)
-	if root != native {
-		t.Fatalf("symlinked profile home: root = %q, want native %q", root, native)
-	}
+	testassert.OnFailure(t, root != native, func() { t.Fatalf("symlinked profile home: root = %q, want native %q", root, native) })
 	if home, _, err := hermesProfileDir(root, "default"); err != nil || home != native {
 		t.Fatalf("-p default: home=%q err=%v, want %q", home, err, native)
 	}
@@ -758,14 +713,10 @@ func TestPrepareHermesNoSkillsLeavesHomeUnset(t *testing.T) {
 		Provider:       "hermes",
 		Task:           TaskContextForEnv{IssueID: "no-skill"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
-	if env.HermesHome != "" {
-		t.Errorf("skill-less Hermes task must not redirect HERMES_HOME, got %q", env.HermesHome)
-	}
+	testassert.OnFailure(t, env.HermesHome != "", func() { t.Errorf("skill-less Hermes task must not redirect HERMES_HOME, got %q", env.HermesHome) })
 	if _, err := os.Stat(filepath.Join(env.RootDir, "hermes-home")); !os.IsNotExist(err) {
 		t.Error("no hermes-home overlay should be created for a skill-less task")
 	}
@@ -791,14 +742,10 @@ func TestReuseHermesTearsDownWhenSkillsRemoved(t *testing.T) {
 		HermesSourceHome: sharedHome,
 		Task:             withSkill,
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
-	if env.HermesHome == "" {
-		t.Fatal("expected HERMES_HOME redirect for a task with a bound skill")
-	}
+	testassert.OnFailure(t, env.HermesHome == "", func() { t.Fatal("expected HERMES_HOME redirect for a task with a bound skill") })
 	overlayDir := filepath.Join(env.RootDir, "hermes-home")
 
 	if reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "hermes", HermesSourceHome: sharedHome, Task: withSkill}, testLogger()); reused == nil {
@@ -809,12 +756,8 @@ func TestReuseHermesTearsDownWhenSkillsRemoved(t *testing.T) {
 
 	noSkill := TaskContextForEnv{IssueID: "hermes-resume"}
 	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "hermes", HermesSourceHome: sharedHome, Task: noSkill}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse without skill returned nil")
-	}
-	if reused.HermesHome != "" {
-		t.Errorf("removing the last skill should clear HERMES_HOME, got %q", reused.HermesHome)
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse without skill returned nil") })
+	testassert.OnFailure(t, reused.HermesHome != "", func() { t.Errorf("removing the last skill should clear HERMES_HOME, got %q", reused.HermesHome) })
 	if _, err := os.Stat(overlayDir); !os.IsNotExist(err) {
 		t.Error("stale hermes-home overlay should be removed on teardown")
 	}

--- a/server/internal/daemon/execenv/hermes_memory_test.go
+++ b/server/internal/daemon/execenv/hermes_memory_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestHermesMemoryProfileSegment covers the store segment derived from a
@@ -31,22 +33,14 @@ func TestHermesMemoryProfileSegment(t *testing.T) {
 	// Same profile name under a different root must not share a memory line.
 	root := t.TempDir()
 	foreign := hermesMemoryProfileSegment(filepath.Join(root, "profiles", "research"))
-	if foreign == "research" {
-		t.Fatalf("foreign-root profile collided with the native one on %q", foreign)
-	}
-	if !strings.HasPrefix(foreign, "research_") {
-		t.Fatalf("foreign-root profile segment = %q, want a research_<hash> form", foreign)
-	}
+	testassert.OnFailure(t, foreign == "research", func() { t.Fatalf("foreign-root profile collided with the native one on %q", foreign) })
+	testassert.OnFailure(t, !strings.HasPrefix(foreign, "research_"), func() { t.Fatalf("foreign-root profile segment = %q, want a research_<hash> form", foreign) })
 
 	custom := hermesMemoryProfileSegment(filepath.Join(root, "custom-home"))
-	if !strings.HasPrefix(custom, "h_") {
-		t.Fatalf("custom home segment = %q, want an h_ hash", custom)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(custom, "h_"), func() { t.Fatalf("custom home segment = %q, want an h_ hash", custom) })
 	// Same basename in a different location must not collide.
 	other := hermesMemoryProfileSegment(filepath.Join(root, "nested", "custom-home"))
-	if custom == other {
-		t.Fatalf("distinct custom homes collided on %q", custom)
-	}
+	testassert.OnFailure(t, custom == other, func() { t.Fatalf("distinct custom homes collided on %q", custom) })
 }
 
 // TestHermesMemoryStorePathLayout pins the on-disk layout the documented
@@ -59,9 +53,7 @@ func TestHermesMemoryStorePathLayout(t *testing.T) {
 	agent := "11111111-2222-3333-4444-555555555555"
 	got := HermesMemoryStorePath("", agent, filepath.Join(platformDefaultHermesHome(), "profiles", "research"))
 	want := filepath.Join(home, ".multica", hermesMemoryStoreRoot, agent, "research")
-	if got != want {
-		t.Fatalf("store path = %q, want %q", got, want)
-	}
+	testassert.OnFailure(t, got != want, func() { t.Fatalf("store path = %q, want %q", got, want) })
 }
 
 // TestHermesMemoryStorePathDisabled covers the task without an agent to key the
@@ -98,22 +90,14 @@ func TestPrepareHermesHomeMemoryStorePersistsAcrossTasks(t *testing.T) {
 		t.Fatalf("prepare second task: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(secondTask, "memories", "MEMORY.md"))
-	if err != nil {
-		t.Fatalf("second task lost the agent's memory: %v", err)
-	}
-	if string(got) != "prefers tabs" {
-		t.Fatalf("memory content = %q, want %q", got, "prefers tabs")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("second task lost the agent's memory: %v", err) })
+	testassert.OnFailure(t, string(got) != "prefers tabs", func() { t.Fatalf("memory content = %q, want %q", got, "prefers tabs") })
 
 	// The link must point at the store, not hold a copy — otherwise the next
 	// task's writes would diverge from it.
 	fi, err := os.Lstat(filepath.Join(secondTask, "memories"))
-	if err != nil {
-		t.Fatalf("lstat memories: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("memories is not a link (mode %v)", fi.Mode())
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat memories: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink == 0, func() { t.Fatalf("memories is not a link (mode %v)", fi.Mode()) })
 }
 
 // TestPrepareHermesHomeMemoryStoreIsolatesAgents guards the isolation promise
@@ -152,15 +136,9 @@ func TestPrepareHermesHomeWithoutStore(t *testing.T) {
 		t.Fatalf("prepare: %v", err)
 	}
 	fi, err := os.Lstat(filepath.Join(hermesHome, "memories"))
-	if err != nil {
-		t.Fatalf("lstat memories: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("memories should be a real dir without a store, got a link")
-	}
-	if !fi.IsDir() {
-		t.Fatalf("memories is not a directory (mode %v)", fi.Mode())
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat memories: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Fatalf("memories should be a real dir without a store, got a link") })
+	testassert.OnFailure(t, !fi.IsDir(), func() { t.Fatalf("memories is not a directory (mode %v)", fi.Mode()) })
 }
 
 // TestPrepareHermesHomeWithoutStoreDetachesExistingStoreLink is the regression
@@ -188,12 +166,8 @@ func TestPrepareHermesHomeWithoutStoreDetachesExistingStoreLink(t *testing.T) {
 	}
 
 	fi, err := os.Lstat(filepath.Join(hermesHome, "memories"))
-	if err != nil {
-		t.Fatalf("lstat memories: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("the store link is still in place; the task still writes to the persistent store")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat memories: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Fatalf("the store link is still in place; the task still writes to the persistent store") })
 	if _, err := os.Stat(filepath.Join(hermesHome, "memories", "MEMORY.md")); !os.IsNotExist(err) {
 		t.Fatalf("a task without a store should get an empty memories dir (err = %v)", err)
 	}
@@ -250,9 +224,9 @@ func TestMigrateHermesTaskMemoriesFailureKeepsSource(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(blocked, 0o700) })
 
 	err := migrateHermesTaskMemories(taskDir, storeDir, testLogger())
-	if err == nil {
+	testassert.OnFailure(t, err == nil, func() {
 		t.Fatalf("migration reported success despite an unreadable entry; the caller would delete the source")
-	}
+	})
 
 	// Source intact.
 	for _, name := range []string{"MEMORY.md", "USER.md"} {
@@ -263,12 +237,8 @@ func TestMigrateHermesTaskMemoriesFailureKeepsSource(t *testing.T) {
 	// Store rolled back — a half-populated store would read as accumulated
 	// memory on the next run and block the retry.
 	left, readErr := os.ReadDir(storeDir)
-	if readErr != nil {
-		t.Fatalf("read store: %v", readErr)
-	}
-	if len(left) != 0 {
-		t.Fatalf("failed migration left %d entries in the store, want 0", len(left))
-	}
+	testassert.OnFailure(t, readErr != nil, func() { t.Fatalf("read store: %v", readErr) })
+	testassert.OnFailure(t, len(left) != 0, func() { t.Fatalf("failed migration left %d entries in the store, want 0", len(left)) })
 }
 
 // TestMountHermesMemoriesUnreadableStoreKeepsSource covers the entry-point I/O
@@ -366,22 +336,14 @@ func TestMigrateHermesTaskMemoriesConcurrentFirstWriterWins(t *testing.T) {
 	wg.Wait()
 
 	for i, err := range errs {
-		if err != nil {
-			t.Fatalf("concurrent migration %d failed: %v", i, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("concurrent migration %d failed: %v", i, err) })
 	}
 
 	memory, err := os.ReadFile(filepath.Join(storeDir, "MEMORY.md"))
-	if err != nil {
-		t.Fatalf("store is missing MEMORY.md after concurrent migration: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("store is missing MEMORY.md after concurrent migration: %v", err) })
 	user, err := os.ReadFile(filepath.Join(storeDir, "USER.md"))
-	if err != nil {
-		t.Fatalf("store is missing USER.md after concurrent migration: %v", err)
-	}
-	if string(memory) != string(user) {
-		t.Fatalf("store interleaved two tasks: MEMORY.md=%q USER.md=%q", memory, user)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("store is missing USER.md after concurrent migration: %v", err) })
+	testassert.OnFailure(t, string(memory) != string(user), func() { t.Fatalf("store interleaved two tasks: MEMORY.md=%q USER.md=%q", memory, user) })
 
 	// Every source survives: a task that lost the race must not have had its
 	// directory reported as migrated.
@@ -392,12 +354,8 @@ func TestMigrateHermesTaskMemoriesConcurrentFirstWriterWins(t *testing.T) {
 	}
 	// No staging directories left behind next to the store.
 	siblings, err := os.ReadDir(filepath.Dir(storeDir))
-	if err != nil {
-		t.Fatalf("read store parent: %v", err)
-	}
-	if len(siblings) != 1 {
-		t.Fatalf("expected only the store next to itself, got %d entries", len(siblings))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read store parent: %v", err) })
+	testassert.OnFailure(t, len(siblings) != 1, func() { t.Fatalf("expected only the store next to itself, got %d entries", len(siblings)) })
 }
 
 // TestPromoteHermesMemoryStagingClassifiesRemoveFailures covers the publish
@@ -417,16 +375,10 @@ func TestPromoteHermesMemoryStagingClassifiesRemoveFailures(t *testing.T) {
 		mustWrite(t, filepath.Join(staging, "MEMORY.md"), "loser")
 
 		promoted, err := promoteHermesStoreStaging(staging, storeDir, hermesStorePopulated)
-		if err != nil {
-			t.Fatalf("a populated store should be a lost race, not an error: %v", err)
-		}
-		if promoted {
-			t.Fatalf("promote clobbered a store another task had published")
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("a populated store should be a lost race, not an error: %v", err) })
+		testassert.OnFailure(t, promoted, func() { t.Fatalf("promote clobbered a store another task had published") })
 		got, readErr := os.ReadFile(filepath.Join(storeDir, "MEMORY.md"))
-		if readErr != nil || string(got) != "winner" {
-			t.Fatalf("winner's store was modified: content=%q err=%v", got, readErr)
-		}
+		testassert.OnFailure(t, readErr != nil || string(got) != "winner", func() { t.Fatalf("winner's store was modified: content=%q err=%v", got, readErr) })
 	})
 
 	// An empty store that cannot be removed is an I/O failure, not a race.
@@ -449,12 +401,8 @@ func TestPromoteHermesMemoryStagingClassifiesRemoveFailures(t *testing.T) {
 		t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
 
 		promoted, err := promoteHermesStoreStaging(staging, storeDir, hermesStorePopulated)
-		if promoted {
-			t.Fatalf("promote reported success against an unremovable store")
-		}
-		if err == nil {
-			t.Fatalf("a permission error was reported as a lost race; the caller would delete the source")
-		}
+		testassert.OnFailure(t, promoted, func() { t.Fatalf("promote reported success against an unremovable store") })
+		testassert.OnFailure(t, err == nil, func() { t.Fatalf("a permission error was reported as a lost race; the caller would delete the source") })
 	})
 }
 
@@ -502,12 +450,8 @@ func TestPrepareHermesHomeMigratesTaskLocalMemories(t *testing.T) {
 		t.Fatalf("prepare with store: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(store, "MEMORY.md"))
-	if err != nil {
-		t.Fatalf("task-local memory was not migrated into the store: %v", err)
-	}
-	if string(got) != "carried over" {
-		t.Fatalf("migrated content = %q, want %q", got, "carried over")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("task-local memory was not migrated into the store: %v", err) })
+	testassert.OnFailure(t, string(got) != "carried over", func() { t.Fatalf("migrated content = %q, want %q", got, "carried over") })
 }
 
 // TestPrepareHermesHomeMigrationKeepsExistingStore is the other half of the
@@ -531,12 +475,8 @@ func TestPrepareHermesHomeMigrationKeepsExistingStore(t *testing.T) {
 		t.Fatalf("prepare with store: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(store, "MEMORY.md"))
-	if err != nil {
-		t.Fatalf("read store memory: %v", err)
-	}
-	if string(got) != "authoritative agent memory" {
-		t.Fatalf("store memory was overwritten by the task-local copy: %q", got)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read store memory: %v", err) })
+	testassert.OnFailure(t, string(got) != "authoritative agent memory", func() { t.Fatalf("store memory was overwritten by the task-local copy: %q", got) })
 }
 
 // TestPruneHermesMemoryStores covers the GC contract: stores idle past retention
@@ -574,12 +514,8 @@ func TestPruneHermesMemoryStores(t *testing.T) {
 	}
 
 	removed, freed := PruneHermesMemoryStores("", 14*24*time.Hour, now, reserve, testLogger())
-	if removed != 1 {
-		t.Fatalf("removed = %d, want 1", removed)
-	}
-	if freed <= 0 {
-		t.Fatalf("bytesFreed = %d, want > 0", freed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("removed = %d, want 1", removed) })
+	testassert.OnFailure(t, freed <= 0, func() { t.Fatalf("bytesFreed = %d, want > 0", freed) })
 	if _, err := os.Stat(idle); !os.IsNotExist(err) {
 		t.Fatalf("idle store survived the prune (err = %v)", err)
 	}

--- a/server/internal/daemon/execenv/hermes_sessions_test.go
+++ b/server/internal/daemon/execenv/hermes_sessions_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestHermesSessionStorePathLayout pins the on-disk layout an operator (and
@@ -23,9 +25,7 @@ func TestHermesSessionStorePathLayout(t *testing.T) {
 	got := HermesSessionStorePath("", agent, filepath.Join(platformDefaultHermesHome(), "profiles", "research"),
 		TaskContextForEnv{AgentID: agent, IssueID: issue})
 	want := filepath.Join(home, ".multica", hermesSessionStoreRoot, agent, "research", issue)
-	if got != want {
-		t.Fatalf("store path = %q, want %q", got, want)
-	}
+	testassert.OnFailure(t, got != want, func() { t.Fatalf("store path = %q, want %q", got, want) })
 }
 
 // TestHermesSessionStorePathScoping covers which tasks get a shard at all, and
@@ -38,14 +38,10 @@ func TestHermesSessionStorePathScoping(t *testing.T) {
 	const agent = "agent-1"
 	issueA := HermesSessionStorePath("", agent, "", TaskContextForEnv{IssueID: "issue-a"})
 	issueB := HermesSessionStorePath("", agent, "", TaskContextForEnv{IssueID: "issue-b"})
-	if issueA == "" || issueA == issueB {
-		t.Fatalf("two issues must get distinct stores, got %q and %q", issueA, issueB)
-	}
+	testassert.OnFailure(t, issueA == "" || issueA == issueB, func() { t.Fatalf("two issues must get distinct stores, got %q and %q", issueA, issueB) })
 
 	chat := HermesSessionStorePath("", agent, "", TaskContextForEnv{ChatSessionID: "sess-1"})
-	if filepath.Base(chat) != "chat_sess-1" {
-		t.Fatalf("chat conversation segment = %q, want chat_sess-1", filepath.Base(chat))
-	}
+	testassert.OnFailure(t, filepath.Base(chat) != "chat_sess-1", func() { t.Fatalf("chat conversation segment = %q, want chat_sess-1", filepath.Base(chat)) })
 	// An issue task and a chat task can never collide even on equal ids.
 	if same := HermesSessionStorePath("", agent, "", TaskContextForEnv{IssueID: "sess-1"}); same == chat {
 		t.Fatalf("issue and chat conversations collided on %q", chat)
@@ -74,15 +70,9 @@ func TestPrepareHermesHomeSessionStorePersistsAcrossTasks(t *testing.T) {
 
 	firstTask := filepath.Join(t.TempDir(), "hermes-home")
 	sessions, err := prepareHermesHome(firstTask, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare first task: %v", err)
-	}
-	if !sessions.Mounted {
-		t.Fatal("first task reported the session store as not mounted")
-	}
-	if sessions.HistoryPresent {
-		t.Fatal("HistoryPresent = true on a conversation's first turn, want false")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare first task: %v", err) })
+	testassert.OnFailure(t, !sessions.Mounted, func() { t.Fatal("first task reported the session store as not mounted") })
+	testassert.OnFailure(t, sessions.HistoryPresent, func() { t.Fatal("HistoryPresent = true on a conversation's first turn, want false") })
 	// Hermes creates state.db lazily and writes the transcript into it.
 	mustWrite(t, filepath.Join(firstTask, "state.db"), "transcript")
 
@@ -91,22 +81,14 @@ func TestPrepareHermesHomeSessionStorePersistsAcrossTasks(t *testing.T) {
 		t.Fatalf("prepare second task: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(secondTask, "state.db"))
-	if err != nil {
-		t.Fatalf("second task lost the conversation transcript: %v", err)
-	}
-	if string(got) != "transcript" {
-		t.Fatalf("transcript = %q, want %q", got, "transcript")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("second task lost the conversation transcript: %v", err) })
+	testassert.OnFailure(t, string(got) != "transcript", func() { t.Fatalf("transcript = %q, want %q", got, "transcript") })
 
 	// It must be a link into the store, not a copy — a copy would take this
 	// turn's writes and throw them away with the task directory.
 	fi, err := os.Lstat(filepath.Join(secondTask, "state.db"))
-	if err != nil {
-		t.Fatalf("lstat state.db: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("state.db is not a link (mode %v)", fi.Mode())
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat state.db: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink == 0, func() { t.Fatalf("state.db is not a link (mode %v)", fi.Mode()) })
 }
 
 // TestPrepareHermesHomeSessionStoreIsolatesConversations guards the property
@@ -146,20 +128,12 @@ func TestPrepareHermesHomeWithoutSessionStoreKeepsStateTaskLocal(t *testing.T) {
 	skills := []SkillContextForEnv{{Name: "deploy", Content: "# Deploy"}}
 
 	sessions, err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", "", testLogger())
-	if err != nil {
-		t.Fatalf("prepare: %v", err)
-	}
-	if sessions.Mounted {
-		t.Fatal("Mounted = true without a session store")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare: %v", err) })
+	testassert.OnFailure(t, sessions.Mounted, func() { t.Fatal("Mounted = true without a session store") })
 	mustWrite(t, filepath.Join(hermesHome, "state.db"), "transcript")
 	fi, err := os.Lstat(filepath.Join(hermesHome, "state.db"))
-	if err != nil {
-		t.Fatalf("lstat state.db: %v", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Fatal("state.db is a link with no store to point at")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("lstat state.db: %v", err) })
+	testassert.OnFailure(t, fi.Mode()&os.ModeSymlink != 0, func() { t.Fatal("state.db is a link with no store to point at") })
 }
 
 // TestPrepareHermesHomeMigratesTaskLocalSessionDB covers the upgrade path: a
@@ -184,19 +158,11 @@ func TestPrepareHermesHomeMigratesTaskLocalSessionDB(t *testing.T) {
 		t.Fatalf("prepare with store: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(store, "state.db"))
-	if err != nil {
-		t.Fatalf("in-flight transcript was dropped: %v", err)
-	}
-	if string(got) != "transcript" {
-		t.Fatalf("migrated transcript = %q, want %q", got, "transcript")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("in-flight transcript was dropped: %v", err) })
+	testassert.OnFailure(t, string(got) != "transcript", func() { t.Fatalf("migrated transcript = %q, want %q", got, "transcript") })
 	wal, err := os.ReadFile(filepath.Join(store, "state.db-wal"))
-	if err != nil {
-		t.Fatalf("write-ahead log was dropped: %v", err)
-	}
-	if string(wal) != "uncheckpointed tail" {
-		t.Fatalf("migrated wal = %q, want %q", wal, "uncheckpointed tail")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("write-ahead log was dropped: %v", err) })
+	testassert.OnFailure(t, string(wal) != "uncheckpointed tail", func() { t.Fatalf("migrated wal = %q, want %q", wal, "uncheckpointed tail") })
 }
 
 // TestPrepareHermesHomeMigrationNeverOverwritesStore is the other half of the
@@ -221,12 +187,8 @@ func TestPrepareHermesHomeMigrationNeverOverwritesStore(t *testing.T) {
 		t.Fatalf("prepare with store: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(store, "state.db"))
-	if err != nil {
-		t.Fatalf("read store db: %v", err)
-	}
-	if string(got) != "the real transcript" {
-		t.Fatalf("store db = %q, want the pre-existing transcript", got)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read store db: %v", err) })
+	testassert.OnFailure(t, string(got) != "the real transcript", func() { t.Fatalf("store db = %q, want the pre-existing transcript", got) })
 }
 
 // TestPrepareHermesHomeSessionMountIsIdempotent covers Reuse: rebuilding the
@@ -249,12 +211,8 @@ func TestPrepareHermesHomeSessionMountIsIdempotent(t *testing.T) {
 	}
 
 	got, err := os.ReadFile(filepath.Join(store, "state.db"))
-	if err != nil {
-		t.Fatalf("reuse dropped the transcript: %v", err)
-	}
-	if string(got) != "transcript" {
-		t.Fatalf("transcript = %q, want %q", got, "transcript")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("reuse dropped the transcript: %v", err) })
+	testassert.OnFailure(t, string(got) != "transcript", func() { t.Fatalf("transcript = %q, want %q", got, "transcript") })
 }
 
 func TestPruneHermesSessionStores(t *testing.T) {
@@ -289,12 +247,8 @@ func TestPruneHermesSessionStores(t *testing.T) {
 	}
 
 	removed, freed := PruneHermesSessionStores("", 14*24*time.Hour, now, reserve, testLogger())
-	if removed != 1 {
-		t.Fatalf("removed = %d, want 1", removed)
-	}
-	if freed <= 0 {
-		t.Fatalf("bytesFreed = %d, want > 0", freed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("removed = %d, want 1", removed) })
+	testassert.OnFailure(t, freed <= 0, func() { t.Fatalf("bytesFreed = %d, want > 0", freed) })
 	if _, err := os.Stat(idle); !os.IsNotExist(err) {
 		t.Fatalf("idle conversation survived the prune (err = %v)", err)
 	}
@@ -352,12 +306,8 @@ func TestPrepareHermesHomeLinkFailureKeepsTaskLocalDB(t *testing.T) {
 	})
 
 	sessions, err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare with unlinkable store: %v", err)
-	}
-	if sessions.Mounted || sessions.HistoryPresent {
-		t.Fatalf("mount = %+v, want both false when the link could not be created", sessions)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare with unlinkable store: %v", err) })
+	testassert.OnFailure(t, sessions.Mounted || sessions.HistoryPresent, func() { t.Fatalf("mount = %+v, want both false when the link could not be created", sessions) })
 
 	// The database — and its un-checkpointed tail — must still be here.
 	for name, want := range map[string]string{
@@ -365,12 +315,8 @@ func TestPrepareHermesHomeLinkFailureKeepsTaskLocalDB(t *testing.T) {
 		"state.db-wal": "uncheckpointed tail",
 	} {
 		got, err := os.ReadFile(filepath.Join(hermesHome, name))
-		if err != nil {
-			t.Fatalf("%s was destroyed by a failed mount: %v", name, err)
-		}
-		if string(got) != want {
-			t.Fatalf("%s = %q, want %q", name, got, want)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("%s was destroyed by a failed mount: %v", name, err) })
+		testassert.OnFailure(t, string(got) != want, func() { t.Fatalf("%s = %q, want %q", name, got, want) })
 	}
 	if entries, err := os.ReadDir(store); err != nil {
 		t.Fatalf("read store: %v", err)
@@ -382,16 +328,10 @@ func TestPrepareHermesHomeLinkFailureKeepsTaskLocalDB(t *testing.T) {
 	// database over — nothing was lost in between.
 	restore()
 	sessions, err = prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare after link support returns: %v", err)
-	}
-	if !sessions.Mounted || !sessions.HistoryPresent {
-		t.Fatalf("mount = %+v, want mounted with history after recovery", sessions)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare after link support returns: %v", err) })
+	testassert.OnFailure(t, !sessions.Mounted || !sessions.HistoryPresent, func() { t.Fatalf("mount = %+v, want mounted with history after recovery", sessions) })
 	got, err := os.ReadFile(filepath.Join(store, "state.db"))
-	if err != nil || string(got) != "transcript" {
-		t.Fatalf("store db = %q (err %v), want the preserved transcript", got, err)
-	}
+	testassert.OnFailure(t, err != nil || string(got) != "transcript", func() { t.Fatalf("store db = %q (err %v), want the preserved transcript", got, err) })
 }
 
 // TestPrepareHermesHomeMigrationIsAtomic covers a migration that dies between
@@ -424,9 +364,7 @@ func TestPrepareHermesHomeMigrationIsAtomic(t *testing.T) {
 	}
 
 	// Nothing published, nothing deleted.
-	if hermesStoreHasSessionDB(store) {
-		t.Fatal("store holds a database after a half-failed migration")
-	}
+	testassert.OnFailure(t, hermesStoreHasSessionDB(store), func() { t.Fatal("store holds a database after a half-failed migration") })
 	for _, name := range []string{"state.db", "state.db-wal"} {
 		if _, err := os.Stat(filepath.Join(hermesHome, name)); err != nil {
 			t.Fatalf("source %s was removed after a failed migration: %v", name, err)
@@ -442,12 +380,8 @@ func TestPrepareHermesHomeMigrationIsAtomic(t *testing.T) {
 		"state.db-wal": "uncheckpointed tail",
 	} {
 		got, err := os.ReadFile(filepath.Join(store, name))
-		if err != nil {
-			t.Fatalf("retry did not carry %s over: %v", name, err)
-		}
-		if string(got) != want {
-			t.Fatalf("%s = %q, want %q", name, got, want)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("retry did not carry %s over: %v", name, err) })
+		testassert.OnFailure(t, string(got) != want, func() { t.Fatalf("%s = %q, want %q", name, got, want) })
 	}
 }
 
@@ -470,12 +404,8 @@ func TestPrepareHermesHomeMountedEmptyStoreReportsNoHistory(t *testing.T) {
 	mustWrite(t, filepath.Join(hermesHome, "state.db"), "transcript")
 
 	sessions, err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare second turn: %v", err)
-	}
-	if !sessions.HistoryPresent {
-		t.Fatal("HistoryPresent = false with a written transcript, want true")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare second turn: %v", err) })
+	testassert.OnFailure(t, !sessions.HistoryPresent, func() { t.Fatal("HistoryPresent = false with a written transcript, want true") })
 
 	// The GC reclaims the store between turns; the overlay's link survives and
 	// now dangles.
@@ -483,27 +413,19 @@ func TestPrepareHermesHomeMountedEmptyStoreReportsNoHistory(t *testing.T) {
 		t.Fatalf("simulate gc reclaim: %v", err)
 	}
 	sessions, err = prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare after gc reclaim: %v", err)
-	}
-	if !sessions.Mounted {
-		t.Fatal("Mounted = false after the store was recreated, want true")
-	}
-	if sessions.HistoryPresent {
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare after gc reclaim: %v", err) })
+	testassert.OnFailure(t, !sessions.Mounted, func() { t.Fatal("Mounted = false after the store was recreated, want true") })
+	testassert.OnFailure(t, sessions.HistoryPresent, func() {
 		t.Fatal("HistoryPresent = true over a reclaimed store — a dead session id would be forwarded")
-	}
+	})
 
 	// An empty file is the other shape of nothing: SQLite leaves one behind for
 	// an open that never wrote a page, and resuming against it is the same
 	// amnesia as resuming against an absent one.
 	mustWrite(t, filepath.Join(store, "state.db"), "")
 	sessions, err = prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-	if err != nil {
-		t.Fatalf("prepare with an empty db: %v", err)
-	}
-	if sessions.HistoryPresent {
-		t.Fatal("HistoryPresent = true for a zero-length database, want false")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare with an empty db: %v", err) })
+	testassert.OnFailure(t, sessions.HistoryPresent, func() { t.Fatal("HistoryPresent = true for a zero-length database, want false") })
 }
 
 // TestPrepareHermesHomeMigrationIntoSemanticallyEmptyStore covers the store
@@ -572,40 +494,26 @@ func TestPrepareHermesHomeMigrationIntoSemanticallyEmptyStore(t *testing.T) {
 
 			sessions, err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
 			if err != nil {
-				if !tt.wantFailClosed {
-					t.Fatalf("prepare: %v", err)
-				}
+				testassert.OnFailure(t, !tt.wantFailClosed, func() { t.Fatalf("prepare: %v", err) })
 				// Failing closed is only acceptable with the source intact.
 				for _, name := range []string{"state.db", "state.db-wal"} {
 					got, statErr := os.ReadFile(filepath.Join(hermesHome, name))
-					if statErr != nil {
-						t.Fatalf("prepare failed (%v) AND dropped the source %s: %v", err, name, statErr)
-					}
-					if len(got) == 0 {
-						t.Fatalf("source %s was emptied by a failed migration", name)
-					}
+					testassert.OnFailure(t, statErr != nil, func() { t.Fatalf("prepare failed (%v) AND dropped the source %s: %v", err, name, statErr) })
+					testassert.OnFailure(t, len(got) == 0, func() { t.Fatalf("source %s was emptied by a failed migration", name) })
 				}
 				return
 			}
-			if tt.wantFailClosed {
-				t.Fatal("prepare succeeded on a store it cannot safely publish into, want an error")
-			}
-			if !sessions.Mounted || !sessions.HistoryPresent {
-				t.Fatalf("mount = %+v, want mounted with history", sessions)
-			}
+			testassert.OnFailure(t, tt.wantFailClosed, func() { t.Fatal("prepare succeeded on a store it cannot safely publish into, want an error") })
+			testassert.OnFailure(t, !sessions.Mounted || !sessions.HistoryPresent, func() { t.Fatalf("mount = %+v, want mounted with history", sessions) })
 
 			got, err := os.ReadFile(filepath.Join(store, "state.db"))
-			if err != nil {
-				t.Fatalf("read store db: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read store db: %v", err) })
 			if tt.wantMoved {
-				if string(got) != "transcript" {
+				testassert.OnFailure(t, string(got) != "transcript", func() {
 					t.Fatalf("store db = %q, want the migrated transcript — the source was dropped for an empty store", got)
-				}
+				})
 				wal, err := os.ReadFile(filepath.Join(store, "state.db-wal"))
-				if err != nil || string(wal) != "uncheckpointed tail" {
-					t.Fatalf("store wal = %q (err %v), want the migrated tail", wal, err)
-				}
+				testassert.OnFailure(t, err != nil || string(wal) != "uncheckpointed tail", func() { t.Fatalf("store wal = %q (err %v), want the migrated tail", wal, err) })
 			} else if string(got) != "the winner's transcript" {
 				t.Fatalf("store db = %q, want the pre-existing transcript left untouched", got)
 			}
@@ -629,9 +537,7 @@ func TestHermesSessionStorePublishSerializesCompetitors(t *testing.T) {
 
 	mkStaging := func(label string) string {
 		staging, err := newHermesStoreStaging(store)
-		if err != nil {
-			t.Fatalf("staging for %s: %v", label, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("staging for %s: %v", label, err) })
 		mustWrite(t, filepath.Join(staging, "state.db"), label+" transcript")
 		mustWrite(t, filepath.Join(staging, "state.db-wal"), label+" tail")
 		return staging
@@ -671,14 +577,12 @@ func TestHermesSessionStorePublishSerializesCompetitors(t *testing.T) {
 		byLabel[r.label] = r
 	}
 	for _, r := range byLabel {
-		if r.err != nil {
-			t.Fatalf("publish %s: %v", r.label, r.err)
-		}
+		testassert.OnFailure(t, r.err != nil, func() { t.Fatalf("publish %s: %v", r.label, r.err) })
 	}
-	if !byLabel["first"].promoted || byLabel["second"].promoted {
+	testassert.OnFailure(t, !byLabel["first"].promoted || byLabel["second"].promoted, func() {
 		t.Fatalf("promoted = first:%v second:%v, want the parked first publisher to win and the second to positively lose",
 			byLabel["first"].promoted, byLabel["second"].promoted)
-	}
+	})
 
 	// The loser never reached the destructive window: its occupancy check
 	// already saw the winner's published database.
@@ -694,9 +598,7 @@ func TestHermesSessionStorePublishSerializesCompetitors(t *testing.T) {
 		"state.db-wal": "first tail",
 	} {
 		got, err := os.ReadFile(filepath.Join(store, name))
-		if err != nil || string(got) != want {
-			t.Fatalf("store %s = %q (err %v), want the winner's %q untouched", name, got, err, want)
-		}
+		testassert.OnFailure(t, err != nil || string(got) != want, func() { t.Fatalf("store %s = %q (err %v), want the winner's %q untouched", name, got, err, want) })
 	}
 	// The loser's staging was not consumed, so its caller still holds a
 	// complete copy of the source it will now yield with.
@@ -760,12 +662,8 @@ func TestPrepareHermesHomeStoreCleanupHandlesUnexpectedEntryTypes(t *testing.T) 
 		mustWrite(t, filepath.Join(hermesHome, "state.db"), "transcript")
 
 		sessions, err := prepareHermesHome(hermesHome, sharedHome, false, skills, nil, "", store, testLogger())
-		if err != nil {
-			t.Fatalf("prepare: %v", err)
-		}
-		if !sessions.Mounted || !sessions.HistoryPresent {
-			t.Fatalf("mount = %+v, want mounted with history", sessions)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepare: %v", err) })
+		testassert.OnFailure(t, !sessions.Mounted || !sessions.HistoryPresent, func() { t.Fatalf("mount = %+v, want mounted with history", sessions) })
 		if got, err := os.ReadFile(filepath.Join(store, "state.db")); err != nil || string(got) != "transcript" {
 			t.Fatalf("store db = %q (err %v), want the migrated transcript", got, err)
 		}

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const preparationHelperTestMode = "execenv-preparation-helper"
@@ -54,9 +56,7 @@ func TestPreparationHelperRoundTripsReuse(t *testing.T) {
 		Task:           TaskContextForEnv{IssueID: "issue-helper-reuse"},
 	}
 	env, err := PrepareIsolated(ctx, preparationHelperTestCommand(), params, logger)
-	if err != nil {
-		t.Fatalf("PrepareIsolated: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PrepareIsolated: %v", err) })
 	reused, err := ReuseIsolated(ctx, preparationHelperTestCommand(), ReuseParams{
 		WorkspacesRoot: params.WorkspacesRoot,
 		WorkDir:        env.WorkDir,
@@ -74,12 +74,10 @@ func TestPreparationHelperRoundTripsReuse(t *testing.T) {
 			},
 		},
 	}, logger)
-	if err != nil {
-		t.Fatalf("ReuseIsolated: %v", err)
-	}
-	if reused == nil || reused.RootDir != env.RootDir || reused.WorkDir != env.WorkDir {
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ReuseIsolated: %v", err) })
+	testassert.OnFailure(t, reused == nil || reused.RootDir != env.RootDir || reused.WorkDir != env.WorkDir, func() {
 		t.Fatalf("reused environment = %#v, want root %q workdir %q", reused, env.RootDir, env.WorkDir)
-	}
+	})
 }
 
 func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
@@ -106,22 +104,16 @@ func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
 	}
 
 	env, err := PrepareIsolated(ctx, preparationHelperTestCommand(), params, logger)
-	if err != nil {
-		t.Fatalf("PrepareIsolated: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PrepareIsolated: %v", err) })
 	defer env.Cleanup(true)
 
 	data, err := os.ReadFile(filepath.Join(env.WorkDir, ".multica", "project", "resources.json"))
-	if err != nil {
-		t.Fatalf("read project resources: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read project resources: %v", err) })
 	var got projectResourceFile
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("decode project resources: %v", err)
 	}
-	if len(got.Resources) != 1 {
-		t.Fatalf("project resources = %#v, want one resource", got.Resources)
-	}
+	testassert.OnFailure(t, len(got.Resources) != 1, func() { t.Fatalf("project resources = %#v, want one resource", got.Resources) })
 	resource := got.Resources[0]
 	var ref struct {
 		URL string `json:"url"`
@@ -129,12 +121,10 @@ func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
 	if err := json.Unmarshal(resource.ResourceRef, &ref); err != nil {
 		t.Fatalf("decode resource ref: %v", err)
 	}
-	if resource.ID != "resource-helper-project-resource" ||
+	testassert.OnFailure(t, resource.ID != "resource-helper-project-resource" ||
 		resource.ResourceType != "github_repo" ||
 		ref.URL != "https://github.com/multica-ai/multica" ||
-		resource.Label != "Multica" {
-		t.Fatalf("project resource = %#v, want all fields preserved", resource)
-	}
+		resource.Label != "Multica", func() { t.Fatalf("project resource = %#v, want all fields preserved", resource) })
 }
 
 func TestPreparationRequestPreservesOpenclawGatewayForHelper(t *testing.T) {
@@ -175,21 +165,13 @@ func TestPreparationRequestPreservesOpenclawGatewayForHelper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			redacted, err := json.Marshal(tt.request)
-			if err != nil {
-				t.Fatalf("marshal redacted request: %v", err)
-			}
-			if bytes.Contains(redacted, []byte(want.Token)) {
-				t.Fatalf("ordinary JSON leaked gateway token: %s", redacted)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("marshal redacted request: %v", err) })
+			testassert.OnFailure(t, bytes.Contains(redacted, []byte(want.Token)), func() { t.Fatalf("ordinary JSON leaked gateway token: %s", redacted) })
 
 			payload, err := marshalPreparationRequest(tt.request)
-			if err != nil {
-				t.Fatalf("marshal preparation request: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("marshal preparation request: %v", err) })
 			got, err := decodePreparationRequest(bytes.NewReader(payload))
-			if err != nil {
-				t.Fatalf("decode preparation request: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("decode preparation request: %v", err) })
 			if got := tt.pin(got); got != want {
 				t.Fatal("gateway pin fields did not survive the helper protocol")
 			}
@@ -228,15 +210,9 @@ func TestPreparationHelperPreservesOpenclawTimeoutKind(t *testing.T) {
 		OpenclawBin:    shim,
 		Task:           TaskContextForEnv{IssueID: "issue-helper-openclaw-timeout"},
 	}, logger)
-	if err == nil {
-		t.Fatal("expected preparation to fail when the openclaw CLI outlasts its deadline")
-	}
-	if !errors.Is(err, ErrOpenclawCLITimeout) {
-		t.Errorf("the timeout sentinel must survive the helper boundary\ngot: %s", err)
-	}
-	if !strings.Contains(err.Error(), "openclaw config file") {
-		t.Errorf("the original diagnostic must survive too\ngot: %s", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected preparation to fail when the openclaw CLI outlasts its deadline") })
+	testassert.OnFailure(t, !errors.Is(err, ErrOpenclawCLITimeout), func() { t.Errorf("the timeout sentinel must survive the helper boundary\ngot: %s", err) })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "openclaw config file"), func() { t.Errorf("the original diagnostic must survive too\ngot: %s", err) })
 }
 
 // TestRehydratePreparationErrorUnknownKind pins the mixed-version direction of
@@ -245,12 +221,8 @@ func TestPreparationHelperPreservesOpenclawTimeoutKind(t *testing.T) {
 // rather than being dropped or mislabelled.
 func TestRehydratePreparationErrorUnknownKind(t *testing.T) {
 	err := rehydratePreparationError("prepare failed somehow", "some_future_kind")
-	if err == nil || err.Error() != "prepare failed somehow" {
-		t.Fatalf("rehydratePreparationError dropped the message: %v", err)
-	}
-	if errors.Is(err, ErrOpenclawCLITimeout) {
-		t.Error("an unknown kind must not be reported as an openclaw CLI timeout")
-	}
+	testassert.OnFailure(t, err == nil || err.Error() != "prepare failed somehow", func() { t.Fatalf("rehydratePreparationError dropped the message: %v", err) })
+	testassert.OnFailure(t, errors.Is(err, ErrOpenclawCLITimeout), func() { t.Error("an unknown kind must not be reported as an openclaw CLI timeout") })
 	if kind := preparationErrorKind(errors.New("plain failure")); kind != "" {
 		t.Errorf("preparationErrorKind(plain) = %q, want empty", kind)
 	}
@@ -285,9 +257,7 @@ func TestPrepareIsolatedKeepsTheClaimWithTheParent(t *testing.T) {
 		IssueIdentifier: "MUL-6063",
 	}
 	claim, err := ClaimEnvRoot(rootParams)
-	if err != nil {
-		t.Fatalf("parent claim: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("parent claim: %v", err) })
 	defer claim.Release()
 
 	env, err := PrepareIsolated(context.Background(), preparationHelperTestCommand(), PrepareParams{
@@ -300,15 +270,9 @@ func TestPrepareIsolatedKeepsTheClaimWithTheParent(t *testing.T) {
 		EnvRootPreclaimed: true,
 		Task:              TaskContextForEnv{IssueID: taskID},
 	}, nil)
-	if err != nil {
-		t.Fatalf("PrepareIsolated: %v", err)
-	}
-	if env == nil || env.WorkDir == "" {
-		t.Fatal("PrepareIsolated returned no environment")
-	}
-	if env.RootDir != claim.RootDir() {
-		t.Fatalf("helper prepared %q while parent claimed %q", env.RootDir, claim.RootDir())
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PrepareIsolated: %v", err) })
+	testassert.OnFailure(t, env == nil || env.WorkDir == "", func() { t.Fatal("PrepareIsolated returned no environment") })
+	testassert.OnFailure(t, env.RootDir != claim.RootDir(), func() { t.Fatalf("helper prepared %q while parent claimed %q", env.RootDir, claim.RootDir()) })
 
 	// The helper has exited. If the claim had been taken inside it, the lock
 	// would be gone and this second claim would succeed.
@@ -320,9 +284,7 @@ func TestPrepareIsolatedKeepsTheClaimWithTheParent(t *testing.T) {
 	// And releasing it must hand the env root back for a later dispatch.
 	claim.Release()
 	next, err := ClaimEnvRoot(rootParams)
-	if err != nil {
-		t.Fatalf("env root stayed locked after release: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("env root stayed locked after release: %v", err) })
 	next.Release()
 }
 
@@ -339,19 +301,13 @@ func TestLockEnvRootForReuseExcludesConcurrentContinuations(t *testing.T) {
 	}
 
 	wsRoot, err := os.OpenRoot(filepath.Dir(filepath.Dir(priorRoot)))
-	if err != nil {
-		t.Fatalf("open workspaces root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("open workspaces root: %v", err) })
 	defer wsRoot.Close()
 	rel := filepath.Join(filepath.Base(filepath.Dir(priorRoot)), filepath.Base(priorRoot))
 
 	first, _, err := LockEnvRootForReuse(wsRoot, rel, priorRoot)
-	if err != nil {
-		t.Fatalf("first continuation: %v", err)
-	}
-	if first == nil {
-		t.Fatal("expected a claim for an existing prior root")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("first continuation: %v", err) })
+	testassert.OnFailure(t, first == nil, func() { t.Fatal("expected a claim for an existing prior root") })
 
 	if second, _, err := LockEnvRootForReuse(wsRoot, rel, priorRoot); err == nil {
 		second.Release()
@@ -360,23 +316,17 @@ func TestLockEnvRootForReuseExcludesConcurrentContinuations(t *testing.T) {
 
 	first.Release()
 	again, _, err := LockEnvRootForReuse(wsRoot, rel, priorRoot)
-	if err != nil {
-		t.Fatalf("prior root stayed locked after release: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prior root stayed locked after release: %v", err) })
 	again.Release()
 
 	// A missing root is not an error — the caller falls through to a fresh
 	// Prepare, and there is nothing to exclude on.
 	base := t.TempDir()
 	baseRoot, err := os.OpenRoot(base)
-	if err != nil {
-		t.Fatalf("open base: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("open base: %v", err) })
 	defer baseRoot.Close()
 	missing, _, err := LockEnvRootForReuse(baseRoot, "absent", filepath.Join(base, "absent"))
-	if err != nil || missing != nil {
-		t.Fatalf("missing prior root: claim=%v err=%v, want nil/nil", missing, err)
-	}
+	testassert.OnFailure(t, err != nil || missing != nil, func() { t.Fatalf("missing prior root: claim=%v err=%v, want nil/nil", missing, err) })
 }
 
 // TestPrepareIsolatedFailsLoudlyWhenPreclaimIsNotDeclared pins what happens if
@@ -393,9 +343,7 @@ func TestPrepareIsolatedFailsLoudlyWhenPreclaimIsNotDeclared(t *testing.T) {
 	)
 
 	claim, err := ClaimEnvRoot(RootDirParams{WorkspacesRoot: workspacesRoot, WorkspaceID: workspaceID, TaskID: taskID})
-	if err != nil {
-		t.Fatalf("parent claim: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("parent claim: %v", err) })
 	defer claim.Release()
 
 	_, err = PrepareIsolated(context.Background(), preparationHelperTestCommand(), PrepareParams{
@@ -406,10 +354,6 @@ func TestPrepareIsolatedFailsLoudlyWhenPreclaimIsNotDeclared(t *testing.T) {
 		// EnvRootPreclaimed deliberately left false while the parent holds it.
 		Task: TaskContextForEnv{IssueID: taskID},
 	}, nil)
-	if err == nil {
-		t.Fatal("preparation ran without declaring the parent's claim")
-	}
-	if !strings.Contains(err.Error(), "running execution") {
-		t.Fatalf("error = %v, want it to name the held claim", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("preparation ran without declaring the parent's claim") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "running execution"), func() { t.Fatalf("error = %v, want it to name the held claim", err) })
 }

--- a/server/internal/daemon/execenv/isolation_unix_test.go
+++ b/server/internal/daemon/execenv/isolation_unix_test.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry is the lifecycle
@@ -43,9 +45,7 @@ func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 
 	startedAt := time.Now()
 	_, err := PrepareIsolated(ctx, preparationHelperTestCommand(), params, logger)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("PrepareIsolated error = %v, want deadline exceeded", err)
-	}
+	testassert.OnFailure(t, !errors.Is(err, context.DeadlineExceeded), func() { t.Fatalf("PrepareIsolated error = %v, want deadline exceeded", err) })
 	if elapsed := time.Since(startedAt); elapsed > 3*time.Second {
 		t.Fatalf("PrepareIsolated took %s, want a bounded process termination", elapsed)
 	}
@@ -61,9 +61,7 @@ func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 		writer.Close()
 		t.Fatal("timed-out preparation helper still has the FIFO open for reading")
 	}
-	if !errors.Is(writerErr, syscall.ENXIO) {
-		t.Fatalf("probe FIFO reader: %v, want ENXIO", writerErr)
-	}
+	testassert.OnFailure(t, !errors.Is(writerErr, syscall.ENXIO), func() { t.Fatalf("probe FIFO reader: %v, want ENXIO", writerErr) })
 
 	// Retry immediately against the same root. It must be the sole writer and
 	// complete successfully after the pathological source is replaced.
@@ -76,10 +74,6 @@ func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer retryCancel()
 	env, err := PrepareIsolated(retryCtx, preparationHelperTestCommand(), params, logger)
-	if err != nil {
-		t.Fatalf("immediate retry PrepareIsolated: %v", err)
-	}
-	if env == nil || env.RootDir != PredictRootDir(RootDirParams{WorkspacesRoot: params.WorkspacesRoot, WorkspaceID: params.WorkspaceID, WorkspaceSlug: params.WorkspaceSlug, TaskID: params.TaskID, IssueIdentifier: params.IssueIdentifier}) {
-		t.Fatalf("retry environment = %#v, want the predicted root", env)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("immediate retry PrepareIsolated: %v", err) })
+	testassert.OnFailure(t, env == nil || env.RootDir != PredictRootDir(RootDirParams{WorkspacesRoot: params.WorkspacesRoot, WorkspaceID: params.WorkspaceID, WorkspaceSlug: params.WorkspaceSlug, TaskID: params.TaskID, IssueIdentifier: params.IssueIdentifier}), func() { t.Fatalf("retry environment = %#v, want the predicted root", env) })
 }

--- a/server/internal/daemon/execenv/isolation_windows_test.go
+++ b/server/internal/daemon/execenv/isolation_windows_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const (
@@ -136,10 +138,6 @@ func TestPrepareIsolated_WindowsKillsDescendantBeforeRetry(t *testing.T) {
 	retryCtx, retryCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer retryCancel()
 	env, err := PrepareIsolated(retryCtx, preparationHelperTestCommand(), params, nil)
-	if err != nil {
-		t.Fatalf("immediate retry PrepareIsolated: %v", err)
-	}
-	if env == nil || env.RootDir != PredictRootDir(RootDirParams{WorkspacesRoot: params.WorkspacesRoot, WorkspaceID: params.WorkspaceID, WorkspaceSlug: params.WorkspaceSlug, TaskID: params.TaskID, IssueIdentifier: params.IssueIdentifier}) {
-		t.Fatalf("retry environment = %#v, want the predicted root", env)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("immediate retry PrepareIsolated: %v", err) })
+	testassert.OnFailure(t, env == nil || env.RootDir != PredictRootDir(RootDirParams{WorkspacesRoot: params.WorkspacesRoot, WorkspaceID: params.WorkspaceID, WorkspaceSlug: params.WorkspaceSlug, TaskID: params.TaskID, IssueIdentifier: params.IssueIdentifier}), func() { t.Fatalf("retry environment = %#v, want the predicted root", env) })
 }

--- a/server/internal/daemon/execenv/local_worktree_test.go
+++ b/server/internal/daemon/execenv/local_worktree_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func worktreeTestLogger() *slog.Logger {
@@ -55,9 +57,7 @@ func gitRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %s: %v", args, out, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("git %v failed: %s: %v", args, out, err) })
 	return strings.TrimSpace(string(out))
 }
 
@@ -71,9 +71,7 @@ func gitTry(t *testing.T, dir string, args ...string) (string, error) {
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", path, err) })
 	return string(b)
 }
 
@@ -85,9 +83,7 @@ func prepareForTest(t *testing.T, localPath string) *LocalWorktree {
 		AgentName: "J",
 		TaskID:    "11112222-3333-4444-5555-666677778888",
 	}, worktreeTestLogger())
-	if err != nil {
-		t.Fatalf("PrepareLocalWorktree: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PrepareLocalWorktree: %v", err) })
 	return wt
 }
 
@@ -111,12 +107,8 @@ func TestPrepareLocalWorktreeReplaysUncommittedWork(t *testing.T) {
 	if got := readFile(t, filepath.Join(wt.Path, "nested/deep.txt")); got != "nested untracked\n" {
 		t.Errorf("nested untracked file not copied: got %q", got)
 	}
-	if !wt.DirtyBaseCaptured {
-		t.Error("DirtyBaseCaptured = false, want true")
-	}
-	if wt.UntrackedCopied != 2 {
-		t.Errorf("UntrackedCopied = %d, want 2", wt.UntrackedCopied)
-	}
+	testassert.OnFailure(t, !wt.DirtyBaseCaptured, func() { t.Error("DirtyBaseCaptured = false, want true") })
+	testassert.OnFailure(t, wt.UntrackedCopied != 2, func() { t.Errorf("UntrackedCopied = %d, want 2", wt.UntrackedCopied) })
 }
 
 // Capturing the dirty state must not disturb the user's own working tree —
@@ -152,12 +144,8 @@ func TestFinalizeCommitsLeftoversAndKeepsBranch(t *testing.T) {
 
 	outcome := finalizeOK(t, wt)
 
-	if !outcome.AutoCommitted {
-		t.Error("AutoCommitted = false, want true")
-	}
-	if outcome.Branch != wt.Branch {
-		t.Errorf("Branch = %q, want %q", outcome.Branch, wt.Branch)
-	}
+	testassert.OnFailure(t, !outcome.AutoCommitted, func() { t.Error("AutoCommitted = false, want true") })
+	testassert.OnFailure(t, outcome.Branch != wt.Branch, func() { t.Errorf("Branch = %q, want %q", outcome.Branch, wt.Branch) })
 	if _, err := os.Stat(wt.Path); !os.IsNotExist(err) {
 		t.Errorf("worktree directory still present after Finalize: %v", err)
 	}
@@ -183,12 +171,8 @@ func TestFinalizeDropsBranchWhenNothingChanged(t *testing.T) {
 
 	outcome := finalizeOK(t, wt)
 
-	if outcome.Branch != "" {
-		t.Errorf("Branch = %q, want empty for a no-op task", outcome.Branch)
-	}
-	if outcome.AutoCommitted {
-		t.Error("AutoCommitted = true, want false")
-	}
+	testassert.OnFailure(t, outcome.Branch != "", func() { t.Errorf("Branch = %q, want empty for a no-op task", outcome.Branch) })
+	testassert.OnFailure(t, outcome.AutoCommitted, func() { t.Error("AutoCommitted = true, want false") })
 	if out, err := gitTry(t, repo, "rev-parse", "--verify", wt.Branch); err == nil {
 		t.Errorf("empty branch should have been deleted, still resolves to %s", out)
 	}
@@ -205,21 +189,15 @@ func TestFinalizeDropsBranchWhenOnlyBaseWasDirty(t *testing.T) {
 	wt := prepareForTest(t, repo)
 
 	// The baseline must be a commit of its own, not left as pending changes.
-	if wt.BaseCommit == "" {
-		t.Fatal("no baseline commit recorded for a dirty base")
-	}
+	testassert.OnFailure(t, wt.BaseCommit == "", func() { t.Fatal("no baseline commit recorded for a dirty base") })
 	if dirty, err := worktreeIsDirty(wt.Path); err != nil || dirty {
 		t.Errorf("worktree still dirty after baseline commit (dirty=%v, err=%v)", dirty, err)
 	}
 
 	outcome := finalizeOK(t, wt)
 
-	if outcome.Branch != "" {
-		t.Errorf("Branch = %q, want empty: the agent changed nothing", outcome.Branch)
-	}
-	if outcome.AutoCommitted {
-		t.Error("AutoCommitted = true, but there was nothing of the agent's to commit")
-	}
+	testassert.OnFailure(t, outcome.Branch != "", func() { t.Errorf("Branch = %q, want empty: the agent changed nothing", outcome.Branch) })
+	testassert.OnFailure(t, outcome.AutoCommitted, func() { t.Error("AutoCommitted = true, but there was nothing of the agent's to commit") })
 }
 
 // With a dirty base, the delivered branch separates the two authorships: the
@@ -233,14 +211,10 @@ func TestFinalizeSeparatesUserBaselineFromAgentWork(t *testing.T) {
 	writeFile(t, filepath.Join(wt.Path, "agent-output.txt"), "work product\n")
 	outcome := finalizeOK(t, wt)
 
-	if outcome.Branch == "" {
-		t.Fatal("no branch delivered for a task that changed a file")
-	}
+	testassert.OnFailure(t, outcome.Branch == "", func() { t.Fatal("no branch delivered for a task that changed a file") })
 	// The agent's commit alone.
 	agentFiles := gitRun(t, repo, "diff", "--name-only", wt.BaseCommit, outcome.Branch)
-	if agentFiles != "agent-output.txt" {
-		t.Errorf("agent diff = %q, want just agent-output.txt", agentFiles)
-	}
+	testassert.OnFailure(t, agentFiles != "agent-output.txt", func() { t.Errorf("agent diff = %q, want just agent-output.txt", agentFiles) })
 	// And the user's uncommitted edit still reached the branch.
 	if got := gitRun(t, repo, "show", outcome.Branch+":tracked.txt"); got != "edited by user" {
 		t.Errorf("branch lost the user's uncommitted edit, got %q", got)
@@ -258,13 +232,9 @@ func TestPrepareLocalWorktreeSubdirectory(t *testing.T) {
 	sub := filepath.Join(repo, "services/api")
 	wt := prepareForTest(t, sub)
 
-	if wt.GitRoot != repo {
-		t.Errorf("GitRoot = %q, want repo root %q", wt.GitRoot, repo)
-	}
+	testassert.OnFailure(t, wt.GitRoot != repo, func() { t.Errorf("GitRoot = %q, want repo root %q", wt.GitRoot, repo) })
 	want := filepath.Join(wt.Path, "services", "api")
-	if wt.WorkDir != want {
-		t.Errorf("WorkDir = %q, want %q", wt.WorkDir, want)
-	}
+	testassert.OnFailure(t, wt.WorkDir != want, func() { t.Errorf("WorkDir = %q, want %q", wt.WorkDir, want) })
 	if got := readFile(t, filepath.Join(wt.WorkDir, "main.go")); got != "package main\n" {
 		t.Errorf("subdirectory content missing from worktree: %q", got)
 	}
@@ -280,12 +250,8 @@ func TestPrepareLocalWorktreeRejectsNonGitDirectory(t *testing.T) {
 		EnvRoot:   t.TempDir(),
 		TaskID:    "task-1",
 	}, worktreeTestLogger())
-	if err == nil {
-		t.Fatal("expected an error for a non-git directory")
-	}
-	if !strings.Contains(err.Error(), "not a git repository") || !strings.Contains(err.Error(), "in_place") {
-		t.Errorf("error should name the problem and the fix, got: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected an error for a non-git directory") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "not a git repository") || !strings.Contains(err.Error(), "in_place"), func() { t.Errorf("error should name the problem and the fix, got: %v", err) })
 }
 
 // A repo with no commits has nothing to branch from. The message has to say so,
@@ -300,12 +266,8 @@ func TestPrepareLocalWorktreeRejectsRepoWithoutCommits(t *testing.T) {
 		EnvRoot:   t.TempDir(),
 		TaskID:    "task-1",
 	}, worktreeTestLogger())
-	if err == nil {
-		t.Fatal("expected an error for a repo with no commits")
-	}
-	if !strings.Contains(err.Error(), "no commit") {
-		t.Errorf("error should explain the missing commit, got: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected an error for a repo with no commits") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "no commit"), func() { t.Errorf("error should explain the missing commit, got: %v", err) })
 }
 
 // Concurrency is the entire point of the mode: two tasks on one directory must
@@ -345,14 +307,10 @@ func TestPrepareLocalWorktreeConcurrentTasks(t *testing.T) {
 	for _, err := range errs {
 		t.Errorf("concurrent prepare failed: %v", err)
 	}
-	if len(results) != tasks {
-		t.Fatalf("got %d worktrees, want %d", len(results), tasks)
-	}
+	testassert.OnFailure(t, len(results) != tasks, func() { t.Fatalf("got %d worktrees, want %d", len(results), tasks) })
 	branches := map[string]bool{}
 	for _, wt := range results {
-		if branches[wt.Branch] {
-			t.Errorf("duplicate branch %q across concurrent tasks", wt.Branch)
-		}
+		testassert.OnFailure(t, branches[wt.Branch], func() { t.Errorf("duplicate branch %q across concurrent tasks", wt.Branch) })
 		branches[wt.Branch] = true
 		if got := readFile(t, filepath.Join(wt.Path, "tracked.txt")); got != "original\n" {
 			t.Errorf("worktree %s has wrong content: %q", wt.Path, got)
@@ -388,20 +346,12 @@ func TestWorktreeModeDeliversBranchWithoutSidecars(t *testing.T) {
 		LocalWorktree:  &LocalWorktreeParams{LocalPath: repo},
 		Task:           TaskContextForEnv{IssueID: "issue-1", AgentName: "J"},
 	}, worktreeTestLogger())
-	if err != nil {
-		t.Fatalf("Prepare: %v", err)
-	}
-	if env.LocalWorktree == nil {
-		t.Fatal("Prepare did not build a worktree")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare: %v", err) })
+	testassert.OnFailure(t, env.LocalWorktree == nil, func() { t.Fatal("Prepare did not build a worktree") })
 	// The env root is ordinary daemon-owned scratch in this mode, so the GC
 	// exemption meant for a user's own directory must not apply.
-	if env.LocalDirectory {
-		t.Error("LocalDirectory = true in worktree mode; the GC would exempt this env root forever")
-	}
-	if env.WorkDir != env.LocalWorktree.Path {
-		t.Errorf("WorkDir = %q, want the worktree root %q", env.WorkDir, env.LocalWorktree.Path)
-	}
+	testassert.OnFailure(t, env.LocalDirectory, func() { t.Error("LocalDirectory = true in worktree mode; the GC would exempt this env root forever") })
+	testassert.OnFailure(t, env.WorkDir != env.LocalWorktree.Path, func() { t.Errorf("WorkDir = %q, want the worktree root %q", env.WorkDir, env.LocalWorktree.Path) })
 	if _, err := os.Stat(filepath.Join(env.WorkDir, ".agent_context")); err != nil {
 		t.Fatalf("precondition: Prepare should have written sidecars into the worktree: %v", err)
 	}
@@ -418,18 +368,12 @@ func TestWorktreeModeDeliversBranchWithoutSidecars(t *testing.T) {
 	}
 	outcome := finalizeOK(t, env.LocalWorktree)
 
-	if outcome.Branch == "" {
-		t.Fatal("no branch delivered for a task that changed a file")
-	}
+	testassert.OnFailure(t, outcome.Branch == "", func() { t.Fatal("no branch delivered for a task that changed a file") })
 	// Every file the branch touches, across the baseline and agent commits.
 	files := gitRun(t, repo, "diff", "--name-only", originalHead, outcome.Branch)
-	if !strings.Contains(files, "real-change.txt") {
-		t.Errorf("branch is missing the agent's work:\n%s", files)
-	}
+	testassert.OnFailure(t, !strings.Contains(files, "real-change.txt"), func() { t.Errorf("branch is missing the agent's work:\n%s", files) })
 	for _, sidecar := range []string{".agent_context", ".multica", "CLAUDE.md"} {
-		if strings.Contains(files, sidecar) {
-			t.Errorf("sidecar %q leaked into the delivered branch:\n%s", sidecar, files)
-		}
+		testassert.OnFailure(t, strings.Contains(files, sidecar), func() { t.Errorf("sidecar %q leaked into the delivered branch:\n%s", sidecar, files) })
 	}
 	// The user's own checkout keeps exactly the edit it started with, and
 	// nothing the agent or the runtime produced.
@@ -450,9 +394,7 @@ func TestPrepareLocalWorktreePrunesStaleRegistrations(t *testing.T) {
 		AgentName: "J",
 		TaskID:    "dead-task",
 	}, worktreeTestLogger())
-	if err != nil {
-		t.Fatalf("seed orphan worktree: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("seed orphan worktree: %v", err) })
 	// Simulate the crash: the directory disappears with GC, the registration
 	// survives in the user's repo.
 	if err := os.RemoveAll(orphan.Path); err != nil {
@@ -475,9 +417,7 @@ func TestPrepareLocalWorktreePrunesStaleRegistrations(t *testing.T) {
 func finalizeOK(t *testing.T, wt *LocalWorktree) LocalWorktreeOutcome {
 	t.Helper()
 	outcome, err := wt.Finalize(worktreeTestLogger())
-	if err != nil {
-		t.Fatalf("Finalize: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Finalize: %v", err) })
 	return outcome
 }
 
@@ -499,12 +439,8 @@ func TestFinalizeKeepsWorktreeWhenCommitFails(t *testing.T) {
 
 	outcome, err := wt.Finalize(worktreeTestLogger())
 
-	if err == nil {
-		t.Fatal("Finalize returned nil error after the commit failed")
-	}
-	if outcome.PreservedPath != wt.Path {
-		t.Errorf("PreservedPath = %q, want %q", outcome.PreservedPath, wt.Path)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Finalize returned nil error after the commit failed") })
+	testassert.OnFailure(t, outcome.PreservedPath != wt.Path, func() { t.Errorf("PreservedPath = %q, want %q", outcome.PreservedPath, wt.Path) })
 	// The whole point: the work is still on disk.
 	if got := readFile(t, filepath.Join(wt.Path, "agent-output.txt")); got != "irreplaceable work\n" {
 		t.Errorf("agent work was destroyed despite the commit failure, got %q", got)
@@ -513,9 +449,7 @@ func TestFinalizeKeepsWorktreeWhenCommitFails(t *testing.T) {
 	if list := gitRun(t, repo, "worktree", "list"); !strings.Contains(list, wt.Path) {
 		t.Errorf("preserved worktree is no longer registered, so the user cannot find it:\n%s", list)
 	}
-	if !strings.Contains(err.Error(), wt.Path) {
-		t.Errorf("error should name the preserved path, got: %v", err)
-	}
+	testassert.OnFailure(t, !strings.Contains(err.Error(), wt.Path), func() { t.Errorf("error should name the preserved path, got: %v", err) })
 }
 
 // An in_place task on the same directory leaves .agent_context/ and .multica/
@@ -575,12 +509,8 @@ func TestPrepareLocalWorktreeFailsWhenUntrackedReplayIsTruncated(t *testing.T) {
 		TaskID:    "task-truncated",
 	}, worktreeTestLogger())
 
-	if err == nil {
-		t.Fatal("expected prepare to fail rather than replay a truncated tree")
-	}
-	if !strings.Contains(err.Error(), "in_place") {
-		t.Errorf("error should offer a way out, got: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepare to fail rather than replay a truncated tree") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "in_place"), func() { t.Errorf("error should offer a way out, got: %v", err) })
 	// A failed prepare must not leave a half-built worktree registered.
 	if list := gitRun(t, repo, "worktree", "list"); strings.Count(list, "\n") != 0 {
 		t.Errorf("aborted prepare left a worktree registered:\n%s", list)
@@ -612,9 +542,7 @@ func TestPrepareWorktreeModeUsesPerIssueCodexSessionStore(t *testing.T) {
 			LocalWorktree:  &LocalWorktreeParams{LocalPath: repo},
 			Task:           TaskContextForEnv{IssueID: "issue-1", AgentID: "agent-1", AgentName: "J"},
 		}, worktreeTestLogger())
-		if err != nil {
-			t.Fatalf("Prepare(%s): %v", taskID, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare(%s): %v", taskID, err) })
 		t.Cleanup(func() { finalizeOK(t, env.LocalWorktree) })
 		return env
 	}
@@ -627,22 +555,18 @@ func TestPrepareWorktreeModeUsesPerIssueCodexSessionStore(t *testing.T) {
 	sessionsOf := func(env *Environment) string {
 		t.Helper()
 		target, err := filepath.EvalSymlinks(filepath.Join(env.CodexHome, "sessions"))
-		if err != nil {
-			t.Fatalf("resolve sessions dir: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve sessions dir: %v", err) })
 		return target
 	}
 
 	firstSessions := sessionsOf(first)
 	secondSessions := sessionsOf(second)
-	if firstSessions != secondSessions {
+	testassert.OnFailure(t, firstSessions != secondSessions, func() {
 		t.Errorf("each turn got its own sessions dir, so Codex cannot resume:\n first  %s\n second %s",
 			firstSessions, secondSessions)
-	}
+	})
 	// And it must be the stable per-issue store, not a task-local directory.
-	if strings.Contains(firstSessions, taskKey("aaaa1111-2222-3333-4444-5555666677aa")) {
-		t.Errorf("sessions dir is task-scoped (%s); it will not survive the next turn", firstSessions)
-	}
+	testassert.OnFailure(t, strings.Contains(firstSessions, taskKey("aaaa1111-2222-3333-4444-5555666677aa")), func() { t.Errorf("sessions dir is task-scoped (%s); it will not survive the next turn", firstSessions) })
 }
 
 // The daemon runs its sidecar cleanup before Finalize commits. If that cleanup
@@ -660,23 +584,13 @@ func TestFinalizeAbortRefusesToCommitAndKeepsWorktree(t *testing.T) {
 	wt.AbortWithReason(errors.New("cleanup failed"))
 	outcome, err := wt.Finalize(worktreeTestLogger())
 
-	if err == nil {
-		t.Fatal("Finalize returned nil error after an abort")
-	}
-	if outcome.Branch != "" {
-		t.Errorf("Branch = %q, want empty: nothing may be delivered after an abort", outcome.Branch)
-	}
-	if outcome.AutoCommitted {
-		t.Error("AutoCommitted = true; the abort must prevent the commit")
-	}
-	if outcome.PreservedPath != wt.Path {
-		t.Errorf("PreservedPath = %q, want %q", outcome.PreservedPath, wt.Path)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Finalize returned nil error after an abort") })
+	testassert.OnFailure(t, outcome.Branch != "", func() { t.Errorf("Branch = %q, want empty: nothing may be delivered after an abort", outcome.Branch) })
+	testassert.OnFailure(t, outcome.AutoCommitted, func() { t.Error("AutoCommitted = true; the abort must prevent the commit") })
+	testassert.OnFailure(t, outcome.PreservedPath != wt.Path, func() { t.Errorf("PreservedPath = %q, want %q", outcome.PreservedPath, wt.Path) })
 	// Nothing committed: the branch must still be sitting on its base.
 	tip := gitRun(t, repo, "rev-parse", wt.Branch)
-	if tip != wt.BaseCommit {
-		t.Errorf("branch moved to %s; the sidecar-carrying commit was delivered anyway", tip)
-	}
+	testassert.OnFailure(t, tip != wt.BaseCommit, func() { t.Errorf("branch moved to %s; the sidecar-carrying commit was delivered anyway", tip) })
 	// And the work is still recoverable on disk.
 	if got := readFile(t, filepath.Join(wt.Path, "agent-output.txt")); got != "real work\n" {
 		t.Errorf("agent work was destroyed: %q", got)
@@ -698,12 +612,8 @@ func TestAbortWithReasonKeepsFirstReason(t *testing.T) {
 	wt.AbortWithReason(nil)
 
 	_, err := wt.Finalize(worktreeTestLogger())
-	if err == nil || !strings.Contains(err.Error(), "first") {
-		t.Fatalf("want the first reason preserved, got: %v", err)
-	}
-	if strings.Contains(err.Error(), "second") {
-		t.Errorf("later abort overwrote the original reason: %v", err)
-	}
+	testassert.OnFailure(t, err == nil || !strings.Contains(err.Error(), "first"), func() { t.Fatalf("want the first reason preserved, got: %v", err) })
+	testassert.OnFailure(t, strings.Contains(err.Error(), "second"), func() { t.Errorf("later abort overwrote the original reason: %v", err) })
 }
 
 // An untracked symlink is content the user can see. Replaying it faithfully is
@@ -722,12 +632,8 @@ func TestPrepareLocalWorktreeFailsOnUntrackedSymlink(t *testing.T) {
 		TaskID:    "task-symlink",
 	}, worktreeTestLogger())
 
-	if err == nil {
-		t.Fatal("expected prepare to fail rather than silently drop the symlink")
-	}
-	if !strings.Contains(err.Error(), "untracked") {
-		t.Errorf("error should name the untracked replay, got: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected prepare to fail rather than silently drop the symlink") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "untracked"), func() { t.Errorf("error should name the untracked replay, got: %v", err) })
 	if list := gitRun(t, repo, "worktree", "list"); strings.Count(list, "\n") != 0 {
 		t.Errorf("aborted prepare left a worktree registered:\n%s", list)
 	}

--- a/server/internal/daemon/execenv/managed_env_provenance_test.go
+++ b/server/internal/daemon/execenv/managed_env_provenance_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestPrepareManagedIssueEnvWritesProvenance verifies Prepare drops the
@@ -23,21 +25,13 @@ func TestPrepareManagedIssueEnvWritesProvenance(t *testing.T) {
 			AgentID: "agent-prov-1",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	prov, err := ReadManagedEnvProvenance(env.RootDir)
-	if err != nil {
-		t.Fatalf("read managed env provenance: %v", err)
-	}
-	if prov.ManagedBy != ManagedEnvProvenanceManagedBy {
-		t.Fatalf("managed_by = %q, want %q", prov.ManagedBy, ManagedEnvProvenanceManagedBy)
-	}
-	if prov.WorkspaceID != "ws-prov-001" || prov.IssueID != "issue-prov-1" || prov.AgentID != "agent-prov-1" {
-		t.Fatalf("provenance owner mismatch: %+v", prov)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read managed env provenance: %v", err) })
+	testassert.OnFailure(t, prov.ManagedBy != ManagedEnvProvenanceManagedBy, func() { t.Fatalf("managed_by = %q, want %q", prov.ManagedBy, ManagedEnvProvenanceManagedBy) })
+	testassert.OnFailure(t, prov.WorkspaceID != "ws-prov-001" || prov.IssueID != "issue-prov-1" || prov.AgentID != "agent-prov-1", func() { t.Fatalf("provenance owner mismatch: %+v", prov) })
 }
 
 // TestPrepareLocalDirectoryWritesNoProvenance pins the local_directory branch:
@@ -58,9 +52,7 @@ func TestPrepareLocalDirectoryWritesNoProvenance(t *testing.T) {
 			AgentID: "agent-prov-local",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if _, err := ReadManagedEnvProvenance(env.RootDir); !os.IsNotExist(err) {
@@ -86,16 +78,10 @@ func TestPrepareManagedChatEnvWritesProvenance(t *testing.T) {
 			AgentID:       "agent-chat",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	prov, err := ReadManagedEnvProvenance(env.RootDir)
-	if err != nil {
-		t.Fatalf("read chat managed env provenance: %v", err)
-	}
-	if prov.WorkspaceID != "ws-prov-chat" || prov.ChatSessionID != "chat-1" || prov.AgentID != "agent-chat" || prov.IssueID != "" {
-		t.Fatalf("chat provenance owner mismatch: %+v", prov)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read chat managed env provenance: %v", err) })
+	testassert.OnFailure(t, prov.WorkspaceID != "ws-prov-chat" || prov.ChatSessionID != "chat-1" || prov.AgentID != "agent-chat" || prov.IssueID != "", func() { t.Fatalf("chat provenance owner mismatch: %+v", prov) })
 }

--- a/server/internal/daemon/execenv/openclaw_config_cache_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_cache_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // openclawCacheFixture is one host: a real (fake) openclaw binary file, a real
@@ -100,13 +102,9 @@ func TestOpenclawDiscoveryCacheHitProducesSameWrapper(t *testing.T) {
 			t.Fatalf("mkdir workdir: %v", err)
 		}
 		result, err := prepareOpenclawConfig(envRoot, workDir, f.prep())
-		if err != nil {
-			t.Fatalf("prepareOpenclawConfig: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 		raw, err := os.ReadFile(result.ConfigPath)
-		if err != nil {
-			t.Fatalf("read wrapper: %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read wrapper: %v", err) })
 		// The workspace override is env-root specific; normalise it away so the
 		// comparison is about the discovered content, not the temp path.
 		return []byte(strings.ReplaceAll(string(raw), workDir, "<WORKDIR>"))
@@ -114,9 +112,7 @@ func TestOpenclawDiscoveryCacheHitProducesSameWrapper(t *testing.T) {
 
 	cold := read()
 	warm := read()
-	if string(cold) != string(warm) {
-		t.Errorf("cache hit produced a different wrapper\ncold: %s\nwarm: %s", cold, warm)
-	}
+	testassert.OnFailure(t, string(cold) != string(warm), func() { t.Errorf("cache hit produced a different wrapper\ncold: %s\nwarm: %s", cold, warm) })
 }
 
 // TestOpenclawDiscoveryCacheInvalidatesOnConfigChange covers the refresh
@@ -176,18 +172,14 @@ func TestOpenclawDiscoveryCacheExpiresWithTTL(t *testing.T) {
 	f.run(t)
 
 	raw, err := os.ReadFile(f.cachePath())
-	if err != nil {
-		t.Fatalf("read cache: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read cache: %v", err) })
 	var entry openclawDiscoveryCacheEntry
 	if err := json.Unmarshal(raw, &entry); err != nil {
 		t.Fatalf("decode cache: %v", err)
 	}
 	entry.CachedAtNano = time.Now().Add(-openclawDiscoveryCacheTTL - time.Second).UnixNano()
 	aged, err := json.Marshal(entry)
-	if err != nil {
-		t.Fatalf("encode aged cache: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("encode aged cache: %v", err) })
 	if err := os.WriteFile(f.cachePath(), aged, 0o600); err != nil {
 		t.Fatalf("write aged cache: %v", err)
 	}
@@ -204,18 +196,14 @@ func TestOpenclawDiscoveryCacheRejectsFutureEntry(t *testing.T) {
 	f.run(t)
 
 	raw, err := os.ReadFile(f.cachePath())
-	if err != nil {
-		t.Fatalf("read cache: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read cache: %v", err) })
 	var entry openclawDiscoveryCacheEntry
 	if err := json.Unmarshal(raw, &entry); err != nil {
 		t.Fatalf("decode cache: %v", err)
 	}
 	entry.CachedAtNano = time.Now().Add(time.Hour).UnixNano()
 	future, err := json.Marshal(entry)
-	if err != nil {
-		t.Fatalf("encode future cache: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("encode future cache: %v", err) })
 	if err := os.WriteFile(f.cachePath(), future, 0o600); err != nil {
 		t.Fatalf("write future cache: %v", err)
 	}
@@ -369,13 +357,9 @@ func TestOpenclawDiscoveryCacheConcurrentPreparations(t *testing.T) {
 
 	// No half-written temp files may survive a clean run.
 	entries, err := os.ReadDir(f.cacheDir)
-	if err != nil {
-		t.Fatalf("read cache dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read cache dir: %v", err) })
 	for _, entry := range entries {
-		if entry.Name() != openclawDiscoveryCacheFile {
-			t.Errorf("leftover file in cache dir: %s", entry.Name())
-		}
+		testassert.OnFailure(t, entry.Name() != openclawDiscoveryCacheFile, func() { t.Errorf("leftover file in cache dir: %s", entry.Name()) })
 	}
 }
 
@@ -418,9 +402,7 @@ func TestOpenclawDiscoveryCacheStoresEmptyAgentsList(t *testing.T) {
 			}
 
 			cold := f.run(t)
-			if cold == 0 {
-				t.Fatalf("cold preparation made no CLI calls, want a live discovery")
-			}
+			testassert.OnFailure(t, cold == 0, func() { t.Fatalf("cold preparation made no CLI calls, want a live discovery") })
 			if got := f.run(t); got != 0 {
 				t.Errorf("warm preparation made %d CLI calls, want 0: an agent-less host must be cacheable too", got)
 			}

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // openclawCLIStub captures one or more (subcommand, response) pairs and
@@ -60,9 +62,7 @@ func (s *openclawCLIStub) exec(_ context.Context, bin string, args ...string) (s
 func mustReadJSON(t *testing.T, path string) map[string]any {
 	t.Helper()
 	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read synthesized cfg: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read synthesized cfg: %v", err) })
 	var got map[string]any
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("parse synthesized cfg: %v", err)
@@ -117,58 +117,44 @@ func TestPrepareOpenclawConfigDelegatesParsingToCLI(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	cfgPath := result.ConfigPath
-	if cfgPath != filepath.Join(envRoot, openclawConfigFile) {
-		t.Errorf("cfgPath = %q, want %q", cfgPath, filepath.Join(envRoot, openclawConfigFile))
-	}
+	testassert.OnFailure(t, cfgPath != filepath.Join(envRoot, openclawConfigFile), func() { t.Errorf("cfgPath = %q, want %q", cfgPath, filepath.Join(envRoot, openclawConfigFile)) })
 
 	got := mustReadJSON(t, cfgPath)
 
 	// $include must reference the user's active config so OpenClaw's own
 	// loader does the JSON5 / $include / env-substitution work.
 	include, ok := got["$include"].([]any)
-	if !ok || len(include) != 1 || include[0] != userConfigPath {
-		t.Errorf("$include = %v, want [%q]", got["$include"], userConfigPath)
-	}
+	testassert.OnFailure(t, !ok || len(include) != 1 || include[0] != userConfigPath, func() { t.Errorf("$include = %v, want [%q]", got["$include"], userConfigPath) })
 
 	// The wrapper $includes a path that lives outside envRoot. OpenClaw
 	// confines $include resolution to the wrapper file's own directory
 	// unless OPENCLAW_INCLUDE_ROOTS lists the target. Surface the user
 	// config's dirname so the daemon can grant it.
-	if result.IncludeRoot != userConfigDir {
+	testassert.OnFailure(t, result.IncludeRoot != userConfigDir, func() {
 		t.Errorf("IncludeRoot = %q, want %q (dirname of active config so wrapper can $include across dirs)", result.IncludeRoot, userConfigDir)
-	}
+	})
 
 	agents := got["agents"].(map[string]any)
 	defaults := agents["defaults"].(map[string]any)
-	if defaults["workspace"] != workDir {
-		t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir)
-	}
+	testassert.OnFailure(t, defaults["workspace"] != workDir, func() { t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir) })
 
 	// Per-agent workspaces must be rewritten so a host-scope agents.list[].
 	// workspace cannot silently win over our defaults override. This is
 	// intentional per-task isolation (see prepareOpenclawConfig doc).
 	list := agents["list"].([]any)
-	if len(list) != 2 {
-		t.Fatalf("agents.list length = %d, want 2", len(list))
-	}
+	testassert.OnFailure(t, len(list) != 2, func() { t.Fatalf("agents.list length = %d, want 2", len(list)) })
 	for i, item := range list {
 		entry := item.(map[string]any)
-		if entry["workspace"] != workDir {
+		testassert.OnFailure(t, entry["workspace"] != workDir, func() {
 			t.Errorf("agents.list[%d].workspace = %v, want %q (per-agent overrides must be rewritten so they don't beat defaults)", i, entry["workspace"], workDir)
-		}
+		})
 	}
 	// Non-workspace fields per entry are carried over so a sibling-replace
 	// merge in OpenClaw's $include semantics doesn't silently lose them.
-	if list[0].(map[string]any)["id"] != "scout" {
-		t.Errorf("agents.list[0].id lost in carryover: %v", list[0])
-	}
-	if list[1].(map[string]any)["model"] != "openai/gpt-5" {
-		t.Errorf("agents.list[1].model lost in carryover: %v", list[1])
-	}
+	testassert.OnFailure(t, list[0].(map[string]any)["id"] != "scout", func() { t.Errorf("agents.list[0].id lost in carryover: %v", list[0]) })
+	testassert.OnFailure(t, list[1].(map[string]any)["model"] != "openai/gpt-5", func() { t.Errorf("agents.list[1].model lost in carryover: %v", list[1]) })
 }
 
 // TestPrepareOpenclawConfigFailsClosedOnCLIError — the headline regression
@@ -188,12 +174,8 @@ func TestPrepareOpenclawConfigFailsClosedOnCLIError(t *testing.T) {
 	})
 
 	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err == nil {
-		t.Fatal("prepareOpenclawConfig succeeded on CLI failure; expected fail closed")
-	}
-	if !strings.Contains(err.Error(), "locate openclaw active config") {
-		t.Errorf("error message %q does not name the failed step", err.Error())
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("prepareOpenclawConfig succeeded on CLI failure; expected fail closed") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "locate openclaw active config"), func() { t.Errorf("error message %q does not name the failed step", err.Error()) })
 
 	// No stale wrapper left behind.
 	if _, err := os.Stat(filepath.Join(envRoot, openclawConfigFile)); !os.IsNotExist(err) {
@@ -229,29 +211,21 @@ func TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 
 	got := mustReadJSON(t, result.ConfigPath)
 	include, ok := got["$include"].([]any)
-	if !ok || len(include) != 1 || include[0] != userConfigPath {
+	testassert.OnFailure(t, !ok || len(include) != 1 || include[0] != userConfigPath, func() {
 		t.Errorf("$include = %v, want fallback OPENCLAW_CONFIG_PATH %q", got["$include"], userConfigPath)
-	}
-	if result.IncludeRoot != userConfigDir {
-		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, userConfigDir)
-	}
+	})
+	testassert.OnFailure(t, result.IncludeRoot != userConfigDir, func() { t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, userConfigDir) })
 	agents := got["agents"].(map[string]any)
 	list := agents["list"].([]any)
-	if len(list) != 1 || list[0].(map[string]any)["workspace"] != workDir {
-		t.Errorf("agents.list workspace rewrite after fallback = %v, want workDir %q", list, workDir)
-	}
-	if len(stub.calls) != 2 {
-		t.Fatalf("openclaw calls = %d, want 2: %+v", len(stub.calls), stub.calls)
-	}
-	if strings.Join(stub.calls[1].args, " ") != "config get agents.list --json" {
+	testassert.OnFailure(t, len(list) != 1 || list[0].(map[string]any)["workspace"] != workDir, func() { t.Errorf("agents.list workspace rewrite after fallback = %v, want workDir %q", list, workDir) })
+	testassert.OnFailure(t, len(stub.calls) != 2, func() { t.Fatalf("openclaw calls = %d, want 2: %+v", len(stub.calls), stub.calls) })
+	testassert.OnFailure(t, strings.Join(stub.calls[1].args, " ") != "config get agents.list --json", func() {
 		t.Errorf("second openclaw call = %q, want config get agents.list --json", strings.Join(stub.calls[1].args, " "))
-	}
+	})
 }
 
 func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
@@ -345,15 +319,9 @@ func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
 			})
 
 			got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
-			if err != nil {
-				t.Fatalf("openclawActiveConfigPath: %v", err)
-			}
-			if !exists {
-				t.Fatal("exists = false, want true")
-			}
-			if got != want {
-				t.Errorf("path = %q, want %q", got, want)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("openclawActiveConfigPath: %v", err) })
+			testassert.OnFailure(t, !exists, func() { t.Fatal("exists = false, want true") })
+			testassert.OnFailure(t, got != want, func() { t.Errorf("path = %q, want %q", got, want) })
 		})
 	}
 }
@@ -367,16 +335,10 @@ func TestOpenclawActiveConfigPathFallbackFreshInstallUsesCanonicalPath(t *testin
 	})
 
 	got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
-	if err != nil {
-		t.Fatalf("openclawActiveConfigPath: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("openclawActiveConfigPath: %v", err) })
 	want := filepath.Join(home, ".openclaw", "openclaw.json")
-	if got != want {
-		t.Errorf("path = %q, want canonical fresh-install path %q", got, want)
-	}
-	if exists {
-		t.Fatal("exists = true, want false for fresh install")
-	}
+	testassert.OnFailure(t, got != want, func() { t.Errorf("path = %q, want canonical fresh-install path %q", got, want) })
+	testassert.OnFailure(t, exists, func() { t.Fatal("exists = true, want false for fresh install") })
 }
 
 func TestOpenclawActiveConfigPathFallbackOpenclawConfigPathHardOverride(t *testing.T) {
@@ -397,15 +359,9 @@ func TestOpenclawActiveConfigPathFallbackOpenclawConfigPathHardOverride(t *testi
 	})
 
 	got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
-	if err != nil {
-		t.Fatalf("openclawActiveConfigPath: %v", err)
-	}
-	if got != explicitPath {
-		t.Errorf("path = %q, want OPENCLAW_CONFIG_PATH hard override %q", got, explicitPath)
-	}
-	if exists {
-		t.Fatal("exists = true, want false when explicit OPENCLAW_CONFIG_PATH is missing")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("openclawActiveConfigPath: %v", err) })
+	testassert.OnFailure(t, got != explicitPath, func() { t.Errorf("path = %q, want OPENCLAW_CONFIG_PATH hard override %q", got, explicitPath) })
+	testassert.OnFailure(t, exists, func() { t.Fatal("exists = true, want false when explicit OPENCLAW_CONFIG_PATH is missing") })
 }
 
 func TestOpenclawActiveConfigPathFallbackErrorIncludesOriginalCLIError(t *testing.T) {
@@ -420,16 +376,10 @@ func TestOpenclawActiveConfigPathFallbackErrorIncludesOriginalCLIError(t *testin
 	})
 
 	_, _, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
-	if err == nil {
-		t.Fatal("openclawActiveConfigPath succeeded with directory config path; expected error")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("openclawActiveConfigPath succeeded with directory config path; expected error") })
 	msg := err.Error()
-	if !strings.Contains(msg, "too many arguments for 'config'") {
-		t.Errorf("error %q lost original unsupported CLI stderr", msg)
-	}
-	if !strings.Contains(msg, "is a directory") {
-		t.Errorf("error %q lost fallback failure detail", msg)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "too many arguments for 'config'"), func() { t.Errorf("error %q lost original unsupported CLI stderr", msg) })
+	testassert.OnFailure(t, !strings.Contains(msg, "is a directory"), func() { t.Errorf("error %q lost fallback failure detail", msg) })
 }
 
 func TestIsOpenclawConfigFileUnsupportedMatchesKnownShapes(t *testing.T) {
@@ -497,12 +447,10 @@ func TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList(t *testing.T) {
 	})
 
 	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err == nil {
+	testassert.OnFailure(t, err == nil, func() {
 		t.Fatal("prepareOpenclawConfig succeeded on malformed agents.list output; expected fail closed")
-	}
-	if !strings.Contains(err.Error(), "agents.list") {
-		t.Errorf("error message %q does not name the failed step", err.Error())
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "agents.list"), func() { t.Errorf("error message %q does not name the failed step", err.Error()) })
 }
 
 // TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty — `config get` exits
@@ -532,17 +480,13 @@ func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	if _, present := got["agents"].(map[string]any)["list"]; present {
 		t.Errorf("agents.list should be omitted when user has none, got %v", got["agents"])
 	}
-	if got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir {
-		t.Errorf("defaults.workspace not set when agents.list missing")
-	}
+	testassert.OnFailure(t, got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir, func() { t.Errorf("defaults.workspace not set when agents.list missing") })
 }
 
 // TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig — the only legitimate
@@ -566,23 +510,19 @@ func TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	if _, present := got["$include"]; present {
 		t.Errorf("$include should be absent for fresh install, got %v", got["$include"])
 	}
-	if got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir {
-		t.Errorf("defaults.workspace not set on fresh-install wrapper")
-	}
+	testassert.OnFailure(t, got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir, func() { t.Errorf("defaults.workspace not set on fresh-install wrapper") })
 	// Fresh install emits no $include, so no extra include root is needed
 	// — the wrapper never steps outside envRoot. Daemon should leave the
 	// user's OPENCLAW_INCLUDE_ROOTS alone.
-	if result.IncludeRoot != "" {
+	testassert.OnFailure(t, result.IncludeRoot != "", func() {
 		t.Errorf("IncludeRoot = %q on fresh install, want empty (no $include emitted)", result.IncludeRoot)
-	}
+	})
 }
 
 // TestPrepareOpenclawConfigExpandsTilde — `openclaw config file` reports
@@ -611,22 +551,20 @@ func TestPrepareOpenclawConfigExpandsTilde(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	include := got["$include"].([]any)
-	if include[0] != realPath {
+	testassert.OnFailure(t, include[0] != realPath, func() {
 		t.Errorf("$include[0] = %v, want %q (tilde must be expanded to absolute)", include[0], realPath)
-	}
+	})
 	// IncludeRoot must also use the expanded absolute dirname, otherwise
 	// the daemon would export a `~/.openclaw`-shaped root that OpenClaw
 	// would not match against the resolved absolute include target.
 	wantRoot := filepath.Join(fakeHome, ".openclaw")
-	if result.IncludeRoot != wantRoot {
+	testassert.OnFailure(t, result.IncludeRoot != wantRoot, func() {
 		t.Errorf("IncludeRoot = %q, want %q (must be expanded absolute dirname)", result.IncludeRoot, wantRoot)
-	}
+	})
 }
 
 // TestPrepareOpenclawConfigParsesPathFromUITerminalOutput — regression test
@@ -671,15 +609,13 @@ func TestPrepareOpenclawConfigParsesPathFromUITerminalOutput(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 
 	got := mustReadJSON(t, result.ConfigPath)
 	include := got["$include"].([]any)
-	if include[0] != userConfigPath {
+	testassert.OnFailure(t, include[0] != userConfigPath, func() {
 		t.Errorf("$include[0] = %v, want %q (path must be extracted from last non-empty line)", include[0], userConfigPath)
-	}
+	})
 }
 
 // TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement is the
@@ -723,15 +659,11 @@ func TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement(t *testing.
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 
 	got := mustReadJSON(t, result.ConfigPath)
 	rawIncludes, ok := got["$include"].([]any)
-	if !ok || len(rawIncludes) == 0 {
-		t.Fatalf("wrapper has no $include entries, but a user config is present: %v", got)
-	}
+	testassert.OnFailure(t, !ok || len(rawIncludes) == 0, func() { t.Fatalf("wrapper has no $include entries, but a user config is present: %v", got) })
 
 	// Mirror OpenClaw's confinement check: every cross-dir $include target
 	// must have its dirname covered by either the wrapper's own dir or the
@@ -743,9 +675,7 @@ func TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement(t *testing.
 	}
 	for _, raw := range rawIncludes {
 		target, ok := raw.(string)
-		if !ok {
-			t.Fatalf("$include entry is not a string: %T %v", raw, raw)
-		}
+		testassert.OnFailure(t, !ok, func() { t.Fatalf("$include entry is not a string: %T %v", raw, raw) })
 		targetDir := filepath.Dir(target)
 		allowed := false
 		for _, g := range granted {
@@ -754,10 +684,10 @@ func TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement(t *testing.
 				break
 			}
 		}
-		if !allowed {
+		testassert.OnFailure(t, !allowed, func() {
 			t.Errorf("$include target %q has dirname %q which is not in granted include roots %v — OpenClaw would refuse to load it",
 				target, targetDir, granted)
-		}
+		})
 	}
 }
 
@@ -806,22 +736,16 @@ func TestPrepareOpenclawConfigStrictReplacesUserMcpServers(t *testing.T) {
 		OpenclawBin: stub.bin,
 		McpConfig:   mcpConfig,
 	})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 
 	got := mustReadJSON(t, result.ConfigPath)
 	mcp, ok := got["mcp"].(map[string]any)
-	if !ok {
-		t.Fatalf("wrapper missing mcp block: %v", got)
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("wrapper missing mcp block: %v", got) })
 	servers, ok := mcp["servers"].(map[string]any)
-	if !ok {
-		t.Fatalf("mcp.servers is not an object: %v", mcp)
-	}
-	if len(servers) != 2 {
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("mcp.servers is not an object: %v", mcp) })
+	testassert.OnFailure(t, len(servers) != 2, func() {
 		t.Errorf("mcp.servers has %d entries, want 2 (managed only — global_one must not leak): %v", len(servers), servers)
-	}
+	})
 	if _, leaked := servers["global_one"]; leaked {
 		t.Errorf("mcp.servers.global_one leaked into wrapper from user config: %v", servers)
 	}
@@ -835,17 +759,13 @@ func TestPrepareOpenclawConfigStrictReplacesUserMcpServers(t *testing.T) {
 	// The wrapper's $include must point at the sanitized snapshot, NOT the
 	// live user config — otherwise OpenClaw would deep-merge user.mcp back in.
 	include, _ := got["$include"].([]any)
-	if len(include) != 1 {
-		t.Fatalf("wrapper $include has %d entries, want 1: %v", len(include), include)
-	}
+	testassert.OnFailure(t, len(include) != 1, func() { t.Fatalf("wrapper $include has %d entries, want 1: %v", len(include), include) })
 	snapshotPath, _ := include[0].(string)
-	if snapshotPath == userCfgPath {
+	testassert.OnFailure(t, snapshotPath == userCfgPath, func() {
 		t.Fatalf("wrapper $includes the live user config (%q) — strict replace requires the sanitized snapshot", userCfgPath)
-	}
+	})
 	wantSnapshot := filepath.Join(envRoot, openclawUserSnapshotFile)
-	if snapshotPath != wantSnapshot {
-		t.Errorf("$include = %q, want sanitized snapshot %q", snapshotPath, wantSnapshot)
-	}
+	testassert.OnFailure(t, snapshotPath != wantSnapshot, func() { t.Errorf("$include = %q, want sanitized snapshot %q", snapshotPath, wantSnapshot) })
 
 	// Snapshot must exist, must drop the `mcp` block, and must preserve the
 	// non-mcp keys (gateway, providers, secrets) so OpenClaw still has API
@@ -863,9 +783,9 @@ func TestPrepareOpenclawConfigStrictReplacesUserMcpServers(t *testing.T) {
 
 	// The snapshot lives in envRoot alongside the wrapper, so the daemon
 	// does NOT need to grant an OPENCLAW_INCLUDE_ROOTS entry for it.
-	if result.IncludeRoot != "" {
+	testassert.OnFailure(t, result.IncludeRoot != "", func() {
 		t.Errorf("IncludeRoot = %q, want empty (snapshot lives in envRoot, no cross-dir include)", result.IncludeRoot)
-	}
+	})
 }
 
 // TestPrepareOpenclawConfigStrictPreservesNonServerMcpKeys — Elon's
@@ -909,16 +829,14 @@ func TestPrepareOpenclawConfigStrictPreservesNonServerMcpKeys(t *testing.T) {
 		OpenclawBin: stub.bin,
 		McpConfig:   mcpConfig,
 	})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 
 	snapPath := filepath.Join(envRoot, openclawUserSnapshotFile)
 	snap := mustReadJSON(t, snapPath)
 	snapMcp, ok := snap["mcp"].(map[string]any)
-	if !ok {
+	testassert.OnFailure(t, !ok, func() {
 		t.Fatalf("snapshot lost the mcp block entirely; mcp.sessionIdleTtlMs should have survived: %v", snap)
-	}
+	})
 	if _, leaked := snapMcp["servers"]; leaked {
 		t.Errorf("snapshot still has mcp.servers; strict scope must drop it: %v", snapMcp)
 	}
@@ -972,21 +890,15 @@ func TestPrepareOpenclawConfigStrictEmptyManagedSetDropsUserMcp(t *testing.T) {
 				OpenclawBin: stub.bin,
 				McpConfig:   raw,
 			})
-			if err != nil {
-				t.Fatalf("prepareOpenclawConfig: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 			got := mustReadJSON(t, result.ConfigPath)
 			mcp, ok := got["mcp"].(map[string]any)
-			if !ok {
-				t.Fatalf("wrapper missing mcp block (managed empty must still be present): %v", got)
-			}
+			testassert.OnFailure(t, !ok, func() { t.Fatalf("wrapper missing mcp block (managed empty must still be present): %v", got) })
 			servers, ok := mcp["servers"].(map[string]any)
-			if !ok {
-				t.Fatalf("mcp.servers is not an object: %v", mcp)
-			}
-			if len(servers) != 0 {
+			testassert.OnFailure(t, !ok, func() { t.Fatalf("mcp.servers is not an object: %v", mcp) })
+			testassert.OnFailure(t, len(servers) != 0, func() {
 				t.Errorf("mcp.servers has %d entries on managed-empty, want 0 (global_one must not leak): %v", len(servers), servers)
-			}
+			})
 			// And the snapshot must have dropped the user's mcp block, so the
 			// $include resolves with no mcp at all.
 			snapPath := filepath.Join(envRoot, openclawUserSnapshotFile)
@@ -1033,23 +945,21 @@ func TestPrepareOpenclawConfigNullMcpConfigKeepsUserInclude(t *testing.T) {
 				OpenclawBin: stub.bin,
 				McpConfig:   raw,
 			})
-			if err != nil {
-				t.Fatalf("prepareOpenclawConfig: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 			got := mustReadJSON(t, result.ConfigPath)
 			if _, present := got["mcp"]; present {
 				t.Errorf("wrapper has mcp block when mcp_config = %q: %v", name, got["mcp"])
 			}
 			include, _ := got["$include"].([]any)
-			if len(include) != 1 || include[0] != userCfgPath {
+			testassert.OnFailure(t, len(include) != 1 || include[0] != userCfgPath, func() {
 				t.Errorf("$include = %v, want live user config %q on inherit path", got["$include"], userCfgPath)
-			}
+			})
 			if _, err := os.Stat(filepath.Join(envRoot, openclawUserSnapshotFile)); !os.IsNotExist(err) {
 				t.Errorf("inherit path wrote a snapshot file (should not): err=%v", err)
 			}
-			if result.IncludeRoot != userCfgDir {
+			testassert.OnFailure(t, result.IncludeRoot != userCfgDir, func() {
 				t.Errorf("IncludeRoot = %q, want %q (cross-dir hop for live $include)", result.IncludeRoot, userCfgDir)
-			}
+			})
 		})
 	}
 }
@@ -1075,26 +985,16 @@ func TestPrepareOpenclawConfigManagedSetFreshInstall(t *testing.T) {
 		OpenclawBin: stub.bin,
 		McpConfig:   mcpConfig,
 	})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	mcp, ok := got["mcp"].(map[string]any)
-	if !ok {
-		t.Fatalf("wrapper missing mcp block: %v", got)
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("wrapper missing mcp block: %v", got) })
 	servers, ok := mcp["servers"].(map[string]any)
-	if !ok {
-		t.Fatalf("mcp.servers is not an object: %v", mcp)
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("mcp.servers is not an object: %v", mcp) })
 	entry, _ := servers["context7"].(map[string]any)
-	if entry == nil || entry["command"] != "uvx" {
-		t.Errorf("context7 entry missing/wrong on fresh install: %v", servers)
-	}
+	testassert.OnFailure(t, entry == nil || entry["command"] != "uvx", func() { t.Errorf("context7 entry missing/wrong on fresh install: %v", servers) })
 	args, _ := entry["args"].([]any)
-	if len(args) != 1 || args[0] != "context7-mcp" {
-		t.Errorf("context7.args = %v", args)
-	}
+	testassert.OnFailure(t, len(args) != 1 || args[0] != "context7-mcp", func() { t.Errorf("context7.args = %v", args) })
 	if _, present := got["$include"]; present {
 		t.Errorf("fresh install should not emit $include: %v", got["$include"])
 	}
@@ -1129,18 +1029,12 @@ func TestPrepareOpenclawConfigFailsClosedOnResolvedConfigError(t *testing.T) {
 		OpenclawBin: stub.bin,
 		McpConfig:   mcpConfig,
 	})
-	if err == nil {
+	testassert.OnFailure(t, err == nil, func() {
 		t.Fatal("prepareOpenclawConfig succeeded when `config get --json` errored; expected fail closed")
-	}
-	if !strings.Contains(err.Error(), "resolved config") {
-		t.Errorf("error %q does not name the resolved-config step", err.Error())
-	}
-	if !strings.Contains(err.Error(), "json error: schema validation failed") {
-		t.Errorf("error %q omits the structured CLI diagnostic", err.Error())
-	}
-	if strings.Contains(err.Error(), "must-not-leak") {
-		t.Errorf("error leaked a non-diagnostic JSON field: %q", err.Error())
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "resolved config"), func() { t.Errorf("error %q does not name the resolved-config step", err.Error()) })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "json error: schema validation failed"), func() { t.Errorf("error %q omits the structured CLI diagnostic", err.Error()) })
+	testassert.OnFailure(t, strings.Contains(err.Error(), "must-not-leak"), func() { t.Errorf("error leaked a non-diagnostic JSON field: %q", err.Error()) })
 	// No stale wrapper / snapshot left behind.
 	if _, err := os.Stat(filepath.Join(envRoot, openclawConfigFile)); !os.IsNotExist(err) {
 		t.Errorf("wrapper exists after fail-closed: %v", err)
@@ -1181,12 +1075,8 @@ func TestPrepareOpenclawConfigFailsClosedOnMalformedMcpConfig(t *testing.T) {
 				OpenclawBin: stub.bin,
 				McpConfig:   raw,
 			})
-			if err == nil {
-				t.Fatalf("prepareOpenclawConfig succeeded on %s; expected fail closed", name)
-			}
-			if !strings.Contains(err.Error(), "mcp_config") && !strings.Contains(err.Error(), "mcp_servers") {
-				t.Errorf("error %q does not name the mcp_config step", err.Error())
-			}
+			testassert.OnFailure(t, err == nil, func() { t.Fatalf("prepareOpenclawConfig succeeded on %s; expected fail closed", name) })
+			testassert.OnFailure(t, !strings.Contains(err.Error(), "mcp_config") && !strings.Contains(err.Error(), "mcp_servers"), func() { t.Errorf("error %q does not name the mcp_config step", err.Error()) })
 		})
 	}
 }
@@ -1220,9 +1110,7 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 	}
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	cfgPath := result.ConfigPath
 	if err := writeContextFiles(workDir, "openclaw", TaskContextForEnv{
 		IssueID:     "issue-1",
@@ -1264,23 +1152,15 @@ func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
 			IssueID: "issue-1",
 		},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatalf("Prepare: %v", err)
-	}
-	if env.OpenclawConfigPath == "" {
-		t.Fatal("Prepare(openclaw) did not set OpenclawConfigPath")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare: %v", err) })
+	testassert.OnFailure(t, env.OpenclawConfigPath == "", func() { t.Fatal("Prepare(openclaw) did not set OpenclawConfigPath") })
 	got := mustReadJSON(t, env.OpenclawConfigPath)
 	workspace := got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"]
-	if workspace != env.WorkDir {
-		t.Errorf("agents.defaults.workspace = %v, want %q", workspace, env.WorkDir)
-	}
+	testassert.OnFailure(t, workspace != env.WorkDir, func() { t.Errorf("agents.defaults.workspace = %v, want %q", workspace, env.WorkDir) })
 	// Fresh install path emits no $include, so the Environment should
 	// leave OpenclawIncludeRoot empty — the daemon must NOT spuriously
 	// grant include roots when no cross-dir hop is being made.
-	if env.OpenclawIncludeRoot != "" {
-		t.Errorf("OpenclawIncludeRoot = %q on fresh install, want empty", env.OpenclawIncludeRoot)
-	}
+	testassert.OnFailure(t, env.OpenclawIncludeRoot != "", func() { t.Errorf("OpenclawIncludeRoot = %q on fresh install, want empty", env.OpenclawIncludeRoot) })
 }
 
 // TestPrepareEnvironmentOpenclawWiresIncludeRoot — when the user has an
@@ -1310,12 +1190,10 @@ func TestPrepareEnvironmentOpenclawWiresIncludeRoot(t *testing.T) {
 		OpenclawBin:    stub.bin,
 		Task:           TaskContextForEnv{IssueID: "issue-1"},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatalf("Prepare: %v", err)
-	}
-	if env.OpenclawIncludeRoot != userCfgDir {
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare: %v", err) })
+	testassert.OnFailure(t, env.OpenclawIncludeRoot != userCfgDir, func() {
 		t.Errorf("OpenclawIncludeRoot = %q, want %q (dirname of active config so daemon can grant OPENCLAW_INCLUDE_ROOTS)", env.OpenclawIncludeRoot, userCfgDir)
-	}
+	})
 }
 
 // TestPrepareEnvironmentOpenclawFailsClosed — when the openclaw CLI errors
@@ -1337,12 +1215,8 @@ func TestPrepareEnvironmentOpenclawFailsClosed(t *testing.T) {
 		OpenclawBin:    stub.bin,
 		Task:           TaskContextForEnv{IssueID: "issue-1"},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err == nil {
-		t.Fatal("Prepare(openclaw) succeeded when CLI errored; expected fail closed")
-	}
-	if !strings.Contains(err.Error(), "prepare openclaw config") {
-		t.Errorf("error message %q does not name the openclaw config step", err.Error())
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Prepare(openclaw) succeeded when CLI errored; expected fail closed") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "prepare openclaw config"), func() { t.Errorf("error message %q does not name the openclaw config step", err.Error()) })
 }
 
 // TestPrepareEnvironmentNonOpenclawSkipsConfig — non-openclaw providers
@@ -1371,20 +1245,18 @@ func TestPrepareEnvironmentNonOpenclawSkipsConfig(t *testing.T) {
 				Provider:       provider,
 				Task:           TaskContextForEnv{IssueID: "issue-1"},
 			}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-			if err != nil {
-				t.Fatalf("Prepare(%s): %v", provider, err)
-			}
-			if env.OpenclawConfigPath != "" {
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare(%s): %v", provider, err) })
+			testassert.OnFailure(t, env.OpenclawConfigPath != "", func() {
 				t.Errorf("provider %s should not get an OpenclawConfigPath, got %q", provider, env.OpenclawConfigPath)
-			}
+			})
 			if _, err := os.Stat(filepath.Join(env.RootDir, openclawConfigFile)); !os.IsNotExist(err) {
 				t.Errorf("provider %s left a stray openclaw-config.json", provider)
 			}
 		})
 	}
-	if len(stub.calls) != 0 {
+	testassert.OnFailure(t, len(stub.calls) != 0, func() {
 		t.Errorf("non-openclaw providers shelled out to openclaw CLI %d times: %+v", len(stub.calls), stub.calls)
-	}
+	})
 }
 
 // ── Gateway endpoint pinning (issue #3260) ──
@@ -1422,30 +1294,16 @@ func TestBuildPerTaskOpenclawConfigWritesGatewayBlock(t *testing.T) {
 	)
 
 	gw, ok := cfg["gateway"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected gateway map, got %T: %v", cfg["gateway"], cfg["gateway"])
-	}
-	if gw["host"] != "gw.internal" {
-		t.Errorf("gateway.host = %v, want %q", gw["host"], "gw.internal")
-	}
-	if gw["port"] != 18789 {
-		t.Errorf("gateway.port = %v, want %d", gw["port"], 18789)
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected gateway map, got %T: %v", cfg["gateway"], cfg["gateway"]) })
+	testassert.OnFailure(t, gw["host"] != "gw.internal", func() { t.Errorf("gateway.host = %v, want %q", gw["host"], "gw.internal") })
+	testassert.OnFailure(t, gw["port"] != 18789, func() { t.Errorf("gateway.port = %v, want %d", gw["port"], 18789) })
 	// Token nests under gateway.auth.{mode,token} to match OpenClaw's own
 	// config shape (see ~/.openclaw/openclaw.json `gateway.auth`).
 	auth, ok := gw["auth"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected gateway.auth map, got %T: %v", gw["auth"], gw["auth"])
-	}
-	if auth["mode"] != "token" {
-		t.Errorf("gateway.auth.mode = %v, want %q", auth["mode"], "token")
-	}
-	if auth["token"] != "secret-token" {
-		t.Errorf("gateway.auth.token = %v, want %q", auth["token"], "secret-token")
-	}
-	if gw["tls"] != true {
-		t.Errorf("gateway.tls = %v, want true", gw["tls"])
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatalf("expected gateway.auth map, got %T: %v", gw["auth"], gw["auth"]) })
+	testassert.OnFailure(t, auth["mode"] != "token", func() { t.Errorf("gateway.auth.mode = %v, want %q", auth["mode"], "token") })
+	testassert.OnFailure(t, auth["token"] != "secret-token", func() { t.Errorf("gateway.auth.token = %v, want %q", auth["token"], "secret-token") })
+	testassert.OnFailure(t, gw["tls"] != true, func() { t.Errorf("gateway.tls = %v, want true", gw["tls"]) })
 }
 
 func TestBuildPerTaskOpenclawConfigPartialGatewayOmitsZeroFields(t *testing.T) {
@@ -1583,15 +1441,9 @@ func TestAnnotateOpenclawJSONError(t *testing.T) {
 			cause,
 			`{"error":"  schema\nvalidation failed  ","resolved":{"apiKey":"must-not-leak"}}`,
 		)
-		if !errors.Is(got, cause) {
-			t.Fatalf("annotated error lost its cause: %v", got)
-		}
-		if !strings.Contains(got.Error(), "json error: schema validation failed") {
-			t.Fatalf("annotated error omitted or failed to normalize the diagnostic: %v", got)
-		}
-		if strings.Contains(got.Error(), "must-not-leak") {
-			t.Fatalf("annotated error leaked a sibling JSON field: %v", got)
-		}
+		testassert.OnFailure(t, !errors.Is(got, cause), func() { t.Fatalf("annotated error lost its cause: %v", got) })
+		testassert.OnFailure(t, !strings.Contains(got.Error(), "json error: schema validation failed"), func() { t.Fatalf("annotated error omitted or failed to normalize the diagnostic: %v", got) })
+		testassert.OnFailure(t, strings.Contains(got.Error(), "must-not-leak"), func() { t.Fatalf("annotated error leaked a sibling JSON field: %v", got) })
 	})
 
 	t.Run("bounds the diagnostic", func(t *testing.T) {
@@ -1602,12 +1454,8 @@ func TestAnnotateOpenclawJSONError(t *testing.T) {
 			cause,
 			`{"error":"`+prefix+`extra"}`,
 		)
-		if !strings.Contains(got.Error(), "json error: "+prefix+"…") {
-			t.Fatalf("annotated error was not truncated at the rune limit: %v", got)
-		}
-		if strings.Contains(got.Error(), "extra") {
-			t.Fatalf("annotated error exceeded its bound: %v", got)
-		}
+		testassert.OnFailure(t, !strings.Contains(got.Error(), "json error: "+prefix+"…"), func() { t.Fatalf("annotated error was not truncated at the rune limit: %v", got) })
+		testassert.OnFailure(t, strings.Contains(got.Error(), "extra"), func() { t.Fatalf("annotated error exceeded its bound: %v", got) })
 	})
 
 	t.Run("ignores malformed envelopes", func(t *testing.T) {
@@ -1662,14 +1510,10 @@ func TestPrepareOpenclawConfigNewSchemaOmitsAgentsList(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	agents := got["agents"].(map[string]any)
-	if agents["defaults"].(map[string]any)["workspace"] != workDir {
-		t.Errorf("defaults.workspace not pinned to workDir")
-	}
+	testassert.OnFailure(t, agents["defaults"].(map[string]any)["workspace"] != workDir, func() { t.Errorf("defaults.workspace not pinned to workDir") })
 	if _, present := agents["list"]; present {
 		t.Fatalf("agents.list must be omitted for a registry-sourced (2026.6.x) host — OpenClaw rejects it; got %v", agents["list"])
 	}
@@ -1696,17 +1540,13 @@ func TestPrepareOpenclawConfigNewSchemaEmptyRegistry(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	agents := got["agents"].(map[string]any)
 	if _, present := agents["list"]; present {
 		t.Errorf("agents.list should be omitted for empty registry, got %v", agents["list"])
 	}
-	if agents["defaults"].(map[string]any)["workspace"] != workDir {
-		t.Errorf("defaults.workspace not set")
-	}
+	testassert.OnFailure(t, agents["defaults"].(map[string]any)["workspace"] != workDir, func() { t.Errorf("defaults.workspace not set") })
 }
 
 // TestExpandOpenclawPathTildeSeparators — `openclaw config file` shortens the
@@ -1733,15 +1573,13 @@ func TestExpandOpenclawPathTildeSeparators(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := expandOpenclawPath(tc.in)
-			if err != nil {
-				t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err)
-			}
-			if strings.Contains(got, "~") {
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err) })
+			testassert.OnFailure(t, strings.Contains(got, "~"), func() {
 				t.Errorf("expandOpenclawPath(%q) = %q, want the tilde expanded (a literal ~ can never stat)", tc.in, got)
-			}
-			if !strings.HasPrefix(got, fakeHome) {
+			})
+			testassert.OnFailure(t, !strings.HasPrefix(got, fakeHome), func() {
 				t.Errorf("expandOpenclawPath(%q) = %q, want it rooted at the home dir %q", tc.in, got, fakeHome)
-			}
+			})
 		})
 	}
 }
@@ -1767,12 +1605,8 @@ func TestExpandOpenclawPathOpenclawHome(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := expandOpenclawPath(tc.in)
-			if err != nil {
-				t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err)
-			}
-			if got != tc.want {
-				t.Errorf("expandOpenclawPath(%q) = %q, want %q", tc.in, got, tc.want)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err) })
+			testassert.OnFailure(t, got != tc.want, func() { t.Errorf("expandOpenclawPath(%q) = %q, want %q", tc.in, got, tc.want) })
 		})
 	}
 }
@@ -1787,16 +1621,10 @@ func TestExpandOpenclawPathOpenclawHomeUnsetFailsLoudly(t *testing.T) {
 	t.Setenv("OPENCLAW_HOME", "")
 
 	got, err := expandOpenclawPath(`$OPENCLAW_HOME/.openclaw/openclaw.json`)
-	if err == nil {
-		t.Fatalf("expandOpenclawPath returned %q, want an error when OPENCLAW_HOME is empty", got)
-	}
-	if !strings.Contains(err.Error(), "OPENCLAW_HOME") {
-		t.Errorf("error %q does not name the variable that could not be expanded", err.Error())
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatalf("expandOpenclawPath returned %q, want an error when OPENCLAW_HOME is empty", got) })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "OPENCLAW_HOME"), func() { t.Errorf("error %q does not name the variable that could not be expanded", err.Error()) })
 	// The path is what the reader of a daemon log needs in order to act.
-	if !strings.Contains(err.Error(), `"$OPENCLAW_HOME/.openclaw/openclaw.json"`) {
-		t.Errorf("error %q does not name the path being expanded", err.Error())
-	}
+	testassert.OnFailure(t, !strings.Contains(err.Error(), `"$OPENCLAW_HOME/.openclaw/openclaw.json"`), func() { t.Errorf("error %q does not name the path being expanded", err.Error()) })
 }
 
 // TestPrepareOpenclawConfigExpandsOpenclawHome — end-to-end guard, mirroring
@@ -1834,20 +1662,14 @@ func TestPrepareOpenclawConfigExpandsOpenclawHome(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	include, ok := got["$include"].([]any)
-	if !ok {
+	testassert.OnFailure(t, !ok, func() {
 		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
-	}
-	if include[0] != wantPath {
-		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
-	}
-	if result.IncludeRoot != filepath.Dir(wantPath) {
-		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
-	}
+	})
+	testassert.OnFailure(t, include[0] != wantPath, func() { t.Errorf("$include[0] = %v, want %q", include[0], wantPath) })
+	testassert.OnFailure(t, result.IncludeRoot != filepath.Dir(wantPath), func() { t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath)) })
 }
 
 // TestExpandOpenclawPathOpenclawHomeIsItselfATilde — the variable's *value* may
@@ -1905,15 +1727,13 @@ func TestExpandOpenclawPathOpenclawHomeIsItselfATilde(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("OPENCLAW_HOME", tc.env)
 			got, err := expandOpenclawPath(tc.in)
-			if err != nil {
-				t.Fatalf("expandOpenclawPath(%q) with OPENCLAW_HOME=%q: %v", tc.in, tc.env, err)
-			}
-			if strings.Contains(got, "~") {
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("expandOpenclawPath(%q) with OPENCLAW_HOME=%q: %v", tc.in, tc.env, err) })
+			testassert.OnFailure(t, strings.Contains(got, "~"), func() {
 				t.Errorf("expandOpenclawPath(%q) = %q, want the value's `~` expanded (a literal ~ can never stat)", tc.in, got)
-			}
-			if got != tc.want {
+			})
+			testassert.OnFailure(t, got != tc.want, func() {
 				t.Errorf("expandOpenclawPath(%q) with OPENCLAW_HOME=%q = %q, want %q", tc.in, tc.env, got, tc.want)
-			}
+			})
 		})
 	}
 }
@@ -1932,18 +1752,12 @@ func TestExpandOpenclawPathLeavesLookalikePrefixesAlone(t *testing.T) {
 	} {
 		t.Run(in, func(t *testing.T) {
 			got, err := expandOpenclawPath(in)
-			if err != nil {
-				t.Fatalf("expandOpenclawPath(%q): %v", in, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("expandOpenclawPath(%q): %v", in, err) })
 			// Untouched by the new branch: still resolved as an ordinary
 			// relative path, exactly as on `main`.
 			want, aerr := filepath.Abs(in)
-			if aerr != nil {
-				t.Fatalf("filepath.Abs(%q): %v", in, aerr)
-			}
-			if got != want {
-				t.Errorf("expandOpenclawPath(%q) = %q, want it left as a relative path -> %q", in, got, want)
-			}
+			testassert.OnFailure(t, aerr != nil, func() { t.Fatalf("filepath.Abs(%q): %v", in, aerr) })
+			testassert.OnFailure(t, got != want, func() { t.Errorf("expandOpenclawPath(%q) = %q, want it left as a relative path -> %q", in, got, want) })
 		})
 	}
 }
@@ -1979,20 +1793,14 @@ func TestPrepareOpenclawConfigExpandsTildeValuedOpenclawHome(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	include, ok := got["$include"].([]any)
-	if !ok {
+	testassert.OnFailure(t, !ok, func() {
 		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
-	}
-	if include[0] != wantPath {
-		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
-	}
-	if result.IncludeRoot != filepath.Dir(wantPath) {
-		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
-	}
+	})
+	testassert.OnFailure(t, include[0] != wantPath, func() { t.Errorf("$include[0] = %v, want %q", include[0], wantPath) })
+	testassert.OnFailure(t, result.IncludeRoot != filepath.Dir(wantPath), func() { t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath)) })
 }
 
 // TestPrepareOpenclawConfigExpandsWindowsTilde — end-to-end guard for #6630:
@@ -2032,20 +1840,14 @@ func TestPrepareOpenclawConfigExpandsWindowsTilde(t *testing.T) {
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	got := mustReadJSON(t, result.ConfigPath)
 	include, ok := got["$include"].([]any)
-	if !ok {
+	testassert.OnFailure(t, !ok, func() {
 		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
-	}
-	if include[0] != wantPath {
-		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
-	}
-	if result.IncludeRoot != filepath.Dir(wantPath) {
-		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
-	}
+	})
+	testassert.OnFailure(t, include[0] != wantPath, func() { t.Errorf("$include[0] = %v, want %q", include[0], wantPath) })
+	testassert.OnFailure(t, result.IncludeRoot != filepath.Dir(wantPath), func() { t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath)) })
 }
 
 // TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing — discovery used to be
@@ -2066,17 +1868,9 @@ func TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin, Logger: logger})
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareOpenclawConfig: %v", err) })
 	out := logs.String()
-	if !strings.Contains(out, "openclaw active config not found") {
-		t.Errorf("missing active config was not warned about; log was:\n%s", out)
-	}
-	if !strings.Contains(out, "include_target=none") {
-		t.Errorf("prepared-config log should record include_target=none; log was:\n%s", out)
-	}
-	if result.IncludeRoot != "" {
-		t.Errorf("IncludeRoot = %q, want empty", result.IncludeRoot)
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "openclaw active config not found"), func() { t.Errorf("missing active config was not warned about; log was:\n%s", out) })
+	testassert.OnFailure(t, !strings.Contains(out, "include_target=none"), func() { t.Errorf("prepared-config log should record include_target=none; log was:\n%s", out) })
+	testassert.OnFailure(t, result.IncludeRoot != "", func() { t.Errorf("IncludeRoot = %q, want empty", result.IncludeRoot) })
 }

--- a/server/internal/daemon/execenv/openclaw_config_timeout_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_timeout_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // slowestMeasuredOpenclawCall is the worst `openclaw config file` timing
@@ -25,16 +27,16 @@ const slowestMeasuredOpenclawCall = 10860 * time.Millisecond
 // there. Anything that lowers this default back under the measured range
 // re-breaks that host.
 func TestOpenclawCLIDefaultTimeoutCoversMeasuredSlowHosts(t *testing.T) {
-	if openclawCLITimeout <= slowestMeasuredOpenclawCall {
+	testassert.OnFailure(t, openclawCLITimeout <= slowestMeasuredOpenclawCall, func() {
 		t.Errorf("default openclaw CLI timeout %v must exceed the slowest measured call %v (#7112)",
 			openclawCLITimeout, slowestMeasuredOpenclawCall)
-	}
+	})
 	// Headroom, not a bare pass: a host at the measured worst case should not
 	// sit one scheduling hiccup away from failing again.
-	if openclawCLITimeout < 2*slowestMeasuredOpenclawCall {
+	testassert.OnFailure(t, openclawCLITimeout < 2*slowestMeasuredOpenclawCall, func() {
 		t.Errorf("default openclaw CLI timeout %v leaves less than 2x headroom over %v",
 			openclawCLITimeout, slowestMeasuredOpenclawCall)
-	}
+	})
 }
 
 func TestResolveOpenclawCLITimeout(t *testing.T) {
@@ -96,18 +98,10 @@ func TestExecOpenclawCLITimeoutIsTypedSentinel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	_, err = execOpenclawCLI(ctx, shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the timed-out invocation to fail")
-	}
-	if !errors.Is(err, ErrOpenclawCLITimeout) {
-		t.Errorf("errors.Is(err, ErrOpenclawCLITimeout) must hold\ngot: %s", err)
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("errors.Is(err, context.DeadlineExceeded) must keep holding\ngot: %s", err)
-	}
-	if !errors.Is(err, ErrOpenclawCLITimeout) || errors.Is(errors.New("openclaw config file: boom"), ErrOpenclawCLITimeout) {
-		t.Errorf("the sentinel must not match unrelated CLI failures")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the timed-out invocation to fail") })
+	testassert.OnFailure(t, !errors.Is(err, ErrOpenclawCLITimeout), func() { t.Errorf("errors.Is(err, ErrOpenclawCLITimeout) must hold\ngot: %s", err) })
+	testassert.OnFailure(t, !errors.Is(err, context.DeadlineExceeded), func() { t.Errorf("errors.Is(err, context.DeadlineExceeded) must keep holding\ngot: %s", err) })
+	testassert.OnFailure(t, !errors.Is(err, ErrOpenclawCLITimeout) || errors.Is(errors.New("openclaw config file: boom"), ErrOpenclawCLITimeout), func() { t.Errorf("the sentinel must not match unrelated CLI failures") })
 }
 
 // TestPrepareOpenclawConfigPropagatesTimeoutSentinel proves the sentinel
@@ -123,12 +117,8 @@ func TestPrepareOpenclawConfigPropagatesTimeoutSentinel(t *testing.T) {
 
 	envRoot := t.TempDir()
 	_, err := prepareOpenclawConfig(envRoot, envRoot, OpenclawConfigPrep{OpenclawBin: stub.bin})
-	if err == nil {
-		t.Fatal("expected preparation to fail on a CLI timeout")
-	}
-	if !errors.Is(err, ErrOpenclawCLITimeout) {
-		t.Errorf("wrapped preparation error must keep the sentinel\ngot: %s", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected preparation to fail on a CLI timeout") })
+	testassert.OnFailure(t, !errors.Is(err, ErrOpenclawCLITimeout), func() { t.Errorf("wrapped preparation error must keep the sentinel\ngot: %s", err) })
 }
 
 // TestExecOpenclawCLICancellationIsNotATimeout keeps the sentinel honest. A
@@ -152,15 +142,9 @@ func TestExecOpenclawCLICancellationIsNotATimeout(t *testing.T) {
 	}()
 	defer cancel()
 	_, err = execOpenclawCLI(ctx, shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the cancelled invocation to fail")
-	}
-	if errors.Is(err, ErrOpenclawCLITimeout) {
-		t.Errorf("cancellation must not be reported as a CLI timeout\ngot: %s", err)
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("cancellation must keep the wrapped context cause\ngot: %s", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the cancelled invocation to fail") })
+	testassert.OnFailure(t, errors.Is(err, ErrOpenclawCLITimeout), func() { t.Errorf("cancellation must not be reported as a CLI timeout\ngot: %s", err) })
+	testassert.OnFailure(t, !errors.Is(err, context.Canceled), func() { t.Errorf("cancellation must keep the wrapped context cause\ngot: %s", err) })
 }
 
 // TestOpenclawCLIMaxTimeoutFitsPreparationBudget is the arithmetic the
@@ -179,13 +163,13 @@ func TestOpenclawCLIMaxTimeoutFitsPreparationBudget(t *testing.T) {
 	const nonOpenclawPrepareSlack = time.Minute
 
 	worst := openclawMaxCLICallsPerPreparation * openclawCLIMaxTimeout
-	if worst+nonOpenclawPrepareSlack > taskPrepareBudget {
+	testassert.OnFailure(t, worst+nonOpenclawPrepareSlack > taskPrepareBudget, func() {
 		t.Errorf("worst-case openclaw discovery %v (%d calls x %v) leaves less than %v under the %v preparation budget",
 			worst, openclawMaxCLICallsPerPreparation, openclawCLIMaxTimeout, nonOpenclawPrepareSlack, taskPrepareBudget)
-	}
-	if openclawCLITimeout > openclawCLIMaxTimeout {
+	})
+	testassert.OnFailure(t, openclawCLITimeout > openclawCLIMaxTimeout, func() {
 		t.Errorf("default %v exceeds the override ceiling %v", openclawCLITimeout, openclawCLIMaxTimeout)
-	}
+	})
 }
 
 // TestPrepareOpenclawConfigWorstCaseCLICallCount pins the multiplier the

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestIsOpenclawShimPath locks the shim-detection surface. Case-insensitivity
@@ -67,9 +69,7 @@ func exitError(t *testing.T) error {
 	}
 	err := cmd.Run()
 	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
-	}
+	testassert.OnFailure(t, !errors.As(err, &exitErr), func() { t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err) })
 	return err
 }
 
@@ -112,18 +112,14 @@ func TestOpenclawShimDiagnosticNamesUnreachableInterpreter(t *testing.T) {
 	pathWithout(t)
 	shim := filepath.Join(t.TempDir(), "openclaw.cmd")
 	got := openclawShimDiagnostic(shim, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none")
-	}
+	testassert.OnFailure(t, got == "", func() { t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none") })
 	for _, want := range []string{
 		"resolves neither alongside the shim nor on the daemon PATH",
 		openclawShimInterpreter,
 		"openclaw.cmd",
 		"install Node.js",
 	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("diagnostic missing %q\ngot: %s", want, got)
-		}
+		testassert.OnFailure(t, !strings.Contains(got, want), func() { t.Errorf("diagnostic missing %q\ngot: %s", want, got) })
 	}
 }
 
@@ -146,15 +142,9 @@ func TestOpenclawShimDiagnosticFindsColocatedInterpreter(t *testing.T) {
 	writeFakeInterpreter(t, dir, name)
 
 	got := openclawShimDiagnostic(shim, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic, got none")
-	}
-	if !strings.Contains(got, "alongside the shim") {
-		t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", got)
-	}
-	if strings.Contains(got, "resolves neither") {
-		t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got)
-	}
+	testassert.OnFailure(t, got == "", func() { t.Fatal("expected a diagnostic, got none") })
+	testassert.OnFailure(t, !strings.Contains(got, "alongside the shim"), func() { t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "resolves neither"), func() { t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got) })
 }
 
 // TestOpenclawShimDiagnosticReportsInterpreterOnPath guards the other
@@ -166,15 +156,9 @@ func TestOpenclawShimDiagnosticReportsInterpreterOnPath(t *testing.T) {
 	pathWithFakeNode(t)
 	shim := filepath.Join(t.TempDir(), "openclaw.cmd")
 	got := openclawShimDiagnostic(shim, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic, got none")
-	}
-	if !strings.Contains(got, "on the daemon PATH") || !strings.Contains(got, "the interpreter is reachable") {
-		t.Errorf("diagnostic should clear PATH of blame\ngot: %s", got)
-	}
-	if strings.Contains(got, "resolves neither") {
-		t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got)
-	}
+	testassert.OnFailure(t, got == "", func() { t.Fatal("expected a diagnostic, got none") })
+	testassert.OnFailure(t, !strings.Contains(got, "on the daemon PATH") || !strings.Contains(got, "the interpreter is reachable"), func() { t.Errorf("diagnostic should clear PATH of blame\ngot: %s", got) })
+	testassert.OnFailure(t, strings.Contains(got, "resolves neither"), func() { t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got) })
 }
 
 // TestOpenclawShimDiagnosticIsPhrasedConditionally is the rest of must-fix 2. A
@@ -185,12 +169,8 @@ func TestOpenclawShimDiagnosticIsPhrasedConditionally(t *testing.T) {
 	pathWithout(t)
 	shim := filepath.Join(t.TempDir(), "custom-wrapper.cmd")
 	got := openclawShimDiagnostic(shim, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic, got none")
-	}
-	if !strings.Contains(got, "if custom-wrapper.cmd is an npm-generated shim") {
-		t.Errorf("diagnostic should be conditional about npm authorship\ngot: %s", got)
-	}
+	testassert.OnFailure(t, got == "", func() { t.Fatal("expected a diagnostic, got none") })
+	testassert.OnFailure(t, !strings.Contains(got, "if custom-wrapper.cmd is an npm-generated shim"), func() { t.Errorf("diagnostic should be conditional about npm authorship\ngot: %s", got) })
 }
 
 // TestOpenclawShimDiagnosticRedactsLocalPaths is Sol-Boy's must-fix 3, and the
@@ -216,20 +196,12 @@ func TestOpenclawShimDiagnosticRedactsLocalPaths(t *testing.T) {
 	t.Setenv("PATH", pathDir)
 
 	got := openclawShimDiagnostic(shim, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic, got none")
-	}
+	testassert.OnFailure(t, got == "", func() { t.Fatal("expected a diagnostic, got none") })
 	for _, leak := range []string{secretDir, shim, pathDir, interpreter, "a-real-person", "another-private-location"} {
-		if strings.Contains(got, leak) {
-			t.Errorf("diagnostic leaked local path detail %q\ngot: %s", leak, got)
-		}
+		testassert.OnFailure(t, strings.Contains(got, leak), func() { t.Errorf("diagnostic leaked local path detail %q\ngot: %s", leak, got) })
 	}
-	if !strings.Contains(got, "openclaw.cmd") {
-		t.Errorf("diagnostic should still name the shim's base name\ngot: %s", got)
-	}
-	if !strings.Contains(got, "1 entry") {
-		t.Errorf("diagnostic should summarise PATH as a count\ngot: %s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "openclaw.cmd"), func() { t.Errorf("diagnostic should still name the shim's base name\ngot: %s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "1 entry"), func() { t.Errorf("diagnostic should summarise PATH as a count\ngot: %s", got) })
 }
 
 // TestOpenclawShimDiagnosticStaysSilentOutOfScope pins the no-op cases. A
@@ -298,16 +270,10 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 	pathWithout(t)
 
 	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the shim failure to surface as an error")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the shim failure to surface as an error") })
 	msg := err.Error()
-	if !strings.Contains(msg, "openclaw config file") {
-		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
-	}
-	if !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH") {
-		t.Errorf("error should carry the shim diagnostic\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "openclaw config file"), func() { t.Errorf("error should name the failing subcommand\ngot: %s", msg) })
+	testassert.OnFailure(t, !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH"), func() { t.Errorf("error should carry the shim diagnostic\ngot: %s", msg) })
 }
 
 // TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter is Sol-Boy's
@@ -347,21 +313,17 @@ func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	_, err = execOpenclawCLI(ctx, shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the timed-out invocation to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the timed-out invocation to fail") })
 	msg := err.Error()
 	t.Logf("timeout error: %s", msg)
 
 	// The nit from round 2: the context error must be the wrapped cause, so
 	// standard cancellation checks work instead of only string matching.
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !errors.Is(err, context.DeadlineExceeded), func() { t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg) })
 	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
-		if strings.Contains(msg, forbidden) {
+		testassert.OnFailure(t, strings.Contains(msg, forbidden), func() {
 			t.Errorf("timeout must not be diagnosed as an interpreter problem (found %q)\ngot: %s", forbidden, msg)
-		}
+		})
 	}
 }
 
@@ -386,12 +348,8 @@ func TestExecOpenclawCLICancellationIsWrapped(t *testing.T) {
 	defer cancel()
 
 	_, err = execOpenclawCLI(ctx, shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the cancelled invocation to fail")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("errors.Is(err, context.Canceled) must hold\ngot: %s", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the cancelled invocation to fail") })
+	testassert.OnFailure(t, !errors.Is(err, context.Canceled), func() { t.Errorf("errors.Is(err, context.Canceled) must hold\ngot: %s", err) })
 }
 
 // TestExecOpenclawCLIPrefersRealStderr guarantees the diagnostic never masks a
@@ -407,16 +365,10 @@ func TestExecOpenclawCLIPrefersRealStderr(t *testing.T) {
 	pathWithout(t)
 
 	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the shim failure to surface as an error")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the shim failure to surface as an error") })
 	msg := err.Error()
-	if !strings.Contains(msg, "openclaw doctor says hello") {
-		t.Errorf("real stderr must be preserved\ngot: %s", msg)
-	}
-	if strings.Contains(msg, "no stderr output") {
-		t.Errorf("diagnostic must not fire when stderr is present\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "openclaw doctor says hello"), func() { t.Errorf("real stderr must be preserved\ngot: %s", msg) })
+	testassert.OnFailure(t, strings.Contains(msg, "no stderr output"), func() { t.Errorf("diagnostic must not fire when stderr is present\ngot: %s", msg) })
 }
 
 // TestExecOpenclawCLIPreservesFailedStdoutWithoutLeakingIt covers the process
@@ -432,15 +384,9 @@ func TestExecOpenclawCLIPreservesFailedStdoutWithoutLeakingIt(t *testing.T) {
 	)
 
 	out, err := execOpenclawCLI(context.Background(), shim, "config", "get", "agents.list", "--json")
-	if err == nil {
-		t.Fatalf("expected the shim failure to surface as an error, got output %q", out)
-	}
-	if !strings.Contains(out, marker) {
-		t.Fatalf("failed stdout was discarded; got %q", out)
-	}
-	if strings.Contains(err.Error(), marker) {
-		t.Fatalf("failed stdout leaked into the error text: %s", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatalf("expected the shim failure to surface as an error, got output %q", out) })
+	testassert.OnFailure(t, !strings.Contains(out, marker), func() { t.Fatalf("failed stdout was discarded; got %q", out) })
+	testassert.OnFailure(t, strings.Contains(err.Error(), marker), func() { t.Fatalf("failed stdout leaked into the error text: %s", err) })
 }
 
 // TestExecOpenclawCLIMissingTempDoesNotChangeOutcome pins the root cause #6061
@@ -458,12 +404,8 @@ func TestExecOpenclawCLIMissingTempDoesNotChangeOutcome(t *testing.T) {
 	t.Setenv("TMP", "")
 
 	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err != nil {
-		t.Fatalf("invocation must not depend on TEMP/TMP: %v", err)
-	}
-	if strings.TrimSpace(out) == "" {
-		t.Fatal("expected the shim's stdout to be returned")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("invocation must not depend on TEMP/TMP: %v", err) })
+	testassert.OnFailure(t, strings.TrimSpace(out) == "", func() { t.Fatal("expected the shim's stdout to be returned") })
 }
 
 // TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode covers the install
@@ -479,12 +421,8 @@ func TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode(t *testing.T) {
 			}
 			shim := writeShim(t, dir, "#!/bin/sh\necho 'ok-marker'\n", "@echo off\r\necho ok-marker\r\n")
 			out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-			if err != nil {
-				t.Fatalf("shim in %q should be invocable: %v", dir, err)
-			}
-			if !strings.Contains(out, "ok-marker") {
-				t.Fatalf("expected shim stdout to survive intact, got %q", out)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("shim in %q should be invocable: %v", dir, err) })
+			testassert.OnFailure(t, !strings.Contains(out, "ok-marker"), func() { t.Fatalf("expected shim stdout to survive intact, got %q", out) })
 		})
 	}
 }

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // This file is the Windows half of the MUL-5422 / #6061 regression. The
@@ -74,9 +76,7 @@ func nodeDir(t *testing.T) string {
 		t.Skipf("no node on PATH, cannot exercise a real npm shim: %v", err)
 	}
 	abs, err := filepath.Abs(resolved)
-	if err != nil {
-		t.Fatalf("resolve node path: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve node path: %v", err) })
 	return filepath.Dir(abs)
 }
 
@@ -108,19 +108,15 @@ func TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr(t *testing.T) {
 	t.Setenv("PATH", systemPath(t))
 
 	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err == nil {
-		t.Fatalf("shim must fail without node on PATH, got output %q", out)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatalf("shim must fail without node on PATH, got output %q", out) })
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
 
-	if !strings.Contains(strings.ToLower(msg), "not recognized") {
+	testassert.OnFailure(t, !strings.Contains(strings.ToLower(msg), "not recognized"), func() {
 		t.Errorf("expected cmd.exe's own stderr to reach Go's pipe; if this now fails, "+
 			"the platform behaviour changed and the shim diagnostic is carrying this case instead\ngot: %s", msg)
-	}
-	if !strings.Contains(msg, "openclaw config file") {
-		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(msg, "openclaw config file"), func() { t.Errorf("error should name the failing subcommand\ngot: %s", msg) })
 }
 
 // TestWindowsOpenclawShimSilentFailureIsDiagnosed is Sol-Boy's must-fix 4: prove
@@ -138,21 +134,13 @@ func TestWindowsOpenclawShimSilentFailureIsDiagnosed(t *testing.T) {
 	t.Setenv("PATH", systemPath(t)) // no Node anywhere, and none co-located
 
 	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the silent shim to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the silent shim to fail") })
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
-	if !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH") {
-		t.Fatalf("the shim diagnostic must carry a silent failure\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH"), func() { t.Fatalf("the shim diagnostic must carry a silent failure\ngot: %s", msg) })
 	// Redaction holds on the platform where the path is actually sensitive.
-	if strings.Contains(msg, dir) {
-		t.Errorf("diagnostic leaked the absolute shim path\ngot: %s", msg)
-	}
-	if !strings.Contains(msg, "openclaw.cmd") {
-		t.Errorf("diagnostic should name the shim's base name\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, strings.Contains(msg, dir), func() { t.Errorf("diagnostic leaked the absolute shim path\ngot: %s", msg) })
+	testassert.OnFailure(t, !strings.Contains(msg, "openclaw.cmd"), func() { t.Errorf("diagnostic should name the shim's base name\ngot: %s", msg) })
 }
 
 // TestWindowsOpenclawShimColocatedNodeIsCredited covers must-fix 2 on the real
@@ -174,16 +162,10 @@ func TestWindowsOpenclawShimColocatedNodeIsCredited(t *testing.T) {
 	t.Setenv("PATH", systemPath(t)) // nothing Node-ish on PATH
 
 	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the silent shim to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the silent shim to fail") })
 	msg := err.Error()
-	if !strings.Contains(msg, "alongside the shim") {
-		t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", msg)
-	}
-	if strings.Contains(msg, "resolves neither") {
-		t.Errorf("diagnostic must not claim Node is unreachable\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !strings.Contains(msg, "alongside the shim"), func() { t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", msg) })
+	testassert.OnFailure(t, strings.Contains(msg, "resolves neither"), func() { t.Errorf("diagnostic must not claim Node is unreachable\ngot: %s", msg) })
 }
 
 // TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed is must-fix 1 on Windows: a
@@ -209,18 +191,14 @@ func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := execOpenclawCLI(ctx, shim, "config", "file")
-	if err == nil {
-		t.Fatal("expected the timed-out invocation to fail")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("expected the timed-out invocation to fail") })
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg)
-	}
+	testassert.OnFailure(t, !errors.Is(err, context.DeadlineExceeded), func() { t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg) })
 	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
-		if strings.Contains(msg, forbidden) {
+		testassert.OnFailure(t, strings.Contains(msg, forbidden), func() {
 			t.Errorf("timeout must not be diagnosed as an interpreter problem (found %q)\ngot: %s", forbidden, msg)
-		}
+		})
 	}
 }
 
@@ -234,12 +212,8 @@ func TestWindowsOpenclawShimSucceedsWithNodeOnPath(t *testing.T) {
 	t.Setenv("PATH", strings.Join([]string{dir, systemPath(t)}, string(os.PathListSeparator)))
 
 	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err != nil {
-		t.Fatalf("shim should succeed with node on PATH: %v", err)
-	}
-	if !strings.Contains(out, `C:\openclaw\config.json`) {
-		t.Fatalf("expected the entrypoint's stdout, got %q", out)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("shim should succeed with node on PATH: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(out, `C:\openclaw\config.json`), func() { t.Fatalf("expected the entrypoint's stdout, got %q", out) })
 }
 
 // TestWindowsOpenclawShimSucceedsWithoutTempVars closes out the root cause
@@ -255,12 +229,8 @@ func TestWindowsOpenclawShimSucceedsWithoutTempVars(t *testing.T) {
 	t.Setenv("TMP", "")
 
 	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-	if err != nil {
-		t.Fatalf("shim must not depend on TEMP/TMP: %v", err)
-	}
-	if !strings.Contains(out, `C:\openclaw\config.json`) {
-		t.Fatalf("expected the entrypoint's stdout, got %q", out)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("shim must not depend on TEMP/TMP: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(out, `C:\openclaw\config.json`), func() { t.Fatalf("expected the entrypoint's stdout, got %q", out) })
 }
 
 // TestWindowsOpenclawShimInPathWithSpacesAndUnicode covers the install
@@ -279,12 +249,8 @@ func TestWindowsOpenclawShimInPathWithSpacesAndUnicode(t *testing.T) {
 			t.Setenv("PATH", strings.Join([]string{nodeRoot, systemPath(t)}, string(os.PathListSeparator)))
 
 			out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
-			if err != nil {
-				t.Fatalf("shim in %q should be invocable: %v", dir, err)
-			}
-			if !strings.Contains(out, `C:\openclaw\config.json`) {
-				t.Fatalf("expected the entrypoint's stdout, got %q", out)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("shim in %q should be invocable: %v", dir, err) })
+			testassert.OnFailure(t, !strings.Contains(out, `C:\openclaw\config.json`), func() { t.Fatalf("expected the entrypoint's stdout, got %q", out) })
 		})
 	}
 }

--- a/server/internal/daemon/execenv/prepare_rollback_test.go
+++ b/server/internal/daemon/execenv/prepare_rollback_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace is the regression test for
@@ -51,9 +53,7 @@ func TestPrepareRollsBackSidecarsWhenPrepareFailsInPlace(t *testing.T) {
 			AgentID: "99999999-8888-7777-6666-555555555555",
 		},
 	}, testLogger())
-	if err == nil {
-		t.Fatal("Prepare succeeded; expected the pre-existing .cursor/mcp.json to fail it")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Prepare succeeded; expected the pre-existing .cursor/mcp.json to fail it") })
 
 	markerPath := filepath.Join(userDir, TaskContextMarkerRelPath)
 	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
@@ -105,9 +105,7 @@ func TestPrepareRollsBackWhenWriteContextFilesFailsAfterMarker(t *testing.T) {
 			AgentID: "77777777-6666-5555-4444-333333333333",
 		},
 	}, testLogger())
-	if err == nil {
-		t.Fatal("Prepare succeeded; expected the .agent_context blocker to fail it")
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("Prepare succeeded; expected the .agent_context blocker to fail it") })
 
 	markerPath := filepath.Join(userDir, TaskContextMarkerRelPath)
 	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
@@ -138,9 +136,7 @@ func TestPrepareSucceedsInPlaceAndLeavesMarker(t *testing.T) {
 			AgentID: "88888888-7777-6666-5555-444444444444",
 		},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 
 	if _, statErr := os.Stat(filepath.Join(userDir, TaskContextMarkerRelPath)); statErr != nil {
 		t.Fatalf("successful Prepare did not leave the daemon task marker: %v", statErr)

--- a/server/internal/daemon/execenv/qwenpaw_workspace_test.go
+++ b/server/internal/daemon/execenv/qwenpaw_workspace_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestPrepareQwenpawWorkspace verifies that the workspace is created with the
@@ -48,51 +50,33 @@ func TestPrepareQwenpawWorkspace(t *testing.T) {
 			t.Fatalf("skill dir %q is not a directory", slug)
 		}
 		body, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
-		if err != nil {
-			t.Fatalf("read SKILL.md for %q: %v", slug, err)
-		}
-		if !strings.Contains(string(body), slug) {
-			t.Errorf("SKILL.md for %q should contain its slug in frontmatter", slug)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read SKILL.md for %q: %v", slug, err) })
+		testassert.OnFailure(t, !strings.Contains(string(body), slug), func() { t.Errorf("SKILL.md for %q should contain its slug in frontmatter", slug) })
 	}
 
 	// Check that skill.json manifest exists with enabled: true
 	manifestPath := filepath.Join(workspaceDir, "skill.json")
 	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read skill.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skill.json: %v", err) })
 
 	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		t.Fatalf("unmarshal skill.json: %v", err)
 	}
 
-	if manifest["schema_version"] != "workspace-skill-manifest.v1" {
-		t.Errorf("schema_version = %q, want workspace-skill-manifest.v1", manifest["schema_version"])
-	}
+	testassert.OnFailure(t, manifest["schema_version"] != "workspace-skill-manifest.v1", func() { t.Errorf("schema_version = %q, want workspace-skill-manifest.v1", manifest["schema_version"]) })
 
 	skillsMap, ok := manifest["skills"].(map[string]any)
-	if !ok {
-		t.Fatal("skills is not a map")
-	}
-	if len(skillsMap) != 2 {
-		t.Fatalf("expected 2 skills in manifest, got %d", len(skillsMap))
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatal("skills is not a map") })
+	testassert.OnFailure(t, len(skillsMap) != 2, func() { t.Fatalf("expected 2 skills in manifest, got %d", len(skillsMap)) })
 
 	for _, slug := range []string{"review-helper", "bug-finder"} {
 		entry, ok := skillsMap[slug].(map[string]any)
-		if !ok {
-			t.Fatalf("skill entry %q is not a map", slug)
-		}
+		testassert.OnFailure(t, !ok, func() { t.Fatalf("skill entry %q is not a map", slug) })
 		enabled, ok := entry["enabled"].(bool)
-		if !ok || !enabled {
-			t.Errorf("skill %q enabled = %v, want true", slug, enabled)
-		}
+		testassert.OnFailure(t, !ok || !enabled, func() { t.Errorf("skill %q enabled = %v, want true", slug, enabled) })
 		channels, ok := entry["channels"].([]any)
-		if !ok || len(channels) != 1 || channels[0] != "all" {
-			t.Errorf("skill %q channels = %v, want [\"all\"]", slug, channels)
-		}
+		testassert.OnFailure(t, !ok || len(channels) != 1 || channels[0] != "all", func() { t.Errorf("skill %q channels = %v, want [\"all\"]", slug, channels) })
 	}
 }
 
@@ -115,45 +99,27 @@ func TestPrepareQwenpawWorkspacePreservesCollidingSkillSlugs(t *testing.T) {
 	}
 	for slug, wantBody := range expectedSkills {
 		data, err := os.ReadFile(filepath.Join(workspaceDir, "skills", slug, "SKILL.md"))
-		if err != nil {
-			t.Fatalf("read SKILL.md for %q: %v", slug, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read SKILL.md for %q: %v", slug, err) })
 		body := string(data)
-		if !frontmatterNameIs(body, slug) {
-			t.Errorf("SKILL.md for %q does not use its directory slug in frontmatter", slug)
-		}
-		if !strings.Contains(body, wantBody) {
-			t.Errorf("SKILL.md for %q does not contain %q", slug, wantBody)
-		}
+		testassert.OnFailure(t, !frontmatterNameIs(body, slug), func() { t.Errorf("SKILL.md for %q does not use its directory slug in frontmatter", slug) })
+		testassert.OnFailure(t, !strings.Contains(body, wantBody), func() { t.Errorf("SKILL.md for %q does not contain %q", slug, wantBody) })
 	}
 
 	data, err := os.ReadFile(filepath.Join(workspaceDir, "skill.json"))
-	if err != nil {
-		t.Fatalf("read skill.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skill.json: %v", err) })
 	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		t.Fatalf("unmarshal skill.json: %v", err)
 	}
 	skillsMap, ok := manifest["skills"].(map[string]any)
-	if !ok {
-		t.Fatal("skills is not a map")
-	}
-	if len(skillsMap) != len(expectedSkills) {
-		t.Fatalf("manifest has %d skills, want %d", len(skillsMap), len(expectedSkills))
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatal("skills is not a map") })
+	testassert.OnFailure(t, len(skillsMap) != len(expectedSkills), func() { t.Fatalf("manifest has %d skills, want %d", len(skillsMap), len(expectedSkills)) })
 	for slug := range expectedSkills {
 		entry, ok := skillsMap[slug].(map[string]any)
-		if !ok {
-			t.Fatalf("skill entry %q is not a map", slug)
-		}
+		testassert.OnFailure(t, !ok, func() { t.Fatalf("skill entry %q is not a map", slug) })
 		metadata, ok := entry["metadata"].(map[string]any)
-		if !ok {
-			t.Fatalf("metadata for %q is not a map", slug)
-		}
-		if metadata["name"] != slug {
-			t.Errorf("metadata name for %q = %v, want %q", slug, metadata["name"], slug)
-		}
+		testassert.OnFailure(t, !ok, func() { t.Fatalf("metadata for %q is not a map", slug) })
+		testassert.OnFailure(t, metadata["name"] != slug, func() { t.Errorf("metadata name for %q = %v, want %q", slug, metadata["name"], slug) })
 	}
 }
 
@@ -224,12 +190,8 @@ func TestPrepareQwenpawWorkspaceWithFiles(t *testing.T) {
 
 	// Verify content
 	body, err := os.ReadFile(filepath.Join(skillDir, "scripts", "analyze.py"))
-	if err != nil {
-		t.Fatalf("read scripts/analyze.py: %v", err)
-	}
-	if string(body) != "print('analyzing')" {
-		t.Errorf("scripts/analyze.py content = %q, want %q", string(body), "print('analyzing')")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read scripts/analyze.py: %v", err) })
+	testassert.OnFailure(t, string(body) != "print('analyzing')", func() { t.Errorf("scripts/analyze.py content = %q, want %q", string(body), "print('analyzing')") })
 }
 
 // TestPrepareQwenpawWorkspacePermissions verifies workspace directory
@@ -341,20 +303,14 @@ func TestPrepareQwenpawWorkspaceReplace(t *testing.T) {
 	// Verify manifest has exactly 2 skills
 	manifestPath := filepath.Join(workspaceDir, "skill.json")
 	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read skill.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skill.json: %v", err) })
 	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		t.Fatalf("unmarshal skill.json: %v", err)
 	}
 	skillsMap, ok := manifest["skills"].(map[string]any)
-	if !ok {
-		t.Fatal("skills is not a map")
-	}
-	if len(skillsMap) != 2 {
-		t.Errorf("expected 2 skills in manifest after replace, got %d", len(skillsMap))
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatal("skills is not a map") })
+	testassert.OnFailure(t, len(skillsMap) != 2, func() { t.Errorf("expected 2 skills in manifest after replace, got %d", len(skillsMap)) })
 }
 
 // TestPrepareQwenpawWorkspaceRepeatedReuse verifies that preparing the same
@@ -395,28 +351,18 @@ func TestPrepareQwenpawWorkspaceRepeatedReuse(t *testing.T) {
 
 	// Verify only the two expected dirs exist in skills
 	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		t.Fatalf("read skills dir: %v", err)
-	}
-	if len(entries) != 2 {
-		t.Errorf("expected 2 entries in skills, got %d", len(entries))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skills dir: %v", err) })
+	testassert.OnFailure(t, len(entries) != 2, func() { t.Errorf("expected 2 entries in skills, got %d", len(entries)) })
 
 	// Verify manifest has exactly 2 skills
 	manifestPath := filepath.Join(workspaceDir, "skill.json")
 	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read skill.json: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skill.json: %v", err) })
 	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		t.Fatalf("unmarshal skill.json: %v", err)
 	}
 	skillsMap, ok := manifest["skills"].(map[string]any)
-	if !ok {
-		t.Fatal("skills is not a map")
-	}
-	if len(skillsMap) != 2 {
-		t.Errorf("expected 2 skills in manifest after repeated reuse, got %d", len(skillsMap))
-	}
+	testassert.OnFailure(t, !ok, func() { t.Fatal("skills is not a map") })
+	testassert.OnFailure(t, len(skillsMap) != 2, func() { t.Errorf("expected 2 skills in manifest after repeated reuse, got %d", len(skillsMap)) })
 }

--- a/server/internal/daemon/execenv/reasonix_permissions_test.go
+++ b/server/internal/daemon/execenv/reasonix_permissions_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -36,9 +37,7 @@ func assertTaskDenyList(t *testing.T, path string, want []string) {
 func taskDenyList(t *testing.T, path string) []string {
 	t.Helper()
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", reasonixProjectConfigFile, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", reasonixProjectConfigFile, err) })
 	var cfg struct {
 		Permissions struct {
 			Deny  []string `toml:"deny"`
@@ -62,9 +61,7 @@ func TestPrepareDeniesReasonixAskTool(t *testing.T) {
 		ReasonixEnv:    reasonixEnvWith(t, ""),
 		Task:           TaskContextForEnv{IssueID: "b1b2c3d4-e5f6-7890-abcd-ef1234567890"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	configPath := filepath.Join(env.WorkDir, reasonixProjectConfigFile)
@@ -94,9 +91,7 @@ func TestReuseRewritesReasonixAskDeny(t *testing.T) {
 		Task:           TaskContextForEnv{IssueID: "c1b2c3d4-e5f6-7890-abcd-ef1234567890"},
 	}
 	env, err := Prepare(params, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	// Reuse rolls back the prior run's sidecars before rebuilding them, so the
@@ -109,13 +104,9 @@ func TestReuseRewritesReasonixAskDeny(t *testing.T) {
 		ReasonixEnv:    params.ReasonixEnv,
 		Task:           params.Task,
 	}, testLogger())
-	if reused == nil {
-		t.Fatal("Reuse returned nil")
-	}
+	testassert.OnFailure(t, reused == nil, func() { t.Fatal("Reuse returned nil") })
 	got := taskDenyList(t, filepath.Join(reused.WorkDir, reasonixProjectConfigFile))
-	if !slices.Equal(got, []string{"bash", "ask"}) {
-		t.Fatalf("deny after reuse = %v, want [bash ask]", got)
-	}
+	testassert.OnFailure(t, !slices.Equal(got, []string{"bash", "ask"}), func() { t.Fatalf("deny after reuse = %v, want [bash ask]", got) })
 }
 
 // TestReasonixProjectConfigMergesOwnerPermissions is the regression test for the
@@ -136,9 +127,7 @@ default = "some-model"
 		t.Fatalf("writeReasonixProjectConfig: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(workDir, reasonixProjectConfigFile))
-	if err != nil {
-		t.Fatalf("read %s: %v", reasonixProjectConfigFile, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", reasonixProjectConfigFile, err) })
 	var cfg struct {
 		Permissions struct {
 			Deny  []string `toml:"deny"`
@@ -148,19 +137,13 @@ default = "some-model"
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("parse written %s: %v\n%s", reasonixProjectConfigFile, err, data)
 	}
-	if !slices.Equal(cfg.Permissions.Deny, []string{"bash", "config_write", "ask"}) {
-		t.Fatalf("deny = %v, want the owner's rules plus ask", cfg.Permissions.Deny)
-	}
+	testassert.OnFailure(t, !slices.Equal(cfg.Permissions.Deny, []string{"bash", "config_write", "ask"}), func() { t.Fatalf("deny = %v, want the owner's rules plus ask", cfg.Permissions.Deny) })
 	// The rest of the owner's table is restated too: the project file overrides
 	// what it declares, so dropping allow here would widen the task as well.
-	if !slices.Equal(cfg.Permissions.Allow, []string{"read"}) {
-		t.Fatalf("allow = %v, want the owner's [read]", cfg.Permissions.Allow)
-	}
+	testassert.OnFailure(t, !slices.Equal(cfg.Permissions.Allow, []string{"read"}), func() { t.Fatalf("allow = %v, want the owner's [read]", cfg.Permissions.Allow) })
 	// Only permissions are restated; unrelated owner settings stay in their own
 	// config, where the task still inherits them.
-	if strings.Contains(string(data), "some-model") {
-		t.Fatalf("project config copied unrelated owner settings:\n%s", data)
-	}
+	testassert.OnFailure(t, strings.Contains(string(data), "some-model"), func() { t.Fatalf("project config copied unrelated owner settings:\n%s", data) })
 }
 
 // TestReasonixProjectConfigKeepsOwnerAskDeny checks the already-denied case: the
@@ -174,9 +157,7 @@ func TestReasonixProjectConfigKeepsOwnerAskDeny(t *testing.T) {
 		t.Fatalf("writeReasonixProjectConfig: %v", err)
 	}
 	got := taskDenyList(t, filepath.Join(workDir, reasonixProjectConfigFile))
-	if !slices.Equal(got, []string{"ask", "bash"}) {
-		t.Fatalf("deny = %v, want the owner's list unchanged", got)
-	}
+	testassert.OnFailure(t, !slices.Equal(got, []string{"ask", "bash"}), func() { t.Fatalf("deny = %v, want the owner's list unchanged", got) })
 }
 
 // TestReasonixProjectConfigSkipsUnreadableOwnerConfig covers the fail-closed
@@ -203,9 +184,7 @@ func TestReasonixProjectConfigSkipsUnreadableOwnerConfig(t *testing.T) {
 			if _, err := os.Stat(filepath.Join(workDir, reasonixProjectConfigFile)); !os.IsNotExist(err) {
 				t.Fatalf("wrote a project config from an owner config it could not restate (stat err = %v)", err)
 			}
-			if len(manifest.Files) != 0 {
-				t.Fatalf("manifest recorded a file it did not write: %+v", manifest.Files)
-			}
+			testassert.OnFailure(t, len(manifest.Files) != 0, func() { t.Fatalf("manifest recorded a file it did not write: %+v", manifest.Files) })
 		})
 	}
 }
@@ -228,16 +207,10 @@ func TestReasonixProjectConfigKeepsRepositoryFile(t *testing.T) {
 		t.Fatalf("writeReasonixProjectConfig: %v", err)
 	}
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read %s: %v", reasonixProjectConfigFile, err)
-	}
-	if string(data) != repoConfig {
-		t.Fatalf("repository reasonix.toml was rewritten:\n%s", data)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", reasonixProjectConfigFile, err) })
+	testassert.OnFailure(t, string(data) != repoConfig, func() { t.Fatalf("repository reasonix.toml was rewritten:\n%s", data) })
 	// Nothing was created, so cleanup must not claim the user's file.
-	if len(manifest.Files) != 0 {
-		t.Fatalf("manifest recorded a file it did not write: %+v", manifest.Files)
-	}
+	testassert.OnFailure(t, len(manifest.Files) != 0, func() { t.Fatalf("manifest recorded a file it did not write: %+v", manifest.Files) })
 }
 
 func TestReasonixProjectConfigSkippedForOtherProviders(t *testing.T) {
@@ -250,9 +223,7 @@ func TestReasonixProjectConfigSkippedForOtherProviders(t *testing.T) {
 		Provider:       "hermes",
 		Task:           TaskContextForEnv{IssueID: "d1b2c3d4-e5f6-7890-abcd-ef1234567890"},
 	}, testLogger())
-	if err != nil {
-		t.Fatalf("Prepare failed: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("Prepare failed: %v", err) })
 	defer env.Cleanup(true)
 
 	if _, err := os.Stat(filepath.Join(env.WorkDir, reasonixProjectConfigFile)); !os.IsNotExist(err) {

--- a/server/internal/daemon/execenv/reasonix_user_config_test.go
+++ b/server/internal/daemon/execenv/reasonix_user_config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // setReasonixGOOS pins the platform the resolver targets so the Windows and
@@ -77,9 +79,7 @@ func TestReasonixUserConfigPathExpandsOverride(t *testing.T) {
 	home := t.TempDir()
 	root := t.TempDir()
 	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("getwd: %v", err) })
 
 	for _, tc := range []struct {
 		name     string

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestBuildCommentReplyInstructionsCodexLinux pins that the Linux/macOS
@@ -37,9 +39,7 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 		"Do NOT write literal `\\n` escapes to simulate line breaks",
 		"do NOT reuse --parent values from previous turns",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("codex/linux reply instructions missing %q\n---\n%s", want, got)
-		}
+		testassert.OnFailure(t, !strings.Contains(got, want), func() { t.Fatalf("codex/linux reply instructions missing %q\n---\n%s", want, got) })
 	}
 
 	for _, banned := range []string{
@@ -48,9 +48,7 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 		"cat <<",
 		"--parent " + triggerID + " --content-stdin",
 	} {
-		if strings.Contains(got, banned) {
-			t.Fatalf("codex/linux reply instructions should not contain %q\n---\n%s", banned, got)
-		}
+		testassert.OnFailure(t, strings.Contains(got, banned), func() { t.Fatalf("codex/linux reply instructions should not contain %q\n---\n%s", banned, got) })
 	}
 }
 
@@ -96,9 +94,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					"do NOT reuse --parent values from previous turns",
 					"Post your reply as a comment",
 				} {
-					if !strings.Contains(got, want) {
-						t.Errorf("%s reply instructions missing %q\n---\n%s", name, want, got)
-					}
+					testassert.OnFailure(t, !strings.Contains(got, want), func() { t.Errorf("%s reply instructions missing %q\n---\n%s", name, want, got) })
 				}
 
 				// The two regressions: agent-authored comments must never be
@@ -110,9 +106,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					"cat <<",
 					"--parent " + triggerID + " --content-stdin",
 				} {
-					if strings.Contains(got, banned) {
-						t.Errorf("%s reply instructions still contains %q\n---\n%s", name, banned, got)
-					}
+					testassert.OnFailure(t, strings.Contains(got, banned), func() { t.Errorf("%s reply instructions still contains %q\n---\n%s", name, banned, got) })
 				}
 			})
 		}
@@ -150,18 +144,16 @@ func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
 				"PowerShell drops non-ASCII",
 				"## Comment Formatting",
 			} {
-				if !strings.Contains(got, want) {
-					t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, got)
-				}
+				testassert.OnFailure(t, !strings.Contains(got, want), func() { t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, got) })
 			}
 			for _, banned := range []string{
 				"<<'COMMENT'",
 				"--parent " + triggerID + " --content-stdin",
 				"cat <<",
 			} {
-				if strings.Contains(got, banned) {
+				testassert.OnFailure(t, strings.Contains(got, banned), func() {
 					t.Errorf("%s/windows reply instructions should not contain %q\n---\n%s", provider, banned, got)
-				}
+				})
 			}
 		})
 	}
@@ -195,14 +187,10 @@ func TestInjectRuntimeConfigKeepsTriggerCommentOutOfBrief(t *testing.T) {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read CLAUDE.md: %v", err) })
 	s := string(content)
 
-	if strings.Contains(s, triggerID) {
-		t.Errorf("CLAUDE.md must not carry the trigger comment id (MUL-5377)\n---\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, triggerID), func() { t.Errorf("CLAUDE.md must not carry the trigger comment id (MUL-5377)\n---\n%s", s) })
 	for _, want := range []string{
 		// MUL-6417 retired the turn-mode router: one workflow, delivery
 		// routed on what the per-turn message carries. Pin the routing RULE
@@ -216,16 +204,12 @@ func TestInjectRuntimeConfigKeepsTriggerCommentOutOfBrief(t *testing.T) {
 		// turn that moved nothing writes nothing (MUL-6300 → MUL-6417).
 		"questions, discussion, and acknowledgements never touch status",
 	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("CLAUDE.md missing %q\n---\n%s", want, s)
-		}
+		testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("CLAUDE.md missing %q\n---\n%s", want, s) })
 	}
 
 	// The retired router must not come back in any phrasing.
 	for _, banned := range []string{"Turn mode", "mode block", "No mode line"} {
-		if strings.Contains(s, banned) {
-			t.Errorf("CLAUDE.md still carries retired mode-router text %q (MUL-6417)\n---\n%s", banned, s)
-		}
+		testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("CLAUDE.md still carries retired mode-router text %q (MUL-6417)\n---\n%s", banned, s) })
 	}
 }
 
@@ -246,17 +230,15 @@ func TestWindowsCommentReplyInstructionsHaveNoStdin(t *testing.T) {
 				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
 				"--content-file",
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, s) })
 			}
 			for _, banned := range []string{
 				"--parent " + triggerID + " --content-stdin",
 				"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
 			} {
-				if strings.Contains(s, banned) {
+				testassert.OnFailure(t, strings.Contains(s, banned), func() {
 					t.Errorf("%s reply instructions must not prescribe stdin on Windows: %q\n---\n%s", provider, banned, s)
-				}
+				})
 			}
 		})
 	}
@@ -292,9 +274,7 @@ func TestInjectRuntimeConfigWindowsAssignmentBriefStaysFileOnly(t *testing.T) {
 				fileName = "AGENTS.md"
 			}
 			data, err := os.ReadFile(filepath.Join(dir, fileName))
-			if err != nil {
-				t.Fatalf("read %s: %v", fileName, err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", fileName, err) })
 			s := string(data)
 
 			// The Windows Comment Formatting section is file-only.
@@ -303,9 +283,7 @@ func TestInjectRuntimeConfigWindowsAssignmentBriefStaysFileOnly(t *testing.T) {
 				"On Windows, **always write the comment body to a UTF-8 file",
 				"do NOT pipe via `--content-stdin`",
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("%s missing Windows file-only guidance %q\n---\n%s", fileName, want, s)
-				}
+				testassert.OnFailure(t, !strings.Contains(s, want), func() { t.Errorf("%s missing Windows file-only guidance %q\n---\n%s", fileName, want, s) })
 			}
 
 			// No prose may RECOMMEND stdin on Windows. The flag synopsis may
@@ -316,9 +294,7 @@ func TestInjectRuntimeConfigWindowsAssignmentBriefStaysFileOnly(t *testing.T) {
 				"using `--content-file` or `--content-stdin`",
 				"use `--content-file <path>` or `--content-stdin`",
 			} {
-				if strings.Contains(s, banned) {
-					t.Errorf("%s recommends stdin on Windows: %q\n---\n%s", fileName, banned, s)
-				}
+				testassert.OnFailure(t, strings.Contains(s, banned), func() { t.Errorf("%s recommends stdin on Windows: %q\n---\n%s", fileName, banned, s) })
 			}
 		})
 	}
@@ -333,18 +309,12 @@ func TestBuildCommentReplyInstructionsSquadLeaderCarveOut(t *testing.T) {
 	t.Parallel()
 
 	leader := BuildCommentReplyInstructions("claude", "issue-1", "comment-1", true)
-	if !strings.Contains(leader, "Unless your outcome is `no_action`, post your reply as a comment") {
-		t.Errorf("leader reply instructions missing the no_action carve-out\n---\n%s", leader)
-	}
-	if strings.Contains(leader, "Post your reply as a comment") {
+	testassert.OnFailure(t, !strings.Contains(leader, "Unless your outcome is `no_action`, post your reply as a comment"), func() { t.Errorf("leader reply instructions missing the no_action carve-out\n---\n%s", leader) })
+	testassert.OnFailure(t, strings.Contains(leader, "Post your reply as a comment"), func() {
 		t.Errorf("leader reply instructions still carry the unconditional imperative\n---\n%s", leader)
-	}
+	})
 
 	ordinary := BuildCommentReplyInstructions("claude", "issue-1", "comment-1", false)
-	if !strings.Contains(ordinary, "Post your reply as a comment") {
-		t.Errorf("ordinary reply instructions missing the imperative\n---\n%s", ordinary)
-	}
-	if strings.Contains(ordinary, "Unless your outcome is") {
-		t.Errorf("ordinary reply instructions leaked the leader carve-out\n---\n%s", ordinary)
-	}
+	testassert.OnFailure(t, !strings.Contains(ordinary, "Post your reply as a comment"), func() { t.Errorf("ordinary reply instructions missing the imperative\n---\n%s", ordinary) })
+	testassert.OnFailure(t, strings.Contains(ordinary, "Unless your outcome is"), func() { t.Errorf("ordinary reply instructions leaked the leader carve-out\n---\n%s", ordinary) })
 }

--- a/server/internal/daemon/execenv/reserved_skill_path_test.go
+++ b/server/internal/daemon/execenv/reserved_skill_path_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestWriteSkillFilesIgnoresBundledSkillMd is the daemon-side regression guard
@@ -45,15 +47,9 @@ func TestWriteSkillFilesIgnoresBundledSkillMd(t *testing.T) {
 
 	// SKILL.md must hold the primary content, never a bundled duplicate.
 	got, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read SKILL.md: %v", err)
-	}
-	if !strings.Contains(string(got), "Primary skill body.") {
-		t.Errorf("SKILL.md = %q, want primary content", string(got))
-	}
-	if strings.Contains(string(got), "must be skipped") {
-		t.Error("SKILL.md was overwritten by a bundled duplicate")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read SKILL.md: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(got), "Primary skill body."), func() { t.Errorf("SKILL.md = %q, want primary content", string(got)) })
+	testassert.OnFailure(t, strings.Contains(string(got), "must be skipped"), func() { t.Error("SKILL.md was overwritten by a bundled duplicate") })
 
 	// Unique supporting files are still written — this also proves the loop
 	// continued past the skipped duplicates instead of aborting on them.

--- a/server/internal/daemon/execenv/root_identity_test.go
+++ b/server/internal/daemon/execenv/root_identity_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const (
@@ -26,9 +28,7 @@ func pruneParams(root, taskID string) RootDirParams {
 func pruneTaskRootIndexForTest(t *testing.T, root string, now time.Time, eligible func(string, string) bool) int {
 	t.Helper()
 	removed, err := PruneTaskRootIndex(root, pruneTTL, now, eligible)
-	if err != nil {
-		t.Fatalf("PruneTaskRootIndex: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("PruneTaskRootIndex: %v", err) })
 	return removed
 }
 
@@ -44,9 +44,7 @@ func TestPruneTaskRootIndexKeepsTheFreezeWindow(t *testing.T) {
 	root := t.TempDir()
 	params := pruneParams(root, "5c57b65b-ee7a-4603-a72d-b659c34a1dc3")
 	frozen, err := ResolveRootDir(params)
-	if err != nil {
-		t.Fatalf("ResolveRootDir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ResolveRootDir: %v", err) })
 	if _, err := os.Stat(frozen); !os.IsNotExist(err) {
 		t.Fatalf("fixture must represent the pre-Prepare window; stat err = %v", err)
 	}
@@ -55,12 +53,8 @@ func TestPruneTaskRootIndexKeepsTheFreezeWindow(t *testing.T) {
 		t.Fatalf("removed %d records inside the freeze window, want 0", removed)
 	}
 	again, err := ResolveRootDir(params)
-	if err != nil {
-		t.Fatalf("ResolveRootDir after prune: %v", err)
-	}
-	if again != frozen {
-		t.Fatalf("task moved from %q to %q after a prune cycle", frozen, again)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ResolveRootDir after prune: %v", err) })
+	testassert.OnFailure(t, again != frozen, func() { t.Fatalf("task moved from %q to %q after a prune cycle", frozen, again) })
 }
 
 func TestPruneTaskRootIndexReclaimsOnlyStrandedRecords(t *testing.T) {
@@ -71,9 +65,7 @@ func TestPruneTaskRootIndexReclaimsOnlyStrandedRecords(t *testing.T) {
 	strandedParams := pruneParams(root, "5c57b65b-ee7a-4603-a72d-c760d45b2ed4")
 
 	livePath, err := ResolveRootDir(liveParams)
-	if err != nil {
-		t.Fatalf("resolve live root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve live root: %v", err) })
 	if err := os.MkdirAll(livePath, 0o755); err != nil {
 		t.Fatalf("create live root: %v", err)
 	}
@@ -91,12 +83,8 @@ func TestPruneTaskRootIndexReclaimsOnlyStrandedRecords(t *testing.T) {
 		t.Fatalf("stranded record survived the sweep; stat err = %v", err)
 	}
 	resolved, err := ResolveRootDir(liveParams)
-	if err != nil {
-		t.Fatalf("resolve live root after sweep: %v", err)
-	}
-	if resolved != livePath {
-		t.Fatalf("live task moved from %q to %q after the sweep", livePath, resolved)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("resolve live root after sweep: %v", err) })
+	testassert.OnFailure(t, resolved != livePath, func() { t.Fatalf("live task moved from %q to %q after the sweep", livePath, resolved) })
 }
 
 // A record that cannot be parsed is what keeps its task failing closed. The
@@ -117,12 +105,8 @@ func TestPruneTaskRootIndexKeepsUnreadableRecords(t *testing.T) {
 
 	past := time.Now().Add(pruneTTL + time.Hour)
 	removed, err := PruneTaskRootIndex(root, pruneTTL, past, func(string, string) bool { return true })
-	if err == nil {
-		t.Fatal("PruneTaskRootIndex did not report the unreadable record")
-	}
-	if removed != 0 {
-		t.Fatalf("removed %d unreadable records, want 0", removed)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("PruneTaskRootIndex did not report the unreadable record") })
+	testassert.OnFailure(t, removed != 0, func() { t.Fatalf("removed %d unreadable records, want 0", removed) })
 	if _, err := os.Stat(filepath.Join(recordDir, taskRootRecordFile)); err != nil {
 		t.Fatalf("unreadable record was reclaimed: %v", err)
 	}
@@ -140,9 +124,7 @@ func TestPruneTaskRootIndexReclaimsAbandonedStagingDirs(t *testing.T) {
 		t.Fatalf("seed index: %v", err)
 	}
 	pending, err := os.MkdirTemp(indexDir, taskRootPendingPrefix)
-	if err != nil {
-		t.Fatalf("seed staging dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("seed staging dir: %v", err) })
 	if err := os.WriteFile(filepath.Join(pending, taskRootRecordFile), []byte(`{"workspace_id":"w"}`), 0o644); err != nil {
 		t.Fatalf("seed staging record: %v", err)
 	}
@@ -194,9 +176,7 @@ func TestResolveRootDirAdoptsRootHoldingOnlyAnUnpublishedOwnerTemp(t *testing.T)
 		t.Fatalf("seed env root: %v", err)
 	}
 	tmp, err := os.CreateTemp(original, envRootOwnerTempPrefix+"*"+envRootOwnerTempSuffix)
-	if err != nil {
-		t.Fatalf("seed unpublished owner temp: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("seed unpublished owner temp: %v", err) })
 	if _, err := tmp.WriteString(`{"workspace_id":"` + pruneWorkspaceID + `","task_id":"` + taskID + `"}`); err != nil {
 		t.Fatalf("write unpublished owner temp: %v", err)
 	}
@@ -206,33 +186,19 @@ func TestResolveRootDirAdoptsRootHoldingOnlyAnUnpublishedOwnerTemp(t *testing.T)
 	}
 
 	resolved, err := ResolveRootDir(params)
-	if err != nil {
-		t.Fatalf("ResolveRootDir refused a root holding only an unpublished owner temp: %v", err)
-	}
-	if resolved != original {
-		t.Fatalf("resolved %q, want the existing root %q", resolved, original)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ResolveRootDir refused a root holding only an unpublished owner temp: %v", err) })
+	testassert.OnFailure(t, resolved != original, func() { t.Fatalf("resolved %q, want the existing root %q", resolved, original) })
 
 	claim, err := ClaimEnvRoot(params)
-	if err != nil {
-		t.Fatalf("ClaimEnvRoot: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ClaimEnvRoot: %v", err) })
 	defer claim.Release()
 	owner, err := ReadEnvRootOwner(original)
-	if err != nil {
-		t.Fatalf("ReadEnvRootOwner: %v", err)
-	}
-	if owner.TaskID != taskID || owner.WorkspaceID != pruneWorkspaceID {
-		t.Fatalf("owner = %+v, want the claiming task's identity", owner)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("ReadEnvRootOwner: %v", err) })
+	testassert.OnFailure(t, owner.TaskID != taskID || owner.WorkspaceID != pruneWorkspaceID, func() { t.Fatalf("owner = %+v, want the claiming task's identity", owner) })
 	entries, err := os.ReadDir(original)
-	if err != nil {
-		t.Fatalf("read env root: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read env root: %v", err) })
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), envRootOwnerTempPrefix) {
-			t.Fatalf("claim left an unpublished owner temp behind: %s", e.Name())
-		}
+		testassert.OnFailure(t, strings.HasPrefix(e.Name(), envRootOwnerTempPrefix), func() { t.Fatalf("claim left an unpublished owner temp behind: %s", e.Name()) })
 	}
 }
 
@@ -265,12 +231,8 @@ func TestValidateTaskRootRecordErrorsNameTheRecordDir(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := validateTaskRootRecord(params, recordDir, tc.record)
-			if err == nil {
-				t.Fatal("validateTaskRootRecord accepted an invalid record")
-			}
-			if !strings.Contains(err.Error(), recordDir) {
-				t.Fatalf("error %q does not name the record dir %q", err, recordDir)
-			}
+			testassert.OnFailure(t, err == nil, func() { t.Fatal("validateTaskRootRecord accepted an invalid record") })
+			testassert.OnFailure(t, !strings.Contains(err.Error(), recordDir), func() { t.Fatalf("error %q does not name the record dir %q", err, recordDir) })
 		})
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_channel_context_test.go
+++ b/server/internal/daemon/execenv/runtime_config_channel_context_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Room audience belongs to the per-turn message, not the cached brief. The
@@ -21,9 +23,7 @@ func TestBriefChatWorkflowDoesNotAssertAudience(t *testing.T) {
 		AgentID:         "9df55bf2-67de-4ae6-803f-4de2fbd45df1",
 		AgentName:       "Eve",
 	})
-	if !strings.Contains(out, "**You are in chat mode.**") {
-		t.Fatal("chat brief must still identify chat mode")
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "**You are in chat mode.**"), func() { t.Fatal("chat brief must still identify chat mode") })
 	for _, retired := range []string{
 		"## Conversation Channel",
 		"Audience:",
@@ -31,9 +31,7 @@ func TestBriefChatWorkflowDoesNotAssertAudience(t *testing.T) {
 		"group room",
 		"direct room",
 	} {
-		if strings.Contains(out, retired) {
-			t.Errorf("cached brief must not contain per-session audience text %q", retired)
-		}
+		testassert.OnFailure(t, strings.Contains(out, retired), func() { t.Errorf("cached brief must not contain per-session audience text %q", retired) })
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_delivery_test.go
+++ b/server/internal/daemon/execenv/runtime_config_delivery_test.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // The MUL-4899 delivery contract as the BRIEF states it. Two orthogonal
@@ -70,9 +72,7 @@ func TestBriefDeliveryInvariantIsAlwaysOn(t *testing.T) {
 	for name, ctx := range deliveryInvariantFixtures() {
 		out := buildMetaSkillContent("claude", ctx)
 		for _, want := range wantAll {
-			if !strings.Contains(out, want) {
-				t.Errorf("kind=%s: brief is missing always-on delivery invariant %q", name, want)
-			}
+			testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("kind=%s: brief is missing always-on delivery invariant %q", name, want) })
 		}
 	}
 }
@@ -199,15 +199,13 @@ func TestBriefSurfaceDeliveryPolicy(t *testing.T) {
 	fixtures := deliveryInvariantFixtures()
 	for name, want := range cases {
 		ctx, ok := fixtures[name]
-		if !ok {
-			t.Fatalf("no fixture for surface %q", name)
-		}
+		testassert.OnFailure(t, !ok, func() { t.Fatalf("no fixture for surface %q", name) })
 		out := buildMetaSkillContent("claude", ctx)
 		for _, phrase := range want.mustHave {
-			if !strings.Contains(out, phrase) {
+			testassert.OnFailure(t, !strings.Contains(out, phrase), func() {
 				t.Errorf("surface=%s: brief missing surface policy %q\n--- Output section ---\n%s",
 					name, phrase, outputSection(out))
-			}
+			})
 		}
 		// mustNot is checked against the WHOLE brief, not just `## Output`: a
 		// denial is wrong wherever it is written, and scoping the search to
@@ -260,10 +258,10 @@ func TestBriefChannelDeliveryCopyIgnoresServerVerdict(t *testing.T) {
 	delivering := buildMetaSkillContent("claude", fixtures["chat_wecom"])
 	for _, name := range []string{"chat_wecom_no_store", "chat_wecom_old_server"} {
 		got := buildMetaSkillContent("claude", fixtures[name])
-		if got != delivering {
+		testassert.OnFailure(t, got != delivering, func() {
 			t.Errorf("brief for %q differs from chat_wecom — the server's per-turn file-delivery verdict reached the cached prefix (MUL-5377).\n%s",
 				name, firstBriefDiff(delivering, got))
-		}
+		})
 	}
 }
 
@@ -304,10 +302,10 @@ func TestBriefChannelDeliveryCopyIsPlatformNeutral(t *testing.T) {
 		baseline := neutralized(ChannelTypeSlack, delivers)
 		for _, channelType := range []string{ChannelTypeFeishu, ChannelTypeWecom} {
 			got := neutralized(channelType, delivers)
-			if got != baseline {
+			testassert.OnFailure(t, got != baseline, func() {
 				t.Errorf("brief for channel %q (delivers=%v) differs from %q beyond the platform name — the brief took a position on one platform's file delivery, which is a per-turn deployment fact (MUL-4899, MUL-5377).\n%s",
 					channelType, delivers, ChannelTypeSlack, firstBriefDiff(baseline, got))
-			}
+			})
 		}
 	}
 }
@@ -333,14 +331,10 @@ func TestBriefInboundAttachmentIsNotADeliverable(t *testing.T) {
 		"not something the reader can open",
 		"the link rules in `## Output` apply to it too",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("Attachments section missing %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("Attachments section missing %q\n---\n%s", want, out) })
 	}
 	// The rule the pointer defers to must actually be present in the brief.
-	if !strings.Contains(out, "NEVER write an absolute path or a `file://` URL as a clickable link") {
-		t.Errorf("Attachments points at ## Output but the rule is missing\n---\n%s", out)
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "NEVER write an absolute path or a `file://` URL as a clickable link"), func() { t.Errorf("Attachments points at ## Output but the rule is missing\n---\n%s", out) })
 }
 
 func TestChannelDisplayName(t *testing.T) {
@@ -372,9 +366,9 @@ func TestQuickActionsInstructionsAbsentFromAllChatBriefs(t *testing.T) {
 	}
 	for _, ctx := range contexts {
 		brief := buildMetaSkillContent("claude", ctx)
-		if strings.Contains(brief, "```quick-actions") || strings.Contains(brief, "### Quick Actions") {
+		testassert.OnFailure(t, strings.Contains(brief, "```quick-actions") || strings.Contains(brief, "### Quick Actions"), func() {
 			t.Fatalf("brief (channel=%q) must not teach the in-band quick-actions syntax", ctx.ChatChannelType)
-		}
+		})
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_issue_status_test.go
+++ b/server/internal/daemon/execenv/runtime_config_issue_status_test.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // legacyStatusLine is the pre-MUL-6460 status bullet. Workspaces without
@@ -19,12 +21,8 @@ func TestBriefStatusCatalogAbsentKeepsLegacyLine(t *testing.T) {
 	t.Parallel()
 	base := TaskContextForEnv{IssueID: "issue-1", AgentID: "a-1", AgentName: "Eve"}
 	out := buildMetaSkillContent("claude", base)
-	if !strings.Contains(out, legacyStatusLine) {
-		t.Fatalf("brief without a catalog must keep the legacy status line\n---\n%s", out)
-	}
-	if strings.Contains(out, catalogBridgeBullet) {
-		t.Errorf("brief without a catalog must not carry the catalog bridge bullet")
-	}
+	testassert.OnFailure(t, !strings.Contains(out, legacyStatusLine), func() { t.Fatalf("brief without a catalog must keep the legacy status line\n---\n%s", out) })
+	testassert.OnFailure(t, strings.Contains(out, catalogBridgeBullet), func() { t.Errorf("brief without a catalog must not carry the catalog bridge bullet") })
 
 	withEmpty := base
 	withEmpty.IssueStatuses = []IssueStatusForEnv{}
@@ -44,9 +42,7 @@ func TestBriefStatusCatalogRendered(t *testing.T) {
 		},
 	}
 	out := buildMetaSkillContent("claude", ctx)
-	if strings.Contains(out, legacyStatusLine) {
-		t.Errorf("catalog brief must replace the legacy seven-value enumeration")
-	}
+	testassert.OnFailure(t, strings.Contains(out, legacyStatusLine), func() { t.Errorf("catalog brief must replace the legacy seven-value enumeration") })
 	for _, want := range []string{
 		"- `multica issue status <id> <status> [--no-start]` — flip status. This workspace's statuses by category — a custom status inherits its category's platform behavior in full:\n",
 		"  - `backlog`: `backlog` (built-in), `later` (Later — Deferred on purpose)\n",
@@ -55,13 +51,9 @@ func TestBriefStatusCatalogRendered(t *testing.T) {
 		"  - Built-in key only: `in_progress`, `done`, `blocked`, `cancelled`.\n",
 		catalogBridgeBullet,
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("catalog brief missing %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("catalog brief missing %q\n---\n%s", want, out) })
 	}
-	if strings.Contains(out, "more custom statuses not listed") {
-		t.Errorf("no truncation disclosure may appear when nothing was omitted")
-	}
+	testassert.OnFailure(t, strings.Contains(out, "more custom statuses not listed"), func() { t.Errorf("no truncation disclosure may appear when nothing was omitted") })
 }
 
 // TestBriefStatusCatalogSanitizesAndDiscloses pins the two safety properties:
@@ -84,11 +76,7 @@ func TestBriefStatusCatalogSanitizesAndDiscloses(t *testing.T) {
 		"  - Built-in key only: `backlog`, `todo`, `in_progress`, `done`, `blocked`, `cancelled`.\n",
 		"  - …and 4 more custom statuses not listed; an invalid status errors with the full valid list.\n",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("catalog brief missing %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("catalog brief missing %q\n---\n%s", want, out) })
 	}
-	if strings.Contains(out, "Evil") || strings.Contains(out, "bad key") {
-		t.Errorf("entry with an invalid key must be dropped entirely\n---\n%s", out)
-	}
+	testassert.OnFailure(t, strings.Contains(out, "Evil") || strings.Contains(out, "bad key"), func() { t.Errorf("entry with an invalid key must be dropped entirely\n---\n%s", out) })
 }

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestClassifyTask pins the precedence rule on classifyTask. All four
@@ -68,12 +70,8 @@ func TestBuildMetaSkillContentBriefContent(t *testing.T) {
 		AgentID:          "eve-1",
 	})
 
-	if !strings.Contains(out, "- `multica issue get <id> --output json` — full issue.\n") {
-		t.Errorf("brief is missing the `issue get` one-liner\n---\n%s", out)
-	}
-	if strings.Contains(out, "Get full issue details.") {
-		t.Errorf("brief still carries the retired legacy `issue get` description\n---\n%s", out)
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "- `multica issue get <id> --output json` — full issue.\n"), func() { t.Errorf("brief is missing the `issue get` one-liner\n---\n%s", out) })
+	testassert.OnFailure(t, strings.Contains(out, "Get full issue details."), func() { t.Errorf("brief still carries the retired legacy `issue get` description\n---\n%s", out) })
 }
 
 // TestBuildMetaSkillContentIssueBodyFormatting pins the shared issue-body
@@ -103,9 +101,7 @@ func TestBuildMetaSkillContentIssueBodyFormatting(t *testing.T) {
 				"start with prose or `##` subheadings",
 				"Only add an H1 when the user specifically requests one",
 			} {
-				if !strings.Contains(out, want) {
-					t.Errorf("brief is missing issue-body formatting guidance %q\n---\n%s", want, out)
-				}
+				testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("brief is missing issue-body formatting guidance %q\n---\n%s", want, out) })
 			}
 		})
 	}
@@ -171,12 +167,10 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 			firstLine := c.heading + "\n"
 			present := strings.HasPrefix(out, firstLine) || strings.Contains(out, needle)
 			want := c.mustHave[kind]
-			if want && !present {
-				t.Errorf("kind=%d: expected heading %q in slim brief", kind, c.heading)
-			}
-			if !want && present {
+			testassert.OnFailure(t, want && !present, func() { t.Errorf("kind=%d: expected heading %q in slim brief", kind, c.heading) })
+			testassert.OnFailure(t, !want && present, func() {
 				t.Errorf("kind=%d: heading %q should NOT be in slim brief (matrix gating regression)", kind, c.heading)
-			}
+			})
 		}
 	}
 }
@@ -193,12 +187,10 @@ func TestBriefDueDateTeachesCalendarDayFormat(t *testing.T) {
 		"quick-create": {QuickCreatePrompt: "create an issue"},
 	} {
 		out := buildMetaSkillContent("claude", ctx)
-		if !strings.Contains(out, "--due-date <YYYY-MM-DD>") {
-			t.Errorf("%s brief missing the calendar-day --due-date synopsis", name)
-		}
-		if strings.Contains(out, "--due-date <RFC3339>") {
+		testassert.OnFailure(t, !strings.Contains(out, "--due-date <YYYY-MM-DD>"), func() { t.Errorf("%s brief missing the calendar-day --due-date synopsis", name) })
+		testassert.OnFailure(t, strings.Contains(out, "--due-date <RFC3339>"), func() {
 			t.Errorf("%s brief still teaches --due-date <RFC3339>, which the server rejects except at UTC midnight (MUL-5696)", name)
-		}
+		})
 	}
 }
 
@@ -208,9 +200,9 @@ func TestBriefDueDateTeachesCalendarDayFormat(t *testing.T) {
 // the deferral side). MUL-5696.
 func TestBriefOwnsAutopilotIssueCommandsGuard(t *testing.T) {
 	out := buildMetaSkillContent("claude", TaskContextForEnv{AutopilotRunID: "run-1"})
-	if !strings.Contains(out, AutopilotIssueCommandsGuard) {
+	testassert.OnFailure(t, !strings.Contains(out, AutopilotIssueCommandsGuard), func() {
 		t.Errorf("autopilot brief missing AutopilotIssueCommandsGuard — the per-turn prompt defers to this single emission point")
-	}
+	})
 }
 
 // TestSlimQuickCreateAvailableCommands locks the minimal-variant content
@@ -228,9 +220,7 @@ func TestSlimQuickCreateAvailableCommands(t *testing.T) {
 		"multica issue create --title",
 		"`multica --help`",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("quick_create slim Available Commands missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("quick_create slim Available Commands missing %q", want) })
 	}
 
 	for _, banned := range []string{
@@ -247,9 +237,9 @@ func TestSlimQuickCreateAvailableCommands(t *testing.T) {
 		"### Squad maintenance",
 		"multica squad member set-role",
 	} {
-		if strings.Contains(out, banned) {
+		testassert.OnFailure(t, strings.Contains(out, banned), func() {
 			t.Errorf("quick_create slim Available Commands should NOT advertise %q (hard guardrails forbid the call)", banned)
-		}
+		})
 	}
 }
 
@@ -300,9 +290,7 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 		"URL, logs, and stop instructions",
 		"survival as best-effort, not guaranteed",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out) })
 	}
 	// Exactly one exception (see the execenv provider-agnostic test for
 	// the incident this guards).
@@ -311,13 +299,13 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 	}
 	// `gh run watch` may only appear as a banned command, never as the
 	// section's example of how to wait properly.
-	if strings.Contains(out, "e.g. `gh run watch`") {
+	testassert.OnFailure(t, strings.Contains(out, "e.g. `gh run watch`"), func() {
 		t.Errorf("slim Background Task Safety should not suggest waiting for external GitHub CI\n---\n%s", out)
-	}
+	})
 	// MUL-5274 review: with the persistent-service exception in the list, a
 	// "The rules above ..." scoping sentence would sweep in work that is
 	// precisely no longer run-owned after handoff.
-	if strings.Contains(out, "The rules above") {
+	testassert.OnFailure(t, strings.Contains(out, "The rules above"), func() {
 		t.Errorf("slim Background Task Safety must not reintroduce the ambiguous \"The rules above\" scoping sentence\n---\n%s", out)
-	}
+	})
 }

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Sub-issue Creation section — after MUL-2538 the platform posts the
@@ -43,9 +44,7 @@ func TestSubIssueCreationSectionPresentForIssueRuns(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
 
-			if !strings.Contains(out, "## Sub-issue Creation") {
-				t.Fatalf("expected Sub-issue Creation section in %s brief", tc.name)
-			}
+			testassert.OnFailure(t, !strings.Contains(out, "## Sub-issue Creation"), func() { t.Fatalf("expected Sub-issue Creation section in %s brief", tc.name) })
 			for _, want := range []string{
 				// MUL-5442 demotes the full todo/backlog/stage playbook to the
 				// multica-working-on-issues skill. The brief keeps a one-line
@@ -58,9 +57,7 @@ func TestSubIssueCreationSectionPresentForIssueRuns(t *testing.T) {
 				"`--stage <N>` groups children into ordered stages",
 				"read the `multica-working-on-issues` skill",
 			} {
-				if !strings.Contains(out, want) {
-					t.Errorf("[%s] section missing %q", tc.name, want)
-				}
+				testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("[%s] section missing %q", tc.name, want) })
 			}
 		})
 	}
@@ -73,9 +70,7 @@ func TestIssueWorkflowCarriesSourceContextPrecedenceOnce(t *testing.T) {
 	if count := strings.Count(out, rule); count != 1 {
 		t.Fatalf("source-context precedence rule count = %d, want 1", count)
 	}
-	if !strings.Contains(out, "current issue title, description, and comments are authoritative task instructions") {
-		t.Fatal("source-context rule does not identify the current issue as authoritative")
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "current issue title, description, and comments are authoritative task instructions"), func() { t.Fatal("source-context rule does not identify the current issue as authoritative") })
 }
 
 // The brief must no longer carry any parent-notification guidance. PR
@@ -144,9 +139,7 @@ func TestBriefHasNoParentNotificationGuidance(t *testing.T) {
 			// Non-existent CLI form Elon's earlier review flagged.
 			"issue list --parent",
 		} {
-			if strings.Contains(out, banned) {
-				t.Errorf("expected %q to be removed from the brief", banned)
-			}
+			testassert.OnFailure(t, strings.Contains(out, banned), func() { t.Errorf("expected %q to be removed from the brief", banned) })
 		}
 	}
 }
@@ -176,9 +169,9 @@ func TestStatusRuleIsFactJudgmentAtBothMoments(t *testing.T) {
 	}
 	out := buildMetaSkillContent("claude", ctx)
 
-	if strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
+	testassert.OnFailure(t, strings.Contains(out, "`multica issue status <this-issue-id> in_review`"), func() {
 		t.Errorf("brief must not contain a placeholder `<this-issue-id> in_review` flip — status is judged from what the turn delivered")
-	}
+	})
 
 	for _, want := range []string{
 		// The anchor: issue state, not run lifecycle, written when it changes.
@@ -209,9 +202,7 @@ func TestStatusRuleIsFactJudgmentAtBothMoments(t *testing.T) {
 		// Invariant 2: concurrent agents converge instead of flapping.
 		"This no-write default is what keeps concurrent runs from flapping the board",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("status rule missing %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("status rule missing %q\n---\n%s", want, out) })
 	}
 
 	// The retired gates must not come back: no trigger-type modes, no
@@ -239,9 +230,7 @@ func TestStatusRuleIsFactJudgmentAtBothMoments(t *testing.T) {
 		"you only answered a question, reviewed, or discussed",
 		"in whatever form: code, research",
 	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("brief still carries retired status gate %q (MUL-6417)\n---\n%s", banned, out)
-		}
+		testassert.OnFailure(t, strings.Contains(out, banned), func() { t.Errorf("brief still carries retired status gate %q (MUL-6417)\n---\n%s", banned, out) })
 	}
 
 	// Position is load-bearing, not style (J's review on #7295): a
@@ -257,20 +246,14 @@ func TestStatusRuleIsFactJudgmentAtBothMoments(t *testing.T) {
 			step5 = line
 		}
 	}
-	if !strings.Contains(step3, "set `in_progress` FIRST") {
-		t.Errorf("the start write must be anchored inside step 3\n---\n%s", step3)
-	}
-	if !strings.Contains(step3, "never decides") {
+	testassert.OnFailure(t, !strings.Contains(step3, "set `in_progress` FIRST"), func() { t.Errorf("the start write must be anchored inside step 3\n---\n%s", step3) })
+	testassert.OnFailure(t, !strings.Contains(step3, "never decides"), func() {
 		t.Errorf("the never-decides guard must live inside step 3, the position that fires\n---\n%s", step3)
-	}
-	if !strings.Contains(step5, "confirm the status still matches") {
-		t.Errorf("the exit-side status check must be anchored inside step 5\n---\n%s", step5)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(step5, "confirm the status still matches"), func() { t.Errorf("the exit-side status check must be anchored inside step 5\n---\n%s", step5) })
 
 	// The squad-leader bullet must not leak into the ordinary path.
-	if strings.Contains(out, "dispatching members is not delivery") {
-		t.Errorf("ordinary-agent brief must not carry the squad-leader status bullet:\n%s", out)
-	}
+	testassert.OnFailure(t, strings.Contains(out, "dispatching members is not delivery"), func() { t.Errorf("ordinary-agent brief must not carry the squad-leader status bullet:\n%s", out) })
 }
 
 // TestPerRunCommentContextStaysOutOfBrief pins MUL-5377: no per-run comment
@@ -301,9 +284,7 @@ func TestPerRunCommentContextStaysOutOfBrief(t *testing.T) {
 		"4 new comment(s) on this issue since your last run",
 		"DISTINCT threads",
 	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("brief must not carry per-run comment value %q (MUL-5377)\n---\n%s", banned, out)
-		}
+		testassert.OnFailure(t, strings.Contains(out, banned), func() { t.Errorf("brief must not carry per-run comment value %q (MUL-5377)\n---\n%s", banned, out) })
 	}
 
 	// The helper that now feeds the per-turn prompt is unchanged.
@@ -314,9 +295,7 @@ func TestPerRunCommentContextStaysOutOfBrief(t *testing.T) {
 		"--thread thread-abc --since " + since + " --compact --output json",
 		"--tail 30",
 	} {
-		if !strings.Contains(hint, want) {
-			t.Errorf("BuildNewCommentsHint missing %q\n---\n%s", want, hint)
-		}
+		testassert.OnFailure(t, !strings.Contains(hint, want), func() { t.Errorf("BuildNewCommentsHint missing %q\n---\n%s", want, hint) })
 	}
 }
 
@@ -326,15 +305,9 @@ func TestColdCommentsHintPointsAtTriggeringThread(t *testing.T) {
 	t.Parallel()
 	const issueID = "55555555-6666-7777-8888-999999999999"
 	hint := BuildColdCommentsHint(issueID, "trigger-1", "thread-root-1")
-	if strings.Contains(hint, "new comment(s) since your last run") {
-		t.Errorf("no since-delta hint should render on cold start, got:\n%s", hint)
-	}
-	if !strings.Contains(hint, "multica issue comment list "+issueID+" --thread thread-root-1 --tail 30 --compact --output json") {
-		t.Errorf("cold start must point at the triggering thread read, got:\n%s", hint)
-	}
-	if strings.Contains(buildMetaSkillContent("claude", TaskContextForEnv{IssueID: issueID, TriggerCommentID: "trigger-1", TriggerThreadID: "thread-root-1"}), "thread-root-1") {
-		t.Error("brief must not carry the per-run thread id (MUL-5377)")
-	}
+	testassert.OnFailure(t, strings.Contains(hint, "new comment(s) since your last run"), func() { t.Errorf("no since-delta hint should render on cold start, got:\n%s", hint) })
+	testassert.OnFailure(t, !strings.Contains(hint, "multica issue comment list "+issueID+" --thread thread-root-1 --tail 30 --compact --output json"), func() { t.Errorf("cold start must point at the triggering thread read, got:\n%s", hint) })
+	testassert.OnFailure(t, strings.Contains(buildMetaSkillContent("claude", TaskContextForEnv{IssueID: issueID, TriggerCommentID: "trigger-1", TriggerThreadID: "thread-root-1"}), "thread-root-1"), func() { t.Error("brief must not carry the per-run thread id (MUL-5377)") })
 }
 
 // Resumed/no-delta routing moved to the per-turn prompt (MUL-5377).
@@ -350,21 +323,17 @@ func TestResumedCommentsHintSkipsDefaultThreadRead(t *testing.T) {
 		"do not rely only on resumed session memory",
 		"multica issue comment list " + issueID + " --thread thread-root-1 --tail 30 --compact --output json",
 	} {
-		if !strings.Contains(hint, want) {
-			t.Errorf("resumed/no-delta hint missing %q\n--- output ---\n%s", want, hint)
-		}
+		testassert.OnFailure(t, !strings.Contains(hint, want), func() { t.Errorf("resumed/no-delta hint missing %q\n--- output ---\n%s", want, hint) })
 	}
 	// The anchor-restating sentence is gone (MUL-5721 OPT-1): the read command
 	// carries the thread anchor and the reply cookbook carries the trigger id.
-	if strings.Contains(hint, "active thread anchor") {
+	testassert.OnFailure(t, strings.Contains(hint, "active thread anchor"), func() {
 		t.Errorf("resumed/no-delta hint must not restate anchors outside the commands, got:\n%s", hint)
-	}
-	if strings.Contains(hint, "scoped to the triggering thread") {
-		t.Errorf("resumed/no-delta hint must not claim the delta is thread-scoped, got:\n%s", hint)
-	}
-	if strings.Contains(hint, "Read the triggering conversation first") {
+	})
+	testassert.OnFailure(t, strings.Contains(hint, "scoped to the triggering thread"), func() { t.Errorf("resumed/no-delta hint must not claim the delta is thread-scoped, got:\n%s", hint) })
+	testassert.OnFailure(t, strings.Contains(hint, "Read the triggering conversation first"), func() {
 		t.Errorf("resumed/no-delta hint must not use the cold-start forced-read wording, got:\n%s", hint)
-	}
+	})
 }
 
 // The continuity notice moved out of the brief and into the per-turn prompt
@@ -376,9 +345,7 @@ func TestSessionContinuityNoticeLivesOutsideBrief(t *testing.T) {
 		"could NOT be restored",
 		"tell the user up front",
 	} {
-		if !strings.Contains(SessionContinuityNoticeUnrecoverable, want) {
-			t.Errorf("SessionContinuityNoticeUnrecoverable missing %q", want)
-		}
+		testassert.OnFailure(t, !strings.Contains(SessionContinuityNoticeUnrecoverable, want), func() { t.Errorf("SessionContinuityNoticeUnrecoverable missing %q", want) })
 	}
 
 	// MUL-5722: the issue variant carries the same heading and the same
@@ -386,39 +353,29 @@ func TestSessionContinuityNoticeLivesOutsideBrief(t *testing.T) {
 	// issue's discussion lives in its comments, which the agent re-reads every
 	// turn, so telling the user it was lost describes a loss that did not
 	// happen — they hear "the discussion is gone" when every word survives.
-	if !strings.Contains(SessionContinuityNoticeIssue, "## Session Continuity Notice") {
-		t.Error("SessionContinuityNoticeIssue must keep the section heading")
-	}
-	if strings.Contains(SessionContinuityNoticeIssue, "tell the user") {
-		t.Errorf("issue variant must not script an apology:\n%s", SessionContinuityNoticeIssue)
-	}
+	testassert.OnFailure(t, !strings.Contains(SessionContinuityNoticeIssue, "## Session Continuity Notice"), func() { t.Error("SessionContinuityNoticeIssue must keep the section heading") })
+	testassert.OnFailure(t, strings.Contains(SessionContinuityNoticeIssue, "tell the user"), func() { t.Errorf("issue variant must not script an apology:\n%s", SessionContinuityNoticeIssue) })
 	// It still has to say what genuinely went missing, or the agent silently
 	// assumes it remembers work it no longer has.
-	if !strings.Contains(SessionContinuityNoticeIssue, "your own working memory") {
-		t.Errorf("issue variant must state the real loss:\n%s", SessionContinuityNoticeIssue)
-	}
+	testassert.OnFailure(t, !strings.Contains(SessionContinuityNoticeIssue, "your own working memory"), func() { t.Errorf("issue variant must state the real loss:\n%s", SessionContinuityNoticeIssue) })
 
 	// The web-chat / Feishu transcript variant points at the read-back command
 	// and must NOT order an announcement — the conversation survives in
 	// chat_message, so "the previous context was lost" would be a false alarm.
-	if !strings.Contains(SessionContinuityNoticeChatTranscript, "multica chat history") {
-		t.Error("transcript variant must point at the read-back command")
-	}
-	if strings.Contains(SessionContinuityNoticeChatTranscript, "tell the user") {
+	testassert.OnFailure(t, !strings.Contains(SessionContinuityNoticeChatTranscript, "multica chat history"), func() { t.Error("transcript variant must point at the read-back command") })
+	testassert.OnFailure(t, strings.Contains(SessionContinuityNoticeChatTranscript, "tell the user"), func() {
 		t.Errorf("transcript variant must not script an apology:\n%s", SessionContinuityNoticeChatTranscript)
-	}
-	if !strings.Contains(SessionContinuityNoticeChatTranscript, "your own working memory") {
+	})
+	testassert.OnFailure(t, !strings.Contains(SessionContinuityNoticeChatTranscript, "your own working memory"), func() {
 		t.Errorf("transcript variant must state the real loss:\n%s", SessionContinuityNoticeChatTranscript)
-	}
+	})
 
 	lost := TaskContextForEnv{
 		IssueID:                       "11111111-2222-3333-4444-555555555555",
 		TriggerCommentID:              "trigger-1",
 		PriorSessionResumeUnavailable: true,
 	}
-	if strings.Contains(buildMetaSkillContent("codex", lost), "Session Continuity Notice") {
-		t.Error("brief must never carry the continuity notice — it is per-run state (MUL-5377)")
-	}
+	testassert.OnFailure(t, strings.Contains(buildMetaSkillContent("codex", lost), "Session Continuity Notice"), func() { t.Error("brief must never carry the continuity notice — it is per-run state (MUL-5377)") })
 }
 
 // The issue workflow must keep every Agent Identity guardrail after the
@@ -447,9 +404,7 @@ func TestIssueWorkflowHonorsAgentIdentity(t *testing.T) {
 		// whose identity forbids comments must still be able to mark blocked.
 		"post a comment explaining the blocker unless your Agent Identity forbids issue comments",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("issue brief missing identity-bound workflow text %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("issue brief missing identity-bound workflow text %q\n---\n%s", want, out) })
 	}
 
 	for _, banned := range []string{
@@ -457,9 +412,9 @@ func TestIssueWorkflowHonorsAgentIdentity(t *testing.T) {
 		"5. Follow your Skills and Agent Identity to complete the task (write code, investigate, etc.)",
 		"8. When done, run `multica issue status " + issueID + " in_review`\n",
 	} {
-		if strings.Contains(out, banned) {
+		testassert.OnFailure(t, strings.Contains(out, banned), func() {
 			t.Errorf("issue brief still contains unconditional legacy workflow text %q\n---\n%s", banned, out)
-		}
+		})
 	}
 }
 
@@ -483,9 +438,7 @@ func TestSquadLeaderIssueWorkflowKeepsParentInProgress(t *testing.T) {
 		// The shared no-write default still governs leader conversation turns.
 		"questions, discussion, and acknowledgements never touch status",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("squad-leader issue brief missing %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("squad-leader issue brief missing %q\n---\n%s", want, out) })
 	}
 }
 
@@ -507,9 +460,7 @@ func TestProtocolHeadingInInstructionsGetsNoLeaderBrief(t *testing.T) {
 		IsSquadLeader:     false,
 	})
 
-	if !strings.Contains(out, instructions) {
-		t.Fatalf("agent instructions must reach the brief verbatim\n---\n%s", out)
-	}
+	testassert.OnFailure(t, !strings.Contains(out, instructions), func() { t.Fatalf("agent instructions must reach the brief verbatim\n---\n%s", out) })
 	for _, banned := range []string{
 		"### Squad maintenance",
 		"multica squad member set-role",
@@ -517,13 +468,9 @@ func TestProtocolHeadingInInstructionsGetsNoLeaderBrief(t *testing.T) {
 		"unless your outcome is `no_action`",
 		"dispatching members is not delivery",
 	} {
-		if strings.Contains(out, banned) {
-			t.Fatalf("ordinary-agent brief leaked leader-only content %q\n---\n%s", banned, out)
-		}
+		testassert.OnFailure(t, strings.Contains(out, banned), func() { t.Fatalf("ordinary-agent brief leaked leader-only content %q\n---\n%s", banned, out) })
 	}
-	if !strings.Contains(out, "**Post your final results as a comment — this step is mandatory**") {
-		t.Fatalf("ordinary-agent brief lost the unconditional reply obligation\n---\n%s", out)
-	}
+	testassert.OnFailure(t, !strings.Contains(out, "**Post your final results as a comment — this step is mandatory**"), func() { t.Fatalf("ordinary-agent brief lost the unconditional reply obligation\n---\n%s", out) })
 }
 
 // Instruction Precedence belongs to the issue workflow only; the issue-less
@@ -556,9 +503,9 @@ func TestInstructionPrecedenceOnlyAppliesToIssueWorkflow(t *testing.T) {
 				"issue workflow below",
 				"Never treat this runtime workflow as permission to change issue status",
 			} {
-				if strings.Contains(out, banned) {
+				testassert.OnFailure(t, strings.Contains(out, banned), func() {
 					t.Errorf("%s brief must not inherit issue-only precedence text %q\n---\n%s", tc.name, banned, out)
-				}
+				})
 			}
 		})
 	}
@@ -573,9 +520,7 @@ func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
 		"This is a chat session",
 		"Your reply is delivered directly to the chat window the user is reading",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("chat brief missing chat output guidance %q\n---\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("chat brief missing chat output guidance %q\n---\n%s", want, out) })
 	}
 
 	for _, banned := range []string{
@@ -584,9 +529,7 @@ func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
 		"do not call `multica issue comment add`",
 		"unless the user explicitly asks",
 	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("chat brief must not inherit issue-comment output warning %q\n---\n%s", banned, out)
-		}
+		testassert.OnFailure(t, strings.Contains(out, banned), func() { t.Errorf("chat brief must not inherit issue-comment output warning %q\n---\n%s", banned, out) })
 	}
 }
 
@@ -613,18 +556,14 @@ func TestOutputForbidsMidRunProgressComments(t *testing.T) {
 		for name, ctx := range issueCtxs {
 			out := buildMetaSkillContent("claude", ctx)
 			for _, want := range wantPhrases {
-				if !strings.Contains(out, want) {
-					t.Errorf("%s/%s brief missing output rule %q\n---\n%s", label, name, want, out)
-				}
+				testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("%s/%s brief missing output rule %q\n---\n%s", label, name, want, out) })
 			}
 		}
 		// Chat keeps its own delivery channel; it must not inherit the
 		// issue-task "post a final comment" rules.
 		chat := buildMetaSkillContent("claude", TaskContextForEnv{ChatSessionID: "chat-1"})
 		for _, banned := range wantPhrases {
-			if strings.Contains(chat, banned) {
-				t.Errorf("%s chat brief must not inherit issue output rule %q", label, banned)
-			}
+			testassert.OnFailure(t, strings.Contains(chat, banned), func() { t.Errorf("%s chat brief must not inherit issue output rule %q", label, banned) })
 		}
 	}
 
@@ -646,9 +585,7 @@ func TestSubIssueCreationSectionIsUnconditional(t *testing.T) {
 
 	const header = "## Sub-issue Creation"
 	start := strings.Index(out, header)
-	if start == -1 {
-		t.Fatalf("sub-issue creation section missing")
-	}
+	testassert.OnFailure(t, start == -1, func() { t.Fatalf("sub-issue creation section missing") })
 	rest := out[start:]
 	end := strings.Index(rest[len(header):], "\n## ")
 	var section string
@@ -658,9 +595,9 @@ func TestSubIssueCreationSectionIsUnconditional(t *testing.T) {
 		section = rest[:len(header)+end]
 	}
 
-	if strings.Contains(section, "parent_issue_id") {
+	testassert.OnFailure(t, strings.Contains(section, "parent_issue_id"), func() {
 		t.Errorf("Sub-issue Creation section must not reference `parent_issue_id` — it applies to any issue-bound run, including top-level parents:\n%s", section)
-	}
+	})
 }
 
 // Workspace Context block: workspace.context (the per-workspace system prompt
@@ -718,19 +655,15 @@ func TestWorkspaceContextRenderedAcrossTaskKinds(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
 
-			if !strings.Contains(out, "## Workspace Context") {
-				t.Fatalf("[%s] expected `## Workspace Context` heading", tc.name)
-			}
-			if !strings.Contains(out, wsContext) {
-				t.Errorf("[%s] brief missing workspace context body %q", tc.name, wsContext)
-			}
+			testassert.OnFailure(t, !strings.Contains(out, "## Workspace Context"), func() { t.Fatalf("[%s] expected `## Workspace Context` heading", tc.name) })
+			testassert.OnFailure(t, !strings.Contains(out, wsContext), func() { t.Errorf("[%s] brief missing workspace context body %q", tc.name, wsContext) })
 			// The block must precede Available Commands so it acts as
 			// background framing, not a footer hidden below CLI usage.
 			ctxIdx := strings.Index(out, "## Workspace Context")
 			cmdsIdx := strings.Index(out, "## Available Commands")
-			if ctxIdx == -1 || cmdsIdx == -1 || ctxIdx > cmdsIdx {
+			testassert.OnFailure(t, ctxIdx == -1 || cmdsIdx == -1 || ctxIdx > cmdsIdx, func() {
 				t.Errorf("[%s] `## Workspace Context` must appear above `## Available Commands` (ctx=%d, cmds=%d)", tc.name, ctxIdx, cmdsIdx)
-			}
+			})
 		})
 	}
 }
@@ -761,9 +694,7 @@ func TestWorkspaceContextHeadingSkippedWhenEmpty(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
-			if strings.Contains(out, "## Workspace Context") {
-				t.Errorf("[%s] empty workspace context must NOT emit the heading", tc.name)
-			}
+			testassert.OnFailure(t, strings.Contains(out, "## Workspace Context"), func() { t.Errorf("[%s] empty workspace context must NOT emit the heading", tc.name) })
 		})
 	}
 }
@@ -785,30 +716,24 @@ func TestConnectedAppsBlockLivesOutsideBrief(t *testing.T) {
 		"- Notion (`notion`) via MCP server `composio`",
 		"Use the listed MCP server when the task asks to read or act in one of these apps.",
 	} {
-		if !strings.Contains(block, want) {
-			t.Fatalf("connected-apps block missing %q\n---\n%s", want, block)
-		}
+		testassert.OnFailure(t, !strings.Contains(block, want), func() { t.Fatalf("connected-apps block missing %q\n---\n%s", want, block) })
 	}
-	if BuildConnectedAppsBlock(nil) != "" {
-		t.Error("empty app list must render nothing")
-	}
+	testassert.OnFailure(t, BuildConnectedAppsBlock(nil) != "", func() { t.Error("empty app list must render nothing") })
 
 	out := buildMetaSkillContent("claude", TaskContextForEnv{
 		IssueID:          "11111111-2222-3333-4444-555555555555",
 		WorkspaceContext: "Prefer source-of-truth systems.",
 		ConnectedApps:    apps,
 	})
-	if strings.Contains(out, "## Connected Apps") {
+	testassert.OnFailure(t, strings.Contains(out, "## Connected Apps"), func() {
 		t.Errorf("brief must not carry Connected Apps — it is per-run state (MUL-5377)\n---\n%s", out)
-	}
+	})
 }
 
 func TestConnectedAppsHeadingSkippedWhenEmpty(t *testing.T) {
 	t.Parallel()
 	out := buildMetaSkillContent("claude", TaskContextForEnv{IssueID: "11111111-2222-3333-4444-555555555555"})
-	if strings.Contains(out, "## Connected Apps") {
-		t.Fatalf("empty connected apps must not emit the heading")
-	}
+	testassert.OnFailure(t, strings.Contains(out, "## Connected Apps"), func() { t.Fatalf("empty connected apps must not emit the heading") })
 }
 
 func TestSubIssueCreationSectionSkippedForNonIssueModes(t *testing.T) {
@@ -835,9 +760,7 @@ func TestSubIssueCreationSectionSkippedForNonIssueModes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
-			if strings.Contains(out, "## Sub-issue Creation") {
-				t.Errorf("%s mode must NOT emit the Sub-issue Creation section", tc.name)
-			}
+			testassert.OnFailure(t, strings.Contains(out, "## Sub-issue Creation"), func() { t.Errorf("%s mode must NOT emit the Sub-issue Creation section", tc.name) })
 		})
 	}
 }
@@ -858,19 +781,11 @@ func TestWriteRuntimeConfigFileCreatesMissingFile(t *testing.T) {
 		t.Fatalf("writeRuntimeConfigFile returned error: %v", err)
 	}
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back file: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back file: %v", err) })
 	s := string(got)
-	if !strings.HasPrefix(s, runtimeMarkerBegin+"\n") {
-		t.Errorf("output should start with begin marker, got:\n%s", s)
-	}
-	if !strings.Contains(s, brief) {
-		t.Errorf("output should contain brief body, got:\n%s", s)
-	}
-	if !strings.Contains(s, "\n"+runtimeMarkerEnd+"\n") {
-		t.Errorf("output should contain end marker followed by newline, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(s, runtimeMarkerBegin+"\n"), func() { t.Errorf("output should start with begin marker, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, brief), func() { t.Errorf("output should contain brief body, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, "\n"+runtimeMarkerEnd+"\n"), func() { t.Errorf("output should contain end marker followed by newline, got:\n%s", s) })
 }
 
 func TestWriteRuntimeConfigFilePreservesUserContent(t *testing.T) {
@@ -888,26 +803,18 @@ func TestWriteRuntimeConfigFilePreservesUserContent(t *testing.T) {
 	}
 
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back file: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back file: %v", err) })
 	s := string(got)
 	// The user's original content must be untouched and appear before the
 	// injected marker block; this is the core regression case from MUL-2753.
-	if !strings.HasPrefix(s, userContent) {
-		t.Errorf("user content must be preserved verbatim at the top of the file, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(s, userContent), func() { t.Errorf("user content must be preserved verbatim at the top of the file, got:\n%s", s) })
 	beginIdx := strings.Index(s, runtimeMarkerBegin)
 	endIdx := strings.Index(s, runtimeMarkerEnd)
-	if beginIdx < 0 || endIdx <= beginIdx {
-		t.Fatalf("expected a well-formed marker block in:\n%s", s)
-	}
-	if beginIdx < len(userContent) {
+	testassert.OnFailure(t, beginIdx < 0 || endIdx <= beginIdx, func() { t.Fatalf("expected a well-formed marker block in:\n%s", s) })
+	testassert.OnFailure(t, beginIdx < len(userContent), func() {
 		t.Errorf("begin marker must appear after user content, beginIdx=%d userLen=%d", beginIdx, len(userContent))
-	}
-	if !strings.Contains(s, brief) {
-		t.Errorf("brief body missing from output:\n%s", s)
-	}
+	})
+	testassert.OnFailure(t, !strings.Contains(s, brief), func() { t.Errorf("brief body missing from output:\n%s", s) })
 }
 
 func TestWriteRuntimeConfigFileReplacesExistingBlock(t *testing.T) {
@@ -931,25 +838,13 @@ func TestWriteRuntimeConfigFileReplacesExistingBlock(t *testing.T) {
 	}
 
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back file: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back file: %v", err) })
 	s := string(got)
-	if !strings.HasPrefix(s, userBefore) {
-		t.Errorf("content above the marker block must be preserved, got:\n%s", s)
-	}
-	if !strings.HasSuffix(s, userAfter) {
-		t.Errorf("content below the marker block must be preserved, got:\n%s", s)
-	}
-	if strings.Contains(s, "OLD BRIEF CONTENT THAT MUST GO AWAY") {
-		t.Errorf("previous block body must be replaced, got:\n%s", s)
-	}
-	if !strings.Contains(s, newBrief) {
-		t.Errorf("new brief body missing from output:\n%s", s)
-	}
-	if strings.Count(s, runtimeMarkerBegin) != 1 || strings.Count(s, runtimeMarkerEnd) != 1 {
-		t.Errorf("there must be exactly one begin/end marker pair, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(s, userBefore), func() { t.Errorf("content above the marker block must be preserved, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.HasSuffix(s, userAfter), func() { t.Errorf("content below the marker block must be preserved, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "OLD BRIEF CONTENT THAT MUST GO AWAY"), func() { t.Errorf("previous block body must be replaced, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, newBrief), func() { t.Errorf("new brief body missing from output:\n%s", s) })
+	testassert.OnFailure(t, strings.Count(s, runtimeMarkerBegin) != 1 || strings.Count(s, runtimeMarkerEnd) != 1, func() { t.Errorf("there must be exactly one begin/end marker pair, got:\n%s", s) })
 }
 
 func TestWriteRuntimeConfigFileIsIdempotent(t *testing.T) {
@@ -969,22 +864,18 @@ func TestWriteRuntimeConfigFileIsIdempotent(t *testing.T) {
 	}
 
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back file: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back file: %v", err) })
 	s := string(got)
-	if strings.Count(s, runtimeMarkerBegin) != 1 {
+	testassert.OnFailure(t, strings.Count(s, runtimeMarkerBegin) != 1, func() {
 		t.Errorf("repeated runs must not duplicate the begin marker, count=%d, file:\n%s", strings.Count(s, runtimeMarkerBegin), s)
-	}
-	if strings.Count(s, runtimeMarkerEnd) != 1 {
+	})
+	testassert.OnFailure(t, strings.Count(s, runtimeMarkerEnd) != 1, func() {
 		t.Errorf("repeated runs must not duplicate the end marker, count=%d, file:\n%s", strings.Count(s, runtimeMarkerEnd), s)
-	}
-	if strings.Count(s, brief) != 1 {
+	})
+	testassert.OnFailure(t, strings.Count(s, brief) != 1, func() {
 		t.Errorf("repeated runs must not duplicate the brief body, count=%d, file:\n%s", strings.Count(s, brief), s)
-	}
-	if !strings.HasPrefix(s, userContent) {
-		t.Errorf("user content must remain intact at the top of the file, got:\n%s", s)
-	}
+	})
+	testassert.OnFailure(t, !strings.HasPrefix(s, userContent), func() { t.Errorf("user content must remain intact at the top of the file, got:\n%s", s) })
 }
 
 // InjectRuntimeConfig is the production entry point — verify the marker
@@ -1028,24 +919,18 @@ func TestInjectRuntimeConfigPreservesUserContent(t *testing.T) {
 			content, err := InjectRuntimeConfig(dir, tc.provider, TaskContextForEnv{
 				IssueID: "11111111-2222-3333-4444-555555555555",
 			})
-			if err != nil {
-				t.Fatalf("InjectRuntimeConfig: %v", err)
-			}
-			if content == "" {
-				t.Fatalf("returned brief content must be non-empty")
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("InjectRuntimeConfig: %v", err) })
+			testassert.OnFailure(t, content == "", func() { t.Fatalf("returned brief content must be non-empty") })
 
 			got, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read back: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 			s := string(got)
-			if !strings.HasPrefix(s, userContent) {
+			testassert.OnFailure(t, !strings.HasPrefix(s, userContent), func() {
 				t.Errorf("[%s] user content must be preserved verbatim at the top of %s, got:\n%s", tc.provider, tc.filename, s)
-			}
-			if !strings.Contains(s, runtimeMarkerBegin) || !strings.Contains(s, runtimeMarkerEnd) {
+			})
+			testassert.OnFailure(t, !strings.Contains(s, runtimeMarkerBegin) || !strings.Contains(s, runtimeMarkerEnd), func() {
 				t.Errorf("[%s] %s must contain the runtime marker block, got:\n%s", tc.provider, tc.filename, s)
-			}
+			})
 		})
 	}
 }
@@ -1063,15 +948,9 @@ func TestRuntimeConfigPathDistinguishesCodebuddyFromClaude(t *testing.T) {
 	claudePath := runtimeConfigPath(dir, "claude")
 	codebuddyPath := runtimeConfigPath(dir, "codebuddy")
 
-	if claudePath != filepath.Join(dir, "CLAUDE.md") {
-		t.Errorf("claude runtime config path = %q, want CLAUDE.md", claudePath)
-	}
-	if codebuddyPath != filepath.Join(dir, "CODEBUDDY.md") {
-		t.Errorf("codebuddy runtime config path = %q, want CODEBUDDY.md", codebuddyPath)
-	}
-	if claudePath == codebuddyPath {
-		t.Fatal("claude and codebuddy must not share a runtime config path")
-	}
+	testassert.OnFailure(t, claudePath != filepath.Join(dir, "CLAUDE.md"), func() { t.Errorf("claude runtime config path = %q, want CLAUDE.md", claudePath) })
+	testassert.OnFailure(t, codebuddyPath != filepath.Join(dir, "CODEBUDDY.md"), func() { t.Errorf("codebuddy runtime config path = %q, want CODEBUDDY.md", codebuddyPath) })
+	testassert.OnFailure(t, claudePath == codebuddyPath, func() { t.Fatal("claude and codebuddy must not share a runtime config path") })
 }
 
 func TestInjectRuntimeConfigUnknownProviderSkipsWrite(t *testing.T) {
@@ -1092,12 +971,8 @@ func TestInjectRuntimeConfigUnknownProviderSkipsWrite(t *testing.T) {
 	}
 	for _, name := range []string{"CLAUDE.md", "CODEBUDDY.md", "AGENTS.md"} {
 		got, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
-		}
-		if string(got) != "untouched\n" {
-			t.Errorf("unknown provider must not write %s; got:\n%s", name, string(got))
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", name, err) })
+		testassert.OnFailure(t, string(got) != "untouched\n", func() { t.Errorf("unknown provider must not write %s; got:\n%s", name, string(got)) })
 	}
 }
 
@@ -1127,30 +1002,22 @@ func TestWriteRuntimeConfigFileIgnoresStrayEndMarkerBeforeBegin(t *testing.T) {
 		t.Fatalf("writeRuntimeConfigFile: %v", err)
 	}
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 	s := string(got)
 
 	// The user's stray end marker line plus surrounding doc text must still
 	// be present, and the file must contain exactly one begin marker and
 	// one *additional* end marker (so two end markers total — the stray
 	// one and the one closing our block).
-	if !strings.Contains(s, userDoc) {
-		t.Errorf("user doc with stray end marker must be preserved verbatim, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(s, userDoc), func() { t.Errorf("user doc with stray end marker must be preserved verbatim, got:\n%s", s) })
 	if got, want := strings.Count(s, runtimeMarkerBegin), 1; got != want {
 		t.Errorf("expected exactly %d begin markers, got %d:\n%s", want, got, s)
 	}
 	if got, want := strings.Count(s, runtimeMarkerEnd), 2; got != want {
 		t.Errorf("expected exactly %d end markers (1 user stray + 1 closing our block), got %d:\n%s", want, got, s)
 	}
-	if strings.Contains(s, "FIRST BRIEF") {
-		t.Errorf("previous brief body must be replaced, got:\n%s", s)
-	}
-	if !strings.Contains(s, newBrief) {
-		t.Errorf("new brief body missing from output:\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, "FIRST BRIEF"), func() { t.Errorf("previous brief body must be replaced, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.Contains(s, newBrief), func() { t.Errorf("new brief body missing from output:\n%s", s) })
 
 	// Idempotency under the stray-end pattern: a second write must not
 	// stack another block.
@@ -1184,25 +1051,17 @@ func TestWriteRuntimeConfigFileReplacesMalformedHalfBlock(t *testing.T) {
 		t.Fatalf("writeRuntimeConfigFile: %v", err)
 	}
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 	s := string(got)
-	if !strings.HasPrefix(s, userTop) {
-		t.Errorf("user content above the half-block must be preserved, got:\n%s", s)
-	}
-	if strings.Contains(s, "leftover from crashed write") {
-		t.Errorf("half-block contents must be replaced, got:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(s, userTop), func() { t.Errorf("user content above the half-block must be preserved, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "leftover from crashed write"), func() { t.Errorf("half-block contents must be replaced, got:\n%s", s) })
 	if got, want := strings.Count(s, runtimeMarkerBegin), 1; got != want {
 		t.Errorf("expected exactly %d begin marker, got %d:\n%s", want, got, s)
 	}
 	if got, want := strings.Count(s, runtimeMarkerEnd), 1; got != want {
 		t.Errorf("expected exactly %d end marker after recovery, got %d:\n%s", want, got, s)
 	}
-	if !strings.Contains(s, newBrief) {
-		t.Errorf("new brief body missing from output:\n%s", s)
-	}
+	testassert.OnFailure(t, !strings.Contains(s, newBrief), func() { t.Errorf("new brief body missing from output:\n%s", s) })
 }
 
 // Cleanup excises the marker block, preserving every byte of surrounding
@@ -1230,19 +1089,13 @@ func TestCleanupRuntimeConfigPreservesUserContent(t *testing.T) {
 		t.Fatalf("CleanupRuntimeConfig: %v", err)
 	}
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 	s := string(got)
-	if strings.Contains(s, runtimeMarkerBegin) || strings.Contains(s, runtimeMarkerEnd) {
-		t.Errorf("marker block must be removed, got:\n%s", s)
-	}
-	if strings.Contains(s, "brief body") {
-		t.Errorf("brief body must be removed, got:\n%s", s)
-	}
-	if s != userExpected {
+	testassert.OnFailure(t, strings.Contains(s, runtimeMarkerBegin) || strings.Contains(s, runtimeMarkerEnd), func() { t.Errorf("marker block must be removed, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "brief body"), func() { t.Errorf("brief body must be removed, got:\n%s", s) })
+	testassert.OnFailure(t, s != userExpected, func() {
 		t.Errorf("user content must be preserved byte-for-byte\n got:\n%q\nwant:\n%q", s, userExpected)
-	}
+	})
 }
 
 // Cleanup removes the file entirely when the marker block was the only
@@ -1280,12 +1133,8 @@ func TestCleanupRuntimeConfigNoOpCases(t *testing.T) {
 		}
 		// And the directory must remain untouched.
 		entries, err := os.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("readdir: %v", err)
-		}
-		if len(entries) != 0 {
-			t.Errorf("expected dir to remain empty, got: %v", entries)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("readdir: %v", err) })
+		testassert.OnFailure(t, len(entries) != 0, func() { t.Errorf("expected dir to remain empty, got: %v", entries) })
 	})
 
 	t.Run("file without marker block", func(t *testing.T) {
@@ -1300,12 +1149,8 @@ func TestCleanupRuntimeConfigNoOpCases(t *testing.T) {
 			t.Errorf("no-marker-block file must be no-op, got: %v", err)
 		}
 		got, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read back: %v", err)
-		}
-		if string(got) != userContent {
-			t.Errorf("file must be untouched\n got:\n%q\nwant:\n%q", string(got), userContent)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
+		testassert.OnFailure(t, string(got) != userContent, func() { t.Errorf("file must be untouched\n got:\n%q\nwant:\n%q", string(got), userContent) })
 	})
 
 	t.Run("unknown provider", func(t *testing.T) {
@@ -1322,12 +1167,8 @@ func TestCleanupRuntimeConfigNoOpCases(t *testing.T) {
 		}
 		for _, name := range []string{"CLAUDE.md", "CODEBUDDY.md", "AGENTS.md"} {
 			got, err := os.ReadFile(filepath.Join(dir, name))
-			if err != nil {
-				t.Fatalf("read %s: %v", name, err)
-			}
-			if string(got) != "untouched\n" {
-				t.Errorf("unknown provider must not touch %s; got:\n%s", name, string(got))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read %s: %v", name, err) })
+			testassert.OnFailure(t, string(got) != "untouched\n", func() { t.Errorf("unknown provider must not touch %s; got:\n%s", name, string(got)) })
 		}
 	})
 }
@@ -1350,19 +1191,11 @@ func TestCleanupRuntimeConfigRemovesMalformedHalfBlock(t *testing.T) {
 		t.Fatalf("CleanupRuntimeConfig: %v", err)
 	}
 	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read back: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 	s := string(got)
-	if strings.Contains(s, runtimeMarkerBegin) {
-		t.Errorf("half-block begin marker must be excised, got:\n%s", s)
-	}
-	if strings.Contains(s, "half-written brief no end") {
-		t.Errorf("half-block body must be excised, got:\n%s", s)
-	}
-	if !strings.HasPrefix(s, userTop) {
-		t.Errorf("user content above the half-block must remain, got:\n%s", s)
-	}
+	testassert.OnFailure(t, strings.Contains(s, runtimeMarkerBegin), func() { t.Errorf("half-block begin marker must be excised, got:\n%s", s) })
+	testassert.OnFailure(t, strings.Contains(s, "half-written brief no end"), func() { t.Errorf("half-block body must be excised, got:\n%s", s) })
+	testassert.OnFailure(t, !strings.HasPrefix(s, userTop), func() { t.Errorf("user content above the half-block must remain, got:\n%s", s) })
 }
 
 // Cleanup must remove the marker block for every provider's target file,
@@ -1415,16 +1248,12 @@ func TestCleanupRuntimeConfigByProvider(t *testing.T) {
 				t.Fatalf("CleanupRuntimeConfig: %v", err)
 			}
 			got, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read back: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 			s := string(got)
-			if strings.Contains(s, runtimeMarkerBegin) || strings.Contains(s, runtimeMarkerEnd) {
-				t.Errorf("[%s] marker block must be removed from %s, got:\n%s", tc.provider, tc.filename, s)
-			}
-			if s != userContent {
+			testassert.OnFailure(t, strings.Contains(s, runtimeMarkerBegin) || strings.Contains(s, runtimeMarkerEnd), func() { t.Errorf("[%s] marker block must be removed from %s, got:\n%s", tc.provider, tc.filename, s) })
+			testassert.OnFailure(t, s != userContent, func() {
 				t.Errorf("[%s] user content in %s must be preserved byte-for-byte\n got:\n%q\nwant:\n%q", tc.provider, tc.filename, s, userContent)
-			}
+			})
 		})
 	}
 }
@@ -1455,12 +1284,10 @@ func TestInjectThenCleanupRoundTrip(t *testing.T) {
 			t.Fatalf("iter %d cleanup: %v", i, err)
 		}
 		got, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("iter %d read back: %v", i, err)
-		}
-		if string(got) != userContent {
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("iter %d read back: %v", i, err) })
+		testassert.OnFailure(t, string(got) != userContent, func() {
 			t.Errorf("iter %d: user file must be byte-identical to pre-injection state\n got:\n%q\nwant:\n%q", i, string(got), userContent)
-		}
+		})
 	}
 }
 
@@ -1561,12 +1388,10 @@ func TestInjectThenCleanupRoundTripByteExactBoundaries(t *testing.T) {
 					continue
 				}
 				got, err := os.ReadFile(path)
-				if err != nil {
-					t.Fatalf("iter %d read back: %v", i, err)
-				}
-				if string(got) != tc.seedContent {
+				testassert.OnFailure(t, err != nil, func() { t.Fatalf("iter %d read back: %v", i, err) })
+				testassert.OnFailure(t, string(got) != tc.seedContent, func() {
 					t.Errorf("iter %d: file must be byte-identical to seed\n got:  %q\n want: %q", i, string(got), tc.seedContent)
-				}
+				})
 			}
 		})
 	}
@@ -1614,12 +1439,10 @@ func TestInjectReplaceThenCleanupRestoresByteExact(t *testing.T) {
 				t.Fatalf("cleanup: %v", err)
 			}
 			got, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read back: %v", err)
-			}
-			if string(got) != tc.seedContent {
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
+			testassert.OnFailure(t, string(got) != tc.seedContent, func() {
 				t.Errorf("file must be byte-identical to seed after replace+cleanup\n got:  %q\n want: %q", string(got), tc.seedContent)
-			}
+			})
 		})
 	}
 }
@@ -1643,21 +1466,17 @@ func TestWriteRuntimeConfigFileAlwaysInsertsFixedManagedSeparator(t *testing.T) 
 				t.Fatalf("write: %v", err)
 			}
 			got, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read back: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
 			s := string(got)
 			// The seed must appear verbatim at the start of the file —
 			// no extra newline appended, no trailing newline trimmed.
-			if !strings.HasPrefix(s, seed) {
+			testassert.OnFailure(t, !strings.HasPrefix(s, seed), func() {
 				t.Errorf("seed bytes must survive verbatim at the start of the file\n got: %q\n seed: %q", s, seed)
-			}
+			})
 			// Immediately after the seed we must see the fixed managed
 			// separator, then the begin marker.
 			markerStart := len(seed) + len(runtimeManagedSeparator)
-			if len(s) < markerStart+len(runtimeMarkerBegin) {
-				t.Fatalf("file shorter than expected layout\n got: %q", s)
-			}
+			testassert.OnFailure(t, len(s) < markerStart+len(runtimeMarkerBegin), func() { t.Fatalf("file shorter than expected layout\n got: %q", s) })
 			if got, want := s[len(seed):markerStart], runtimeManagedSeparator; got != want {
 				t.Errorf("expected managed separator %q immediately after seed, got %q", want, got)
 			}
@@ -1689,9 +1508,7 @@ func TestMultiThreadReplyInstructionsFanOut(t *testing.T) {
 		"DISTINCT body file per thread",
 		"never reuse a `--parent` from an earlier turn",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("cross-thread instructions must contain %q, got:\n%s", want, out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, want), func() { t.Errorf("cross-thread instructions must contain %q, got:\n%s", want, out) })
 	}
 
 	// Pin ledger (MUL-5825): the embedded file-operations cookbook was
@@ -1714,9 +1531,9 @@ func TestMultiThreadReplyInstructionsFanOut(t *testing.T) {
 		"Remove-Item",                          // windows cleanup example
 		"`\\n` escape",                         // restated \n-escape rule, any phrasing
 	} {
-		if strings.Contains(out, banned) {
+		testassert.OnFailure(t, strings.Contains(out, banned), func() {
 			t.Errorf("fan-out block re-grew retired cookbook text %q (mechanism lives in ## Comment Formatting — MUL-5825), got:\n%s", banned, out)
-		}
+		})
 	}
 }
 
@@ -1741,9 +1558,9 @@ func TestMultiThreadReplyInstructionsOSInvariant(t *testing.T) {
 		linux := BuildMultiThreadCommentReplyInstructions("55555555-6666-7777-8888-999999999999", targets, leader)
 		runtimeGOOS = "windows"
 		windows := BuildMultiThreadCommentReplyInstructions("55555555-6666-7777-8888-999999999999", targets, leader)
-		if linux != windows {
+		testassert.OnFailure(t, linux != windows, func() {
 			t.Errorf("fan-out block (leader=%v) must be OS-invariant\nlinux:\n%s\nwindows:\n%s", leader, linux, windows)
-		}
+		})
 	}
 }
 
@@ -1752,12 +1569,12 @@ func TestSingleThreadReplyInstructionsKeepSingleParent(t *testing.T) {
 	t.Parallel()
 	out := BuildCommentReplyInstructions("claude", "55555555-6666-7777-8888-999999999999", "c3", false)
 
-	if strings.Contains(out, "DISTINCT threads") {
+	testassert.OnFailure(t, strings.Contains(out, "DISTINCT threads"), func() {
 		t.Errorf("single/same-thread instructions must not emit the multi-thread fan-out block, got:\n%s", out)
-	}
-	if !strings.Contains(out, "--parent c3 --content-file ./reply.md") {
+	})
+	testassert.OnFailure(t, !strings.Contains(out, "--parent c3 --content-file ./reply.md"), func() {
 		t.Errorf("single/same-thread instructions must keep the single --parent=trigger cookbook, got:\n%s", out)
-	}
+	})
 }
 
 // TestInjectRuntimeConfigByteIdenticalAcrossTriggers is the regression guard
@@ -1846,9 +1663,9 @@ func TestInjectRuntimeConfigByteIdenticalAcrossTriggers(t *testing.T) {
 	// guard now varies a different stable input: the agent identity.
 	otherAgent := base
 	otherAgent.AgentName = "Someone Else"
-	if buildMetaSkillContent("claude", base) == buildMetaSkillContent("claude", otherAgent) {
+	testassert.OnFailure(t, buildMetaSkillContent("claude", base) == buildMetaSkillContent("claude", otherAgent), func() {
 		t.Fatal("brief does not vary with agent identity — byte-identity assertions below would be vacuous")
-	}
+	})
 
 	// The stronger MUL-5442 invariant this PR claims as a design benefit:
 	// with identical stable inputs, two DIFFERENT issue ids must render the
@@ -1859,9 +1676,9 @@ func TestInjectRuntimeConfigByteIdenticalAcrossTriggers(t *testing.T) {
 	for _, provider := range []string{"claude", "codex"} {
 		otherIssue := base
 		otherIssue.IssueID = "99999999-8888-7777-6666-555555555555"
-		if buildMetaSkillContent(provider, base) != buildMetaSkillContent(provider, otherIssue) {
+		testassert.OnFailure(t, buildMetaSkillContent(provider, base) != buildMetaSkillContent(provider, otherIssue), func() {
 			t.Fatalf("%s brief differs across issue ids — the cross-issue cache invariant is broken", provider)
-		}
+		})
 	}
 
 	for _, provider := range []string{"claude", "codex"} {
@@ -1877,10 +1694,10 @@ func TestInjectRuntimeConfigByteIdenticalAcrossTriggers(t *testing.T) {
 					want = got
 					continue
 				}
-				if got != want {
+				testassert.OnFailure(t, got != want, func() {
 					t.Errorf("brief differs for variant %q — per-run state leaked into messages[0] (MUL-5377).\n%s",
 						v.name, firstBriefDiff(want, got))
-				}
+				})
 			}
 		})
 	}
@@ -1988,10 +1805,10 @@ func TestBriefByteIdenticalAcrossRunsForEveryKind(t *testing.T) {
 					want = got
 					continue
 				}
-				if got != want {
+				testassert.OnFailure(t, got != want, func() {
 					t.Errorf("%s brief differs for variant %q — per-run state leaked into the cached prefix (MUL-5377).\n%s",
 						kindName, v.name, firstBriefDiff(want, got))
-				}
+				})
 			}
 		})
 	}
@@ -2032,18 +1849,12 @@ func TestBriefSkillsListIsNamesOnly(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent(provider, ctx)
 
-			if !strings.Contains(out, "- **pr-review**\n") {
-				t.Errorf("brief does not list the skill by slug:\n%s", out)
-			}
-			if strings.Contains(out, "Use when reviewing a pull request") {
+			testassert.OnFailure(t, !strings.Contains(out, "- **pr-review**\n"), func() { t.Errorf("brief does not list the skill by slug:\n%s", out) })
+			testassert.OnFailure(t, strings.Contains(out, "Use when reviewing a pull request"), func() {
 				t.Errorf("brief still carries the skill description; the CLI's own listing already has it:\n%s", out)
-			}
-			if strings.Contains(out, ".agent_context/skills/") {
-				t.Errorf("brief still points at the removed fallback path:\n%s", out)
-			}
-			if !strings.Contains(out, "discovered automatically") {
-				t.Errorf("brief lost the native-discovery framing:\n%s", out)
-			}
+			})
+			testassert.OnFailure(t, strings.Contains(out, ".agent_context/skills/"), func() { t.Errorf("brief still points at the removed fallback path:\n%s", out) })
+			testassert.OnFailure(t, !strings.Contains(out, "discovered automatically"), func() { t.Errorf("brief lost the native-discovery framing:\n%s", out) })
 		})
 	}
 }
@@ -2088,12 +1899,10 @@ func TestEveryBriefThatTeachesJSONOutputAlsoWarnsAgainstMergingStderr(t *testing
 		"quick-create": buildMetaSkillContent("claude", TaskContextForEnv{QuickCreatePrompt: "make an issue"}),
 	}
 	for name, brief := range briefs {
-		if !strings.Contains(brief, wantFlag) {
-			t.Fatalf("%s brief does not mention %s at all; this test's premise is gone", name, wantFlag)
-		}
-		if !strings.Contains(brief, wantPremise) {
+		testassert.OnFailure(t, !strings.Contains(brief, wantFlag), func() { t.Fatalf("%s brief does not mention %s at all; this test's premise is gone", name, wantFlag) })
+		testassert.OnFailure(t, !strings.Contains(brief, wantPremise), func() {
 			t.Errorf("%s brief teaches %s without saying %q — the rule below it is only correct while the streams carry what this says they carry", name, wantFlag, wantPremise)
-		}
+		})
 		switch got := strings.Count(brief, wantRule); got {
 		case 1:
 		case 0:
@@ -2102,8 +1911,8 @@ func TestEveryBriefThatTeachesJSONOutputAlsoWarnsAgainstMergingStderr(t *testing
 		default:
 			t.Errorf("%s brief repeats %q %d times; one rule, one place, or the next edit fixes only one of them", name, wantRule, got)
 		}
-		if !strings.Contains(brief, wantWhy) {
+		testassert.OnFailure(t, !strings.Contains(brief, wantWhy), func() {
 			t.Errorf("%s brief states %q without %q; a rule with no reason is the first one dropped under pressure", name, wantRule, wantWhy)
-		}
+		})
 	}
 }

--- a/server/internal/daemon/execenv/runtime_skill_policy_test.go
+++ b/server/internal/daemon/execenv/runtime_skill_policy_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestPrepareClaudeSkillSettings(t *testing.T) {
@@ -16,16 +18,10 @@ func TestPrepareClaudeSkillSettings(t *testing.T) {
 		{Root: "provider", Key: "review-dir", Name: "review"},
 		{Root: "plugin", Key: "paper:design-to-code", Plugin: "paper@market"},
 	}, nil)
-	if err != nil {
-		t.Fatalf("prepareClaudeSkillSettings: %v", err)
-	}
-	if path == "" {
-		t.Fatal("expected task-local settings path")
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareClaudeSkillSettings: %v", err) })
+	testassert.OnFailure(t, path == "", func() { t.Fatal("expected task-local settings path") })
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read settings: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read settings: %v", err) })
 	var got struct {
 		SkillOverrides map[string]string `json:"skillOverrides"`
 		Permissions    struct {
@@ -35,9 +31,7 @@ func TestPrepareClaudeSkillSettings(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("decode settings: %v", err)
 	}
-	if got.SkillOverrides["review"] != "off" {
-		t.Fatalf("ordinary skill override = %q, want off", got.SkillOverrides["review"])
-	}
+	testassert.OnFailure(t, got.SkillOverrides["review"] != "off", func() { t.Fatalf("ordinary skill override = %q, want off", got.SkillOverrides["review"]) })
 	if _, exists := got.SkillOverrides["paper:design-to-code"]; exists {
 		t.Fatal("plugin skills must not use Claude's unsupported skillOverrides path")
 	}
@@ -51,18 +45,12 @@ func TestPrepareClaudeSkillSettings(t *testing.T) {
 		for _, rule := range got.Permissions.Deny {
 			found = found || rule == want
 		}
-		if !found {
-			t.Errorf("missing deny rule %q in %v", want, got.Permissions.Deny)
-		}
+		testassert.OnFailure(t, !found, func() { t.Errorf("missing deny rule %q in %v", want, got.Permissions.Deny) })
 	}
 
 	cleared, err := prepareClaudeSkillSettings(root, nil, nil)
-	if err != nil {
-		t.Fatalf("clear settings: %v", err)
-	}
-	if cleared != "" {
-		t.Fatalf("cleared settings path = %q, want empty", cleared)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("clear settings: %v", err) })
+	testassert.OnFailure(t, cleared != "", func() { t.Fatalf("cleared settings path = %q, want empty", cleared) })
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("stale settings file still exists: %v", err)
 	}
@@ -84,20 +72,12 @@ func TestEnsureCodexDisabledSkillsConfig(t *testing.T) {
 		t.Fatalf("ensureCodexDisabledSkillsConfig: %v", err)
 	}
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatal(err) })
 	content := string(data)
-	if strings.Count(content, "[[skills.config]]") != 2 {
-		t.Fatalf("disabled entry count mismatch:\n%s", content)
-	}
+	testassert.OnFailure(t, strings.Count(content, "[[skills.config]]") != 2, func() { t.Fatalf("disabled entry count mismatch:\n%s", content) })
 	wantProvider := filepath.ToSlash(filepath.Join(root, "skills", "review", "SKILL.md"))
-	if !strings.Contains(content, wantProvider) {
-		t.Fatalf("missing provider skill path %q:\n%s", wantProvider, content)
-	}
-	if strings.Contains(content, "escape") {
-		t.Fatalf("unsafe key leaked into config:\n%s", content)
-	}
+	testassert.OnFailure(t, !strings.Contains(content, wantProvider), func() { t.Fatalf("missing provider skill path %q:\n%s", wantProvider, content) })
+	testassert.OnFailure(t, strings.Contains(content, "escape"), func() { t.Fatalf("unsafe key leaked into config:\n%s", content) })
 }
 
 func TestRuntimeSkillPoliciesYieldToWorkspaceSkills(t *testing.T) {
@@ -108,12 +88,8 @@ func TestRuntimeSkillPoliciesYieldToWorkspaceSkills(t *testing.T) {
 	settingsPath, err := prepareClaudeSkillSettings(root, []RuntimeSkillRefForEnv{
 		{Root: "provider", Key: "review-dir", Name: "review"},
 	}, workspaceSkills)
-	if err != nil {
-		t.Fatalf("prepareClaudeSkillSettings: %v", err)
-	}
-	if settingsPath != "" {
-		t.Fatalf("workspace-owned Claude skill was disabled via %q", settingsPath)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("prepareClaudeSkillSettings: %v", err) })
+	testassert.OnFailure(t, settingsPath != "", func() { t.Fatalf("workspace-owned Claude skill was disabled via %q", settingsPath) })
 
 	configPath := filepath.Join(root, "config.toml")
 	if err := ensureCodexDisabledSkillsConfig(configPath, root, []RuntimeSkillRefForEnv{

--- a/server/internal/daemon/execenv/sidecar_manifest_test.go
+++ b/server/internal/daemon/execenv/sidecar_manifest_test.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // walkRelative returns every relative path inside root (files and directories),
@@ -38,9 +40,7 @@ func walkRelative(t *testing.T, root string) []string {
 		entries = append(entries, rel)
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("walk %s: %v", root, err) })
 	sort.Strings(entries)
 	return entries
 }
@@ -76,17 +76,15 @@ func snapshot(t *testing.T, root string) workdirSnapshot {
 		snap.files[rel] = string(data)
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("walk-for-content %s: %v", root, err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("walk-for-content %s: %v", root, err) })
 	return snap
 }
 
 func assertSnapshotEqual(t *testing.T, label string, want, got workdirSnapshot) {
 	t.Helper()
-	if !reflect.DeepEqual(want.entries, got.entries) {
+	testassert.OnFailure(t, !reflect.DeepEqual(want.entries, got.entries), func() {
 		t.Errorf("[%s] directory listing differs\n want: %v\n  got: %v", label, want.entries, got.entries)
-	}
+	})
 	if !reflect.DeepEqual(want.files, got.files) {
 		// Find a small diff first so the failure is actionable.
 		for k, wv := range want.files {
@@ -95,9 +93,7 @@ func assertSnapshotEqual(t *testing.T, label string, want, got workdirSnapshot) 
 				t.Errorf("[%s] missing file %s after round-trip", label, k)
 				continue
 			}
-			if wv != gv {
-				t.Errorf("[%s] file %s differs\n want: %q\n  got: %q", label, k, wv, gv)
-			}
+			testassert.OnFailure(t, wv != gv, func() { t.Errorf("[%s] file %s differs\n want: %q\n  got: %q", label, k, wv, gv) })
 		}
 		for k := range got.files {
 			if _, ok := want.files[k]; !ok {
@@ -278,12 +274,8 @@ func TestPrepareThenCleanupSidecarsPreservesUserSkillSibling(t *testing.T) {
 			// Defensive: independently re-read the user skill to make
 			// sure no clever cleanup heuristic stripped its content.
 			got, err := os.ReadFile(filepath.Join(userDir, tc.userSkillFile))
-			if err != nil {
-				t.Fatalf("user skill went missing after round-trip: %v", err)
-			}
-			if string(got) != userBody {
-				t.Errorf("user skill content changed\n want: %q\n  got: %q", userBody, string(got))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("user skill went missing after round-trip: %v", err) })
+			testassert.OnFailure(t, string(got) != userBody, func() { t.Errorf("user skill content changed\n want: %q\n  got: %q", userBody, string(got)) })
 		})
 	}
 }
@@ -471,12 +463,8 @@ func TestCleanupSidecarsLeavesUserContentInTrackedDirIntact(t *testing.T) {
 	// .multica still holds user-notes.txt, so rmdir must have been
 	// skipped silently — the directory must survive.
 	got, err := os.ReadFile(userFile)
-	if err != nil {
-		t.Fatalf("user file went missing: %v", err)
-	}
-	if string(got) != "hello" {
-		t.Errorf("user file content changed: %q", string(got))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("user file went missing: %v", err) })
+	testassert.OnFailure(t, string(got) != "hello", func() { t.Errorf("user file content changed: %q", string(got)) })
 }
 
 // TestCleanupSidecarsDoesNotRemovePreExistingDirs is the directed unit
@@ -501,9 +489,9 @@ func TestCleanupSidecarsDoesNotRemovePreExistingDirs(t *testing.T) {
 		t.Fatalf("recordMkdirAll: %v", err)
 	}
 	for _, d := range manifest.Dirs {
-		if d == userDir {
+		testassert.OnFailure(t, d == userDir, func() {
 			t.Fatalf("manifest must not record pre-existing user dir %s\nfull dirs: %v", userDir, manifest.Dirs)
-		}
+		})
 	}
 
 	if err := writeSidecarManifest(envRoot, manifest); err != nil {
@@ -537,23 +525,19 @@ func TestRecordWriteFileRefusesToOverwritePreExistingFile(t *testing.T) {
 
 	m := &sidecarManifest{}
 	err := recordWriteFile(target, []byte("ours"), 0o644, m)
-	if !errors.Is(err, errPathPreExists) {
+	testassert.OnFailure(t, !errors.Is(err, errPathPreExists), func() {
 		t.Fatalf("recordWriteFile must return errPathPreExists for a pre-existing target, got: %v", err)
-	}
+	})
 	for _, f := range m.Files {
-		if f == target {
-			t.Errorf("manifest must not record pre-existing user file %s", target)
-		}
+		testassert.OnFailure(t, f == target, func() { t.Errorf("manifest must not record pre-existing user file %s", target) })
 	}
 	// User bytes must survive the refused write — the whole point of
 	// the new behaviour is that pre-existing paths are NEVER mutated.
 	got, err := os.ReadFile(target)
-	if err != nil {
-		t.Fatalf("read back: %v", err)
-	}
-	if string(got) != "user bytes" {
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read back: %v", err) })
+	testassert.OnFailure(t, string(got) != "user bytes", func() {
 		t.Errorf("user bytes must survive refused write\n want: %q\n  got: %q", "user bytes", string(got))
-	}
+	})
 }
 
 // TestRecordWriteFileRefusesToOverwriteSymlinkOrDir is the directed
@@ -602,13 +586,9 @@ func TestSidecarManifestRoundTripJSON(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	raw, err := os.ReadFile(filepath.Join(envRoot, sidecarManifestFile))
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read: %v", err) })
 	for _, want := range []string{"files", "dirs", "issue_context.md", ".agent_context"} {
-		if !strings.Contains(string(raw), want) {
-			t.Errorf("manifest JSON missing %q\n got: %s", want, string(raw))
-		}
+		testassert.OnFailure(t, !strings.Contains(string(raw), want), func() { t.Errorf("manifest JSON missing %q\n got: %s", want, string(raw)) })
 	}
 }
 
@@ -704,19 +684,11 @@ func TestPrepareThenCleanupSidecarsSameSlugCollisionPerProvider(t *testing.T) {
 			// Defensive double-check: read the user's files
 			// directly to make sure their content survived.
 			gotBody, err := os.ReadFile(userSkillFile)
-			if err != nil {
-				t.Fatalf("user SKILL.md went missing: %v", err)
-			}
-			if string(gotBody) != userBody {
-				t.Errorf("user SKILL.md mutated\n want: %q\n  got: %q", userBody, string(gotBody))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("user SKILL.md went missing: %v", err) })
+			testassert.OnFailure(t, string(gotBody) != userBody, func() { t.Errorf("user SKILL.md mutated\n want: %q\n  got: %q", userBody, string(gotBody)) })
 			gotExtra, err := os.ReadFile(userExtra)
-			if err != nil {
-				t.Fatalf("user extra file went missing: %v", err)
-			}
-			if string(gotExtra) != "private notes" {
-				t.Errorf("user extra file mutated\n want: %q\n  got: %q", "private notes", string(gotExtra))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("user extra file went missing: %v", err) })
+			testassert.OnFailure(t, string(gotExtra) != "private notes", func() { t.Errorf("user extra file mutated\n want: %q\n  got: %q", "private notes", string(gotExtra)) })
 		})
 	}
 }
@@ -758,12 +730,8 @@ func TestPrepareThenCleanupSidecarsIssueContextCollisionPerProvider(t *testing.T
 			assertSnapshotEqual(t, provider, before, after)
 
 			got, err := os.ReadFile(userPath)
-			if err != nil {
-				t.Fatalf("user issue_context.md went missing: %v", err)
-			}
-			if string(got) != userBody {
-				t.Errorf("user issue_context.md mutated\n want: %q\n  got: %q", userBody, string(got))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("user issue_context.md went missing: %v", err) })
+			testassert.OnFailure(t, string(got) != userBody, func() { t.Errorf("user issue_context.md mutated\n want: %q\n  got: %q", userBody, string(got)) })
 		})
 	}
 }
@@ -811,12 +779,8 @@ func TestPrepareThenCleanupSidecarsProjectResourcesCollisionPerProvider(t *testi
 			assertSnapshotEqual(t, provider, before, after)
 
 			got, err := os.ReadFile(userPath)
-			if err != nil {
-				t.Fatalf("user resources.json went missing: %v", err)
-			}
-			if string(got) != userBody {
-				t.Errorf("user resources.json mutated\n want: %q\n  got: %q", userBody, string(got))
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("user resources.json went missing: %v", err) })
+			testassert.OnFailure(t, string(got) != userBody, func() { t.Errorf("user resources.json mutated\n want: %q\n  got: %q", userBody, string(got)) })
 		})
 	}
 }
@@ -833,45 +797,27 @@ func TestAllocateCollisionFreeSkillDir(t *testing.T) {
 
 	// 1) No collision → use the base slug as-is.
 	slug, dir, err := allocateCollisionFreeSkillDir(parent, "issue-review")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if slug != "issue-review" {
-		t.Errorf("first allocation should use base slug; got %q", slug)
-	}
-	if dir != filepath.Join(parent, "issue-review") {
-		t.Errorf("first allocation path = %q, want under parent", dir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("unexpected error: %v", err) })
+	testassert.OnFailure(t, slug != "issue-review", func() { t.Errorf("first allocation should use base slug; got %q", slug) })
+	testassert.OnFailure(t, dir != filepath.Join(parent, "issue-review"), func() { t.Errorf("first allocation path = %q, want under parent", dir) })
 
 	// 2) Pre-existing user dir at the base slug → bump to `-multica`.
 	if err := os.MkdirAll(filepath.Join(parent, "issue-review"), 0o755); err != nil {
 		t.Fatalf("seed user dir: %v", err)
 	}
 	slug, dir, err = allocateCollisionFreeSkillDir(parent, "issue-review")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if slug != "issue-review-multica" {
-		t.Errorf("second allocation should bump to `-multica`; got %q", slug)
-	}
-	if dir != filepath.Join(parent, "issue-review-multica") {
-		t.Errorf("second allocation path = %q, want under parent", dir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("unexpected error: %v", err) })
+	testassert.OnFailure(t, slug != "issue-review-multica", func() { t.Errorf("second allocation should bump to `-multica`; got %q", slug) })
+	testassert.OnFailure(t, dir != filepath.Join(parent, "issue-review-multica"), func() { t.Errorf("second allocation path = %q, want under parent", dir) })
 
 	// 3) Pre-existing collision at the bumped slug too → bump again.
 	if err := os.MkdirAll(filepath.Join(parent, "issue-review-multica"), 0o755); err != nil {
 		t.Fatalf("seed bumped dir: %v", err)
 	}
 	slug, dir, err = allocateCollisionFreeSkillDir(parent, "issue-review")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if slug != "issue-review-multica-2" {
-		t.Errorf("third allocation should be `-multica-2`; got %q", slug)
-	}
-	if dir != filepath.Join(parent, "issue-review-multica-2") {
-		t.Errorf("third allocation path = %q, want under parent", dir)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("unexpected error: %v", err) })
+	testassert.OnFailure(t, slug != "issue-review-multica-2", func() { t.Errorf("third allocation should be `-multica-2`; got %q", slug) })
+	testassert.OnFailure(t, dir != filepath.Join(parent, "issue-review-multica-2"), func() { t.Errorf("third allocation path = %q, want under parent", dir) })
 }
 
 // TestPrepareThenCleanupSidecarsMultiSkillCollisionFreeAllocation is
@@ -913,12 +859,8 @@ func TestPrepareThenCleanupSidecarsMultiSkillCollisionFreeAllocation(t *testing.
 		t.Errorf("Multica sibling skill should exist at %s: %v", multicaDir, err)
 	}
 	got, err := os.ReadFile(userFile)
-	if err != nil {
-		t.Fatalf("user SKILL.md went missing during inject: %v", err)
-	}
-	if string(got) != userBody {
-		t.Errorf("user SKILL.md mutated during inject\n want: %q\n  got: %q", userBody, string(got))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("user SKILL.md went missing during inject: %v", err) })
+	testassert.OnFailure(t, string(got) != userBody, func() { t.Errorf("user SKILL.md mutated during inject\n want: %q\n  got: %q", userBody, string(got)) })
 
 	// Now persist manifest + run cleanup. After cleanup the
 	// Multica sibling is gone; user's path survives.
@@ -932,12 +874,8 @@ func TestPrepareThenCleanupSidecarsMultiSkillCollisionFreeAllocation(t *testing.
 		t.Errorf("Multica sibling should be removed by Cleanup; stat err=%v", err)
 	}
 	got, err = os.ReadFile(userFile)
-	if err != nil {
-		t.Fatalf("user SKILL.md went missing after cleanup: %v", err)
-	}
-	if string(got) != userBody {
-		t.Errorf("user SKILL.md mutated after cleanup\n want: %q\n  got: %q", userBody, string(got))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("user SKILL.md went missing after cleanup: %v", err) })
+	testassert.OnFailure(t, string(got) != userBody, func() { t.Errorf("user SKILL.md mutated after cleanup\n want: %q\n  got: %q", userBody, string(got)) })
 }
 
 // TestCleanupSidecarsSwallowsMissingAndNonEmptyDirs pins the two
@@ -979,12 +917,8 @@ func TestCleanupSidecarsSwallowsMissingAndNonEmptyDirs(t *testing.T) {
 		t.Errorf("CleanupSidecars(non-empty dir) should swallow ENOTEMPTY silently, got: %v", err)
 	}
 	got, err := os.ReadFile(userFile)
-	if err != nil {
-		t.Fatalf("user content went missing: %v", err)
-	}
-	if string(got) != "user content" {
-		t.Errorf("user content mutated: %q", string(got))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("user content went missing: %v", err) })
+	testassert.OnFailure(t, string(got) != "user content", func() { t.Errorf("user content mutated: %q", string(got)) })
 }
 
 // TestCleanupSidecarsSurfacesEACCESOnEmptyRecordedDir is the directed
@@ -1026,15 +960,9 @@ func TestCleanupSidecarsSurfacesEACCESOnEmptyRecordedDir(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
 
 	err := CleanupSidecars(envRoot)
-	if err == nil {
-		t.Fatal("CleanupSidecars should surface the EACCES rmdir error, got nil")
-	}
-	if !strings.Contains(err.Error(), "empty-dir") {
-		t.Errorf("expected surfaced error to reference recorded path, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "rmdir") {
-		t.Errorf("expected surfaced error to come from rmdir branch, got: %v", err)
-	}
+	testassert.OnFailure(t, err == nil, func() { t.Fatal("CleanupSidecars should surface the EACCES rmdir error, got nil") })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "empty-dir"), func() { t.Errorf("expected surfaced error to reference recorded path, got: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "rmdir"), func() { t.Errorf("expected surfaced error to come from rmdir branch, got: %v", err) })
 }
 
 // TestCleanupSidecarsSurfacesEACCESWhenReadDirFailsToo is the matching
@@ -1082,15 +1010,13 @@ func TestCleanupSidecarsSurfacesEACCESWhenReadDirFailsToo(t *testing.T) {
 	})
 
 	err := CleanupSidecars(envRoot)
-	if err == nil {
+	testassert.OnFailure(t, err == nil, func() {
 		t.Fatal("CleanupSidecars should surface the rmdir error even when ReadDir also fails, got nil")
-	}
-	if !strings.Contains(err.Error(), "locked-dir") {
-		t.Errorf("expected surfaced error to reference recorded path, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "rmdir") {
+	})
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "locked-dir"), func() { t.Errorf("expected surfaced error to reference recorded path, got: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(err.Error(), "rmdir"), func() {
 		t.Errorf("expected surfaced error to be the ORIGINAL rmdir error, not the ReadDir failure, got: %v", err)
-	}
+	})
 }
 
 // TestDirHasEntries is the directed unit test for the helper Cleanup

--- a/server/internal/daemon/execenv/skill_frontmatter_test.go
+++ b/server/internal/daemon/execenv/skill_frontmatter_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -13,14 +14,10 @@ import (
 // text between the leading `---` and the next `---`, and yaml.Unmarshal it.
 func parseFrontmatter(t *testing.T, content string) map[string]any {
 	t.Helper()
-	if !strings.HasPrefix(content, "---\n") {
-		t.Fatalf("content does not start with a frontmatter block:\n%s", content)
-	}
+	testassert.OnFailure(t, !strings.HasPrefix(content, "---\n"), func() { t.Fatalf("content does not start with a frontmatter block:\n%s", content) })
 	rest := content[len("---\n"):]
 	end := strings.Index(rest, "\n---")
-	if end < 0 {
-		t.Fatalf("frontmatter has no closing delimiter:\n%s", content)
-	}
+	testassert.OnFailure(t, end < 0, func() { t.Fatalf("frontmatter has no closing delimiter:\n%s", content) })
 	var m map[string]any
 	if err := yaml.Unmarshal([]byte(rest[:end]), &m); err != nil {
 		t.Fatalf("frontmatter is not valid YAML: %v\nblock:\n%s", err, rest[:end])
@@ -60,9 +57,7 @@ func TestEnsureSkillFrontmatterReSynthesizesInvalidYAML(t *testing.T) {
 			// the issue: the second `: ` makes YAML treat the tail as a
 			// nested mapping.
 			broken := "---\n" + tc.nameLine + "\ndescription: bad: value here\n---\n\n" + body
-			if isFrontmatterValidYAML(broken) {
-				t.Fatalf("fixture parses; it no longer exercises the malformed branch:\n%s", broken)
-			}
+			testassert.OnFailure(t, isFrontmatterValidYAML(broken), func() { t.Fatalf("fixture parses; it no longer exercises the malformed branch:\n%s", broken) })
 
 			got := ensureSkillFrontmatter(broken, "my-slug", "DB description: with a colon")
 
@@ -75,9 +70,7 @@ func TestEnsureSkillFrontmatterReSynthesizesInvalidYAML(t *testing.T) {
 			if desc, _ := fm["description"].(string); desc != "DB description: with a colon" {
 				t.Errorf("description = %#v, want the DB description verbatim\noutput:\n%s", fm["description"], got)
 			}
-			if !strings.Contains(got, "Real skill body.") {
-				t.Errorf("body was dropped during re-synthesis:\n%s", got)
-			}
+			testassert.OnFailure(t, !strings.Contains(got, "Real skill body."), func() { t.Errorf("body was dropped during re-synthesis:\n%s", got) })
 		})
 	}
 }
@@ -99,9 +92,7 @@ func TestEnsureSkillFrontmatterReSynthesizesInvalidYAMLWithEmptyDescription(t *t
 	if _, present := fm["description"]; present {
 		t.Errorf("description should be omitted when DB description is empty, got %#v", fm["description"])
 	}
-	if !strings.Contains(got, "body text") {
-		t.Errorf("body was dropped during re-synthesis:\n%s", got)
-	}
+	testassert.OnFailure(t, !strings.Contains(got, "body text"), func() { t.Errorf("body was dropped during re-synthesis:\n%s", got) })
 }
 
 // Valid frontmatter survives re-synthesis: every key keeps its upstream
@@ -204,9 +195,7 @@ func TestEnsureSkillFrontmatterReplacesMultiLineNameValues(t *testing.T) {
 			if desc, _ := fm["description"].(string); desc != "kept" {
 				t.Errorf("description = %#v, want %q\noutput:\n%s", fm["description"], "kept", got)
 			}
-			if !strings.Contains(got, "body") {
-				t.Errorf("body was dropped:\n%s", got)
-			}
+			testassert.OnFailure(t, !strings.Contains(got, "body"), func() { t.Errorf("body was dropped:\n%s", got) })
 		})
 	}
 }
@@ -235,9 +224,9 @@ func TestEnsureSkillFrontmatterKeepsPolicyKeysWhenSurgicalRewriteFails(t *testin
 	if name, _ := fm["name"].(string); name != "my-slug" {
 		t.Errorf("name = %#v, want %q\noutput:\n%s", fm["name"], "my-slug", got)
 	}
-	if fm["disable-model-invocation"] != true {
+	testassert.OnFailure(t, fm["disable-model-invocation"] != true, func() {
 		t.Errorf("disable-model-invocation was dropped (%#v); the written skill would be exposed to native discovery\noutput:\n%s", fm["disable-model-invocation"], got)
-	}
+	})
 	if custom, _ := fm["custom-key"].(string); custom != "kept" {
 		t.Errorf("custom-key = %#v, want %q\noutput:\n%s", fm["custom-key"], "kept", got)
 	}
@@ -250,12 +239,8 @@ func TestEnsureSkillFrontmatterKeepsPolicyKeysWhenSurgicalRewriteFails(t *testin
 	}
 	// The written file must still read as hidden to the visibility check that
 	// gates whether a skill is advertised.
-	if !skillDisablesModelInvocation(got) {
-		t.Errorf("written skill no longer reads as disable-model-invocation:\n%s", got)
-	}
-	if !strings.Contains(got, "body") {
-		t.Errorf("body was dropped:\n%s", got)
-	}
+	testassert.OnFailure(t, !skillDisablesModelInvocation(got), func() { t.Errorf("written skill no longer reads as disable-model-invocation:\n%s", got) })
+	testassert.OnFailure(t, !strings.Contains(got, "body"), func() { t.Errorf("body was dropped:\n%s", got) })
 }
 
 // lookupPath resolves a dotted key path through nested frontmatter mappings,
@@ -319,16 +304,12 @@ func TestEnsureSkillFrontmatterKeepsAliasedValuesWhenNameIsRenamed(t *testing.T)
 			parseFrontmatter(t, tc.content)
 
 			// The skill starts out hidden from model invocation...
-			if !skillDisablesModelInvocation(tc.content) {
-				t.Fatalf("fixture is not hidden to begin with; the test proves nothing")
-			}
+			testassert.OnFailure(t, !skillDisablesModelInvocation(tc.content), func() { t.Fatalf("fixture is not hidden to begin with; the test proves nothing") })
 
 			got := ensureSkillFrontmatter(tc.content, "my-slug", "")
 
 			// ...and must still be hidden afterwards.
-			if !skillDisablesModelInvocation(got) {
-				t.Errorf("rewrite exposed a hidden skill\noutput:\n%s", got)
-			}
+			testassert.OnFailure(t, !skillDisablesModelInvocation(got), func() { t.Errorf("rewrite exposed a hidden skill\noutput:\n%s", got) })
 
 			fm := parseFrontmatter(t, got)
 			if name, _ := fm["name"].(string); name != "my-slug" {
@@ -344,9 +325,7 @@ func TestEnsureSkillFrontmatterKeepsAliasedValuesWhenNameIsRenamed(t *testing.T)
 					t.Errorf("aliased %s = %#v, want %q\noutput:\n%s", path, v, "true", got)
 				}
 			}
-			if strings.Contains(got, "*shared") || strings.Contains(got, "&shared") {
-				t.Errorf("anchor/alias survived instead of being materialized\noutput:\n%s", got)
-			}
+			testassert.OnFailure(t, strings.Contains(got, "*shared") || strings.Contains(got, "&shared"), func() { t.Errorf("anchor/alias survived instead of being materialized\noutput:\n%s", got) })
 		})
 	}
 }
@@ -392,15 +371,13 @@ func TestEnsureSkillFrontmatterRecognizesQuotedAndEmptyNameKeys(t *testing.T) {
 			if name, _ := fm["name"].(string); name != "my-slug" {
 				t.Errorf("name = %#v, want %q\noutput:\n%s", fm["name"], "my-slug", got)
 			}
-			if fm["disable-model-invocation"] != true {
+			testassert.OnFailure(t, fm["disable-model-invocation"] != true, func() {
 				t.Errorf("disable-model-invocation = %#v, want true\noutput:\n%s", fm["disable-model-invocation"], got)
-			}
+			})
 			if custom, _ := fm["custom-key"].(string); custom != "kept" {
 				t.Errorf("custom-key = %#v, want %q\noutput:\n%s", fm["custom-key"], "kept", got)
 			}
-			if !skillDisablesModelInvocation(got) {
-				t.Errorf("written skill no longer reads as hidden:\n%s", got)
-			}
+			testassert.OnFailure(t, !skillDisablesModelInvocation(got), func() { t.Errorf("written skill no longer reads as hidden:\n%s", got) })
 		})
 	}
 }
@@ -434,9 +411,7 @@ func TestEnsureSkillFrontmatterHandlesHashInsideBlockScalarName(t *testing.T) {
 	if name, _ := fm["name"].(string); name != "my-slug" {
 		t.Errorf("parsed name = %#v, want %q\noutput:\n%s", fm["name"], "my-slug", got)
 	}
-	if strings.Contains(got, "# not a comment") {
-		t.Errorf("block scalar content was stranded outside the replaced span:\n%s", got)
-	}
+	testassert.OnFailure(t, strings.Contains(got, "# not a comment"), func() { t.Errorf("block scalar content was stranded outside the replaced span:\n%s", got) })
 }
 
 // The rewrite is byte-surgical: a CRLF block keeps its line endings instead of
@@ -514,10 +489,10 @@ func TestFrontmatterPartsClosingDelimiterVariants(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fm, body, ok := frontmatterParts(tc.content)
-			if ok != tc.wantOK || fm != tc.wantFM || body != tc.wantBody {
+			testassert.OnFailure(t, ok != tc.wantOK || fm != tc.wantFM || body != tc.wantBody, func() {
 				t.Errorf("frontmatterParts(%q) = (%q, %q, %v), want (%q, %q, %v)",
 					tc.content, fm, body, ok, tc.wantFM, tc.wantBody, tc.wantOK)
-			}
+			})
 		})
 	}
 }

--- a/server/internal/daemon/execenv/skill_visibility_test.go
+++ b/server/internal/daemon/execenv/skill_visibility_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestSkillModelInvocationVisibility(t *testing.T) {
@@ -78,9 +80,7 @@ body`,
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := skillModelInvocationVisible(SkillContextForEnv{Content: tc.content})
-			if got != tc.want {
-				t.Errorf("skillModelInvocationVisible = %v, want %v", got, tc.want)
-			}
+			testassert.OnFailure(t, got != tc.want, func() { t.Errorf("skillModelInvocationVisible = %v, want %v", got, tc.want) })
 		})
 	}
 }
@@ -126,15 +126,9 @@ Hidden body.`,
 	} {
 		out := buildMetaSkillContent("codex", kind)
 		// Listings carry the on-disk slug, not the display name (MUL-5529).
-		if !strings.Contains(out, "visible-skill") {
-			t.Errorf("brief missing visible skill:\n%s", out)
-		}
-		if strings.Contains(out, "Visible Skill") {
-			t.Errorf("brief lists the display name instead of the slug:\n%s", out)
-		}
-		if strings.Contains(out, "hidden-skill") || strings.Contains(out, "hidden description") {
-			t.Errorf("brief advertised disable-model-invocation skill:\n%s", out)
-		}
+		testassert.OnFailure(t, !strings.Contains(out, "visible-skill"), func() { t.Errorf("brief missing visible skill:\n%s", out) })
+		testassert.OnFailure(t, strings.Contains(out, "Visible Skill"), func() { t.Errorf("brief lists the display name instead of the slug:\n%s", out) })
+		testassert.OnFailure(t, strings.Contains(out, "hidden-skill") || strings.Contains(out, "hidden description"), func() { t.Errorf("brief advertised disable-model-invocation skill:\n%s", out) })
 	}
 
 	// issue_context.md and its quick-create / autopilot variants no longer
@@ -144,9 +138,7 @@ Hidden body.`,
 		"quick create":  renderQuickCreateContext(TaskContextForEnv{QuickCreatePrompt: ctx.QuickCreatePrompt, AgentSkills: ctx.AgentSkills}),
 		"autopilot":     renderAutopilotContext(TaskContextForEnv{AutopilotRunID: ctx.AutopilotRunID, AgentSkills: ctx.AgentSkills}),
 	} {
-		if strings.Contains(out, "## Agent Skills") || strings.Contains(out, "visible-skill") {
-			t.Errorf("%s still renders a skill list:\n%s", name, out)
-		}
+		testassert.OnFailure(t, strings.Contains(out, "## Agent Skills") || strings.Contains(out, "visible-skill"), func() { t.Errorf("%s still renders a skill list:\n%s", name, out) })
 	}
 }
 
@@ -175,9 +167,7 @@ func TestSkillListingNamesMatchDirectoriesOnBatchSlugCollision(t *testing.T) {
 
 	onDisk := map[string]struct{}{}
 	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read skills dir: %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read skills dir: %v", err) })
 	for _, e := range entries {
 		onDisk[e.Name()] = struct{}{}
 		if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err != nil {
@@ -193,9 +183,7 @@ func TestSkillListingNamesMatchDirectoriesOnBatchSlugCollision(t *testing.T) {
 		listed[s.Name] = struct{}{}
 	}
 
-	if len(listed) != len(skills) {
-		t.Errorf("listed %d distinct names for %d skills: %v", len(listed), len(skills), listed)
-	}
+	testassert.OnFailure(t, len(listed) != len(skills), func() { t.Errorf("listed %d distinct names for %d skills: %v", len(listed), len(skills), listed) })
 	for name := range listed {
 		if _, ok := onDisk[name]; !ok {
 			t.Errorf("listing advertises %q but no such directory exists; on disk: %v", name, onDisk)
@@ -225,14 +213,10 @@ func TestBatchSlugAllocationCountsHiddenSkills(t *testing.T) {
 	}
 
 	visible := modelVisibleSkills(skills)
-	if len(visible) != 1 {
-		t.Fatalf("expected 1 visible skill, got %d", len(visible))
-	}
+	testassert.OnFailure(t, len(visible) != 1, func() { t.Fatalf("expected 1 visible skill, got %d", len(visible)) })
 	// The hidden skill took `a-b`, so the visible one must be listed — and
 	// written — as `a-b-multica`.
-	if visible[0].Name != "a-b-multica" {
-		t.Errorf("visible skill listed as %q, want %q", visible[0].Name, "a-b-multica")
-	}
+	testassert.OnFailure(t, visible[0].Name != "a-b-multica", func() { t.Errorf("visible skill listed as %q, want %q", visible[0].Name, "a-b-multica") })
 	if _, err := os.Stat(filepath.Join(dir, "a-b-multica", "SKILL.md")); err != nil {
 		t.Errorf("listed name has no matching directory: %v", err)
 	}
@@ -257,14 +241,14 @@ Hidden body.`,
 	}
 
 	runtimeConfig := buildMetaSkillContent("codex", ctx)
-	if strings.Contains(runtimeConfig, "## Skills") {
+	testassert.OnFailure(t, strings.Contains(runtimeConfig, "## Skills"), func() {
 		t.Errorf("runtime config should omit Skills section when every skill disables model invocation:\n%s", runtimeConfig)
-	}
+	})
 
 	issueContext := renderIssueContext("codex", ctx)
-	if strings.Contains(issueContext, "## Agent Skills") {
+	testassert.OnFailure(t, strings.Contains(issueContext, "## Agent Skills"), func() {
 		t.Errorf("issue context should omit Agent Skills section when every skill disables model invocation:\n%s", issueContext)
-	}
+	})
 }
 
 func TestWriteContextFilesHydratesDisableModelInvocationSkillButDoesNotAdvertiseIt(t *testing.T) {
@@ -299,18 +283,10 @@ Hidden body.`,
 	}
 
 	issueContext, err := os.ReadFile(filepath.Join(dir, ".agent_context", "issue_context.md"))
-	if err != nil {
-		t.Fatalf("read issue_context.md: %v", err)
-	}
-	if strings.Contains(string(issueContext), "Hidden Skill") {
-		t.Fatalf("issue_context.md advertised hidden skill:\n%s", string(issueContext))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("read issue_context.md: %v", err) })
+	testassert.OnFailure(t, strings.Contains(string(issueContext), "Hidden Skill"), func() { t.Fatalf("issue_context.md advertised hidden skill:\n%s", string(issueContext)) })
 
 	hiddenSkill, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "hidden-skill", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("disabled skill should still be hydrated on disk: %v", err)
-	}
-	if !strings.Contains(string(hiddenSkill), "disable-model-invocation: true") {
-		t.Errorf("hidden skill frontmatter should be preserved on disk:\n%s", string(hiddenSkill))
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("disabled skill should still be hydrated on disk: %v", err) })
+	testassert.OnFailure(t, !strings.Contains(string(hiddenSkill), "disable-model-invocation: true"), func() { t.Errorf("hidden skill frontmatter should be preserved on disk:\n%s", string(hiddenSkill)) })
 }

--- a/server/internal/daemon/execenv/task_temp_test.go
+++ b/server/internal/daemon/execenv/task_temp_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // makeTaskTempDir creates a temp dir the way ensureTaskTempDir does, optionally
@@ -17,9 +19,7 @@ func makeTaskTempDir(t *testing.T, base, suffix string, withLock bool) string {
 	}
 	if withLock {
 		lock, err := LockTaskTempDir(dir)
-		if err != nil {
-			t.Fatalf("LockTaskTempDir(): %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("LockTaskTempDir(): %v", err) })
 		ReleaseTaskTempLock(lock)
 	}
 	return dir
@@ -40,9 +40,7 @@ func TestPruneTaskTempDirsHoldsOffLiveDirThenReclaimsIt(t *testing.T) {
 		t.Fatalf("create task temp dir: %v", err)
 	}
 	lock, err := LockTaskTempDir(dir)
-	if err != nil {
-		t.Fatalf("LockTaskTempDir(): %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("LockTaskTempDir(): %v", err) })
 
 	// legacyTTL 0 so nothing here can be reclaimed on age: the lock is the only
 	// thing under test. `now` is far in the future for the same reason.
@@ -57,9 +55,7 @@ func TestPruneTaskTempDirsHoldsOffLiveDirThenReclaimsIt(t *testing.T) {
 	ReleaseTaskTempLock(lock)
 
 	removed, _ := PruneTaskTempDirs(base, 0, future, testLogger())
-	if removed != 1 {
-		t.Fatalf("prune removed %d dirs after the lock was released, want 1", removed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("prune removed %d dirs after the lock was released, want 1", removed) })
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("task temp dir still present after prune: %v", err)
 	}
@@ -78,12 +74,8 @@ func TestPruneTaskTempDirsReclaimsUnlockedDirImmediately(t *testing.T) {
 	}
 
 	removed, bytesFreed := PruneTaskTempDirs(base, 0, time.Now(), testLogger())
-	if removed != 1 {
-		t.Fatalf("prune removed %d dirs, want 1", removed)
-	}
-	if bytesFreed < 4096 {
-		t.Fatalf("prune reported %d bytes freed, want at least 4096", bytesFreed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("prune removed %d dirs, want 1", removed) })
+	testassert.OnFailure(t, bytesFreed < 4096, func() { t.Fatalf("prune reported %d bytes freed, want at least 4096", bytesFreed) })
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("task temp dir still present after prune: %v", err)
 	}
@@ -160,9 +152,7 @@ func TestPruneTaskTempDirsOnlyTouchesOwnDirs(t *testing.T) {
 	}
 
 	removed, _ := PruneTaskTempDirs(base, time.Hour, time.Now().Add(10*365*24*time.Hour), testLogger())
-	if removed != 0 {
-		t.Fatalf("prune removed %d entries, want 0", removed)
-	}
+	testassert.OnFailure(t, removed != 0, func() { t.Fatalf("prune removed %d entries, want 0", removed) })
 	for _, path := range []string{base, foreignDir, foreignFile, prefixedFile} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("prune touched %s: %v", path, err)
@@ -174,9 +164,7 @@ func TestPruneTaskTempDirsOnlyTouchesOwnDirs(t *testing.T) {
 // daemon that has never run a task, and a GC cycle must not care.
 func TestPruneTaskTempDirsMissingBaseIsNotAnError(t *testing.T) {
 	removed, bytesFreed := PruneTaskTempDirs(filepath.Join(t.TempDir(), "nope"), time.Hour, time.Now(), testLogger())
-	if removed != 0 || bytesFreed != 0 {
-		t.Fatalf("prune over a missing base = (%d, %d), want (0, 0)", removed, bytesFreed)
-	}
+	testassert.OnFailure(t, removed != 0 || bytesFreed != 0, func() { t.Fatalf("prune over a missing base = (%d, %d), want (0, 0)", removed, bytesFreed) })
 }
 
 // TestLockTaskTempDirPublishesAnAlreadyHeldMarker pins the publication order:
@@ -191,9 +179,7 @@ func TestLockTaskTempDirPublishesAnAlreadyHeldMarker(t *testing.T) {
 		t.Fatalf("create task temp dir: %v", err)
 	}
 	lock, err := LockTaskTempDir(dir)
-	if err != nil {
-		t.Fatalf("LockTaskTempDir(): %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("LockTaskTempDir(): %v", err) })
 	t.Cleanup(func() { ReleaseTaskTempLock(lock) })
 
 	if _, err := os.Stat(filepath.Join(dir, envRootLockFile)); err != nil {
@@ -221,9 +207,7 @@ func TestPruneTaskTempDirsSpareDirMidClaim(t *testing.T) {
 			}
 			// Exactly the on-disk state between claim and publish.
 			claim, err := openLockFile(filepath.Join(dir, taskTempLockClaimFile))
-			if err != nil {
-				t.Fatalf("open claim: %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("open claim: %v", err) })
 			if ok, err := lockFileExclusiveNonBlocking(claim); err != nil || !ok {
 				t.Fatalf("lock claim: ok=%v err=%v", ok, err)
 			}
@@ -265,13 +249,9 @@ func TestLockTaskTempDirRacesPruneCleanly(t *testing.T) {
 
 	for i := 0; i < 200; i++ {
 		dir, err := os.MkdirTemp(base, TaskTempDirPrefix)
-		if err != nil {
-			t.Fatalf("MkdirTemp(): %v", err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("MkdirTemp(): %v", err) })
 		lock, err := LockTaskTempDir(dir)
-		if err != nil {
-			t.Fatalf("LockTaskTempDir() on iteration %d: %v", i, err)
-		}
+		testassert.OnFailure(t, err != nil, func() { t.Fatalf("LockTaskTempDir() on iteration %d: %v", i, err) })
 		// What the task does next: write into the TMPDIR it was handed.
 		if err := os.WriteFile(filepath.Join(dir, "payload"), []byte("x"), 0o600); err != nil {
 			t.Fatalf("task temp dir vanished under its owner on iteration %d: %v", i, err)
@@ -293,9 +273,7 @@ func TestPruneTaskTempDirsSparesDirBeforeItsClaimExists(t *testing.T) {
 		t.Run(legacyTTL.String(), func(t *testing.T) {
 			base := t.TempDir()
 			dir, err := os.MkdirTemp(base, TaskTempDirPrefix)
-			if err != nil {
-				t.Fatalf("MkdirTemp(): %v", err)
-			}
+			testassert.OnFailure(t, err != nil, func() { t.Fatalf("MkdirTemp(): %v", err) })
 			now := time.Now().Add(legacyTTL + time.Second)
 			if removed, _ := PruneTaskTempDirs(base, legacyTTL, now, testLogger()); removed != 0 {
 				t.Fatalf("prune removed %d dirs before their claim existed, want 0", removed)
@@ -319,9 +297,7 @@ func TestPruneTaskTempDirsLegacyBranchNeedsContent(t *testing.T) {
 	}
 
 	removed, _ := PruneTaskTempDirs(base, time.Hour, time.Now().Add(48*time.Hour), testLogger())
-	if removed != 1 {
-		t.Fatalf("prune removed %d dirs, want 1 (only the one holding content)", removed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("prune removed %d dirs, want 1 (only the one holding content)", removed) })
 	if _, err := os.Stat(withContent); !os.IsNotExist(err) {
 		t.Fatalf("expired legacy dir with content survived: %v", err)
 	}
@@ -372,12 +348,10 @@ func TestPruneTaskTempDirsRechecksLockBeforeRemoving(t *testing.T) {
 	})
 
 	removed, _ := PruneTaskTempDirs(base, time.Hour, time.Now().Add(72*time.Hour), testLogger())
-	if barrierRuns != 1 {
+	testassert.OnFailure(t, barrierRuns != 1, func() {
 		t.Fatalf("barrier ran %d times, want 1 — the sweep never reached the removal decision", barrierRuns)
-	}
-	if removed != 0 {
-		t.Fatalf("sweep removed %d dirs after the owner published mid-decision, want 0", removed)
-	}
+	})
+	testassert.OnFailure(t, removed != 0, func() { t.Fatalf("sweep removed %d dirs after the owner published mid-decision, want 0", removed) })
 	if _, err := os.Stat(filepath.Join(dir, "task-output")); err != nil {
 		t.Fatalf("sweep destroyed a live task's temp dir: %v", err)
 	}

--- a/server/internal/daemon/execenv/task_temp_unix_test.go
+++ b/server/internal/daemon/execenv/task_temp_unix_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // blockContentRemoval plants a payload inside dir that cannot be unlinked,
@@ -89,12 +91,8 @@ func TestPruneTaskTempDirsRetriesUntilContentCanBeRemoved(t *testing.T) {
 	unblock()
 
 	removed, bytesFreed := PruneTaskTempDirs(base, 0, time.Now(), testLogger())
-	if removed != 1 {
-		t.Fatalf("prune removed %d dirs once the payload was releasable, want 1", removed)
-	}
-	if bytesFreed < 2048 {
-		t.Fatalf("prune reported %d bytes freed, want at least 2048", bytesFreed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("prune removed %d dirs once the payload was releasable, want 1", removed) })
+	testassert.OnFailure(t, bytesFreed < 2048, func() { t.Fatalf("prune reported %d bytes freed, want at least 2048", bytesFreed) })
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("task temp dir still present: %v", err)
 	}
@@ -118,9 +116,7 @@ func TestPruneTaskTempDirsFailsClosedOnUnreadableDir(t *testing.T) {
 	// An ancient legacy TTL that would otherwise fire: the point is that an
 	// unreadable directory is never classified legacy in the first place.
 	removed, _ := PruneTaskTempDirs(base, time.Hour, time.Now().Add(10*365*24*time.Hour), testLogger())
-	if removed != 0 {
-		t.Fatalf("prune removed %d unreadable dirs, want 0", removed)
-	}
+	testassert.OnFailure(t, removed != 0, func() { t.Fatalf("prune removed %d unreadable dirs, want 0", removed) })
 	if _, err := os.Stat(dir); err != nil {
 		t.Fatalf("prune removed an unreadable dir: %v", err)
 	}

--- a/server/internal/daemon/execenv/task_temp_windows_test.go
+++ b/server/internal/daemon/execenv/task_temp_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	testassert "github.com/multica-ai/multica/server/internal/testutil"
 	"golang.org/x/sys/windows"
 )
 
@@ -30,9 +31,7 @@ func TestPruneTaskTempDirsSurvivesRealSharingViolation(t *testing.T) {
 		t.Fatalf("write payload: %v", err)
 	}
 	payloadPtr, err := windows.UTF16PtrFromString(payload)
-	if err != nil {
-		t.Fatalf("UTF16PtrFromString(): %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("UTF16PtrFromString(): %v", err) })
 	// No FILE_SHARE_DELETE: Windows now refuses to delete this file.
 	handle, err := windows.CreateFile(
 		payloadPtr,
@@ -43,9 +42,7 @@ func TestPruneTaskTempDirsSurvivesRealSharingViolation(t *testing.T) {
 		windows.FILE_ATTRIBUTE_NORMAL,
 		0,
 	)
-	if err != nil {
-		t.Fatalf("CreateFile(): %v", err)
-	}
+	testassert.OnFailure(t, err != nil, func() { t.Fatalf("CreateFile(): %v", err) })
 	handleClosed := false
 	closeHandle := func() {
 		if handleClosed {
@@ -72,12 +69,8 @@ func TestPruneTaskTempDirsSurvivesRealSharingViolation(t *testing.T) {
 	closeHandle()
 
 	removed, bytesFreed := PruneTaskTempDirs(base, 0, time.Now(), testLogger())
-	if removed != 1 {
-		t.Fatalf("prune removed %d dirs after the handle closed, want 1", removed)
-	}
-	if bytesFreed < 2048 {
-		t.Fatalf("prune reported %d bytes freed, want at least 2048", bytesFreed)
-	}
+	testassert.OnFailure(t, removed != 1, func() { t.Fatalf("prune removed %d dirs after the handle closed, want 1", removed) })
+	testassert.OnFailure(t, bytesFreed < 2048, func() { t.Fatalf("prune reported %d bytes freed, want at least 2048", bytesFreed) })
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("task temp dir still present after prune: %v", err)
 	}

--- a/server/internal/testutil/assertions.go
+++ b/server/internal/testutil/assertions.go
@@ -1,0 +1,15 @@
+package testutil
+
+type helperTB interface {
+	Helper()
+}
+
+// OnFailure runs report only when failed is true. Keeping the original
+// testing call inside report preserves Fatal versus Error control flow, the
+// exact diagnostic, and lazy evaluation of diagnostic arguments.
+func OnFailure(t helperTB, failed bool, report func()) {
+	t.Helper()
+	if failed {
+		report()
+	}
+}

--- a/server/internal/testutil/assertions_test.go
+++ b/server/internal/testutil/assertions_test.go
@@ -1,0 +1,29 @@
+package testutil
+
+import "testing"
+
+type helperSpy struct {
+	helperCalls int
+}
+
+func (s *helperSpy) Helper() {
+	s.helperCalls++
+}
+
+func TestOnFailurePreservesLazyReporting(t *testing.T) {
+	t.Parallel()
+
+	spy := &helperSpy{}
+	reports := 0
+	OnFailure(spy, false, func() { reports++ })
+	if reports != 0 {
+		t.Fatalf("false condition ran report %d times", reports)
+	}
+	OnFailure(spy, true, func() { reports++ })
+	if reports != 1 {
+		t.Fatalf("true condition ran report %d times", reports)
+	}
+	if spy.helperCalls != 2 {
+		t.Fatalf("Helper calls = %d, want 2", spy.helperCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- add a behavior-free `testutil.OnFailure` helper that preserves the original `Fatal`/`Fatalf`/`Error`/`Errorf` call, diagnostic, and lazy argument evaluation
- add an AST-based, idempotent rewriter and use it to collapse 1,526 safe one-call assertion blocks across 48 `execenv` test files
- retain blocks with `if` initializers, `else` branches, or explanatory comments, and add a test guard that rejects new collapsible blocks or growth above the 1,236-block remainder

This is the first-package PoC proposed for MUL-6748. It changes test scaffolding only; no production code or test cases are removed.

## Size

- `execenv` test LOC: 26,070 -> 23,396 (-2,674, -10.3%)
- whole PR: +2,316 / -4,439 (net -2,123, including the reusable rewriter and its tests)
- before/after `go test -json` final-action manifest: 1,235 records with the same SHA-256, `1b7f8a0b5e17fd33fa5767e10290de59ffffe2abbbe049fd592a735dfd27051c`

## Validation

- `go test -count=1 ./cmd/rewrite-test-assertions ./internal/testutil`
- `env -u MULTICA_TASK_CONFIG_ROOT go test -count=1 ./internal/daemon/execenv`
- `env -u MULTICA_TASK_CONFIG_ROOT go test -race -count=1 ./internal/daemon/execenv ./internal/testutil ./cmd/rewrite-test-assertions`
- `go vet ./internal/daemon/execenv ./internal/testutil ./cmd/rewrite-test-assertions`
- `GOOS=windows GOARCH=amd64 go test -run '^$' -exec=/usr/bin/true ./internal/daemon/execenv`
- `go build ./...`
- `go run ./cmd/rewrite-test-assertions -check -max-handwritten 1236 ./internal/daemon/execenv`
- `git diff --check`

The broader local `go test ./...` run was also attempted. It reached and passed the changed `execenv`, `testutil`, rewriter, and `pkg/agent` packages, but the overall run is not a usable clean-room signal in this daemon task checkout: CLI tests detect the runtime's task marker, and database integration packages are pointed at a shared schema that is behind current migrations. CI provisions its own migrated database.
