### PR TITLE
MUL-6769: test(ghsnapshot): close the pool after cleanups, not before them

### DIFF
--- a/server/internal/integrations/ghsnapshot/refresh_db_test.go
+++ b/server/internal/integrations/ghsnapshot/refresh_db_test.go
@@ -26,6 +26,20 @@ func testDBPool(t *testing.T) *pgxpool.Pool {
 		pool.Close()
 		t.Skipf("skipping DB test: database not reachable: %v", err)
 	}
+	// Close via t.Cleanup, registered FIRST, so it runs LAST — after every
+	// row-deleting cleanup the test registers later, and after the context
+	// cancel that stops the manager's workers. The previous shape, a `defer
+	// pool.Close()` at each call site, ran BEFORE any t.Cleanup: the row
+	// deletions then executed against a closed pool and failed silently, so
+	// every run leaked its PR rows into the shared database. The refresh
+	// worker looks rows up by ADDRESS (installation/owner/repo/number), which
+	// every test here shares — once enough leaked rows accumulate, a sweep
+	// applies a snapshot to a leaked row first, the onApplied signal fires for
+	// THAT row, and the test asserts on its own row before the worker reaches
+	// it. That is the "trailing refresh did not replace old snapshot" failure,
+	// and the "closed pool" WARN spam was the same ordering bug seen from the
+	// worker's side.
+	t.Cleanup(pool.Close)
 	return pool
 }
 
@@ -100,7 +114,6 @@ func checkRunCount(t *testing.T, pool *pgxpool.Pool, prID pgtype.UUID) int {
 
 func TestListStaleUndecidedGitHubPRsExcludesDecidedAndRotatesCursor(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_010_000, 0)
@@ -201,7 +214,6 @@ func TestListStaleUndecidedGitHubPRsExcludesDecidedAndRotatesCursor(t *testing.T
 // response for an old head must never overwrite a newer head's snapshot.
 func TestApplySnapshotHeadSHAGuard(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_000_100, 0)
@@ -277,7 +289,6 @@ func TestApplySnapshotHeadSHAGuard(t *testing.T) {
 // trailing edge must still fetch and apply B immediately.
 func TestInFlightOldHeadKeepsTrailingRefresh(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
 	q := db.New(pool)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -368,7 +379,6 @@ func TestInFlightOldHeadKeepsTrailingRefresh(t *testing.T) {
 // replace, not an accumulation.
 func TestApplySnapshotReplacesRuns(t *testing.T) {
 	pool := testDBPool(t)
-	defer pool.Close()
 	q := db.New(pool)
 	ctx := context.Background()
 	now := time.Unix(1_700_000_200, 0)


### PR DESCRIPTION
`TestInFlightOldHeadKeepsTrailingRefresh` is permanently red on any database with test history, while a fresh database stays green — which makes it look flaky in CI and locally reads as "always broken".

**Root cause.** Every DB test here pairs `defer pool.Close()` with `t.Cleanup` row deletions, and defers run **before** cleanups: each deletion executes against a closed pool and fails silently (`_, _ =`), so every run leaks its PR fixture rows into the shared database. 37 had accumulated locally. The refresh worker looks rows up by **address** (installation/owner/repo/number), which all tests in this file share — once enough leaked rows exist, a sweep applies the snapshot to a leaked row first, `onApplied` fires for *that* row, and the test asserts on its own row before the worker reaches it:

```
trailing refresh did not replace old snapshot: {... SnapshotHeadSha: ...}
```

The long-standing `WARN ghsnapshot: apply snapshot failed err="closed pool"` spam in test output is the same ordering bug seen from the worker's side.

**Fix.** The pool now closes via `t.Cleanup` registered inside `testDBPool` — first registered, last run — so row deletions and the manager's context cancel both happen while the pool is still alive. The four call-site `defer pool.Close()` lines are removed.

**Verification.** Purged the leaked rows, then five consecutive package runs green (previously red on every run against a database with history), with zero fixture rows left behind afterwards.
