### PR TITLE
fix(scheduler): serialize scheduled autopilot dispatch

### DIFF
--- a/server/internal/scheduler/jobs_autopilot.go
+++ b/server/internal/scheduler/jobs_autopilot.go
@@ -224,6 +224,13 @@ func autopilotScopes(
 // missed slot; the lateness guard prevents a paused / newly eligible
 // trigger from firing hours after its configured time.
 //
+// A trigger is also single-flight: while its latest execution lease is
+// RUNNING, no newer occurrence is planned. This matters for run_only
+// autopilots whose work can outlive a short cron cadence; without the guard,
+// every tick creates another downstream task even though the prior task is
+// still active. The stale-lease sweep in manager.runJob runs before this hook,
+// so an abandoned lease is converted to FAILED and remains retry-eligible.
+//
 // Retry-eligible state is handled specially: when the most recent
 // stored plan_time is a FAILED row with attempts remaining and
 // next_retry_at <= now, the hook returns THAT plan_time unchanged so
@@ -254,8 +261,24 @@ func autopilotPlansForScope(cache *autopilotScheduleCache) func(
 		// MUST surface it here — moving forward to a newer occurrence
 		// would strand the FAILED row at attempt < max_attempts
 		// forever and leak the missed dispatch.
-		if latest.RetryEligible(now) {
-			return []time.Time{latest.PlanTime}, nil
+		if latest.Found {
+			switch latest.Status {
+			case "RUNNING":
+				// The prior task is still live and must not be
+				// overlapped by a newer cron occurrence.
+				return nil, nil
+			case "FAILED":
+				// Keep a failed occurrence serial while it still owns
+				// retry budget. Before backoff expires, suppress newer
+				// cron occurrences; once due, return the original
+				// plan_time so tryClaim can take its retry path.
+				if latest.Attempt < latest.MaxAttempts {
+					if latest.RetryEligible(now) {
+						return []time.Time{latest.PlanTime}, nil
+					}
+					return nil, nil
+				}
+			}
 		}
 
 		// Anchor selection — three cases, in order:

--- a/server/internal/scheduler/jobs_autopilot_test.go
+++ b/server/internal/scheduler/jobs_autopilot_test.go
@@ -1,9 +1,80 @@
 package scheduler
 
 import (
+	"context"
 	"testing"
 	"time"
 )
+
+func TestAutopilotScheduleSingleFlightWhileRunning(t *testing.T) {
+	cache := newAutopilotScheduleCache()
+	created := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	scope := Scope{Kind: ScopeKindAutopilotTrigger, ID: "trigger-single-flight"}
+	cache.replace(map[string]autopilotTriggerConfig{
+		scope.ID: {
+			TriggerID:      scope.ID,
+			CronExpression: "*/5 * * * *",
+			Timezone:       "UTC",
+			CreatedAt:      created,
+		},
+	})
+	plans := autopilotPlansForScope(cache)
+	now := created.Add(16 * time.Minute)
+
+	got, err := plans(context.Background(), scope, now, LatestPlanInfo{
+		Found:    true,
+		PlanTime: created.Add(15 * time.Minute),
+		Status:   "RUNNING",
+	})
+	if err != nil {
+		t.Fatalf("plan while running: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a running trigger must not overlap a newer cron occurrence, got %v", got)
+	}
+
+	// A failed occurrence with retry budget is serial too. Before its
+	// backoff expires, the scheduler must not skip ahead to a newer
+	// occurrence and strand the retry.
+	failed := LatestPlanInfo{
+		Found:       true,
+		PlanTime:    created.Add(10 * time.Minute),
+		Status:      "FAILED",
+		Attempt:     1,
+		MaxAttempts: 3,
+		NextRetryAt: now.Add(time.Minute),
+	}
+	got, err = plans(context.Background(), scope, now, failed)
+	if err != nil {
+		t.Fatalf("plan during retry backoff: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a failed trigger with retry budget must wait for backoff, got %v", got)
+	}
+
+	failed.NextRetryAt = now.Add(-time.Second)
+	got, err = plans(context.Background(), scope, now, failed)
+	if err != nil {
+		t.Fatalf("plan when retry is due: %v", err)
+	}
+	if len(got) != 1 || !got[0].Equal(failed.PlanTime) {
+		t.Fatalf("retry must reuse the failed plan_time %s, got %v", failed.PlanTime, got)
+	}
+
+	// Terminal rows release the single-flight gate. The next occurrence
+	// remains due and is returned normally.
+	got, err = plans(context.Background(), scope, now, LatestPlanInfo{
+		Found:    true,
+		PlanTime: created.Add(10 * time.Minute),
+		Status:   "SUCCESS",
+	})
+	if err != nil {
+		t.Fatalf("plan after terminal run: %v", err)
+	}
+	if len(got) != 1 || !got[0].Equal(created.Add(15*time.Minute)) {
+		t.Fatalf("terminal trigger should return the next occurrence, got %v", got)
+	}
+}
 
 // TestAdvancedNextRunStrictlyAfterPlanTime is the regression guard for
 // MUL-3749's boundary case: the post-dispatch next_run_at write-back must


### PR DESCRIPTION
## Summary

Scheduled autopilot triggers now enforce single-flight planning. A live RUNNING execution suppresses newer cron occurrences, and a FAILED execution with retry budget remains serialized until its backoff is due. Once retry is due, the original plan time is returned so the existing retry path can reclaim it.

This prevents short-cadence `run_only` autopilots from creating overlapping downstream tasks while preserving stale-lease recovery and terminal-run progression.

## Validation

- `go test ./internal/scheduler`
- `go test ./internal/scheduler ./internal/service`

Both pass from `server/`.

## Regression coverage

`TestAutopilotScheduleSingleFlightWhileRunning` covers RUNNING suppression, FAILED backoff suppression, retry plan-time reuse, and release after SUCCESS.
