### PR TITLE
MUL-6753: fix(issues): preflight shared agents without runtime access

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -472,6 +472,13 @@ export interface Agent {
   runtime_id: string;
   /** False exactly when the agent has no runtime. Older backends omit it. */
   runtime_bound?: boolean;
+  /**
+   * CLI version projected from the bound runtime for Quick Create
+   * compatibility checks. This is intentionally separate from runtime-list
+   * access: a member may invoke a shared agent without being allowed to view
+   * its owner's private machine. Older servers and non-list responses omit it.
+   */
+  runtime_cli_version?: string;
   name: string;
   description: string;
   /** What this agent's owner wrote. For a system agent this holds only the

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -139,6 +139,15 @@ const mockMembersData = vi.hoisted(() => ({
   list: [{ user_id: "user-1", role: "admin" }],
 }));
 
+const mockRuntimesQuery = vi.hoisted(() => ({
+  data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }] as
+    | Array<{ id: string; metadata: Record<string, unknown> }>
+    | undefined,
+  isSuccess: true,
+  isPending: false,
+  isError: false,
+}));
+
 // Per-test override for the squads list so we can flip between "squads
 // exist and one's leader is reachable" and "no squads" cases without
 // re-mocking the whole module.
@@ -164,11 +173,15 @@ vi.mock("@tanstack/react-query", () => ({
       case "agents":
         return { data: mockAgentsData.list };
       case "runtimes":
-        if (!enabled) return { data: undefined, isSuccess: false };
-        return {
-          data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }],
-          isSuccess: true,
-        };
+        if (!enabled) {
+          return {
+            data: undefined,
+            isSuccess: false,
+            isPending: false,
+            isError: false,
+          };
+        }
+        return mockRuntimesQuery;
       case "projects":
         return mockProjectsQuery;
       default:
@@ -274,7 +287,8 @@ vi.mock("@multica/core/runtimes", () => ({
     version
       ? { state: "ok", min: "1.0.0" }
       : { state: "missing", min: "1.0.0" },
-  readRuntimeCliVersion: () => "1.2.3",
+  readRuntimeCliVersion: (metadata?: Record<string, unknown>) =>
+    typeof metadata?.cli_version === "string" ? metadata.cli_version : "",
   MIN_QUICK_CREATE_CLI_VERSION: "1.0.0",
 }));
 
@@ -557,6 +571,15 @@ describe("AgentCreatePanel", () => {
       runtime_cli_version: "1.2.3",
     }];
     mockMembersData.list = [{ user_id: "user-1", role: "admin" }];
+    mockRuntimesQuery.data = [
+      {
+        id: "runtime-1",
+        metadata: { cli_version: "1.2.3" },
+      },
+    ];
+    mockRuntimesQuery.isSuccess = true;
+    mockRuntimesQuery.isPending = false;
+    mockRuntimesQuery.isError = false;
     mockSquadsData.list = [];
     mockQuickCreateIssue.mockResolvedValue(undefined);
     mockCreateCommentSubIssue.mockResolvedValue({ task_id: "task-source-child" });
@@ -705,17 +728,57 @@ describe("AgentCreatePanel", () => {
   });
 
   it("falls back to the runtime list for an older server without the agent projection", () => {
+    mockAgentsData.list = [
+      {
+        id: "agent-1",
+        name: "Bohan",
+        archived_at: null,
+        runtime_id: "runtime-1",
+      },
+    ];
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(
+      screen.queryByText(/doesn't report a CLI version/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeEnabled();
+  });
+
+  it("keeps Create disabled while an older server's runtime fallback is loading", () => {
+    mockAgentsData.list = [
+      {
+        id: "agent-1",
+        name: "Bohan",
+        archived_at: null,
+        runtime_id: "runtime-1",
+      },
+    ];
+    mockRuntimesQuery.data = undefined;
+    mockRuntimesQuery.isSuccess = false;
+    mockRuntimesQuery.isPending = true;
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.queryByText(/doesn't report a CLI version/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeDisabled();
+  });
+
+  it("fails closed when an older server's runtime fallback request fails", () => {
     mockAgentsData.list = [{
       id: "agent-1",
       name: "Bohan",
       archived_at: null,
       runtime_id: "runtime-1",
     }];
+    mockRuntimesQuery.data = undefined;
+    mockRuntimesQuery.isSuccess = false;
+    mockRuntimesQuery.isError = true;
 
     renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
 
-    expect(screen.queryByText(/doesn't report a CLI version/)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^Create$/i })).toBeEnabled();
+    expect(screen.getByText(/doesn't report a CLI version/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeDisabled();
   });
 
   it("reveals optional fields from the overflow and submits their values", async () => {

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -119,6 +119,26 @@ const mockProjectsQuery = vi.hoisted(() => ({
   isSuccess: true,
 }));
 
+const mockAgentsData = vi.hoisted(() => ({
+  list: [{
+    id: "agent-1",
+    name: "Bohan",
+    archived_at: null,
+    runtime_id: "runtime-1",
+    runtime_cli_version: "1.2.3",
+  }] as Array<{
+    id: string;
+    name: string;
+    archived_at: string | null;
+    runtime_id: string;
+    runtime_cli_version?: string;
+  }>,
+}));
+
+const mockMembersData = vi.hoisted(() => ({
+  list: [{ user_id: "user-1", role: "admin" }],
+}));
+
 // Per-test override for the squads list so we can flip between "squads
 // exist and one's leader is reachable" and "no squads" cases without
 // re-mocking the whole module.
@@ -132,7 +152,7 @@ const mockSquadsData = vi.hoisted(
 let mockUploadIdSeq = 0;
 
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+  useQuery: ({ queryKey, enabled = true }: { queryKey: string[]; enabled?: boolean }) => {
     // Workspace-scoped query keys carry the wsId as `queryKey[1]`; the
     // discriminator is at `queryKey[2]` (e.g. ["workspaces", wsId, "squads"]).
     if (queryKey[0] === "workspaces" && queryKey[2] === "squads") {
@@ -140,13 +160,15 @@ vi.mock("@tanstack/react-query", () => ({
     }
     switch (queryKey[0]) {
       case "members":
-        return { data: [{ user_id: "user-1", role: "admin" }] };
+        return { data: mockMembersData.list };
       case "agents":
-        return {
-          data: [{ id: "agent-1", name: "Bohan", archived_at: null, runtime_id: "runtime-1" }],
-        };
+        return { data: mockAgentsData.list };
       case "runtimes":
-        return { data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }] };
+        if (!enabled) return { data: undefined, isSuccess: false };
+        return {
+          data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }],
+          isSuccess: true,
+        };
       case "projects":
         return mockProjectsQuery;
       default:
@@ -244,8 +266,14 @@ vi.mock("@multica/core/auth", () => ({
 
 vi.mock("@multica/core/runtimes", () => ({
   runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
-  checkQuickCreateCliVersion: () => ({ state: "ok", min: "1.0.0" }),
-  checkQuickCreateFieldsCliVersion: () => ({ state: "ok", min: "1.0.0" }),
+  checkQuickCreateCliVersion: (version: string) =>
+    version
+      ? { state: "ok", min: "1.0.0" }
+      : { state: "missing", min: "1.0.0" },
+  checkQuickCreateFieldsCliVersion: (version: string) =>
+    version
+      ? { state: "ok", min: "1.0.0" }
+      : { state: "missing", min: "1.0.0" },
   readRuntimeCliVersion: () => "1.2.3",
   MIN_QUICK_CREATE_CLI_VERSION: "1.0.0",
 }));
@@ -521,6 +549,14 @@ describe("AgentCreatePanel", () => {
     });
     mockProjectsQuery.data = [];
     mockProjectsQuery.isSuccess = true;
+    mockAgentsData.list = [{
+      id: "agent-1",
+      name: "Bohan",
+      archived_at: null,
+      runtime_id: "runtime-1",
+      runtime_cli_version: "1.2.3",
+    }];
+    mockMembersData.list = [{ user_id: "user-1", role: "admin" }];
     mockSquadsData.list = [];
     mockQuickCreateIssue.mockResolvedValue(undefined);
     mockCreateCommentSubIssue.mockResolvedValue({ task_id: "task-source-child" });
@@ -649,6 +685,37 @@ describe("AgentCreatePanel", () => {
     expect(mockToastSuccess).not.toHaveBeenCalled();
     expect(mockClearDraft).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("uses the agent CLI projection when a regular member cannot list the private runtime", async () => {
+    const user = userEvent.setup();
+    mockMembersData.list = [{ user_id: "user-1", role: "member" }];
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.queryByText(/doesn't report a CLI version/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(mockQuickCreateIssue).toHaveBeenCalledWith(expect.objectContaining({
+        agent_id: "agent-1",
+      }));
+    });
+  });
+
+  it("falls back to the runtime list for an older server without the agent projection", () => {
+    mockAgentsData.list = [{
+      id: "agent-1",
+      name: "Bohan",
+      archived_at: null,
+      runtime_id: "runtime-1",
+    }];
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.queryByText(/doesn't report a CLI version/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeEnabled();
   });
 
   it("reveals optional fields from the overflow and submits their values", async () => {

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -330,7 +330,17 @@ export function AgentCreatePanel({
   // (git-describe shape) are exempted inside checkQuickCreateCliVersion
   // — frontend and server share the same signal there, so they agree by
   // construction across web/desktop/staging without comparing env flags.
-  const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
+  // New servers project the one safe compatibility signal Quick Create needs
+  // onto each visible agent. Fall back to the legacy runtime list only when an
+  // older server omits it; a regular member cannot see another owner's private
+  // runtime there, which is the misleading "CLI version missing" bug fixed by
+  // the projection.
+  const projectedRuntimeCliVersion = selectedAgent?.runtime_cli_version;
+  const hasAgentCLIVersionProjection = projectedRuntimeCliVersion !== undefined;
+  const { data: runtimes = [], isSuccess: runtimesLoaded } = useQuery({
+    ...runtimeListOptions(wsId),
+    enabled: !!selectedAgent && !hasAgentCLIVersionProjection,
+  });
   const selectedRuntime = useMemo(
     () =>
       selectedAgent?.runtime_id
@@ -338,7 +348,9 @@ export function AgentCreatePanel({
         : undefined,
     [runtimes, selectedAgent?.runtime_id],
   );
-  const runtimeCliVersion = readRuntimeCliVersion(selectedRuntime?.metadata);
+  const runtimeCliVersion = hasAgentCLIVersionProjection
+    ? projectedRuntimeCliVersion
+    : readRuntimeCliVersion(selectedRuntime?.metadata);
   const baseVersionCheck = useMemo(
     () => checkQuickCreateCliVersion(runtimeCliVersion),
     [runtimeCliVersion],
@@ -349,9 +361,11 @@ export function AgentCreatePanel({
   );
   const usesExplicitFields = priority !== "none" || dueDate !== null;
   const versionCheck = usesExplicitFields ? fieldVersionCheck : baseVersionCheck;
+  const runtimeVersionLoaded = hasAgentCLIVersionProjection || runtimesLoaded;
   const versionBlocked =
-    baseVersionCheck.state !== "ok" ||
-    (usesExplicitFields && fieldVersionCheck.state !== "ok");
+    runtimeVersionLoaded &&
+    (baseVersionCheck.state !== "ok" ||
+      (usesExplicitFields && fieldVersionCheck.state !== "ok"));
 
   const initialPrompt = draft.agent.prompt || (data?.prompt as string) || "";
   // The editor is uncontrolled — we read the latest markdown via the ref at

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -337,9 +337,16 @@ export function AgentCreatePanel({
   // the projection.
   const projectedRuntimeCliVersion = selectedAgent?.runtime_cli_version;
   const hasAgentCLIVersionProjection = projectedRuntimeCliVersion !== undefined;
-  const { data: runtimes = [], isSuccess: runtimesLoaded } = useQuery({
+  const needsRuntimeListFallback =
+    !!selectedAgent && !hasAgentCLIVersionProjection;
+  const {
+    data: runtimes = [],
+    isSuccess: runtimesLoaded,
+    isPending: runtimesPending,
+    isError: runtimesError,
+  } = useQuery({
     ...runtimeListOptions(wsId),
-    enabled: !!selectedAgent && !hasAgentCLIVersionProjection,
+    enabled: needsRuntimeListFallback,
   });
   const selectedRuntime = useMemo(
     () =>
@@ -361,11 +368,16 @@ export function AgentCreatePanel({
   );
   const usesExplicitFields = priority !== "none" || dueDate !== null;
   const versionCheck = usesExplicitFields ? fieldVersionCheck : baseVersionCheck;
-  const runtimeVersionLoaded = hasAgentCLIVersionProjection || runtimesLoaded;
+  const runtimeVersionPending = needsRuntimeListFallback && runtimesPending;
+  const runtimeVersionError = needsRuntimeListFallback && runtimesError;
+  const runtimeVersionLoaded =
+    hasAgentCLIVersionProjection ||
+    (needsRuntimeListFallback && runtimesLoaded);
   const versionBlocked =
-    runtimeVersionLoaded &&
-    (baseVersionCheck.state !== "ok" ||
-      (usesExplicitFields && fieldVersionCheck.state !== "ok"));
+    runtimeVersionError ||
+    (runtimeVersionLoaded &&
+      (baseVersionCheck.state !== "ok" ||
+        (usesExplicitFields && fieldVersionCheck.state !== "ok")));
 
   const initialPrompt = draft.agent.prompt || (data?.prompt as string) || "";
   // The editor is uncontrolled — we read the latest markdown via the ref at
@@ -422,9 +434,15 @@ export function AgentCreatePanel({
     editorRef,
     uploadGate: gate,
     onSubmit: async (md): Promise<boolean> => {
-      // The button already disables on !actor / versionBlocked, but the
-      // ⌘+Enter path bypasses it — re-guard here and keep the draft in place.
-      if (!actor || versionBlocked || (anchorCommentId && !sourcePreview)) return false;
+      // The button already disables on !actor / runtimeVersionPending /
+      // versionBlocked, but the ⌘+Enter path bypasses it — re-guard here and
+      // keep the draft in place.
+      if (
+        !actor ||
+        runtimeVersionPending ||
+        versionBlocked ||
+        (anchorCommentId && !sourcePreview)
+      ) return false;
       // Flush the prompt editor's pending debounce before snapshotting — see
       // ManualCreatePanel.
       const pendingPrompt = editorRef.current?.flushPendingUpdate?.();
@@ -897,7 +915,15 @@ export function AgentCreatePanel({
           <Button
             size="sm"
             onClick={submit}
-            disabled={!hasContent || !actor || submitting || versionBlocked || gate.uploading || (!!anchorCommentId && !sourcePreview)}
+            disabled={
+              !hasContent ||
+              !actor ||
+              submitting ||
+              runtimeVersionPending ||
+              versionBlocked ||
+              gate.uploading ||
+              (!!anchorCommentId && !sourcePreview)
+            }
             aria-disabled={gate.uploading || undefined}
             // Sending is a busy state too, not just uploading.
             aria-busy={gate.uploading || submitting || undefined}

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -58,9 +58,15 @@ type AgentResponse struct {
 	// branch on this rather than on RuntimeID being falsy, and must not confuse
 	// it with a bound-but-offline runtime (a different user story: reconnect the
 	// machine vs. pick a new one).
-	RuntimeBound bool   `json:"runtime_bound"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
+	RuntimeBound bool `json:"runtime_bound"`
+	// RuntimeCLIVersion is the one non-secret runtime compatibility signal an
+	// invoker needs for Quick Create. ListAgents populates it even when the
+	// bound machine is private; other response paths omit it. This preserves
+	// runtime resource privacy while avoiding a second, permission-filtered
+	// runtime-list request that used to turn "not visible" into "CLI missing".
+	RuntimeCLIVersion *string `json:"runtime_cli_version,omitempty"`
+	Name              string  `json:"name"`
+	Description       string  `json:"description"`
 	// Instructions is what this agent's owner wrote. For a system agent it
 	// holds only the workspace's own notes — the product half lives in
 	// SystemInstructions and is never stored on the row.
@@ -984,12 +990,15 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 	}
 	userID := requestUserID(r)
 
-	var agents []db.Agent
-	var err error
-	if r.URL.Query().Get("include_archived") == "true" {
-		agents, err = h.Queries.ListAllAgents(r.Context(), parseUUID(workspaceID))
-	} else {
-		agents, err = h.Queries.ListAgents(r.Context(), parseUUID(workspaceID))
+	agents := []db.Agent{}
+	runtimeCLIVersions := map[string]string{}
+	rows, err := h.Queries.ListAgentsWithRuntimeCLI(r.Context(), db.ListAgentsWithRuntimeCLIParams{
+		WorkspaceID:     parseUUID(workspaceID),
+		IncludeArchived: r.URL.Query().Get("include_archived") == "true",
+	})
+	for _, row := range rows {
+		agents = append(agents, row.Agent)
+		runtimeCLIVersions[uuidToString(row.Agent.ID)] = row.RuntimeCliVersion
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agents")
@@ -1046,6 +1055,8 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		resp := h.agentToResponse(a)
+		cliVersion := runtimeCLIVersions[resp.ID]
+		resp.RuntimeCLIVersion = &cliVersion
 		applyInvocationTargetsToResponse(&resp, targets)
 		if skills, ok := skillMap[resp.ID]; ok {
 			resp.Skills = skills

--- a/server/internal/handler/agent_runtime_cli_projection_test.go
+++ b/server/internal/handler/agent_runtime_cli_projection_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+func TestListAgentsProjectsCLIForInvocableAgentOnPrivateRuntime(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeOwnerID := dbfx.User(t, "CLI Projection Runtime Owner", "cli-projection-owner-"+uuid.NewString()+"@example.com")
+	dbfx.Member(t, testWorkspaceID, runtimeOwnerID, "member")
+	viewerID := dbfx.User(t, "CLI Projection Viewer", "cli-projection-viewer-"+uuid.NewString()+"@example.com")
+	dbfx.Member(t, testWorkspaceID, viewerID, "member")
+	runtimeID := dbfx.Runtime(t, "CLI Projection Private Runtime", testutil.Cols{
+		"owner_id":   runtimeOwnerID,
+		"visibility": "private",
+		"metadata":   testutil.Raw(`jsonb_build_object('cli_version', '0.2.99')`),
+	})
+	agentID := dbfx.Agent(t, "CLI Projection Shared Agent", runtimeID, testutil.Cols{
+		"owner_id":        runtimeOwnerID,
+		"visibility":      "private",
+		"permission_mode": "public_to",
+	})
+	dbfx.InsertNoID(t, "agent_invocation_target", testutil.Cols{
+		"agent_id":    agentID,
+		"target_type": "member",
+		"target_id":   viewerID,
+	}, "agent_id = $1 AND target_type = 'member' AND target_id = $2", agentID, viewerID)
+
+	var runtimes []AgentRuntimeResponse
+	testutil.Call(t, testHandler.ListAgentRuntimes,
+		newRequestAs(viewerID, http.MethodGet, "/api/runtimes", nil),
+	).Want(http.StatusOK).JSON(&runtimes)
+	for _, runtime := range runtimes {
+		if runtime.ID == runtimeID {
+			t.Fatalf("private runtime %s leaked into the regular member's runtime list", runtimeID)
+		}
+	}
+
+	var agents []AgentResponse
+	testutil.Call(t, testHandler.ListAgents,
+		newRequestAs(viewerID, http.MethodGet, "/api/agents", nil),
+	).Want(http.StatusOK).JSON(&agents)
+	for _, agent := range agents {
+		if agent.ID != agentID {
+			continue
+		}
+		if agent.RuntimeCLIVersion == nil || *agent.RuntimeCLIVersion != "0.2.99" {
+			t.Fatalf("runtime_cli_version = %#v, want 0.2.99", agent.RuntimeCLIVersion)
+		}
+		return
+	}
+	t.Fatalf("invocable agent %s missing from regular member's agent list", agentID)
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -5416,6 +5416,85 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 	return items, nil
 }
 
+const listAgentsWithRuntimeCLI = `-- name: ListAgentsWithRuntimeCLI :many
+SELECT a.id, a.workspace_id, a.name, a.avatar_url, a.runtime_mode, a.runtime_config, a.visibility, a.status, a.max_concurrent_tasks, a.owner_id, a.created_at, a.updated_at, a.description, a.runtime_id, a.instructions, a.archived_at, a.archived_by, a.custom_env, a.custom_args, a.mcp_config, a.model, a.thinking_level, a.composio_toolkit_allowlist, a.permission_mode, a.kind, a.system_key, a.disabled_runtime_skills, a.service_tier, a.conversation_starters,
+       CASE
+         WHEN jsonb_typeof(r.metadata->'cli_version') = 'string'
+           THEN r.metadata->>'cli_version'
+         ELSE ''
+       END::text AS runtime_cli_version
+FROM agent AS a
+LEFT JOIN agent_runtime AS r ON r.id = a.runtime_id
+WHERE a.workspace_id = $1
+  AND a.kind = 'user'
+  AND ($2::boolean OR a.archived_at IS NULL)
+ORDER BY a.created_at ASC
+`
+
+type ListAgentsWithRuntimeCLIParams struct {
+	WorkspaceID     pgtype.UUID `json:"workspace_id"`
+	IncludeArchived bool        `json:"include_archived"`
+}
+
+type ListAgentsWithRuntimeCLIRow struct {
+	Agent             Agent  `json:"agent"`
+	RuntimeCliVersion string `json:"runtime_cli_version"`
+}
+
+// Quick Create needs only the bound runtime's CLI version, not the private
+// machine resource. Project that one non-secret compatibility signal onto the
+// visible agent in the same query so clients do not need runtime-list access.
+func (q *Queries) ListAgentsWithRuntimeCLI(ctx context.Context, arg ListAgentsWithRuntimeCLIParams) ([]ListAgentsWithRuntimeCLIRow, error) {
+	rows, err := q.db.Query(ctx, listAgentsWithRuntimeCLI, arg.WorkspaceID, arg.IncludeArchived)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAgentsWithRuntimeCLIRow{}
+	for rows.Next() {
+		var i ListAgentsWithRuntimeCLIRow
+		if err := rows.Scan(
+			&i.Agent.ID,
+			&i.Agent.WorkspaceID,
+			&i.Agent.Name,
+			&i.Agent.AvatarUrl,
+			&i.Agent.RuntimeMode,
+			&i.Agent.RuntimeConfig,
+			&i.Agent.Visibility,
+			&i.Agent.Status,
+			&i.Agent.MaxConcurrentTasks,
+			&i.Agent.OwnerID,
+			&i.Agent.CreatedAt,
+			&i.Agent.UpdatedAt,
+			&i.Agent.Description,
+			&i.Agent.RuntimeID,
+			&i.Agent.Instructions,
+			&i.Agent.ArchivedAt,
+			&i.Agent.ArchivedBy,
+			&i.Agent.CustomEnv,
+			&i.Agent.CustomArgs,
+			&i.Agent.McpConfig,
+			&i.Agent.Model,
+			&i.Agent.ThinkingLevel,
+			&i.Agent.ComposioToolkitAllowlist,
+			&i.Agent.PermissionMode,
+			&i.Agent.Kind,
+			&i.Agent.SystemKey,
+			&i.Agent.DisabledRuntimeSkills,
+			&i.Agent.ServiceTier,
+			&i.Agent.ConversationStarters,
+			&i.RuntimeCliVersion,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAllAgents = `-- name: ListAllAgents :many
 SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
 WHERE workspace_id = $1 AND kind = 'user'

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -8,6 +8,23 @@ SELECT * FROM agent
 WHERE workspace_id = $1 AND kind = 'user'
 ORDER BY created_at ASC;
 
+-- name: ListAgentsWithRuntimeCLI :many
+-- Quick Create needs only the bound runtime's CLI version, not the private
+-- machine resource. Project that one non-secret compatibility signal onto the
+-- visible agent in the same query so clients do not need runtime-list access.
+SELECT sqlc.embed(a),
+       CASE
+         WHEN jsonb_typeof(r.metadata->'cli_version') = 'string'
+           THEN r.metadata->>'cli_version'
+         ELSE ''
+       END::text AS runtime_cli_version
+FROM agent AS a
+LEFT JOIN agent_runtime AS r ON r.id = a.runtime_id
+WHERE a.workspace_id = @workspace_id
+  AND a.kind = 'user'
+  AND (@include_archived::boolean OR a.archived_at IS NULL)
+ORDER BY a.created_at ASC;
+
 -- name: ListAllAgentsAnyKind :many
 -- Every agent row in the workspace, INCLUDING `kind = 'system'` execution
 -- carriers (agent builder sessions) that ListAllAgents deliberately hides.


### PR DESCRIPTION
## What does this PR do?

Fixes Quick Create for regular members who are allowed to invoke a shared agent but cannot view the private runtime that hosts it.

- Agent-list responses project the bound runtime's CLI version as `runtime_cli_version`.
- Quick Create uses that projection for its CLI compatibility preflight and skips the runtime-list request on upgraded backends.
- Older backends remain supported through the existing runtime-list fallback.
- The fallback now fails closed: Create stays disabled while the runtime query is pending or when it fails.

This does not grant runtime access or broaden agent invocation permission. It only moves the compatibility signal to the resource whose permission already governs the action.

## Root cause and permission contract

Quick Create previously resolved the selected agent's CLI version through `GET /api/runtimes`:

1. Read the selected agent's `runtime_id`.
2. Find that runtime in the caller's permission-filtered runtime list.
3. Read `runtime.metadata.cli_version`.

Agent invocation permission and runtime resource permission are intentionally separate. A member can be included in an agent's `public_to` invocation targets while still being unable to list, inspect, bind to, or manage the owner's private runtime. In that valid state, the runtime lookup returned no row and the UI incorrectly treated "not visible" as "daemon did not report a CLI version." Promoting the same member to admin made the preflight pass only because governance access made the runtime visible.

The new path keeps those boundaries intact:

- `memberAllowedToViewAgent` / the invocation allow-list still decides whether the agent is returned and can be invoked.
- Runtime list/detail/binding permissions are unchanged.
- The agent list exposes only the CLI compatibility signal, not the runtime name, owner, status, configuration, or metadata bag.

## API and compatibility behavior

`GET /api/agents` now returns `runtime_cli_version` on visible list entries:

- A non-empty string means the bound runtime reported a CLI version; the existing minimum-version checks apply.
- An empty string means the upgraded backend checked the runtime but found no valid string version; Quick Create remains blocked.
- An omitted field identifies an older backend or a non-list response; Quick Create falls back to the legacy runtime-list lookup.

The backend uses a single `LEFT JOIN` from `agent.runtime_id` to `agent_runtime.id` and projects only a string-valued `metadata.cli_version`. Missing or malformed metadata becomes an empty string. The join avoids an N+1 query and preserves unbound agents.

For the legacy fallback, loading and failure are separate from the version verdict: loading disables submission without flashing a false missing-version warning, while a failed query blocks both the button and the keyboard-submit path.

## Review-oriented commit split

1. `7423b4a5d` — project runtime CLI compatibility through visible agent-list responses and consume it in Quick Create, with old-backend fallback and permission regression coverage.
2. `38c08edae` — make the legacy fallback fail closed while loading or failed, including button and keyboard-submit guards.

## How was this validated?

- Views: 405 files / 4,796 tests.
- `pnpm --filter @multica/views typecheck`.
- `pnpm typecheck`.
- `pnpm --filter @multica/views lint` (0 errors; pre-existing warnings only).
- `go test ./internal/handler -count=1`.
- `go vet ./internal/handler`.
- `git diff --check`.
- DB-backed regression coverage verifies that a regular member cannot list the private runtime but can receive the projected CLI version for an invocable agent. Local DB execution was unavailable because the shared Docker/containerd store failed with an I/O error; the backend CI job exercises it.

## Related issue

Fixes #7633

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [x] Tests
- [ ] CI / infrastructure

## Checklist

- [x] I have run the affected frontend and backend tests.
- [x] I have added regression coverage for the permission boundary and old-backend fallback states.
- [x] I have preserved agent invocation and runtime resource permissions as separate contracts.
- [x] I have considered installed-client compatibility and fail-closed behavior.
- [x] I will address reviewer comments before requesting merge.

## AI disclosure

**AI tool used:** Codex

**Approach:** Reproduced the member/admin difference through the permission-filtered runtime lookup, traced the independent agent-invocation and runtime-resource gates, projected the minimum compatibility signal onto visible agents, preserved old-backend fallback behavior, and added permission plus loading/error regression coverage.

## Screenshots

Not included. This PR does not add a visual component; it corrects the data source and submission state behind the existing Quick Create version message and Create button.
