### PR TITLE
MUL-6794: fix skill import dialog footer overflow and trim its copy

### DIFF
--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -248,34 +248,24 @@
     "method": {
       "chooser": {
         "title": "New skill",
-        "desc": "Choose how you want to add a skill to this workspace."
+        "desc": "Choose how to add a skill to this workspace."
       },
       "manual": {
         "title": "Create manually",
-        "desc": "Write a new SKILL.md from scratch."
+        "desc": "Start from a blank SKILL.md."
       },
       "local": {
         "title": "Import from local",
-        "desc": "Choose a skill folder on this computer. Files are packed and uploaded."
+        "desc": "Pick a folder with SKILL.md, or a .skill / .zip archive."
       },
       "url": {
         "title": "Import from URL",
-        "desc": "Fetch a published skill by URL. Files are pulled server-side."
+        "desc": "Fetch a published skill by URL."
       },
       "runtime": {
         "title": "Copy from runtime",
-        "desc": "Scan a local runtime and promote one of its on-disk skills into this workspace."
+        "desc": "Promote a skill installed on your local runtime."
       }
-    },
-    "method_card": {
-      "manual_title": "Create manually",
-      "manual_desc": "Start from a blank SKILL.md and write your own instructions.",
-      "local_title": "Import from local",
-      "local_desc": "Pick a folder that contains SKILL.md, or a .skill / .zip archive.",
-      "url_title": "Import from URL",
-      "url_desc": "Pull a published skill from ClawHub or Skills.sh.",
-      "runtime_title": "Copy from runtime",
-      "runtime_desc": "Promote a skill already installed on your local runtime."
     },
     "manual": {
       "name_label": "Name",
@@ -293,7 +283,6 @@
     "local": {
       "choose_folder": "Choose folder",
       "choose_archive": "Choose .skill / .zip",
-      "pick_hint": "Select a folder that contains SKILL.md, or a packaged .skill / .zip file.",
       "folder_label": "Folder",
       "archive_label": "Archive",
       "files_one": "{{count}} file",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -233,34 +233,24 @@
     "method": {
       "chooser": {
         "title": "新規スキル",
-        "desc": "このワークスペースにスキルを追加する方法を選択してください。"
+        "desc": "スキルを追加する方法を選択してください。"
       },
       "manual": {
         "title": "手動で作成",
-        "desc": "新しい SKILL.md を一から作成します。"
+        "desc": "空の SKILL.md から作成します。"
       },
       "local": {
         "title": "ローカルからインポート",
-        "desc": "このコンピュータ上のスキルフォルダを選びます。ファイルはまとめてアップロードされます。"
+        "desc": "SKILL.md を含むフォルダ、または .skill / .zip を選択します。"
       },
       "url": {
         "title": "URL からインポート",
-        "desc": "公開済みのスキルを URL で取得します。ファイルはサーバー側で取得されます。"
+        "desc": "公開済みのスキルを URL で取得します。"
       },
       "runtime": {
         "title": "ランタイムからコピー",
-        "desc": "ローカルランタイムをスキャンし、ディスク上のスキルの 1 つをこのワークスペースに昇格します。"
+        "desc": "ローカルランタイムにあるスキルをワークスペースに昇格します。"
       }
-    },
-    "method_card": {
-      "manual_title": "手動で作成",
-      "manual_desc": "空の SKILL.md から始めて、独自の指示を記述します。",
-      "local_title": "ローカルからインポート",
-      "local_desc": "SKILL.md を含むフォルダ、または .skill / .zip アーカイブを選びます。",
-      "url_title": "URL からインポート",
-      "url_desc": "ClawHub または Skills.sh の公開スキルを取得します。",
-      "runtime_title": "ランタイムからコピー",
-      "runtime_desc": "ローカルランタイムにすでにインストールされているスキルを昇格します。"
     },
     "manual": {
       "name_label": "名前",
@@ -278,7 +268,6 @@
     "local": {
       "choose_folder": "フォルダを選択",
       "choose_archive": ".skill / .zip を選択",
-      "pick_hint": "SKILL.md を含むフォルダ、またはパッケージ済みの .skill / .zip ファイルを選択してください。",
       "folder_label": "フォルダ",
       "archive_label": "アーカイブ",
       "files_other": "{{count}} 個のファイル",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -233,34 +233,24 @@
     "method": {
       "chooser": {
         "title": "새 스킬",
-        "desc": "이 워크스페이스에 스킬을 추가할 방식을 선택하세요."
+        "desc": "스킬을 추가할 방식을 선택하세요."
       },
       "manual": {
         "title": "직접 만들기",
-        "desc": "새 SKILL.md를 처음부터 작성합니다."
+        "desc": "빈 SKILL.md에서 시작합니다."
       },
       "local": {
         "title": "로컬에서 가져오기",
-        "desc": "이 컴퓨터의 스킬 폴더를 선택합니다. 파일은 묶어서 업로드됩니다."
+        "desc": "SKILL.md가 있는 폴더 또는 .skill / .zip을 선택합니다."
       },
       "url": {
         "title": "URL에서 가져오기",
-        "desc": "공개된 스킬을 URL로 가져옵니다. 파일은 서버에서 가져옵니다."
+        "desc": "공개된 스킬을 URL로 가져옵니다."
       },
       "runtime": {
         "title": "런타임에서 복사",
-        "desc": "로컬 런타임을 스캔해 디스크에 있는 스킬을 이 워크스페이스로 승격합니다."
+        "desc": "로컬 런타임에 설치된 스킬을 워크스페이스로 가져옵니다."
       }
-    },
-    "method_card": {
-      "manual_title": "직접 만들기",
-      "manual_desc": "빈 SKILL.md에서 시작해 직접 지침을 작성합니다.",
-      "local_title": "로컬에서 가져오기",
-      "local_desc": "SKILL.md가 있는 폴더, 또는 .skill / .zip 아카이브를 선택합니다.",
-      "url_title": "URL에서 가져오기",
-      "url_desc": "ClawHub 또는 Skills.sh의 공개 스킬을 가져옵니다.",
-      "runtime_title": "런타임에서 복사",
-      "runtime_desc": "로컬 런타임에 이미 설치된 스킬을 워크스페이스로 가져옵니다."
     },
     "manual": {
       "name_label": "이름",
@@ -278,7 +268,6 @@
     "local": {
       "choose_folder": "폴더 선택",
       "choose_archive": ".skill / .zip 선택",
-      "pick_hint": "SKILL.md가 있는 폴더, 또는 패키지된 .skill / .zip 파일을 선택하세요.",
       "folder_label": "폴더",
       "archive_label": "아카이브",
       "files_other": "파일 {{count}}개",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -233,7 +233,7 @@
     "method": {
       "chooser": {
         "title": "新建 skill",
-        "desc": "选择一种方式把 skill 添加到工作区。"
+        "desc": "选择添加 skill 的方式。"
       },
       "manual": {
         "title": "手动创建",
@@ -241,26 +241,16 @@
       },
       "local": {
         "title": "从本地导入",
-        "desc": "在这台电脑上选择一个 skill 文件夹，文件会打包后上传。"
+        "desc": "选择包含 SKILL.md 的文件夹，或 .skill / .zip 压缩包。"
       },
       "url": {
         "title": "从 URL 导入",
-        "desc": "通过 URL 拉取已发布的 skill，文件由服务端拉取。"
+        "desc": "通过 URL 拉取已发布的 skill。"
       },
       "runtime": {
         "title": "从运行时复制",
-        "desc": "扫描本地运行时，把它磁盘上的 skill 提升到工作区。"
+        "desc": "把本地运行时里已装好的 skill 提升到工作区。"
       }
-    },
-    "method_card": {
-      "manual_title": "手动创建",
-      "manual_desc": "从空白 SKILL.md 开始，自己写指令。",
-      "local_title": "从本地导入",
-      "local_desc": "选择包含 SKILL.md 的文件夹，或一个 .skill / .zip 压缩包。",
-      "url_title": "从 URL 导入",
-      "url_desc": "从 ClawHub 或 Skills.sh 拉取已发布的 skill。",
-      "runtime_title": "从运行时复制",
-      "runtime_desc": "把本地运行时里已经装好的 skill 提升过来。"
     },
     "manual": {
       "name_label": "名称",
@@ -278,7 +268,6 @@
     "local": {
       "choose_folder": "选择文件夹",
       "choose_archive": "选择 .skill / .zip",
-      "pick_hint": "选择包含 SKILL.md 的文件夹，或打包好的 .skill / .zip 文件。",
       "folder_label": "文件夹",
       "archive_label": "压缩包",
       "files_other": "{{count}} 个文件",

--- a/packages/views/skills/components/create-skill-dialog.test.tsx
+++ b/packages/views/skills/components/create-skill-dialog.test.tsx
@@ -155,6 +155,43 @@ describe("CreateSkillDialog local import", () => {
     expect(click).toHaveBeenCalled();
   });
 
+  // The local panel keeps its footer at Cancel + Import: a footer that also
+  // carried both source pickers overflowed the dialog and clipped Cancel
+  // (MUL-6794). The pickers live in the panel body instead.
+  it("offers both source pickers in the panel body", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Import from local/i }));
+
+    const archiveInput = document.querySelector(
+      'input[type="file"][accept]',
+    ) as HTMLInputElement;
+    const click = vi.fn();
+    archiveInput.click = click;
+    fireEvent.click(
+      screen.getByRole("button", { name: /Choose \.skill \/ \.zip/i }),
+    );
+    expect(click).toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /Choose folder/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps Import disabled until a folder is prepared", async () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Import from local/i }));
+    expect(screen.getByRole("button", { name: /^Import$/i })).toBeDisabled();
+
+    const input = document.querySelector(
+      'input[type="file"][multiple]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [new File(["---\nname: review-helper\n---\n"], "SKILL.md")] },
+    });
+
+    expect((await screen.findAllByText("review-helper")).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /^Import$/i })).toBeEnabled();
+  });
+
   it("does not import when the folder has no SKILL.md", async () => {
     mockPrepareFromPicker.mockResolvedValue({ ok: false, error: "missing_skill_md" });
     renderDialog();

--- a/packages/views/skills/components/create-skill-dialog.tsx
+++ b/packages/views/skills/components/create-skill-dialog.tsx
@@ -69,18 +69,17 @@ function seedAfterCreate(
 function MethodChooser({ onChoose }: { onChoose: (m: Method) => void }) {
   const { t } = useT("skills");
   const methods: {
-    key: Method;
+    key: Exclude<Method, "chooser">;
     icon: typeof Plus;
-    titleKey: "manual" | "local" | "url" | "runtime";
   }[] = [
-    { key: "manual", icon: Plus, titleKey: "manual" },
-    { key: "local", icon: FolderOpen, titleKey: "local" },
-    { key: "url", icon: Download, titleKey: "url" },
-    { key: "runtime", icon: HardDrive, titleKey: "runtime" },
+    { key: "manual", icon: Plus },
+    { key: "local", icon: FolderOpen },
+    { key: "url", icon: Download },
+    { key: "runtime", icon: HardDrive },
   ];
   return (
     <div className="grid gap-2 p-5">
-      {methods.map(({ key, icon: Icon, titleKey }) => (
+      {methods.map(({ key, icon: Icon }) => (
         <button
           key={key}
           type="button"
@@ -92,10 +91,10 @@ function MethodChooser({ onChoose }: { onChoose: (m: Method) => void }) {
           </div>
           <div className="min-w-0 flex-1">
             <div className="text-body font-medium">
-              {t(($) => $.create.method_card[`${titleKey}_title`])}
+              {t(($) => $.create.method[key].title)}
             </div>
             <div className="mt-0.5 text-caption text-muted-foreground">
-              {t(($) => $.create.method_card[`${titleKey}_desc`])}
+              {t(($) => $.create.method[key].desc)}
             </div>
           </div>
           <ChevronRight className="h-4 w-4 shrink-0 text-faint-foreground transition-colors group-hover:text-muted-foreground" />
@@ -455,20 +454,10 @@ function LocalForm({
   const scrollRef = useRef<HTMLDivElement>(null);
   const fadeStyle = useScrollFade(scrollRef);
 
+  // Import stays disabled until a valid selection exists, so an invalid one
+  // never reaches here — `prepareError` below already explains why.
   const submit = async () => {
-    if (!prepared || !prepared.ok) {
-      setError(
-        prepared && !prepared.ok
-          ? {
-              missing_skill_md: t(($) => $.create.local.missing_skill_md),
-              too_large: t(($) => $.create.local.too_large),
-              empty: t(($) => $.create.local.empty),
-              too_many_files: t(($) => $.create.local.too_many_files),
-            }[prepared.error]
-          : t(($) => $.create.local.pick_hint),
-      );
-      return;
-    }
+    if (!prepared?.ok) return;
     setLoading(true);
     setError("");
     try {
@@ -539,11 +528,32 @@ function LocalForm({
           </div>
         )}
 
-        {!preparing && !prepared && (
-          <p className="text-caption text-muted-foreground">
-            {t(($) => $.create.local.pick_hint)}
-          </p>
-        )}
+        {/* Source pickers belong in the body: four buttons in the footer
+            overflow the dialog width and clip Cancel (MUL-6794). */}
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={onChooseFolder}
+            disabled={loading || preparing}
+          >
+            <FolderOpen className="h-3 w-3" />
+            {t(($) => $.create.local.choose_folder)}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={onChooseArchive}
+            disabled={loading || preparing}
+          >
+            <FileArchive className="h-3 w-3" />
+            {t(($) => $.create.local.choose_archive)}
+          </Button>
+        </div>
 
         {displayError && (
           <div
@@ -573,29 +583,9 @@ function LocalForm({
         </Button>
         <Button
           type="button"
-          variant="outline"
-          size="sm"
-          onClick={onChooseArchive}
-          disabled={loading || preparing}
-        >
-          <FileArchive className="h-3 w-3" />
-          {t(($) => $.create.local.choose_archive)}
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={onChooseFolder}
-          disabled={loading || preparing}
-        >
-          <FolderOpen className="h-3 w-3" />
-          {t(($) => $.create.local.choose_folder)}
-        </Button>
-        <Button
-          type="button"
           size="sm"
           onClick={submit}
-          disabled={loading || preparing}
+          disabled={!prepared?.ok || loading || preparing}
         >
           {loading ? (
             <>
@@ -731,7 +721,7 @@ export function CreateSkillDialog({
       >
         {/* Header */}
         <div className="flex shrink-0 items-start justify-between gap-3 border-b px-5 pt-4 pb-3">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-start gap-2 min-w-0">
             {method !== "chooser" && (
               <Tooltip>
                 <TooltipTrigger
@@ -742,7 +732,7 @@ export function CreateSkillDialog({
                         resetLocal();
                         setMethod("chooser");
                       }}
-                      className="-ml-1 rounded-sm p-1 text-faint-foreground transition-colors hover:bg-accent/60 hover:text-muted-foreground"
+                      className="-ml-1 mt-px rounded-sm p-1 text-faint-foreground transition-colors hover:bg-accent/60 hover:text-muted-foreground"
                       aria-label={t(($) => $.create.back_aria)}
                     >
                       <ArrowLeft className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Problem

In the skill **Import from local** dialog, the footer held four buttons — Cancel, `Choose .skill / .zip`, `Choose folder`, Import. Buttons are `shrink-0`, so in the 448px dialog that row is wider than the content box: it overflowed to the left and `overflow-hidden` clipped Cancel to "ancel". The header description and the body hint also said the same thing twice.

## Changes

- Move the two source pickers into the panel body as an equal-width pair — where a user looks for them anyway — and leave the footer at Cancel + Import, matching the manual and URL panels.
- Disable Import until a valid selection exists, instead of turning the click into an error. This drops the prepare-error map that was duplicated inside `submit()`.
- Drop the duplicated body hint; the header line now carries what the panel accepts.
- Chooser cards read the same strings as the panel header. The parallel `method_card` set repeated all four titles/descriptions in every locale and could drift; removing it deletes 8 keys × 4 locales.
- Trim every `create.method.*.desc` line (en / zh-Hans / ja / ko) and align the back arrow with the title instead of the middle of the two-line header block.

## Verification

- `pnpm --filter @multica/views test` — 407 files, 4815 tests pass, including two new regression tests: Import stays disabled until a folder is prepared, and both source pickers stay reachable from the panel body.
- `pnpm typecheck` — 7/7 workspaces pass. `pnpm --filter @multica/views lint` — no new findings.
- Rendered the real dialog in a headless Chromium harness with Inter loaded, in en and zh-Hans, before and after: the pre-fix build reproduces the clipped Cancel exactly as reported; the post-fix footer sits inside the dialog in both locales and in the empty, selected, and chooser states.
