### PR TITLE
feat(daemon): prevent macOS idle sleep during active tasks

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -529,6 +529,10 @@ type Daemon struct {
 	// It deliberately includes preparation and local-directory waiters because
 	// restart/update barriers must not kill any claimed task.
 	activeTasks atomic.Int64
+	// taskActivityMu serializes the active-task transition that acquires or
+	// releases the macOS idle-sleep assertion.
+	taskActivityMu     sync.Mutex
+	idleSleepAssertion idleSleepAssertion
 	// runningTasks counts live provider execution sessions, beginning only after
 	// backend.Execute returns. It can briefly lag the server-side running state,
 	// which starts during preparation before provider launch. resourceWaitTasks
@@ -642,6 +646,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		pendingWorkLastRun:        make(map[string]time.Time),
 		reregisterNextAttempt:     make(map[string]time.Time),
 		reregisterLastCompletedAt: make(map[string]time.Time),
+		idleSleepAssertion:        newIdleSleepAssertion(logger),
 		cancelPollInterval:        5 * time.Second,
 		taskPrepareTimeout:        defaultTaskPrepareTimeout,
 		reconcile:                 newReconcileBroadcaster(),
@@ -1935,6 +1940,7 @@ func (d *Daemon) clearWSHeartbeatAcks() {
 func (d *Daemon) Run(ctx context.Context) error {
 	// Wrap context so handleUpdate can cancel the daemon for restart.
 	ctx, cancel := context.WithCancel(ctx)
+	defer d.releaseIdleSleepAssertion()
 	d.cancelFunc = cancel
 	d.rootCtx = ctx
 
@@ -4800,7 +4806,7 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			}
 			d.logger.Info("task received", "task", shortID(t.ID), "target", taskTarget)
 			taskWG.Add(1)
-			d.activeTasks.Add(1)
+			d.taskStarted()
 			if cache, ok := d.repoCache.(interface{ CancelMaintenance() }); ok {
 				// A task can reuse an existing worktree and never enter the
 				// checkout path that normally preempts repository maintenance.
@@ -4810,7 +4816,7 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			}
 			go func(t Task, slot int) {
 				defer taskWG.Done()
-				defer d.activeTasks.Add(-1)
+				defer d.taskFinished()
 				defer func() {
 					// Release local capacity before waking the poller. The task's
 					// terminal callback and local cleanup have both finished at this

--- a/server/internal/daemon/idle_sleep.go
+++ b/server/internal/daemon/idle_sleep.go
@@ -1,0 +1,36 @@
+package daemon
+
+type idleSleepAssertion interface {
+	Acquire() error
+	Release()
+}
+
+func (d *Daemon) taskStarted() {
+	d.taskActivityMu.Lock()
+	defer d.taskActivityMu.Unlock()
+
+	if d.activeTasks.Add(1) != 1 || d.idleSleepAssertion == nil {
+		return
+	}
+	if err := d.idleSleepAssertion.Acquire(); err != nil && d.logger != nil {
+		d.logger.Warn("prevent idle system sleep failed", "error", err)
+	}
+}
+
+func (d *Daemon) taskFinished() {
+	d.taskActivityMu.Lock()
+	defer d.taskActivityMu.Unlock()
+
+	if d.activeTasks.Add(-1) == 0 && d.idleSleepAssertion != nil {
+		d.idleSleepAssertion.Release()
+	}
+}
+
+func (d *Daemon) releaseIdleSleepAssertion() {
+	d.taskActivityMu.Lock()
+	defer d.taskActivityMu.Unlock()
+
+	if d.idleSleepAssertion != nil {
+		d.idleSleepAssertion.Release()
+	}
+}

--- a/server/internal/daemon/idle_sleep_darwin.go
+++ b/server/internal/daemon/idle_sleep_darwin.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type caffeinateIdleSleepAssertion struct {
+	mu     sync.Mutex
+	logger *slog.Logger
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func newIdleSleepAssertion(logger *slog.Logger) idleSleepAssertion {
+	return &caffeinateIdleSleepAssertion{logger: logger}
+}
+
+func (a *caffeinateIdleSleepAssertion) Acquire() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cancel != nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "/usr/bin/caffeinate", "-i", "-w", strconv.Itoa(os.Getpid()))
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return err
+	}
+	a.cancel = cancel
+	a.done = make(chan struct{})
+	go a.supervise(ctx, cmd, a.done)
+	return nil
+}
+
+func (a *caffeinateIdleSleepAssertion) Release() {
+	a.mu.Lock()
+	cancel := a.cancel
+	done := a.done
+	a.cancel = nil
+	a.done = nil
+	a.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		<-done
+	}
+}
+
+func (a *caffeinateIdleSleepAssertion) supervise(ctx context.Context, cmd *exec.Cmd, done chan<- struct{}) {
+	defer close(done)
+	for {
+		err := cmd.Wait()
+		if ctx.Err() != nil {
+			return
+		}
+		if a.logger != nil {
+			a.logger.Warn("idle sleep assertion process exited; restarting", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+
+		cmd = exec.CommandContext(ctx, "/usr/bin/caffeinate", "-i", "-w", strconv.Itoa(os.Getpid()))
+		if err := cmd.Start(); err != nil {
+			if a.logger != nil {
+				a.logger.Warn("restart idle sleep assertion process failed", "error", err)
+			}
+			continue
+		}
+	}
+}

--- a/server/internal/daemon/idle_sleep_darwin_test.go
+++ b/server/internal/daemon/idle_sleep_darwin_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCaffeinateAssertionRestartsAndReleasesSynchronously(t *testing.T) {
+	assertion := newIdleSleepAssertion(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := assertion.Acquire(); err != nil {
+		t.Fatalf("acquire assertion: %v", err)
+	}
+	t.Cleanup(assertion.Release)
+
+	firstPID := waitForCaffeinateChild(t, 0)
+	if err := syscall.Kill(firstPID, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill first caffeinate process: %v", err)
+	}
+	_ = waitForCaffeinateChild(t, firstPID)
+
+	assertion.Release()
+	if children := caffeinateChildPIDs(t); len(children) != 0 {
+		t.Fatalf("caffeinate children after release = %v, want none", children)
+	}
+}
+
+func waitForCaffeinateChild(t *testing.T, excluding int) int {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, pid := range caffeinateChildPIDs(t) {
+			if pid != excluding {
+				return pid
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for caffeinate child other than %d", excluding)
+	return 0
+}
+
+func caffeinateChildPIDs(t *testing.T) []int {
+	t.Helper()
+	out, err := exec.Command("/usr/bin/pgrep", "-P", strconv.Itoa(os.Getpid()), "-x", "caffeinate").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		t.Fatalf("list caffeinate children: %v", err)
+	}
+
+	var pids []int
+	for _, field := range strings.Fields(string(out)) {
+		pid, err := strconv.Atoi(field)
+		if err != nil {
+			t.Fatalf("parse caffeinate pid %q: %v", field, err)
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}

--- a/server/internal/daemon/idle_sleep_other.go
+++ b/server/internal/daemon/idle_sleep_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+package daemon
+
+import "log/slog"
+
+type noopIdleSleepAssertion struct{}
+
+func newIdleSleepAssertion(*slog.Logger) idleSleepAssertion {
+	return noopIdleSleepAssertion{}
+}
+
+func (noopIdleSleepAssertion) Acquire() error { return nil }
+func (noopIdleSleepAssertion) Release()       {}

--- a/server/internal/daemon/idle_sleep_test.go
+++ b/server/internal/daemon/idle_sleep_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+)
+
+type recordingIdleSleepAssertion struct {
+	acquires int
+	releases int
+}
+
+func (a *recordingIdleSleepAssertion) Acquire() error {
+	a.acquires++
+	return nil
+}
+
+func (a *recordingIdleSleepAssertion) Release() {
+	a.releases++
+}
+
+func TestActiveTaskSleepAssertionIsReferenceCounted(t *testing.T) {
+	assertion := &recordingIdleSleepAssertion{}
+	d := &Daemon{idleSleepAssertion: assertion}
+
+	d.taskStarted()
+	d.taskStarted()
+	if got := assertion.acquires; got != 1 {
+		t.Fatalf("acquires after two starts = %d, want 1", got)
+	}
+
+	d.taskFinished()
+	if got := assertion.releases; got != 0 {
+		t.Fatalf("releases while one task remains = %d, want 0", got)
+	}
+
+	d.taskFinished()
+	if got := assertion.releases; got != 1 {
+		t.Fatalf("releases after the last task = %d, want 1", got)
+	}
+
+	d.taskStarted()
+	d.releaseIdleSleepAssertion()
+	if got := assertion.releases; got != 2 {
+		t.Fatalf("releases on daemon shutdown with an active task = %d, want 2", got)
+	}
+}
+
+func TestConcurrentTasksShareOneSleepAssertion(t *testing.T) {
+	assertion := &recordingIdleSleepAssertion{}
+	d := &Daemon{idleSleepAssertion: assertion}
+
+	const taskCount = 20
+	var wg sync.WaitGroup
+	for range taskCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.taskStarted()
+		}()
+	}
+	wg.Wait()
+	if got := assertion.acquires; got != 1 {
+		t.Fatalf("concurrent acquires = %d, want 1", got)
+	}
+
+	for range taskCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.taskFinished()
+		}()
+	}
+	wg.Wait()
+	if got := assertion.releases; got != 1 {
+		t.Fatalf("concurrent releases = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Prevents macOS from entering idle system sleep while the local Multica daemon has claimed work in flight.

The daemon acquires one shared `/usr/bin/caffeinate -i -w <daemon-pid>` assertion when `activeTasks` moves from zero to one, keeps that assertion across concurrent tasks, and releases it when the last task finishes or the daemon shuts down. If the helper exits unexpectedly while work remains active, the assertion supervises and restarts it. Other operating systems use a no-op implementation.

The scope is intentionally task-bound rather than process-bound: an idle daemon does not keep the Mac awake indefinitely.

## Related Issue

No linked issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add a small platform-neutral idle-sleep assertion interface and reference-count it at the daemon's existing active-task boundary.
- Add a Darwin implementation backed by `caffeinate`, including synchronous release and restart supervision.
- Add a no-op implementation for non-Darwin builds.
- Add concurrency/reference-count tests plus a Darwin integration test for restart and cleanup.

## How to Test

1. Run `go test ./internal/daemon -run 'TestActiveTaskSleepAssertionIsReferenceCounted|TestConcurrentTasksShareOneSleepAssertion' -count=1`.
2. Build the Darwin test package with `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go test -c ./internal/daemon`.
3. On macOS, run `go test ./internal/daemon -run TestCaffeinateAssertionRestartsAndReleasesSynchronously -count=1` and confirm no child `caffeinate` process remains after release.

Current verification: the focused tests pass and the Darwin/arm64 test package compiles. The native macOS integration test is still pending, so this PR is opened as a draft.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI
- [x] No user-facing documentation currently describes daemon sleep behavior
- [x] This does not add a runtime, coding tool, or UI tab
- [x] This PR does not touch Chinese product copy
- [x] I have considered and documented the process-lifecycle and cleanup risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex / Multica Agent

**Prompt / approach:** Audited the daemon's existing `activeTasks` lifecycle, kept the change at that single ownership boundary, used one reference-counted macOS assertion for concurrent work, and added platform-specific lifecycle coverage without changing non-Darwin behavior.

## Screenshots (optional)

Not applicable; this change has no visual surface.
