### PR TITLE
fix(daemon): keep task-scoped MULTICA_TOKEN after secrets wrappers

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -7458,6 +7458,20 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		profileFixedArgs, hermesOverlayCustomArgs = agent.StripHermesProfileSelectors(
 			profileFixedArgs, rawCustomArgs, d.logger)
 	}
+	// Secrets wrappers (`doppler run -- …`) overlay the grandchild env after
+	// the daemon injects the task-scoped token, so a stored mul_ MULTICA_TOKEN
+	// would otherwise win. Re-assert identity after `--` when the prefix has
+	// that wrapper shape (GH #7666). Built-in launches have no `--` and are
+	// unchanged.
+	if pinPath, err := writeTaskIdentityPin(taskTempDir, agentEnv); err != nil {
+		taskLog.Warn("could not write task-identity pin for secrets wrappers", "error", err)
+	} else if pinPath != "" {
+		pinned := insertTaskIdentityPinAfterWrapper(profileFixedArgs, pinPath)
+		if len(pinned) != len(profileFixedArgs) {
+			profileFixedArgs = pinned
+			taskLog.Info("re-asserting task identity env after secrets wrapper")
+		}
+	}
 	// Resolve the backend through the unified runtime resolver: built-in
 	// runtime identities (e.g. "omp") dispatch through NewRuntime, protocol
 	// families go through New. This is the single production boundary — the

--- a/server/internal/daemon/task_env_pin.go
+++ b/server/internal/daemon/task_env_pin.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"sort"
+	"strings"
+)
+
+const taskIdentityPinName = "reassert-task-env"
+
+// taskIdentityEnv copies MULTICA_* keys from the assembled child environment.
+// These are task identity, not user secrets-tool overlay, and must still be
+// present on the process that actually runs the agent after a wrapper such as
+// `doppler run --` rebuilds the grandchild env.
+func taskIdentityEnv(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for k, v := range env {
+		if strings.HasPrefix(strings.ToUpper(k), "MULTICA_") {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func sortedEnvKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// insertTaskIdentityPinAfterWrapper splices pinPath immediately after the
+// first `--` in a custom-runtime launch prefix (`doppler run -- opencode`).
+// Secrets wrappers treat everything after `--` as the command they exec, so
+// the pin runs in that grandchild and re-exports task identity last.
+// Prefixes without `--` are returned unchanged (built-in runtimes).
+func insertTaskIdentityPinAfterWrapper(prefix []string, pinPath string) []string {
+	if pinPath == "" {
+		return prefix
+	}
+	for i, arg := range prefix {
+		if arg != "--" {
+			continue
+		}
+		out := make([]string, 0, len(prefix)+1)
+		out = append(out, prefix[:i+1]...)
+		out = append(out, pinPath)
+		out = append(out, prefix[i+1:]...)
+		return out
+	}
+	return prefix
+}
+
+func writeTaskIdentityPin(dir string, env map[string]string) (string, error) {
+	vars := taskIdentityEnv(env)
+	if dir == "" || len(vars) == 0 {
+		return "", nil
+	}
+	return writeTaskIdentityPinScript(dir, vars)
+}
+
+func isSafeEnvKey(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i, c := range k {
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c == '_':
+			continue
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/daemon/task_env_pin_test.go
+++ b/server/internal/daemon/task_env_pin_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestTaskIdentityEnvKeepsMulticaKeysOnly(t *testing.T) {
+	t.Parallel()
+
+	got := taskIdentityEnv(map[string]string{
+		"MULTICA_TOKEN":   "mat_task",
+		"MULTICA_TASK_ID": "task-1",
+		"PATH":            "/bin",
+		"TMPDIR":          "/tmp",
+	})
+	want := map[string]string{
+		"MULTICA_TOKEN":   "mat_task",
+		"MULTICA_TASK_ID": "task-1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("taskIdentityEnv() = %#v, want %#v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("taskIdentityEnv()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestInsertTaskIdentityPinAfterWrapper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prefix []string
+		pin    string
+		want   []string
+	}{
+		{
+			name:   "doppler run dashdash opencode",
+			prefix: []string{"run", "--", "opencode"},
+			pin:    "/tmp/reassert-task-env",
+			want:   []string{"run", "--", "/tmp/reassert-task-env", "opencode"},
+		},
+		{
+			name:   "no wrapper separator",
+			prefix: []string{"--dangerously-skip-permissions"},
+			pin:    "/tmp/reassert-task-env",
+			want:   []string{"--dangerously-skip-permissions"},
+		},
+		{
+			name:   "empty pin",
+			prefix: []string{"run", "--", "opencode"},
+			pin:    "",
+			want:   []string{"run", "--", "opencode"},
+		},
+		{
+			name:   "wrapper with no command after dashdash",
+			prefix: []string{"run", "--"},
+			pin:    "/tmp/reassert-task-env",
+			want:   []string{"run", "--", "/tmp/reassert-task-env"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := insertTaskIdentityPinAfterWrapper(tt.prefix, tt.pin)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("insertTaskIdentityPinAfterWrapper() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteTaskIdentityPinSkipsWhenNothingToPin(t *testing.T) {
+	t.Parallel()
+
+	path, err := writeTaskIdentityPin(t.TempDir(), map[string]string{"PATH": "/bin"})
+	if err != nil {
+		t.Fatalf("writeTaskIdentityPin() error = %v", err)
+	}
+	if path != "" {
+		t.Fatalf("writeTaskIdentityPin() = %q, want empty", path)
+	}
+}
+
+func TestWriteTaskIdentityPinCreatesScript(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path, err := writeTaskIdentityPin(dir, map[string]string{
+		"MULTICA_TOKEN":   "mat_task",
+		"MULTICA_TASK_ID": "task-1",
+		"PATH":            "/bin",
+	})
+	if err != nil {
+		t.Fatalf("writeTaskIdentityPin() error = %v", err)
+	}
+	if path == "" {
+		t.Fatal("writeTaskIdentityPin() returned empty path")
+	}
+	if filepath.Dir(path) != dir {
+		t.Fatalf("pin path %q not under %q", path, dir)
+	}
+}

--- a/server/internal/daemon/task_env_pin_unix.go
+++ b/server/internal/daemon/task_env_pin_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeTaskIdentityPinScript(dir string, vars map[string]string) (string, error) {
+	path := filepath.Join(dir, taskIdentityPinName)
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	for _, k := range sortedEnvKeys(vars) {
+		if !isSafeEnvKey(k) {
+			continue
+		}
+		fmt.Fprintf(&b, "export %s=%s\n", k, posixShellQuote(vars[k]))
+	}
+	b.WriteString("exec \"$@\"\n")
+	if err := os.WriteFile(path, []byte(b.String()), 0o700); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func posixShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/server/internal/daemon/task_env_pin_unix_test.go
+++ b/server/internal/daemon/task_env_pin_unix_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTaskIdentityPinSurvivesSecretsWrapperOverlay(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wrapper := filepath.Join(dir, "doppler")
+	agent := filepath.Join(dir, "agent")
+	if err := os.WriteFile(wrapper, []byte("#!/bin/sh\nwhile [ $# -gt 0 ]; do\n  arg=$1\n  shift\n  if [ \"$arg\" = \"--\" ]; then\n    break\n  fi\ndone\nexport MULTICA_TOKEN=mul_from_doppler\nexec \"$@\"\n"), 0o700); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	if err := os.WriteFile(agent, []byte("#!/bin/sh\nprintf '%s\\n' \"$MULTICA_TOKEN\"\n"), 0o700); err != nil {
+		t.Fatalf("write agent: %v", err)
+	}
+
+	pin, err := writeTaskIdentityPin(dir, map[string]string{"MULTICA_TOKEN": "mat_task"})
+	if err != nil {
+		t.Fatalf("writeTaskIdentityPin: %v", err)
+	}
+
+	withoutPin := exec.Command(wrapper, "run", "--", agent)
+	withoutPin.Env = []string{"MULTICA_TOKEN=mat_task", "PATH=/usr/bin:/bin"}
+	out, err := withoutPin.Output()
+	if err != nil {
+		t.Fatalf("wrapper without pin: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "mul_from_doppler" {
+		t.Fatalf("without pin token = %q, want mul_from_doppler (precondition)", got)
+	}
+
+	prefix := insertTaskIdentityPinAfterWrapper([]string{"run", "--", agent}, pin)
+	args := append([]string{}, prefix...)
+	withPin := exec.Command(wrapper, args...)
+	withPin.Env = []string{"MULTICA_TOKEN=mat_task", "PATH=/usr/bin:/bin"}
+	out, err = withPin.Output()
+	if err != nil {
+		t.Fatalf("wrapper with pin: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "mat_task" {
+		t.Fatalf("with pin token = %q, want mat_task", got)
+	}
+}

--- a/server/internal/daemon/task_env_pin_windows.go
+++ b/server/internal/daemon/task_env_pin_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeTaskIdentityPinScript(dir string, vars map[string]string) (string, error) {
+	path := filepath.Join(dir, taskIdentityPinName+".cmd")
+	var b strings.Builder
+	b.WriteString("@echo off\r\nsetlocal\r\n")
+	for _, k := range sortedEnvKeys(vars) {
+		if !isSafeEnvKey(k) {
+			continue
+		}
+		fmt.Fprintf(&b, "set \"%s=%s\"\r\n", k, windowsEnvValue(vars[k]))
+	}
+	b.WriteString("%*\r\n")
+	if err := os.WriteFile(path, []byte(b.String()), 0o700); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func windowsEnvValue(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
+}


### PR DESCRIPTION
## What does this PR do?

If a runtime command is something like `doppler run -- opencode`, Doppler rebuilds the grandchild environment from its secret store *after* the daemon has already injected the task-scoped `mat_` token. A leftover `MULTICA_TOKEN=mul_…` in that Doppler config then wins, and every `multica` CLI call inside the task fails closed.

For prefixes that contain `--`, the daemon now writes a small pin script into the task temp dir and splices it in right after `--`. The wrapper still runs first; the pin then re-exports `MULTICA_*` and execs the real agent. Built-in launches (no `--`) are unchanged.

Fixes #7666

## Related Issue

Closes #7666

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/task_env_pin.go` (+ unix/windows): pin script and `--` splice
- `server/internal/daemon/daemon.go`: write the pin and splice it into `profileFixedArgs` before ResolveBackend
- tests: unit cases for the splice, plus a fake `doppler run --` overlay that a stored `mul_` token no longer survives

## How to Test

1. `go test ./internal/daemon -count=1 -run 'TaskIdentity|InsertTaskIdentity|WriteTaskIdentity'`
2. Runtime profile `command_name=doppler` / `fixed_args=run -- opencode` with a Doppler `MULTICA_TOKEN=mul_…` secret: task process should still see the injected `mat_` token

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes, or not applicable
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Built-in runtimes without a `--` in fixed_args never take this path. The pin only re-exports `MULTICA_*`; it does not block Doppler from injecting other secrets.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Looked at the process tree in #7666 (`doppler run` still has `mat_`, the agent grandchild has `mul_`) and spliced a pin script after `--` so task identity is applied last.