### PR TITLE
MUL-6781: perf(server): enable gzip compression for JSON responses

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1230,6 +1230,9 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		r.Use(opts.HTTPMetrics.Middleware)
 	}
 	r.Use(chimw.Recoverer)
+	// Negotiate gzip for JSON responses while leaving WebSocket upgrades on the
+	// underlying connection.
+	r.Use(chimw.Compress(5, "application/json"))
 	r.Use(h.PluginSurfaceHostBoundary)
 	r.Use(middleware.ContentSecurityPolicy)
 

--- a/server/cmd/server/router_compression_test.go
+++ b/server/cmd/server/router_compression_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+)
+
+func TestMainRouterCompressesJSONWhenRequested(t *testing.T) {
+	router := NewRouter(nil, realtime.NewHub(), events.New(), analytics.NoopClient{}, nil)
+
+	t.Run("gzip accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("Content-Encoding = %q, want gzip", got)
+		}
+		if got := strings.Join(rec.Header().Values("Vary"), ","); !strings.Contains(got, "Accept-Encoding") {
+			t.Fatalf("Vary = %q, want it to include Accept-Encoding", got)
+		}
+		if got := rec.Header().Get("Content-Length"); got != "" {
+			t.Fatalf("Content-Length = %q, want empty for compressed response", got)
+		}
+
+		reader, err := gzip.NewReader(rec.Body)
+		if err != nil {
+			t.Fatalf("open gzip response: %v", err)
+		}
+		defer reader.Close()
+
+		var body liveResponse
+		if err := json.NewDecoder(reader).Decode(&body); err != nil {
+			t.Fatalf("decode gzip response: %v", err)
+		}
+		if body.Status != "ok" {
+			t.Fatalf("status = %q, want ok", body.Status)
+		}
+	})
+
+	t.Run("gzip not accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("Content-Encoding = %q, want empty", got)
+		}
+		if got := rec.Header().Get("Content-Length"); got == "" {
+			t.Fatal("Content-Length is empty for uncompressed response")
+		}
+
+		var body liveResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if body.Status != "ok" {
+			t.Fatalf("status = %q, want ok", body.Status)
+		}
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Enables negotiated gzip compression for JSON API responses from the main server router. Large list responses currently travel uncompressed, increasing bandwidth use and latency for remote clients.

The middleware is placed after panic recovery and restricted to `application/json`. Chi selects gzip only when the request's `Accept-Encoding` allows it, removes the stale uncompressed `Content-Length`, and keeps WebSocket upgrades on the underlying hijacked connection.

## Related Issue

Closes #7677

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/server/router.go`: add `chimw.Compress(5, "application/json")` to the global middleware chain.
- `server/cmd/server/router_compression_test.go`: verify negotiated gzip headers and payload decoding, plus the uncompressed fallback when gzip is not requested.

## How to Test

1. Run `make test` and confirm the full Go suite passes with the race detector. The existing WebSocket integration test also exercises upgrades through the updated router.
2. Run `go vet ./cmd/server` and `go build ./cmd/server` from `server/`.
3. Send `GET /health` with `Accept-Encoding: gzip`; verify `Content-Encoding: gzip`, `Vary` includes `Accept-Encoding`, and the decoded JSON reports `status: ok`.
4. Send the same request without `Accept-Encoding`; verify the response remains uncompressed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code and OpenAI Codex

**Prompt / approach:** Traced the global middleware chain, checked chi v5.3.0 compression and `http.Hijacker` behavior, isolated the change on a fresh branch from `upstream/main`, and added router-level regression coverage for negotiated and uncompressed JSON responses. Ran the full Go race suite, vet, and build before opening the PR.

## Screenshots (optional)

Not applicable; this change has no UI surface.
