### PR TITLE
MUL-6759: feat(core): add truncateWithEllipsis utility

### DIFF
--- a/packages/core/utils.test.ts
+++ b/packages/core/utils.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRequestId, createSafeId, generateUUID, isImeComposing } from "./utils";
+import {
+  createRequestId,
+  createSafeId,
+  generateUUID,
+  isImeComposing,
+  truncateWithEllipsis,
+} from "./utils";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -51,5 +57,30 @@ describe("isImeComposing", () => {
   it("returns false when not composing", () => {
     expect(isImeComposing({ nativeEvent: { isComposing: false, keyCode: 13 } })).toBe(false);
     expect(isImeComposing({ isComposing: false, keyCode: 13 })).toBe(false);
+  });
+});
+
+describe("truncateWithEllipsis", () => {
+  it("returns text shorter than maxLength unchanged", () => {
+    expect(truncateWithEllipsis("hello", 10)).toBe("hello");
+  });
+
+  it("returns text exactly at maxLength unchanged", () => {
+    expect(truncateWithEllipsis("hello", 5)).toBe("hello");
+  });
+
+  it("truncates longer text and appends an ellipsis", () => {
+    expect(truncateWithEllipsis("hello world", 8)).toBe("hello...");
+  });
+
+  it("keeps the truncated result within maxLength", () => {
+    const result = truncateWithEllipsis("hello world", 8);
+    expect(result).toHaveLength(8);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("clamps to maxLength when it is smaller than the ellipsis", () => {
+    expect(truncateWithEllipsis("hello", 2)).toBe("..");
+    expect(truncateWithEllipsis("hello", 0)).toBe("");
   });
 });

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -62,3 +62,20 @@ export function isImeComposing(event: {
   const e = event.nativeEvent ?? event;
   return Boolean(e.isComposing) || e.keyCode === 229;
 }
+
+/**
+ * Truncate `text` to at most `maxLength` characters, appending an ellipsis
+ * ("...") when it is shortened. Text at or under the limit is returned as-is.
+ *
+ * The result never exceeds `maxLength`: the ellipsis is counted toward the
+ * budget, so the text is sliced to `maxLength - 3` characters. When
+ * `maxLength` is smaller than the ellipsis itself the slice length is clamped
+ * to 0, yielding a leading run of dots trimmed to `maxLength`.
+ */
+export function truncateWithEllipsis(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`.slice(0, Math.max(0, maxLength));
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `truncateWithEllipsis(text: string, maxLength: number): string` utility to `packages/core/utils.ts`, following the existing code style in that file, plus a matching test suite in `packages/core/utils.test.ts`.

## Related Issue

Closes #7544

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `packages/core/utils.ts`: new exported `truncateWithEllipsis` function.
  - Text with `length <= maxLength` is returned unchanged (no ellipsis).
  - Longer text is sliced to `maxLength - 3` characters with `"..."` appended, so the result's total length equals `maxLength`.
  - The ellipsis is counted toward the budget and the result is clamped so it never exceeds `maxLength`, including when `maxLength < 3` (slice length clamps to 0, trailing dots trimmed to `maxLength`).
- `packages/core/utils.test.ts`: new `describe("truncateWithEllipsis", ...)` block following the file's existing structure.

No existing function, export, or test was modified, reordered, or removed. No new dependencies, no build/lint/config changes.

## How to Test

```bash
cd packages/core
pnpm test        # 19 tests pass, incl. the new truncateWithEllipsis suite
pnpm typecheck   # clean
pnpm lint        # clean
```

New tests cover: shorter-than-limit unchanged, exactly-at-limit unchanged, longer text truncated with ellipsis, total length equals `maxLength`, and the small-`maxLength` edge case (`<= 3`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective / my feature works
- [x] New and existing unit tests pass locally with my changes

## AI Disclosure

This change was implemented with the assistance of Claude Code.
