### PR TITLE
MUL-6782: MUL-6772: fix(repocache): give Git commands a stable cwd

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -70,6 +70,9 @@ const repoCacheGitTimeout = 10 * time.Minute
 
 func newGitCommand(args ...string) *exec.Cmd {
 	cmd := exec.Command("git", args...)
+	// A daemon can outlive the checkout it was launched from. Run Git from the
+	// filesystem root instead of inheriting a cwd that may have been deleted.
+	cmd.Dir = filepath.VolumeName(os.TempDir()) + string(os.PathSeparator)
 	cmd.Env = gitEnv()
 	return cmd
 }

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -120,6 +120,54 @@ func TestRunGitOutputTimesOut(t *testing.T) {
 	}
 }
 
+func TestNewGitCommandUsesStableWorkingDirectory(t *testing.T) {
+	cmd := newGitCommand("--version")
+	if cmd.Dir == "" {
+		t.Fatal("newGitCommand Dir is empty; Git would inherit the daemon working directory")
+	}
+	if !filepath.IsAbs(cmd.Dir) {
+		t.Fatalf("newGitCommand Dir = %q, want an absolute path", cmd.Dir)
+	}
+	if info, err := os.Stat(cmd.Dir); err != nil {
+		t.Fatalf("newGitCommand Dir = %q is unavailable: %v", cmd.Dir, err)
+	} else if !info.IsDir() {
+		t.Fatalf("newGitCommand Dir = %q is not a directory", cmd.Dir)
+	}
+}
+
+func TestSyncSurvivesDeletedProcessWorkingDirectory(t *testing.T) {
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get original working directory: %v", err)
+	}
+	deletedRoot := t.TempDir()
+	deletedCWD := filepath.Join(deletedRoot, "worktree")
+	if err := os.Mkdir(deletedCWD, 0o755); err != nil {
+		t.Fatalf("create disposable working directory: %v", err)
+	}
+	if err := os.Chdir(deletedCWD); err != nil {
+		t.Fatalf("chdir to disposable working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalCWD); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	}()
+	if err := os.RemoveAll(deletedRoot); err != nil {
+		t.Skipf("platform does not allow removing the process working directory: %v", err)
+	}
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-deleted-cwd", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("Sync with deleted process working directory failed: %v", err)
+	}
+	if cachedPath := cache.Lookup("ws-deleted-cwd", sourceRepo); !isBareRepo(cachedPath) {
+		t.Fatalf("expected synced bare repo, got %q", cachedPath)
+	}
+}
+
 func TestRepoMaintenanceYieldsToForeground(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Repocache Git commands now run from an explicit filesystem root instead of inheriting the daemon process cwd. This keeps clone, fetch, and worktree operations usable when a long-lived daemon outlives the checkout it was launched from.

Thinking path: issue #7665 showed that repository arguments and cache paths were valid, but every Git child inherited a deleted daemon cwd. All repocache Git execution converges on `newGitCommand`, so setting `cmd.Dir` there fixes the shared process boundary without changing daemon claiming, checkout readiness, or repository synchronization policy.

## Related Issue

Addresses #7665

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Set an absolute, existing filesystem-root `cmd.Dir` for every Git command created by `server/internal/daemon/repocache`.
- Add a cross-platform invariant test that rejects inherited cwd behavior.
- Add a real filesystem regression covering cache sync after the daemon cwd is removed; platforms that prohibit removing an active cwd skip that scenario.

## How to Test

1. `cd server && go test ./internal/daemon/repocache -run "^(TestNewGitCommandUsesStableWorkingDirectory|TestSyncSurvivesDeletedProcessWorkingDirectory)$" -count=1 -v`
2. `cd server && go test -race ./internal/daemon/repocache -count=1`
3. `cd server && go test ./internal/daemon -count=1`
4. `cd server && go vet ./internal/daemon/repocache`
5. `cd server && GOOS=windows GOARCH=amd64 go test -c -o /tmp/repocache.test.exe ./internal/daemon/repocache`

Negative control: temporarily removing the `cmd.Dir` assignment makes `TestNewGitCommandUsesStableWorkingDirectory` fail with `newGitCommand Dir is empty`, at the intended old-behavior assertion.

## Risks

- Relative path arguments would resolve from the filesystem root rather than the daemon launch directory. Production repocache cache/worktree paths are absolute and configured repositories are remote URLs or absolute local paths, so they do not rely on the launch cwd.
- The single-daemon guard, daemon doctor signal, and broader readiness-policy changes proposed in #7665 are intentionally outside this low-risk root-cause fix. The issue should remain open for those durable follow-ups.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented contract changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Asked Codex to claim issue #7665, implement the smallest easily reviewable root-cause fix, open a draft PR, and run a maintainer-grade review. Codex traced all repocache Git execution through `newGitCommand`, added a discriminating invariant before the implementation, exercised the deleted-cwd filesystem scenario, reviewed the current merge result, and ran focused, race, package, cross-platform build, and repository CI checks.

## Screenshots (optional)

Not applicable; daemon-only change.