### PR TITLE
MUL-6753: fix(views): defer hidden runtime version check

### DIFF
--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -126,6 +126,16 @@ const mockSquadsData = vi.hoisted(
   () => ({ list: [] as Array<{ id: string; name: string; leader_id: string; archived_at: string | null }> }),
 );
 
+// Plain members cannot list another member's private runtime, even when they
+// may invoke the public agent bound to it. Keep the runtime list overridable so
+// the Quick Create gate covers that visibility boundary (GH #7633).
+const mockRuntimesData = vi.hoisted(() => ({
+  list: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }] as Array<{
+    id: string;
+    metadata: Record<string, unknown>;
+  }>,
+}));
+
 // The real handle mints an id when it inserts the placeholder and hands it to
 // the uploader, which adopts it as the draft `clientUploadId`. Mocks must do
 // the same or the two records drift apart only in tests.
@@ -146,7 +156,7 @@ vi.mock("@tanstack/react-query", () => ({
           data: [{ id: "agent-1", name: "Bohan", archived_at: null, runtime_id: "runtime-1" }],
         };
       case "runtimes":
-        return { data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }] };
+        return { data: mockRuntimesData.list };
       case "projects":
         return mockProjectsQuery;
       default:
@@ -242,14 +252,15 @@ vi.mock("@multica/core/auth", () => ({
     (selector ? selector({ user: { id: "user-1" } }) : { user: { id: "user-1" } }),
 }));
 
-vi.mock("@multica/core/runtimes", () => ({
-  runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
-  checkQuickCreateCliVersion: () => ({ state: "ok", min: "1.0.0" }),
-  checkQuickCreateFieldsCliVersion: () => ({ state: "ok", min: "1.0.0" }),
-  readRuntimeCliVersion: () => "1.2.3",
-  MIN_QUICK_CREATE_CLI_VERSION: "1.0.0",
-}));
-
+vi.mock("@multica/core/runtimes", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/runtimes")>(
+    "@multica/core/runtimes",
+  );
+  return {
+    ...actual,
+    runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
+  };
+});
 
 vi.mock("../issues/components/pickers/assignee-picker", () => ({
   canAssignAgent: () => true,
@@ -522,6 +533,9 @@ describe("AgentCreatePanel", () => {
     mockProjectsQuery.data = [];
     mockProjectsQuery.isSuccess = true;
     mockSquadsData.list = [];
+    mockRuntimesData.list = [
+      { id: "runtime-1", metadata: { cli_version: "1.2.3" } },
+    ];
     mockQuickCreateIssue.mockResolvedValue(undefined);
     mockCreateCommentSubIssue.mockResolvedValue({ task_id: "task-source-child" });
     mockApiUploadFile.mockResolvedValue({
@@ -554,6 +568,30 @@ describe("AgentCreatePanel", () => {
         'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
       ),
     ).toHaveValue("Persisted draft prompt");
+  });
+
+  it("defers version validation when an invokable agent's private runtime is hidden", async () => {
+    mockRuntimesData.list = [];
+    const user = userEvent.setup();
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.queryByText(/doesn't report a CLI version/i)).not.toBeInTheDocument();
+    const create = screen.getByRole("button", { name: /^Create$/i });
+    expect(create).toBeEnabled();
+
+    await user.click(create);
+
+    await waitFor(() => expect(mockQuickCreateIssue).toHaveBeenCalledTimes(1));
+  });
+
+  it("still blocks a visible runtime that does not report a CLI version", () => {
+    mockRuntimesData.list = [{ id: "runtime-1", metadata: {} }];
+
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.getByText(/doesn't report a CLI version/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeDisabled();
   });
 
   it("restores unfinished actor, project, priority, and due-date selections after remount", async () => {

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -349,9 +349,14 @@ export function AgentCreatePanel({
   );
   const usesExplicitFields = priority !== "none" || dueDate !== null;
   const versionCheck = usesExplicitFields ? fieldVersionCheck : baseVersionCheck;
+  // A member may invoke a shared agent without being allowed to list the
+  // owner's private runtime. Absence from this privacy-filtered list is
+  // therefore unknown, not "version missing"; defer that case to the
+  // authoritative server gate, which can read the target runtime directly.
   const versionBlocked =
-    baseVersionCheck.state !== "ok" ||
-    (usesExplicitFields && fieldVersionCheck.state !== "ok");
+    selectedRuntime !== undefined &&
+    (baseVersionCheck.state !== "ok" ||
+      (usesExplicitFields && fieldVersionCheck.state !== "ok"));
 
   const initialPrompt = draft.agent.prompt || (data?.prompt as string) || "";
   // The editor is uncontrolled — we read the latest markdown via the ref at


### PR DESCRIPTION
## What does this PR do?

Fix Quick Create for workspace members invoking a shared agent that is bound to another member's private runtime.

Runtime list queries are privacy-filtered. A regular member may be allowed to invoke a shared agent while being unable to list its owner's private runtime. Quick Create previously treated the absent runtime as if it reported no CLI version, disabled the Create button, and displayed a misleading upgrade message.

This change treats an absent runtime as an unknown client-side state and defers validation to the authoritative server preflight, which can resolve the target runtime directly. Visible runtimes that genuinely omit or report an unsupported CLI version remain blocked.

No runtime visibility or invocation permissions are changed.

## Related Issue

Closes #7633

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/modals/quick-create-issue.tsx` to avoid treating a runtime hidden by list permissions as a missing-version runtime.
- Added regression coverage in `packages/views/modals/quick-create-issue.test.tsx` for:
  - a shared agent whose private runtime is hidden from the current member;
  - a visible runtime that genuinely does not report a CLI version.

## How to Test

1. Run the focused test suite:

   ```bash
   pnpm --filter @multica/views test -- modals/quick-create-issue.test.tsx
   ```

2. As a regular workspace member, select a shared agent bound to another member's private runtime and verify that Quick Create remains enabled.
3. Verify that a visible runtime without CLI version metadata still shows the upgrade warning and disables Quick Create.

Local verification:

- Focused tests: 31 passed
- `@multica/views` TypeScript check: passed
- Changed-file ESLint: passed
- Full `@multica/views` ESLint: 0 errors

## Risks

The client no longer blocks creation when the selected runtime is absent from its privacy-filtered list. Validation is still enforced by the existing server-side preflight, so unsupported, unavailable, or otherwise invalid runtimes continue to be rejected authoritatively.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The unchecked documentation, landing-copy, and terminology items are not applicable. There is no visual layout or copy change, so screenshots are not included.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Used Codex to investigate issue #7633, trace runtime visibility from the privacy-filtered list query through the Quick Create client-side version gate and server-side preflight, implement the minimal guard, and add regression tests for both hidden and genuinely version-missing runtimes.

## Screenshots (optional)

Not applicable. This changes validation behavior without changing the visual layout or product copy.
