### PR TITLE
fix(metrics): normalize the [1m] context tag before pricing lookup

### DIFF
--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -172,13 +172,37 @@ var modelAliasRules = []struct {
 	// model identity, so it stays unmapped.
 }
 
-func PriceForModelAlias(model string) (ModelPrice, bool) {
-	model = strings.ToLower(strings.TrimSpace(model))
+// contextTagRe matches a trailing context-window variant tag such as the
+// `[1m]` Claude Code appends to the model id. A complete bracket tag with at
+// least one character inside, anchored at the end — the same shape the
+// frontend's `stripContextTag` strips (`\[[^\]]+\]$` in
+// packages/views/runtimes/utils.ts), so empty tags (`model[]`) and non-tag
+// trailing brackets (`model[`) stay unmapped on both sides.
+var contextTagRe = regexp.MustCompile(`\[[^\]]+\]$`)
+
+func matchModelAlias(model string) (ModelPrice, bool) {
 	for _, rule := range modelAliasRules {
 		if rule.re.MatchString(model) {
 			price, ok := modelPrices[rule.priceKey]
 			return price, ok
 		}
+	}
+	return ModelPrice{}, false
+}
+
+func PriceForModelAlias(model string) (ModelPrice, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if price, ok := matchModelAlias(model); ok {
+		return price, true
+	}
+	// The raw id did not resolve: a harness-appended context-window tag
+	// (`kimi-k3[1m]`, `grok-4.5[1m]`) is the same SKU at the same tier, so
+	// retry against the bare id. The anchored Codex / Grok / Kimi rules end at
+	// `$`, so without this a bracketed variant would take the unpriced branch
+	// in RecordLLMUsage. Only ever turns a miss into a hit — the raw form is
+	// tried first, so an explicit bracketed rule still wins.
+	if stripped := contextTagRe.ReplaceAllString(model, ""); stripped != model {
+		return matchModelAlias(stripped)
 	}
 	return ModelPrice{}, false
 }

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -341,3 +341,54 @@ func TestPriceForModelAliasNoFalseBorrowing(t *testing.T) {
 		}
 	}
 }
+
+// TestPriceForModelAliasContextTagStripping pins the `[1m]` context-variant
+// suffix normalization across every rule, including the anchored Codex / Grok /
+// Kimi rules that do not carry a per-rule optional bracket group. Claude Code
+// (and other harnesses) append a context-window tag such as `[1m]` to the
+// model id; it is the same SKU at the same tier, so the row must price instead
+// of falling into the unpriced bucket in RecordLLMUsage. Mirrors the frontend's
+// `stripContextTag` (`\[[^\]]+\]$`) in packages/views/runtimes/utils.ts.
+func TestPriceForModelAliasContextTagStripping(t *testing.T) {
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{
+			model: "grok-4.5[1m]",
+			want:  ModelPrice{Provider: "xai", Model: "grok-4.5", InputPerM: 2.00, CacheReadPerM: 0.30, CacheWritePerM: 2.00, OutputPerM: 6.00},
+		},
+		{
+			model: "gpt-5.6-luna[1m]",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 6.00},
+		},
+		{
+			model: "kimi-k3[1m]",
+			want:  ModelPrice{Provider: "moonshotai", Model: "kimi-k3", InputPerM: 3.0, CacheReadPerM: 0.30, CacheWritePerM: 3.0, OutputPerM: 15.0},
+		},
+	}
+
+	for _, tc := range cases {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", tc.model)
+		}
+		if got != tc.want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+
+	// The tag stripper is anchored at end-of-string with a non-empty tag, so it
+	// must not turn these misses into hits: a trailing bracket that is not a
+	// complete end-of-string tag, and an empty tag, both stay unmapped — the
+	// same guard the frontend keeps.
+	for _, model := range []string{
+		"grok-4.5[1m]-extra",
+		"gpt-5.6-luna[]",
+		"kimi-k3[",
+	} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved to %+v; want unmapped", model, got)
+		}
+	}
+}


### PR DESCRIPTION
## What
`PriceForModelAlias` now strips a trailing `[...]` context-variant tag and retries the pricing-table lookup when the raw id misses. Claude Code appends a `[1m]` context-window suffix to runtime-reported model ids (e.g. `grok-4.5[1m]`, `kimi-k3[1m]`), and the alias rules are anchored with `$` and carry no optional bracket group, so those ids missed every rule and fell into the uncosted branch.

The raw id is tried first, so already-priced rows are untouched, and rules that already carry an inline optional bracket group still resolve on the first pass, preserving the existing no-false-borrowing guarantees. This mirrors the frontend's `stripContextTag` in `packages/views/runtimes/utils.ts`, so backend and frontend now agree.

## Why
Addresses the `[1m]` context-tag normalization wrinkle called out in #7606. Scoped to that sub-problem only: it does not implement the broader workspace-scoped alias map, automatic pricing, manual overrides, or backfill from that issue, so it does not fully close it.

## Tests
New `TestPriceForModelAliasContextTagStripping` (bracketed genuine ids resolve; empty and unterminated brackets stay unmapped). `go build ./...`, `go vet ./internal/metrics/...`, and `gofmt -l` are clean; `go test ./internal/metrics/...` is green, including the pre-existing no-false-borrowing test.
