### PR TITLE
MUL-6784: fix(desktop): share public web URLs

### DIFF
--- a/apps/desktop/src/renderer/src/platform/issue-window-navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/platform/issue-window-navigation.test.tsx
@@ -10,6 +10,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  currentPath,
+  useNavigation,
+  type NavigationAdapter,
+} from "@multica/views/navigation";
 
 const APP_URL = "https://app.example";
 
@@ -94,5 +99,55 @@ describe("IssueWindowNavigationProvider content links", () => {
     navigate("/acme/chat");
 
     expect(openExternal).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * MUL-6784 — an issue window is a MemoryRouter over the packaged file:// page,
+ * so `window.location` knows nothing about the route. A report or share link
+ * built from this adapter must still name the comment the user was reading.
+ */
+describe("IssueWindowNavigationProvider current location", () => {
+  function renderAdapter(entry: string): () => NavigationAdapter {
+    let adapter: NavigationAdapter | null = null;
+    function Probe() {
+      adapter = useNavigation();
+      return null;
+    }
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route
+            path=":workspaceSlug/issues/:id"
+            element={
+              <IssueWindowNavigationProvider>
+                <Probe />
+              </IssueWindowNavigationProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    return () => adapter!;
+  }
+
+  it("reports the route's fragment, which window.location cannot", () => {
+    expect(window.location.hash).toBe("");
+
+    expect(renderAdapter("/acme/issues/MUL-1#comment-c1")().hash).toBe(
+      "#comment-c1",
+    );
+  });
+
+  it('reports "" for a route without a fragment', () => {
+    expect(renderAdapter("/acme/issues/MUL-1")().hash).toBe("");
+  });
+
+  it("rebuilds the current page as a web URL that keeps the fragment", () => {
+    const adapter = renderAdapter("/acme/issues/MUL-1#comment-c1")();
+
+    expect(adapter.getShareableUrl(currentPath(adapter))).toBe(
+      `${APP_URL}/acme/issues/MUL-1#comment-c1`,
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/platform/issue-window-navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/issue-window-navigation.tsx
@@ -105,6 +105,7 @@ export function IssueWindowNavigationProvider({
       back: () => void navigate(-1),
       pathname: location.pathname,
       searchParams: new URLSearchParams(location.search),
+      hash: location.hash,
       openInNewTab: (path, title) => {
         void window.desktopAPI.openIssueWindow({
           path,
@@ -114,7 +115,13 @@ export function IssueWindowNavigationProvider({
       getShareableUrl: (path) =>
         runtimeConfig.ok ? `${runtimeConfig.config.appUrl}${path}` : path,
     };
-  }, [location.pathname, location.search, navigate, runtimeConfig]);
+  }, [
+    location.pathname,
+    location.search,
+    location.hash,
+    navigate,
+    runtimeConfig,
+  ]);
 
   return <NavigationProvider value={adapter}>{children}</NavigationProvider>;
 }

--- a/apps/desktop/src/renderer/src/platform/navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { useEffect } from "react";
 
 // MUL-4741: the adapter mutates tab sessions in the REAL store (no router,
@@ -28,7 +28,7 @@ vi.mock("@multica/core/auth", () => ({
 }));
 
 import { DesktopNavigationProvider, routeContentLinkPath } from "./navigation";
-import { useNavigation } from "@multica/views/navigation";
+import { currentPath, useNavigation } from "@multica/views/navigation";
 import { useTabStore, getActiveTab } from "@/stores/tab-store";
 
 beforeEach(() => {
@@ -254,6 +254,40 @@ describe("canGoBack", () => {
     getAdapter().openInNewTab!("/acme/agents", "Agents", { activate: true });
 
     expect(getAdapter().canGoBack!()).toBe(false);
+  });
+});
+
+// MUL-6784: the tab URL is the only place the fragment survives on desktop —
+// the renderer's own `window.location` is the packaged file:// page — so a
+// share or feedback link built from this adapter depends on `hash` being here.
+describe("current location", () => {
+  it("splits the active tab URL into pathname, search and fragment", () => {
+    const getAdapter = renderProvider();
+
+    act(() => getAdapter().push("/acme/issues/MUL-1?tab=activity#comment-c1"));
+
+    expect(getAdapter().pathname).toBe("/acme/issues/MUL-1");
+    expect(getAdapter().searchParams.get("tab")).toBe("activity");
+    expect(getAdapter().hash).toBe("#comment-c1");
+  });
+
+  it('reports "" for a tab URL that carries no fragment', () => {
+    const getAdapter = renderProvider();
+
+    act(() => getAdapter().push("/acme/issues/MUL-1?tab=activity"));
+
+    expect(getAdapter().hash).toBe("");
+  });
+
+  it("rebuilds the current page as a web URL that keeps the fragment", () => {
+    const getAdapter = renderProvider();
+
+    act(() => getAdapter().push("/acme/issues/MUL-1#comment-c1"));
+
+    const adapter = getAdapter();
+    expect(adapter.getShareableUrl(currentPath(adapter))).toBe(
+      "https://app.example/acme/issues/MUL-1#comment-c1",
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -180,7 +180,8 @@ export function DesktopNavigationProvider({
     const { pathname, suffix } = splitTabUrl(url);
     const hashIdx = suffix.indexOf("#");
     const search = hashIdx === -1 ? suffix : suffix.slice(0, hashIdx);
-    return { pathname, search };
+    const hash = hashIdx === -1 ? "" : suffix.slice(hashIdx);
+    return { pathname, search, hash };
   }, [activeUrl]);
 
   const adapter: NavigationAdapter = useMemo(
@@ -218,6 +219,9 @@ export function DesktopNavigationProvider({
       },
       pathname: location.pathname,
       searchParams: new URLSearchParams(location.search),
+      // The tab's URL is the only place the fragment survives on desktop: the
+      // renderer's own `window.location` is the packaged file:// page.
+      hash: location.hash,
       openInNewTab: (
         path: string,
         title?: string,

--- a/apps/web/platform/navigation.test.tsx
+++ b/apps/web/platform/navigation.test.tsx
@@ -7,7 +7,7 @@
  * answer it with a router push, or those links silently do nothing.
  */
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),
@@ -121,5 +121,39 @@ describe("WebNavigationProvider canGoBack", () => {
 
   it("reports false where the browser cannot answer, so callers use the fallback", () => {
     expect(renderAdapter()().canGoBack!()).toBe(false);
+  });
+});
+
+/**
+ * MUL-6784 — the fragment is the only part of the current location Next.js
+ * never hands to React: `usePathname()` drops it. Shared views rebuild share
+ * and feedback links from the adapter, so a missing `hash` silently turns a
+ * `#comment-…` deep link into a link to the whole page.
+ */
+describe("WebNavigationProvider hash", () => {
+  afterEach(() => {
+    window.location.hash = "";
+  });
+
+  it("reports the fragment of the page being rendered", () => {
+    window.location.hash = "#comment-c1";
+
+    expect(renderAdapter()().hash).toBe("#comment-c1");
+  });
+
+  it('reports "" when the location has no fragment', () => {
+    expect(renderAdapter()().hash).toBe("");
+  });
+
+  it("re-reads the fragment when it changes after mount", async () => {
+    const adapter = renderAdapter();
+
+    await act(async () => {
+      window.location.hash = "#comment-c2";
+      // jsdom dispatches hashchange in a later task, like the browser.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(adapter().hash).toBe("#comment-c2");
   });
 });

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useSyncExternalStore } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
   NavigationProvider,
@@ -44,6 +44,22 @@ function useInternalLinkHandler(router: ReturnType<typeof useRouter>) {
   }, [router]);
 }
 
+/**
+ * The fragment is client-only state Next.js never surfaces: `usePathname()`
+ * drops it, and a `router.replace("/x#y")` mutates `window.location` without
+ * a render of its own. Reading it through an external store re-reads the URL
+ * on every render and re-renders on the events that change it behind React's
+ * back, so `adapter.hash` is never a stale copy.
+ */
+function subscribeToHash(onStoreChange: () => void): () => void {
+  window.addEventListener("hashchange", onStoreChange);
+  window.addEventListener("popstate", onStoreChange);
+  return () => {
+    window.removeEventListener("hashchange", onStoreChange);
+    window.removeEventListener("popstate", onStoreChange);
+  };
+}
+
 function NavigationProviderInner({
   children,
 }: {
@@ -52,6 +68,11 @@ function NavigationProviderInner({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const hash = useSyncExternalStore(
+    subscribeToHash,
+    () => window.location.hash,
+    () => "",
+  );
   useInternalLinkHandler(router);
 
   const adapter: NavigationAdapter = {
@@ -62,6 +83,7 @@ function NavigationProviderInner({
     canGoBack: canGoBackInApp,
     pathname,
     searchParams: new URLSearchParams(searchParams.toString()),
+    hash,
     getShareableUrl: (path: string) =>
       typeof window === "undefined" ? path : window.location.origin + path,
     // router.prefetch is a no-op in dev mode by Next.js design; in production

--- a/packages/views/agents/components/agent-detail-page.test.tsx
+++ b/packages/views/agents/components/agent-detail-page.test.tsx
@@ -195,6 +195,7 @@ function renderPage() {
     back: vi.fn(),
     pathname: "/acme/agents/agent-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => path,
   };
   const view = render(

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -144,6 +144,7 @@ function renderPane(
     back: vi.fn(),
     pathname: "/acme/agents/agent-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => path,
   };
   return render(

--- a/packages/views/agents/components/agents-page.test.tsx
+++ b/packages/views/agents/components/agents-page.test.tsx
@@ -213,6 +213,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/test-workspace/agents",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -18,6 +18,7 @@ const navigationStub: NavigationAdapter = {
   back: vi.fn(),
   pathname: "/",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (path: string) => path,
 };
 

--- a/packages/views/agents/components/tabs/activity-tab.render.test.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.render.test.tsx
@@ -65,6 +65,7 @@ function renderTab() {
     back: vi.fn(),
     pathname: "/acme/agents/agent-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => path,
   };
   return render(

--- a/packages/views/agents/components/tabs/instructions-tab.test.tsx
+++ b/packages/views/agents/components/tabs/instructions-tab.test.tsx
@@ -202,6 +202,7 @@ describe("InstructionsTab conversation-starters deep link", () => {
     back: vi.fn(),
     pathname: "/acme/agents/agent-1",
     searchParams: new URLSearchParams(search),
+    hash: "",
     getShareableUrl: (path: string) => `https://app.test${path}`,
   });
 

--- a/packages/views/agents/create/create-agent-ui.test.ts
+++ b/packages/views/agents/create/create-agent-ui.test.ts
@@ -21,6 +21,7 @@ const TEST_NAVIGATION: NavigationAdapter = {
   back: vi.fn(),
   pathname: "/acme/agents/new",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (path: string) => path,
 };
 

--- a/packages/views/billing/billing-return-page.test.tsx
+++ b/packages/views/billing/billing-return-page.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../navigation", () => ({
   useNavigation: () => ({
     replace: mockReplace,
     searchParams: searchRef.current,
+    hash: "",
     pathname: "/billing/return",
   }),
 }));

--- a/packages/views/chat/chat-page.test.tsx
+++ b/packages/views/chat/chat-page.test.tsx
@@ -208,6 +208,7 @@ function renderPage(search: string, { strict = false } = {}) {
     back: vi.fn(),
     pathname: "/acme/chat",
     searchParams: new URLSearchParams(search),
+    hash: "",
     getShareableUrl: (path) => path,
   };
   // A fresh element per render — reusing one element object lets React bail

--- a/packages/views/chat/components/chat-empty-state.test.tsx
+++ b/packages/views/chat/components/chat-empty-state.test.tsx
@@ -28,6 +28,7 @@ const adapter = (): NavigationAdapter => ({
   back: vi.fn(),
   pathname: "/acme/chat",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (path: string) => `https://app.test${path}`,
 });
 

--- a/packages/views/common/actor-avatar-profile-link.test.tsx
+++ b/packages/views/common/actor-avatar-profile-link.test.tsx
@@ -61,6 +61,7 @@ function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdap
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => `https://app.example${p}`,
     ...overrides,
   };

--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -274,6 +274,7 @@ function DashboardHarness({ initialSearch = "" }: { initialSearch?: string }) {
       back: vi.fn(),
       pathname: "/acme/usage",
       searchParams: new URLSearchParams(search),
+      hash: "",
       getShareableUrl: (path: string) => `https://example.test${path}`,
     }),
     [search],

--- a/packages/views/editor/attachment-preview-modal.test.tsx
+++ b/packages/views/editor/attachment-preview-modal.test.tsx
@@ -75,6 +75,7 @@ vi.mock("../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     ...(navState.hasOpenInNewTab ? { openInNewTab: openInNewTabMock } : {}),
     getShareableUrl: getShareableUrlMock,
   }),

--- a/packages/views/editor/attachment.test.tsx
+++ b/packages/views/editor/attachment.test.tsx
@@ -78,6 +78,7 @@ vi.mock("../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     openInNewTab: vi.fn(),
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),

--- a/packages/views/editor/content-editor-current-issue.test.tsx
+++ b/packages/views/editor/content-editor-current-issue.test.tsx
@@ -59,6 +59,7 @@ function adapter(): NavigationAdapter {
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => `https://app.example${path}`,
   };
 }

--- a/packages/views/editor/extensions/file-card.test.tsx
+++ b/packages/views/editor/extensions/file-card.test.tsx
@@ -45,6 +45,7 @@ vi.mock("../../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     openInNewTab: vi.fn(),
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),

--- a/packages/views/editor/extensions/mention-view.test.tsx
+++ b/packages/views/editor/extensions/mention-view.test.tsx
@@ -51,6 +51,7 @@ function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdap
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => `https://app.example${p}`,
     ...overrides,
   };

--- a/packages/views/editor/html-attachment-preview.test.tsx
+++ b/packages/views/editor/html-attachment-preview.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     ...(navState.hasOpenInNewTab ? { openInNewTab: openInNewTabMock } : {}),
     getShareableUrl: getShareableUrlMock,
   }),

--- a/packages/views/editor/image-sequence-context.test.tsx
+++ b/packages/views/editor/image-sequence-context.test.tsx
@@ -35,6 +35,7 @@ vi.mock("../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),
 }));

--- a/packages/views/inbox/components/inbox-context-menu.test.tsx
+++ b/packages/views/inbox/components/inbox-context-menu.test.tsx
@@ -64,6 +64,7 @@ const navigationAdapter = {
   back: vi.fn(),
   pathname: "/",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (p: string) => p,
   openInNewTab: vi.fn(),
 };

--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -104,6 +104,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -99,6 +99,7 @@ vi.mock("../../../navigation", () => ({
     push: vi.fn(),
     pathname: "/test/issues/issue-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     back: vi.fn(),
     replace: vi.fn(),
     ...(navState.hasOpenInNewTab ? { openInNewTab: openInNewTabMock } : {}),

--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -96,6 +96,7 @@ vi.mock("../../../navigation", () => ({
     push: vi.fn(),
     pathname: "/test/issues/issue-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     back: vi.fn(),
     replace: vi.fn(),
     getShareableUrl: (p: string) => `https://app.multica.com${p}`,

--- a/packages/views/issues/components/board-card-assignee-picker.test.tsx
+++ b/packages/views/issues/components/board-card-assignee-picker.test.tsx
@@ -97,6 +97,7 @@ const navigation: NavigationAdapter = {
   back: vi.fn(),
   pathname: "/acme/issues",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (path) => `https://app.example${path}`,
 };
 

--- a/packages/views/issues/components/comment-card.test.tsx
+++ b/packages/views/issues/components/comment-card.test.tsx
@@ -27,6 +27,7 @@ vi.mock("../../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     openInNewTab: vi.fn(),
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),

--- a/packages/views/issues/components/issue-detail-route.test.tsx
+++ b/packages/views/issues/components/issue-detail-route.test.tsx
@@ -37,6 +37,7 @@ function wrapper({ children }: { children: ReactNode }) {
     back: vi.fn(),
     pathname: "/acme/issues/x",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p: string) => `https://app.multica.com${p}`,
   };
   return <NavigationProvider value={adapter}>{children}</NavigationProvider>;
@@ -139,6 +140,7 @@ describe("IssueDetailRoute with an identifier that names no issue", () => {
             back: vi.fn(),
             pathname: "/acme/issues/ZZZ-134",
             searchParams: new URLSearchParams(),
+            hash: "",
             getShareableUrl: (p: string) => `https://app.multica.com${p}`,
           }}
         >
@@ -160,6 +162,7 @@ describe("IssueDetailRoute with an identifier that names no issue", () => {
             back: vi.fn(),
             pathname: "/acme/issues/ZZZ-134",
             searchParams: new URLSearchParams(),
+            hash: "",
             getShareableUrl: (p: string) => `https://app.multica.com${p}`,
           }}
         >

--- a/packages/views/issues/components/issue-mention-card.test.tsx
+++ b/packages/views/issues/components/issue-mention-card.test.tsx
@@ -42,6 +42,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/layout/global-shortcuts.history.test.tsx
+++ b/packages/views/layout/global-shortcuts.history.test.tsx
@@ -38,6 +38,7 @@ function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdap
     forward: vi.fn(),
     pathname: "/w/issues",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => path,
     ...overrides,
   };

--- a/packages/views/layout/navigation-progress.test.tsx
+++ b/packages/views/layout/navigation-progress.test.tsx
@@ -10,6 +10,7 @@ const adapter: NavigationAdapter = {
   back: vi.fn(),
   pathname: "/",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (p) => p,
 };
 

--- a/packages/views/modals/delete-issue-confirm.test.tsx
+++ b/packages/views/modals/delete-issue-confirm.test.tsx
@@ -40,6 +40,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/acme/issues/issue-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/modals/feedback.test.tsx
+++ b/packages/views/modals/feedback.test.tsx
@@ -4,7 +4,10 @@ import { forwardRef, useImperativeHandle, useRef } from "react";
 
 let storedDraftMessage = "saved draft";
 let liveEditorMarkdown = "";
-const feedbackMocks = vi.hoisted(() => ({ mutateAsync: vi.fn() }));
+const feedbackMocks = vi.hoisted(() => ({
+  getShareableUrl: vi.fn((path: string) => `https://app.example${path}`),
+  mutateAsync: vi.fn(),
+}));
 // Deferred controlling the mock editor's in-flight upload: `reset` arms a new
 // pending upload, `resolve` lands it so a test can watch the gate re-open.
 const pendingUpload = vi.hoisted(() => {
@@ -52,6 +55,13 @@ vi.mock("../i18n", () => ({
 }));
 
 vi.mock("@multica/core/paths", () => ({ useCurrentWorkspace: () => ({ id: "ws1" }) }));
+vi.mock("../navigation", () => ({
+  useOptionalNavigation: () => ({
+    pathname: "/test-workspace/projects/project-1",
+    searchParams: new URLSearchParams("view=board"),
+    getShareableUrl: feedbackMocks.getShareableUrl,
+  }),
+}));
 vi.mock("@multica/core/hooks/use-file-upload", () => ({
   useFileUpload: () => ({ uploadWithToast: vi.fn() }),
 }));
@@ -131,6 +141,7 @@ describe("FeedbackModal", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     feedbackMocks.mutateAsync.mockReset().mockResolvedValue(undefined);
+    feedbackMocks.getShareableUrl.mockClear();
   });
 
   afterEach(() => {
@@ -166,6 +177,26 @@ describe("FeedbackModal", () => {
     await waitFor(() => {
       expect(feedbackMocks.mutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({ message: "fresh feedback" }),
+      );
+    });
+  });
+
+  it("submits the platform shareable URL instead of the renderer URL", async () => {
+    storedDraftMessage = "";
+    render(<FeedbackModal onClose={vi.fn()} />);
+
+    const editor = screen.getByLabelText("feedback editor");
+    fireEvent.change(editor, { target: { value: "Desktop feedback" } });
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(feedbackMocks.getShareableUrl).toHaveBeenCalledWith(
+        "/test-workspace/projects/project-1?view=board",
+      );
+      expect(feedbackMocks.mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://app.example/test-workspace/projects/project-1?view=board",
+        }),
       );
     });
   });

--- a/packages/views/modals/feedback.test.tsx
+++ b/packages/views/modals/feedback.test.tsx
@@ -7,6 +7,8 @@ let liveEditorMarkdown = "";
 const feedbackMocks = vi.hoisted(() => ({
   getShareableUrl: vi.fn((path: string) => `https://app.example${path}`),
   mutateAsync: vi.fn(),
+  // The fragment the adapter reports for the page the modal is opened from.
+  hash: { current: "" },
 }));
 // Deferred controlling the mock editor's in-flight upload: `reset` arms a new
 // pending upload, `resolve` lands it so a test can watch the gate re-open.
@@ -55,10 +57,14 @@ vi.mock("../i18n", () => ({
 }));
 
 vi.mock("@multica/core/paths", () => ({ useCurrentWorkspace: () => ({ id: "ws1" }) }));
-vi.mock("../navigation", () => ({
+// Only the adapter is stubbed: `currentPath()` stays real, because how it
+// composes pathname + search + fragment is exactly what these tests check.
+vi.mock("../navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../navigation")>()),
   useOptionalNavigation: () => ({
     pathname: "/test-workspace/projects/project-1",
     searchParams: new URLSearchParams("view=board"),
+    hash: feedbackMocks.hash.current,
     getShareableUrl: feedbackMocks.getShareableUrl,
   }),
 }));
@@ -142,6 +148,7 @@ describe("FeedbackModal", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     feedbackMocks.mutateAsync.mockReset().mockResolvedValue(undefined);
     feedbackMocks.getShareableUrl.mockClear();
+    feedbackMocks.hash.current = "";
   });
 
   afterEach(() => {
@@ -196,6 +203,29 @@ describe("FeedbackModal", () => {
       expect(feedbackMocks.mutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://app.example/test-workspace/projects/project-1?view=board",
+        }),
+      );
+    });
+  });
+
+  // MUL-6784: rebuilding the URL from pathname + search alone downgraded a
+  // `#comment-…` deep link to the whole issue, so a report sent from one
+  // comment no longer said which one. Desktop cannot fall back to
+  // `window.location` for the fragment — its renderer is a MemoryRouter over a
+  // file:// page — so the adapter has to carry it.
+  it("keeps the comment fragment of the page the report was sent from", async () => {
+    storedDraftMessage = "";
+    feedbackMocks.hash.current = "#comment-c1";
+    render(<FeedbackModal onClose={vi.fn()} />);
+
+    const editor = screen.getByLabelText("feedback editor");
+    fireEvent.change(editor, { target: { value: "Broken on this comment" } });
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(feedbackMocks.mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://app.example/test-workspace/projects/project-1?view=board#comment-c1",
         }),
       );
     });

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -29,6 +29,7 @@ import { useCurrentWorkspace } from "@multica/core/paths";
 import { useT } from "../i18n";
 import { useShortcut } from "@multica/core/shortcuts";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
+import { useOptionalNavigation } from "../navigation";
 
 const MAX_MESSAGE_LEN = 10000;
 
@@ -60,6 +61,7 @@ export function FeedbackModal({
   const { t } = useT("modals");
   const { t: tEditor } = useT("editor");
   const workspace = useCurrentWorkspace();
+  const navigation = useOptionalNavigation();
   const draft = useFeedbackDraftStore((s) => s.draft);
   const setDraft = useFeedbackDraftStore((s) => s.setDraft);
   const clearDraft = useFeedbackDraftStore((s) => s.clearDraft);
@@ -109,9 +111,21 @@ export function FeedbackModal({
       return;
     }
     try {
+      const search = navigation?.searchParams.toString() ?? "";
+      const browserUrl =
+        typeof window !== "undefined" &&
+        (window.location.protocol === "http:" ||
+          window.location.protocol === "https:")
+          ? window.location.href
+          : undefined;
+      const currentUrl = navigation
+        ? navigation.getShareableUrl(
+            `${navigation.pathname}${search ? `?${search}` : ""}`,
+          )
+        : browserUrl;
       await mutation.mutateAsync({
         message: latest,
-        url: typeof window !== "undefined" ? window.location.href : undefined,
+        url: currentUrl,
         workspace_id: workspace?.id,
         kind,
         context,

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -29,7 +29,7 @@ import { useCurrentWorkspace } from "@multica/core/paths";
 import { useT } from "../i18n";
 import { useShortcut } from "@multica/core/shortcuts";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
-import { useOptionalNavigation } from "../navigation";
+import { currentPath, useOptionalNavigation } from "../navigation";
 
 const MAX_MESSAGE_LEN = 10000;
 
@@ -111,7 +111,6 @@ export function FeedbackModal({
       return;
     }
     try {
-      const search = navigation?.searchParams.toString() ?? "";
       const browserUrl =
         typeof window !== "undefined" &&
         (window.location.protocol === "http:" ||
@@ -119,9 +118,7 @@ export function FeedbackModal({
           ? window.location.href
           : undefined;
       const currentUrl = navigation
-        ? navigation.getShareableUrl(
-            `${navigation.pathname}${search ? `?${search}` : ""}`,
-          )
+        ? navigation.getShareableUrl(currentPath(navigation))
         : browserUrl;
       await mutation.mutateAsync({
         message: latest,

--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -11,6 +11,7 @@ function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdap
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -28,6 +28,33 @@ function renderLink(
 }
 
 describe("AppLink", () => {
+  it("renders the public web URL on desktop so native copy-link affordances never expose the renderer URL", () => {
+    const adapter = makeAdapter({
+      openInNewTab: vi.fn(),
+      getShareableUrl: (path) => `https://app.example${path}`,
+    });
+
+    renderLink(adapter, { href: "/acme/issues/MUL-7" });
+
+    expect(screen.getByRole("link", { name: "go" })).toHaveAttribute(
+      "href",
+      "https://app.example/acme/issues/MUL-7",
+    );
+  });
+
+  it("keeps web anchors route-relative for SSR and native browser navigation", () => {
+    const adapter = makeAdapter({
+      getShareableUrl: (path) => `https://app.example${path}`,
+    });
+
+    renderLink(adapter, { href: "/acme/issues/MUL-7" });
+
+    expect(screen.getByRole("link", { name: "go" })).toHaveAttribute(
+      "href",
+      "/acme/issues/MUL-7",
+    );
+  });
+
   it("calls caller onClick BEFORE push so synchronous side effects (close menu, etc) commit before the transition starts", () => {
     const order: string[] = [];
     const adapter = makeAdapter({

--- a/packages/views/navigation/app-link.tsx
+++ b/packages/views/navigation/app-link.tsx
@@ -29,7 +29,16 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
     },
     ref,
   ) {
-    const { push, openInNewTab, prefetch } = useNavigation();
+    const { push, openInNewTab, getShareableUrl, prefetch } = useNavigation();
+    // A packaged Electron renderer runs at file://.../index.html. Keeping a
+    // route-relative href there makes native affordances such as right-click
+    // "Copy Link Address" expose (or reject) a local file URL. Desktop is
+    // identified by its tab adapter; render the connected environment's web
+    // URL in the DOM while click handlers continue routing with the original
+    // in-app path. Web stays route-relative, preserving SSR hydration and the
+    // browser's native navigation semantics.
+    const anchorHref =
+      openInNewTab && href.startsWith("/") ? getShareableUrl(href) : href;
 
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
       // Caller's onClick runs BEFORE any navigation, on every path, so:
@@ -119,7 +128,7 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
     return (
       <a
         ref={ref}
-        href={href}
+        href={anchorHref}
         target={target}
         // Referrer is same-origin noise here and noopener hygiene applies
         // even though the destination is our own app.

--- a/packages/views/navigation/current-path.test.ts
+++ b/packages/views/navigation/current-path.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { currentPath } from "./current-path";
+
+function location(pathname: string, search: string, hash: string) {
+  return { pathname, searchParams: new URLSearchParams(search), hash };
+}
+
+describe("currentPath", () => {
+  it("returns the pathname alone when there is no search or fragment", () => {
+    expect(currentPath(location("/acme/issues", "", ""))).toBe("/acme/issues");
+  });
+
+  it("appends the search string", () => {
+    expect(currentPath(location("/acme/issues", "view=board", ""))).toBe(
+      "/acme/issues?view=board",
+    );
+  });
+
+  // MUL-6784: a share/feedback link rebuilt without the fragment silently
+  // points at the whole issue instead of the comment the user was reading.
+  it("keeps the fragment, with and without a search string", () => {
+    expect(currentPath(location("/acme/issues/MUL-1", "", "#comment-c1"))).toBe(
+      "/acme/issues/MUL-1#comment-c1",
+    );
+    expect(
+      currentPath(location("/acme/issues/MUL-1", "tab=activity", "#comment-c1")),
+    ).toBe("/acme/issues/MUL-1?tab=activity#comment-c1");
+  });
+});

--- a/packages/views/navigation/current-path.ts
+++ b/packages/views/navigation/current-path.ts
@@ -1,0 +1,16 @@
+import type { NavigationAdapter } from "./types";
+
+/**
+ * Rebuild the adapter's location as a single in-app path —
+ * `/pathname?search#fragment` — the form `getShareableUrl()` expects.
+ *
+ * Every caller that turns "where the user is" into a link must go through
+ * here. Composing only `pathname` + `searchParams` silently drops the
+ * fragment, which downgrades a `#comment-…` deep link to the whole issue.
+ */
+export function currentPath(
+  navigation: Pick<NavigationAdapter, "pathname" | "searchParams" | "hash">,
+): string {
+  const search = navigation.searchParams.toString();
+  return `${navigation.pathname}${search ? `?${search}` : ""}${navigation.hash}`;
+}

--- a/packages/views/navigation/index.ts
+++ b/packages/views/navigation/index.ts
@@ -6,6 +6,7 @@ export {
   useReportNavigating,
 } from "./context";
 export { AppLink } from "./app-link";
+export { currentPath } from "./current-path";
 export { resolveClickIntent } from "./click-intent";
 export type { LinkClickIntent } from "./click-intent";
 export { useAppOrigin } from "./use-app-origin";

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -5,6 +5,16 @@ export interface NavigationAdapter {
   pathname: string;
   searchParams: URLSearchParams;
   /**
+   * Current fragment, including its leading `#`, or `""` when the location has
+   * none. Part of "where am I" alongside `pathname` / `searchParams`: shared
+   * views that rebuild the current URL (copy link, feedback) must keep a deep
+   * link such as `#comment-…` intact, and only the platform can report it —
+   * the desktop renderer runs a MemoryRouter over a `file://` page, so its
+   * `window.location.hash` is always empty. Compose the three with
+   * `currentPath()` rather than concatenating them at each call site.
+   */
+  hash: string;
+  /**
    * Desktop only: open a path in a new tab. Optional `title` overrides the
    * default tab label. `opts.activate` controls focus:
    *   - `false` / omitted → background tab (browser cmd+click semantics; what

--- a/packages/views/navigation/use-back-or-replace.test.tsx
+++ b/packages/views/navigation/use-back-or-replace.test.tsx
@@ -13,6 +13,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/navigation/use-row-link.test.tsx
+++ b/packages/views/navigation/use-row-link.test.tsx
@@ -13,6 +13,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -282,6 +282,7 @@ function renderProjectDetail() {
     back: vi.fn(),
     pathname: "/test-workspace/projects/project-1",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: mocks.getShareableUrl,
   };
 

--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -9,10 +9,16 @@ import { ProjectDetail } from "./project-detail";
 
 const mocks = vi.hoisted(() => ({
   role: "admin",
+  copyText: vi.fn(),
   deleteProject: vi.fn(),
+  getShareableUrl: vi.fn((path: string) => `https://app.example${path}`),
   push: vi.fn(),
   recordVisit: vi.fn(),
   toastSuccess: vi.fn(),
+}));
+
+vi.mock("@multica/ui/lib/clipboard", () => ({
+  copyText: mocks.copyText,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -276,7 +282,7 @@ function renderProjectDetail() {
     back: vi.fn(),
     pathname: "/test-workspace/projects/project-1",
     searchParams: new URLSearchParams(),
-    getShareableUrl: (path) => path,
+    getShareableUrl: mocks.getShareableUrl,
   };
 
   renderWithI18n(
@@ -288,10 +294,28 @@ function renderProjectDetail() {
 
 beforeEach(() => {
   mocks.role = "admin";
+  mocks.copyText.mockReset().mockResolvedValue(true);
   mocks.deleteProject.mockReset();
+  mocks.getShareableUrl.mockClear();
   mocks.push.mockReset();
   mocks.recordVisit.mockReset();
   mocks.toastSuccess.mockReset();
+});
+
+describe("ProjectDetail sharing", () => {
+  it("copies the platform shareable URL instead of the renderer URL", async () => {
+    const user = userEvent.setup();
+    renderProjectDetail();
+
+    await user.click(screen.getByRole("button", { name: "Copy link" }));
+
+    expect(mocks.getShareableUrl).toHaveBeenCalledWith(
+      "/test-workspace/projects/project-1",
+    );
+    expect(mocks.copyText).toHaveBeenCalledWith(
+      "https://app.example/test-workspace/projects/project-1",
+    );
+  });
 });
 
 describe("ProjectDetail project deletion", () => {

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -22,7 +22,7 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { PROJECT_STATUS_ORDER, PROJECT_STATUS_CONFIG, PROJECT_PRIORITY_ORDER } from "@multica/core/projects/config";
 import { getProjectIssueMetrics } from "./project-issue-metrics";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { useNavigation } from "../../navigation";
+import { currentPath, useNavigation } from "../../navigation";
 import { TitleEditor, ContentEditor, type ContentEditorRef } from "../../editor";
 import { PriorityIcon } from "../../issues/components/priority-icon";
 import { ProjectResourcesSection } from "./project-resources-section";
@@ -508,9 +508,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                 />
                 <DropdownMenuContent align="end" className="w-auto">
                   <DropdownMenuItem onClick={() => {
-                    const search = router.searchParams.toString();
-                    const path = `${router.pathname}${search ? `?${search}` : ""}`;
-                    void copyText(router.getShareableUrl(path)).then((ok) => {
+                    void copyText(router.getShareableUrl(currentPath(router))).then((ok) => {
                       if (ok) toast.success(t(($) => $.detail.toast_link_copied));
                     });
                   }}>

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -508,7 +508,9 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                 />
                 <DropdownMenuContent align="end" className="w-auto">
                   <DropdownMenuItem onClick={() => {
-                    void copyText(window.location.href).then((ok) => {
+                    const search = router.searchParams.toString();
+                    const path = `${router.pathname}${search ? `?${search}` : ""}`;
+                    void copyText(router.getShareableUrl(path)).then((ok) => {
                       if (ok) toast.success(t(($) => $.detail.toast_link_copied));
                     });
                   }}>

--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -210,6 +210,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/test-workspace/projects",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/rich-content/current-issue-rendering.test.tsx
+++ b/packages/views/rich-content/current-issue-rendering.test.tsx
@@ -118,6 +118,7 @@ function adapter(): NavigationAdapter {
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (path) => `${APP_ORIGIN}${path}`,
   };
 }

--- a/packages/views/rich-content/entity-link-unfurl.test.tsx
+++ b/packages/views/rich-content/entity-link-unfurl.test.tsx
@@ -90,6 +90,7 @@ function adapter(): NavigationAdapter {
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     // The real platform adapters return an absolute URL; useAppOrigin derives
     // the deployment origin from it, and without that nothing is "in-app".
     getShareableUrl: (p) => `${APP_ORIGIN}${p}`,

--- a/packages/views/rich-content/project-mention-a11y.test.tsx
+++ b/packages/views/rich-content/project-mention-a11y.test.tsx
@@ -74,6 +74,7 @@ function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdap
     back: vi.fn(),
     pathname: "/",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/runtimes/components/runtime-row-menu.test.tsx
+++ b/packages/views/runtimes/components/runtime-row-menu.test.tsx
@@ -156,6 +156,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/ws-1/runtimes",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     ...overrides,
   };

--- a/packages/views/settings/components/billing-tab.test.tsx
+++ b/packages/views/settings/components/billing-tab.test.tsx
@@ -164,6 +164,7 @@ vi.mock("../../navigation", () => ({
   useNavigation: () => ({
     pathname: "/acme/settings",
     searchParams: new URLSearchParams(navigationState.search),
+    hash: "",
     push: vi.fn(),
     replace: navigationState.replace,
     back: vi.fn(),

--- a/packages/views/settings/components/composio-tab.test.tsx
+++ b/packages/views/settings/components/composio-tab.test.tsx
@@ -56,6 +56,7 @@ vi.mock("../../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/settings",
     searchParams: searchParamsRef.current,
+    hash: "",
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),
 }));

--- a/packages/views/settings/components/github-tab.test.tsx
+++ b/packages/views/settings/components/github-tab.test.tsx
@@ -105,6 +105,7 @@ vi.mock("../../navigation/context", () => ({
     back: vi.fn(),
     pathname: "/acme/settings",
     searchParams: new URLSearchParams("tab=github"),
+    hash: "",
     getShareableUrl: (p: string) => `https://app.example${p}`,
   }),
 }));

--- a/packages/views/settings/components/repositories-tab.test.tsx
+++ b/packages/views/settings/components/repositories-tab.test.tsx
@@ -123,6 +123,7 @@ vi.mock("../../navigation", () => ({
     back: vi.fn(),
     pathname: "/acme/settings",
     searchParams: searchParamsRef.current,
+    hash: "",
     getShareableUrl: (path: string) => `https://app.example${path}`,
   }),
 }));

--- a/packages/views/settings/components/settings-page.test.tsx
+++ b/packages/views/settings/components/settings-page.test.tsx
@@ -42,6 +42,7 @@ const navigationState = { search: "" };
 vi.mock("../../navigation", () => ({
   useNavigation: () => ({
     searchParams: new URLSearchParams(navigationState.search),
+    hash: "",
     pathname: "/acme/settings",
     replace,
   }),

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -123,6 +123,7 @@ function renderPage(searchParams = new URLSearchParams()) {
     back: vi.fn(),
     pathname: "/acme/skills/skill-1",
     searchParams,
+    hash: "",
     getShareableUrl: (path) => path,
   };
   render(

--- a/packages/views/skills/components/skills-page.source-link.test.tsx
+++ b/packages/views/skills/components/skills-page.source-link.test.tsx
@@ -143,6 +143,7 @@ function makeAdapter(
     back: vi.fn(),
     pathname: "/acme/skills",
     searchParams: new URLSearchParams(),
+    hash: "",
     getShareableUrl: (p) => p,
     openInNewTab: vi.fn(),
     ...overrides,

--- a/packages/views/workspace/welcome-after-onboarding.test.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.test.tsx
@@ -69,6 +69,7 @@ const navigationAdapter: NavigationAdapter = {
   back: vi.fn(),
   pathname: "/test",
   searchParams: new URLSearchParams(),
+  hash: "",
   getShareableUrl: (path: string) => `https://test.local${path}`,
 };
 


### PR DESCRIPTION
## Summary

- make project Copy link use the platform navigation adapter instead of the Electron renderer location
- render public web URLs in Desktop AppLink anchors so native copy-link and drag affordances never expose file:// renderer paths
- attach the shareable web page URL to feedback submitted from Desktop
- keep Web anchors route-relative to preserve SSR hydration and native browser navigation

## Root cause

Shared views assumed window.location represented the public application URL. In packaged Electron builds it points at the local app.asar renderer index.html, so direct clipboard and diagnostic uses produced a machine-local file URL. AppLink anchors also kept route-relative hrefs, which Chromium resolved against that file renderer for native link affordances.

The existing NavigationAdapter.getShareableUrl boundary already provides the connected environment Web URL on Desktop and the browser origin on Web. This change routes the remaining current-page uses through that boundary.

## Verification

- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/desktop typecheck
- pnpm --filter @multica/views test (405 files, 4,797 tests)
- pnpm --filter @multica/desktop test (54 files, 518 tests)
- pnpm --filter @multica/desktop build
- targeted ESLint on all six changed files (no errors; one pre-existing project-detail hooks warning)