### PR TITLE
feat(wecom): show issue status transitions in notifications (#7639)

### DIFF
--- a/server/internal/integrations/wecom/inbox_message.go
+++ b/server/internal/integrations/wecom/inbox_message.go
@@ -6,6 +6,7 @@ package wecom
 // focused on delivery and this module owns the wording + link building.
 
 import (
+	"encoding/json"
 	"net/url"
 	"os"
 	"strings"
@@ -33,6 +34,16 @@ var inboxTypeLabels = map[string]string{
 	"priority_changed":   "优先级变更",
 	"due_date_changed":   "截止日期变更",
 	"start_date_changed": "开始日期变更",
+}
+
+var inboxStatusLabels = map[string]string{
+	"backlog":     "Backlog",
+	"todo":        "Todo",
+	"in_progress": "In Progress",
+	"in_review":   "In Review",
+	"done":        "Done",
+	"blocked":     "Blocked",
+	"cancelled":   "Cancelled",
 }
 
 func inboxTypeLabel(t string) string {
@@ -171,6 +182,46 @@ func inboxItemBody(item map[string]any) string {
 		return v
 	}
 	return ""
+}
+
+// inboxStatusTransitionBody renders the structured details carried by a real
+// status_changed inbox:new event. statusName resolves custom keys through the
+// workspace catalog; built-ins do not need a database lookup.
+func inboxStatusTransitionBody(item map[string]any, statusName func(string) string) string {
+	if typeStr, _ := item["type"].(string); typeStr != "status_changed" {
+		return ""
+	}
+
+	var details map[string]string
+	switch raw := item["details"].(type) {
+	case json.RawMessage:
+		if json.Unmarshal(raw, &details) != nil {
+			return ""
+		}
+	case map[string]string:
+		details = raw
+	default:
+		return ""
+	}
+
+	from := strings.TrimSpace(details["from"])
+	to := strings.TrimSpace(details["to"])
+	if from != "" {
+		from = statusName(from)
+	}
+	if to != "" {
+		to = statusName(to)
+	}
+	switch {
+	case from != "" && to != "":
+		return from + " → " + to
+	case from != "":
+		return from + " →"
+	case to != "":
+		return "→ " + to
+	default:
+		return ""
+	}
 }
 
 // inboxItemLink builds the {appURL}/{slug|wsUUID}/inbox?issue={issueID}

--- a/server/internal/integrations/wecom/inbox_message_test.go
+++ b/server/internal/integrations/wecom/inbox_message_test.go
@@ -1,6 +1,7 @@
 package wecom
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -24,6 +25,37 @@ func TestBuildInboxMarkdown_TitleBodyLink(t *testing.T) {
 	}
 	if !strings.Contains(got, "[查看详情](https://example.com/acme/inbox?issue=9194c058-e8a4-4c15-9c65-86d1784ba715)") {
 		t.Fatalf("missing detail link: %q", got)
+	}
+}
+
+func TestInboxStatusTransitionBody_FallsBackWhenOneSideIsMissing(t *testing.T) {
+	t.Parallel()
+	name := func(key string) string {
+		if label, ok := inboxStatusLabels[key]; ok {
+			return label
+		}
+		return key
+	}
+	for _, tc := range []struct {
+		name    string
+		details string
+		want    string
+	}{
+		{"both", `{"from":"todo","to":"in_review"}`, "Todo → In Review"},
+		{"from only", `{"from":"todo"}`, "Todo →"},
+		{"to only", `{"to":"in_review"}`, "→ In Review"},
+		{"neither", `{}`, ""},
+		{"malformed", `{`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := map[string]any{
+				"type":    "status_changed",
+				"details": json.RawMessage(tc.details),
+			}
+			if got := inboxStatusTransitionBody(item, name); got != tc.want {
+				t.Fatalf("inboxStatusTransitionBody() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/server/internal/integrations/wecom/outbound.go
+++ b/server/internal/integrations/wecom/outbound.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ type outboundQueries interface {
 	GetChannelInstallation(ctx context.Context, arg db.GetChannelInstallationParams) (db.ChannelInstallation, error)
 	FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error)
 	GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error)
+	GetIssueStatusEntryByKey(ctx context.Context, arg db.GetIssueStatusEntryByKeyParams) (db.IssueStatus, error)
 	ListAttachmentsByChatMessage(ctx context.Context, arg db.ListAttachmentsByChatMessageParams) ([]db.Attachment, error)
 }
 
@@ -350,6 +352,28 @@ func (o *Outbound) tryDeliverInbox(ctx context.Context, item map[string]any, rec
 	slug := ""
 	if ws, err := o.q.GetWorkspace(ctx, workspaceID); err == nil {
 		slug = ws.Slug
+	}
+	if inboxItemBody(item) == "" {
+		if body := inboxStatusTransitionBody(item, func(key string) string {
+			if label, ok := inboxStatusLabels[key]; ok {
+				return label
+			}
+			entry, err := o.q.GetIssueStatusEntryByKey(ctx, db.GetIssueStatusEntryByKeyParams{
+				WorkspaceID: workspaceID,
+				Key:         key,
+			})
+			if err == nil && strings.TrimSpace(entry.Name) != "" {
+				return entry.Name
+			}
+			return key
+		}); body != "" {
+			copy := make(map[string]any, len(item)+1)
+			for key, value := range item {
+				copy[key] = value
+			}
+			item = copy
+			item["body"] = body
+		}
 	}
 	content := buildInboxMarkdown(item, workspaceIDStr, slug)
 	if content == "" {

--- a/server/internal/integrations/wecom/outbound_test.go
+++ b/server/internal/integrations/wecom/outbound_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -39,6 +40,7 @@ type fakeOutboundQueries struct {
 	memberErr      error
 	workspace      db.Workspace
 	workspaceErr   error
+	statuses       map[string]db.IssueStatus
 	attachments    []db.Attachment
 	attachmentsErr error
 	// lookupGate holds every attachment lookup open until it is closed, which
@@ -103,6 +105,13 @@ func (f *fakeOutboundQueries) FindChannelBindingForMember(context.Context, db.Fi
 }
 func (f *fakeOutboundQueries) GetWorkspace(context.Context, pgtype.UUID) (db.Workspace, error) {
 	return f.workspace, f.workspaceErr
+}
+func (f *fakeOutboundQueries) GetIssueStatusEntryByKey(_ context.Context, arg db.GetIssueStatusEntryByKeyParams) (db.IssueStatus, error) {
+	status, ok := f.statuses[arg.Key]
+	if !ok {
+		return db.IssueStatus{}, pgx.ErrNoRows
+	}
+	return status, nil
 }
 func (f *fakeOutboundQueries) ListAttachmentsByChatMessage(context.Context, db.ListAttachmentsByChatMessageParams) ([]db.Attachment, error) {
 	if f.lookupGate != nil {
@@ -312,6 +321,37 @@ func TestTryDeliverInbox_PushesToBoundMemberPrivately(t *testing.T) {
 	}
 	if body["chat_type"] != float64(chatTypeSingleInt) {
 		t.Errorf("inbox push chat_type = %v, want single (1)", body["chat_type"])
+	}
+}
+
+func TestTryDeliverInbox_StatusChangeUsesStructuredDetails(t *testing.T) {
+	t.Parallel()
+	q := &fakeOutboundQueries{
+		memberBinding: db.ChannelUserBinding{ChannelUserID: "T_USER_1"},
+		workspace:     db.Workspace{Slug: "acme"},
+		statuses: map[string]db.IssueStatus{
+			"human_review": {Key: "human_review", Name: "Human Review"},
+		},
+	}
+	o, instID, conn := newOutboundWithConn(t, q)
+	q.memberBinding.InstallationID = instID
+
+	item := map[string]any{
+		"recipient_type": "member",
+		"recipient_id":   "33333333-3333-3333-3333-333333333333",
+		"workspace_id":   "44444444-4444-4444-4444-444444444444",
+		"type":           "status_changed",
+		"title":          "Login page returns 500",
+		"details":        json.RawMessage(`{"from":"todo","to":"human_review"}`),
+	}
+	if !o.tryDeliverInbox(context.Background(), item, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444") {
+		t.Fatal("tryDeliverInbox returned false; expected status notification delivery")
+	}
+	body := conn.sendBody(t, 0)
+	markdown, _ := body["markdown"].(map[string]any)
+	content, _ := markdown["content"].(string)
+	if !strings.Contains(content, "Todo → Human Review") {
+		t.Fatalf("status transition missing from WeCom card: %q", content)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR shows the previous and new issue statuses in WeCom inbox notifications.

Status-change inbox events already include `details.from` and `details.to`, but the WeCom formatter previously ignored them because it only rendered `type`, `title`, and `body`.

This change keeps the shared inbox contract unchanged and enriches only the WeCom delivery path:

- Built-in status keys use their standard display labels.
- Custom status keys are resolved through the workspace status catalog.
- Failed custom-status lookups safely fall back to the raw status key.
- Missing or malformed transition details preserve the existing notification behavior.

Example:

```text
[Status changed] Login page returns 500
Todo → In Review
View details
```

## Related Issue

Closes #7639

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added structured status-transition parsing in `server/internal/integrations/wecom/inbox_message.go`.
- Added built-in status display labels for WeCom notifications.
- Resolved custom status names through the workspace status catalog in `server/internal/integrations/wecom/outbound.go`.
- Preserved existing notification bodies and left other WeCom notification types unchanged.
- Added tests covering:
  - The real `json.RawMessage` inbox payload.
  - Built-in and custom statuses.
  - Missing `from` or `to` values.
  - Missing and malformed transition details.

## How to Test

1. Run:

   ```bash
   cd server
   go test ./internal/integrations/wecom
   ```

2. Change an issue from a built-in status to another built-in or custom status.

3. Confirm that the bound WeCom recipient sees a transition such as:

   ```text
   Todo → Human Review
   ```

## Risks

- Resolving a custom status adds a catalog lookup during WeCom delivery. Built-in statuses do not perform this query.
- If a custom status cannot be resolved or has an empty name, the notification falls back to its raw status key and is still delivered.
- Missing or malformed transition details leave the existing notification shape unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, this changes an outbound WeCom notification
- [x] I have updated relevant documentation to reflect my changes — N/A, no documented contract changed
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) — N/A
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` — N/A, existing Chinese copy is unchanged
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Traced the issue status-update event through inbox item creation and WeCom outbound formatting. Confirmed that the transition was already preserved in `details`, then implemented a channel-local change that consumes the existing payload without modifying the shared inbox contract.

Added production-shape payload coverage and focused tests for built-in statuses, custom statuses, partial details, and malformed details.

## Screenshots (optional)

Not included. The behavior is an outbound WeCom notification and is covered by the WeCom outbound frame tests.
