### PR TITLE
MUL-6795: VENU-68: contain analytics leaderboard horizontal overflow

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -742,14 +742,12 @@ describe("DashboardPage — leaderboard density", () => {
     const user = userEvent.setup();
     renderDashboard();
 
-    // Scoped to the leaderboard card — the trend chart's metric toggle owns
-    // a "Time" button too.
-    const card = screen
-      .getByRole("list", { name: "Leaderboard" })
-      .closest(".rounded-lg") as HTMLElement;
     // Re-ranking must not quietly reveal the tail: the cap belongs to the
     // list, not to one metric.
-    await user.click(within(card).getByRole("button", { name: "Time" }));
+    const sortControls = within(
+      screen.getByRole("group", { name: "Rank agents by" }),
+    );
+    await user.click(sortControls.getByRole("button", { name: "Time" }));
 
     const list = within(screen.getByRole("list", { name: "Leaderboard" }));
     expect(list.getAllByRole("listitem")).toHaveLength(10);
@@ -765,18 +763,25 @@ describe("DashboardPage — leaderboard density", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("contains wide leaderboard columns in a local horizontal scroller", () => {
+  it("exposes wide columns through a named keyboard-focusable local scroller", () => {
     renderDashboard();
 
-    const list = screen.getByRole("list", { name: "Leaderboard" });
-    const grid = list.parentElement;
-    const scroller = grid?.parentElement;
+    const scroller = screen.getByRole("region", { name: "Leaderboard" });
+    const list = within(scroller).getByRole("list", { name: "Leaderboard" });
+    const row = within(list).getByRole("listitem");
 
-    expect(grid).toHaveClass("min-w-[44rem]");
+    expect(scroller).toHaveAttribute("tabindex", "0");
+    scroller.focus();
+    expect(scroller).toHaveFocus();
     expect(scroller).toHaveClass(
       "overflow-x-auto",
       "overscroll-x-contain",
       "[-webkit-overflow-scrolling:touch]",
     );
+    expect(row).toHaveStyle({
+      minWidth: "fit-content",
+      gridTemplateColumns:
+        "minmax(10rem, 1.6fr) minmax(6rem, 1fr) 5rem 5rem 5rem 4rem",
+    });
   });
 });

--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -744,8 +744,9 @@ describe("DashboardPage — leaderboard density", () => {
 
     // Scoped to the leaderboard card — the trend chart's metric toggle owns
     // a "Time" button too.
-    const card = screen.getByRole("list", { name: "Leaderboard" })
-      .parentElement as HTMLElement;
+    const card = screen
+      .getByRole("list", { name: "Leaderboard" })
+      .closest(".rounded-lg") as HTMLElement;
     // Re-ranking must not quietly reveal the tail: the cap belongs to the
     // list, not to one metric.
     await user.click(within(card).getByRole("button", { name: "Time" }));
@@ -762,5 +763,20 @@ describe("DashboardPage — leaderboard density", () => {
     expect(
       screen.queryByRole("button", { name: "Show all" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("contains wide leaderboard columns in a local horizontal scroller", () => {
+    renderDashboard();
+
+    const list = screen.getByRole("list", { name: "Leaderboard" });
+    const grid = list.parentElement;
+    const scroller = grid?.parentElement;
+
+    expect(grid).toHaveClass("min-w-[44rem]");
+    expect(scroller).toHaveClass(
+      "overflow-x-auto",
+      "overscroll-x-contain",
+      "[-webkit-overflow-scrolling:touch]",
+    );
   });
 });

--- a/packages/views/dashboard/components/leaderboard.css
+++ b/packages/views/dashboard/components/leaderboard.css
@@ -1,0 +1,11 @@
+/* Large interaction regions share the inset focus treatment defined by
+   editor/styles/zoom-canvas.css: the indicator stays visible without adding
+   an outer halo around the containing card. */
+.leaderboard-scroll-region {
+  outline: none;
+}
+
+.leaderboard-scroll-region:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}

--- a/packages/views/dashboard/components/leaderboard.tsx
+++ b/packages/views/dashboard/components/leaderboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, type CSSProperties } from "react";
 import { EyeOff, Trash2 } from "lucide-react";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { formatTokens } from "../../runtimes/utils";
@@ -13,6 +13,7 @@ import {
   type AgentDashboardRow,
 } from "../utils";
 import { Segmented } from "./dashboard-shared";
+import "./leaderboard.css";
 
 // Which metric ranks the leaderboard. Drives row order, progress bar
 // width, and which column header is emphasised — keeping the three in
@@ -33,8 +34,19 @@ const SORT_METRIC: Record<LeaderboardSort, (r: AgentDashboardRow) => number> = {
 // tail is reachable via the toggle.
 const LEADERBOARD_LIMIT = 10;
 
-const LEADERBOARD_GRID =
-  "grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_5rem_5rem_5rem_4rem] items-center gap-3";
+// The flexible columns own the readability constraints they protect instead
+// of deriving them from a detached total width. Agent keeps a 24px avatar, an
+// 8px gap, and 128px of readable name; Progress keeps its 8px bar at a 12:1
+// comparison length. `fit-content` lets those floors plus the fixed tracks,
+// gaps, and row padding form the intrinsic scroll width while the fr tracks
+// still expand on wider cards.
+const LEADERBOARD_GRID_STYLE = {
+  minWidth: "fit-content",
+  gridTemplateColumns:
+    "minmax(10rem, 1.6fr) minmax(6rem, 1fr) 5rem 5rem 5rem 4rem",
+} satisfies CSSProperties;
+
+const LEADERBOARD_GRID = "grid items-center gap-3";
 
 export function Leaderboard({
   rows,
@@ -135,17 +147,31 @@ export function Leaderboard({
           {t(($) => $.leaderboard.no_data)}
         </p>
       ) : (
-        <div className="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
-          <div className="min-w-[44rem]">
+        <div
+          role="region"
+          aria-label={t(($) => $.leaderboard.title)}
+          tabIndex={0}
+          className="leaderboard-scroll-region overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]"
+        >
+          <div>
             <div
               className={`${LEADERBOARD_GRID} border-b px-4 py-2 text-caption font-medium text-muted-foreground`}
+              style={LEADERBOARD_GRID_STYLE}
             >
               <span>{t(($) => $.leaderboard.header_agent)}</span>
               <span />
-              <span className={colClass("tokens")}>{t(($) => $.leaderboard.header_tokens)}</span>
-              <span className={colClass("cost")}>{t(($) => $.leaderboard.header_cost)}</span>
-              <span className={colClass("time")}>{t(($) => $.leaderboard.header_time)}</span>
-              <span className={colClass("tasks")}>{t(($) => $.leaderboard.header_tasks)}</span>
+              <span className={colClass("tokens")}>
+                {t(($) => $.leaderboard.header_tokens)}
+              </span>
+              <span className={colClass("cost")}>
+                {t(($) => $.leaderboard.header_cost)}
+              </span>
+              <span className={colClass("time")}>
+                {t(($) => $.leaderboard.header_time)}
+              </span>
+              <span className={colClass("tasks")}>
+                {t(($) => $.leaderboard.header_tasks)}
+              </span>
             </div>
             {/* A real list, like the offender list on the Errors tab: the rows are
                 a truncated ranking, so screen readers need the count and the
@@ -168,13 +194,18 @@ export function Leaderboard({
                 // agent-builder sessions, which nobody can name — including the
                 // admin who owns them.
                 const isDeletedBucket = row.agentId === DELETED_AGENTS_ROW_ID;
-                const isRestrictedBucket = row.agentId === RESTRICTED_AGENTS_ROW_ID;
+                const isRestrictedBucket =
+                  row.agentId === RESTRICTED_AGENTS_ROW_ID;
                 const isBucket = isDeletedBucket || isRestrictedBucket;
                 const agent = agents.find((a) => a.id === row.agentId);
                 const value = SORT_METRIC[sortBy](row);
                 const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
                 return (
-                  <li key={row.agentId} className={`${LEADERBOARD_GRID} px-4 py-2`}>
+                  <li
+                    key={row.agentId}
+                    className={`${LEADERBOARD_GRID} px-4 py-2`}
+                    style={LEADERBOARD_GRID_STYLE}
+                  >
                     <div className="flex min-w-0 items-center gap-2">
                       {isBucket ? (
                         <>

--- a/packages/views/dashboard/components/leaderboard.tsx
+++ b/packages/views/dashboard/components/leaderboard.tsx
@@ -135,108 +135,110 @@ export function Leaderboard({
           {t(($) => $.leaderboard.no_data)}
         </p>
       ) : (
-        <>
-          <div
-            className={`${LEADERBOARD_GRID} border-b px-4 py-2 text-caption font-medium text-muted-foreground`}
-          >
-            <span>{t(($) => $.leaderboard.header_agent)}</span>
-            <span />
-            <span className={colClass("tokens")}>{t(($) => $.leaderboard.header_tokens)}</span>
-            <span className={colClass("cost")}>{t(($) => $.leaderboard.header_cost)}</span>
-            <span className={colClass("time")}>{t(($) => $.leaderboard.header_time)}</span>
-            <span className={colClass("tasks")}>{t(($) => $.leaderboard.header_tasks)}</span>
-          </div>
-          {/* A real list, like the offender list on the Errors tab: the rows are
-              a truncated ranking, so screen readers need the count and the
-              item boundaries rather than a bag of divs. */}
-          <ul aria-label={t(($) => $.leaderboard.title)} className="divide-y">
-            {visibleRows.map((row) => {
-              // Two synthetic rows, neither a real agent: both render a neutral
-              // placeholder (no avatar fetch / hover card / UUID) instead of
-              // looking the id up in the agent list.
-              //
-              // Only the deleted bucket dashes out Time/Tasks — it genuinely
-              // never carries them (see bucketUnknownAgentRows). The server's
-              // bucket does: those agents are alive and ran, the server just
-              // merged them (MUL-5409), so zeroing their columns would
-              // under-report the workspace's run time.
-              //
-              // Its copy is the neutral "Other agents" rather than anything
-              // about permissions, because it covers two populations: agents
-              // this viewer may not see, and the hidden system carriers behind
-              // agent-builder sessions, which nobody can name — including the
-              // admin who owns them.
-              const isDeletedBucket = row.agentId === DELETED_AGENTS_ROW_ID;
-              const isRestrictedBucket = row.agentId === RESTRICTED_AGENTS_ROW_ID;
-              const isBucket = isDeletedBucket || isRestrictedBucket;
-              const agent = agents.find((a) => a.id === row.agentId);
-              const value = SORT_METRIC[sortBy](row);
-              const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
-              return (
-                <li key={row.agentId} className={`${LEADERBOARD_GRID} px-4 py-2`}>
-                  <div className="flex min-w-0 items-center gap-2">
-                    {isBucket ? (
-                      <>
-                        <span className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                          {isDeletedBucket ? (
-                            <Trash2 className="h-3 w-3" />
-                          ) : (
-                            <EyeOff className="h-3 w-3" />
-                          )}
-                        </span>
-                        <span className="truncate text-body font-medium italic text-muted-foreground">
-                          {isDeletedBucket
-                            ? t(($) => $.leaderboard.deleted_agents)
-                            : t(($) => $.leaderboard.other_agents)}
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <ActorAvatar
-                          actorType="agent"
-                          actorId={row.agentId}
-                          size="md"
-                          enableHoverCard
-                        />
-                        <span className="cursor-pointer truncate text-body font-medium">
-                          {agent?.name ?? row.agentId}
-                        </span>
-                      </>
-                    )}
-                  </div>
-                  <div className="relative h-2 overflow-hidden rounded-full bg-muted">
+        <div className="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+          <div className="min-w-[44rem]">
+            <div
+              className={`${LEADERBOARD_GRID} border-b px-4 py-2 text-caption font-medium text-muted-foreground`}
+            >
+              <span>{t(($) => $.leaderboard.header_agent)}</span>
+              <span />
+              <span className={colClass("tokens")}>{t(($) => $.leaderboard.header_tokens)}</span>
+              <span className={colClass("cost")}>{t(($) => $.leaderboard.header_cost)}</span>
+              <span className={colClass("time")}>{t(($) => $.leaderboard.header_time)}</span>
+              <span className={colClass("tasks")}>{t(($) => $.leaderboard.header_tasks)}</span>
+            </div>
+            {/* A real list, like the offender list on the Errors tab: the rows are
+                a truncated ranking, so screen readers need the count and the
+                item boundaries rather than a bag of divs. */}
+            <ul aria-label={t(($) => $.leaderboard.title)} className="divide-y">
+              {visibleRows.map((row) => {
+                // Two synthetic rows, neither a real agent: both render a neutral
+                // placeholder (no avatar fetch / hover card / UUID) instead of
+                // looking the id up in the agent list.
+                //
+                // Only the deleted bucket dashes out Time/Tasks — it genuinely
+                // never carries them (see bucketUnknownAgentRows). The server's
+                // bucket does: those agents are alive and ran, the server just
+                // merged them (MUL-5409), so zeroing their columns would
+                // under-report the workspace's run time.
+                //
+                // Its copy is the neutral "Other agents" rather than anything
+                // about permissions, because it covers two populations: agents
+                // this viewer may not see, and the hidden system carriers behind
+                // agent-builder sessions, which nobody can name — including the
+                // admin who owns them.
+                const isDeletedBucket = row.agentId === DELETED_AGENTS_ROW_ID;
+                const isRestrictedBucket = row.agentId === RESTRICTED_AGENTS_ROW_ID;
+                const isBucket = isDeletedBucket || isRestrictedBucket;
+                const agent = agents.find((a) => a.id === row.agentId);
+                const value = SORT_METRIC[sortBy](row);
+                const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
+                return (
+                  <li key={row.agentId} className={`${LEADERBOARD_GRID} px-4 py-2`}>
+                    <div className="flex min-w-0 items-center gap-2">
+                      {isBucket ? (
+                        <>
+                          <span className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                            {isDeletedBucket ? (
+                              <Trash2 className="h-3 w-3" />
+                            ) : (
+                              <EyeOff className="h-3 w-3" />
+                            )}
+                          </span>
+                          <span className="truncate text-body font-medium italic text-muted-foreground">
+                            {isDeletedBucket
+                              ? t(($) => $.leaderboard.deleted_agents)
+                              : t(($) => $.leaderboard.other_agents)}
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          <ActorAvatar
+                            actorType="agent"
+                            actorId={row.agentId}
+                            size="md"
+                            enableHoverCard
+                          />
+                          <span className="cursor-pointer truncate text-body font-medium">
+                            {agent?.name ?? row.agentId}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                    <div className="relative h-2 overflow-hidden rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full bg-chart-1 transition-[width] duration-300 ease-out"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
                     <div
-                      className="h-full rounded-full bg-chart-1 transition-[width] duration-300 ease-out"
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
-                  <div
-                    className={`text-right text-caption tabular-nums ${sortBy === "tokens" ? "font-medium text-foreground" : "text-muted-foreground"}`}
-                  >
-                    {formatTokens(row.tokens)}
-                  </div>
-                  <div
-                    className={`text-right tabular-nums ${sortBy === "cost" ? "text-body font-medium" : "text-caption text-muted-foreground"}`}
-                  >
-                    ${row.cost.toFixed(2)}
-                  </div>
-                  <div
-                    className={`text-right text-caption tabular-nums ${sortBy === "time" ? "font-medium text-foreground" : "text-muted-foreground"}`}
-                  >
-                    {isDeletedBucket
-                      ? "—"
-                      : formatDuration(row.seconds, lessThanMinuteLabel)}
-                  </div>
-                  <div
-                    className={`text-right text-caption tabular-nums ${sortBy === "tasks" ? "font-medium text-foreground" : "text-muted-foreground"}`}
-                  >
-                    {isDeletedBucket ? "—" : row.taskCount}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </>
+                      className={`text-right text-caption tabular-nums ${sortBy === "tokens" ? "font-medium text-foreground" : "text-muted-foreground"}`}
+                    >
+                      {formatTokens(row.tokens)}
+                    </div>
+                    <div
+                      className={`text-right tabular-nums ${sortBy === "cost" ? "text-body font-medium" : "text-caption text-muted-foreground"}`}
+                    >
+                      ${row.cost.toFixed(2)}
+                    </div>
+                    <div
+                      className={`text-right text-caption tabular-nums ${sortBy === "time" ? "font-medium text-foreground" : "text-muted-foreground"}`}
+                    >
+                      {isDeletedBucket
+                        ? "—"
+                        : formatDuration(row.seconds, lessThanMinuteLabel)}
+                    </div>
+                    <div
+                      className={`text-right text-caption tabular-nums ${sortBy === "tasks" ? "font-medium text-foreground" : "text-muted-foreground"}`}
+                    >
+                      {isDeletedBucket ? "—" : row.taskCount}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Fixes #7698
Fixes VENU-68

Review follow-up tracked in VENU-129.

## Summary

- contain leaderboard columns in a named, keyboard-focusable horizontal scroll region
- replace the detached `44rem` container width with intrinsic column constraints: Agent `10rem`, Progress `6rem`, plus the existing fixed metric tracks
- preserve the full trailing padding with `min-width: fit-content` on each grid while allowing the flexible tracks to expand on wider cards
- reuse the inset focus treatment from `packages/views/editor/styles/zoom-canvas.css` so keyboard focus stays visible without adding an outer halo
- test the region through its role/name contract and pin the product-level CSS constraints instead of Tailwind class strings or DOM parent hops

## Width rationale

The grid now owns its readability policy at the column level:

- Agent: `10rem` for a 24px avatar, an 8px gap, and 128px of readable name
- Progress: `6rem`, keeping the 8px bar at a 12:1 comparison length
- Metrics: `5rem + 5rem + 5rem + 4rem = 19rem`
- Gutters and row padding: `3.75rem + 2rem`

Together these form a natural `40.75rem` / `652px` scroll floor, but the code does not duplicate that total as another magic constant. Above the floor, the `1.6fr / 1fr` tracks continue to expand normally.

## Accessibility

The local scroller now has `role="region"`, the translated leaderboard title as its accessible name, and `tabIndex={0}`. Keyboard users can focus the region directly and use the browser's native horizontal scrolling keys. Its `:focus-visible` state uses `2px solid var(--ring)` with `outline-offset: -2px`, matching the large-interaction-region pattern in `zoom-canvas.css`.

## Verification

- `pnpm --filter @multica/views exec vitest run dashboard/components/dashboard-page.test.tsx` (24 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (0 errors; 27 pre-existing warnings outside the changed files)
- `git diff --check`
- `pnpm --filter @multica/views test` was also attempted on the rebased tree: 4,872 passed and 20 unrelated tests failed across 10 files, primarily on existing 5s/30s timeouts. The focused dashboard suite above passes; CI is re-running on the pushed head.

## Responsive recordings

These recordings supersede the earlier single 375px capture. Each enters the named region from the preceding button with Tab, scrolls with the keyboard, and displays live region/page geometry:

- [375×812](https://static.multica.ai/workspaces/093192fd-8085-4b7c-800d-038a539f4998/01a056cf-2f47-71b3-9055-473a5af12ac4.webm): region `325/652px`, max scroll `327px`; page `375/375px`
- [640×812](https://static.multica.ai/workspaces/093192fd-8085-4b7c-800d-038a539f4998/01a056cf-31ae-78f2-9e9c-f55b8051646b.webm): region `590/652px`, max scroll `62px`; page `640/640px`
- [704×812](https://static.multica.ai/workspaces/093192fd-8085-4b7c-800d-038a539f4998/01a056cf-3405-70f3-9519-a433e4e2a406.webm): region `654/654px`; page `704/704px`
- [1024×812](https://static.multica.ai/workspaces/093192fd-8085-4b7c-800d-038a539f4998/01a056cf-364d-7d42-b5e1-8be54f19b137.webm): region `850/850px`; page `1024/1024px`
- [1440×900](https://static.multica.ai/workspaces/093192fd-8085-4b7c-800d-038a539f4998/01a056cf-38b4-7578-9d0e-be748f42bbd1.webm): region `1102/1102px`; page `1440/1440px`
