### PR TITLE
feat(inbox): surface action-required severity in the inbox list

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -132,6 +132,51 @@ function renderRow(props: {
 
 const unreadDot = (container: HTMLElement) => container.querySelector(".bg-brand");
 const title = (container: HTMLElement) => container.querySelector(".truncate");
+const severityMarker = (container: HTMLElement) =>
+  container.querySelector(".text-destructive");
+
+describe("InboxListItem severity affordance", () => {
+  it("flags an action-required row with a marker", () => {
+    // `action_required` is the "needs you" tier (issue_assigned, mentioned,
+    // task_failed). It is stored on every row but was never rendered, so it
+    // read identically to routine churn while triaging.
+    const { container } = renderRow({
+      item: item({ severity: "action_required" }),
+      view: "inbox",
+    });
+
+    expect(severityMarker(container)).not.toBeNull();
+  });
+
+  it("leaves an info row unmarked", () => {
+    const { container } = renderRow({
+      item: item({ severity: "info" }),
+      view: "inbox",
+    });
+
+    expect(severityMarker(container)).toBeNull();
+  });
+
+  it("does not flag an attention row (marker is scoped to action_required)", () => {
+    const { container } = renderRow({
+      item: item({ severity: "attention" }),
+      view: "inbox",
+    });
+
+    expect(severityMarker(container)).toBeNull();
+  });
+
+  it("keeps the marker in the archived view", () => {
+    // Severity is intrinsic to the item, not a function of read/archived
+    // state, so the marker is not suppressed the way the unread dot is.
+    const { container } = renderRow({
+      item: item({ severity: "action_required", archived: true }),
+      view: "archived",
+    });
+
+    expect(severityMarker(container)).not.toBeNull();
+  });
+});
 
 describe("InboxListItem unread affordance", () => {
   it("marks an unread row in the main inbox", () => {

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -6,7 +6,7 @@ import {
   IssueAgentActivityIndicator,
 } from "../../issues/components/issue-agent-activity-indicator";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { Archive, ArchiveRestore } from "lucide-react";
+import { AlertCircle, Archive, ArchiveRestore } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import type { InboxView } from "./inbox-view";
 import { InboxDetailLabel } from "./inbox-detail-label";
@@ -79,6 +79,13 @@ export function InboxListItem({
     ? t(($) => $.list.unarchive_tooltip)
     : t(($) => $.list.archive_tooltip);
   const actorType = item.actor_type ?? item.recipient_type;
+  // `severity` is assigned at creation time but was never rendered, so a
+  // "needs you" row (issue_assigned, task_failed, a failed quick-create) read
+  // identically to routine churn while triaging. Mark the `action_required`
+  // tier — the clear "needs you" case — and leave `attention`/`info` unmarked.
+  // Severity is intrinsic to the item, so unlike the unread dot it is not
+  // suppressed in the archived view.
+  const isActionRequired = item.severity === "action_required";
   // The glyph is per CATEGORY, so it alone cannot tell "In Review" from a
   // custom "Human Review" — moving between two statuses of the same category
   // left this row pixel-identical and read as "the inbox never updated"
@@ -134,6 +141,13 @@ export function InboxListItem({
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">
+            {isActionRequired && (
+              <AlertCircle
+                role="img"
+                aria-label={t(($) => $.list.action_required)}
+                className="h-3.5 w-3.5 shrink-0 text-destructive"
+              />
+            )}
             {showUnread && (
               <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" />
             )}

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -42,7 +42,8 @@
     "archived_title": "Archived",
     "archived_empty": "No archived notifications",
     "unarchive_tooltip": "Unarchive",
-    "actions_aria": "Notification actions"
+    "actions_aria": "Notification actions",
+    "action_required": "Action required"
   },
   "detail": {
     "select_prompt": "Select a notification to view details",

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -40,7 +40,8 @@
     "archived_title": "アーカイブ済み",
     "archived_empty": "アーカイブされた通知はありません",
     "unarchive_tooltip": "アーカイブ解除",
-    "actions_aria": "通知の操作"
+    "actions_aria": "通知の操作",
+    "action_required": "要対応"
   },
   "detail": {
     "select_prompt": "詳細を表示する通知を選択してください",

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -40,7 +40,8 @@
     "archived_title": "보관됨",
     "archived_empty": "보관된 알림이 없습니다",
     "unarchive_tooltip": "보관 해제",
-    "actions_aria": "알림 작업"
+    "actions_aria": "알림 작업",
+    "action_required": "조치 필요"
   },
   "detail": {
     "select_prompt": "자세히 볼 알림을 선택하세요",

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -40,7 +40,8 @@
     "archived_title": "已归档",
     "archived_empty": "暂无已归档通知",
     "unarchive_tooltip": "取消归档",
-    "actions_aria": "通知操作"
+    "actions_aria": "通知操作",
+    "action_required": "需要处理"
   },
   "detail": {
     "select_prompt": "选择一条通知查看详情",


### PR DESCRIPTION
## What
The inbox stores a `severity` on every item but the client never rendered it, so an action-required row (issue assigned, task failed, a failed quick-create) looked identical to routine churn. This surfaces it with the issue's cheapest proposed treatment (option 1): a leading `AlertCircle` marker in `text-destructive` when `severity === "action_required"`. `attention` and `info` stay unmarked; the marker is intrinsic to the item, so it persists in the archived view. No new filter, lane, or sort is added.

## Why
Closes #6469.

## Tests
New cases in `inbox-list-item.test.tsx` (marker present for action_required, absent for info/attention, retained when archived). Adds the `inbox.list.action_required` accessible-name label to all four locale bundles so the locale-parity test passes. `tsc --noEmit` and eslint are clean; the inbox suite is green.
