### PR TITLE
MUL-6783: perf(server): set read-header and idle timeouts on main HTTP server

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -566,8 +566,14 @@ func main() {
 	})
 
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: r,
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		// Bound header reads to stop Slowloris; IdleTimeout is looser than the
+		// metrics/profiling servers' 30s for keep-alive-heavy CLI and daemon
+		// clients. ReadTimeout and WriteTimeout are unset so WebSocket upgrades
+		// (/ws, /api/daemon/ws) on this listener aren't killed mid-connection.
 	}
 	profilingServer := profiling.NewServer()
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -269,6 +269,23 @@ func jwtSecretBootError(jwtSecret, appEnv string) error {
 	return auth.ValidateJWTSecret(jwtSecret)
 }
 
+// newMainHTTPServer builds the public HTTP server with the production timeout
+// defaults. These values are load-bearing safety settings, not cosmetic tuning,
+// so they live in one helper that main() and the config regression test share.
+//
+// Bound header reads to stop Slowloris; IdleTimeout is looser than the
+// metrics/profiling servers' 30s for keep-alive-heavy CLI and daemon clients.
+// ReadTimeout and WriteTimeout are deliberately left zero so WebSocket upgrades
+// (/ws, /api/daemon/ws) on this listener aren't killed mid-connection.
+func newMainHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+}
+
 func main() {
 	logger.Init()
 	// Warn about missing configuration
@@ -565,16 +582,7 @@ func main() {
 		LLMMaxRetries:       llmMaxRetries,
 	})
 
-	srv := &http.Server{
-		Addr:              ":" + port,
-		Handler:           r,
-		ReadHeaderTimeout: 5 * time.Second,
-		IdleTimeout:       120 * time.Second,
-		// Bound header reads to stop Slowloris; IdleTimeout is looser than the
-		// metrics/profiling servers' 30s for keep-alive-heavy CLI and daemon
-		// clients. ReadTimeout and WriteTimeout are unset so WebSocket upgrades
-		// (/ws, /api/daemon/ws) on this listener aren't killed mid-connection.
-	}
+	srv := newMainHTTPServer(":"+port, r)
 	profilingServer := profiling.NewServer()
 
 	// Start background workers.

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -513,3 +513,28 @@ func TestJWTSecretBootError(t *testing.T) {
 		})
 	}
 }
+
+// TestNewMainHTTPServerTimeouts pins the production timeout defaults on the
+// public HTTP server. These are safety settings, not tuning: removing them,
+// resetting them to zero, or making ReadTimeout/WriteTimeout non-zero would
+// silently reintroduce the Slowloris exposure or start killing uploads and
+// long-lived WebSocket connections mid-stream — none of which the rest of the
+// suite would catch.
+func TestNewMainHTTPServerTimeouts(t *testing.T) {
+	srv := newMainHTTPServer(":8080", nil)
+
+	if got, want := srv.ReadHeaderTimeout, 5*time.Second; got != want {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", got, want)
+	}
+	if got, want := srv.IdleTimeout, 120*time.Second; got != want {
+		t.Errorf("IdleTimeout = %v, want %v", got, want)
+	}
+	// Zero is intentional: WebSocket upgrades and large uploads share this
+	// listener and must not be bounded by a whole-request deadline.
+	if got := srv.ReadTimeout; got != 0 {
+		t.Errorf("ReadTimeout = %v, want 0", got)
+	}
+	if got := srv.WriteTimeout; got != 0 {
+		t.Errorf("WriteTimeout = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

The main HTTP server (`server/cmd/server/main.go`) was constructed with only `Addr` and `Handler`, so every timeout defaulted to zero — i.e. **never time out**. Two consequences:

- **Slowloris exposure.** With no `ReadHeaderTimeout`, a slow or half-open client that dribbles request headers one byte at a time pins a goroutine and its read buffer indefinitely. A few thousand such connections can exhaust goroutines/connections at near-zero cost to the attacker. `net/http` gives no header-read deadline by default, and static scanners (gosec) flag exactly this.
- **No idle reclaim.** With no `IdleTimeout`, keep-alive connections are never reclaimed once idle.

The sibling **metrics** (`internal/metrics/server.go`) and **profiling** (`internal/profiling/server.go`) servers already set these timeouts, so the public server was the odd one out — this looks like an oversight rather than intent.

This sets:
- `ReadHeaderTimeout: 5s` — matches the metrics/profiling servers; bounds header reads and closes Slowloris.
- `IdleTimeout: 120s` — deliberately looser than their 30s, because this listener serves browsers, the CLI, and high-frequency daemon polling that heavily reuse keep-alive connections; too short a value would churn TCP/TLS handshakes.

`ReadTimeout` and `WriteTimeout` are **intentionally left unset**: WebSocket upgrades (`/ws`, `/api/daemon/ws`) live on this same listener, and a global read/write deadline would kill those long-lived connections mid-stream. This mirrors the profiling server, which omits the same two timeouts so long captures aren't truncated.

`MaxHeaderBytes` is left at Go's 1MB default (setting it explicitly would only be noise).

## Related Issue

Closes #7682

## Type of Change

- [ ] Refactor / code improvement (no behavior change)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

> This intentionally changes the default request-timeout behavior for **every deployment** (unbounded → bounded header reads + idle reclaim), so it is classified as a bug fix / security hardening rather than a no-behavior-change refactor.

## Changes Made

- `server/cmd/server/main.go`: extract the public HTTP server construction into `newMainHTTPServer`, which sets `ReadHeaderTimeout: 5s` and `IdleTimeout: 120s`, with a comment explaining why `ReadTimeout`/`WriteTimeout` are deliberately left zero (WebSocket upgrades on the same listener).
- `server/cmd/server/main_test.go`: add `TestNewMainHTTPServerTimeouts`, a structure-level regression test asserting `ReadHeaderTimeout == 5s`, `IdleTimeout == 120s`, and `ReadTimeout == WriteTimeout == 0`, so the safety defaults can't be silently removed, zeroed, or made non-zero without failing CI.

## How to Test

1. `cd server && go build ./cmd/server/ && go vet ./cmd/server/` → clean.
2. `cd server && go test ./cmd/server/ -run TestNewMainHTTPServerTimeouts` → passes; fails if any of the four timeout invariants is broken.
3. **WebSocket unaffected:** start the server, open a `/ws` (and daemon `/ws`) connection and keep it idle well past 120s → it stays connected (no global write/read deadline).
4. **Slowloris defense active:** open a raw TCP connection and send partial request headers slowly without completing them → the server closes it after ~5s (previously it would hang indefinitely). `slowhttptest -c 200 -H -u http://localhost:8080/` shows connections being dropped instead of held open.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against the conventions doc
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** As part of a broader server performance/hardening audit, identified that the main `http.Server` set no timeouts while the sibling metrics and profiling servers did. Verified the WebSocket constraint by tracing `/ws` and `/api/daemon/ws` on the same listener, and aligned the values with the existing servers (`ReadHeaderTimeout: 5s`) while keeping `IdleTimeout` looser (120s) for keep-alive-heavy CLI/daemon clients. After review, extracted the construction into a helper and added a structure-level regression test pinning all four timeout invariants. Confirmed with `go build`, `go vet`, and `go test`.
