### PR TITLE
MUL-6796: fix mobile issue header activity status (VENU-69)

### DIFF
--- a/packages/views/issues/components/issue-agent-header-chip.test.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.test.tsx
@@ -318,6 +318,20 @@ describe("IssueAgentHeaderChip", () => {
     expect(screen.getByText("Walt 在工作")).toBeInTheDocument();
   });
 
+  it("hides the visible label on mobile while preserving a larger tap target and accessible name", () => {
+    mockState.tasks = [makeTask({ status: "queued" })];
+
+    renderWithI18n(<IssueAgentHeaderChip issueId="issue-1" />);
+
+    const trigger = screen.getByRole("button", { name: "Walt is queued" });
+    expect(trigger.querySelector("[data-slot='avatar']")).not.toBeNull();
+    expect(trigger.className).toContain("h-9 min-w-9");
+    expect(trigger.className).toContain("md:h-7 md:min-w-0");
+    const label = screen.getByText("Walt is queued");
+    expect(label.className).toContain("hidden");
+    expect(label.className).toContain("md:inline");
+  });
+
   it("does not render when the issue has only terminal tasks", () => {
     // The list is issue-scoped by the endpoint, so the chip's only job is to
     // ignore terminal statuses (those are the execution log's story).

--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -178,7 +178,7 @@ function ActiveChip({
               // header. Queued-only state stays calm (no beam) to reserve the
               // motion for work that is genuinely in flight.
               className={cn(
-                "flex h-7 max-w-[11rem] items-center gap-1.5 rounded-md px-1.5 text-muted-foreground outline-none transition-colors hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-ring",
+                "flex h-9 min-w-9 max-w-[11rem] items-center justify-center gap-1.5 rounded-md px-2 text-muted-foreground outline-none transition-colors hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-ring md:h-7 md:min-w-0 md:justify-start md:px-1.5",
                 anyRunning && "border-beam bg-brand/5",
               )}
             />
@@ -191,7 +191,10 @@ function ActiveChip({
             opacity={anyRunning ? "full" : "half"}
           />
           <span
-            className={`min-w-0 truncate text-caption ${anyRunning ? "text-info" : "text-muted-foreground"}`}
+            className={cn(
+              "hidden min-w-0 truncate text-caption md:inline",
+              anyRunning ? "text-info" : "text-muted-foreground",
+            )}
           >
             {label}
           </span>


### PR DESCRIPTION

## What does this PR do?

Keeps issue-detail headers usable on mobile while preserving the live Agent cue. Below the `md` breakpoint, `IssueAgentHeaderChip` hides its visible status label in every host, retains the avatar and full accessible name, and expands the avatar-only trigger from roughly 32×28px to at least 36×36px. Desktop continues to show the complete status label at its original height.

The original diagnosis pointed to the inbox list row. Review confirmed that the row already truncates its detail text gracefully; the real defect is the shared issue-detail header. #7702 has been updated to record that corrected diagnosis, and this final diff intentionally contains no list-row change.

## Related Issue

Closes #7702

Resolves VENU-69

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [x] Tests

## Changes Made

- Apply `hidden md:inline` directly in the header chip instead of threading opt-in props through `InboxPage` and `IssueDetail`.
- Keep the Agent avatar, popover trigger, and `aria-label` at every breakpoint.
- Increase the mobile trigger to `h-9 min-w-9` while retaining the desktop `h-7` presentation.
- Add focused regression coverage for the responsive label, target size, avatar, and accessible name.
- Squash the PR to one commit and rebase it onto the latest `main`.

## How to Test

```bash
pnpm --filter @multica/views exec vitest run \
  inbox/components/inbox-page.test.tsx \
  inbox/components/inbox-list-item.test.tsx \
  issues/components/issue-agent-header-chip.test.tsx \
  issues/components/issue-agent-activity-indicator.test.tsx
pnpm --filter @multica/views typecheck
pnpm --dir packages/views exec eslint \
  issues/components/issue-agent-header-chip.tsx \
  issues/components/issue-agent-header-chip.test.tsx
git diff --check
```

Local result from the code-changing revision: 4 test files passed, 70/70 tests; typecheck, focused ESLint, and `git diff --check` passed.

## Browser QA

The 390×844 check below uses the complete Next.js application shell and production inbox/issue-detail components. Only backend API responses are mocked to keep a running Agent task deterministic.

- viewport: 390×844;
- Agent label computed `display: none`;
- Agent trigger measured 36×36px;
- real header measured `clientWidth = scrollWidth = 390px` (no horizontal overflow);
- back control, title/breadcrumb, Agent avatar, action buttons, and sidebar toggle are all present.

### Mobile — Before (390×844)

![Mobile Before — Agent status text crowds the inbox header](https://raw.githubusercontent.com/iceprosurface/multica/69f156b5748c26826d618667a11d64e0aab9ad3f/.github/pr-assets/7703/mobile-before.png)

### Mobile — After, real application (390×844)

<img width="390" height="844" alt="Mobile After — real inbox header remains within the viewport" src="https://github.com/user-attachments/assets/a180ffa2-3a99-4e19-aeee-09e0c7f116d9" />

### Desktop — Regression check (1024×768)

![Desktop regression — full Agent status remains visible](https://raw.githubusercontent.com/iceprosurface/multica/69f156b5748c26826d618667a11d64e0aab9ad3f/.github/pr-assets/7703/desktop-regression.png)

## Checklist

- [x] The issue record and PR description match the final surface being fixed
- [x] Responsive behavior applies to every `IssueDetail` host
- [x] Mobile touch target is larger without changing desktop height
- [x] Screen-reader and keyboard access are preserved
- [x] Real-application mobile evidence is included without adding PR assets to the repository
- [x] Local focused tests and typecheck pass
- [x] PR history is one commit rebased onto current `main`

## AI Disclosure

**AI tool used:** Multica coding agent

**Approach:** Follow the review to remove the unnecessary opt-in seam, correct the issue/PR record, enlarge the mobile touch target, verify the complete application header at 390px, and produce a single rebased commit.
