### PR TITLE
MUL-6748: migrate handler tests to shared testutil

### DIFF
--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // fetchTimeline issues a GET /timeline request and returns the decoded entries
@@ -15,10 +16,10 @@ import (
 // (created_at, id) ascending (oldest first); see ListTimeline / #1929.
 func fetchTimeline(t *testing.T, issueID string) ([]TimelineEntry, int) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/issues/"+issueID+"/timeline", nil)
 	req = withURLParam(req, "id", issueID)
-	testHandler.ListTimeline(w, req)
+	w := testutil.Call(t, testHandler.ListTimeline, req)
 	var entries []TimelineEntry
 	if w.Code == http.StatusOK {
 		json.NewDecoder(w.Body).Decode(&entries)
@@ -30,15 +31,12 @@ func fetchTimeline(t *testing.T, issueID string) ([]TimelineEntry, int) {
 // cleanup so its timeline rows are deleted after the test.
 func createIssueForTimeline(t *testing.T, title string) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  title,
 		"status": "todo",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() {
@@ -163,10 +161,10 @@ func TestListTimeline_MergesCommentsAndActivities(t *testing.T) {
 // flat array. Used to verify the boundary-compat path doesn't regress.
 func fetchTimelineWrapped(t *testing.T, issueID, query string) (timelinePaginatedResponse, int) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/issues/"+issueID+"/timeline?"+query, nil)
 	req = withURLParam(req, "id", issueID)
-	testHandler.ListTimeline(w, req)
+	w := testutil.Call(t, testHandler.ListTimeline, req)
 	var resp timelinePaginatedResponse
 	if w.Code == http.StatusOK {
 		json.NewDecoder(w.Body).Decode(&resp)

--- a/server/internal/handler/actor_guards_test.go
+++ b/server/internal/handler/actor_guards_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestRequireHumanActor_AllowsHumanRequest pins the happy path: a
@@ -27,12 +28,7 @@ func TestRequireHumanActor_AllowsHumanRequest(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/cloud-billing/balance", nil)
 	// No X-Actor-Source — this is the JWT / mul_ PAT shape.
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
-	}
+	testutil.Call(t, mw.ServeHTTP, req).Want(http.StatusOK)
 	if !called {
 		t.Fatal("inner handler must run for non-task-token requests")
 	}
@@ -76,12 +72,7 @@ func TestRequireHumanActor_BlocksMachineCredentials(t *testing.T) {
 			// client-supplied value before stamping their own, so a
 			// non-empty value at this point IS authoritative.
 			req.Header.Set("X-Actor-Source", tc.actorSource)
-			w := httptest.NewRecorder()
-			mw.ServeHTTP(w, req)
-
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("status = %d, want 403", w.Code)
-			}
+			testutil.Call(t, mw.ServeHTTP, req).Want(http.StatusForbidden)
 		})
 	}
 }
@@ -122,12 +113,7 @@ func TestRequireHumanActor_IgnoresUnknownActorSource(t *testing.T) {
 	// A hypothetical future value the gate doesn't know about.
 	req := httptest.NewRequest(http.MethodGet, "/api/cloud-billing/balance", nil)
 	req.Header.Set("X-Actor-Source", "future_kind")
-	w := httptest.NewRecorder()
-	mw.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 — gate should only block exact 'task_token'", w.Code)
-	}
+	testutil.Call(t, mw.ServeHTTP, req).Want(http.StatusOK)
 	if !called {
 		t.Fatal("inner handler must run for unknown actor sources")
 	}
@@ -152,10 +138,5 @@ func TestRequireHumanActor_AppliedViaChiRouterUse(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/billing/probe", nil)
 	req.Header.Set("X-Actor-Source", "task_token")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", w.Code)
-	}
+	testutil.Call(t, r.ServeHTTP, req).Want(http.StatusForbidden)
 }

--- a/server/internal/handler/admission_security_mul4525_test.go
+++ b/server/internal/handler/admission_security_mul4525_test.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/dispatch"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -63,16 +63,7 @@ func TestSendChatMessage_InvokeRevokedAfterSessionCreate(t *testing.T) {
 	// public_to agent owned by someone else, with testUserID on its member
 	// allow-list — so testUserID may invoke it while it is public_to.
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args)
-		VALUES ($1, 'chat-revoke-agent', '', 'cloud', '{}'::jsonb, $2, 'private', 'public_to', 1, $3,
-			'', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id`, testWorkspaceID, handlerTestRuntimeID(t), ownerID).Scan(&agentID); err != nil {
-		t.Fatalf("seed agent: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID) })
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'chat-revoke-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": handlerTestRuntimeID(t), "visibility": testutil.Raw("'private'"), "permission_mode": testutil.Raw("'public_to'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": ownerID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO agent_invocation_target (agent_id, target_type, target_id)
 		VALUES ($1, 'member', $2)`, agentID, testUserID); err != nil {
@@ -80,21 +71,16 @@ func TestSendChatMessage_InvokeRevokedAfterSessionCreate(t *testing.T) {
 	}
 
 	// Create the session as testUserID while they can still invoke the agent.
-	createW := httptest.NewRecorder()
+
 	createReq := withChatTestWorkspaceCtx(t, newRequest("POST", "/api/chat/sessions", map[string]any{
 		"agent_id": agentID,
 		"title":    "revoke test",
 	}))
-	testHandler.CreateChatSession(createW, createReq)
-	if createW.Code != http.StatusCreated {
-		t.Fatalf("CreateChatSession while invokable: expected 201, got %d: %s", createW.Code, createW.Body.String())
-	}
+	createW := testutil.Call(t, testHandler.CreateChatSession, createReq).Want(http.StatusCreated)
 	var session struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(createW.Body.Bytes(), &session); err != nil {
-		t.Fatalf("decode session: %v", err)
-	}
+	createW.JSON(&session)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, session.ID) })
 
 	// Revoke invoke permission: flip the agent to private. testUserID keeps VIEW
@@ -109,13 +95,7 @@ func TestSendChatMessage_InvokeRevokedAfterSessionCreate(t *testing.T) {
 	// gate runs BEFORE attachment binding, so this guards against anyone later
 	// moving the binding ahead of the permission gate.
 	var attachmentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO attachment (workspace_id, uploader_type, uploader_id, filename, url, content_type, size_bytes)
-		VALUES ($1, 'member', $2, 'unbound.png', 'https://cdn.test/unbound.png', 'image/png', 10)
-		RETURNING id`, testWorkspaceID, testUserID).Scan(&attachmentID); err != nil {
-		t.Fatalf("seed unbound attachment: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID) })
+	attachmentID = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "uploader_type": testutil.Raw("'member'"), "uploader_id": testUserID, "filename": testutil.Raw("'unbound.png'"), "url": testutil.Raw("'https://cdn.test/unbound.png'"), "content_type": testutil.Raw("'image/png'"), "size_bytes": testutil.Raw("10")})
 
 	countMessages := func() int {
 		var n int
@@ -137,17 +117,13 @@ func TestSendChatMessage_InvokeRevokedAfterSessionCreate(t *testing.T) {
 
 	// The send must be refused before anything is written — including the
 	// attachment binding.
-	sendW := httptest.NewRecorder()
+
 	sendReq := withChatTestWorkspaceCtx(t, newRequest("POST", "/api/chat/sessions/"+session.ID+"/messages", map[string]any{
 		"content":        "are you still there?",
 		"attachment_ids": []string{attachmentID},
 	}))
 	sendReq = withURLParam(sendReq, "sessionId", session.ID)
-	testHandler.SendChatMessage(sendW, sendReq)
-
-	if sendW.Code != http.StatusForbidden {
-		t.Fatalf("SendChatMessage after revoke: expected 403, got %d: %s", sendW.Code, sendW.Body.String())
-	}
+	sendW := testutil.Call(t, testHandler.SendChatMessage, sendReq).Want(http.StatusForbidden)
 	if code := readReasonCode(t, sendW.Body.Bytes()); code != string(dispatch.ReasonInvocationNotAllowed) {
 		t.Errorf("reason_code = %q, want invocation_not_allowed", code)
 	}
@@ -240,12 +216,9 @@ func TestRerunIssue_PrivateHistoricalAgent(t *testing.T) {
 	// DENY: testUserID (workspace owner) can view the issue AND can invoke the
 	// current assignee, but cannot invoke the HISTORICAL private agent named by
 	// task_id → structured 403, and nothing is cancelled or created.
-	denyW := httptest.NewRecorder()
+
 	denyReq := withURLParam(newRequest("POST", "/api/issues/"+issueID+"/rerun", map[string]any{"task_id": origID}), "id", issueID)
-	testHandler.RerunIssue(denyW, denyReq)
-	if denyW.Code != http.StatusForbidden {
-		t.Fatalf("RerunIssue as non-invoker of historical agent: expected 403, got %d: %s", denyW.Code, denyW.Body.String())
-	}
+	denyW := testutil.Call(t, testHandler.RerunIssue, denyReq).Want(http.StatusForbidden)
 	if code := readReasonCode(t, denyW.Body.Bytes()); code != string(dispatch.ReasonInvocationNotAllowed) {
 		t.Errorf("reason_code = %q, want invocation_not_allowed", code)
 	}
@@ -258,19 +231,14 @@ func TestRerunIssue_PrivateHistoricalAgent(t *testing.T) {
 
 	// ALLOW: the HISTORICAL agent's owner may rerun it, and the new task must
 	// target the historical agent — not the issue's current assignee.
-	allowW := httptest.NewRecorder()
+
 	allowReq := withURLParam(newRequestAs(ownerID, "POST", "/api/issues/"+issueID+"/rerun", map[string]any{"task_id": origID}), "id", issueID)
-	testHandler.RerunIssue(allowW, allowReq)
-	if allowW.Code != http.StatusAccepted {
-		t.Fatalf("RerunIssue as historical agent owner: expected 202, got %d: %s", allowW.Code, allowW.Body.String())
-	}
+	allowW := testutil.Call(t, testHandler.RerunIssue, allowReq).Want(http.StatusAccepted)
 	var reran struct {
 		ID      string `json:"id"`
 		AgentID string `json:"agent_id"`
 	}
-	if err := json.Unmarshal(allowW.Body.Bytes(), &reran); err != nil {
-		t.Fatalf("decode rerun response: %v", err)
-	}
+	allowW.JSON(&reran)
 	if reran.AgentID != agentID {
 		t.Errorf("reran task agent_id = %q, want historical agent %q (not current assignee %q)", reran.AgentID, agentID, currentAgentID)
 	}

--- a/server/internal/handler/agent_access_test.go
+++ b/server/internal/handler/agent_access_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -98,22 +99,7 @@ func privateAgentTestFixture(t *testing.T) (agentID, ownerID, memberID string) {
 		t.Fatalf("add plain member: %v", err)
 	}
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args
-		)
-		VALUES ($1, 'private-access-test-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, handlerTestRuntimeID(t), ownerID).Scan(&agentID); err != nil {
-		t.Fatalf("create private agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(),
-			`DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'private-access-test-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": handlerTestRuntimeID(t), "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": ownerID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 
 	return agentID, ownerID, memberID
 }
@@ -139,23 +125,17 @@ func TestGetAgent_PrivateAgentForbidsPlainMember(t *testing.T) {
 	// Workspace owner (testUserID): allowed via role.
 	w := httptest.NewRecorder()
 	testHandler.GetAgent(w, withURLParam(newRequest("GET", "/api/agents/"+agentID, nil), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgent as workspace owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Agent owner (plain member who happens to own the agent): allowed.
 	w = httptest.NewRecorder()
 	testHandler.GetAgent(w, withURLParam(newRequestAs(ownerID, "GET", "/api/agents/"+agentID, nil), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgent as agent owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Plain member (not in allowed_principals): denied with 403.
 	w = httptest.NewRecorder()
 	testHandler.GetAgent(w, withURLParam(newRequestAs(memberID, "GET", "/api/agents/"+agentID, nil), "id", agentID))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("GetAgent as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestListAgents_FiltersPrivateForPlainMember verifies that the workspace
@@ -172,9 +152,7 @@ func TestListAgents_FiltersPrivateForPlainMember(t *testing.T) {
 	// Workspace owner sees the agent.
 	w := httptest.NewRecorder()
 	testHandler.ListAgents(w, newRequest("GET", "/api/agents", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgents as owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if !listContainsAgent(t, w.Body.Bytes(), agentID) {
 		t.Fatalf("ListAgents as owner did not include private agent %s", agentID)
 	}
@@ -182,9 +160,7 @@ func TestListAgents_FiltersPrivateForPlainMember(t *testing.T) {
 	// Plain member does NOT see the agent.
 	w = httptest.NewRecorder()
 	testHandler.ListAgents(w, newRequestAs(memberID, "GET", "/api/agents", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgents as plain member: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if listContainsAgent(t, w.Body.Bytes(), agentID) {
 		t.Fatalf("ListAgents as plain member leaked private agent %s", agentID)
 	}
@@ -215,15 +191,11 @@ func TestListAgentTasks_PrivateAgentForbidsPlainMember(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.ListAgentTasks(w, withURLParam(newRequestAs(ownerID, "GET", "/api/agents/"+agentID+"/tasks", nil), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgentTasks as owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	w = httptest.NewRecorder()
 	testHandler.ListAgentTasks(w, withURLParam(newRequestAs(memberID, "GET", "/api/agents/"+agentID+"/tasks", nil), "id", agentID))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("ListAgentTasks as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestCreateIssue_AssignToPrivateAgentForbidsPlainMember verifies that the
@@ -252,25 +224,19 @@ func TestCreateIssue_AssignToPrivateAgentForbidsPlainMember(t *testing.T) {
 	// longer grants the ability to invoke someone else's private agent.
 	w := httptest.NewRecorder()
 	testHandler.CreateIssue(w, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body(testUserID)))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateIssue as workspace owner (not agent owner): expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Agent owner (plain member who happens to own the agent): allowed.
 	w = httptest.NewRecorder()
 	testHandler.CreateIssue(w, newRequestAs(ownerID, "POST", "/api/issues?workspace_id="+testWorkspaceID, body(ownerID)))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue as agent owner: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Plain member: denied with 403 — closes the back door where issue
 	// assignment would otherwise hand the agent a task without going
 	// through chat / @-mention.
 	w = httptest.NewRecorder()
 	testHandler.CreateIssue(w, newRequestAs(memberID, "POST", "/api/issues?workspace_id="+testWorkspaceID, body(memberID)))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateIssue as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestCreateChatSession_PrivateAgentForbidsPlainMember verifies that members
@@ -298,13 +264,10 @@ func TestCreateChatSession_PrivateAgentForbidsPlainMember(t *testing.T) {
 		"agent_id": agentID,
 		"title":    "should be denied",
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequestAs(memberID, "POST", "/api/chat/sessions", body)
 	req = req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, memberRow))
-	testHandler.CreateChatSession(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateChatSession as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateChatSession, req).Want(http.StatusForbidden)
 }
 
 // TestGetAgent_RejectsForgedAgentIDHeader is the regression test for the
@@ -319,17 +282,13 @@ func TestGetAgent_RejectsForgedAgentIDHeader(t *testing.T) {
 
 	agentID, _, memberID := privateAgentTestFixture(t)
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(memberID, "GET", "/api/agents/"+agentID, nil)
 	// Forge X-Agent-ID without X-Task-ID. Pre-fix this would have made
 	// resolveActor return ("agent", agentID) and canAccessPrivateAgent
 	// would have unconditionally allowed the read.
 	req.Header.Set("X-Agent-ID", agentID)
 	req = withURLParam(req, "id", agentID)
-	testHandler.GetAgent(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("GetAgent with forged X-Agent-ID: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetAgent, req).Want(http.StatusForbidden)
 }
 
 // TestListChatMessages_PrivateAgentForbidsAfterAccessRevoked is the regression
@@ -352,16 +311,7 @@ func TestListChatMessages_PrivateAgentForbidsAfterAccessRevoked(t *testing.T) {
 	// that existed before the member lost access (or before the gate
 	// landed).
 	var sessionID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status)
-		VALUES ($1, $2, $3, 'pre-revocation session', 'active')
-		RETURNING id
-	`, testWorkspaceID, agentID, memberID).Scan(&sessionID); err != nil {
-		t.Fatalf("seed chat session: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID)
-	})
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": memberID, "title": testutil.Raw("'pre-revocation session'"), "status": testutil.Raw("'active'")})
 
 	memberRow, err := testHandler.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
 		UserID:      util.MustParseUUID(memberID),
@@ -371,14 +321,10 @@ func TestListChatMessages_PrivateAgentForbidsAfterAccessRevoked(t *testing.T) {
 		t.Fatalf("load plain member row: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(memberID, "GET", "/api/chat/sessions/"+sessionID+"/messages", nil)
 	req = req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, memberRow))
 	req = withURLParam(req, "sessionId", sessionID)
-	testHandler.ListChatMessages(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("ListChatMessages on stale session: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ListChatMessages, req).Want(http.StatusForbidden)
 }
 
 // TestMentionAgent_RejectsCrossWorkspaceAgentUUID is the regression test for
@@ -459,16 +405,7 @@ func TestMentionAgent_RejectsCrossWorkspaceAgentUUID(t *testing.T) {
 
 	// Multica's mention format is markdown-linked: [@Name](mention://agent/<uuid>).
 	mention := "[@Foreign](mention://agent/" + foreignAgentID + ")"
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
-		VALUES ($1, $2, 'member', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, issueID, testUserID, mention).Scan(&commentID); err != nil {
-		t.Fatalf("create test comment: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM comment WHERE id = $1`, commentID)
-	})
+	commentID = dbfx.Insert(t, "comment", testutil.Cols{"workspace_id": testWorkspaceID, "issue_id": issueID, "author_type": testutil.Raw("'member'"), "author_id": testUserID, "content": mention})
 
 	issue, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(issueID))
 	if err != nil {

--- a/server/internal/handler/agent_builder_test.go
+++ b/server/internal/handler/agent_builder_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -41,18 +42,12 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	})
 
 	create := func(model string) CreateAgentBuilderSessionResponse {
-		w := httptest.NewRecorder()
-		testHandler.CreateAgentBuilderSession(w, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
+		w := testutil.Call(t, testHandler.CreateAgentBuilderSession, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
 			"runtime_id": testRuntimeID,
 			"model":      model,
-		}))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateAgentBuilderSession: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		})).Want(http.StatusCreated)
 		var response CreateAgentBuilderSessionResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.JSON(&response)
 		if response.SessionID == "" || response.BuilderAgentID == "" {
 			t.Fatalf("missing builder identifiers: %+v", response)
 		}
@@ -92,9 +87,7 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.ListAgents(w, newRequest(http.MethodGet, "/api/agents", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgents: %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var listed []AgentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode agent list: %v", err)
@@ -110,9 +103,7 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	w = httptest.NewRecorder()
 	req := withURLParams(newRequest(http.MethodGet, "/api/agents/"+first.BuilderAgentID, nil), "id", first.BuilderAgentID)
 	testHandler.GetAgent(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("GetAgent(system): expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	// Deleting the private Builder chat also removes its session-scoped hidden
 	// Agent, so completed/cancelled flows do not accumulate infrastructure rows.
@@ -120,9 +111,7 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	req = withURLParams(newRequest(http.MethodDelete, "/api/chat/sessions/"+first.SessionID, nil), "sessionId", first.SessionID)
 	req = withChatTestWorkspaceCtx(t, req)
 	testHandler.DeleteChatSession(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteChatSession(builder): expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 	var remaining int
 	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM agent WHERE id = $1`, first.BuilderAgentID).Scan(&remaining); err != nil {
 		t.Fatalf("count deleted builder: %v", err)
@@ -150,19 +139,13 @@ func TestCreateAgentAttachesSkillsWithoutCreatingAWelcomeChat(t *testing.T) {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, skillID)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", map[string]any{
+	w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", map[string]any{
 		"name":       "Atomic Skill Agent",
 		"runtime_id": testRuntimeID,
 		"skill_ids":  []string{skillID},
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var response AgentResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&response)
 	if len(response.Skills) != 1 || response.Skills[0].ID != skillID {
 		t.Fatalf("create response did not include attached skill: %+v", response.Skills)
 	}
@@ -188,18 +171,12 @@ func newBuilderSession(t *testing.T) CreateAgentBuilderSessionResponse {
 		`, testWorkspaceID)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.CreateAgentBuilderSession(w, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
+	w := testutil.Call(t, testHandler.CreateAgentBuilderSession, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
 		"runtime_id": testRuntimeID,
 		"model":      "model-pinned-to-runtime-a",
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAgentBuilderSession: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var session CreateAgentBuilderSessionResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &session); err != nil {
-		t.Fatalf("decode create response: %v", err)
-	}
+	w.JSON(&session)
 	return session
 }
 
@@ -245,9 +222,7 @@ func TestSwitchAgentBuilderRuntimeRebindsCarrier(t *testing.T) {
 	target := newTestRuntime(t, "Builder Switch Target", "online")
 
 	w := switchBuilderRuntime(t, session.SessionID, target)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SwitchAgentBuilderRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var response SwitchAgentBuilderRuntimeResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode switch response: %v", err)
@@ -305,19 +280,11 @@ func TestSwitchAgentBuilderRuntimeRejectsWhileReplyPending(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
+
 	session := newBuilderSession(t)
 	target := newTestRuntime(t, "Builder Switch Pending Target", "online")
 
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO agent_task_queue (agent_id, chat_session_id, status, priority, context, runtime_id)
-		VALUES ($1, $2, 'running', 2, '{}'::jsonb, $3)
-	`, session.BuilderAgentID, session.SessionID, testRuntimeID); err != nil {
-		t.Fatalf("insert pending task: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE chat_session_id = $1`, session.SessionID)
-	})
+	dbfx.InsertNoID(t, "agent_task_queue", testutil.Cols{"agent_id": session.BuilderAgentID, "chat_session_id": session.SessionID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("2"), "context": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID}, "chat_session_id = $1", session.SessionID)
 
 	if w := switchBuilderRuntime(t, session.SessionID, target); w.Code != http.StatusConflict {
 		t.Fatalf("pending reply: expected 409, got %d: %s", w.Code, w.Body.String())
@@ -371,15 +338,9 @@ func TestSwitchAgentBuilderRuntimeRejectsNonBuilderSession(t *testing.T) {
 
 func listBuilderSessions(t *testing.T) ListAgentBuilderSessionsResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
-	testHandler.ListAgentBuilderSessions(w, newRequest(http.MethodGet, "/api/agent-builder/sessions", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgentBuilderSessions: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAgentBuilderSessions, newRequest(http.MethodGet, "/api/agent-builder/sessions", nil)).Want(http.StatusOK)
 	var response ListAgentBuilderSessionsResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
+	w.JSON(&response)
 	return response
 }
 
@@ -550,7 +511,6 @@ func TestDeleteChatSessionPrunesTheBuilderDraft(t *testing.T) {
 	session := newBuilderSession(t)
 	saveBuilderDraft(t, session.SessionID, map[string]any{"name": "Doomed"})
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequest(http.MethodDelete, "/api/chat/sessions/"+session.SessionID, nil),
 		"sessionId", session.SessionID,
@@ -558,10 +518,7 @@ func TestDeleteChatSessionPrunesTheBuilderDraft(t *testing.T) {
 	// DeleteChatSession reads the workspace off the context the middleware
 	// normally fills, not the header.
 	req = withChatTestWorkspaceCtx(t, req)
-	testHandler.DeleteChatSession(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteChatSession: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteChatSession, req).Want(http.StatusNoContent)
 
 	var remaining int
 	if err := testPool.QueryRow(ctx, `
@@ -670,9 +627,7 @@ func TestSaveAgentBuilderDraftLosesToAConcurrentDelete(t *testing.T) {
 	runSaveDraftAgainst(t, session.SessionID, w, req,
 		`DELETE FROM chat_session WHERE id = $1`)
 
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("save after the conversation was deleted: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 	if n := countBuilderDrafts(t, session.SessionID); n != 0 {
 		t.Fatalf("orphaned draft rows = %d, want 0", n)
 	}
@@ -692,9 +647,7 @@ func TestSaveAgentBuilderDraftLosesToAConcurrentArchive(t *testing.T) {
 	runSaveDraftAgainst(t, session.SessionID, w, req,
 		`UPDATE chat_session SET status = 'archived' WHERE id = $1`)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("save after the conversation was archived: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 	if n := countBuilderDrafts(t, session.SessionID); n != 0 {
 		t.Fatalf("draft rows on an archived conversation = %d, want 0", n)
 	}
@@ -1105,8 +1058,7 @@ func TestDeleteBuilderSessionLocksAgentBeforeTasks(t *testing.T) {
 	deleteReq = withChatTestWorkspaceCtx(t, deleteReq)
 	deleteCodes := make(chan int, 1)
 	go func() {
-		w := httptest.NewRecorder()
-		testHandler.DeleteChatSession(w, deleteReq)
+		w := testutil.Call(t, testHandler.DeleteChatSession, deleteReq)
 		deleteCodes <- w.Code
 	}()
 
@@ -1176,14 +1128,14 @@ func TestSwitchAgentBuilderRuntimeWaitsForUncommittedSend(t *testing.T) {
 
 	codes := make(chan int, 1)
 	go func() {
-		w := httptest.NewRecorder()
+
 		req := withURLParams(
 			newRequest(http.MethodPatch, "/api/agent-builder/sessions/"+created.SessionID+"/runtime", map[string]any{
 				"runtime_id": target,
 			}),
 			"sessionId", created.SessionID,
 		)
-		testHandler.SwitchAgentBuilderRuntime(w, req)
+		w := testutil.Call(t, testHandler.SwitchAgentBuilderRuntime, req)
 		codes <- w.Code
 	}()
 
@@ -1246,32 +1198,15 @@ func TestSwitchAgentBuilderRuntimeEnforcesRuntimeAndSessionOwnership(t *testing.
 	// The fixture runtime is private to the workspace owner, so start this
 	// member's session on a public one.
 	var publicRuntimeID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, visibility, last_seen_at
-		)
-		VALUES ($1, NULL, 'Builder Switch Public', 'cloud', 'builder_switch_public', 'online', 'public', '{}'::jsonb, $2, 'public', now())
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&publicRuntimeID); err != nil {
-		t.Fatalf("create public runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, publicRuntimeID)
-	})
+	publicRuntimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": testutil.Raw("'Builder Switch Public'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'builder_switch_public'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'public'"), "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": testUserID, "visibility": testutil.Raw("'public'"), "last_seen_at": testutil.Raw("now()")})
 
 	// That member's own builder session, so the creator gate passes and the
 	// runtime gate is what we are actually testing.
-	createW := httptest.NewRecorder()
-	testHandler.CreateAgentBuilderSession(createW, newRequestAs(plainMemberID, http.MethodPost, "/api/agent-builder/sessions", map[string]any{
+	createW := testutil.Call(t, testHandler.CreateAgentBuilderSession, newRequestAs(plainMemberID, http.MethodPost, "/api/agent-builder/sessions", map[string]any{
 		"runtime_id": publicRuntimeID,
-	}))
-	if createW.Code != http.StatusCreated {
-		t.Fatalf("CreateAgentBuilderSession as plain member: expected 201, got %d: %s", createW.Code, createW.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var created CreateAgentBuilderSessionResponse
-	if err := json.Unmarshal(createW.Body.Bytes(), &created); err != nil {
-		t.Fatalf("decode create response: %v", err)
-	}
+	createW.JSON(&created)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `
 			DELETE FROM agent
@@ -1281,29 +1216,14 @@ func TestSwitchAgentBuilderRuntimeEnforcesRuntimeAndSessionOwnership(t *testing.
 
 	// The workspace owner's private runtime is not a legal target for them.
 	var privateRuntimeID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, visibility, last_seen_at
-		)
-		VALUES ($1, NULL, 'Builder Switch Private', 'cloud', 'builder_switch_private', 'online', 'private', '{}'::jsonb, $2, 'private', now())
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&privateRuntimeID); err != nil {
-		t.Fatalf("create private runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, privateRuntimeID)
-	})
+	privateRuntimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": testutil.Raw("'Builder Switch Private'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'builder_switch_private'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'private'"), "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": testUserID, "visibility": testutil.Raw("'private'"), "last_seen_at": testutil.Raw("now()")})
 
-	forbiddenW := httptest.NewRecorder()
-	testHandler.SwitchAgentBuilderRuntime(forbiddenW, withURLParams(
+	testutil.Call(t, testHandler.SwitchAgentBuilderRuntime, withURLParams(
 		newRequestAs(plainMemberID, http.MethodPatch, "/api/agent-builder/sessions/"+created.SessionID+"/runtime", map[string]any{
 			"runtime_id": privateRuntimeID,
 		}),
 		"sessionId", created.SessionID,
-	))
-	if forbiddenW.Code != http.StatusForbidden {
-		t.Fatalf("someone else's private runtime: expected 403, got %d: %s", forbiddenW.Code, forbiddenW.Body.String())
-	}
+	)).Want(http.StatusForbidden)
 
 	// And a session the caller does not own is not theirs to rebind, whatever
 	// their workspace role — this one is issued by the workspace owner.

--- a/server/internal/handler/agent_composio_allowlist_test.go
+++ b/server/internal/handler/agent_composio_allowlist_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // allowlistFixture seeds an agent owned by a freshly-created user (not the
@@ -35,22 +37,7 @@ func allowlistFixture(t *testing.T) (agentID, agentOwnerID string) {
 		t.Fatalf("add owner as workspace member: %v", err)
 	}
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args
-		)
-		VALUES ($1, 'allowlist-test-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'workspace', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, handlerTestRuntimeID(t), agentOwnerID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(),
-			`DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'allowlist-test-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": handlerTestRuntimeID(t), "visibility": testutil.Raw("'workspace'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": agentOwnerID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 	return agentID, agentOwnerID
 }
 
@@ -91,9 +78,7 @@ func TestUpdateAgent_AllowlistRoundtripForOwner(t *testing.T) {
 			"composio_toolkit_allowlist": []string{" Notion ", "NOTION", "github", ""},
 		},
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent owner write: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	stored, isNull := readAllowlistColumn(t, agentID)
 	if isNull {
 		t.Fatalf("after owner write, allowlist still NULL")
@@ -108,9 +93,7 @@ func TestUpdateAgent_AllowlistRoundtripForOwner(t *testing.T) {
 		ownerID, http.MethodPut, "/api/agents/"+agentID,
 		map[string]any{"composio_toolkit_allowlist": []string{}},
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent owner empty write: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	stored, isNull = readAllowlistColumn(t, agentID)
 	if isNull {
 		t.Fatalf("empty array must persist as empty TEXT[], not NULL")
@@ -125,9 +108,7 @@ func TestUpdateAgent_AllowlistRoundtripForOwner(t *testing.T) {
 		ownerID, http.MethodPut, "/api/agents/"+agentID,
 		map[string]any{"composio_toolkit_allowlist": nil},
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent owner null write: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	_, isNull = readAllowlistColumn(t, agentID)
 	if !isNull {
 		t.Errorf("explicit null must persist as NULL")
@@ -158,8 +139,7 @@ func TestUpdateAgent_AllowlistSilentlyDroppedForNonOwner(t *testing.T) {
 	}
 
 	// Workspace owner (testUserID) is NOT the agent owner.
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, withURLParam(newRequest(
+	w := testutil.Call(t, testHandler.UpdateAgent, withURLParam(newRequest(
 		http.MethodPut, "/api/agents/"+agentID,
 		map[string]any{
 			// Touch some other field too, so the request is otherwise
@@ -169,10 +149,7 @@ func TestUpdateAgent_AllowlistSilentlyDroppedForNonOwner(t *testing.T) {
 				"github", "slack", // would-be widening
 			},
 		},
-	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent admin sweep: got %d: %s", w.Code, w.Body.String())
-	}
+	), "id", agentID)).Want(http.StatusOK)
 	// The non-owner-edit must NOT have replaced the allowlist; the
 	// description update must have landed.
 	stored, isNull := readAllowlistColumn(t, agentID)
@@ -187,9 +164,7 @@ func TestUpdateAgent_AllowlistSilentlyDroppedForNonOwner(t *testing.T) {
 	// (unchanged) DB row, and the owner-only redaction at the end of
 	// UpdateAgent then strips it for the admin caller.
 	var resp AgentResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if len(resp.ComposioToolkitAllowlist) != 0 {
 		t.Errorf("admin response leaked allowlist contents: %v", resp.ComposioToolkitAllowlist)
 	}
@@ -220,9 +195,7 @@ func TestGetAgent_AllowlistVisibility(t *testing.T) {
 	testHandler.GetAgent(w, withURLParam(newRequestAs(
 		ownerID, http.MethodGet, "/api/agents/"+agentID, nil,
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgent as owner: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var ownerResp AgentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &ownerResp); err != nil {
 		t.Fatalf("decode owner response: %v", err)
@@ -239,9 +212,7 @@ func TestGetAgent_AllowlistVisibility(t *testing.T) {
 	testHandler.GetAgent(w, withURLParam(newRequest(
 		http.MethodGet, "/api/agents/"+agentID, nil,
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgent as ws-owner: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var adminResp AgentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &adminResp); err != nil {
 		t.Fatalf("decode admin response: %v", err)
@@ -271,9 +242,7 @@ func TestAgentAllowlistSuppressedWhenComposioFlagDisabled(t *testing.T) {
 		ownerID, http.MethodPut, "/api/agents/"+agentID,
 		map[string]any{"composio_toolkit_allowlist": []string{"github"}},
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent owner write with flag off: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	stored, isNull := readAllowlistColumn(t, agentID)
 	if isNull || len(stored) != 1 || stored[0] != "notion" {
 		t.Fatalf("flag-off write changed allowlist: stored=%v isNull=%v; want unchanged [notion]", stored, isNull)
@@ -290,9 +259,7 @@ func TestAgentAllowlistSuppressedWhenComposioFlagDisabled(t *testing.T) {
 	testHandler.GetAgent(w, withURLParam(newRequestAs(
 		ownerID, http.MethodGet, "/api/agents/"+agentID, nil,
 	), "id", agentID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgent owner with flag off: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var getResp AgentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &getResp); err != nil {
 		t.Fatalf("decode get response: %v", err)

--- a/server/internal/handler/agent_concurrency_test.go
+++ b/server/internal/handler/agent_concurrency_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestCreateAgent_MaxConcurrentTasksBoundsAndDefault(t *testing.T) {
@@ -42,11 +42,7 @@ func TestCreateAgent_MaxConcurrentTasksBoundsAndDefault(t *testing.T) {
 				body["max_concurrent_tasks"] = tt.value
 			}
 
-			w := httptest.NewRecorder()
-			testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-			if w.Code != tt.wantCode {
-				t.Fatalf("status = %d, want %d: %s", w.Code, tt.wantCode, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(tt.wantCode)
 
 			if tt.wantCode == http.StatusBadRequest {
 				if !strings.Contains(w.Body.String(), "between 1 and 50") {
@@ -56,9 +52,7 @@ func TestCreateAgent_MaxConcurrentTasksBoundsAndDefault(t *testing.T) {
 			}
 
 			var response AgentResponse
-			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-				t.Fatalf("decode response: %v", err)
-			}
+			w.Decode(&response)
 			t.Cleanup(func() {
 				testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, response.ID)
 			})
@@ -94,15 +88,11 @@ func TestUpdateAgent_MaxConcurrentTasksBoundsAndOmission(t *testing.T) {
 
 	for _, value := range []int32{0, -1, 51} {
 		t.Run(fmt.Sprintf("rejects_%d", value), func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := withURLParam(newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
 				"max_concurrent_tasks": value,
 			}), "id", agentID)
-			testHandler.UpdateAgent(w, req)
-
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusBadRequest)
 			if !strings.Contains(w.Body.String(), "between 1 and 50") {
 				t.Fatalf("error should explain the 1-50 range: %s", w.Body.String())
 			}
@@ -114,15 +104,11 @@ func TestUpdateAgent_MaxConcurrentTasksBoundsAndOmission(t *testing.T) {
 
 	for _, value := range []int32{1, 50} {
 		t.Run(fmt.Sprintf("accepts_%d", value), func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := withURLParam(newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
 				"max_concurrent_tasks": value,
 			}), "id", agentID)
-			testHandler.UpdateAgent(w, req)
-
-			if w.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 			if got := readPersisted(); got != value {
 				t.Fatalf("persisted max_concurrent_tasks = %d, want %d", got, value)
 			}
@@ -130,30 +116,22 @@ func TestUpdateAgent_MaxConcurrentTasksBoundsAndOmission(t *testing.T) {
 	}
 
 	t.Run("omitted preserves existing value", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
 			"description": "concurrency unchanged",
 		}), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		if got := readPersisted(); got != 50 {
 			t.Fatalf("omitted max_concurrent_tasks changed value to %d, want 50", got)
 		}
 	})
 
 	t.Run("null preserves existing value", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
 			"max_concurrent_tasks": nil,
 		}), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		if got := readPersisted(); got != 50 {
 			t.Fatalf("null max_concurrent_tasks changed value to %d, want 50", got)
 		}

--- a/server/internal/handler/agent_env_permission_test.go
+++ b/server/internal/handler/agent_env_permission_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -85,9 +86,7 @@ func TestAgentEnv_AgentOwnerMemberCanRevealAndUpdate(t *testing.T) {
 	req := withURLParam(newRequestAs(ownerUserID, http.MethodGet, "/api/agents/"+agentID+"/env", nil), "id", agentID)
 	w := httptest.NewRecorder()
 	testHandler.GetAgentEnv(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgentEnv as agent owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp AgentEnvResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode reveal response: %v", err)
@@ -100,9 +99,7 @@ func TestAgentEnv_AgentOwnerMemberCanRevealAndUpdate(t *testing.T) {
 	req = withURLParam(newRequestAs(ownerUserID, http.MethodPut, "/api/agents/"+agentID+"/env", body), "id", agentID)
 	w = httptest.NewRecorder()
 	testHandler.UpdateAgentEnv(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgentEnv as agent owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var stored string
 	if err := testPool.QueryRow(ctx, `SELECT custom_env::text FROM agent WHERE id = $1`, agentID).Scan(&stored); err != nil {
@@ -161,11 +158,7 @@ func TestAgentEnv_UnrelatedMemberForbidden(t *testing.T) {
 				method = http.MethodPut
 			}
 			req := withURLParam(newRequestAs(strangerID, method, "/api/agents/"+agentID+"/env", tc.body), "id", agentID)
-			w := httptest.NewRecorder()
-			tc.fn(w, req)
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("expected 403 for an unrelated member, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.fn, req).Want(http.StatusForbidden)
 		})
 	}
 
@@ -200,8 +193,7 @@ func TestAgentEnv_WorkspaceRolesUnchanged(t *testing.T) {
 	// testUserID is the workspace owner and does NOT own this agent.
 	for _, actorID := range []string{testUserID, adminID} {
 		req := withURLParam(newRequestAs(actorID, http.MethodGet, "/api/agents/"+agentID+"/env", nil), "id", agentID)
-		w := httptest.NewRecorder()
-		testHandler.GetAgentEnv(w, req)
+		w := testutil.Call(t, testHandler.GetAgentEnv, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("GetAgentEnv as %s: expected 200, got %d: %s", actorID, w.Code, w.Body.String())
 		}
@@ -246,11 +238,7 @@ func TestAgentEnv_AgentActorRejectedForOwnedAgent(t *testing.T) {
 			req := withURLParam(newRequestAs(ownerUserID, method, "/api/agents/"+targetID+"/env", tc.body), "id", targetID)
 			req.Header.Set("X-Agent-ID", hostAgentID)
 			req.Header.Set("X-Task-ID", hostTaskID)
-			w := httptest.NewRecorder()
-			tc.fn(w, req)
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("expected 403 from an agent actor, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.fn, req).Want(http.StatusForbidden)
 		})
 	}
 }

--- a/server/internal/handler/agent_permission_test.go
+++ b/server/internal/handler/agent_permission_test.go
@@ -2,11 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -42,8 +41,7 @@ func TestCreateAgent_LegacyVisibilityMapsToPermission(t *testing.T) {
 	runtimeID := handlerTestRuntimeID(t)
 
 	create := func(name, visibility string) AgentResponse {
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
 			"name":       name,
 			"runtime_id": runtimeID,
 			"visibility": visibility,
@@ -52,9 +50,7 @@ func TestCreateAgent_LegacyVisibilityMapsToPermission(t *testing.T) {
 			t.Fatalf("create %q (visibility=%s): expected 201, got %d: %s", name, visibility, w.Code, w.Body.String())
 		}
 		var resp AgentResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		w.Decode(&resp)
 		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID) })
 		return resp
 	}
@@ -101,18 +97,7 @@ func TestMigrationBackfill_VisibilityToPermission(t *testing.T) {
 	runtimeID := handlerTestRuntimeID(t)
 
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, 'backfill-legacy-workspace-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'workspace', 'private', 1, $3)
-		RETURNING id
-	`, testWorkspaceID, runtimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("insert pre-migration agent: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID) })
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'backfill-legacy-workspace-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'workspace'"), "permission_mode": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	// Exact backfill statements from migration 130 (idempotent).
 	if _, err := testPool.Exec(ctx, `UPDATE agent SET permission_mode = 'public_to' WHERE visibility = 'workspace'`); err != nil {
@@ -159,22 +144,16 @@ func TestCanInvokeAgent_PublicToMemberWhitelist(t *testing.T) {
 	otherMember := createPermissionTestMember(t, "perm-other-member@multica.test")
 
 	// Owner (testUserID) creates an agent public_to the allowed member only.
-	w := httptest.NewRecorder()
-	testHandler.CreateAgent(w, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateAgent, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
 		"name":            "public-to-specific-member-agent",
 		"runtime_id":      runtimeID,
 		"permission_mode": "public_to",
 		"invocation_targets": []map[string]any{
 			{"target_type": "member", "target_id": allowedMember},
 		},
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create agent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var agent AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&agent); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&agent)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agent.ID) })
 
 	// Derived legacy visibility for a member-only public_to agent must be
@@ -184,8 +163,7 @@ func TestCanInvokeAgent_PublicToMemberWhitelist(t *testing.T) {
 	}
 
 	assignAs := func(actorID string) int {
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, newRequestAs(actorID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		rec := testutil.Call(t, testHandler.CreateIssue, newRequestAs(actorID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 			"title":         "assign to member-scoped agent",
 			"status":        "todo",
 			"assignee_type": "agent",
@@ -213,8 +191,7 @@ func TestCanInvokeAgent_PublicToMemberWhitelist(t *testing.T) {
 // and returns its id.
 func createPublicToAgentWithTargets(t *testing.T, name string, targets []map[string]any) string {
 	t.Helper()
-	w := httptest.NewRecorder()
-	testHandler.CreateAgent(w, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateAgent, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
 		"name":               name,
 		"runtime_id":         handlerTestRuntimeID(t),
 		"permission_mode":    "public_to",
@@ -224,9 +201,7 @@ func createPublicToAgentWithTargets(t *testing.T, name string, targets []map[str
 		t.Fatalf("create %q: expected 201, got %d: %s", name, w.Code, w.Body.String())
 	}
 	var resp AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&resp)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID) })
 	return resp.ID
 }
@@ -305,7 +280,7 @@ func TestUpdateAgent_BatchReplaceOverlappingMembers(t *testing.T) {
 	}
 
 	// Batch-replace the allow-list with an overlapping set: drop A, keep B, add C.
-	w := httptest.NewRecorder()
+
 	r := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
 		"permission_mode": "public_to",
 		"invocation_targets": []map[string]any{
@@ -314,10 +289,7 @@ func TestUpdateAgent_BatchReplaceOverlappingMembers(t *testing.T) {
 		},
 	})
 	r = withURLParam(r, "id", agentID)
-	testHandler.UpdateAgent(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("update: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgent, r).Want(http.StatusOK)
 
 	if n := invocationTargetCount(t, agentID); n != 2 {
 		t.Errorf("after batch replace expected exactly 2 targets, got %d (stale rows not cleared?)", n)
@@ -355,7 +327,7 @@ func TestUpdateAgent_WorkspaceStacksWithMembersThenNarrowed(t *testing.T) {
 
 	// Narrow to member C only — workspace grant is dropped by the replace.
 	memberC := createPermissionTestMember(t, "perm-stack-c@multica.test")
-	w := httptest.NewRecorder()
+
 	r := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
 		"permission_mode": "public_to",
 		"invocation_targets": []map[string]any{
@@ -363,10 +335,7 @@ func TestUpdateAgent_WorkspaceStacksWithMembersThenNarrowed(t *testing.T) {
 		},
 	})
 	r = withURLParam(r, "id", agentID)
-	testHandler.UpdateAgent(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("narrow update: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgent, r).Want(http.StatusOK)
 	if canMemberInvoke(t, agentID, memberB) {
 		t.Errorf("after dropping workspace target, non-listed member B must lose access")
 	}
@@ -384,20 +353,14 @@ func TestCreateAgent_EmptyPublicToNormalizesToWorkspace(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	w := httptest.NewRecorder()
-	testHandler.CreateAgent(w, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateAgent, newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
 		"name":            "empty-public-to-agent",
 		"runtime_id":      handlerTestRuntimeID(t),
 		"permission_mode": "public_to",
 		// no invocation_targets on purpose
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var resp AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&resp)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, resp.ID) })
 
 	if resp.PermissionMode != "public_to" {
@@ -545,14 +508,7 @@ func TestRevokeMember_InvocationTargetCleanupIsWorkspaceScoped(t *testing.T) {
 	// allow-lists the same userX.
 	testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = 'xws-b-perm-test'`)
 	var wsB string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ('XWS B', 'xws-b-perm-test', '', 'XWB')
-		RETURNING id
-	`).Scan(&wsB); err != nil {
-		t.Fatalf("create workspace B: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsB) })
+	wsB = dbfx.Insert(t, "workspace", testutil.Cols{"name": testutil.Raw("'XWS B'"), "slug": testutil.Raw("'xws-b-perm-test'"), "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'XWB'")})
 
 	if _, err := testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'owner')`, wsB, testUserID); err != nil {
 		t.Fatalf("add owner to B: %v", err)
@@ -647,21 +603,18 @@ func TestUpdateAgent_AccessChangeIsOwnerOnly(t *testing.T) {
 	adminID := createPermissionTestAdmin(t, "perm-access-admin@multica.test")
 
 	put := func(actorID string, body map[string]any) int {
-		rec := httptest.NewRecorder()
+
 		r := newRequestAs(actorID, "PUT", "/api/agents/"+agentID, body)
 		r = withURLParam(r, "id", agentID)
-		testHandler.UpdateAgent(rec, r)
+		rec := testutil.Call(t, testHandler.UpdateAgent, r)
 		return rec.Code
 	}
 
 	// Admin (non-owner) attempts a REAL access change → 403.
-	rec := httptest.NewRecorder()
+
 	r := newRequestAs(adminID, "PUT", "/api/agents/"+agentID, map[string]any{"permission_mode": "private"})
 	r = withURLParam(r, "id", agentID)
-	testHandler.UpdateAgent(rec, r)
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("admin access change: expected 403, got %d: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgent, r).Want(http.StatusForbidden)
 	// Access must be unchanged (still public_to workspace).
 	if a, _ := testHandler.Queries.GetAgent(ctx, util.MustParseUUID(agentID)); a.PermissionMode != "public_to" {
 		t.Errorf("access must be unchanged after rejected admin write, got %q", a.PermissionMode)
@@ -708,10 +661,10 @@ func TestUpdateAgent_LegacyVisibilityNoOpForMemberOnlyPublicTo(t *testing.T) {
 	adminID := createPermissionTestAdmin(t, "perm-legacyvis-admin@multica.test")
 
 	put := func(actorID string, body map[string]any) int {
-		rec := httptest.NewRecorder()
+
 		r := newRequestAs(actorID, "PUT", "/api/agents/"+agentID, body)
 		r = withURLParam(r, "id", agentID)
-		testHandler.UpdateAgent(rec, r)
+		rec := testutil.Call(t, testHandler.UpdateAgent, r)
 		return rec.Code
 	}
 

--- a/server/internal/handler/agent_runtime_required_test.go
+++ b/server/internal/handler/agent_runtime_required_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // An unbound agent is refused by every execution entry point — that part already
@@ -70,23 +70,17 @@ func TestChatSend_UnboundAgentReturnsStructuredConflict(t *testing.T) {
 
 	unbindRuntime(t, ctx, runtimeID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/chat/sessions/"+sessionID+"/messages",
 		map[string]any{"content": "are you still there?"})
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	testHandler.SendChatMessage(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.SendChatMessage, req).Want(http.StatusConflict)
 
 	var body struct {
 		Error      string `json:"error"`
 		ReasonCode string `json:"reason_code"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&body)
 	if body.ReasonCode != string(ReasonAgentRuntimeRequired) {
 		t.Fatalf("reason_code = %q, want agent_runtime_required", body.ReasonCode)
 	}
@@ -105,16 +99,12 @@ func TestCreateAutopilot_UnboundAgentRejected(t *testing.T) {
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Autopilot Create Unbound Agent")
 	unbindRuntime(t, ctx, runtimeID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "must not start unbound",
 		"assignee_id":    agentID,
 		"execution_mode": "run_only",
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusUnprocessableEntity)
 
 	var rows int
 	if err := testPool.QueryRow(ctx,
@@ -138,31 +128,14 @@ func TestUpdateAutopilot_UnboundAgentCannotResume(t *testing.T) {
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Autopilot Resume Unbound Agent")
 
 	var autopilotID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO autopilot (
-			workspace_id, title, assignee_type, assignee_id, status,
-			execution_mode, created_by_type, created_by_id
-		)
-		VALUES ($1, 'cannot resume unbound', 'agent', $2, 'active',
-			'run_only', 'member', $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&autopilotID); err != nil {
-		t.Fatalf("insert paused autopilot: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID)
-	})
+	autopilotID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'cannot resume unbound'"), "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID, "status": testutil.Raw("'active'"), "execution_mode": testutil.Raw("'run_only'"), "created_by_type": testutil.Raw("'member'"), "created_by_id": testUserID})
 
 	unbindRuntime(t, ctx, runtimeID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+autopilotID+"?workspace_id="+testWorkspaceID,
 		map[string]any{"status": "active"})
 	req = withURLParam(req, "id", autopilotID)
-	testHandler.UpdateAutopilot(w, req)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilot, req).Want(http.StatusUnprocessableEntity)
 
 	var status, pauseReason string
 	if err := testPool.QueryRow(ctx,
@@ -180,12 +153,12 @@ func TestUpdateAutopilot_UnboundAgentCannotResume(t *testing.T) {
 // reason_code of its trigger outcome, or "" when the mention was admitted.
 func mentionAgentReasonCode(t *testing.T, issueID, agentID string) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Agent](mention://agent/" + agentID + ") please take a look",
 	})
 	req = withURLParam(req, "id", issueID)
-	testHandler.CreateComment(w, req)
+	w := testutil.Call(t, testHandler.CreateComment, req)
 	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
 		t.Fatalf("CreateComment: expected 200/201, got %d: %s", w.Code, w.Body.String())
 	}
@@ -198,9 +171,7 @@ func mentionAgentReasonCode(t *testing.T, issueID, agentID string) string {
 			ReasonCode string `json:"reason_code"`
 		} `json:"trigger_outcomes"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode comment response: %v", err)
-	}
+	w.Decode(&body)
 	for _, o := range body.TriggerOutcomes {
 		if o.TargetID != agentID {
 			continue

--- a/server/internal/handler/agent_runtime_skills_broadcast_test.go
+++ b/server/internal/handler/agent_runtime_skills_broadcast_test.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
-	"context"
 	"net/http/httptest"
 	"sync"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -21,19 +21,7 @@ import (
 func TestSetAgentRuntimeSkillEnabledBroadcastsAgentStatus(t *testing.T) {
 	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
 	var agentID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'local', '{}'::jsonb, $3, 'private', 'private', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, "Runtime Skill Broadcast "+t.Name(), runtimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Runtime Skill Broadcast " + t.Name(), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'local'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "permission_mode": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	// The bus is synchronous, so counts observed right after each request are
 	// deterministic; the mutex only guards against a future async listener.

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestListWorkspaceAgentTaskSnapshot covers the agent presence snapshot endpoint:
@@ -100,17 +101,11 @@ func TestListWorkspaceAgentTaskSnapshot(t *testing.T) {
 		}
 	})
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodGet, "/api/agent-task-snapshot", nil)
-	testHandler.ListWorkspaceAgentTaskSnapshot(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListWorkspaceAgentTaskSnapshot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListWorkspaceAgentTaskSnapshot, req).Want(http.StatusOK)
 
 	var tasks []AgentTaskResponse
-	if err := json.NewDecoder(w.Body).Decode(&tasks); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&tasks)
 
 	// Per-agent breakdown so leftover tasks from other tests in this package
 	// don't pollute the assertions.
@@ -205,24 +200,7 @@ func TestListWorkspaceWorkingAgents(t *testing.T) {
 	})
 
 	var outsiderAgentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args, mcp_config
-		)
-		VALUES (
-			$1, 'working-agents-outsider', '', 'cloud', '{}'::jsonb,
-			$2, 'workspace', 'private', 1, $3,
-			'', '{}'::jsonb, '[]'::jsonb, '{}'::jsonb
-		)
-		RETURNING id
-	`, testWorkspaceID, testRuntimeID, outsiderUserID).Scan(&outsiderAgentID); err != nil {
-		t.Fatalf("insert outsider agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, outsiderAgentID)
-	})
+	outsiderAgentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'working-agents-outsider'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID, "visibility": testutil.Raw("'workspace'"), "permission_mode": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": outsiderUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb"), "mcp_config": testutil.Raw("'{}'::jsonb")})
 
 	insertedSquadIDs := make([]string, 0, 3)
 	insertSquad := func(name, leaderID string) string {
@@ -503,19 +481,10 @@ func TestListWorkspaceWorkingAgents(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			testHandler.ListWorkspaceWorkingAgents(
-				w,
-				newRequest(http.MethodGet, "/api/working-agents"+tc.query, nil),
-			)
-			if w.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.ListWorkspaceWorkingAgents, newRequest(http.MethodGet, "/api/working-agents"+tc.query, nil)).Want(http.StatusOK)
 
 			var agents []WorkspaceWorkingAgent
-			if err := json.NewDecoder(w.Body).Decode(&agents); err != nil {
-				t.Fatalf("decode response: %v", err)
-			}
+			w.Decode(&agents)
 
 			var working *WorkspaceWorkingAgent
 			for i := range agents {
@@ -568,14 +537,7 @@ func TestListWorkspaceWorkingAgentsRejectsInvalidFilters(t *testing.T) {
 		"/api/working-agents?type=issue&scope=mine&parent=00000000-0000-0000-0000-000000000000",
 	} {
 		t.Run(path, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			testHandler.ListWorkspaceWorkingAgents(
-				w,
-				newRequest(http.MethodGet, path, nil),
-			)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.ListWorkspaceWorkingAgents, newRequest(http.MethodGet, path, nil)).Want(http.StatusBadRequest)
 		})
 	}
 }
@@ -655,18 +617,9 @@ func TestListWorkspaceWorkingAgentsParentScope(t *testing.T) {
 
 	read := func(t *testing.T, query string) map[string]WorkspaceWorkingAgent {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.ListWorkspaceWorkingAgents(
-			w,
-			newRequest(http.MethodGet, "/api/working-agents"+query, nil),
-		)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListWorkspaceWorkingAgents, newRequest(http.MethodGet, "/api/working-agents"+query, nil)).Want(http.StatusOK)
 		var agents []WorkspaceWorkingAgent
-		if err := json.NewDecoder(w.Body).Decode(&agents); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&agents)
 		byID := make(map[string]WorkspaceWorkingAgent, len(agents))
 		for _, agent := range agents {
 			byID[agent.ID] = agent
@@ -747,15 +700,9 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 	}
 
 	// First call — creates the agent.
-	w1 := httptest.NewRecorder()
-	testHandler.CreateAgent(w1, newRequest(http.MethodPost, "/api/agents", body))
-	if w1.Code != http.StatusCreated {
-		t.Fatalf("first CreateAgent: expected 201, got %d: %s", w1.Code, w1.Body.String())
-	}
+	w1 := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 	var resp1 map[string]any
-	if err := json.NewDecoder(w1.Body).Decode(&resp1); err != nil {
-		t.Fatalf("decode first response: %v", err)
-	}
+	w1.Decode(&resp1)
 	agentID1, _ := resp1["id"].(string)
 	if agentID1 == "" {
 		t.Fatalf("first CreateAgent: no id in response: %v", resp1)
@@ -764,11 +711,7 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 	// Second call — same name must be rejected with 409 Conflict.
 	// The unique constraint prevents silent duplicates; the UI shows a clear error.
 	body["description"] = "updated description"
-	w2 := httptest.NewRecorder()
-	testHandler.CreateAgent(w2, newRequest(http.MethodPost, "/api/agents", body))
-	if w2.Code != http.StatusConflict {
-		t.Fatalf("second CreateAgent with duplicate name: expected 409, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusConflict)
 }
 
 // TestUpdateAgent_RejectsRenameToArchivedName is the regression for #5914: the
@@ -786,21 +729,12 @@ func TestUpdateAgent_RejectsRenameToArchivedName(t *testing.T) {
 	const heldName = "rename-collision-archived-name"
 	idA := createHandlerTestAgent(t, heldName, nil)
 	archiveReq := withURLParam(newRequest(http.MethodPost, "/api/agents/"+idA+"/archive", nil), "id", idA)
-	archiveW := httptest.NewRecorder()
-	testHandler.ArchiveAgent(archiveW, archiveReq)
-	if archiveW.Code != http.StatusOK {
-		t.Fatalf("ArchiveAgent: expected 200, got %d: %s", archiveW.Code, archiveW.Body.String())
-	}
+	testutil.Call(t, testHandler.ArchiveAgent, archiveReq).Want(http.StatusOK)
 
 	// Agent B renames itself into the archived agent's name.
 	idB := createHandlerTestAgent(t, "rename-collision-source", nil)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, withURLParam(
-		newRequest(http.MethodPatch, "/api/agents/"+idB, map[string]any{"name": heldName}), "id", idB))
-
-	if w.Code != http.StatusConflict {
-		t.Fatalf("rename to archived agent's name: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgent, withURLParam(
+		newRequest(http.MethodPatch, "/api/agents/"+idB, map[string]any{"name": heldName}), "id", idB)).Want(http.StatusConflict)
 	if strings.Contains(w.Body.String(), "agent_workspace_name_unique") {
 		t.Fatalf("409 body leaked the raw constraint name: %s", w.Body.String())
 	}
@@ -844,16 +778,10 @@ func TestCreateAgent_AssignsAvatarDefault(t *testing.T) {
 				body["avatar_url"] = *tt.avatarURL
 			}
 
-			w := httptest.NewRecorder()
-			testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-			if w.Code != http.StatusCreated {
-				t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 
 			var response AgentResponse
-			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-				t.Fatalf("decode response: %v", err)
-			}
+			w.Decode(&response)
 			if response.AvatarURL == nil {
 				t.Fatal("CreateAgent: avatar_url is nil")
 			}
@@ -923,12 +851,7 @@ func TestGetAgent_ResponseHasNoCustomEnv(t *testing.T) {
 
 	req := newRequest("GET", "/agents/"+agentID, nil)
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.GetAgent(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAgent, req).Want(http.StatusOK)
 
 	raw := rawJSONResponse(t, w.Body.Bytes())
 	if _, ok := raw["custom_env"]; ok {
@@ -947,9 +870,7 @@ func TestGetAgent_ResponseHasNoCustomEnv(t *testing.T) {
 	// Sanity-check the typed shape too — the struct must not have
 	// rehydrated the masked map.
 	var typed AgentResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &typed); err != nil {
-		t.Fatalf("typed decode failed: %v", err)
-	}
+	w.JSON(&typed)
 	if typed.HasCustomEnv != true {
 		t.Errorf("typed.HasCustomEnv expected true")
 	}
@@ -974,16 +895,10 @@ func TestListAgents_ResponseHasNoCustomEnv(t *testing.T) {
 	}
 
 	req := newRequest("GET", "/agents", nil)
-	w := httptest.NewRecorder()
-	testHandler.ListAgents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAgents, req).Want(http.StatusOK)
 
 	var rawAgents []map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &rawAgents); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
+	w.JSON(&rawAgents)
 
 	var found map[string]any
 	for _, a := range rawAgents {
@@ -1023,17 +938,10 @@ func TestGetAgentEnv_OwnerSucceedsAndAudits(t *testing.T) {
 
 	req := newRequest("GET", "/api/agents/"+agentID+"/env", nil)
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.GetAgentEnv(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAgentEnv: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAgentEnv, req).Want(http.StatusOK)
 
 	var resp AgentEnvResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.AgentID != agentID {
 		t.Errorf("agent_id mismatch: got %q", resp.AgentID)
 	}
@@ -1100,11 +1008,7 @@ func TestAgentEnv_AgentActorRejected(t *testing.T) {
 			req = withURLParam(req, "id", targetID)
 			req.Header.Set("X-Agent-ID", hostAgentID)
 			req.Header.Set("X-Task-ID", hostTaskID)
-			w := httptest.NewRecorder()
-			tc.fn(w, req)
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("expected 403 from agent actor, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.fn, req).Want(http.StatusForbidden)
 		})
 	}
 }
@@ -1137,11 +1041,7 @@ func TestAgentEnv_TaskTokenActorSource(t *testing.T) {
 	req.Header.Set("X-Actor-Source", "task_token")
 	req.Header.Del("X-Agent-ID")
 	req.Header.Del("X-Task-ID")
-	w := httptest.NewRecorder()
-	testHandler.GetAgentEnv(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 when X-Actor-Source=task_token, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetAgentEnv, req).Want(http.StatusForbidden)
 }
 
 // TestUpdateAgentEnv_PreservesSentinelValues verifies the **** guard.
@@ -1172,11 +1072,7 @@ func TestUpdateAgentEnv_PreservesSentinelValues(t *testing.T) {
 	}
 	req := newRequest(http.MethodPut, "/api/agents/"+agentID+"/env", body)
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgentEnv(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgentEnv: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgentEnv, req).Want(http.StatusOK)
 
 	// Refetch from DB so we don't rely on the response body alone.
 	var stored string
@@ -1257,11 +1153,7 @@ func TestUpdateAgent_RejectsCustomEnvInBody(t *testing.T) {
 	}
 	req := newRequest(http.MethodPut, "/api/agents/"+agentID, body)
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("UpdateAgent: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "custom_env") || !strings.Contains(w.Body.String(), "/env") {
 		t.Errorf("error body should mention custom_env and the env endpoint; got %s", w.Body.String())
 	}
@@ -1398,16 +1290,10 @@ func TestUpdateAgent_RedactsMcpConfigForAgentActor(t *testing.T) {
 	req.Header.Set("X-Actor-Source", "task_token")
 	req.Header.Set("X-Agent-ID", caller)
 	req.Header.Set("X-Task-ID", taskID)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 
 	var resp AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	// The response contract keeps `mcp_config` always-present so clients
 	// can distinguish "no config" vs "redacted" via the companion flag.
 	// `json.RawMessage` of a JSON null decodes to the literal bytes
@@ -1436,15 +1322,9 @@ func TestUpdateAgent_KeepsMcpConfigForMemberActor(t *testing.T) {
 		"description": "owner-visible mutation",
 	})
 	req = withURLParam(req, "id", target)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 	var resp AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.McpConfig == nil {
 		t.Errorf("UpdateAgent response should keep mcp_config for member actor; got nil")
 	}
@@ -1483,16 +1363,10 @@ func TestUpdateAgent_PreservesSkillsInResponse(t *testing.T) {
 		"description": "metadata-only update",
 	})
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 
 	var resp AgentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	gotIDs := map[string]bool{}
 	for _, s := range resp.Skills {
 		gotIDs[s.ID] = true
@@ -1522,15 +1396,9 @@ func TestUpdateAgent_PreservesSkillsInResponse(t *testing.T) {
 	// on the very next read.
 	getReq := newRequest(http.MethodGet, "/api/agents/"+agentID, nil)
 	getReq = withURLParam(getReq, "id", agentID)
-	getW := httptest.NewRecorder()
-	testHandler.GetAgent(getW, getReq)
-	if getW.Code != http.StatusOK {
-		t.Fatalf("GetAgent: expected 200, got %d: %s", getW.Code, getW.Body.String())
-	}
+	getW := testutil.Call(t, testHandler.GetAgent, getReq).Want(http.StatusOK)
 	var getResp AgentResponse
-	if err := json.NewDecoder(getW.Body).Decode(&getResp); err != nil {
-		t.Fatalf("decode GetAgent: %v", err)
-	}
+	getW.Decode(&getResp)
 	if len(getResp.Skills) != len(resp.Skills) {
 		t.Errorf("GetAgent skill count %d != UpdateAgent skill count %d",
 			len(getResp.Skills), len(resp.Skills))
@@ -1561,30 +1429,18 @@ func TestArchiveRestoreAgent_PreservesSkillsInResponse(t *testing.T) {
 
 	archiveReq := newRequest(http.MethodPost, "/api/agents/"+agentID+"/archive", nil)
 	archiveReq = withURLParam(archiveReq, "id", agentID)
-	archiveW := httptest.NewRecorder()
-	testHandler.ArchiveAgent(archiveW, archiveReq)
-	if archiveW.Code != http.StatusOK {
-		t.Fatalf("ArchiveAgent: expected 200, got %d: %s", archiveW.Code, archiveW.Body.String())
-	}
+	archiveW := testutil.Call(t, testHandler.ArchiveAgent, archiveReq).Want(http.StatusOK)
 	var archived AgentResponse
-	if err := json.NewDecoder(archiveW.Body).Decode(&archived); err != nil {
-		t.Fatalf("decode archive: %v", err)
-	}
+	archiveW.Decode(&archived)
 	if len(archived.Skills) != 1 || archived.Skills[0].ID != skillID {
 		t.Errorf("ArchiveAgent: expected 1 skill %s, got %+v", skillID, archived.Skills)
 	}
 
 	restoreReq := newRequest(http.MethodPost, "/api/agents/"+agentID+"/restore", nil)
 	restoreReq = withURLParam(restoreReq, "id", agentID)
-	restoreW := httptest.NewRecorder()
-	testHandler.RestoreAgent(restoreW, restoreReq)
-	if restoreW.Code != http.StatusOK {
-		t.Fatalf("RestoreAgent: expected 200, got %d: %s", restoreW.Code, restoreW.Body.String())
-	}
+	restoreW := testutil.Call(t, testHandler.RestoreAgent, restoreReq).Want(http.StatusOK)
 	var restored AgentResponse
-	if err := json.NewDecoder(restoreW.Body).Decode(&restored); err != nil {
-		t.Fatalf("decode restore: %v", err)
-	}
+	restoreW.Decode(&restored)
 	if len(restored.Skills) != 1 || restored.Skills[0].ID != skillID {
 		t.Errorf("RestoreAgent: expected 1 skill %s, got %+v", skillID, restored.Skills)
 	}
@@ -1595,18 +1451,9 @@ func TestArchiveRestoreAgent_PreservesSkillsInResponse(t *testing.T) {
 // dragging the full TaskService into the test.
 func insertHandlerTestTask(t *testing.T, agentID string) string {
 	t.Helper()
-	ctx := context.Background()
+
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority)
-		VALUES ($1, $2, 'running', 0)
-		RETURNING id
-	`, agentID, handlerTestRuntimeID(t)).Scan(&taskID); err != nil {
-		t.Fatalf("insert test task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": handlerTestRuntimeID(t), "status": testutil.Raw("'running'"), "priority": testutil.Raw("0")})
 	return taskID
 }
 

--- a/server/internal/handler/agent_thinking_test.go
+++ b/server/internal/handler/agent_thinking_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateAgent_ThinkingLevel_ValidationConsistency exercises the
@@ -38,11 +39,7 @@ func TestCreateAgent_ThinkingLevel_ValidationConsistency(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("empty thinking_level: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 	})
 
 	t.Run("known claude value succeeds", func(t *testing.T) {
@@ -53,11 +50,7 @@ func TestCreateAgent_ThinkingLevel_ValidationConsistency(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "high",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("thinking_level=high: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "high" {
@@ -76,11 +69,7 @@ func TestCreateAgent_ThinkingLevel_ValidationConsistency(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "none",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("codex-only thinking_level on claude runtime: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 	})
 
 	t.Run("garbage value rejected", func(t *testing.T) {
@@ -91,11 +80,7 @@ func TestCreateAgent_ThinkingLevel_ValidationConsistency(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "supersonic",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("garbage thinking_level: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 	})
 }
 
@@ -121,11 +106,7 @@ func TestCreateAgent_PiThinkingLevelValidation(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "max",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("Pi thinking_level=max: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "max" {
@@ -141,11 +122,7 @@ func TestCreateAgent_PiThinkingLevelValidation(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "ultra",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("Pi thinking_level=ultra: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 	})
 }
 
@@ -167,11 +144,7 @@ func TestAgentServiceTierValidationAndTriState(t *testing.T) {
 			"model":                "gpt-5.6-sol",
 			"service_tier":         "priority",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("create service_tier: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["service_tier"] != "priority" {
@@ -182,14 +155,10 @@ func TestAgentServiceTierValidationAndTriState(t *testing.T) {
 			testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
 		})
 
-		clear := httptest.NewRecorder()
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, map[string]any{
 			"service_tier": "",
 		}), "id", agentID)
-		testHandler.UpdateAgent(clear, req)
-		if clear.Code != http.StatusOK {
-			t.Fatalf("clear service_tier: expected 200, got %d: %s", clear.Code, clear.Body.String())
-		}
+		clear := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var cleared map[string]any
 		_ = json.NewDecoder(clear.Body).Decode(&cleared)
 		if cleared["service_tier"] != "" {
@@ -205,11 +174,7 @@ func TestAgentServiceTierValidationAndTriState(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"service_tier":         "priority",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("Claude service_tier: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 	})
 }
 
@@ -240,12 +205,9 @@ func TestUpdateAgent_ThinkingLevel_TriState(t *testing.T) {
 		body := map[string]any{
 			"name": "thinking-update-test-renamed",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("name-only update: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "high" {
@@ -258,12 +220,9 @@ func TestUpdateAgent_ThinkingLevel_TriState(t *testing.T) {
 		body := map[string]any{
 			"thinking_level": "",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("clear update: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "" {
@@ -276,12 +235,9 @@ func TestUpdateAgent_ThinkingLevel_TriState(t *testing.T) {
 		body := map[string]any{
 			"thinking_level": "warp-speed",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("garbage thinking_level: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusBadRequest)
 	})
 
 	// 4. Codex-only token while bound to a Claude runtime → 400. This
@@ -292,12 +248,9 @@ func TestUpdateAgent_ThinkingLevel_TriState(t *testing.T) {
 		body := map[string]any{
 			"thinking_level": "minimal",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("codex token on claude runtime: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusBadRequest)
 	})
 }
 
@@ -339,12 +292,9 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 		body := map[string]any{
 			"runtime_id": claudeRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 when existing value is still valid, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "high" {
@@ -360,12 +310,9 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 		body := map[string]any{
 			"runtime_id": claudeRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 when existing value is invalid for new runtime, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusBadRequest)
 	})
 
 	t.Run("simultaneous explicit clear lets the switch through", func(t *testing.T) {
@@ -378,12 +325,9 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 			"runtime_id":     claudeRuntimeID,
 			"thinking_level": "",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 with simultaneous clear, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "" {
@@ -399,12 +343,9 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 			"runtime_id":     claudeRuntimeID,
 			"thinking_level": "high",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 with simultaneous set, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["thinking_level"] != "high" {
@@ -438,12 +379,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		body := map[string]any{
 			"runtime_id": codexRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 switching runtime with incompatible model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "" {
@@ -456,12 +394,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		body := map[string]any{
 			"runtime_id": codexRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 switching runtime with provider-prefixed model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "" {
@@ -474,12 +409,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		body := map[string]any{
 			"runtime_id": codexRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 preserving exact target accepted model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "gpt-5.5" {
@@ -492,12 +424,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		body := map[string]any{
 			"runtime_id": secondClaudeRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 preserving context-tagged Claude model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "claude-opus-5[1m]" {
@@ -511,12 +440,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 			"runtime_id": codexRuntimeID,
 			"model":      "gpt-5.5",
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 with explicit replacement model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "gpt-5.5" {
@@ -529,12 +455,9 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 		body := map[string]any{
 			"runtime_id": codexRuntimeID,
 		}
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
-		testHandler.UpdateAgent(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200 preserving unknown custom model, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusOK)
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
 		if resp["model"] != "private-lab-model" {
@@ -619,11 +542,7 @@ func TestCreateAgent_NoReasoningControlRejectsThinkingLevel(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "high",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("copilot thinking_level=high: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 		if !strings.Contains(w.Body.String(), "does not support a per-agent reasoning effort") {
 			t.Errorf("expected a capability explanation in the 400 body, got %s", w.Body.String())
 		}
@@ -637,11 +556,7 @@ func TestCreateAgent_NoReasoningControlRejectsThinkingLevel(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("copilot empty thinking_level: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 	})
 
 	// hermes with no discovered catalog must REFUSE, not accept. The catalog is
@@ -659,11 +574,7 @@ func TestCreateAgent_NoReasoningControlRejectsThinkingLevel(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "high",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("hermes thinking_level=high with no catalog: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusBadRequest)
 		if !strings.Contains(w.Body.String(), "has not reported a model catalog yet") {
 			t.Errorf("expected the not-yet-discovered explanation, got %s", w.Body.String())
 		}
@@ -683,11 +594,7 @@ func TestCreateAgent_NoReasoningControlRejectsThinkingLevel(t *testing.T) {
 			"max_concurrent_tasks": 1,
 			"thinking_level":       "",
 		}
-		w := httptest.NewRecorder()
-		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("hermes empty thinking_level: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 	})
 }
 
@@ -705,39 +612,28 @@ func TestUpdateAgent_ThinkingLevelCarriesOverToUndiscoveredHermes(t *testing.T) 
 	claudeRuntimeID := createClaudeProviderRuntime(t)
 	hermesRuntimeID := createProviderRuntime(t, "hermes")
 
-	created := httptest.NewRecorder()
-	testHandler.CreateAgent(created, newRequest(http.MethodPost, "/api/agents", map[string]any{
+	created := testutil.Call(t, testHandler.CreateAgent, newRequest(http.MethodPost, "/api/agents", map[string]any{
 		"name":                 "carryover-thinking-agent",
 		"runtime_id":           claudeRuntimeID,
 		"visibility":           "private",
 		"max_concurrent_tasks": 1,
 		"thinking_level":       "high",
-	}))
-	if created.Code != http.StatusCreated {
-		t.Fatalf("seed agent: expected 201, got %d: %s", created.Code, created.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var seeded map[string]any
 	_ = json.NewDecoder(created.Body).Decode(&seeded)
 	agentID, _ := seeded["id"].(string)
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
 
-	w := httptest.NewRecorder()
-	testHandler.UpdateAgent(w, withURLParam(
+	w := testutil.Call(t, testHandler.UpdateAgent, withURLParam(
 		newRequest(http.MethodPatch, "/api/agents/"+agentID, map[string]any{
 			"runtime_id": hermesRuntimeID,
-		}), "id", agentID))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("carry-over onto undiscovered hermes: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+		}), "id", agentID)).Want(http.StatusBadRequest)
 	// Decode rather than substring-match the raw body: the escape hatch contains
 	// quotes, which JSON-escapes to `thinking_level=\"\"` on the wire.
 	var errBody struct {
 		Error string `json:"error"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&errBody); err != nil {
-		t.Fatalf("decode error body: %v", err)
-	}
+	w.Decode(&errBody)
 	if !strings.Contains(errBody.Error, "has not reported a model catalog yet") {
 		t.Errorf("expected the not-yet-discovered explanation, got %q", errBody.Error)
 	}

--- a/server/internal/handler/attachment_capability_test.go
+++ b/server/internal/handler/attachment_capability_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/auth"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const capabilityTestAttachmentID = "11111111-2222-3333-4444-555555555555"
@@ -199,9 +200,7 @@ func TestDownloadAttachmentWithCapability_ServesWithoutAuthentication(t *testing
 	req, w := newCapabilityRequest(id, capabilityQuery(t, id, time.Now()))
 	testHandler.DownloadAttachmentWithCapability(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if !bytes.Equal(w.Body.Bytes(), body) {
 		t.Fatalf("body = %q, want %q", w.Body.String(), body)
 	}
@@ -248,9 +247,7 @@ func TestDownloadAttachmentWithCapability_RejectsInvalidCapabilities(t *testing.
 			req, w := newCapabilityRequest(id, tc.query)
 			testHandler.DownloadAttachmentWithCapability(w, req)
 
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 			if bytes.Contains(w.Body.Bytes(), body) {
 				t.Fatal("rejected response leaked the attachment body")
 			}
@@ -269,9 +266,7 @@ func TestDownloadAttachmentWithCapability_PreservesRangeAndHeaders(t *testing.T)
 	req.Header.Set("Range", "bytes=100-199")
 	testHandler.DownloadAttachmentWithCapability(w, req)
 
-	if w.Code != http.StatusPartialContent {
-		t.Fatalf("status = %d, want 206; body len=%d", w.Code, w.Body.Len())
-	}
+	testutil.Equal(t, w.Code, http.StatusPartialContent, "HTTP status")
 	if got := w.Header().Get("Content-Range"); got != "bytes 100-199/4096" {
 		t.Fatalf("Content-Range = %q", got)
 	}
@@ -297,13 +292,7 @@ func TestGetAttachmentByID_ProxyModeReturnsRedeemableCapability(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.GetAttachmentByID(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAttachmentByID, req).Want(http.StatusOK)
 	var resp AttachmentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
@@ -348,13 +337,7 @@ func TestGetAttachmentByID_ProxyModeDownloadURLForcesAttachment(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.GetAttachmentByID(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAttachmentByID, req).Want(http.StatusOK)
 	var resp AttachmentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
@@ -383,9 +366,7 @@ func TestGetAttachmentByID_ProxyModeDownloadURLForcesAttachment(t *testing.T) {
 	// Redeeming it forces an attachment disposition even for an image.
 	req2, w2 := newCapabilityRequest(id, parsed.Query())
 	testHandler.DownloadAttachmentWithCapability(w2, req2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("redeem status = %d, want 200; body=%s", w2.Code, w2.Body.String())
-	}
+	testutil.Equal(t, w2.Code, http.StatusOK, "HTTP status")
 	if !bytes.Equal(w2.Body.Bytes(), body) {
 		t.Fatalf("redeemed body mismatch: got %q", w2.Body.String())
 	}
@@ -426,9 +407,7 @@ func TestDownloadAttachment_StillRequiresAuthentication(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.DownloadAttachment(w, req)
+	w := testutil.Call(t, testHandler.DownloadAttachment, req)
 
 	if w.Code == http.StatusOK {
 		t.Fatalf("unauthenticated request to the legacy download path succeeded: %s", w.Body.String())

--- a/server/internal/handler/attachment_url_mode_test.go
+++ b/server/internal/handler/attachment_url_mode_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -204,17 +204,9 @@ func TestGetAttachmentByID_IgnoresStableCapability(t *testing.T) {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.GetAttachmentByID(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("GET /api/attachments/{id} = %d, body %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAttachmentByID, req).Want(http.StatusOK)
 	var resp AttachmentResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if !strings.Contains(resp.DownloadURL, "Signature=") {
 		t.Errorf("single-attachment endpoint must always sign, even for stable-mode callers; got %q", resp.DownloadURL)
 	}

--- a/server/internal/handler/attribution_response_test.go
+++ b/server/internal/handler/attribution_response_test.go
@@ -2,12 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -121,14 +120,7 @@ func TestListTasksByIssueHydratesAttribution(t *testing.T) {
 	agentID := createHandlerTestAgent(t, "AttributionListAgent", []byte("[]"))
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-		VALUES ($1, 'attribution-list-issue', 'todo', 'medium', $2, 'member', 92777, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'attribution-list-issue'"), "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'medium'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("92777"), "position": testutil.Raw("0")})
 
 	// direct_human: accountable == originator == the fixture user, whose name
 	// lives in the global user table — so hydration has a name to fill.
@@ -144,16 +136,10 @@ func TestListTasksByIssueHydratesAttribution(t *testing.T) {
 
 	req := newRequest("GET", "/api/issues/"+issueID+"/tasks", nil)
 	req = withURLParam(req, "id", issueID)
-	w := httptest.NewRecorder()
-	testHandler.ListTasksByIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListTasksByIssue, req).Want(http.StatusOK)
 
 	var resp []AgentTaskResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode task list: %v", err)
-	}
+	w.JSON(&resp)
 
 	var got *TaskAttribution
 	for i := range resp {

--- a/server/internal/handler/autopilot_attribution_transfer_test.go
+++ b/server/internal/handler/autopilot_attribution_transfer_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // These tests drive the REAL autopilot update handlers to prove the substantive /
@@ -65,24 +66,18 @@ func triggerPublisherMember(t *testing.T, triggerID string) string {
 
 func patchAutopilot(t *testing.T, apID string, body map[string]any) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, body)
 	req = withURLParam(req, "id", apID)
-	testHandler.UpdateAutopilot(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilot, req).Want(http.StatusOK)
 }
 
 func patchTrigger(t *testing.T, apID, triggerID string, body map[string]any) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+triggerID, body)
 	req = withURLParams(req, "id", apID, "triggerId", triggerID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilotTrigger: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusOK)
 }
 
 // TestUpdateAutopilot_PromptEditTransfersAllTriggers: the autopilot description IS the

--- a/server/internal/handler/autopilot_cron_preview_test.go
+++ b/server/internal/handler/autopilot_cron_preview_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func cronPreviewRequest(expr, tz string) *http.Request {
@@ -35,9 +37,7 @@ func TestCronPreview_ValidExpression(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	testHandler.CronPreview(w, cronPreviewRequest("0 9 * * *", "UTC"))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	runs := decodeCronPreview(t, w)
 	if len(runs) != 3 {
 		t.Fatalf("expected 3 next_runs, got %d: %v", len(runs), runs)
@@ -64,9 +64,7 @@ func TestCronPreview_CompoundExpression(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	testHandler.CronPreview(w, cronPreviewRequest("0 9-21/2 * * 2-4", "Asia/Shanghai"))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	if err != nil {
 		t.Fatalf("failed to load location: %v", err)
@@ -92,9 +90,7 @@ func TestCronPreview_TimezoneApplied(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	testHandler.CronPreview(w, cronPreviewRequest("0 9 * * *", "Asia/Shanghai"))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	runs := decodeCronPreview(t, w)
 	if len(runs) == 0 {
 		t.Fatal("expected next_runs, got none")
@@ -115,9 +111,7 @@ func TestCronPreview_DefaultsToUTC(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	testHandler.CronPreview(w, cronPreviewRequest("30 18 * * *", ""))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	runs := decodeCronPreview(t, w)
 	if len(runs) == 0 {
 		t.Fatal("expected next_runs, got none")
@@ -140,9 +134,7 @@ func TestCronPreview_NeverFiringExpression(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	testHandler.CronPreview(w, cronPreviewRequest("0 0 30 2 *", "UTC"))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if runs := decodeCronPreview(t, w); len(runs) != 0 {
 		t.Fatalf("expected no next_runs, got %v", runs)
 	}
@@ -169,11 +161,7 @@ func TestCronPreview_BadRequests(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			testHandler.CronPreview(w, cronPreviewRequest(tc.expr, tc.tz))
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.CronPreview, cronPreviewRequest(tc.expr, tc.tz)).Want(http.StatusBadRequest)
 			var body struct {
 				Error string `json:"error"`
 				Code  string `json:"code"`
@@ -181,9 +169,7 @@ func TestCronPreview_BadRequests(t *testing.T) {
 			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil || body.Error == "" {
 				t.Fatalf("expected {\"error\": ...} body, got %s", w.Body.String())
 			}
-			if body.Code != tc.code {
-				t.Fatalf("expected code %q, got %q", tc.code, body.Code)
-			}
+			testutil.Equal(t, body.Code, tc.code, "HTTP status")
 		})
 	}
 }

--- a/server/internal/handler/autopilot_list_test.go
+++ b/server/internal/handler/autopilot_list_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // insertListTestAutopilot creates a bare autopilot row and registers cleanup.
@@ -13,19 +15,7 @@ import (
 func insertListTestAutopilot(t *testing.T, agentID, title string) string {
 	t.Helper()
 	var id string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO autopilot (
-			workspace_id, title, assignee_type, assignee_id,
-			status, execution_mode, created_by_type, created_by_id
-		)
-		VALUES ($1, $2, 'agent', $3, 'active', 'run_only', 'member', $4)
-		RETURNING id
-	`, testWorkspaceID, title, agentID, testUserID).Scan(&id); err != nil {
-		t.Fatalf("failed to insert test autopilot: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, id)
-	})
+	id = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": title, "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID, "status": testutil.Raw("'active'"), "execution_mode": testutil.Raw("'run_only'"), "created_by_type": testutil.Raw("'member'"), "created_by_id": testUserID})
 	return id
 }
 
@@ -73,18 +63,12 @@ func TestListAutopilots_DerivedFields(t *testing.T) {
 		}
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.ListAutopilots(w, newRequest("GET", "/api/autopilots", nil))
-	if w.Code != 200 {
-		t.Fatalf("ListAutopilots: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAutopilots, newRequest("GET", "/api/autopilots", nil)).Want(200)
 
 	var body struct {
 		Autopilots []map[string]any `json:"autopilots"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("failed to decode body: %v", err)
-	}
+	w.JSON(&body)
 	rows := make(map[string]map[string]any)
 	for _, row := range body.Autopilots {
 		rows[row["id"].(string)] = row
@@ -130,9 +114,7 @@ func TestListAutopilots_DefaultExcludesArchived(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.ListAutopilots(w, newRequest("GET", "/api/autopilots", nil))
-	if w.Code != 200 {
-		t.Fatalf("ListAutopilots default: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, 200, "HTTP status")
 	var body struct {
 		Autopilots []map[string]any `json:"autopilots"`
 	}
@@ -147,9 +129,7 @@ func TestListAutopilots_DefaultExcludesArchived(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	testHandler.ListAutopilots(w, newRequest("GET", "/api/autopilots?status=archived", nil))
-	if w.Code != 200 {
-		t.Fatalf("ListAutopilots archived: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, 200, "HTTP status")
 	body.Autopilots = nil
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode archived list: %v", err)
@@ -192,9 +172,7 @@ func TestListAutopilots_SubscribersMatchDetail(t *testing.T) {
 	// list
 	w := httptest.NewRecorder()
 	testHandler.ListAutopilots(w, newRequest("GET", "/api/autopilots", nil))
-	if w.Code != 200 {
-		t.Fatalf("ListAutopilots: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, 200, "HTTP status")
 	var listBody struct {
 		Autopilots []map[string]any `json:"autopilots"`
 	}
@@ -210,9 +188,7 @@ func TestListAutopilots_SubscribersMatchDetail(t *testing.T) {
 	w = httptest.NewRecorder()
 	testHandler.GetAutopilot(w, withURLParam(
 		newRequest("GET", "/api/autopilots/"+withSubs+"?workspace_id="+testWorkspaceID, nil), "id", withSubs))
-	if w.Code != 200 {
-		t.Fatalf("GetAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, 200, "HTTP status")
 	var detailBody struct {
 		Autopilot map[string]any `json:"autopilot"`
 	}
@@ -289,23 +265,15 @@ func TestAutopilotSubscriberReadFailureFailsClosed(t *testing.T) {
 	hideAutopilotSubscriberTable(t)
 
 	t.Run("list", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		testHandler.ListAutopilots(w, newRequest("GET", "/api/autopilots", nil))
-		if w.Code != 500 {
-			t.Fatalf("expected 500 when the subscriber read fails, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListAutopilots, newRequest("GET", "/api/autopilots", nil)).Want(500)
 		if strings.Contains(w.Body.String(), `"subscribers":[]`) {
 			t.Errorf("response must not carry an authoritative empty subscriber list: %s", w.Body.String())
 		}
 	})
 
 	t.Run("detail", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		testHandler.GetAutopilot(w, withURLParam(
-			newRequest("GET", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, nil), "id", apID))
-		if w.Code != 500 {
-			t.Fatalf("expected 500 when the subscriber read fails, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetAutopilot, withURLParam(
+			newRequest("GET", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, nil), "id", apID)).Want(500)
 		if strings.Contains(w.Body.String(), `"subscribers":[]`) {
 			t.Errorf("response must not carry an authoritative empty subscriber list: %s", w.Body.String())
 		}

--- a/server/internal/handler/autopilot_mention_authority_test.go
+++ b/server/internal/handler/autopilot_mention_authority_test.go
@@ -3,10 +3,10 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -49,13 +49,7 @@ func newAutopilotDelegationFixture(t *testing.T, targetAgentID, autopilotCreator
 	// A member-created autopilot; assignee is the target agent (any valid agent
 	// satisfies the assignee reference).
 	var autopilotID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO autopilot (workspace_id, title, assignee_id, execution_mode, created_by_type, created_by_id)
-		VALUES ($1, 'MUL-4857 delegation', $2, 'create_issue', 'member', $3) RETURNING id
-	`, testWorkspaceID, targetAgentID, autopilotCreatorUserID).Scan(&autopilotID); err != nil {
-		t.Fatalf("create autopilot: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID) })
+	autopilotID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'MUL-4857 delegation'"), "assignee_id": targetAgentID, "execution_mode": testutil.Raw("'create_issue'"), "created_by_type": testutil.Raw("'member'"), "created_by_id": autopilotCreatorUserID})
 
 	// Next per-workspace issue number (default 0 would trip uq_issue_workspace_number).
 	var number int
@@ -151,13 +145,7 @@ func setCommentSourceTask(t *testing.T, fx *autopilotDelegationFixture, sourceTa
 func seedTaskOnIssue(t *testing.T, agentID, issueID, runtimeID string) string {
 	t.Helper()
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
-		VALUES ($1, $2, $3, 'running', 0) RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-		t.Fatalf("seed task on issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0")})
 	return taskID
 }
 
@@ -294,17 +282,14 @@ func TestCreateComment_AutopilotLeaderMentionEnqueuesPrivateWorker(t *testing.T)
 
 	// The leader posts the mention comment in its agent identity. resolveActor
 	// trusts the header pair because fx.LeaderTaskID belongs to the leader agent.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Worker](mention://agent/" + workerID + ") please handle",
 	})
 	r.Header.Set("X-Agent-ID", fx.LeaderAgentID)
 	r.Header.Set("X-Task-ID", fx.LeaderTaskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("leader mention CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	var workerTasks int
 	if err := testPool.QueryRow(context.Background(), `
@@ -372,13 +357,7 @@ func seedBareIssue(t *testing.T, creatorAgentID string) string {
 func seedCompletedTaskOnIssueBefore(t *testing.T, agentID, issueID, runtimeID string) string {
 	t.Helper()
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, created_at)
-		VALUES ($1, $2, $3, 'completed', 0, now() - interval '1 hour') RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-		t.Fatalf("seed completed task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'completed'"), "priority": testutil.Raw("0"), "created_at": testutil.Raw("now() - interval '1 hour'")})
 	return taskID
 }
 
@@ -472,17 +451,14 @@ func TestUpdateComment_AutopilotAuthorityReStampedToEditingTask(t *testing.T) {
 	workerID, ownerID, _ := privateAgentTestFixture(t)
 
 	editAddingMention := func(t *testing.T, editTaskID, commentID, issueID string, fx autopilotDelegationFixture) {
-		w := httptest.NewRecorder()
+
 		r := newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 			"content": "[@Worker](mention://agent/" + workerID + ") please take this",
 		})
 		r.Header.Set("X-Agent-ID", fx.LeaderAgentID)
 		r.Header.Set("X-Task-ID", editTaskID)
 		r = withURLParam(r, "commentId", commentID)
-		testHandler.UpdateComment(w, r)
-		if w.Code != http.StatusOK {
-			t.Fatalf("UpdateComment: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateComment, r).Want(http.StatusOK)
 	}
 	countQueued := func(t *testing.T, issueID string) int {
 		var n int
@@ -555,22 +531,10 @@ func TestCreateComment_AutopilotWorkerResultWakesSquadLeader(t *testing.T) {
 	}
 
 	var autopilotID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO autopilot (workspace_id, title, assignee_id, execution_mode, created_by_type, created_by_id)
-		VALUES ($1, 'MUL-4857 squad', $2, 'create_issue', 'member', $3) RETURNING id
-	`, testWorkspaceID, leaderID, ownerID).Scan(&autopilotID); err != nil {
-		t.Fatalf("create autopilot: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID) })
+	autopilotID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'MUL-4857 squad'"), "assignee_id": leaderID, "execution_mode": testutil.Raw("'create_issue'"), "created_by_type": testutil.Raw("'member'"), "created_by_id": ownerID})
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'MUL-4857 Squad', '', $2, $3) RETURNING id
-	`, testWorkspaceID, leaderID, ownerID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'MUL-4857 Squad'"), "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": ownerID})
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `
@@ -589,17 +553,14 @@ func TestCreateComment_AutopilotWorkerResultWakesSquadLeader(t *testing.T) {
 	workerTaskID := seedTaskOnIssue(t, workerID, issueID, runtimeID)
 
 	// The worker posts a PLAIN result comment (no @mention) via HTTP.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "done — pushed the change",
 	})
 	r.Header.Set("X-Agent-ID", workerID)
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("worker result CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	var leaderTasks int
 	if err := testPool.QueryRow(ctx, `
@@ -658,15 +619,12 @@ func TestUpdateComment_AdminEditOfAgentCommentClearsStaleLineage(t *testing.T) {
 	}
 
 	// The admin edits the leader's comment to add the private @Worker mention.
-	w := httptest.NewRecorder()
+
 	r := newRequestAs(adminID, http.MethodPut, "/api/comments/"+commentID, map[string]any{
 		"content": "[@Worker](mention://agent/" + workerID + ") please take this",
 	})
 	r = withURLParam(r, "commentId", commentID)
-	testHandler.UpdateComment(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("admin UpdateComment: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateComment, r).Want(http.StatusOK)
 
 	// Immediate save is judged on the admin's member identity, which holds no invoke
 	// right over the private worker — nothing is enqueued.

--- a/server/internal/handler/autopilot_permissions_test.go
+++ b/server/internal/handler/autopilot_permissions_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // createPlainMember adds a fresh member-role user to the test workspace and
@@ -48,7 +50,7 @@ func createAutopilotAs(t *testing.T, userID, title string) string {
 		"assignee_id":    agentID,
 		"execution_mode": "create_issue",
 	}
-	w := httptest.NewRecorder()
+
 	path := "/api/autopilots?workspace_id=" + testWorkspaceID
 	var r *http.Request
 	if userID == "" {
@@ -56,14 +58,9 @@ func createAutopilotAs(t *testing.T, userID, title string) string {
 	} else {
 		r = newRequestAs(userID, "POST", path, body)
 	}
-	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, r).Want(http.StatusCreated)
 	var ap AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&ap)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM autopilot_run WHERE autopilot_id = $1`, ap.ID)
 		testPool.Exec(context.Background(), `DELETE FROM autopilot_trigger WHERE autopilot_id = $1`, ap.ID)
@@ -77,7 +74,7 @@ func createAutopilotAs(t *testing.T, userID, title string) string {
 // given caller (empty caller = workspace owner), asserting the expected status.
 func grantAutopilotAccess(t *testing.T, caller, apID, targetUserID string, wantStatus int) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	path := "/api/autopilots/" + apID + "/collaborators?workspace_id=" + testWorkspaceID
 	body := map[string]any{"user_id": targetUserID}
 	var r *http.Request
@@ -87,17 +84,14 @@ func grantAutopilotAccess(t *testing.T, caller, apID, targetUserID string, wantS
 		r = newRequestAs(caller, "POST", path, body)
 	}
 	r = withURLParam(r, "id", apID)
-	testHandler.AddAutopilotCollaborator(w, r)
-	if w.Code != wantStatus {
-		t.Fatalf("AddAutopilotCollaborator: expected %d, got %d: %s", wantStatus, w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.AddAutopilotCollaborator, r).Want(wantStatus)
 }
 
 // autopilotCanWrite fetches the detail as the given caller and returns the
 // can_write flag the server stamped for them.
 func autopilotCanWrite(t *testing.T, caller, apID string) bool {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	path := "/api/autopilots/" + apID + "?workspace_id=" + testWorkspaceID
 	var r *http.Request
 	if caller == "" {
@@ -106,16 +100,11 @@ func autopilotCanWrite(t *testing.T, caller, apID string) bool {
 		r = newRequestAs(caller, "GET", path, nil)
 	}
 	r = withURLParam(r, "id", apID)
-	testHandler.GetAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAutopilot, r).Want(http.StatusOK)
 	var got struct {
 		Autopilot AutopilotResponse `json:"autopilot"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&got)
 	if got.Autopilot.CanWrite == nil {
 		t.Fatalf("expected can_write to be set on detail response")
 	}
@@ -126,7 +115,7 @@ func autopilotCanWrite(t *testing.T, caller, apID string) bool {
 // the can_manage_access flag (narrower than can_write — collaborators lack it).
 func autopilotCanManageAccess(t *testing.T, caller, apID string) bool {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	path := "/api/autopilots/" + apID + "?workspace_id=" + testWorkspaceID
 	var r *http.Request
 	if caller == "" {
@@ -135,16 +124,11 @@ func autopilotCanManageAccess(t *testing.T, caller, apID string) bool {
 		r = newRequestAs(caller, "GET", path, nil)
 	}
 	r = withURLParam(r, "id", apID)
-	testHandler.GetAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAutopilot, r).Want(http.StatusOK)
 	var got struct {
 		Autopilot AutopilotResponse `json:"autopilot"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&got)
 	if got.Autopilot.CanManageAccess == nil {
 		t.Fatalf("expected can_manage_access to be set on detail response")
 	}
@@ -163,10 +147,10 @@ func TestAutopilotCollaborator_GrantedMemberCanWrite(t *testing.T) {
 	member := createPlainMember(t, "ap-collab-grantee@multica.test")
 
 	updateAs := func(caller string) int {
-		w := httptest.NewRecorder()
+
 		r := newRequestAs(caller, "PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, map[string]any{"title": "edited by " + caller})
 		r = withURLParam(r, "id", apID)
-		testHandler.UpdateAutopilot(w, r)
+		w := testutil.Call(t, testHandler.UpdateAutopilot, r)
 		return w.Code
 	}
 
@@ -190,13 +174,10 @@ func TestAutopilotCollaborator_GrantedMemberCanWrite(t *testing.T) {
 	}
 
 	// Revoke.
-	w := httptest.NewRecorder()
+
 	r := newRequest("DELETE", "/api/autopilots/"+apID+"/collaborators/"+member+"?workspace_id="+testWorkspaceID, nil)
 	r = withURLParams(r, "id", apID, "userId", member)
-	testHandler.RemoveAutopilotCollaborator(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("RemoveAutopilotCollaborator: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.RemoveAutopilotCollaborator, r).Want(http.StatusOK)
 
 	// After revoke: blocked again.
 	if code := updateAs(member); code != http.StatusForbidden {
@@ -245,9 +226,7 @@ func TestAutopilotCollaborator_CannotManageAccessList(t *testing.T) {
 	r := newRequestAs(carol, "PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, map[string]any{"title": "carol edit"})
 	r = withURLParam(r, "id", apID)
 	testHandler.UpdateAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("collaborator update: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// ...but cannot grant access to a new member.
 	grantAutopilotAccess(t, carol, apID, bob, http.StatusForbidden)
@@ -257,9 +236,7 @@ func TestAutopilotCollaborator_CannotManageAccessList(t *testing.T) {
 	r = newRequestAs(carol, "DELETE", "/api/autopilots/"+apID+"/collaborators/"+dave+"?workspace_id="+testWorkspaceID, nil)
 	r = withURLParams(r, "id", apID, "userId", dave)
 	testHandler.RemoveAutopilotCollaborator(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("collaborator revoke peer: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// can_manage_access: false for the collaborator, true for the owner.
 	if autopilotCanManageAccess(t, carol, apID) {
@@ -286,27 +263,21 @@ func TestAutopilotWrite_PlainMemberCannotMutateOthers(t *testing.T) {
 	r := newRequestAs(member, "PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, map[string]any{"title": "hijacked"})
 	r = withURLParam(r, "id", apID)
 	testHandler.UpdateAutopilot(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("UpdateAutopilot by stranger: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Trigger.
 	w = httptest.NewRecorder()
 	r = newRequestAs(member, "POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", apID)
 	testHandler.TriggerAutopilot(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("TriggerAutopilot by stranger: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Delete.
 	w = httptest.NewRecorder()
 	r = newRequestAs(member, "DELETE", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", apID)
 	testHandler.DeleteAutopilot(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("DeleteAutopilot by stranger: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestAutopilotWrite_CreatorCanMutateOwn verifies that the member who created
@@ -319,13 +290,9 @@ func TestAutopilotWrite_CreatorCanMutateOwn(t *testing.T) {
 	member := createPlainMember(t, "ap-perm-creator@multica.test")
 	apID := createAutopilotAs(t, member, "ap-perm-member-created")
 
-	w := httptest.NewRecorder()
 	r := newRequestAs(member, "PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, map[string]any{"title": "creator edit"})
 	r = withURLParam(r, "id", apID)
-	testHandler.UpdateAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilot by creator: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilot, r).Want(http.StatusOK)
 }
 
 // TestAutopilotWrite_AdminCanMutateMembersAutopilot verifies that a workspace
@@ -339,13 +306,10 @@ func TestAutopilotWrite_AdminCanMutateMembersAutopilot(t *testing.T) {
 	apID := createAutopilotAs(t, member, "ap-perm-admin-target")
 
 	// testUserID is the workspace owner.
-	w := httptest.NewRecorder()
+
 	r := newRequest("PATCH", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, map[string]any{"title": "admin edit"})
 	r = withURLParam(r, "id", apID)
-	testHandler.UpdateAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilot by owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilot, r).Want(http.StatusOK)
 }
 
 // TestAutopilotWrite_WebhookSecretRedactedForNonWriter verifies that the
@@ -365,9 +329,7 @@ func TestAutopilotWrite_WebhookSecretRedactedForNonWriter(t *testing.T) {
 	r := newRequest("POST", "/api/autopilots/"+apID+"/triggers?workspace_id="+testWorkspaceID, map[string]any{"kind": "webhook"})
 	r = withURLParam(r, "id", apID)
 	testHandler.CreateAutopilotTrigger(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilotTrigger: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	type getResp struct {
 		Triggers []AutopilotTriggerResponse `json:"triggers"`
@@ -377,9 +339,7 @@ func TestAutopilotWrite_WebhookSecretRedactedForNonWriter(t *testing.T) {
 	w = httptest.NewRecorder()
 	r = withURLParam(newRequest("GET", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, nil), "id", apID)
 	testHandler.GetAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAutopilot as owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var ownerView getResp
 	if err := json.NewDecoder(w.Body).Decode(&ownerView); err != nil {
 		t.Fatalf("decode owner view: %v", err)
@@ -398,9 +358,7 @@ func TestAutopilotWrite_WebhookSecretRedactedForNonWriter(t *testing.T) {
 	w = httptest.NewRecorder()
 	r = withURLParam(newRequestAs(stranger, "GET", "/api/autopilots/"+apID+"?workspace_id="+testWorkspaceID, nil), "id", apID)
 	testHandler.GetAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetAutopilot as stranger: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var strangerView getResp
 	if err := json.NewDecoder(w.Body).Decode(&strangerView); err != nil {
 		t.Fatalf("decode stranger view: %v", err)

--- a/server/internal/handler/autopilot_private_leader_test.go
+++ b/server/internal/handler/autopilot_private_leader_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateAutopilot_SquadPrivateLeader_PlainMemberBlocked verifies that a
@@ -15,33 +17,19 @@ func TestCreateAutopilot_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Create', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Create'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
-	w := httptest.NewRecorder()
 	r := newRequestAs(memberID, "POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "should be blocked",
 		"assignee_type":  "squad",
 		"assignee_id":    squadID,
 		"execution_mode": "create_issue",
 	})
-	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilot, r).Want(http.StatusForbidden)
 }
 
 // TestUpdateAutopilot_SquadPrivateLeader_PlainMemberBlocked verifies that a
@@ -50,7 +38,6 @@ func TestUpdateAutopilot_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, _, memberID := privateAgentTestFixture(t)
 
@@ -58,16 +45,7 @@ func TestUpdateAutopilot_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	publicAgentID := createHandlerTestAgent(t, "ap-private-leader-public", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Update', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Update'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create autopilot as workspace owner assigned to the public agent.
 	w := httptest.NewRecorder()
@@ -77,9 +55,7 @@ func TestUpdateAutopilot_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 		"execution_mode": "create_issue",
 	})
 	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var ap AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -97,9 +73,7 @@ func TestUpdateAutopilot_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	})
 	r = withURLParam(r, "id", ap.ID)
 	testHandler.UpdateAutopilot(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestCreateAutopilot_SquadPrivateLeader_OwnerAllowed verifies that a
@@ -108,39 +82,24 @@ func TestCreateAutopilot_SquadPrivateLeader_OwnerAllowed(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, ownerID, _ := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Owner', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Owner'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// The AGENT OWNER creates the autopilot — allowed under MUL-3963 (workspace
 	// owner/admin no longer bypasses a private leader's invocation gate).
-	w := httptest.NewRecorder()
+
 	r := newRequestAs(ownerID, "POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "owner creates private-leader squad ap",
 		"assignee_type":  "squad",
 		"assignee_id":    squadID,
 		"execution_mode": "create_issue",
 	})
-	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, r).Want(http.StatusCreated)
 	var ap AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&ap)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
 	})
@@ -153,21 +112,11 @@ func TestTriggerAutopilot_SquadPrivateLeader_OwnerCanDispatch(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, ownerID, _ := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Dispatch', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Dispatch'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create autopilot as the AGENT OWNER (MUL-3963: only owner/allow-listed
 	// may invoke the private leader; workspace admin no longer bypasses).
@@ -179,9 +128,7 @@ func TestTriggerAutopilot_SquadPrivateLeader_OwnerCanDispatch(t *testing.T) {
 		"execution_mode": "create_issue",
 	})
 	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var ap AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -201,9 +148,7 @@ func TestTriggerAutopilot_SquadPrivateLeader_OwnerCanDispatch(t *testing.T) {
 	r = newRequestAs(ownerID, "POST", "/api/autopilots/"+ap.ID+"/trigger?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", ap.ID)
 	testHandler.TriggerAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("TriggerAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var run AutopilotRunResponse
 	if err := json.NewDecoder(w.Body).Decode(&run); err != nil {
 		t.Fatalf("decode run: %v", err)
@@ -225,21 +170,11 @@ func TestTriggerAutopilot_SquadPrivateLeader_NonOwnerClicker_Blocked(t *testing.
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, ownerID, _ := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Clicker Fork', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Clicker Fork'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Owner creates a legitimate autopilot (creator CAN invoke the leader).
 	w := httptest.NewRecorder()
@@ -250,9 +185,7 @@ func TestTriggerAutopilot_SquadPrivateLeader_NonOwnerClicker_Blocked(t *testing.
 		"execution_mode": "create_issue",
 	})
 	testHandler.CreateAutopilot(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var ap AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -270,9 +203,7 @@ func TestTriggerAutopilot_SquadPrivateLeader_NonOwnerClicker_Blocked(t *testing.
 	r = newRequest("POST", "/api/autopilots/"+ap.ID+"/trigger?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", ap.ID)
 	testHandler.TriggerAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("TriggerAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var run AutopilotRunResponse
 	if err := json.NewDecoder(w.Body).Decode(&run); err != nil {
 		t.Fatalf("decode run: %v", err)
@@ -301,16 +232,7 @@ func TestTriggerAutopilot_SquadPrivateLeader_PlainMemberCreator_Blocked(t *testi
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP Private Leader Blocked Dispatch', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP Private Leader Blocked Dispatch'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Directly insert an autopilot with the plain member as creator
 	// (simulating legacy data before the save-time gate).
@@ -330,19 +252,15 @@ func TestTriggerAutopilot_SquadPrivateLeader_PlainMemberCreator_Blocked(t *testi
 
 	// Trigger as workspace owner — the dispatch should fail because the
 	// autopilot's creator (plain member) cannot access the private leader.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", apID)
-	testHandler.TriggerAutopilot(w, r)
+	w := testutil.Call(t, testHandler.TriggerAutopilot, r)
 	// Dispatch returns 200 with status=skipped (or failed) — the run is created
 	// but the dispatch is blocked by the private-leader gate.
-	if w.Code != http.StatusOK {
-		t.Fatalf("TriggerAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var run AutopilotRunResponse
-	if err := json.NewDecoder(w.Body).Decode(&run); err != nil {
-		t.Fatalf("decode run: %v", err)
-	}
+	w.Decode(&run)
 	// The dispatch-time gate should cause a skipped or failed run.
 	if run.Status == "issue_created" || run.Status == "running" {
 		t.Fatalf("run status = %q; want skipped/failed since creator is plain member", run.Status)
@@ -362,16 +280,7 @@ func TestTriggerAutopilot_RunOnly_SquadPrivateLeader_PlainMemberCreator_Blocked(
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'AP RunOnly Private Leader Blocked', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'AP RunOnly Private Leader Blocked'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Legacy autopilot: run_only mode, plain member creator, private-leader squad.
 	var apID string
@@ -388,17 +297,11 @@ func TestTriggerAutopilot_RunOnly_SquadPrivateLeader_PlainMemberCreator_Blocked(
 		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, apID)
 	})
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID, nil)
 	r = withURLParam(r, "id", apID)
-	testHandler.TriggerAutopilot(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("TriggerAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.TriggerAutopilot, r).Want(http.StatusOK)
 	var run AutopilotRunResponse
-	if err := json.NewDecoder(w.Body).Decode(&run); err != nil {
-		t.Fatalf("decode run: %v", err)
-	}
+	w.Decode(&run)
 	if run.Status == "running" {
 		t.Fatalf("run status = %q; want skipped/failed since creator is plain member and leader is private", run.Status)
 	}

--- a/server/internal/handler/autopilot_quota_handler_test.go
+++ b/server/internal/handler/autopilot_quota_handler_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/multica-ai/multica/server/internal/entitlement"
 	"github.com/multica-ai/multica/server/internal/entitlement/entitlementtest"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestAutopilotQuotaManualAndWebhookEnforcement(t *testing.T) {
@@ -37,14 +37,10 @@ func TestAutopilotQuotaManualAndWebhookEnforcement(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "Quota Handler Agent")
 	autopilotID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	manual := httptest.NewRecorder()
 	manualReq := newRequest("POST", "/api/autopilots/"+autopilotID+"/trigger", nil)
 	manualReq.Header.Set("Idempotency-Key", "manual-over-limit")
 	manualReq = withURLParam(manualReq, "id", autopilotID)
-	testHandler.TriggerAutopilot(manual, manualReq)
-	if manual.Code != http.StatusTooManyRequests {
-		t.Fatalf("manual status = %d body=%s, want 429", manual.Code, manual.Body.String())
-	}
+	manual := testutil.Call(t, testHandler.TriggerAutopilot, manualReq).Want(http.StatusTooManyRequests)
 	if manual.Header().Get("Retry-After") == "" {
 		t.Fatal("manual quota refusal must include Retry-After")
 	}
@@ -55,9 +51,7 @@ func TestAutopilotQuotaManualAndWebhookEnforcement(t *testing.T) {
 
 	trigger := createWebhookTriggerViaHandler(t, autopilotID)
 	webhook := postWebhook(t, *trigger.WebhookToken, map[string]any{"event": "quota.test"}, nil)
-	if webhook.Code != http.StatusOK {
-		t.Fatalf("webhook status = %d body=%s, want 200 ignored", webhook.Code, webhook.Body.String())
-	}
+	testutil.Equal(t, webhook.Code, http.StatusOK, "HTTP status")
 	var webhookBody map[string]any
 	if err := json.Unmarshal(webhook.Body.Bytes(), &webhookBody); err != nil ||
 		webhookBody["status"] != "ignored" || webhookBody["reason_code"] != "quota_exceeded" {
@@ -71,16 +65,10 @@ func TestAutopilotQuotaManualAndWebhookEnforcement(t *testing.T) {
 		t.Fatalf("blocked manual/webhook requests created %d runs, want zero", runCount)
 	}
 
-	usageRecorder := httptest.NewRecorder()
 	usageReq := newRequest("GET", "/api/autopilots/usage", nil)
-	testHandler.GetAutopilotQuotaUsage(usageRecorder, usageReq)
-	if usageRecorder.Code != http.StatusOK {
-		t.Fatalf("usage status = %d body=%s, want 200", usageRecorder.Code, usageRecorder.Body.String())
-	}
+	usageRecorder := testutil.Call(t, testHandler.GetAutopilotQuotaUsage, usageReq).Want(http.StatusOK)
 	var usage AutopilotQuotaUsageResponse
-	if err := json.Unmarshal(usageRecorder.Body.Bytes(), &usage); err != nil {
-		t.Fatalf("decode usage response: %v", err)
-	}
+	usageRecorder.JSON(&usage)
 	if usage.BlockedCounts["manual"] != 1 || usage.BlockedCounts["webhook"] != 1 {
 		t.Fatalf("blocked counts = %#v, want one manual and one webhook", usage.BlockedCounts)
 	}

--- a/server/internal/handler/autopilot_subscriber_test.go
+++ b/server/internal/handler/autopilot_subscriber_test.go
@@ -61,7 +61,6 @@ func TestCreateAutopilotPersistsMemberSubscribers(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "Subscriber template autopilot",
 		"assignee_id":    agentID,
@@ -70,14 +69,9 @@ func TestCreateAutopilotPersistsMemberSubscribers(t *testing.T) {
 			{"user_type": "member", "user_id": testUserID},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusCreated)
 	var resp AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&resp)
 	autopilotID = resp.ID
 	if len(resp.Subscribers) != 1 {
 		t.Fatalf("subscribers in response = %d, want 1", len(resp.Subscribers))
@@ -109,7 +103,6 @@ func TestCreateAutopilotRejectsNonMemberSubscriberType(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "Bad subscriber type",
 		"assignee_id":    agentID,
@@ -118,10 +111,7 @@ func TestCreateAutopilotRejectsNonMemberSubscriberType(t *testing.T) {
 			{"user_type": "agent", "user_id": agentID},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateAutopilot: expected 400 for non-member subscriber, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusBadRequest)
 }
 
 // TestCreateAutopilotRejectsForeignSubscriber covers the boundary check:
@@ -133,7 +123,6 @@ func TestCreateAutopilotRejectsForeignSubscriber(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          "Foreign subscriber",
 		"assignee_id":    agentID,
@@ -142,10 +131,7 @@ func TestCreateAutopilotRejectsForeignSubscriber(t *testing.T) {
 			{"user_type": "member", "user_id": "00000000-0000-0000-0000-000000000000"},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateAutopilot: expected 400 for foreign member subscriber, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusBadRequest)
 }
 
 // TestAutopilotSubscriberSave_LosesToConcurrentRevoke covers the race between
@@ -172,7 +158,7 @@ func TestAutopilotSubscriberSave_LosesToConcurrentRevoke(t *testing.T) {
 			prepare: func(t *testing.T, targetUserID string) func() (int, string, string) {
 				title := fmt.Sprintf("Concurrent revoke create %d", time.Now().UnixNano())
 				return func() (int, string, string) {
-					w := httptest.NewRecorder()
+
 					req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 						"title":          title,
 						"assignee_id":    agentID,
@@ -181,7 +167,7 @@ func TestAutopilotSubscriberSave_LosesToConcurrentRevoke(t *testing.T) {
 							{"user_type": "member", "user_id": targetUserID},
 						},
 					})
-					testHandler.CreateAutopilot(w, req)
+					w := testutil.Call(t, testHandler.CreateAutopilot, req)
 
 					var autopilotID string
 					testPool.QueryRow(ctx, `SELECT id FROM autopilot WHERE workspace_id = $1 AND title = $2`, testWorkspaceID, title).Scan(&autopilotID)
@@ -203,14 +189,14 @@ func TestAutopilotSubscriberSave_LosesToConcurrentRevoke(t *testing.T) {
 					JSON(&created)
 
 				return func() (int, string, string) {
-					w := httptest.NewRecorder()
+
 					req := newRequest("PATCH", "/api/autopilots/"+created.ID+"?workspace_id="+testWorkspaceID, map[string]any{
 						"subscribers": []map[string]any{
 							{"user_type": "member", "user_id": targetUserID},
 						},
 					})
 					req = withURLParam(req, "id", created.ID)
-					testHandler.UpdateAutopilot(w, req)
+					w := testutil.Call(t, testHandler.UpdateAutopilot, req)
 					return w.Code, w.Body.String(), created.ID
 				}
 			},
@@ -309,7 +295,6 @@ func TestCreateAutopilotRollsBackWhenSubscriberInsertFails(t *testing.T) {
 
 	installAutopilotSubscriberInsertFailure(t)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":          title,
 		"assignee_id":    agentID,
@@ -318,10 +303,7 @@ func TestCreateAutopilotRollsBackWhenSubscriberInsertFails(t *testing.T) {
 			{"user_type": "member", "user_id": testUserID},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("CreateAutopilot: expected 500 for forced subscriber insert failure, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusInternalServerError)
 
 	var count int
 	if err := testPool.QueryRow(ctx, `
@@ -363,9 +345,7 @@ func TestUpdateAutopilotFullReplaceSubscribers(t *testing.T) {
 		},
 	})
 	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode created: %v", err)
@@ -379,9 +359,7 @@ func TestUpdateAutopilotFullReplaceSubscribers(t *testing.T) {
 	})
 	req = withURLParam(req, "id", autopilotID)
 	testHandler.UpdateAutopilot(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var updated AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode updated: %v", err)
@@ -425,9 +403,7 @@ func TestUpdateAutopilotRollsBackWhenSubscriberInsertFails(t *testing.T) {
 		},
 	})
 	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode created: %v", err)
@@ -445,9 +421,7 @@ func TestUpdateAutopilotRollsBackWhenSubscriberInsertFails(t *testing.T) {
 	})
 	req = withURLParam(req, "id", autopilotID)
 	testHandler.UpdateAutopilot(w, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("UpdateAutopilot: expected 500 for forced subscriber insert failure, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusInternalServerError, "HTTP status")
 
 	var gotTitle string
 	if err := testPool.QueryRow(ctx, `SELECT title FROM autopilot WHERE id = $1`, autopilotID).Scan(&gotTitle); err != nil {
@@ -493,9 +467,7 @@ func TestUpdateAutopilotPreservesSubscribersWhenOmitted(t *testing.T) {
 		},
 	})
 	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode created: %v", err)
@@ -509,9 +481,7 @@ func TestUpdateAutopilotPreservesSubscribersWhenOmitted(t *testing.T) {
 	})
 	req = withURLParam(req, "id", autopilotID)
 	testHandler.UpdateAutopilot(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var count int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_subscriber WHERE autopilot_id = $1`, autopilotID).Scan(&count); err != nil {
@@ -609,7 +579,6 @@ func TestAutopilotDispatchFansOutSubscribersToIssue(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":                "Subscriber fanout autopilot",
 		"assignee_id":          agentID,
@@ -619,14 +588,9 @@ func TestAutopilotDispatchFansOutSubscribersToIssue(t *testing.T) {
 			{"user_type": "member", "user_id": testUserID},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusCreated)
 	var autopilot AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&autopilot)
 	autopilotID = autopilot.ID
 
 	queries := db.New(testPool)
@@ -682,7 +646,6 @@ func TestAutopilotDispatchNotifiesSubscribersOnCreate(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":                "Subscriber inbox autopilot",
 		"assignee_id":          agentID,
@@ -692,14 +655,9 @@ func TestAutopilotDispatchNotifiesSubscribersOnCreate(t *testing.T) {
 			{"user_type": "member", "user_id": testUserID},
 		},
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusCreated)
 	var autopilot AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&autopilot)
 	autopilotID = autopilot.ID
 
 	queries := db.New(testPool)
@@ -767,21 +725,15 @@ func TestAutopilotDispatchSkipsInboxWhenNoSubscribers(t *testing.T) {
 		t.Fatalf("load test agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
 		"title":                "No-subscriber autopilot",
 		"assignee_id":          agentID,
 		"execution_mode":       "create_issue",
 		"issue_title_template": title,
 	})
-	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilot, req).Want(http.StatusCreated)
 	var autopilot AutopilotResponse
-	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
-		t.Fatalf("decode autopilot: %v", err)
-	}
+	w.Decode(&autopilot)
 	autopilotID = autopilot.ID
 
 	queries := db.New(testPool)
@@ -847,9 +799,7 @@ func TestDeleteAutopilotArchivesAndPreservesHistory(t *testing.T) {
 		},
 	})
 	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode created: %v", err)
@@ -886,9 +836,7 @@ func TestDeleteAutopilotArchivesAndPreservesHistory(t *testing.T) {
 	req = newRequest("DELETE", "/api/autopilots/"+autopilotID+"?workspace_id="+testWorkspaceID, nil)
 	req = withURLParam(req, "id", autopilotID)
 	testHandler.DeleteAutopilot(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteAutopilot: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 
 	var status string
 	if err := testPool.QueryRow(ctx, `SELECT status FROM autopilot WHERE id = $1`, autopilotID).Scan(&status); err != nil {

--- a/server/internal/handler/autopilot_webhook_handler_test.go
+++ b/server/internal/handler/autopilot_webhook_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -24,56 +25,27 @@ import (
 func createWebhookTestAgent(t *testing.T, name string) string {
 	t.Helper()
 	var agentID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args, mcp_config
-		)
-		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '{}'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, name, testRuntimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": name, "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb"), "mcp_config": testutil.Raw("'{}'::jsonb")})
 	return agentID
 }
 
 func createWebhookTestAutopilot(t *testing.T, agentID, status, mode string) string {
 	t.Helper()
 	var apID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO autopilot (
-			workspace_id, title, assignee_id, status, execution_mode,
-			created_by_type, created_by_id
-		) VALUES ($1, $2, $3, $4, $5, 'member', $6)
-		RETURNING id
-	`, testWorkspaceID, "Webhook test "+status, agentID, status, mode, testUserID).Scan(&apID); err != nil {
-		t.Fatalf("create autopilot: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, apID)
-	})
+	apID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": "Webhook test " + status, "assignee_id": agentID, "status": status, "execution_mode": mode, "created_by_type": testutil.Raw("'member'"), "created_by_id": testUserID})
 	return apID
 }
 
 func createWebhookTriggerViaHandler(t *testing.T, autopilotID string) AutopilotTriggerResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/autopilots/"+autopilotID+"/triggers", map[string]any{
 		"kind": "webhook",
 	})
 	req = withURLParam(req, "id", autopilotID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilotTrigger: expected 201, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusCreated)
 	var resp AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	return resp
 }
 
@@ -107,16 +79,13 @@ func TestCreateTrigger_RepublishesRuleVersionAtomically(t *testing.T) {
 	}
 
 	// Schedule create appends a fresh version, also published by the acting member.
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind":            "schedule",
 		"cron_expression": "0 0 * * *",
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("schedule CreateAutopilotTrigger: got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusCreated)
 	ver2, err := testHandler.Queries.GetActiveAutopilotRuleVersion(ctx, verParams)
 	if err != nil {
 		t.Fatalf("schedule trigger create must republish a rule version: %v", err)
@@ -138,20 +107,15 @@ func TestCreateTrigger_RepublishesRuleVersionAtomically(t *testing.T) {
 // actual contract bug fixed in PR #3231 review.
 func createWebhookTriggerWithFilters(t *testing.T, autopilotID string, filters []WebhookEventFilter) AutopilotTriggerResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/autopilots/"+autopilotID+"/triggers", map[string]any{
 		"kind":          "webhook",
 		"event_filters": filters,
 	})
 	req = withURLParam(req, "id", autopilotID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilotTrigger: expected 201, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusCreated)
 	var resp AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	return resp
 }
 
@@ -167,9 +131,7 @@ func TestWebhookHandler_FiltersUndeclaredEvent(t *testing.T) {
 		"action":       "in_progress",
 		"workflow_run": map[string]any{"id": 123},
 	}, map[string]string{"X-GitHub-Event": "workflow_run"})
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -246,19 +208,14 @@ func TestCreateWebhookTrigger_EventFiltersRoundTripAsJSONArray(t *testing.T) {
 			{"event": "pull_request", "actions": []string{"opened", "synchronize"}},
 		},
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", body)
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusCreated)
 
 	// Decode against the strongly-typed response to verify shape.
 	var typed AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &typed); err != nil {
-		t.Fatalf("decode typed: %v", err)
-	}
+	w.JSON(&typed)
 	if len(typed.EventFilters) != 2 {
 		t.Fatalf("expected 2 filters, got %d body=%s", len(typed.EventFilters), w.Body.String())
 	}
@@ -278,9 +235,7 @@ func TestCreateWebhookTrigger_EventFiltersRoundTripAsJSONArray(t *testing.T) {
 	var raw struct {
 		EventFilters json.RawMessage `json:"event_filters"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode raw: %v", err)
-	}
+	w.JSON(&raw)
 	trimmed := bytes.TrimSpace(raw.EventFilters)
 	if len(trimmed) == 0 || trimmed[0] != '[' {
 		t.Fatalf("event_filters must serialize as a JSON array, got %s", raw.EventFilters)
@@ -298,19 +253,13 @@ func TestUpdateWebhookTrigger_ExplicitEmptyArrayClearsFilters(t *testing.T) {
 		t.Fatalf("seed should have 1 filter, got %d", len(created.EventFilters))
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+created.ID, map[string]any{
 		"event_filters": []any{},
 	})
 	req = withURLParams(req, "id", apID, "triggerId", created.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusOK)
 	var updated AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&updated)
 	if len(updated.EventFilters) != 0 {
 		t.Fatalf("expected cleared filters in response, got %#v", updated.EventFilters)
 	}
@@ -339,19 +288,14 @@ func TestUpdateWebhookTrigger_OmittedFiltersPreserveExisting(t *testing.T) {
 
 	// PATCH that does NOT include event_filters at all. Must leave the
 	// existing filter set untouched (omitted ≠ clear).
-	w := httptest.NewRecorder()
+
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+created.ID, map[string]any{
 		"label": "renamed-but-keep-filters",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", created.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusOK)
 	var updated AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&updated)
 	if len(updated.EventFilters) != 1 || updated.EventFilters[0].Event != "workflow_run" {
 		t.Fatalf("filters must be preserved when field omitted, got %#v", updated.EventFilters)
 	}
@@ -365,7 +309,6 @@ func TestUpdateWebhookTrigger_ReplacesFilters(t *testing.T) {
 		{Event: "workflow_run", Actions: []string{"completed"}},
 	})
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+created.ID, map[string]any{
 		"event_filters": []map[string]any{
 			{"event": "pull_request", "actions": []string{"opened"}},
@@ -373,14 +316,9 @@ func TestUpdateWebhookTrigger_ReplacesFilters(t *testing.T) {
 		},
 	})
 	req = withURLParams(req, "id", apID, "triggerId", created.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusOK)
 	var updated AutopilotTriggerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&updated)
 	if len(updated.EventFilters) != 2 {
 		t.Fatalf("expected 2 replaced filters, got %d", len(updated.EventFilters))
 	}
@@ -393,7 +331,6 @@ func TestCreateAutopilotTrigger_RejectsInvalidEventFilter(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "EventFilterInvalid Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind": "webhook",
 		"event_filters": []map[string]any{
@@ -401,17 +338,13 @@ func TestCreateAutopilotTrigger_RejectsInvalidEventFilter(t *testing.T) {
 		},
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on empty event name, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusBadRequest)
 }
 
 func TestCreateAutopilotTrigger_RejectsEventFiltersOnSchedule(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "EventFilterSched Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind":            "schedule",
 		"cron_expression": "0 9 * * *",
@@ -420,10 +353,7 @@ func TestCreateAutopilotTrigger_RejectsEventFiltersOnSchedule(t *testing.T) {
 		},
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on event_filters for schedule trigger, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusBadRequest)
 }
 
 func postWebhook(t *testing.T, token string, body any, headers map[string]string) *httptest.ResponseRecorder {
@@ -454,9 +384,7 @@ func postWebhook(t *testing.T, token string, body any, headers map[string]string
 
 func requireAcceptedWebhookResponse(t *testing.T, w *httptest.ResponseRecorder) string {
 	t.Helper()
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 accepted/skipped, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode accepted response: %v", err)
@@ -560,9 +488,7 @@ func TestCreateWebhookTrigger_PublicURLAffectsResponse(t *testing.T) {
 
 func TestWebhookHandler_404OnUnknownToken(t *testing.T) {
 	w := postWebhook(t, "awt_unknown_token_value", map[string]any{"hello": "world"}, nil)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 func TestWebhookHandler_RejectsInvalidJSON(t *testing.T) {
@@ -571,9 +497,7 @@ func TestWebhookHandler_RejectsInvalidJSON(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 
 	w := postWebhook(t, *trig.WebhookToken, []byte(`not json`), nil)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestWebhookHandler_RejectsScalarBody(t *testing.T) {
@@ -582,9 +506,7 @@ func TestWebhookHandler_RejectsScalarBody(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 
 	w := postWebhook(t, *trig.WebhookToken, []byte(`"hello"`), nil)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestWebhookHandler_RejectsOversized(t *testing.T) {
@@ -600,9 +522,7 @@ func TestWebhookHandler_RejectsOversized(t *testing.T) {
 	body = append(body, []byte(`"}`)...)
 
 	w := postWebhook(t, *trig.WebhookToken, body, nil)
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("expected 413, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusRequestEntityTooLarge, "HTTP status")
 }
 
 func TestWebhookHandler_DisabledTriggerReturnsIgnored(t *testing.T) {
@@ -618,9 +538,7 @@ func TestWebhookHandler_DisabledTriggerReturnsIgnored(t *testing.T) {
 	}
 
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"hello": "world"}, nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["status"] != "ignored" {
@@ -637,9 +555,7 @@ func TestWebhookHandler_PausedAutopilotReturnsIgnored(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"x": 1}, nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["reason"] != "autopilot_paused" {
@@ -710,18 +626,7 @@ func TestWebhookHandler_ActiveDispatchesRunWithPayload(t *testing.T) {
 
 func TestWebhookHandler_ActiveSkippedRunReturnsLegacyContract(t *testing.T) {
 	var offlineRuntimeID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status,
-			device_info, metadata, owner_id, last_seen_at
-		) VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, $5, now())
-		RETURNING id
-	`, testWorkspaceID, "Webhook Offline Runtime", "webhook_test_runtime", "Webhook test runtime", testUserID).Scan(&offlineRuntimeID); err != nil {
-		t.Fatalf("create offline runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, offlineRuntimeID)
-	})
+	offlineRuntimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": "Webhook Offline Runtime", "runtime_mode": testutil.Raw("'cloud'"), "provider": "webhook_test_runtime", "status": testutil.Raw("'offline'"), "device_info": "Webhook test runtime", "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": testUserID, "last_seen_at": testutil.Raw("now()")})
 
 	agentID := createWebhookTestAgent(t, "WebhookSkipped Agent")
 	if _, err := testPool.Exec(context.Background(), `UPDATE agent SET runtime_id = $1 WHERE id = $2`, offlineRuntimeID, agentID); err != nil {
@@ -807,13 +712,9 @@ func TestRotateWebhookToken_ReplacesOldToken(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 	oldToken := *trig.WebhookToken
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", fmt.Sprintf("/api/autopilots/%s/triggers/%s/rotate-webhook-token", apID, trig.ID), nil)
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.RotateAutopilotTriggerWebhookToken(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("rotate: expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.RotateAutopilotTriggerWebhookToken, req).Want(http.StatusOK)
 	var rotated AutopilotTriggerResponse
 	json.Unmarshal(w.Body.Bytes(), &rotated)
 	if rotated.WebhookToken == nil || *rotated.WebhookToken == oldToken {
@@ -822,9 +723,7 @@ func TestRotateWebhookToken_ReplacesOldToken(t *testing.T) {
 
 	// Old token should now 404.
 	resOld := postWebhook(t, oldToken, map[string]any{"x": 1}, nil)
-	if resOld.Code != http.StatusNotFound {
-		t.Fatalf("old token should be 404, got %d", resOld.Code)
-	}
+	testutil.Equal(t, resOld.Code, http.StatusNotFound, "HTTP status")
 	// New token should accept.
 	resNew := postWebhook(t, *rotated.WebhookToken, map[string]any{"x": 1}, nil)
 	requireAcceptedWebhookResponse(t, resNew)
@@ -838,9 +737,7 @@ func TestWebhookHandler_EmptyBodyReturns400(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 
 	w := postWebhook(t, *trig.WebhookToken, []byte(``), nil)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for empty body, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestWebhookHandler_ArchivedAutopilotReturnsIgnored(t *testing.T) {
@@ -854,9 +751,7 @@ func TestWebhookHandler_ArchivedAutopilotReturnsIgnored(t *testing.T) {
 	}
 
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"x": 1}, nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["status"] != "ignored" || resp["reason"] != "autopilot_archived" {
@@ -881,8 +776,7 @@ func TestWebhookHandler_IPRateLimitReturns429BeforeDBLookup(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		req.RemoteAddr = "192.0.2.7:1234" // stable source, three calls = same bucket
 		req = withURLParam(req, "token", token)
-		w := httptest.NewRecorder()
-		testHandler.HandleAutopilotWebhook(w, req)
+		w := testutil.Call(t, testHandler.HandleAutopilotWebhook, req)
 		return w.Code
 	}
 
@@ -913,8 +807,7 @@ func TestWebhookHandler_IPRateLimitNotBypassedByXFFSpoof(t *testing.T) {
 		req.Header.Set("X-Forwarded-For", xff) // <-- attacker-controlled
 		req.RemoteAddr = "198.51.100.42:5555"  // real (untrusted) source
 		req = withURLParam(req, "token", token)
-		w := httptest.NewRecorder()
-		testHandler.HandleAutopilotWebhook(w, req)
+		w := testutil.Call(t, testHandler.HandleAutopilotWebhook, req)
 		return w.Code
 	}
 
@@ -943,9 +836,7 @@ func TestWebhookHandler_AbsoluteIPRateLimitRetainsEmergencyCeiling(t *testing.T)
 
 	requireAcceptedWebhookResponse(t, postWebhook(t, *trig.WebhookToken, map[string]any{"n": 1}, nil))
 	second := postWebhook(t, *trig.WebhookToken, map[string]any{"n": 2}, nil)
-	if second.Code != http.StatusTooManyRequests {
-		t.Fatalf("absolute ceiling: expected 429, got %d body=%s", second.Code, second.Body.String())
-	}
+	testutil.Equal(t, second.Code, http.StatusTooManyRequests, "HTTP status")
 	if second.Header().Get("Retry-After") == "" {
 		t.Fatal("absolute ceiling 429 must include Retry-After")
 	}
@@ -975,15 +866,11 @@ func TestCreateAutopilotTrigger_RejectsAPIKind(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "WebhookAPIKind Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind": "api",
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on kind=api, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "schedule or webhook") {
 		t.Fatalf("expected message to name allowed kinds, body=%s", w.Body.String())
 	}
@@ -993,16 +880,12 @@ func TestCreateAutopilotTrigger_RejectsWebhookWithTimezone(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "WebhookTZReject Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind":     "webhook",
 		"timezone": "Europe/Berlin",
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on webhook+timezone, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusBadRequest)
 }
 
 func TestUpdateAutopilotTrigger_RejectsCronExpressionOnWebhookKind(t *testing.T) {
@@ -1013,15 +896,11 @@ func TestUpdateAutopilotTrigger_RejectsCronExpressionOnWebhookKind(t *testing.T)
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 	trig := createWebhookTriggerViaHandler(t, apID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+trig.ID, map[string]any{
 		"cron_expression": "0 0 * * *",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on cron_expression for webhook trigger, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "cron_expression") {
 		t.Fatalf("error message should mention cron_expression, got %s", w.Body.String())
 	}
@@ -1032,15 +911,11 @@ func TestUpdateAutopilotTrigger_RejectsTimezoneOnWebhookKind(t *testing.T) {
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 	trig := createWebhookTriggerViaHandler(t, apID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+trig.ID, map[string]any{
 		"timezone": "Europe/Berlin",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on timezone for webhook trigger, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "timezone") {
 		t.Fatalf("error message should mention timezone, got %s", w.Body.String())
 	}
@@ -1053,16 +928,12 @@ func TestUpdateAutopilotTrigger_AcceptsEnabledAndLabelOnWebhookKind(t *testing.T
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 	trig := createWebhookTriggerViaHandler(t, apID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+trig.ID, map[string]any{
 		"enabled": false,
 		"label":   "renamed",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.UpdateAutopilotTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 on enabled+label PATCH, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAutopilotTrigger, req).Want(http.StatusOK)
 }
 
 func TestGetAutopilotRun_ReturnsFullPayload(t *testing.T) {
@@ -1081,25 +952,19 @@ func TestGetAutopilotRun_ReturnsFullPayload(t *testing.T) {
 	runID := uuidToString(delivery.AutopilotRunID)
 
 	// LIST: trigger_payload should be omitted (slim response).
-	wList := httptest.NewRecorder()
+
 	reqList := newRequest("GET", "/api/autopilots/"+apID+"/runs", nil)
 	reqList = withURLParam(reqList, "id", apID)
-	testHandler.ListAutopilotRuns(wList, reqList)
-	if wList.Code != http.StatusOK {
-		t.Fatalf("list: expected 200, got %d body=%s", wList.Code, wList.Body.String())
-	}
+	wList := testutil.Call(t, testHandler.ListAutopilotRuns, reqList).Want(http.StatusOK)
 	if strings.Contains(wList.Body.String(), `"answer":42`) {
 		t.Fatalf("list response should NOT carry trigger_payload, body=%s", wList.Body.String())
 	}
 
 	// DETAIL: trigger_payload should be present.
-	wDetail := httptest.NewRecorder()
+
 	reqDetail := newRequest("GET", "/api/autopilots/"+apID+"/runs/"+runID, nil)
 	reqDetail = withURLParams(reqDetail, "id", apID, "runId", runID)
-	testHandler.GetAutopilotRun(wDetail, reqDetail)
-	if wDetail.Code != http.StatusOK {
-		t.Fatalf("detail: expected 200, got %d body=%s", wDetail.Code, wDetail.Body.String())
-	}
+	wDetail := testutil.Call(t, testHandler.GetAutopilotRun, reqDetail).Want(http.StatusOK)
 	if !strings.Contains(wDetail.Body.String(), `"answer":42`) {
 		t.Fatalf("detail response should carry full trigger_payload, body=%s", wDetail.Body.String())
 	}

--- a/server/internal/handler/avatar_test.go
+++ b/server/internal/handler/avatar_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/multica-ai/multica/server/internal/storage"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // withAvatarStorage swaps the handler's storage/config for one test and
@@ -263,16 +264,7 @@ func seedAvatarObject(t *testing.T, opts avatarObjectOpts) string {
 		issueID = seedIssueForAvatarTest(t, workspaceID)
 	}
 	key := "workspaces/" + workspaceID + "/" + id.String() + ".png"
-	if _, err := testPool.Exec(context.Background(), `
-		INSERT INTO attachment (id, workspace_id, uploader_type, uploader_id, filename, url, content_type, size_bytes, issue_id)
-		VALUES ($1, $2, 'member', $3, 'avatar.png', $4, $5, 10, $6)
-	`, id.String(), workspaceID, testUserID,
-		"https://cdn.example.com/"+key, opts.contentType, issueID); err != nil {
-		t.Fatalf("seed attachment row: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, id.String())
-	})
+	dbfx.InsertNoID(t, "attachment", testutil.Cols{"id": id.String(), "workspace_id": workspaceID, "uploader_type": testutil.Raw("'member'"), "uploader_id": testUserID, "filename": testutil.Raw("'avatar.png'"), "url": "https://cdn.example.com/" + key, "content_type": opts.contentType, "size_bytes": testutil.Raw("10"), "issue_id": issueID}, "id = $1", id.String())
 	return key
 }
 
@@ -284,9 +276,7 @@ func TestServeAvatar_PresignRedirects(t *testing.T) {
 	key := seedAvatarObject(t, avatarObjectOpts{})
 
 	w := serveAvatarRequest(t, signAvatarKey(key), key)
-	if w.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	loc, err := url.Parse(w.Header().Get("Location"))
 	if err != nil {
 		t.Fatalf("parse Location: %v", err)
@@ -334,9 +324,7 @@ func TestServeAvatar_ProxiesPrivateHostBody(t *testing.T) {
 	store.put(key, []byte("PNGBYTES"))
 
 	w := serveAvatarRequest(t, signAvatarKey(key), key)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Header().Get("Content-Type"); got != "image/png" {
 		t.Fatalf("Content-Type = %q, want image/png", got)
 	}
@@ -547,9 +535,7 @@ func TestServeAvatar_ShortTTLDisablesRedirectCaching(t *testing.T) {
 	key := seedAvatarObject(t, avatarObjectOpts{})
 
 	w := serveAvatarRequest(t, signAvatarKey(key), key)
-	if w.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	if got := w.Header().Get("Cache-Control"); got != "no-store" {
 		t.Fatalf("Cache-Control = %q, want no-store", got)
 	}

--- a/server/internal/handler/cancel_task_by_user_test.go
+++ b/server/internal/handler/cancel_task_by_user_test.go
@@ -2,9 +2,7 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -158,12 +156,7 @@ func TestCancelTaskByUser_QueuedOnlyDoesNotCancelPromotedTask(t *testing.T) {
 		nil,
 	)
 	req = withURLParam(req, "taskId", taskID)
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, withChatTestWorkspaceCtx(t, req))
-
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, withChatTestWorkspaceCtx(t, req)).Want(http.StatusConflict)
 	if got := taskStatus(t, taskID); got != "running" {
 		t.Fatalf("queued-only cancellation changed promoted task status to %q", got)
 	}
@@ -183,14 +176,7 @@ func TestCancelTaskByUser_QueuedEditPersistsDraftRestore(t *testing.T) {
 		"edit this queued prompt",
 	)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(
-		w,
-		cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "edit"),
-	)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "edit")).Want(http.StatusOK)
 	if got := taskStatus(t, taskID); got != "cancelled" {
 		t.Fatalf("queued edit task status = %q, want cancelled", got)
 	}
@@ -254,14 +240,7 @@ func TestCancelTaskByUser_QueuedEditRollsBackOnRestoreFailure(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM chat_draft_restore WHERE id = $1`, messageID)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(
-		w,
-		cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "edit"),
-	)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "edit")).Want(http.StatusBadRequest)
 	if got := taskStatus(t, taskID); got != "queued" {
 		t.Fatalf("failed queued edit left task status %q", got)
 	}
@@ -292,14 +271,7 @@ func TestCancelTaskByUser_QueuedRemoveDeletesAttachment(t *testing.T) {
 		"discard this queued prompt",
 	)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(
-		w,
-		cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "remove"),
-	)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelQueuedTaskByUserRequest(t, testUserID, taskID, sessionID, "remove")).Want(http.StatusOK)
 	if got := taskStatus(t, taskID); got != "cancelled" {
 		t.Fatalf("queued remove task status = %q, want cancelled", got)
 	}
@@ -363,15 +335,9 @@ func TestCancelTaskByUser_StartedEmptyChat_WithDraftRestoreCapability_Defers(t *
 
 	req := cancelTaskByUserRequest(t, testUserID, taskID)
 	req.Header.Set("X-Client-Capabilities", protocol.AppCapabilityChatDraftRestoreV1)
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, req).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage != nil {
 		t.Fatalf("capable client must get no synchronous restore, got %#v", resp.CancelledChatMessage)
 	}
@@ -400,15 +366,9 @@ func TestCancelTaskByUser_StartedEmptyChat_LegacyClient_StillGetsSynchronousRest
 	taskID, userMessageID := createStartedEmptyChatTask(t, sessionID, agentID, userContent)
 
 	// No X-Client-Capabilities: a build that predates the durable restore.
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage == nil {
 		t.Fatal("legacy client must still get the synchronous restore payload")
 	}
@@ -448,11 +408,7 @@ func TestCancelTaskByUser_RunOnlyAutopilot_Succeeds(t *testing.T) {
 	agentID := createHandlerTestAgent(t, "CancelRunOnlyAgent", []byte("[]"))
 	taskID := createAutopilotRunOnlyTask(t, agentID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	if got := taskStatus(t, taskID); got != "cancelled" {
 		t.Fatalf("task not cancelled: status = %q", got)
 	}
@@ -469,11 +425,7 @@ func TestCancelTaskByUser_RunOnlyAutopilot_CrossWorkspace_Returns404(t *testing.
 	foreignAgentID := createForeignWorkspaceAgent(t)
 	taskID := createAutopilotRunOnlyTask(t, foreignAgentID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusNotFound)
 	if got := taskStatus(t, taskID); got != "queued" {
 		t.Fatalf("foreign task was mutated: status = %q", got)
 	}
@@ -498,11 +450,7 @@ func TestCancelTaskByUser_QuickCreate_Succeeds(t *testing.T) {
 	`, agentID).Scan(&taskID)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	if got := taskStatus(t, taskID); got != "cancelled" {
 		t.Fatalf("task not cancelled: status = %q", got)
 	}
@@ -528,11 +476,7 @@ func TestCancelTaskByUser_RetryClone_Autopilot_Succeeds(t *testing.T) {
 	`, parentID).Scan(&cloneID)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, cloneID) })
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, cloneID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, cloneID)).Want(http.StatusOK)
 	if got := taskStatus(t, cloneID); got != "cancelled" {
 		t.Fatalf("clone not cancelled: status = %q", got)
 	}
@@ -562,11 +506,7 @@ func TestCancelTaskByUser_IssueTask_Succeeds(t *testing.T) {
 	`, agentID, issueID).Scan(&taskID)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	if got := taskStatus(t, taskID); got != "cancelled" {
 		t.Fatalf("task not cancelled: status = %q", got)
 	}
@@ -613,11 +553,7 @@ func TestCancelTaskByUser_DelegatedFailureRecoveryAcknowledgesSignal(t *testing.
 		RETURNING id
 	`, agentID, issueID, recoveryCommentID, failedTaskID).Scan(&recoveryTaskID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, recoveryTaskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, recoveryTaskID)).Want(http.StatusOK)
 	var status string
 	var acknowledged bool
 	dbfx.QueryRow(t, `
@@ -648,11 +584,7 @@ func TestCancelTaskByUser_ChatTask_NonCreator_Returns403(t *testing.T) {
 	`, agentID, sessionID).Scan(&taskID)
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, otherUserID, taskID))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, otherUserID, taskID)).Want(http.StatusForbidden)
 	if got := taskStatus(t, taskID); got != "running" {
 		t.Fatalf("chat task was mutated: status = %q", got)
 	}
@@ -683,15 +615,9 @@ func TestCancelTaskByUser_ChatTaskWithTranscript_PersistsAssistantSnapshot(t *te
 		VALUES ($1, 1, 'text', 'partial answer')
 	`, taskID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage != nil {
 		t.Fatalf("expected no restore payload when transcript exists, got %#v", resp.CancelledChatMessage)
 	}
@@ -734,15 +660,9 @@ func TestCancelTaskByUser_ChatTaskWithoutTranscript_RestoresUserDraft(t *testing
 		RETURNING id
 	`, sessionID, userContent, taskID).Scan(&userMessageID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage == nil {
 		t.Fatal("expected restore payload for empty transcript cancel")
 	}
@@ -830,15 +750,9 @@ func TestCancelTaskByUser_ChatRetryRestoresRootInput(t *testing.T) {
 		t.Fatalf("queued retry hid its historical root input: %+v", transcript)
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, retryTaskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, retryTaskID)).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode retry cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage == nil ||
 		resp.CancelledChatMessage.MessageID != messageID ||
 		resp.CancelledChatMessage.Content != content {
@@ -896,15 +810,9 @@ func TestCancelTaskByUser_ChatTaskWithBoundAttachment_SurvivesCancelAndRebinds(t
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID) })
 
 	// Cancel the empty chat task (no transcript) — this deletes the user message.
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, testUserID, taskID)).Want(http.StatusOK)
 	var resp CancelTaskByUserResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode cancel response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.CancelledChatMessage == nil {
 		t.Fatal("expected restore payload for empty transcript cancel")
 	}
@@ -957,15 +865,9 @@ func TestCancelTaskByUser_ChatTaskWithBoundAttachment_SurvivesCancelAndRebinds(t
 	})
 	sendReq = withURLParam(sendReq, "sessionId", sessionID)
 	sendReq = withChatTestWorkspaceCtx(t, sendReq)
-	sendW := httptest.NewRecorder()
-	testHandler.SendChatMessage(sendW, sendReq)
-	if sendW.Code != http.StatusCreated {
-		t.Fatalf("resend: expected 201, got %d: %s", sendW.Code, sendW.Body.String())
-	}
+	sendW := testutil.Call(t, testHandler.SendChatMessage, sendReq).Want(http.StatusCreated)
 	var sendResp SendChatMessageResponse
-	if err := json.Unmarshal(sendW.Body.Bytes(), &sendResp); err != nil {
-		t.Fatalf("decode resend response: %v", err)
-	}
+	sendW.JSON(&sendResp)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, sendResp.TaskID)
 	})
@@ -999,11 +901,7 @@ func TestCancelTaskByUser_PrivateAgent_PlainMember_Returns403(t *testing.T) {
 	agentID, _, memberID := privateAgentTestFixture(t)
 	taskID := createAutopilotRunOnlyTask(t, agentID)
 
-	w := httptest.NewRecorder()
-	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, memberID, taskID))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CancelTaskByUser, cancelTaskByUserRequest(t, memberID, taskID)).Want(http.StatusForbidden)
 	if got := taskStatus(t, taskID); got != "queued" {
 		t.Fatalf("task was mutated: status = %q", got)
 	}

--- a/server/internal/handler/chat_archive_cancel_test.go
+++ b/server/internal/handler/chat_archive_cancel_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -396,11 +397,7 @@ func archiveChatSession(t *testing.T, sessionID string) {
 	req = withChatTestWorkspaceCtx(t, req)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	w := httptest.NewRecorder()
-	testHandler.SetChatSessionArchived(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("archive returned %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SetChatSessionArchived, req).Want(http.StatusOK)
 }
 
 func (f *archiveCancelFixture) taskStatus(t *testing.T, taskID string) string {
@@ -502,16 +499,7 @@ func TestNoHistoryNoteNamesTheActualChannel(t *testing.T) {
 	}
 
 	var instID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, status, installer_user_id)
-		VALUES ($1, $2, 'wecom', '{"app_id":"bot-history-note"}'::jsonb, 'active', $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&instID); err != nil {
-		t.Fatalf("create installation: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE id = $1`, instID)
-	})
+	instID = dbfx.Insert(t, "channel_installation", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "channel_type": testutil.Raw("'wecom'"), "config": testutil.Raw("'{\"app_id\":\"bot-history-note\"}'::jsonb"), "status": testutil.Raw("'active'"), "installer_user_id": testUserID})
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO channel_chat_session_binding
 			(chat_session_id, installation_id, channel_type, channel_chat_id, chat_type)

--- a/server/internal/handler/chat_attachment_reply_test.go
+++ b/server/internal/handler/chat_attachment_reply_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // seedRunningChatTask inserts a running chat task (chat_session_id set) for the
@@ -16,16 +18,7 @@ import (
 func seedRunningChatTask(t *testing.T, agentID, sessionID string) string {
 	t.Helper()
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, chat_session_id, started_at)
-		VALUES ($1, $2, 'running', 0, $3, now())
-		RETURNING id
-	`, agentID, handlerTestRuntimeID(t), sessionID).Scan(&taskID); err != nil {
-		t.Fatalf("seed running chat task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": handlerTestRuntimeID(t), "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "chat_session_id": sessionID, "started_at": testutil.Raw("now()")})
 	return taskID
 }
 
@@ -35,16 +28,7 @@ func seedRunningChatTask(t *testing.T, agentID, sessionID string) string {
 func seedAgentChatAttachment(t *testing.T, agentID, sessionID, taskID string) string {
 	t.Helper()
 	var id string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO attachment (workspace_id, task_id, chat_session_id, uploader_type, uploader_id, filename, url, content_type, size_bytes)
-		VALUES ($1, $2, $3, 'agent', $4, 'chart.png', 'https://cdn.example/chart.png', 'image/png', 123)
-		RETURNING id
-	`, testWorkspaceID, taskID, sessionID, agentID).Scan(&id); err != nil {
-		t.Fatalf("seed agent chat attachment: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, id)
-	})
+	id = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "task_id": taskID, "chat_session_id": sessionID, "uploader_type": testutil.Raw("'agent'"), "uploader_id": agentID, "filename": testutil.Raw("'chart.png'"), "url": testutil.Raw("'https://cdn.example/chart.png'"), "content_type": testutil.Raw("'image/png'"), "size_bytes": testutil.Raw("123")})
 	return id
 }
 
@@ -134,9 +118,7 @@ func TestUploadFile_TaskScopedChatAttachment(t *testing.T) {
 
 	t.Run("agent uploads for own chat task", func(t *testing.T) {
 		w := uploadWithTaskID(t, agentID, taskID, taskID)
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 		var resp AttachmentResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("decode: %v; body: %s", err, w.Body.String())
@@ -168,9 +150,7 @@ func TestUploadFile_TaskScopedChatAttachment(t *testing.T) {
 		// A plain member request (no task-token headers) is rejected by the
 		// task-token boundary before any task lookup.
 		w := uploadWithTaskID(t, "", "", taskID)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("member upload: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 	})
 
 	t.Run("forged agent headers without task token rejected", func(t *testing.T) {
@@ -188,9 +168,7 @@ func TestUploadFile_TaskScopedChatAttachment(t *testing.T) {
 			"X-Task-ID":      taskID,
 			// deliberately NO X-Actor-Source
 		})
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("forged non-task-token upload: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 	})
 
 	t.Run("different agent's task rejected", func(t *testing.T) {
@@ -199,9 +177,7 @@ func TestUploadFile_TaskScopedChatAttachment(t *testing.T) {
 		// Actor is agentID (valid X-Agent-ID/X-Task-ID pair), but the upload
 		// targets a task owned by a different agent.
 		w := uploadWithTaskID(t, agentID, taskID, otherTask)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("foreign task upload: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 	})
 
 	t.Run("same agent's other chat task rejected", func(t *testing.T) {
@@ -212,24 +188,18 @@ func TestUploadFile_TaskScopedChatAttachment(t *testing.T) {
 		otherSession := createHandlerTestChatSession(t, agentID)
 		otherChatTask := seedRunningChatTask(t, agentID, otherSession)
 		w := uploadWithTaskID(t, agentID, taskID, otherChatTask)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("cross-task upload: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 	})
 
 	t.Run("non-chat task rejected", func(t *testing.T) {
 		issueTask := createHandlerTestTaskForAgent(t, agentID) // no chat_session_id
 		w := uploadWithTaskID(t, agentID, issueTask, issueTask)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("non-chat task upload: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 	})
 
 	t.Run("malformed task_id rejected", func(t *testing.T) {
 		w := uploadWithTaskID(t, agentID, taskID, "not-a-uuid")
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("bad task_id: expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 	})
 }
 
@@ -330,14 +300,7 @@ func TestCompleteTask_BindsChatAttachments(t *testing.T) {
 		// A loose session attachment with NO task_id (e.g. legacy row) must be
 		// left alone — binding is scoped to the producing task.
 		var looseID string
-		if err := testPool.QueryRow(context.Background(), `
-			INSERT INTO attachment (workspace_id, chat_session_id, uploader_type, uploader_id, filename, url, content_type, size_bytes)
-			VALUES ($1, $2, 'agent', $3, 'loose.png', 'https://cdn.example/loose.png', 'image/png', 10)
-			RETURNING id
-		`, testWorkspaceID, sessionID, agentID).Scan(&looseID); err != nil {
-			t.Fatalf("seed loose attachment: %v", err)
-		}
-		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, looseID) })
+		looseID = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "chat_session_id": sessionID, "uploader_type": testutil.Raw("'agent'"), "uploader_id": agentID, "filename": testutil.Raw("'loose.png'"), "url": testutil.Raw("'https://cdn.example/loose.png'"), "content_type": testutil.Raw("'image/png'"), "size_bytes": testutil.Raw("10")})
 
 		if _, err := testHandler.TaskService.CompleteTask(context.Background(),
 			parseUUID(taskID), []byte(`{"output":"done"}`), "", "", "", false, "", ""); err != nil {
@@ -356,22 +319,9 @@ func TestCompleteTask_BindsChatAttachments(t *testing.T) {
 		// never re-pointed at the new reply.
 		taskID := seedRunningChatTask(t, agentID, sessionID)
 		var claimedID string
-		if err := testPool.QueryRow(context.Background(), `
-			INSERT INTO attachment (workspace_id, task_id, chat_session_id, uploader_type, uploader_id, filename, url, content_type, size_bytes)
-			VALUES ($1, $2, $3, 'agent', $4, 'claimed.png', 'https://cdn.example/claimed.png', 'image/png', 10)
-			RETURNING id
-		`, testWorkspaceID, taskID, sessionID, agentID).Scan(&claimedID); err != nil {
-			t.Fatalf("seed attachment: %v", err)
-		}
-		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, claimedID) })
+		claimedID = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "task_id": taskID, "chat_session_id": sessionID, "uploader_type": testutil.Raw("'agent'"), "uploader_id": agentID, "filename": testutil.Raw("'claimed.png'"), "url": testutil.Raw("'https://cdn.example/claimed.png'"), "content_type": testutil.Raw("'image/png'"), "size_bytes": testutil.Raw("10")})
 		var priorMsgID string
-		if err := testPool.QueryRow(context.Background(), `
-			INSERT INTO chat_message (chat_session_id, role, content)
-			VALUES ($1, 'assistant', 'prior') RETURNING id
-		`, sessionID).Scan(&priorMsgID); err != nil {
-			t.Fatalf("seed prior message: %v", err)
-		}
-		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM chat_message WHERE id = $1`, priorMsgID) })
+		priorMsgID = dbfx.Insert(t, "chat_message", testutil.Cols{"chat_session_id": sessionID, "role": testutil.Raw("'assistant'"), "content": testutil.Raw("'prior'")})
 		if _, err := testPool.Exec(context.Background(),
 			`UPDATE attachment SET chat_message_id = $1 WHERE id = $2`, priorMsgID, claimedID); err != nil {
 			t.Fatalf("pre-bind attachment: %v", err)

--- a/server/internal/handler/chat_channel_command_visibility_test.go
+++ b/server/internal/handler/chat_channel_command_visibility_test.go
@@ -2,13 +2,13 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -46,15 +46,9 @@ func TestChannelCommandVisibility_MessageListsExcludeCommandsBeforePagination(t 
 	legacyReq.Header.Set("X-User-ID", testUserID)
 	legacyReq = withURLParam(legacyReq, "sessionId", sessionID)
 	legacyReq = withChatTestWorkspaceCtx(t, legacyReq)
-	legacyW := httptest.NewRecorder()
-	testHandler.ListChatMessages(legacyW, legacyReq)
-	if legacyW.Code != http.StatusOK {
-		t.Fatalf("ListChatMessages: expected 200, got %d: %s", legacyW.Code, legacyW.Body.String())
-	}
+	legacyW := testutil.Call(t, testHandler.ListChatMessages, legacyReq).Want(http.StatusOK)
 	var legacy []ChatMessageResponse
-	if err := json.Unmarshal(legacyW.Body.Bytes(), &legacy); err != nil {
-		t.Fatalf("decode legacy messages: %v", err)
-	}
+	legacyW.JSON(&legacy)
 	if len(legacy) != 3 || legacy[0].Content != "visible oldest" || legacy[1].Content != "visible middle" || legacy[2].Content != "visible newest" {
 		t.Fatalf("legacy visible messages = %#v", legacy)
 	}

--- a/server/internal/handler/chat_channel_debounce_boundary_test.go
+++ b/server/internal/handler/chat_channel_debounce_boundary_test.go
@@ -3,10 +3,10 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -54,14 +54,14 @@ type claimResult struct {
 
 func claimTaskRaw(t *testing.T, runtimeID, daemonID string) claimResult {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
 		testWorkspaceID, daemonID)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("runtimeId", runtimeID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.ClaimTaskByRuntime(w, req)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req)
 	out := claimResult{code: w.Code, body: w.Body.String()}
 	if w.Code == 200 {
 		var resp struct {

--- a/server/internal/handler/chat_delete_cancel_broadcast_test.go
+++ b/server/internal/handler/chat_delete_cancel_broadcast_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -32,14 +33,7 @@ func TestDeleteChatSession_BroadcastsTaskCancelled(t *testing.T) {
 	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
 
 	var sessionID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status)
-		VALUES ($1, $2, $3, 'delete cancels its tasks', 'active')
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&sessionID); err != nil {
-		t.Fatalf("setup: create chat session: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, sessionID) })
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": testUserID, "title": testutil.Raw("'delete cancels its tasks'"), "status": testutil.Raw("'active'")})
 
 	var taskID string
 	if err := testPool.QueryRow(ctx, `
@@ -64,11 +58,7 @@ func TestDeleteChatSession_BroadcastsTaskCancelled(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.DeleteChatSession(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteChatSession: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteChatSession, req).Want(http.StatusNoContent)
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/server/internal/handler/chat_draft_restore_race_test.go
+++ b/server/internal/handler/chat_draft_restore_race_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -216,9 +216,9 @@ func TestDeleteWorkspace_SweepsRestoreCommittedByAConcurrentFinalizer(t *testing
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodDelete, fmt.Sprintf("/api/workspaces/%s", f.workspaceID), nil), "id", f.workspaceID)
-		testHandler.DeleteWorkspace(w, req)
+		w := testutil.Call(t, testHandler.DeleteWorkspace, req)
 		code <- w.Code
 	}()
 
@@ -291,13 +291,13 @@ func TestCreateChatSession_BlocksWhileTheWorkspaceDeleteLockIsHeld(t *testing.T)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		w := httptest.NewRecorder()
+
 		req := newRequestAs(testUserID, http.MethodPost, "/api/chat/sessions", map[string]any{
 			"agent_id": agentID,
 			"title":    "Session racing the teardown",
 		})
 		req = req.WithContext(middleware.SetMemberContext(req.Context(), f.workspaceID, member))
-		testHandler.CreateChatSession(w, req)
+		w := testutil.Call(t, testHandler.CreateChatSession, req)
 		code <- w.Code
 	}()
 
@@ -326,12 +326,8 @@ func TestFinalizeDeferredCancelledChat_SkipsTheInsertWhenTheSessionIsGone(t *tes
 	ctx := context.Background()
 	f := seedDraftRestoreRaceFixture(t, "handler-tests-draft-restore-race-gone")
 
-	w := httptest.NewRecorder()
 	req := withURLParam(newRequest(http.MethodDelete, fmt.Sprintf("/api/workspaces/%s", f.workspaceID), nil), "id", f.workspaceID)
-	testHandler.DeleteWorkspace(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteWorkspace: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	testHandler.TaskService.FinalizeDeferredCancelledChat(ctx, parseUUID(f.taskID))
 

--- a/server/internal/handler/chat_draft_restore_test.go
+++ b/server/internal/handler/chat_draft_restore_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // withDraftRestoreParams sets both chi URL params in one route context —
@@ -39,34 +40,14 @@ func seedDraftRestore(t *testing.T, sessionID, content string, attachmentIDs []s
 		}
 		ids += "}"
 	}
-	if _, err := testPool.Exec(context.Background(), `
-		INSERT INTO chat_draft_restore (id, chat_session_id, task_id, content, attachment_ids)
-		VALUES ($1, $2, $3, $4, $5::uuid[])
-	`, restoreID, sessionID, uuid.NewString(), content, ids); err != nil {
-		t.Fatalf("seed draft restore: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM chat_draft_restore WHERE id = $1`, restoreID)
-	})
+	dbfx.InsertNoID(t, "chat_draft_restore", testutil.Cols{"id": restoreID, "chat_session_id": sessionID, "task_id": uuid.NewString(), "content": content, "attachment_ids": ids}, "id = $1", restoreID)
 	return restoreID
 }
 
 func seedDetachedChatAttachment(t *testing.T, sessionID string) string {
 	t.Helper()
 	var attachmentID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO attachment (
-			workspace_id, chat_session_id, uploader_type, uploader_id,
-			filename, url, content_type, size_bytes
-		)
-		VALUES ($1, $2, 'member', $3, 'notes.txt', 'https://files.test/notes.txt', 'text/plain', 12)
-		RETURNING id
-	`, testWorkspaceID, sessionID, testUserID).Scan(&attachmentID); err != nil {
-		t.Fatalf("seed detached attachment: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID)
-	})
+	attachmentID = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "chat_session_id": sessionID, "uploader_type": testutil.Raw("'member'"), "uploader_id": testUserID, "filename": testutil.Raw("'notes.txt'"), "url": testutil.Raw("'https://files.test/notes.txt'"), "content_type": testutil.Raw("'text/plain'"), "size_bytes": testutil.Raw("12")})
 	return attachmentID
 }
 
@@ -83,9 +64,7 @@ func TestChatDraftRestores_CreatorFetchesAndConsumes(t *testing.T) {
 	listReq = withChatTestWorkspaceCtx(t, listReq)
 	listW := httptest.NewRecorder()
 	testHandler.ListChatDraftRestores(listW, listReq)
-	if listW.Code != http.StatusOK {
-		t.Fatalf("list: expected 200, got %d: %s", listW.Code, listW.Body.String())
-	}
+	testutil.Equal(t, listW.Code, http.StatusOK, "HTTP status")
 	var resp ChatDraftRestoresResponse
 	if err := json.Unmarshal(listW.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode list: %v", err)
@@ -111,8 +90,7 @@ func TestChatDraftRestores_CreatorFetchesAndConsumes(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		delReq := withDraftRestoreParams(newRequest(http.MethodDelete, "/api/chat/sessions/"+sessionID+"/draft-restores/"+restoreID, nil), sessionID, restoreID)
 		delReq = withChatTestWorkspaceCtx(t, delReq)
-		delW := httptest.NewRecorder()
-		testHandler.ConsumeChatDraftRestore(delW, delReq)
+		delW := testutil.Call(t, testHandler.ConsumeChatDraftRestore, delReq)
 		if delW.Code != http.StatusNoContent {
 			t.Fatalf("consume call %d: expected 204, got %d: %s", i+1, delW.Code, delW.Body.String())
 		}
@@ -120,9 +98,7 @@ func TestChatDraftRestores_CreatorFetchesAndConsumes(t *testing.T) {
 
 	listW = httptest.NewRecorder()
 	testHandler.ListChatDraftRestores(listW, withChatTestWorkspaceCtx(t, withURLParam(newRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/draft-restores", nil), "sessionId", sessionID)))
-	if listW.Code != http.StatusOK {
-		t.Fatalf("relist: expected 200, got %d", listW.Code)
-	}
+	testutil.Equal(t, listW.Code, http.StatusOK, "HTTP status")
 	resp = ChatDraftRestoresResponse{}
 	if err := json.Unmarshal(listW.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode relist: %v", err)
@@ -161,20 +137,12 @@ func TestChatDraftRestores_NonCreatorForbidden(t *testing.T) {
 	listReq := withURLParam(newRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/draft-restores", nil), "sessionId", sessionID)
 	listReq = withChatTestWorkspaceCtx(t, listReq)
 	listReq.Header.Set("X-User-ID", otherUserID)
-	listW := httptest.NewRecorder()
-	testHandler.ListChatDraftRestores(listW, listReq)
-	if listW.Code != http.StatusForbidden {
-		t.Fatalf("list as non-creator: expected 403, got %d: %s", listW.Code, listW.Body.String())
-	}
+	testutil.Call(t, testHandler.ListChatDraftRestores, listReq).Want(http.StatusForbidden)
 
 	delReq := withDraftRestoreParams(newRequest(http.MethodDelete, "/api/chat/sessions/"+sessionID+"/draft-restores/"+restoreID, nil), sessionID, restoreID)
 	delReq = withChatTestWorkspaceCtx(t, delReq)
 	delReq.Header.Set("X-User-ID", otherUserID)
-	delW := httptest.NewRecorder()
-	testHandler.ConsumeChatDraftRestore(delW, delReq)
-	if delW.Code != http.StatusForbidden {
-		t.Fatalf("consume as non-creator: expected 403, got %d: %s", delW.Code, delW.Body.String())
-	}
+	testutil.Call(t, testHandler.ConsumeChatDraftRestore, delReq).Want(http.StatusForbidden)
 
 	var count int
 	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM chat_draft_restore WHERE id = $1`, restoreID).Scan(&count); err != nil {
@@ -195,11 +163,7 @@ func TestDeleteChatSession_PrunesDraftRestores(t *testing.T) {
 	req := withURLParam(newRequest(http.MethodDelete, "/api/chat/sessions/"+sessionID, nil), "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
 	req.Header.Set("X-User-ID", testUserID)
-	w := httptest.NewRecorder()
-	testHandler.DeleteChatSession(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteChatSession: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteChatSession, req).Want(http.StatusNoContent)
 
 	var count int
 	if err := testPool.QueryRow(context.Background(),
@@ -240,12 +204,8 @@ func TestDeleteAgentRuntime_PrunesDraftRestoresOfSystemAgentSessions(t *testing.
 	sessionID := createHandlerTestChatSession(t, systemAgent)
 	seedDraftRestore(t, sessionID, "prompt stranded by the agent cascade", nil)
 
-	w := httptest.NewRecorder()
 	req := withURLParam(newRequest(http.MethodDelete, "/api/runtimes/"+runtimeID, nil), "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if agentExists(t, systemAgent) {
 		t.Fatal("system agent should have been deleted — the cascade under test never ran")
@@ -270,12 +230,8 @@ func TestDeleteAgentRuntime_KeepsDraftRestoresOfUnboundAgentSessions(t *testing.
 	sessionID := createHandlerTestChatSession(t, archivedAgent)
 	seedDraftRestore(t, sessionID, "prompt that must survive the machine being retired", nil)
 
-	w := httptest.NewRecorder()
 	req := withURLParam(newRequest(http.MethodDelete, "/api/runtimes/"+runtimeID, nil), "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if !agentExists(t, archivedAgent) {
 		t.Fatal("archived user agent must survive its runtime as an unbound agent")
@@ -298,16 +254,7 @@ func TestDeleteWorkspace_PrunesDraftRestoresOfCascadedSessions(t *testing.T) {
 	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
 	var wsID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description)
-		VALUES ($1, $2, '')
-		RETURNING id
-	`, "Handler Test Draft Restore Cascade", slug).Scan(&wsID); err != nil {
-		t.Fatalf("create workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-	})
+	wsID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Handler Test Draft Restore Cascade", "slug": slug, "description": testutil.Raw("''")})
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO member (workspace_id, user_id, role)
 		VALUES ($1, $2, 'owner')
@@ -348,12 +295,8 @@ func TestDeleteWorkspace_PrunesDraftRestoresOfCascadedSessions(t *testing.T) {
 	}
 	seedDraftRestore(t, sessionID, "prompt stranded by the workspace cascade", nil)
 
-	w := httptest.NewRecorder()
 	req := withURLParam(newRequest(http.MethodDelete, "/api/workspaces/"+wsID, nil), "id", wsID)
-	testHandler.DeleteWorkspace(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteWorkspace: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	if n := countDraftRestores(t, sessionID); n != 0 {
 		t.Errorf("draft restores of a workspace-cascaded session must be pruned, count = %d", n)

--- a/server/internal/handler/chat_history_test.go
+++ b/server/internal/handler/chat_history_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -71,16 +72,7 @@ func newChatHistoryTask(t *testing.T, chatSession bool) string {
 		sessionArg = createHandlerTestChatSession(t, agentID)
 	}
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, chat_session_id)
-		VALUES ($1, $2, 'completed', 0, $3)
-		RETURNING id
-	`, agentID, runtimeID, sessionArg).Scan(&taskID); err != nil {
-		t.Fatalf("insert chat history task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'completed'"), "priority": testutil.Raw("0"), "chat_session_id": sessionArg})
 	return taskID
 }
 
@@ -91,16 +83,7 @@ func newChatHistoryTaskForSession(t *testing.T, sessionID string) string {
 	agentID := createHandlerTestAgent(t, "ChatHistorySessionAgent-"+uuid.NewString(), []byte("[]"))
 	runtimeID := handlerTestRuntimeID(t)
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, chat_session_id)
-		VALUES ($1, $2, 'completed', 0, $3)
-		RETURNING id
-	`, agentID, runtimeID, sessionID).Scan(&taskID); err != nil {
-		t.Fatalf("insert chat history task for session: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'completed'"), "priority": testutil.Raw("0"), "chat_session_id": sessionID})
 	return taskID
 }
 
@@ -136,16 +119,9 @@ func TestGetChatChannelHistory_Success(t *testing.T) {
 	}}
 	withSlackHistory(t, fake)
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history?limit=10", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history?limit=10", taskID)).Want(http.StatusOK)
 	var resp ChatChannelHistoryResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.ChannelType != "slack" || len(resp.Messages) != 2 || resp.NextCursor != "100" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
@@ -165,12 +141,7 @@ func TestGetChatThread_CurrentThread(t *testing.T) {
 	fake := &fakeChatHistoryReader{page: channel.HistoryPage{ChannelType: "slack", ThreadID: "50.0", Messages: []channel.HistoryMessage{{ID: "50.0", TS: "50.0", Text: "root"}}}}
 	withSlackHistory(t, fake)
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatThread(w, taskActorReq("/api/chat/thread", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetChatThread, taskActorReq("/api/chat/thread", taskID)).Want(http.StatusOK)
 	if fake.threadCalls != 1 || fake.overviewCalls != 0 {
 		t.Errorf("expected Thread, got overview=%d thread=%d", fake.overviewCalls, fake.threadCalls)
 	}
@@ -187,12 +158,7 @@ func TestGetChatThread_ByID(t *testing.T) {
 	fake := &fakeChatHistoryReader{page: channel.HistoryPage{ChannelType: "slack", ThreadID: "70.0"}}
 	withSlackHistory(t, fake)
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatThread(w, taskActorReq("/api/chat/thread?id=70.0", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetChatThread, taskActorReq("/api/chat/thread?id=70.0", taskID)).Want(http.StatusOK)
 	if fake.gotThreadID != "70.0" {
 		t.Errorf("thread id passed to reader = %q, want 70.0", fake.gotThreadID)
 	}
@@ -209,12 +175,7 @@ func TestGetChatHistory_NoSlackBindingFallsBackToTranscript(t *testing.T) {
 	taskID := newChatHistoryTask(t, true)
 	withSlackHistory(t, &fakeChatHistoryReader{err: slack.ErrNoSlackSession})
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID)).Want(http.StatusOK)
 	var resp ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Note != "" || len(resp.Messages) != 0 {
@@ -242,12 +203,7 @@ func TestGetChatHistory_NoSlackBindingReadsStoredTranscript(t *testing.T) {
 	insertChatVisibilityMessage(t, sessionID, "/issue hidden", "channel_command", true, base.Add(2*time.Second))
 	insertChatVisibilityMessage(t, sessionID, "second user turn", "message", true, base.Add(3*time.Second))
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID)).Want(http.StatusOK)
 	var resp ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Note != "" {
@@ -285,12 +241,7 @@ func TestGetChatHistory_NilReaderServesTranscript(t *testing.T) {
 	taskID := newChatHistoryTask(t, true)
 	withSlackHistory(t, nil)
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID)).Want(http.StatusOK)
 	var resp ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Note != "" || len(resp.Messages) != 0 {
@@ -316,12 +267,7 @@ func TestGetChatHistory_NilReaderServesStoredTranscript(t *testing.T) {
 	insertChatVisibilityMessage(t, sessionID, "nil reader still reads me", "message", true, base)
 	insertChatMessageRole(t, sessionID, "assistant", "and my reply", "message", true, base.Add(time.Second))
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID)).Want(http.StatusOK)
 	var resp ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Note != "" {
@@ -349,16 +295,7 @@ func TestGetChatHistory_TranscriptNamesItsChannel(t *testing.T) {
 	withSlackHistory(t, nil)
 
 	var instID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, status, installer_user_id)
-		VALUES ($1, $2, 'wecom', '{"app_id":"bot-transcript-channel"}'::jsonb, 'active', $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&instID); err != nil {
-		t.Fatalf("create installation: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE id = $1`, instID)
-	})
+	instID = dbfx.Insert(t, "channel_installation", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "channel_type": testutil.Raw("'wecom'"), "config": testutil.Raw("'{\"app_id\":\"bot-transcript-channel\"}'::jsonb"), "status": testutil.Raw("'active'"), "installer_user_id": testUserID})
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO channel_chat_session_binding
 			(chat_session_id, installation_id, channel_type, channel_chat_id, chat_type)
@@ -378,9 +315,7 @@ func TestGetChatHistory_TranscriptNamesItsChannel(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var served ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &served)
 
@@ -408,8 +343,7 @@ func TestGetChatHistory_WebOnlyTranscriptHasNoChannelType(t *testing.T) {
 	withSlackHistory(t, nil)
 	insertChatVisibilityMessage(t, sessionID, "a web turn", "message", true, time.Date(2026, 8, 12, 1, 0, 0, 0, time.UTC))
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
+	w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID))
 
 	var resp ChatChannelHistoryResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
@@ -484,9 +418,7 @@ func TestGetChatHistory_ChannelTaskCannotReadEarlierContextGeneration(t *testing
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp ChatChannelHistoryResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -497,9 +429,7 @@ func TestGetChatHistory_ChannelTaskCannotReadEarlierContextGeneration(t *testing
 
 	w = httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", legacyTaskID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("legacy status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode legacy response: %v", err)
 	}
@@ -538,8 +468,7 @@ func TestGetChatHistory_TranscriptPagesWithoutDuplicatesOrGaps(t *testing.T) {
 		if before != "" {
 			target += "&before=" + url.QueryEscape(before)
 		}
-		w := httptest.NewRecorder()
-		testHandler.GetChatChannelHistory(w, taskActorReq(target, taskID))
+		w := testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq(target, taskID))
 		if w.Code != http.StatusOK {
 			t.Fatalf("page %d status = %d, want 200: %s", page, w.Code, w.Body.String())
 		}
@@ -606,12 +535,7 @@ func TestGetChatHistory_RejectsForgedTaskID(t *testing.T) {
 
 	req := newRequest("GET", "/api/chat/history", nil)
 	req.Header.Set("X-Task-ID", taskID) // forged: no X-Actor-Source=task_token
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", w.Code)
-	}
+	testutil.Call(t, testHandler.GetChatChannelHistory, req).Want(http.StatusForbidden)
 	if fake.overviewCalls != 0 || fake.threadCalls != 0 {
 		t.Fatalf("reader must not be called for a forged X-Task-ID")
 	}
@@ -624,11 +548,7 @@ func TestGetChatHistory_MissingTaskHeader(t *testing.T) {
 	// Task-token actor source but no X-Task-ID: a defensive 400.
 	req := newRequest("GET", "/api/chat/history", nil)
 	req.Header.Set("X-Actor-Source", "task_token")
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", w.Code)
-	}
+	testutil.Call(t, testHandler.GetChatChannelHistory, req).Want(http.StatusBadRequest)
 }
 
 func TestGetChatHistory_NonChatTask(t *testing.T) {
@@ -638,9 +558,5 @@ func TestGetChatHistory_NonChatTask(t *testing.T) {
 	taskID := newChatHistoryTask(t, false) // task with no chat_session_id
 	withSlackHistory(t, &fakeChatHistoryReader{})
 
-	w := httptest.NewRecorder()
-	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetChatChannelHistory, taskActorReq("/api/chat/history", taskID)).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/chat_input_ownership_test.go
+++ b/server/internal/handler/chat_input_ownership_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -19,14 +20,7 @@ import (
 func setupDirectChatSession(t *testing.T, ctx context.Context, title string) (agentID, sessionID, runtimeID, daemonID string) {
 	t.Helper()
 	agentID, runtimeID, daemonID = createRuntimeGuardAgent(t, ctx)
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, explicitly_created_at)
-		VALUES ($1, $2, $3, $4, now())
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID, title).Scan(&sessionID); err != nil {
-		t.Fatalf("setup: create chat session: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, sessionID) })
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": testUserID, "title": title, "explicitly_created_at": testutil.Raw("now()")})
 	return agentID, sessionID, runtimeID, daemonID
 }
 

--- a/server/internal/handler/chat_pending_tasks_test.go
+++ b/server/internal/handler/chat_pending_tasks_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -38,16 +39,7 @@ func chatPendingCtxAs(t *testing.T, req *http.Request, userID string) *http.Requ
 func insertChatSessionAs(t *testing.T, agentID, creatorID string) string {
 	t.Helper()
 	var sessionID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status)
-		VALUES ($1, $2, $3, 'pending-tasks-test', 'active')
-		RETURNING id
-	`, testWorkspaceID, agentID, creatorID).Scan(&sessionID); err != nil {
-		t.Fatalf("insert chat session: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID)
-	})
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": creatorID, "title": testutil.Raw("'pending-tasks-test'"), "status": testutil.Raw("'active'")})
 	return sessionID
 }
 
@@ -56,16 +48,7 @@ func insertChatSessionAs(t *testing.T, agentID, creatorID string) string {
 func insertPendingChatTask(t *testing.T, agentID, sessionID, status string) string {
 	t.Helper()
 	var taskID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, chat_session_id)
-		VALUES ($1, $2, $3, 0, $4)
-		RETURNING id
-	`, agentID, handlerTestRuntimeID(t), status, sessionID).Scan(&taskID); err != nil {
-		t.Fatalf("insert pending chat task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": handlerTestRuntimeID(t), "status": status, "priority": testutil.Raw("0"), "chat_session_id": sessionID})
 	return taskID
 }
 
@@ -90,30 +73,13 @@ func insertQueuedChatInputWithAttachment(
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM chat_draft_restore WHERE id = $1`, messageID)
 	})
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO attachment (
-			workspace_id, uploader_type, uploader_id, filename, url,
-			content_type, size_bytes, chat_session_id, chat_message_id
-		)
-		VALUES (
-			$1, 'member', $2, 'queued.png', 'https://cdn.example.com/queued.png',
-			'image/png', 9, $3, $4
-		)
-		RETURNING id
-	`, testWorkspaceID, testUserID, sessionID, messageID).Scan(&attachmentID); err != nil {
-		t.Fatalf("insert queued attachment: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID)
-	})
+	attachmentID = dbfx.Insert(t, "attachment", testutil.Cols{"workspace_id": testWorkspaceID, "uploader_type": testutil.Raw("'member'"), "uploader_id": testUserID, "filename": testutil.Raw("'queued.png'"), "url": testutil.Raw("'https://cdn.example.com/queued.png'"), "content_type": testutil.Raw("'image/png'"), "size_bytes": testutil.Raw("9"), "chat_session_id": sessionID, "chat_message_id": messageID})
 	return taskID, messageID, attachmentID
 }
 
 func decodePendingTasks(t *testing.T, w *httptest.ResponseRecorder) PendingChatTasksResponse {
 	t.Helper()
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp PendingChatTasksResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode pending tasks: %v", err)
@@ -123,9 +89,7 @@ func decodePendingTasks(t *testing.T, w *httptest.ResponseRecorder) PendingChatT
 
 func decodeHasPending(t *testing.T, w *httptest.ResponseRecorder) bool {
 	t.Helper()
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp HasPendingChatTasksResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode has-any: %v", err)
@@ -233,9 +197,7 @@ func TestGetPendingChatTask_ReturnsActiveHeadAndFIFOQueue(t *testing.T) {
 	w := httptest.NewRecorder()
 	testHandler.GetPendingChatTask(w, chatPendingCtxAs(t, req, testUserID))
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp PendingChatTaskResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode pending task queue: %v", err)
@@ -274,18 +236,9 @@ func TestGetPendingChatTask_ReturnsActiveHeadAndFIFOQueue(t *testing.T) {
 		"sessionId", sessionID,
 		"taskId", laterID,
 	)
-	prioritizeW := httptest.NewRecorder()
-	testHandler.PrioritizeQueuedChatTask(
-		prioritizeW,
-		chatPendingCtxAs(t, prioritizeReq, testUserID),
-	)
-	if prioritizeW.Code != http.StatusOK {
-		t.Fatalf("expected prioritize 200, got %d: %s", prioritizeW.Code, prioritizeW.Body.String())
-	}
+	prioritizeW := testutil.Call(t, testHandler.PrioritizeQueuedChatTask, chatPendingCtxAs(t, prioritizeReq, testUserID)).Want(http.StatusOK)
 	var prioritized PrioritizeQueuedChatTaskResponse
-	if err := json.Unmarshal(prioritizeW.Body.Bytes(), &prioritized); err != nil {
-		t.Fatalf("decode prioritize response: %v", err)
-	}
+	prioritizeW.JSON(&prioritized)
 	if prioritized.TaskID != laterID || prioritized.ActiveTaskID != activeID {
 		t.Fatalf("prioritize response is not server-authoritative: %+v", prioritized)
 	}
@@ -474,17 +427,11 @@ func TestPrioritizeQueuedChatTask_StaleTargetPreservesExistingPriority(t *testin
 		"sessionId", sessionID,
 		"taskId", staleID,
 	)
-	w := httptest.NewRecorder()
-	testHandler.PrioritizeQueuedChatTask(w, chatPendingCtxAs(t, req, testUserID))
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.PrioritizeQueuedChatTask, chatPendingCtxAs(t, req, testUserID)).Want(http.StatusConflict)
 	var conflictBody struct {
 		Error string `json:"error"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &conflictBody); err != nil {
-		t.Fatalf("decode stale-task conflict: %v", err)
-	}
+	w.JSON(&conflictBody)
 	if conflictBody.Error != "task is no longer queued" {
 		t.Fatalf("stale-task error = %q", conflictBody.Error)
 	}
@@ -530,17 +477,11 @@ func TestPrioritizeQueuedChatTask_RejectsWhileVisibleHeadIsUnclaimed(t *testing.
 		"sessionId", sessionID,
 		"taskId", targetID,
 	)
-	w := httptest.NewRecorder()
-	testHandler.PrioritizeQueuedChatTask(w, chatPendingCtxAs(t, req, testUserID))
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.PrioritizeQueuedChatTask, chatPendingCtxAs(t, req, testUserID)).Want(http.StatusConflict)
 	var conflictBody struct {
 		Error string `json:"error"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &conflictBody); err != nil {
-		t.Fatalf("decode unclaimed-head conflict: %v", err)
-	}
+	w.JSON(&conflictBody)
 	if conflictBody.Error != "there is no active reply to replace" {
 		t.Fatalf("unclaimed-head error = %q", conflictBody.Error)
 	}
@@ -582,11 +523,7 @@ func TestPrioritizeQueuedChatTask_BroadcastsQueueInvalidation(t *testing.T) {
 		"sessionId", sessionID,
 		"taskId", taskID,
 	)
-	w := httptest.NewRecorder()
-	testHandler.PrioritizeQueuedChatTask(w, chatPendingCtxAs(t, req, testUserID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.PrioritizeQueuedChatTask, chatPendingCtxAs(t, req, testUserID)).Want(http.StatusOK)
 
 	select {
 	case event := <-got:
@@ -635,11 +572,7 @@ func TestClearQueuedChatTasks_PreservesUnclaimedHeadAndDeletesFollowUps(t *testi
 		"sessionId",
 		sessionID,
 	)
-	w := httptest.NewRecorder()
-	testHandler.ClearQueuedChatTasks(w, chatPendingCtxAs(t, req, testUserID))
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ClearQueuedChatTasks, chatPendingCtxAs(t, req, testUserID)).Want(http.StatusNoContent)
 
 	if got := taskStatus(t, taskIDs[0]); got != "queued" {
 		t.Fatalf("unclaimed head status = %q, want queued", got)

--- a/server/internal/handler/chat_project_context_test.go
+++ b/server/internal/handler/chat_project_context_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func createChatProjectTestProject(t *testing.T, workspaceID, title, description string) string {
@@ -31,18 +32,7 @@ func createChatSessionWithProjectForTest(t *testing.T, agentID, projectID string
 	t.Helper()
 
 	var sessionID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO chat_session (
-			workspace_id, agent_id, creator_id, title, status, project_id, explicitly_created_at
-		)
-		VALUES ($1, $2, $3, 'Project context chat', 'active', $4, now())
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID, projectID).Scan(&sessionID); err != nil {
-		t.Fatalf("create chat session: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID)
-	})
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": testUserID, "title": testutil.Raw("'Project context chat'"), "status": testutil.Raw("'active'"), "project_id": projectID, "explicitly_created_at": testutil.Raw("now()")})
 	return sessionID
 }
 
@@ -55,21 +45,16 @@ func TestCreateChatSession_ProjectContext(t *testing.T) {
 	projectID := createChatProjectTestProject(t, testWorkspaceID, "Chat project", "Durable context")
 
 	t.Run("persists a workspace project", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := withChatTestWorkspaceCtx(t, newRequest(http.MethodPost, "/api/chat/sessions", map[string]any{
 			"agent_id":   agentID,
 			"title":      "with project",
 			"project_id": projectID,
 		}))
-		testHandler.CreateChatSession(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateChatSession: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateChatSession, req).Want(http.StatusCreated)
 
 		var response ChatSessionResponse
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&response)
 		t.Cleanup(func() {
 			testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, response.ID)
 		})
@@ -87,16 +72,10 @@ func TestCreateChatSession_ProjectContext(t *testing.T) {
 			t.Fatalf("stored project_id = %v, want %s", storedProjectID, projectID)
 		}
 
-		listW := httptest.NewRecorder()
 		listReq := withChatTestWorkspaceCtx(t, newRequest(http.MethodGet, "/api/chat/sessions", nil))
-		testHandler.ListChatSessions(listW, listReq)
-		if listW.Code != http.StatusOK {
-			t.Fatalf("ListChatSessions: expected 200, got %d: %s", listW.Code, listW.Body.String())
-		}
+		listW := testutil.Call(t, testHandler.ListChatSessions, listReq).Want(http.StatusOK)
 		var sessions []ChatSessionResponse
-		if err := json.NewDecoder(listW.Body).Decode(&sessions); err != nil {
-			t.Fatalf("decode session list: %v", err)
-		}
+		listW.Decode(&sessions)
 		found := false
 		for _, session := range sessions {
 			if session.ID != response.ID {
@@ -113,54 +92,35 @@ func TestCreateChatSession_ProjectContext(t *testing.T) {
 	})
 
 	t.Run("rejects malformed project id", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := withChatTestWorkspaceCtx(t, newRequest(http.MethodPost, "/api/chat/sessions", map[string]any{
 			"agent_id":   agentID,
 			"project_id": "not-a-uuid",
 		}))
-		testHandler.CreateChatSession(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateChatSession, req).Want(http.StatusBadRequest)
 	})
 
 	t.Run("rejects a project from another workspace", func(t *testing.T) {
 		var foreignWorkspaceID string
-		if err := testPool.QueryRow(context.Background(), `
-			INSERT INTO workspace (name, slug) VALUES ('Foreign chat context', $1) RETURNING id
-		`, "chat-context-"+uuid.NewString()).Scan(&foreignWorkspaceID); err != nil {
-			t.Fatalf("create foreign workspace: %v", err)
-		}
-		t.Cleanup(func() {
-			testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-		})
+		foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": testutil.Raw("'Foreign chat context'"), "slug": "chat-context-" + uuid.NewString()})
 		foreignProjectID := createChatProjectTestProject(t, foreignWorkspaceID, "Foreign project", "")
 
-		w := httptest.NewRecorder()
 		req := withChatTestWorkspaceCtx(t, newRequest(http.MethodPost, "/api/chat/sessions", map[string]any{
 			"agent_id":   agentID,
 			"project_id": foreignProjectID,
 		}))
-		testHandler.CreateChatSession(w, req)
-		if w.Code != http.StatusNotFound {
-			t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateChatSession, req).Want(http.StatusNotFound)
 	})
 
 	t.Run("keeps project optional", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := withChatTestWorkspaceCtx(t, newRequest(http.MethodPost, "/api/chat/sessions", map[string]any{
 			"agent_id": agentID,
 			"title":    "workspace context only",
 		}))
-		testHandler.CreateChatSession(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateChatSession: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateChatSession, req).Want(http.StatusCreated)
 		var response ChatSessionResponse
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&response)
 		t.Cleanup(func() {
 			testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, response.ID)
 		})
@@ -195,9 +155,7 @@ func TestUpdateChatSession_UpdatesProjectContext(t *testing.T) {
 	}
 
 	w := updateProject(replacementProjectID)
-	if w.Code != http.StatusOK {
-		t.Fatalf("replace project: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var response ChatSessionResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -210,24 +168,13 @@ func TestUpdateChatSession_UpdatesProjectContext(t *testing.T) {
 	}
 
 	var foreignWorkspaceID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO workspace (name, slug) VALUES ('Foreign chat update', $1) RETURNING id
-	`, "chat-update-"+uuid.NewString()).Scan(&foreignWorkspaceID); err != nil {
-		t.Fatalf("create foreign workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-	})
+	foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": testutil.Raw("'Foreign chat update'"), "slug": "chat-update-" + uuid.NewString()})
 	foreignProjectID := createChatProjectTestProject(t, foreignWorkspaceID, "Foreign replacement", "")
 	foreignW := updateProject(foreignProjectID)
-	if foreignW.Code != http.StatusNotFound {
-		t.Fatalf("foreign project: expected 404, got %d: %s", foreignW.Code, foreignW.Body.String())
-	}
+	testutil.Equal(t, foreignW.Code, http.StatusNotFound, "HTTP status")
 
 	w = updateProject(nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("remove project: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	response = ChatSessionResponse{}
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("decode remove response: %v", err)
@@ -256,16 +203,12 @@ func TestDeleteProject_ClearsChatSessionContext(t *testing.T) {
 	agentID := createHandlerTestAgent(t, "DeletedChatProjectAgent", []byte("[]"))
 	sessionID := createChatSessionWithProjectForTest(t, agentID, projectID)
 
-	w := httptest.NewRecorder()
 	req := withURLParam(
 		newRequest(http.MethodDelete, "/api/projects/"+projectID, nil),
 		"id",
 		projectID,
 	)
-	testHandler.DeleteProject(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteProject: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteProject, req).Want(http.StatusNoContent)
 
 	var storedProjectID *string
 	if err := testPool.QueryRow(context.Background(), `
@@ -314,19 +257,8 @@ func TestClaimTaskByRuntime_ChatProjectContext(t *testing.T) {
 	}
 
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (
-			agent_id, runtime_id, status, priority, chat_session_id
-		) VALUES ($1, $2, 'queued', 1000, $3)
-		RETURNING id
-	`, agentID, runtimeID, sessionID).Scan(&taskID); err != nil {
-		t.Fatalf("create chat task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("1000"), "chat_session_id": sessionID})
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest(
 		http.MethodPost,
 		"/api/daemon/runtimes/"+runtimeID+"/claim",
@@ -335,10 +267,7 @@ func TestClaimTaskByRuntime_ChatProjectContext(t *testing.T) {
 		"chat-project-context-test",
 	)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 
 	var response struct {
 		Task *struct {
@@ -350,9 +279,7 @@ func TestClaimTaskByRuntime_ChatProjectContext(t *testing.T) {
 			Repos              []RepoData            `json:"repos"`
 		} `json:"task"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&response)
 	if response.Task == nil || response.Task.ID != taskID {
 		t.Fatalf("claimed task = %+v, want %s", response.Task, taskID)
 	}

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -44,15 +44,9 @@ func TestSendChatMessage_ReportsPositionInsteadOfQueuedStatus(t *testing.T) {
 		})
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SendChatMessage(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("SendChatMessage: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.SendChatMessage, req).Want(http.StatusCreated)
 		var response SendChatMessageResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-			t.Fatalf("decode send response: %v", err)
-		}
+		w.JSON(&response)
 		return response
 	}
 
@@ -79,15 +73,9 @@ func TestSendChatMessage_DeferredPredecessorStaysHeadAcrossPromotion(t *testing.
 		})
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SendChatMessage(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("SendChatMessage: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.SendChatMessage, req).Want(http.StatusCreated)
 		var response SendChatMessageResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-			t.Fatalf("decode send response: %v", err)
-		}
+		w.JSON(&response)
 		return response
 	}
 
@@ -155,15 +143,9 @@ func TestSendChatMessage_LinksAttachments(t *testing.T) {
 	uploadReq.Header.Set("X-User-ID", testUserID)
 	uploadReq.Header.Set("X-Workspace-ID", testWorkspaceID)
 
-	uploadW := httptest.NewRecorder()
-	testHandler.UploadFile(uploadW, uploadReq)
-	if uploadW.Code != http.StatusOK {
-		t.Fatalf("upload precondition: %d %s", uploadW.Code, uploadW.Body.String())
-	}
+	uploadW := testutil.Call(t, testHandler.UploadFile, uploadReq).Want(http.StatusOK)
 	var uploadResp AttachmentResponse
-	if err := json.Unmarshal(uploadW.Body.Bytes(), &uploadResp); err != nil {
-		t.Fatalf("decode upload: %v", err)
-	}
+	uploadW.JSON(&uploadResp)
 	attachmentID := uploadResp.ID
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID)
@@ -176,16 +158,10 @@ func TestSendChatMessage_LinksAttachments(t *testing.T) {
 	})
 	sendReq = withURLParam(sendReq, "sessionId", sessionID)
 	sendReq = withChatTestWorkspaceCtx(t, sendReq)
-	sendW := httptest.NewRecorder()
-	testHandler.SendChatMessage(sendW, sendReq)
-	if sendW.Code != http.StatusCreated {
-		t.Fatalf("SendChatMessage: expected 201, got %d: %s", sendW.Code, sendW.Body.String())
-	}
+	sendW := testutil.Call(t, testHandler.SendChatMessage, sendReq).Want(http.StatusCreated)
 
 	var sendResp SendChatMessageResponse
-	if err := json.Unmarshal(sendW.Body.Bytes(), &sendResp); err != nil {
-		t.Fatalf("decode send: %v", err)
-	}
+	sendW.JSON(&sendResp)
 	if sendResp.MessageID == "" {
 		t.Fatal("expected non-empty message_id in send response")
 	}
@@ -245,12 +221,7 @@ func TestSendChatMessage_ArchivedAgent(t *testing.T) {
 	})
 	sendReq = withURLParam(sendReq, "sessionId", sessionID)
 	sendReq = withChatTestWorkspaceCtx(t, sendReq)
-	sendW := httptest.NewRecorder()
-	testHandler.SendChatMessage(sendW, sendReq)
-
-	if sendW.Code != http.StatusConflict {
-		t.Fatalf("SendChatMessage to archived agent: expected 409, got %d: %s", sendW.Code, sendW.Body.String())
-	}
+	testutil.Call(t, testHandler.SendChatMessage, sendReq).Want(http.StatusConflict)
 
 	// The rejected send must not have persisted an orphan user message.
 	var count int
@@ -288,15 +259,9 @@ func TestSendChatMessage_LinksUnattachedAttachments(t *testing.T) {
 	uploadReq.Header.Set("X-User-ID", testUserID)
 	uploadReq.Header.Set("X-Workspace-ID", testWorkspaceID)
 
-	uploadW := httptest.NewRecorder()
-	testHandler.UploadFile(uploadW, uploadReq)
-	if uploadW.Code != http.StatusOK {
-		t.Fatalf("upload precondition: %d %s", uploadW.Code, uploadW.Body.String())
-	}
+	uploadW := testutil.Call(t, testHandler.UploadFile, uploadReq).Want(http.StatusOK)
 	var uploadResp AttachmentResponse
-	if err := json.Unmarshal(uploadW.Body.Bytes(), &uploadResp); err != nil {
-		t.Fatalf("decode upload: %v", err)
-	}
+	uploadW.JSON(&uploadResp)
 	attachmentID := uploadResp.ID
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, attachmentID)
@@ -314,16 +279,10 @@ func TestSendChatMessage_LinksUnattachedAttachments(t *testing.T) {
 	})
 	sendReq = withURLParam(sendReq, "sessionId", sessionID)
 	sendReq = withChatTestWorkspaceCtx(t, sendReq)
-	sendW := httptest.NewRecorder()
-	testHandler.SendChatMessage(sendW, sendReq)
-	if sendW.Code != http.StatusCreated {
-		t.Fatalf("SendChatMessage: expected 201, got %d: %s", sendW.Code, sendW.Body.String())
-	}
+	sendW := testutil.Call(t, testHandler.SendChatMessage, sendReq).Want(http.StatusCreated)
 
 	var sendResp SendChatMessageResponse
-	if err := json.Unmarshal(sendW.Body.Bytes(), &sendResp); err != nil {
-		t.Fatalf("decode send: %v", err)
-	}
+	sendW.JSON(&sendResp)
 
 	var dbSessionID, dbMessageID *string
 	if err := testPool.QueryRow(
@@ -352,16 +311,10 @@ func TestUpdateChatSession_RenamesTitle(t *testing.T) {
 	})
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.UpdateChatSession(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateChatSession: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateChatSession, req).Want(http.StatusOK)
 
 	var resp ChatSessionResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode update: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Title != "Renamed Session" {
 		t.Fatalf("response title: want %q, got %q", "Renamed Session", resp.Title)
 	}
@@ -401,15 +354,12 @@ func TestSetChatSessionPinned_TogglesPin(t *testing.T) {
 		})
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SetChatSessionPinned(w, req)
+		w := testutil.Call(t, testHandler.SetChatSessionPinned, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("SetChatSessionPinned(%v): expected 200, got %d: %s", pinned, w.Code, w.Body.String())
 		}
 		var resp ChatSessionResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode pin: %v", err)
-		}
+		w.JSON(&resp)
 		return resp
 	}
 
@@ -462,15 +412,12 @@ func TestSetChatSessionArchived_TogglesStatus(t *testing.T) {
 		})
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SetChatSessionArchived(w, req)
+		w := testutil.Call(t, testHandler.SetChatSessionArchived, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("SetChatSessionArchived(%v): expected 200, got %d: %s", archived, w.Code, w.Body.String())
 		}
 		var resp ChatSessionResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode archive: %v", err)
-		}
+		w.JSON(&resp)
 		return resp
 	}
 
@@ -514,11 +461,7 @@ func TestUpdateChatSession_RejectsBlank(t *testing.T) {
 	})
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.UpdateChatSession(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("UpdateChatSession blank: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateChatSession, req).Want(http.StatusBadRequest)
 }
 
 // TestSendChatMessage_InvalidAttachmentIDs rejects malformed UUIDs in
@@ -533,11 +476,7 @@ func TestSendChatMessage_InvalidAttachmentIDs(t *testing.T) {
 	})
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.SendChatMessage(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("SendChatMessage with bad attachment id: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SendChatMessage, req).Want(http.StatusBadRequest)
 
 	// Confirm no message row was created.
 	var count int
@@ -563,15 +502,9 @@ func fetchChatMessagesPageForTest(t *testing.T, sessionID string, params url.Val
 	req.Header.Set("X-User-ID", testUserID)
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.ListChatMessagesPage(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListChatMessagesPage: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListChatMessagesPage, req).Want(http.StatusOK)
 	var page ChatMessagesPageResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
-		t.Fatalf("decode page messages: %v", err)
-	}
+	w.JSON(&page)
 	return page
 }
 
@@ -597,15 +530,9 @@ func TestListChatMessagesPage_UsesCursorWithoutChangingLegacyList(t *testing.T) 
 	legacyReq.Header.Set("X-User-ID", testUserID)
 	legacyReq = withURLParam(legacyReq, "sessionId", sessionID)
 	legacyReq = withChatTestWorkspaceCtx(t, legacyReq)
-	legacyW := httptest.NewRecorder()
-	testHandler.ListChatMessages(legacyW, legacyReq)
-	if legacyW.Code != http.StatusOK {
-		t.Fatalf("ListChatMessages: expected 200, got %d: %s", legacyW.Code, legacyW.Body.String())
-	}
+	legacyW := testutil.Call(t, testHandler.ListChatMessages, legacyReq).Want(http.StatusOK)
 	var legacy []ChatMessageResponse
-	if err := json.Unmarshal(legacyW.Body.Bytes(), &legacy); err != nil {
-		t.Fatalf("decode legacy messages: %v", err)
-	}
+	legacyW.JSON(&legacy)
 	if len(legacy) != 3 || legacy[0].Content != "oldest" || legacy[2].Content != "newest" {
 		t.Fatalf("legacy messages = %#v", legacy)
 	}
@@ -705,11 +632,7 @@ func TestListChatMessagesPage_RejectsInvalidLimit(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.ListChatMessagesPage(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("ListChatMessagesPage invalid limit: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ListChatMessagesPage, req).Want(http.StatusBadRequest)
 }
 
 // TestDeleteChatSession_PrunesChannelRows verifies the application-layer
@@ -768,12 +691,7 @@ VALUES ($1, 'feishu', $2, $3, 'final')
 	req.Header.Set("X-User-ID", testUserID)
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)
-	w := httptest.NewRecorder()
-	testHandler.DeleteChatSession(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteChatSession: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteChatSession, req).Want(http.StatusNoContent)
 
 	var bindingExists bool
 	if err := testPool.QueryRow(ctx,
@@ -846,8 +764,7 @@ VALUES ($1, $2, 'feishu', $3, 'p2p')
 		req.Header.Set("X-User-ID", testUserID)
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SetChatSessionArchived(w, req)
+		w := testutil.Call(t, testHandler.SetChatSessionArchived, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("SetChatSessionArchived(%v): expected 200, got %d: %s", archived, w.Code, w.Body.String())
 		}
@@ -915,15 +832,9 @@ func TestListChatSessions_ArchivedSessionReportsZeroUnread(t *testing.T) {
 		t.Helper()
 		req := newRequest("GET", "/api/chat/sessions?status=all", nil)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.ListChatSessions(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListChatSessions: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListChatSessions, req).Want(http.StatusOK)
 		var resp []ChatSessionResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode list: %v", err)
-		}
+		w.JSON(&resp)
 		for _, s := range resp {
 			if s.ID == sessionID {
 				return s.UnreadCount, s.HasUnread
@@ -938,8 +849,7 @@ func TestListChatSessions_ArchivedSessionReportsZeroUnread(t *testing.T) {
 		req := newRequest("PATCH", "/api/chat/sessions/"+sessionID+"/archive", map[string]any{"archived": archived})
 		req = withURLParam(req, "sessionId", sessionID)
 		req = withChatTestWorkspaceCtx(t, req)
-		w := httptest.NewRecorder()
-		testHandler.SetChatSessionArchived(w, req)
+		w := testutil.Call(t, testHandler.SetChatSessionArchived, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("SetChatSessionArchived(%v): expected 200, got %d: %s", archived, w.Code, w.Body.String())
 		}

--- a/server/internal/handler/client_usage_test.go
+++ b/server/internal/handler/client_usage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func ptrInt32(value int32) *int32 { return &value }
@@ -70,9 +71,7 @@ func TestUpsertClientUsageKeepsRuntimeSnapshotOnActivityRefresh(t *testing.T) {
 			"online_count":     1, "offline_count": 0,
 		},
 	})
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("runtime report status = %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 	if w = report(map[string]any{"install_id": installID}); w.Code != http.StatusNoContent {
 		t.Fatalf("activity refresh status = %d: %s", w.Code, w.Body.String())
 	}

--- a/server/internal/handler/cloud_billing_test.go
+++ b/server/internal/handler/cloud_billing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/cloudruntime"
 	"github.com/multica-ai/multica/server/internal/featureflags"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -124,9 +125,7 @@ func TestCloudBillingProxiesForwardCorrectly(t *testing.T) {
 			w := httptest.NewRecorder()
 			tc.invoke(t, w, req)
 
-			if w.Code != http.StatusOK {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 			if !proxy.called {
 				t.Fatal("expected cloud proxy to be called")
 			}
@@ -169,13 +168,7 @@ func TestGetCloudBillingCheckoutSession_AppendsSessionIDToPath(t *testing.T) {
 
 	req := newRequest(http.MethodGet, "/api/cloud-billing/checkout-sessions/cs_test_abc", nil)
 	req = withURLParam(req, "sessionId", "cs_test_abc")
-	w := httptest.NewRecorder()
-
-	testHandler.GetCloudBillingCheckoutSession(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetCloudBillingCheckoutSession, req).Want(http.StatusOK)
 	if proxy.req.Path != "/api/v1/billing/checkout-sessions/cs_test_abc" {
 		t.Errorf("upstream path = %s, want /api/v1/billing/checkout-sessions/cs_test_abc", proxy.req.Path)
 	}
@@ -201,11 +194,7 @@ func TestGetCloudBillingCheckoutSession_RejectsPathTraversal(t *testing.T) {
 		t.Run(sessionID, func(t *testing.T) {
 			req := newRequest(http.MethodGet, "/api/cloud-billing/checkout-sessions/x", nil)
 			req = withURLParam(req, "sessionId", sessionID)
-			w := httptest.NewRecorder()
-			testHandler.GetCloudBillingCheckoutSession(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.GetCloudBillingCheckoutSession, req).Want(http.StatusBadRequest)
 			if proxy.called {
 				t.Fatal("upstream must not be called for invalid session_id")
 			}
@@ -222,12 +211,7 @@ func TestGetCloudBillingCheckoutSession_MissingPathParamReturns400(t *testing.T)
 
 	req := newRequest(http.MethodGet, "/api/cloud-billing/checkout-sessions/", nil)
 	// No URL param injected.
-	w := httptest.NewRecorder()
-	testHandler.GetCloudBillingCheckoutSession(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetCloudBillingCheckoutSession, req).Want(http.StatusBadRequest)
 	if proxy.called {
 		t.Fatal("upstream must not be called when session_id is missing")
 	}
@@ -240,12 +224,7 @@ func TestCloudBillingDisabledReturnsUnavailable(t *testing.T) {
 	useCloudRuntimeProxy(t, &fakeCloudRuntimeProxy{enabled: false})
 
 	req := newRequest(http.MethodGet, "/api/cloud-billing/balance", nil)
-	w := httptest.NewRecorder()
-	testHandler.GetCloudBillingBalance(w, req)
-
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetCloudBillingBalance, req).Want(http.StatusServiceUnavailable)
 }
 
 func withCloudSubscriptionWorkspace(req *http.Request, role string) *http.Request {
@@ -266,12 +245,7 @@ func TestCloudWorkspaceSubscriptionsDisabledByDefault(t *testing.T) {
 			useCloudRuntimeProxy(t, proxy)
 
 			req := withCloudSubscriptionWorkspace(newRequest(http.MethodGet, path, nil), "member")
-			w := httptest.NewRecorder()
-			invoke(w, req)
-
-			if w.Code != http.StatusServiceUnavailable {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, invoke, req).Want(http.StatusServiceUnavailable)
 			if proxy.called {
 				t.Fatal("upstream must not be called while the feature flag is off")
 			}
@@ -344,12 +318,7 @@ func TestCloudWorkspaceSubscriptionReadAndWritesUseScopedPaths(t *testing.T) {
 			if strings.Contains(tc.path, "portal-sessions") {
 				req.Header.Set(idempotencyKeyHeader, "portal-request-1")
 			}
-			w := httptest.NewRecorder()
-			tc.invoke(w, req)
-
-			if w.Code != tc.wantStatus {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.invoke, req).Want(tc.wantStatus)
 			if proxy.req.Method != tc.method || proxy.req.Path != tc.wantPath {
 				t.Fatalf("upstream = %s %s, want %s %s", proxy.req.Method, proxy.req.Path, tc.method, tc.wantPath)
 			}
@@ -385,12 +354,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutInjectsAuthoritativeWorkspaceAn
 	})
 	req.Header.Set(idempotencyKeyHeader, "checkout-header-1")
 	req = withCloudSubscriptionWorkspace(req, "owner")
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionCheckout, req).Want(http.StatusCreated)
 	if proxy.req.Path != "/api/v1/subscriptions/checkout-sessions" || proxy.req.Method != http.MethodPost {
 		t.Fatalf("upstream = %s %s", proxy.req.Method, proxy.req.Path)
 	}
@@ -420,8 +384,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutFailsWhenPayerCannotBeResolved(
 	})
 	req.Header.Set("X-User-ID", "00000000-0000-0000-0000-000000000099")
 	req = withCloudSubscriptionWorkspace(req, "owner")
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+	w := testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionCheckout, req)
 
 	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "failed to resolve checkout payer") {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
@@ -442,8 +405,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutRejectsInvalidPayerID(t *testin
 	})
 	req.Header.Set("X-User-ID", "not-a-uuid")
 	req = withCloudSubscriptionWorkspace(req, "owner")
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+	w := testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionCheckout, req)
 
 	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "invalid user id") {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
@@ -466,8 +428,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutRejectsEmptyPayerEmail(t *testi
 	})
 	req.Header.Set("X-User-ID", emptyEmailUserID)
 	req = withCloudSubscriptionWorkspace(req, "owner")
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
+	w := testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionCheckout, req)
 
 	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "checkout payer email is unavailable") {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
@@ -493,12 +454,7 @@ func TestCreateCloudWorkspaceSubscriptionCheckoutAcceptsHeaderIdempotencyKey(t *
 		"admin",
 	)
 	req.Header.Set(idempotencyKeyHeader, "checkout-header-only")
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionCheckout(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionCheckout, req).Want(http.StatusCreated)
 	var body cloudSubscriptionCheckoutUpstreamRequest
 	if err := json.Unmarshal(proxy.req.Body, &body); err != nil {
 		t.Fatalf("decode upstream body: %v", err)
@@ -522,8 +478,7 @@ func TestCloudWorkspaceSeatPurchaseForwardsOnlyAdditiveConfirmation(t *testing.T
 		"currency":                  "USD",
 		"idempotency_key":           "seat-request-1",
 	}), "admin")
-	w := httptest.NewRecorder()
-	testHandler.PurchaseCloudWorkspaceSubscriptionSeats(w, req)
+	w := testutil.Call(t, testHandler.PurchaseCloudWorkspaceSubscriptionSeats, req)
 
 	if w.Code != http.StatusAccepted || proxy.req.Path != "/api/v1/subscriptions/"+testWorkspaceID+"/seats/purchases" {
 		t.Fatalf("status=%d path=%s body=%s", w.Code, proxy.req.Path, w.Body.String())
@@ -553,8 +508,7 @@ func TestCloudWorkspaceSeatPurchasePreviewUsesAuthoritativePath(t *testing.T) {
 	req := withCloudSubscriptionWorkspace(newRequest(http.MethodPost, "/api/cloud-subscriptions/seats/purchase-preview", map[string]any{
 		"additional_seats": 10_001, "workspace_id": "00000000-0000-0000-0000-000000000002", "target_seats": 999,
 	}), "owner")
-	w := httptest.NewRecorder()
-	testHandler.PreviewCloudWorkspaceSubscriptionSeatPurchase(w, req)
+	w := testutil.Call(t, testHandler.PreviewCloudWorkspaceSubscriptionSeatPurchase, req)
 
 	if w.Code != http.StatusOK || proxy.req.Path != "/api/v1/subscriptions/"+testWorkspaceID+"/seats/purchase-preview" {
 		t.Fatalf("status=%d path=%s body=%s", w.Code, proxy.req.Path, w.Body.String())
@@ -585,11 +539,7 @@ func TestCloudWorkspaceSeatPurchaseRejectsInvalidRequests(t *testing.T) {
 			if tc.header != "" {
 				req.Header.Set(idempotencyKeyHeader, tc.header)
 			}
-			w := httptest.NewRecorder()
-			testHandler.PurchaseCloudWorkspaceSubscriptionSeats(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.PurchaseCloudWorkspaceSubscriptionSeats, req).Want(http.StatusBadRequest)
 			if proxy.called {
 				t.Fatal("invalid request reached upstream")
 			}
@@ -606,12 +556,7 @@ func TestCloudWorkspaceSubscriptionWritesRequireManagerRole(t *testing.T) {
 		newRequest(http.MethodPost, "/api/cloud-subscriptions/portal-sessions", nil),
 		"member",
 	)
-	w := httptest.NewRecorder()
-	testHandler.CreateCloudWorkspaceSubscriptionPortal(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionPortal, req).Want(http.StatusForbidden)
 	if proxy.called {
 		t.Fatal("upstream must not be called for a non-manager member")
 	}
@@ -631,12 +576,7 @@ func TestCloudWorkspaceSubscriptionsRejectMachineActorsAtHandler(t *testing.T) {
 			)
 			req.Header.Set("X-Actor-Source", actorSource)
 			req.Header.Set(idempotencyKeyHeader, "portal-request-1")
-			w := httptest.NewRecorder()
-			testHandler.CreateCloudWorkspaceSubscriptionPortal(w, req)
-
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.CreateCloudWorkspaceSubscriptionPortal, req).Want(http.StatusForbidden)
 			if proxy.called {
 				t.Fatal("upstream must not be called for a machine actor")
 			}
@@ -693,12 +633,7 @@ func TestCloudWorkspaceSubscriptionMutationsValidateLocally(t *testing.T) {
 			if tc.header != "" {
 				req.Header.Set(idempotencyKeyHeader, tc.header)
 			}
-			w := httptest.NewRecorder()
-			tc.invoke(w, req)
-
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, tc.invoke, req).Want(http.StatusBadRequest)
 			if !strings.Contains(w.Body.String(), tc.wantError) {
 				t.Fatalf("body = %s, want error containing %q", w.Body.String(), tc.wantError)
 			}
@@ -739,13 +674,7 @@ func TestStripeWebhookForwardsRawBodyAndSignature(t *testing.T) {
 	req.Header.Set("Stripe-Signature", sig)
 	req.Header.Set("Content-Type", ct)
 	// Deliberately NO X-User-ID — the webhook must work without auth.
-	w := httptest.NewRecorder()
-
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req).Want(http.StatusOK)
 	if !proxy.called {
 		t.Fatal("upstream proxy must be called")
 	}
@@ -788,12 +717,7 @@ func TestStripeWebhookMissingSignatureRejectedLocally(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe",
 		strings.NewReader(`{"id":"evt"}`))
-	w := httptest.NewRecorder()
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
-
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req).Want(http.StatusUnauthorized)
 	if proxy.called {
 		t.Fatal("upstream must NOT be called when Stripe-Signature is missing")
 	}
@@ -817,8 +741,7 @@ func TestStripeWebhookForwardsEmptyBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", http.NoBody)
 	req.Header.Set("Stripe-Signature", "t=1,v1=deadbeef")
-	w := httptest.NewRecorder()
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req)
 
 	if !proxy.called {
 		t.Fatal("upstream must be called even on empty body")
@@ -840,12 +763,7 @@ func TestStripeWebhookRejectsLargeBody(t *testing.T) {
 	body := bytes.NewReader(bytes.Repeat([]byte("a"), maxStripeWebhookBodySize+1))
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", body)
 	req.Header.Set("Stripe-Signature", "t=1,v1=deadbeef")
-	w := httptest.NewRecorder()
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
-
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req).Want(http.StatusRequestEntityTooLarge)
 	if proxy.called {
 		t.Fatal("upstream must not be called for oversized webhook body")
 	}
@@ -860,12 +778,7 @@ func TestStripeWebhookDisabledReturnsUnavailable(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe",
 		strings.NewReader(`{"id":"evt"}`))
 	req.Header.Set("Stripe-Signature", "t=1,v1=deadbeef")
-	w := httptest.NewRecorder()
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
-
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req).Want(http.StatusServiceUnavailable)
 }
 
 // TestStripeWebhookRateLimited pins the per-IP rate-limit fast
@@ -886,12 +799,7 @@ func TestStripeWebhookRateLimited(t *testing.T) {
 		strings.NewReader(`{"id":"evt"}`))
 	req.Header.Set("Stripe-Signature", "t=1,v1=deadbeef")
 	req.RemoteAddr = "203.0.113.7:1234"
-	w := httptest.NewRecorder()
-	testHandler.HandleCloudBillingStripeWebhook(w, req)
-
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleCloudBillingStripeWebhook, req).Want(http.StatusTooManyRequests)
 	if proxy.called {
 		t.Fatal("upstream must not be called when rate limited")
 	}

--- a/server/internal/handler/cloud_runtime_test.go
+++ b/server/internal/handler/cloud_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/cloudruntime"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 type fakeCloudRuntimeProxy struct {
@@ -61,13 +62,7 @@ func TestCreateCloudRuntimeNodeForwardsBody(t *testing.T) {
 		"instance_type": "g5.xlarge",
 	})
 	req.Header.Set("X-Request-ID", "api-request-id")
-	w := httptest.NewRecorder()
-
-	testHandler.CreateCloudRuntimeNode(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateCloudRuntimeNode, req).Want(http.StatusCreated)
 	if !proxy.called {
 		t.Fatal("cloud runtime proxy was not called")
 	}
@@ -89,13 +84,7 @@ func TestCloudRuntimeDisabledReturnsUnavailable(t *testing.T) {
 	useCloudRuntimeProxy(t, &fakeCloudRuntimeProxy{enabled: false})
 
 	req := newRequest(http.MethodGet, "/api/cloud-runtime/nodes", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.ListCloudRuntimeNodes(w, req)
-
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ListCloudRuntimeNodes, req).Want(http.StatusServiceUnavailable)
 }
 
 func TestListCloudRuntimeNodesForwardsQuery(t *testing.T) {
@@ -109,13 +98,7 @@ func TestListCloudRuntimeNodesForwardsQuery(t *testing.T) {
 	useCloudRuntimeProxy(t, proxy)
 
 	req := newRequest(http.MethodGet, "/api/cloud-runtime/nodes?limit=10&offset=20", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.ListCloudRuntimeNodes(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ListCloudRuntimeNodes, req).Want(http.StatusOK)
 	if !proxy.called {
 		t.Fatal("cloud runtime proxy was not called")
 	}
@@ -138,13 +121,7 @@ func TestCloudRuntimeNonJSONResponseIsWrapped(t *testing.T) {
 	useCloudRuntimeProxy(t, proxy)
 
 	req := newRequest(http.MethodGet, "/api/cloud-runtime/healthz", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetCloudRuntimeHealth(w, req)
-
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetCloudRuntimeHealth, req).Want(http.StatusBadGateway)
 	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
 		t.Fatalf("content type = %q", ct)
 	}
@@ -164,13 +141,7 @@ func TestCloudRuntimeEmptyResponseKeepsStatus(t *testing.T) {
 	useCloudRuntimeProxy(t, proxy)
 
 	req := newRequest(http.MethodGet, "/api/cloud-runtime/healthz", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetCloudRuntimeHealth(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetCloudRuntimeHealth, req).Want(http.StatusNoContent)
 	if body := w.Body.String(); body != "" {
 		t.Fatalf("body = %s", body)
 	}
@@ -190,13 +161,7 @@ func TestCreateCloudRuntimeNodeRejectsLargeBody(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/cloud-runtime/nodes", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-User-ID", testUserID)
-	w := httptest.NewRecorder()
-
-	testHandler.CreateCloudRuntimeNode(w, req)
-
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateCloudRuntimeNode, req).Want(http.StatusRequestEntityTooLarge)
 	if proxy.called {
 		t.Fatal("cloud runtime proxy should not be called")
 	}

--- a/server/internal/handler/comment_content_sanitize_test.go
+++ b/server/internal/handler/comment_content_sanitize_test.go
@@ -1,13 +1,12 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -26,21 +25,15 @@ func TestCreateComment_StripsNullBytesInsteadOf500(t *testing.T) {
 	issueID := createTestIssue(t, "null-byte comment fixture (GH #5388)", "todo", "medium")
 	t.Cleanup(func() { deleteTestIssue(t, issueID) })
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "diagnosis body\x00 with a stray NUL byte",
 	})
 	r = withURLParam(r, "id", issueID)
 
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment with NUL byte: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	var body map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&body)
 	got, _ := body["content"].(string)
 	if strings.ContainsRune(got, '\x00') {
 		t.Fatalf("stored content still contains a NUL byte: %q", got)

--- a/server/internal/handler/comment_duplicate_enqueue_race_test.go
+++ b/server/internal/handler/comment_duplicate_enqueue_race_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -386,10 +387,7 @@ func TestCommentEnqueueRaceQueuedWinnerReattributesOriginator(t *testing.T) {
 		t.Fatalf("create M2 user: %v", err)
 	}
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, m2) })
-	if _, err := testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')`, testWorkspaceID, m2); err != nil {
-		t.Fatalf("create M2 member: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM member WHERE user_id = $1`, m2) })
+	dbfx.InsertNoID(t, "member", testutil.Cols{"workspace_id": testWorkspaceID, "user_id": m2, "role": testutil.Raw("'member'")}, "user_id = $1", m2)
 
 	// Winner: a queued task attributed to M1 (testUserID) via its own comment.
 	winnerCommentID := insertDupRaceComment(t, issueID, "M1 instruction", "6 minutes")

--- a/server/internal/handler/comment_list_test.go
+++ b/server/internal/handler/comment_list_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -75,16 +76,7 @@ func newCommentListFixture(t *testing.T) commentListFixture {
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "comment list fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "comment list fixture"})
 
 	base := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
 
@@ -334,16 +326,7 @@ func TestListComments_SummaryClipsContent(t *testing.T) {
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "summary fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "summary fixture"})
 
 	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	insert := func(body string, offset time.Duration) string {
@@ -426,16 +409,7 @@ func TestListComments_RootsOnlySummaryComposes(t *testing.T) {
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "roots+summary fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "roots+summary fixture"})
 
 	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	insert := func(parent *string, body string, offset time.Duration) string {
@@ -517,16 +491,12 @@ func TestListComments_ThreadAnchorErrors(t *testing.T) {
 
 	t.Run("non-uuid thread returns 400", func(t *testing.T) {
 		w, _ := listComments(t, fx.IssueID, "thread=not-a-uuid")
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 	})
 
 	t.Run("unknown thread anchor returns 404", func(t *testing.T) {
 		w, _ := listComments(t, fx.IssueID, "thread=00000000-0000-0000-0000-000000000001")
-		if w.Code != http.StatusNotFound {
-			t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 	})
 }
 
@@ -545,9 +515,7 @@ func TestListComments_ThreadRootWalkFailsClosedAcrossIssueBoundary(t *testing.T)
 	localReplyID := seedCommentRow(t, issueID, base.Add(time.Second), "local anomalous reply", &foreignRootID, nil)
 
 	w, rows := listComments(t, issueID, "thread="+localReplyID)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("cross-issue root walk status = %d, want 404: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 	if rows != nil {
 		t.Fatalf("cross-issue root walk returned rows: %v", ids(rows))
 	}
@@ -597,15 +565,7 @@ func TestListComments_RecentRanksStaleThreadAheadIfRecentlyReplied(t *testing.T)
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3) RETURNING id
-	`, testWorkspaceID, testUserID, "stale-but-fresh fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "stale-but-fresh fixture"})
 
 	base := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
 	insert := func(parent *string, offset time.Duration, body string) string {
@@ -724,15 +684,7 @@ func TestListComments_ThreadCursorStableUnderSameLastActivity(t *testing.T) {
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3) RETURNING id
-	`, testWorkspaceID, testUserID, "thread tie-break fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "thread tie-break fixture"})
 
 	ts := time.Now().UTC().Add(-30 * time.Minute).Truncate(time.Millisecond)
 	insertRoot := func(body string) string {
@@ -1343,9 +1295,7 @@ func TestListComments_ThreadTailZeroReplyCountIsAllowed(t *testing.T) {
 	v.Set("thread", fx.Root1)
 	v.Set("tail", "0")
 	w, rows := listComments(t, fx.IssueID, v.Encode())
-	if w.Code != http.StatusOK {
-		t.Fatalf("tail=0 should succeed, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	eqIDs(t, ids(rows), []string{fx.Root1}, "tail=0 returns only root")
 }
 
@@ -1364,9 +1314,7 @@ func TestListComments_ThreadTailNotFoundReturns404(t *testing.T) {
 	v.Set("thread", "00000000-0000-0000-0000-000000000001")
 	v.Set("tail", "5")
 	w, _ := listComments(t, fx.IssueID, v.Encode())
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404 for unknown anchor, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 	_ = fx
 }
 
@@ -1447,19 +1395,9 @@ func TestCreateCommentPreservesDirectParent(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("requires DB")
 	}
-	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "direct parent fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "direct parent fixture"})
 
 	create := func(parentID, body string) CommentResponse {
 		t.Helper()
@@ -1467,10 +1405,10 @@ func TestCreateCommentPreservesDirectParent(t *testing.T) {
 		if parentID != "" {
 			payload["parent_id"] = parentID
 		}
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/"+issueID+"/comments", payload)
 		req = withURLParam(req, "id", issueID)
-		testHandler.CreateComment(w, req)
+		w := testutil.Call(t, testHandler.CreateComment, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateComment(%q): expected 201, got %d: %s", body, w.Code, w.Body.String())
 		}

--- a/server/internal/handler/comment_merge_failclosed_test.go
+++ b/server/internal/handler/comment_merge_failclosed_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -25,13 +26,7 @@ func TestMergeCommentIntoPendingTask_FailClosedKeepsOriginalSnapshot(t *testing.
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, creator_type, creator_id, assignee_type, assignee_id, priority)
-		VALUES ($1, 'merge fail-closed', 'member', $2, 'agent', $3, 'medium') RETURNING id`,
-		testWorkspaceID, testUserID, agentID).Scan(&issueID); err != nil {
-		t.Fatalf("seed issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'merge fail-closed'"), "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID, "priority": testutil.Raw("'medium'")})
 
 	// cidA: the precise member comment the queued task is attributed to.
 	var cidA string

--- a/server/internal/handler/comment_reply_authz_handler_test.go
+++ b/server/internal/handler/comment_reply_authz_handler_test.go
@@ -2,11 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateComment_TriggeredTaskRejectsTopLevelComment exercises the full
@@ -23,7 +23,6 @@ func TestCreateComment_TriggeredTaskRejectsTopLevelComment(t *testing.T) {
 
 	fx := newRunningSquadLeaderTaskFixture(t)
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
 		"content": "dispatching a squad from this task",
 	})
@@ -31,18 +30,13 @@ func TestCreateComment_TriggeredTaskRejectsTopLevelComment(t *testing.T) {
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", fx.TaskID)
 
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("CreateComment top-level: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusConflict)
 	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 0 {
 		t.Fatalf("expected rejected top-level comment not to be stored, got %d", got)
 	}
 
 	var body map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode error response: %v", err)
-	}
+	w.Decode(&body)
 	msg, _ := body["error"].(string)
 	// Pin the three semantic pieces without locking the exact wording: why it
 	// was rejected, the comment to reply under, and the actionable fix. The last
@@ -69,7 +63,6 @@ func TestCreateComment_TriggeredTaskAllowsReplyUnderTrigger(t *testing.T) {
 
 	fx := newRunningSquadLeaderTaskFixture(t)
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
 		"content":   "replying under the trigger comment",
 		"parent_id": fx.TriggerCommentID,
@@ -78,10 +71,7 @@ func TestCreateComment_TriggeredTaskAllowsReplyUnderTrigger(t *testing.T) {
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", fx.TaskID)
 
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment reply-under-trigger: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 }
 
 // TestCreateComment_TriggeredTaskRejectsForeignParent covers the resumed-session
@@ -108,7 +98,6 @@ func TestCreateComment_TriggeredTaskRejectsForeignParent(t *testing.T) {
 		t.Fatalf("create foreign parent comment: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
 		"content":   "posting under a parent carried over from a previous turn",
 		"parent_id": foreignParentID,
@@ -117,18 +106,13 @@ func TestCreateComment_TriggeredTaskRejectsForeignParent(t *testing.T) {
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", fx.TaskID)
 
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("CreateComment foreign parent: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusConflict)
 	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 0 {
 		t.Fatalf("expected rejected comment not to be stored, got %d", got)
 	}
 
 	var body map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode error response: %v", err)
-	}
+	w.Decode(&body)
 	msg, _ := body["error"].(string)
 	for _, want := range []string{
 		foreignParentID,        // the parent that was refused

--- a/server/internal/handler/comment_resolve_test.go
+++ b/server/internal/handler/comment_resolve_test.go
@@ -2,14 +2,13 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -18,17 +17,15 @@ import (
 // hits.
 func resolveCommentHTTP(t *testing.T, commentID string) CommentResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/comments/"+commentID+"/resolve", nil)
 	r = withURLParam(r, "commentId", commentID)
-	testHandler.ResolveComment(w, r)
+	w := testutil.Call(t, testHandler.ResolveComment, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("resolve %s: status %d: %s", commentID, w.Code, w.Body.String())
 	}
 	var resp CommentResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode resolve response: %v", err)
-	}
+	w.JSON(&resp)
 	return resp
 }
 
@@ -126,16 +123,7 @@ func newResolveTestFixture(t *testing.T) resolveTestFixture {
 	ctx := context.Background()
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "resolve fixture").Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "resolve fixture"})
 
 	base := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
 	insert := func(parent *string, offset time.Duration, body string) string {

--- a/server/internal/handler/comment_touch_issue_test.go
+++ b/server/internal/handler/comment_touch_issue_test.go
@@ -2,10 +2,8 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -38,15 +36,11 @@ func TestCreateComment_BumpsIssueActivity(t *testing.T) {
 	// evaluated per statement and the issue was inserted moments ago.
 	time.Sleep(10 * time.Millisecond)
 
-	w := httptest.NewRecorder()
 	r := withURLParam(
 		newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{"content": "a fresh comment"}),
 		"id", issueID,
 	)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	var after, activityAfter time.Time
 	if err := testPool.QueryRow(ctx, `SELECT updated_at, last_activity_at FROM issue WHERE id = $1`, issueID).Scan(&after, &activityAfter); err != nil {
@@ -213,17 +207,11 @@ func TestCommentMutationEventsCarryIssueRevision(t *testing.T) {
 		deletedEvent = event
 	})
 
-	update := httptest.NewRecorder()
-	h.UpdateComment(update, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
+	update := testutil.Call(t, h.UpdateComment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 		"content": "after",
-	}), "commentId", commentID))
-	if update.Code != http.StatusOK {
-		t.Fatalf("UpdateComment = %d: %s", update.Code, update.Body.String())
-	}
+	}), "commentId", commentID)).Want(http.StatusOK)
 	var response CommentResponse
-	if err := json.NewDecoder(update.Body).Decode(&response); err != nil {
-		t.Fatalf("decode update response: %v", err)
-	}
+	update.Decode(&response)
 	if response.IssueRevision != 2 {
 		t.Fatalf("update response issue_revision = %d, want 2", response.IssueRevision)
 	}
@@ -232,11 +220,7 @@ func TestCommentMutationEventsCarryIssueRevision(t *testing.T) {
 		t.Fatalf("update event issue_revision = %#v, want 2", updatedEvent.Payload)
 	}
 
-	deleted := httptest.NewRecorder()
-	h.DeleteComment(deleted, withURLParam(newRequest(http.MethodDelete, "/api/comments/"+commentID, nil), "commentId", commentID))
-	if deleted.Code != http.StatusNoContent {
-		t.Fatalf("DeleteComment = %d: %s", deleted.Code, deleted.Body.String())
-	}
+	testutil.Call(t, h.DeleteComment, withURLParam(newRequest(http.MethodDelete, "/api/comments/"+commentID, nil), "commentId", commentID)).Want(http.StatusNoContent)
 	deletedPayload, ok := deletedEvent.Payload.(map[string]any)
 	if !ok || deletedPayload["issue_revision"] != int64(3) {
 		t.Fatalf("delete event issue_revision = %#v, want 3", deletedEvent.Payload)

--- a/server/internal/handler/comment_trigger_outcomes_test.go
+++ b/server/internal/handler/comment_trigger_outcomes_test.go
@@ -2,11 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func findCommentOutcome(t *testing.T, outcomes []CommentTriggerOutcome, targetID string) CommentTriggerOutcome {
@@ -57,16 +57,11 @@ func TestCreateComment_MixedMentionSurfacesPartialTriggerOutcomes(t *testing.T) 
 	}
 
 	// Create the comment: it must save (201) and report partial outcomes.
-	w := httptest.NewRecorder()
+
 	r := withURLParam(newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{"content": content}), "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201 (comment must save despite blocked mention), got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	var resp CommentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode comment: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.ID == "" {
 		t.Fatal("comment was not saved")
 	}
@@ -158,16 +153,10 @@ func TestCreateComment_AgentAndSameLeaderSquad(t *testing.T) {
 			squadID := createCommentTriggerPreviewSquad(t, "Shared Leader Squad "+tc.name, agentID)
 			issueID := createCommentTriggerPreviewIssue(t, "same-leader "+tc.name, "", "")
 
-			w := httptest.NewRecorder()
 			r := withURLParam(newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{"content": tc.content(agentID, squadID)}), "id", issueID)
-			testHandler.CreateComment(w, r)
-			if w.Code != http.StatusCreated {
-				t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 			var resp CommentResponse
-			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-				t.Fatalf("decode comment: %v", err)
-			}
+			w.Decode(&resp)
 
 			// One coalesced execution carrying the leader role for squad S.
 			var taskCount int
@@ -219,16 +208,10 @@ func TestCreateComment_TwoSquadsSharingLeaderCoalescesNonWinner(t *testing.T) {
 	issueID := createCommentTriggerPreviewIssue(t, "two squads sharing leader", "", "")
 	content := fmt.Sprintf("[@S1](mention://squad/%s) [@S2](mention://squad/%s) please", squad1, squad2)
 
-	w := httptest.NewRecorder()
 	r := withURLParam(newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{"content": content}), "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	var resp CommentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode comment: %v", err)
-	}
+	w.Decode(&resp)
 
 	// Exactly one queued task (a single leader agent can only run once).
 	if got := countQueuedCommentTriggerTasks(t, issueID, leaderID); got != 1 {
@@ -279,19 +262,14 @@ func TestCreateComment_SquadLeaderSelfMentionCompletedTaskDoesNotFakeSuccess(t *
 	}
 
 	content := fmt.Sprintf("[@S](mention://squad/%s) revisit please", squadID)
-	w := httptest.NewRecorder()
+
 	r := withURLParam(newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{"content": content}), "id", issueID)
 	// Author the comment AS the leader agent (A2A self-mention).
 	r.Header.Set("X-Agent-ID", leaderID)
 	r.Header.Set("X-Task-ID", completedTaskID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	var resp CommentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode comment: %v", err)
-	}
+	w.Decode(&resp)
 
 	// The self-mention neither re-fired the leader nor is covered by an active
 	// run: the outcome is non-success, never a fake `deferred`.

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -55,36 +54,24 @@ func createCommentTriggerPreviewIssue(t *testing.T, title string, assigneeType, 
 func previewCommentTriggersForTest(t *testing.T, issueID string, body any) CommentTriggerPreviewResponse {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	r := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments/trigger-preview", body)
 	r = withURLParam(r, "id", issueID)
-	testHandler.PreviewCommentTriggers(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PreviewCommentTriggers: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.PreviewCommentTriggers, r).Want(http.StatusOK)
 
 	var resp CommentTriggerPreviewResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode preview response: %v", err)
-	}
+	w.Decode(&resp)
 	return resp
 }
 
 func postCommentForTriggerPreviewTest(t *testing.T, issueID string, body map[string]any) string {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	r := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", body)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	var resp CommentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode created comment: %v", err)
-	}
+	w.Decode(&resp)
 	return resp.ID
 }
 
@@ -105,13 +92,9 @@ func insertMemberRootCommentForTriggerPreviewTest(t *testing.T, issueID, content
 func updateCommentForTriggerPreviewTest(t *testing.T, commentID string, body map[string]any) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	r := newRequest(http.MethodPut, "/api/comments/"+commentID, body)
 	r = withURLParam(r, "commentId", commentID)
-	testHandler.UpdateComment(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateComment: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateComment, r).Want(http.StatusOK)
 }
 
 func countQueuedCommentTriggerTasks(t *testing.T, issueID, agentID string) int {
@@ -144,16 +127,7 @@ func createCommentTriggerPreviewSquad(t *testing.T, name, leaderID string) strin
 	t.Helper()
 
 	var squadID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, name, leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": name, "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 	return squadID
 }
 
@@ -522,7 +496,6 @@ func TestCreateComment_TopLevelNewThreadFallsBackToAssignee(t *testing.T) {
 		t.Fatalf("complete initial conversation task: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	r := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{
 		"content":   "Pong",
 		"parent_id": rootID,
@@ -530,10 +503,7 @@ func TestCreateComment_TopLevelNewThreadFallsBackToAssignee(t *testing.T) {
 	r = withURLParam(r, "id", issueID)
 	r.Header.Set("X-Agent-ID", conversationAgentID)
 	r.Header.Set("X-Task-ID", conversationTaskID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("agent reply: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	followUpContent := "人生的意义是什么?"
 	preview := previewCommentTriggersForTest(t, issueID, CommentTriggerPreviewRequest{
@@ -778,7 +748,6 @@ func TestCreateComment_ParentAgentReplyCancelsPromotedFallbackBeforeClaim(t *tes
 		t.Fatalf("queued assignee fallback before parent ack = %d, want 1", got)
 	}
 
-	w := httptest.NewRecorder()
 	r := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{
 		"content":   "acknowledged",
 		"parent_id": memberReplyID,
@@ -786,10 +755,7 @@ func TestCreateComment_ParentAgentReplyCancelsPromotedFallbackBeforeClaim(t *tes
 	r = withURLParam(r, "id", issueID)
 	r.Header.Set("X-Agent-ID", parentAgentID)
 	r.Header.Set("X-Task-ID", primaryTaskID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("agent ack comment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	if got := countCommentTriggerTasksWithStatus(t, issueID, assigneeID, "deferred"); got != 0 {
 		t.Fatalf("deferred assignee fallback after parent ack = %d, want 0", got)
@@ -1321,20 +1287,10 @@ func TestPreviewCommentTriggers_AssignedSquadLeaderAndSuppress(t *testing.T) {
 		t.Skip("database not available")
 	}
 
-	ctx := context.Background()
 	leaderID := createHandlerTestAgent(t, "Preview Squad Leader", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, "Preview Trigger Squad", leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Preview Trigger Squad", "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	issueID := createCommentTriggerPreviewIssue(t, "comment trigger squad assignee", "squad", squadID)
 
@@ -1363,20 +1319,10 @@ func TestPreviewCommentTriggers_MentionedSquadLeaderAndSuppress(t *testing.T) {
 		t.Skip("database not available")
 	}
 
-	ctx := context.Background()
 	leaderID := createHandlerTestAgent(t, "Preview Mentioned Squad Leader", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, "Preview Mentioned Trigger Squad", leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Preview Mentioned Trigger Squad", "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	issueID := createCommentTriggerPreviewIssue(t, "comment trigger mentioned squad", "", "")
 	content := fmt.Sprintf("[@Squad](mention://squad/%s) please take this", squadID)

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -22,15 +22,9 @@ func TestGetConfigReportsCdnSignedMode(t *testing.T) {
 	fetch := func() AppConfig {
 		t.Helper()
 		req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-		w := httptest.NewRecorder()
-		testHandler.GetConfig(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 		var cfg AppConfig
-		if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-			t.Fatalf("decode config: %v", err)
-		}
+		w.JSON(&cfg)
 		return cfg
 	}
 
@@ -65,17 +59,10 @@ func TestGetConfigIncludesRuntimeAuthConfig(t *testing.T) {
 	t.Setenv("MULTICA_APP_URL", "https://app.example.com/")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 
 	if cfg.CdnDomain != "cdn.example.com" {
 		t.Fatalf("cdn_domain: want cdn.example.com, got %q", cfg.CdnDomain)
@@ -129,15 +116,9 @@ func TestGetConfigHonorsVCSIntegrationSwitch(t *testing.T) {
 	fetch := func() map[string]json.RawMessage {
 		t.Helper()
 		req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-		w := httptest.NewRecorder()
-		testHandler.GetConfig(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 		var cfg map[string]json.RawMessage
-		if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-			t.Fatalf("decode config: %v", err)
-		}
+		w.JSON(&cfg)
 		return cfg
 	}
 
@@ -162,17 +143,10 @@ func TestGetConfigUsesAppURLForSameOriginDaemonSetup(t *testing.T) {
 	t.Setenv("MULTICA_APP_URL", "https://multica.internal.example/")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if cfg.DaemonServerURL != "https://multica.internal.example" {
 		t.Fatalf("daemon_server_url: want same-origin URL, got %q", cfg.DaemonServerURL)
 	}
@@ -188,17 +162,10 @@ func TestGetConfigUsesFrontendOriginForSameOriginDaemonSetup(t *testing.T) {
 	t.Setenv("FRONTEND_ORIGIN", "https://multica.internal.example/")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if cfg.DaemonServerURL != "https://multica.internal.example" {
 		t.Fatalf("daemon_server_url: want same-origin URL, got %q", cfg.DaemonServerURL)
 	}
@@ -213,17 +180,10 @@ func TestGetConfigOmitsOfficialCloudDaemonSetup(t *testing.T) {
 	t.Setenv("FRONTEND_ORIGIN", "https://multica.ai")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if cfg.DaemonServerURL != "" {
 		t.Fatalf("daemon_server_url: want omitted for cloud, got %q", cfg.DaemonServerURL)
 	}
@@ -247,17 +207,10 @@ func TestGetConfigOmitsCloudDaemonSetupWithoutPublicURL(t *testing.T) {
 	t.Setenv("FRONTEND_ORIGIN", "https://multica.ai")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if cfg.DaemonServerURL != "" {
 		t.Fatalf("daemon_server_url: want omitted for official cloud, got %q", cfg.DaemonServerURL)
 	}
@@ -274,17 +227,10 @@ func TestGetConfigOmitsCloudDaemonSetupForConfiguredAppURL(t *testing.T) {
 	t.Setenv("FRONTEND_ORIGIN", "")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if cfg.DaemonServerURL != "" {
 		t.Fatalf("daemon_server_url: want omitted for official cloud, got %q", cfg.DaemonServerURL)
 	}
@@ -327,17 +273,10 @@ func TestGetConfigExposesWorkspaceCreationDisabled(t *testing.T) {
 	t.Setenv("DISABLE_WORKSPACE_CREATION", "true")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if !cfg.WorkspaceCreationDisabled {
 		t.Fatalf("workspace_creation_disabled: want true with env on, got false (body=%s)", w.Body.String())
 	}
@@ -359,9 +298,7 @@ func TestGetConfigExposesServerVersion(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
 	w := httptest.NewRecorder()
 	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var cfg AppConfig
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("decode config: %v", err)
@@ -422,9 +359,7 @@ func TestGetConfigExposesFrontendFeatureFlags(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
 	w := httptest.NewRecorder()
 	h.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig default flags: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var cfg AppConfig
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("decode default config: %v", err)
@@ -460,9 +395,7 @@ func TestGetConfigExposesFrontendFeatureFlags(t *testing.T) {
 	withComposioMCPAppsFlag(t, h, true)
 	w = httptest.NewRecorder()
 	h.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig enabled flags: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("decode enabled config: %v", err)
 	}
@@ -476,15 +409,9 @@ func TestGetConfigExposesEnabledPluginsV1Flag(t *testing.T) {
 	withPluginsV1Flag(t, h, true)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-	h.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig enabled plugins_v1: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, h.GetConfig, req).Want(http.StatusOK)
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode enabled config: %v", err)
-	}
+	w.JSON(&cfg)
 	if !cfg.FeatureFlags["plugins_v1"] {
 		t.Fatal("plugins_v1: want true with flag enabled, got false")
 	}
@@ -498,24 +425,16 @@ func TestGetConfigExposesEnabledPluginsV1Flag(t *testing.T) {
 // flag, all of which would disable worktree mode for the users who can run it.
 func TestGetConfigDeclaresLocalWorktreeSupport(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if !cfg.LocalWorktreeSupported {
 		t.Fatal("this build runs the worktree save gate but does not advertise it; clients will hide the mode")
 	}
 	// Serialised as a real key, not omitted when false-by-accident: the client
 	// distinguishes "absent" (old server) from an explicit answer.
 	var raw map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode raw config: %v", err)
-	}
+	w.JSON(&raw)
 	if _, ok := raw["local_worktree_supported"]; !ok {
 		t.Fatal("local_worktree_supported missing from the JSON body")
 	}
@@ -527,22 +446,14 @@ func TestGetConfigDeclaresLocalWorktreeSupport(t *testing.T) {
 // update writes that contain it.
 func TestGetConfigDeclaresAgentConversationStartersSupport(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
-	w := httptest.NewRecorder()
-	testHandler.GetConfig(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetConfig, req).Want(http.StatusOK)
 	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
+	w.JSON(&cfg)
 	if !cfg.AgentConversationStartersSupported {
 		t.Fatal("this build persists conversation_starters but does not advertise the contract")
 	}
 	var raw map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode raw config: %v", err)
-	}
+	w.JSON(&raw)
 	if _, ok := raw["agent_conversation_starters_supported"]; !ok {
 		t.Fatal("agent_conversation_starters_supported missing from the JSON body")
 	}

--- a/server/internal/handler/contact_sales_test.go
+++ b/server/internal/handler/contact_sales_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func newContactSalesRequest(body CreateContactSalesRequest) *http.Request {
@@ -48,16 +50,9 @@ func TestCreateContactSalesHappyPath(t *testing.T) {
 	body := validContactSalesRequest()
 	clearContactSalesForEmail(t, body.BusinessEmail)
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusCreated)
 	var resp ContactSalesResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.ID == "" {
 		t.Fatal("expected inquiry id in response")
 	}
@@ -67,60 +62,35 @@ func TestCreateContactSalesRejectsFreeEmail(t *testing.T) {
 	body := validContactSalesRequest()
 	body.BusinessEmail = "ada@gmail.com"
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesRejectsInvalidEmail(t *testing.T) {
 	body := validContactSalesRequest()
 	body.BusinessEmail = "not-an-email"
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesRejectsUnknownCompanySize(t *testing.T) {
 	body := validContactSalesRequest()
 	body.CompanySize = "ten-ish"
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesRejectsUnknownUseCase(t *testing.T) {
 	body := validContactSalesRequest()
 	body.UseCase = "world-domination"
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesMissingFirstName(t *testing.T) {
 	body := validContactSalesRequest()
 	body.FirstName = "   "
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesPerEmailRateLimit(t *testing.T) {
@@ -129,18 +99,13 @@ func TestCreateContactSalesPerEmailRateLimit(t *testing.T) {
 	clearContactSalesForEmail(t, body.BusinessEmail)
 
 	for i := 0; i < contactSalesHourlyEmailCap; i++ {
-		w := httptest.NewRecorder()
-		testHandler.CreateContactSales(w, newContactSalesRequest(body))
+		w := testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body))
 		if w.Code != http.StatusCreated {
 			t.Fatalf("iteration %d: expected 201, got %d: %s", i, w.Code, w.Body.String())
 		}
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected 429, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusTooManyRequests)
 }
 
 func TestIsBusinessEmailDomain(t *testing.T) {
@@ -204,12 +169,7 @@ func TestCreateContactSalesRejectsFreeEmailWithDisplayName(t *testing.T) {
 	body := validContactSalesRequest()
 	body.BusinessEmail = "Ada Lovelace <ada@gmail.com>"
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusBadRequest)
 }
 
 func TestCreateContactSalesNormalizesDisplayNameEmail(t *testing.T) {
@@ -217,12 +177,7 @@ func TestCreateContactSalesNormalizesDisplayNameEmail(t *testing.T) {
 	body.BusinessEmail = "Ada Lovelace <ada@display-name.example>"
 	clearContactSalesForEmail(t, "ada@display-name.example")
 
-	w := httptest.NewRecorder()
-	testHandler.CreateContactSales(w, newContactSalesRequest(body))
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateContactSales, newContactSalesRequest(body)).Want(http.StatusCreated)
 
 	var stored string
 	if err := testPool.QueryRow(context.Background(),

--- a/server/internal/handler/daemon_batch_claim_finalize_test.go
+++ b/server/internal/handler/daemon_batch_claim_finalize_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 type batchClaimReceiptResponse struct {
@@ -31,9 +32,7 @@ func TestClaimTasksByRuntime_MaxTasksZeroClaimsNothing(t *testing.T) {
 	taskID := seedQueuedIssueTask(t, ctx, a, rt, i)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, 0)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -58,9 +57,7 @@ func TestClaimTasksByRuntime_MaxTasksNegativeIsBadRequest(t *testing.T) {
 	}
 	rt := createClaimReclaimRuntime(t, context.Background(), "Batch neg rt")
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, -1)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for negative max_tasks, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 // TestClaimTasksByRuntime_SkipsInvalidRuntimeID pins the MUL-4257 review fix:
@@ -76,9 +73,7 @@ func TestClaimTasksByRuntime_SkipsInvalidRuntimeID(t *testing.T) {
 	seedQueuedIssueTask(t, ctx, a, rt, i)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{"not-a-uuid", rt}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 (invalid id skipped, not 500), got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -93,24 +88,10 @@ func TestClaimTasksByRuntime_SkipsInvalidRuntimeID(t *testing.T) {
 func seedCommentBackedQueuedTask(t *testing.T, ctx context.Context, agentID, runtimeID, issueID string) (string, string) {
 	t.Helper()
 	var commentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
-		VALUES ($1, $2, 'member', $3, 'please handle this')
-		RETURNING id
-	`, testWorkspaceID, issueID, testUserID).Scan(&commentID); err != nil {
-		t.Fatalf("seed comment: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, commentID) })
+	commentID = dbfx.Insert(t, "comment", testutil.Cols{"workspace_id": testWorkspaceID, "issue_id": issueID, "author_type": testutil.Raw("'member'"), "author_id": testUserID, "content": testutil.Raw("'please handle this'")})
 
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, trigger_comment_id, status, priority)
-		VALUES ($1, $2, $3, $4, 'queued', 0)
-		RETURNING id
-	`, agentID, runtimeID, issueID, commentID).Scan(&taskID); err != nil {
-		t.Fatalf("seed comment-backed task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "trigger_comment_id": commentID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("0")})
 	return taskID, commentID
 }
 
@@ -141,9 +122,7 @@ func TestClaimTasksByRuntime_PersistsCommentDeliveryReceipt(t *testing.T) {
 	taskID, commentID := seedCommentBackedQueuedTask(t, ctx, a, rt, i)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -176,30 +155,14 @@ func TestClaimTasksByRuntime_StaleReclaimRecordsDeliveryReceipt(t *testing.T) {
 	a, i := createClaimReclaimAgentAndIssue(t, ctx, rt, "Batch stale-receipt agent")
 
 	var commentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
-		VALUES ($1, $2, 'member', $3, 'stale reclaim comment')
-		RETURNING id
-	`, testWorkspaceID, i, testUserID).Scan(&commentID); err != nil {
-		t.Fatalf("seed comment: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, commentID) })
+	commentID = dbfx.Insert(t, "comment", testutil.Cols{"workspace_id": testWorkspaceID, "issue_id": i, "author_type": testutil.Raw("'member'"), "author_id": testUserID, "content": testutil.Raw("'stale reclaim comment'")})
 
 	// Stale dispatched, comment-backed, never started, past the 90s window.
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, trigger_comment_id, status, priority, dispatched_at, started_at)
-		VALUES ($1, $2, $3, $4, 'dispatched', 0, now() - interval '120 seconds', NULL)
-		RETURNING id
-	`, a, rt, i, commentID).Scan(&taskID); err != nil {
-		t.Fatalf("seed stale dispatched comment task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": a, "runtime_id": rt, "issue_id": i, "trigger_comment_id": commentID, "status": testutil.Raw("'dispatched'"), "priority": testutil.Raw("0"), "dispatched_at": testutil.Raw("now() - interval '120 seconds'"), "started_at": testutil.Raw("NULL")})
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -222,14 +185,7 @@ func TestClaimTasksByRuntime_SkipsRuntimeOwnedByAnotherDaemon(t *testing.T) {
 
 	// Runtime bound to a different daemon in the same (handler-test) workspace.
 	var rt string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, visibility, owner_id)
-		VALUES ($1, 'other-daemon-machine', 'Other daemon RT', 'cloud', 'handler_test_runtime', 'online', 'x', '{}'::jsonb, now(), 'private', $2)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&rt); err != nil {
-		t.Fatalf("create other-daemon runtime: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, rt) })
+	rt = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("'other-daemon-machine'"), "name": testutil.Raw("'Other daemon RT'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'handler_test_runtime'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'x'"), "metadata": testutil.Raw("'{}'::jsonb"), "last_seen_at": testutil.Raw("now()"), "visibility": testutil.Raw("'private'"), "owner_id": testUserID})
 
 	a, i := createClaimReclaimAgentAndIssue(t, ctx, rt, "Other daemon agent")
 	taskID := seedQueuedIssueTask(t, ctx, a, rt, i)
@@ -237,9 +193,7 @@ func TestClaimTasksByRuntime_SkipsRuntimeOwnedByAnotherDaemon(t *testing.T) {
 	// postBatchClaim sends daemon_id = batchClaimTestDaemonID ("batch-claim-review"),
 	// which differs from the runtime's "other-daemon-machine".
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -262,14 +216,11 @@ func TestClaimTasksByRuntime_RequiresDaemonID(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/claim",
 		map[string]any{"runtime_ids": []string{}, "max_tasks": 5},
 		testWorkspaceID, batchClaimTestDaemonID)
-	testHandler.ClaimTasksByRuntime(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 when daemon_id is missing, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ClaimTasksByRuntime, req).Want(http.StatusBadRequest)
 }
 
 // TestClaimTasksByRuntime_RepairsStaleCommentPlan pins the MUL-4257 review
@@ -291,14 +242,7 @@ func TestClaimTasksByRuntime_RepairsStaleCommentPlan(t *testing.T) {
 
 	// A surviving member comment on the issue.
 	var survivorID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
-		VALUES ($1, $2, 'member', $3, 'please still handle this')
-		RETURNING id
-	`, testWorkspaceID, issueID, testUserID).Scan(&survivorID); err != nil {
-		t.Fatalf("seed survivor comment: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, survivorID) })
+	survivorID = dbfx.Insert(t, "comment", testutil.Cols{"workspace_id": testWorkspaceID, "issue_id": issueID, "author_type": testutil.Raw("'member'"), "author_id": testUserID, "content": testutil.Raw("'please still handle this'")})
 
 	// Stale plan: trigger_comment_id NULL, only coalesced survivor remains.
 	var staleID string
@@ -313,9 +257,7 @@ func TestClaimTasksByRuntime_RepairsStaleCommentPlan(t *testing.T) {
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rt}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimReceiptResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)

--- a/server/internal/handler/daemon_batch_claim_test.go
+++ b/server/internal/handler/daemon_batch_claim_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
@@ -30,14 +31,7 @@ type batchClaimResponse struct {
 func seedQueuedIssueTask(t *testing.T, ctx context.Context, agentID, runtimeID, issueID string) string {
 	t.Helper()
 	var id string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
-		VALUES ($1, $2, $3, 'queued', 0)
-		RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&id); err != nil {
-		t.Fatalf("seed queued task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, id) })
+	id = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("0")})
 	return id
 }
 
@@ -73,9 +67,7 @@ func TestClaimTasksByRuntime_RoutesAcrossRuntimesAndMintsTokens(t *testing.T) {
 	seedQueuedIssueTask(t, ctx, a2, rt2, i2)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rt1, rt2}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -134,9 +126,7 @@ func TestClaimTasksByRuntime_IncludesActiveSiblingRun(t *testing.T) {
 	seedQueuedIssueTask(t, ctx, agentID, runtimeID, queuedSiblingIssueID)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{runtimeID}, 1)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -168,10 +158,7 @@ func TestClaimTasksByRuntime_SkipsCrossWorkspaceRuntime(t *testing.T) {
 		t.Fatalf("foreign user: %v", err)
 	}
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, foreignUser) })
-	if err := testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug, description, issue_prefix) VALUES ('Foreign WS','batch-foreign-ws','x','FGN') RETURNING id`).Scan(&foreignWS); err != nil {
-		t.Fatalf("foreign workspace: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, foreignWS) })
+	foreignWS = dbfx.Insert(t, "workspace", testutil.Cols{"name": testutil.Raw("'Foreign WS'"), "slug": testutil.Raw("'batch-foreign-ws'"), "description": testutil.Raw("'x'"), "issue_prefix": testutil.Raw("'FGN'")})
 	if _, err := testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1,$2,'owner')`, foreignWS, foreignUser); err != nil {
 		t.Fatalf("foreign member: %v", err)
 	}
@@ -198,9 +185,7 @@ func TestClaimTasksByRuntime_SkipsCrossWorkspaceRuntime(t *testing.T) {
 
 	// Daemon token scoped to the (unrelated) handler-test workspace.
 	w := postBatchClaim(t, testWorkspaceID, []string{foreignRT}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -228,21 +213,13 @@ func TestClaimTasksByRuntime_CancelsTaskWhenRuntimeOwnerMissing(t *testing.T) {
 	ctx := context.Background()
 
 	var rtNull string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, visibility, owner_id)
-		VALUES ($1, NULL, 'Ownerless RT', 'cloud', 'handler_test_runtime', 'online', 'x', '{}'::jsonb, now(), 'private', NULL)
-		RETURNING id`, testWorkspaceID).Scan(&rtNull); err != nil {
-		t.Fatalf("ownerless runtime: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, rtNull) })
+	rtNull = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": testutil.Raw("'Ownerless RT'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'handler_test_runtime'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'x'"), "metadata": testutil.Raw("'{}'::jsonb"), "last_seen_at": testutil.Raw("now()"), "visibility": testutil.Raw("'private'"), "owner_id": testutil.Raw("NULL")})
 
 	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, rtNull, "Ownerless agent")
 	taskID := seedQueuedIssueTask(t, ctx, agentID, rtNull, issueID)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{rtNull}, 1)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp batchClaimResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)

--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -452,7 +451,7 @@ func TestPinTaskSession_PointerAdvanceIsAtomicWithPin(t *testing.T) {
 
 	pinDone := make(chan int, 1)
 	go func() {
-		w := httptest.NewRecorder()
+
 		req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
 			map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
 			testWorkspaceID, daemonID)
@@ -463,7 +462,7 @@ func TestPinTaskSession_PointerAdvanceIsAtomicWithPin(t *testing.T) {
 		rctx := chi.NewRouteContext()
 		rctx.URLParams.Add("taskId", taskID)
 		req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
-		testHandler.PinTaskSession(w, req)
+		w := testutil.Call(t, testHandler.PinTaskSession, req)
 		pinDone <- w.Code
 	}()
 
@@ -744,7 +743,7 @@ func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
 		{
 			name: "pin-vs-fail",
 			first: func(taskID string) error {
-				w := httptest.NewRecorder()
+
 				req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
 					map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
 					testWorkspaceID, daemonID)
@@ -753,7 +752,7 @@ func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("taskId", taskID)
 				req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
-				testHandler.PinTaskSession(w, req)
+				w := testutil.Call(t, testHandler.PinTaskSession, req)
 				// Any non-204 fails, deliberately: a pin that loses a deadlock is
 				// reported by the handler as a plain 500, so a check that only
 				// recognised *pgconn.PgError(40P01) would skip the very failure
@@ -903,17 +902,13 @@ func raceCtx() (context.Context, context.CancelFunc) {
 func pinTaskSessionViaAPI(t *testing.T, taskID, daemonID, sessionID, workDir string) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
 		map[string]any{"session_id": sessionID, "work_dir": workDir}, testWorkspaceID, daemonID)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.PinTaskSession(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("PinTaskSession: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.PinTaskSession, req).Want(http.StatusNoContent)
 }
 
 // TestPinTaskSession_LateCancelledPin covers the mid-flight pin racing the

--- a/server/internal/handler/daemon_claim_channel_type_test.go
+++ b/server/internal/handler/daemon_claim_channel_type_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Claim must report the chat session's real channel type for EVERY registered
@@ -101,21 +101,16 @@ type claimedChatChannel struct {
 // channel-awareness fields the daemon reads off the claim response.
 func claimChatChannelFields(t *testing.T, runtimeID string) claimedChatChannel {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "claim-channel-type")
 	req = withURLParam(req, "runtimeId", runtimeID)
 
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var resp struct {
 		Task *claimedChatChannel `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode claim response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Task == nil {
 		t.Fatal("expected a claimed task")
 	}

--- a/server/internal/handler/daemon_claim_continuity_gap_test.go
+++ b/server/internal/handler/daemon_claim_continuity_gap_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // claimContinuityGapProbe decodes just the continuity-gap fields off a claim
@@ -20,17 +20,12 @@ type claimContinuityGapProbe struct {
 
 func claimOneTaskForRuntime(t *testing.T, runtimeID, daemonID string) claimContinuityGapProbe {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, daemonID)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var probe claimContinuityGapProbe
-	if err := json.NewDecoder(w.Body).Decode(&probe); err != nil {
-		t.Fatalf("decode claim response: %v", err)
-	}
+	w.Decode(&probe)
 	if probe.Task == nil {
 		t.Fatal("expected a claimed task in the response")
 	}
@@ -53,14 +48,7 @@ func TestClaimTaskByRuntime_ChatRolloutMissingDisclosesGap(t *testing.T) {
 
 	// Chat session that still carries a good resume pointer from an earlier turn.
 	var sessionID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status, runtime_id, session_id, work_dir)
-		VALUES ($1, $2, $3, 'gap chat', 'active', $4, 'OLD-GOOD-CHAT-SESSION', '/tmp/chat')
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&sessionID); err != nil {
-		t.Fatalf("create chat session: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID) })
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": testUserID, "title": testutil.Raw("'gap chat'"), "status": testutil.Raw("'active'"), "runtime_id": runtimeID, "session_id": testutil.Raw("'OLD-GOOD-CHAT-SESSION'"), "work_dir": testutil.Raw("'/tmp/chat'")})
 
 	// Most recent terminal turn on this session withheld its Codex session.
 	if _, err := testPool.Exec(ctx, `
@@ -76,14 +64,7 @@ func TestClaimTaskByRuntime_ChatRolloutMissingDisclosesGap(t *testing.T) {
 		t.Fatalf("insert chat message: %v", err)
 	}
 
-	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, chat_session_id)
-		VALUES ($1, $2, 'queued', 1000, $3) RETURNING id
-	`, agentID, runtimeID, sessionID).Scan(&taskID); err != nil {
-		t.Fatalf("create chat follow-up task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("1000"), "chat_session_id": sessionID})
 
 	probe := claimOneTaskForRuntime(t, runtimeID, "chat-gap-claim-test")
 	if !probe.Task.PriorSessionResumeUnavailable {
@@ -130,14 +111,8 @@ func TestClaimTaskByRuntime_RerunSourceRolloutMissingDisclosesGap(t *testing.T) 
 
 	// A manual rerun of that source task, queued to claim (rerun carries
 	// force_fresh_session=true; the disclosure must still fire from the source).
-	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, rerun_of_task_id, force_fresh_session)
-		VALUES ($1, $2, $3, 'queued', 1000, $4, TRUE) RETURNING id
-	`, agentID, runtimeID, issueID, srcID).Scan(&taskID); err != nil {
-		t.Fatalf("create rerun task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("1000"), "rerun_of_task_id": srcID, "force_fresh_session": testutil.Raw("TRUE")})
 
 	probe := claimOneTaskForRuntime(t, runtimeID, "rerun-gap-claim-test")
 	if !probe.Task.PriorSessionResumeUnavailable {

--- a/server/internal/handler/daemon_claim_workspace_mcp_test.go
+++ b/server/internal/handler/daemon_claim_workspace_mcp_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // claimAgentMcpConfigForTest runs one claim for the given runtime and returns
@@ -13,20 +14,14 @@ import (
 func claimAgentMcpConfigForTest(t *testing.T, runtimeID string) json.RawMessage {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil, testWorkspaceID, "ws-mcp-daemon")
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 
 	var claimResp struct {
 		Task *AgentTaskResponse `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &claimResp); err != nil {
-		t.Fatalf("decode claim: %v", err)
-	}
+	w.JSON(&claimResp)
 	if claimResp.Task == nil || claimResp.Task.Agent == nil {
 		t.Fatalf("missing task agent in claim response: %s", w.Body.String())
 	}
@@ -56,15 +51,7 @@ func setupWorkspaceMcpClaimFixture(t *testing.T, ctx context.Context, name, agen
 		t.Fatalf("setup: set agent mcp_config: %v", err)
 	}
 
-	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
-		VALUES ($1, $2, $3, 'queued', 0)
-		RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-		t.Fatalf("setup: create task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("0")})
 
 	return runtimeID
 }

--- a/server/internal/handler/daemon_comment_delivery_test.go
+++ b/server/internal/handler/daemon_comment_delivery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -235,23 +236,18 @@ func createCommentDeliveryFixture(t *testing.T, label string) commentDeliveryFix
 
 func claimCommentDeliveryFixture(t *testing.T, fixture commentDeliveryFixture, capabilities string) AgentTaskResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+fixture.runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "comment-delivery-matrix")
 	if capabilities != "" {
 		req.Header.Set("X-Client-Capabilities", capabilities)
 	}
 	req = withURLParam(req, "runtimeId", fixture.runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var response struct {
 		Task *AgentTaskResponse `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode claim response: %v", err)
-	}
+	w.JSON(&response)
 	if response.Task == nil {
 		t.Fatalf("claim returned no task: %s", w.Body.String())
 	}
@@ -360,21 +356,15 @@ func TestClaimTaskByRuntime_CoalescedOnlyStaleTaskDoesNotReuseDeletedTriggerCapa
 		t.Fatalf("delete trigger directly: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+fixture.runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "stale-comment-plan-repair")
 	req.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilityCoalescedCommentsV1)
 	req = withURLParam(req, "runtimeId", fixture.runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("repair stale claim: got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var response struct {
 		Task *AgentTaskResponse `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode stale-plan repair response: %v", err)
-	}
+	w.JSON(&response)
 	if response.Task != nil {
 		t.Fatalf("stale plan was dispatched instead of repaired: %+v", response.Task)
 	}
@@ -390,15 +380,11 @@ func TestUpdateComment_RequeuesSurvivingCoalescedBatch(t *testing.T) {
 		t.Fatalf("assign edited-trigger issue: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodPut, "/api/comments/"+fixture.commentID[2], map[string]any{
 		"content": "edited latest instruction",
 	})
 	req = withURLParam(req, "commentId", fixture.commentID[2])
-	testHandler.UpdateComment(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateComment: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateComment, req).Want(http.StatusOK)
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[2], fixture.commentID[:2])
 }
@@ -412,13 +398,9 @@ func TestDeleteComment_RequeuesSurvivingCoalescedBatch(t *testing.T) {
 		t.Fatalf("assign deleted-trigger issue: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodDelete, "/api/comments/"+fixture.commentID[2], nil)
 	req = withURLParam(req, "commentId", fixture.commentID[2])
-	testHandler.DeleteComment(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteComment: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteComment, req).Want(http.StatusNoContent)
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[1], fixture.commentID[:1])
 	var deletedCount int
@@ -439,15 +421,11 @@ func TestUpdateComment_CancelsAndRequeuesWhenEditedInputIsCoalesced(t *testing.T
 		t.Fatalf("assign edited-coalesced issue: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodPut, "/api/comments/"+fixture.commentID[0], map[string]any{
 		"content": "edited earlier instruction",
 	})
 	req = withURLParam(req, "commentId", fixture.commentID[0])
-	testHandler.UpdateComment(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateComment: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateComment, req).Want(http.StatusOK)
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[0], fixture.commentID[1:])
 }
@@ -461,13 +439,9 @@ func TestDeleteComment_CancelsAndRequeuesWhenDeletedInputIsCoalesced(t *testing.
 		t.Fatalf("assign deleted-coalesced issue: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodDelete, "/api/comments/"+fixture.commentID[0], nil)
 	req = withURLParam(req, "commentId", fixture.commentID[0])
-	testHandler.DeleteComment(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteComment: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteComment, req).Want(http.StatusNoContent)
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[2], fixture.commentID[1:2])
 }
@@ -483,13 +457,10 @@ func TestDeleteComment_FailureRestoresCancelledCompleteBatch(t *testing.T) {
 
 	failingHandler := *testHandler
 	failingHandler.Queries = db.New(&failDeleteCommentDB{delegate: testPool})
-	w := httptest.NewRecorder()
+
 	req := newRequest(http.MethodDelete, "/api/comments/"+fixture.commentID[2], nil)
 	req = withURLParam(req, "commentId", fixture.commentID[2])
-	failingHandler.DeleteComment(w, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("DeleteComment failure: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, failingHandler.DeleteComment, req).Want(http.StatusInternalServerError)
 
 	var existing int
 	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM comment WHERE id = $1`, fixture.commentID[2]).Scan(&existing); err != nil {
@@ -512,13 +483,10 @@ func TestDeleteComment_ConcurrentNoOpIsReportedAndRestoresCancelledBatch(t *test
 
 	zeroHandler := *testHandler
 	zeroHandler.Queries = db.New(&zeroDeleteCommentDB{delegate: testPool})
-	w := httptest.NewRecorder()
+
 	req := newRequest(http.MethodDelete, "/api/comments/"+fixture.commentID[2], nil)
 	req = withURLParam(req, "commentId", fixture.commentID[2])
-	zeroHandler.DeleteComment(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("DeleteComment no-op: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, zeroHandler.DeleteComment, req).Want(http.StatusNotFound)
 
 	assertRepairedCommentBatch(t, fixture, fixture.commentID[2], fixture.commentID[:2])
 }
@@ -906,15 +874,11 @@ func TestClaimTaskByRuntime_FinalizationFailureRequeuesImmediately(t *testing.T)
 	testHandler.TaskService.TxStarter = &failNthBegin{delegate: testPool, failAt: 2}
 	defer func() { testHandler.TaskService.TxStarter = originalTxStarter }()
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+fixture.runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "comment-delivery-finalize-failure")
 	req.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilityCoalescedCommentsV1)
 	req = withURLParam(req, "runtimeId", fixture.runtimeID)
-	failingHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("failed finalization status = %d, want 500: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, failingHandler.ClaimTaskByRuntime, req).Want(http.StatusInternalServerError)
 	if strings.Contains(w.Body.String(), "auth_token") || strings.Contains(w.Body.String(), `"task"`) {
 		t.Fatalf("failed claim leaked a task payload: %s", w.Body.String())
 	}

--- a/server/internal/handler/daemon_comment_workspace_scope_test.go
+++ b/server/internal/handler/daemon_comment_workspace_scope_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -17,14 +16,7 @@ import (
 func insertCommentForScopeTest(t *testing.T, ctx context.Context, issueID, workspaceID, content string) string {
 	t.Helper()
 	var id string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
-		VALUES ($1, $2, 'member', $3, $4, 'comment')
-		RETURNING id
-	`, issueID, workspaceID, testUserID, content).Scan(&id); err != nil {
-		t.Fatalf("insert comment: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM comment WHERE id = $1`, id) })
+	id = dbfx.Insert(t, "comment", testutil.Cols{"issue_id": issueID, "workspace_id": workspaceID, "author_type": testutil.Raw("'member'"), "author_id": testUserID, "content": content, "type": testutil.Raw("'comment'")})
 	return id
 }
 
@@ -57,14 +49,11 @@ func enqueueIssueTaskWithTrigger(t *testing.T, ctx context.Context, agentID, iss
 // when absent — omitempty on the wire) plus the raw response body.
 func claimTriggerFieldsForTest(t *testing.T, runtimeID string) (taskID, triggerContent, triggerSummary, raw string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "comment-workspace-scope")
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var resp struct {
 		Task *struct {
 			ID                    string `json:"id"`
@@ -72,9 +61,7 @@ func claimTriggerFieldsForTest(t *testing.T, runtimeID string) (taskID, triggerC
 			TriggerSummary        string `json:"trigger_summary"`
 		} `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode claim response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Task == nil {
 		return "", "", "", w.Body.String()
 	}

--- a/server/internal/handler/daemon_context_exhausted_test.go
+++ b/server/internal/handler/daemon_context_exhausted_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
@@ -44,28 +44,14 @@ func TestCompleteTask_ContextExhaustionFromOlderDaemonIsRecordedAsFailed(t *test
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-		VALUES ($1, 'gh-6402 context exhaustion fixture', 'in_progress', 'none', $2, 'member', 6402, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("setup: create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'gh-6402 context exhaustion fixture'"), "status": testutil.Raw("'in_progress'"), "priority": testutil.Raw("'none'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("6402"), "position": testutil.Raw("0")})
 
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
-		VALUES ($1, $2, $3, 'running', 0, now())
-		RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-		t.Fatalf("setup: create task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "started_at": testutil.Raw("now()")})
 
 	// Exactly what an older daemon posts: a successful completion whose output
 	// is the provider's notice, carrying the saturated session id.
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 		map[string]any{
 			"output": "Prompt is too long · the request is ~274931 tokens (limit 200000) but this conversation is only ~1597 tokens — " +
@@ -79,10 +65,7 @@ func TestCompleteTask_ContextExhaustionFromOlderDaemonIsRecordedAsFailed(t *test
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	var status, failureReason string
 	if err := testPool.QueryRow(ctx, `
@@ -169,26 +152,11 @@ func TestCompleteTask_RealAnswerStillCompletes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var issueID string
-			if err := testPool.QueryRow(ctx, `
-				INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-				VALUES ($1, 'gh-6402 control fixture', 'in_progress', 'none', $2, 'member', $3, 0)
-				RETURNING id
-			`, testWorkspaceID, testUserID, tc.number).Scan(&issueID); err != nil {
-				t.Fatalf("setup: create issue: %v", err)
-			}
-			t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+			issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'gh-6402 control fixture'"), "status": testutil.Raw("'in_progress'"), "priority": testutil.Raw("'none'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": tc.number, "position": testutil.Raw("0")})
 
 			var taskID string
-			if err := testPool.QueryRow(ctx, `
-				INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
-				VALUES ($1, $2, $3, 'running', 0, now())
-				RETURNING id
-			`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-				t.Fatalf("setup: create task: %v", err)
-			}
-			t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+			taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "started_at": testutil.Raw("now()")})
 
-			w := httptest.NewRecorder()
 			req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 				map[string]any{"output": tc.output, "session_id": "sess-healthy"},
 				testWorkspaceID, "legit-daemon")
@@ -196,10 +164,7 @@ func TestCompleteTask_RealAnswerStillCompletes(t *testing.T) {
 			rctx.URLParams.Add("taskId", taskID)
 			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-			testHandler.CompleteTask(w, req)
-			if w.Code != http.StatusOK {
-				t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 			var status string
 			if err := testPool.QueryRow(ctx, `

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -624,7 +624,7 @@ func TestClaimTaskByRuntime_SkillBundleRefsAndResolve(t *testing.T) {
 	dbfx.Exec(t, `UPDATE agent_task_queue SET status = 'running', started_at = now() WHERE id = $1`, taskID)
 	req = newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/"+taskID+"/skill-bundles/resolve", resolveBody, testWorkspaceID, "skill-refs-daemon")
 	req = withURLParams(req, "runtimeId", runtimeID, "taskId", taskID)
-	w = testutil.Call(t, testHandler.ResolveTaskSkillBundles, req).Want(http.StatusConflict)
+	testutil.Call(t, testHandler.ResolveTaskSkillBundles, req).Want(http.StatusConflict)
 }
 
 // TestClaimTaskByRuntime_PopulatesWorkspaceContext verifies the claim
@@ -869,7 +869,6 @@ func TestDaemonRegister_WithDaemonToken_WorkspaceMismatch(t *testing.T) {
 		t.Skip("database not available")
 	}
 
-	w := httptest.NewRecorder()
 	// Daemon token is for a different workspace than the request body.
 	req := newDaemonTokenRequest("POST", "/api/daemon/register", map[string]any{
 		"workspace_id": testWorkspaceID,
@@ -880,10 +879,7 @@ func TestDaemonRegister_WithDaemonToken_WorkspaceMismatch(t *testing.T) {
 		},
 	}, "00000000-0000-0000-0000-000000000000", "test-daemon-mdt")
 
-	testHandler.DaemonRegister(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("DaemonRegister with mismatched workspace: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DaemonRegister, req).Want(http.StatusNotFound)
 }
 
 func TestDaemonHeartbeat_WithDaemonToken_CrossWorkspace(t *testing.T) {
@@ -911,7 +907,7 @@ func TestDaemonHeartbeat_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	req = newDaemonTokenRequest("POST", "/api/daemon/heartbeat", map[string]any{
 		"runtime_id": runtimeID,
 	}, "00000000-0000-0000-0000-000000000000", "attacker-daemon")
-	w = testutil.Call(t, testHandler.DaemonHeartbeat, req).Want(http.StatusNotFound)
+	testutil.Call(t, testHandler.DaemonHeartbeat, req).Want(http.StatusNotFound)
 }
 
 // TestHandleDaemonWSHeartbeat_RuntimeGoneReturnsAckNotError pins the fix for
@@ -1017,18 +1013,15 @@ func TestDaemonHeartbeat_SlowProbeDoesNotWedge(t *testing.T) {
 		testHandler.LocalSkillImportStore = origImport
 	})
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/heartbeat", map[string]any{
 		"runtime_id": runtimeID,
 	}, testWorkspaceID, "runtime-local-skills-daemon")
 
 	start := time.Now()
-	testHandler.DaemonHeartbeat(w, req)
+	w := testutil.Call(t, testHandler.DaemonHeartbeat, req)
 	elapsed := time.Since(start)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("DaemonHeartbeat with slow probes: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	// Two bounded probes at 1s each + a small fixed slack.
 	if elapsed > 3*time.Second {
 		t.Fatalf("DaemonHeartbeat took %s; expected fast return despite slow probes", elapsed)
@@ -1114,9 +1107,7 @@ func TestGetTaskStatus_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	testHandler.GetTaskStatus(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("GetTaskStatus with cross-workspace token: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	// Same request with the CORRECT workspace should succeed.
 	w = httptest.NewRecorder()
@@ -1127,9 +1118,7 @@ func TestGetTaskStatus_WithDaemonToken_CrossWorkspace(t *testing.T) {
 		chi.RouteCtxKey, rctx))
 
 	testHandler.GetTaskStatus(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetTaskStatus with correct workspace token: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 // TestGetTaskStatus_TransientDBError_Returns500 verifies that a transient DB
@@ -1256,7 +1245,7 @@ func TestBatchIssueGCCheck_WithDaemonToken(t *testing.T) {
 		"issue_ids": []string{issueID},
 	}, "00000000-0000-0000-0000-000000000000", "attacker-daemon")
 	req = withURLParam(req, "workspaceId", testWorkspaceID)
-	w = testutil.Call(t, testHandler.BatchIssueGCCheck, req).Want(http.StatusNotFound)
+	testutil.Call(t, testHandler.BatchIssueGCCheck, req).Want(http.StatusNotFound)
 }
 
 // withURLParams merges the given chi URL parameters into the request context.
@@ -1276,15 +1265,11 @@ func withURLParams(req *http.Request, kv ...string) *http.Request {
 }
 
 func TestListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := httptest.NewRequest(http.MethodGet, "/api/tasks/optimistic-optimistic-1778739487737/messages", nil)
 	req = withURLParams(req, "taskId", "optimistic-optimistic-1778739487737")
 
-	(&Handler{}).ListTaskMessagesByUser(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid task id, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, (&Handler{}).ListTaskMessagesByUser, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "task_id") {
 		t.Fatalf("expected task_id validation error, got %s", w.Body.String())
 	}
@@ -1957,9 +1942,7 @@ func TestStartTask_AutopilotRunOnlyTask_ResolvesWorkspace(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	testHandler.StartTask(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("StartTask with cross-workspace token: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	// Same-workspace daemon token must succeed — this is the bug in #1224.
 	w = httptest.NewRecorder()
@@ -1968,9 +1951,7 @@ func TestStartTask_AutopilotRunOnlyTask_ResolvesWorkspace(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	testHandler.StartTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("StartTask for run_only autopilot task: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var status string
 	dbfx.QueryRow(t, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status)
@@ -2258,17 +2239,13 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceAndProjectContext(t *testi
 	})
 	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
 		testWorkspaceID, "test-daemon-claim")
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("runtimeId", runtimeID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 
 	var resp struct {
 		Task *struct {
@@ -2281,9 +2258,7 @@ func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceAndProjectContext(t *testi
 			ProjectResources   []ProjectResourceData `json:"project_resources"`
 		} `json:"task"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.Task == nil {
 		t.Fatal("expected a task in response, got nil")
 	}
@@ -2379,17 +2354,13 @@ func TestClaimTaskByRuntime_TaskWorkspaceMismatch_CancelsAndRejects(t *testing.T
 		"priority":   2,
 	})
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+localRuntimeID+"/claim", nil,
 		testWorkspaceID, "legit-daemon")
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("runtimeId", localRuntimeID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("ClaimTaskByRuntime (mismatch): expected 500, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusInternalServerError)
 
 	// Task must NOT remain dispatched — it has to be cancelled so the agent
 	// is released immediately rather than stuck until the sweeper fires.
@@ -2444,7 +2415,6 @@ func TestCompleteTask_CommentTriggered_SynthesizesCommentWhenAgentSilent(t *test
 		issueID,
 	)
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 		map[string]any{"output": agentFinalOutput},
 		testWorkspaceID, "legit-daemon")
@@ -2452,10 +2422,7 @@ func TestCompleteTask_CommentTriggered_SynthesizesCommentWhenAgentSilent(t *test
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	// Exactly one agent comment on the issue, threaded under the trigger,
 	// carrying the agent's final output.
@@ -2529,7 +2496,6 @@ func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t
 		VALUES ($1, $2, 'agent', $3, 'done, see PR', 'comment', $4)
 	`, issueID, testWorkspaceID, agentID, triggerCommentID)
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 		map[string]any{"output": "final terminal text that must NOT become a comment"},
 		testWorkspaceID, "legit-daemon")
@@ -2537,10 +2503,7 @@ func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	var count int
 	dbfx.QueryRow(t, `
@@ -2577,7 +2540,6 @@ func TestCompleteTask_CommentTriggered_SuppressesTrivialDoneOutput(t *testing.T)
 		"started_at":         testutil.Raw("now()"),
 	})
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 		map[string]any{"output": "Done."},
 		testWorkspaceID, "legit-daemon")
@@ -2585,10 +2547,7 @@ func TestCompleteTask_CommentTriggered_SuppressesTrivialDoneOutput(t *testing.T)
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	var count int
 	dbfx.QueryRow(t, `
@@ -2622,7 +2581,6 @@ func TestCompleteTask_AssignmentTriggered_DoesNotSuppressTrivialDoneOutput(t *te
 		"started_at": testutil.Raw("now()"),
 	})
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
 		map[string]any{"output": "Done."},
 		testWorkspaceID, "legit-daemon")
@@ -2630,10 +2588,7 @@ func TestCompleteTask_AssignmentTriggered_DoesNotSuppressTrivialDoneOutput(t *te
 	rctx.URLParams.Add("taskId", taskID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	var content string
 	dbfx.QueryRow(t, `
@@ -2685,24 +2640,18 @@ type claimRuntimeGuardTask struct {
 func claimTaskForRuntimeGuard(t *testing.T, runtimeID, daemonID string) *claimRuntimeGuardTask {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
 		testWorkspaceID, daemonID)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("runtimeId", runtimeID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 
 	var resp struct {
 		Task *claimRuntimeGuardTask `json:"task"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.Task == nil {
 		t.Fatal("expected a task in response, got nil")
 	}
@@ -3642,7 +3591,7 @@ func TestGetChatSessionGCCheck(t *testing.T) {
 	req = newDaemonTokenRequest("GET", "/api/daemon/chat-sessions/"+sessionID+"/gc-check", nil,
 		testWorkspaceID, "legit-daemon")
 	req = withURLParam(req, "sessionId", sessionID)
-	w = testutil.Call(t, testHandler.GetChatSessionGCCheck, req).Want(http.StatusNotFound)
+	testutil.Call(t, testHandler.GetChatSessionGCCheck, req).Want(http.StatusNotFound)
 }
 
 // TestGetAutopilotRunGCCheck verifies the autopilot-run gc-check endpoint:

--- a/server/internal/handler/dashboard_agent_visibility_test.go
+++ b/server/internal/handler/dashboard_agent_visibility_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // dashboardAgentPresence is the expected membership of the three agent ids that
@@ -46,31 +47,8 @@ func TestDashboardPerAgentRollupsFoldRestrictedAgents(t *testing.T) {
 	// Second agent, public_to the whole workspace: the plain member CAN see
 	// this one, so its rows must survive with their real UUID.
 	var publicAgentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args
-		)
-		VALUES ($1, 'dashboard-visibility-public-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'workspace', 'public_to', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, runtimeID, testUserID).Scan(&publicAgentID); err != nil {
-		t.Fatalf("create public agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, publicAgentID)
-	})
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO agent_invocation_target (agent_id, target_type, target_id)
-		VALUES ($1, 'workspace', $2)
-	`, publicAgentID, testWorkspaceID); err != nil {
-		t.Fatalf("grant workspace invocation target: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(),
-			`DELETE FROM agent_invocation_target WHERE agent_id = $1`, publicAgentID)
-	})
+	publicAgentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'dashboard-visibility-public-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'workspace'"), "permission_mode": testutil.Raw("'public_to'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
+	dbfx.InsertNoID(t, "agent_invocation_target", testutil.Cols{"agent_id": publicAgentID, "target_type": testutil.Raw("'workspace'"), "target_id": testWorkspaceID}, "agent_id = $1", publicAgentID)
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `
@@ -138,8 +116,7 @@ func TestDashboardPerAgentRollupsFoldRestrictedAgents(t *testing.T) {
 		out any,
 	) string {
 		t.Helper()
-		w := httptest.NewRecorder()
-		handler(w, newRequestAs(userID, "GET", path, nil))
+		w := testutil.Call(t, handler, newRequestAs(userID, "GET", path, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("%s as %s: expected 200, got %d: %s", name, userID, w.Code, w.Body.String())
 		}
@@ -343,8 +320,7 @@ func TestDashboardPerAgentRollupsFoldSystemAgentCarriers(t *testing.T) {
 		var out totals
 		var bodies []string
 		read := func(name string, handler func(http.ResponseWriter, *http.Request), path string, decode func([]byte)) {
-			w := httptest.NewRecorder()
-			handler(w, newRequestAs(userID, "GET", path, nil))
+			w := testutil.Call(t, handler, newRequestAs(userID, "GET", path, nil))
 			if w.Code != http.StatusOK {
 				t.Fatalf("%s as %s: expected 200, got %d: %s", name, userID, w.Code, w.Body.String())
 			}
@@ -401,22 +377,7 @@ func TestDashboardPerAgentRollupsFoldSystemAgentCarriers(t *testing.T) {
 	// A builder carrier, shaped exactly like CreateAgentBuilder writes one:
 	// kind=system, permission_mode=private, owned by the workspace owner.
 	var carrierID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config, runtime_id,
-			visibility, permission_mode, max_concurrent_tasks, owner_id, instructions,
-			custom_env, custom_args, kind, system_key
-		)
-		VALUES ($1, 'agent-builder-carrier', '', 'cloud', '{}'::jsonb, $2,
-		        'private', 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb,
-		        'system', 'agent_builder:' || gen_random_uuid()::text)
-		RETURNING id
-	`, testWorkspaceID, runtimeID, testUserID).Scan(&carrierID); err != nil {
-		t.Fatalf("create builder carrier: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, carrierID)
-	})
+	carrierID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'agent-builder-carrier'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "permission_mode": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb"), "kind": testutil.Raw("'system'"), "system_key": testutil.Raw("'agent_builder:' || gen_random_uuid()::text")})
 
 	started := time.Now().UTC().Add(-30 * time.Minute)
 	completed := started.Add(10 * time.Minute) // 600s per run

--- a/server/internal/handler/dashboard_test.go
+++ b/server/internal/handler/dashboard_test.go
@@ -245,11 +245,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 	// daily — workspace-wide
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=1&"+dashboardFixtureTZParam, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("daily ws: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetDashboardUsageDaily, newRequest("GET", "/api/dashboard/usage/daily?days=1&"+dashboardFixtureTZParam, nil)).Want(http.StatusOK)
 		var rows []dailyRow
 		_ = json.NewDecoder(w.Body).Decode(&rows)
 		var total int64
@@ -265,11 +261,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 	// daily — project-scoped
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("daily project: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetDashboardUsageDaily, newRequest("GET", "/api/dashboard/usage/daily?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil)).Want(http.StatusOK)
 		var rows []dailyRow
 		_ = json.NewDecoder(w.Body).Decode(&rows)
 		var total int64
@@ -291,11 +283,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 	// by-agent — project-scoped
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("by-agent project: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetDashboardUsageByAgent, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil)).Want(http.StatusOK)
 		var rows []byAgentRow
 		_ = json.NewDecoder(w.Body).Decode(&rows)
 		found := false
@@ -311,11 +299,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 	// agent-runtime — project-scoped
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardAgentRunTime(w, newRequest("GET", "/api/dashboard/agent-runtime?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("agent-runtime: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetDashboardAgentRunTime, newRequest("GET", "/api/dashboard/agent-runtime?days=1&"+dashboardFixtureTZParam+"&project_id="+projectID, nil)).Want(http.StatusOK)
 		var rows []runtimeRow
 		_ = json.NewDecoder(w.Body).Decode(&rows)
 		var seconds int64
@@ -336,8 +320,7 @@ func TestDashboardEndpoints(t *testing.T) {
 
 	// agent-runtime — invalid project_id rejected
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardAgentRunTime(w, newRequest("GET", "/api/dashboard/agent-runtime?project_id=not-a-uuid", nil))
+		w := testutil.Call(t, testHandler.GetDashboardAgentRunTime, newRequest("GET", "/api/dashboard/agent-runtime?project_id=not-a-uuid", nil))
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("agent-runtime: expected 400 for invalid uuid, got %d", w.Code)
 		}
@@ -346,11 +329,7 @@ func TestDashboardEndpoints(t *testing.T) {
 	// Workspace-wide by-agent through the same rollup, just to confirm
 	// the no-project-filter shape matches up.
 	{
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&"+dashboardFixtureTZParam, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("by-agent ws: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetDashboardUsageByAgent, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&"+dashboardFixtureTZParam, nil)).Want(http.StatusOK)
 		var aRows []byAgentRow
 		_ = json.NewDecoder(w.Body).Decode(&aRows)
 		var aTotal int64
@@ -413,8 +392,7 @@ func TestDashboardUsageDailyBucketsByViewerTimezone(t *testing.T) {
 	}
 
 	readDate := func(tz string) string {
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=10&tz="+tz, nil))
+		w := testutil.Call(t, testHandler.GetDashboardUsageDaily, newRequest("GET", "/api/dashboard/usage/daily?days=10&tz="+tz, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("tz=%s: expected 200, got %d: %s", tz, w.Code, w.Body.String())
 		}
@@ -493,8 +471,7 @@ func TestDashboardRunTimeDailyBucketsByViewerTimezone(t *testing.T) {
 	}
 
 	readRow := func(tz string) (string, int64, int32) {
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardRunTimeDaily(w, newRequest("GET", "/api/dashboard/runtime/daily?days=10&tz="+tz, nil))
+		w := testutil.Call(t, testHandler.GetDashboardRunTimeDaily, newRequest("GET", "/api/dashboard/runtime/daily?days=10&tz="+tz, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("tz=%s: expected 200, got %d: %s", tz, w.Code, w.Body.String())
 		}
@@ -598,20 +575,14 @@ func TestDashboardRunTimeCountsCancelledRuns(t *testing.T) {
 // one agent from GetDashboardAgentRunTime. Zeroes when the agent has no row.
 func readAgentRunTime(t *testing.T, agentID string) (int64, int32, int32) {
 	t.Helper()
-	w := httptest.NewRecorder()
-	testHandler.GetDashboardAgentRunTime(w, newRequest("GET", "/api/dashboard/agent-runtime?days=10&tz=UTC", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetDashboardAgentRunTime, newRequest("GET", "/api/dashboard/agent-runtime?days=10&tz=UTC", nil)).Want(http.StatusOK)
 	var rows []struct {
 		AgentID        string `json:"agent_id"`
 		TotalSeconds   int64  `json:"total_seconds"`
 		TaskCount      int32  `json:"task_count"`
 		CancelledCount int32  `json:"cancelled_count"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode agent run time: %v", err)
-	}
+	w.Decode(&rows)
 	for _, r := range rows {
 		if r.AgentID == agentID {
 			return r.TotalSeconds, r.TaskCount, r.CancelledCount
@@ -1326,8 +1297,7 @@ func TestDashboardUsageDailyCrossMidnightFullPipeline(t *testing.T) {
 	}
 
 	readDate := func(tz string) string {
-		w := httptest.NewRecorder()
-		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=10&tz="+tz, nil))
+		w := testutil.Call(t, testHandler.GetDashboardUsageDaily, newRequest("GET", "/api/dashboard/usage/daily?days=10&tz="+tz, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("tz=%s: expected 200, got %d: %s", tz, w.Code, w.Body.String())
 		}
@@ -1521,9 +1491,7 @@ func TestDashboardFailuresCountNeverStartedTasks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			tc.call(w)
-			if w.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 			var rows []failureRow
 			if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
 				t.Fatalf("decode: %v", err)
@@ -1613,9 +1581,7 @@ func TestDashboardFailuresByAgentUsesExactWindow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.GetDashboardFailuresByAgent(w, newRequest("GET", "/api/dashboard/failures/by-agent?days=1&tz=UTC", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("by-agent: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := countTimeouts(w.Body.Bytes()); got != 0 {
 		t.Errorf("days=1 must not reach yesterday's failure, but by-agent counted %d", got)
 	}
@@ -1624,9 +1590,7 @@ func TestDashboardFailuresByAgentUsesExactWindow(t *testing.T) {
 	// proving the window was closed, not that the fixture is unreachable.
 	w = httptest.NewRecorder()
 	testHandler.GetDashboardFailuresByAgent(w, newRequest("GET", "/api/dashboard/failures/by-agent?days=2&tz=UTC", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("by-agent days=2: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := countTimeouts(w.Body.Bytes()); got < 1 {
 		t.Errorf("days=2 must include yesterday's failure, got %d", got)
 	}
@@ -1837,11 +1801,7 @@ func dashboardRunTimeSeconds(t *testing.T, at time.Time, loc *time.Location, que
 		"created_at":   started,
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.GetDashboardAgentRunTime(w, newRequest("GET", "/api/dashboard/agent-runtime?"+query, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("agent-runtime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetDashboardAgentRunTime, newRequest("GET", "/api/dashboard/agent-runtime?"+query, nil)).Want(http.StatusOK)
 	var rows []struct {
 		AgentID      string `json:"agent_id"`
 		TotalSeconds int64  `json:"total_seconds"`

--- a/server/internal/handler/delegated_failure_recovery_test.go
+++ b/server/internal/handler/delegated_failure_recovery_test.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestUpdateComment_RequeuesDelegatedFailureRecoverySurvivor(t *testing.T) {
@@ -20,16 +21,7 @@ func TestUpdateComment_RequeuesDelegatedFailureRecoverySurvivor(t *testing.T) {
 	}
 
 	var workerID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, 'delegated recovery worker', '', 'cloud', '{}'::jsonb, $2, 'private', 1, $3)
-		RETURNING id`, testWorkspaceID, runtimeID, testUserID).Scan(&workerID); err != nil {
-		t.Fatalf("create worker agent: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, workerID) })
+	workerID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'delegated recovery worker'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	var workerIssueID string
 	if err := testPool.QueryRow(ctx, `
@@ -91,15 +83,12 @@ func TestUpdateComment_RequeuesDelegatedFailureRecoverySurvivor(t *testing.T) {
 		RETURNING id`, coordinatorID, runtimeID, sourceIssueID, recoveryCommentID, humanCommentID, testUserID).Scan(&cancelledTaskID); err != nil {
 		t.Fatalf("create queued coordinator batch: %v", err)
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequest(http.MethodPut, "/api/comments/"+humanCommentID, map[string]any{
 		"content": "edited instruction",
 	})
 	req = withURLParam(req, "commentId", humanCommentID)
-	testHandler.UpdateComment(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateComment: got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateComment, req).Want(http.StatusOK)
 
 	var cancelledStatus string
 	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, cancelledTaskID).Scan(&cancelledStatus); err != nil {

--- a/server/internal/handler/dingtalk_test.go
+++ b/server/internal/handler/dingtalk_test.go
@@ -200,8 +200,7 @@ func TestListDingTalkGroupsForAgent_FollowsAgentViewPermissionMatrix(t *testing.
 				}
 				req := newRequestAs(actor.userID, http.MethodGet, "/api/agents/"+agentID+"/dingtalk/groups", nil)
 				req = withURLParams(req, "id", agentID)
-				w := httptest.NewRecorder()
-				testHandler.ListDingTalkGroupsForAgent(w, req)
+				w := testutil.Call(t, testHandler.ListDingTalkGroupsForAgent, req)
 				if want := accessModel.want[actor.name]; w.Code != want {
 					t.Fatalf("ListDingTalkGroupsForAgent: want %d, got %d: %s", want, w.Code, w.Body.String())
 				}
@@ -298,14 +297,12 @@ INSERT INTO dingtalk_group_presence (
 				installReq := newRequestAs(actor.userID, http.MethodGet,
 					"/api/workspaces/"+testWorkspaceID+"/dingtalk/installations", nil)
 				installReq = withURLParams(installReq, "id", testWorkspaceID)
-				installRec := httptest.NewRecorder()
-				testHandler.ListDingTalkInstallations(installRec, installReq)
+				installRec := testutil.Call(t, testHandler.ListDingTalkInstallations, installReq)
 
 				groupReq := newRequestAs(actor.userID, http.MethodGet,
 					"/api/workspaces/"+testWorkspaceID+"/dingtalk/groups", nil)
 				groupReq = withURLParams(groupReq, "id", testWorkspaceID)
-				groupRec := httptest.NewRecorder()
-				testHandler.ListDingTalkGroups(groupRec, groupReq)
+				groupRec := testutil.Call(t, testHandler.ListDingTalkGroups, groupReq)
 
 				wantStatus := http.StatusOK
 				if actor.userID == "" {
@@ -323,13 +320,9 @@ INSERT INTO dingtalk_group_presence (
 				var installations struct {
 					Installations []DingTalkInstallationResponse `json:"installations"`
 				}
-				if err := json.Unmarshal(installRec.Body.Bytes(), &installations); err != nil {
-					t.Fatal(err)
-				}
+				installRec.JSON(&installations)
 				var groups ListDingTalkGroupsResponse
-				if err := json.Unmarshal(groupRec.Body.Bytes(), &groups); err != nil {
-					t.Fatal(err)
-				}
+				groupRec.JSON(&groups)
 				wantCount := 0
 				if accessModel.visible[actor.name] {
 					wantCount = 1
@@ -501,17 +494,11 @@ func TestListDingTalkInstallations_OrphanIsAdminOnlyAndMarkedUnavailable(t *test
 		req := newRequestAs(userID, http.MethodGet,
 			"/api/workspaces/"+testWorkspaceID+"/dingtalk/installations", nil)
 		req = withURLParams(req, "id", testWorkspaceID)
-		rec := httptest.NewRecorder()
-		testHandler.ListDingTalkInstallations(rec, req)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("ListDingTalkInstallations status = %d: %s", rec.Code, rec.Body.String())
-		}
+		rec := testutil.Call(t, testHandler.ListDingTalkInstallations, req).Want(http.StatusOK)
 		var response struct {
 			Installations []DingTalkInstallationResponse `json:"installations"`
 		}
-		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
-			t.Fatal(err)
-		}
+		rec.JSON(&response)
 		return response.Installations
 	}
 
@@ -564,9 +551,7 @@ func TestRegisterDingTalkBYO_AuthorizesAgentOwnerAndAdmins(t *testing.T) {
 					want = http.StatusBadRequest
 				}
 				w := register(tc.userID)
-				if w.Code != want {
-					t.Fatalf("RegisterDingTalkBYO: want %d, got %d: %s", want, w.Code, w.Body.String())
-				}
+				testutil.Equal(t, w.Code, want, "HTTP status")
 			})
 		}
 	}
@@ -610,8 +595,7 @@ INSERT INTO dingtalk_bot_identity (
 		)
 		req := newRequestAs(userID, http.MethodDelete,
 			"/api/workspaces/"+testWorkspaceID+"/dingtalk/installations/"+installationID+"/groups/cid%2Fforget", nil)
-		rec := httptest.NewRecorder()
-		router.ServeHTTP(rec, req)
+		rec := testutil.Call(t, router.ServeHTTP, req)
 		return rec.Code
 	}
 	if got := forget(memberID); got != http.StatusForbidden {
@@ -638,15 +622,9 @@ SELECT
 	listReq := newRequestAs(testUserID, http.MethodGet,
 		"/api/workspaces/"+testWorkspaceID+"/dingtalk/groups", nil)
 	listReq = withURLParams(listReq, "id", testWorkspaceID)
-	listRec := httptest.NewRecorder()
-	testHandler.ListDingTalkGroups(listRec, listReq)
-	if listRec.Code != http.StatusOK {
-		t.Fatalf("list groups after forget status = %d: %s", listRec.Code, listRec.Body.String())
-	}
+	listRec := testutil.Call(t, testHandler.ListDingTalkGroups, listReq).Want(http.StatusOK)
 	var listing ListDingTalkGroupsResponse
-	if err := json.Unmarshal(listRec.Body.Bytes(), &listing); err != nil {
-		t.Fatal(err)
-	}
+	listRec.JSON(&listing)
 	forgottenGroupPresent := false
 	for _, group := range listing.Groups {
 		for _, bot := range group.Bots {
@@ -682,8 +660,7 @@ func TestRevokeDingTalkInstallation_AuthorizesAgentOwnerAndAdmins(t *testing.T) 
 		req := newRequestAs(userID, http.MethodDelete,
 			"/api/workspaces/"+testWorkspaceID+"/dingtalk/installations/"+installationID, nil)
 		req = withURLParams(req, "id", testWorkspaceID, "installationId", installationID)
-		w := httptest.NewRecorder()
-		testHandler.RevokeDingTalkInstallation(w, req)
+		w := testutil.Call(t, testHandler.RevokeDingTalkInstallation, req)
 		return w.Code
 	}
 
@@ -733,8 +710,7 @@ func TestRevokeDingTalkInstallation_OrphanCleanableByAdminNotMember(t *testing.T
 		req := newRequestAs(userID, http.MethodDelete,
 			"/api/workspaces/"+testWorkspaceID+"/dingtalk/installations/"+installationID, nil)
 		req = withURLParams(req, "id", testWorkspaceID, "installationId", installationID)
-		w := httptest.NewRecorder()
-		testHandler.RevokeDingTalkInstallation(w, req)
+		w := testutil.Call(t, testHandler.RevokeDingTalkInstallation, req)
 		return w.Code
 	}
 
@@ -843,16 +819,11 @@ func TestRedeemDingTalkBindingTokenPublishesAccountBindingUpdateAfterCommit(t *t
 		)
 	})
 
-	recorder := httptest.NewRecorder()
-	h.RedeemDingTalkBindingToken(recorder, newRequest(
+	testutil.Call(t, h.RedeemDingTalkBindingToken, newRequest(
 		http.MethodPost,
 		"/api/dingtalk/binding/redeem",
 		RedeemDingTalkBindingTokenRequest{Token: token.Raw},
-	))
-
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("redeem status = %d, body = %s", recorder.Code, recorder.Body.String())
-	}
+	)).Want(http.StatusOK)
 	if eventCount != 1 {
 		t.Fatalf("binding update event count = %d, want 1", eventCount)
 	}
@@ -938,19 +909,13 @@ INSERT INTO dingtalk_group_presence (
 	rctx.URLParams.Add("id", testWorkspaceID)
 	req := newRequestAs(testUserID, http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/dingtalk/groups", nil)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	rec := httptest.NewRecorder()
-	testHandler.ListDingTalkGroups(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("list groups status = %d: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.ListDingTalkGroups, req).Want(http.StatusOK)
 	var response struct {
 		Groups                  []DingTalkGroupResponse `json:"groups"`
 		GroupDiscoverySupported bool                    `json:"group_discovery_supported"`
 		InactiveGroupCounts     map[string]int64        `json:"inactive_group_counts"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
-		t.Fatal(err)
-	}
+	rec.JSON(&response)
 	if !response.GroupDiscoverySupported || len(response.Groups) != 1 || response.Groups[0].ConversationID != "cid-shared" ||
 		response.Groups[0].ConversationTitle != "Platform" || len(response.Groups[0].Bots) != 2 {
 		t.Fatalf("group response = %+v", response.Groups)
@@ -971,14 +936,8 @@ INSERT INTO dingtalk_group_presence (
 	inactiveReq := newRequestAs(testUserID, http.MethodGet,
 		"/api/workspaces/"+testWorkspaceID+"/dingtalk/groups?activity=inactive&installation_id="+installOne, nil)
 	inactiveReq = inactiveReq.WithContext(context.WithValue(inactiveReq.Context(), chi.RouteCtxKey, rctx))
-	inactiveRec := httptest.NewRecorder()
-	testHandler.ListDingTalkGroups(inactiveRec, inactiveReq)
-	if inactiveRec.Code != http.StatusOK {
-		t.Fatalf("list inactive groups status = %d: %s", inactiveRec.Code, inactiveRec.Body.String())
-	}
-	if err := json.Unmarshal(inactiveRec.Body.Bytes(), &response); err != nil {
-		t.Fatal(err)
-	}
+	inactiveRec := testutil.Call(t, testHandler.ListDingTalkGroups, inactiveReq).Want(http.StatusOK)
+	inactiveRec.JSON(&response)
 	if len(response.Groups) != 2 || response.Groups[0].ConversationID != "cid-z" ||
 		response.Groups[1].ConversationID != "cid-untitled" {
 		t.Fatalf("inactive groups = %+v", response.Groups)
@@ -986,9 +945,7 @@ INSERT INTO dingtalk_group_presence (
 
 	agentRec := httptest.NewRecorder()
 	testHandler.listDingTalkGroups(agentRec, req, parseUUID(testWorkspaceID), agentOne, nil)
-	if agentRec.Code != http.StatusOK {
-		t.Fatalf("list Agent groups status = %d: %s", agentRec.Code, agentRec.Body.String())
-	}
+	testutil.Equal(t, agentRec.Code, http.StatusOK, "HTTP status")
 	if err := json.Unmarshal(agentRec.Body.Bytes(), &response); err != nil {
 		t.Fatal(err)
 	}
@@ -999,8 +956,7 @@ INSERT INTO dingtalk_group_presence (
 }
 
 func TestListDingTalkGroupsDisabledDeploymentReturnsStableEmptyShape(t *testing.T) {
-	rec := httptest.NewRecorder()
-	(&Handler{}).ListDingTalkGroups(rec, httptest.NewRequest(http.MethodGet, "/api/workspaces/bad/dingtalk/groups", nil))
+	rec := testutil.Call(t, (&Handler{}).ListDingTalkGroups, httptest.NewRequest(http.MethodGet, "/api/workspaces/bad/dingtalk/groups", nil))
 	if rec.Code != http.StatusOK || rec.Body.String() != "{\"groups\":[],\"group_discovery_supported\":true,\"inactive_group_counts\":{},\"bot_identities\":{}}\n" {
 		t.Fatalf("disabled groups response = %d %q", rec.Code, rec.Body.String())
 	}
@@ -1021,11 +977,7 @@ func TestListDingTalkGroupsReturnsInternalErrorOnDatabaseFailure(t *testing.T) {
 	cancel()
 	req := newRequestAs(testUserID, http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/dingtalk/groups", nil)
 	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
-	rec := httptest.NewRecorder()
-	testHandler.ListDingTalkGroups(rec, req)
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("database failure status = %d, want 500: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Call(t, testHandler.ListDingTalkGroups, req).Want(http.StatusInternalServerError)
 
 	inactiveReq := newRequestAs(testUserID, http.MethodGet,
 		"/api/workspaces/"+testWorkspaceID+"/dingtalk/groups?activity=inactive&installation_id=d1473000-0000-4000-8000-000000000099", nil)

--- a/server/internal/handler/feedback_test.go
+++ b/server/internal/handler/feedback_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strconv"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestCreateFeedbackHappyPath(t *testing.T) {
@@ -15,16 +16,9 @@ func TestCreateFeedbackHappyPath(t *testing.T) {
 	req := newRequest("POST", "/api/feedback", CreateFeedbackRequest{
 		Message: "Love the product, dark mode flashes on startup",
 	})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusCreated)
 	var resp FeedbackResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.ID == "" {
 		t.Fatal("expected feedback id in response")
 	}
@@ -45,16 +39,9 @@ func TestCreateFeedbackStoresStructuredContext(t *testing.T) {
 			},
 		},
 	})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusCreated)
 	var resp FeedbackResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 
 	var metadata []byte
 	if err := testPool.QueryRow(
@@ -101,12 +88,7 @@ func TestCreateFeedbackRejectsMalformedContext(t *testing.T) {
 		"message": "Desktop route crashed",
 		"context": "not-an-object",
 	})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusBadRequest)
 }
 
 func TestCreateFeedbackRejectsUnknownContextKind(t *testing.T) {
@@ -121,12 +103,7 @@ func TestCreateFeedbackRejectsUnknownContextKind(t *testing.T) {
 			},
 		},
 	})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusBadRequest)
 }
 
 func TestCreateFeedbackRejectsEmptyContextFields(t *testing.T) {
@@ -178,23 +155,14 @@ func TestCreateFeedbackRejectsEmptyContextFields(t *testing.T) {
 				Message: "Desktop route crashed",
 				Context: &tt.context,
 			})
-			w := httptest.NewRecorder()
-			testHandler.CreateFeedback(w, req)
-
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusBadRequest)
 		})
 	}
 }
 
 func TestCreateFeedbackEmptyMessage(t *testing.T) {
 	req := newRequest("POST", "/api/feedback", CreateFeedbackRequest{Message: "   "})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusBadRequest)
 }
 
 func TestCreateFeedbackRateLimit(t *testing.T) {
@@ -204,18 +172,13 @@ func TestCreateFeedbackRateLimit(t *testing.T) {
 		req := newRequest("POST", "/api/feedback", CreateFeedbackRequest{
 			Message: "feedback #" + strconv.Itoa(i),
 		})
-		w := httptest.NewRecorder()
-		testHandler.CreateFeedback(w, req)
+		w := testutil.Call(t, testHandler.CreateFeedback, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("iteration %d: expected 201, got %d: %s", i, w.Code, w.Body.String())
 		}
 	}
 	req := newRequest("POST", "/api/feedback", CreateFeedbackRequest{Message: "one too many"})
-	w := httptest.NewRecorder()
-	testHandler.CreateFeedback(w, req)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected 429, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateFeedback, req).Want(http.StatusTooManyRequests)
 }
 
 // clearFeedbackForTestUser wipes all feedback rows for the shared test user

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/storage"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -35,18 +36,7 @@ func createHandlerTestChatSession(t *testing.T, agentID string) string {
 	t.Helper()
 
 	var sessionID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO chat_session (
-			workspace_id, agent_id, creator_id, title, status, explicitly_created_at
-		)
-		VALUES ($1, $2, $3, $4, 'active', now())
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID, "Handler Test Chat Session").Scan(&sessionID); err != nil {
-		t.Fatalf("failed to create handler test chat session: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID)
-	})
+	sessionID = dbfx.Insert(t, "chat_session", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "creator_id": testUserID, "title": "Handler Test Chat Session", "status": testutil.Raw("'active'"), "explicitly_created_at": testutil.Raw("now()")})
 	return sessionID
 }
 
@@ -247,11 +237,7 @@ func TestUploadFileForeignWorkspace(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req.Header.Set("X-Workspace-ID", foreignWorkspaceID)
 
-	w := httptest.NewRecorder()
-	testHandler.UploadFile(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("UploadFile with foreign workspace: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UploadFile, req).Want(http.StatusForbidden)
 }
 
 // TestUploadFileResolvesWorkspaceViaSlugHeader is a regression test for the
@@ -282,11 +268,7 @@ func TestUploadFileResolvesWorkspaceViaSlugHeader(t *testing.T) {
 	// Intentionally NOT setting X-Workspace-ID — post-v2 clients only send slug.
 	req.Header.Set("X-Workspace-Slug", handlerTestWorkspaceSlug)
 
-	w := httptest.NewRecorder()
-	testHandler.UploadFile(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UploadFile with slug header: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UploadFile, req).Want(http.StatusOK)
 
 	// The workspace-aware branch returns the full AttachmentResponse (with
 	// id, workspace_id, uploader, etc.). The no-workspace-context branch
@@ -349,11 +331,7 @@ func TestUploadFileResolvesWorkspaceViaIDHeaderStill(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 
-	w := httptest.NewRecorder()
-	testHandler.UploadFile(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UploadFile with UUID header: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UploadFile, req).Want(http.StatusOK)
 
 	// Clean up.
 	if _, err := testPool.Exec(
@@ -395,11 +373,7 @@ func TestUploadFile_AttachesToChatSession(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 
-	w := httptest.NewRecorder()
-	testHandler.UploadFile(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UploadFile with chat_session_id: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UploadFile, req).Want(http.StatusOK)
 
 	var resp AttachmentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
@@ -460,8 +434,7 @@ func TestUploadFile_RejectsForeignChatSession(t *testing.T) {
 	req.Header.Set("X-User-ID", testUserID)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 
-	w := httptest.NewRecorder()
-	testHandler.UploadFile(w, req)
+	w := testutil.Call(t, testHandler.UploadFile, req)
 	if w.Code != http.StatusNotFound && w.Code != http.StatusForbidden && w.Code != http.StatusBadRequest {
 		t.Fatalf("UploadFile with unknown chat_session_id: expected 4xx, got %d: %s", w.Code, w.Body.String())
 	}
@@ -699,13 +672,7 @@ func TestGetAttachmentByID_AutoPublicEndpointReturnsPresignedDownloadURL(t *test
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.GetAttachmentByID(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAttachmentByID, req).Want(http.StatusOK)
 	var resp AttachmentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
@@ -777,13 +744,7 @@ func TestGetAttachmentByID_CloudFrontModeSignsForcedAttachmentDownloadURL(t *tes
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", id)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	w := httptest.NewRecorder()
-
-	testHandler.GetAttachmentByID(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetAttachmentByID, req).Want(http.StatusOK)
 	var resp AttachmentResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
@@ -839,9 +800,7 @@ func TestDownloadAttachment_CloudFrontRedirectSignsAttachmentDisposition(t *test
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	loc := w.Header().Get("Location")
 	parsed, err := url.Parse(loc)
 	if err != nil {
@@ -877,13 +836,7 @@ func TestDownloadAttachment_BareNavigationWithWorkspaceSlugQueryPassesMiddleware
 
 	req := httptest.NewRequest("GET", "/api/attachments/"+id+"/download?workspace_slug="+url.QueryEscape(handlerTestWorkspaceSlug), nil)
 	req.Header.Set("X-User-ID", testUserID)
-	w := httptest.NewRecorder()
-
-	newDownloadRouter().ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, newDownloadRouter().ServeHTTP, req).Want(http.StatusOK)
 	if got := w.Body.String(); got != string(body) {
 		t.Fatalf("body = %q, want %q", got, body)
 	}
@@ -922,13 +875,7 @@ func TestDownloadAttachment_BareNavigationServesMemberWithoutWorkspaceHeaders(t 
 	// when the markdown stores `/api/attachments/<id>/download`.
 	req := httptest.NewRequest("GET", "/api/attachments/"+id+"/download", nil)
 	req.Header.Set("X-User-ID", testUserID)
-	w := httptest.NewRecorder()
-
-	newDownloadRouter().ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, newDownloadRouter().ServeHTTP, req).Want(http.StatusOK)
 	if got := w.Body.String(); got != string(body) {
 		t.Fatalf("body = %q, want %q", got, body)
 	}
@@ -988,13 +935,7 @@ func TestDownloadAttachment_BareNavigationDeniesNonMemberWith404(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/api/attachments/"+id+"/download", nil)
 	req.Header.Set("X-User-ID", testUserID)
-	w := httptest.NewRecorder()
-
-	newDownloadRouter().ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404 for non-member; body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, newDownloadRouter().ServeHTTP, req).Want(http.StatusNotFound)
 	if strings.Contains(w.Body.String(), "foreign-body") {
 		t.Fatalf("response body leaked file contents: %q", w.Body.String())
 	}
@@ -1024,9 +965,7 @@ func TestDownloadAttachment_AutoInternalEndpointProxies(t *testing.T) {
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Body.String(); got != string(body) {
 		t.Fatalf("body = %q, want %q", got, body)
 	}
@@ -1070,9 +1009,7 @@ func TestDownloadAttachment_AutoPublicEndpointPresigns(t *testing.T) {
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	loc := w.Header().Get("Location")
 	if !strings.Contains(loc, "X-Amz-Signature=mock") {
 		t.Fatalf("Location = %q, want fake S3 signature", loc)
@@ -1115,9 +1052,7 @@ func TestDownloadAttachment_ExplicitProxyStreamsPublicEndpoint(t *testing.T) {
 	req, w := newDownloadRequest(t, id, testWorkspaceID)
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Body.Bytes(); !bytes.Equal(got, body) {
 		t.Fatalf("body mismatch: got %q want %q", got, body)
 	}
@@ -1180,9 +1115,7 @@ func runProxyRangeMatrix(t *testing.T, newStore func() storage.Storage) {
 		req.Header.Set("Range", "bytes=0-1023")
 		testHandler.DownloadAttachment(w, req)
 
-		if w.Code != http.StatusPartialContent {
-			t.Fatalf("status = %d, want 206; body=%s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusPartialContent, "HTTP status")
 		if got, want := w.Header().Get("Accept-Ranges"), "bytes"; got != want {
 			t.Fatalf("Accept-Ranges = %q, want %q", got, want)
 		}
@@ -1204,9 +1137,7 @@ func runProxyRangeMatrix(t *testing.T, newStore func() storage.Storage) {
 		req.Header.Set("Range", "bytes=1000-1999")
 		testHandler.DownloadAttachment(w, req)
 
-		if w.Code != http.StatusPartialContent {
-			t.Fatalf("status = %d, want 206; body=%s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusPartialContent, "HTTP status")
 		if got, want := w.Header().Get("Content-Range"), fmt.Sprintf("bytes 1000-1999/%d", len(body)); got != want {
 			t.Fatalf("Content-Range = %q, want %q", got, want)
 		}
@@ -1221,9 +1152,7 @@ func runProxyRangeMatrix(t *testing.T, newStore func() storage.Storage) {
 		req.Header.Set("Range", "bytes=-500")
 		testHandler.DownloadAttachment(w, req)
 
-		if w.Code != http.StatusPartialContent {
-			t.Fatalf("status = %d, want 206; body=%s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusPartialContent, "HTTP status")
 		start := len(body) - 500
 		if got, want := w.Header().Get("Content-Range"), fmt.Sprintf("bytes %d-%d/%d", start, len(body)-1, len(body)); got != want {
 			t.Fatalf("Content-Range = %q, want %q", got, want)
@@ -1239,9 +1168,7 @@ func runProxyRangeMatrix(t *testing.T, newStore func() storage.Storage) {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", len(body)+10, len(body)+20))
 		testHandler.DownloadAttachment(w, req)
 
-		if w.Code != http.StatusRequestedRangeNotSatisfiable {
-			t.Fatalf("status = %d, want 416; body=%s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusRequestedRangeNotSatisfiable, "HTTP status")
 		if got, want := w.Header().Get("Content-Range"), fmt.Sprintf("bytes */%d", len(body)); got != want {
 			t.Fatalf("Content-Range = %q, want %q", got, want)
 		}
@@ -1252,9 +1179,7 @@ func runProxyRangeMatrix(t *testing.T, newStore func() storage.Storage) {
 		req, w := newDownloadRequest(t, id, testWorkspaceID)
 		testHandler.DownloadAttachment(w, req)
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 		if got, want := w.Header().Get("Accept-Ranges"), "bytes"; got != want {
 			t.Fatalf("Accept-Ranges = %q, want %q", got, want)
 		}
@@ -1295,9 +1220,7 @@ func TestDownloadAttachment_NonSeekableRangeSkipFailureReturns502(t *testing.T) 
 	req.Header.Set("Range", "bytes=1000-1999")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadGateway, "HTTP status")
 	if !strings.Contains(w.Body.String(), "failed to read attachment range") {
 		t.Fatalf("502 body should carry the honest error, got %q", w.Body.String())
 	}
@@ -1319,9 +1242,7 @@ func TestDownloadAttachment_NonSeekableMultiRangeServesFull200(t *testing.T) {
 	req.Header.Set("Range", "bytes=0-10,20-30")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 (multi-range ignored); body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Body.Bytes(); !bytes.Equal(got, body) {
 		t.Fatalf("multi-range should serve full body: len(got)=%d, want %d", len(got), len(body))
 	}
@@ -1347,9 +1268,7 @@ func TestDownloadAttachment_SeekableMultiRangeServes206(t *testing.T) {
 	req.Header.Set("Range", "bytes=0-10,20-30")
 	testHandler.DownloadAttachment(w, req)
 
-	if w.Code != http.StatusPartialContent {
-		t.Fatalf("status = %d, want 206 (multipart); body len=%d", w.Code, w.Body.Len())
-	}
+	testutil.Equal(t, w.Code, http.StatusPartialContent, "HTTP status")
 	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "multipart/byteranges") {
 		t.Fatalf("Content-Type = %q, want multipart/byteranges", ct)
 	}
@@ -1375,9 +1294,7 @@ func TestDownloadAttachment_NonSeekableEmptyObjectRangeServesFull200(t *testing.
 			req.Header.Set("Range", rangeHeader)
 			testHandler.DownloadAttachment(w, req)
 
-			if w.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200 (Range ignored on empty object); body=%s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 			if got := w.Body.Len(); got != 0 {
 				t.Fatalf("empty object must serve an empty body, got %d bytes", got)
 			}
@@ -1411,9 +1328,7 @@ func TestDownloadAttachment_NonSeekableEmptyObjectMalformedRangeReturns416(t *te
 			req.Header.Set("Range", rangeHeader)
 			testHandler.DownloadAttachment(w, req)
 
-			if w.Code != http.StatusRequestedRangeNotSatisfiable {
-				t.Fatalf("status = %d, want 416 for malformed range on empty object; body=%s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusRequestedRangeNotSatisfiable, "HTTP status")
 		})
 	}
 }
@@ -1520,9 +1435,7 @@ func TestGetAttachmentContent_HappyPath_Markdown(t *testing.T) {
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.GetAttachmentContent(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Body.String(); got != string(body) {
 		t.Errorf("body = %q, want %q", got, body)
 	}
@@ -1551,9 +1464,7 @@ func TestGetAttachmentContent_AcceptsByExtensionWhenContentTypeIsGeneric(t *test
 
 	req, w := newPreviewRequest(t, id, testWorkspaceID)
 	testHandler.GetAttachmentContent(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 func TestGetAttachmentContent_Unsupported_PDF(t *testing.T) {
@@ -1566,9 +1477,7 @@ func TestGetAttachmentContent_Unsupported_PDF(t *testing.T) {
 
 	req, w := newPreviewRequest(t, id, testWorkspaceID)
 	testHandler.GetAttachmentContent(w, req)
-	if w.Code != http.StatusUnsupportedMediaType {
-		t.Fatalf("status = %d, want 415; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnsupportedMediaType, "HTTP status")
 }
 
 func TestGetAttachmentContent_TooLarge(t *testing.T) {
@@ -1583,9 +1492,7 @@ func TestGetAttachmentContent_TooLarge(t *testing.T) {
 
 	req, w := newPreviewRequest(t, id, testWorkspaceID)
 	testHandler.GetAttachmentContent(w, req)
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("status = %d, want 413; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusRequestEntityTooLarge, "HTTP status")
 }
 
 func TestGetAttachmentContent_ForeignWorkspace(t *testing.T) {
@@ -1600,9 +1507,7 @@ func TestGetAttachmentContent_ForeignWorkspace(t *testing.T) {
 	foreign := "00000000-0000-0000-0000-000000000099"
 	req, w := newPreviewRequest(t, id, foreign)
 	testHandler.GetAttachmentContent(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 func TestGetAttachmentContent_NotFound(t *testing.T) {
@@ -1613,9 +1518,7 @@ func TestGetAttachmentContent_NotFound(t *testing.T) {
 
 	req, w := newPreviewRequest(t, "00000000-0000-0000-0000-000000000abc", testWorkspaceID)
 	testHandler.GetAttachmentContent(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404; body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // isTextPreviewable is the whitelist linkpin between the proxy and the
@@ -1926,9 +1829,7 @@ func TestServeLocalUpload_RelaxesFrameAncestorsForPreview(t *testing.T) {
 
 	h.ServeLocalUpload(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := w.Body.String(); got != body {
 		t.Fatalf("body = %q, want %q", got, body)
 	}
@@ -1941,9 +1842,5 @@ func TestServeLocalUpload_RelaxesFrameAncestorsForPreview(t *testing.T) {
 func TestServeLocalUpload_NonLocalStorage404(t *testing.T) {
 	h := &Handler{Storage: &mockStorage{}}
 	req := httptest.NewRequest(http.MethodGet, "/uploads/workspaces/ws-1/x.png", nil)
-	w := httptest.NewRecorder()
-	h.ServeLocalUpload(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", w.Code)
-	}
+	testutil.Call(t, h.ServeLocalUpload, req).Want(http.StatusNotFound)
 }

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -321,15 +321,9 @@ func TestGitHubConnectRepositoryReturnTarget(t *testing.T) {
 		nil,
 	)
 	req = withURLParam(req, "id", wsID)
-	rec := httptest.NewRecorder()
-	(&Handler{}).GitHubConnect(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("GitHubConnect: got %d (%s)", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, (&Handler{}).GitHubConnect, req).Want(http.StatusOK)
 	var body GitHubConnectResponse
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("decode connect response: %v", err)
-	}
+	rec.Decode(&body)
 	installURL, err := url.Parse(body.URL)
 	if err != nil {
 		t.Fatalf("parse install URL: %v", err)
@@ -345,11 +339,7 @@ func TestGitHubConnectRepositoryReturnTarget(t *testing.T) {
 		nil,
 	)
 	badReq = withURLParam(badReq, "id", wsID)
-	badRec := httptest.NewRecorder()
-	(&Handler{}).GitHubConnect(badRec, badReq)
-	if badRec.Code != http.StatusBadRequest {
-		t.Fatalf("invalid return target: got %d, want 400", badRec.Code)
-	}
+	testutil.Call(t, (&Handler{}).GitHubConnect, badReq).Want(http.StatusBadRequest)
 }
 
 func TestGitHubSetupCallbackRepositoryReturnTarget(t *testing.T) {
@@ -366,11 +356,7 @@ func TestGitHubSetupCallbackRepositoryReturnTarget(t *testing.T) {
 		"/api/github/setup?installation_id=not-a-number&state="+url.QueryEscape(state),
 		nil,
 	)
-	rec := httptest.NewRecorder()
-	(&Handler{}).GitHubSetupCallback(rec, req)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("GitHubSetupCallback: got %d, want 302", rec.Code)
-	}
+	rec := testutil.Call(t, (&Handler{}).GitHubSetupCallback, req).Want(http.StatusFound)
 	if got := rec.Header().Get("Location"); got != "https://app.multica.test/settings?tab=repositories&github_error=bad_installation_id" {
 		t.Fatalf("redirect = %q, want repository settings error", got)
 	}
@@ -458,7 +444,7 @@ func TestWebhook_MergedPR_AdvancesLinkedIssueToDone(t *testing.T) {
 	req2 := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(raw))
 	req2.Header.Set("X-GitHub-Event", "pull_request")
 	req2.Header.Set("X-Hub-Signature-256", sig)
-	w = testutil.Call(t, testHandler.HandleGitHubWebhook, req2).Want(http.StatusAccepted)
+	testutil.Call(t, testHandler.HandleGitHubWebhook, req2).Want(http.StatusAccepted)
 
 	// Verify PR row + link + issue status.
 	pr, err := testHandler.Queries.GetGitHubPullRequest(ctx, db.GetGitHubPullRequestParams{
@@ -546,7 +532,7 @@ func TestWebhook_MergedPR_PreservesCancelled(t *testing.T) {
 	req2 := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(body))
 	req2.Header.Set("X-GitHub-Event", "pull_request")
 	req2.Header.Set("X-Hub-Signature-256", sig)
-	w = testutil.Call(t, testHandler.HandleGitHubWebhook, req2)
+	testutil.Call(t, testHandler.HandleGitHubWebhook, req2)
 
 	updated, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
 	if err != nil {
@@ -1741,8 +1727,7 @@ func TestListGitHubInstallations_RoleGating(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/github/installations", nil)
 		req = withURLParam(req, "id", testWorkspaceID)
 		req = req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, db.Member{Role: role}))
-		w := httptest.NewRecorder()
-		testHandler.ListGitHubInstallations(w, req)
+		w := testutil.Call(t, testHandler.ListGitHubInstallations, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("ListGitHubInstallations(%s): %d %s", role, w.Code, w.Body.String())
 		}
@@ -1910,8 +1895,7 @@ INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, $3)
 		if userID != "" {
 			req.Header.Set("X-User-ID", userID)
 		}
-		rec := httptest.NewRecorder()
-		router.ServeHTTP(rec, req)
+		rec := testutil.Call(t, router.ServeHTTP, req)
 		return rec.Code
 	}
 
@@ -2097,7 +2081,7 @@ func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
 	req2 := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(body))
 	req2.Header.Set("X-GitHub-Event", "pull_request")
 	req2.Header.Set("X-Hub-Signature-256", sig)
-	w = testutil.Call(t, testHandler.HandleGitHubWebhook, req2).Want(http.StatusAccepted)
+	testutil.Call(t, testHandler.HandleGitHubWebhook, req2).Want(http.StatusAccepted)
 
 	// Child must now be done (sanity check — the existing path).
 	updatedChild, err := testHandler.Queries.GetIssue(ctx, parseUUID(child.ID))
@@ -2361,16 +2345,13 @@ func TestListGitHubInstallationRepositoriesRejectsCrossWorkspaceRow(t *testing.T
 		"/api/workspaces/"+otherWorkspaceID+"/github/installations/"+uuidToString(row.ID)+"/repositories",
 		nil,
 	)
-	rec := httptest.NewRecorder()
+
 	router := chi.NewRouter()
 	router.Get(
 		"/api/workspaces/{id}/github/installations/{installationId}/repositories",
 		testHandler.ListGitHubInstallationRepositories,
 	)
-	router.ServeHTTP(rec, req)
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("cross-workspace row: got %d (%s), want 404", rec.Code, rec.Body.String())
-	}
+	testutil.Call(t, router.ServeHTTP, req).Want(http.StatusNotFound)
 }
 
 // TestFetchInstallationAccount_AuthenticatedPopulatesRow simulates the
@@ -2651,14 +2632,10 @@ func TestSetupCallback_ConsumesPendingInstallationCreated(t *testing.T) {
 	mac.Write(body)
 	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
 
-	rec := httptest.NewRecorder()
 	hookReq := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(body))
 	hookReq.Header.Set("X-GitHub-Event", "installation")
 	hookReq.Header.Set("X-Hub-Signature-256", sig)
-	testHandler.HandleGitHubWebhook(rec, hookReq)
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("webhook: expected 202, got %d (%s)", rec.Code, rec.Body.String())
-	}
+	testutil.Call(t, testHandler.HandleGitHubWebhook, hookReq).Want(http.StatusAccepted)
 
 	var pendingLogin string
 	dbfx.QueryRow(t,
@@ -2677,11 +2654,7 @@ func TestSetupCallback_ConsumesPendingInstallationCreated(t *testing.T) {
 		fmt.Sprintf("/api/github/setup?installation_id=%d&state=%s", installationID, state),
 		nil,
 	)
-	setupRec := httptest.NewRecorder()
-	testHandler.GitHubSetupCallback(setupRec, setupReq)
-	if setupRec.Code != http.StatusFound {
-		t.Fatalf("setup callback: expected 302, got %d (%s)", setupRec.Code, setupRec.Body.String())
-	}
+	setupRec := testutil.Call(t, testHandler.GitHubSetupCallback, setupReq).Want(http.StatusFound)
 	if loc := setupRec.Header().Get("Location"); !strings.Contains(loc, "github_connected=1") {
 		t.Fatalf("setup callback redirect = %q, want github_connected=1", loc)
 	}
@@ -2728,14 +2701,10 @@ func TestWebhook_PullRequest_FansOutToBoundWorkspaces(t *testing.T) {
 	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
 
 	// Workspace B is the shared test workspace (prefix HAN) and owns the issue.
-	w := httptest.NewRecorder()
-	testHandler.CreateIssue(w, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateIssue, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "fan-out PR test",
 		"status": "in_progress",
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var created IssueResponse
 	json.NewDecoder(w.Body).Decode(&created)
 
@@ -2826,14 +2795,10 @@ func TestWebhook_PullRequest_AmbiguousCloseAcrossWorkspaces(t *testing.T) {
 
 	// Workspace B is the shared test workspace and owns the issue the PR is
 	// really for.
-	w := httptest.NewRecorder()
-	testHandler.CreateIssue(w, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateIssue, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "ambiguous close test",
 		"status": "in_progress",
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var issueB IssueResponse
 	json.NewDecoder(w.Body).Decode(&issueB)
 
@@ -2995,14 +2960,10 @@ func TestWebhook_PullRequest_UniqueResolverAmongBindingsStillAutoCompletes(t *te
 	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
 	setWorkspaceIssuePrefixForTest(t, "UNQ")
 
-	w := httptest.NewRecorder()
-	testHandler.CreateIssue(w, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateIssue, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "unique resolver test",
 		"status": "in_progress",
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var issueB IssueResponse
 	json.NewDecoder(w.Body).Decode(&issueB)
 
@@ -3055,14 +3016,10 @@ func TestWebhook_PullRequest_UnreadableWorkspaceWithholdsCloseIntent(t *testing.
 	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
 	setWorkspaceIssuePrefixForTest(t, "UNR")
 
-	w := httptest.NewRecorder()
-	testHandler.CreateIssue(w, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+	w := testutil.Call(t, testHandler.CreateIssue, newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "unreadable workspace test",
 		"status": "in_progress",
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var issueB IssueResponse
 	json.NewDecoder(w.Body).Decode(&issueB)
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -341,9 +341,7 @@ func TestIssueCRUD(t *testing.T) {
 		"priority": "medium",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	var created IssueResponse
 	json.NewDecoder(w.Body).Decode(&created)
@@ -360,9 +358,7 @@ func TestIssueCRUD(t *testing.T) {
 	req = newRequest("GET", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.GetIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var fetched IssueResponse
 	json.NewDecoder(w.Body).Decode(&fetched)
@@ -378,9 +374,7 @@ func TestIssueCRUD(t *testing.T) {
 	})
 	req = withURLParam(req, "id", issueID)
 	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var updated IssueResponse
 	json.NewDecoder(w.Body).Decode(&updated)
@@ -398,9 +392,7 @@ func TestIssueCRUD(t *testing.T) {
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/issues?workspace_id="+testWorkspaceID, nil)
 	testHandler.ListIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var listResp map[string]any
 	json.NewDecoder(w.Body).Decode(&listResp)
@@ -414,18 +406,14 @@ func TestIssueCRUD(t *testing.T) {
 	req = newRequest("DELETE", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.DeleteIssue(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteIssue: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 
 	// Verify deleted
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.GetIssue(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("GetIssue after delete: expected 404, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // TestDeleteIssueByIdentifier guards against #1661 — DELETE /api/issues/{id}
@@ -464,7 +452,7 @@ func TestDeleteIssueByIdentifier(t *testing.T) {
 	// Delete using the human-readable identifier (e.g. "HAN-1") rather than the UUID.
 	req = newRequest("DELETE", "/api/issues/"+created.Identifier, nil)
 	req = withURLParam(req, "id", created.Identifier)
-	w = testutil.Call(t, testHandler.DeleteIssue, req).Want(http.StatusNoContent)
+	testutil.Call(t, testHandler.DeleteIssue, req).Want(http.StatusNoContent)
 
 	// Verify the row is actually gone — the silent-data-loss bug would have
 	// returned 204 here too, but the row would still exist.
@@ -546,9 +534,7 @@ func TestDeleteIssueRejectsInvalidUUID(t *testing.T) {
 	if w.Code == http.StatusNoContent {
 		t.Fatalf("DeleteIssue with invalid id: must not return 204; got %d", w.Code)
 	}
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("DeleteIssue with invalid id: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // TestCreateIssueDefaultStatusIsTodo verifies that issues created without an
@@ -844,9 +830,7 @@ func TestCreateIssueRejectsActiveDuplicate(t *testing.T) {
 		Issue IssueResponse `json:"issue"`
 	}
 	w.JSON(&conflict)
-	if conflict.Code != "active_duplicate_issue" {
-		t.Fatalf("code = %q, want active_duplicate_issue", conflict.Code)
-	}
+	testutil.Equal(t, conflict.Code, "active_duplicate_issue", "HTTP status")
 	if conflict.Issue.ID != issueID || conflict.Issue.Status != "in_progress" {
 		t.Fatalf("conflict issue = %#v, want original %s in_progress", conflict.Issue, issueID)
 	}
@@ -1271,7 +1255,7 @@ func TestAutopilotDispatchUsesCurrentProjectBinding(t *testing.T) {
 		"project_id": projectBID,
 	})
 	req = withURLParam(req, "id", autopilotID)
-	w = testutil.Call(t, testHandler.UpdateAutopilot, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateAutopilot, req).Want(http.StatusOK)
 
 	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "manual", nil)
 	if err != nil {
@@ -1470,7 +1454,7 @@ func TestUpdateIssueRejectsMalformedAssigneeID(t *testing.T) {
 		"assignee_id": "not-a-uuid",
 	})
 	req = withURLParam(req, "id", created.ID)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
 }
 
 // TestUpdateIssueRejectsNonexistentMemberAssignee verifies the same gap is
@@ -1493,7 +1477,7 @@ func TestUpdateIssueRejectsNonexistentMemberAssignee(t *testing.T) {
 		"assignee_id":   "00000000-0000-0000-0000-000000000000",
 	})
 	req = withURLParam(req, "id", created.ID)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
 }
 
 // TestUpdateIssueAllowsExplicitUnassign verifies that sending null for both
@@ -1561,7 +1545,7 @@ func TestCommentCRUD(t *testing.T) {
 	// Cleanup
 	req = newRequest("DELETE", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
-	w = testutil.Call(t, testHandler.DeleteIssue, req)
+	testutil.Call(t, testHandler.DeleteIssue, req)
 }
 
 func TestCommentWritePathsPreserveIssueIdentifiers(t *testing.T) {
@@ -1635,11 +1619,11 @@ func TestCreateCommentRejectsMalformedParentID(t *testing.T) {
 		"parent_id": "not-a-uuid",
 	})
 	req = withURLParam(req, "id", issue.ID)
-	w = testutil.Call(t, testHandler.CreateComment, req).Want(http.StatusBadRequest)
+	testutil.Call(t, testHandler.CreateComment, req).Want(http.StatusBadRequest)
 
 	req = newRequest("DELETE", "/api/issues/"+issue.ID, nil)
 	req = withURLParam(req, "id", issue.ID)
-	w = testutil.Call(t, testHandler.DeleteIssue, req)
+	testutil.Call(t, testHandler.DeleteIssue, req)
 }
 
 func TestGetChatSessionRejectsMalformedSessionID(t *testing.T) {
@@ -1776,8 +1760,7 @@ func TestRequestBodyUUIDFieldsRejectMalformed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			tt.handle(w, tt.req)
+			w := testutil.Call(t, tt.handle, tt.req)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("%s: expected 400 for malformed body UUID, got %d: %s", tt.name, w.Code, w.Body.String())
 			}
@@ -2058,7 +2041,7 @@ func TestWorkspaceCRUD(t *testing.T) {
 	wsID := workspaces[0].ID
 	req := newRequest("GET", "/api/workspaces/"+wsID, nil)
 	req = withURLParam(req, "id", wsID)
-	w = testutil.Call(t, testHandler.GetWorkspace, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.GetWorkspace, req).Want(http.StatusOK)
 }
 
 func TestCreateWorkspaceUsesRequestedSlug(t *testing.T) {
@@ -2112,16 +2095,13 @@ func TestCreateWorkspaceInvalidSlugReturnsBadRequest(t *testing.T) {
 }
 
 func TestSendCode(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	body := map[string]string{"email": "sendcode-test@multica.ai"}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(body)
 	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
-	testHandler.SendCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.SendCode, req).Want(http.StatusOK)
 
 	var resp map[string]string
 	json.NewDecoder(w.Body).Decode(&resp)
@@ -2144,7 +2124,6 @@ func TestSendCodeDbError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	w := httptest.NewRecorder()
 	body := map[string]string{"email": "dberror-test@multica.ai"}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(body)
@@ -2152,13 +2131,11 @@ func TestSendCodeDbError(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(ctx)
 
-	testHandler.SendCode(w, req)
+	w := testutil.Call(t, testHandler.SendCode, req)
 
 	// If the DB query respects the cancelled context, it should return an error.
 	// pgx usually returns context.Canceled which is not what isNotFound checks for.
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("SendCode (db error): expected 500, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusInternalServerError, "HTTP status")
 
 	var resp map[string]string
 	json.NewDecoder(w.Body).Decode(&resp)
@@ -2181,9 +2158,7 @@ func TestSendCodeRateLimit(t *testing.T) {
 	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.SendCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SendCode (first): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Second request within 60s should be rate limited
 	w = httptest.NewRecorder()
@@ -2192,9 +2167,7 @@ func TestSendCodeRateLimit(t *testing.T) {
 	req = httptest.NewRequest("POST", "/auth/send-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.SendCode(w, req)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("SendCode (second): expected 429, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusTooManyRequests, "HTTP status")
 }
 
 func TestVerifyCode(t *testing.T) {
@@ -2222,9 +2195,7 @@ func TestVerifyCode(t *testing.T) {
 	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.SendCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Read code from DB
 	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
@@ -2239,9 +2210,7 @@ func TestVerifyCode(t *testing.T) {
 	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("VerifyCode: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var resp LoginResponse
 	json.NewDecoder(w.Body).Decode(&resp)
@@ -2278,15 +2247,11 @@ func TestVerifyCodeRejectsDevCodeUnlessExplicitlyConfigured(t *testing.T) {
 
 	createVerificationCodeForTest(t, email, "123456")
 
-	w := httptest.NewRecorder()
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(map[string]string{"email": email, "code": "888888"})
 	req := httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
-	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("VerifyCode (disabled dev code): expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.VerifyCode, req).Want(http.StatusBadRequest)
 }
 
 func TestVerifyCodeAcceptsConfiguredDevCodeOutsideProduction(t *testing.T) {
@@ -2303,15 +2268,11 @@ func TestVerifyCodeAcceptsConfiguredDevCodeOutsideProduction(t *testing.T) {
 
 	createVerificationCodeForTest(t, email, "123456")
 
-	w := httptest.NewRecorder()
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(map[string]string{"email": email, "code": "888888"})
 	req := httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
-	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("VerifyCode (enabled dev code): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.VerifyCode, req).Want(http.StatusOK)
 }
 
 func TestVerifyCodeRejectsConfiguredDevCodeInProduction(t *testing.T) {
@@ -2327,15 +2288,11 @@ func TestVerifyCodeRejectsConfiguredDevCodeInProduction(t *testing.T) {
 
 	createVerificationCodeForTest(t, email, "123456")
 
-	w := httptest.NewRecorder()
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(map[string]string{"email": email, "code": "888888"})
 	req := httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
-	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("VerifyCode (production dev code): expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.VerifyCode, req).Want(http.StatusBadRequest)
 }
 
 func TestVerifyCodeWrongCode(t *testing.T) {
@@ -2363,9 +2320,7 @@ func TestVerifyCodeWrongCode(t *testing.T) {
 	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("VerifyCode (wrong code): expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestVerifyCodeBruteForceProtection(t *testing.T) {
@@ -2385,9 +2340,7 @@ func TestVerifyCodeBruteForceProtection(t *testing.T) {
 	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.SendCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Read actual code so we can try it after lockout
 	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
@@ -2415,9 +2368,7 @@ func TestVerifyCodeBruteForceProtection(t *testing.T) {
 	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("after lockout: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestVerifyCodeNewUserHasNoWorkspace(t *testing.T) {
@@ -2450,9 +2401,7 @@ func TestVerifyCodeNewUserHasNoWorkspace(t *testing.T) {
 	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
 	req.Header.Set("Content-Type", "application/json")
 	testHandler.VerifyCode(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("VerifyCode: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	user, err := testHandler.Queries.GetUserByEmail(ctx, email)
 	if err != nil {
@@ -2659,7 +2608,7 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 		"status": "todo",
 	})
 	req = withURLParam(req, "id", created.ID)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	// Verify exactly one task was enqueued (from the status transition, not creation).
 	var taskCount int
@@ -2720,7 +2669,7 @@ func TestBacklogToTodoByAgentTriggersDifferentAssignee(t *testing.T) {
 	req = withURLParam(req, "id", created.ID)
 	req.Header.Set("X-Agent-ID", parentAgent)
 	req.Header.Set("X-Task-ID", parentTask)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	var childTasks int
 	dbfx.QueryRow(t,
@@ -2772,7 +2721,7 @@ func TestBacklogToTodoByAgentSameIssueDoesNotSelfTrigger(t *testing.T) {
 	req = withURLParam(req, "id", created.ID)
 	req.Header.Set("X-Agent-ID", selfAgent)
 	req.Header.Set("X-Task-ID", selfTask)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	var tasks int
 	dbfx.QueryRow(t,
@@ -2835,7 +2784,7 @@ func TestBacklogToTodoByAgentSameAgentDifferentIssue(t *testing.T) {
 	req = withURLParam(req, "id", step2.ID)
 	req.Header.Set("X-Agent-ID", agentID)
 	req.Header.Set("X-Task-ID", step1Task)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	var step2Tasks int
 	dbfx.QueryRow(t,
@@ -3026,7 +2975,7 @@ func TestBatchBacklogToTodoByAgentTriggersAssignee(t *testing.T) {
 	})
 	req.Header.Set("X-Agent-ID", parentAgent)
 	req.Header.Set("X-Task-ID", parentTask)
-	w = testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 
 	var childTasks int
 	dbfx.QueryRow(t,
@@ -3076,7 +3025,7 @@ func TestBacklogToTodoByAgentTriggersSquadLeader(t *testing.T) {
 	req = withURLParam(req, "id", created.ID)
 	req.Header.Set("X-Agent-ID", driverAgent)
 	req.Header.Set("X-Task-ID", driverTask)
-	w = testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	var leaderTasks int
 	dbfx.QueryRow(t,
@@ -3123,9 +3072,7 @@ func TestRootMentionOwnerRoutesMemberReplyButNotAgentReply(t *testing.T) {
 		"status": "todo",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	issueID := issue.ID
@@ -3174,9 +3121,7 @@ func TestRootMentionOwnerRoutesMemberReplyButNotAgentReply(t *testing.T) {
 	// 1. Member posts top-level comment mentioning Agent B.
 	mentionB := fmt.Sprintf("[@Agent B](mention://agent/%s) please review", agentB)
 	w = postComment(issueID, map[string]any{"content": mentionB}, nil)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("member mention comment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var parentComment CommentResponse
 	json.NewDecoder(w.Body).Decode(&parentComment)
 	if countTasks(agentB) != 1 {
@@ -3198,9 +3143,7 @@ func TestRootMentionOwnerRoutesMemberReplyButNotAgentReply(t *testing.T) {
 		"content":   "No reply needed — just an acknowledgment.",
 		"parent_id": parentComment.ID,
 	}, map[string]string{"X-Agent-ID": agentA, "X-Task-ID": agentATask})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("agent A reply: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	if countTasks(agentB) != 0 {
 		t.Fatalf("expected 0 tasks for Agent B after agent reply (no parent inheritance), got %d", countTasks(agentB))
 	}
@@ -3214,9 +3157,7 @@ func TestRootMentionOwnerRoutesMemberReplyButNotAgentReply(t *testing.T) {
 		"content":   "Thanks for the review.",
 		"parent_id": parentComment.ID,
 	}, nil)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("member reply: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	if countTasks(agentB) != 1 {
 		t.Fatalf("expected 1 task for Agent B after member reply (root owner), got %d", countTasks(agentB))
 	}
@@ -3298,7 +3239,7 @@ func TestMemberReplyToAgentRootDoesNotInheritParentMentions(t *testing.T) {
 		"parent_id": rootComment.ID,
 	})
 	r = withURLParam(r, "id", issueID)
-	w = testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	if got := countTasks(reviewerAgent); got != 0 {
 		t.Fatalf("expected 0 tasks for Reviewer after plain member reply (no inheritance from agent root), got %d", got)
 	}
@@ -3514,7 +3455,7 @@ func TestAgentExplicitMentionStillTriggers(t *testing.T) {
 	r = withURLParam(r, "id", issueID)
 	r.Header.Set("X-Agent-ID", agentA)
 	r.Header.Set("X-Task-ID", agentATask)
-	w = testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	if got := countTasks(agentB); got != 1 {
 		t.Fatalf("expected 1 task for Agent B after explicit mention by Agent A, got %d", got)
 	}
@@ -3537,17 +3478,10 @@ func TestCreateSkillSkipsSkillMdFile(t *testing.T) {
 			{Path: "helper.go", Content: "package main"},
 		},
 	})
-	rec := httptest.NewRecorder()
-	testHandler.CreateSkill(rec, req)
-
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateSkill, req).Want(http.StatusCreated)
 
 	var resp SkillWithFilesResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
+	rec.JSON(&resp)
 
 	// Should only have README.md and helper.go, not SKILL.md
 	if len(resp.Files) != 2 {
@@ -3598,16 +3532,10 @@ func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
 			{Path: "README.md", Content: "readme"},
 		},
 	})
-	rec := httptest.NewRecorder()
-	testHandler.CreateSkill(rec, req)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("create skill: expected 201, got %d: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateSkill, req).Want(http.StatusCreated)
 
 	var createResp SkillWithFilesResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
-		t.Fatalf("unmarshal create response: %v", err)
-	}
+	rec.JSON(&createResp)
 
 	// Update with SKILL.md in files
 	updateReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID, UpdateSkillRequest{
@@ -3620,17 +3548,10 @@ func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
 		},
 	})
 	updateReq = withURLParam(updateReq, "id", createResp.ID)
-	updateRec := httptest.NewRecorder()
-	testHandler.UpdateSkill(updateRec, updateReq)
-
-	if updateRec.Code != http.StatusOK {
-		t.Fatalf("update skill: expected 200, got %d: %s", updateRec.Code, updateRec.Body.String())
-	}
+	updateRec := testutil.Call(t, testHandler.UpdateSkill, updateReq).Want(http.StatusOK)
 
 	var updateResp SkillWithFilesResponse
-	if err := json.Unmarshal(updateRec.Body.Bytes(), &updateResp); err != nil {
-		t.Fatalf("unmarshal update response: %v", err)
-	}
+	updateRec.JSON(&updateResp)
 
 	if len(updateResp.Files) != 2 {
 		t.Fatalf("expected 2 files after update, got %d", len(updateResp.Files))
@@ -3681,16 +3602,10 @@ func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
 		Name:    "test-skill-upsert-reject-skillmd",
 		Content: "# SKILL.md content",
 	})
-	rec := httptest.NewRecorder()
-	testHandler.CreateSkill(rec, req)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("create skill: expected 201, got %d: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateSkill, req).Want(http.StatusCreated)
 
 	var createResp SkillWithFilesResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
-		t.Fatalf("unmarshal create response: %v", err)
-	}
+	rec.JSON(&createResp)
 
 	// Try to upsert SKILL.md
 	upsertReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID+"/files", CreateSkillFileRequest{
@@ -3698,12 +3613,7 @@ func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
 		Content: "should be rejected",
 	})
 	upsertReq = withURLParam(upsertReq, "id", createResp.ID)
-	upsertRec := httptest.NewRecorder()
-	testHandler.UpsertSkillFile(upsertRec, upsertReq)
-
-	if upsertRec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", upsertRec.Code, upsertRec.Body.String())
-	}
+	upsertRec := testutil.Call(t, testHandler.UpsertSkillFile, upsertReq).Want(http.StatusBadRequest)
 	if !strings.Contains(upsertRec.Body.String(), "SKILL.md is reserved") {
 		t.Fatalf("expected error message about reserved SKILL.md, got: %s", upsertRec.Body.String())
 	}

--- a/server/internal/handler/handler_writejson_test.go
+++ b/server/internal/handler/handler_writejson_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestWriteMeasuredJSONByteIdenticalToWriteJSON locks the load-bearing assumption
@@ -79,9 +81,7 @@ func TestWriteMeasuredJSONByteIdenticalToWriteJSON(t *testing.T) {
 			if n != len(encBody) {
 				t.Fatalf("reported payload bytes %d != writeJSON body length %d", n, len(encBody))
 			}
-			if recEnc.Code != recMeasured.Code {
-				t.Fatalf("status code differs: writeJSON=%d writeMeasuredJSON=%d", recEnc.Code, recMeasured.Code)
-			}
+			testutil.Equal(t, recEnc.Code, recMeasured.Code, "HTTP status")
 			if got, want := recMeasured.Header().Get("Content-Type"), recEnc.Header().Get("Content-Type"); got != want {
 				t.Fatalf("Content-Type differs: writeMeasuredJSON=%q writeJSON=%q", got, want)
 			}

--- a/server/internal/handler/integrations_composio_test.go
+++ b/server/internal/handler/integrations_composio_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	composio "github.com/multica-ai/multica/server/internal/integrations/composio"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	sdk "github.com/multica-ai/multica/server/pkg/composio"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -168,8 +169,7 @@ func TestComposio_ServiceUnavailableWhenNil(t *testing.T) {
 	for _, hf := range []http.HandlerFunc{
 		h.ComposioConnectInit, h.ComposioCallback, h.ListComposioConnections, h.DeleteComposioConnection,
 	} {
-		w := httptest.NewRecorder()
-		hf(w, composioReq(http.MethodGet, "/", ""))
+		w := testutil.Call(t, hf, composioReq(http.MethodGet, "/", ""))
 		if w.Code != http.StatusServiceUnavailable {
 			t.Errorf("expected 503 when Composio nil, got %d", w.Code)
 		}
@@ -180,11 +180,7 @@ func TestComposio_ServiceUnavailableWhenFlagDisabled(t *testing.T) {
 	h := newComposioTestHandler(t, &composioFakeSDK{}, &composioFakeStore{})
 	withComposioMCPAppsFlag(t, h, false)
 
-	w := httptest.NewRecorder()
-	h.ListComposioToolkits(w, composioReq(http.MethodGet, "/toolkits", ""))
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 when feature flag disabled, got %d", w.Code)
-	}
+	testutil.Call(t, h.ListComposioToolkits, composioReq(http.MethodGet, "/toolkits", "")).Want(http.StatusServiceUnavailable)
 }
 
 func TestComposio_ConnectInit(t *testing.T) {
@@ -193,9 +189,7 @@ func TestComposio_ConnectInit(t *testing.T) {
 	// success
 	w := httptest.NewRecorder()
 	h.ComposioConnectInit(w, composioReq(http.MethodPost, "/", `{"toolkit_slug":"notion"}`))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp ComposioConnectInitResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -222,15 +216,9 @@ func TestComposio_ConnectInit(t *testing.T) {
 func TestComposio_ListToolkits(t *testing.T) {
 	h := newComposioTestHandler(t, &composioFakeSDK{}, &composioFakeStore{})
 
-	w := httptest.NewRecorder()
-	h.ListComposioToolkits(w, composioReq(http.MethodGet, "/toolkits", ""))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, h.ListComposioToolkits, composioReq(http.MethodGet, "/toolkits", "")).Want(http.StatusOK)
 	var toolkits []ComposioToolkitResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &toolkits); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&toolkits)
 	// Only notion has an enabled auth config; github is filtered out server-side
 	// (MUL-4009), so a single connectable toolkit comes back.
 	if len(toolkits) != 1 {
@@ -257,11 +245,7 @@ func TestComposio_ListToolkits(t *testing.T) {
 func TestComposio_ListToolkits_ResolverErrorIs502(t *testing.T) {
 	h := newComposioTestHandler(t, &composioFakeSDK{listAuthErr: errors.New("auth_configs upstream blip")}, &composioFakeStore{})
 
-	w := httptest.NewRecorder()
-	h.ListComposioToolkits(w, composioReq(http.MethodGet, "/toolkits", ""))
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("expected 502 on resolver error, got %d (%s)", w.Code, w.Body.String())
-	}
+	testutil.Call(t, h.ListComposioToolkits, composioReq(http.MethodGet, "/toolkits", "")).Want(http.StatusBadGateway)
 }
 
 func TestComposio_CallbackRedirects(t *testing.T) {
@@ -271,8 +255,7 @@ func TestComposio_CallbackRedirects(t *testing.T) {
 	// SDK, then replay it through the real callback handler.
 	capturing := &composioCapturingSDK{}
 	h2 := newComposioTestHandler(t, capturing, store)
-	bw := httptest.NewRecorder()
-	h2.ComposioConnectInit(bw, composioReq(http.MethodPost, "/", `{"toolkit_slug":"notion"}`))
+	testutil.Call(t, h2.ComposioConnectInit, composioReq(http.MethodPost, "/", `{"toolkit_slug":"notion"}`))
 	state := capturing.stateFromCallback()
 	if state == "" {
 		t.Fatal("could not capture signed state")
@@ -280,9 +263,7 @@ func TestComposio_CallbackRedirects(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	h2.ComposioCallback(w, composioReq(http.MethodGet, "/callback?state="+state+"&status=success&connected_account_id=ca_1", ""))
-	if w.Code != http.StatusFound {
-		t.Fatalf("expected 302, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	if loc := w.Header().Get("Location"); !strings.Contains(loc, "connected=notion") {
 		t.Errorf("success location = %q", loc)
 	}
@@ -290,9 +271,7 @@ func TestComposio_CallbackRedirects(t *testing.T) {
 	// failure path: bad state → error redirect
 	w = httptest.NewRecorder()
 	h2.ComposioCallback(w, composioReq(http.MethodGet, "/callback?state=bad&status=success&connected_account_id=ca_1", ""))
-	if w.Code != http.StatusFound {
-		t.Fatalf("expected 302 on bad state, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusFound, "HTTP status")
 	if loc := w.Header().Get("Location"); !strings.Contains(loc, "error=composio_connect_failed") {
 		t.Errorf("failure location = %q", loc)
 	}
@@ -313,9 +292,7 @@ func TestComposio_ListAndDelete(t *testing.T) {
 	// list
 	w := httptest.NewRecorder()
 	h.ListComposioConnections(w, composioReq(http.MethodGet, "/connections", ""))
-	if w.Code != http.StatusOK {
-		t.Fatalf("list: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var conns []ComposioConnectionResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &conns); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -330,17 +307,13 @@ func TestComposio_ListAndDelete(t *testing.T) {
 	delReq := composioReq(http.MethodDelete, "/api/integrations/composio/connections/"+util.UUIDToString(row.ID), "")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, delReq)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("delete: expected 204, got %d (%s)", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 
 	// delete unknown id → 404
 	missing := "33333333-3333-3333-3333-333333333333"
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, composioReq(http.MethodDelete, "/api/integrations/composio/connections/"+missing, ""))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("delete missing: expected 404, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // composioCapturingSDK records the callback URL so a test can replay the signed

--- a/server/internal/handler/invitation_test.go
+++ b/server/internal/handler/invitation_test.go
@@ -19,6 +19,7 @@ import (
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/seatcapacity"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const invitationTestEmail = "invitation-test@multica.ai"
@@ -178,22 +179,14 @@ func TestCreateInvitation_BlocksWhilePending(t *testing.T) {
 		Role:  "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.CreateInvitation(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("first invite: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusCreated)
 
 	req2 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/members", CreateMemberRequest{
 		Email: invitationTestEmail,
 		Role:  "member",
 	})
 	req2 = withURLParam(req2, "id", testWorkspaceID)
-	w2 := httptest.NewRecorder()
-	testHandler.CreateInvitation(w2, req2)
-	if w2.Code != http.StatusConflict {
-		t.Fatalf("second invite: expected 409 while still pending, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateInvitation, req2).Want(http.StatusConflict)
 	for name, calls := range map[string]int{
 		"actor checks": len(actor.checkKeys), "workspace checks": len(workspace.checkKeys), "recipient checks": len(recipient.checkKeys),
 		"actor allows": len(actor.allowKeys), "workspace allows": len(workspace.allowKeys), "recipient allows": len(recipient.allowKeys),
@@ -222,21 +215,12 @@ func TestCreateInvitation_BlocksWhenPurchasedCapacityIsFull(t *testing.T) {
 		Email: "capacity-full-invite@multica.ai", Role: "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusConflict)
 	var body struct {
 		Code string `json:"code"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatal(err)
-	}
-	if body.Code != "seat_capacity_full" {
-		t.Fatalf("code = %q, want seat_capacity_full", body.Code)
-	}
+	rec.JSON(&body)
+	testutil.Equal(t, body.Code, "seat_capacity_full", "HTTP status")
 	if capacity.reserveCalls != 1 {
 		t.Fatalf("reserve calls = %d, want 1", capacity.reserveCalls)
 	}
@@ -285,21 +269,12 @@ func TestCreateInvitation_BlocksOvercommittedCapacityWithoutOfferingSingleSeatSe
 		Email: "capacity-overcommitted-invite@multica.ai", Role: "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusConflict)
 	var body struct {
 		Code string `json:"code"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatal(err)
-	}
-	if body.Code != "seat_capacity_overcommitted" {
-		t.Fatalf("code = %q, want seat_capacity_overcommitted", body.Code)
-	}
+	rec.JSON(&body)
+	testutil.Equal(t, body.Code, "seat_capacity_overcommitted", "HTTP status")
 	if capacity.reserveCalls != 1 {
 		t.Fatalf("reserve calls = %d, want 1", capacity.reserveCalls)
 	}
@@ -334,24 +309,15 @@ func TestCreateInvitation_MapsCloudCapacityRateLimitWithoutConsumingInvitationBu
 		Email: "capacity-rate-limited@multica.ai", Role: "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusTooManyRequests)
 	if rec.Header().Get("Retry-After") != "3" || rec.Header().Get("Cache-Control") != "no-store" {
 		t.Fatalf("unexpected retry/cache headers: %v", rec.Header())
 	}
 	var body struct {
 		Code string `json:"code"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatal(err)
-	}
-	if body.Code != "seat_capacity_rate_limited" {
-		t.Fatalf("code = %q, want seat_capacity_rate_limited", body.Code)
-	}
+	rec.JSON(&body)
+	testutil.Equal(t, body.Code, "seat_capacity_rate_limited", "HTTP status")
 	if capacity.reserveCalls != 1 || capacity.releaseCalls != 0 {
 		t.Fatalf("capacity calls reserve=%d release=%d, want 1/0", capacity.reserveCalls, capacity.releaseCalls)
 	}
@@ -386,12 +352,7 @@ func TestCreateInvitation_CompensatesCapacityWhenCommitRollsBack(t *testing.T) {
 		Email: email, Role: "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusInternalServerError)
 	if capacity.reserveCalls != 1 || capacity.releaseCalls != 1 {
 		t.Fatalf("reserve calls = %d, release calls = %d; want one each", capacity.reserveCalls, capacity.releaseCalls)
 	}
@@ -431,16 +392,10 @@ func TestCreateInvitation_AllowsAfterExpiry(t *testing.T) {
 		Role:  "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.CreateInvitation(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("re-invite after expiry: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusCreated)
 
 	var resp InvitationResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.ID == "" || resp.ID == staleID {
 		t.Fatalf("expected a new invitation row, got id=%q (stale=%q)", resp.ID, staleID)
 	}
@@ -485,12 +440,7 @@ func TestCreateInvitation_RateLimitChecksEveryGateBeforeCapacityReservation(t *t
 		Role:  "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusTooManyRequests)
 	if got := rec.Header().Get("Retry-After"); got != "86400" {
 		t.Errorf("Retry-After = %q, want 86400", got)
 	}
@@ -502,9 +452,7 @@ func TestCreateInvitation_RateLimitChecksEveryGateBeforeCapacityReservation(t *t
 		Code              string `json:"code"`
 		RetryAfterSeconds int64  `json:"retry_after_seconds"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	rec.JSON(&body)
 	if body.Error != "too many invitation requests" || body.Code != "invitation_rate_limited" || body.RetryAfterSeconds != 86400 {
 		t.Errorf("unexpected body: %+v", body)
 	}
@@ -573,19 +521,12 @@ func TestCreateInvitation_RateLimiterFailureReturnsServiceUnavailable(t *testing
 		Role:  "member",
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	rec := httptest.NewRecorder()
-	testHandler.CreateInvitation(rec, req)
-
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503: %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.CreateInvitation, req).Want(http.StatusServiceUnavailable)
 	if rec.Header().Get("Retry-After") != "5" || rec.Header().Get("Cache-Control") != "no-store" {
 		t.Errorf("unexpected retry/cache headers: %v", rec.Header())
 	}
 	var body map[string]string
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	rec.JSON(&body)
 	if body["code"] != "invitation_rate_limiter_unavailable" {
 		t.Errorf("code = %q, want invitation_rate_limiter_unavailable", body["code"])
 	}

--- a/server/internal/handler/issue_agent_create_e2e_test.go
+++ b/server/internal/handler/issue_agent_create_e2e_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // createPrivateAgentOwnedBy inserts a private agent owned by ownerID and
@@ -62,14 +64,7 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	leaderID := createPrivateAgentOwnedBy(t, "mul4305-e2e-private-leader", ownerH)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'MUL-4305 E2E Squad', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'MUL-4305 E2E Squad'"), "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	// Creator agent A, running a task on behalf of the human H. resolveActor
 	// validates the (A, task) pair; the handler then trusts X-Task-ID as A's
@@ -98,9 +93,7 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)
@@ -147,9 +140,7 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	r.Header.Set("X-Task-ID", leaderTaskID)
 	r = withURLParam(r, "id", created.ID)
 	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment (leader mentions worker): expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Step 3: the private worker J must now have a queued task whose originator
 	// is the original human H — the whole point of the fix.
@@ -187,14 +178,7 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	leaderID, ownerH, _ := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'MUL-4305 E2E Update-Assign Squad', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'MUL-4305 E2E Update-Assign Squad'"), "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	creatorAID := createHandlerTestAgent(t, "mul4305-e2e-update-creator", nil)
 	var creatorTaskID string
@@ -217,9 +201,7 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)
@@ -240,9 +222,7 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	r = withURLParam(r, "id", created.ID)
 	testHandler.UpdateIssue(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue (assign squad): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// The gated handler path must have enqueued the private leader carrying H.
 	var leaderCount int

--- a/server/internal/handler/issue_agent_create_origin_test.go
+++ b/server/internal/handler/issue_agent_create_origin_test.go
@@ -2,10 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateIssue_AgentCreate_StampsActingTaskOrigin locks the MUL-4305 fix at
@@ -33,29 +34,16 @@ func TestCreateIssue_AgentCreate_StampsActingTaskOrigin(t *testing.T) {
 	// Acting task carrying the human originator (testUserID). resolveActor
 	// validates this (agent, task) pair before the handler trusts X-Task-ID.
 	var taskID string
-	if err := testPool.QueryRow(ctx,
-		`INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, originator_user_id, accountable_user_id)
-		 VALUES ($1, $2, 'running', 0, $3, $3) RETURNING id`,
-		agentID, runtimeID, testUserID,
-	).Scan(&taskID); err != nil {
-		t.Fatalf("seed acting task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "originator_user_id": testUserID, "accountable_user_id": testUserID})
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "Agent-created via normal create (MUL-4305)",
 	})
 	req.Header.Set("X-Agent-ID", agentID)
 	req.Header.Set("X-Task-ID", taskID)
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var created IssueResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode issue: %v", err)
-	}
+	w.Decode(&created)
 	t.Cleanup(func() {
 		cleanup := withURLParam(newRequest("DELETE", "/api/issues/"+created.ID, nil), "id", created.ID)
 		testHandler.DeleteIssue(httptest.NewRecorder(), cleanup)
@@ -97,21 +85,16 @@ func TestCreateIssue_NoAgentCreateStampForMemberOrForgedAgent(t *testing.T) {
 
 	assertNoAgentOrigin := func(t *testing.T, mutate func(*http.Request)) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 			"title": "No agent_create stamp expected (MUL-4305)",
 		})
 		if mutate != nil {
 			mutate(req)
 		}
-		testHandler.CreateIssue(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 		var created IssueResponse
-		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-			t.Fatalf("decode issue: %v", err)
-		}
+		w.Decode(&created)
 		t.Cleanup(func() {
 			cleanup := withURLParam(newRequest("DELETE", "/api/issues/"+created.ID, nil), "id", created.ID)
 			testHandler.DeleteIssue(httptest.NewRecorder(), cleanup)

--- a/server/internal/handler/issue_assignee_types_test.go
+++ b/server/internal/handler/issue_assignee_types_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Backs the workspace Members/Agents tabs: assignee_types on ListIssues must
@@ -21,25 +21,10 @@ func TestListIssues_AssigneeTypesFilter(t *testing.T) {
 	// Dedicated project so counts aren't polluted by other tests sharing the
 	// workspace.
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("Assignee Types %d", suffix)).Scan(&projectID); err != nil {
-		t.Fatalf("create project: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": fmt.Sprintf("Assignee Types %d", suffix)})
 
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("Assignee Types Agent %d", suffix), testRuntimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID) })
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": fmt.Sprintf("Assignee Types Agent %d", suffix), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID, "visibility": testutil.Raw("'workspace'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	insertIssue := func(title string, assigneeType, assigneeID *string) string {
 		var number int
@@ -69,18 +54,12 @@ func TestListIssues_AssigneeTypesFilter(t *testing.T) {
 	list := func(query string) (ids []string, total int64) {
 		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500%s",
 			testWorkspaceID, projectID, query)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var resp struct {
 			Issues []IssueResponse `json:"issues"`
 			Total  int64           `json:"total"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode list response: %v", err)
-		}
+		w.Decode(&resp)
 		for _, iss := range resp.Issues {
 			ids = append(ids, iss.ID)
 		}
@@ -124,10 +103,6 @@ func TestListIssues_AssigneeTypesFilter(t *testing.T) {
 	}
 
 	// Unknown actor kinds are a client bug — reject, don't coerce.
-	bad := httptest.NewRecorder()
-	testHandler.ListIssues(bad, newRequest("GET", fmt.Sprintf(
-		"/api/issues?workspace_id=%s&assignee_types=bogus", testWorkspaceID), nil))
-	if bad.Code != http.StatusBadRequest {
-		t.Fatalf("invalid assignee_types: expected 400, got %d: %s", bad.Code, bad.Body.String())
-	}
+	testutil.Call(t, testHandler.ListIssues, newRequest("GET", fmt.Sprintf(
+		"/api/issues?workspace_id=%s&assignee_types=bogus", testWorkspaceID), nil)).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/issue_batch_test.go
+++ b/server/internal/handler/issue_batch_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestBatchUpdateNoMutationReturnsZero — regression for #1660.
@@ -57,12 +58,9 @@ func TestBatchUpdateNoMutationReturnsZero(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest("POST", "/api/issues/batch-update", tc.body)
-			testHandler.BatchUpdateIssues(w, req)
-			if w.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 			var resp struct {
 				Updated int `json:"updated"`
 			}
@@ -73,10 +71,10 @@ func TestBatchUpdateNoMutationReturnsZero(t *testing.T) {
 
 			// Belt and braces: confirm the issues weren't touched.
 			for _, id := range []string{a, b} {
-				gw := httptest.NewRecorder()
+
 				gr := newRequest("GET", "/api/issues/"+id, nil)
 				gr = withURLParam(gr, "id", id)
-				testHandler.GetIssue(gw, gr)
+				gw := testutil.Call(t, testHandler.GetIssue, gr)
 				var got IssueResponse
 				json.NewDecoder(gw.Body).Decode(&got)
 				if got.Status != "todo" {
@@ -95,15 +93,11 @@ func TestBatchUpdateValidUpdatesPersistAndCount(t *testing.T) {
 	t.Cleanup(func() { deleteTestIssue(t, a) })
 	t.Cleanup(func() { deleteTestIssue(t, b) })
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": []string{a, b},
 		"updates":   map[string]any{"status": "in_progress"},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 	var resp struct {
 		Updated int `json:"updated"`
 	}
@@ -112,10 +106,10 @@ func TestBatchUpdateValidUpdatesPersistAndCount(t *testing.T) {
 		t.Errorf("expected updated=2, got %d", resp.Updated)
 	}
 	for _, id := range []string{a, b} {
-		gw := httptest.NewRecorder()
+
 		gr := newRequest("GET", "/api/issues/"+id, nil)
 		gr = withURLParam(gr, "id", id)
-		testHandler.GetIssue(gw, gr)
+		gw := testutil.Call(t, testHandler.GetIssue, gr)
 		var got IssueResponse
 		json.NewDecoder(gw.Body).Decode(&got)
 		if got.Status != "in_progress" {
@@ -131,15 +125,11 @@ func TestBatchUpdateStageOnly(t *testing.T) {
 	a := createTestIssue(t, "BU-stage A", "todo", "low")
 	t.Cleanup(func() { deleteTestIssue(t, a) })
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": []string{a},
 		"updates":   map[string]any{"stage": 2},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 	var resp struct {
 		Updated int `json:"updated"`
 	}
@@ -148,10 +138,9 @@ func TestBatchUpdateStageOnly(t *testing.T) {
 		t.Fatalf("expected updated=1 for a stage-only batch update, got %d", resp.Updated)
 	}
 
-	gw := httptest.NewRecorder()
 	gr := newRequest("GET", "/api/issues/"+a, nil)
 	gr = withURLParam(gr, "id", a)
-	testHandler.GetIssue(gw, gr)
+	gw := testutil.Call(t, testHandler.GetIssue, gr)
 	var got IssueResponse
 	json.NewDecoder(gw.Body).Decode(&got)
 	if got.Stage == nil || *got.Stage != 2 {
@@ -163,13 +152,13 @@ func TestBatchUpdateStageOnly(t *testing.T) {
 // Returns the new issue's id; caller is responsible for cleanup.
 func createTestIssue(t *testing.T, title, status, priority string) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    title,
 		"status":   status,
 		"priority": priority,
 	})
-	testHandler.CreateIssue(w, req)
+	w := testutil.Call(t, testHandler.CreateIssue, req)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("CreateIssue %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
 	}
@@ -180,10 +169,10 @@ func createTestIssue(t *testing.T, title, status, priority string) string {
 
 func deleteTestIssue(t *testing.T, id string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("DELETE", "/api/issues/"+id, nil)
 	req = withURLParam(req, "id", id)
-	testHandler.DeleteIssue(w, req)
+	testutil.Call(t, testHandler.DeleteIssue, req)
 }
 
 // --- MUL-4155: batch cross-stage child-done aggregation ---
@@ -212,15 +201,11 @@ func newStagedBatchFixture(t *testing.T) stagedBatchFixture {
 		t.Skip("database not available")
 	}
 
-	pw := httptest.NewRecorder()
 	preq := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "batch-stage parent " + time.Now().Format(time.RFC3339Nano),
 		"status": "in_progress",
 	})
-	testHandler.CreateIssue(pw, preq)
-	if pw.Code != http.StatusCreated {
-		t.Fatalf("create parent: expected 201, got %d: %s", pw.Code, pw.Body.String())
-	}
+	pw := testutil.Call(t, testHandler.CreateIssue, preq).Want(http.StatusCreated)
 	var parent IssueResponse
 	json.NewDecoder(pw.Body).Decode(&parent)
 
@@ -237,16 +222,13 @@ func newStagedBatchFixture(t *testing.T) stagedBatchFixture {
 	setIssueAssigneeDirect(t, parent.ID, "agent", agentID)
 
 	mkChild := func(stage int32) IssueResponse {
-		cw := httptest.NewRecorder()
+
 		creq := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 			"title":           "batch-stage child " + time.Now().Format(time.RFC3339Nano),
 			"status":          "in_progress",
 			"parent_issue_id": parent.ID,
 		})
-		testHandler.CreateIssue(cw, creq)
-		if cw.Code != http.StatusCreated {
-			t.Fatalf("create child: expected 201, got %d: %s", cw.Code, cw.Body.String())
-		}
+		cw := testutil.Call(t, testHandler.CreateIssue, creq).Want(http.StatusCreated)
 		var child IssueResponse
 		json.NewDecoder(cw.Body).Decode(&child)
 		// Set the stage directly — the barrier logic only reads issue.stage.
@@ -276,12 +258,12 @@ func newStagedBatchFixture(t *testing.T) stagedBatchFixture {
 // batchSetStatus drives BatchUpdateIssues over the given ids, in order.
 func batchSetStatus(t *testing.T, ids []string, status string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": ids,
 		"updates":   map[string]any{"status": status},
 	})
-	testHandler.BatchUpdateIssues(w, req)
+	w := testutil.Call(t, testHandler.BatchUpdateIssues, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("BatchUpdateIssues status=%q: expected 200, got %d: %s", status, w.Code, w.Body.String())
 	}

--- a/server/internal/handler/issue_cancel_status_no_cancel_test.go
+++ b/server/internal/handler/issue_cancel_status_no_cancel_test.go
@@ -3,9 +3,10 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // activeTaskStatuses are the non-terminal states CancelAgentTasksByIssue sweeps
@@ -61,15 +62,11 @@ func TestUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 			ownerTask := insertIssueTaskWithStatus(t, ownerAgent, issueID, status)
 			mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
 
-			w := httptest.NewRecorder()
 			req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
 				"status": "cancelled",
 			})
 			req = withURLParam(req, "id", issueID)
-			testHandler.UpdateIssue(w, req)
-			if w.Code != http.StatusOK {
-				t.Fatalf("UpdateIssue cancel: expected 200, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 			if got := taskStatus(t, ownerTask); got != status {
 				t.Fatalf("assignee's %s task must survive issue → cancelled, got status %q", status, got)
@@ -100,17 +97,13 @@ func TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 		issueIDs = append(issueIDs, issueID)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": issueIDs,
 		"updates": map[string]any{
 			"status": "cancelled",
 		},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("BatchUpdateIssues cancel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 
 	for status, taskID := range taskByStatus {
 		if got := taskStatus(t, taskID); got != status {

--- a/server/internal/handler/issue_channel_media_merge_test.go
+++ b/server/internal/handler/issue_channel_media_merge_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/channelmedia"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -94,21 +94,15 @@ func TestUpdateIssueMergesChannelMediaAppendedAfterEditorBase(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	create := httptest.NewRecorder()
 	createReq := newRequest(http.MethodPost, "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":       "Channel media description merge",
 		"description": "Original",
 		"status":      "todo",
 		"priority":    "none",
 	})
-	testHandler.CreateIssue(create, createReq)
-	if create.Code != http.StatusCreated {
-		t.Fatalf("create issue: status %d: %s", create.Code, create.Body.String())
-	}
+	create := testutil.Call(t, testHandler.CreateIssue, createReq).Want(http.StatusCreated)
 	var created IssueResponse
-	if err := json.NewDecoder(create.Body).Decode(&created); err != nil {
-		t.Fatalf("decode created issue: %v", err)
-	}
+	create.Decode(&created)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, created.ID)
 	})
@@ -128,40 +122,29 @@ func TestUpdateIssueMergesChannelMediaAppendedAfterEditorBase(t *testing.T) {
 		t.Fatalf("append remote channel media: %v", err)
 	}
 
-	update := httptest.NewRecorder()
 	updateReq := newRequest(http.MethodPut, "/api/issues/"+created.ID, map[string]any{
 		"description":      "Original with local edit",
 		"description_base": "Original",
 	})
 	updateReq = withURLParam(updateReq, "id", created.ID)
-	testHandler.UpdateIssue(update, updateReq)
-	if update.Code != http.StatusOK {
-		t.Fatalf("update issue: status %d: %s", update.Code, update.Body.String())
-	}
+	update := testutil.Call(t, testHandler.UpdateIssue, updateReq).Want(http.StatusOK)
 	var merged IssueResponse
-	if err := json.NewDecoder(update.Body).Decode(&merged); err != nil {
-		t.Fatalf("decode merged issue: %v", err)
-	}
+	update.Decode(&merged)
 	if merged.Description == nil || !strings.Contains(*merged.Description, "Original with local edit") || !strings.Contains(*merged.Description, channelmedia.DownloadPath(attachmentID)) {
 		t.Fatalf("merged description = %#v", merged.Description)
 	}
 
 	// Once the client has adopted the media-bearing description as its base,
 	// removing the image is an explicit edit and must remain possible.
-	remove := httptest.NewRecorder()
+
 	removeReq := newRequest(http.MethodPut, "/api/issues/"+created.ID, map[string]any{
 		"description":      "Original with local edit",
 		"description_base": *merged.Description,
 	})
 	removeReq = withURLParam(removeReq, "id", created.ID)
-	testHandler.UpdateIssue(remove, removeReq)
-	if remove.Code != http.StatusOK {
-		t.Fatalf("remove image: status %d: %s", remove.Code, remove.Body.String())
-	}
+	remove := testutil.Call(t, testHandler.UpdateIssue, removeReq).Want(http.StatusOK)
 	var removed IssueResponse
-	if err := json.NewDecoder(remove.Body).Decode(&removed); err != nil {
-		t.Fatalf("decode image removal: %v", err)
-	}
+	remove.Decode(&removed)
 	if removed.Description == nil || *removed.Description != "Original with local edit" {
 		t.Fatalf("description after explicit image removal = %#v", removed.Description)
 	}
@@ -173,21 +156,15 @@ func TestBatchUpdateIssuePreservesMarkedChannelMedia(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	create := httptest.NewRecorder()
 	createReq := newRequest(http.MethodPost, "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":       "Batch channel media merge",
 		"description": "Original",
 		"status":      "todo",
 		"priority":    "none",
 	})
-	testHandler.CreateIssue(create, createReq)
-	if create.Code != http.StatusCreated {
-		t.Fatalf("create issue: status %d: %s", create.Code, create.Body.String())
-	}
+	create := testutil.Call(t, testHandler.CreateIssue, createReq).Want(http.StatusCreated)
 	var created IssueResponse
-	if err := json.NewDecoder(create.Body).Decode(&created); err != nil {
-		t.Fatalf("decode created issue: %v", err)
-	}
+	create.Decode(&created)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, created.ID)
 	})
@@ -206,17 +183,13 @@ func TestBatchUpdateIssuePreservesMarkedChannelMedia(t *testing.T) {
 		t.Fatalf("append channel media: %v", err)
 	}
 
-	update := httptest.NewRecorder()
 	updateReq := newRequest(http.MethodPut, "/api/issues/batch?workspace_id="+testWorkspaceID, map[string]any{
 		"issue_ids": []string{created.ID},
 		"updates": map[string]any{
 			"description": "Batch edit",
 		},
 	})
-	testHandler.BatchUpdateIssues(update, updateReq)
-	if update.Code != http.StatusOK {
-		t.Fatalf("batch update: status %d: %s", update.Code, update.Body.String())
-	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, updateReq).Want(http.StatusOK)
 
 	var description string
 	if err := testPool.QueryRow(ctx, `SELECT description FROM issue WHERE id = $1`, created.ID).Scan(&description); err != nil {

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // childDoneFixture creates a parent + child pair so the parent-notification
@@ -27,9 +29,7 @@ func newChildDoneFixture(t *testing.T, parentStatus string) childDoneFixture {
 		"status": parentStatus,
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create parent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var parent IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&parent); err != nil {
 		t.Fatalf("decode parent: %v", err)
@@ -42,9 +42,7 @@ func newChildDoneFixture(t *testing.T, parentStatus string) childDoneFixture {
 		"parent_issue_id": parent.ID,
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create child: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var child IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&child); err != nil {
 		t.Fatalf("decode child: %v", err)
@@ -64,10 +62,9 @@ func newChildDoneFixture(t *testing.T, parentStatus string) childDoneFixture {
 func updateChildStatus(t *testing.T, childID, status string) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/issues/"+childID, map[string]any{"status": status})
 	req = withURLParam(req, "id", childID)
-	testHandler.UpdateIssue(w, req)
+	w := testutil.Call(t, testHandler.UpdateIssue, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("UpdateIssue child status=%q: expected 200, got %d: %s", status, w.Code, w.Body.String())
 	}
@@ -231,15 +228,12 @@ func TestChildDoneSkippedWhenParentBacklog(t *testing.T) {
 // TestChildDoneSkippedWhenNoParent — an issue with no parent_issue_id must
 // not produce any system comment on anything.
 func TestChildDoneSkippedWhenNoParent(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "orphan child-done " + time.Now().Format(time.RFC3339Nano),
 		"status": "in_progress",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create orphan: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var orphan IssueResponse
 	json.NewDecoder(w.Body).Decode(&orphan)
 	t.Cleanup(func() {
@@ -492,19 +486,9 @@ func TestChildDoneWakesLeaderWhenParentAndChildSquadsShareLeader(t *testing.T) {
 	parentSquad := newSquadCommentTriggerFixture(t)
 
 	// Spin up a SECOND squad that reuses the same leader as parentSquad.
-	ctx := context.Background()
+
 	var childSquadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, "Child Done Shared Leader Squad", parentSquad.LeaderID, testUserID).
-		Scan(&childSquadID); err != nil {
-		t.Fatalf("create second squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, childSquadID)
-	})
+	childSquadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Child Done Shared Leader Squad", "description": testutil.Raw("''"), "leader_id": parentSquad.LeaderID, "creator_id": testUserID})
 
 	setIssueAssigneeDirect(t, fx.parent.ID, "squad", parentSquad.SquadID)
 	setIssueAssigneeDirect(t, fx.child.ID, "squad", childSquadID)
@@ -585,9 +569,7 @@ func TestStageLeaderPrepareTimeoutRetryCanAdvanceNextStage(t *testing.T) {
 		"assignee_id":     sq.SquadID,
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create stage 2: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var stage2 IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&stage2); err != nil {
 		t.Fatalf("decode stage 2: %v", err)
@@ -661,9 +643,7 @@ func TestStageLeaderPrepareTimeoutRetryCanAdvanceNextStage(t *testing.T) {
 	req.Header.Set("X-Task-ID", retryID)
 	req = withURLParam(req, "id", stage2.ID)
 	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("retry leader promote Stage 2: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var stage2Status string
 	if err := testPool.QueryRow(ctx, `SELECT status FROM issue WHERE id = $1`, stage2.ID).Scan(&stage2Status); err != nil {
 		t.Fatalf("load promoted Stage 2: %v", err)

--- a/server/internal/handler/issue_children_for_parents_test.go
+++ b/server/internal/handler/issue_children_for_parents_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // childrenBatchFixture creates two parents with a couple of children each,
@@ -26,7 +27,7 @@ func newChildrenBatchFixture(t *testing.T) childrenBatchFixture {
 	t.Helper()
 
 	mkIssue := func(title, status, parentID string) IssueResponse {
-		w := httptest.NewRecorder()
+
 		body := map[string]any{
 			"title":  title + " " + time.Now().Format(time.RFC3339Nano),
 			"status": status,
@@ -35,7 +36,7 @@ func newChildrenBatchFixture(t *testing.T) childrenBatchFixture {
 			body["parent_issue_id"] = parentID
 		}
 		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
-		testHandler.CreateIssue(w, req)
+		w := testutil.Call(t, testHandler.CreateIssue, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("create %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
 		}
@@ -85,9 +86,7 @@ func TestListChildrenByParents_ReturnsChildrenForBothParentsInOneCall(t *testing
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids="+fx.parentA.ID+","+fx.parentB.ID, nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	got := decodeIssueBatch(t, w)
 	if len(got) != 3 {
@@ -113,9 +112,7 @@ func TestListChildrenByParents_EmptyParentIdsReturnsEmptyList(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID, nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := decodeIssueBatch(t, w); len(got) != 0 {
 		t.Fatalf("expected 0 children, got %d", len(got))
 	}
@@ -129,22 +126,17 @@ func TestListChildrenByParents_UnknownParentYieldsNoChildren(t *testing.T) {
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids=00000000-0000-0000-0000-000000000000", nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := decodeIssueBatch(t, w); len(got) != 0 {
 		t.Fatalf("expected 0 children, got %d", len(got))
 	}
 }
 
 func TestListChildrenByParents_RejectsMalformedID(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids=not-a-uuid", nil)
-	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", w.Code)
-	}
+	testutil.Call(t, testHandler.ListChildrenByParents, req).Want(http.StatusBadRequest)
 }
 
 func TestListChildrenByParents_RejectsTooManyParents(t *testing.T) {
@@ -155,13 +147,10 @@ func TestListChildrenByParents_RejectsTooManyParents(t *testing.T) {
 	for i := range ids {
 		ids[i] = "00000000-0000-0000-0000-000000000000"
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids="+strings.Join(ids, ","), nil)
-	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", w.Code)
-	}
+	testutil.Call(t, testHandler.ListChildrenByParents, req).Want(http.StatusBadRequest)
 }
 
 // TestListChildrenByParents_IgnoresForeignWorkspaceParents pins the
@@ -208,9 +197,7 @@ func TestListChildrenByParents_IgnoresForeignWorkspaceParents(t *testing.T) {
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids="+foreignParentID, nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	got := decodeIssueBatch(t, w)
 	if len(got) != 0 {
 		t.Fatalf("expected 0 children (foreign workspace isolation), got %d (first child id=%s)",
@@ -223,7 +210,7 @@ func TestListChildrenByParents_IgnoresForeignWorkspaceParents(t *testing.T) {
 // across repeated runs against the shared test database.
 func createChildIssue(t *testing.T, title, status, parentID string) IssueResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	body := map[string]any{
 		"title":  title + " " + time.Now().Format(time.RFC3339Nano),
 		"status": status,
@@ -232,7 +219,7 @@ func createChildIssue(t *testing.T, title, status, parentID string) IssueRespons
 		body["parent_issue_id"] = parentID
 	}
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
-	testHandler.CreateIssue(w, req)
+	w := testutil.Call(t, testHandler.CreateIssue, req)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("create %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
 	}
@@ -313,9 +300,7 @@ func TestListChildIssues_OrdersByNumberAsc(t *testing.T) {
 		"id", parent.ID,
 	)
 	testHandler.ListChildIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	assertNumberAscending(t, decodeIssueBatch(t, w), children)
 }
@@ -330,9 +315,7 @@ func TestListChildrenByParents_OrdersByNumberAscWithinParent(t *testing.T) {
 	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids="+parent.ID, nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	assertNumberAscending(t, decodeIssueBatch(t, w), children)
 }
@@ -384,9 +367,7 @@ func TestListChildIssues_IncludesLabels(t *testing.T) {
 		"id", fx.parentA.ID,
 	)
 	testHandler.ListChildIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListChildIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	assertChildLabels(t, decodeIssueBatch(t, w))
 
 	// Batched listing.
@@ -394,8 +375,6 @@ func TestListChildIssues_IncludesLabels(t *testing.T) {
 	req = newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
 		"&parent_ids="+fx.parentA.ID, nil)
 	testHandler.ListChildrenByParents(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListChildrenByParents: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	assertChildLabels(t, decodeIssueBatch(t, w))
 }

--- a/server/internal/handler/issue_collection_revision_test.go
+++ b/server/internal/handler/issue_collection_revision_test.go
@@ -2,13 +2,13 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
@@ -58,8 +58,7 @@ func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
 	})
 
 	groupKey := "status:in_review"
-	tableRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableRows(tableRecorder, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
+	tableRecorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
 		Query: issueTableQuerySpec{
 			Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 			Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
@@ -68,14 +67,9 @@ func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
 		GroupKey:  &groupKey,
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 10},
-	}))
-	if tableRecorder.Code != http.StatusOK {
-		t.Fatalf("table rows status = %d: %s", tableRecorder.Code, tableRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var tableResponse issueTableRowsResponse
-	if err := json.NewDecoder(tableRecorder.Body).Decode(&tableResponse); err != nil {
-		t.Fatalf("decode table rows: %v", err)
-	}
+	tableRecorder.Decode(&tableResponse)
 	if len(tableResponse.Rows) != 1 || tableResponse.Rows[0].Issue.ID != issueID {
 		t.Fatalf("table rows = %+v, want issue %s", tableResponse.Rows, issueID)
 	}
@@ -83,32 +77,20 @@ func TestIssueCollectionProjectionsIncludePositiveRevision(t *testing.T) {
 		t.Fatalf("table row revision = %d, want 7", tableResponse.Rows[0].Issue.Revision)
 	}
 
-	listRecorder := httptest.NewRecorder()
-	testHandler.ListIssues(listRecorder, newRequest(http.MethodGet, "/api/issues?project_id="+url.QueryEscape(projectID), nil))
-	if listRecorder.Code != http.StatusOK {
-		t.Fatalf("list issues status = %d: %s", listRecorder.Code, listRecorder.Body.String())
-	}
+	listRecorder := testutil.Call(t, testHandler.ListIssues, newRequest(http.MethodGet, "/api/issues?project_id="+url.QueryEscape(projectID), nil)).Want(http.StatusOK)
 	var listResponse struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(listRecorder.Body).Decode(&listResponse); err != nil {
-		t.Fatalf("decode issue list: %v", err)
-	}
+	listRecorder.Decode(&listResponse)
 	if len(listResponse.Issues) != 1 || listResponse.Issues[0].ID != issueID || listResponse.Issues[0].Revision != 7 {
 		t.Fatalf("list projection = %+v, want issue %s at revision 7", listResponse.Issues, issueID)
 	}
 
-	searchRecorder := httptest.NewRecorder()
-	testHandler.SearchIssues(searchRecorder, newRequest(http.MethodGet, "/api/issues/search?q="+url.QueryEscape(title), nil))
-	if searchRecorder.Code != http.StatusOK {
-		t.Fatalf("search issues status = %d: %s", searchRecorder.Code, searchRecorder.Body.String())
-	}
+	searchRecorder := testutil.Call(t, testHandler.SearchIssues, newRequest(http.MethodGet, "/api/issues/search?q="+url.QueryEscape(title), nil)).Want(http.StatusOK)
 	var searchResponse struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(searchRecorder.Body).Decode(&searchResponse); err != nil {
-		t.Fatalf("decode issue search: %v", err)
-	}
+	searchRecorder.Decode(&searchResponse)
 	if len(searchResponse.Issues) != 1 || searchResponse.Issues[0].ID != issueID || searchResponse.Issues[0].Revision != 7 {
 		t.Fatalf("search projection = %+v, want issue %s at revision 7", searchResponse.Issues, issueID)
 	}

--- a/server/internal/handler/issue_create_labels_test.go
+++ b/server/internal/handler/issue_create_labels_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -17,19 +17,17 @@ import (
 // the public handler and registers cleanup. It returns the new label id.
 func createTestIssueLabel(t *testing.T, name string) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/labels", map[string]any{
 		"name":  name,
 		"color": "#ef4444",
 	})
-	testHandler.CreateLabel(w, req)
+	w := testutil.Call(t, testHandler.CreateLabel, req)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("CreateLabel %q: expected 201, got %d: %s", name, w.Code, w.Body.String())
 	}
 	var created LabelResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode label: %v", err)
-	}
+	w.Decode(&created)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM issue_label WHERE id = $1`, created.ID)
 	})
@@ -67,17 +65,13 @@ func TestCreateIssueAttachesLabelsAtomically(t *testing.T) {
 	labelA := createTestIssueLabel(t, "cl-a-"+uuid.NewString()[:8])
 	labelB := createTestIssueLabel(t, "cl-b-"+uuid.NewString()[:8])
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":     "create-labels attaches",
 		"status":    "todo",
 		"priority":  "low",
 		"label_ids": []string{labelA, labelB},
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() { deleteTestIssue(t, issue.ID) })
@@ -109,16 +103,13 @@ func TestCreateIssueAttachesLabelsAtomically(t *testing.T) {
 // list — the signal a newer client uses to know the backend handled labels and
 // skip its legacy per-label attach fallback.
 func TestCreateIssueResponseAlwaysIncludesLabelsField(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "create-labels no-label response",
 		"status":   "todo",
 		"priority": "low",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() { deleteTestIssue(t, issue.ID) })
@@ -146,17 +137,13 @@ func TestCreateIssueEventCarriesLabels(t *testing.T) {
 		}
 	})
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":     "create-labels event carries",
 		"status":    "todo",
 		"priority":  "low",
 		"label_ids": []string{label},
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() { deleteTestIssue(t, issue.ID) })
@@ -193,17 +180,13 @@ func TestCreateIssueEventCarriesLabels(t *testing.T) {
 func TestCreateIssueDedupesDuplicateLabelIDs(t *testing.T) {
 	label := createTestIssueLabel(t, "cl-dup-"+uuid.NewString()[:8])
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":     "create-labels dedupe",
 		"status":    "todo",
 		"priority":  "low",
 		"label_ids": []string{label, label},
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() { deleteTestIssue(t, issue.ID) })
@@ -218,17 +201,14 @@ func TestCreateIssueDedupesDuplicateLabelIDs(t *testing.T) {
 // atomicity guarantee the old post-create attach flow could not offer.
 func TestCreateIssueRejectsUnknownLabelWithoutCreating(t *testing.T) {
 	const title = "create-labels unknown rejected"
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":     title,
 		"status":    "todo",
 		"priority":  "low",
 		"label_ids": []string{uuid.NewString()},
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateIssue: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	if got := countIssuesWithTitle(t, title); got != 0 {
 		t.Errorf("expected no issue created on invalid label, found %d", got)
 	}
@@ -239,29 +219,17 @@ func TestCreateIssueRejectsUnknownLabelWithoutCreating(t *testing.T) {
 // mirroring the resource_type guard baked into AttachLabelToIssue.
 func TestCreateIssueRejectsNonIssueScopedLabel(t *testing.T) {
 	var agentLabelID string
-	if err := testPool.QueryRow(context.Background(),
-		`INSERT INTO issue_label (workspace_id, resource_type, name, color)
-		 VALUES ($1, 'agent', $2, '#000000') RETURNING id`,
-		testWorkspaceID, "create-labels agent "+uuid.NewString(),
-	).Scan(&agentLabelID); err != nil {
-		t.Fatalf("insert agent label: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue_label WHERE id = $1`, agentLabelID)
-	})
+	agentLabelID = dbfx.Insert(t, "issue_label", testutil.Cols{"workspace_id": testWorkspaceID, "resource_type": testutil.Raw("'agent'"), "name": "create-labels agent " + uuid.NewString(), "color": testutil.Raw("'#000000'")})
 
 	const title = "create-labels wrong scope rejected"
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":     title,
 		"status":    "todo",
 		"priority":  "low",
 		"label_ids": []string{agentLabelID},
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateIssue: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	if got := countIssuesWithTitle(t, title); got != 0 {
 		t.Errorf("expected no issue created on wrong-scope label, found %d", got)
 	}

--- a/server/internal/handler/issue_create_position_test.go
+++ b/server/internal/handler/issue_create_position_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -28,13 +29,13 @@ func TestCreateIssuePositionTopOfColumn(t *testing.T) {
 	// previous one, which is exactly the desired behavior.
 	createIssueAndGetPosition := func(t *testing.T, title string) (string, float64) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 			"title":    title,
 			"status":   "todo",
 			"priority": "low",
 		})
-		testHandler.CreateIssue(w, req)
+		w := testutil.Call(t, testHandler.CreateIssue, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateIssue %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
 		}
@@ -68,16 +69,13 @@ func TestCreateIssuePositionTopOfColumn(t *testing.T) {
 // API should land below the explicit minimum, not at 0.
 func TestCreateIssuePositionBelowExplicitMinimum(t *testing.T) {
 	// Create a seed issue via the API.
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "position-seed issue",
 		"status":   "todo",
 		"priority": "low",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("seed CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var seed IssueResponse
 	json.NewDecoder(w.Body).Decode(&seed)
 	t.Cleanup(func() { deleteTestIssue(t, seed.ID) })
@@ -93,16 +91,13 @@ func TestCreateIssuePositionBelowExplicitMinimum(t *testing.T) {
 	}
 
 	// Now create a new issue. It must land below -9999, not at 0.
-	w2 := httptest.NewRecorder()
+
 	req2 := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "position-new issue",
 		"status":   "todo",
 		"priority": "low",
 	})
-	testHandler.CreateIssue(w2, req2)
-	if w2.Code != http.StatusCreated {
-		t.Fatalf("new CreateIssue: expected 201, got %d: %s", w2.Code, w2.Body.String())
-	}
+	w2 := testutil.Call(t, testHandler.CreateIssue, req2).Want(http.StatusCreated)
 	var newIssue IssueResponse
 	json.NewDecoder(w2.Body).Decode(&newIssue)
 	t.Cleanup(func() { deleteTestIssue(t, newIssue.ID) })
@@ -130,9 +125,7 @@ func TestAutopilotCreateIssuePositionBelowCurrentMinimum(t *testing.T) {
 		"priority": "low",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("seed CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var seed IssueResponse
 	json.NewDecoder(w.Body).Decode(&seed)
 	t.Cleanup(func() { deleteTestIssue(t, seed.ID) })
@@ -161,9 +154,7 @@ func TestAutopilotCreateIssuePositionBelowCurrentMinimum(t *testing.T) {
 		"issue_title_template": autopilotIssueTitle,
 	})
 	testHandler.CreateAutopilot(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var autopilot AutopilotResponse
 	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
 		t.Fatalf("decode autopilot: %v", err)

--- a/server/internal/handler/issue_grouped_test.go
+++ b/server/internal/handler/issue_grouped_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
@@ -34,19 +34,7 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 	}
 
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, "Grouped Issues Test Agent", testRuntimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Grouped Issues Test Agent", "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID, "visibility": testutil.Raw("'workspace'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	createIssue := func(title, assigneeType, assigneeID string, position float64, startDate *time.Time, stage *int32) string {
 		t.Helper()
@@ -94,16 +82,10 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 		assigneeID,
 		agentID,
 	)
-	w := httptest.NewRecorder()
-	testHandler.ListGroupedIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListGroupedIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListGroupedIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 
 	var resp GroupedIssuesResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode grouped response: %v", err)
-	}
+	w.Decode(&resp)
 
 	memberGroupID := "assignee:member:" + assigneeID
 	agentGroupID := "assignee:agent:" + agentID
@@ -142,16 +124,10 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 		testWorkspaceID,
 		assigneeID,
 	)
-	next := httptest.NewRecorder()
-	testHandler.ListGroupedIssues(next, newRequest("GET", nextPath, nil))
-	if next.Code != http.StatusOK {
-		t.Fatalf("ListGroupedIssues next page: expected 200, got %d: %s", next.Code, next.Body.String())
-	}
+	next := testutil.Call(t, testHandler.ListGroupedIssues, newRequest("GET", nextPath, nil)).Want(http.StatusOK)
 
 	var nextResp GroupedIssuesResponse
-	if err := json.NewDecoder(next.Body).Decode(&nextResp); err != nil {
-		t.Fatalf("decode next grouped response: %v", err)
-	}
+	next.Decode(&nextResp)
 	if len(nextResp.Groups) != 1 {
 		t.Fatalf("expected one next-page group, got %#v", nextResp.Groups)
 	}

--- a/server/internal/handler/issue_involves_test.go
+++ b/server/internal/handler/issue_involves_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // involvesFixture seeds, for a single test, the data needed to exercise every
@@ -99,14 +99,7 @@ func setupInvolvesFixture(t *testing.T) *involvesFixture {
 
 	// --- second workspace, mirroring all four shapes for cross-ws negatives ---
 	var otherWsID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ($1, $2, '', 'OTH')
-		RETURNING id
-	`, fmt.Sprintf("InvolvesOtherWs-%d", suffix), fmt.Sprintf("involves-other-ws-%d", suffix)).Scan(&otherWsID); err != nil {
-		t.Fatalf("create other workspace: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, otherWsID) })
+	otherWsID = dbfx.Insert(t, "workspace", testutil.Cols{"name": fmt.Sprintf("InvolvesOtherWs-%d", suffix), "slug": fmt.Sprintf("involves-other-ws-%d", suffix), "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'OTH'")})
 	fx.otherWsID = otherWsID
 
 	// Membership in other workspace (so the user could legitimately be assigned
@@ -229,17 +222,11 @@ func listIssuesInvolves(t *testing.T, userID string) []string {
 	t.Helper()
 	path := fmt.Sprintf("/api/issues?workspace_id=%s&involves_user_id=%s&limit=500",
 		testWorkspaceID, userID)
-	w := httptest.NewRecorder()
-	testHandler.ListIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 	var resp struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
+	w.Decode(&resp)
 	ids := make([]string, 0, len(resp.Issues))
 	for _, iss := range resp.Issues {
 		ids = append(ids, iss.ID)
@@ -254,15 +241,9 @@ func listGroupedIssuesInvolves(t *testing.T, userID string) []string {
 	path := fmt.Sprintf(
 		"/api/issues/grouped?workspace_id=%s&group_by=assignee&statuses=todo&involves_user_id=%s&limit=100",
 		testWorkspaceID, userID)
-	w := httptest.NewRecorder()
-	testHandler.ListGroupedIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListGroupedIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListGroupedIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 	var resp GroupedIssuesResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode grouped response: %v", err)
-	}
+	w.Decode(&resp)
 	ids := []string{}
 	for _, g := range resp.Groups {
 		for _, iss := range g.Issues {
@@ -424,17 +405,11 @@ func TestListIssues_InvolvesUserID_CombinesWithCreatorID(t *testing.T) {
 
 	path := fmt.Sprintf("/api/issues?workspace_id=%s&involves_user_id=%s&creator_id=%s&limit=500",
 		testWorkspaceID, fx.userID, fx.userID)
-	w := httptest.NewRecorder()
-	testHandler.ListIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 	var resp struct {
 		Issues []IssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
+	w.Decode(&resp)
 	got := make([]string, 0, len(resp.Issues))
 	for _, iss := range resp.Issues {
 		got = append(got, iss.ID)
@@ -447,11 +422,7 @@ func TestListIssues_InvolvesUserID_CombinesWithCreatorID(t *testing.T) {
 
 func TestListIssues_InvolvesUserID_InvalidUUIDReturns400(t *testing.T) {
 	path := fmt.Sprintf("/api/issues?workspace_id=%s&involves_user_id=not-a-uuid", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.ListIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 on invalid UUID, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusBadRequest)
 }
 
 // Grouped path also exercises canonical-leader resolution, so a single positive

--- a/server/internal/handler/issue_last_activity_test.go
+++ b/server/internal/handler/issue_last_activity_test.go
@@ -2,12 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -25,16 +24,11 @@ func TestUpdateIssueActivityExcludesPositionOnlyWrites(t *testing.T) {
 
 	update := func(body map[string]any) IssueResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := withURLParam(newRequest(http.MethodPut, "/api/issues/"+created.ID, body), "id", created.ID)
-		testHandler.UpdateIssue(w, r)
-		if w.Code != http.StatusOK {
-			t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateIssue, r).Want(http.StatusOK)
 		var response IssueResponse
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode UpdateIssue: %v", err)
-		}
+		w.Decode(&response)
 		return response
 	}
 

--- a/server/internal/handler/issue_limit_validation_test.go
+++ b/server/internal/handler/issue_limit_validation_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Backs issue #3563 / MUL-2847: ListIssues must validate and clamp the `limit`
@@ -70,8 +71,7 @@ func TestListIssues_LimitValidation(t *testing.T) {
 	call := func(query string) (int, listResp, string) {
 		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s%s",
 			testWorkspaceID, projectID, query)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil))
 		var resp listResp
 		body := w.Body.String()
 		if w.Code == http.StatusOK {
@@ -194,8 +194,7 @@ func TestListIssues_LimitClamp(t *testing.T) {
 	call := func(query string) (int, listResp, string) {
 		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s%s",
 			testWorkspaceID, projectID, query)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil))
 		var resp listResp
 		body := w.Body.String()
 		if w.Code == http.StatusOK {

--- a/server/internal/handler/issue_metadata_test.go
+++ b/server/internal/handler/issue_metadata_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Round-trip: set primitives of each type, list, get them back, delete, confirm gone.
@@ -25,10 +27,10 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/"+c.key, json.RawMessage(`{"value":`+c.value+`}`))
 		req = withURLParams(req, "id", issueID, "key", c.key)
-		testHandler.SetIssueMetadataKey(w, req)
+		w := testutil.Call(t, testHandler.SetIssueMetadataKey, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("Set %s=%s: expected 200, got %d: %s", c.key, c.value, w.Code, w.Body.String())
 		}
@@ -39,9 +41,7 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 	req := newRequest("GET", "/api/issues/"+issueID+"/metadata", nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.ListIssueMetadata(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("List metadata: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp struct {
 		Metadata map[string]any `json:"metadata"`
 	}
@@ -66,9 +66,7 @@ func TestIssueMetadataSetGetDelete(t *testing.T) {
 	req = newRequest("DELETE", "/api/issues/"+issueID+"/metadata/pipeline_status", nil)
 	req = withURLParams(req, "id", issueID, "key", "pipeline_status")
 	testHandler.DeleteIssueMetadataKey(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("Delete pipeline_status: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/issues/"+issueID+"/metadata", nil)
 	req = withURLParam(req, "id", issueID)
@@ -106,16 +104,13 @@ func TestIssueMetadataValidation(t *testing.T) {
 	}
 	for _, c := range bad {
 		t.Run(c.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			// chi pulls the key from URL params (injected via withURLParams);
 			// the raw URL needs to be a valid request line, so PathEscape any
 			// chars (spaces, etc.) that would otherwise break httptest.NewRequest.
 			req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/"+url.PathEscape(c.key), json.RawMessage(c.rawBody))
 			req = withURLParams(req, "id", issueID, "key", c.key)
-			testHandler.SetIssueMetadataKey(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.SetIssueMetadataKey, req).Want(http.StatusBadRequest)
 		})
 	}
 }
@@ -128,13 +123,10 @@ func TestIssueMetadataSizeLimit(t *testing.T) {
 
 	huge := strings.Repeat("a", 9000)
 	body, _ := json.Marshal(map[string]any{"value": huge})
-	w := httptest.NewRecorder()
+
 	req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/blob", body)
 	req = withURLParams(req, "id", issueID, "key", "blob")
-	testHandler.SetIssueMetadataKey(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 from size CHECK, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SetIssueMetadataKey, req).Want(http.StatusBadRequest)
 }
 
 // The 50-key cap is enforced in the handler with a clear 400.
@@ -143,10 +135,10 @@ func TestIssueMetadataKeyCountCap(t *testing.T) {
 
 	for i := 0; i < maxIssueMetadataKeys; i++ {
 		key := fmt.Sprintf("k_%d", i)
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/"+key, json.RawMessage(`{"value":"v"}`))
 		req = withURLParams(req, "id", issueID, "key", key)
-		testHandler.SetIssueMetadataKey(w, req)
+		w := testutil.Call(t, testHandler.SetIssueMetadataKey, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("key #%d: expected 200, got %d: %s", i, w.Code, w.Body.String())
 		}
@@ -155,9 +147,7 @@ func TestIssueMetadataKeyCountCap(t *testing.T) {
 	req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/overflow", json.RawMessage(`{"value":"v"}`))
 	req = withURLParams(req, "id", issueID, "key", "overflow")
 	testHandler.SetIssueMetadataKey(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("overflow key: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Updating an existing key past the cap is still allowed — only new keys
 	// are blocked.
@@ -165,9 +155,7 @@ func TestIssueMetadataKeyCountCap(t *testing.T) {
 	req = newRequest("PUT", "/api/issues/"+issueID+"/metadata/k_0", json.RawMessage(`{"value":"v2"}`))
 	req = withURLParams(req, "id", issueID, "key", "k_0")
 	testHandler.SetIssueMetadataKey(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("update existing at cap: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 // ListIssues with `metadata` query param does JSONB containment filtering and
@@ -177,11 +165,11 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 	doneID := createMetadataTestIssue(t, "Done issue")
 
 	for issueID, status := range map[string]string{waitingID: "waiting_review", doneID: "deployed"} {
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/pipeline_status",
 			json.RawMessage(`{"value":"`+status+`"}`))
 		req = withURLParams(req, "id", issueID, "key", "pipeline_status")
-		testHandler.SetIssueMetadataKey(w, req)
+		w := testutil.Call(t, testHandler.SetIssueMetadataKey, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("seed %s: %d %s", issueID, w.Code, w.Body.String())
 		}
@@ -190,9 +178,7 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("GET", `/api/issues?metadata={"pipeline_status":"waiting_review"}`, nil)
 	testHandler.ListIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("List with filter: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var listResp struct {
 		Issues []IssueResponse `json:"issues"`
 	}
@@ -218,9 +204,7 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 	w = httptest.NewRecorder()
 	req = newRequest("GET", `/api/issues?metadata={not-json}`, nil)
 	testHandler.ListIssues(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("malformed metadata: expected 400, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 // New issues default to an empty metadata object — never null — so frontend
@@ -228,13 +212,9 @@ func TestListIssuesMetadataFilter(t *testing.T) {
 func TestNewIssueDefaultsToEmptyMetadata(t *testing.T) {
 	issueID := createMetadataTestIssue(t, "Default empty metadata")
 
-	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
-	testHandler.GetIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetIssue: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetIssue, req).Want(http.StatusOK)
 	var got IssueResponse
 	json.NewDecoder(w.Body).Decode(&got)
 	if got.Metadata == nil {
@@ -247,19 +227,14 @@ func TestNewIssueDefaultsToEmptyMetadata(t *testing.T) {
 
 func createMetadataTestIssue(t *testing.T, title string) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    title,
 		"status":   "todo",
 		"priority": "medium",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("createMetadataTestIssue: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
-	if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
-		t.Fatalf("decode issue: %v", err)
-	}
+	w.Decode(&issue)
 	return issue.ID
 }

--- a/server/internal/handler/issue_move_test.go
+++ b/server/internal/handler/issue_move_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestIssueMovePositionUsesRelativeAnchors(t *testing.T) {
@@ -73,16 +74,7 @@ func TestMoveIssueRejectsUnsafeInputs(t *testing.T) {
 	})
 
 	var foreignWorkspaceID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ($1, $2, '', 'MOV')
-		RETURNING id
-	`, "Move boundary foreign workspace "+suffix, "move-boundary-"+suffix).Scan(&foreignWorkspaceID); err != nil {
-		t.Fatalf("insert foreign workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-	})
+	foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Move boundary foreign workspace " + suffix, "slug": "move-boundary-" + suffix, "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'MOV'")})
 
 	var foreignAnchorID string
 	if err := testPool.QueryRow(ctx, `
@@ -148,18 +140,14 @@ func TestMoveIssueRejectsUnsafeInputs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest(
 				http.MethodPost,
 				"/api/issues/"+movedIssueID+"/move",
 				tc.body,
 			)
 			req = withURLParam(req, "id", movedIssueID)
-			testHandler.MoveIssue(w, req)
-
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("MoveIssue: expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.MoveIssue, req).Want(http.StatusBadRequest)
 			if !strings.Contains(w.Body.String(), tc.wantError) {
 				t.Fatalf("MoveIssue: expected error %q, got %s", tc.wantError, w.Body.String())
 			}

--- a/server/internal/handler/issue_reassign_no_cancel_test.go
+++ b/server/internal/handler/issue_reassign_no_cancel_test.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // insertRunningIssueTask inserts an in-flight (running) task for the given agent
@@ -28,14 +29,7 @@ func insertRunningIssueTask(t *testing.T, agentID, issueID string) string {
 func insertAgentAssignedIssue(t *testing.T, agentID string, number int, title string) string {
 	t.Helper()
 	var issueID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
-		VALUES ($1, $2, 'todo', 'medium', $3, 'member', $4, 0, 'agent', $5)
-		RETURNING id
-	`, testWorkspaceID, title, testUserID, number, agentID).Scan(&issueID); err != nil {
-		t.Fatalf("insert issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": title, "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'medium'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": number, "position": testutil.Raw("0"), "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID})
 	return issueID
 }
 
@@ -57,16 +51,13 @@ func TestUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
 
 	// Reassign from ownerAgent to a member — a genuine assignee change that
 	// does not itself enqueue a new agent run.
-	w := httptest.NewRecorder()
+
 	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
 		"assignee_type": "member",
 		"assignee_id":   testUserID,
 	})
 	req = withURLParam(req, "id", issueID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue reassign: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	if got := taskStatus(t, ownerTask); got != "running" {
 		t.Fatalf("previous assignee's own task must survive reassignment, got status %q", got)
@@ -91,7 +82,6 @@ func TestBatchUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
 	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
 	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": []string{issueID},
 		"updates": map[string]any{
@@ -99,10 +89,7 @@ func TestBatchUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
 			"assignee_id":   testUserID,
 		},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("BatchUpdateIssues reassign: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusOK)
 
 	if got := taskStatus(t, ownerTask); got != "running" {
 		t.Fatalf("previous assignee's own task must survive batch reassignment, got status %q", got)
@@ -142,16 +129,13 @@ func TestUpdateIssueReassignToAgentKeepsOldTaskAndEnqueuesNew(t *testing.T) {
 	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
 
 	// Reassign from ownerAgent to newAgent — an agent→agent ownership handoff.
-	w := httptest.NewRecorder()
+
 	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
 		"assignee_type": "agent",
 		"assignee_id":   newAgent,
 	})
 	req = withURLParam(req, "id", issueID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue reassign: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	if got := taskStatus(t, ownerTask); got != "running" {
 		t.Fatalf("previous agent's own task must survive agent→agent reassignment, got status %q", got)

--- a/server/internal/handler/issue_revision_test.go
+++ b/server/internal/handler/issue_revision_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -143,13 +144,9 @@ func TestRevisionConflictsPreserveLatestIssueAndComment(t *testing.T) {
 	if title != "revision latest" || issueRevision != 2 {
 		t.Fatalf("issue after stale write = (%q, %d), want latest/2", title, issueRevision)
 	}
-	legacyIssue := httptest.NewRecorder()
-	testHandler.UpdateIssue(legacyIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"title": "legacy issue update",
-	}), "id", issueID))
-	if legacyIssue.Code != http.StatusOK {
-		t.Fatalf("legacy issue update = %d: %s", legacyIssue.Code, legacyIssue.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusOK)
 	if err := testPool.QueryRow(ctx, `SELECT title, revision FROM issue WHERE id = $1`, issueID).Scan(&title, &issueRevision); err != nil {
 		t.Fatalf("reload legacy issue update: %v", err)
 	}
@@ -216,13 +213,9 @@ func TestRevisionConflictsPreserveLatestIssueAndComment(t *testing.T) {
 	if commentRevision != 3 {
 		t.Fatalf("comment revision after attachment update = %d, want 3", commentRevision)
 	}
-	legacyComment := httptest.NewRecorder()
-	testHandler.UpdateComment(legacyComment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
+	testutil.Call(t, testHandler.UpdateComment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 		"content": "legacy comment update",
-	}), "commentId", commentID))
-	if legacyComment.Code != http.StatusOK {
-		t.Fatalf("legacy comment update = %d: %s", legacyComment.Code, legacyComment.Body.String())
-	}
+	}), "commentId", commentID)).Want(http.StatusOK)
 	if err := testPool.QueryRow(ctx, `SELECT content, revision FROM comment WHERE id = $1`, commentID).Scan(&content, &commentRevision); err != nil {
 		t.Fatalf("reload legacy comment update: %v", err)
 	}
@@ -254,55 +247,35 @@ func TestTextBaselinesIgnoreUnrelatedAggregateRevisionChanges(t *testing.T) {
 	})
 
 	// An unrelated priority write advances the aggregate owner revision.
-	priority := httptest.NewRecorder()
-	testHandler.UpdateIssue(priority, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"priority": "high",
-	}), "id", issueID))
-	if priority.Code != http.StatusOK {
-		t.Fatalf("unrelated issue update = %d: %s", priority.Code, priority.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusOK)
 
-	text := httptest.NewRecorder()
-	testHandler.UpdateIssue(text, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"title":            "edited title",
 		"title_base":       "baseline title",
 		"description":      "edited description",
 		"description_base": "baseline description",
-	}), "id", issueID))
-	if text.Code != http.StatusOK {
-		t.Fatalf("text update after unrelated revision = %d: %s", text.Code, text.Body.String())
-	}
-	staleDescription := httptest.NewRecorder()
-	testHandler.UpdateIssue(staleDescription, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	}), "id", issueID)).Want(http.StatusOK)
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"description":      "stale description overwrite",
 		"description_base": "baseline description",
-	}), "id", issueID))
-	if staleDescription.Code != http.StatusConflict {
-		t.Fatalf("true issue description conflict = %d, want 409: %s", staleDescription.Code, staleDescription.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusConflict)
 
 	// A reaction/resolve-style aggregate bump on the comment must likewise not
 	// reject a body edit whose content baseline is still current.
 	if _, err := testPool.Exec(ctx, `UPDATE comment SET revision = revision + 1 WHERE id = $1`, commentID); err != nil {
 		t.Fatalf("bump comment revision: %v", err)
 	}
-	comment := httptest.NewRecorder()
-	testHandler.UpdateComment(comment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
+	testutil.Call(t, testHandler.UpdateComment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 		"content":      "edited comment",
 		"content_base": "baseline comment",
-	}), "commentId", commentID))
-	if comment.Code != http.StatusOK {
-		t.Fatalf("comment edit after unrelated revision = %d: %s", comment.Code, comment.Body.String())
-	}
+	}), "commentId", commentID)).Want(http.StatusOK)
 
-	stale := httptest.NewRecorder()
-	testHandler.UpdateComment(stale, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
+	testutil.Call(t, testHandler.UpdateComment, withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 		"content":      "stale overwrite",
 		"content_base": "baseline comment",
-	}), "commentId", commentID))
-	if stale.Code != http.StatusConflict {
-		t.Fatalf("true comment content conflict = %d, want 409: %s", stale.Code, stale.Body.String())
-	}
+	}), "commentId", commentID)).Want(http.StatusConflict)
 }
 
 func TestConcurrentRevisionWritesHaveExactlyOneWinner(t *testing.T) {
@@ -350,20 +323,20 @@ func TestConcurrentRevisionWritesHaveExactlyOneWinner(t *testing.T) {
 	}
 
 	assertOneWinner(func(title string) int {
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 			"title": title, "title_base": "concurrent revision",
 		}), "id", issueID)
-		testHandler.UpdateIssue(w, req)
+		w := testutil.Call(t, testHandler.UpdateIssue, req)
 		return w.Code
 	})
 
 	assertOneWinner(func(content string) int {
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest(http.MethodPut, "/api/comments/"+commentID, map[string]any{
 			"content": content, "content_base": "concurrent original",
 		}), "commentId", commentID)
-		testHandler.UpdateComment(w, req)
+		w := testutil.Call(t, testHandler.UpdateComment, req)
 		return w.Code
 	})
 
@@ -406,12 +379,12 @@ func TestConcurrentCommentRevisionConflictCancelsTaskBatchOnce(t *testing.T) {
 	for _, content := range []string{"concurrent edit a", "concurrent edit b"} {
 		go func() {
 			<-start
-			w := httptest.NewRecorder()
+
 			req := withURLParam(newRequest(http.MethodPut, "/api/comments/"+fixture.commentID[2], map[string]any{
 				"content":      content,
 				"content_base": fixture.content[2],
 			}), "commentId", fixture.commentID[2])
-			testHandler.UpdateComment(w, req)
+			w := testutil.Call(t, testHandler.UpdateComment, req)
 			results <- w.Code
 		}()
 	}
@@ -465,14 +438,10 @@ func TestNoOpIssueUpdateDoesNotAdvanceRevisionOrUpdatedAt(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.UpdateIssue(w, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, testHandler.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"title":             "no-op issue update",
 		"expected_revision": 1,
-	}), "id", issueID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("no-op update = %d: %s", w.Code, w.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusOK)
 	var revision int64
 	var updatedAt time.Time
 	if err := testPool.QueryRow(ctx, `SELECT revision, updated_at FROM issue WHERE id = $1`, issueID).Scan(&revision, &updatedAt); err != nil {
@@ -517,15 +486,11 @@ func TestNoOpIssueWithAttachmentPublishesFreshOwnerBeforeAttachmentEvent(t *test
 		}
 	})
 
-	w := httptest.NewRecorder()
-	h.UpdateIssue(w, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, h.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"title":             "ordered attachment events",
 		"attachment_ids":    []string{attachmentID},
 		"expected_revision": 1,
-	}), "id", issueID))
-	if w.Code != http.StatusOK {
-		t.Fatalf("combined update = %d: %s", w.Code, w.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusOK)
 	if len(ordered) != 2 || ordered[0].Type != protocol.EventIssueUpdated || ordered[1].Type != protocol.EventIssueAttachmentsChanged {
 		t.Fatalf("event order = %#v, want issue:updated then issue_attachments:changed", ordered)
 	}
@@ -649,9 +614,7 @@ func TestIssueUpdateAndAttachmentBindingExcludeInterleavingMutation(t *testing.T
 
 	close(releaseLink)
 	response := <-handlerDone
-	if response.Code != http.StatusOK {
-		t.Fatalf("combined update = %d: %s", response.Code, response.Body.String())
-	}
+	testutil.Equal(t, response.Code, http.StatusOK, "HTTP status")
 	var updated IssueResponse
 	if err := json.NewDecoder(response.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode combined update: %v", err)
@@ -702,14 +665,10 @@ func TestIssueUpdateRollsBackWhenAttachmentBindingFails(t *testing.T) {
 
 	h := *testHandler
 	h.TxStarter = failIssueAttachmentLinkTxStarter{inner: testHandler.TxStarter}
-	w := httptest.NewRecorder()
-	h.UpdateIssue(w, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
+	testutil.Call(t, h.UpdateIssue, withURLParam(newRequest(http.MethodPut, "/api/issues/"+issueID, map[string]any{
 		"title":          "attachment rollback changed",
 		"attachment_ids": []string{attachmentID},
-	}), "id", issueID))
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("injected link failure = %d, want 500: %s", w.Code, w.Body.String())
-	}
+	}), "id", issueID)).Want(http.StatusInternalServerError)
 
 	var title string
 	var revision int64
@@ -769,11 +728,7 @@ func TestAuxiliaryVisibleMutationsAdvanceOwnerRevisionExactlyOnce(t *testing.T) 
 	if err != nil || attached.Changed || attached.IssueRevision != 0 {
 		t.Fatalf("duplicate label attach = (%+v, %v), want no-op", attached, err)
 	}
-	labelsResponse := httptest.NewRecorder()
-	testHandler.ListLabelsForIssue(labelsResponse, withURLParam(newRequest(http.MethodGet, "/api/issues/"+issueID+"/labels", nil), "id", issueID))
-	if labelsResponse.Code != http.StatusOK {
-		t.Fatalf("list issue labels = %d: %s", labelsResponse.Code, labelsResponse.Body.String())
-	}
+	labelsResponse := testutil.Call(t, testHandler.ListLabelsForIssue, withURLParam(newRequest(http.MethodGet, "/api/issues/"+issueID+"/labels", nil), "id", issueID)).Want(http.StatusOK)
 	var labelPayload struct {
 		IssueRevision int64 `json:"issue_revision"`
 	}

--- a/server/internal/handler/issue_scheduled_test.go
+++ b/server/internal/handler/issue_scheduled_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Backs the Project Gantt view: only issues with at least one of
@@ -21,12 +21,7 @@ func TestListIssues_ScheduledFilter(t *testing.T) {
 	// with due_date only, and one with neither. Using a dedicated project so
 	// the assertion isn't polluted by other issues seeded by parallel tests.
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("Gantt Scheduled %d", suffix)).Scan(&projectID); err != nil {
-		t.Fatalf("create project: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": fmt.Sprintf("Gantt Scheduled %d", suffix)})
 
 	insertIssue := func(title string, startDate, dueDate *time.Time) string {
 		var number int
@@ -58,18 +53,12 @@ func TestListIssues_ScheduledFilter(t *testing.T) {
 	list := func(query string) (ids []string, total int64) {
 		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500%s",
 			testWorkspaceID, projectID, query)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var resp struct {
 			Issues []IssueResponse `json:"issues"`
 			Total  int64           `json:"total"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode list response: %v", err)
-		}
+		w.Decode(&resp)
 		for _, iss := range resp.Issues {
 			ids = append(ids, iss.ID)
 		}
@@ -108,12 +97,7 @@ func TestListIssuesReturnsStage(t *testing.T) {
 	suffix := time.Now().UnixNano()
 
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("Stage List %d", suffix)).Scan(&projectID); err != nil {
-		t.Fatalf("create project: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": fmt.Sprintf("Stage List %d", suffix)})
 
 	var number int
 	if err := testPool.QueryRow(ctx, `
@@ -125,29 +109,16 @@ func TestListIssuesReturnsStage(t *testing.T) {
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number, project_id, stage)
-		VALUES ($1, $2, 'todo', 'none', 'member', $3, 0, $4, $5, 2)
-		RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("stage-list-%d", suffix), testUserID, number, projectID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": fmt.Sprintf("stage-list-%d", suffix), "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'none'"), "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "position": testutil.Raw("0"), "number": number, "project_id": projectID, "stage": testutil.Raw("2")})
 
 	path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500", testWorkspaceID, projectID)
-	w := httptest.NewRecorder()
-	testHandler.ListIssues(w, newRequest("GET", path, nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 
 	var resp struct {
 		Issues []IssueResponse `json:"issues"`
 		Total  int64           `json:"total"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.Total != 1 || len(resp.Issues) != 1 {
 		t.Fatalf("expected one staged issue, total=%d len=%d", resp.Total, len(resp.Issues))
 	}

--- a/server/internal/handler/issue_sort_test.go
+++ b/server/internal/handler/issue_sort_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestListIssuesSortsByStatusAndUpdatedAt(t *testing.T) {
@@ -15,14 +15,7 @@ func TestListIssuesSortsByStatusAndUpdatedAt(t *testing.T) {
 	suffix := time.Now().UnixNano()
 
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, fmt.Sprintf("Issue table sort %d", suffix)).Scan(&projectID); err != nil {
-		t.Fatalf("create project: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
-	})
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": fmt.Sprintf("Issue table sort %d", suffix)})
 
 	type fixture struct {
 		title      string
@@ -66,17 +59,11 @@ func TestListIssuesSortsByStatusAndUpdatedAt(t *testing.T) {
 		if direction != "" {
 			path += "&direction=" + direction
 		}
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var response struct {
 			Issues []IssueResponse `json:"issues"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&response)
 		titles := make([]string, 0, len(response.Issues))
 		for _, issue := range response.Issues {
 			titles = append(titles, issue.Title)
@@ -94,15 +81,9 @@ func TestListIssuesSortsByStatusAndUpdatedAt(t *testing.T) {
 		if direction != "" {
 			path += "&direction=" + direction
 		}
-		w := httptest.NewRecorder()
-		testHandler.ListGroupedIssues(w, newRequest("GET", path, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListGroupedIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListGroupedIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var response GroupedIssuesResponse
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode grouped response: %v", err)
-		}
+		w.Decode(&response)
 		if len(response.Groups) != 1 {
 			t.Fatalf("ListGroupedIssues groups = %d, want 1", len(response.Groups))
 		}

--- a/server/internal/handler/issue_status_reorder_test.go
+++ b/server/internal/handler/issue_status_reorder_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/issuestatus"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // insertCustomStatus adds one custom status directly, returning its id.
@@ -64,9 +65,7 @@ func TestReorderIssueStatusesWritesIntraCategoryPositionsFromOne(t *testing.T) {
 	second := insertCustomStatus(t, fmt.Sprintf("qa_b_%d", suffix), "in_review", 2, false)
 
 	rec := reorderVia(t, "in_review", []string{second, first})
-	if rec.Code != http.StatusOK {
-		t.Fatalf("reorder status = %d: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Equal(t, rec.Code, http.StatusOK, "HTTP status")
 
 	positions := positionsByID(t, first, second)
 	// Positions start at 1: the category's built-in is seeded at 0 and never
@@ -99,9 +98,7 @@ func TestReorderIssueStatusesRejectsArchivedWithoutPartialWrite(t *testing.T) {
 	before := positionsByID(t, first, second, archived)
 
 	rec := reorderVia(t, "in_review", []string{second, archived, first})
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("reorder status = %d, want 409: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Equal(t, rec.Code, http.StatusConflict, "HTTP status")
 
 	after := positionsByID(t, first, second, archived)
 	for id, position := range before {
@@ -232,9 +229,7 @@ func TestReorderIssueStatusesRejectsAPartialSet(t *testing.T) {
 	before := positionsByID(t, first, second)
 
 	rec := reorderVia(t, "in_review", []string{second})
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("reorder status = %d, want 409: %s", rec.Code, rec.Body.String())
-	}
+	testutil.Equal(t, rec.Code, http.StatusConflict, "HTTP status")
 
 	after := positionsByID(t, first, second)
 	for id, position := range before {

--- a/server/internal/handler/issue_status_test.go
+++ b/server/internal/handler/issue_status_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"slices"
 	"testing"
 	"time"
@@ -181,18 +180,12 @@ func TestIssueWriteAcceptsCustomStatusAndRejectsUnknown(t *testing.T) {
 			"title":  "custom status write",
 			"status": "human_review_w",
 		})
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, req)
-		if rec.Code != http.StatusCreated {
-			t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
-		}
+		rec := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 		var created struct {
 			ID     string `json:"id"`
 			Status string `json:"status"`
 		}
-		if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		rec.JSON(&created)
 		if created.Status != "human_review_w" {
 			t.Errorf("issue.status = %q, want the custom key stored verbatim", created.Status)
 		}
@@ -206,11 +199,7 @@ func TestIssueWriteAcceptsCustomStatusAndRejectsUnknown(t *testing.T) {
 			"title":  "unknown status write",
 			"status": "not_a_status",
 		})
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for an unknown status, got %d: %s", rec.Code, rec.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	})
 
 	t.Run("archived status is rejected", func(t *testing.T) {
@@ -225,11 +214,7 @@ func TestIssueWriteAcceptsCustomStatusAndRejectsUnknown(t *testing.T) {
 			"title":  "archived status write",
 			"status": "retired_w",
 		})
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, req)
-		if rec.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for an archived status, got %d: %s", rec.Code, rec.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	})
 }
 
@@ -251,22 +236,14 @@ func TestBuiltInStatusesAreImmutable(t *testing.T) {
 		req := withURLParam(
 			newRequest(http.MethodPatch, "/api/issue-statuses/"+uuidToString(builtIn.ID), map[string]any{"name": "Renamed"}),
 			"id", uuidToString(builtIn.ID))
-		rec := httptest.NewRecorder()
-		testHandler.UpdateIssueStatus(rec, req)
-		if rec.Code != http.StatusForbidden {
-			t.Fatalf("expected 403 renaming a built-in, got %d: %s", rec.Code, rec.Body.String())
-		}
+		testutil.Call(t, testHandler.UpdateIssueStatus, req).Want(http.StatusForbidden)
 	})
 
 	t.Run("archive is refused at the API", func(t *testing.T) {
 		req := withURLParam(
 			newRequest(http.MethodDelete, "/api/issue-statuses/"+uuidToString(builtIn.ID), nil),
 			"id", uuidToString(builtIn.ID))
-		rec := httptest.NewRecorder()
-		testHandler.ArchiveIssueStatus(rec, req)
-		if rec.Code != http.StatusForbidden {
-			t.Fatalf("expected 403 archiving a built-in, got %d: %s", rec.Code, rec.Body.String())
-		}
+		testutil.Call(t, testHandler.ArchiveIssueStatus, req).Want(http.StatusForbidden)
 	})
 
 	// Defense in depth: even a direct query cannot rename or archive a
@@ -317,13 +294,9 @@ func TestArchiveRetiresStatusWithoutTouchingExistingIssues(t *testing.T) {
 	}
 
 	// But nothing NEW can be assigned to it.
-	rec := httptest.NewRecorder()
-	testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+	testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 		"title": "should be refused", "status": "in_use_a",
-	}))
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 assigning an archived status to a new issue, got %d: %s", rec.Code, rec.Body.String())
-	}
+	})).Want(http.StatusBadRequest)
 }
 
 // TestCreateIssueStatusValidation covers the reserved-key and category rules.
@@ -344,11 +317,7 @@ func TestCreateIssueStatusValidation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			testHandler.CreateIssueStatus(rec, newRequest(http.MethodPost, "/api/issue-statuses", tc.body))
-			if rec.Code != tc.want {
-				t.Fatalf("expected %d, got %d: %s", tc.want, rec.Code, rec.Body.String())
-			}
+			testutil.Call(t, testHandler.CreateIssueStatus, newRequest(http.MethodPost, "/api/issue-statuses", tc.body)).Want(tc.want)
 		})
 	}
 }
@@ -377,8 +346,7 @@ func TestIssueWriteStoresCanonicalStatusKey(t *testing.T) {
 
 	for _, input := range []string{"HUMAN_REVIEW_C", "  human_review_c  ", "Human_Review_C"} {
 		t.Run(input, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+			rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 				"title": "canonical key " + input, "status": input,
 			}))
 			if rec.Code != http.StatusCreated {
@@ -421,8 +389,7 @@ func TestCustomTerminalStatusCountsAsTerminalInSQL(t *testing.T) {
 
 	mkIssue := func(title, status string) pgtype.UUID {
 		t.Helper()
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+		rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 			"title": title, "status": status,
 		}))
 		if rec.Code != http.StatusCreated {
@@ -510,8 +477,7 @@ func TestCustomTerminalStatusCountsAsTerminalInSQL(t *testing.T) {
 // archiveStatusVia runs the real archive endpoint and returns its status code.
 func archiveStatusVia(t *testing.T, entry db.IssueStatus) int {
 	t.Helper()
-	rec := httptest.NewRecorder()
-	testHandler.ArchiveIssueStatus(rec, withURLParam(
+	rec := testutil.Call(t, testHandler.ArchiveIssueStatus, withURLParam(
 		newRequest(http.MethodDelete, "/api/issue-statuses/"+uuidToString(entry.ID), nil),
 		"id", uuidToString(entry.ID)))
 	return rec.Code
@@ -557,24 +523,21 @@ func TestWritesRejectAnArchivedStatus(t *testing.T) {
 		write func(t *testing.T, key string) int
 	}{
 		{"create", "race_a_create", func(t *testing.T, key string) int {
-			rec := httptest.NewRecorder()
-			testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+			rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 				"title": "race create " + key, "status": key,
 			}))
 			return rec.Code
 		}},
 		{"update", "race_a_update", func(t *testing.T, key string) int {
 			seed := mustCreateIssue(t, "race update seed "+key, "todo")
-			rec := httptest.NewRecorder()
-			testHandler.UpdateIssue(rec, withURLParam(
+			rec := testutil.Call(t, testHandler.UpdateIssue, withURLParam(
 				newRequest(http.MethodPatch, "/api/issues/"+uuidToString(seed), map[string]any{"status": key}),
 				"id", uuidToString(seed)))
 			return rec.Code
 		}},
 		{"update with description merge", "race_a_upd_merge", func(t *testing.T, key string) int {
 			seed := mustCreateIssue(t, "race merge seed "+key, "todo")
-			rec := httptest.NewRecorder()
-			testHandler.UpdateIssue(rec, withURLParam(
+			rec := testutil.Call(t, testHandler.UpdateIssue, withURLParam(
 				newRequest(http.MethodPatch, "/api/issues/"+uuidToString(seed), map[string]any{
 					"status": key, "description": "merged body",
 				}),
@@ -583,8 +546,7 @@ func TestWritesRejectAnArchivedStatus(t *testing.T) {
 		}},
 		{"batch", "race_a_batch", func(t *testing.T, key string) int {
 			seed := mustCreateIssue(t, "race batch seed "+key, "todo")
-			rec := httptest.NewRecorder()
-			testHandler.BatchUpdateIssues(rec, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+			rec := testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
 				"issue_ids": []string{uuidToString(seed)},
 				"updates":   map[string]any{"status": key},
 			}))
@@ -592,8 +554,7 @@ func TestWritesRejectAnArchivedStatus(t *testing.T) {
 		}},
 		{"batch with description merge", "race_a_batch_merge", func(t *testing.T, key string) int {
 			seed := mustCreateIssue(t, "race batch merge seed "+key, "todo")
-			rec := httptest.NewRecorder()
-			testHandler.BatchUpdateIssues(rec, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+			rec := testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
 				"issue_ids": []string{uuidToString(seed)},
 				"updates":   map[string]any{"status": key, "description": "merged body"},
 			}))
@@ -637,13 +598,9 @@ func TestArchiveSucceedsAfterACommittedWrite(t *testing.T) {
 	t.Run("writer wins: archive still succeeds and leaves the issue alone", func(t *testing.T) {
 		entry := createTestCustomStatus(t, "race_b_writer", issuestatus.InProgress)
 
-		rec := httptest.NewRecorder()
-		testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+		rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 			"title": "race writer wins", "status": "race_b_writer",
-		}))
-		if rec.Code != http.StatusCreated {
-			t.Fatalf("create on custom status: %d %s", rec.Code, rec.Body.String())
-		}
+		})).Want(http.StatusCreated)
 		var created struct {
 			ID string `json:"id"`
 		}
@@ -673,8 +630,7 @@ func TestArchiveSucceedsAfterACommittedWrite(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			rec := httptest.NewRecorder()
-			testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+			rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 				"title": "race blocked writer", "status": "race_block",
 			}))
 			done <- rec.Code
@@ -724,8 +680,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 			name: "create",
 			key:  "win_create",
 			write: func(t *testing.T, key string, _ pgtype.UUID) int {
-				rec := httptest.NewRecorder()
-				testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+				rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 					"title": "race window create", "status": key,
 				}))
 				return rec.Code
@@ -738,8 +693,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 				return mustCreateIssue(t, "race window update "+key, "todo")
 			},
 			write: func(t *testing.T, key string, seed pgtype.UUID) int {
-				rec := httptest.NewRecorder()
-				testHandler.UpdateIssue(rec, withURLParam(
+				rec := testutil.Call(t, testHandler.UpdateIssue, withURLParam(
 					newRequest(http.MethodPatch, "/api/issues/"+uuidToString(seed), map[string]any{"status": key}),
 					"id", uuidToString(seed)))
 				return rec.Code
@@ -752,8 +706,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 				return mustCreateIssue(t, "race window merge "+key, "todo")
 			},
 			write: func(t *testing.T, key string, seed pgtype.UUID) int {
-				rec := httptest.NewRecorder()
-				testHandler.UpdateIssue(rec, withURLParam(
+				rec := testutil.Call(t, testHandler.UpdateIssue, withURLParam(
 					newRequest(http.MethodPatch, "/api/issues/"+uuidToString(seed), map[string]any{
 						"status": key, "description": "merged body",
 					}),
@@ -768,8 +721,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 				return mustCreateIssue(t, "race window batch "+key, "todo")
 			},
 			write: func(t *testing.T, key string, seed pgtype.UUID) int {
-				rec := httptest.NewRecorder()
-				testHandler.BatchUpdateIssues(rec, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+				rec := testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
 					"issue_ids": []string{uuidToString(seed)},
 					"updates":   map[string]any{"status": key},
 				}))
@@ -783,8 +735,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 				return mustCreateIssue(t, "race window batch merge "+key, "todo")
 			},
 			write: func(t *testing.T, key string, seed pgtype.UUID) int {
-				rec := httptest.NewRecorder()
-				testHandler.BatchUpdateIssues(rec, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+				rec := testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
 					"issue_ids": []string{uuidToString(seed)},
 					"updates":   map[string]any{"status": key, "description": "merged body"},
 				}))
@@ -863,8 +814,7 @@ func TestArchiveCommitsInsideTheWriteRaceWindow(t *testing.T) {
 // mustCreateIssue creates an issue through the real endpoint and returns its id.
 func mustCreateIssue(t *testing.T, title, status string) pgtype.UUID {
 	t.Helper()
-	rec := httptest.NewRecorder()
-	testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+	rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 		"title": title, "status": status,
 	}))
 	if rec.Code != http.StatusCreated {
@@ -894,14 +844,10 @@ func TestBatchCustomTerminalStatusEntersStageBarrier(t *testing.T) {
 		t.Fatalf("attach child: %v", err)
 	}
 
-	rec := httptest.NewRecorder()
-	testHandler.BatchUpdateIssues(rec, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
+	testutil.Call(t, testHandler.BatchUpdateIssues, newRequest(http.MethodPatch, "/api/issues/batch", map[string]any{
 		"issue_ids": []string{uuidToString(child)},
 		"updates":   map[string]any{"status": "batch_done_s"},
-	}))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("batch update: %d %s", rec.Code, rec.Body.String())
-	}
+	})).Want(http.StatusOK)
 
 	// The observable effect of entering the barrier is the system comment on
 	// the parent. Without the fix the batch is silent.
@@ -928,13 +874,9 @@ func TestChildrenResponseCarriesStatusCategory(t *testing.T) {
 		t.Fatalf("attach child: %v", err)
 	}
 
-	rec := httptest.NewRecorder()
-	testHandler.ListChildIssues(rec, withURLParam(
+	rec := testutil.Call(t, testHandler.ListChildIssues, withURLParam(
 		newRequest(http.MethodGet, "/api/issues/"+uuidToString(parent)+"/children", nil),
-		"id", uuidToString(parent)))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("list children: %d %s", rec.Code, rec.Body.String())
-	}
+		"id", uuidToString(parent))).Want(http.StatusOK)
 
 	var payload struct {
 		Issues []struct {
@@ -942,9 +884,7 @@ func TestChildrenResponseCarriesStatusCategory(t *testing.T) {
 			StatusCategory string `json:"status_category"`
 		} `json:"issues"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	rec.JSON(&payload)
 	if len(payload.Issues) != 1 {
 		t.Fatalf("expected 1 child, got %d: %s", len(payload.Issues), rec.Body.String())
 	}
@@ -1030,11 +970,7 @@ func TestListFilterByCategoryReturnsCustomStatusIssues(t *testing.T) {
 	otherID := mustCreateIssue(t, "unrelated todo", "todo")
 	_ = ctx
 
-	rec := httptest.NewRecorder()
-	testHandler.ListIssues(rec, newRequest(http.MethodGet, "/api/issues?status_category=in_review&limit=100", nil))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("list: %d %s", rec.Code, rec.Body.String())
-	}
+	rec := testutil.Call(t, testHandler.ListIssues, newRequest(http.MethodGet, "/api/issues?status_category=in_review&limit=100", nil)).Want(http.StatusOK)
 	var payload struct {
 		Issues []struct {
 			ID             string `json:"id"`
@@ -1042,9 +978,7 @@ func TestListFilterByCategoryReturnsCustomStatusIssues(t *testing.T) {
 			StatusCategory string `json:"status_category"`
 		} `json:"issues"`
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	rec.JSON(&payload)
 	got := map[string]string{}
 	for _, i := range payload.Issues {
 		got[i.ID] = i.StatusCategory
@@ -1080,13 +1014,9 @@ func TestCreateEventCarriesCustomStatusCategory(t *testing.T) {
 		}
 	})
 
-	rec := httptest.NewRecorder()
-	testHandler.CreateIssue(rec, newRequest(http.MethodPost, "/api/issues", map[string]any{
+	rec := testutil.Call(t, testHandler.CreateIssue, newRequest(http.MethodPost, "/api/issues", map[string]any{
 		"title": "custom status event", "status": "human_review_ev",
-	}))
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
-	}
+	})).Want(http.StatusCreated)
 	var created struct {
 		ID             string `json:"id"`
 		StatusCategory string `json:"status_category"`
@@ -1129,11 +1059,7 @@ func TestListEndpointsCarryStatusCategory(t *testing.T) {
 	}
 
 	t.Run("list carries category for every custom row", func(t *testing.T) {
-		rec := httptest.NewRecorder()
-		testHandler.ListIssues(rec, newRequest(http.MethodGet, "/api/issues?status_category=in_review&limit=100", nil))
-		if rec.Code != http.StatusOK {
-			t.Fatalf("list: %d %s", rec.Code, rec.Body.String())
-		}
+		rec := testutil.Call(t, testHandler.ListIssues, newRequest(http.MethodGet, "/api/issues?status_category=in_review&limit=100", nil)).Want(http.StatusOK)
 		var payload struct {
 			Issues []struct {
 				Status         string `json:"status"`
@@ -1178,12 +1104,8 @@ func TestListEndpointsCarryStatusCategory(t *testing.T) {
 
 	t.Run("get carries category", func(t *testing.T) {
 		id := mustCreateIssue(t, "get carries category", "human_review_n")
-		rec := httptest.NewRecorder()
-		testHandler.GetIssue(rec, withURLParam(
-			newRequest(http.MethodGet, "/api/issues/"+uuidToString(id), nil), "id", uuidToString(id)))
-		if rec.Code != http.StatusOK {
-			t.Fatalf("get: %d %s", rec.Code, rec.Body.String())
-		}
+		rec := testutil.Call(t, testHandler.GetIssue, withURLParam(
+			newRequest(http.MethodGet, "/api/issues/"+uuidToString(id), nil), "id", uuidToString(id))).Want(http.StatusOK)
 		var got struct {
 			StatusCategory string `json:"status_category"`
 		}

--- a/server/internal/handler/issue_table_filters_test.go
+++ b/server/internal/handler/issue_table_filters_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Flat table facets must be evaluated before LIMIT/OFFSET and COUNT. This
@@ -104,18 +106,12 @@ func TestListIssues_TableFacetsAreServerSide(t *testing.T) {
 			url.QueryEscape(metadata),
 			query,
 		)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var response struct {
 			Issues []IssueResponse `json:"issues"`
 			Total  int64           `json:"total"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&response)
 		ids := make([]string, 0, len(response.Issues))
 		for _, issue := range response.Issues {
 			ids = append(ids, issue.ID)
@@ -267,14 +263,11 @@ func TestQueryIssues_PostTwinMatchesGet(t *testing.T) {
 	}
 
 	// Malformed body fails closed.
-	badRecorder := httptest.NewRecorder()
+
 	badRequest := httptest.NewRequest("POST", "/api/issues/query", strings.NewReader("not json"))
 	badRequest.Header.Set("X-User-ID", testUserID)
 	badRequest.Header.Set("X-Workspace-ID", testWorkspaceID)
-	testHandler.QueryIssues(badRecorder, badRequest)
-	if badRecorder.Code != http.StatusBadRequest {
-		t.Fatalf("malformed body: expected 400, got %d", badRecorder.Code)
-	}
+	testutil.Call(t, testHandler.QueryIssues, badRequest).Want(http.StatusBadRequest)
 }
 
 // Offset pages are only stable when the full ORDER BY is deterministic. All
@@ -327,8 +320,7 @@ func TestListIssues_OffsetPaginationStableOnCreatedAtTies(t *testing.T) {
 			"/api/issues?workspace_id=%s&metadata=%s&sort=status&direction=asc&limit=2&offset=%d",
 			testWorkspaceID, url.QueryEscape(metadata), offset,
 		)
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", path, nil))
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", path, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("ListIssues offset=%d: expected 200, got %d: %s", offset, w.Code, w.Body.String())
 		}
@@ -336,9 +328,7 @@ func TestListIssues_OffsetPaginationStableOnCreatedAtTies(t *testing.T) {
 			Issues []IssueResponse `json:"issues"`
 			Total  int64           `json:"total"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&response)
 		if response.Total != totalIssues {
 			t.Fatalf("offset=%d total = %d, want %d", offset, response.Total, totalIssues)
 		}

--- a/server/internal/handler/issue_table_query_test.go
+++ b/server/internal/handler/issue_table_query_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 type issueTableEnrichmentFailTxStarter struct {
@@ -338,22 +339,9 @@ func TestIssueTableWorkingIssueProjectionMatchesTaskIssuesNotAssignees(t *testin
 	createHandlerTestTaskForAgentOnIssue(t, workingAgentID, editedIssueID)
 	createHandlerTestTaskForAgentOnIssue(t, otherAgentID, otherAgentIssueID)
 
-	workingRecorder := httptest.NewRecorder()
-	testHandler.ListWorkspaceWorkingAgents(
-		workingRecorder,
-		newRequest(http.MethodGet, "/api/working-agents?type=issue", nil),
-	)
-	if workingRecorder.Code != http.StatusOK {
-		t.Fatalf(
-			"list working agents status = %d: %s",
-			workingRecorder.Code,
-			workingRecorder.Body.String(),
-		)
-	}
+	workingRecorder := testutil.Call(t, testHandler.ListWorkspaceWorkingAgents, newRequest(http.MethodGet, "/api/working-agents?type=issue", nil)).Want(http.StatusOK)
 	var workingAgents []WorkspaceWorkingAgent
-	if err := json.NewDecoder(workingRecorder.Body).Decode(&workingAgents); err != nil {
-		t.Fatalf("decode working agents: %v", err)
-	}
+	workingRecorder.Decode(&workingAgents)
 	workingIssueIDs := make([]string, 0, 2)
 	for _, agent := range workingAgents {
 		if agent.ID == workingAgentID || agent.ID == otherAgentID {
@@ -363,35 +351,26 @@ func TestIssueTableWorkingIssueProjectionMatchesTaskIssuesNotAssignees(t *testin
 
 	listRows := func(issueIDs []string) issueTableRowsResponse {
 		t.Helper()
-		recorder := httptest.NewRecorder()
-		testHandler.ListIssueTableRows(
-			recorder,
-			newRequest(http.MethodPost, "/api/issues/table/rows", map[string]any{
-				"query": map[string]any{
-					"scope": map[string]any{"kind": "workspace"},
-					"filters": map[string]any{
-						// A map intentionally preserves [] in JSON. Marshaling
-						// issueTableFiltersRequest directly would apply its
-						// omitempty tag and turn the match-none case into no filter.
-						"working_issue_ids": issueIDs,
-					},
-					"sort": map[string]any{
-						"field":     "position",
-						"direction": "asc",
-					},
+		recorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", map[string]any{
+			"query": map[string]any{
+				"scope": map[string]any{"kind": "workspace"},
+				"filters": map[string]any{
+					// A map intentionally preserves [] in JSON. Marshaling
+					// issueTableFiltersRequest directly would apply its
+					// omitempty tag and turn the match-none case into no filter.
+					"working_issue_ids": issueIDs,
 				},
-				"group":     map[string]any{"kind": "none"},
-				"hierarchy": map[string]any{"enabled": false},
-				"page":      map[string]any{"limit": 10},
-			}),
-		)
-		if recorder.Code != http.StatusOK {
-			t.Fatalf("list rows status = %d: %s", recorder.Code, recorder.Body.String())
-		}
+				"sort": map[string]any{
+					"field":     "position",
+					"direction": "asc",
+				},
+			},
+			"group":     map[string]any{"kind": "none"},
+			"hierarchy": map[string]any{"enabled": false},
+			"page":      map[string]any{"limit": 10},
+		})).Want(http.StatusOK)
 		var response issueTableRowsResponse
-		if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-			t.Fatalf("decode rows: %v", err)
-		}
+		recorder.Decode(&response)
 		return response
 	}
 
@@ -430,9 +409,7 @@ func TestIssueTableCursorRejectsAnotherQuery(t *testing.T) {
 	if issueTableCursorMatches(w, &cursor, "sha256:new", &groupKey, nil) {
 		t.Fatal("cursor from another query unexpectedly matched")
 	}
-	if w.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusConflict)
-	}
+	testutil.Equal(t, w.Code, http.StatusConflict, "HTTP status")
 }
 
 func TestIssueTablePositionCursorIncludesIndexableLowerBound(t *testing.T) {
@@ -585,8 +562,7 @@ func TestIssueTableRowsCommitsBeforeBestEffortEnrichment(t *testing.T) {
 		tableQueryCalls: &tableQueryCalls,
 		rowQuerySQL:     &rowQuerySQL,
 	}
-	recorder := httptest.NewRecorder()
-	handler.ListIssueTableRows(recorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+	recorder := testutil.Call(t, handler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 		Query: issueTableQuerySpec{
 			Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 			Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
@@ -594,18 +570,12 @@ func TestIssueTableRowsCommitsBeforeBestEffortEnrichment(t *testing.T) {
 		Group:     issueTableGroupSpec{Kind: "none"},
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 10},
-	}))
-
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("rows status = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	if labelCalls != 0 {
 		t.Fatalf("best-effort labels ran inside snapshot transaction %d times", labelCalls)
 	}
 	var response issueTableRowsResponse
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode rows: %v", err)
-	}
+	recorder.Decode(&response)
 	if len(response.Rows) != 1 {
 		t.Fatalf("rows = %d, want 1", len(response.Rows))
 	}
@@ -670,19 +640,13 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		Filters: issueTableFiltersRequest{},
 		Sort:    issueTableSortRequest{Field: "title", Direction: "asc"},
 	}
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: query,
 		Group: issueTableGroupSpec{Kind: "status"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var groups issueTableGroupsResponse
-	if err := json.NewDecoder(w.Body).Decode(&groups); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	w.Decode(&groups)
 	if groups.Total != 1001 {
 		t.Fatalf("total = %d, want 1001", groups.Total)
 	}
@@ -693,35 +657,25 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 	if counts["status:todo"] != 501 || counts["status:done"] != 500 {
 		t.Fatalf("unexpected group counts: %#v", counts)
 	}
-	firstGroupPageRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(firstGroupPageRecorder, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	firstGroupPageRecorder := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: query,
 		Group: issueTableGroupSpec{Kind: "status"},
 		Page:  issueTablePageRequest{Limit: 1},
 	}))
 	var firstGroupPage issueTableGroupsResponse
-	if firstGroupPageRecorder.Code != http.StatusOK {
-		t.Fatalf("first group page status = %d: %s", firstGroupPageRecorder.Code, firstGroupPageRecorder.Body.String())
-	}
-	if err := json.NewDecoder(firstGroupPageRecorder.Body).Decode(&firstGroupPage); err != nil {
-		t.Fatalf("decode first group page: %v", err)
-	}
+	testutil.Equal(t, firstGroupPageRecorder.Code, http.StatusOK, "HTTP status")
+	firstGroupPageRecorder.Decode(&firstGroupPage)
 	if len(firstGroupPage.Groups) != 1 || firstGroupPage.NextCursor == nil {
 		t.Fatalf("unexpected first group page: %#v", firstGroupPage)
 	}
-	secondGroupPageRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(secondGroupPageRecorder, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	secondGroupPageRecorder := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: query,
 		Group: issueTableGroupSpec{Kind: "status"},
 		Page:  issueTablePageRequest{Limit: 1, Cursor: firstGroupPage.NextCursor},
 	}))
 	var secondGroupPage issueTableGroupsResponse
-	if secondGroupPageRecorder.Code != http.StatusOK {
-		t.Fatalf("second group page status = %d: %s", secondGroupPageRecorder.Code, secondGroupPageRecorder.Body.String())
-	}
-	if err := json.NewDecoder(secondGroupPageRecorder.Body).Decode(&secondGroupPage); err != nil {
-		t.Fatalf("decode second group page: %v", err)
-	}
+	testutil.Equal(t, secondGroupPageRecorder.Code, http.StatusOK, "HTTP status")
+	secondGroupPageRecorder.Decode(&secondGroupPage)
 	if len(secondGroupPage.Groups) != 1 || secondGroupPage.Groups[0].Key == firstGroupPage.Groups[0].Key || secondGroupPage.Total != 1001 {
 		t.Fatalf("group keyset pagination mismatch: first=%#v second=%#v", firstGroupPage, secondGroupPage)
 	}
@@ -735,21 +689,15 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		labelCalls:      &labelCalls,
 		tableQueryCalls: &tableQueryCalls,
 	}
-	rowsRecorder := httptest.NewRecorder()
-	rowsHandler.ListIssueTableRows(rowsRecorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+	rowsRecorder := testutil.Call(t, rowsHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 		Query:     query,
 		Group:     issueTableGroupSpec{Kind: "status"},
 		GroupKey:  &groupKey,
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 50},
-	}))
-	if rowsRecorder.Code != http.StatusOK {
-		t.Fatalf("rows status = %d: %s", rowsRecorder.Code, rowsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var rows issueTableRowsResponse
-	if err := json.NewDecoder(rowsRecorder.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode rows: %v", err)
-	}
+	rowsRecorder.Decode(&rows)
 	if rows.Total != 0 || rows.BranchTotal != 50 || len(rows.Rows) != 50 || rows.NextCursor == nil {
 		t.Fatalf("unexpected rows page: total=%d branch_total=%d rows=%d cursor=%v", rows.Total, rows.BranchTotal, len(rows.Rows), rows.NextCursor)
 	}
@@ -760,21 +708,15 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 	for _, row := range rows.Rows {
 		firstPageIDs[row.Issue.ID] = struct{}{}
 	}
-	secondRowsRecorder := httptest.NewRecorder()
-	rowsHandler.ListIssueTableRows(secondRowsRecorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+	secondRowsRecorder := testutil.Call(t, rowsHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 		Query:     query,
 		Group:     issueTableGroupSpec{Kind: "status"},
 		GroupKey:  &groupKey,
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 50, Cursor: rows.NextCursor},
-	}))
-	if secondRowsRecorder.Code != http.StatusOK {
-		t.Fatalf("second rows status = %d: %s", secondRowsRecorder.Code, secondRowsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var secondRows issueTableRowsResponse
-	if err := json.NewDecoder(secondRowsRecorder.Body).Decode(&secondRows); err != nil {
-		t.Fatalf("decode second rows: %v", err)
-	}
+	secondRowsRecorder.Decode(&secondRows)
 	if secondRows.Total != 0 || secondRows.BranchTotal != 50 || len(secondRows.Rows) != 50 {
 		t.Fatalf("unexpected grouped continuation: total=%d branch_total=%d rows=%d", secondRows.Total, secondRows.BranchTotal, len(secondRows.Rows))
 	}
@@ -787,20 +729,14 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		}
 	}
 
-	ungroupedRecorder := httptest.NewRecorder()
-	rowsHandler.ListIssueTableRows(ungroupedRecorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+	ungroupedRecorder := testutil.Call(t, rowsHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 		Query:     query,
 		Group:     issueTableGroupSpec{Kind: "none"},
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 50},
-	}))
-	if ungroupedRecorder.Code != http.StatusOK {
-		t.Fatalf("ungrouped rows status = %d: %s", ungroupedRecorder.Code, ungroupedRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var ungroupedRows issueTableRowsResponse
-	if err := json.NewDecoder(ungroupedRecorder.Body).Decode(&ungroupedRows); err != nil {
-		t.Fatalf("decode ungrouped rows: %v", err)
-	}
+	ungroupedRecorder.Decode(&ungroupedRows)
 	if ungroupedRows.Total != 1001 || ungroupedRows.BranchTotal != 50 || len(ungroupedRows.Rows) != 50 || ungroupedRows.NextCursor == nil {
 		t.Fatalf("unexpected ungrouped root head: total=%d branch_total=%d rows=%d cursor=%v", ungroupedRows.Total, ungroupedRows.BranchTotal, len(ungroupedRows.Rows), ungroupedRows.NextCursor)
 	}
@@ -808,20 +744,14 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		t.Fatalf("ungrouped root head executed %d cumulative table queries, want 4", tableQueryCalls)
 	}
 
-	ungroupedNextRecorder := httptest.NewRecorder()
-	rowsHandler.ListIssueTableRows(ungroupedNextRecorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+	ungroupedNextRecorder := testutil.Call(t, rowsHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 		Query:     query,
 		Group:     issueTableGroupSpec{Kind: "none"},
 		Hierarchy: issueTableHierarchyRequest{Enabled: false},
 		Page:      issueTablePageRequest{Limit: 50, Cursor: ungroupedRows.NextCursor},
-	}))
-	if ungroupedNextRecorder.Code != http.StatusOK {
-		t.Fatalf("ungrouped continuation status = %d: %s", ungroupedNextRecorder.Code, ungroupedNextRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var ungroupedNext issueTableRowsResponse
-	if err := json.NewDecoder(ungroupedNextRecorder.Body).Decode(&ungroupedNext); err != nil {
-		t.Fatalf("decode ungrouped continuation: %v", err)
-	}
+	ungroupedNextRecorder.Decode(&ungroupedNext)
 	if ungroupedNext.Total != 0 || ungroupedNext.BranchTotal != 50 || len(ungroupedNext.Rows) != 50 {
 		t.Fatalf("unexpected ungrouped continuation: total=%d branch_total=%d rows=%d", ungroupedNext.Total, ungroupedNext.BranchTotal, len(ungroupedNext.Rows))
 	}
@@ -838,8 +768,7 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		sortQuery.Sort = sortCase
 		fetchPage := func(cursor *string) issueTableRowsResponse {
 			t.Helper()
-			recorder := httptest.NewRecorder()
-			testHandler.ListIssueTableRows(recorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+			recorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 				Query:     sortQuery,
 				Group:     issueTableGroupSpec{Kind: "status"},
 				GroupKey:  &groupKey,
@@ -876,18 +805,12 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 
 	filteredQuery := query
 	filteredQuery.Filters.Statuses = []string{"todo"}
-	facetsRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableFacets(facetsRecorder, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
+	facetsRecorder := testutil.Call(t, testHandler.ListIssueTableFacets, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
 		Query:  filteredQuery,
 		Facets: []issueTableFacetSpec{{Kind: "status"}},
-	}))
-	if facetsRecorder.Code != http.StatusOK {
-		t.Fatalf("facets status = %d: %s", facetsRecorder.Code, facetsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var facets issueTableFacetsResponse
-	if err := json.NewDecoder(facetsRecorder.Body).Decode(&facets); err != nil {
-		t.Fatalf("decode facets: %v", err)
-	}
+	facetsRecorder.Decode(&facets)
 	if facets.Total != 501 || len(facets.Facets) != 1 {
 		t.Fatalf("unexpected filtered facet response: total=%d facets=%d", facets.Total, len(facets.Facets))
 	}
@@ -906,19 +829,13 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		inner:           testHandler.TxStarter,
 		tableQueryCalls: &facetCountQueries,
 	}
-	noTotalRecorder := httptest.NewRecorder()
-	facetsHandler.ListIssueTableFacets(noTotalRecorder, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
+	noTotalRecorder := testutil.Call(t, facetsHandler.ListIssueTableFacets, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
 		Query:        filteredQuery,
 		Facets:       []issueTableFacetSpec{{Kind: "status"}},
 		IncludeTotal: &includeTotal,
-	}))
-	if noTotalRecorder.Code != http.StatusOK {
-		t.Fatalf("facets without total status = %d: %s", noTotalRecorder.Code, noTotalRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var noTotal issueTableFacetsResponse
-	if err := json.NewDecoder(noTotalRecorder.Body).Decode(&noTotal); err != nil {
-		t.Fatalf("decode facets without total: %v", err)
-	}
+	noTotalRecorder.Decode(&noTotal)
 	if noTotal.Total != 0 || len(noTotal.Facets) != 1 {
 		t.Fatalf("unexpected facets without total: %#v", noTotal)
 	}
@@ -934,8 +851,7 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		facetQueryCalls: &batchFacetQueries,
 		tableQueryCalls: &batchTotalQueries,
 	}
-	batchRecorder := httptest.NewRecorder()
-	batchHandler.ListIssueTableFacets(batchRecorder, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
+	batchRecorder := testutil.Call(t, batchHandler.ListIssueTableFacets, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
 		Query: query,
 		Facets: []issueTableFacetSpec{
 			{Kind: "status"},
@@ -944,14 +860,9 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 			{Kind: "creator"},
 			{Kind: "project"},
 		},
-	}))
-	if batchRecorder.Code != http.StatusOK {
-		t.Fatalf("batch facets status = %d: %s", batchRecorder.Code, batchRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var batchResponse issueTableFacetsResponse
-	if err := json.NewDecoder(batchRecorder.Body).Decode(&batchResponse); err != nil {
-		t.Fatalf("decode batch facets: %v", err)
-	}
+	batchRecorder.Decode(&batchResponse)
 	if batchResponse.Total != 1001 || len(batchResponse.Facets) != 5 {
 		t.Fatalf("unexpected batch facets response: total=%d facets=%d", batchResponse.Total, len(batchResponse.Facets))
 	}
@@ -974,18 +885,12 @@ func TestIssueTableStatusGroupingOverOneThousandRows(t *testing.T) {
 		t.Fatalf("unexpected batched facet counts: %#v", batchCounts)
 	}
 
-	mixedRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableFacets(mixedRecorder, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
+	mixedRecorder := testutil.Call(t, testHandler.ListIssueTableFacets, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
 		Query:  filteredQuery,
 		Facets: []issueTableFacetSpec{{Kind: "status"}, {Kind: "priority"}},
-	}))
-	if mixedRecorder.Code != http.StatusOK {
-		t.Fatalf("mixed facets status = %d: %s", mixedRecorder.Code, mixedRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var mixedResponse issueTableFacetsResponse
-	if err := json.NewDecoder(mixedRecorder.Body).Decode(&mixedResponse); err != nil {
-		t.Fatalf("decode mixed facets: %v", err)
-	}
+	mixedRecorder.Decode(&mixedResponse)
 	if mixedResponse.Total != 501 || len(mixedResponse.Facets) != 2 ||
 		mixedResponse.Facets[0].Kind != "status" || mixedResponse.Facets[1].Kind != "priority" {
 		t.Fatalf("unexpected mixed facets response: %#v", mixedResponse)
@@ -1049,22 +954,16 @@ func TestIssueTableAssigneeNamesResolveAfterGrouping(t *testing.T) {
 		inner:         testHandler.TxStarter,
 		groupQuerySQL: &groupQuerySQL,
 	}
-	recorder := httptest.NewRecorder()
-	handler.ListIssueTableGroups(recorder, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	recorder := testutil.Call(t, handler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: issueTableQuerySpec{
 			Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 			Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
 		},
 		Group: issueTableGroupSpec{Kind: "assignee"},
 		Page:  issueTablePageRequest{Limit: 10},
-	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var response issueTableGroupsResponse
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	recorder.Decode(&response)
 	counts := make(map[string]int64, len(response.Groups))
 	for _, group := range response.Groups {
 		counts[group.Key] = group.Count
@@ -1135,22 +1034,16 @@ func TestIssueTableCompoundParentGroupsReturnExactStatusCells(t *testing.T) {
 		t.Fatalf("seed grouped issues: %v", err)
 	}
 
-	recorder := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(recorder, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	recorder := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: issueTableQuerySpec{
 			Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 			Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
 		},
 		Group: issueTableGroupSpec{Kind: "compound", Primary: "parent", Secondary: "status"},
 		Page:  issueTablePageRequest{Limit: 10},
-	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("compound groups status = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var response issueTableGroupsResponse
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode compound groups: %v", err)
-	}
+	recorder.Decode(&response)
 	if response.Total != 4 || len(response.Groups) != 2 {
 		t.Fatalf("unexpected compound group totals: %#v", response)
 	}
@@ -1219,22 +1112,16 @@ func TestIssueTableCompoundParentGroupsReturnExactStatusCells(t *testing.T) {
 		Secondary:       "status",
 		SecondaryValues: []string{"todo"},
 	}
-	filteredRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(filteredRecorder, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
+	filteredRecorder := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest("POST", "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: issueTableQuerySpec{
 			Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 			Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
 		},
 		Group: filteredGroup,
 		Page:  issueTablePageRequest{Limit: 10},
-	}))
-	if filteredRecorder.Code != http.StatusOK {
-		t.Fatalf("filtered compound groups status = %d: %s", filteredRecorder.Code, filteredRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var filtered issueTableGroupsResponse
-	if err := json.NewDecoder(filteredRecorder.Body).Decode(&filtered); err != nil {
-		t.Fatalf("decode filtered compound groups: %v", err)
-	}
+	filteredRecorder.Decode(&filtered)
 	if filtered.Total != 3 || len(filtered.Groups) != 2 {
 		t.Fatalf("unexpected visible compound groups: %#v", filtered)
 	}
@@ -1263,8 +1150,7 @@ func TestIssueTableCompoundParentGroupsReturnExactStatusCells(t *testing.T) {
 	}
 	listCell := func(key string) issueTableRowsResponse {
 		t.Helper()
-		rowsRecorder := httptest.NewRecorder()
-		testHandler.ListIssueTableRows(rowsRecorder, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+		rowsRecorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 			Query: issueTableQuerySpec{
 				Scope: issueTableScope{Kind: "project", ProjectID: projectID},
 				Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
@@ -1273,14 +1159,9 @@ func TestIssueTableCompoundParentGroupsReturnExactStatusCells(t *testing.T) {
 			GroupKey:  &key,
 			Hierarchy: issueTableHierarchyRequest{Enabled: false},
 			Page:      issueTablePageRequest{Limit: 10},
-		}))
-		if rowsRecorder.Code != http.StatusOK {
-			t.Fatalf("filtered compound rows status = %d: %s", rowsRecorder.Code, rowsRecorder.Body.String())
-		}
+		})).Want(http.StatusOK)
 		var result issueTableRowsResponse
-		if err := json.NewDecoder(rowsRecorder.Body).Decode(&result); err != nil {
-			t.Fatalf("decode filtered compound rows: %v", err)
-		}
+		rowsRecorder.Decode(&result)
 		return result
 	}
 	noParentTodo := listCell(cellKey(filteredNoParent, "todo"))
@@ -1363,8 +1244,7 @@ func TestIssueTableHierarchyDoesNotCrossGroups(t *testing.T) {
 	}
 	listGroup := func(groupKey string) issueTableRowsResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
-		rowsHandler.ListIssueTableRows(w, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+		w := testutil.Call(t, rowsHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 			Query:     query,
 			Group:     issueTableGroupSpec{Kind: "status"},
 			GroupKey:  &groupKey,
@@ -1463,20 +1343,14 @@ func TestIssueTableHierarchyRootKeysetPagination(t *testing.T) {
 	}
 	fetchPage := func(cursor *string) issueTableRowsResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.ListIssueTableRows(w, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
+		w := testutil.Call(t, testHandler.ListIssueTableRows, newRequest("POST", "/api/issues/table/rows", issueTableRowsRequest{
 			Query:     query,
 			Group:     issueTableGroupSpec{Kind: "none"},
 			Hierarchy: issueTableHierarchyRequest{Enabled: true},
 			Page:      issueTablePageRequest{Limit: 2, Cursor: cursor},
-		}))
-		if w.Code != http.StatusOK {
-			t.Fatalf("list hierarchy roots: status=%d body=%s", w.Code, w.Body.String())
-		}
+		})).Want(http.StatusOK)
 		var response issueTableRowsResponse
-		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-			t.Fatalf("decode hierarchy roots: %v", err)
-		}
+		w.Decode(&response)
 		return response
 	}
 

--- a/server/internal/handler/issue_table_status_category_test.go
+++ b/server/internal/handler/issue_table_status_category_test.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/issuestatus"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -80,19 +80,13 @@ func statusCategoryQuery(projectID string) issueTableQuerySpec {
 func TestIssueTableStatusCategoryGroupsFoldCustomStatuses(t *testing.T) {
 	projectID, _ := seedStatusCategoryFixture(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{Kind: "status_category"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var groups issueTableGroupsResponse
-	if err := json.NewDecoder(w.Body).Decode(&groups); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	w.Decode(&groups)
 
 	counts := map[string]int64{}
 	for _, group := range groups.Groups {
@@ -117,20 +111,14 @@ func TestIssueTableStatusCategoryRowsReturnCustomStatusIssues(t *testing.T) {
 	projectID, customKey := seedStatusCategoryFixture(t)
 
 	groupKey := statusCategoryGroupKey("in_review")
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableRows(w, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
 		Query:    statusCategoryQuery(projectID),
 		Group:    issueTableGroupSpec{Kind: "status_category"},
 		GroupKey: &groupKey,
 		Page:     issueTablePageRequest{Limit: 50},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("rows status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var rows issueTableRowsResponse
-	if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode rows: %v", err)
-	}
+	w.Decode(&rows)
 
 	byStatus := map[string]int{}
 	for _, row := range rows.Rows {
@@ -159,8 +147,7 @@ func TestIssueTableStatusCategoryRowsReturnCustomStatusIssues(t *testing.T) {
 func TestIssueTableCompoundStatusCategoryCellsFoldCustomStatuses(t *testing.T) {
 	projectID, customKey := seedStatusCategoryFixture(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{
 			Kind:      "compound",
@@ -168,14 +155,9 @@ func TestIssueTableCompoundStatusCategoryCellsFoldCustomStatuses(t *testing.T) {
 			Secondary: "status_category",
 		},
 		Page: issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var groups issueTableGroupsResponse
-	if err := json.NewDecoder(w.Body).Decode(&groups); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	w.Decode(&groups)
 	if len(groups.Groups) != 1 {
 		t.Fatalf("groups = %d, want 1 project lane", len(groups.Groups))
 	}
@@ -195,8 +177,7 @@ func TestIssueTableCompoundStatusCategoryCellsFoldCustomStatuses(t *testing.T) {
 
 	// And the cell's own group_key has to page back the same three rows.
 	cellKey := compoundCellGroupKey(groups.Groups[0].Key, "in_review", true)
-	rowsRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableRows(rowsRecorder, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
+	rowsRecorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{
 			Kind:      "compound",
@@ -205,14 +186,9 @@ func TestIssueTableCompoundStatusCategoryCellsFoldCustomStatuses(t *testing.T) {
 		},
 		GroupKey: &cellKey,
 		Page:     issueTablePageRequest{Limit: 50},
-	}))
-	if rowsRecorder.Code != http.StatusOK {
-		t.Fatalf("cell rows status = %d: %s", rowsRecorder.Code, rowsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var cellRows issueTableRowsResponse
-	if err := json.NewDecoder(rowsRecorder.Body).Decode(&cellRows); err != nil {
-		t.Fatalf("decode cell rows: %v", err)
-	}
+	rowsRecorder.Decode(&cellRows)
 	if len(cellRows.Rows) != 3 {
 		t.Fatalf("cell rows = %d, want 3", len(cellRows.Rows))
 	}
@@ -252,8 +228,7 @@ func TestIssueTableStatusCategoryMatchesStatusWithoutCustomStatuses(t *testing.T
 
 	collect := func(kind string) map[string]int64 {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+		w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 			Query: statusCategoryQuery(projectID),
 			Group: issueTableGroupSpec{Kind: kind},
 			Page:  issueTablePageRequest{Limit: 100},
@@ -338,15 +313,11 @@ func TestIssueTableStatusCategoryReadsCatalogOncePerRequest(t *testing.T) {
 	projectID, _ := seedStatusCategoryFixture(t)
 	counter := withCountingCatalog(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{Kind: "status_category"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 
 	// Exactly one, not "at most one": a zero would mean the counter never saw
 	// the request and the assertion proved nothing.
@@ -364,8 +335,7 @@ func TestIssueTableCompoundStatusCategoryReadsCatalogOncePerRequest(t *testing.T
 	projectID, _ := seedStatusCategoryFixture(t)
 	counter := withCountingCatalog(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{
 			Kind:      "compound",
@@ -373,10 +343,7 @@ func TestIssueTableCompoundStatusCategoryReadsCatalogOncePerRequest(t *testing.T
 			Secondary: "status_category",
 		},
 		Page: issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	if counter.entryReads != 1 {
 		t.Fatalf("catalog entry reads = %d, want exactly 1", counter.entryReads)
 	}
@@ -392,15 +359,11 @@ func TestIssueTableStatusGroupingReadsNoCatalog(t *testing.T) {
 	projectID, _ := seedStatusCategoryFixture(t)
 	counter := withCountingCatalog(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{Kind: "status"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	if counter.entryReads != 0 || counter.categoryReads != 0 {
 		t.Fatalf("plain status grouping read the catalog (%d entry, %d category), want 0",
 			counter.entryReads, counter.categoryReads)
@@ -415,19 +378,13 @@ func TestIssueTableStatusGroupingReadsNoCatalog(t *testing.T) {
 func TestIssueTableStatusGroupingCarriesCustomStatusGroups(t *testing.T) {
 	projectID, customKey := seedStatusCategoryFixture(t)
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: statusCategoryQuery(projectID),
 		Group: issueTableGroupSpec{Kind: "status"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var groups issueTableGroupsResponse
-	if err := json.NewDecoder(w.Body).Decode(&groups); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	w.Decode(&groups)
 
 	counts := map[string]int64{}
 	for _, group := range groups.Groups {
@@ -442,20 +399,14 @@ func TestIssueTableStatusGroupingCarriesCustomStatusGroups(t *testing.T) {
 
 	// And its group_key has to page back its own rows.
 	groupKey := "status:" + customKey
-	rowsRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableRows(rowsRecorder, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
+	rowsRecorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
 		Query:    statusCategoryQuery(projectID),
 		Group:    issueTableGroupSpec{Kind: "status"},
 		GroupKey: &groupKey,
 		Page:     issueTablePageRequest{Limit: 50},
-	}))
-	if rowsRecorder.Code != http.StatusOK {
-		t.Fatalf("rows status = %d: %s", rowsRecorder.Code, rowsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var rows issueTableRowsResponse
-	if err := json.NewDecoder(rowsRecorder.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode rows: %v", err)
-	}
+	rowsRecorder.Decode(&rows)
 	if len(rows.Rows) != 2 {
 		t.Fatalf("custom status rows = %d, want 2", len(rows.Rows))
 	}
@@ -471,38 +422,26 @@ func TestIssueTableFiltersAcceptCustomStatusKeys(t *testing.T) {
 	query := statusCategoryQuery(projectID)
 	query.Filters = issueTableFiltersRequest{Statuses: []string{customKey}}
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueTableGroups(w, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
+	w := testutil.Call(t, testHandler.ListIssueTableGroups, newRequest(http.MethodPost, "/api/issues/table/groups", issueTableGroupsRequest{
 		Query: query,
 		Group: issueTableGroupSpec{Kind: "status_category"},
 		Page:  issueTablePageRequest{Limit: 100},
-	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("groups status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var groups issueTableGroupsResponse
-	if err := json.NewDecoder(w.Body).Decode(&groups); err != nil {
-		t.Fatalf("decode groups: %v", err)
-	}
+	w.Decode(&groups)
 	if groups.Total != 2 {
 		t.Fatalf("total = %d, want 2 (only the QA rows)", groups.Total)
 	}
 
 	groupKey := statusCategoryGroupKey("in_review")
-	rowsRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableRows(rowsRecorder, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
+	rowsRecorder := testutil.Call(t, testHandler.ListIssueTableRows, newRequest(http.MethodPost, "/api/issues/table/rows", issueTableRowsRequest{
 		Query:    query,
 		Group:    issueTableGroupSpec{Kind: "status_category"},
 		GroupKey: &groupKey,
 		Page:     issueTablePageRequest{Limit: 50},
-	}))
-	if rowsRecorder.Code != http.StatusOK {
-		t.Fatalf("rows status = %d, want 200: %s", rowsRecorder.Code, rowsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var rows issueTableRowsResponse
-	if err := json.NewDecoder(rowsRecorder.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode rows: %v", err)
-	}
+	rowsRecorder.Decode(&rows)
 	// The in_review column holds 3 issues, but only the 2 on `qa` match the filter.
 	if len(rows.Rows) != 2 {
 		t.Fatalf("rows = %d, want 2", len(rows.Rows))
@@ -513,12 +452,8 @@ func TestIssueTableFiltersAcceptCustomStatusKeys(t *testing.T) {
 		}
 	}
 
-	facetsRecorder := httptest.NewRecorder()
-	testHandler.ListIssueTableFacets(facetsRecorder, newRequest(http.MethodPost, "/api/issues/table/facets", issueTableFacetsRequest{
+	testutil.Call(t, testHandler.ListIssueTableFacets, newRequest(http.MethodPost, "/api/issues/table/facets", issueTableFacetsRequest{
 		Query:  query,
 		Facets: []issueTableFacetSpec{{Kind: "status"}},
-	}))
-	if facetsRecorder.Code != http.StatusOK {
-		t.Fatalf("facets status = %d, want 200: %s", facetsRecorder.Code, facetsRecorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 }

--- a/server/internal/handler/issue_table_working_agents_facet_test.go
+++ b/server/internal/handler/issue_table_working_agents_facet_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // workingAgentsFacetCounts posts one facets request and returns the
@@ -16,15 +16,9 @@ func workingAgentsFacetCounts(
 ) map[string]int64 {
 	t.Helper()
 
-	recorder := httptest.NewRecorder()
-	testHandler.ListIssueTableFacets(recorder, request)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("facets status = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.ListIssueTableFacets, request).Want(http.StatusOK)
 	var response issueTableFacetsResponse
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode facets: %v", err)
-	}
+	recorder.Decode(&response)
 	counts := map[string]int64{}
 	for _, facet := range response.Facets {
 		if facet.Kind != "working_agents" {
@@ -68,16 +62,7 @@ func TestIssueTableWorkingAgentsFacetFollowsSurfaceScopeAndFilters(t *testing.T)
 	idleAgentID := createHandlerTestAgent(t, "facet-working-idle", []byte(`{}`))
 
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title)
-		VALUES ($1, 'Working Agents Facet Project')
-		RETURNING id
-	`, testWorkspaceID).Scan(&projectID); err != nil {
-		t.Fatalf("create project: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
-	})
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'Working Agents Facet Project'")})
 
 	var finalNumber int
 	if err := testPool.QueryRow(ctx, `
@@ -228,19 +213,7 @@ func TestIssueTableWorkingAgentsFacetHidesInaccessibleAgents(t *testing.T) {
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (
-			workspace_id, title, status, priority, creator_type, creator_id,
-			position, number
-		)
-		VALUES ($1, 'worked on by a private agent', 'todo', 'none', 'member', $2, $3, $4)
-		RETURNING id
-	`, testWorkspaceID, testUserID, finalNumber, finalNumber).Scan(&issueID); err != nil {
-		t.Fatalf("insert issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'worked on by a private agent'"), "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'none'"), "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "position": finalNumber, "number": finalNumber})
 	createHandlerTestTaskForAgentOnIssue(t, privateAgentID, issueID)
 
 	facetRequest := func(userID string) *http.Request {

--- a/server/internal/handler/issue_trigger_backlog_category_test.go
+++ b/server/internal/handler/issue_trigger_backlog_category_test.go
@@ -27,15 +27,7 @@ func TestBacklogToCustomBacklogStatusDoesNotTrigger(t *testing.T) {
 
 	agentID := createHandlerTestAgent(t, "Backlog Category Move Agent", nil)
 	parkedKey := fmt.Sprintf("later_%d", time.Now().UnixNano())
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO issue_status (workspace_id, key, name, description, category, color, position)
-		VALUES ($1, $2, 'Later', '', 'backlog', '#ff0000', 1)
-	`, testWorkspaceID, parkedKey); err != nil {
-		t.Fatalf("create custom backlog status: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM issue_status WHERE workspace_id = $1 AND key = $2`, testWorkspaceID, parkedKey)
-	})
+	dbfx.InsertNoID(t, "issue_status", testutil.Cols{"workspace_id": testWorkspaceID, "key": parkedKey, "name": testutil.Raw("'Later'"), "description": testutil.Raw("''"), "category": testutil.Raw("'backlog'"), "color": testutil.Raw("'#ff0000'"), "position": testutil.Raw("1")}, "workspace_id = $1 AND key = $2", testWorkspaceID, parkedKey)
 
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":         "Parked issue",

--- a/server/internal/handler/issue_trigger_preview_test.go
+++ b/server/internal/handler/issue_trigger_preview_test.go
@@ -2,11 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // seededReadyAgentID returns a workspace agent that has a runtime bound (the
@@ -25,31 +26,21 @@ func seededReadyAgentID(t *testing.T) string {
 
 func previewIssueTrigger(t *testing.T, body map[string]any) IssueTriggerPreviewResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, body)
-	testHandler.PreviewIssueTrigger(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PreviewIssueTrigger: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.PreviewIssueTrigger, req).Want(http.StatusOK)
 	var resp IssueTriggerPreviewResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode preview: %v", err)
-	}
+	w.Decode(&resp)
 	return resp
 }
 
 func createIssueForTest(t *testing.T, body map[string]any) IssueResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var created IssueResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode issue: %v", err)
-	}
+	w.Decode(&created)
 	t.Cleanup(func() {
 		r := withURLParam(newRequest("DELETE", "/api/issues/"+created.ID, nil), "id", created.ID)
 		testHandler.DeleteIssue(httptest.NewRecorder(), r)
@@ -154,12 +145,9 @@ func TestPreviewIssueTrigger_MatchesWritePath(t *testing.T) {
 	if pv.TotalCount != 1 {
 		t.Fatalf("preview assign: expected 1, got %+v", pv)
 	}
-	w := httptest.NewRecorder()
+
 	req := withURLParam(newRequest("PUT", "/api/issues/"+issue.ID, map[string]any{"assignee_type": "agent", "assignee_id": agentID}), "id", issue.ID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue assign: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 	if got := taskCountFor(t, issue.ID, agentID); got == 0 {
 		t.Fatalf("preview promised a run but write path enqueued none")
 	}
@@ -175,12 +163,9 @@ func TestPreviewIssueTrigger_MatchesWritePath(t *testing.T) {
 	if pv2.TotalCount != 0 {
 		t.Fatalf("preview backlog assign: expected 0, got %+v", pv2)
 	}
-	w2 := httptest.NewRecorder()
+
 	req2 := withURLParam(newRequest("PUT", "/api/issues/"+issue2.ID, map[string]any{"assignee_type": "agent", "assignee_id": agentID}), "id", issue2.ID)
-	testHandler.UpdateIssue(w2, req2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue backlog assign: %d %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req2).Want(http.StatusOK)
 	if got := taskCountFor(t, issue2.ID, agentID); got != 0 {
 		t.Fatalf("preview said no run for backlog assign but write path enqueued %d", got)
 	}
@@ -193,28 +178,22 @@ func TestUpdateIssueSuppressRunSkipsEnqueue(t *testing.T) {
 
 	// Suppressed assign: assignee set, no task.
 	suppressed := createIssueForTest(t, map[string]any{"title": "suppress on", "status": "todo"})
-	w := httptest.NewRecorder()
+
 	req := withURLParam(newRequest("PUT", "/api/issues/"+suppressed.ID, map[string]any{
 		"assignee_type": "agent", "assignee_id": agentID, "suppress_run": true,
 	}), "id", suppressed.ID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue suppressed: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 	if got := taskCountFor(t, suppressed.ID, agentID); got != 0 {
 		t.Fatalf("suppress_run=true should not enqueue, got %d tasks", got)
 	}
 
 	// Control: same write without suppress_run enqueues.
 	control := createIssueForTest(t, map[string]any{"title": "suppress off", "status": "todo"})
-	w2 := httptest.NewRecorder()
+
 	req2 := withURLParam(newRequest("PUT", "/api/issues/"+control.ID, map[string]any{
 		"assignee_type": "agent", "assignee_id": agentID,
 	}), "id", control.ID)
-	testHandler.UpdateIssue(w2, req2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue control: %d %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req2).Want(http.StatusOK)
 	if got := taskCountFor(t, control.ID, agentID); got == 0 {
 		t.Fatalf("control (no suppress_run) should enqueue, got 0 tasks")
 	}
@@ -228,14 +207,11 @@ func TestUpdateIssueHandoffNotePersistsOnTask(t *testing.T) {
 	note := "Only touch the login flow."
 
 	issue := createIssueForTest(t, map[string]any{"title": "handoff persist", "status": "todo"})
-	w := httptest.NewRecorder()
+
 	req := withURLParam(newRequest("PUT", "/api/issues/"+issue.ID, map[string]any{
 		"assignee_type": "agent", "assignee_id": agentID, "handoff_note": note,
 	}), "id", issue.ID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue with handoff: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 
 	var stored string
 	if err := testPool.QueryRow(context.Background(), `
@@ -250,14 +226,11 @@ func TestUpdateIssueHandoffNotePersistsOnTask(t *testing.T) {
 
 	// Suppressed assign with a note: no task at all (no run to inject into).
 	suppressed := createIssueForTest(t, map[string]any{"title": "handoff suppressed", "status": "todo"})
-	w2 := httptest.NewRecorder()
+
 	req2 := withURLParam(newRequest("PUT", "/api/issues/"+suppressed.ID, map[string]any{
 		"assignee_type": "agent", "assignee_id": agentID, "handoff_note": note, "suppress_run": true,
 	}), "id", suppressed.ID)
-	testHandler.UpdateIssue(w2, req2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue suppressed handoff: %d %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req2).Want(http.StatusOK)
 	if got := taskCountFor(t, suppressed.ID, agentID); got != 0 {
 		t.Fatalf("suppressed handoff should enqueue no task, got %d", got)
 	}
@@ -266,13 +239,10 @@ func TestUpdateIssueHandoffNotePersistsOnTask(t *testing.T) {
 // TestPreviewIssueTrigger_MalformedBody verifies the endpoint rejects a
 // malformed body with 400 rather than a 500 or a silent empty result.
 func TestPreviewIssueTrigger_MalformedBody(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := httptest.NewRequest("POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, strings.NewReader("{not json"))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-User-ID", testUserID)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
-	testHandler.PreviewIssueTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("malformed body: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.PreviewIssueTrigger, req).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/issue_update_project_scope_test.go
+++ b/server/internal/handler/issue_update_project_scope_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestUpdateIssueProjectStaysInWorkspace mirrors
@@ -43,70 +45,35 @@ func TestUpdateIssueProjectStaysInWorkspace(t *testing.T) {
 	})
 
 	var localProjectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title)
-		VALUES ($1, $2)
-		RETURNING id
-	`, testWorkspaceID, "Local update project "+suffix).Scan(&localProjectID); err != nil {
-		t.Fatalf("insert local project: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, localProjectID)
-	})
+	localProjectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": "Local update project " + suffix})
 
 	var foreignWorkspaceID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ($1, $2, '', 'UPB')
-		RETURNING id
-	`, "Update boundary foreign workspace "+suffix, "update-boundary-"+suffix).Scan(&foreignWorkspaceID); err != nil {
-		t.Fatalf("insert foreign workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-	})
+	foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Update boundary foreign workspace " + suffix, "slug": "update-boundary-" + suffix, "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'UPB'")})
 
 	var foreignProjectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title)
-		VALUES ($1, $2)
-		RETURNING id
-	`, foreignWorkspaceID, "Foreign update project "+suffix).Scan(&foreignProjectID); err != nil {
-		t.Fatalf("insert foreign project: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, foreignProjectID)
-	})
+	foreignProjectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": foreignWorkspaceID, "title": "Foreign update project " + suffix})
 
 	t.Run("same-workspace project is accepted", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
 			"project_id": localProjectID,
 		})
 		req = withURLParam(req, "id", issueID)
-		testHandler.UpdateIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusOK)
 		var updated IssueResponse
-		if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&updated)
 		if updated.ProjectID == nil || *updated.ProjectID != localProjectID {
 			t.Fatalf("UpdateIssue: expected project %s, got %v", localProjectID, updated.ProjectID)
 		}
 	})
 
 	t.Run("cross-workspace project is rejected", func(t *testing.T) {
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
 			"project_id": foreignProjectID,
 		})
 		req = withURLParam(req, "id", issueID)
-		testHandler.UpdateIssue(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("UpdateIssue: expected 400 for foreign project, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
 		if !strings.Contains(w.Body.String(), "project not found in this workspace") {
 			t.Fatalf("UpdateIssue: expected boundary error message, got %s", w.Body.String())
 		}
@@ -127,47 +94,20 @@ func TestUpdateIssueProjectStaysInWorkspace(t *testing.T) {
 // POST /api/issues/batch-update, reachable with a multi-select drag on the
 // board: a project from another workspace is rejected and no target row moves.
 func TestBatchUpdateIssuesProjectStaysInWorkspace(t *testing.T) {
-	ctx := context.Background()
+
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 
 	first := insertProjectScopeTestIssue(t, "Batch project boundary A "+suffix)
 	second := insertProjectScopeTestIssue(t, "Batch project boundary B "+suffix)
 
 	var localProjectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title)
-		VALUES ($1, $2)
-		RETURNING id
-	`, testWorkspaceID, "Local batch project "+suffix).Scan(&localProjectID); err != nil {
-		t.Fatalf("insert local project: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, localProjectID)
-	})
+	localProjectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": "Local batch project " + suffix})
 
 	var foreignWorkspaceID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ($1, $2, '', 'BPB')
-		RETURNING id
-	`, "Batch boundary foreign workspace "+suffix, "batch-boundary-"+suffix).Scan(&foreignWorkspaceID); err != nil {
-		t.Fatalf("insert foreign workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-	})
+	foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Batch boundary foreign workspace " + suffix, "slug": "batch-boundary-" + suffix, "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'BPB'")})
 
 	var foreignProjectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title)
-		VALUES ($1, $2)
-		RETURNING id
-	`, foreignWorkspaceID, "Foreign batch project "+suffix).Scan(&foreignProjectID); err != nil {
-		t.Fatalf("insert foreign project: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, foreignProjectID)
-	})
+	foreignProjectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": foreignWorkspaceID, "title": "Foreign batch project " + suffix})
 
 	batchUpdateProject := func(projectID string) *httptest.ResponseRecorder {
 		w := httptest.NewRecorder()
@@ -198,9 +138,7 @@ func TestBatchUpdateIssuesProjectStaysInWorkspace(t *testing.T) {
 	// value rather than a NULL a skipped write would also leave.
 	t.Run("same-workspace project is accepted", func(t *testing.T) {
 		w := batchUpdateProject(localProjectID)
-		if w.Code != http.StatusOK {
-			t.Fatalf("BatchUpdateIssues: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 		var resp struct {
 			Updated int `json:"updated"`
 		}
@@ -215,9 +153,7 @@ func TestBatchUpdateIssuesProjectStaysInWorkspace(t *testing.T) {
 
 	t.Run("cross-workspace project changes no row", func(t *testing.T) {
 		w := batchUpdateProject(foreignProjectID)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("BatchUpdateIssues: expected 400 for foreign project, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 		if !strings.Contains(w.Body.String(), "project not found in this workspace") {
 			t.Fatalf("BatchUpdateIssues: expected boundary error message, got %s", w.Body.String())
 		}
@@ -228,9 +164,7 @@ func TestBatchUpdateIssuesProjectStaysInWorkspace(t *testing.T) {
 	// error too, not a per-issue skip.
 	t.Run("unparseable project is rejected", func(t *testing.T) {
 		w := batchUpdateProject("not-a-uuid")
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("BatchUpdateIssues: expected 400 for unparseable project, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 		assertStoredProjects(t, localProjectID)
 	})
 }

--- a/server/internal/handler/issue_validation_test.go
+++ b/server/internal/handler/issue_validation_test.go
@@ -2,36 +2,31 @@ package handler
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestCreateIssueInvalidStatusReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "invalid status issue",
 		"status": "active",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	if body := w.Body.String(); !strings.Contains(body, "backlog") {
 		t.Errorf("expected error to list valid statuses, got: %s", body)
 	}
 }
 
 func TestCreateIssueInvalidPriorityReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "invalid priority issue",
 		"priority": "P1",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusBadRequest)
 	if body := w.Body.String(); !strings.Contains(body, "urgent") {
 		t.Errorf("expected error to list valid priorities, got: %s", body)
 	}
@@ -41,52 +36,38 @@ func TestUpdateIssueInvalidStatusReturns400(t *testing.T) {
 	issueID := createTestIssue(t, "update invalid status issue", "todo", "none")
 	t.Cleanup(func() { deleteTestIssue(t, issueID) })
 
-	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "active"})
 	req = withURLParam(req, "id", issueID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
 }
 
 func TestUpdateIssueInvalidPriorityReturns400(t *testing.T) {
 	issueID := createTestIssue(t, "update invalid priority issue", "todo", "none")
 	t.Cleanup(func() { deleteTestIssue(t, issueID) })
 
-	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"priority": "P1"})
 	req = withURLParam(req, "id", issueID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, req).Want(http.StatusBadRequest)
 }
 
 func TestBatchUpdateIssuesInvalidStatusReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": []string{"not-needed"},
 		"updates": map[string]any{
 			"status": "active",
 		},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusBadRequest)
 }
 
 func TestBatchUpdateIssuesInvalidPriorityReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
 		"issue_ids": []string{"not-needed"},
 		"updates": map[string]any{
 			"priority": "P1",
 		},
 	})
-	testHandler.BatchUpdateIssues(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.BatchUpdateIssues, req).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/issue_view_preference_test.go
+++ b/server/internal/handler/issue_view_preference_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestIssueViewPreferenceRoundTrip(t *testing.T) {
@@ -17,9 +19,7 @@ func TestIssueViewPreferenceRoundTrip(t *testing.T) {
 	// Empty document before any write.
 	w := httptest.NewRecorder()
 	testHandler.GetIssueViewPreference(w, newRequest("GET", "/api/issue-view-preferences?scope_type=workspace", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("get(empty): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var got IssueViewPreferenceResponse
 	json.NewDecoder(w.Body).Decode(&got)
 	if string(got.Prefs) != "{}" {
@@ -36,9 +36,7 @@ func TestIssueViewPreferenceRoundTrip(t *testing.T) {
 		"scope_type": "workspace",
 		"prefs":      prefs,
 	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("put: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	w = httptest.NewRecorder()
 	testHandler.GetIssueViewPreference(w, newRequest("GET", "/api/issue-view-preferences?scope_type=workspace", nil))
@@ -55,9 +53,7 @@ func TestIssueViewPreferenceRoundTrip(t *testing.T) {
 		"scope_type": "workspace",
 		"prefs":      map[string]any{"hidden": []string{}},
 	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("put2: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	w = httptest.NewRecorder()
 	testHandler.GetIssueViewPreference(w, newRequest("GET", "/api/issue-view-preferences?scope_type=workspace", nil))
 	json.NewDecoder(w.Body).Decode(&got)
@@ -81,9 +77,7 @@ func TestIssueViewPreferenceIsPerUser(t *testing.T) {
 		"scope_type": "workspace",
 		"prefs":      map[string]any{"hidden": []string{"view:x"}},
 	}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("put: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	otherID := createSecondWorkspaceMember(t)
 	w = httptest.NewRecorder()

--- a/server/internal/handler/issue_view_test.go
+++ b/server/internal/handler/issue_view_test.go
@@ -8,13 +8,15 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func createIssueViewForTest(t *testing.T, body map[string]any) (IssueViewResponse, int, string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issue-views", body)
-	testHandler.CreateIssueView(w, req)
+	w := testutil.Call(t, testHandler.CreateIssueView, req)
 	var view IssueViewResponse
 	if w.Code == http.StatusCreated {
 		json.NewDecoder(w.Body).Decode(&view)
@@ -44,11 +46,7 @@ func TestCreateAndListIssueView(t *testing.T) {
 		t.Fatalf("expected workspace visibility, got %s", view.Visibility)
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.ListIssueViews(w, newRequest("GET", "/api/issue-views?scope_type=workspace", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("list: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListIssueViews, newRequest("GET", "/api/issue-views?scope_type=workspace", nil)).Want(http.StatusOK)
 	var views []IssueViewResponse
 	json.NewDecoder(w.Body).Decode(&views)
 	found := false
@@ -114,9 +112,7 @@ func TestIssueViewPrivateInvisibleToOthers(t *testing.T) {
 	req.Header.Set("X-User-ID", otherID)
 	req = withURLParam(req, "id", view.ID)
 	testHandler.GetIssueViewByID(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404 for foreign private view, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 func TestUpdateIssueViewRevisionConflict(t *testing.T) {
@@ -131,13 +127,13 @@ func TestUpdateIssueViewRevisionConflict(t *testing.T) {
 	}
 
 	patch := func(rev int32, name string) int {
-		w := httptest.NewRecorder()
+
 		req := newRequest("PATCH", "/api/issue-views/"+view.ID, map[string]any{
 			"name":              name,
 			"expected_revision": rev,
 		})
 		req = withURLParam(req, "id", view.ID)
-		testHandler.UpdateIssueView(w, req)
+		w := testutil.Call(t, testHandler.UpdateIssueView, req)
 		return w.Code
 	}
 
@@ -222,16 +218,13 @@ func TestWorkspaceIssueViewVariant(t *testing.T) {
 	}
 
 	// Switching the variant via PATCH works; the scope_type stays fixed.
-	w := httptest.NewRecorder()
+
 	req := newRequest("PATCH", "/api/issue-views/"+view.ID, map[string]any{
 		"scope_variant":     "members",
 		"expected_revision": 1,
 	})
 	req = withURLParam(req, "id", view.ID)
-	testHandler.UpdateIssueView(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("patch variant: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateIssueView, req).Want(http.StatusOK)
 	var updated IssueViewResponse
 	json.NewDecoder(w.Body).Decode(&updated)
 	if updated.ScopeVariant == nil || *updated.ScopeVariant != "members" {
@@ -241,18 +234,12 @@ func TestWorkspaceIssueViewVariant(t *testing.T) {
 
 func TestProjectIssueViewVariant(t *testing.T) {
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "variant project",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create project: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	t.Cleanup(func() {
 		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
 		req = withURLParam(req, "id", project.ID)
@@ -327,7 +314,7 @@ func TestPinIssueView(t *testing.T) {
 	})
 
 	pinView := func(userID, viewID string) int {
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/pins", map[string]any{
 			"item_type": "view",
 			"item_id":   viewID,
@@ -335,7 +322,7 @@ func TestPinIssueView(t *testing.T) {
 		if userID != "" {
 			req.Header.Set("X-User-ID", userID)
 		}
-		testHandler.CreatePin(w, req)
+		w := testutil.Call(t, testHandler.CreatePin, req)
 		return w.Code
 	}
 
@@ -353,14 +340,10 @@ func TestPinIssueView(t *testing.T) {
 		t.Fatalf("pin foreign private view: expected 404, got %d", got)
 	}
 	// Unknown type still rejected.
-	w := httptest.NewRecorder()
-	testHandler.CreatePin(w, newRequest("POST", "/api/pins", map[string]any{
+	testutil.Call(t, testHandler.CreatePin, newRequest("POST", "/api/pins", map[string]any{
 		"item_type": "label",
 		"item_id":   shared.ID,
-	}))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for unknown item_type, got %d", w.Code)
-	}
+	})).Want(http.StatusBadRequest)
 }
 
 // Old clients (built before saved views) classify every non-issue pin as a
@@ -382,21 +365,13 @@ func TestListPinsHidesViewPinsWithoutOptIn(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM pinned_item WHERE item_type = 'view'`)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.CreatePin(w, newRequest("POST", "/api/pins", map[string]any{
+	testutil.Call(t, testHandler.CreatePin, newRequest("POST", "/api/pins", map[string]any{
 		"item_type": "view",
 		"item_id":   view.ID,
-	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("pin view: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	})).Want(http.StatusCreated)
 
 	listPins := func(path string) []PinnedItemResponse {
-		rec := httptest.NewRecorder()
-		testHandler.ListPins(rec, newRequest("GET", path, nil))
-		if rec.Code != http.StatusOK {
-			t.Fatalf("list pins: expected 200, got %d: %s", rec.Code, rec.Body.String())
-		}
+		rec := testutil.Call(t, testHandler.ListPins, newRequest("GET", path, nil)).Want(http.StatusOK)
 		var pins []PinnedItemResponse
 		json.NewDecoder(rec.Body).Decode(&pins)
 		return pins
@@ -551,14 +526,10 @@ func TestDeletingViewsSweepsTheirPins(t *testing.T) {
 		return n
 	}
 	pinView := func(viewID string) {
-		w := httptest.NewRecorder()
-		testHandler.CreatePin(w, newRequest("POST", "/api/pins", map[string]any{
+		testutil.Call(t, testHandler.CreatePin, newRequest("POST", "/api/pins", map[string]any{
 			"item_type": "view",
 			"item_id":   viewID,
-		}))
-		if w.Code != http.StatusCreated {
-			t.Fatalf("pin view: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		})).Want(http.StatusCreated)
 	}
 
 	// 1) Direct handler delete.
@@ -574,9 +545,7 @@ func TestDeletingViewsSweepsTheirPins(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := withURLParam(newRequest("DELETE", "/api/issue-views/"+view.ID, nil), "id", view.ID)
 	testHandler.DeleteIssueView(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("delete view: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 	if n := countViewPins(); n != 0 {
 		t.Fatalf("pin survived direct view delete: %d rows", n)
 	}
@@ -586,9 +555,7 @@ func TestDeletingViewsSweepsTheirPins(t *testing.T) {
 	testHandler.CreateProject(w, newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "pin sweep project",
 	}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create project: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	json.NewDecoder(w.Body).Decode(&project)
 

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestLabelCRUD exercises label create/list/get/update/delete.
@@ -20,9 +21,7 @@ func TestLabelCRUD(t *testing.T) {
 		"color": "#ef4444",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created LabelResponse
 	json.NewDecoder(w.Body).Decode(&created)
 	if created.Name != "bug" || created.Color != "#ef4444" {
@@ -31,10 +30,10 @@ func TestLabelCRUD(t *testing.T) {
 	labelID := created.ID
 
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+labelID, nil)
 		req = withURLParam(req, "id", labelID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 
 	// Duplicate name → 409
@@ -44,9 +43,7 @@ func TestLabelCRUD(t *testing.T) {
 		"color": "#000000",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("Duplicate CreateLabel: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusConflict, "HTTP status")
 
 	// Invalid color → 400
 	w = httptest.NewRecorder()
@@ -55,17 +52,13 @@ func TestLabelCRUD(t *testing.T) {
 		"color": "nope",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("Invalid color: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// List
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/labels", nil)
 	testHandler.ListLabels(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListLabels: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var listResp struct {
 		Labels []LabelResponse `json:"labels"`
 		Total  int             `json:"total"`
@@ -80,9 +73,7 @@ func TestLabelCRUD(t *testing.T) {
 	req = newRequest("GET", "/api/labels/"+labelID, nil)
 	req = withURLParam(req, "id", labelID)
 	testHandler.GetLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetLabel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Update
 	w = httptest.NewRecorder()
@@ -92,9 +83,7 @@ func TestLabelCRUD(t *testing.T) {
 	})
 	req = withURLParam(req, "id", labelID)
 	testHandler.UpdateLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateLabel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var updated LabelResponse
 	json.NewDecoder(w.Body).Decode(&updated)
 	if updated.Name != "Bug (P0)" || updated.Color != "#b91c1c" {
@@ -112,9 +101,7 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 		"priority": "medium",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	issueID := issue.ID
@@ -131,10 +118,10 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 	labelID := label.ID
 
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+labelID, nil)
 		req = withURLParam(req, "id", labelID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 
 	// Attach
@@ -144,9 +131,7 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 	})
 	req = withURLParam(req, "id", issueID)
 	testHandler.AttachLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("AttachLabel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Attach again (idempotent — ON CONFLICT DO NOTHING)
 	w = httptest.NewRecorder()
@@ -155,18 +140,14 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 	})
 	req = withURLParam(req, "id", issueID)
 	testHandler.AttachLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("AttachLabel (second): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// List labels for issue
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/issues/"+issueID+"/labels", nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.ListLabelsForIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListLabelsForIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var issueLabels struct {
 		Labels []LabelResponse `json:"labels"`
 	}
@@ -183,9 +164,7 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 	req = newRequest("DELETE", "/api/issues/"+issueID+"/labels/"+labelID, nil)
 	req = withURLParams(req, "id", issueID, "labelId", labelID)
 	testHandler.DetachLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DetachLabel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Confirm detached
 	w = httptest.NewRecorder()
@@ -206,9 +185,7 @@ func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
 		"priority": "medium",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var issue IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
 		t.Fatalf("decode issue: %v", err)
@@ -221,18 +198,16 @@ func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
 		"color":         "#3b82f6",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var label LabelResponse
 	if err := json.NewDecoder(w.Body).Decode(&label); err != nil {
 		t.Fatalf("decode label: %v", err)
 	}
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+label.ID, nil)
 		req = withURLParam(req, "id", label.ID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 
 	w = httptest.NewRecorder()
@@ -241,17 +216,13 @@ func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
 	})
 	req = withURLParam(req, "id", issue.ID)
 	testHandler.AttachLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("AttachLabel with agent label: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	w = httptest.NewRecorder()
 	req = newRequest("DELETE", "/api/issues/"+issue.ID+"/labels/"+label.ID, nil)
 	req = withURLParams(req, "id", issue.ID, "labelId", label.ID)
 	testHandler.DetachLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("DetachLabel with agent label: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // TestLabelNotFoundAcrossWorkspaces ensures GET with a foreign workspace
@@ -263,18 +234,16 @@ func TestLabelNotFoundAcrossWorkspaces(t *testing.T) {
 		"color": "#a855f7",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var label LabelResponse
 	json.NewDecoder(w.Body).Decode(&label)
 	labelID := label.ID
 
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+labelID, nil)
 		req = withURLParam(req, "id", labelID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 
 	// GET with a different workspace ID → 404
@@ -283,9 +252,7 @@ func TestLabelNotFoundAcrossWorkspaces(t *testing.T) {
 	req.Header.Set("X-Workspace-ID", "00000000-0000-0000-0000-000000000000")
 	req = withURLParam(req, "id", labelID)
 	testHandler.GetLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("GetLabel cross-workspace: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 }
 
 // TestUpdateLabelCrossWorkspace — PUT with a foreign workspace header must not
@@ -299,18 +266,16 @@ func TestUpdateLabelCrossWorkspace(t *testing.T) {
 		"color": "#10b981",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel: expected 201, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var label LabelResponse
 	json.NewDecoder(w.Body).Decode(&label)
 	labelID := label.ID
 
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+labelID, nil)
 		req = withURLParam(req, "id", labelID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 
 	// PUT with a foreign workspace ID → 404
@@ -319,18 +284,14 @@ func TestUpdateLabelCrossWorkspace(t *testing.T) {
 	req.Header.Set("X-Workspace-ID", "00000000-0000-0000-0000-000000000000")
 	req = withURLParam(req, "id", labelID)
 	testHandler.UpdateLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("UpdateLabel cross-workspace: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	// Sanity: the label wasn't renamed.
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/labels/"+labelID, nil)
 	req = withURLParam(req, "id", labelID)
 	testHandler.GetLabel(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetLabel after failed cross-workspace PUT: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var after LabelResponse
 	json.NewDecoder(w.Body).Decode(&after)
 	if after.Name != "cross-ws-update-test" {
@@ -351,9 +312,7 @@ func TestAttachLabelCrossWorkspaceLabel(t *testing.T) {
 		"priority": "medium",
 	})
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 
@@ -379,9 +338,7 @@ func TestAttachLabelCrossWorkspaceLabel(t *testing.T) {
 	})
 	req = withURLParam(req, "id", issue.ID)
 	testHandler.AttachLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("AttachLabel cross-workspace label: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNotFound, "HTTP status")
 
 	// Confirm nothing was attached.
 	w = httptest.NewRecorder()
@@ -406,9 +363,7 @@ func TestLabelNameTooLong(t *testing.T) {
 		"color": "#123456",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateLabel too-long name: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Exactly 32 chars is fine.
 	okName := strings.Repeat("b", 32)
@@ -418,16 +373,14 @@ func TestLabelNameTooLong(t *testing.T) {
 		"color": "#123456",
 	})
 	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel 32-char name: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created LabelResponse
 	json.NewDecoder(w.Body).Decode(&created)
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+created.ID, nil)
 		req = withURLParam(req, "id", created.ID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 }
 
@@ -466,23 +419,18 @@ func TestLabelNameRejectsControlCharacters(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newRequest("POST", "/api/labels", tc.body)
 			tc.call(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 		})
 	}
 }
 
 func TestLabelNameAllowsEmoji(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/labels", map[string]any{
 		"name":  "🐛 bug",
 		"color": "#123456",
 	})
-	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateLabel emoji name: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateLabel, req).Want(http.StatusCreated)
 
 	var created LabelResponse
 	json.NewDecoder(w.Body).Decode(&created)
@@ -490,39 +438,37 @@ func TestLabelNameAllowsEmoji(t *testing.T) {
 		t.Fatalf("CreateLabel emoji name: got %q", created.Name)
 	}
 	t.Cleanup(func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/labels/"+created.ID, nil)
 		req = withURLParam(req, "id", created.ID)
-		testHandler.DeleteLabel(w, req)
+		testutil.Call(t, testHandler.DeleteLabel, req)
 	})
 }
 
 func TestLabelResourceTypesHaveIndependentNamespaces(t *testing.T) {
 	name := "shared-scope-label-" + uuid.NewString()[:8]
 	for _, resourceType := range []string{"issue", "agent", "skill"} {
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/labels", map[string]any{
 			"resource_type": resourceType,
 			"name":          name,
 			"description":   resourceType + " description",
 			"color":         "#3b82f6",
 		})
-		testHandler.CreateLabel(w, req)
+		w := testutil.Call(t, testHandler.CreateLabel, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateLabel resource_type=%s: expected 201, got %d: %s", resourceType, w.Code, w.Body.String())
 		}
 		var created LabelResponse
-		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-			t.Fatalf("decode created label: %v", err)
-		}
+		w.Decode(&created)
 		if created.ResourceType != resourceType || created.Description != resourceType+" description" {
 			t.Fatalf("unexpected scoped label: %+v", created)
 		}
 		t.Cleanup(func() {
-			w := httptest.NewRecorder()
+
 			req := newRequest("DELETE", "/api/labels/"+created.ID, nil)
 			req = withURLParam(req, "id", created.ID)
-			testHandler.DeleteLabel(w, req)
+			testutil.Call(t, testHandler.DeleteLabel, req)
 		})
 	}
 }
@@ -533,8 +479,7 @@ func TestDeleteResourceLabelCleansAssignments(t *testing.T) {
 
 	create := func(resourceType string) LabelResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.CreateLabel(w, newRequest("POST", "/api/labels", map[string]any{
+		w := testutil.Call(t, testHandler.CreateLabel, newRequest("POST", "/api/labels", map[string]any{
 			"resource_type": resourceType,
 			"name":          resourceType + "-cleanup-" + uuid.NewString()[:8],
 			"color":         "#3b82f6",
@@ -565,12 +510,9 @@ func TestDeleteResourceLabelCleansAssignments(t *testing.T) {
 	}
 
 	for _, labelID := range []string{agentLabel.ID, skillLabel.ID} {
-		w := httptest.NewRecorder()
+
 		req := withURLParam(newRequest("DELETE", "/api/labels/"+labelID, nil), "id", labelID)
-		testHandler.DeleteLabel(w, req)
-		if w.Code != http.StatusNoContent {
-			t.Fatalf("delete resource label: expected 204, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.DeleteLabel, req).Want(http.StatusNoContent)
 	}
 
 	for _, check := range []struct {
@@ -591,16 +533,13 @@ func TestDeleteResourceLabelCleansAssignments(t *testing.T) {
 }
 
 func TestLabelRejectsUnknownResourceType(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/labels", map[string]any{
 		"resource_type": "project",
 		"name":          "invalid-scope",
 		"color":         "#3b82f6",
 	})
-	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateLabel, req).Want(http.StatusBadRequest)
 }
 
 // TestColorCaseNormalization — input `#ABCDEF` must be stored as `#abcdef`
@@ -618,13 +557,13 @@ func TestColorCaseNormalization(t *testing.T) {
 		{"lower", "#123abc", "#123abc"},
 	}
 	for _, tc := range cases {
-		w := httptest.NewRecorder()
+
 		name := "color-norm-" + tc.nameSuffix // unique & case-independent
 		req := newRequest("POST", "/api/labels", map[string]any{
 			"name":  name,
 			"color": tc.input,
 		})
-		testHandler.CreateLabel(w, req)
+		w := testutil.Call(t, testHandler.CreateLabel, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateLabel %q: expected 201, got %d: %s", tc.input, w.Code, w.Body.String())
 		}
@@ -634,10 +573,10 @@ func TestColorCaseNormalization(t *testing.T) {
 			t.Errorf("color normalization %q: got %q, want %q", tc.input, got.Color, tc.want)
 		}
 		t.Cleanup(func() {
-			w := httptest.NewRecorder()
+
 			req := newRequest("DELETE", "/api/labels/"+got.ID, nil)
 			req = withURLParam(req, "id", got.ID)
-			testHandler.DeleteLabel(w, req)
+			testutil.Call(t, testHandler.DeleteLabel, req)
 		})
 	}
 }

--- a/server/internal/handler/lark_test.go
+++ b/server/internal/handler/lark_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/integrations/lark"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util/secretbox"
 )
 
@@ -24,21 +25,13 @@ import (
 func TestRevokeLarkInstallation_NotConfigured(t *testing.T) {
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/x/lark/installations/y", nil)
-	w := httptest.NewRecorder()
-	h.RevokeLarkInstallation(w, req)
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", w.Code)
-	}
+	testutil.Call(t, h.RevokeLarkInstallation, req).Want(http.StatusServiceUnavailable)
 }
 
 func TestRedeemLarkBindingToken_NotConfigured(t *testing.T) {
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodPost, "/api/lark/binding/redeem", strings.NewReader(`{"token":"x"}`))
-	w := httptest.NewRecorder()
-	h.RedeemLarkBindingToken(w, req)
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", w.Code)
-	}
+	testutil.Call(t, h.RedeemLarkBindingToken, req).Want(http.StatusServiceUnavailable)
 }
 
 func TestBeginLarkInstall_NotConfigured(t *testing.T) {
@@ -50,21 +43,13 @@ func TestBeginLarkInstall_NotConfigured(t *testing.T) {
 	// so this should not be reached through the normal flow.
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/x/lark/install/begin?agent_id=y", nil)
-	w := httptest.NewRecorder()
-	h.BeginLarkInstall(w, req)
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, h.BeginLarkInstall, req).Want(http.StatusServiceUnavailable)
 }
 
 func TestGetLarkInstallStatus_NotConfigured(t *testing.T) {
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/x/lark/install/sess_y/status", nil)
-	w := httptest.NewRecorder()
-	h.GetLarkInstallStatus(w, req)
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", w.Code)
-	}
+	testutil.Call(t, h.GetLarkInstallStatus, req).Want(http.StatusServiceUnavailable)
 }
 
 func TestListLarkInstallations_NotConfiguredReturnsEmpty(t *testing.T) {
@@ -74,19 +59,13 @@ func TestListLarkInstallations_NotConfiguredReturnsEmpty(t *testing.T) {
 	// "not connected" empty state instead of an error banner.
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/x/lark/installations", nil)
-	w := httptest.NewRecorder()
-	h.ListLarkInstallations(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, h.ListLarkInstallations, req).Want(http.StatusOK)
 	var resp struct {
 		Installations    []any `json:"installations"`
 		Configured       bool  `json:"configured"`
 		InstallSupported bool  `json:"install_supported"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Configured {
 		t.Fatalf("configured should be false when LarkInstallations is nil")
 	}
@@ -111,18 +90,12 @@ func TestListLarkInstallations_StubClientReportsInstallNotSupported(t *testing.T
 		LarkAPIClient: lark.NewStubAPIClient(stubLogger),
 	}
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/x/lark/installations", nil)
-	w := httptest.NewRecorder()
-	h.ListLarkInstallations(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
+	w := testutil.Call(t, h.ListLarkInstallations, req).Want(http.StatusOK)
 	var resp struct {
 		Configured       bool `json:"configured"`
 		InstallSupported bool `json:"install_supported"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.InstallSupported {
 		t.Fatalf("install_supported must be false while only stub APIClient is wired")
 	}
@@ -143,18 +116,12 @@ func TestListLarkInstallations_NotConfigured_HardCodedInstallSupportedFalse(t *t
 		LarkAPIClient:     lark.NewStubAPIClient(stubLogger),
 	}
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/x/lark/installations", nil)
-	w := httptest.NewRecorder()
-	h.ListLarkInstallations(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
+	w := testutil.Call(t, h.ListLarkInstallations, req).Want(http.StatusOK)
 	var resp struct {
 		Configured       bool `json:"configured"`
 		InstallSupported bool `json:"install_supported"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Configured {
 		t.Fatalf("configured must be false when LarkInstallations is nil")
 	}
@@ -335,9 +302,7 @@ func TestGetLarkInstallStatus_ScopedToInitiatorOrAdmin(t *testing.T) {
 
 	// The agent owner begins the install, so they are the session initiator.
 	begin := beginLarkInstallAs(ownerID, agentID)
-	if begin.Code != http.StatusOK {
-		t.Fatalf("begin as agent owner: want 200, got %d: %s", begin.Code, begin.Body.String())
-	}
+	testutil.Equal(t, begin.Code, http.StatusOK, "HTTP status")
 	var beginResp BeginLarkInstallResponse
 	if err := json.Unmarshal(begin.Body.Bytes(), &beginResp); err != nil {
 		t.Fatalf("decode begin response: %v", err)
@@ -347,8 +312,7 @@ func TestGetLarkInstallStatus_ScopedToInitiatorOrAdmin(t *testing.T) {
 		req := newRequestAs(userID, http.MethodGet,
 			"/api/workspaces/"+testWorkspaceID+"/lark/install/"+beginResp.SessionID+"/status", nil)
 		req = withURLParams(req, "id", testWorkspaceID, "sessionId", beginResp.SessionID)
-		w := httptest.NewRecorder()
-		testHandler.GetLarkInstallStatus(w, req)
+		w := testutil.Call(t, testHandler.GetLarkInstallStatus, req)
 		return w.Code
 	}
 
@@ -380,16 +344,7 @@ func TestRevokeLarkInstallation_AuthorizesAgentOwnerAndAdmins(t *testing.T) {
 			t.Fatalf("clear prior installation: %v", err)
 		}
 		var instID string
-		if err := testPool.QueryRow(context.Background(), `
-INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
-VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', 'cli_revoke_test'), $3, 'active')
-RETURNING id
-`, testWorkspaceID, agentID, ownerID).Scan(&instID); err != nil {
-			t.Fatalf("seed installation: %v", err)
-		}
-		t.Cleanup(func() {
-			testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE id = $1`, instID)
-		})
+		instID = dbfx.Insert(t, "channel_installation", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": agentID, "channel_type": testutil.Raw("'feishu'"), "config": testutil.Raw("jsonb_build_object('app_id', 'cli_revoke_test')"), "installer_user_id": ownerID, "status": testutil.Raw("'active'")})
 		return instID
 	}
 
@@ -397,8 +352,7 @@ RETURNING id
 		req := newRequestAs(userID, http.MethodDelete,
 			"/api/workspaces/"+testWorkspaceID+"/lark/installations/"+instID, nil)
 		req = withURLParams(req, "id", testWorkspaceID, "installationId", instID)
-		w := httptest.NewRecorder()
-		testHandler.RevokeLarkInstallation(w, req)
+		w := testutil.Call(t, testHandler.RevokeLarkInstallation, req)
 		return w.Code
 	}
 
@@ -438,16 +392,7 @@ func TestRevokeLarkInstallation_OrphanCleanableByAdminNotMember(t *testing.T) {
 			t.Fatalf("clear prior orphan: %v", err)
 		}
 		var instID string
-		if err := testPool.QueryRow(context.Background(), `
-INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
-VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', 'cli_orphan'), $3, 'active')
-RETURNING id
-`, testWorkspaceID, orphanAgent, testUserID).Scan(&instID); err != nil {
-			t.Fatalf("seed orphan installation: %v", err)
-		}
-		t.Cleanup(func() {
-			testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE id = $1`, instID)
-		})
+		instID = dbfx.Insert(t, "channel_installation", testutil.Cols{"workspace_id": testWorkspaceID, "agent_id": orphanAgent, "channel_type": testutil.Raw("'feishu'"), "config": testutil.Raw("jsonb_build_object('app_id', 'cli_orphan')"), "installer_user_id": testUserID, "status": testutil.Raw("'active'")})
 		return instID
 	}
 
@@ -455,8 +400,7 @@ RETURNING id
 		req := newRequestAs(userID, http.MethodDelete,
 			"/api/workspaces/"+testWorkspaceID+"/lark/installations/"+instID, nil)
 		req = withURLParams(req, "id", testWorkspaceID, "installationId", instID)
-		w := httptest.NewRecorder()
-		testHandler.RevokeLarkInstallation(w, req)
+		w := testutil.Call(t, testHandler.RevokeLarkInstallation, req)
 		return w.Code
 	}
 

--- a/server/internal/handler/mika_agent_test.go
+++ b/server/internal/handler/mika_agent_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -49,9 +50,7 @@ func TestCreateMikaAgent_ServerOwnsTheDefinition(t *testing.T) {
 		"runtime_id": handlerTestRuntimeID(t),
 		"language":   "en",
 	})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	resp := decodeAgent(t, w)
 
 	if resp.SystemKey != service.MikaSystemKey {
@@ -89,13 +88,9 @@ func TestCreateMikaAgent_IsIdempotentPerWorkspace(t *testing.T) {
 	runtimeID := handlerTestRuntimeID(t)
 
 	first := createMika(t, map[string]any{"runtime_id": runtimeID, "language": "en"})
-	if first.Code != http.StatusCreated {
-		t.Fatalf("first call: expected 201, got %d: %s", first.Code, first.Body.String())
-	}
+	testutil.Equal(t, first.Code, http.StatusCreated, "HTTP status")
 	second := createMika(t, map[string]any{"runtime_id": runtimeID, "language": "zh"})
-	if second.Code != http.StatusOK {
-		t.Fatalf("second call: expected 200, got %d: %s", second.Code, second.Body.String())
-	}
+	testutil.Equal(t, second.Code, http.StatusOK, "HTTP status")
 	if a, b := decodeAgent(t, first).ID, decodeAgent(t, second).ID; a != b {
 		t.Fatalf("expected the same agent back, got %s then %s", a, b)
 	}
@@ -114,9 +109,7 @@ func TestCreateMikaAgent_IsIdempotentPerWorkspace(t *testing.T) {
 func TestCreateMikaAgent_RejectsUnsupportedLanguage(t *testing.T) {
 	cleanupMika(t)
 	w := createMika(t, map[string]any{"runtime_id": handlerTestRuntimeID(t), "language": "fr"})
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 // TestComposeMikaInstructions covers the layering contract: the product half
@@ -184,19 +177,13 @@ func TestArchiveMikaIsRejected(t *testing.T) {
 		"runtime_id": handlerTestRuntimeID(t),
 		"language":   "en",
 	})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	agentID := decodeAgent(t, w).ID
 
 	req := withChatTestWorkspaceCtx(t, withURLParam(
 		newRequest("POST", "/api/agents/"+agentID+"/archive", nil), "id", agentID,
 	))
-	archiveW := httptest.NewRecorder()
-	testHandler.ArchiveAgent(archiveW, req)
-	if archiveW.Code != http.StatusBadRequest {
-		t.Fatalf("archiving a system agent: expected 400, got %d: %s", archiveW.Code, archiveW.Body.String())
-	}
+	testutil.Call(t, testHandler.ArchiveAgent, req).Want(http.StatusBadRequest)
 
 	var archivedAt *string
 	if err := testPool.QueryRow(context.Background(),

--- a/server/internal/handler/mika_onboarding_endpoint_test.go
+++ b/server/internal/handler/mika_onboarding_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -77,9 +78,7 @@ func TestStartMikaOnboarding_WritesTheOpeningWithoutRunningAnAgent(t *testing.T)
 	cleanupSessionTasks(t, sessionID)
 
 	w := startMikaOnboarding(t, sessionID, map[string]any{"language": "en"})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	resp := decodeStartMikaOnboarding(t, w)
 	if !resp.Started || resp.MessageID == "" {
 		t.Fatalf("expected a started opening with a message id, got %+v", resp)
@@ -149,15 +148,9 @@ func TestStartMikaOnboarding_WritesTheOpeningWithoutRunningAnAgent(t *testing.T)
 		newRequest("GET", "/api/chat/sessions/"+sessionID+"/messages", nil),
 		"sessionId", sessionID,
 	))
-	listW := httptest.NewRecorder()
-	testHandler.ListChatMessages(listW, listReq)
-	if listW.Code != http.StatusOK {
-		t.Fatalf("list messages: expected 200, got %d: %s", listW.Code, listW.Body.String())
-	}
+	listW := testutil.Call(t, testHandler.ListChatMessages, listReq).Want(http.StatusOK)
 	var visible []ChatMessageResponse
-	if err := json.Unmarshal(listW.Body.Bytes(), &visible); err != nil {
-		t.Fatalf("decode visible messages: %v", err)
-	}
+	listW.JSON(&visible)
 	if len(visible) != 1 {
 		t.Fatalf("expected only the opening to be visible, got %d message(s)", len(visible))
 	}
@@ -199,14 +192,10 @@ func TestStartMikaOnboarding_IsIdempotent(t *testing.T) {
 	cleanupSessionTasks(t, sessionID)
 
 	first := startMikaOnboarding(t, sessionID, map[string]any{"language": "zh"})
-	if first.Code != http.StatusCreated {
-		t.Fatalf("first call: expected 201, got %d: %s", first.Code, first.Body.String())
-	}
+	testutil.Equal(t, first.Code, http.StatusCreated, "HTTP status")
 
 	second := startMikaOnboarding(t, sessionID, map[string]any{"language": "zh"})
-	if second.Code != http.StatusOK {
-		t.Fatalf("second call: expected 200, got %d: %s", second.Code, second.Body.String())
-	}
+	testutil.Equal(t, second.Code, http.StatusOK, "HTTP status")
 	if resp := decodeStartMikaOnboarding(t, second); resp.Started {
 		t.Fatalf("second call must report started=false, got %+v", resp)
 	}
@@ -246,9 +235,7 @@ func TestStartMikaOnboarding_RejectsBadInput(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			w := startMikaOnboarding(t, tc.sessionID, tc.body)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 		})
 	}
 

--- a/server/internal/handler/mika_second_member_test.go
+++ b/server/internal/handler/mika_second_member_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // addSecondWorkspaceMember creates another member of the handler test
@@ -71,9 +72,7 @@ func TestStartMikaOnboarding_AllowsAnyMemberNotJustTheOwner(t *testing.T) {
 		"runtime_id": handlerTestRuntimeID(t),
 		"language":   "en",
 	})
-	if owner.Code != http.StatusCreated {
-		t.Fatalf("provision mika: expected 201, got %d: %s", owner.Code, owner.Body.String())
-	}
+	testutil.Equal(t, owner.Code, http.StatusCreated, "HTTP status")
 
 	second := addSecondWorkspaceMember(t, "mika-second-member@multica.test")
 	joined := createMikaAs(t, second, map[string]any{
@@ -81,9 +80,7 @@ func TestStartMikaOnboarding_AllowsAnyMemberNotJustTheOwner(t *testing.T) {
 		"language":      "en",
 		"session_title": "Getting started with Mika",
 	})
-	if joined.Code != http.StatusOK {
-		t.Fatalf("second member: expected the existing Mika (200), got %d: %s", joined.Code, joined.Body.String())
-	}
+	testutil.Equal(t, joined.Code, http.StatusOK, "HTTP status")
 	resp := decodeMika(t, joined)
 	if resp.SystemKey != service.MikaSystemKey {
 		t.Fatalf("second member did not get the workspace Mika: %+v", resp)
@@ -99,12 +96,7 @@ func TestStartMikaOnboarding_AllowsAnyMemberNotJustTheOwner(t *testing.T) {
 			map[string]any{"language": "en"}),
 		"sessionId", sessionID,
 	))
-	w := httptest.NewRecorder()
-	testHandler.StartMikaOnboarding(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("non-owner member must be able to start onboarding, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.StartMikaOnboarding, req).Want(http.StatusCreated)
 }
 
 // TestCreateMikaAgent_RecoversFromAPartialBootstrap is the retry path for the
@@ -137,9 +129,7 @@ func TestCreateMikaAgent_RecoversFromAPartialBootstrap(t *testing.T) {
 	retry := createMika(t, map[string]any{
 		"runtime_id": runtimeID, "language": "en", "session_title": "Getting started with Mika",
 	})
-	if retry.Code != http.StatusOK {
-		t.Fatalf("retry: expected 200, got %d: %s", retry.Code, retry.Body.String())
-	}
+	testutil.Equal(t, retry.Code, http.StatusOK, "HTTP status")
 	retryResp := decodeMika(t, retry)
 	if retryResp.OnboardingSession == nil {
 		t.Fatal("retry must rebuild the missing session, got none")
@@ -166,9 +156,7 @@ func TestCreateMikaAgent_SessionIsPerMemberAndStable(t *testing.T) {
 	first := createMika(t, map[string]any{
 		"runtime_id": runtimeID, "language": "en", "session_title": "Getting started with Mika",
 	})
-	if first.Code != http.StatusCreated {
-		t.Fatalf("first call: expected 201, got %d: %s", first.Code, first.Body.String())
-	}
+	testutil.Equal(t, first.Code, http.StatusCreated, "HTTP status")
 	firstResp := decodeMika(t, first)
 	if firstResp.OnboardingSession == nil {
 		t.Fatal("first call returned no onboarding session")
@@ -193,9 +181,7 @@ func TestCreateMikaAgent_SessionIsPerMemberAndStable(t *testing.T) {
 	second := createMika(t, map[string]any{
 		"runtime_id": runtimeID, "language": "zh", "session_title": "开始使用 Mika",
 	})
-	if second.Code != http.StatusOK {
-		t.Fatalf("second call: expected 200, got %d: %s", second.Code, second.Body.String())
-	}
+	testutil.Equal(t, second.Code, http.StatusOK, "HTTP status")
 	secondResp := decodeMika(t, second)
 	if secondResp.OnboardingSession == nil {
 		t.Fatal("second call returned no onboarding session")

--- a/server/internal/handler/notification_preference_test.go
+++ b/server/internal/handler/notification_preference_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -56,35 +56,19 @@ func TestPatchNotificationPreferencesMergesWithoutReplacing(t *testing.T) {
 		`, testWorkspaceID, testUserID)
 	})
 
-	putRecorder := httptest.NewRecorder()
-	testHandler.UpdateNotificationPreferences(
-		putRecorder,
-		notificationPreferenceRequest(t, http.MethodPut, map[string]string{
-			"status_changes": "muted",
-		}),
-	)
-	if putRecorder.Code != http.StatusOK {
-		t.Fatalf("seed preference: status=%d body=%s", putRecorder.Code, putRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateNotificationPreferences, notificationPreferenceRequest(t, http.MethodPut, map[string]string{
+		"status_changes": "muted",
+	})).Want(http.StatusOK)
 
-	patchRecorder := httptest.NewRecorder()
-	testHandler.PatchNotificationPreferences(
-		patchRecorder,
-		notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
-			"comments": "muted",
-		}),
-	)
-	if patchRecorder.Code != http.StatusOK {
-		t.Fatalf("patch preference: status=%d body=%s", patchRecorder.Code, patchRecorder.Body.String())
-	}
+	patchRecorder := testutil.Call(t, testHandler.PatchNotificationPreferences, notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
+		"comments": "muted",
+	})).Want(http.StatusOK)
 
 	var response struct {
 		WorkspaceID string            `json:"workspace_id"`
 		Preferences map[string]string `json:"preferences"`
 	}
-	if err := json.NewDecoder(patchRecorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode patch response: %v", err)
-	}
+	patchRecorder.Decode(&response)
 	if response.WorkspaceID != testWorkspaceID {
 		t.Fatalf("workspace_id = %q, want %q", response.WorkspaceID, testWorkspaceID)
 	}
@@ -95,16 +79,9 @@ func TestPatchNotificationPreferencesMergesWithoutReplacing(t *testing.T) {
 		t.Fatalf("comments patch missing: %#v", response.Preferences)
 	}
 
-	enableRecorder := httptest.NewRecorder()
-	testHandler.PatchNotificationPreferences(
-		enableRecorder,
-		notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
-			"status_changes": "all",
-		}),
-	)
-	if enableRecorder.Code != http.StatusOK {
-		t.Fatalf("enable preference: status=%d body=%s", enableRecorder.Code, enableRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.PatchNotificationPreferences, notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
+		"status_changes": "all",
+	})).Want(http.StatusOK)
 
 	var persisted []byte
 	if err := testPool.QueryRow(ctx, `
@@ -138,23 +115,14 @@ func TestPatchNotificationPreferencesAcceptsMentions(t *testing.T) {
 		`, testWorkspaceID, testUserID)
 	})
 
-	recorder := httptest.NewRecorder()
-	testHandler.PatchNotificationPreferences(
-		recorder,
-		notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
-			"mentions": "muted",
-		}),
-	)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.PatchNotificationPreferences, notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
+		"mentions": "muted",
+	})).Want(http.StatusOK)
 
 	var response struct {
 		Preferences map[string]string `json:"preferences"`
 	}
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	recorder.Decode(&response)
 	if response.Preferences["mentions"] != "muted" {
 		t.Fatalf("mentions not persisted: %#v", response.Preferences)
 	}
@@ -165,14 +133,7 @@ func TestPatchNotificationPreferencesRejectsUnknownGroups(t *testing.T) {
 		t.Skip("database not available")
 	}
 
-	recorder := httptest.NewRecorder()
-	testHandler.PatchNotificationPreferences(
-		recorder,
-		notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
-			"unknown_group": "muted",
-		}),
-	)
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.PatchNotificationPreferences, notificationPreferenceRequest(t, http.MethodPatch, map[string]string{
+		"unknown_group": "muted",
+	})).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/onboarding_test.go
+++ b/server/internal/handler/onboarding_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // newWaitlistTestUser inserts a fresh user row, returns its id, and
@@ -51,15 +52,11 @@ func newWaitlistRequest(userID string, body map[string]string) *http.Request {
 func TestJoinCloudWaitlistRecordsEmailAndReason(t *testing.T) {
 	userID := newWaitlistTestUser(t, "waitlist-ok@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newWaitlistRequest(userID, map[string]string{
 		"email":  "Someone@Example.COM",
 		"reason": "evaluating for our team",
 	})
-	testHandler.JoinCloudWaitlist(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinCloudWaitlist, req).Want(http.StatusOK)
 
 	var (
 		waitlistEmail  *string
@@ -90,14 +87,10 @@ func TestJoinCloudWaitlistRecordsEmailAndReason(t *testing.T) {
 func TestJoinCloudWaitlistAllowsEmptyReason(t *testing.T) {
 	userID := newWaitlistTestUser(t, "waitlist-noreason@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newWaitlistRequest(userID, map[string]string{
 		"email": "noreason@example.com",
 	})
-	testHandler.JoinCloudWaitlist(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinCloudWaitlist, req).Want(http.StatusOK)
 
 	var waitlistReason *string
 	if err := testPool.QueryRow(context.Background(),
@@ -121,9 +114,9 @@ func TestJoinCloudWaitlistMissingEmailReturns400(t *testing.T) {
 	}
 
 	for i, body := range cases {
-		w := httptest.NewRecorder()
+
 		req := newWaitlistRequest(userID, body)
-		testHandler.JoinCloudWaitlist(w, req)
+		w := testutil.Call(t, testHandler.JoinCloudWaitlist, req)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("case %d: expected 400, got %d: %s", i, w.Code, w.Body.String())
 		}
@@ -133,15 +126,11 @@ func TestJoinCloudWaitlistMissingEmailReturns400(t *testing.T) {
 func TestJoinCloudWaitlistRejectsOverlongReason(t *testing.T) {
 	userID := newWaitlistTestUser(t, "waitlist-long@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newWaitlistRequest(userID, map[string]string{
 		"email":  "long@example.com",
 		"reason": strings.Repeat("x", cloudWaitlistReasonMaxLen+1),
 	})
-	testHandler.JoinCloudWaitlist(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for overlong reason, got %d", w.Code)
-	}
+	testutil.Call(t, testHandler.JoinCloudWaitlist, req).Want(http.StatusBadRequest)
 }
 
 func TestJoinCloudWaitlistSecondCallOverwrites(t *testing.T) {
@@ -154,9 +143,7 @@ func TestJoinCloudWaitlistSecondCallOverwrites(t *testing.T) {
 		"reason": "first",
 	})
 	testHandler.JoinCloudWaitlist(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("first call: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Second submission with different values.
 	w = httptest.NewRecorder()
@@ -165,9 +152,7 @@ func TestJoinCloudWaitlistSecondCallOverwrites(t *testing.T) {
 		"reason": "changed my mind",
 	})
 	testHandler.JoinCloudWaitlist(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("second call: expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var (
 		waitlistEmail  string
@@ -245,16 +230,10 @@ func TestBootstrapOnboardingRuntimeCreatesSingleGuideIssue(t *testing.T) {
 		"workspace_id": testWorkspaceID,
 		"runtime_id":   testRuntimeID,
 	}
-	w := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingRuntime(w, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body))
-	if w.Code != http.StatusOK {
-		t.Fatalf("BootstrapOnboardingRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BootstrapOnboardingRuntime, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body)).Want(http.StatusOK)
 
 	var resp bootstrapOnboardingRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.WorkspaceID != testWorkspaceID || resp.AgentID == "" || resp.IssueID == "" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
@@ -339,15 +318,9 @@ func TestBootstrapOnboardingRuntimeCreatesSingleGuideIssue(t *testing.T) {
 		t.Fatal("expected onboarding issue to enqueue an agent task")
 	}
 
-	w2 := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingRuntime(w2, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body))
-	if w2.Code != http.StatusOK {
-		t.Fatalf("second BootstrapOnboardingRuntime: expected 200, got %d: %s", w2.Code, w2.Body.String())
-	}
+	w2 := testutil.Call(t, testHandler.BootstrapOnboardingRuntime, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body)).Want(http.StatusOK)
 	var resp2 bootstrapOnboardingRuntimeResponse
-	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
-		t.Fatalf("decode second response: %v", err)
-	}
+	w2.Decode(&resp2)
 	if resp2.AgentID != resp.AgentID || resp2.IssueID != resp.IssueID {
 		t.Fatalf("bootstrap should be idempotent: first=%+v second=%+v", resp, resp2)
 	}
@@ -399,15 +372,9 @@ func TestBootstrapOnboardingRuntime_WithStarterPrompt(t *testing.T) {
 		"runtime_id":     testRuntimeID,
 		"starter_prompt": wantPrompt,
 	}
-	w := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingRuntime(w, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body))
-	if w.Code != http.StatusOK {
-		t.Fatalf("BootstrapOnboardingRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BootstrapOnboardingRuntime, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body)).Want(http.StatusOK)
 	var resp bootstrapOnboardingRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 
 	var description *string
 	if err := testPool.QueryRow(ctx, `
@@ -464,15 +431,9 @@ func TestBootstrapOnboardingRuntime_NoStarterPrompt(t *testing.T) {
 		"workspace_id": testWorkspaceID,
 		"runtime_id":   testRuntimeID,
 	}
-	w := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingRuntime(w, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body))
-	if w.Code != http.StatusOK {
-		t.Fatalf("BootstrapOnboardingRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BootstrapOnboardingRuntime, newRequest(http.MethodPost, "/api/me/onboarding/runtime-bootstrap", body)).Want(http.StatusOK)
 	var resp bootstrapOnboardingRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 
 	var description *string
 	if err := testPool.QueryRow(ctx, `
@@ -513,16 +474,10 @@ func TestBootstrapOnboardingNoRuntimeCreatesSingleGuideIssue(t *testing.T) {
 	body := map[string]string{
 		"workspace_id": testWorkspaceID,
 	}
-	w := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingNoRuntime(w, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body))
-	if w.Code != http.StatusOK {
-		t.Fatalf("BootstrapOnboardingNoRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BootstrapOnboardingNoRuntime, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body)).Want(http.StatusOK)
 
 	var resp bootstrapOnboardingNoRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.WorkspaceID != testWorkspaceID || resp.IssueID == "" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
@@ -594,15 +549,9 @@ func TestBootstrapOnboardingNoRuntimeCreatesSingleGuideIssue(t *testing.T) {
 		t.Fatalf("expected no agent tasks for no-runtime issue, got %d", taskCount)
 	}
 
-	w2 := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingNoRuntime(w2, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body))
-	if w2.Code != http.StatusOK {
-		t.Fatalf("second BootstrapOnboardingNoRuntime: expected 200, got %d: %s", w2.Code, w2.Body.String())
-	}
+	w2 := testutil.Call(t, testHandler.BootstrapOnboardingNoRuntime, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body)).Want(http.StatusOK)
 	var resp2 bootstrapOnboardingNoRuntimeResponse
-	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
-		t.Fatalf("decode second response: %v", err)
-	}
+	w2.Decode(&resp2)
 	if resp2.IssueID != resp.IssueID {
 		t.Fatalf("bootstrap should be idempotent: first=%+v second=%+v", resp, resp2)
 	}
@@ -636,16 +585,10 @@ func TestBootstrapOnboardingNoRuntimeUsesChineseGuideForChineseUsers(t *testing.
 	body := map[string]string{
 		"workspace_id": testWorkspaceID,
 	}
-	w := httptest.NewRecorder()
-	testHandler.BootstrapOnboardingNoRuntime(w, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body))
-	if w.Code != http.StatusOK {
-		t.Fatalf("BootstrapOnboardingNoRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.BootstrapOnboardingNoRuntime, newRequest(http.MethodPost, "/api/me/onboarding/no-runtime-bootstrap", body)).Want(http.StatusOK)
 
 	var resp bootstrapOnboardingNoRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 
 	var description string
 	if err := testPool.QueryRow(ctx, `
@@ -702,11 +645,7 @@ func patchOnboardingAs(t *testing.T, h *Handler, userID, questionnaire string) {
 	req := httptest.NewRequest("PATCH", "/api/me/onboarding", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-User-ID", userID)
-	w := httptest.NewRecorder()
-	h.PatchOnboarding(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("patch onboarding: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, h.PatchOnboarding, req).Want(http.StatusOK)
 }
 
 // The in-flow questionnaire is role + use_case only (MUL-5159): its

--- a/server/internal/handler/personal_access_token_test.go
+++ b/server/internal/handler/personal_access_token_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/auth"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -72,9 +73,7 @@ func TestRenewPAT_ExtendsWhenInsideRenewalWindow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	resp := decodeRenewResponse(t, w)
 	if !resp.Renewed {
 		t.Fatalf("expected renewed=true, got false (expires_at=%s)", resp.ExpiresAt)
@@ -105,9 +104,7 @@ func TestRenewPAT_NoOpWhenOutsideRenewalWindow(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	resp := decodeRenewResponse(t, w)
 	if resp.Renewed {
 		t.Fatalf("expected renewed=false, got true (expires_at=%s)", resp.ExpiresAt)
@@ -127,14 +124,11 @@ func TestRenewPAT_NoOpWhenOutsideRenewalWindow(t *testing.T) {
 func TestRenewPAT_RejectsExpiredToken(t *testing.T) {
 	raw, _ := insertTestPAT(t, time.Now().Add(-time.Hour))
 
-	w := httptest.NewRecorder()
-	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
+	w := testutil.Call(t, testHandler.RenewCurrentPersonalAccessToken, newRenewRequest(raw))
 	// Expired tokens are filtered by GetPersonalAccessTokenByHash, so the
 	// handler reports 401 — the auth middleware in production would already
 	// have rejected the request, but the handler defends in depth.
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for expired token, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnauthorized, "HTTP status")
 }
 
 func TestRenewPAT_RejectsRevokedToken(t *testing.T) {
@@ -145,11 +139,7 @@ func TestRenewPAT_RejectsRevokedToken(t *testing.T) {
 		t.Fatalf("revoke: %v", err)
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for revoked token, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.RenewCurrentPersonalAccessToken, newRenewRequest(raw)).Want(http.StatusUnauthorized)
 }
 
 func TestRenewPAT_RejectsNonPATAuthHeader(t *testing.T) {
@@ -168,11 +158,7 @@ func TestRenewPAT_RejectsNonPATAuthHeader(t *testing.T) {
 			if tt.header != "" {
 				req.Header.Set("Authorization", tt.header)
 			}
-			w := httptest.NewRecorder()
-			testHandler.RenewCurrentPersonalAccessToken(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.RenewCurrentPersonalAccessToken, req).Want(http.StatusBadRequest)
 		})
 	}
 }
@@ -184,9 +170,7 @@ func TestRenewPAT_HandlesNullExpiresAt(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	resp := decodeRenewResponse(t, w)
 	if resp.Renewed {
 		t.Fatalf("expected renewed=false for NULL expiry, got true")
@@ -205,9 +189,7 @@ func TestRenewPAT_ConcurrentRenewIsIdempotent(t *testing.T) {
 
 	w1 := httptest.NewRecorder()
 	testHandler.RenewCurrentPersonalAccessToken(w1, newRenewRequest(raw))
-	if w1.Code != http.StatusOK {
-		t.Fatalf("first renew: expected 200, got %d: %s", w1.Code, w1.Body.String())
-	}
+	testutil.Equal(t, w1.Code, http.StatusOK, "HTTP status")
 	resp1 := decodeRenewResponse(t, w1)
 	if !resp1.Renewed {
 		t.Fatal("first renew should have extended the row")
@@ -215,9 +197,7 @@ func TestRenewPAT_ConcurrentRenewIsIdempotent(t *testing.T) {
 
 	w2 := httptest.NewRecorder()
 	testHandler.RenewCurrentPersonalAccessToken(w2, newRenewRequest(raw))
-	if w2.Code != http.StatusOK {
-		t.Fatalf("second renew: expected 200, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Equal(t, w2.Code, http.StatusOK, "HTTP status")
 	resp2 := decodeRenewResponse(t, w2)
 	if resp2.Renewed {
 		t.Fatal("second renew should be a no-op (token now far in the future)")
@@ -276,8 +256,7 @@ func TestRenewPAT_ParallelRenewExtendsExactlyOnce(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			w := httptest.NewRecorder()
-			testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
+			w := testutil.Call(t, testHandler.RenewCurrentPersonalAccessToken, newRenewRequest(raw))
 			var resp RenewPATResponse
 			_ = json.NewDecoder(w.Body).Decode(&resp)
 			results[i] = result{code: w.Code, expiresAt: resp.ExpiresAt, renewed: resp.Renewed}
@@ -358,10 +337,6 @@ func TestRenewPAT_RejectsTokenBelongingToDifferentUser(t *testing.T) {
 		testPool.Exec(ctx, `DELETE FROM personal_access_token WHERE id = $1`, pat.ID)
 	})
 
-	w := httptest.NewRecorder()
 	// newRequest sets X-User-ID = testUserID, but the bearer is otherUser's PAT.
-	testHandler.RenewCurrentPersonalAccessToken(w, newRenewRequest(raw))
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401 on user mismatch, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.RenewCurrentPersonalAccessToken, newRenewRequest(raw)).Want(http.StatusUnauthorized)
 }

--- a/server/internal/handler/plugin_action_test.go
+++ b/server/internal/handler/plugin_action_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	publicapiv1 "github.com/multica-ai/multica/server/pkg/publicapi/v1"
 )
 
@@ -40,17 +41,11 @@ func installPluginForAction(t *testing.T, scopes []string) string {
 	versionID := withLocalPluginSource(t, manifest)
 
 	body, _ := json.Marshal(map[string]any{"version_id": versionID, "granted_scopes": scopes})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	return installed.ID
 }
 
@@ -87,38 +82,23 @@ func TestPluginInstallTokenRunsIssueCommentWorkflow(t *testing.T) {
 	}
 	issueID := createTestIssue(t, "Install token workflow", "todo", "none")
 
-	get := httptest.NewRecorder()
-	testHandler.GetPluginIssue(get, pluginInstallTokenRequest(http.MethodGet, "/v1/issues/"+issueID, token, nil,
-		map[string]string{"issue_ref": issueID}))
-	if get.Code != http.StatusOK {
-		t.Fatalf("install-token issue read status=%d body=%s", get.Code, get.Body.String())
-	}
+	get := testutil.Call(t, testHandler.GetPluginIssue, pluginInstallTokenRequest(http.MethodGet, "/v1/issues/"+issueID, token, nil,
+		map[string]string{"issue_ref": issueID})).Want(http.StatusOK)
 
 	patchRequest := pluginInstallTokenRequest(http.MethodPatch, "/v1/issues/"+issueID, token,
 		map[string]any{"title": "Updated by install token"}, map[string]string{"issue_ref": issueID})
 	patchRequest.Header.Set("If-Match", get.Header().Get("ETag"))
-	patch := httptest.NewRecorder()
-	testHandler.PatchPluginIssue(patch, patchRequest)
-	if patch.Code != http.StatusOK {
-		t.Fatalf("install-token issue patch status=%d body=%s", patch.Code, patch.Body.String())
-	}
+	testutil.Call(t, testHandler.PatchPluginIssue, patchRequest).Want(http.StatusOK)
 
-	create := httptest.NewRecorder()
-	testHandler.CreatePluginComment(create, pluginInstallTokenRequest(http.MethodPost, "/v1/issues/"+issueID+"/comments", token,
-		map[string]any{"content": "created with a real mpi token"}, map[string]string{"issue_ref": issueID}))
-	if create.Code != http.StatusCreated {
-		t.Fatalf("install-token comment create status=%d body=%s", create.Code, create.Body.String())
-	}
+	create := testutil.Call(t, testHandler.CreatePluginComment, pluginInstallTokenRequest(http.MethodPost, "/v1/issues/"+issueID+"/comments", token,
+		map[string]any{"content": "created with a real mpi token"}, map[string]string{"issue_ref": issueID})).Want(http.StatusCreated)
 	var comment publicapiv1.Comment
-	if err := json.Unmarshal(create.Body.Bytes(), &comment); err != nil {
-		t.Fatalf("decode install-token comment: %v", err)
-	}
+	create.JSON(&comment)
 	if comment.AuthorType != "plugin" || comment.AuthorID != installationID {
 		t.Fatalf("install-token comment attribution = %+v", comment)
 	}
 
-	list := httptest.NewRecorder()
-	testHandler.ListPluginComments(list, pluginInstallTokenRequest(http.MethodGet, "/v1/issues/"+issueID+"/comments", token, nil,
+	list := testutil.Call(t, testHandler.ListPluginComments, pluginInstallTokenRequest(http.MethodGet, "/v1/issues/"+issueID+"/comments", token, nil,
 		map[string]string{"issue_ref": issueID}))
 	if list.Code != http.StatusOK || !strings.Contains(list.Body.String(), comment.ID) {
 		t.Fatalf("install-token comment list status=%d body=%s", list.Code, list.Body.String())
@@ -135,15 +115,9 @@ func TestPluginInstallTokenEnforcesGrantedScope(t *testing.T) {
 
 	request := pluginInstallTokenRequest(http.MethodPatch, "/v1/issues/"+issueID, token,
 		map[string]any{"title": "must not update"}, map[string]string{"issue_ref": issueID})
-	response := httptest.NewRecorder()
-	testHandler.PatchPluginIssue(response, request)
-	if response.Code != http.StatusForbidden {
-		t.Fatalf("ungranted install-token patch status=%d body=%s", response.Code, response.Body.String())
-	}
+	response := testutil.Call(t, testHandler.PatchPluginIssue, request).Want(http.StatusForbidden)
 	var problem publicapiv1.Problem
-	if err := json.Unmarshal(response.Body.Bytes(), &problem); err != nil {
-		t.Fatalf("decode scope problem: %v", err)
-	}
+	response.JSON(&problem)
 	if problem.Code != "forbidden" || !strings.Contains(problem.Detail, "issues:write") {
 		t.Fatalf("unexpected scope problem: %+v", problem)
 	}
@@ -158,16 +132,12 @@ func TestPluginActionRequiresAGrantedScope(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	testHandler.GetPluginIssue(recorder, pluginActionRequest(http.MethodGet, "/issues", installationID, nil,
 		map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("granted scope was refused: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 
 	recorder = httptest.NewRecorder()
 	testHandler.CreatePluginComment(recorder, pluginActionRequest(http.MethodPost, "/comments", installationID,
 		map[string]any{"content": "hello"}, map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("ungranted scope status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusForbidden, "HTTP status")
 	if !strings.Contains(recorder.Body.String(), "comments:write") {
 		t.Fatalf("refusal does not name the missing scope: %s", recorder.Body.String())
 	}
@@ -184,16 +154,10 @@ func TestPluginIssueUsesStableDTOAndRevisionETag(t *testing.T) {
 	installationID := installPluginForAction(t, []string{"issues:read", "issues:write"})
 	issueID := createTestIssue(t, "Plugin public DTO test", "todo", "none")
 
-	get := httptest.NewRecorder()
-	testHandler.GetPluginIssue(get, pluginActionRequest(http.MethodGet, "/v1/issues/"+issueID, installationID, nil,
-		map[string]string{"issue_ref": issueID}))
-	if get.Code != http.StatusOK {
-		t.Fatalf("get issue status=%d body=%s", get.Code, get.Body.String())
-	}
+	get := testutil.Call(t, testHandler.GetPluginIssue, pluginActionRequest(http.MethodGet, "/v1/issues/"+issueID, installationID, nil,
+		map[string]string{"issue_ref": issueID})).Want(http.StatusOK)
 	var issue publicapiv1.Issue
-	if err := json.Unmarshal(get.Body.Bytes(), &issue); err != nil {
-		t.Fatalf("decode public issue: %v", err)
-	}
+	get.JSON(&issue)
 	if issue.ID != issueID || issue.Identifier == "" || issue.Revision < 1 || issue.Metadata == nil || issue.Properties == nil {
 		t.Fatalf("unexpected public issue: %+v", issue)
 	}
@@ -202,9 +166,7 @@ func TestPluginIssueUsesStableDTOAndRevisionETag(t *testing.T) {
 		t.Fatalf("ETag = %q, want %q", got, wantETag)
 	}
 	var raw map[string]any
-	if err := json.Unmarshal(get.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode issue map: %v", err)
-	}
+	get.JSON(&raw)
 	for _, appOnly := range []string{"labels", "attachments", "reactions"} {
 		if _, leaked := raw[appOnly]; leaked {
 			t.Fatalf("App-only field %q leaked into Public API: %s", appOnly, get.Body.String())
@@ -214,15 +176,9 @@ func TestPluginIssueUsesStableDTOAndRevisionETag(t *testing.T) {
 	patchRequest := pluginActionRequest(http.MethodPatch, "/v1/issues/"+issueID, installationID,
 		map[string]any{"title": "Updated through Public API"}, map[string]string{"issue_ref": issueID})
 	patchRequest.Header.Set("If-Match", wantETag)
-	patch := httptest.NewRecorder()
-	testHandler.PatchPluginIssue(patch, patchRequest)
-	if patch.Code != http.StatusOK {
-		t.Fatalf("patch issue status=%d body=%s", patch.Code, patch.Body.String())
-	}
+	patch := testutil.Call(t, testHandler.PatchPluginIssue, patchRequest).Want(http.StatusOK)
 	var updated publicapiv1.Issue
-	if err := json.Unmarshal(patch.Body.Bytes(), &updated); err != nil {
-		t.Fatalf("decode updated issue: %v", err)
-	}
+	patch.JSON(&updated)
 	if updated.Title != "Updated through Public API" || updated.Revision <= issue.Revision {
 		t.Fatalf("unexpected updated issue: %+v", updated)
 	}
@@ -233,30 +189,18 @@ func TestPluginIssueUsesStableDTOAndRevisionETag(t *testing.T) {
 	staleRequest := pluginActionRequest(http.MethodPatch, "/v1/issues/"+issueID, installationID,
 		map[string]any{"description": "stale"}, map[string]string{"issue_ref": issueID})
 	staleRequest.Header.Set("If-Match", wantETag)
-	stale := httptest.NewRecorder()
-	testHandler.PatchPluginIssue(stale, staleRequest)
-	if stale.Code != http.StatusConflict {
-		t.Fatalf("stale patch status=%d body=%s", stale.Code, stale.Body.String())
-	}
+	stale := testutil.Call(t, testHandler.PatchPluginIssue, staleRequest).Want(http.StatusConflict)
 	var conflict publicapiv1.Problem
-	if err := json.Unmarshal(stale.Body.Bytes(), &conflict); err != nil {
-		t.Fatalf("decode revision conflict: %v", err)
-	}
-	if conflict.Code != "revision_conflict" {
-		t.Fatalf("conflict code = %q", conflict.Code)
-	}
+	stale.JSON(&conflict)
+	testutil.Equal(t, conflict.Code, "revision_conflict", "HTTP status")
 }
 
 func TestPluginIssueConditionalPatchHasSingleWinner(t *testing.T) {
 	installationID := installPluginForAction(t, []string{"issues:read", "issues:write"})
 	issueID := createTestIssue(t, "Plugin conditional write test", "todo", "none")
 
-	get := httptest.NewRecorder()
-	testHandler.GetPluginIssue(get, pluginActionRequest(http.MethodGet, "/v1/issues/"+issueID, installationID, nil,
-		map[string]string{"issue_ref": issueID}))
-	if get.Code != http.StatusOK {
-		t.Fatalf("get issue status=%d body=%s", get.Code, get.Body.String())
-	}
+	get := testutil.Call(t, testHandler.GetPluginIssue, pluginActionRequest(http.MethodGet, "/v1/issues/"+issueID, installationID, nil,
+		map[string]string{"issue_ref": issueID})).Want(http.StatusOK)
 	etag := get.Header().Get("ETag")
 
 	start := make(chan struct{})
@@ -270,8 +214,7 @@ func TestPluginIssueConditionalPatchHasSingleWinner(t *testing.T) {
 				map[string]any{"title": title}, map[string]string{"issue_ref": issueID})
 			request.Header.Set("If-Match", etag)
 			<-start
-			response := httptest.NewRecorder()
-			testHandler.PatchPluginIssue(response, request)
+			response := testutil.Call(t, testHandler.PatchPluginIssue, request)
 			results <- response.Code
 		}(title)
 	}
@@ -297,17 +240,13 @@ func TestPluginActionRefusedWithoutAnInstallation(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	testHandler.GetPluginIssue(recorder, pluginActionRequest(http.MethodGet, "/issues", "", nil,
 		map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("missing installation header status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusBadRequest, "HTTP status")
 
 	// An installation id that does not exist is a 404, never a pass-through.
 	recorder = httptest.NewRecorder()
 	testHandler.GetPluginIssue(recorder, pluginActionRequest(http.MethodGet, "/issues",
 		"11111111-1111-1111-1111-111111111111", nil, map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("unknown installation status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusNotFound, "HTTP status")
 }
 
 func TestPluginActionStopsWhenTheInstallationIsDisabled(t *testing.T) {
@@ -317,38 +256,28 @@ func TestPluginActionStopsWhenTheInstallationIsDisabled(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	testHandler.DisablePlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/disable", nil,
 		map[string]string{"id": testWorkspaceID, "installationId": installationID}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("disable status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 
 	// A surface left open in a stale tab keeps its bridge; disabling has to cut
 	// it off server-side or "disabled" only means "hidden".
 	recorder = httptest.NewRecorder()
 	testHandler.GetPluginIssue(recorder, pluginActionRequest(http.MethodGet, "/issues", installationID, nil,
 		map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("disabled installation status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusForbidden, "HTTP status")
 }
 
 func TestPluginCommentIsAuthoredByTheUserAndMarkedWithThePlugin(t *testing.T) {
 	installationID := installPluginForAction(t, []string{"issues:read", "comments:write"})
 	issueID := createTestIssue(t, "Plugin action attribution test", "todo", "none")
 
-	recorder := httptest.NewRecorder()
-	testHandler.CreatePluginComment(recorder, pluginActionRequest(http.MethodPost, "/comments", installationID,
-		map[string]any{"content": "posted through a plugin"}, map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("create comment status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.CreatePluginComment, pluginActionRequest(http.MethodPost, "/comments", installationID,
+		map[string]any{"content": "posted through a plugin"}, map[string]string{"issue_ref": issueID})).Want(http.StatusCreated)
 	var created struct {
 		ID         string `json:"id"`
 		AuthorType string `json:"author_type"`
 		AuthorID   string `json:"author_id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &created); err != nil {
-		t.Fatalf("decode comment: %v", err)
-	}
+	recorder.JSON(&created)
 	// Permission-wise the write is the user's...
 	if created.AuthorType != "member" || created.AuthorID != testUserID {
 		t.Fatalf("comment was not authored by the calling user: %+v", created)
@@ -371,12 +300,8 @@ func TestPluginActionCannotReachAnotherWorkspacesIssue(t *testing.T) {
 	// plugin inherits the user's reach and nothing more, so this is the same
 	// answer the ordinary issue endpoint gives.
 	otherWorkspaceIssue := createIssueInForeignWorkspace(t)
-	recorder := httptest.NewRecorder()
-	testHandler.GetPluginIssue(recorder, pluginActionRequest(http.MethodGet, "/issues", installationID, nil,
-		map[string]string{"issue_ref": otherWorkspaceIssue}))
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("cross-workspace read status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, pluginActionRequest(http.MethodGet, "/issues", installationID, nil,
+		map[string]string{"issue_ref": otherWorkspaceIssue})).Want(http.StatusNotFound)
 }
 
 // createIssueInForeignWorkspace seeds a workspace the test user is NOT a member

--- a/server/internal/handler/plugin_callback_test.go
+++ b/server/internal/handler/plugin_callback_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/plugincontract"
 )
@@ -75,14 +76,10 @@ func TestCallbackFromAUserTriggeredHookWritesAsTheUser(t *testing.T) {
 	issueID := createTestIssue(t, "Callback attribution member", "todo", "none")
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "member", ID: parseUUID(testUserID)})
-	recorder := httptest.NewRecorder()
-	testHandler.CreatePluginComment(recorder, callbackRequest(token, http.MethodPost,
+	testutil.Call(t, testHandler.CreatePluginComment, callbackRequest(token, http.MethodPost,
 		"/v1/issues/"+issueID+"/comments",
 		map[string]any{"content": "posted by a manual hook"},
-		map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+		map[string]string{"issue_ref": issueID})).Want(http.StatusCreated)
 
 	comment := latestComment(t, issueID)
 	if comment.AuthorType != "member" {
@@ -106,14 +103,10 @@ func TestCallbackFromAnEventHookWritesAsThePlugin(t *testing.T) {
 	issueID := createTestIssue(t, "Callback attribution plugin", "todo", "none")
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "plugin", ID: parseUUID(installationID)})
-	recorder := httptest.NewRecorder()
-	testHandler.CreatePluginComment(recorder, callbackRequest(token, http.MethodPost,
+	testutil.Call(t, testHandler.CreatePluginComment, callbackRequest(token, http.MethodPost,
 		"/v1/issues/"+issueID+"/comments",
 		map[string]any{"content": "posted by an event hook"},
-		map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+		map[string]string{"issue_ref": issueID})).Want(http.StatusCreated)
 
 	comment := latestComment(t, issueID)
 	if comment.AuthorType != "plugin" {
@@ -135,31 +128,19 @@ func TestCallbackTokenServesTheWholeInvocation(t *testing.T) {
 	issueID := createTestIssue(t, "Callback single use", "todo", "none")
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "member", ID: parseUUID(testUserID)})
-	first := httptest.NewRecorder()
-	testHandler.GetPluginIssue(first, callbackRequest(token, http.MethodGet,
-		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID}))
-	if first.Code != http.StatusOK {
-		t.Fatalf("first use: status=%d body=%s", first.Code, first.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, callbackRequest(token, http.MethodGet,
+		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID})).Want(http.StatusOK)
 
 	// The read-then-write shape every non-trivial handler has.
-	second := httptest.NewRecorder()
-	testHandler.CreatePluginComment(second, callbackRequest(token, http.MethodPost,
+	testutil.Call(t, testHandler.CreatePluginComment, callbackRequest(token, http.MethodPost,
 		"/v1/issues/"+issueID+"/comments",
 		map[string]any{"content": "and now a comment about what I read"},
-		map[string]string{"issue_ref": issueID}))
-	if second.Code != http.StatusCreated {
-		t.Fatalf("a handler must be able to write after reading: status=%d body=%s", second.Code, second.Body.String())
-	}
+		map[string]string{"issue_ref": issueID})).Want(http.StatusCreated)
 
 	// Revoked once the invocation is over.
 	testHandler.PluginService.Callbacks.Revoke(token)
-	third := httptest.NewRecorder()
-	testHandler.GetPluginIssue(third, callbackRequest(token, http.MethodGet,
-		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID}))
-	if third.Code != http.StatusForbidden {
-		t.Fatalf("a revoked grant must be refused: status=%d body=%s", third.Code, third.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, callbackRequest(token, http.MethodGet,
+		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID})).Want(http.StatusForbidden)
 }
 
 // storage:user is per-member state. A caller with no member has no such scope
@@ -172,14 +153,10 @@ func TestPluginActorCannotReachUserStorage(t *testing.T) {
 	installationID := installPluginForAction(t, []string{"issues:read", "comments:write", "storage:user"})
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "plugin", ID: parseUUID(installationID)})
-	recorder := httptest.NewRecorder()
-	testHandler.PutPluginStorage(recorder, callbackRequest(token, http.MethodPut,
+	testutil.Call(t, testHandler.PutPluginStorage, callbackRequest(token, http.MethodPut,
 		"/v1/storage/user/pref",
 		map[string]any{"value": "x"},
-		map[string]string{"scope": "user", "key": "pref"}))
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status=%d body=%s, want 403", recorder.Code, recorder.Body.String())
-	}
+		map[string]string{"scope": "user", "key": "pref"})).Want(http.StatusForbidden)
 }
 
 // /context has no scope requirement, but it must not invent a user for a caller
@@ -192,16 +169,10 @@ func TestPluginContextOmitsTheUserForAPluginActor(t *testing.T) {
 	installationID := installHookPlugin(t)
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "plugin", ID: parseUUID(installationID)})
-	recorder := httptest.NewRecorder()
-	testHandler.GetPluginContext(recorder, callbackRequest(token, http.MethodGet, "/v1/context", nil, nil))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.GetPluginContext, callbackRequest(token, http.MethodGet, "/v1/context", nil, nil)).Want(http.StatusOK)
 
 	var payload map[string]any
-	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
-		t.Fatalf("decode context: %v", err)
-	}
+	recorder.JSON(&payload)
 	if _, present := payload["user"]; present {
 		t.Fatalf("context carried a user for a plugin actor: %s", recorder.Body.String())
 	}
@@ -257,29 +228,17 @@ func TestCallbackTokenCannotReachAnotherIssue(t *testing.T) {
 	}
 
 	// The issue it was issued for: allowed.
-	ok := httptest.NewRecorder()
-	testHandler.GetPluginIssue(ok, callbackRequest(token, http.MethodGet,
-		"/v1/issues/"+granted, nil, map[string]string{"issue_ref": granted}))
-	if ok.Code != http.StatusOK {
-		t.Fatalf("the granted issue must be reachable: status=%d body=%s", ok.Code, ok.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, callbackRequest(token, http.MethodGet,
+		"/v1/issues/"+granted, nil, map[string]string{"issue_ref": granted})).Want(http.StatusOK)
 
 	// Any other issue in the same workspace: refused, on both read and write.
-	refusedRead := httptest.NewRecorder()
-	testHandler.GetPluginIssue(refusedRead, callbackRequest(token, http.MethodGet,
-		"/v1/issues/"+other, nil, map[string]string{"issue_ref": other}))
-	if refusedRead.Code != http.StatusNotFound {
-		t.Fatalf("reading another issue must be refused: status=%d body=%s", refusedRead.Code, refusedRead.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, callbackRequest(token, http.MethodGet,
+		"/v1/issues/"+other, nil, map[string]string{"issue_ref": other})).Want(http.StatusNotFound)
 
-	refusedWrite := httptest.NewRecorder()
-	testHandler.CreatePluginComment(refusedWrite, callbackRequest(token, http.MethodPost,
+	testutil.Call(t, testHandler.CreatePluginComment, callbackRequest(token, http.MethodPost,
 		"/v1/issues/"+other+"/comments",
 		map[string]any{"content": "should never land"},
-		map[string]string{"issue_ref": other}))
-	if refusedWrite.Code != http.StatusNotFound {
-		t.Fatalf("commenting on another issue must be refused: status=%d body=%s", refusedWrite.Code, refusedWrite.Body.String())
-	}
+		map[string]string{"issue_ref": other})).Want(http.StatusNotFound)
 }
 
 // An invocation with no issue produces an unscoped grant. That is not a hole —
@@ -293,10 +252,6 @@ func TestCallbackTokenWithoutAnIssueIsNotNarrowed(t *testing.T) {
 	issueID := createTestIssue(t, "Callback unscoped grant", "todo", "none")
 
 	token := issueCallbackToken(t, installationID, service.HookActor{Type: "member", ID: parseUUID(testUserID)})
-	recorder := httptest.NewRecorder()
-	testHandler.GetPluginIssue(recorder, callbackRequest(token, http.MethodGet,
-		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("an unscoped grant must still reach the workspace: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.GetPluginIssue, callbackRequest(token, http.MethodGet,
+		"/v1/issues/"+issueID, nil, map[string]string{"issue_ref": issueID})).Want(http.StatusOK)
 }

--- a/server/internal/handler/plugin_example_test.go
+++ b/server/internal/handler/plugin_example_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util/secretbox"
 	"github.com/multica-ai/multica/server/pkg/plugincontract"
 	"github.com/multica-ai/multica/server/pkg/remotemcp"
@@ -181,20 +182,13 @@ func installExamplePlugin(t *testing.T, servers exampleServers) string {
 		"version_id":     versionID,
 		"granted_scopes": scopes,
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install deploy-sentinel: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	t.Cleanup(func() {
-		cleanup := httptest.NewRecorder()
-		testHandler.UninstallPlugin(cleanup, pluginHandlerRequest(http.MethodDelete, "/plugins", nil,
+		testutil.Call(t, testHandler.UninstallPlugin, pluginHandlerRequest(http.MethodDelete, "/plugins", nil,
 			map[string]string{"id": testWorkspaceID, "installationId": installed.ID}))
 	})
 	return installed.ID
@@ -209,12 +203,8 @@ func configureExamplePlugin(t *testing.T, installationID string) {
 		"environment":             "production",
 		"sentinel_token":          "sentinel-secret",
 	}})
-	recorder := httptest.NewRecorder()
-	testHandler.ConfigurePlugin(recorder, pluginHandlerRequest(http.MethodPut, "/config", body,
-		map[string]string{"id": testWorkspaceID, "installationId": installationID}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("configure: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.ConfigurePlugin, pluginHandlerRequest(http.MethodPut, "/config", body,
+		map[string]string{"id": testWorkspaceID, "installationId": installationID})).Want(http.StatusOK)
 }
 
 // quietServer is the plugin's own hook endpoint: TLS, because the http
@@ -387,9 +377,7 @@ func TestExamplePluginMCPToolsNeedApproval(t *testing.T) {
 	testHandler.ListPluginMCPTools(recorder, pluginHandlerRequest(http.MethodGet, "/mcp/tools", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID, "hookKey": "metrics",
 	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("discover: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 	var discovered struct {
 		Tools []struct {
 			Name     string `json:"name"`
@@ -422,9 +410,7 @@ func TestExamplePluginMCPToolsNeedApproval(t *testing.T) {
 	testHandler.ApprovePluginMCPTools(recorder, pluginHandlerRequest(http.MethodPut, "/mcp/tools", approve, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID, "hookKey": "metrics",
 	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("approve: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 
 	connections, err = testHandler.PluginService.AgentMCPConnections(context.Background(), parseUUID(testWorkspaceID))
 	if err != nil {

--- a/server/internal/handler/plugin_hook_test.go
+++ b/server/internal/handler/plugin_hook_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/multica-ai/multica/server/internal/service"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/pkg/plugincontract"
@@ -52,17 +54,11 @@ func installHookPlugin(t *testing.T) string {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read", "comments:write", "net:example.com"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install hook plugin: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	return installed.ID
 }
 
@@ -86,8 +82,7 @@ func TestInvokePluginHookRefusesHostDrivenTriggers(t *testing.T) {
 	installationID := installHookPlugin(t)
 
 	for _, trigger := range []string{plugincontract.TriggerEvent, plugincontract.TriggerAgent, "", "nonsense"} {
-		recorder := httptest.NewRecorder()
-		testHandler.InvokePluginHook(recorder, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": trigger}))
+		recorder := testutil.Call(t, testHandler.InvokePluginHook, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": trigger}))
 		if recorder.Code != http.StatusBadRequest {
 			t.Fatalf("trigger %q: status=%d body=%s, want 400", trigger, recorder.Code, recorder.Body.String())
 		}
@@ -101,15 +96,12 @@ func TestInvokePluginHookRefusesTriggerTheManifestDidNotDeclare(t *testing.T) {
 	cleanupPluginInstallations(t)
 	installationID := installHookPlugin(t)
 
-	recorder := httptest.NewRecorder()
 	// manual_only declares manual, not ui.
-	testHandler.InvokePluginHook(recorder, invokeHookRequest(installationID, "manual_only", map[string]any{"trigger": "ui"}))
+	recorder := testutil.Call(t, testHandler.InvokePluginHook, invokeHookRequest(installationID, "manual_only", map[string]any{"trigger": "ui"}))
 	if recorder.Code == http.StatusOK {
 		t.Fatalf("a hook was invoked through a trigger it never declared: %s", recorder.Body.String())
 	}
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status=%d body=%s, want 403", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusForbidden, "HTTP status")
 }
 
 func TestInvokePluginHookRefusesUnknownHook(t *testing.T) {
@@ -117,11 +109,7 @@ func TestInvokePluginHookRefusesUnknownHook(t *testing.T) {
 	cleanupPluginInstallations(t)
 	installationID := installHookPlugin(t)
 
-	recorder := httptest.NewRecorder()
-	testHandler.InvokePluginHook(recorder, invokeHookRequest(installationID, "not_declared", map[string]any{"trigger": "manual"}))
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("status=%d body=%s, want 404", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.InvokePluginHook, invokeHookRequest(installationID, "not_declared", map[string]any{"trigger": "manual"})).Want(http.StatusNotFound)
 }
 
 // The flag gates the hook endpoint like every other plugin route: fail closed,
@@ -132,11 +120,7 @@ func TestInvokePluginHookRequiresTheFeatureFlag(t *testing.T) {
 	installationID := installHookPlugin(t)
 
 	withPluginsV1Flag(t, testHandler, false)
-	recorder := httptest.NewRecorder()
-	testHandler.InvokePluginHook(recorder, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": "manual"}))
-	if recorder.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status=%d body=%s, want 503", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.InvokePluginHook, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": "manual"})).Want(http.StatusServiceUnavailable)
 }
 
 // A disabled installation is off, not hidden. A stale tab must not keep
@@ -146,19 +130,11 @@ func TestInvokePluginHookRefusesDisabledInstallation(t *testing.T) {
 	cleanupPluginInstallations(t)
 	installationID := installHookPlugin(t)
 
-	disable := httptest.NewRecorder()
-	testHandler.DisablePlugin(disable, pluginHandlerRequest(http.MethodPost, "/disable", nil, map[string]string{
+	testutil.Call(t, testHandler.DisablePlugin, pluginHandlerRequest(http.MethodPost, "/disable", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if disable.Code != http.StatusOK {
-		t.Fatalf("disable: status=%d body=%s", disable.Code, disable.Body.String())
-	}
+	})).Want(http.StatusOK)
 
-	recorder := httptest.NewRecorder()
-	testHandler.InvokePluginHook(recorder, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": "manual"}))
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status=%d body=%s, want 403", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.InvokePluginHook, invokeHookRequest(installationID, "summarize", map[string]any{"trigger": "manual"})).Want(http.StatusForbidden)
 }
 
 // The install token is returned once and stored only as a hash, so the same
@@ -234,13 +210,9 @@ func TestRotatePluginTokenPreservesPreviousTokenWhenPreparationFails(t *testing.
 	previous := rotateToken(t, installationID)
 	testHandler.PluginService.DeploymentKey = []byte("invalid")
 
-	response := httptest.NewRecorder()
-	testHandler.RotatePluginToken(response, pluginHandlerRequest(http.MethodPost, "/token", nil, map[string]string{
+	testutil.Call(t, testHandler.RotatePluginToken, pluginHandlerRequest(http.MethodPost, "/token", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if response.Code != http.StatusBadGateway {
-		t.Fatalf("failed preparation status=%d body=%s", response.Code, response.Body.String())
-	}
+	})).Want(http.StatusBadGateway)
 	if _, err := testHandler.PluginService.AuthenticateInstallToken(context.Background(), previous.Token); err != nil {
 		t.Fatalf("failed credential preparation invalidated the previous token: %v", err)
 	}
@@ -254,13 +226,9 @@ func TestRevokePluginTokenStopsAuthentication(t *testing.T) {
 	t.Cleanup(func() { testHandler.PluginService.DeploymentKey = nil })
 
 	issued := rotateToken(t, installationID)
-	recorder := httptest.NewRecorder()
-	testHandler.RevokePluginToken(recorder, pluginHandlerRequest(http.MethodDelete, "/token", nil, map[string]string{
+	testutil.Call(t, testHandler.RevokePluginToken, pluginHandlerRequest(http.MethodDelete, "/token", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if recorder.Code != http.StatusNoContent {
-		t.Fatalf("revoke: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusNoContent)
 	if _, err := testHandler.PluginService.AuthenticateInstallToken(context.Background(), issued.Token); err == nil {
 		t.Fatal("a revoked token must not authenticate")
 	}
@@ -279,17 +247,11 @@ func TestAuthenticateInstallTokenRefusesMalformedValues(t *testing.T) {
 
 func rotateToken(t *testing.T, installationID string) pluginTokenResponse {
 	t.Helper()
-	recorder := httptest.NewRecorder()
-	testHandler.RotatePluginToken(recorder, pluginHandlerRequest(http.MethodPost, "/token", nil, map[string]string{
+	recorder := testutil.Call(t, testHandler.RotatePluginToken, pluginHandlerRequest(http.MethodPost, "/token", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("rotate: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var issued pluginTokenResponse
-	if err := json.Unmarshal(recorder.Body.Bytes(), &issued); err != nil {
-		t.Fatalf("decode token response: %v", err)
-	}
+	recorder.JSON(&issued)
 	return issued
 }
 
@@ -350,11 +312,7 @@ func TestEventDispatchRespectsTheFeatureFlagEndToEnd(t *testing.T) {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read", "comments:write", "net:" + host},
 	})
-	install := httptest.NewRecorder()
-	testHandler.InstallPlugin(install, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if install.Code != http.StatusCreated {
-		t.Fatalf("install: status=%d body=%s", install.Code, install.Body.String())
-	}
+	testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 
 	dispatch := func() {
 		dispatcher := service.NewPluginEventDispatcher(testHandler.PluginService)

--- a/server/internal/handler/plugin_mcp_test.go
+++ b/server/internal/handler/plugin_mcp_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // The gates in front of an mcp hook's tool list.
@@ -61,20 +63,13 @@ func installMCPPlugin(t *testing.T, manifest string, scopes []string) string {
 	withPluginsV1Flag(t, testHandler, true)
 	versionID := withLocalPluginSource(t, manifest)
 	body, _ := json.Marshal(map[string]any{"version_id": versionID, "granted_scopes": scopes})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	t.Cleanup(func() {
-		cleanup := httptest.NewRecorder()
-		testHandler.UninstallPlugin(cleanup, pluginHandlerRequest(http.MethodDelete, "/plugins",
+		testutil.Call(t, testHandler.UninstallPlugin, pluginHandlerRequest(http.MethodDelete, "/plugins",
 			nil, map[string]string{"id": testWorkspaceID, "installationId": installed.ID}))
 	})
 	return installed.ID
@@ -93,18 +88,14 @@ func TestMCPToolListRejectsAnHTTPTransportHook(t *testing.T) {
 	installationID := installMCPPlugin(t, httpHookManifest, []string{"issues:read", "net:hooks.example.com"})
 
 	recorder := listMCPTools(t, installationID, "notify")
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("an http hook must not answer a tool list: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestMCPToolListRejectsAnUnknownHook(t *testing.T) {
 	installationID := installMCPPlugin(t, mcpToolboxManifest, []string{"issues:read", "net:tools.example.com"})
 
 	recorder := listMCPTools(t, installationID, "does-not-exist")
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("status=%d body=%s, want 404", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusNotFound, "HTTP status")
 }
 
 // The `net:` scope is the consent, and a hook's own transport URL is not
@@ -147,9 +138,7 @@ func TestMCPHookWithoutANetScopeCannotBePublished(t *testing.T) {
 	t.Cleanup(func() { testHandler.PluginService.LocalDir = previousDir })
 
 	body, _ := json.Marshal(map[string]string{"name": "hello"})
-	recorder := httptest.NewRecorder()
-	testHandler.PublishLocalPluginPackage(recorder,
-		pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
+	recorder := testutil.Call(t, testHandler.PublishLocalPluginPackage, pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
 	if recorder.Code == http.StatusCreated {
 		t.Fatal("a hook pointing outside its declared net: scopes was published")
 	}

--- a/server/internal/handler/plugin_package_concurrency_test.go
+++ b/server/internal/handler/plugin_package_concurrency_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Publish, install and delete race each other.
@@ -44,14 +45,11 @@ func TestDeleteAndInstallRaceLeavesNoDanglingInstallation(t *testing.T) {
 		go func() {
 			defer wait.Done()
 			body, _ := json.Marshal(map[string]any{"version_id": versionID, "granted_scopes": []string{"issues:read"}})
-			recorder := httptest.NewRecorder()
-			testHandler.InstallPlugin(recorder,
-				pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
+			testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
 		}()
 		go func() {
 			defer wait.Done()
-			recorder := httptest.NewRecorder()
-			testHandler.DeletePluginPackage(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil,
+			testutil.Call(t, testHandler.DeletePluginPackage, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil,
 				map[string]string{"id": testWorkspaceID, "packageId": published.ID}))
 		}()
 		wait.Wait()
@@ -91,8 +89,7 @@ func TestPublishAndDeleteRaceLeavesNoOrphanVersion(t *testing.T) {
 		}()
 		go func() {
 			defer wait.Done()
-			recorder := httptest.NewRecorder()
-			testHandler.DeletePluginPackage(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil,
+			testutil.Call(t, testHandler.DeletePluginPackage, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil,
 				map[string]string{"id": testWorkspaceID, "packageId": published.ID}))
 		}()
 		wait.Wait()
@@ -129,9 +126,7 @@ func TestFailedPublishDoesNotMovePackageState(t *testing.T) {
 	renamed := packageManifest("1.0.0")
 	renamed = replaceOnce(t, renamed, `"name": "Published Panel"`, `"name": "Renamed Panel"`)
 	recorder := uploadPluginBundle(t, pluginBundleZip(t, renamed, "console.log('tampered');\n"))
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("republish status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusConflict, "HTTP status")
 
 	var name string
 	var versions int

--- a/server/internal/handler/plugin_package_test.go
+++ b/server/internal/handler/plugin_package_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/plugincontract"
 )
 
@@ -94,9 +95,7 @@ func uploadPluginBundle(t *testing.T, archive []byte) *httptest.ResponseRecorder
 func publishUploadedBundle(t *testing.T, manifest, script string) service.PluginPackageSummary {
 	t.Helper()
 	recorder := uploadPluginBundle(t, pluginBundleZip(t, manifest, script))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("publish: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	var published service.PluginPackageSummary
 	if err := json.Unmarshal(recorder.Body.Bytes(), &published); err != nil {
 		t.Fatalf("decode published package: %v", err)
@@ -107,17 +106,11 @@ func publishUploadedBundle(t *testing.T, manifest, script string) service.Plugin
 func installPublishedVersion(t *testing.T, versionID string) string {
 	t.Helper()
 	body, _ := json.Marshal(map[string]any{"version_id": versionID, "granted_scopes": []string{"issues:read"}})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	return installed.ID
 }
 
@@ -146,13 +139,10 @@ func surfaceScript(t *testing.T, installationID, surfaceKey string) (*httptest.R
 		t.Fatalf("decode surface launch: %v", err)
 	}
 	token := launch.URL[strings.LastIndex(launch.URL, "/")+1:]
-	documentRecorder := httptest.NewRecorder()
+
 	documentRequest := pluginHandlerRequest(http.MethodGet, "/plugin-surfaces/"+token, nil, map[string]string{"token": token})
 	documentRequest.Host = "plugin-content.example.test"
-	testHandler.ServePluginSurface(documentRecorder, documentRequest)
-	if documentRecorder.Code != http.StatusOK {
-		t.Fatalf("serve hosted surface: status=%d body=%s", documentRecorder.Code, documentRecorder.Body.String())
-	}
+	documentRecorder := testutil.Call(t, testHandler.ServePluginSurface, documentRequest).Want(http.StatusOK)
 	encoded := regexp.MustCompile(`id="multica-surface-code">([^<]+)</script>`).FindStringSubmatch(documentRecorder.Body.String())
 	if len(encoded) != 2 {
 		t.Fatal("hosted surface did not contain stored code")
@@ -182,9 +172,7 @@ func TestUploadedBundleInstallsAndServesItsOwnCode(t *testing.T) {
 
 	installationID := installPublishedVersion(t, published.Versions[0].ID)
 	recorder, script := surfaceScript(t, installationID, "hello")
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("surface script: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 	if !strings.Contains(script.Code, "console.log('v1')") {
 		t.Fatalf("the served code is not what was uploaded: %q", script.Code)
 	}
@@ -250,9 +238,7 @@ func TestPublishRefusesToOverwriteAnExistingVersion(t *testing.T) {
 
 	publishUploadedBundle(t, packageManifest("1.0.0"), "console.log('v1');\n")
 	recorder := uploadPluginBundle(t, pluginBundleZip(t, packageManifest("1.0.0"), "console.log('tampered');\n"))
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("republish status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusConflict, "HTTP status")
 	if !strings.Contains(recorder.Body.String(), "immutable") {
 		t.Fatalf("the conflict does not explain itself: %s", recorder.Body.String())
 	}
@@ -269,23 +255,15 @@ func TestDeletePublishedPackageRefusesWhileInstalled(t *testing.T) {
 	params := map[string]string{"id": testWorkspaceID, "packageId": published.ID}
 	recorder := httptest.NewRecorder()
 	testHandler.DeletePluginPackage(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil, params))
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("delete while installed status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusConflict, "HTTP status")
 
-	uninstall := httptest.NewRecorder()
-	testHandler.UninstallPlugin(uninstall, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, map[string]string{
+	testutil.Call(t, testHandler.UninstallPlugin, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if uninstall.Code != http.StatusNoContent {
-		t.Fatalf("uninstall status=%d body=%s", uninstall.Code, uninstall.Body.String())
-	}
+	})).Want(http.StatusNoContent)
 
 	recorder = httptest.NewRecorder()
 	testHandler.DeletePluginPackage(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins/packages", nil, params))
-	if recorder.Code != http.StatusNoContent {
-		t.Fatalf("delete after uninstall status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusNoContent, "HTTP status")
 
 	// The stored bundle goes with it; a package row with orphaned files behind
 	// it is storage nothing can reach.
@@ -315,13 +293,9 @@ func TestSurfaceScriptRefusesWhatWasNeverInstalled(t *testing.T) {
 		t.Fatalf("unknown surface key status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
 
-	disable := httptest.NewRecorder()
-	testHandler.DisablePlugin(disable, pluginHandlerRequest(http.MethodPost, "/plugins/disable", nil, map[string]string{
+	testutil.Call(t, testHandler.DisablePlugin, pluginHandlerRequest(http.MethodPost, "/plugins/disable", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if disable.Code != http.StatusOK {
-		t.Fatalf("disable status=%d body=%s", disable.Code, disable.Body.String())
-	}
+	})).Want(http.StatusOK)
 	// Disabling has to stop the code from being served, or "disabled" is a UI
 	// state rather than a decision.
 	if recorder, _ := surfaceScript(t, installationID, "hello"); recorder.Code != http.StatusForbidden {

--- a/server/internal/handler/plugin_skill_test.go
+++ b/server/internal/handler/plugin_skill_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // A plugin's skill resource becomes an ordinary workspace skill, and uninstall
@@ -57,17 +58,11 @@ func installSkillPlugin(t *testing.T, root, manifest string) string {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 	var installed struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &installed); err != nil {
-		t.Fatalf("decode installation: %v", err)
-	}
+	recorder.JSON(&installed)
 	return installed.ID
 }
 
@@ -117,13 +112,9 @@ func TestPluginSkillInstallsAndIsRemovedOnUninstall(t *testing.T) {
 		t.Fatal("description should come from the frontmatter")
 	}
 
-	uninstall := httptest.NewRecorder()
-	testHandler.UninstallPlugin(uninstall, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, map[string]string{
+	testutil.Call(t, testHandler.UninstallPlugin, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, map[string]string{
 		"id": testWorkspaceID, "installationId": installationID,
-	}))
-	if uninstall.Code != http.StatusNoContent {
-		t.Fatalf("uninstall: status=%d body=%s", uninstall.Code, uninstall.Body.String())
-	}
+	})).Want(http.StatusNoContent)
 	if remaining := skillNamesForInstallation(t, installationID); len(remaining) != 0 {
 		t.Fatalf("uninstall left skills behind: %v", remaining)
 	}
@@ -170,15 +161,7 @@ func TestPluginSkillWillNotOverwriteAHumanAuthoredSkill(t *testing.T) {
 	cleanupPluginInstallations(t)
 
 	var existingID string
-	if err := testPool.QueryRow(context.Background(),
-		`INSERT INTO skill (workspace_id, name, description, content) VALUES ($1, 'pr-review', 'mine', 'written by a person') RETURNING id`,
-		testWorkspaceID,
-	).Scan(&existingID); err != nil {
-		t.Fatalf("seed human skill: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, existingID)
-	})
+	existingID = dbfx.Insert(t, "skill", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'pr-review'"), "description": testutil.Raw("'mine'"), "content": testutil.Raw("'written by a person'")})
 
 	root := t.TempDir()
 	writePluginSkillFile(t, root, "pr-review", prReviewSkill)
@@ -187,8 +170,7 @@ func TestPluginSkillWillNotOverwriteAHumanAuthoredSkill(t *testing.T) {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
 	if recorder.Code == http.StatusCreated {
 		t.Fatal("a plugin claiming an existing skill name must not install")
 	}

--- a/server/internal/handler/plugin_surface_test.go
+++ b/server/internal/handler/plugin_surface_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func pluginSurfaceTokenHandler(t *testing.T) *Handler {
@@ -116,12 +118,7 @@ func TestServePluginSurfaceRejectsConfiguredAppOriginBeforeOpeningToken(t *testi
 
 	request := pluginHandlerRequest(http.MethodGet, "/plugin-surfaces/"+token, nil, map[string]string{"token": token})
 	request.Host = "app.example.test"
-	recorder := httptest.NewRecorder()
-	h.ServePluginSurface(recorder, request)
-
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("shared app/content origin: status=%d, want %d", recorder.Code, http.StatusNotFound)
-	}
+	testutil.Call(t, h.ServePluginSurface, request).Want(http.StatusNotFound)
 }
 
 func TestPluginSurfaceHostExposesOnlySurfaceDocuments(t *testing.T) {
@@ -134,16 +131,14 @@ func TestPluginSurfaceHostExposesOnlySurfaceDocuments(t *testing.T) {
 
 	blocked := httptest.NewRequest(http.MethodGet, "https://plugin-content.example.test/api/config", nil)
 	blocked.Host = "plugin-content.example.test"
-	blockedRecorder := httptest.NewRecorder()
-	boundary.ServeHTTP(blockedRecorder, blocked)
+	blockedRecorder := testutil.Call(t, boundary.ServeHTTP, blocked)
 	if blockedRecorder.Code != http.StatusNotFound || called {
 		t.Fatalf("content host API request: status=%d called=%v", blockedRecorder.Code, called)
 	}
 
 	allowed := httptest.NewRequest(http.MethodGet, "https://plugin-content.example.test/plugin-surfaces/token", nil)
 	allowed.Host = "plugin-content.example.test"
-	allowedRecorder := httptest.NewRecorder()
-	boundary.ServeHTTP(allowedRecorder, allowed)
+	allowedRecorder := testutil.Call(t, boundary.ServeHTTP, allowed)
 	if allowedRecorder.Code != http.StatusNoContent || !called {
 		t.Fatalf("content document request: status=%d called=%v", allowedRecorder.Code, called)
 	}

--- a/server/internal/handler/plugin_test.go
+++ b/server/internal/handler/plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util/secretbox"
 	"github.com/multica-ai/multica/server/pkg/plugincontract"
 )
@@ -180,16 +181,12 @@ func withLocalPluginSourceIn(t *testing.T, root string, manifest string) string 
 func publishLocalPlugin(t *testing.T, name string) string {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{"name": name})
-	recorder := httptest.NewRecorder()
-	testHandler.PublishLocalPluginPackage(recorder,
-		pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
+	recorder := testutil.Call(t, testHandler.PublishLocalPluginPackage, pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("publish %s: status=%d body=%s", name, recorder.Code, recorder.Body.String())
 	}
 	var published service.PluginPackageSummary
-	if err := json.Unmarshal(recorder.Body.Bytes(), &published); err != nil {
-		t.Fatalf("decode published package: %v", err)
-	}
+	recorder.JSON(&published)
 	if len(published.Versions) == 0 {
 		t.Fatalf("publish %s returned no versions", name)
 	}
@@ -226,9 +223,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 	})
 	recorder := httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", install, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	var installed struct {
 		ID string `json:"id"`
 	}
@@ -256,9 +251,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	testHandler.DisablePlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/disable", nil, params))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("disable status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 	enabled, generationDisabled, _ := loadSchedule()
 	if enabled || generationDisabled != generation1 {
 		t.Fatalf("disabled schedule enabled=%v generation=%q, want disabled generation %q", enabled, generationDisabled, generation1)
@@ -275,9 +268,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	testHandler.EnablePlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/enable", nil, params))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("enable status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 	enabled, generation2, _ := loadSchedule()
 	if !enabled || generation2 == generation1 {
 		t.Fatalf("reactivated schedule enabled=%v generation=%q, previous %q", enabled, generation2, generation1)
@@ -292,9 +283,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 	upgrade, _ := json.Marshal(map[string]any{"version_id": upgradeVersionID, "granted_scopes": []string{"net:example.com"}})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", upgrade, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("unchanged upgrade status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	_, generationUnchanged, _ := loadSchedule()
 	if generationUnchanged != generation2 {
 		t.Fatalf("code-only upgrade rotated generation: got %q want %q", generationUnchanged, generation2)
@@ -307,9 +296,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 	upgrade, _ = json.Marshal(map[string]any{"version_id": changedVersionID, "granted_scopes": []string{"net:example.com"}})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", upgrade, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("changed upgrade status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	_, generation3, cron := loadSchedule()
 	if generation3 == generation2 || cron != "*/10 * * * *" {
 		t.Fatalf("changed schedule generation=%q cron=%q, previous generation %q", generation3, cron, generation2)
@@ -323,9 +310,7 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 	upgrade, _ = json.Marshal(map[string]any{"version_id": removedVersionID, "granted_scopes": []string{"net:example.com"}})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", upgrade, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("schedule-removing upgrade status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	var remaining int
 	if err := testPool.QueryRow(context.Background(), `SELECT COUNT(*) FROM plugin_hook_schedule WHERE installation_id = $1`, installed.ID).Scan(&remaining); err != nil {
 		t.Fatalf("count removed schedules: %v", err)
@@ -342,16 +327,12 @@ func TestPluginScheduleLifecycleReconcilesAtomically(t *testing.T) {
 	upgrade, _ = json.Marshal(map[string]any{"version_id": restoredVersionID, "granted_scopes": []string{"net:example.com"}})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", upgrade, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("schedule-restoring upgrade status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	loadSchedule()
 
 	recorder = httptest.NewRecorder()
 	testHandler.UninstallPlugin(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, params))
-	if recorder.Code != http.StatusNoContent {
-		t.Fatalf("uninstall status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusNoContent, "HTTP status")
 	if err := testPool.QueryRow(context.Background(), `SELECT COUNT(*) FROM plugin_hook_schedule WHERE installation_id = $1`, installed.ID).Scan(&remaining); err != nil {
 		t.Fatalf("count schedules after uninstall: %v", err)
 	}
@@ -372,11 +353,7 @@ func TestPluginManagementRequiresPluginsV1(t *testing.T) {
 		"uninstall": testHandler.UninstallPlugin,
 	} {
 		t.Run(name, func(t *testing.T) {
-			recorder := httptest.NewRecorder()
-			handler(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", []byte(`{}`), map[string]string{"id": testWorkspaceID}))
-			if recorder.Code != http.StatusServiceUnavailable {
-				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-			}
+			testutil.Call(t, handler, pluginHandlerRequest(http.MethodPost, "/plugins", []byte(`{}`), map[string]string{"id": testWorkspaceID})).Want(http.StatusServiceUnavailable)
 		})
 	}
 }
@@ -386,17 +363,11 @@ func TestPluginPreviewShowsScopesWithoutInstalling(t *testing.T) {
 	cleanupPluginInstallations(t)
 	versionID := withLocalPluginSource(t, handlerTestManifest)
 
-	recorder := httptest.NewRecorder()
 	body, _ := json.Marshal(map[string]string{"version_id": versionID})
-	testHandler.PreviewPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/preview", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("preview status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.PreviewPlugin, pluginHandlerRequest(http.MethodPost, "/plugins/preview", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusOK)
 
 	var preview service.PluginPreview
-	if err := json.Unmarshal(recorder.Body.Bytes(), &preview); err != nil {
-		t.Fatalf("decode preview: %v", err)
-	}
+	recorder.JSON(&preview)
 	if len(preview.Scopes) != 3 || preview.Installed {
 		t.Fatalf("unexpected preview: %+v", preview)
 	}
@@ -406,17 +377,11 @@ func TestPluginPreviewShowsScopesWithoutInstalling(t *testing.T) {
 
 	// Preview must be side-effect free: the consent screen has to be able to
 	// show scopes before anything exists to revoke.
-	listRecorder := httptest.NewRecorder()
-	testHandler.ListPlugins(listRecorder, pluginHandlerRequest(http.MethodGet, "/plugins", nil, map[string]string{"id": testWorkspaceID}))
-	if listRecorder.Code != http.StatusOK {
-		t.Fatalf("list status=%d body=%s", listRecorder.Code, listRecorder.Body.String())
-	}
+	listRecorder := testutil.Call(t, testHandler.ListPlugins, pluginHandlerRequest(http.MethodGet, "/plugins", nil, map[string]string{"id": testWorkspaceID})).Want(http.StatusOK)
 	var list struct {
 		Plugins []map[string]any `json:"plugins"`
 	}
-	if err := json.Unmarshal(listRecorder.Body.Bytes(), &list); err != nil {
-		t.Fatalf("decode list: %v", err)
-	}
+	listRecorder.JSON(&list)
 	if len(list.Plugins) != 0 {
 		t.Fatalf("preview created an installation: %v", list.Plugins)
 	}
@@ -430,9 +395,7 @@ func TestPluginInstallRequiresExactConsent(t *testing.T) {
 	partial, _ := json.Marshal(map[string]any{"version_id": versionID, "granted_scopes": []string{"issues:read"}})
 	recorder := httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", partial, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("partial consent status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusConflict, "HTTP status")
 
 	extra, _ := json.Marshal(map[string]any{
 		"version_id":     versionID,
@@ -440,9 +403,7 @@ func TestPluginInstallRequiresExactConsent(t *testing.T) {
 	})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", extra, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusConflict {
-		t.Fatalf("over-consent status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusConflict, "HTTP status")
 }
 
 func TestPluginInstallConfigureAndUninstall(t *testing.T) {
@@ -456,9 +417,7 @@ func TestPluginInstallConfigureAndUninstall(t *testing.T) {
 	})
 	recorder := httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", install, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	var installed struct {
 		ID                string         `json:"id"`
 		PluginKey         string         `json:"plugin_key"`
@@ -477,9 +436,7 @@ func TestPluginInstallConfigureAndUninstall(t *testing.T) {
 	configure, _ := json.Marshal(map[string]any{"values": map[string]any{"repo": "multica-ai/multica", "token": "sk-super-secret"}})
 	recorder = httptest.NewRecorder()
 	testHandler.ConfigurePlugin(recorder, pluginHandlerRequest(http.MethodPut, "/plugins/config", configure, params))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("configure status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusOK, "HTTP status")
 	// The secret must not come back in any form: not in `config`, not masked,
 	// not anywhere else in the payload.
 	if strings.Contains(recorder.Body.String(), "sk-super-secret") {
@@ -511,9 +468,7 @@ func TestPluginInstallConfigureAndUninstall(t *testing.T) {
 	unknown, _ := json.Marshal(map[string]any{"values": map[string]any{"nope": "x"}})
 	recorder = httptest.NewRecorder()
 	testHandler.ConfigurePlugin(recorder, pluginHandlerRequest(http.MethodPut, "/plugins/config", unknown, params))
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("unknown config field status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusBadRequest, "HTTP status")
 
 	recorder = httptest.NewRecorder()
 	testHandler.DisablePlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/disable", nil, params))
@@ -523,9 +478,7 @@ func TestPluginInstallConfigureAndUninstall(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	testHandler.UninstallPlugin(recorder, pluginHandlerRequest(http.MethodDelete, "/plugins", nil, params))
-	if recorder.Code != http.StatusNoContent {
-		t.Fatalf("uninstall status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusNoContent, "HTTP status")
 
 	// Uninstall must take the plugin's own state with it, or a reinstall would
 	// silently inherit rows nobody can audit.
@@ -555,12 +508,7 @@ func TestPluginPublishRejectsMalformedManifest(t *testing.T) {
 	t.Cleanup(func() { testHandler.PluginService.LocalDir = previousDir })
 
 	body, _ := json.Marshal(map[string]string{"name": "hello"})
-	recorder := httptest.NewRecorder()
-	testHandler.PublishLocalPluginPackage(recorder,
-		pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("malformed manifest status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.PublishLocalPluginPackage, pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusBadRequest)
 	if !strings.Contains(recorder.Body.String(), "manifest") {
 		t.Fatalf("malformed manifest error is not actionable: %s", recorder.Body.String())
 	}
@@ -586,12 +534,7 @@ func TestPluginPublishRejectsMissingSurfaceEntry(t *testing.T) {
 	t.Cleanup(func() { testHandler.PluginService.LocalDir = previousDir })
 
 	body, _ := json.Marshal(map[string]string{"name": "hello"})
-	recorder := httptest.NewRecorder()
-	testHandler.PublishLocalPluginPackage(recorder,
-		pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("missing surface entry status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.PublishLocalPluginPackage, pluginHandlerRequest(http.MethodPost, "/plugins/packages/local", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusBadRequest)
 	if !strings.Contains(recorder.Body.String(), "ui/main.js") {
 		t.Fatalf("error does not name the missing file: %s", recorder.Body.String())
 	}
@@ -621,11 +564,7 @@ func TestPluginInstallRejectsUnshippedCapabilities(t *testing.T) {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read", "net:example.com"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("unshipped capability status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusUnprocessableEntity)
 	// A declared-but-unrunnable contribution must fail the install outright and
 	// name what is missing: silently dropping it would look installed and never
 	// fire.
@@ -647,13 +586,10 @@ func TestPluginInstallAcceptsEveryCapabilityThisHostShips(t *testing.T) {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read", "net:example.com"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
+	recorder := testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
 	// hookOnlyTestManifest declares ui + http, both shipped by the hook engine.
 	// If this starts failing, the gate is refusing something the host can run.
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("a manifest declaring only shipped capabilities was refused: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 }
 
 func TestPluginInstallAcceptsAShippedSurface(t *testing.T) {
@@ -669,23 +605,15 @@ func TestPluginInstallAcceptsAShippedSurface(t *testing.T) {
 		"version_id":     versionID,
 		"granted_scopes": []string{"issues:read", "comments:write", "storage:user"},
 	})
-	recorder := httptest.NewRecorder()
-	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("shipped surface was refused: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, testHandler.InstallPlugin, pluginHandlerRequest(http.MethodPost, "/plugins", body, map[string]string{"id": testWorkspaceID})).Want(http.StatusCreated)
 }
 
 func TestPluginInstallationFromAnotherWorkspaceIsNotFound(t *testing.T) {
 	withPluginsV1Flag(t, testHandler, true)
-	recorder := httptest.NewRecorder()
-	testHandler.EnablePlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins/enable", nil, map[string]string{
+	testutil.Call(t, testHandler.EnablePlugin, pluginHandlerRequest(http.MethodPost, "/plugins/enable", nil, map[string]string{
 		"id":             testWorkspaceID,
 		"installationId": "11111111-1111-1111-1111-111111111111",
-	}))
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusNotFound)
 }
 
 func TestPluginUpgradePrunesSecretsTheNewManifestDropped(t *testing.T) {
@@ -700,9 +628,7 @@ func TestPluginUpgradePrunesSecretsTheNewManifestDropped(t *testing.T) {
 	})
 	recorder := httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", install, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("install status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	var installed struct {
 		ID string `json:"id"`
 	}
@@ -733,9 +659,7 @@ func TestPluginUpgradePrunesSecretsTheNewManifestDropped(t *testing.T) {
 	})
 	recorder = httptest.NewRecorder()
 	testHandler.InstallPlugin(recorder, pluginHandlerRequest(http.MethodPost, "/plugins", upgrade, map[string]string{"id": testWorkspaceID}))
-	if recorder.Code != http.StatusCreated {
-		t.Fatalf("upgrade status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Equal(t, recorder.Code, http.StatusCreated, "HTTP status")
 	if !strings.Contains(recorder.Body.String(), `"configured_secrets":[]`) {
 		t.Fatalf("upgrade left an unreachable secret: %s", recorder.Body.String())
 	}
@@ -792,19 +716,11 @@ func TestPluginRoutesRequireWorkspaceAdmin(t *testing.T) {
 		t.Run(route.method+" "+route.path, func(t *testing.T) {
 			request := newRequest(route.method, route.path, map[string]any{})
 			request.Header.Set("X-User-ID", memberID)
-			recorder := httptest.NewRecorder()
-			router.ServeHTTP(recorder, request)
-			if recorder.Code != http.StatusForbidden {
-				t.Fatalf("plain member reached an admin route: status=%d body=%s", recorder.Code, recorder.Body.String())
-			}
+			testutil.Call(t, router.ServeHTTP, request).Want(http.StatusForbidden)
 		})
 	}
 
 	request := newRequest(http.MethodGet, base+"/plugins", nil)
 	request.Header.Set("X-User-ID", memberID)
-	recorder := httptest.NewRecorder()
-	router.ServeHTTP(recorder, request)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("plain member could not list Plugins: status=%d body=%s", recorder.Code, recorder.Body.String())
-	}
+	testutil.Call(t, router.ServeHTTP, request).Want(http.StatusOK)
 }

--- a/server/internal/handler/project_dates_test.go
+++ b/server/internal/handler/project_dates_test.go
@@ -6,15 +6,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // decodeProject decodes a ProjectResponse from a recorder, failing the test on
 // a non-expected status or a decode error.
 func decodeProject(t *testing.T, w *httptest.ResponseRecorder, wantStatus int) ProjectResponse {
 	t.Helper()
-	if w.Code != wantStatus {
-		t.Fatalf("expected status %d, got %d: %s", wantStatus, w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, wantStatus, "HTTP status")
 	var p ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&p); err != nil {
 		t.Fatalf("decode ProjectResponse: %v", err)
@@ -99,9 +99,7 @@ func TestSearchProjectsCarriesDates(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	testHandler.SearchProjects(w, newRequest("GET", "/api/projects/search?q=zzsearchdated", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("search status = %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp struct {
 		Projects []SearchProjectResponse `json:"projects"`
 	}
@@ -130,9 +128,7 @@ func TestProjectInvalidDateReturns400(t *testing.T) {
 		"title":      "bad date project",
 		"start_date": "03/01/2026",
 	}))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid create start_date, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Seed a valid project, then reject a malformed update due_date.
 	w = httptest.NewRecorder()
@@ -149,7 +145,5 @@ func TestProjectInvalidDateReturns400(t *testing.T) {
 		"due_date": "not-a-date",
 	}), "id", project.ID)
 	testHandler.UpdateProject(w, putReq)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid update due_date, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -20,9 +21,7 @@ func TestProjectResourceLifecycle(t *testing.T) {
 		"title": "Resource lifecycle project",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -44,9 +43,7 @@ func TestProjectResourceLifecycle(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode CreateProjectResource: %v", err)
@@ -73,9 +70,7 @@ func TestProjectResourceLifecycle(t *testing.T) {
 	req = newRequest("GET", "/api/projects/"+project.ID+"/resources", nil)
 	req = withURLParam(req, "id", project.ID)
 	testHandler.ListProjectResources(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListProjectResources: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var listResp struct {
 		Resources []ProjectResourceResponse `json:"resources"`
 		Total     int                       `json:"total"`
@@ -134,9 +129,7 @@ func TestProjectResourceLifecycle(t *testing.T) {
 	req = newRequest("DELETE", "/api/projects/"+project.ID+"/resources/"+created.ID, nil)
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.DeleteProjectResource(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteProjectResource: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 
 	// After deletion the list should be empty.
 	w = httptest.NewRecorder()
@@ -156,18 +149,13 @@ func TestProjectResourceLifecycle(t *testing.T) {
 // repos configured with an SSH remote previously got rejected when attached
 // to a project.
 func TestProjectResourceAcceptsSSHRepoURLs(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "SSH repo URL acceptance",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	defer func() {
 		r := newRequest("DELETE", "/api/projects/"+project.ID, nil)
 		r = withURLParam(r, "id", project.ID)
@@ -183,20 +171,18 @@ func TestProjectResourceAcceptsSSHRepoURLs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest("POST", "/api/projects/"+project.ID+"/resources", map[string]any{
 				"resource_type": "github_repo",
 				"resource_ref":  map[string]any{"url": tc.url},
 			})
 			req = withURLParam(req, "id", project.ID)
-			testHandler.CreateProjectResource(w, req)
+			w := testutil.Call(t, testHandler.CreateProjectResource, req)
 			if w.Code != http.StatusCreated {
 				t.Fatalf("CreateProjectResource(%s): expected 201, got %d: %s", tc.url, w.Code, w.Body.String())
 			}
 			var created ProjectResourceResponse
-			if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-				t.Fatalf("decode: %v", err)
-			}
+			w.Decode(&created)
 			var ref struct {
 				URL string `json:"url"`
 			}
@@ -255,18 +241,16 @@ func TestIsValidGitRepoURL(t *testing.T) {
 // not to add a UNIQUE(daemon_id, local_path) constraint.
 func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 	createProject := func(title string) ProjectResponse {
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 			"title": title,
 		})
-		testHandler.CreateProject(w, req)
+		w := testutil.Call(t, testHandler.CreateProject, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateProject(%s): %d %s", title, w.Code, w.Body.String())
 		}
 		var p ProjectResponse
-		if err := json.NewDecoder(w.Body).Decode(&p); err != nil {
-			t.Fatalf("decode CreateProject: %v", err)
-		}
+		w.Decode(&p)
 		return p
 	}
 	deleteProject := func(id string) {
@@ -297,9 +281,7 @@ func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 	})
 	req = withURLParam(req, "id", projectA.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode CreateProjectResource: %v", err)
@@ -324,9 +306,7 @@ func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 	req = newRequest("GET", "/api/projects/"+projectA.ID+"/resources", nil)
 	req = withURLParam(req, "id", projectA.ID)
 	testHandler.ListProjectResources(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListProjectResources: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var listResp struct {
 		Resources []ProjectResourceResponse `json:"resources"`
 		Total     int                       `json:"total"`
@@ -351,9 +331,7 @@ func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 	})
 	req = withURLParam(req, "id", projectB.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("same path on project B: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Duplicate attach on the same project must still conflict — the
 	// UNIQUE(project_id, resource_type, resource_ref) row constraint
@@ -378,9 +356,7 @@ func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 	req = newRequest("DELETE", "/api/projects/"+projectA.ID+"/resources/"+created.ID, nil)
 	req = withURLParams(req, "id", projectA.ID, "resourceId", created.ID)
 	testHandler.DeleteProjectResource(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteProjectResource: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 }
 
 // TestProjectResourceLocalDirectoryValidation pins the schema rejection
@@ -389,18 +365,13 @@ func TestProjectResourceLocalDirectoryLifecycle(t *testing.T) {
 // errors agents will hit, so freezing them as tests prevents accidental
 // loosening when someone touches the validator.
 func TestProjectResourceLocalDirectoryValidation(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "Local directory validation",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	defer func() {
 		r := newRequest("DELETE", "/api/projects/"+project.ID, nil)
 		r = withURLParam(r, "id", project.ID)
@@ -421,13 +392,13 @@ func TestProjectResourceLocalDirectoryValidation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest("POST", "/api/projects/"+project.ID+"/resources", map[string]any{
 				"resource_type": "local_directory",
 				"resource_ref":  tc.ref,
 			})
 			req = withURLParam(req, "id", project.ID)
-			testHandler.CreateProjectResource(w, req)
+			w := testutil.Call(t, testHandler.CreateProjectResource, req)
 			if w.Code != http.StatusBadRequest {
 				t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
 			}
@@ -469,7 +440,7 @@ func TestIsAbsoluteLocalPath(t *testing.T) {
 }
 
 func TestCreateProjectAttachesResources(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "Project with bundled resources",
 		"resources": []map[string]any{
@@ -479,17 +450,12 @@ func TestCreateProjectAttachesResources(t *testing.T) {
 			},
 		},
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject with resources: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var resp struct {
 		ID        string                    `json:"id"`
 		Resources []ProjectResourceResponse `json:"resources"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&resp)
 	defer func() {
 		r := newRequest("DELETE", "/api/projects/"+resp.ID, nil)
 		r = withURLParam(r, "id", resp.ID)
@@ -510,9 +476,7 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 		"title": "Resource count breadcrumb",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -524,17 +488,12 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	}()
 
 	getCount := func() int64 {
-		w := httptest.NewRecorder()
+
 		req := newRequest("GET", "/api/projects/"+project.ID, nil)
 		req = withURLParam(req, "id", project.ID)
-		testHandler.GetProject(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("GetProject: %d %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.GetProject, req).Want(http.StatusOK)
 		var resp ProjectResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode GetProject: %v", err)
-		}
+		w.Decode(&resp)
 		return resp.ResourceCount
 	}
 	if got := getCount(); got != 0 {
@@ -548,9 +507,7 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	if got := getCount(); got != 1 {
 		t.Errorf("after attach GetProject ResourceCount = %d, want 1", got)
@@ -559,9 +516,7 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
 	testHandler.ListProjects(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListProjects: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var list struct {
 		Projects []ProjectResponse `json:"projects"`
 	}
@@ -590,20 +545,8 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	`, testWorkspaceID).Scan(&number); err != nil {
 		t.Fatalf("next issue number: %v", err)
 	}
-	var issueID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO issue (
-			workspace_id, creator_type, creator_id, title, status, priority,
-			project_id, number, position
-		)
-		VALUES ($1, 'member', $2, 'Project update stats breadcrumb', 'done', 'none', $3, $4, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID, project.ID, number).Scan(&issueID); err != nil {
-		t.Fatalf("create project issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+
+	dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": testutil.Raw("'Project update stats breadcrumb'"), "status": testutil.Raw("'done'"), "priority": testutil.Raw("'none'"), "project_id": project.ID, "number": number, "position": testutil.Raw("0")})
 
 	// UpdateProject must preserve the breadcrumb. A title-only PUT used to
 	// reset derived counts to 0 because UpdateProject didn't reload them.
@@ -613,9 +556,7 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.UpdateProject(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateProject: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var updated ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode UpdateProject: %v", err)
@@ -632,7 +573,7 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 // echo carries resource_count matching the attached resources, so the HTTP
 // response and the published project:created event agree.
 func TestCreateProjectWithResourcesEchoesCount(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "Create echo with resource_count",
 		"resources": []map[string]any{
@@ -642,18 +583,13 @@ func TestCreateProjectWithResourcesEchoesCount(t *testing.T) {
 			},
 		},
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject with resources: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var resp struct {
 		ID            string                    `json:"id"`
 		ResourceCount int64                     `json:"resource_count"`
 		Resources     []ProjectResourceResponse `json:"resources"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&resp)
 	defer func() {
 		r := newRequest("DELETE", "/api/projects/"+resp.ID, nil)
 		r = withURLParam(r, "id", resp.ID)
@@ -676,18 +612,14 @@ func TestCreateProjectRollsBackOnInvalidResource(t *testing.T) {
 		},
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("CreateProject with invalid resource: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Confirm no project survived (transactional rollback). Listing all projects
 	// in the workspace and checking for the title is enough.
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
 	testHandler.ListProjects(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListProjects: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var list struct {
 		Projects []ProjectResponse `json:"projects"`
 	}
@@ -711,9 +643,7 @@ func TestProjectResourceUpdateLifecycle(t *testing.T) {
 		"title": "Update lifecycle project",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -737,9 +667,7 @@ func TestProjectResourceUpdateLifecycle(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode CreateProjectResource: %v", err)
@@ -755,9 +683,7 @@ func TestProjectResourceUpdateLifecycle(t *testing.T) {
 	})
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.UpdateProjectResource(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateProjectResource label-only: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var updated ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode UpdateProjectResource: %v", err)
@@ -788,9 +714,7 @@ func TestProjectResourceUpdateLifecycle(t *testing.T) {
 	})
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.UpdateProjectResource(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateProjectResource ref+position: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode UpdateProjectResource: %v", err)
 	}
@@ -826,9 +750,7 @@ func TestProjectResourceUpdateLifecycle(t *testing.T) {
 	})
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.UpdateProjectResource(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateProjectResource label=null: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("decode UpdateProjectResource: %v", err)
 	}
@@ -880,9 +802,7 @@ func TestProjectResourceLabelConvergence(t *testing.T) {
 		"title": "Label convergence project",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -906,9 +826,7 @@ func TestProjectResourceLabelConvergence(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var created ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode CreateProjectResource: %v", err)
@@ -916,17 +834,15 @@ func TestProjectResourceLabelConvergence(t *testing.T) {
 
 	update := func(body map[string]any) ProjectResourceResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/projects/"+project.ID+"/resources/"+created.ID, body)
 		req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
-		testHandler.UpdateProjectResource(w, req)
+		w := testutil.Call(t, testHandler.UpdateProjectResource, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("UpdateProjectResource %v: %d %s", body, w.Code, w.Body.String())
 		}
 		var resp ProjectResourceResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode UpdateProjectResource: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 	refFields := func(resp ProjectResourceResponse) map[string]json.RawMessage {
@@ -1072,9 +988,7 @@ func TestProjectResourceLocalDirectoryDaemonScopedConflict(t *testing.T) {
 		"title": "Local dir daemon-scoped conflict",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -1103,9 +1017,7 @@ func TestProjectResourceLocalDirectoryDaemonScopedConflict(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("first attach: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var first ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&first); err != nil {
 		t.Fatalf("decode first: %v", err)
@@ -1159,9 +1071,7 @@ func TestProjectResourceLocalDirectoryDaemonScopedConflict(t *testing.T) {
 	})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("other daemon attach: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var second ProjectResourceResponse
 	if err := json.NewDecoder(w.Body).Decode(&second); err != nil {
 		t.Fatalf("decode other-daemon row: %v", err)
@@ -1229,17 +1139,13 @@ func TestCreateProjectBundledLocalDirectoryDaemonConflict(t *testing.T) {
 		},
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("bundled label shadow: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Confirm the rollback: no project with the title should exist.
 	w = httptest.NewRecorder()
 	req = newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
 	testHandler.ListProjects(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListProjects: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var list struct {
 		Projects []ProjectResponse `json:"projects"`
 	}
@@ -1278,9 +1184,7 @@ func TestCreateProjectBundledLocalDirectoryDaemonConflict(t *testing.T) {
 		},
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("distinct-paths same daemon bundle: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// A bundle with one row per daemon is allowed — each daemon owns its
 	// own local_directory.
@@ -1307,9 +1211,7 @@ func TestCreateProjectBundledLocalDirectoryDaemonConflict(t *testing.T) {
 		},
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("per-daemon bundle: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var resp struct {
 		ID        string                    `json:"id"`
 		Resources []ProjectResourceResponse `json:"resources"`
@@ -1472,7 +1374,7 @@ func TestCreateProjectGatesWorktreeLocalDirectory(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "Bundled worktree resource",
 		"resources": []map[string]any{
@@ -1486,24 +1388,18 @@ func TestCreateProjectGatesWorktreeLocalDirectory(t *testing.T) {
 			},
 		},
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("CreateProject with un-runnable worktree resource: expected 422, got %d: %s",
-			w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusUnprocessableEntity)
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp["code"] != "daemon_version_unsupported" {
 		t.Fatalf("expected the shared gate's error code, got %#v", resp["code"])
 	}
 
 	// The gate runs before the transaction opens, so the rejection must not
 	// leave a half-created project behind.
-	lw := httptest.NewRecorder()
+
 	lreq := newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
-	testHandler.ListProjects(lw, lreq)
+	lw := testutil.Call(t, testHandler.ListProjects, lreq)
 	if strings.Contains(lw.Body.String(), "Bundled worktree resource") {
 		t.Fatal("rejected create left a project behind")
 	}
@@ -1514,16 +1410,11 @@ func TestCreateProjectGatesWorktreeLocalDirectory(t *testing.T) {
 // the rows look exactly like a client's would.
 func createTestProjectForResources(t *testing.T, title string) ProjectResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{"title": title})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	t.Cleanup(func() {
 		r := newRequest("DELETE", "/api/projects/"+project.ID, nil)
 		r = withURLParam(r, "id", project.ID)
@@ -1534,20 +1425,15 @@ func createTestProjectForResources(t *testing.T, title string) ProjectResponse {
 
 func createLocalDirectoryResourceFor(t *testing.T, projectID string, ref map[string]any) ProjectResourceResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects/"+projectID+"/resources", map[string]any{
 		"resource_type": "local_directory",
 		"resource_ref":  ref,
 	})
 	req = withURLParam(req, "id", projectID)
-	testHandler.CreateProjectResource(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProjectResource: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProjectResource, req).Want(http.StatusCreated)
 	var created ProjectResourceResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode CreateProjectResource: %v", err)
-	}
+	w.Decode(&created)
 	return created
 }
 
@@ -1576,17 +1462,15 @@ func TestProjectResourceStaleRefSnapshotDoesNotRollBackARename(t *testing.T) {
 
 	update := func(body map[string]any) ProjectResourceResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("PUT", "/api/projects/"+project.ID+"/resources/"+created.ID, body)
 		req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
-		testHandler.UpdateProjectResource(w, req)
+		w := testutil.Call(t, testHandler.UpdateProjectResource, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("UpdateProjectResource(%v): %d %s", body, w.Code, w.Body.String())
 		}
 		var resp ProjectResourceResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 	refLabelOf := func(resp ProjectResourceResponse) string {
@@ -1676,10 +1560,7 @@ func TestProjectResourceLegacyRenameSkipsWorktreeGate(t *testing.T) {
 	})
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.UpdateProjectResource(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("a rename that changes no execution semantics must not hit the capability gate: %d %s",
-			w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// And the gate still fires when the same client actually changes the mode.
 	w = httptest.NewRecorder()
@@ -1693,7 +1574,5 @@ func TestProjectResourceLegacyRenameSkipsWorktreeGate(t *testing.T) {
 	})
 	req = withURLParams(req, "id", project.ID, "resourceId", created.ID)
 	testHandler.UpdateProjectResource(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("switching to in_place needs no capability: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }

--- a/server/internal/handler/project_validation_test.go
+++ b/server/internal/handler/project_validation_test.go
@@ -7,52 +7,43 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // An unknown project status must fail fast with a 400 and the valid list, not
 // surface the DB CHECK violation as a 500 (#3925: `--status active`).
 func TestCreateProjectInvalidStatusReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "invalid status project",
 		"status": "active",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusBadRequest)
 	if body := w.Body.String(); !strings.Contains(body, "planned") {
 		t.Errorf("expected error to list valid statuses, got: %s", body)
 	}
 }
 
 func TestCreateProjectInvalidPriorityReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "invalid priority project",
 		"priority": "critical",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusBadRequest)
 }
 
 // A valid status still creates the project (the validation does not over-reject).
 func TestCreateProjectValidStatusReturns201(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title":  "valid status project",
 		"status": "in_progress",
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 for valid status, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	t.Cleanup(func() {
 		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
 		req = withURLParam(req, "id", project.ID)
@@ -71,9 +62,7 @@ func TestUpdateProjectInvalidStatusReturns400(t *testing.T) {
 		"title": "update validation project",
 	})
 	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("seed CreateProject: %d %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var project ProjectResponse
 	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
 		t.Fatalf("decode CreateProject: %v", err)
@@ -88,23 +77,16 @@ func TestUpdateProjectInvalidStatusReturns400(t *testing.T) {
 	req = newRequest("PUT", "/api/projects/"+project.ID, map[string]any{"status": "active"})
 	req = withURLParam(req, "id", project.ID)
 	testHandler.UpdateProject(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid update status, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 }
 
 func TestDeleteProjectRequiresAdminOrOwner(t *testing.T) {
 	memberUserID := createProjectPermissionTestMember(t, "member")
 	project := createProjectPermissionTestProject(t, "delete permission denied project")
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(memberUserID, "DELETE", "/api/projects/"+project.ID, nil)
 	req = withURLParam(req, "id", project.ID)
-	testHandler.DeleteProject(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for plain member project delete, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteProject, req).Want(http.StatusForbidden)
 
 	var exists bool
 	if err := testPool.QueryRow(context.Background(), `SELECT EXISTS (SELECT 1 FROM project WHERE id = $1)`, project.ID).Scan(&exists); err != nil {
@@ -119,14 +101,9 @@ func TestDeleteProjectAllowsAdmin(t *testing.T) {
 	adminUserID := createProjectPermissionTestMember(t, "admin")
 	project := createProjectPermissionTestProject(t, "delete permission admin project")
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(adminUserID, "DELETE", "/api/projects/"+project.ID, nil)
 	req = withURLParam(req, "id", project.ID)
-	testHandler.DeleteProject(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204 for admin project delete, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteProject, req).Want(http.StatusNoContent)
 
 	var exists bool
 	if err := testPool.QueryRow(context.Background(), `SELECT EXISTS (SELECT 1 FROM project WHERE id = $1)`, project.ID).Scan(&exists); err != nil {
@@ -175,18 +152,12 @@ VALUES ($1, $2, $3)
 func createProjectPermissionTestProject(t *testing.T, title string) ProjectResponse {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
 		"title": title,
 	})
-	testHandler.CreateProject(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProject, req).Want(http.StatusCreated)
 	var project ProjectResponse
-	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
-		t.Fatalf("decode CreateProject: %v", err)
-	}
+	w.Decode(&project)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, project.ID)
 	})

--- a/server/internal/handler/property_test.go
+++ b/server/internal/handler/property_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -34,12 +35,9 @@ func withIssuePropertyParams(req *http.Request, issueID, propertyID string) *htt
 
 func createTestProperty(t *testing.T, body map[string]any) PropertyResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/properties", body)
-	testHandler.CreateProperty(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateProperty: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateProperty, req).Want(http.StatusCreated)
 	var created PropertyResponse
 	json.NewDecoder(w.Body).Decode(&created)
 	t.Cleanup(func() { deleteTestProperty(t, created.ID) })
@@ -110,9 +108,7 @@ func TestPropertyDefinitionCRUD(t *testing.T) {
 		"name": "severity", "type": "text",
 	})
 	testHandler.CreateProperty(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("duplicate name: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusConflict, "HTTP status")
 
 	// Rename + replace options, keeping the first option's id: values that
 	// reference it must survive option-list edits.
@@ -128,9 +124,7 @@ func TestPropertyDefinitionCRUD(t *testing.T) {
 	})
 	req = withURLParam(req, "id", created.ID)
 	testHandler.UpdateProperty(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateProperty: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var updated PropertyResponse
 	json.NewDecoder(w.Body).Decode(&updated)
 	if updated.Name != "Sev" || updated.Icon != "shield" || updated.Config.Options[0].ID != keepID || updated.Config.Options[0].Name != "Blocker" {
@@ -142,9 +136,7 @@ func TestPropertyDefinitionCRUD(t *testing.T) {
 	req = newRequest("PATCH", "/api/properties/"+created.ID, map[string]any{"icon": ""})
 	req = withURLParam(req, "id", created.ID)
 	testHandler.UpdateProperty(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("clear icon: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	json.NewDecoder(w.Body).Decode(&updated)
 	if updated.Icon != "" {
 		t.Fatalf("icon not cleared: %q", updated.Icon)
@@ -155,13 +147,10 @@ func TestPropertyDefinitionCRUD(t *testing.T) {
 	req = newRequest("PATCH", "/api/properties/"+created.ID, map[string]any{"archived": true})
 	req = withURLParam(req, "id", created.ID)
 	testHandler.UpdateProperty(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("archive: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	listProperties := func(query string) []PropertyResponse {
-		w := httptest.NewRecorder()
-		testHandler.ListProperties(w, newRequest("GET", "/api/properties"+query, nil))
+		w := testutil.Call(t, testHandler.ListProperties, newRequest("GET", "/api/properties"+query, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("ListProperties%s: expected 200, got %d: %s", query, w.Code, w.Body.String())
 		}
@@ -208,8 +197,7 @@ func TestPropertyDefinitionValidation(t *testing.T) {
 			}}}, "duplicate option name"},
 	}
 	for _, tc := range cases {
-		w := httptest.NewRecorder()
-		testHandler.CreateProperty(w, newRequest("POST", "/api/properties", tc.body))
+		w := testutil.Call(t, testHandler.CreateProperty, newRequest("POST", "/api/properties", tc.body))
 		if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), tc.want) {
 			t.Fatalf("%s: expected 400 containing %q, got %d: %s", tc.name, tc.want, w.Code, w.Body.String())
 		}
@@ -226,9 +214,7 @@ func TestPropertyAdminGate(t *testing.T) {
 	req.Header.Set("X-Actor-Source", "task_token")
 	req.Header.Set("X-Agent-ID", uuid.NewString())
 	testHandler.CreateProperty(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("agent CreateProperty: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	property := createTestProperty(t, map[string]any{"name": "AgentWritable" + uuid.NewString()[:8], "type": "text"})
 	issueID := createPropertyTestIssue(t, "agent value write")
@@ -239,9 +225,7 @@ func TestPropertyAdminGate(t *testing.T) {
 	req.Header.Set("X-Agent-ID", uuid.NewString())
 	req = withIssuePropertyParams(req, issueID, property.ID)
 	testHandler.SetIssueProperty(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("agent SetIssueProperty: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 func TestIssuePropertyValues(t *testing.T) {
@@ -279,9 +263,7 @@ func TestIssuePropertyValues(t *testing.T) {
 	// multi_select: duplicates dropped, order canonicalized to config order.
 	webID, iosID := multi.Config.Options[2].ID, multi.Config.Options[0].ID
 	w := setIssuePropertyRaw(t, issueID, multi.ID, []string{webID, iosID, webID})
-	if w.Code != http.StatusOK {
-		t.Fatalf("multi_select set: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp struct {
 		Properties map[string]any `json:"properties"`
 	}
@@ -312,23 +294,17 @@ func TestIssuePropertyValues(t *testing.T) {
 	}
 
 	// Archived definitions reject new values but allow unset.
-	warch := httptest.NewRecorder()
+
 	req := newRequest("PATCH", "/api/properties/"+sel.ID, map[string]any{"archived": true})
 	req = withURLParam(req, "id", sel.ID)
-	testHandler.UpdateProperty(warch, req)
-	if warch.Code != http.StatusOK {
-		t.Fatalf("archive: expected 200, got %d: %s", warch.Code, warch.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateProperty, req).Want(http.StatusOK)
 	if w := setIssuePropertyRaw(t, issueID, sel.ID, sel.Config.Options[1].ID); w.Code != http.StatusBadRequest {
 		t.Fatalf("set on archived: expected 400, got %d: %s", w.Code, w.Body.String())
 	}
-	wdel := httptest.NewRecorder()
+
 	req = newRequest("DELETE", "/api/issues/"+issueID+"/properties/"+sel.ID, nil)
 	req = withIssuePropertyParams(req, issueID, sel.ID)
-	testHandler.DeleteIssueProperty(wdel, req)
-	if wdel.Code != http.StatusOK {
-		t.Fatalf("unset on archived: expected 200, got %d: %s", wdel.Code, wdel.Body.String())
-	}
+	wdel := testutil.Call(t, testHandler.DeleteIssueProperty, req).Want(http.StatusOK)
 	// Fresh struct: json.Decode merges into a pre-populated map, which would
 	// leave the earlier bag contents (including sel.ID) in place.
 	var afterDelete struct {
@@ -410,15 +386,11 @@ func TestPropertyOptionRemovalGuard(t *testing.T) {
 		{"id": usedID, "name": "Used (renamed)", "color": "#ef4444"},
 		{"id": unusedID, "name": "Unused", "color": "#6b7280"},
 	})
-	if w.Code != http.StatusOK {
-		t.Fatalf("rename: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Dropping only the unused option → 200.
 	w = patchConfig([]map[string]any{{"id": usedID, "name": "Used (renamed)", "color": "#ef4444"}})
-	if w.Code != http.StatusOK {
-		t.Fatalf("unused removal: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 // TestListIssuesPropertyFilterAndSort covers the server-side list support:
@@ -483,8 +455,7 @@ func TestListIssuesPropertyFilterAndSort(t *testing.T) {
 
 	listIssues := func(query string) []IssueResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.ListIssues(w, newRequest("GET", "/api/issues"+query, nil))
+		w := testutil.Call(t, testHandler.ListIssues, newRequest("GET", "/api/issues"+query, nil))
 		if w.Code != http.StatusOK {
 			t.Fatalf("ListIssues%s: expected 200, got %d: %s", query, w.Code, w.Body.String())
 		}
@@ -572,11 +543,7 @@ func TestListIssuesPropertyFilterAndSort(t *testing.T) {
 	}
 
 	// Malformed property sort id → 400; unknown definition → 200 position order.
-	w := httptest.NewRecorder()
-	testHandler.ListIssues(w, newRequest("GET", "/api/issues?sort=property:nope", nil))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("malformed property sort: expected 400, got %d", w.Code)
-	}
+	testutil.Call(t, testHandler.ListIssues, newRequest("GET", "/api/issues?sort=property:nope", nil)).Want(http.StatusBadRequest)
 	if got := listIssues("?limit=5&sort=property:" + uuid.NewString()); len(got) == 0 {
 		t.Fatalf("unknown-definition sort should fall back to position order, got empty")
 	}
@@ -887,8 +854,7 @@ func TestPropertyActorDefinitionRejectsOptions(t *testing.T) {
 		}
 	}
 
-	w := httptest.NewRecorder()
-	testHandler.CreateProperty(w, newRequest("POST", "/api/properties", map[string]any{
+	w := testutil.Call(t, testHandler.CreateProperty, newRequest("POST", "/api/properties", map[string]any{
 		"name": "Owner" + uuid.NewString()[:8],
 		"type": "actor",
 		"config": map[string]any{"options": []map[string]any{
@@ -921,24 +887,17 @@ func TestIssueActorPropertyValues(t *testing.T) {
 
 	// A real workspace member round-trips as "member:<user_id>".
 	w := setIssuePropertyRaw(t, issueID, owner.ID, memberRef)
-	if w.Code != http.StatusOK {
-		t.Fatalf("actor set member: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := decodePropertiesBag(t, w)[owner.ID]; got != memberRef {
 		t.Fatalf("actor value not stored as %q: %v", memberRef, got)
 	}
 	// Read back through the issue endpoint, not just the write response.
-	wget := httptest.NewRecorder()
+
 	getReq := newRequest("GET", "/api/issues/"+issueID, nil)
 	getReq = withURLParam(getReq, "id", issueID)
-	testHandler.GetIssue(wget, getReq)
-	if wget.Code != http.StatusOK {
-		t.Fatalf("GetIssue: expected 200, got %d: %s", wget.Code, wget.Body.String())
-	}
+	wget := testutil.Call(t, testHandler.GetIssue, getReq).Want(http.StatusOK)
 	var fetched IssueResponse
-	if err := json.NewDecoder(wget.Body).Decode(&fetched); err != nil {
-		t.Fatalf("decode issue: %v", err)
-	}
+	wget.Decode(&fetched)
 	if fetched.Properties[owner.ID] != memberRef {
 		t.Fatalf("actor value missing from the issue bag: %v", fetched.Properties)
 	}
@@ -948,9 +907,7 @@ func TestIssueActorPropertyValues(t *testing.T) {
 	// which matches the reference string exactly, silently misses it.
 	upper := "member:" + strings.ToUpper(testUserID)
 	w = setIssuePropertyRaw(t, issueID, owner.ID, upper)
-	if w.Code != http.StatusOK {
-		t.Fatalf("actor set uppercase member: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if got := decodePropertiesBag(t, w)[owner.ID]; got != memberRef {
 		t.Fatalf("uppercase actor id not canonicalized on write: %v", got)
 	}
@@ -979,9 +936,7 @@ func TestIssueActorPropertyValues(t *testing.T) {
 	}
 	// multi_actor: duplicates dropped, insertion order kept.
 	w = setIssuePropertyRaw(t, issueID, reviewers.ID, []string{memberRef, secondRef, memberRef})
-	if w.Code != http.StatusOK {
-		t.Fatalf("multi_actor set: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	stored, ok := decodePropertiesBag(t, w)[reviewers.ID].([]any)
 	if !ok || len(stored) != 2 {
 		t.Fatalf("multi_actor not stored as a 2-element array: %v", stored)
@@ -1041,7 +996,7 @@ func TestIssueActorPropertyFacets(t *testing.T) {
 
 	facetKeys := func(userID string) map[string]int64 {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequestAs(userID, http.MethodPost, "/api/issues/table/facets", map[string]any{
 			"query": map[string]any{
 				"scope":   map[string]any{"kind": "workspace"},
@@ -1051,14 +1006,9 @@ func TestIssueActorPropertyFacets(t *testing.T) {
 			"facets":        []map[string]any{{"kind": "property", "property_id": property.ID}},
 			"include_total": false,
 		})
-		testHandler.ListIssueTableFacets(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssueTableFacets: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListIssueTableFacets, req).Want(http.StatusOK)
 		var resp issueTableFacetsResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode facets: %v", err)
-		}
+		w.Decode(&resp)
 		counts := map[string]int64{}
 		for _, facet := range resp.Facets {
 			for _, value := range facet.Values {
@@ -1104,7 +1054,6 @@ func TestIssuePropertyFacetNoValue(t *testing.T) {
 		t.Fatalf("set hold: %d %s", w.Code, w.Body.String())
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodPost, "/api/issues/table/facets", map[string]any{
 		"query": map[string]any{
 			"scope":   map[string]any{"kind": "workspace"},
@@ -1114,14 +1063,9 @@ func TestIssuePropertyFacetNoValue(t *testing.T) {
 		"facets":        []map[string]any{{"kind": "property", "property_id": hold.ID}},
 		"include_total": false,
 	})
-	testHandler.ListIssueTableFacets(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListIssueTableFacets: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListIssueTableFacets, req).Want(http.StatusOK)
 	var resp issueTableFacetsResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode facets: %v", err)
-	}
+	w.Decode(&resp)
 	counts := map[string]int64{}
 	for _, facet := range resp.Facets {
 		for _, value := range facet.Values {

--- a/server/internal/handler/quick_action_access_test.go
+++ b/server/internal/handler/quick_action_access_test.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Cross-member access regression for private quick actions (MUL-5465, review
@@ -38,19 +39,7 @@ func seedPrivateQuickActionOwnedByOther(t *testing.T) string {
 	agentID := createHandlerTestAgent(t, "QA Access Agent", []byte("null"))
 
 	var actionID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO quick_action (
-			workspace_id, name, description, assignee_type, assignee_id, prompt,
-			visibility, created_by_type, created_by_id
-		) VALUES ($1, 'Other Private', '', 'agent', $2, 'secret prompt', 'private', 'member', $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, otherUserID).Scan(&actionID); err != nil {
-		t.Fatalf("seed private quick action: %v", err)
-	}
-
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM quick_action WHERE id = $1`, actionID)
-	})
+	actionID = dbfx.Insert(t, "quick_action", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Other Private'"), "description": testutil.Raw("''"), "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID, "prompt": testutil.Raw("'secret prompt'"), "visibility": testutil.Raw("'private'"), "created_by_type": testutil.Raw("'member'"), "created_by_id": otherUserID})
 	return actionID
 }
 
@@ -63,12 +52,7 @@ func TestUpdateQuickActionRejectsNonOwnerOfPrivateAction(t *testing.T) {
 		}),
 		"id", actionID,
 	)
-	rr := httptest.NewRecorder()
-	testHandler.UpdateQuickAction(rr, req)
-
-	if rr.Code != http.StatusNotFound {
-		t.Fatalf("a non-owner must not reach another member's private action: got %d, want 404", rr.Code)
-	}
+	testutil.Call(t, testHandler.UpdateQuickAction, req).Want(http.StatusNotFound)
 
 	// The prompt must be untouched, not merely un-returned.
 	var name string
@@ -88,12 +72,7 @@ func TestDeleteQuickActionRejectsNonOwnerOfPrivateAction(t *testing.T) {
 		newRequest(http.MethodDelete, "/api/quick-actions/"+actionID, nil),
 		"id", actionID,
 	)
-	rr := httptest.NewRecorder()
-	testHandler.DeleteQuickAction(rr, req)
-
-	if rr.Code != http.StatusNotFound {
-		t.Fatalf("a non-owner must not delete another member's private action: got %d, want 404", rr.Code)
-	}
+	testutil.Call(t, testHandler.DeleteQuickAction, req).Want(http.StatusNotFound)
 
 	var alive int
 	if err := testPool.QueryRow(context.Background(),

--- a/server/internal/handler/quick_create_parent_test.go
+++ b/server/internal/handler/quick_create_parent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/entitlement"
 	"github.com/multica-ai/multica/server/internal/entitlement/entitlementtest"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
@@ -92,15 +93,7 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, foreignUserID)
 	})
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ($1, $2, $3, $4) RETURNING id
-	`, "QuickCreate Foreign WS", "quickcreate-foreign-ws", "", "QCF").Scan(&foreignWorkspaceID); err != nil {
-		t.Fatalf("create foreign workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
-	})
+	foreignWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "QuickCreate Foreign WS", "slug": "quickcreate-foreign-ws", "description": "", "issue_prefix": "QCF"})
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO issue (workspace_id, title, creator_id, creator_type, number)
 		VALUES ($1, 'quick-create parent (foreign)', $2, 'member',
@@ -133,7 +126,7 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 
 	t.Run("same workspace parent enqueues with context", func(t *testing.T) {
 		attachmentID := "019ec09d-6222-722b-bdfa-427b105d80be"
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/quick-create", map[string]any{
 			"agent_id":        agentID,
 			"prompt":          "Create a follow-up issue for the local parent",
@@ -142,14 +135,9 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 			"parent_issue_id": localParentID,
 			"attachment_ids":  []string{attachmentID},
 		})
-		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusAccepted {
-			t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusAccepted)
 		var resp QuickCreateIssueResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode response: %v", err)
-		}
+		w.Decode(&resp)
 		t.Cleanup(func() {
 			testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, resp.TaskID)
 		})
@@ -207,23 +195,17 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 			testHandler.TaskService.Entitlements = priorProvider
 		})
 
-		w := httptest.NewRecorder()
 		req := newRequest("POST", "/api/issues/quick-create", map[string]any{
 			"agent_id": agentID,
 			"prompt":   "This task must not be queued when the workspace is full",
 		})
-		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusPaymentRequired {
-			t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusPaymentRequired)
 		var body struct {
 			Code           string `json:"code"`
 			Limit          int    `json:"limit"`
 			PolicyRevision int    `json:"policy_revision"`
 		}
-		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-			t.Fatalf("decode issue-limit response: %v", err)
-		}
+		w.Decode(&body)
 		if body.Code != "issue_limit_reached" || body.Limit != issueCount || body.PolicyRevision != 23 {
 			t.Fatalf("unexpected issue-limit response: %+v", body)
 		}
@@ -234,16 +216,13 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 
 	t.Run("foreign workspace parent is rejected", func(t *testing.T) {
 		before := countQuickCreateTasks(t)
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/quick-create", map[string]any{
 			"agent_id":        agentID,
 			"prompt":          "Try to smuggle a foreign parent",
 			"parent_issue_id": foreignParentID,
 		})
-		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for foreign parent, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusBadRequest)
 		if got := countQuickCreateTasks(t); got != before {
 			// Any increase means the foreign-parent request enqueued a
 			// task despite the 400 — the trust boundary leaked.
@@ -253,16 +232,13 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 
 	t.Run("bogus uuid parent is rejected", func(t *testing.T) {
 		before := countQuickCreateTasks(t)
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/quick-create", map[string]any{
 			"agent_id":        agentID,
 			"prompt":          "Try a malformed parent UUID",
 			"parent_issue_id": "not-a-uuid",
 		})
-		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for bogus parent, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusBadRequest)
 		if got := countQuickCreateTasks(t); got != before {
 			t.Fatalf("bogus parent must not enqueue a task: expected %d quick-create tasks, got %d", before, got)
 		}
@@ -270,16 +246,13 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 
 	t.Run("bogus uuid attachment id is rejected", func(t *testing.T) {
 		before := countQuickCreateTasks(t)
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/quick-create", map[string]any{
 			"agent_id":       agentID,
 			"prompt":         "Try a malformed attachment UUID",
 			"attachment_ids": []string{"not-a-uuid"},
 		})
-		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("expected 400 for bogus attachment id, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusBadRequest)
 		if got := countQuickCreateTasks(t); got != before {
 			t.Fatalf("bogus attachment id must not enqueue a task: expected %d quick-create tasks, got %d", before, got)
 		}
@@ -300,12 +273,9 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 				"prompt":   "Try an invalid explicit field",
 				tc.field:   tc.value,
 			}
-			w := httptest.NewRecorder()
+
 			req := newRequest("POST", "/api/issues/quick-create", body)
-			testHandler.QuickCreateIssue(w, req)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.QuickCreateIssue, req).Want(http.StatusBadRequest)
 			if got := countQuickCreateTasks(t); got != before {
 				t.Fatalf("invalid field must not enqueue a task: expected %d, got %d", before, got)
 			}
@@ -332,9 +302,7 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 			"priority": "high",
 		})
 		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusUnprocessableEntity {
-			t.Fatalf("explicit fields on 0.4.2: expected 422, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusUnprocessableEntity, "HTTP status")
 		if got := countQuickCreateTasks(t); got != before {
 			t.Fatalf("unsupported explicit fields must not enqueue: expected %d, got %d", before, got)
 		}
@@ -345,9 +313,7 @@ func TestQuickCreateIssueParentTrustBoundary(t *testing.T) {
 			"prompt":   "Basic quick create remains backward compatible",
 		})
 		testHandler.QuickCreateIssue(w, req)
-		if w.Code != http.StatusAccepted {
-			t.Fatalf("basic quick create on 0.4.2: expected 202, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusAccepted, "HTTP status")
 		var resp QuickCreateIssueResponse
 		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 			t.Fatalf("decode response: %v", err)

--- a/server/internal/handler/resource_label_cascade_test.go
+++ b/server/internal/handler/resource_label_cascade_test.go
@@ -3,11 +3,11 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Resource-label junction tables (agent_to_label / skill_to_label) deliberately
@@ -24,16 +24,7 @@ import (
 func insertLabelRow(t *testing.T, ctx context.Context, workspaceID, resourceType string) string {
 	t.Helper()
 	var labelID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue_label (workspace_id, resource_type, name, color)
-		VALUES ($1, $2, $3, '#3b82f6')
-		RETURNING id
-	`, workspaceID, resourceType, resourceType+"-"+uuid.NewString()[:8]).Scan(&labelID); err != nil {
-		t.Fatalf("insert issue_label: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue_label WHERE id = $1`, labelID)
-	})
+	labelID = dbfx.Insert(t, "issue_label", testutil.Cols{"workspace_id": workspaceID, "resource_type": resourceType, "name": resourceType + "-" + uuid.NewString()[:8], "color": testutil.Raw("'#3b82f6'")})
 	return labelID
 }
 
@@ -91,13 +82,9 @@ func TestDeleteAgentRuntime_KeepsUnboundAgentLabelAssignments(t *testing.T) {
 	agentID := seedAgentOnRuntime(t, runtimeID, "Label Cleanup Archived Agent", true)
 	seedAgentLabel(t, ctx, testWorkspaceID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if !agentExists(t, agentID) {
 		t.Fatalf("archived agent must survive its runtime as an unbound agent")
@@ -119,14 +106,10 @@ func TestUnbindAgentsAndDeleteRuntime_KeepsAgentLabelAssignments(t *testing.T) {
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Label Cascade Agent")
 	seedAgentLabel(t, ctx, testWorkspaceID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{agentID}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UnbindAgentsAndDeleteRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusOK)
 
 	if n := countAgentLabelAssignments(t, ctx, agentID); n != 1 {
 		t.Fatalf("agent_to_label rows for a surviving agent: got %d, want 1", n)
@@ -149,13 +132,9 @@ func TestDeleteRuntimeProfile_KeepsAgentLabelAssignments(t *testing.T) {
 	}
 	seedAgentLabel(t, ctx, testWorkspaceID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteRuntimeProfile: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteRuntimeProfile, req).Want(http.StatusNoContent)
 
 	if !agentExists(t, agentID) {
 		t.Fatalf("archived agent must survive its runtime profile as an unbound agent")
@@ -184,13 +163,9 @@ func TestDeleteAgentRuntime_CleansSystemAgentLabelAssignments(t *testing.T) {
 	}
 	seedAgentLabel(t, ctx, testWorkspaceID, agentID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if agentExists(t, agentID) {
 		t.Fatalf("system agent should still be hard-deleted with its runtime")
@@ -205,16 +180,7 @@ func seedWorkspaceResourceLabelFixture(t *testing.T, ctx context.Context, slug s
 	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
 	var wsID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description)
-		VALUES ($1, $2, $3)
-		RETURNING id
-	`, "Handler Test Delete Labels", slug, "resource-label atomic cleanup test").Scan(&wsID); err != nil {
-		t.Fatalf("create workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-	})
+	wsID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Handler Test Delete Labels", "slug": slug, "description": "resource-label atomic cleanup test"})
 	if _, err := testPool.Exec(ctx,
 		`INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'owner')`,
 		wsID, testUserID); err != nil {
@@ -274,13 +240,9 @@ func TestDeleteWorkspace_CleansResourceLabelAssignments(t *testing.T) {
 	ctx := context.Background()
 	wsID, agentID, skillID := seedWorkspaceResourceLabelFixture(t, ctx, "handler-tests-delete-labels")
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
 	req = withURLParam(req, "id", wsID)
-	testHandler.DeleteWorkspace(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteWorkspace: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	if n := countAgentLabelAssignments(t, ctx, agentID); n != 0 {
 		t.Fatalf("agent_to_label rows survived workspace delete: %d", n)
@@ -315,15 +277,12 @@ func TestDeleteWorkspace_RollsBackResourceLabelCleanup(t *testing.T) {
 		t.Fatalf("lock workspace member: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
 	req = withURLParam(req, "id", wsID)
-	testHandler.DeleteWorkspace(w, req)
+	w := testutil.Call(t, testHandler.DeleteWorkspace, req)
 	// A lock the teardown cannot get is transient, so the handler reports it
 	// as a retryable 503 rather than a generic failure.
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("DeleteWorkspace: expected 503, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusServiceUnavailable, "HTTP status")
 	if err := blocker.Rollback(ctx); err != nil {
 		t.Fatalf("release member blocker: %v", err)
 	}

--- a/server/internal/handler/runtime_custom_name_test.go
+++ b/server/internal/handler/runtime_custom_name_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // patchRuntimeCustomName is a small helper that PATCHes /api/runtimes/:id with
@@ -31,9 +33,7 @@ func TestUpdateAgentRuntime_CustomNamePatchApplies(t *testing.T) {
 
 	// Owner sets a custom name.
 	w := patchRuntimeCustomName(runtimeOwnerID, runtimeID, map[string]any{"custom_name": "  Prod Box  "})
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH custom_name: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp AgentRuntimeResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -48,9 +48,7 @@ func TestUpdateAgentRuntime_CustomNamePatchApplies(t *testing.T) {
 
 	// Empty string clears the override back to NULL.
 	w = patchRuntimeCustomName(runtimeOwnerID, runtimeID, map[string]any{"custom_name": "   "})
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH clear custom_name: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	resp = AgentRuntimeResponse{}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -61,15 +59,11 @@ func TestUpdateAgentRuntime_CustomNamePatchApplies(t *testing.T) {
 
 	// Over-long name is rejected before any mutation.
 	w = patchRuntimeCustomName(runtimeOwnerID, runtimeID, map[string]any{"custom_name": strings.Repeat("x", maxRuntimeCustomNameLen+1)})
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("PATCH over-long custom_name: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadRequest, "HTTP status")
 
 	// Plain member cannot rename someone else's runtime.
 	w = patchRuntimeCustomName(plainMemberID, runtimeID, map[string]any{"custom_name": "hijack"})
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("PATCH custom_name as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestUpdateAgentRuntime_CustomNameMachineFanout verifies that
@@ -109,9 +103,7 @@ func TestUpdateAgentRuntime_CustomNameMachineFanout(t *testing.T) {
 		"custom_name":      "Bohan's MacBook",
 		"apply_to_machine": true,
 	})
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH machine rename: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Both runtimes on the daemon must now carry the name.
 	for _, id := range []string{idA, idB} {
@@ -129,7 +121,7 @@ func TestUpdateAgentRuntime_CustomNameMachineFanout(t *testing.T) {
 // the daemon-token path and returns the first runtime object from the response.
 func registerRuntimeOnDaemon(t *testing.T, daemonID, provider string) map[string]any {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/register", map[string]any{
 		"workspace_id": testWorkspaceID,
 		"daemon_id":    daemonID,
@@ -138,14 +130,12 @@ func registerRuntimeOnDaemon(t *testing.T, daemonID, provider string) map[string
 			{"name": provider + " (host)", "type": provider, "version": "1.0.0", "status": "online"},
 		},
 	}, testWorkspaceID, daemonID)
-	testHandler.DaemonRegister(w, req)
+	w := testutil.Call(t, testHandler.DaemonRegister, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("register %s: expected 200, got %d: %s", provider, w.Code, w.Body.String())
 	}
 	var resp map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode register response: %v", err)
-	}
+	w.Decode(&resp)
 	runtimes, ok := resp["runtimes"].([]any)
 	if !ok || len(runtimes) == 0 {
 		t.Fatalf("register %s: no runtimes in response: %v", provider, resp)
@@ -242,7 +232,6 @@ func TestDaemonRegister_FailedProfileInheritsMachineName(t *testing.T) {
 	// A custom runtime profile fails to resolve on this machine.
 	profileID := insertRuntimeProfileFixture(t, ctx, "Custom Codex", "codex", "missing-codex")
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/register", map[string]any{
 		"workspace_id": testWorkspaceID,
 		"daemon_id":    daemonID,
@@ -251,10 +240,7 @@ func TestDaemonRegister_FailedProfileInheritsMachineName(t *testing.T) {
 			{"profile_id": profileID, "command_name": "missing-codex", "reason": "command not found on PATH"},
 		},
 	}, testWorkspaceID, daemonID)
-	testHandler.DaemonRegister(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("register failed profile: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DaemonRegister, req).Want(http.StatusOK)
 
 	// The failed-profile row must have inherited the machine name.
 	var name *string

--- a/server/internal/handler/runtime_local_skills_overwrite_test.go
+++ b/server/internal/handler/runtime_local_skills_overwrite_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // createImportTargetSkill inserts a skill (owned by ownerID) plus the given
@@ -112,54 +112,38 @@ func reportBundleBody(name, description, content string, files map[string]string
 func initiateLocalSkillImport(t *testing.T, runtimeID string, body map[string]any) string {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequestAsUser(testUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills/import", body),
 		"runtimeId", runtimeID,
 	)
-	testHandler.InitiateImportLocalSkill(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("InitiateImportLocalSkill: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.InitiateImportLocalSkill, req).Want(http.StatusOK)
 	var importReq RuntimeLocalSkillImportRequest
-	if err := json.NewDecoder(w.Body).Decode(&importReq); err != nil {
-		t.Fatalf("decode import request: %v", err)
-	}
+	w.Decode(&importReq)
 	return importReq.ID
 }
 
 func reportLocalSkillImport(t *testing.T, runtimeID, requestID string, body map[string]any) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/local-skills/import/"+requestID+"/result", body, testWorkspaceID, "overwrite-test-daemon"),
 		"runtimeId", runtimeID,
 		"requestId", requestID,
 	)
-	testHandler.ReportLocalSkillImportResult(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ReportLocalSkillImportResult: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ReportLocalSkillImportResult, req).Want(http.StatusOK)
 }
 
 func pollLocalSkillImport(t *testing.T, runtimeID, requestID string) RuntimeLocalSkillImportRequest {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequestAsUser(testUserID, http.MethodGet, "/api/runtimes/"+runtimeID+"/local-skills/import/"+requestID, nil),
 		"runtimeId", runtimeID,
 		"requestId", requestID,
 	)
-	testHandler.GetLocalSkillImportRequest(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetLocalSkillImportRequest: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetLocalSkillImportRequest, req).Want(http.StatusOK)
 	var got RuntimeLocalSkillImportRequest
-	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
-		t.Fatalf("decode poll response: %v", err)
-	}
+	w.Decode(&got)
 	return got
 }
 

--- a/server/internal/handler/runtime_local_skills_test.go
+++ b/server/internal/handler/runtime_local_skills_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func newRequestAsUser(userID, method, path string, body any) *http.Request {
@@ -30,19 +32,7 @@ func createRuntimeLocalSkillTestRuntime(t *testing.T, ownerID string) string {
 	daemonID := fmt.Sprintf("runtime-local-skill-daemon-%d", time.Now().UnixNano())
 
 	var runtimeID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at
-		)
-		VALUES ($1, $2, $3, 'local', 'claude', 'online', 'Runtime Local Skills Test', '{}'::jsonb, $4, now())
-		RETURNING id
-	`, testWorkspaceID, daemonID, runtimeName, ownerID).Scan(&runtimeID); err != nil {
-		t.Fatalf("create local runtime: %v", err)
-	}
-
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
-	})
+	runtimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": daemonID, "name": runtimeName, "runtime_mode": testutil.Raw("'local'"), "provider": testutil.Raw("'claude'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'Runtime Local Skills Test'"), "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": ownerID, "last_seen_at": testutil.Raw("now()")})
 
 	return runtimeID
 }
@@ -243,9 +233,7 @@ func TestListLocalSkills_AllowsNonOwnerForPublicRuntime(t *testing.T) {
 	)
 
 	testHandler.InitiateListLocalSkills(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var initResp RuntimeLocalSkillListRequest
 	if err := json.NewDecoder(w.Body).Decode(&initResp); err != nil {
@@ -260,9 +248,7 @@ func TestListLocalSkills_AllowsNonOwnerForPublicRuntime(t *testing.T) {
 	)
 
 	testHandler.GetLocalSkillListRequest(w, pollReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 func TestListLocalSkills_RejectsNonMember(t *testing.T) {
@@ -285,16 +271,12 @@ func TestListLocalSkills_RejectsNonMember(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, outsiderID)
 	})
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequestAsUser(outsiderID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills", nil),
 		"runtimeId", runtimeID,
 	)
 
-	testHandler.InitiateListLocalSkills(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.InitiateListLocalSkills, req).Want(http.StatusNotFound)
 }
 
 func TestInitiateImportLocalSkill_RequiresRuntimeOwner(t *testing.T) {
@@ -305,7 +287,6 @@ func TestInitiateImportLocalSkill_RequiresRuntimeOwner(t *testing.T) {
 	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
 	adminUserID := createRuntimeLocalSkillTestMember(t, "admin")
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequestAsUser(adminUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills/import", map[string]any{
 			"skill_key": "review-helper",
@@ -313,10 +294,7 @@ func TestInitiateImportLocalSkill_RequiresRuntimeOwner(t *testing.T) {
 		"runtimeId", runtimeID,
 	)
 
-	testHandler.InitiateImportLocalSkill(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.InitiateImportLocalSkill, req).Want(http.StatusNotFound)
 }
 
 func TestGetLocalSkillImportRequest_RequiresRuntimeOwner(t *testing.T) {
@@ -335,17 +313,13 @@ func TestGetLocalSkillImportRequest_RequiresRuntimeOwner(t *testing.T) {
 		t.Fatalf("create import request: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := withURLParams(
 		newRequestAsUser(adminUserID, http.MethodGet, "/api/runtimes/"+runtimeID+"/local-skills/import/"+importReq.ID, nil),
 		"runtimeId", runtimeID,
 		"requestId", importReq.ID,
 	)
 
-	testHandler.GetLocalSkillImportRequest(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetLocalSkillImportRequest, req).Want(http.StatusNotFound)
 }
 
 func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
@@ -365,9 +339,7 @@ func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
 		"runtimeId", runtimeID,
 	)
 	testHandler.InitiateImportLocalSkill(w, initReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("InitiateImportLocalSkill: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var importReq RuntimeLocalSkillImportRequest
 	if err := json.NewDecoder(w.Body).Decode(&importReq); err != nil {
@@ -379,9 +351,7 @@ func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
 		"runtime_id": runtimeID,
 	}, testWorkspaceID, "runtime-local-skills-daemon")
 	testHandler.DaemonHeartbeat(w, heartbeatReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DaemonHeartbeat: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var heartbeatResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&heartbeatResp); err != nil {
@@ -426,9 +396,7 @@ func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
 		"requestId", importReq.ID,
 	)
 	testHandler.ReportLocalSkillImportResult(w, reportReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ReportLocalSkillImportResult: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	w = httptest.NewRecorder()
 	pollReq := withURLParams(
@@ -437,9 +405,7 @@ func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
 		"requestId", importReq.ID,
 	)
 	testHandler.GetLocalSkillImportRequest(w, pollReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetLocalSkillImportRequest: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var completed RuntimeLocalSkillImportRequest
 	if err := json.NewDecoder(w.Body).Decode(&completed); err != nil {
@@ -479,21 +445,19 @@ func TestBatchImportViaHeartbeat(t *testing.T) {
 	skillKeys := []string{"skill-a", "skill-b", "skill-c", "skill-d", "skill-e"}
 	importIDs := make([]string, 0, len(skillKeys))
 	for _, key := range skillKeys {
-		w := httptest.NewRecorder()
+
 		req := withURLParams(
 			newRequestAsUser(testUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills/import", map[string]any{
 				"skill_key": key,
 			}),
 			"runtimeId", runtimeID,
 		)
-		testHandler.InitiateImportLocalSkill(w, req)
+		w := testutil.Call(t, testHandler.InitiateImportLocalSkill, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("InitiateImportLocalSkill(%s): expected 200, got %d: %s", key, w.Code, w.Body.String())
 		}
 		var importReq RuntimeLocalSkillImportRequest
-		if err := json.NewDecoder(w.Body).Decode(&importReq); err != nil {
-			t.Fatalf("decode import request: %v", err)
-		}
+		w.Decode(&importReq)
 		importIDs = append(importIDs, importReq.ID)
 	}
 
@@ -504,9 +468,7 @@ func TestBatchImportViaHeartbeat(t *testing.T) {
 		"supports_batch_import": true,
 	}, testWorkspaceID, "runtime-local-skills-daemon")
 	testHandler.DaemonHeartbeat(w, heartbeatReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DaemonHeartbeat: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var heartbeatResp map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&heartbeatResp); err != nil {
@@ -553,9 +515,7 @@ func TestBatchImportViaHeartbeat(t *testing.T) {
 		"supports_batch_import": true,
 	}, testWorkspaceID, "runtime-local-skills-daemon")
 	testHandler.DaemonHeartbeat(w, heartbeatReq2)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DaemonHeartbeat: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	var heartbeatResp2 map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&heartbeatResp2); err != nil {
@@ -600,7 +560,6 @@ func TestReportLocalSkillImportResult_IgnoresTimedOutRequests(t *testing.T) {
 
 	beforeCount := countSkillsByName(t, "Timed Out Import")
 
-	w := httptest.NewRecorder()
 	reportReq := withURLParams(
 		newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/local-skills/import/"+importReq.ID+"/result", map[string]any{
 			"status": "completed",
@@ -615,10 +574,7 @@ func TestReportLocalSkillImportResult_IgnoresTimedOutRequests(t *testing.T) {
 		"runtimeId", runtimeID,
 		"requestId", importReq.ID,
 	)
-	testHandler.ReportLocalSkillImportResult(w, reportReq)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ReportLocalSkillImportResult: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ReportLocalSkillImportResult, reportReq).Want(http.StatusOK)
 
 	afterCount := countSkillsByName(t, "Timed Out Import")
 	if afterCount != beforeCount {
@@ -641,7 +597,6 @@ func TestReportLocalSkillImportResult_RejectsCrossWorkspaceDaemonToken(t *testin
 		t.Fatalf("create import request: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	reportReq := withURLParams(
 		newDaemonTokenRequest(http.MethodPost, "/api/daemon/runtimes/"+runtimeID+"/local-skills/import/"+importReq.ID+"/result", map[string]any{
 			"status": "failed",
@@ -650,10 +605,7 @@ func TestReportLocalSkillImportResult_RejectsCrossWorkspaceDaemonToken(t *testin
 		"runtimeId", runtimeID,
 		"requestId", importReq.ID,
 	)
-	testHandler.ReportLocalSkillImportResult(w, reportReq)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ReportLocalSkillImportResult, reportReq).Want(http.StatusNotFound)
 }
 
 func TestCleanOptionalString(t *testing.T) {

--- a/server/internal/handler/runtime_profile_handler_test.go
+++ b/server/internal/handler/runtime_profile_handler_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -16,16 +16,7 @@ import (
 func insertRuntimeProfileFixture(t *testing.T, ctx context.Context, displayName, protocolFamily, commandName string) string {
 	t.Helper()
 	var profileID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO runtime_profile (workspace_id, display_name, protocol_family, command_name, created_by)
-		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id
-	`, testWorkspaceID, displayName, protocolFamily, commandName, testUserID).Scan(&profileID); err != nil {
-		t.Fatalf("insert runtime_profile fixture: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM runtime_profile WHERE id = $1`, profileID)
-	})
+	profileID = dbfx.Insert(t, "runtime_profile", testutil.Cols{"workspace_id": testWorkspaceID, "display_name": displayName, "protocol_family": protocolFamily, "command_name": commandName, "created_by": testUserID})
 	return profileID
 }
 
@@ -102,14 +93,9 @@ VALUES ($1, $2, 'feishu', 'oc_rp', 'p2p')`, rpChat, rpInstallID); err != nil {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_chat_session_binding WHERE chat_session_id = $1`, rpChat)
 	})
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteRuntimeProfile, req).Want(http.StatusNoContent)
 
 	var profileRows, rtRows, agentRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM runtime_profile WHERE id = $1`, profileID).Scan(&profileRows); err != nil {
@@ -167,14 +153,9 @@ func TestDeleteRuntimeProfile_ActiveAgentBlocks(t *testing.T) {
 	runtimeID := insertProfileRuntimeFixture(t, ctx, profileID, "Cascade Profile Active Runtime", "codex")
 	_ = createCascadeFixtureAgent(t, ctx, runtimeID, "Cascade Profile Active Agent")
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
-
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteRuntimeProfile, req).Want(http.StatusConflict)
 
 	var profileRows, rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM runtime_profile WHERE id = $1`, profileID).Scan(&profileRows); err != nil {
@@ -203,14 +184,9 @@ func TestDeleteRuntimeProfile_MissingProfileWithOrphanRuntimesCleansUp(t *testin
 		t.Fatalf("delete profile row: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+profileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", profileID)
-	testHandler.DeleteRuntimeProfile(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteRuntimeProfile, req).Want(http.StatusNoContent)
 
 	var rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
@@ -227,14 +203,10 @@ func TestDeleteRuntimeProfile_MissingProfileNoOrphansStillReturns404(t *testing.
 	}
 
 	missingProfileID := "00000000-0000-0000-0000-000000415800"
-	w := httptest.NewRecorder()
+
 	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles/"+missingProfileID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "profileId", missingProfileID)
-	testHandler.DeleteRuntimeProfile(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteRuntimeProfile, req).Want(http.StatusNotFound)
 }
 
 func TestRuntimeProfileDeleteLockSerializesRegistration(t *testing.T) {
@@ -293,7 +265,6 @@ func TestCreateRuntimeProfile_ForcesWorkspaceVisibility(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles", map[string]any{
 		"display_name":    "Visibility Forced Profile",
 		"protocol_family": "codex",
@@ -301,15 +272,9 @@ func TestCreateRuntimeProfile_ForcesWorkspaceVisibility(t *testing.T) {
 		"visibility":      "private", // must be ignored
 	})
 	req = withURLParam(req, "id", testWorkspaceID)
-	testHandler.CreateRuntimeProfile(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateRuntimeProfile, req).Want(http.StatusCreated)
 	var resp RuntimeProfileResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM runtime_profile WHERE id = $1`, resp.ID)
 	})
@@ -356,7 +321,7 @@ func TestCreateRuntimeProfile_ValidatesCommandAndFixedArgs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles", map[string]any{
 				"display_name":    "Validation " + tc.name,
 				"protocol_family": "codex",
@@ -364,10 +329,7 @@ func TestCreateRuntimeProfile_ValidatesCommandAndFixedArgs(t *testing.T) {
 				"fixed_args":      tc.fixedArgs,
 			})
 			req = withURLParam(req, "id", testWorkspaceID)
-			testHandler.CreateRuntimeProfile(w, req)
-			if w.Code != tc.wantStatus {
-				t.Fatalf("status = %d, want %d: %s", w.Code, tc.wantStatus, w.Body.String())
-			}
+			w := testutil.Call(t, testHandler.CreateRuntimeProfile, req).Want(tc.wantStatus)
 			if w.Code == http.StatusCreated {
 				var resp RuntimeProfileResponse
 				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {

--- a/server/internal/handler/runtime_test.go
+++ b/server/internal/handler/runtime_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -72,10 +71,10 @@ func TestRuntimeHandlersRejectMalformedRuntimeID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest(tt.method, tt.path, nil)
 			req = withURLParam(req, "runtimeId", "not-a-uuid")
-			tt.handle(w, req)
+			w := testutil.Call(t, tt.handle, req)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("%s: expected 400 for malformed runtimeId, got %d: %s", tt.name, w.Code, w.Body.String())
 			}
@@ -111,16 +110,7 @@ func TestGetRuntimeUsage_BucketsByUsageTime(t *testing.T) {
 
 	// Create an issue for the tasks to reference.
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, creator_id, creator_type)
-		VALUES ($1, 'runtime usage test', $2, 'member')
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'runtime usage test'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'")})
 
 	// enqueued yesterday 23:58 UTC, finished today 00:05 UTC — tokens belong to today.
 	now := time.Now().UTC()
@@ -177,18 +167,13 @@ func TestGetRuntimeUsage_BucketsByUsageTime(t *testing.T) {
 
 	// Call the handler with ?days=1 at whatever "now" is. That should include
 	// both today and yesterday in full.
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/runtimes/"+runtimeID+"/usage?days=1", nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.GetRuntimeUsage(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("GetRuntimeUsage: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetRuntimeUsage, req).Want(http.StatusOK)
 
 	var resp []RuntimeUsageResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 
 	byDate := make(map[string]int64)
 	for _, r := range resp {
@@ -233,14 +218,7 @@ func TestListRuntimeUsageByAgent_MergesMixedCaseProvider(t *testing.T) {
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, creator_id, creator_type)
-		VALUES ($1, 'mixed-case provider test', $2, 'member')
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'mixed-case provider test'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'")})
 
 	now := time.Now().UTC()
 	// Two tasks for the same agent/model under this runtime, reporting the
@@ -464,10 +442,10 @@ func TestRuntimeHeatmapEndpointsUseViewerTZ(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := newRequest("GET", c.path, nil)
 			req = withURLParam(req, "runtimeId", runtimeID)
-			c.handle(w, req)
+			w := testutil.Call(t, c.handle, req)
 			if w.Code != http.StatusOK {
 				t.Fatalf("%s: expected 200, got %d: %s", c.name, w.Code, w.Body.String())
 			}

--- a/server/internal/handler/runtime_unbind_delete_test.go
+++ b/server/internal/handler/runtime_unbind_delete_test.go
@@ -2,12 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -144,25 +143,17 @@ func TestDeleteAgentRuntime_StructuredConflict(t *testing.T) {
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Cascade 409 Agent")
 	_ = agentID
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusConflict)
 
 	var body struct {
 		Error        string          `json:"error"`
 		Code         string          `json:"code"`
 		ActiveAgents []AgentResponse `json:"active_agents"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if body.Code != "runtime_has_active_agents" {
-		t.Fatalf("expected code runtime_has_active_agents, got %q", body.Code)
-	}
+	w.Decode(&body)
+	testutil.Equal(t, body.Code, "runtime_has_active_agents", "HTTP status")
 	if len(body.ActiveAgents) != 1 || body.ActiveAgents[0].ID != agentID {
 		t.Fatalf("expected one active agent %s, got %+v", agentID, body.ActiveAgents)
 	}
@@ -254,23 +245,15 @@ func TestDeleteAgentRuntime_CustomProfileInstanceRefusesDirectDelete(t *testing.
 
 	runtimeID, _ := createProfileBackedRuntime(t, ctx, "Custom Instance Delete Guard")
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusConflict)
 
 	var body struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if body.Code != "runtime_profile_instance_delete_unsupported" {
-		t.Fatalf("expected runtime_profile_instance_delete_unsupported, got %q", body.Code)
-	}
+	w.Decode(&body)
+	testutil.Equal(t, body.Code, "runtime_profile_instance_delete_unsupported", "HTTP status")
 
 	var rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
@@ -292,13 +275,9 @@ func TestDeleteAgentRuntime_OrphanedProfileAllowsDirectDelete(t *testing.T) {
 		t.Fatalf("delete profile row: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	var rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
@@ -322,14 +301,10 @@ func TestUnbindAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 	runtimeID := createCascadeFixtureRuntime(t, ctx, "Cascade Happy Runtime")
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Cascade Happy Agent")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{agentID}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusOK)
 
 	// Runtime row must be gone.
 	var rtRows int
@@ -370,9 +345,7 @@ func TestUnbindAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 		AgentsUnbound  int `json:"agents_unbound"`
 		AgentsArchived int `json:"agents_archived"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&body)
 	if body.AgentsUnbound != 1 {
 		t.Fatalf("agents_unbound = %d, want 1", body.AgentsUnbound)
 	}
@@ -391,24 +364,16 @@ func TestUnbindAgentsAndDeleteRuntime_CustomProfileInstanceRefusesDirectDelete(t
 
 	runtimeID, _ := createProfileBackedRuntime(t, ctx, "Custom Instance Cascade Guard")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusConflict)
 
 	var body struct {
 		Code string `json:"code"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if body.Code != "runtime_profile_instance_delete_unsupported" {
-		t.Fatalf("expected runtime_profile_instance_delete_unsupported, got %q", body.Code)
-	}
+	w.Decode(&body)
+	testutil.Equal(t, body.Code, "runtime_profile_instance_delete_unsupported", "HTTP status")
 
 	var rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
@@ -430,14 +395,10 @@ func TestUnbindAgentsAndDeleteRuntime_OrphanedProfileAllowsCascade(t *testing.T)
 		t.Fatalf("delete profile row: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusOK)
 
 	var rtRows int
 	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
@@ -464,25 +425,18 @@ func TestUnbindAgentsAndDeleteRuntime_PlanChanged(t *testing.T) {
 	agent2 := createCascadeFixtureAgent(t, ctx, runtimeID, "Cascade Drift Agent B")
 
 	// User confirmed only agent1 — but the live set is {agent1, agent2}.
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{agent1}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusConflict)
 
 	var body struct {
 		Code         string          `json:"code"`
 		ActiveAgents []AgentResponse `json:"active_agents"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if body.Code != "runtime_delete_plan_changed" {
-		t.Fatalf("expected code runtime_delete_plan_changed, got %q", body.Code)
-	}
+	w.Decode(&body)
+	testutil.Equal(t, body.Code, "runtime_delete_plan_changed", "HTTP status")
 	if len(body.ActiveAgents) != 2 {
 		t.Fatalf("expected 2 active agents in fresh snapshot, got %d", len(body.ActiveAgents))
 	}
@@ -561,18 +515,6 @@ func createProfileBackedRuntime(t *testing.T, ctx context.Context, name string) 
 func createCascadeFixtureAgent(t *testing.T, ctx context.Context, runtimeID, name string) string {
 	t.Helper()
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, name, runtimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("insert cascade fixture agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": name, "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 	return agentID
 }

--- a/server/internal/handler/runtime_unbind_preserves_data_test.go
+++ b/server/internal/handler/runtime_unbind_preserves_data_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -221,19 +220,7 @@ func TestUnbindAgentsAndDeleteRuntime_KeepsAutopilotConfig(t *testing.T) {
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Unbind Autopilot Agent")
 
 	var autopilotID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO autopilot (
-			workspace_id, title, description, assignee_type, assignee_id,
-			created_by_type, created_by_id, status, execution_mode
-		)
-		VALUES ($1, 'unbind autopilot', 'do the thing', 'agent', $2, 'member', $3, 'active', 'run_only')
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&autopilotID); err != nil {
-		t.Fatalf("insert autopilot: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID)
-	})
+	autopilotID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'unbind autopilot'"), "description": testutil.Raw("'do the thing'"), "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID, "created_by_type": testutil.Raw("'member'"), "created_by_id": testUserID, "status": testutil.Raw("'active'"), "execution_mode": testutil.Raw("'run_only'")})
 
 	unbindRuntime(t, ctx, runtimeID, agentID)
 
@@ -362,22 +349,16 @@ func TestUnbindAgentsAndDeleteRuntime_LegacyRouteBehavesTheSame(t *testing.T) {
 	runtimeID := createCascadeFixtureRuntime(t, ctx, "Legacy Route Runtime")
 	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Legacy Route Agent")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/archive-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": []string{agentID}})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("legacy route: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusOK)
 
 	var body struct {
 		AgentsUnbound  int `json:"agents_unbound"`
 		AgentsArchived int `json:"agents_archived"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&body)
 	if body.AgentsUnbound != 1 || body.AgentsArchived != 1 {
 		t.Fatalf("counts = unbound %d / archived-mirror %d, want 1/1", body.AgentsUnbound, body.AgentsArchived)
 	}
@@ -435,14 +416,11 @@ func TestAgentResponse_RuntimeBoundSignal(t *testing.T) {
 // runtime does not go away.
 func unbindRuntime(t *testing.T, ctx context.Context, runtimeID string, activeAgentIDs ...string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/unbind-agents-and-delete",
 		map[string]any{"expected_active_agent_ids": activeAgentIDs})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UnbindAgentsAndDeleteRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UnbindAgentsAndDeleteRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UnbindAgentsAndDeleteRuntime, req).Want(http.StatusOK)
 	var rtRows int
 	if err := testPool.QueryRow(ctx,
 		`SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {

--- a/server/internal/handler/runtime_unbind_squad_test.go
+++ b/server/internal/handler/runtime_unbind_squad_test.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // These tests cover what a runtime teardown does to squads whose leader lives
@@ -162,13 +163,9 @@ func TestDeleteAgentRuntime_KeepsSquadsLedByUnboundAgents(t *testing.T) {
 	archivedSquad := seedSquad(t, archivedLeader, "Archived Squad For Runtime Delete", true)
 	activeSquad := seedSquad(t, archivedLeader, "Active Squad For Runtime Delete", false)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if !squadExists(t, archivedSquad) {
 		t.Errorf("archived squad must survive: its leader is unbound, not deleted")
@@ -199,27 +196,11 @@ func TestDeleteAgentRuntime_ActiveSquadWithArchivedLeaderNoLongerConflicts(t *te
 	archivedLeader := seedAgentOnRuntime(t, runtimeID, "Archived Leader Formerly Blocking Delete", true)
 	activeSquad := seedSquad(t, archivedLeader, "Active Squad Formerly Blocking Delete", false)
 	var autopilotID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO autopilot (
-			workspace_id, title, assignee_type, assignee_id,
-			created_by_type, created_by_id, status, execution_mode
-		)
-		VALUES ($1, 'squad runtime pause', 'squad', $2, 'member', $3, 'active', 'run_only')
-		RETURNING id
-	`, testWorkspaceID, activeSquad, testUserID).Scan(&autopilotID); err != nil {
-		t.Fatalf("seed squad autopilot: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID)
-	})
+	autopilotID = dbfx.Insert(t, "autopilot", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'squad runtime pause'"), "assignee_type": testutil.Raw("'squad'"), "assignee_id": activeSquad, "created_by_type": testutil.Raw("'member'"), "created_by_id": testUserID, "status": testutil.Raw("'active'"), "execution_mode": testutil.Raw("'run_only'")})
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200 (guard removed), got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if !squadExists(t, activeSquad) {
 		t.Errorf("active squad must survive the runtime delete")
@@ -252,13 +233,9 @@ func TestDeleteAgentRuntime_NoSquadsRegression(t *testing.T) {
 	runtimeID := seedIsolatedRuntime(t, "Runtime With No Squad References")
 	archivedAgent := seedAgentOnRuntime(t, runtimeID, "Archived Agent No Squad", true)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("DeleteAgentRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusOK)
 
 	if !agentExists(t, archivedAgent) {
 		t.Errorf("archived agent must survive its runtime as an unbound agent")
@@ -320,17 +297,13 @@ func TestUpdateSquad_UnboundLeaderPausesOnlySquadAutopilots(t *testing.T) {
 		)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.UpdateSquad(w, squadScopeReq(
+	testutil.Call(t, testHandler.UpdateSquad, squadScopeReq(
 		"",
 		http.MethodPatch,
 		"/api/squads/"+squadID,
 		map[string]any{"leader_id": unboundLeaderID},
 		map[string]string{"id": squadID},
-	))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateSquad: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	)).Want(http.StatusOK)
 
 	var squadStatus, pauseReason, directStatus string
 	if err := testPool.QueryRow(ctx,
@@ -365,13 +338,9 @@ func TestDeleteAgentRuntime_StillBlockedByActiveAgents(t *testing.T) {
 	runtimeID := seedIsolatedRuntime(t, "Runtime With Active Agent")
 	activeAgent := seedAgentOnRuntime(t, runtimeID, "Active Agent Blocking Delete", false)
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.DeleteAgentRuntime(w, req)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("DeleteAgentRuntime: expected 409 active-agent guard, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAgentRuntime, req).Want(http.StatusConflict)
 
 	if !agentExists(t, activeAgent) {
 		t.Errorf("active agent must NOT have been touched by a refused runtime delete")

--- a/server/internal/handler/runtime_update_authorization_test.go
+++ b/server/internal/handler/runtime_update_authorization_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func setRuntimeTestMemberRole(t *testing.T, userID, role string) {
@@ -54,7 +54,6 @@ func TestInitiateUpdateRequiresRuntimeManager(t *testing.T) {
 				actorID = plainMemberID
 			}
 
-			w := httptest.NewRecorder()
 			req := withURLParam(
 				newRequestAs(actorID, http.MethodPost, "/api/runtimes/"+runtimeID+"/update", map[string]any{
 					"target_version": "v9.9.9",
@@ -62,11 +61,7 @@ func TestInitiateUpdateRequiresRuntimeManager(t *testing.T) {
 				"runtimeId",
 				runtimeID,
 			)
-			testHandler.InitiateUpdate(w, req)
-
-			if w.Code != tc.wantStatus {
-				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.InitiateUpdate, req).Want(tc.wantStatus)
 
 			hasPending, err := testHandler.UpdateStore.HasPending(context.Background(), runtimeID)
 			if err != nil {
@@ -112,17 +107,12 @@ func TestGetUpdateRequiresRuntimeManager(t *testing.T) {
 				t.Fatalf("create update request: %v", err)
 			}
 
-			w := httptest.NewRecorder()
 			req := withURLParams(
 				newRequestAs(actorID, http.MethodGet, "/api/runtimes/"+runtimeID+"/update/"+update.ID, nil),
 				"runtimeId", runtimeID,
 				"updateId", update.ID,
 			)
-			testHandler.GetUpdate(w, req)
-
-			if w.Code != tc.wantStatus {
-				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
-			}
+			testutil.Call(t, testHandler.GetUpdate, req).Want(tc.wantStatus)
 		})
 	}
 }
@@ -142,7 +132,6 @@ func TestGetUpdateAllowsInitiatorAfterAdminDemotionOnPublicRuntime(t *testing.T)
 	}
 	promoteRuntimeTestMemberToAdmin(t, adminID)
 
-	initRecorder := httptest.NewRecorder()
 	initRequest := withURLParam(
 		newRequestAs(adminID, http.MethodPost, "/api/runtimes/"+runtimeID+"/update", map[string]any{
 			"target_version": "v9.9.9",
@@ -150,28 +139,19 @@ func TestGetUpdateAllowsInitiatorAfterAdminDemotionOnPublicRuntime(t *testing.T)
 		"runtimeId",
 		runtimeID,
 	)
-	testHandler.InitiateUpdate(initRecorder, initRequest)
-	if initRecorder.Code != http.StatusOK {
-		t.Fatalf("initiate update: expected 200, got %d: %s", initRecorder.Code, initRecorder.Body.String())
-	}
+	initRecorder := testutil.Call(t, testHandler.InitiateUpdate, initRequest).Want(http.StatusOK)
 
 	var update UpdateRequest
-	if err := json.Unmarshal(initRecorder.Body.Bytes(), &update); err != nil {
-		t.Fatalf("decode initiated update: %v", err)
-	}
+	initRecorder.JSON(&update)
 	if update.InitiatorUserID != "" {
 		t.Fatalf("initiator user ID leaked in API response: %q", update.InitiatorUserID)
 	}
 	setRuntimeTestMemberRole(t, adminID, "member")
 
-	pollRecorder := httptest.NewRecorder()
 	pollRequest := withURLParams(
 		newRequestAs(adminID, http.MethodGet, "/api/runtimes/"+runtimeID+"/update/"+update.ID, nil),
 		"runtimeId", runtimeID,
 		"updateId", update.ID,
 	)
-	testHandler.GetUpdate(pollRecorder, pollRequest)
-	if pollRecorder.Code != http.StatusOK {
-		t.Fatalf("poll after admin demotion: expected 200, got %d: %s", pollRecorder.Code, pollRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.GetUpdate, pollRequest).Want(http.StatusOK)
 }

--- a/server/internal/handler/runtime_update_error_classification_test.go
+++ b/server/internal/handler/runtime_update_error_classification_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // failingUpdateStore returns a chosen error from Create. The embedded interface
@@ -39,15 +40,10 @@ func TestInitiateUpdate_InfrastructureErrorIsNotAConflict(t *testing.T) {
 	testHandler.UpdateStore = &failingUpdateStore{createErr: infraErr}
 	t.Cleanup(func() { testHandler.UpdateStore = original })
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/runtimes/"+testRuntimeID+"/update", map[string]any{"target_version": "v1.2.3"})
 	r = withURLParams(r, "runtimeId", testRuntimeID)
 
-	testHandler.InitiateUpdate(w, r)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("infrastructure failure: expected 500, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.InitiateUpdate, r).Want(http.StatusInternalServerError)
 	body := w.Body.String()
 	for _, leak := range []string{"10.1.2.3:6379", "connection refused", "reserve active update"} {
 		if strings.Contains(body, leak) {
@@ -68,15 +64,10 @@ func TestInitiateUpdate_InProgressStillConflicts(t *testing.T) {
 	testHandler.UpdateStore = &failingUpdateStore{createErr: errUpdateInProgress}
 	t.Cleanup(func() { testHandler.UpdateStore = original })
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/runtimes/"+testRuntimeID+"/update", map[string]any{"target_version": "v1.2.3"})
 	r = withURLParams(r, "runtimeId", testRuntimeID)
 
-	testHandler.InitiateUpdate(w, r)
-
-	if w.Code != http.StatusConflict {
-		t.Fatalf("update-in-progress: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.InitiateUpdate, r).Want(http.StatusConflict)
 	if !strings.Contains(w.Body.String(), "already in progress") {
 		t.Fatalf("409 should keep its actionable message, got %s", w.Body.String())
 	}

--- a/server/internal/handler/runtime_visibility_test.go
+++ b/server/internal/handler/runtime_visibility_test.go
@@ -125,20 +125,7 @@ func runtimeVisibilityFixture(t *testing.T) (runtimeID, runtimeOwnerID, plainMem
 		t.Fatalf("add plain member: %v", err)
 	}
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status,
-			device_info, metadata, owner_id, visibility, last_seen_at
-		)
-		VALUES ($1, NULL, 'Visibility Test Runtime', 'cloud', 'visibility_test_provider', 'online', 'visibility test', '{}'::jsonb, $2, 'private', now())
-		RETURNING id
-	`, testWorkspaceID, runtimeOwnerID).Scan(&runtimeID); err != nil {
-		t.Fatalf("create runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(),
-			`DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
-	})
+	runtimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": testutil.Raw("'Visibility Test Runtime'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'visibility_test_provider'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'visibility test'"), "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": runtimeOwnerID, "visibility": testutil.Raw("'private'"), "last_seen_at": testutil.Raw("now()")})
 
 	return runtimeID, runtimeOwnerID, plainMemberID
 }
@@ -176,23 +163,17 @@ func TestCreateAgent_RejectsPrivateRuntimeForNonOwner(t *testing.T) {
 	// needs the machine flips its visibility to public instead.
 	w := httptest.NewRecorder()
 	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body("runtime-visibility-test-admin")))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateAgent as workspace owner on another member's private runtime: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Runtime owner: allowed because they own the runtime.
 	w = httptest.NewRecorder()
 	testHandler.CreateAgent(w, newRequestAs(runtimeOwnerID, http.MethodPost, "/api/agents", body("runtime-visibility-test-runtime-owner")))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAgent as runtime owner: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Plain member: this is the hole MUL-2062 closes — must be 403.
 	w = httptest.NewRecorder()
 	testHandler.CreateAgent(w, newRequestAs(plainMemberID, http.MethodPost, "/api/agents", body("runtime-visibility-test-plain-member")))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateAgent as plain member on private runtime: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }
 
 // TestCreateAgent_AllowsPublicRuntimeForPlainMember verifies the "public"
@@ -224,11 +205,7 @@ func TestCreateAgent_AllowsPublicRuntimeForPlainMember(t *testing.T) {
 		"visibility":           "private",
 		"max_concurrent_tasks": 1,
 	}
-	w := httptest.NewRecorder()
-	testHandler.CreateAgent(w, newRequestAs(plainMemberID, http.MethodPost, "/api/agents", body))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateAgent as plain member on public runtime: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAgent, newRequestAs(plainMemberID, http.MethodPost, "/api/agents", body)).Want(http.StatusCreated)
 }
 
 func TestListAgentRuntimes_HidesOtherMembersPrivateRuntimes(t *testing.T) {
@@ -321,24 +298,18 @@ func TestPrivateRuntimeReadEndpointsHideKnownRuntimeFromNonOwners(t *testing.T) 
 
 	for _, tc := range tests {
 		t.Run("plain member/"+tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := withURLParams(newRequestAs(plainMemberID, tc.method, tc.path, nil), tc.params...)
-			tc.handle(w, req)
-			if w.Code != http.StatusNotFound {
-				t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.handle, req).Want(http.StatusNotFound)
 		})
 	}
 
 	promoteRuntimeTestMemberToAdmin(t, plainMemberID)
 	for _, tc := range tests {
 		t.Run("workspace admin/"+tc.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
+
 			req := withURLParams(newRequestAs(plainMemberID, tc.method, tc.path, nil), tc.params...)
-			tc.handle(w, req)
-			if w.Code != http.StatusNotFound {
-				t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
-			}
+			testutil.Call(t, tc.handle, req).Want(http.StatusNotFound)
 		})
 	}
 
@@ -346,9 +317,7 @@ func TestPrivateRuntimeReadEndpointsHideKnownRuntimeFromNonOwners(t *testing.T) 
 	w := httptest.NewRecorder()
 	req := withURLParam(newRequestAs(runtimeOwnerID, http.MethodPost, "/api/runtimes/"+runtimeID+"/models", nil), "runtimeId", runtimeID)
 	testHandler.InitiateListModels(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("owner model discovery: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	if _, err := testPool.Exec(context.Background(), `UPDATE agent_runtime SET visibility = 'public' WHERE id = $1`, runtimeID); err != nil {
 		t.Fatalf("make runtime public: %v", err)
@@ -356,9 +325,7 @@ func TestPrivateRuntimeReadEndpointsHideKnownRuntimeFromNonOwners(t *testing.T) 
 	w = httptest.NewRecorder()
 	req = withURLParam(newRequestAs(plainMemberID, http.MethodPost, "/api/runtimes/"+runtimeID+"/models", nil), "runtimeId", runtimeID)
 	testHandler.InitiateListModels(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("public runtime model discovery: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 // TestUpdateAgent_RejectsRebindToPrivateRuntime is the regression for the
@@ -372,51 +339,21 @@ func TestUpdateAgent_RejectsRebindToPrivateRuntime(t *testing.T) {
 
 	privateRuntimeID, _, plainMemberID := runtimeVisibilityFixture(t)
 
-	ctx := context.Background()
 	// Create a public runtime that the plain member can legitimately own
 	// an agent on, then we try to move the agent onto the private runtime.
 	var publicRuntimeID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider, status,
-			device_info, metadata, owner_id, visibility, last_seen_at
-		)
-		VALUES ($1, NULL, 'Public Runtime', 'cloud', 'visibility_test_public_provider', 'online', 'public', '{}'::jsonb, $2, 'public', now())
-		RETURNING id
-	`, testWorkspaceID, plainMemberID).Scan(&publicRuntimeID); err != nil {
-		t.Fatalf("create public runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, publicRuntimeID)
-	})
+	publicRuntimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": testutil.Raw("NULL"), "name": testutil.Raw("'Public Runtime'"), "runtime_mode": testutil.Raw("'cloud'"), "provider": testutil.Raw("'visibility_test_public_provider'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'public'"), "metadata": testutil.Raw("'{}'::jsonb"), "owner_id": plainMemberID, "visibility": testutil.Raw("'public'"), "last_seen_at": testutil.Raw("now()")})
 
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args
-		)
-		VALUES ($1, 'rebind-test-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, publicRuntimeID, plainMemberID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent on public runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'rebind-test-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": publicRuntimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": plainMemberID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 
 	body := map[string]any{
 		"runtime_id": privateRuntimeID,
 	}
-	w := httptest.NewRecorder()
+
 	req := newRequestAs(plainMemberID, http.MethodPut, "/api/agents/"+agentID, body)
 	req = withURLParam(req, "id", agentID)
-	testHandler.UpdateAgent(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("UpdateAgent rebinding to private runtime: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgent, req).Want(http.StatusForbidden)
 }
 
 // TestUpdateAgent_WorkspaceAdminCannotRebindToMemberPrivateRuntime walks the
@@ -433,25 +370,10 @@ func TestUpdateAgent_WorkspaceAdminCannotRebindToMemberPrivateRuntime(t *testing
 
 	memberPrivateRuntimeID, runtimeOwnerID, _ := runtimeVisibilityFixture(t)
 
-	ctx := context.Background()
 	// The admin's own agent, on the fixture runtime they own — so the only
 	// thing this update can trip over is the runtime gate.
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args
-		)
-		VALUES ($1, 'admin-rebind-test-agent', '', 'cloud', '{}'::jsonb,
-		        $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id
-	`, testWorkspaceID, testRuntimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent on the workspace owner's runtime: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'admin-rebind-test-agent'"), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": testRuntimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 
 	rebind := func() *httptest.ResponseRecorder {
 		w := httptest.NewRecorder()
@@ -544,19 +466,13 @@ func TestUpdateAgentRuntime_VisibilityPatchApplies(t *testing.T) {
 
 	runtimeID, runtimeOwnerID, _ := runtimeVisibilityFixture(t)
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(runtimeOwnerID, http.MethodPatch, "/api/runtimes/"+runtimeID, map[string]any{
 		"visibility": "public",
 	})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UpdateAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH visibility: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgentRuntime, req).Want(http.StatusOK)
 	var resp AgentRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.Visibility != "public" {
 		t.Fatalf("visibility patch: got %q, want public", resp.Visibility)
 	}
@@ -574,7 +490,6 @@ func TestUpdateAgentRuntime_IgnoresTimezoneField(t *testing.T) {
 
 	runtimeID, runtimeOwnerID, _ := runtimeVisibilityFixture(t)
 
-	w := httptest.NewRecorder()
 	// NOTE: visibility is "public" (not "workspace"): the runtime visibility
 	// enum is private|public — "workspace" would 400 before any mutation,
 	// which would not exercise the "visibility still applied" assertion.
@@ -583,25 +498,18 @@ func TestUpdateAgentRuntime_IgnoresTimezoneField(t *testing.T) {
 		"visibility": "public",
 	})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UpdateAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH with stray timezone: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgentRuntime, req).Want(http.StatusOK)
 
 	// The response must carry no `timezone` key — runtimes have no such field.
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&raw)
 	if _, present := raw["timezone"]; present {
 		t.Errorf("response unexpectedly contains a timezone key: %s", w.Body.String())
 	}
 
 	// `visibility` was still applied.
 	var resp AgentRuntimeResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Visibility != "public" {
 		t.Errorf("visibility patch: got %q, want public", resp.Visibility)
 	}
@@ -616,15 +524,11 @@ func TestUpdateAgentRuntime_InvalidVisibilityReturns400(t *testing.T) {
 
 	runtimeID, runtimeOwnerID, _ := runtimeVisibilityFixture(t)
 
-	w := httptest.NewRecorder()
 	req := newRequestAs(runtimeOwnerID, http.MethodPatch, "/api/runtimes/"+runtimeID, map[string]any{
 		"visibility": "everyone",
 	})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UpdateAgentRuntime(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("PATCH with invalid visibility: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateAgentRuntime, req).Want(http.StatusBadRequest)
 }
 
 // TestUpdateAgentRuntime_VisibilityToggle covers the PATCH endpoint: the
@@ -696,21 +600,15 @@ func TestUpdateAgentRuntime_AdminMayEchoUnchangedVisibility(t *testing.T) {
 
 	runtimeID, _, _ := runtimeVisibilityFixture(t)
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodPatch, "/api/runtimes/"+runtimeID, map[string]any{
 		"visibility":  "private", // unchanged — the fixture runtime is private
 		"custom_name": "Renamed By Admin",
 	})
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.UpdateAgentRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("admin rename echoing unchanged visibility: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateAgentRuntime, req).Want(http.StatusOK)
 
 	var resp AgentRuntimeResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.CustomName == nil || *resp.CustomName != "Renamed By Admin" {
 		t.Errorf("custom name was not applied: %v", resp.CustomName)
 	}

--- a/server/internal/handler/search_cancelled_rank_test.go
+++ b/server/internal/handler/search_cancelled_rank_test.go
@@ -2,13 +2,13 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // MUL-5824: cancelled work is abandoned work. It stays reachable, but it must
@@ -66,8 +66,7 @@ func searchTitles(t *testing.T, q string) []string {
 		"/api/issues/search?workspace_id=%s&q=%s&limit=50&include_closed=true",
 		testWorkspaceID, url.QueryEscape(q),
 	)
-	w := httptest.NewRecorder()
-	testHandler.SearchIssues(w, newRequest("GET", path, nil))
+	w := testutil.Call(t, testHandler.SearchIssues, newRequest("GET", path, nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("SearchIssues(%q): expected 200, got %d: %s", q, w.Code, w.Body.String())
 	}
@@ -75,9 +74,7 @@ func searchTitles(t *testing.T, q string) []string {
 	var response struct {
 		Issues []SearchIssueResponse `json:"issues"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("decode search response: %v", err)
-	}
+	w.Decode(&response)
 
 	titles := make([]string, 0, len(response.Issues))
 	for _, issue := range response.Issues {

--- a/server/internal/handler/share_link_test.go
+++ b/server/internal/handler/share_link_test.go
@@ -2,10 +2,8 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/seatcapacity"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -154,22 +153,14 @@ func TestCreateShareLink_RequiresOwnerAdmin(t *testing.T) {
 	// Owner succeeds.
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member"})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("owner create: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, r.ServeHTTP, req).Want(http.StatusCreated)
 
 	// Plain member is denied.
 	memberID := createTestUserAndMember(t, "member")
 	req2 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member"})
 	req2.Header.Set("X-User-ID", memberID)
 	req2 = withURLParam(req2, "id", testWorkspaceID)
-	w2 := httptest.NewRecorder()
-	r.ServeHTTP(w2, req2)
-	if w2.Code != http.StatusForbidden {
-		t.Fatalf("member create: expected 403, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, r.ServeHTTP, req2).Want(http.StatusForbidden)
 }
 
 func TestListShareLinks_RequiresOwnerAdmin(t *testing.T) {
@@ -185,22 +176,14 @@ func TestListShareLinks_RequiresOwnerAdmin(t *testing.T) {
 	// Owner can list.
 	req := newRequest("GET", "/api/workspaces/"+testWorkspaceID+"/share-links", nil)
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("owner list: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, r.ServeHTTP, req).Want(http.StatusOK)
 
 	// Plain member denied.
 	memberID := createTestUserAndMember(t, "member")
 	req2 := newRequest("GET", "/api/workspaces/"+testWorkspaceID+"/share-links", nil)
 	req2.Header.Set("X-User-ID", memberID)
 	req2 = withURLParam(req2, "id", testWorkspaceID)
-	w2 := httptest.NewRecorder()
-	r.ServeHTTP(w2, req2)
-	if w2.Code != http.StatusForbidden {
-		t.Fatalf("member list: expected 403, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, r.ServeHTTP, req2).Want(http.StatusForbidden)
 }
 
 func TestCreateShareLink_InvalidatesOldLink(t *testing.T) {
@@ -210,11 +193,7 @@ func TestCreateShareLink_InvalidatesOldLink(t *testing.T) {
 
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member"})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.CreateShareLink(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req).Want(http.StatusCreated)
 
 	var active bool
 	if err := testPool.QueryRow(context.Background(),
@@ -233,21 +212,13 @@ func TestCreateShareLink_RejectsInvalidInput(t *testing.T) {
 	neg := -1
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", ExpiresIn: &neg})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.CreateShareLink(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("negative expires_in: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req).Want(http.StatusBadRequest)
 
 	// Zero max_uses is rejected.
 	zero := 0
 	req2 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", MaxUses: &zero})
 	req2 = withURLParam(req2, "id", testWorkspaceID)
-	w2 := httptest.NewRecorder()
-	testHandler.CreateShareLink(w2, req2)
-	if w2.Code != http.StatusBadRequest {
-		t.Fatalf("zero max_uses: expected 400, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req2).Want(http.StatusBadRequest)
 }
 
 func TestCreateShareLink_RejectsOverflowingInput(t *testing.T) {
@@ -257,32 +228,20 @@ func TestCreateShareLink_RejectsOverflowingInput(t *testing.T) {
 	overMax := 2147483648 // MaxInt32 + 1
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", MaxUses: &overMax})
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	testHandler.CreateShareLink(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("max_uses over MaxInt32: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req).Want(http.StatusBadRequest)
 
 	// expires_in above the duration-safe bound overflows time.Duration * time.Hour.
 	overExp := int(expiresInMaxHours) + 1
 	req2 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", ExpiresIn: &overExp})
 	req2 = withURLParam(req2, "id", testWorkspaceID)
-	w2 := httptest.NewRecorder()
-	testHandler.CreateShareLink(w2, req2)
-	if w2.Code != http.StatusBadRequest {
-		t.Fatalf("expires_in over duration-safe bound: expected 400, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req2).Want(http.StatusBadRequest)
 
 	// Boundary: expires_in == expiresInMaxHours must be accepted, and the
 	// stored expires_at must be strictly in the future (not wrapped negative).
 	maxExp := int(expiresInMaxHours)
 	req3 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", ExpiresIn: &maxExp})
 	req3 = withURLParam(req3, "id", testWorkspaceID)
-	w3 := httptest.NewRecorder()
-	testHandler.CreateShareLink(w3, req3)
-	if w3.Code != http.StatusCreated {
-		t.Fatalf("expires_in = duration-safe max: expected 201, got %d: %s", w3.Code, w3.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req3).Want(http.StatusCreated)
 	var expiresAt pgtype.Timestamptz
 	if err := testPool.QueryRow(context.Background(),
 		`SELECT expires_at FROM workspace_share_link WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 1`,
@@ -302,11 +261,7 @@ func TestCreateShareLink_RejectsOverflowingInput(t *testing.T) {
 	maxUse := 2147483647
 	req4 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member", MaxUses: &maxUse})
 	req4 = withURLParam(req4, "id", testWorkspaceID)
-	w4 := httptest.NewRecorder()
-	testHandler.CreateShareLink(w4, req4)
-	if w4.Code != http.StatusCreated {
-		t.Fatalf("max_uses = MaxInt32: expected 201, got %d: %s", w4.Code, w4.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateShareLink, req4).Want(http.StatusCreated)
 }
 
 func TestJoinShareLink_ExpiredAndRevoked(t *testing.T) {
@@ -318,11 +273,7 @@ func TestJoinShareLink_ExpiredAndRevoked(t *testing.T) {
 
 	req := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: expired.Code})
 	req.Header.Set("X-User-ID", userID)
-	w := httptest.NewRecorder()
-	testHandler.JoinByShareLink(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expired join: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinByShareLink, req).Want(http.StatusNotFound)
 
 	// Deactivate the expired link so the workspace has room for a new active one.
 	if _, err := testPool.Exec(context.Background(),
@@ -338,11 +289,7 @@ func TestJoinShareLink_ExpiredAndRevoked(t *testing.T) {
 	}
 	req2 := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: revoked.Code})
 	req2.Header.Set("X-User-ID", userID)
-	w2 := httptest.NewRecorder()
-	testHandler.JoinByShareLink(w2, req2)
-	if w2.Code != http.StatusNotFound {
-		t.Fatalf("revoked join: expected 404, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinByShareLink, req2).Want(http.StatusNotFound)
 }
 
 func TestJoinShareLink_ConcurrentLastUse(t *testing.T) {
@@ -361,8 +308,7 @@ func TestJoinShareLink_ConcurrentLastUse(t *testing.T) {
 			userID := createTestUserAndMember(t, "")
 			req := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: link.Code})
 			req.Header.Set("X-User-ID", userID)
-			w := httptest.NewRecorder()
-			testHandler.JoinByShareLink(w, req)
+			w := testutil.Call(t, testHandler.JoinByShareLink, req)
 			results <- w.Code
 		}()
 	}
@@ -395,20 +341,12 @@ func TestJoinShareLink_DuplicateJoinDoesNotConsumeUse(t *testing.T) {
 	// First join succeeds.
 	req := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: link.Code})
 	req.Header.Set("X-User-ID", userID)
-	w := httptest.NewRecorder()
-	testHandler.JoinByShareLink(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("first join: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinByShareLink, req).Want(http.StatusOK)
 
 	// Duplicate join is rejected and must NOT consume another use.
 	req2 := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: link.Code})
 	req2.Header.Set("X-User-ID", userID)
-	w2 := httptest.NewRecorder()
-	testHandler.JoinByShareLink(w2, req2)
-	if w2.Code != http.StatusConflict {
-		t.Fatalf("duplicate join: expected 409, got %d: %s", w2.Code, w2.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinByShareLink, req2).Want(http.StatusConflict)
 
 	var useCount int32
 	if err := testPool.QueryRow(context.Background(),
@@ -450,11 +388,7 @@ func TestJoinShareLink_ReactivatesDeadLetterWithSameCapacityToken(t *testing.T) 
 
 	req := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: link.Code})
 	req.Header.Set("X-User-ID", userID)
-	w := httptest.NewRecorder()
-	testHandler.JoinByShareLink(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("join: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.JoinByShareLink, req).Want(http.StatusOK)
 	tokens := stub.tokens()
 	if len(tokens) != 1 || tokens[0] != originalToken {
 		t.Fatalf("claim tokens=%v, want original %s", tokens, originalToken)
@@ -486,8 +420,7 @@ func TestJoinShareLink_ConcurrentSameUserUsesOneCapacityOperation(t *testing.T) 
 			<-start
 			req := newRequest("POST", "/api/share-links/join", JoinByShareLinkRequest{Code: link.Code})
 			req.Header.Set("X-User-ID", userID)
-			w := httptest.NewRecorder()
-			testHandler.JoinByShareLink(w, req)
+			w := testutil.Call(t, testHandler.JoinByShareLink, req)
 			statuses <- w.Code
 		}()
 	}
@@ -529,16 +462,9 @@ func TestGetShareLinkInfo_PublicResponseSlim(t *testing.T) {
 
 	req := newRequest("GET", "/api/share-links/"+link.Code, nil)
 	req = withURLParam(req, "code", link.Code)
-	w := httptest.NewRecorder()
-	testHandler.GetShareLinkInfo(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("public preview: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetShareLinkInfo, req).Want(http.StatusOK)
 	var raw map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("parse preview: %v", err)
-	}
+	w.JSON(&raw)
 	if _, ok := raw["creator_email"]; ok {
 		t.Fatal("public preview must not expose the inviter's email")
 	}
@@ -585,8 +511,7 @@ func TestShareLink_CrossWorkspaceDenied(t *testing.T) {
 	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member"})
 	req.Header.Set("X-User-ID", otherUser)
 	req = withURLParam(req, "id", testWorkspaceID)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := testutil.Call(t, r.ServeHTTP, req)
 	if w.Code != http.StatusForbidden && w.Code != http.StatusNotFound {
 		t.Fatalf("cross-workspace create: expected 403 or 404, got %d: %s", w.Code, w.Body.String())
 	}
@@ -608,8 +533,7 @@ func TestCreateShareLink_ConcurrentCreatesSingleActive(t *testing.T) {
 			defer wg.Done()
 			req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/share-links", CreateShareLinkRequest{Role: "member"})
 			req = withURLParam(req, "id", testWorkspaceID)
-			w := httptest.NewRecorder()
-			testHandler.CreateShareLink(w, req)
+			w := testutil.Call(t, testHandler.CreateShareLink, req)
 			results <- w.Code
 		}()
 	}

--- a/server/internal/handler/skill_import_archive_test.go
+++ b/server/internal/handler/skill_import_archive_test.go
@@ -4,12 +4,13 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/json"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // buildTestZip packs the given path->content map into an in-memory zip and
@@ -244,16 +245,9 @@ func TestImportSkill_ArchiveUploadCreatesSkill(t *testing.T) {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM skill WHERE workspace_id = $1 AND name = $2`, testWorkspaceID, name)
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.ImportSkill(w, newSkillArchiveImportRequest(testUserID, archive, name+".skill", "fail"))
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ImportSkill, newSkillArchiveImportRequest(testUserID, archive, name+".skill", "fail")).Want(http.StatusCreated)
 	var body SkillImportResult
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&body)
 	if body.Status != "created" || body.Skill == nil {
 		t.Fatalf("body = %#v", body)
 	}
@@ -282,16 +276,9 @@ func TestImportSkill_ArchiveUploadConflictSkip(t *testing.T) {
 		skillName + "/SKILL.md": skillMdWithName(skillName, "From archive"),
 	})
 
-	w := httptest.NewRecorder()
-	testHandler.ImportSkill(w, newSkillArchiveImportRequest(testUserID, archive, skillName+".skill", "skip"))
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ImportSkill, newSkillArchiveImportRequest(testUserID, archive, skillName+".skill", "skip")).Want(http.StatusOK)
 	var body SkillImportResult
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&body)
 	if body.Status != "skipped" {
 		t.Fatalf("status = %q, want skipped", body.Status)
 	}
@@ -304,9 +291,5 @@ func TestImportSkill_ArchiveUploadRejectsNonZip(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("handler test DB not configured")
 	}
-	w := httptest.NewRecorder()
-	testHandler.ImportSkill(w, newSkillArchiveImportRequest(testUserID, []byte("not a zip at all"), "bad.skill", "fail"))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ImportSkill, newSkillArchiveImportRequest(testUserID, []byte("not a zip at all"), "bad.skill", "fail")).Want(http.StatusBadRequest)
 }

--- a/server/internal/handler/skill_import_duplicate_test.go
+++ b/server/internal/handler/skill_import_duplicate_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestExistingSkillIdentityByNameReturnsIDAndName(t *testing.T) {
@@ -29,9 +31,7 @@ func TestWriteSkillImportDuplicateConflictIncludesExistingSkill(t *testing.T) {
 	w := httptest.NewRecorder()
 	writeSkillImportDuplicateConflict(w, ExistingSkillIdentity{ID: "skill-123", Name: "review-helper"})
 
-	if w.Code != 409 {
-		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, 409, "HTTP status")
 	var body map[string]any
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode body: %v", err)
@@ -95,20 +95,13 @@ func TestImportSkillOnConflictSkipReturnsStructuredResult(t *testing.T) {
 	existingID := insertHandlerTestSkill(t, namePrefix, "# Existing")
 	importURL := withMockClawHubImport(t, skillName)
 
-	w := httptest.NewRecorder()
 	req := newRequestAsUser(testUserID, http.MethodPost, "/api/skills/import", map[string]any{
 		"url":         importURL,
 		"on_conflict": "skip",
 	})
-	testHandler.ImportSkill(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ImportSkill, req).Want(http.StatusOK)
 	var body SkillImportResult
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode body: %v", err)
-	}
+	w.JSON(&body)
 	if body.Status != "skipped" {
 		t.Fatalf("status = %q", body.Status)
 	}
@@ -126,20 +119,13 @@ func TestImportSkillOnConflictRenameCreatesSuffixedSkill(t *testing.T) {
 	insertHandlerTestSkill(t, namePrefix, "# Existing")
 	importURL := withMockClawHubImport(t, skillName)
 
-	w := httptest.NewRecorder()
 	req := newRequestAsUser(testUserID, http.MethodPost, "/api/skills/import", map[string]any{
 		"url":         importURL,
 		"on_conflict": "rename",
 	})
-	testHandler.ImportSkill(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ImportSkill, req).Want(http.StatusCreated)
 	var body SkillImportResult
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode body: %v", err)
-	}
+	w.JSON(&body)
 	if body.Status != "created" || body.Skill == nil {
 		t.Fatalf("body = %#v", body)
 	}

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestListSkills_OmitsContent guards the fix for GH multica-ai/multica#2174:
@@ -18,20 +18,14 @@ import (
 func TestListSkills_OmitsContent(t *testing.T) {
 	skillID := insertHandlerTestSkill(t, "list-omits-content", strings.Repeat("a", 4096))
 
-	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/skills?workspace_id="+testWorkspaceID, nil)
-	testHandler.ListSkills(w, req)
-	if w.Code != 200 {
-		t.Fatalf("ListSkills: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListSkills, req).Want(200)
 
 	// Decode into a generic shape so we can prove the wire format has no
 	// `content` field at all — not "content present but empty", which would
 	// still leave the bytes on the wire.
 	var rows []map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
-		t.Fatalf("ListSkills: failed to decode body: %v", err)
-	}
+	w.JSON(&rows)
 
 	var found bool
 	for _, row := range rows {
@@ -61,18 +55,12 @@ func TestGetSkill_IncludesContent(t *testing.T) {
 	body := "# detail body\nstill served on /api/skills/{id}"
 	skillID := insertHandlerTestSkill(t, "detail-includes-content", body)
 
-	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/skills/"+skillID, nil)
 	req = withURLParam(req, "id", skillID)
-	testHandler.GetSkill(w, req)
-	if w.Code != 200 {
-		t.Fatalf("GetSkill: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.GetSkill, req).Want(200)
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("GetSkill: failed to decode body: %v", err)
-	}
+	w.JSON(&resp)
 	if got, _ := resp["content"].(string); got != body {
 		t.Fatalf("GetSkill: expected content %q, got %q", body, got)
 	}
@@ -91,18 +79,12 @@ func TestListAgentSkills_OmitsContent(t *testing.T) {
 		t.Fatalf("attach skill to agent: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/agents/"+agentID+"/skills", nil)
 	req = withURLParam(req, "id", agentID)
-	testHandler.ListAgentSkills(w, req)
-	if w.Code != 200 {
-		t.Fatalf("ListAgentSkills: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAgentSkills, req).Want(200)
 
 	var rows []map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
-		t.Fatalf("ListAgentSkills: failed to decode body: %v", err)
-	}
+	w.JSON(&rows)
 	if len(rows) == 0 {
 		t.Fatalf("ListAgentSkills: expected at least 1 skill")
 	}
@@ -164,19 +146,7 @@ func TestSetAgentSkillEnabledControlsExecutionWithoutRemovingAssignment(t *testi
 func TestSetAgentRuntimeSkillEnabledPersistsScopedOverride(t *testing.T) {
 	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
 	var agentID string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'local', '{}'::jsonb, $3, 'private', 'private', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, "Runtime Skill Toggle "+t.Name(), runtimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Runtime Skill Toggle " + t.Name(), "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'local'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "permission_mode": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	setEnabled := func(enabled bool) *httptest.ResponseRecorder {
 		t.Helper()
@@ -233,13 +203,10 @@ func TestSetAgentRuntimeSkillEnabledPersistsScopedOverride(t *testing.T) {
 // the malformed input panicked in MustParseUUID and was rescued by the
 // chi Recoverer middleware as a 500.
 func TestGetSkill_MalformedUUIDReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/skills/not-a-uuid", nil)
 	req = withURLParam(req, "id", "not-a-uuid")
-	testHandler.GetSkill(w, req)
-	if w.Code != 400 {
-		t.Fatalf("GetSkill malformed uuid: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.GetSkill, req).Want(400)
 }
 
 // insertHandlerTestSkill writes a skill row directly via SQL and registers a
@@ -249,15 +216,6 @@ func insertHandlerTestSkill(t *testing.T, namePrefix, content string) string {
 	t.Helper()
 	name := namePrefix + "-" + t.Name()
 	var id string
-	if err := testPool.QueryRow(context.Background(), `
-		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
-		VALUES ($1, $2, $3, $4, '{}'::jsonb, $5)
-		RETURNING id
-	`, testWorkspaceID, name, "fixture", content, testUserID).Scan(&id); err != nil {
-		t.Fatalf("insert skill: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, id)
-	})
+	id = dbfx.Insert(t, "skill", testutil.Cols{"workspace_id": testWorkspaceID, "name": name, "description": "fixture", "content": content, "config": testutil.Raw("'{}'::jsonb"), "created_by": testUserID})
 	return id
 }

--- a/server/internal/handler/skill_refresh_test.go
+++ b/server/internal/handler/skill_refresh_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // createImportTargetSkillWithConfig is createImportTargetSkill with an explicit
@@ -150,9 +152,7 @@ func TestRefreshSkill_UpdatesContentPreservingIdentityAndBindings(t *testing.T) 
 	})
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp SkillWithFilesResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -220,9 +220,7 @@ func TestRefreshSkill_UpstreamRenameCollisionReturns409(t *testing.T) {
 	installClawHubFixture(t, slug, takenName, "incoming", map[string]string{"SKILL.md": "# incoming"})
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusConflict, "HTTP status")
 	// Whole refresh rolled back: name, description, and content unchanged.
 	name, desc, content, _ := getSkillRow(t, skillID)
 	if name != oldName || desc != "original description" || content != "# original" {
@@ -245,9 +243,7 @@ func TestRefreshSkill_AdminCanRefresh(t *testing.T) {
 	installClawHubFixture(t, slug, slug, "admin refreshed", map[string]string{"SKILL.md": "# refreshed"})
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	// Creator still preserved even when an admin refreshes.
 	if _, desc, _, createdBy := getSkillRow(t, skillID); desc != "admin refreshed" || createdBy != creatorID {
 		t.Fatalf("desc=%q createdBy=%q, want refreshed desc with original creator %q", desc, createdBy, creatorID)
@@ -266,9 +262,7 @@ func TestRefreshSkill_PlainMemberNonCreatorForbidden(t *testing.T) {
 	requests := installClawHubFixture(t, slug, slug, "incoming", map[string]string{"SKILL.md": "# incoming"})
 
 	w := doRefreshSkill(t, memberID, skillID)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 	if _, desc, _, _ := getSkillRow(t, skillID); desc != "original description" {
 		t.Fatalf("forbidden refresh must not mutate the skill, description = %q", desc)
 	}
@@ -287,9 +281,7 @@ func TestRefreshSkill_ManualSkillNotRefreshable(t *testing.T) {
 	skillID := createImportTargetSkill(t, name, testUserID, nil)
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnprocessableEntity, "HTTP status")
 	if _, desc, _, _ := getSkillRow(t, skillID); desc != "original description" {
 		t.Fatalf("non-refreshable refresh must not mutate the skill, description = %q", desc)
 	}
@@ -305,9 +297,7 @@ func TestRefreshSkill_RuntimeLocalOriginNotRefreshable(t *testing.T) {
 	skillID := createImportTargetSkillWithConfig(t, name, testUserID, config, nil)
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnprocessableEntity, "HTTP status")
 }
 
 func TestRefreshSkill_OriginHostMismatchRejected(t *testing.T) {
@@ -322,9 +312,7 @@ func TestRefreshSkill_OriginHostMismatchRejected(t *testing.T) {
 	skillID := createImportTargetSkillWithConfig(t, name, testUserID, config, nil)
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnprocessableEntity, "HTTP status")
 }
 
 func TestRefreshSkill_UpstreamGoneReturns502(t *testing.T) {
@@ -342,9 +330,7 @@ func TestRefreshSkill_UpstreamGoneReturns502(t *testing.T) {
 	t.Cleanup(func() { clawHubAPIBase = prev; srv.Close() })
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("expected 502, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusBadGateway, "HTTP status")
 	if _, desc, _, _ := getSkillRow(t, skillID); desc != "original description" {
 		t.Fatalf("failed refresh must not mutate the skill, description = %q", desc)
 	}
@@ -364,9 +350,7 @@ func TestRefreshSkill_CapExceededReturns413(t *testing.T) {
 	})
 
 	w := doRefreshSkill(t, testUserID, skillID)
-	if w.Code != http.StatusRequestEntityTooLarge {
-		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusRequestEntityTooLarge, "HTTP status")
 	if _, desc, _, _ := getSkillRow(t, skillID); desc != "original description" {
 		t.Fatalf("cap-exceeded refresh must not mutate the skill, description = %q", desc)
 	}

--- a/server/internal/handler/skill_search_test.go
+++ b/server/internal/handler/skill_search_test.go
@@ -1,11 +1,12 @@
 package handler
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestSearchSkillsReturnsNormalizedClawHubCandidates(t *testing.T) {
@@ -65,17 +66,11 @@ func TestSearchSkillsReturnsNormalizedClawHubCandidates(t *testing.T) {
 	clawHubAPIBase = upstream.URL
 	t.Cleanup(func() { clawHubAPIBase = oldBase })
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodGet, "/api/skills/search?q=react", nil)
-	testHandler.SearchSkills(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SearchSkills: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.SearchSkills, req).Want(http.StatusOK)
 
 	var got []map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-		t.Fatalf("SearchSkills: decode response: %v", err)
-	}
+	w.JSON(&got)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 candidates, got %d: %#v", len(got), got)
 	}
@@ -104,12 +99,9 @@ func TestSearchSkillsReturnsNormalizedClawHubCandidates(t *testing.T) {
 }
 
 func TestSearchSkillsEmptyQueryReturns400(t *testing.T) {
-	w := httptest.NewRecorder()
+
 	req := newRequest(http.MethodGet, "/api/skills/search?q=", nil)
-	testHandler.SearchSkills(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("SearchSkills empty query: expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.SearchSkills, req).Want(http.StatusBadRequest)
 	if !strings.Contains(w.Body.String(), "query is required") {
 		t.Fatalf("expected query is required error, got %s", w.Body.String())
 	}
@@ -125,16 +117,10 @@ func TestSearchSkillsUpstreamUnavailableReturnsStructuredError(t *testing.T) {
 	clawHubAPIBase = upstream.URL
 	t.Cleanup(func() { clawHubAPIBase = oldBase })
 
-	w := httptest.NewRecorder()
 	req := newRequest(http.MethodGet, "/api/skills/search?q=react", nil)
-	testHandler.SearchSkills(w, req)
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("SearchSkills outage: expected 502, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.SearchSkills, req).Want(http.StatusBadGateway)
 	var got map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode error body: %v", err)
-	}
+	w.JSON(&got)
 	if got["code"] != "upstream_unavailable" {
 		t.Fatalf("expected structured upstream_unavailable code, got %#v", got)
 	}

--- a/server/internal/handler/source_context_integration_test.go
+++ b/server/internal/handler/source_context_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -26,9 +27,7 @@ func TestWriteSourceContextErrorHidesInternalDetails(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	(&Handler{}).writeSourceContextError(recorder, errors.New("postgres password=do-not-leak"), service.SourceContextLimitUsage{})
 
-	if recorder.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
-	}
+	testutil.Equal(t, recorder.Code, http.StatusInternalServerError, "HTTP status")
 	if strings.Contains(recorder.Body.String(), "do-not-leak") {
 		t.Fatalf("internal error leaked in response: %s", recorder.Body.String())
 	}
@@ -109,7 +108,6 @@ func TestRetrySourceContextQuickCreateReturnsIssueLimitRecovery(t *testing.T) {
 		testHandler.TaskService.Entitlements = priorProvider
 	})
 
-	recorder := httptest.NewRecorder()
 	request := withURLParam(newRequest(http.MethodPost, "/api/tasks/"+taskID+"/retry-source-context", nil), "taskId", taskID)
 	member, err := testHandler.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
 		UserID:      util.MustParseUUID(testUserID),
@@ -119,18 +117,13 @@ func TestRetrySourceContextQuickCreateReturnsIssueLimitRecovery(t *testing.T) {
 		t.Fatalf("load retry caller membership: %v", err)
 	}
 	request = request.WithContext(middleware.SetMemberContext(request.Context(), testWorkspaceID, member))
-	testHandler.RetrySourceContextQuickCreate(recorder, request)
-	if recorder.Code != http.StatusPaymentRequired {
-		t.Fatalf("source-context retry at limit = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	recorder := testutil.Call(t, testHandler.RetrySourceContextQuickCreate, request).Want(http.StatusPaymentRequired)
 	var body struct {
 		Code           string `json:"code"`
 		Limit          int    `json:"limit"`
 		PolicyRevision int    `json:"policy_revision"`
 	}
-	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode retry issue-limit response: %v", err)
-	}
+	recorder.JSON(&body)
 	if body.Code != "issue_limit_reached" || body.Limit != issueCount || body.PolicyRevision != 43 {
 		t.Fatalf("retry issue-limit response = %+v", body)
 	}
@@ -249,16 +242,10 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, sourceIssueID)
 	})
 
-	previewRecorder := httptest.NewRecorder()
 	previewRequest := withURLParam(newRequest(http.MethodGet, "/api/comments/"+selectedID+"/sub-issue-preview", nil), "commentId", selectedID)
-	testHandler.PreviewCommentSubIssue(previewRecorder, previewRequest)
-	if previewRecorder.Code != http.StatusOK {
-		t.Fatalf("preview = %d: %s", previewRecorder.Code, previewRecorder.Body.String())
-	}
+	previewRecorder := testutil.Call(t, testHandler.PreviewCommentSubIssue, previewRequest).Want(http.StatusOK)
 	var preview sourceContextPreviewResponse
-	if err := json.Unmarshal(previewRecorder.Body.Bytes(), &preview); err != nil {
-		t.Fatalf("decode preview: %v", err)
-	}
+	previewRecorder.JSON(&preview)
 	wantThreadHistory := []string{rootID, earlierSiblingID, earlierNestedID, replyID, selectedID}
 	if len(preview.CommentThread) != len(wantThreadHistory) {
 		t.Fatalf("preview thread history length = %d, want %d: %#v", len(preview.CommentThread), len(wantThreadHistory), preview.CommentThread)
@@ -313,15 +300,12 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 	if _, err := testPool.Exec(ctx, `UPDATE comment SET content = 'changed before submit', revision = revision + 1, updated_at = now() WHERE id = $1`, earlierSiblingID); err != nil {
 		t.Fatalf("edit earlier thread comment before submit: %v", err)
 	}
-	staleRecorder := httptest.NewRecorder()
+
 	staleRequest := withURLParam(newRequest(http.MethodPost, "/api/comments/"+selectedID+"/sub-issues", map[string]any{
 		"mode": "manual", "capture_token": preview.CaptureToken,
 		"issue": map[string]any{"title": "must not be created", "status": "todo", "priority": "none"},
 	}), "commentId", selectedID)
-	testHandler.CreateCommentSubIssue(staleRecorder, staleRequest)
-	if staleRecorder.Code != http.StatusConflict {
-		t.Fatalf("stale source create = %d: %s", staleRecorder.Code, staleRecorder.Body.String())
-	}
+	staleRecorder := testutil.Call(t, testHandler.CreateCommentSubIssue, staleRequest).Want(http.StatusConflict)
 	var staleBody map[string]any
 	if err := json.Unmarshal(staleRecorder.Body.Bytes(), &staleBody); err != nil || staleBody["code"] != "source_context_changed" {
 		t.Fatalf("stale source body = %#v, err=%v", staleBody, err)
@@ -374,7 +358,7 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 
 		beforeReads, beforeUploads := store.streamCopyCalls()
 		prompt := "source context must not enqueue while the workspace is full"
-		fullRecorder := httptest.NewRecorder()
+
 		fullRequest := withURLParam(newRequest(http.MethodPost, "/api/comments/"+selectedID+"/sub-issues", map[string]any{
 			"mode":          "agent",
 			"capture_token": preview.CaptureToken,
@@ -383,10 +367,7 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 				"prompt":   prompt,
 			},
 		}), "commentId", selectedID)
-		testHandler.CreateCommentSubIssue(fullRecorder, fullRequest)
-		if fullRecorder.Code != http.StatusPaymentRequired {
-			t.Fatalf("full source-context create = %d: %s", fullRecorder.Code, fullRecorder.Body.String())
-		}
+		fullRecorder := testutil.Call(t, testHandler.CreateCommentSubIssue, fullRequest).Want(http.StatusPaymentRequired)
 		var body struct {
 			Code string `json:"code"`
 		}
@@ -434,7 +415,6 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 		t.Fatalf("delete foreign issue: %v", err)
 	}
 
-	createRecorder := httptest.NewRecorder()
 	createRequest := withURLParam(newRequest(http.MethodPost, "/api/comments/"+selectedID+"/sub-issues", map[string]any{
 		"mode":          "manual",
 		"capture_token": preview.CaptureToken,
@@ -442,14 +422,9 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 			"title": "new independent task", "description": "new instructions", "status": "todo", "priority": "none", "stage": 2,
 		},
 	}), "commentId", selectedID)
-	testHandler.CreateCommentSubIssue(createRecorder, createRequest)
-	if createRecorder.Code != http.StatusCreated {
-		t.Fatalf("manual source create = %d: %s", createRecorder.Code, createRecorder.Body.String())
-	}
+	createRecorder := testutil.Call(t, testHandler.CreateCommentSubIssue, createRequest).Want(http.StatusCreated)
 	var created IssueResponse
-	if err := json.Unmarshal(createRecorder.Body.Bytes(), &created); err != nil {
-		t.Fatalf("decode created issue: %v", err)
-	}
+	createRecorder.JSON(&created)
 	targetIssueID = created.ID
 	if created.ParentIssueID == nil || *created.ParentIssueID != sourceIssueID || created.Stage == nil || *created.Stage != 2 {
 		t.Fatalf("created relation = parent %#v stage %#v", created.ParentIssueID, created.Stage)
@@ -475,12 +450,9 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 		t.Fatalf("stored clone ids = %#v", selectedSnapshot.Attachments[0])
 	}
 	cloneKey := "workspaces/" + testWorkspaceID + "/source-context/" + cloneID + ".txt"
-	deleteCloneRecorder := httptest.NewRecorder()
+
 	deleteCloneRequest := withURLParam(newRequest(http.MethodDelete, "/api/attachments/"+cloneID, nil), "id", cloneID)
-	testHandler.DeleteAttachment(deleteCloneRecorder, deleteCloneRequest)
-	if deleteCloneRecorder.Code != http.StatusNotFound {
-		t.Fatalf("delete immutable source-context clone = %d: %s", deleteCloneRecorder.Code, deleteCloneRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteAttachment, deleteCloneRequest).Want(http.StatusNotFound)
 	if _, err := store.GetReader(ctx, cloneKey); err != nil {
 		t.Fatalf("immutable source-context clone missing after direct delete: %v", err)
 	}
@@ -575,9 +547,9 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 	}}) {
 		t.Fatalf("attachment changes = %#v, want removed issue.txt from description", attachmentDetail.ChangeDetails.DescriptionAttachmentChanges)
 	}
-	issueDownloadRecorder := httptest.NewRecorder()
+
 	issueDownloadRequest := withURLParam(newRequest(http.MethodGet, "/api/attachments/"+issueCloneID+"/download", nil), "id", issueCloneID)
-	testHandler.DownloadAttachment(issueDownloadRecorder, issueDownloadRequest)
+	issueDownloadRecorder := testutil.Call(t, testHandler.DownloadAttachment, issueDownloadRequest)
 	if issueDownloadRecorder.Code != http.StatusOK || issueDownloadRecorder.Body.String() != "issue attachment" {
 		t.Fatalf("snapshot issue clone download after live deletion = %d %q", issueDownloadRecorder.Code, issueDownloadRecorder.Body.String())
 	}
@@ -608,11 +580,7 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 	// Deleting the source explicitly detaches the target, clears stage, bumps
 	// revision, and leaves its immutable context readable.
 	beforeRevision := issue.Revision
-	deleteRecorder := httptest.NewRecorder()
-	testHandler.DeleteIssue(deleteRecorder, withURLParam(newRequest(http.MethodDelete, "/api/issues/"+sourceIssueID, nil), "id", sourceIssueID))
-	if deleteRecorder.Code != http.StatusNoContent {
-		t.Fatalf("delete source issue = %d: %s", deleteRecorder.Code, deleteRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteIssue, withURLParam(newRequest(http.MethodDelete, "/api/issues/"+sourceIssueID, nil), "id", sourceIssueID)).Want(http.StatusNoContent)
 	sourceIssueID = ""
 	detached, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(targetIssueID))
 	if err != nil {
@@ -639,9 +607,9 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 	if deletedDetail.SourceIssueState != "deleted" || deletedDetail.CanOpenCurrentSource {
 		t.Fatalf("deleted-source detail = state %q open=%v", deletedDetail.SourceIssueState, deletedDetail.CanOpenCurrentSource)
 	}
-	downloadRecorder := httptest.NewRecorder()
+
 	downloadRequest := withURLParam(newRequest(http.MethodGet, "/api/attachments/"+cloneID+"/download", nil), "id", cloneID)
-	testHandler.DownloadAttachment(downloadRecorder, downloadRequest)
+	downloadRecorder := testutil.Call(t, testHandler.DownloadAttachment, downloadRequest)
 	if downloadRecorder.Code != http.StatusOK || downloadRecorder.Body.String() != "selected attachment" {
 		t.Fatalf("snapshot clone download after source deletion = %d %q", downloadRecorder.Code, downloadRecorder.Body.String())
 	}
@@ -649,11 +617,7 @@ func TestCommentSourceContextLifecycle(t *testing.T) {
 	// Deleting the target removes DB ownership atomically and leaves durable
 	// intents for the legacy no-result bulk object deletion path. The sweeper
 	// then reclaims exactly those now-unreferenced clone objects.
-	targetDeleteRecorder := httptest.NewRecorder()
-	testHandler.DeleteIssue(targetDeleteRecorder, withURLParam(newRequest(http.MethodDelete, "/api/issues/"+targetIssueID, nil), "id", targetIssueID))
-	if targetDeleteRecorder.Code != http.StatusNoContent {
-		t.Fatalf("delete target issue = %d: %s", targetDeleteRecorder.Code, targetDeleteRecorder.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteIssue, withURLParam(newRequest(http.MethodDelete, "/api/issues/"+targetIssueID, nil), "id", targetIssueID)).Want(http.StatusNoContent)
 	targetIssueID = ""
 	var contextExists, cloneExists bool
 	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM issue_source_context WHERE id = $1)`, contextID).Scan(&contextExists); err != nil {
@@ -741,13 +705,9 @@ func TestBatchDeleteParentAndChildPublishesOnlySurvivingDetach(t *testing.T) {
 		updatedIDs = append(updatedIDs, issue.ID)
 	})
 
-	recorder := httptest.NewRecorder()
-	testHandler.BatchDeleteIssues(recorder, newRequest(http.MethodPost, "/api/issues/batch-delete", map[string]any{
+	recorder := testutil.Call(t, testHandler.BatchDeleteIssues, newRequest(http.MethodPost, "/api/issues/batch-delete", map[string]any{
 		"issue_ids": []string{parentID, childID, parentID},
-	}))
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("batch delete = %d: %s", recorder.Code, recorder.Body.String())
-	}
+	})).Want(http.StatusOK)
 	var response map[string]int
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil || response["deleted"] != 2 {
 		t.Fatalf("batch delete response = %#v, err=%v", response, err)

--- a/server/internal/handler/squad_assign_trigger_test.go
+++ b/server/internal/handler/squad_assign_trigger_test.go
@@ -2,10 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateIssueAssignedToSquadEnqueuesLeader verifies that creating an
@@ -34,21 +35,16 @@ func TestCreateIssueAssignedToSquadEnqueuesLeader(t *testing.T) {
 	defer testPool.Exec(ctx, `DELETE FROM squad WHERE id = $1`, squadID)
 
 	// Create an issue assigned to the squad.
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":         "Squad-assigned at creation",
 		"assignee_type": "squad",
 		"assignee_id":   squadID,
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 
 	var created IssueResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode issue: %v", err)
-	}
+	w.Decode(&created)
 	defer func() {
 		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
 		cleanupReq = withURLParam(cleanupReq, "id", created.ID)

--- a/server/internal/handler/squad_briefing_claim_test.go
+++ b/server/internal/handler/squad_briefing_claim_test.go
@@ -2,11 +2,11 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // claimAgentInstructionsForTest claims the next queued task for runtimeID and
@@ -17,15 +17,11 @@ import (
 func claimAgentInstructionsForTest(t *testing.T, runtimeID string) (taskID string, instructions string, isLeaderTask bool, raw string) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
 		testWorkspaceID, "squad-briefing-claim")
 	req = withURLParam(req, "runtimeId", runtimeID)
 
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 
 	var resp struct {
 		Task *struct {
@@ -37,9 +33,7 @@ func claimAgentInstructionsForTest(t *testing.T, runtimeID string) (taskID strin
 			} `json:"agent"`
 		} `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode claim response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Task == nil {
 		return "", "", false, w.Body.String()
 	}
@@ -86,14 +80,7 @@ func newSquadBriefingClaimFixture(t *testing.T, ctx context.Context, name string
 	}
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, name+" squad", agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": name + " squad", "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	return squadBriefingClaimFixture{
 		RuntimeID: runtimeID,
@@ -112,14 +99,7 @@ func enqueueClaimTask(t *testing.T, ctx context.Context, fx squadBriefingClaimFi
 	} else {
 		squadArg = nil
 	}
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, is_leader_task, squad_id)
-		VALUES ($1, $2, $3, 'queued', 0, $4, $5)
-		RETURNING id
-	`, fx.AgentID, fx.RuntimeID, fx.IssueID, isLeader, squadArg).Scan(&taskID); err != nil {
-		t.Fatalf("enqueue claim task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": fx.AgentID, "runtime_id": fx.RuntimeID, "issue_id": fx.IssueID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("0"), "is_leader_task": isLeader, "squad_id": squadArg})
 	return taskID
 }
 

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -136,16 +135,7 @@ func seedSquadForBriefing(t *testing.T, leaderID string, name, instructions stri
 	ctx := context.Background()
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id, instructions)
-		VALUES ($1, $2, '', $3, $4, $5)
-		RETURNING id
-	`, testWorkspaceID, name, leaderID, testUserID, instructions).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": name, "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID, "instructions": instructions})
 
 	uuid := util.MustParseUUID(squadID)
 	squad, err := testHandler.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
@@ -389,21 +379,16 @@ func TestBuildSquadLeaderBriefing_MentionsRoundTrip(t *testing.T) {
 // returns the agent block of the response. Fails the test on non-200.
 func claimAndDecodeAgent(t *testing.T, runtimeID string) *TaskAgentData {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-squad-briefing")
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var resp struct {
 		Task *struct {
 			Agent *TaskAgentData `json:"agent"`
 		} `json:"task"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&resp)
 	if resp.Task == nil || resp.Task.Agent == nil {
 		t.Fatalf("expected task.agent in response, got: %s", w.Body.String())
 	}
@@ -415,17 +400,7 @@ func claimAndDecodeAgent(t *testing.T, runtimeID string) *TaskAgentData {
 func queueSquadIssueTaskFor(t *testing.T, squadID, agentID, runtimeID string, issueNumber int) (issueID, taskID string) {
 	t.Helper()
 	ctx := context.Background()
-	if err := testPool.QueryRow(ctx, `
-INSERT INTO issue (
-workspace_id, title, status, priority, creator_id, creator_type,
-assignee_type, assignee_id, number, position
-) VALUES ($1, 'Squad briefing claim test', 'todo', 'medium', $2, 'member',
-'squad', $3, $4, 0)
-RETURNING id
-`, testWorkspaceID, testUserID, squadID, issueNumber).Scan(&issueID); err != nil {
-		t.Fatalf("create squad-assigned issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'Squad briefing claim test'"), "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'medium'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "assignee_type": testutil.Raw("'squad'"), "assignee_id": squadID, "number": issueNumber, "position": testutil.Raw("0")})
 
 	if err := testPool.QueryRow(ctx, `
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, is_leader_task, squad_id)

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -2,11 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -90,28 +89,10 @@ func newSquadCommentTriggerFixture(t *testing.T) squadCommentTriggerFixture {
 	otherID := createHandlerTestAgent(t, "Squad Comment Other", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, "Squad Comment Trigger", leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Squad Comment Trigger", "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title, assignee_type, assignee_id)
-		VALUES ($1, 'member', $2, $3, 'squad', $4)
-		RETURNING id
-	`, testWorkspaceID, testUserID, "squad comment trigger", squadID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": "squad comment trigger", "assignee_type": testutil.Raw("'squad'"), "assignee_id": squadID})
 
 	issue, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(issueID))
 	if err != nil {
@@ -340,17 +321,12 @@ func TestCreateComment_SquadPlainReplyToMemberParentKeepsRootMentionOwner(t *tes
 
 	postMemberComment := func(body map[string]any) CommentResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
 		r = withURLParam(r, "id", issueID)
-		testHandler.CreateComment(w, r)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 		var resp CommentResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode comment: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 
@@ -432,17 +408,14 @@ func TestCreateComment_DualRoleAgentWorkerCommentWakesLeader(t *testing.T) {
 
 	// L posts a comment in its agent identity (X-Agent-ID + X-Task-ID, the
 	// pair required by resolveActor to trust the agent header).
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "done — pushed the change",
 	})
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// A new leader-role task is enqueued so the leader coordinates next steps.
 	var leaderTasks int
@@ -481,30 +454,22 @@ func TestCreateComment_SquadLeaderMentionTaskDoesNotSelfTriggerAssignedFallback(
 
 	postMemberComment := func(body map[string]any) CommentResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
 		r = withURLParam(r, "id", issueID)
-		testHandler.CreateComment(w, r)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateComment(member): expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 		var resp CommentResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode member comment: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 	postAgentComment := func(taskID string, body map[string]any) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
 		r.Header.Set("X-Agent-ID", fx.LeaderID)
 		r.Header.Set("X-Task-ID", taskID)
 		r = withURLParam(r, "id", issueID)
-		testHandler.CreateComment(w, r)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateComment(agent): expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 	}
 	countQueuedLeaderTasks := func() int {
 		t.Helper()
@@ -579,34 +544,24 @@ func TestCreateComment_SquadLeaderThreadParentTaskDoesNotSelfTriggerAssignedFall
 
 	postAgentComment := func(taskID string, body map[string]any) CommentResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
 		r.Header.Set("X-Agent-ID", fx.LeaderID)
 		r.Header.Set("X-Task-ID", taskID)
 		r = withURLParam(r, "id", issueID)
-		testHandler.CreateComment(w, r)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateComment(agent): expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 		var resp CommentResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode agent comment: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 	postMemberComment := func(body map[string]any) CommentResponse {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
 		r = withURLParam(r, "id", issueID)
-		testHandler.CreateComment(w, r)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateComment(member): expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 		var resp CommentResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode member comment: %v", err)
-		}
+		w.Decode(&resp)
 		return resp
 	}
 	countQueuedLeaderTasks := func() int {
@@ -728,16 +683,7 @@ func TestCreateComment_SquadMentionPrivateLeaderBlocksPlainMember(t *testing.T) 
 
 	// Create a squad with the private agent as leader.
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Squad', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Squad'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create an issue.
 	var issueID string
@@ -755,15 +701,12 @@ func TestCreateComment_SquadMentionPrivateLeaderBlocksPlainMember(t *testing.T) 
 	})
 
 	// Plain member posts a comment mentioning the squad.
-	w := httptest.NewRecorder()
+
 	r := newRequestAs(memberID, "POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Squad](mention://squad/" + squadID + ") please handle",
 	})
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// The private leader must NOT have a queued task — plain member lacks access.
 	var count int
@@ -796,16 +739,7 @@ func TestCreateComment_SquadMentionTriggersLeader(t *testing.T) {
 	}
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, $2, '', $3, $4)
-		RETURNING id
-	`, testWorkspaceID, "Mention Trigger Squad", leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": "Mention Trigger Squad", "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	// Create an issue NOT assigned to the squad (assigned to nobody).
 	var issueID string
@@ -834,15 +768,12 @@ func TestCreateComment_SquadMentionTriggersLeader(t *testing.T) {
 	}
 
 	// Post a comment that @mentions the squad.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Squad](mention://squad/" + squadID + ") please handle this",
 	})
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// The squad's leader should have a queued task.
 	if got := countQueued(leaderID); got != 1 {

--- a/server/internal/handler/squad_creator_scope_test.go
+++ b/server/internal/handler/squad_creator_scope_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // squadScopeReq builds a request as the given user (empty = workspace owner)
@@ -34,19 +35,17 @@ func squadScopeReq(userID, method, path string, body any, params map[string]stri
 // returns the decoded response. Registers cleanup for the squad + its members.
 func createSquadAs(t *testing.T, userID, name, leaderID string) SquadResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	r := squadScopeReq(userID, "POST", "/api/squads", map[string]any{
 		"name":      name,
 		"leader_id": leaderID,
 	}, nil)
-	testHandler.CreateSquad(w, r)
+	w := testutil.Call(t, testHandler.CreateSquad, r)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("CreateSquad(%s): expected 201, got %d: %s", name, w.Code, w.Body.String())
 	}
 	var resp SquadResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode squad: %v", err)
-	}
+	w.Decode(&resp)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM squad_member WHERE squad_id = $1`, resp.ID)
 		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, resp.ID)
@@ -87,9 +86,7 @@ func TestManageSquad_CreatorCanManageOwn(t *testing.T) {
 	testHandler.UpdateSquad(w, squadScopeReq(memberID, "PATCH", "/api/squads", map[string]any{
 		"name": "Renamed By Creator",
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateSquad as creator: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// Add a public agent worker.
 	w = httptest.NewRecorder()
@@ -97,17 +94,13 @@ func TestManageSquad_CreatorCanManageOwn(t *testing.T) {
 		"member_type": "agent",
 		"member_id":   worker,
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("AddSquadMember as creator: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Archive.
 	w = httptest.NewRecorder()
 	testHandler.DeleteSquad(w, squadScopeReq(memberID, "DELETE", "/api/squads", nil,
 		map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteSquad as creator: expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusNoContent, "HTTP status")
 }
 
 // TestManageSquad_StrangerMemberForbidden verifies a plain member who did not
@@ -127,26 +120,20 @@ func TestManageSquad_StrangerMemberForbidden(t *testing.T) {
 	testHandler.UpdateSquad(w, squadScopeReq(strangerID, "PATCH", "/api/squads", map[string]any{
 		"name": "Hijacked",
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("UpdateSquad as stranger: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Stranger member: archive denied.
 	w = httptest.NewRecorder()
 	testHandler.DeleteSquad(w, squadScopeReq(strangerID, "DELETE", "/api/squads", nil,
 		map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("DeleteSquad as stranger: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Workspace owner (testUserID): update allowed — admin management unchanged.
 	w = httptest.NewRecorder()
 	testHandler.UpdateSquad(w, squadScopeReq("", "PATCH", "/api/squads", map[string]any{
 		"name": "Renamed By Admin",
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateSquad as workspace owner: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 }
 
 // TestAddSquadMember_CreatorAgentAccessGate verifies the comment-#2 rule: a
@@ -169,9 +156,7 @@ func TestAddSquadMember_CreatorAgentAccessGate(t *testing.T) {
 		"member_type": "agent",
 		"member_id":   publicWorkerID,
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("AddSquadMember public agent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	// Creator adds a private agent they cannot invoke — denied.
 	w = httptest.NewRecorder()
@@ -179,9 +164,7 @@ func TestAddSquadMember_CreatorAgentAccessGate(t *testing.T) {
 		"member_type": "agent",
 		"member_id":   privateAgentID,
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("AddSquadMember private agent as creator: expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 
 	// Workspace owner adds the same private agent — allowed (admin unchanged).
 	w = httptest.NewRecorder()
@@ -189,9 +172,7 @@ func TestAddSquadMember_CreatorAgentAccessGate(t *testing.T) {
 		"member_type": "agent",
 		"member_id":   privateAgentID,
 	}, map[string]string{"id": squad.ID}))
-	if w.Code != http.StatusCreated {
-		t.Fatalf("AddSquadMember private agent as owner: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 }
 
 // TestCreateSquad_CreatorPrivateLeaderForbidden verifies a non-admin cannot
@@ -202,12 +183,11 @@ func TestCreateSquad_CreatorPrivateLeaderForbidden(t *testing.T) {
 	}
 	privateAgentID, _, memberID := privateAgentTestFixture(t)
 
-	w := httptest.NewRecorder()
 	r := squadScopeReq(memberID, "POST", "/api/squads", map[string]any{
 		"name":      "Private Leader Squad",
 		"leader_id": privateAgentID,
 	}, nil)
-	testHandler.CreateSquad(w, r)
+	w := testutil.Call(t, testHandler.CreateSquad, r)
 	if w.Code != http.StatusForbidden {
 		// Nothing should have been created; if it slipped through, clean up.
 		if w.Code == http.StatusCreated {

--- a/server/internal/handler/squad_id_enqueue_test.go
+++ b/server/internal/handler/squad_id_enqueue_test.go
@@ -3,9 +3,9 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -30,14 +30,7 @@ func TestCreateComment_SquadMentionStampsSquadIDOnLeaderTask(t *testing.T) {
 	}
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Squad ID Stamp Squad', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Squad ID Stamp Squad'"), "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	// Issue assigned to nobody (definitely not the squad) — the leader task is
 	// produced purely by the @squad comment mention.
@@ -55,15 +48,11 @@ func TestCreateComment_SquadMentionStampsSquadIDOnLeaderTask(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
 	})
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Squad](mention://squad/" + squadID + ") please handle this",
 	})
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// The leader task must be queued AND carry squad_id = squadID, with
 	// is_leader_task = true.

--- a/server/internal/handler/squad_member_status_test.go
+++ b/server/internal/handler/squad_member_status_test.go
@@ -2,13 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func TestDeriveSquadMemberStatus(t *testing.T) {
@@ -65,27 +64,10 @@ func TestListSquadMemberStatusRetainsWaiterIssueWithoutWorkingStatus(t *testing.
 	squadID := createCommentTriggerPreviewSquad(t, "Squad Status Local Directory Waiter", agentID)
 	issueID := createCommentTriggerPreviewIssue(t, "Directory waiter remains visible", "agent", agentID)
 
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO squad_member (squad_id, member_type, member_id)
-		VALUES ($1, 'agent', $2)
-	`, squadID, agentID); err != nil {
-		t.Fatalf("insert squad member: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad_member WHERE squad_id = $1 AND member_id = $2`, squadID, agentID)
-	})
+	dbfx.InsertNoID(t, "squad_member", testutil.Cols{"squad_id": squadID, "member_type": testutil.Raw("'agent'"), "member_id": agentID}, "squad_id = $1 AND member_id = $2", squadID, agentID)
 
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, dispatched_at)
-		VALUES ($1, $2, $3, 'waiting_local_directory', 0, now())
-		RETURNING id
-	`, agentID, handlerTestRuntimeID(t), issueID).Scan(&taskID); err != nil {
-		t.Fatalf("insert local-directory waiter: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": handlerTestRuntimeID(t), "issue_id": issueID, "status": testutil.Raw("'waiting_local_directory'"), "priority": testutil.Raw("0"), "dispatched_at": testutil.Raw("now()")})
 
 	rows, err := testHandler.Queries.ListSquadMemberStatusRows(ctx, parseUUID(squadID))
 	if err != nil {
@@ -97,21 +79,15 @@ func TestListSquadMemberStatusRetainsWaiterIssueWithoutWorkingStatus(t *testing.
 
 	assertSquadMember := func(wantWorking bool) {
 		t.Helper()
-		w := httptest.NewRecorder()
-		testHandler.ListSquadMemberStatus(w, squadScopeReq(
+		w := testutil.Call(t, testHandler.ListSquadMemberStatus, squadScopeReq(
 			"",
 			http.MethodGet,
 			"/api/squads/"+squadID+"/members/status",
 			nil,
 			map[string]string{"id": squadID},
-		))
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListSquadMemberStatus: got %d: %s", w.Code, w.Body.String())
-		}
+		)).Want(http.StatusOK)
 		var resp SquadMemberStatusListResponse
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode squad member status: %v", err)
-		}
+		w.Decode(&resp)
 		if len(resp.Members) != 1 {
 			t.Fatalf("squad members = %+v, want one member", resp.Members)
 		}

--- a/server/internal/handler/squad_no_action_test.go
+++ b/server/internal/handler/squad_no_action_test.go
@@ -2,9 +2,7 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -60,7 +58,6 @@ func recordSquadLeaderEvaluationForTask(t *testing.T, fx runningSquadLeaderTaskF
 func recordSquadLeaderEvaluationForTaskWithHeader(t *testing.T, fx runningSquadLeaderTaskFixture, outcome, taskIDHeader string) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/squad-evaluated", map[string]any{
 		"outcome": outcome,
 		"reason":  "test reason",
@@ -69,16 +66,12 @@ func recordSquadLeaderEvaluationForTaskWithHeader(t *testing.T, fx runningSquadL
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", taskIDHeader)
 
-	testHandler.RecordSquadLeaderEvaluation(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("RecordSquadLeaderEvaluation: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.RecordSquadLeaderEvaluation, r).Want(http.StatusCreated)
 }
 
 func completeRunningTask(t *testing.T, fx runningSquadLeaderTaskFixture, output string) {
 	t.Helper()
 
-	w := httptest.NewRecorder()
 	r := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+fx.TaskID+"/complete",
 		map[string]any{"output": output},
 		testWorkspaceID, "legit-daemon")
@@ -86,10 +79,7 @@ func completeRunningTask(t *testing.T, fx runningSquadLeaderTaskFixture, output 
 	rctx.URLParams.Add("taskId", fx.TaskID)
 	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 
-	testHandler.CompleteTask(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, r).Want(http.StatusOK)
 }
 
 func countAgentCommentsForIssue(t *testing.T, issueID, agentID string) int {
@@ -157,7 +147,6 @@ func TestCreateComment_SquadLeaderNoActionRejectsComment(t *testing.T) {
 	fx := newRunningSquadLeaderTaskFixture(t)
 	recordSquadLeaderEvaluationForTask(t, fx, "no_action")
 
-	w := httptest.NewRecorder()
 	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
 		"content":   "No action needed.",
 		"parent_id": fx.TriggerCommentID,
@@ -166,18 +155,13 @@ func TestCreateComment_SquadLeaderNoActionRejectsComment(t *testing.T) {
 	r.Header.Set("X-Agent-ID", fx.LeaderID)
 	r.Header.Set("X-Task-ID", fx.TaskID)
 
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("CreateComment: expected 409, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusConflict)
 	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 0 {
 		t.Fatalf("expected rejected no_action comment not to be stored, got %d", got)
 	}
 
 	var body map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatalf("decode error response: %v", err)
-	}
+	w.Decode(&body)
 	if body["error"] == "" {
 		t.Fatalf("expected error message in response, got %v", body)
 	}

--- a/server/internal/handler/squad_private_leader_test.go
+++ b/server/internal/handler/squad_private_leader_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateIssue_SquadPrivateLeader_PlainMemberBlocked verifies that a
@@ -15,32 +17,18 @@ func TestCreateIssue_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Create Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Create Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
-	w := httptest.NewRecorder()
 	r := newRequestAs(memberID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":         "Should be blocked",
 		"assignee_type": "squad",
 		"assignee_id":   squadID,
 	})
-	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateIssue, r).Want(http.StatusForbidden)
 }
 
 // TestUpdateIssue_SquadPrivateLeader_PlainMemberBlocked verifies that a
@@ -49,45 +37,22 @@ func TestUpdateIssue_SquadPrivateLeader_PlainMemberBlocked(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Update Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Update Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create an unassigned issue as workspace owner.
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
-		VALUES ($1, 'member', $2, 'update target')
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
-	})
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "creator_type": testutil.Raw("'member'"), "creator_id": testUserID, "title": testutil.Raw("'update target'")})
 
-	w := httptest.NewRecorder()
 	r := newRequestAs(memberID, "PATCH", "/api/issues/"+issueID, map[string]any{
 		"assignee_type": "squad",
 		"assignee_id":   squadID,
 	})
 	r = withURLParam(r, "id", issueID)
-	testHandler.UpdateIssue(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateIssue, r).Want(http.StatusForbidden)
 }
 
 // TestCreateIssue_SquadPrivateLeader_OwnerAllowed verifies that the LEADER
@@ -99,39 +64,24 @@ func TestCreateIssue_SquadPrivateLeader_OwnerAllowed(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
 
 	agentID, ownerID, _ := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Owner Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Owner Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// The AGENT OWNER assigns — allowed. (MUL-3963: workspace owner/admin no
 	// longer bypasses a private leader's invocation gate.)
-	w := httptest.NewRecorder()
+
 	r := newRequestAs(ownerID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":         "Owner assigns private-leader squad",
 		"assignee_type": "squad",
 		"assignee_id":   squadID,
 	})
-	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, r).Want(http.StatusCreated)
 
 	var created IssueResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.Decode(&created)
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
 		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, created.ID)
@@ -150,16 +100,7 @@ func TestComment_SquadPrivateLeader_PlainMemberNoEnqueue(t *testing.T) {
 	agentID, _, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Comment Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Comment Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create issue assigned to the squad as workspace owner.
 	var issueID string
@@ -177,15 +118,12 @@ func TestComment_SquadPrivateLeader_PlainMemberNoEnqueue(t *testing.T) {
 	})
 
 	// Plain member posts a plain comment (not a @mention).
-	w := httptest.NewRecorder()
+
 	r := newRequestAs(memberID, "POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "any update on this?",
 	})
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// The private leader must NOT have a queued task.
 	var count int
@@ -217,16 +155,7 @@ func TestChildDone_SquadPrivateLeader_PlainMemberWakesLeader(t *testing.T) {
 	agentID, ownerID, memberID := privateAgentTestFixture(t)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader ChildDone Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader ChildDone Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create parent issue assigned to the squad (as the AGENT OWNER, who is
 	// allowed to invoke the private leader under MUL-3963).
@@ -237,9 +166,7 @@ func TestChildDone_SquadPrivateLeader_PlainMemberWakesLeader(t *testing.T) {
 		"assignee_id":   squadID,
 	})
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create parent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var parent IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&parent); err != nil {
 		t.Fatalf("decode parent: %v", err)
@@ -264,9 +191,7 @@ func TestChildDone_SquadPrivateLeader_PlainMemberWakesLeader(t *testing.T) {
 		"status":          "in_progress",
 	})
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create child: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var child IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&child); err != nil {
 		t.Fatalf("decode child: %v", err)
@@ -282,9 +207,7 @@ func TestChildDone_SquadPrivateLeader_PlainMemberWakesLeader(t *testing.T) {
 	})
 	r = withURLParam(r, "id", child.ID)
 	testHandler.UpdateIssue(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue (child done): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// The private leader MUST have a queued task on the parent — child-done
 	// wakes the parent's own leader regardless of who closed the child.
@@ -317,16 +240,7 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 	workerAgentID := createHandlerTestAgent(t, "squad-private-leader-childdone-worker", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader ChildDone AgentActor Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader ChildDone AgentActor Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Parent assigned to the squad by the agent owner (allowed under MUL-3963).
 	w := httptest.NewRecorder()
@@ -336,9 +250,7 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 		"assignee_id":   squadID,
 	})
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create parent: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var parent IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&parent); err != nil {
 		t.Fatalf("decode parent: %v", err)
@@ -364,9 +276,7 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 		"status":          "in_progress",
 	})
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create child: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 	var child IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&child); err != nil {
 		t.Fatalf("decode child: %v", err)
@@ -400,9 +310,7 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", child.ID)
 	testHandler.UpdateIssue(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue (child done): expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 	// The private leader MUST have a queued task on the parent.
 	var count int
@@ -429,16 +337,7 @@ func TestComment_SquadPrivateLeader_AgentActorAllowed(t *testing.T) {
 	otherAgentID := createHandlerTestAgent(t, "squad-private-leader-agent-actor", nil)
 
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'Private Leader Agent Actor Test', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'Private Leader Agent Actor Test'"), "description": testutil.Raw("''"), "leader_id": agentID, "creator_id": testUserID})
 
 	// Create issue assigned to the squad.
 	var issueID string
@@ -472,17 +371,14 @@ func TestComment_SquadPrivateLeader_AgentActorAllowed(t *testing.T) {
 	})
 
 	// Agent posts a comment with an explicit squad mention.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "[@Squad](mention://squad/" + squadID + ") agent reporting in",
 	})
 	r.Header.Set("X-Agent-ID", otherAgentID)
 	r.Header.Set("X-Task-ID", taskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// The private leader SHOULD have a queued task — the agent-actor mention's
 	// top-of-chain originator is the leader's owner, so A2A-by-originator

--- a/server/internal/handler/squad_worker_comment_wakes_leader_test.go
+++ b/server/internal/handler/squad_worker_comment_wakes_leader_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestCreateComment_WorkerAgentCommentWakesSquadLeader_MUL4015 pins the
@@ -73,17 +74,14 @@ func TestCreateComment_WorkerAgentCommentWakesSquadLeader_MUL4015(t *testing.T) 
 
 	// W posts a result comment in its agent identity (X-Agent-ID + X-Task-ID,
 	// the pair required by resolveActor to trust the agent header).
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "done — pushed the change, PR is up",
 	})
 	r.Header.Set("X-Agent-ID", fx.OtherID)
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// A new leader-role task is enqueued for L so the leader coordinates
 	// next steps.
@@ -147,17 +145,14 @@ func TestCreateComment_WorkerAgentCommentDoesNotWakeLeader_WhenLeaderTaskPending
 	}
 
 	// W posts a result comment.
-	w := httptest.NewRecorder()
+
 	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "done",
 	})
 	r.Header.Set("X-Agent-ID", fx.OtherID)
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", issueID)
-	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateComment, r).Want(http.StatusCreated)
 
 	// Expected: still exactly 1 queued leader task (the pre-seeded one) —
 	// no double enqueue.
@@ -231,16 +226,7 @@ func TestCreateComment_WorkerAgentCommentWakesPrivateSquadLeader_MUL4015(t *test
 
 	// Squad with the private leader.
 	var squadID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
-		VALUES ($1, 'MUL-4015 Private Squad', '', $2, $3)
-		RETURNING id
-	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
-		t.Fatalf("create private squad: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
-	})
+	squadID = dbfx.Insert(t, "squad", testutil.Cols{"workspace_id": testWorkspaceID, "name": testutil.Raw("'MUL-4015 Private Squad'"), "description": testutil.Raw("''"), "leader_id": leaderID, "creator_id": testUserID})
 
 	// Issue assigned to the squad, created by M (testUserID). CreatorType=member
 	// keeps the assign-time originator resolution to M.
@@ -286,9 +272,7 @@ func TestCreateComment_WorkerAgentCommentWakesPrivateSquadLeader_MUL4015(t *test
 	r.Header.Set("X-Task-ID", leaderTaskID)
 	r = withURLParam(r, "id", issueID)
 	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("leader mention CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	var workerTaskID string
 	if err := testPool.QueryRow(ctx, `
@@ -341,9 +325,7 @@ func TestCreateComment_WorkerAgentCommentWakesPrivateSquadLeader_MUL4015(t *test
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", issueID)
 	testHandler.CreateComment(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("worker done CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusCreated, "HTTP status")
 
 	var leaderTasksQueued int
 	if err := testPool.QueryRow(ctx, `

--- a/server/internal/handler/subscriber_revoke_race_test.go
+++ b/server/internal/handler/subscriber_revoke_race_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -97,13 +97,13 @@ func TestSubtreeUnsubscribe_LosesToConcurrentRevoke(t *testing.T) {
 	// pre-check sees a member that is about to stop existing.
 	done := make(chan int, 1)
 	go func() {
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/"+issueID+"/unsubscribe/subtree", map[string]any{
 			"user_id":   userID,
 			"user_type": "member",
 		})
 		req = withURLParam(req, "id", issueID)
-		testHandler.UnsubscribeFromIssueSubtree(w, req)
+		w := testutil.Call(t, testHandler.UnsubscribeFromIssueSubtree, req)
 		done <- w.Code
 	}()
 
@@ -144,21 +144,18 @@ func TestSubtreeUnsubscribe_LosesToConcurrentRevoke(t *testing.T) {
 
 func createRaceIssue(t *testing.T) string {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title": "subtree revoke race",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var issue IssueResponse
 	json.NewDecoder(w.Body).Decode(&issue)
 	t.Cleanup(func() {
-		dw := httptest.NewRecorder()
+
 		dreq := newRequest("DELETE", "/api/issues/"+issue.ID, nil)
 		dreq = withURLParam(dreq, "id", issue.ID)
-		testHandler.DeleteIssue(dw, dreq)
+		testutil.Call(t, testHandler.DeleteIssue, dreq)
 	})
 	return issue.ID
 }

--- a/server/internal/handler/subscriber_subtree_endpoint_test.go
+++ b/server/internal/handler/subscriber_subtree_endpoint_test.go
@@ -3,9 +3,9 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -36,15 +36,12 @@ func TestUnsubscribeEndpoints_SubtreeIsASeparateRoute(t *testing.T) {
 	// A body field named "subtree" must be inert on the shared endpoint. If it
 	// ever regains meaning here, an old backend and a new backend disagree
 	// about what the same request does — which is the whole defect.
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/"+parentID+"/unsubscribe", map[string]any{
 		"subtree": true,
 	})
 	req = withURLParam(req, "id", parentID)
-	testHandler.UnsubscribeFromIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UnsubscribeFromIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UnsubscribeFromIssue, req).Want(http.StatusOK)
 
 	if isSubscriberOf(t, parentID) {
 		t.Fatal("the plain endpoint must still unsubscribe the issue it targets")
@@ -64,13 +61,9 @@ func TestUnsubscribeEndpoints_SubtreeRouteLeavesDescendants(t *testing.T) {
 	subscribeTo(t, parentID)
 	subscribeTo(t, childID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/"+parentID+"/unsubscribe/subtree", nil)
 	req = withURLParam(req, "id", parentID)
-	testHandler.UnsubscribeFromIssueSubtree(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UnsubscribeFromIssueSubtree: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UnsubscribeFromIssueSubtree, req).Want(http.StatusOK)
 
 	if isSubscriberOf(t, parentID) {
 		t.Fatal("subtree unsubscribe must leave the root issue")
@@ -88,13 +81,13 @@ func createSubscriberTreeFixture(t *testing.T) (parentID, childID string) {
 	t.Helper()
 
 	create := func(title string, parent *string) string {
-		w := httptest.NewRecorder()
+
 		body := map[string]any{"title": title}
 		if parent != nil {
 			body["parent_issue_id"] = *parent
 		}
 		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
-		testHandler.CreateIssue(w, req)
+		w := testutil.Call(t, testHandler.CreateIssue, req)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("CreateIssue(%s): expected 201, got %d: %s", title, w.Code, w.Body.String())
 		}
@@ -108,10 +101,10 @@ func createSubscriberTreeFixture(t *testing.T) (parentID, childID string) {
 
 	t.Cleanup(func() {
 		for _, id := range []string{childID, parentID} {
-			w := httptest.NewRecorder()
+
 			req := newRequest("DELETE", "/api/issues/"+id, nil)
 			req = withURLParam(req, "id", id)
-			testHandler.DeleteIssue(w, req)
+			testutil.Call(t, testHandler.DeleteIssue, req)
 		}
 	})
 	return parentID, childID
@@ -119,10 +112,10 @@ func createSubscriberTreeFixture(t *testing.T) (parentID, childID string) {
 
 func subscribeTo(t *testing.T, issueID string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 	req = withURLParam(req, "id", issueID)
-	testHandler.SubscribeToIssue(w, req)
+	w := testutil.Call(t, testHandler.SubscribeToIssue, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("SubscribeToIssue(%s): expected 200, got %d: %s", issueID, w.Code, w.Body.String())
 	}

--- a/server/internal/handler/subscriber_test.go
+++ b/server/internal/handler/subscriber_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -16,14 +17,11 @@ func TestSubscriberAPI(t *testing.T) {
 	// Helper: create an issue for subscriber tests
 	createIssue := func(t *testing.T) string {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 			"title": "Subscriber test issue",
 		})
-		testHandler.CreateIssue(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 		var issue IssueResponse
 		json.NewDecoder(w.Body).Decode(&issue)
 		return issue.ID
@@ -32,23 +30,19 @@ func TestSubscriberAPI(t *testing.T) {
 	// Helper: delete an issue
 	deleteIssue := func(t *testing.T, issueID string) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newRequest("DELETE", "/api/issues/"+issueID, nil)
 		req = withURLParam(req, "id", issueID)
-		testHandler.DeleteIssue(w, req)
+		testutil.Call(t, testHandler.DeleteIssue, req)
 	}
 
 	t.Run("Subscribe", func(t *testing.T) {
 		issueID := createIssue(t)
 		defer deleteIssue(t, issueID)
 
-		w := httptest.NewRecorder()
 		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 		req = withURLParam(req, "id", issueID)
-		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.SubscribeToIssue, req).Want(http.StatusOK)
 
 		var resp map[string]bool
 		json.NewDecoder(w.Body).Decode(&resp)
@@ -79,18 +73,14 @@ func TestSubscriberAPI(t *testing.T) {
 		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue (1st): expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		// Subscribe second time — should also succeed
 		w = httptest.NewRecorder()
 		req = newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue (2nd): expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	})
 
 	t.Run("ListSubscribers", func(t *testing.T) {
@@ -102,18 +92,14 @@ func TestSubscriberAPI(t *testing.T) {
 		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		// List
 		w = httptest.NewRecorder()
 		req = newRequest("GET", "/api/issues/"+issueID+"/subscribers", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.ListIssueSubscribers(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssueSubscribers: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		var subscribers []SubscriberResponse
 		json.NewDecoder(w.Body).Decode(&subscribers)
@@ -141,18 +127,14 @@ func TestSubscriberAPI(t *testing.T) {
 		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		// Unsubscribe
 		w = httptest.NewRecorder()
 		req = newRequest("POST", "/api/issues/"+issueID+"/unsubscribe", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.UnsubscribeFromIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("UnsubscribeFromIssue: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		var resp map[string]bool
 		json.NewDecoder(w.Body).Decode(&resp)
@@ -179,16 +161,13 @@ func TestSubscriberAPI(t *testing.T) {
 		defer deleteIssue(t, issueID)
 
 		foreignUserID := "00000000-0000-0000-0000-000000000099"
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
 			"user_id":   foreignUserID,
 			"user_type": "member",
 		})
 		req = withURLParam(req, "id", issueID)
-		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("SubscribeToIssue with cross-workspace user: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.SubscribeToIssue, req).Want(http.StatusForbidden)
 
 		subscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
 			IssueID:  parseUUID(issueID),
@@ -208,16 +187,13 @@ func TestSubscriberAPI(t *testing.T) {
 		defer deleteIssue(t, issueID)
 
 		foreignUserID := "00000000-0000-0000-0000-000000000099"
-		w := httptest.NewRecorder()
+
 		req := newRequest("POST", "/api/issues/"+issueID+"/unsubscribe", map[string]any{
 			"user_id":   foreignUserID,
 			"user_type": "member",
 		})
 		req = withURLParam(req, "id", issueID)
-		testHandler.UnsubscribeFromIssue(w, req)
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("UnsubscribeFromIssue with cross-workspace user: expected 403, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Call(t, testHandler.UnsubscribeFromIssue, req).Want(http.StatusForbidden)
 	})
 
 	t.Run("AgentCallerSubscribesItself", func(t *testing.T) {
@@ -245,9 +221,7 @@ func TestSubscriberAPI(t *testing.T) {
 		req.Header.Set("X-Agent-ID", agentID)
 		req.Header.Set("X-Task-ID", agentTask)
 		testHandler.SubscribeToIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("SubscribeToIssue (agent caller): expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		agentSubscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
 			IssueID:  parseUUID(issueID),
@@ -282,9 +256,7 @@ func TestSubscriberAPI(t *testing.T) {
 		req.Header.Set("X-Agent-ID", agentID)
 		req.Header.Set("X-Task-ID", agentTask)
 		testHandler.UnsubscribeFromIssue(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("UnsubscribeFromIssue (agent caller): expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		agentSubscribed, err = testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
 			IssueID:  parseUUID(issueID),
@@ -320,9 +292,7 @@ func TestSubscriberAPI(t *testing.T) {
 		req = newRequest("GET", "/api/issues/"+issueID+"/subscribers", nil)
 		req = withURLParam(req, "id", issueID)
 		testHandler.ListIssueSubscribers(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListIssueSubscribers: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 
 		var subscribers []SubscriberResponse
 		json.NewDecoder(w.Body).Decode(&subscribers)

--- a/server/internal/handler/task_payload_nul_test.go
+++ b/server/internal/handler/task_payload_nul_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -20,17 +20,7 @@ func seedNULTask(t *testing.T, label string) (agentID, taskID string) {
 	t.Helper()
 	ctx := context.Background()
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id,
-			instructions, custom_env, custom_args)
-		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb)
-		RETURNING id`, testWorkspaceID, label, handlerTestRuntimeID(t), testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("seed agent: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
-	})
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": label, "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'cloud'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": handlerTestRuntimeID(t), "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID, "instructions": testutil.Raw("''"), "custom_env": testutil.Raw("'{}'::jsonb"), "custom_args": testutil.Raw("'[]'::jsonb")})
 
 	// The task needs an issue: requireDaemonTaskAccess resolves the workspace
 	// through it, and a task with no issue / chat / autopilot link 404s before
@@ -47,15 +37,7 @@ func seedNULTask(t *testing.T, label string) (agentID, taskID string) {
 		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
 	})
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
-		VALUES ($1, $2, $3, 'running', 0, now())
-		RETURNING id`, agentID, handlerTestRuntimeID(t), issueID).Scan(&taskID); err != nil {
-		t.Fatalf("seed running task: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
-	})
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": handlerTestRuntimeID(t), "issue_id": issueID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "started_at": testutil.Raw("now()")})
 	return agentID, taskID
 }
 
@@ -81,7 +63,6 @@ func TestCompleteTaskCallbackWithNULSucceeds(t *testing.T) {
 	ctx := context.Background()
 	_, taskID := seedNULTask(t, "nul-complete-agent")
 
-	w := httptest.NewRecorder()
 	req := daemonTaskRequest(t, "/api/daemon/tasks/"+taskID+"/complete", taskID, map[string]any{
 		"output":           "done\x00 summary text",
 		"work_dir":         "/tmp/work\x00dir",
@@ -89,10 +70,7 @@ func TestCompleteTaskCallbackWithNULSucceeds(t *testing.T) {
 		"session_id":       "sess-nul-complete",
 	})
 
-	testHandler.CompleteTask(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("CompleteTask returned %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CompleteTask, req).Want(http.StatusOK)
 
 	var (
 		status      string
@@ -138,7 +116,6 @@ func TestReportTaskMessagesCallbackWithNULSucceeds(t *testing.T) {
 	ctx := context.Background()
 	_, taskID := seedNULTask(t, "nul-messages-agent")
 
-	w := httptest.NewRecorder()
 	req := daemonTaskRequest(t, "/api/daemon/tasks/"+taskID+"/messages", taskID, map[string]any{
 		"messages": []any{
 			map[string]any{
@@ -158,10 +135,7 @@ func TestReportTaskMessagesCallbackWithNULSucceeds(t *testing.T) {
 		},
 	})
 
-	testHandler.ReportTaskMessages(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ReportTaskMessages returned %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ReportTaskMessages, req).Want(http.StatusOK)
 
 	var (
 		msgType    string
@@ -207,7 +181,6 @@ func TestReportTaskMessagesCreatesUUIDv7(t *testing.T) {
 	ctx := context.Background()
 	_, taskID := seedNULTask(t, "uuidv7-messages-agent")
 
-	w := httptest.NewRecorder()
 	req := daemonTaskRequest(t, "/api/daemon/tasks/"+taskID+"/messages", taskID, map[string]any{
 		"messages": []any{
 			map[string]any{
@@ -218,10 +191,7 @@ func TestReportTaskMessagesCreatesUUIDv7(t *testing.T) {
 		},
 	})
 
-	testHandler.ReportTaskMessages(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ReportTaskMessages returned %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ReportTaskMessages, req).Want(http.StatusOK)
 
 	var rawID string
 	if err := testPool.QueryRow(ctx, `

--- a/server/internal/handler/task_terminal_wakeup_test.go
+++ b/server/internal/handler/task_terminal_wakeup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 type terminalWakeupRecorder struct {
@@ -48,14 +49,7 @@ func TestTerminalTransitionsNotifyRuntime(t *testing.T) {
 	}
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
-		VALUES ($1, 'terminal wakeup fixture', 'in_progress', 'none', $2, 'member', 999099, 0, 'agent', $3)
-		RETURNING id
-	`, testWorkspaceID, testUserID, agentID).Scan(&issueID); err != nil {
-		t.Fatalf("setup: create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'terminal wakeup fixture'"), "status": testutil.Raw("'in_progress'"), "priority": testutil.Raw("'none'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("999099"), "position": testutil.Raw("0"), "assignee_type": testutil.Raw("'agent'"), "assignee_id": agentID})
 
 	var taskID string
 	if err := testPool.QueryRow(ctx, `

--- a/server/internal/handler/task_usage_response_test.go
+++ b/server/internal/handler/task_usage_response_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // TestListTasksByIssueHydratesUsage guards the per-run token figure on the
@@ -27,14 +27,7 @@ func TestListTasksByIssueHydratesUsage(t *testing.T) {
 	agentID := createHandlerTestAgent(t, "UsageListAgent", []byte("[]"))
 
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-		VALUES ($1, 'usage-list-issue', 'todo', 'medium', $2, 'member', 92778, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'usage-list-issue'"), "status": testutil.Raw("'todo'"), "priority": testutil.Raw("'medium'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("92778"), "position": testutil.Raw("0")})
 
 	newTask := func(status string) string {
 		var id string
@@ -65,16 +58,10 @@ func TestListTasksByIssueHydratesUsage(t *testing.T) {
 
 	req := newRequest("GET", "/api/issues/"+issueID+"/task-runs", nil)
 	req = withURLParam(req, "id", issueID)
-	w := httptest.NewRecorder()
-	testHandler.ListTasksByIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListTasksByIssue, req).Want(http.StatusOK)
 
 	var resp []AgentTaskResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode task list: %v", err)
-	}
+	w.JSON(&resp)
 
 	byID := make(map[string]AgentTaskResponse, len(resp))
 	for _, task := range resp {
@@ -130,9 +117,7 @@ func TestListTasksByIssueHydratesUsage(t *testing.T) {
 	// omitempty must keep the key off the wire entirely, so the client sees
 	// `undefined` rather than an empty array it might read as "hydrated, zero".
 	var raw []map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode raw task list: %v", err)
-	}
+	w.JSON(&raw)
 	for _, task := range raw {
 		if task["id"] != unpricedTask {
 			continue

--- a/server/internal/handler/telegram_test.go
+++ b/server/internal/handler/telegram_test.go
@@ -10,27 +10,20 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 func TestListTelegramInstallationsNotConfiguredReturnsEmpty(t *testing.T) {
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/x/telegram/installations", nil)
-	w := httptest.NewRecorder()
-
-	h.ListTelegramInstallations(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, h.ListTelegramInstallations, req).Want(http.StatusOK)
 	var resp struct {
 		Installations    []any `json:"installations"`
 		Configured       bool  `json:"configured"`
 		InstallSupported bool  `json:"install_supported"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Configured || resp.InstallSupported || len(resp.Installations) != 0 {
 		t.Fatalf("unexpected unconfigured response: %+v", resp)
 	}
@@ -74,9 +67,7 @@ func TestTelegramMutationHandlersRejectUnconfiguredDeployment(t *testing.T) {
 
 			tt.run(h, w, req)
 
-			if w.Code != http.StatusServiceUnavailable {
-				t.Fatalf("expected 503, got %d body=%s", w.Code, w.Body.String())
-			}
+			testutil.Equal(t, w.Code, http.StatusServiceUnavailable, "HTTP status")
 		})
 	}
 }

--- a/server/internal/handler/timeline_hardcap_test.go
+++ b/server/internal/handler/timeline_hardcap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -43,9 +44,7 @@ func fetchTimelineRecorder(t *testing.T, issueID, rawQuery string) *httptest.Res
 
 func decodeTimelineEntries(t *testing.T, w *httptest.ResponseRecorder) []TimelineEntry {
 	t.Helper()
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var entries []TimelineEntry
 	if err := json.Unmarshal(w.Body.Bytes(), &entries); err != nil {
 		t.Fatalf("decode timeline: %v", err)
@@ -474,9 +473,7 @@ func TestListTimeline_WrappedShapeReportsHasMoreBefore(t *testing.T) {
 	bulkSeedActivities(t, issueID, start, total)
 
 	w := fetchTimelineRecorder(t, issueID, "limit=50")
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp timelinePaginatedResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode wrapped response: %v", err)

--- a/server/internal/handler/user_language_test.go
+++ b/server/internal/handler/user_language_test.go
@@ -2,11 +2,12 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func newLanguageTestUser(t *testing.T, email string) string {
@@ -36,13 +37,8 @@ func newPatchMeRequest(userID, body string) *http.Request {
 func TestUpdateMeAcceptsLanguage(t *testing.T) {
 	userID := newLanguageTestUser(t, "lang-set@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"language":"zh-Hans"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateMe, req).Want(http.StatusOK)
 
 	var lang *string
 	if err := testPool.QueryRow(context.Background(),
@@ -55,9 +51,7 @@ func TestUpdateMeAcceptsLanguage(t *testing.T) {
 	}
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if got, _ := resp["language"].(string); got != "zh-Hans" {
 		t.Fatalf("expected response language=zh-Hans, got %v", resp["language"])
 	}
@@ -66,18 +60,11 @@ func TestUpdateMeAcceptsLanguage(t *testing.T) {
 func TestUpdateMeAcceptsKoreanLanguage(t *testing.T) {
 	userID := newLanguageTestUser(t, "lang-ko@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"language":"ko"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateMe, req).Want(http.StatusOK)
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if got, _ := resp["language"].(string); got != "ko" {
 		t.Fatalf("expected response language=ko, got %v", resp["language"])
 	}
@@ -86,18 +73,11 @@ func TestUpdateMeAcceptsKoreanLanguage(t *testing.T) {
 func TestUpdateMeAcceptsJapaneseLanguage(t *testing.T) {
 	userID := newLanguageTestUser(t, "lang-ja@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"language":"ja"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateMe, req).Want(http.StatusOK)
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if got, _ := resp["language"].(string); got != "ja" {
 		t.Fatalf("expected response language=ja, got %v", resp["language"])
 	}
@@ -106,13 +86,8 @@ func TestUpdateMeAcceptsJapaneseLanguage(t *testing.T) {
 func TestUpdateMeRejectsUnsupportedLanguage(t *testing.T) {
 	userID := newLanguageTestUser(t, "lang-reject@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"language":"<script>"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateMe, req).Want(http.StatusBadRequest)
 
 	var lang *string
 	if err := testPool.QueryRow(context.Background(),
@@ -135,13 +110,8 @@ func TestUpdateMePreservesLanguageWhenNotProvided(t *testing.T) {
 		t.Fatalf("preset language: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"name":"Updated Name"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateMe, req).Want(http.StatusOK)
 
 	var lang *string
 	if err := testPool.QueryRow(context.Background(),

--- a/server/internal/handler/user_timezone_test.go
+++ b/server/internal/handler/user_timezone_test.go
@@ -2,9 +2,9 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
-	"net/http/httptest"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func newTimezoneTestUser(t *testing.T, email string) string {
@@ -27,13 +27,8 @@ func newTimezoneTestUser(t *testing.T, email string) string {
 func TestUpdateMeAcceptsTimezone(t *testing.T) {
 	userID := newTimezoneTestUser(t, "tz-set@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"timezone":"Asia/Shanghai"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateMe, req).Want(200)
 
 	var stored *string
 	if err := testPool.QueryRow(context.Background(),
@@ -46,9 +41,7 @@ func TestUpdateMeAcceptsTimezone(t *testing.T) {
 	}
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	if got, _ := resp["timezone"].(string); got != "Asia/Shanghai" {
 		t.Fatalf("expected response timezone=Asia/Shanghai, got %v", resp["timezone"])
 	}
@@ -57,13 +50,8 @@ func TestUpdateMeAcceptsTimezone(t *testing.T) {
 func TestUpdateMeRejectsInvalidTimezone(t *testing.T) {
 	userID := newTimezoneTestUser(t, "tz-reject@multica.ai")
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"timezone":"Not/A/Real/Zone"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != 400 {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateMe, req).Want(400)
 
 	var stored *string
 	if err := testPool.QueryRow(context.Background(),
@@ -86,13 +74,8 @@ func TestUpdateMePreservesTimezoneWhenNotProvided(t *testing.T) {
 		t.Fatalf("preset timezone: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"name":"Updated Name"}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateMe, req).Want(200)
 
 	var stored *string
 	if err := testPool.QueryRow(context.Background(),
@@ -118,13 +101,8 @@ func TestUpdateMeClearsTimezoneOnEmptyString(t *testing.T) {
 		t.Fatalf("preset timezone: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newPatchMeRequest(userID, `{"timezone":""}`)
-	testHandler.UpdateMe(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.UpdateMe, req).Want(200)
 
 	var stored *string
 	if err := testPool.QueryRow(context.Background(),
@@ -137,9 +115,7 @@ func TestUpdateMeClearsTimezoneOnEmptyString(t *testing.T) {
 	}
 
 	var resp map[string]any
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	// JSON null marshals from *string nil — confirm the response reflects
 	// the cleared state, so the frontend can switch its picker back to
 	// "(browser)" without a refetch.

--- a/server/internal/handler/vcs_test.go
+++ b/server/internal/handler/vcs_test.go
@@ -2,13 +2,13 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 func vcsHandlerRequest(method, path string, body any, connectionID string) *http.Request {
@@ -34,19 +34,13 @@ func TestListVCSConnectionsHonorsDeploymentSwitch(t *testing.T) {
 	} {
 		t.Helper()
 		req := vcsHandlerRequest(http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/vcs/connections", nil, "")
-		w := httptest.NewRecorder()
-		testHandler.ListVCSConnections(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("ListVCSConnections: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.ListVCSConnections, req).Want(http.StatusOK)
 		var resp struct {
 			Connections []VCSConnectionResponse `json:"connections"`
 			Available   bool                    `json:"available"`
 			Configured  bool                    `json:"configured"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode ListVCSConnections: %v", err)
-		}
+		w.JSON(&resp)
 		return resp
 	}
 

--- a/server/internal/handler/vcs_webhook_test.go
+++ b/server/internal/handler/vcs_webhook_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	"github.com/multica-ai/multica/server/internal/util/secretbox"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -75,14 +76,11 @@ func cleanupVCS(ctx context.Context, issueID string) {
 
 func newVCSIssue(t *testing.T, title string) IssueResponse {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title": title, "status": "in_progress",
 	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateIssue, req).Want(http.StatusCreated)
 	var created IssueResponse
 	json.NewDecoder(w.Body).Decode(&created)
 	return created
@@ -124,13 +122,9 @@ func TestVCSWebhook_ForgejoMirrorsAndCloses(t *testing.T) {
 		},
 		"repository": map[string]any{"name": "widget", "owner": map[string]any{"username": "acme"}},
 	})
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
-	}, raw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
-	}
+	}, raw)).Want(http.StatusAccepted)
 
 	rows, err := testHandler.Queries.ListVCSPullRequestsByIssue(ctx, parseUUID(issue.ID))
 	if err != nil {
@@ -174,9 +168,7 @@ func TestVCSWebhook_ReferenceOnlyExcludedAndNonBlocking(t *testing.T) {
 	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(refRaw),
 	}, refRaw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("ref PR: expected 202, got %d (%s)", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusAccepted, "HTTP status")
 
 	// The link exists but is reference_only, so it is hidden from the PR list.
 	var referenceOnly bool
@@ -213,9 +205,7 @@ func TestVCSWebhook_ReferenceOnlyExcludedAndNonBlocking(t *testing.T) {
 	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(closeRaw),
 	}, closeRaw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("close PR: expected 202, got %d (%s)", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusAccepted, "HTTP status")
 
 	updated, _ := testHandler.Queries.GetIssue(ctx, parseUUID(issue.ID))
 	if updated.Status != "done" {
@@ -307,13 +297,9 @@ func TestDeleteIssue_VCSLinkCleanupIsWorkspaceScoped(t *testing.T) {
 		},
 		"repository": map[string]any{"name": "widget", "owner": map[string]any{"username": "acme"}},
 	})
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
-	}, raw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("seed PR: %d %s", w.Code, w.Body.String())
-	}
+	}, raw)).Want(http.StatusAccepted)
 
 	linkCount := func() int {
 		var n int
@@ -368,8 +354,7 @@ func TestVCSWebhook_StaleEventDoesNotRewriteLink(t *testing.T) {
 			},
 			"repository": map[string]any{"name": "widget", "owner": map[string]any{"username": "acme"}},
 		})
-		w := httptest.NewRecorder()
-		testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+		w := testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 			"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
 		}, raw))
 		if w.Code != http.StatusAccepted {
@@ -418,13 +403,9 @@ func TestVCSWebhook_GitlabMergeRequest(t *testing.T) {
 		},
 	})
 	// GitLab authenticates by plaintext X-Gitlab-Token, not HMAC.
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitlab-Event": "Merge Request Hook", "X-Gitlab-Token": vcsTestSecret,
-	}, raw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
-	}
+	}, raw)).Want(http.StatusAccepted)
 
 	rows, err := testHandler.Queries.ListVCSPullRequestsByIssue(ctx, parseUUID(issue.ID))
 	if err != nil {
@@ -464,18 +445,14 @@ func TestVCSWebhook_CommitStatusMirrors(t *testing.T) {
 	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(prRaw),
 	}, prRaw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("pr: expected 202, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusAccepted, "HTTP status")
 
 	stRaw, _ := json.Marshal(map[string]any{"sha": "deadbeef", "context": "ci/woodpecker", "state": "success"})
 	w = httptest.NewRecorder()
 	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "status", "X-Gitea-Signature": giteaSig(stRaw),
 	}, stRaw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("status: expected 202, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusAccepted, "HTTP status")
 
 	rows, _ := testHandler.Queries.ListVCSPullRequestsByIssue(ctx, parseUUID(issue.ID))
 	if len(rows) != 1 || rows[0].ChecksTotal != 1 || rows[0].ChecksPassed != 1 {
@@ -490,13 +467,9 @@ func TestVCSWebhook_BadSignature(t *testing.T) {
 	t.Cleanup(func() { cleanupVCS(ctx, "") })
 
 	raw := []byte(`{"action":"opened","pull_request":{"number":1}}`)
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": "00",
-	}, raw))
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Code)
-	}
+	}, raw)).Want(http.StatusUnauthorized)
 }
 
 func TestVCSWebhook_UnknownConnection(t *testing.T) {
@@ -504,11 +477,7 @@ func TestVCSWebhook_UnknownConnection(t *testing.T) {
 	req := vcsWebhookReq("00000000-0000-0000-0000-000000000000", map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": "00",
 	}, []byte(`{}`))
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", w.Code)
-	}
+	testutil.Call(t, testHandler.HandleVCSWebhook, req).Want(http.StatusNotFound)
 }
 
 // TestVCSWebhook_DisabledDeploymentReturns404 verifies the deployment-level
@@ -527,13 +496,9 @@ func TestVCSWebhook_DisabledDeploymentReturns404(t *testing.T) {
 	testHandler.cfg.VCSIntegrationEnabled = false
 
 	raw := []byte(`{"action":"opened","pull_request":{"number":1}}`)
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
-	}, raw))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404 when integration disabled, got %d (%s)", w.Code, w.Body.String())
-	}
+	}, raw)).Want(http.StatusNotFound)
 }
 
 func TestVCSWebhook_MalformedTolerated(t *testing.T) {
@@ -543,13 +508,9 @@ func TestVCSWebhook_MalformedTolerated(t *testing.T) {
 	t.Cleanup(func() { cleanupVCS(ctx, "") })
 
 	raw := []byte(`{"action":"opened","pull_request":"not-an-object"}`)
-	w := httptest.NewRecorder()
-	testHandler.HandleVCSWebhook(w, vcsWebhookReq(connID, map[string]string{
+	testutil.Call(t, testHandler.HandleVCSWebhook, vcsWebhookReq(connID, map[string]string{
 		"X-Gitea-Event": "pull_request", "X-Gitea-Signature": giteaSig(raw),
-	}, raw))
-	if w.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
-	}
+	}, raw)).Want(http.StatusAccepted)
 	var count int
 	testPool.QueryRow(ctx, `SELECT count(*) FROM vcs_pull_request WHERE workspace_id = $1`, testWorkspaceID).Scan(&count)
 	if count != 0 {

--- a/server/internal/handler/webhook_delivery_test.go
+++ b/server/internal/handler/webhook_delivery_test.go
@@ -9,11 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -23,15 +23,12 @@ const testSigningSecret = "this-is-a-test-secret-32-chars-x"
 
 func setSigningSecretViaHandler(t *testing.T, apID, triggerID, secret string) {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("PUT", fmt.Sprintf("/api/autopilots/%s/triggers/%s/signing-secret", apID, triggerID), map[string]any{
 		"signing_secret": secret,
 	})
 	req = withURLParams(req, "id", apID, "triggerId", triggerID)
-	testHandler.SetAutopilotTriggerSigningSecret(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("set signing secret: %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SetAutopilotTriggerSigningSecret, req).Want(http.StatusOK)
 }
 
 func setTriggerProvider(t *testing.T, triggerID, provider string) {
@@ -83,19 +80,14 @@ FOR EACH ROW EXECUTE FUNCTION %s();
 // listDeliveries calls ListAutopilotDeliveries and decodes the body.
 func listDeliveries(t *testing.T, apID string) []map[string]any {
 	t.Helper()
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/autopilots/"+apID+"/deliveries", nil)
 	req = withURLParam(req, "id", apID)
-	testHandler.ListAutopilotDeliveries(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("list deliveries: %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAutopilotDeliveries, req).Want(http.StatusOK)
 	var resp struct {
 		Deliveries []map[string]any `json:"deliveries"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	return resp.Deliveries
 }
 
@@ -177,9 +169,7 @@ func TestWebhookHandler_DedupeViaIdempotencyKey(t *testing.T) {
 	// Retry before the worker processes the queued delivery. The admitted run
 	// must already be discoverable so the duplicate returns the same run_id.
 	w2 := postWebhook(t, *trig.WebhookToken, body, headers)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("second: %d body=%s", w2.Code, w2.Body.String())
-	}
+	testutil.Equal(t, w2.Code, http.StatusOK, "HTTP status")
 	var r2 map[string]any
 	json.Unmarshal(w2.Body.Bytes(), &r2)
 	if r2["status"] != "duplicate" {
@@ -247,9 +237,7 @@ func TestWebhookHandler_InvalidSignatureReturns401AndPersistsRejected(t *testing
 	w := postWebhook(t, *trig.WebhookToken, body, map[string]string{
 		"X-Hub-Signature-256": "sha256=deadbeef",
 	})
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnauthorized, "HTTP status")
 	var resp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["status"] != "rejected" {
@@ -281,9 +269,7 @@ func TestWebhookHandler_MissingSignatureReturns401WhenSecretSet(t *testing.T) {
 	setSigningSecretViaHandler(t, apID, trig.ID, testSigningSecret)
 
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"hello": "world"}, nil)
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusUnauthorized, "HTTP status")
 	var resp map[string]any
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["reason"] != "missing_signature" {
@@ -324,13 +310,10 @@ func TestSigningSecretNotEchoedInTriggerResponse(t *testing.T) {
 	setSigningSecretViaHandler(t, apID, trig.ID, testSigningSecret)
 
 	// GET the autopilot — trigger response embedded.
-	w := httptest.NewRecorder()
+
 	req := newRequest("GET", "/api/autopilots/"+apID, nil)
 	req = withURLParam(req, "id", apID)
-	testHandler.GetAutopilot(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("get autopilot: %d", w.Code)
-	}
+	w := testutil.Call(t, testHandler.GetAutopilot, req).Want(http.StatusOK)
 	if bytes.Contains(w.Body.Bytes(), []byte(testSigningSecret)) {
 		t.Fatalf("signing secret leaked in trigger response: %s", w.Body.String())
 	}
@@ -347,15 +330,11 @@ func TestSigningSecret_MinLengthEnforced(t *testing.T) {
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 	trig := createWebhookTriggerViaHandler(t, apID)
 
-	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/autopilots/"+apID+"/triggers/"+trig.ID+"/signing-secret", map[string]any{
 		"signing_secret": "short",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.SetAutopilotTriggerSigningSecret(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for short secret, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SetAutopilotTriggerSigningSecret, req).Want(http.StatusBadRequest)
 }
 
 func TestSigningSecret_EmptyClearsSecret(t *testing.T) {
@@ -365,15 +344,12 @@ func TestSigningSecret_EmptyClearsSecret(t *testing.T) {
 	setSigningSecretViaHandler(t, apID, trig.ID, testSigningSecret)
 
 	// Now clear with empty string.
-	w := httptest.NewRecorder()
+
 	req := newRequest("PUT", "/api/autopilots/"+apID+"/triggers/"+trig.ID+"/signing-secret", map[string]any{
 		"signing_secret": "",
 	})
 	req = withURLParams(req, "id", apID, "triggerId", trig.ID)
-	testHandler.SetAutopilotTriggerSigningSecret(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("clear secret: %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.SetAutopilotTriggerSigningSecret, req).Want(http.StatusOK)
 	// Unsigned request should now go through (back to not_required).
 	post := postWebhook(t, *trig.WebhookToken, map[string]any{"x": 1}, nil)
 	requireAcceptedWebhookResponse(t, post)
@@ -393,14 +369,11 @@ func TestReplay_QueuesIdempotentDeliveryForDurableWorker(t *testing.T) {
 	originalRunID := uuidToString(originalDelivery.AutopilotRunID)
 
 	// Replay the original.
-	wr := httptest.NewRecorder()
+
 	req := newRequest("POST", fmt.Sprintf("/api/autopilots/%s/deliveries/%s/replay", apID, originalID), nil)
 	req.Header.Set("Idempotency-Key", "replay-request")
 	req = withURLParams(req, "id", apID, "deliveryId", originalID)
-	testHandler.ReplayAutopilotDelivery(wr, req)
-	if wr.Code != http.StatusAccepted {
-		t.Fatalf("replay: %d body=%s", wr.Code, wr.Body.String())
-	}
+	wr := testutil.Call(t, testHandler.ReplayAutopilotDelivery, req).Want(http.StatusAccepted)
 	var replay map[string]any
 	json.Unmarshal(wr.Body.Bytes(), &replay)
 	if replay["id"] == originalID {
@@ -423,14 +396,11 @@ func TestReplay_QueuesIdempotentDeliveryForDurableWorker(t *testing.T) {
 
 	// Retrying the replay request with the same key returns the same delivery
 	// and cannot enqueue or reserve a second run.
-	retryRecorder := httptest.NewRecorder()
+
 	retryReq := newRequest("POST", fmt.Sprintf("/api/autopilots/%s/deliveries/%s/replay", apID, originalID), nil)
 	retryReq.Header.Set("Idempotency-Key", "replay-request")
 	retryReq = withURLParams(retryReq, "id", apID, "deliveryId", originalID)
-	testHandler.ReplayAutopilotDelivery(retryRecorder, retryReq)
-	if retryRecorder.Code != http.StatusAccepted {
-		t.Fatalf("replay retry: %d body=%s", retryRecorder.Code, retryRecorder.Body.String())
-	}
+	retryRecorder := testutil.Call(t, testHandler.ReplayAutopilotDelivery, retryReq).Want(http.StatusAccepted)
 	var retried map[string]any
 	json.Unmarshal(retryRecorder.Body.Bytes(), &retried)
 	if retried["id"] != replayID {
@@ -453,21 +423,16 @@ func TestReplay_RejectsInvalidSignatureDelivery(t *testing.T) {
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"x": 1}, map[string]string{
 		"X-Hub-Signature-256": "sha256=baadf00d",
 	})
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("setup: expected 401, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusUnauthorized, "HTTP status")
 	var rej map[string]any
 	json.Unmarshal(w.Body.Bytes(), &rej)
 	rejectedID := rej["delivery_id"].(string)
 
 	// Replay the rejected delivery → 400.
-	wr := httptest.NewRecorder()
+
 	req := newRequest("POST", fmt.Sprintf("/api/autopilots/%s/deliveries/%s/replay", apID, rejectedID), nil)
 	req = withURLParams(req, "id", apID, "deliveryId", rejectedID)
-	testHandler.ReplayAutopilotDelivery(wr, req)
-	if wr.Code != http.StatusBadRequest {
-		t.Fatalf("replay of rejected: expected 400, got %d body=%s", wr.Code, wr.Body.String())
-	}
+	testutil.Call(t, testHandler.ReplayAutopilotDelivery, req).Want(http.StatusBadRequest)
 }
 
 func TestGetDelivery_ReturnsFullPayload(t *testing.T) {
@@ -479,22 +444,19 @@ func TestGetDelivery_ReturnsFullPayload(t *testing.T) {
 	deliveryID := requireAcceptedWebhookResponse(t, w)
 
 	// List response should NOT include raw_body / selected_headers.
-	wList := httptest.NewRecorder()
+
 	reqList := newRequest("GET", "/api/autopilots/"+apID+"/deliveries", nil)
 	reqList = withURLParam(reqList, "id", apID)
-	testHandler.ListAutopilotDeliveries(wList, reqList)
+	wList := testutil.Call(t, testHandler.ListAutopilotDeliveries, reqList)
 	if bytes.Contains(wList.Body.Bytes(), []byte(`"raw_body"`)) {
 		t.Fatalf("list response should not include raw_body, body=%s", wList.Body.String())
 	}
 
 	// Detail response SHOULD include raw_body and selected_headers.
-	wDetail := httptest.NewRecorder()
+
 	reqDetail := newRequest("GET", "/api/autopilots/"+apID+"/deliveries/"+deliveryID, nil)
 	reqDetail = withURLParams(reqDetail, "id", apID, "deliveryId", deliveryID)
-	testHandler.GetAutopilotDelivery(wDetail, reqDetail)
-	if wDetail.Code != http.StatusOK {
-		t.Fatalf("detail: %d body=%s", wDetail.Code, wDetail.Body.String())
-	}
+	wDetail := testutil.Call(t, testHandler.GetAutopilotDelivery, reqDetail).Want(http.StatusOK)
 	// raw_body is serialised as a JSON string (escaped); decode the response
 	// and assert against the decoded payload so we don't rely on a brittle
 	// substring search against the escaped form.
@@ -533,45 +495,34 @@ func TestGetDelivery_CrossAutopilotReturns404(t *testing.T) {
 	deliveryID := seed["delivery_id"].(string)
 
 	// Try reading via the OTHER autopilot's URL.
-	wDetail := httptest.NewRecorder()
+
 	reqDetail := newRequest("GET", "/api/autopilots/"+apB+"/deliveries/"+deliveryID, nil)
 	reqDetail = withURLParams(reqDetail, "id", apB, "deliveryId", deliveryID)
-	testHandler.GetAutopilotDelivery(wDetail, reqDetail)
-	if wDetail.Code != http.StatusNotFound {
-		t.Fatalf("cross-autopilot GET: expected 404, got %d", wDetail.Code)
-	}
+	testutil.Call(t, testHandler.GetAutopilotDelivery, reqDetail).Want(http.StatusNotFound)
 }
 
 func TestCreateAutopilotTrigger_RejectsUnknownProvider(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "ProviderInvalid Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind":     "webhook",
 		"provider": "stripe",
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for unknown provider, got %d body=%s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusBadRequest)
 }
 
 func TestCreateAutopilotTrigger_AcceptsGitHubProvider(t *testing.T) {
 	agentID := createWebhookTestAgent(t, "ProviderGH Agent")
 	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
 
-	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
 		"kind":     "webhook",
 		"provider": "github",
 	})
 	req = withURLParam(req, "id", apID)
-	testHandler.CreateAutopilotTrigger(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d body=%s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.CreateAutopilotTrigger, req).Want(http.StatusCreated)
 	var resp AutopilotTriggerResponse
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Provider == nil || *resp.Provider != "github" {
@@ -889,9 +840,7 @@ func TestWebhookHandler_InvalidSignatureCountsAgainstRateLimit(t *testing.T) {
 		}
 	}
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"i": "third"}, bad)
-	if w.Code != http.StatusTooManyRequests {
-		t.Fatalf("third request expected 429 (rate-limited despite bad sig), got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusTooManyRequests, "HTTP status")
 	if w.Header().Get("Retry-After") == "" {
 		t.Fatal("429 must include Retry-After")
 	}
@@ -905,9 +854,7 @@ func TestWebhookHandler_IgnoredPathStillPersistsDelivery(t *testing.T) {
 	trig := createWebhookTriggerViaHandler(t, apID)
 
 	w := postWebhook(t, *trig.WebhookToken, map[string]any{"x": 1}, nil)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	deliveries := listDeliveries(t, apID)
 	if len(deliveries) != 1 {
 		t.Fatalf("expected 1 delivery on paused autopilot, got %d", len(deliveries))

--- a/server/internal/handler/wecom_web_test.go
+++ b/server/internal/handler/wecom_web_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/wecom"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // fakeRedeemer records whether the handler ever got as far as the service.
@@ -45,8 +46,7 @@ func TestRedeemWecomBindingTokenRefusesAnOversizedBody(t *testing.T) {
 	h := &Handler{WecomBindingTokens: fake}
 
 	huge := `{"token":"` + strings.Repeat("A", wecomBodyLimit*2) + `"}`
-	w := httptest.NewRecorder()
-	h.RedeemWecomBindingToken(w, redeemRequest(huge))
+	w := testutil.Call(t, h.RedeemWecomBindingToken, redeemRequest(huge))
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
@@ -63,8 +63,7 @@ func TestRedeemWecomBindingTokenAcceptsAnOrdinaryBody(t *testing.T) {
 	fake := &fakeRedeemer{}
 	h := &Handler{WecomBindingTokens: fake}
 
-	w := httptest.NewRecorder()
-	h.RedeemWecomBindingToken(w, redeemRequest(`{"token":"an-ordinary-32-byte-looking-token"}`))
+	w := testutil.Call(t, h.RedeemWecomBindingToken, redeemRequest(`{"token":"an-ordinary-32-byte-looking-token"}`))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())

--- a/server/internal/handler/workspace_delete_lock_test.go
+++ b/server/internal/handler/workspace_delete_lock_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // setWorkspaceDeleteLockTimeoutForTest is a package-private hook used only by
@@ -70,16 +72,7 @@ func TestDeleteWorkspace_FailsFastWhenRollupLockHeld(t *testing.T) {
 	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
 	var wsID string
-	if err := testPool.QueryRow(ctx, `
-INSERT INTO workspace (name, slug, description)
-VALUES ($1, $2, $3)
-RETURNING id
-`, "Handler Test Delete Lock", slug, "DeleteWorkspace lock timeout test").Scan(&wsID); err != nil {
-		t.Fatalf("create workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-	})
+	wsID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Handler Test Delete Lock", "slug": slug, "description": "DeleteWorkspace lock timeout test"})
 
 	if _, err := testPool.Exec(ctx, `
 INSERT INTO member (workspace_id, user_id, role)
@@ -108,9 +101,7 @@ VALUES ($1, $2, 'owner')
 		t.Fatal("DeleteWorkspace blocked on advisory lock 4246 instead of timing out — this is the hang users see as 'delete workspace does nothing' (MUL-5983)")
 	}
 
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 while advisory lock 4246 is held, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusServiceUnavailable, "HTTP status")
 
 	var exists bool
 	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
@@ -140,16 +131,7 @@ func TestDeleteWorkspace_SucceedsWhenRollupLockIsFree(t *testing.T) {
 	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
 	var wsID string
-	if err := testPool.QueryRow(ctx, `
-INSERT INTO workspace (name, slug, description)
-VALUES ($1, $2, $3)
-RETURNING id
-`, "Handler Test Delete Lock Free", slug, "DeleteWorkspace lock timeout test").Scan(&wsID); err != nil {
-		t.Fatalf("create workspace: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-	})
+	wsID = dbfx.Insert(t, "workspace", testutil.Cols{"name": "Handler Test Delete Lock Free", "slug": slug, "description": "DeleteWorkspace lock timeout test"})
 
 	if _, err := testPool.Exec(ctx, `
 INSERT INTO member (workspace_id, user_id, role)
@@ -158,14 +140,9 @@ VALUES ($1, $2, 'owner')
 		t.Fatalf("create owner member: %v", err)
 	}
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
 	req = withURLParam(req, "id", wsID)
-	testHandler.DeleteWorkspace(w, req)
-
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204 from an uncontended delete, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	var exists bool
 	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {

--- a/server/internal/handler/workspace_delete_task_discovery_test.go
+++ b/server/internal/handler/workspace_delete_task_discovery_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -241,13 +241,9 @@ func TestDeleteWorkspace_CollectsTasksThroughEveryOwnershipPath(t *testing.T) {
 	}
 	f := newWorkspaceDeletePathFixture(t, "endtoend")
 
-	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+f.victimID, nil)
 	req = withURLParam(req, "id", f.victimID)
-	testHandler.DeleteWorkspace(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DeleteWorkspace = %d, want 204: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspace, req).Want(http.StatusNoContent)
 
 	for name, id := range map[string]string{
 		"task reachable only via agent_id":   f.taskViaAgent,

--- a/server/internal/handler/workspace_mcp_api_test.go
+++ b/server/internal/handler/workspace_mcp_api_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 const workspaceMcpTestSecret = "sk-live-workspace-should-never-be-echoed"
@@ -42,8 +44,7 @@ func listWorkspaceMcpServersForTest(t *testing.T, mutate func(*http.Request)) (i
 	if mutate != nil {
 		mutate(req)
 	}
-	w := httptest.NewRecorder()
-	testHandler.ListWorkspaceMcpServers(w, req)
+	w := testutil.Call(t, testHandler.ListWorkspaceMcpServers, req)
 
 	var resp []WorkspaceMcpServerResponse
 	raw := w.Body.String()
@@ -103,8 +104,7 @@ func createWorkspaceMcpServerViaAPI(t *testing.T, body any, mutate func(*http.Re
 	if mutate != nil {
 		mutate(req)
 	}
-	w := httptest.NewRecorder()
-	testHandler.CreateWorkspaceMcpServer(w, req)
+	w := testutil.Call(t, testHandler.CreateWorkspaceMcpServer, req)
 
 	var resp WorkspaceMcpServerResponse
 	raw := w.Body.String()
@@ -221,11 +221,7 @@ func TestUpdateWorkspaceMcpServer_RenameKeepsBindings(t *testing.T) {
 	req := newRequest(http.MethodPut, "/api/workspaces/"+testWorkspaceID+"/mcp-servers/"+serverID,
 		map[string]any{"name": "linear-v2"})
 	req = withURLParams(req, "id", testWorkspaceID, "serverId", serverID)
-	w := httptest.NewRecorder()
-	testHandler.UpdateWorkspaceMcpServer(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.UpdateWorkspaceMcpServer, req).Want(http.StatusOK)
 
 	servers := listAgentMcpServersForTest(t, agentID)
 	if len(servers) != 1 || servers[0].Name != "linear-v2" {
@@ -245,11 +241,7 @@ func TestDeleteWorkspaceMcpServer_SweepsBindings(t *testing.T) {
 
 	req := newRequest(http.MethodDelete, "/api/workspaces/"+testWorkspaceID+"/mcp-servers/"+serverID, nil)
 	req = withURLParams(req, "id", testWorkspaceID, "serverId", serverID)
-	w := httptest.NewRecorder()
-	testHandler.DeleteWorkspaceMcpServer(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.DeleteWorkspaceMcpServer, req).Want(http.StatusNoContent)
 
 	var bindings int
 	if err := testPool.QueryRow(context.Background(),
@@ -266,15 +258,9 @@ func listAgentMcpServersForTest(t *testing.T, agentID string) []WorkspaceMcpServ
 
 	req := newRequest(http.MethodGet, "/api/agents/"+agentID+"/mcp-servers", nil)
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.ListAgentMcpServers(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("ListAgentMcpServers: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ListAgentMcpServers, req).Want(http.StatusOK)
 	var resp []WorkspaceMcpServerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	return resp
 }
 
@@ -284,15 +270,9 @@ func addAgentMcpServerForTest(t *testing.T, agentID, serverID string) []Workspac
 	req := newRequest(http.MethodPost, "/api/agents/"+agentID+"/mcp-servers",
 		map[string]any{"server_id": serverID})
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.AddAgentMcpServer(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("AddAgentMcpServer: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.AddAgentMcpServer, req).Want(http.StatusOK)
 	var resp []WorkspaceMcpServerResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	w.JSON(&resp)
 	return resp
 }
 
@@ -323,9 +303,7 @@ func TestAgentMcpServerBinding_AddToggleRemove(t *testing.T) {
 	req = withURLParams(req, "id", agentID, "serverId", serverID)
 	w := httptest.NewRecorder()
 	testHandler.SetAgentMcpServerEnabled(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("SetAgentMcpServerEnabled: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	servers = listAgentMcpServersForTest(t, agentID)
 	if len(servers) != 1 || servers[0].Enabled == nil || *servers[0].Enabled {
 		t.Fatalf("expected the binding to survive as disabled, got %+v", servers)
@@ -336,9 +314,7 @@ func TestAgentMcpServerBinding_AddToggleRemove(t *testing.T) {
 	req = withURLParams(req, "id", agentID, "serverId", serverID)
 	w = httptest.NewRecorder()
 	testHandler.RemoveAgentMcpServer(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("RemoveAgentMcpServer: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	if servers = listAgentMcpServersForTest(t, agentID); len(servers) != 0 {
 		t.Fatalf("expected no bindings after removal, got %+v", servers)
 	}
@@ -357,36 +333,16 @@ func TestAddAgentMcpServer_RejectsServerFromAnotherWorkspace(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	ctx := context.Background()
+
 	var otherWorkspaceID, otherServerID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace (name, slug, description, issue_prefix)
-		VALUES ('Other WS', 'ws-mcp-other', '', 'OTH')
-		RETURNING id
-	`).Scan(&otherWorkspaceID); err != nil {
-		t.Fatalf("create other workspace: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, otherWorkspaceID) })
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO workspace_mcp_server (workspace_id, name, config)
-		VALUES ($1, 'foreign', '{"url":"https://foreign.example"}')
-		RETURNING id
-	`, otherWorkspaceID).Scan(&otherServerID); err != nil {
-		t.Fatalf("create foreign server: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `DELETE FROM workspace_mcp_server WHERE id = $1`, otherServerID)
-	})
+	otherWorkspaceID = dbfx.Insert(t, "workspace", testutil.Cols{"name": testutil.Raw("'Other WS'"), "slug": testutil.Raw("'ws-mcp-other'"), "description": testutil.Raw("''"), "issue_prefix": testutil.Raw("'OTH'")})
+	otherServerID = dbfx.Insert(t, "workspace_mcp_server", testutil.Cols{"workspace_id": otherWorkspaceID, "name": testutil.Raw("'foreign'"), "config": testutil.Raw("'{\"url\":\"https://foreign.example\"}'")})
 
 	agentID := createHandlerTestAgent(t, "ws-mcp-tenant-agent", nil)
 	req := newRequest(http.MethodPost, "/api/agents/"+agentID+"/mcp-servers",
 		map[string]any{"server_id": otherServerID})
 	req = withURLParam(req, "id", agentID)
-	w := httptest.NewRecorder()
-	testHandler.AddAgentMcpServer(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404 for a server from another workspace, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.AddAgentMcpServer, req).Want(http.StatusNotFound)
 }
 
 // The agent's binding list is secret-free too, and an agent actor may not
@@ -415,7 +371,5 @@ func TestAgentMcpServerBinding_ResponseIsSecretFreeAndAgentActorsCannotWrite(t *
 	req.Header.Set("X-Task-ID", taskID)
 	w = httptest.NewRecorder()
 	testHandler.AddAgentMcpServer(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for an agent actor, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusForbidden, "HTTP status")
 }

--- a/server/internal/handler/workspace_mcp_race_test.go
+++ b/server/internal/handler/workspace_mcp_race_test.go
@@ -3,9 +3,10 @@ package handler
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
+
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 )
 
 // Neither workspace_mcp_server nor agent_mcp_server carries a foreign key
@@ -92,8 +93,7 @@ func TestWorkspaceMcpServerCreate_CannotLandAfterWorkspaceTeardownCommits(t *tes
 		})
 		req.Header.Set("X-Workspace-ID", victimID)
 		req = withURLParam(req, "id", victimID)
-		w := httptest.NewRecorder()
-		h.CreateWorkspaceMcpServer(w, req)
+		w := testutil.Call(t, h.CreateWorkspaceMcpServer, req)
 		writerCode = w.Code
 	}()
 
@@ -182,8 +182,7 @@ func TestAgentMcpServerAdd_CannotLandAfterServerDeleteCommits(t *testing.T) {
 		req := newRequest(http.MethodPost, "/api/agents/"+agentID+"/mcp-servers",
 			map[string]any{"server_id": serverID})
 		req = withURLParam(req, "id", agentID)
-		w := httptest.NewRecorder()
-		h.AddAgentMcpServer(w, req)
+		w := testutil.Call(t, h.AddAgentMcpServer, req)
 		writerCode = w.Code
 	}()
 

--- a/server/internal/handler/worktree_claim_gate_test.go
+++ b/server/internal/handler/worktree_claim_gate_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	testutil "github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -141,38 +141,24 @@ func TestWorktreeDeliveryMetadataRoundTripsThroughBothTerminalPaths(t *testing.T
 	// The terminal handlers resolve the task's workspace through its issue, so
 	// a bare task row reads as "failed to load task".
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-		VALUES ($1, 'branch name round-trip fixture', 'in_progress', 'none', $2, 'member', 993310, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("setup: create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'branch name round-trip fixture'"), "status": testutil.Raw("'in_progress'"), "priority": testutil.Raw("'none'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("993310"), "position": testutil.Raw("0")})
 
 	newRunningTask := func(t *testing.T) string {
 		t.Helper()
 		var taskID string
-		if err := testPool.QueryRow(ctx, `
-			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
-			VALUES ($1, $2, $3, 'running', 0, now())
-			RETURNING id
-		`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-			t.Fatalf("setup: create task: %v", err)
-		}
-		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+		taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'running'"), "priority": testutil.Raw("0"), "started_at": testutil.Raw("now()")})
 		return taskID
 	}
 
 	post := func(t *testing.T, taskID, endpoint string, body map[string]any, call func(http.ResponseWriter, *http.Request)) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/"+endpoint,
 			body, testWorkspaceID, "legit-daemon")
 		rctx := chi.NewRouteContext()
 		rctx.URLParams.Add("taskId", taskID)
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-		call(w, req)
+		w := testutil.Call(t, call, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("%s: expected 200, got %d: %s", endpoint, w.Code, w.Body.String())
 		}
@@ -254,37 +240,23 @@ func TestWorktreeDeliveryMetadataSurvivesEveryTerminalPath(t *testing.T) {
 		t.Fatalf("setup: get agent: %v", err)
 	}
 	var issueID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
-		VALUES ($1, 'terminal path branch fixture', 'in_progress', 'none', $2, 'member', 993311, 0)
-		RETURNING id
-	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
-		t.Fatalf("setup: create issue: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	issueID = dbfx.Insert(t, "issue", testutil.Cols{"workspace_id": testWorkspaceID, "title": testutil.Raw("'terminal path branch fixture'"), "status": testutil.Raw("'in_progress'"), "priority": testutil.Raw("'none'"), "creator_id": testUserID, "creator_type": testutil.Raw("'member'"), "number": testutil.Raw("993311"), "position": testutil.Raw("0")})
 
 	newTask := func(t *testing.T, status string) string {
 		t.Helper()
 		var taskID string
-		if err := testPool.QueryRow(ctx, `
-			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
-			VALUES ($1, $2, $3, $4, 0, now())
-			RETURNING id
-		`, agentID, runtimeID, issueID, status).Scan(&taskID); err != nil {
-			t.Fatalf("setup: create task: %v", err)
-		}
-		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+		taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": status, "priority": testutil.Raw("0"), "started_at": testutil.Raw("now()")})
 		return taskID
 	}
 	post := func(t *testing.T, taskID, endpoint string, body map[string]any, call func(http.ResponseWriter, *http.Request)) {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/"+endpoint,
 			body, testWorkspaceID, "legit-daemon")
 		rctx := chi.NewRouteContext()
 		rctx.URLParams.Add("taskId", taskID)
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-		call(w, req)
+		w := testutil.Call(t, call, req)
 		if w.Code != http.StatusOK {
 			t.Fatalf("%s: expected 200, got %d: %s", endpoint, w.Code, w.Body.String())
 		}
@@ -509,14 +481,7 @@ func TestWorktreeClaimGateCancelPersistsReason(t *testing.T) {
 		t.Fatalf("setup: get agent: %v", err)
 	}
 	var taskID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, dispatched_at)
-		VALUES ($1, $2, 'dispatched', 0, now())
-		RETURNING id
-	`, agentID, runtimeID).Scan(&taskID); err != nil {
-		t.Fatalf("setup: create task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "status": testutil.Raw("'dispatched'"), "priority": testutil.Raw("0"), "dispatched_at": testutil.Raw("now()")})
 
 	const reason = "worktree mode needs a newer runtime on that machine"
 	if _, err := testHandler.Queries.CancelAgentTaskWithReason(ctx, db.CancelAgentTaskWithReasonParams{
@@ -556,49 +521,15 @@ func seedWorktreeGateClaimFixture(t *testing.T, ctx context.Context, label, daem
 	if cliVersion != "" {
 		metadata = `{"cli_version":"` + cliVersion + `"}`
 	}
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_runtime (
-			workspace_id, daemon_id, name, runtime_mode, provider,
-			status, device_info, metadata, last_seen_at, visibility, owner_id
-		)
-		VALUES ($1, $2, $3, 'local', 'handler_test_runtime', 'online', 'worktree gate fixture', $4::jsonb, now(), 'private', $5)
-		RETURNING id
-	`, testWorkspaceID, daemonID, label+" runtime", metadata, testUserID).Scan(&runtimeID); err != nil {
-		t.Fatalf("setup: create runtime: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID) })
+	runtimeID = dbfx.Insert(t, "agent_runtime", testutil.Cols{"workspace_id": testWorkspaceID, "daemon_id": daemonID, "name": label + " runtime", "runtime_mode": testutil.Raw("'local'"), "provider": testutil.Raw("'handler_test_runtime'"), "status": testutil.Raw("'online'"), "device_info": testutil.Raw("'worktree gate fixture'"), "metadata": metadata, "last_seen_at": testutil.Raw("now()"), "visibility": testutil.Raw("'private'"), "owner_id": testUserID})
 
 	var agentID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent (
-			workspace_id, name, description, runtime_mode, runtime_config,
-			runtime_id, visibility, max_concurrent_tasks, owner_id
-		)
-		VALUES ($1, $2, '', 'local', '{}'::jsonb, $3, 'private', 1, $4)
-		RETURNING id
-	`, testWorkspaceID, label+" agent", runtimeID, testUserID).Scan(&agentID); err != nil {
-		t.Fatalf("setup: create agent: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
+	agentID = dbfx.Insert(t, "agent", testutil.Cols{"workspace_id": testWorkspaceID, "name": label + " agent", "description": testutil.Raw("''"), "runtime_mode": testutil.Raw("'local'"), "runtime_config": testutil.Raw("'{}'::jsonb"), "runtime_id": runtimeID, "visibility": testutil.Raw("'private'"), "max_concurrent_tasks": testutil.Raw("1"), "owner_id": testUserID})
 
 	var projectID string
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, label+" project").Scan(&projectID); err != nil {
-		t.Fatalf("setup: create project: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, projectID) })
+	projectID = dbfx.Insert(t, "project", testutil.Cols{"workspace_id": testWorkspaceID, "title": label + " project"})
 
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO project_resource (project_id, workspace_id, resource_type, resource_ref, position)
-		VALUES ($1, $2, 'local_directory', $3::jsonb, 0)
-	`, projectID, testWorkspaceID,
-		`{"local_path":"/Users/dev/wtgate","daemon_id":"`+daemonID+`","execution_mode":"worktree"}`); err != nil {
-		t.Fatalf("setup: create project_resource: %v", err)
-	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM project_resource WHERE project_id = $1`, projectID)
-	})
+	dbfx.InsertNoID(t, "project_resource", testutil.Cols{"project_id": projectID, "workspace_id": testWorkspaceID, "resource_type": testutil.Raw("'local_directory'"), "resource_ref": `{"local_path":"/Users/dev/wtgate","daemon_id":"` + daemonID + `","execution_mode":"worktree"}`, "position": testutil.Raw("0")}, "project_id = $1", projectID)
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `
@@ -614,14 +545,7 @@ func seedWorktreeGateClaimFixture(t *testing.T, ctx context.Context, label, daem
 	}
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
 
-	if err := testPool.QueryRow(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
-		VALUES ($1, $2, $3, 'queued', 0)
-		RETURNING id
-	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-		t.Fatalf("setup: create task: %v", err)
-	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	taskID = dbfx.Insert(t, "agent_task_queue", testutil.Cols{"agent_id": agentID, "runtime_id": runtimeID, "issue_id": issueID, "status": testutil.Raw("'queued'"), "priority": testutil.Raw("0")})
 
 	return runtimeID, taskID
 }
@@ -660,14 +584,9 @@ func TestClaimTask_WorktreeGateSingular(t *testing.T) {
 	const daemonID = "wtgate-singular-daemon"
 	runtimeID, taskID := seedWorktreeGateClaimFixture(t, ctx, "WT gate singular", daemonID, "0.4.10")
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, daemonID)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422 for a too-old runtime, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusUnprocessableEntity)
 	if body := w.Body.String(); !strings.Contains(body, "/Users/dev/wtgate") ||
 		!strings.Contains(body, "does not support parallel") ||
 		!strings.Contains(body, "Update the Multica app") {
@@ -689,9 +608,7 @@ func TestClaimTask_WorktreeGateBatch(t *testing.T) {
 	runtimeID, taskID := seedWorktreeGateClaimFixture(t, ctx, "WT gate batch", batchClaimTestDaemonID, "0.4.10")
 
 	w := postBatchClaim(t, testWorkspaceID, []string{runtimeID}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("batch claim: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp struct {
 		Tasks []AgentTaskResponse `json:"tasks"`
 	}
@@ -717,21 +634,14 @@ func TestClaimTask_WorktreeGateAllowsCurrentRuntime(t *testing.T) {
 	const daemonID = "wtgate-ok-daemon"
 	runtimeID, taskID := seedWorktreeGateClaimFixture(t, ctx, "WT gate ok", daemonID, "0.0.1")
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, daemonID)
 	req.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilityLocalWorktreeV1)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 for a current runtime, got %d: %s", w.Code, w.Body.String())
-	}
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
 	var resp struct {
 		Task *AgentTaskResponse `json:"task"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	w.JSON(&resp)
 	if resp.Task == nil {
 		t.Fatal("expected the task to be claimed by a new-enough runtime")
 	}
@@ -786,14 +696,9 @@ func TestClaimTask_WorktreeGateCancelFailureRequeuesSingular(t *testing.T) {
 	runtimeID, taskID := seedWorktreeGateClaimFixture(t, ctx, "WT gate cancelfail", daemonID, "0.4.10")
 	injectCancelFailureForTask(t, ctx, taskID)
 
-	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, daemonID)
 	req = withURLParam(req, "runtimeId", runtimeID)
-	testHandler.ClaimTaskByRuntime(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 (transient server problem, not a claim refusal), got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusInternalServerError)
 	var status string
 	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
 		t.Fatalf("read task: %v", err)
@@ -812,9 +717,7 @@ func TestClaimTask_WorktreeGateCancelFailureRequeuesBatch(t *testing.T) {
 	injectCancelFailureForTask(t, ctx, taskID)
 
 	w := postBatchClaim(t, testWorkspaceID, []string{runtimeID}, 5)
-	if w.Code != http.StatusOK {
-		t.Fatalf("batch claim: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+	testutil.Equal(t, w.Code, http.StatusOK, "HTTP status")
 	var resp struct {
 		Tasks []AgentTaskResponse `json:"tasks"`
 	}
@@ -987,7 +890,7 @@ func TestDaemonRegisterPersistsCapabilities(t *testing.T) {
 
 	register := func(t *testing.T, capabilities string) string {
 		t.Helper()
-		w := httptest.NewRecorder()
+
 		req := newDaemonTokenRequest("POST", "/api/daemon/register", map[string]any{
 			"workspace_id": testWorkspaceID,
 			"daemon_id":    daemonID,
@@ -1001,14 +904,9 @@ func TestDaemonRegisterPersistsCapabilities(t *testing.T) {
 		} else {
 			req.Header.Del("X-Client-Capabilities")
 		}
-		testHandler.DaemonRegister(w, req)
-		if w.Code != http.StatusOK {
-			t.Fatalf("DaemonRegister: expected 200, got %d: %s", w.Code, w.Body.String())
-		}
+		w := testutil.Call(t, testHandler.DaemonRegister, req).Want(http.StatusOK)
 		var resp map[string]any
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		w.Decode(&resp)
 		runtimes, ok := resp["runtimes"].([]any)
 		if !ok || len(runtimes) == 0 {
 			t.Fatalf("expected runtimes in response, got %v", resp)

--- a/server/internal/testutil/assert.go
+++ b/server/internal/testutil/assert.go
@@ -1,0 +1,11 @@
+package testutil
+
+// Equal reports a value mismatch without encoding any product rule. Context
+// is included verbatim so callers can retain the diagnostic that matters to
+// the test case.
+func Equal[T comparable](t TB, got, want T, context string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: got %v, want %v", context, got, want)
+	}
+}

--- a/server/internal/testutil/assert_test.go
+++ b/server/internal/testutil/assert_test.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEqual(t *testing.T) {
+	spy := &spyTB{}
+	Equal(spy, 201, 201, "response body")
+	if spy.failed {
+		t.Fatal("Equal failed for identical values")
+	}
+
+	spy.capture(func() {
+		Equal(spy, 400, 201, `{"error":"invalid"}`)
+	})
+	for _, want := range []string{"invalid", "got 400", "want 201"} {
+		if !strings.Contains(spy.message, want) {
+			t.Fatalf("failure message %q missing %q", spy.message, want)
+		}
+	}
+}

--- a/server/internal/testutil/http.go
+++ b/server/internal/testutil/http.go
@@ -134,6 +134,18 @@ func (r *Response) JSON(dest any) *Response {
 	return r
 }
 
+// Decode decodes the first JSON value in the response body into dest. It
+// preserves json.Decoder semantics for tests whose existing handler contract
+// intentionally permits trailing whitespace or another streamed value.
+func (r *Response) Decode(dest any) *Response {
+	r.t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		r.t.Fatalf("%s %s: decode response: %v: %s",
+			r.req.Method, r.req.URL.RequestURI(), err, r.Body.String())
+	}
+	return r
+}
+
 // Map decodes the body into a generic object, for assertions that only touch
 // one or two fields and do not earn a named struct.
 func (r *Response) Map() map[string]any {

--- a/server/internal/testutil/http_test.go
+++ b/server/internal/testutil/http_test.go
@@ -91,6 +91,14 @@ func TestCallRecordsStatusAndDecodesBody(t *testing.T) {
 	}](t, h, JSONRequest("POST", "/api/issues", nil), http.StatusCreated); got.ID != "issue-1" {
 		t.Fatalf("Decode id = %q, want issue-1", got.ID)
 	}
+
+	var streamed map[string]any
+	Call(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"first":true}{"second":true}`)
+	}, JSONRequest("GET", "/api/stream", nil)).Decode(&streamed)
+	if streamed["first"] != true {
+		t.Fatalf("streamed first value = %#v, want true", streamed["first"])
+	}
 }
 
 // TestWantReportsTheBodyOnMismatch pins the one thing the shared assertion has


### PR DESCRIPTION
## Summary

- migrate 932 handler invocations to `testutil.Call`, including 752 status checks and 303 response decodes
- replace 432 behavior-free equality blocks with `testutil.Equal`
- migrate 172 adjacent insert/cleanup fixtures to `dbfx.Insert` or `dbfx.InsertNoID`
- add streaming decoder support while preserving `json.Decoder` semantics

This moves `internal/testutil` adoption from 33/250 to 199/250 handler test files. Handler test code drops from 109,679 to 103,650 lines without removing a test, benchmark, fuzz target, or `t.Run` case. Patterns that reuse recorder variables, cross typed helper boundaries, or have non-local database cleanup remain explicit.

## Validation

- `go test -count=1 ./internal/testutil ./internal/handler`
- `go vet ./internal/handler ./internal/testutil`
- `go build ./...`
- pre/post inventory: 1,997 Test/Benchmark/Fuzz functions with identical name hash; 447 `t.Run` sites on both sides
- full handler JSON run: 3,312 final test actions
- `go test -race -count=1 ./internal/handler` reaches the existing `TestCommentSourceContextLifecycle` failure (`cleaned=1`, expected at least 3); the same targeted race test fails unchanged on `origin/main`

Issue: MUL-6748
