### PR TITLE
test(service): reconciler assertions only speak for their own rows

### DIFF
--- a/server/internal/service/channel_media_reconciler_test.go
+++ b/server/internal/service/channel_media_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -46,6 +47,27 @@ func (f *fakeObjectDeleter) deletedKeys() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.deleted...)
+}
+
+// deletedOwn returns only this test's deletions — every fixture key lives
+// under "ws/lark/". The sweep walks the whole table and the test database is
+// shared by every package `go test ./...` runs in parallel, so a due row
+// seeded by a wecom or handler test is legitimately deleted by THIS test's
+// RunOnce. Asserting on the global list made these tests flake under full-suite
+// load (reproduced: four workspaces/…/wecom/… keys inside deletedKeys), while
+// standalone runs — nothing else writing the table — always passed. Order is
+// preserved, so per-key sequencing assertions keep their strength; only the
+// claim "and nothing else happened in the world" is dropped, which was never
+// this suite's to make.
+func (f *fakeObjectDeleter) deletedOwn() []string {
+	all := f.deletedKeys()
+	own := make([]string, 0, len(all))
+	for _, k := range all {
+		if strings.HasPrefix(k, "ws/lark/") {
+			own = append(own, k)
+		}
+	}
+	return own
 }
 
 type reconcilerFixture struct {
@@ -197,7 +219,7 @@ func TestChannelMediaReconciler_SettlesThreeStates(t *testing.T) {
 	if state, _, exists := f.rowState(t, "ws/lark/young"); !exists || state != "pending" {
 		t.Fatalf("young row = (%q, %v), want untouched 'pending'", state, exists)
 	}
-	deleted := deleter.deletedKeys()
+	deleted := deleter.deletedOwn()
 	if len(deleted) != 1 || deleted[0] != "ws/lark/orphan" {
 		t.Fatalf("deleted keys = %v, want only the orphan", deleted)
 	}
@@ -225,7 +247,7 @@ func TestChannelMediaReconciler_ReclaimsExpiredLease(t *testing.T) {
 	if state, _, exists := f.rowState(t, "ws/lark/crashed"); !exists || state != "tombstoned" {
 		t.Fatalf("expired-lease row = (%q, %v), want reclaimed and settled to 'tombstoned'", state, exists)
 	}
-	if deleted := deleter.deletedKeys(); len(deleted) != 1 || deleted[0] != "ws/lark/crashed" {
+	if deleted := deleter.deletedOwn(); len(deleted) != 1 || deleted[0] != "ws/lark/crashed" {
 		t.Fatalf("deleted keys = %v, want the reclaimed key", deleted)
 	}
 }
@@ -298,8 +320,8 @@ func TestChannelMediaReconciler_LeavesFreshPendingToBind(t *testing.T) {
 	if err != nil || tag.RowsAffected() != 1 {
 		t.Fatalf("bind-side claim failed: rows=%d err=%v", tag.RowsAffected(), err)
 	}
-	if len(deleter.deletedKeys()) != 0 {
-		t.Fatalf("nothing should have been deleted: %v", deleter.deletedKeys())
+	if own := deleter.deletedOwn(); len(own) != 0 {
+		t.Fatalf("nothing of this test's should have been deleted: %v", own)
 	}
 }
 
@@ -517,7 +539,7 @@ func TestChannelMediaReconciler_TailRowIsUnclaimedUntilItsTurn(t *testing.T) {
 		t.Fatalf("tail row during the first delete = (%q, attempt=%d), want an unclaimed ('pending', 0)", tailState, tailAttempt)
 	}
 	// Both rows are still settled by the same sweep, just in turn.
-	if deleted := deleter.deletedKeys(); len(deleted) != 2 {
+	if deleted := deleter.deletedOwn(); len(deleted) != 2 {
 		t.Fatalf("deleted keys = %v, want both rows settled in one sweep", deleted)
 	}
 	for _, key := range []string{"ws/lark/first", "ws/lark/second"} {
@@ -638,7 +660,7 @@ func TestChannelMediaReconciler_TombstoneSchedulesThenClears(t *testing.T) {
 	if _, _, exists := f.rowState(t, key); exists {
 		t.Fatal("row must clear after the schedule is exhausted")
 	}
-	if got := len(deleter.deletedKeys()); got != len(channelMediaTombstoneRedelete)+1 {
+	if got := len(deleter.deletedOwn()); got != len(channelMediaTombstoneRedelete)+1 {
 		t.Fatalf("delete calls = %d, want one per pass plus the final one", got)
 	}
 }
@@ -669,7 +691,7 @@ func TestChannelMediaReconciler_TombstoneKeepsReferencedObject(t *testing.T) {
 	f.makeDue(t, key)
 	rec.RunOnce(context.Background())
 
-	if got := len(deleter.deletedKeys()); got != 1 {
+	if got := len(deleter.deletedOwn()); got != 1 {
 		t.Fatalf("delete calls = %d, want the referenced object left alone (only the first delete)", got)
 	}
 	if state, _, exists := f.rowState(t, key); exists {


### PR DESCRIPTION
`TestChannelMediaReconciler_SettlesThreeStates` (and five siblings) flake under a full `go test ./...` run and always pass standalone.

**Root cause.** The tests assert on the fake deleter's *global* key list (`len(deleted) == 1`, "nothing was deleted"). `RunOnce` sweeps the whole `channel_media_pending_object` table — the correct production semantic for a global reclaimer — and the test database is shared by every package the test runner executes in parallel: the wecom, dingtalk and handler suites all write that table. Under load, this test's sweep legitimately claims and deletes another package's due rows mid-assertion, and the count breaks. Reproduced on the first round of a three-package loop:

```
deleted keys = [workspaces/<ws>/wecom/<...> ×4  ws/lark/orphan], want only the orphan
```

**Fix.** `deletedOwn()` filters the recorded deletions to the fixture's `ws/lark/` prefix, preserving order, so per-key sequencing assertions keep their strength. Only the claim "and nothing else happened in the world" is dropped — which was never this suite's to make on a shared table. `CancelledSweepIsQuiet` keeps the global zero deliberately: a sweep with a cancelled context must not have touched anyone's rows, foreign ones included.

**Verification.** Before: reproduced on round 1 of `go test ./internal/service/ ./internal/handler/ ./cmd/migrate/ -count=1` in a loop. After: 6/6 clean rounds of the same loop; `-run TestChannelMediaReconciler -count=2` green.
