### PR TITLE
MUL-6768: ISE-1320: prevent concurrent agent state clobbering

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
@@ -2043,7 +2044,33 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	updated, err := h.Queries.UpdateAgent(r.Context(), params)
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update agent")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	locked, err := qtx.LockAgentForUpdate(r.Context(), db.LockAgentForUpdateParams{
+		ID:          existing.ID,
+		WorkspaceID: existing.WorkspaceID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update agent")
+		return
+	}
+	if locked.UpdatedAt.Valid != existing.UpdatedAt.Valid ||
+		(locked.UpdatedAt.Valid && !locked.UpdatedAt.Time.Equal(existing.UpdatedAt.Time)) {
+		writeEditConflict(w, "agent", existing.ID)
+		return
+	}
+
+	updated, err := qtx.UpdateAgent(r.Context(), params)
 	if err != nil {
 		// Unique constraint on (workspace_id, name) — mirror CreateAgent and
 		// return a clear conflict instead of a 500 that leaks the raw
@@ -2069,7 +2096,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// clear the field. COALESCE in UpdateAgent cannot set a column to NULL, so
 	// mcp_config, thinking_level, and service_tier use dedicated clear queries.
 	if shouldClearMcpConfig {
-		updated, err = h.Queries.ClearAgentMcpConfig(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentMcpConfig(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent mcp_config failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear mcp_config: "+err.Error())
@@ -2077,7 +2104,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearThinkingLevel {
-		updated, err = h.Queries.ClearAgentThinkingLevel(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentThinkingLevel(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent thinking_level failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear thinking_level: "+err.Error())
@@ -2085,7 +2112,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearServiceTier {
-		updated, err = h.Queries.ClearAgentServiceTier(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentServiceTier(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent service_tier failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear service_tier: "+err.Error())
@@ -2093,7 +2120,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if shouldClearComposioAllowlist {
-		updated, err = h.Queries.ClearAgentComposioToolkitAllowlist(r.Context(), updated.ID)
+		updated, err = qtx.ClearAgentComposioToolkitAllowlist(r.Context(), updated.ID)
 		if err != nil {
 			slog.Warn("clear agent composio_toolkit_allowlist failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear composio_toolkit_allowlist: "+err.Error())
@@ -2105,11 +2132,15 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// permission. Done after the row update so a permission_mode flip and its
 	// targets land together.
 	if replacePermissionTargets {
-		if err := h.replaceInvocationTargets(r.Context(), updated.ID, parseUUID(requestUserID(r)), resolvedPerm.targets); err != nil {
+		if err := replaceInvocationTargetsWithQueries(r.Context(), qtx, updated.ID, parseUUID(requestUserID(r)), resolvedPerm.targets); err != nil {
 			slog.Warn("update agent: persist invocation targets failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to update invocation targets: "+err.Error())
 			return
 		}
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update agent")
+		return
 	}
 
 	resp := h.agentToResponse(updated)

--- a/server/internal/handler/agent_concurrency_test.go
+++ b/server/internal/handler/agent_concurrency_test.go
@@ -7,8 +7,22 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 )
+
+type synchronizedTxStarter struct {
+	begin   func(context.Context) (pgx.Tx, error)
+	barrier *sync.WaitGroup
+}
+
+func (s synchronizedTxStarter) Begin(ctx context.Context) (pgx.Tx, error) {
+	s.barrier.Done()
+	s.barrier.Wait()
+	return s.begin(ctx)
+}
 
 func TestCreateAgent_MaxConcurrentTasksBoundsAndDefault(t *testing.T) {
 	if testHandler == nil || testPool == nil {
@@ -158,4 +172,67 @@ func TestUpdateAgent_MaxConcurrentTasksBoundsAndOmission(t *testing.T) {
 			t.Fatalf("null max_concurrent_tasks changed value to %d, want 50", got)
 		}
 	})
+}
+
+func TestUpdateAgent_ConcurrentStaleWritersConflict(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "concurrency-stale-writers", nil)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	originalStarter := testHandler.TxStarter
+	barrier := &sync.WaitGroup{}
+	barrier.Add(2)
+	testHandler.TxStarter = synchronizedTxStarter{
+		begin:   originalStarter.Begin,
+		barrier: barrier,
+	}
+	t.Cleanup(func() { testHandler.TxStarter = originalStarter })
+
+	type result struct {
+		status int
+		body   string
+	}
+	results := make(chan result, 2)
+	for _, instructions := range []string{"first stale writer", "second stale writer"} {
+		go func(instructions string) {
+			w := httptest.NewRecorder()
+			req := withURLParam(newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
+				"instructions": instructions,
+			}), "id", agentID)
+			testHandler.UpdateAgent(w, req)
+			results <- result{status: w.Code, body: w.Body.String()}
+		}(instructions)
+	}
+
+	var successes, conflicts int
+	for range 2 {
+		result := <-results
+		switch result.status {
+		case http.StatusOK:
+			successes++
+		case http.StatusConflict:
+			conflicts++
+			if !strings.Contains(result.body, `"code":"revision_conflict"`) {
+				t.Fatalf("conflict response missing stable code: %s", result.body)
+			}
+		default:
+			t.Fatalf("concurrent update status = %d: %s", result.status, result.body)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent updates: successes = %d, conflicts = %d, want one of each", successes, conflicts)
+	}
+
+	var instructions string
+	if err := testPool.QueryRow(context.Background(), `SELECT instructions FROM agent WHERE id = $1`, agentID).Scan(&instructions); err != nil {
+		t.Fatalf("read persisted instructions: %v", err)
+	}
+	if instructions != "first stale writer" && instructions != "second stale writer" {
+		t.Fatalf("persisted instructions = %q, want one successful writer", instructions)
+	}
 }

--- a/server/internal/handler/agent_env.go
+++ b/server/internal/handler/agent_env.go
@@ -202,15 +202,6 @@ func (h *Handler) UpdateAgentEnv(w http.ResponseWriter, r *http.Request) {
 		req.CustomEnv = map[string]string{}
 	}
 
-	existing := unmarshalCustomEnv(agent)
-	merged, audit := mergeAgentEnv(existing, req.CustomEnv)
-
-	envBytes, err := json.Marshal(merged)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to encode env")
-		return
-	}
-
 	tx, err := h.TxStarter.Begin(r.Context())
 	if err != nil {
 		slog.Error("agent_env update: begin tx failed",
@@ -220,6 +211,29 @@ func (h *Handler) UpdateAgentEnv(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback(r.Context())
 	qtx := h.Queries.WithTx(tx)
+
+	// Serialize whole-map replacements with every other agent state update, then
+	// merge against the row protected by the lock rather than the authorization
+	// snapshot. This preserves keys added by a concurrent writer.
+	locked, err := qtx.LockAgentForUpdate(r.Context(), db.LockAgentForUpdateParams{
+		ID:          agent.ID,
+		WorkspaceID: agent.WorkspaceID,
+	})
+	if err != nil {
+		slog.Warn("agent_env update: lock agent failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to update env")
+		return
+	}
+	agent = locked
+	existing := unmarshalCustomEnv(agent)
+	merged, audit := mergeAgentEnv(existing, req.CustomEnv)
+
+	envBytes, err := json.Marshal(merged)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode env")
+		return
+	}
 
 	updated, err := qtx.UpdateAgentCustomEnv(r.Context(), db.UpdateAgentCustomEnvParams{
 		ID:        agent.ID,

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -4156,6 +4156,56 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 	return i, err
 }
 
+const lockAgentForUpdate = `-- name: LockAgentForUpdate :one
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
+FOR UPDATE
+`
+
+type LockAgentForUpdateParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// UpdateAgent and other whole-agent replacements use this lock to serialize
+// against a pre-transaction snapshot.
+func (q *Queries) LockAgentForUpdate(ctx context.Context, arg LockAgentForUpdateParams) (Agent, error) {
+	row := q.db.QueryRow(ctx, lockAgentForUpdate, arg.ID, arg.WorkspaceID)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.Kind,
+		&i.SystemKey,
+		&i.DisabledRuntimeSkills,
+		&i.ServiceTier,
+		&i.ConversationStarters,
+	)
+	return i, err
+}
+
 const getAgentTask = `-- name: GetAgentTask :one
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
 WHERE id = $1

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -4156,56 +4156,6 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 	return i, err
 }
 
-const lockAgentForUpdate = `-- name: LockAgentForUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
-WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
-FOR UPDATE
-`
-
-type LockAgentForUpdateParams struct {
-	ID          pgtype.UUID `json:"id"`
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-}
-
-// UpdateAgent and other whole-agent replacements use this lock to serialize
-// against a pre-transaction snapshot.
-func (q *Queries) LockAgentForUpdate(ctx context.Context, arg LockAgentForUpdateParams) (Agent, error) {
-	row := q.db.QueryRow(ctx, lockAgentForUpdate, arg.ID, arg.WorkspaceID)
-	var i Agent
-	err := row.Scan(
-		&i.ID,
-		&i.WorkspaceID,
-		&i.Name,
-		&i.AvatarUrl,
-		&i.RuntimeMode,
-		&i.RuntimeConfig,
-		&i.Visibility,
-		&i.Status,
-		&i.MaxConcurrentTasks,
-		&i.OwnerID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Description,
-		&i.RuntimeID,
-		&i.Instructions,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
-		&i.CustomEnv,
-		&i.CustomArgs,
-		&i.McpConfig,
-		&i.Model,
-		&i.ThinkingLevel,
-		&i.ComposioToolkitAllowlist,
-		&i.PermissionMode,
-		&i.Kind,
-		&i.SystemKey,
-		&i.DisabledRuntimeSkills,
-		&i.ServiceTier,
-		&i.ConversationStarters,
-	)
-	return i, err
-}
-
 const getAgentTask = `-- name: GetAgentTask :one
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision FROM agent_task_queue
 WHERE id = $1
@@ -6539,6 +6489,57 @@ type LockAgentForAutopilotAssignmentParams struct {
 //     rejects the active Autopilot.
 func (q *Queries) LockAgentForAutopilotAssignment(ctx context.Context, arg LockAgentForAutopilotAssignmentParams) (Agent, error) {
 	row := q.db.QueryRow(ctx, lockAgentForAutopilotAssignment, arg.ID, arg.WorkspaceID)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.Kind,
+		&i.SystemKey,
+		&i.DisabledRuntimeSkills,
+		&i.ServiceTier,
+		&i.ConversationStarters,
+	)
+	return i, err
+}
+
+const lockAgentForUpdate = `-- name: LockAgentForUpdate :one
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
+FOR UPDATE
+`
+
+type LockAgentForUpdateParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// UpdateAgent is assembled from a pre-transaction snapshot. Lock and compare
+// that row before applying the patch so concurrent agent edits cannot silently
+// overwrite a newer update.
+func (q *Queries) LockAgentForUpdate(ctx context.Context, arg LockAgentForUpdateParams) (Agent, error) {
+	row := q.db.QueryRow(ctx, lockAgentForUpdate, arg.ID, arg.WorkspaceID)
 	var i Agent
 	err := row.Scan(
 		&i.ID,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -38,6 +38,14 @@ FOR UPDATE;
 SELECT * FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user';
 
+-- name: LockAgentForUpdate :one
+-- UpdateAgent is assembled from a pre-transaction snapshot. Lock and compare
+-- that row before applying the patch so concurrent agent edits cannot silently
+-- overwrite a newer update.
+SELECT * FROM agent
+WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
+FOR UPDATE;
+
 -- name: LockAgentForAutopilotAssignment :one
 -- Serializes creating, retargeting, or resuming an active Autopilot with
 -- Runtime teardown. Teardown takes FOR UPDATE on this same Agent row before it


### PR DESCRIPTION
## Summary

ISE-1320: prevent concurrent agent state updates from silently clobbering one another.

`UpdateAgent` previously loaded an agent, then wrote the row and related nullable fields and invocation targets without a transaction or stale-snapshot check. Two concurrent Helper runs could therefore lose a prompt edit. The autopilot update path already used the required locking pattern.

This change:

- Adds a workspace-scoped `LockAgentForUpdate` query.
- Locks and compares `updated_at` before applying `UpdateAgent`.
- Returns the existing `revision_conflict` 409 response for stale writes.
- Makes nullable clears and invocation target replacement atomic with the agent row.
- Recomputes `custom_env` merges from the locked row, preventing concurrent whole-map env updates from dropping keys.
- Adds a deterministic concurrent stale-writer test.

## Verification

- `git diff --check` passes.
- `make sqlc` could not run in this runtime because Go is not installed (`/bin/sh: 1: go: not found`). The generated sqlc method is included manually and matches the repository's generated query shape.
- Go tests could not run for the same missing Go toolchain.
