### PR TITLE
MUL-6774: fix(selfhost): pass MULTICA_TELEGRAM_SECRET_KEY to the backend container

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -171,6 +171,12 @@ services:
       # in the database, so this single deployment-wide key is all the operator
       # needs to set here.
       MULTICA_SLACK_SECRET_KEY: ${MULTICA_SLACK_SECRET_KEY:-}
+      # Telegram bot integration. MULTICA_TELEGRAM_SECRET_KEY is the opt-in:
+      # unset = integration disabled. It encrypts each installation's BYO bot
+      # token at rest; inbound is one getUpdates long-polling loop per active
+      # installation, so no inbound webhook needs to be exposed. See
+      # docs/telegram-bot-integration.
+      MULTICA_TELEGRAM_SECRET_KEY: ${MULTICA_TELEGRAM_SECRET_KEY:-}
       # Self-hosted Git provider integration (Forgejo / Gitea / GitLab). This
       # is a self-host-only feature, so the compose file turns it on by default;
       # the managed cloud leaves it unset (off). It still needs a valid


### PR DESCRIPTION
## What does this PR do?

Adds the missing `MULTICA_TELEGRAM_SECRET_KEY` forward to the backend `environment` block of `docker-compose.selfhost.yml`.

The server gates the entire Telegram integration on `secretbox.LoadKey("MULTICA_TELEGRAM_SECRET_KEY")`, which reads the variable with `os.Getenv` (`server/cmd/server/router.go`, `server/internal/util/secretbox/secretbox.go`). The compose file forwards the Lark, Slack, VCS, and WeCom secretbox keys into the backend container but never this one, so on a Compose self-host the value set in `.env` never reaches the process: no channel factory is registered, the Telegram handlers return 503, and startup logs

```
telegram integration disabled (MULTICA_TELEGRAM_SECRET_KEY not set)
```

even though the operator set the key exactly as [docs/telegram-bot-integration](https://github.com/multica-ai/multica/blob/main/apps/docs/content/docs/telegram-bot-integration.mdx) instructs. Nothing points at the compose file, so the misconfiguration reads as operator error — the same forgot-to-forward class as #7259 (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`).

The entry sits between the Slack and self-hosted VCS entries, with a comment in the neighboring entries' style. As established in #7259, `docker-compose.selfhost.build.yml` overrides only `image`/`build` and inherits this environment block, so it needs no matching change; `docker-compose.yml` has no backend service to configure.

## Related Issue

No open issue for this; the full report is above.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `docker-compose.selfhost.yml`: add `MULTICA_TELEGRAM_SECRET_KEY: ${MULTICA_TELEGRAM_SECRET_KEY:-}` (plus a comment matching the neighboring integrations) to the backend `environment` block. Additive and default-empty: deployments that don't set the key are unchanged, and unset remains the integration's off switch.

## How to Test

1. On a Compose self-host, set `MULTICA_TELEGRAM_SECRET_KEY` in `.env` per the docs (`openssl rand -base64 32`) and start the stack with `docker compose -f docker-compose.selfhost.yml up -d`.
2. Without this change the backend logs `telegram integration disabled (MULTICA_TELEGRAM_SECRET_KEY not set)` and the Telegram settings tab gets 503s; with it, the backend logs `telegram integration enabled (per-installation long polling)` and a bot token can be connected.
3. `docker compose -f docker-compose.selfhost.yml config --no-interpolate` still parses.
4. Our own self-hosted deployment (pinned v0.4.33) has been running this exact line as a local patch; with it the integration connects and runs end to end.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass (compose-only change; no code paths touched)
- [ ] I have added or updated tests where applicable (none apply)
- [ ] If this change affects the UI, I have included before/after screenshots (no UI change)
- [ ] I have updated relevant documentation to reflect my changes (docs already document the variable; only the compose file lagged)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** We hit the bug on our own Compose self-host (key set in `.env`, integration still reporting "not set"). Claude Code traced the gate to `secretbox.LoadKey` in `router.go`, confirmed the compose file forwards every other integration's secretbox key except Telegram's, and prepared this patch and PR; human-reviewed before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
