### PR TITLE
MUL-6737: fix(daemon): raise the agent inactivity budget to 2h and derive the tool budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,7 +164,6 @@ MULTICA_DAEMON_HEARTBEAT_INTERVAL=15s
 MULTICA_CODEX_PATH=codex
 MULTICA_CODEX_MODEL=
 MULTICA_CODEX_WORKDIR=
-MULTICA_CODEX_TIMEOUT=20m
 
 # Feature flags
 # Optional path to a YAML file declaring feature flag rules. When unset,

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -248,7 +248,11 @@ Daemon behavior is configured via flags or environment variables:
 | Poll interval | `--poll-interval` | `MULTICA_DAEMON_POLL_INTERVAL` | `3s` |
 | Heartbeat interval | `--heartbeat-interval` | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` |
 | Agent timeout | `--agent-timeout` | `MULTICA_AGENT_TIMEOUT` | `0` (no cap; bounded by the watchdogs) |
+| Agent idle watchdog | — | `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` (`0` disables the whole watchdog suite) |
+| Agent tool watchdog | — | `MULTICA_AGENT_TOOL_WATCHDOG` | same as the idle watchdog (`0` = never force-stop during a tool call) |
 | Codex semantic inactivity timeout | `--codex-semantic-inactivity-timeout` | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` |
+| Codex first-turn no-progress timeout | — | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` (keeps the built-in `60s` ceiling) |
+| Codex handshake timeout | `--codex-handshake-timeout` | `MULTICA_CODEX_HANDSHAKE_TIMEOUT` | `30s` |
 | OpenCode idle watchdog | — | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` (`0` falls back to the generic idle watchdog; cannot extend it) |
 | Max concurrent tasks | `--max-concurrent-tasks` | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` |
 | Daemon ID | `--daemon-id` | `MULTICA_DAEMON_ID` | hostname |

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -227,8 +227,8 @@ API key と base URL の両方が空の場合、このレイヤーは無効に�
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | ハートビート間隔 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | デーモン 1 つあたりの同時実行タスク上限 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 1 回の実行の絶対時間上限。`0` は上限なし |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 出力もツール実行もない状態の静穏上限。ハングをどれだけ早く検知するかではなく、正当に静穏でいられる最長のステップ（長いアシスタントメッセージ 1 通、サブエージェント、テストスイート全体）に合わせた値です。正常な実行を強制停止すると作業が失われる一方、検知が遅れてもスロットを長く占有するだけだからです。`0` で watchdog 全体を無効化 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG` と同じ | 単一のツール呼び出しが静穏なままでいられる上限。モデルより長い余裕をツールに与えたい場合のみ設定します。`0` はツール実行中に強制停止しないことを意味します |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 出力もツール実行もない状態の静穏上限。`0` で watchdog 全体を無効化 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG` と同じ | 単一のツール呼び出しが静穏なままでいられる上限。モデルより長い余裕をツールに与えたい場合のみ設定し、`0` はツール実行中に強制停止しません |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 専用の静穏しきい値 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex のセマンティック静穏しきい値 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 初回ターンの無進捗上限を明示的に上書き；`0` はデフォルトを維持。実効の初回ターン待機は依然として `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` と全体の実行タイムアウトに制限される——`MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` をこの値より厳密に大きく（余裕を持たせて）設定すること。さもないと待機はその値で打ち切られ、モデルカタログの起動リトライがスキップされる。同値では不十分：セマンティックタイマーが先に起動するため、同値の場合でもリトライが失われることがある |

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -227,8 +227,8 @@ API key と base URL の両方が空の場合、このレイヤーは無効に�
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | ハートビート間隔 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | デーモン 1 つあたりの同時実行タスク上限 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 1 回の実行の絶対時間上限。`0` は上限なし |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `30m` | 出力もツール実行もない状態の静穏上限 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `2h` | 単一のツール呼び出しが静穏なままでいられる上限 |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 出力もツール実行もない状態の静穏上限。ハングをどれだけ早く検知するかではなく、正当に静穏でいられる最長のステップ（長いアシスタントメッセージ 1 通、サブエージェント、テストスイート全体）に合わせた値です。正常な実行を強制停止すると作業が失われる一方、検知が遅れてもスロットを長く占有するだけだからです。`0` で watchdog 全体を無効化 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG` と同じ | 単一のツール呼び出しが静穏なままでいられる上限。モデルより長い余裕をツールに与えたい場合のみ設定します。`0` はツール実行中に強制停止しないことを意味します |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 専用の静穏しきい値 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex のセマンティック静穏しきい値 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 初回ターンの無進捗上限を明示的に上書き；`0` はデフォルトを維持。実効の初回ターン待機は依然として `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` と全体の実行タイムアウトに制限される——`MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` をこの値より厳密に大きく（余裕を持たせて）設定すること。さもないと待機はその値で打ち切られ、モデルカタログの起動リトライがスキップされる。同値では不十分：セマンティックタイマーが先に起動するため、同値の場合でもリトライが失われることがある |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -227,8 +227,8 @@ API key와 base URL이 모두 비어 있으면 이 레이어가 꺼지고 업스
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | heartbeat 간격 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | 데몬 하나의 동시 실행 태스크 상한 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 단일 실행의 절대 시간 제한. `0`은 제한 없음 |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 출력과 도구 실행이 모두 없을 때의 무응답 상한. 행을 얼마나 빨리 발견하는지가 아니라 정상적으로 조용할 수 있는 가장 긴 단계(긴 어시스턴트 메시지 하나, 서브에이전트, 전체 테스트 스위트)를 기준으로 정한 값입니다. 정상 실행을 강제 종료하면 작업이 사라지지만, 늦게 발견해도 슬롯을 조금 더 점유할 뿐이기 때문입니다. `0`이면 watchdog 전체가 비활성화됩니다 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG`와 동일 | 단일 도구 호출이 계속 무응답인 시간 상한. 모델보다 도구에 더 여유를 주고 싶을 때만 따로 설정합니다. `0`이면 도구 실행 중에는 강제 종료하지 않습니다 |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 출력과 도구 실행이 모두 없을 때의 무응답 상한. `0`이면 watchdog 전체가 비활성화됩니다 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG`와 동일 | 단일 도구 호출이 계속 무응답인 시간 상한. 모델보다 도구에 더 여유를 주고 싶을 때만 따로 설정하며, `0`이면 도구 실행 중에는 강제 종료하지 않습니다 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 전용 무응답 기준값 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex 의미 활동 없음 기준값 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 첫 턴 무진행 상한의 명시적 재정의; `0` 은 기본값 유지. 실제 첫 턴 대기는 여전히 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 및 전체 실행 타임아웃으로 제한됨 — `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 을 이 값보다 엄격히 크게(여유를 두고) 설정해야 하며, 그렇지 않으면 대기가 그 값으로 잘리고 모델 카탈로그 시작 재시도가 건너뛰어짐. 값이 같으면 충분하지 않음: 의미 타이머가 먼저 시작되므로 값이 같을 때도 재시도가 손실될 수 있음 |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -227,8 +227,8 @@ API key와 base URL이 모두 비어 있으면 이 레이어가 꺼지고 업스
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | heartbeat 간격 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | 데몬 하나의 동시 실행 태스크 상한 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 단일 실행의 절대 시간 제한. `0`은 제한 없음 |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `30m` | 출력과 도구 실행이 모두 없을 때의 무응답 상한 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `2h` | 단일 도구 호출이 계속 무응답인 시간 상한 |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 출력과 도구 실행이 모두 없을 때의 무응답 상한. 행을 얼마나 빨리 발견하는지가 아니라 정상적으로 조용할 수 있는 가장 긴 단계(긴 어시스턴트 메시지 하나, 서브에이전트, 전체 테스트 스위트)를 기준으로 정한 값입니다. 정상 실행을 강제 종료하면 작업이 사라지지만, 늦게 발견해도 슬롯을 조금 더 점유할 뿐이기 때문입니다. `0`이면 watchdog 전체가 비활성화됩니다 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | `MULTICA_AGENT_IDLE_WATCHDOG`와 동일 | 단일 도구 호출이 계속 무응답인 시간 상한. 모델보다 도구에 더 여유를 주고 싶을 때만 따로 설정합니다. `0`이면 도구 실행 중에는 강제 종료하지 않습니다 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 전용 무응답 기준값 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex 의미 활동 없음 기준값 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Codex 첫 턴 무진행 상한의 명시적 재정의; `0` 은 기본값 유지. 실제 첫 턴 대기는 여전히 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 및 전체 실행 타임아웃으로 제한됨 — `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 을 이 값보다 엄격히 크게(여유를 두고) 설정해야 하며, 그렇지 않으면 대기가 그 값으로 잘리고 모델 카탈로그 시작 재시도가 건너뛰어짐. 값이 같으면 충분하지 않음: 의미 타이머가 먼저 시작되므로 값이 같을 때도 재시도가 손실될 수 있음 |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -227,8 +227,8 @@ The variables below are read on the computer that runs your agents, not in the A
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | Heartbeat interval |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | Concurrent task ceiling per daemon |
 | `MULTICA_AGENT_TIMEOUT` | `0` | Absolute time limit per run; `0` means no limit |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `30m` | Silence ceiling with no output and no tool execution |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `2h` | Silence ceiling for a single tool call |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | Silence ceiling with no output and no tool execution. Sized for the longest legitimate silent step (a single long assistant message, a subagent, a full test suite), not for how fast a hang is noticed — force-stopping a healthy run loses its work, while noticing late only holds a slot. `0` disables the watchdog entirely |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | same as `MULTICA_AGENT_IDLE_WATCHDOG` | Silence ceiling for a single tool call. Set this only to give tools more room than the model gets; `0` means a tool call is never force-stopped |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode-specific silence threshold |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex semantic-silence threshold |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Explicit override for the Codex first-turn no-progress ceiling; `0` keeps the default. The effective first-turn wait stays bounded by `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` and the overall execution timeout — set `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` strictly above this value (with some margin), or the wait is truncated to it and the model-catalog startup retry is skipped. Equal values are not enough: the semantic timer is armed first, so at equal durations the retry can still be lost |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -227,8 +227,8 @@ The variables below are read on the computer that runs your agents, not in the A
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | Heartbeat interval |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | Concurrent task ceiling per daemon |
 | `MULTICA_AGENT_TIMEOUT` | `0` | Absolute time limit per run; `0` means no limit |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | Silence ceiling with no output and no tool execution. Sized for the longest legitimate silent step (a single long assistant message, a subagent, a full test suite), not for how fast a hang is noticed — force-stopping a healthy run loses its work, while noticing late only holds a slot. `0` disables the watchdog entirely |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | same as `MULTICA_AGENT_IDLE_WATCHDOG` | Silence ceiling for a single tool call. Set this only to give tools more room than the model gets; `0` means a tool call is never force-stopped |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | Silence ceiling with no output and no tool execution; `0` disables the watchdog entirely |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | same as `MULTICA_AGENT_IDLE_WATCHDOG` | Silence ceiling for a single tool call; set it only to give tools more room than the model gets, `0` never force-stops a tool call |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode-specific silence threshold |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex semantic-silence threshold |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | Explicit override for the Codex first-turn no-progress ceiling; `0` keeps the default. The effective first-turn wait stays bounded by `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` and the overall execution timeout — set `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` strictly above this value (with some margin), or the wait is truncated to it and the model-catalog startup retry is skipped. Equal values are not enough: the semantic timer is armed first, so at equal durations the retry can still be lost |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -227,8 +227,8 @@ API key 与 base URL 都为空时，这一层关闭，不会发出任何上游�
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | 心跳间隔 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | 单个守护进程的并发执行任务上限 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 单次执行的绝对时限；`0` 表示不设置 |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 没有输出且没有工具执行时的静默上限。取值依据是「最长的合法静默步骤」（一条超长回复、一个 subagent、一整套测试），而不是「多快发现卡死」——误杀正常运行会丢掉已完成的工作，晚发现只是多占一个并发槽。`0` 表示整套 watchdog 关闭 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | 同 `MULTICA_AGENT_IDLE_WATCHDOG` | 单个工具调用持续静默的上限。只有在希望工具比模型有更多余量时才需要单独设置；`0` 表示工具执行期间永不强制停止 |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 没有输出且没有工具执行时的静默上限；`0` 表示整套 watchdog 关闭 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | 同 `MULTICA_AGENT_IDLE_WATCHDOG` | 单个工具调用持续静默的上限；只有希望工具比模型有更多余量时才单独设置，`0` 表示工具执行期间永不强制停止 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 专用静默阈值 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex 语义静默阈值 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | 显式覆盖 Codex 首轮无进展上限；`0` 保持默认值。实际首轮等待仍受 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 和总执行超时限制——需将 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 设为严格大于此值（并留出余量），否则等待会被截断至该值，且会跳过模型目录启动重试。设为相等还不够：语义计时器先启动，两者相等时仍可能丢失该重试 |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -227,8 +227,8 @@ API key 与 base URL 都为空时，这一层关闭，不会发出任何上游�
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | 心跳间隔 |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | 单个守护进程的并发执行任务上限 |
 | `MULTICA_AGENT_TIMEOUT` | `0` | 单次执行的绝对时限；`0` 表示不设置 |
-| `MULTICA_AGENT_IDLE_WATCHDOG` | `30m` | 没有输出且没有工具执行时的静默上限 |
-| `MULTICA_AGENT_TOOL_WATCHDOG` | `2h` | 单个工具调用持续静默的上限 |
+| `MULTICA_AGENT_IDLE_WATCHDOG` | `2h` | 没有输出且没有工具执行时的静默上限。取值依据是「最长的合法静默步骤」（一条超长回复、一个 subagent、一整套测试），而不是「多快发现卡死」——误杀正常运行会丢掉已完成的工作，晚发现只是多占一个并发槽。`0` 表示整套 watchdog 关闭 |
+| `MULTICA_AGENT_TOOL_WATCHDOG` | 同 `MULTICA_AGENT_IDLE_WATCHDOG` | 单个工具调用持续静默的上限。只有在希望工具比模型有更多余量时才需要单独设置；`0` 表示工具执行期间永不强制停止 |
 | `MULTICA_OPENCODE_IDLE_WATCHDOG` | `10m` | OpenCode 专用静默阈值 |
 | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` | Codex 语义静默阈值 |
 | `MULTICA_CODEX_FIRST_TURN_TIMEOUT` | `0` | 显式覆盖 Codex 首轮无进展上限；`0` 保持默认值。实际首轮等待仍受 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 和总执行超时限制——需将 `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` 设为严格大于此值（并留出余量），否则等待会被截断至该值，且会跳过模型目录启动重试。设为相等还不够：语义计时器先启动，两者相等时仍可能丢失该重试 |

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -23,8 +23,8 @@ const (
 	DefaultPollInterval      = 30 * time.Second
 	DefaultHeartbeatInterval = 15 * time.Second
 	// DefaultAgentTimeout is the optional absolute wall-clock cap on a single
-	// agent run. 0 = no cap: a run is bounded only by the inactivity watchdogs
-	// (DefaultAgentIdleWatchdog / DefaultAgentToolWatchdog), so a session that keeps emitting events is
+	// agent run. 0 = no cap: a run is bounded only by the inactivity watchdog
+	// (DefaultAgentIdleWatchdog), so a session that keeps emitting events is
 	// never killed merely for running long (MUL-3064). Operators who want a
 	// hard ceiling for cost/resource control can set MULTICA_AGENT_TIMEOUT.
 	DefaultAgentTimeout                   = 0
@@ -42,23 +42,19 @@ const (
 	// on a stuck child process (e.g. `docker ps` against a frozen dockerd),
 	// in which case `cmd.Wait()` never returns. With no wall-clock cap
 	// (DefaultAgentTimeout = 0) such a run would otherwise sit at "running"
-	// forever, so this watchdog is its sole liveness net. The previous 5 min default
-	// killed legitimate long assistant outputs (e.g. RFC-length writeups)
-	// where the model streams a single message for many minutes without any
-	// daemon-visible activity — see MUL-2300. 30 min keeps the safety net for
-	// truly stuck runs (dockerd hang) while leaving headroom for long writes.
-	// Set MULTICA_AGENT_IDLE_WATCHDOG=0 to disable.
-	DefaultAgentIdleWatchdog = 30 * time.Minute
-	// DefaultAgentToolWatchdog bounds how long a single tool call may stay in
-	// flight (tool_use emitted, no tool_result and no other message) before the
-	// idle watchdog force-stops the run. The idle watchdog ignores its normal
-	// window while a tool is in flight, because a real build/install/test
-	// legitimately runs silently for many minutes — but with no wall-clock cap
-	// (DefaultAgentTimeout = 0) a backend that emits tool_use and never the
-	// matching tool_result would otherwise run forever. This is the backstop for
-	// that stuck-tool case (MUL-3064). Set MULTICA_AGENT_TOOL_WATCHDOG=0 to
-	// disable, in which case an in-flight tool never force-stops the run.
-	DefaultAgentToolWatchdog              = 2 * time.Hour
+	// forever, so this watchdog is its sole liveness net.
+	//
+	// The budget answers one question: how long may the LONGEST legitimate
+	// silent step take? Not "how fast do we want to notice a hang". Those
+	// two costs are wildly asymmetric — force-stopping a healthy run throws
+	// away the work and flips the issue to blocked, while noticing a hang
+	// late only holds a concurrency slot. So the value tracks the legitimate
+	// end: a single RFC-length assistant message (MUL-2300, which moved this
+	// from 5 min to 30 min), a subagent, a full test suite. 30 min still cut
+	// real work short, so this is 2h.
+	//
+	// Set MULTICA_AGENT_IDLE_WATCHDOG=0 to disable the whole watchdog suite.
+	DefaultAgentIdleWatchdog              = 2 * time.Hour
 	DefaultRuntimeName                    = "Local Agent"
 	DefaultWorkspaceBootstrapSyncInterval = 30 * time.Second
 	DefaultWorkspaceLegacySyncInterval    = 5 * time.Minute
@@ -140,7 +136,7 @@ type Config struct {
 	CodexHandshakeTimeout           time.Duration
 	OpenCodeIdleWatchdog            time.Duration // OpenCode-specific no-message window; 0 falls back to AgentIdleWatchdog and values above it cannot extend the global bound
 	AgentIdleWatchdog               time.Duration // force-stop a run when the backend goes silent this long with an empty queue (0 = disabled)
-	AgentToolWatchdog               time.Duration // force-stop a run when a single tool call stays in flight (silent) this long (0 = disabled); backstop for hung tools now that there is no wall-clock cap
+	AgentToolWatchdog               time.Duration // force-stop a run when a single tool call stays in flight (silent) this long (0 = never force-stop during a tool call); defaults to AgentIdleWatchdog, so operators tune one number unless they deliberately want a wider tool budget
 	ClaudeArgs                      []string
 	CodexArgs                       []string
 	CodebuddyArgs                   []string
@@ -374,9 +370,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
-	// MULTICA_AGENT_TOOL_WATCHDOG=0 disables the in-flight-tool backstop; any
-	// positive duration overrides DefaultAgentToolWatchdog.
-	agentToolWatchdog, err := durationFromEnv("MULTICA_AGENT_TOOL_WATCHDOG", DefaultAgentToolWatchdog)
+	// The in-flight-tool budget defaults to the idle budget: the tool window
+	// only ever existed because 30 min was too short for a real build/install/
+	// test, and now that the idle budget is sized for the longest legitimate
+	// silent step it already covers those. Keeping it derived means an operator
+	// who raises MULTICA_AGENT_IDLE_WATCHDOG does not silently leave tool calls
+	// on the old ceiling. MULTICA_AGENT_TOOL_WATCHDOG still overrides for the
+	// deliberate "tools may run longer than the model may think" case, and 0
+	// keeps its meaning: never force-stop while a tool is in flight.
+	agentToolWatchdog, err := durationFromEnv("MULTICA_AGENT_TOOL_WATCHDOG", agentIdleWatchdog)
 	if err != nil {
 		return Config{}, err
 	}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -373,11 +373,19 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// The in-flight-tool budget defaults to the idle budget: the tool window
 	// only ever existed because 30 min was too short for a real build/install/
 	// test, and now that the idle budget is sized for the longest legitimate
-	// silent step it already covers those. Keeping it derived means an operator
-	// who raises MULTICA_AGENT_IDLE_WATCHDOG does not silently leave tool calls
-	// on the old ceiling. MULTICA_AGENT_TOOL_WATCHDOG still overrides for the
-	// deliberate "tools may run longer than the model may think" case, and 0
-	// keeps its meaning: never force-stop while a tool is in flight.
+	// silent step it already covers those.
+	//
+	// The derivation tracks in BOTH directions, which is the point of collapsing
+	// this to one number. Raising MULTICA_AGENT_IDLE_WATCHDOG no longer leaves
+	// tool calls silently pinned to the old ceiling — and lowering it now also
+	// lowers the tool budget, where previously a shortened idle window left
+	// tools at a separate, larger 2h. That second direction is a real behaviour
+	// change for anyone who had deliberately shortened the idle window; the
+	// override below is how they keep the two apart.
+	//
+	// MULTICA_AGENT_TOOL_WATCHDOG still overrides for the deliberate "tools may
+	// run longer than the model may think" case, and 0 keeps its meaning: never
+	// force-stop while a tool is in flight.
 	agentToolWatchdog, err := durationFromEnv("MULTICA_AGENT_TOOL_WATCHDOG", agentIdleWatchdog)
 	if err != nil {
 		return Config{}, err

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -760,6 +760,70 @@ func TestLoadConfig_CodexFirstTurnTimeoutEqualToSemanticWarns(t *testing.T) {
 	}
 }
 
+// TestLoadConfig_ToolWatchdogDefaultsToIdleWatchdog pins the merge: the
+// in-flight-tool budget is no longer an independent constant, so an operator
+// who raises the idle budget cannot accidentally leave tool calls capped at a
+// lower, invisible ceiling.
+func TestLoadConfig_ToolWatchdogDefaultsToIdleWatchdog(t *testing.T) {
+	stageFakeAgent(t)
+	t.Setenv("MULTICA_AGENT_IDLE_WATCHDOG", "")
+	t.Setenv("MULTICA_AGENT_TOOL_WATCHDOG", "")
+
+	load := func(t *testing.T) Config {
+		t.Helper()
+		cfg, err := LoadConfig(Overrides{
+			ServerURL:      "http://localhost:8080",
+			WorkspacesRoot: t.TempDir(),
+		})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		return cfg
+	}
+
+	cfg := load(t)
+	if cfg.AgentIdleWatchdog != DefaultAgentIdleWatchdog {
+		t.Fatalf("AgentIdleWatchdog = %s, want default %s", cfg.AgentIdleWatchdog, DefaultAgentIdleWatchdog)
+	}
+	if cfg.AgentToolWatchdog != cfg.AgentIdleWatchdog {
+		t.Fatalf("AgentToolWatchdog = %s, want it to track AgentIdleWatchdog %s", cfg.AgentToolWatchdog, cfg.AgentIdleWatchdog)
+	}
+
+	// Raising only the idle budget must carry the tool budget with it.
+	t.Setenv("MULTICA_AGENT_IDLE_WATCHDOG", "6h")
+	cfg = load(t)
+	if cfg.AgentIdleWatchdog != 6*time.Hour || cfg.AgentToolWatchdog != 6*time.Hour {
+		t.Fatalf("idle=%s tool=%s, want both 6h", cfg.AgentIdleWatchdog, cfg.AgentToolWatchdog)
+	}
+
+	// An explicit tool override still wins, so "tools may run longer than the
+	// model may think" stays expressible.
+	t.Setenv("MULTICA_AGENT_TOOL_WATCHDOG", "12h")
+	cfg = load(t)
+	if cfg.AgentIdleWatchdog != 6*time.Hour {
+		t.Fatalf("AgentIdleWatchdog = %s, want 6h", cfg.AgentIdleWatchdog)
+	}
+	if cfg.AgentToolWatchdog != 12*time.Hour {
+		t.Fatalf("AgentToolWatchdog = %s, want 12h from env", cfg.AgentToolWatchdog)
+	}
+
+	// Zero keeps its distinct meaning: never force-stop while a tool is in
+	// flight. It must NOT be re-derived from the idle budget.
+	t.Setenv("MULTICA_AGENT_TOOL_WATCHDOG", "0")
+	cfg = load(t)
+	if cfg.AgentToolWatchdog != 0 {
+		t.Fatalf("AgentToolWatchdog = %s, want 0 from env", cfg.AgentToolWatchdog)
+	}
+
+	// Disabling the suite disables both.
+	t.Setenv("MULTICA_AGENT_IDLE_WATCHDOG", "0")
+	t.Setenv("MULTICA_AGENT_TOOL_WATCHDOG", "")
+	cfg = load(t)
+	if cfg.AgentIdleWatchdog != 0 || cfg.AgentToolWatchdog != 0 {
+		t.Fatalf("idle=%s tool=%s, want both 0", cfg.AgentIdleWatchdog, cfg.AgentToolWatchdog)
+	}
+}
+
 func TestLoadConfig_OpenCodeIdleWatchdog(t *testing.T) {
 	stageFakeAgent(t)
 	t.Setenv("MULTICA_OPENCODE_IDLE_WATCHDOG", "")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -85,6 +85,14 @@ const (
 	// pendingWorkHintBookkeepingTTL is how long a runtime's last-hint timestamp
 	// is retained before it is swept — purely to keep the map bounded.
 	pendingWorkHintBookkeepingTTL = 10 * time.Minute
+	// idleWatchdogMaxTick caps the idle watchdog's polling interval. The
+	// interval is window/2, which was fine when the window was minutes but
+	// makes the overshoot scale with the budget: a 2h window would only be
+	// checked hourly, so a genuinely stuck run could hold its slot for 3h.
+	// Capping the tick keeps worst-case detection at window + 5m regardless of
+	// how large an operator sets the budget, at the cost of a no-op comparison
+	// every 5 minutes.
+	idleWatchdogMaxTick = 5 * time.Minute
 )
 
 // pendingWorkHintMinInterval is the floor between two hint-driven heartbeats
@@ -8513,6 +8521,27 @@ func idleWatchdogReason(window time.Duration) string {
 	return fmt.Sprintf("agent produced no new messages for %s and message queue was empty; force-stopped by idle watchdog", window)
 }
 
+// idleWatchdogTickInterval picks how often the idle watchdog re-checks the
+// silence budget. Half the window is the base rate; the 30 s floor only applies
+// to windows of at least a minute, so tests can pass tiny windows (50 ms) and
+// still see the watchdog fire within a few ticks. idleWatchdogMaxTick caps the
+// other end: without it the overshoot scales with the budget, and a multi-hour
+// window would be polled so rarely that a genuinely stuck run outlives its
+// budget by hours. Worst-case detection is therefore window + tick.
+func idleWatchdogTickInterval(window time.Duration) time.Duration {
+	interval := window / 2
+	if window >= time.Minute && interval < 30*time.Second {
+		interval = 30 * time.Second
+	}
+	if interval > idleWatchdogMaxTick {
+		interval = idleWatchdogMaxTick
+	}
+	if interval <= 0 {
+		interval = window
+	}
+	return interval
+}
+
 // runIdleWatchdog ticks until either agentCtx is cancelled or the backend has
 // been silent past the applicable budget. On firing, it records the tripped
 // threshold, sets fired, and calls cancel, which propagates to the agent
@@ -8520,30 +8549,24 @@ func idleWatchdogReason(window time.Duration) string {
 // silence budget depends on whether a tool call is in flight:
 //
 //  1. No tool in flight — a silent backend is a hang after `window`.
-//  2. A tool in flight (tool_use with no matching tool_result yet) — a real
-//     tool (e.g. `npm install`, `docker build`) legitimately runs silently for
-//     many minutes, so the larger `toolWindow` applies instead. toolWindow <= 0
-//     keeps the historical behavior of never force-stopping while a tool is in
-//     flight. Without this in-flight budget a backend that emits tool_use and
-//     never the matching tool_result would run forever now that there is no
-//     wall-clock cap (MUL-3064).
+//  2. A tool in flight (tool_use with no matching tool_result yet) —
+//     `toolWindow` applies instead. It defaults to `window`, so the two are
+//     normally identical and this branch only changes which duration the
+//     failure message reports; an operator who deliberately sets
+//     MULTICA_AGENT_TOOL_WATCHDOG higher buys long tools extra room, and
+//     toolWindow <= 0 keeps the historical behavior of never force-stopping
+//     while a tool is in flight. Without this in-flight budget a backend that
+//     emits tool_use and never the matching tool_result would run forever now
+//     that there is no wall-clock cap (MUL-3064).
 //
 // In both cases the watchdog also requires the session.Messages buffer to be
 // empty — a buffered-but-undrained message means the drain loop is behind, not
 // the backend.
 //
-// Tick interval is window/2 (floored at 30 s in production, but the floor only
-// kicks in for windows >= 1 min so tests can pass tiny windows like 50 ms and
-// see the watchdog fire within a few ticks).
+// Polling rate comes from idleWatchdogTickInterval, so a run is force-stopped
+// somewhere between its budget and budget + tick, never earlier.
 func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, firedThreshold *atomic.Int64, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger, taskID string) {
-	interval := window / 2
-	if window >= time.Minute && interval < 30*time.Second {
-		interval = 30 * time.Second
-	}
-	if interval <= 0 {
-		interval = window
-	}
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(idleWatchdogTickInterval(window))
 	defer ticker.Stop()
 	for {
 		select {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -85,13 +85,16 @@ const (
 	// pendingWorkHintBookkeepingTTL is how long a runtime's last-hint timestamp
 	// is retained before it is swept — purely to keep the map bounded.
 	pendingWorkHintBookkeepingTTL = 10 * time.Minute
-	// idleWatchdogMaxTick caps the idle watchdog's polling interval. The
-	// interval is window/2, which was fine when the window was minutes but
-	// makes the overshoot scale with the budget: a 2h window would only be
-	// checked hourly, so a genuinely stuck run could hold its slot for 3h.
-	// Capping the tick keeps worst-case detection at window + 5m regardless of
-	// how large an operator sets the budget, at the cost of a no-op comparison
-	// every 5 minutes.
+	// idleWatchdogMaxTick caps the idle watchdog's polling interval. At the
+	// base rate of window/2 the overshoot scales with the budget: a 2h window
+	// would only be checked hourly, so a genuinely stuck run could hold its
+	// slot for 3h. The cap makes worst-case detection window + 5m no matter how
+	// large an operator sets the budget.
+	//
+	// 5m is chosen as the largest overshoot worth tolerating on top of a budget
+	// already measured in hours, not for its polling cost — a tick is an atomic
+	// load and a channel length check, so it is free at any interval anyone
+	// would pick.
 	idleWatchdogMaxTick = 5 * time.Minute
 )
 
@@ -1970,6 +1973,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		"heartbeat_interval", d.cfg.HeartbeatInterval,
 		"agent_timeout", d.cfg.AgentTimeout,
 		"idle_watchdog", d.cfg.AgentIdleWatchdog,
+		// Logged explicitly because it is normally derived from idle_watchdog:
+		// without it an operator cannot read the tool budget actually in effect.
+		"tool_watchdog", d.cfg.AgentToolWatchdog,
 		"opencode_idle_watchdog", d.cfg.OpenCodeIdleWatchdog,
 		"max_concurrent_tasks", d.cfg.MaxConcurrentTasks,
 		"gc_enabled", d.cfg.GCEnabled,
@@ -8522,17 +8528,18 @@ func idleWatchdogReason(window time.Duration) string {
 }
 
 // idleWatchdogTickInterval picks how often the idle watchdog re-checks the
-// silence budget. Half the window is the base rate; the 30 s floor only applies
-// to windows of at least a minute, so tests can pass tiny windows (50 ms) and
-// still see the watchdog fire within a few ticks. idleWatchdogMaxTick caps the
-// other end: without it the overshoot scales with the budget, and a multi-hour
-// window would be polled so rarely that a genuinely stuck run outlives its
-// budget by hours. Worst-case detection is therefore window + tick.
+// silence budget. Half the window is the base rate, capped at
+// idleWatchdogMaxTick so a run is force-stopped within window + tick rather
+// than window * 1.5. Sub-nanosecond halves fall back to the window itself so
+// tests can pass tiny budgets and still get a valid ticker.
+//
+// There used to be a `window >= time.Minute && interval < 30*time.Second` floor
+// here, meant to keep production polling no faster than 30 s. It was
+// unreachable — window >= 1 min implies window/2 >= 30 s — and its only effect
+// was to make the tests around it read as if a floor were being exercised.
+// Production windows are minutes or hours, so window/2 already clears 30 s.
 func idleWatchdogTickInterval(window time.Duration) time.Duration {
 	interval := window / 2
-	if window >= time.Minute && interval < 30*time.Second {
-		interval = 30 * time.Second
-	}
 	if interval > idleWatchdogMaxTick {
 		interval = idleWatchdogMaxTick
 	}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3267,22 +3267,22 @@ func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOp
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 
-// TestIdleWatchdogTickInterval covers both ends of the clamp. The ceiling is
-// the point: at window/2 alone, the default 2h budget would only be polled
-// every hour, so a stuck run would hold its slot for up to 3h — the overshoot
-// would grow with every increase to the budget instead of staying bounded.
+// TestIdleWatchdogTickInterval pins the ceiling, which is the reason the helper
+// exists: at window/2 alone the default 2h budget would only be polled hourly,
+// so a stuck run would hold its slot for up to 3h, and the overshoot would grow
+// with every increase to the budget instead of staying bounded.
 func TestIdleWatchdogTickInterval(t *testing.T) {
 	tests := []struct {
 		name   string
 		window time.Duration
 		want   time.Duration
 	}{
-		// Sub-minute windows keep the raw half-window so tests that pass tiny
-		// budgets still see the watchdog fire within a few ticks.
-		{name: "tiny test window keeps half", window: 50 * time.Millisecond, want: 25 * time.Millisecond},
-		{name: "floor applies at one minute", window: time.Minute, want: 30 * time.Second},
-		{name: "floor applies below its own half", window: 90 * time.Second, want: 45 * time.Second},
-		{name: "half rate between floor and ceiling", window: 8 * time.Minute, want: 4 * time.Minute},
+		// Tiny budgets keep the raw half-window so the watchdog tests below,
+		// which use millisecond windows, still see it fire within a few ticks.
+		{name: "millisecond test window halves", window: 50 * time.Millisecond, want: 25 * time.Millisecond},
+		{name: "half rate at one minute", window: time.Minute, want: 30 * time.Second},
+		{name: "half rate below the ceiling", window: 8 * time.Minute, want: 4 * time.Minute},
+		{name: "ceiling engages exactly at its double", window: 10 * time.Minute, want: idleWatchdogMaxTick},
 		{name: "ceiling caps the default budget", window: 2 * time.Hour, want: idleWatchdogMaxTick},
 		{name: "ceiling holds for very large budgets", window: 24 * time.Hour, want: idleWatchdogMaxTick},
 	}
@@ -3292,6 +3292,19 @@ func TestIdleWatchdogTickInterval(t *testing.T) {
 				t.Fatalf("idleWatchdogTickInterval(%s) = %s, want %s", tt.window, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIdleWatchdogTickInterval_NeverPollsFasterThanThirtySecondsInProduction
+// keeps the guarantee the removed 30 s floor was written for. The floor itself
+// was unreachable (window >= 1 min implies window/2 >= 30 s), so this asserts
+// the property directly against every production-shaped budget instead of
+// re-introducing a branch that can never run.
+func TestIdleWatchdogTickInterval_NeverPollsFasterThanThirtySecondsInProduction(t *testing.T) {
+	for window := time.Minute; window <= 4*time.Hour; window += time.Second {
+		if got := idleWatchdogTickInterval(window); got < 30*time.Second {
+			t.Fatalf("idleWatchdogTickInterval(%s) = %s, want >= 30s", window, got)
+		}
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3267,6 +3267,34 @@ func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOp
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 
+// TestIdleWatchdogTickInterval covers both ends of the clamp. The ceiling is
+// the point: at window/2 alone, the default 2h budget would only be polled
+// every hour, so a stuck run would hold its slot for up to 3h — the overshoot
+// would grow with every increase to the budget instead of staying bounded.
+func TestIdleWatchdogTickInterval(t *testing.T) {
+	tests := []struct {
+		name   string
+		window time.Duration
+		want   time.Duration
+	}{
+		// Sub-minute windows keep the raw half-window so tests that pass tiny
+		// budgets still see the watchdog fire within a few ticks.
+		{name: "tiny test window keeps half", window: 50 * time.Millisecond, want: 25 * time.Millisecond},
+		{name: "floor applies at one minute", window: time.Minute, want: 30 * time.Second},
+		{name: "floor applies below its own half", window: 90 * time.Second, want: 45 * time.Second},
+		{name: "half rate between floor and ceiling", window: 8 * time.Minute, want: 4 * time.Minute},
+		{name: "ceiling caps the default budget", window: 2 * time.Hour, want: idleWatchdogMaxTick},
+		{name: "ceiling holds for very large budgets", window: 24 * time.Hour, want: idleWatchdogMaxTick},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := idleWatchdogTickInterval(tt.window); got != tt.want {
+				t.Fatalf("idleWatchdogTickInterval(%s) = %s, want %s", tt.window, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecuteAndDrain_IdleWatchdog_FiresOnInactivity(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -508,9 +508,10 @@ func antigravityModelError(model string, available []Model) error {
 // configures no wall-clock cap (opts.Timeout <= 0). agy's --print-timeout has no
 // "disabled" sentinel and falls back to a 5-minute default when omitted, so "no
 // cap" must instead be a value large enough that agy's own guillotine never
-// fires before the daemon's idle (30m) / tool (2h) watchdogs reclaim a genuinely
-// stuck run. 24h is effectively unbounded for any real turn while still being a
-// finite duration agy can parse.
+// fires before the daemon's inactivity watchdog reclaims a genuinely stuck run.
+// 24h is effectively unbounded for any real turn while still being a finite
+// duration agy can parse, and it stays above the watchdog budget even when an
+// operator raises MULTICA_AGENT_IDLE_WATCHDOG well past its default.
 const antigravityNoCapPrintTimeout = 24 * time.Hour
 
 // antigravityPrintTimeout resolves the wall-clock budget handed to agy's


### PR DESCRIPTION
## Summary

Step 1 of consolidating the timeout model discussed in MUL-6737: make the agent inactivity budget large enough for real work, and stop it from being two numbers.

The idle watchdog was sized to notice a hang quickly (30m). But the two costs it trades between are not symmetric — force-stopping a healthy run throws away the work and flips the issue to `blocked`, while noticing a hang late only holds a concurrency slot. Users running heavy tasks were landing on the wrong side of that trade, and the failure looks like an unexplained "Agent stopped after inactivity".

## Changes

**`DefaultAgentIdleWatchdog` 30m → 2h.** Sized by the longest legitimate silent step (a single long assistant message, a subagent, a full test suite) rather than by hang-detection latency. `MULTICA_AGENT_IDLE_WATCHDOG=0` still disables the whole suite.

**`AgentToolWatchdog` now defaults to the idle budget** instead of its own 2h constant. The separate tool ceiling only ever existed because 30m was too short for a real `npm install` / `docker build` / test run; at a 2h idle budget it is redundant. Deriving it also fixes a real footgun — raising `MULTICA_AGENT_IDLE_WATCHDOG` used to silently leave tool calls capped at the old 2h. `MULTICA_AGENT_TOOL_WATCHDOG` still overrides for the deliberate "tools may run longer than the model may think" case, and `0` keeps its distinct meaning: never force-stop while a tool is in flight.

The derivation tracks in **both** directions, which is worth calling out explicitly. Self-hosted operators who had deliberately set `MULTICA_AGENT_IDLE_WATCHDOG` *below* 2h previously kept a separate, larger 2h tool budget; their tool calls now follow the same shortened number. That is the intended consequence of collapsing this to one knob, but it is a behaviour change in the tightening direction rather than only the loosening one, and `MULTICA_AGENT_TOOL_WATCHDOG` is how those operators keep the two apart.

**Watchdog tick capped at 5m.** It was `window/2`, so overshoot scaled with the budget — a 2h window would only be polled hourly, letting a genuinely stuck run hold its slot for up to 3h. Worst-case detection is now `budget + 5m` regardless of how large an operator sets the budget. Extracted as `idleWatchdogTickInterval` so the clamp is directly testable.

Extracting it surfaced that the existing `window >= time.Minute && interval < 30*time.Second` floor was unreachable — `window >= 1min` implies `window/2 >= 30s` — so it is removed rather than carried forward. The guarantee it was written for (never poll faster than 30s in production) is now asserted directly against every production-shaped budget in `TestIdleWatchdogTickInterval_NeverPollsFasterThanThirtySecondsInProduction`. No behaviour change: the branch never executed.

**Docs / cleanup.** Removed `MULTICA_CODEX_TIMEOUT` from `.env.example` (dead — nothing in the codebase reads it). Added the `MULTICA_AGENT_IDLE_WATCHDOG` / `MULTICA_AGENT_TOOL_WATCHDOG` / `MULTICA_CODEX_FIRST_TURN_TIMEOUT` / `MULTICA_CODEX_HANDSHAKE_TIMEOUT` rows that `CLI_AND_DAEMON.md` never had. Updated the four `environment-variables*.mdx` locales with the new values plus the reasoning behind them, and corrected a stale `idle (30m) / tool (2h)` comment in `antigravity.go`.

## Not in this PR

Deliberately out of scope, tracked as step 2 in MUL-6737:

- OpenCode's 10m idle window and Codex's 10m semantic-inactivity timeout still act as lower per-backend ceilings, so those two backends do not get the full 2h yet.
- The server-side `runningTimeoutSeconds = 9000` backstop and `TASK_QUEUED_TTL` folding into the reconnect grace.

`CLI_AND_DAEMON.md` also documents the poll interval as `3s` while the code default is `30s`. Left alone here — unrelated to this change.

## Verification

```
go build ./...
go vet ./internal/daemon/... ./pkg/agent/...
go test ./internal/daemon/ -run 'Watchdog' -count=1        # ok
go test ./internal/daemon/... ./pkg/agent/... -count=1
```

All idle/tool watchdog tests pass, including the existing suite (`TestExecuteAndDrain_IdleWatchdog_*`), which uses millisecond windows and is unaffected by the default change. New coverage:

- `TestLoadConfig_ToolWatchdogDefaultsToIdleWatchdog` — pins the derivation: default tracks idle, raising idle carries tool with it, explicit override wins, `0` is not re-derived, and disabling the suite disables both.
- `TestIdleWatchdogTickInterval` — both ends of the clamp, including that a 2h budget is polled every 5m rather than hourly.

Pre-existing failures unrelated to this change, confirmed identical on a clean tree in this environment: `TestHermesMemoryStorePathLayout`, `TestPruneHermesMemoryStores`, `TestHermesSessionStorePathLayout`, `TestPruneHermesSessionStores`, `TestLoadConfig_BackendOverrides_BackwardCompat_NoConfigFile`, `TestPrepareReasonixTaskStateHome`, `TestPrepareDshTaskSessionRoot`, `TestEnsureDaemonID_*`, `TestLegacyDaemonUUIDs_ScansProfileDirs`.

