### PR TITLE
feat(agents): add per-agent built-in skill controls

### DIFF
--- a/apps/docs/content/docs/cli.ja.mdx
+++ b/apps/docs/content/docs/cli.ja.mdx
@@ -127,7 +127,12 @@ multica skill list
 multica skill get <skill-id>
 multica skill import --url <skill-url>
 multica agent skills add <agent-id> --skill-ids <skill-id>
+multica agent builtins list <agent-id>
+multica agent builtins disable <agent-id> builtin:multica-working-on-issues
 ```
+
+組み込みスキルは、最初に無効化するまではプラットフォームのデフォルトを継承します。
+`multica agent builtins reset <agent-id>` を実行すると、現在および将来のすべての組み込みスキルを再び継承します。
 
 インポートで同名のスキルに当たった場合、デフォルトでは既存の内容を変更せずに停止します。意図に応じて選択してください:
 
@@ -255,6 +260,7 @@ CLI の設定ファイルには、あなたとして Multica にアクセスで�
 | | `avatar <id>` | アバターをアップロード | |
 | | `env get/set <agent-id>` | カスタム環境変数の読み書き（owner と admin のみ） | |
 | | `skills list/set/add <agent-id>` | 紐付けられたスキルを管理 | `--skill-ids`（`set` は全置換、`add` は追加） |
+| | `builtins list/enable/disable/reset <agent-id>` | エージェントごとの Multica 組み込みスキルを管理 | `list` は `inherit_all` または `exact` を表示。`reset` は現在および将来のすべての組み込みスキルの継承を復元 |
 | | `mcp list/add/enable/disable/remove <agent-id>` | ワークスペース MCP サーバーをこのエージェントに割り当て | server id は `workspace mcp list` から取得。ライブラリの項目はここで追加するまで機能しません。`disable` は割り当てを残したまま送信を停止します |
 | `autopilot` | `list/get/create/update/delete` | オートパイロットを管理 | `create`: `--title`、`--agent`、`--mode`（いずれも必須）、`--project`、`--subscriber`（繰り返し可） |
 | | `trigger <id>` | 手動で 1 回トリガー | |

--- a/apps/docs/content/docs/cli.ko.mdx
+++ b/apps/docs/content/docs/cli.ko.mdx
@@ -127,7 +127,12 @@ multica skill list
 multica skill get <skill-id>
 multica skill import --url <skill-url>
 multica agent skills add <agent-id> --skill-ids <skill-id>
+multica agent builtins list <agent-id>
+multica agent builtins disable <agent-id> builtin:multica-working-on-issues
 ```
+
+기본 제공 스킬은 처음 비활성화하기 전까지 플랫폼 기본값을 상속합니다.
+`multica agent builtins reset <agent-id>`을 실행하면 현재 및 향후의 모든 기본 제공 스킬을 다시 상속합니다.
 
 가져올 때 같은 이름의 스킬이 있으면 기본적으로 중지하고 기존 내용을 수정하지 않습니다. 의도에 맞는 방식을 선택하세요.
 
@@ -255,6 +260,7 @@ CLI 설정 파일에는 사용자를 대신해 Multica에 접근할 수 있는 t
 | | `avatar <id>` | 아바타 업로드 | |
 | | `env get/set <agent-id>` | 사용자 지정 환경 변수 읽기/쓰기(owner와 admin만) | |
 | | `skills list/set/add <agent-id>` | 연결된 스킬 관리 | `--skill-ids`(`set`은 전체 교체, `add`는 증분 추가) |
+| | `builtins list/enable/disable/reset <agent-id>` | 에이전트별 Multica 기본 제공 스킬 관리 | `list`는 `inherit_all` 또는 `exact`를 표시하며, `reset`은 현재 및 향후의 모든 기본 제공 스킬 상속을 복원 |
 | | `mcp list/add/enable/disable/remove <agent-id>` | 워크스페이스 MCP 서버를 이 에이전트에 할당 | server id는 `workspace mcp list`에서 확인. 라이브러리 항목은 여기서 추가하기 전까지 동작하지 않으며, `disable`은 할당을 유지한 채 전달만 중단합니다 |
 | `autopilot` | `list/get/create/update/delete` | 자동화 관리 | `create`: `--title`, `--agent`, `--mode`(모두 필수), `--project`, `--subscriber`(반복 가능) |
 | | `trigger <id>` | 수동으로 한 번 트리거 | |

--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -127,7 +127,13 @@ multica skill list
 multica skill get <skill-id>
 multica skill import --url <skill-url>
 multica agent skills add <agent-id> --skill-ids <skill-id>
+multica agent builtins list <agent-id>
+multica agent builtins disable <agent-id> builtin:multica-working-on-issues
 ```
+
+Built-ins inherit the platform defaults until the first disable. Use
+`multica agent builtins reset <agent-id>` to inherit every current and future
+built-in again.
 
 When an import hits a skill with the same name, the default is to stop without modifying existing content. Pick by intent:
 
@@ -263,6 +269,7 @@ The tables below cover every current top-level command, grouped the way the CLI 
 | | `avatar <id>` | Upload an avatar | |
 | | `env get/set <agent-id>` | Read and write custom environment variables (owner and admin only) | |
 | | `skills list/set/add <agent-id>` | Manage attached skills | `--skill-ids` (`set` replaces the full list, `add` appends) |
+| | `builtins list/enable/disable/reset <agent-id>` | Manage Multica built-in skills for one agent | `list` reports `inherit_all` or `exact`; `reset` restores every current and future built-in |
 | | `mcp list/add/enable/disable/remove <agent-id>` | Assign workspace MCP servers to this agent | Take the server id from `workspace mcp list`. A library entry does nothing until it is added here; `disable` stops sending it without dropping the assignment |
 | `autopilot` | `list/get/create/update/delete` | Manage automations | `create`: `--title`, `--agent`, `--mode` (all required), `--project`, `--subscriber` (repeatable) |
 | | `trigger <id>` | Trigger a run manually | |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -127,7 +127,12 @@ multica skill list
 multica skill get <skill-id>
 multica skill import --url <skill-url>
 multica agent skills add <agent-id> --skill-ids <skill-id>
+multica agent builtins list <agent-id>
+multica agent builtins disable <agent-id> builtin:multica-working-on-issues
 ```
+
+内置 skill 默认继承平台设置；首次禁用后会改为精确列表。运行
+`multica agent builtins reset <agent-id>` 可重新继承当前及未来的所有内置 skill。
 
 导入时遇到同名 skill，默认会停止且不修改现有内容。按意图选择：
 
@@ -255,6 +260,7 @@ CLI 配置文件包含可代表你访问 Multica 的令牌。不要提交到仓�
 | | `avatar <id>` | 上传头像 | |
 | | `env get/set <agent-id>` | 读写自定义环境变量（仅 owner 和 admin） | |
 | | `skills list/set/add <agent-id>` | 管理绑定的 skill | `--skill-ids`（`set` 全量替换，`add` 增量添加） |
+| | `builtins list/enable/disable/reset <agent-id>` | 管理单个智能体的 Multica 内置 skill | `list` 显示 `inherit_all` 或 `exact`；`reset` 恢复继承当前及未来的所有内置 skill |
 | | `mcp list/add/enable/disable/remove <agent-id>` | 给该 agent 分配工作区 MCP 服务 | server id 从 `workspace mcp list` 获取。库里的条目在这里添加之前不会生效；`disable` 只停止下发，保留分配 |
 | `autopilot` | `list/get/create/update/delete` | 管理自动化 | `create`：`--title`、`--agent`、`--mode`（均必填）、`--project`、`--subscriber`（可重复） |
 | | `trigger <id>` | 手动触发一次 | |

--- a/packages/core/agents/draft.test.ts
+++ b/packages/core/agents/draft.test.ts
@@ -193,12 +193,13 @@ describe("agent draft execution overrides", () => {
     const request = buildCreateAgentRequest({
       draft: { ...draft(), thinkingLevel: "high", serviceTier: "priority" },
       runtimeId: "runtime-1",
-      duplicateSource: sourceAgent(),
+      duplicateSource: sourceAgent({ enabled_builtin_skill_ids: [] }),
     });
 
     expect(request.custom_args).toEqual(["--verbose"]);
     expect(request.max_concurrent_tasks).toBe(9);
     expect(request.thinking_level).toBe("high");
+    expect(request.enabled_builtin_skill_ids).toEqual([]);
   });
 
   it.each([0, -1, 51])(

--- a/packages/core/agents/draft.ts
+++ b/packages/core/agents/draft.ts
@@ -206,7 +206,7 @@ export function buildDuplicateDraft(
  * Assembles the `POST /api/agents` body. Empty execution overrides are omitted
  * rather than sent as `""` so the runtime resolves its own default, and the
  * duplicate-only fields are the runtime-independent ones (`custom_args`,
- * concurrency) — mirroring `multica agent copy`.
+ * concurrency, built-in skill policy) — mirroring `multica agent copy`.
  */
 export function buildCreateAgentRequest(options: {
   draft: AgentDraft;
@@ -250,6 +250,10 @@ export function buildCreateAgentRequest(options: {
       sourceConcurrency <= AGENT_MAX_CONCURRENT_TASKS_MAX
     ) {
       request.max_concurrent_tasks = sourceConcurrency;
+    }
+    if (duplicateSource.enabled_builtin_skill_ids !== undefined) {
+      request.enabled_builtin_skill_ids =
+        duplicateSource.enabled_builtin_skill_ids;
     }
   }
   return request;

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -206,6 +206,60 @@ describe("ApiClient pull-request response schema", () => {
   });
 });
 
+describe("ApiClient agent response schema", () => {
+  it("preserves a valid exact built-in policy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: "agent-1",
+            builtin_skills: [
+              {
+                id: "builtin:multica-mentioning",
+                name: "multica-mentioning",
+                description: "Mention collaborators",
+                enabled: false,
+              },
+            ],
+            enabled_builtin_skill_ids: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(
+      new ApiClient("https://api.example.test").getAgent("agent-1"),
+    ).resolves.toMatchObject({
+      id: "agent-1",
+      builtin_skills: [{ enabled: false }],
+      enabled_builtin_skill_ids: [],
+    });
+  });
+
+  it("falls back safely when builtin_skills is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ id: "agent-1", builtin_skills: {} }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const result = await new ApiClient("https://api.example.test").getAgent(
+      "agent-1",
+    );
+    expect(result).toMatchObject({
+      id: "agent-1",
+      skills: [],
+    });
+    expect(result.builtin_skills).toBeUndefined();
+  });
+});
+
 describe("ApiClient Plugin preview response schema", () => {
   it("degrades a malformed preview so a blank scope list is never shown as approval", async () => {
     vi.stubGlobal(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -60,6 +60,7 @@ import type {
   UpdateSkillRequest,
   SetAgentSkillsRequest,
   SetAgentRuntimeSkillEnabledRequest,
+  SetAgentBuiltinSkillEnabledRequest,
   PersonalAccessToken,
   CreatePersonalAccessTokenRequest,
   CreatePersonalAccessTokenResponse,
@@ -238,6 +239,8 @@ import { createRequestId, createSafeId } from "../utils";
 import { getCurrentSlug } from "../platform/workspace-storage";
 import { parseWithFallback } from "./schema";
 import {
+  AgentListSchema,
+  AgentSchema,
   AgentTaskListSchema,
   AttachmentResponseSchema,
   CancelTaskResponseSchema,
@@ -268,6 +271,8 @@ import {
   DashboardFailureByAgentListSchema,
   DashboardUsageByAgentListSchema,
   DashboardUsageDailyListSchema,
+  EMPTY_AGENT,
+  EMPTY_AGENT_LIST,
   EMPTY_APP_CONFIG,
   EMPTY_ATTACHMENT,
   EMPTY_CHAT_MESSAGE_LIST,
@@ -1457,11 +1462,17 @@ export class ApiClient {
     const search = new URLSearchParams();
     if (params?.workspace_id) search.set("workspace_id", params.workspace_id);
     if (params?.include_archived) search.set("include_archived", "true");
-    return this.fetch(`/api/agents?${search}`);
+    const raw = await this.fetch<unknown>(`/api/agents?${search}`);
+    return parseWithFallback<Agent[]>(raw, AgentListSchema, EMPTY_AGENT_LIST, {
+      endpoint: "GET /api/agents",
+    });
   }
 
   async getAgent(id: string): Promise<Agent> {
-    return this.fetch(`/api/agents/${id}`);
+    const raw = await this.fetch<unknown>(`/api/agents/${id}`);
+    return parseWithFallback<Agent>(raw, AgentSchema, { ...EMPTY_AGENT, id }, {
+      endpoint: "GET /api/agents/:id",
+    });
   }
 
   async createAgent(data: CreateAgentRequest): Promise<Agent> {
@@ -3106,6 +3117,22 @@ export class ApiClient {
 			body: JSON.stringify({ enabled }),
 		});
 	}
+
+  async setAgentBuiltinSkillEnabled(
+    agentId: string,
+    data: SetAgentBuiltinSkillEnabledRequest,
+  ): Promise<void> {
+    await this.fetch(`/api/agents/${agentId}/builtin-skills/enabled`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async resetAgentBuiltinSkills(agentId: string): Promise<void> {
+    await this.fetch(`/api/agents/${agentId}/builtin-skills`, {
+      method: "DELETE",
+    });
+  }
 
   async setAgentRuntimeSkillEnabled(
     agentId: string,

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type {
+  Agent,
   AgentBuilderRuntimeSwitch,
   AgentBuilderSession,
   AgentBuilderSessionSummary,
@@ -1684,6 +1685,113 @@ const RuntimeUsageByHourSchema = z.object({
 }).loose();
 
 export const RuntimeUsageByHourListSchema = z.array(RuntimeUsageByHourSchema);
+
+const AgentInvocationTargetSchema = z
+  .object({
+    target_type: z.enum(["workspace", "member", "team"]).catch("team"),
+    target_id: z.string().nullable().default(null),
+  })
+  .loose();
+
+const AgentSkillSummarySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().default(""),
+    enabled: z.boolean().optional(),
+  })
+  .loose();
+
+const DisabledRuntimeSkillSchema = z
+  .object({
+    runtime_id: z.string(),
+    provider: z.string(),
+    root: z.string() as unknown as z.ZodType<
+      NonNullable<Agent["disabled_runtime_skills"]>[number]["root"]
+    >,
+    key: z.string(),
+    name: z.string().optional(),
+    plugin: z.string().optional(),
+  })
+  .loose();
+
+// Agent responses are consumed by installed desktop builds and must degrade
+// safely when a newer or malformed backend drifts. Keep enums open via plain
+// strings, default additive legacy omissions, but validate nested collections
+// before UI code iterates them.
+export const AgentSchema: z.ZodType<Agent> = z
+  .object({
+    id: z.string(),
+    workspace_id: z.string().default(""),
+    runtime_id: z.string().default(""),
+    runtime_bound: z.boolean().optional(),
+    name: z.string().default(""),
+    description: z.string().default(""),
+    instructions: z.string().default(""),
+    system_key: z.string().optional(),
+    system_instructions: z.string().optional(),
+    avatar_url: z.string().nullable().default(null),
+    runtime_mode: z.string().default("local") as unknown as z.ZodType<
+      Agent["runtime_mode"]
+    >,
+    runtime_config: z.record(z.string(), z.unknown()).default({}),
+    custom_args: z.array(z.string()).default([]),
+    has_custom_env: z.boolean().optional(),
+    custom_env_key_count: z.number().optional(),
+    mcp_config: z.unknown().optional(),
+    mcp_config_redacted: z.boolean().optional(),
+    composio_toolkit_allowlist: z.array(z.string()).optional(),
+    composio_toolkit_allowlist_redacted: z.boolean().optional(),
+    visibility: z.string().default("private") as unknown as z.ZodType<
+      Agent["visibility"]
+    >,
+    permission_mode: z.enum(["private", "public_to"]).catch("private"),
+    invocation_targets: z.array(AgentInvocationTargetSchema).default([]),
+    status: z.string().default("idle") as unknown as z.ZodType<Agent["status"]>,
+    max_concurrent_tasks: z.number().default(1),
+    model: z.string().default(""),
+    thinking_level: z.string().optional(),
+    service_tier: z.string().optional(),
+    owner_id: z.string().nullable().default(null),
+    skills: z.array(AgentSkillSummarySchema).default([]),
+    builtin_skills: z.array(AgentSkillSummarySchema).optional(),
+    enabled_builtin_skill_ids: z.array(z.string()).nullable().optional(),
+    disabled_runtime_skills: z.array(DisabledRuntimeSkillSchema).optional(),
+    created_at: z.string().default(""),
+    updated_at: z.string().default(""),
+    archived_at: z.string().nullable().default(null),
+    archived_by: z.string().nullable().default(null),
+  })
+  .loose();
+
+export const AgentListSchema = z.array(AgentSchema);
+
+export const EMPTY_AGENT: Agent = {
+  id: "",
+  workspace_id: "",
+  runtime_id: "",
+  name: "",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "local",
+  runtime_config: {},
+  custom_args: [],
+  visibility: "private",
+  permission_mode: "private",
+  invocation_targets: [],
+  status: "idle",
+  max_concurrent_tasks: 1,
+  model: "",
+  owner_id: null,
+  skills: [],
+  created_at: "",
+  updated_at: "",
+  archived_at: null,
+  archived_by: null,
+};
+
+export const EMPTY_AGENT_LIST: Agent[] = [];
 
 // ---------------------------------------------------------------------------
 // Agent task responses. The base object stays loose so daemon/runtime fields

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -582,6 +582,10 @@ export interface Agent {
   service_tier?: string;
   owner_id: string | null;
   skills: AgentSkillSummary[];
+  /** Server-provided built-in skill inventory with per-agent enabled state. */
+  builtin_skills?: AgentSkillSummary[];
+  /** `null`/undefined inherits all built-ins; an array is the exact enabled set. */
+  enabled_builtin_skill_ids?: string[] | null;
   /** Runtime-local skills this agent must not inherit. Older servers omit it. */
   disabled_runtime_skills?: DisabledRuntimeSkill[];
   created_at: string;
@@ -612,6 +616,11 @@ export interface SetAgentRuntimeSkillEnabledRequest {
   key: string;
   name: string;
   plugin?: string;
+  enabled: boolean;
+}
+
+export interface SetAgentBuiltinSkillEnabledRequest {
+  skill_id: string;
   enabled: boolean;
 }
 
@@ -662,6 +671,9 @@ export interface CreateAgentRequest {
   template?: string;
   /** Workspace skill IDs attached atomically with the agent row. */
   skill_ids?: string[];
+  /** Exact enabled built-in set copied from another agent. Null/omitted
+   *  restores inherit-all; an empty array disables every built-in. */
+  enabled_builtin_skill_ids?: string[] | null;
 }
 
 export interface AgentBuilderSession {

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -46,6 +46,7 @@ export type {
   SkillSummary,
   AgentSkillSummary,
   DisabledRuntimeSkill,
+  SetAgentBuiltinSkillEnabledRequest,
   SetAgentRuntimeSkillEnabledRequest,
   SkillFile,
   CreateSkillRequest,

--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -13,7 +13,10 @@ const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
 
 const mockListSkills = vi.hoisted(() => vi.fn());
 const mockGetSkill = vi.hoisted(() => vi.fn());
+const mockGetAgent = vi.hoisted(() => vi.fn());
 const mockSetAgentSkillEnabled = vi.hoisted(() => vi.fn());
+const mockSetAgentBuiltinSkillEnabled = vi.hoisted(() => vi.fn());
+const mockResetAgentBuiltinSkills = vi.hoisted(() => vi.fn());
 const mockSetAgentRuntimeSkillEnabled = vi.hoisted(() => vi.fn());
 const mockRemoveAgentSkill = vi.hoisted(() => vi.fn());
 const mockRuntimeCapabilities = vi.hoisted(() => vi.fn());
@@ -42,8 +45,13 @@ vi.mock("@multica/core/api", () => ({
   api: {
     listSkills: (...args: unknown[]) => mockListSkills(...args),
     getSkill: (...args: unknown[]) => mockGetSkill(...args),
+    getAgent: (...args: unknown[]) => mockGetAgent(...args),
     setAgentSkills: vi.fn(),
     setAgentSkillEnabled: (...args: unknown[]) => mockSetAgentSkillEnabled(...args),
+    setAgentBuiltinSkillEnabled: (...args: unknown[]) =>
+      mockSetAgentBuiltinSkillEnabled(...args),
+    resetAgentBuiltinSkills: (...args: unknown[]) =>
+      mockResetAgentBuiltinSkills(...args),
     setAgentRuntimeSkillEnabled: (...args: unknown[]) =>
       mockSetAgentRuntimeSkillEnabled(...args),
     removeAgentSkill: (...args: unknown[]) => mockRemoveAgentSkill(...args),
@@ -149,7 +157,10 @@ describe("SkillsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListSkills.mockResolvedValue([]);
+    mockGetAgent.mockResolvedValue(agent);
     mockSetAgentSkillEnabled.mockResolvedValue(undefined);
+    mockSetAgentBuiltinSkillEnabled.mockResolvedValue(undefined);
+    mockResetAgentBuiltinSkills.mockResolvedValue(undefined);
     mockSetAgentRuntimeSkillEnabled.mockResolvedValue(undefined);
     mockRemoveAgentSkill.mockResolvedValue(undefined);
     mockRuntimeCapabilities.mockResolvedValue({
@@ -191,6 +202,92 @@ describe("SkillsTab", () => {
       false,
     );
     expect(mockRemoveAgentSkill).not.toHaveBeenCalled();
+  });
+
+  it("turns off a Multica built-in for this agent", async () => {
+    const user = userEvent.setup();
+    renderSkillsTab({
+      builtin_skills: [
+        {
+          id: "builtin:multica-working-on-issues",
+          name: "multica-working-on-issues",
+          description: "Work on Multica issues",
+          enabled: true,
+        },
+      ],
+    });
+
+    await user.click(
+      screen.getByRole("switch", {
+        name: /Toggle built-in multica-working-on-issues/i,
+      }),
+    );
+
+    expect(mockSetAgentBuiltinSkillEnabled).toHaveBeenCalledWith("agent-1", {
+      skill_id: "builtin:multica-working-on-issues",
+      enabled: false,
+    });
+  });
+
+  it("loads built-in controls from agent detail when the list shape omits them", async () => {
+    mockGetAgent.mockResolvedValue({
+      ...agent,
+      builtin_skills: [
+        {
+          id: "builtin:multica-mentioning",
+          name: "multica-mentioning",
+          description: "Mention collaborators",
+          enabled: true,
+        },
+      ],
+    });
+
+    renderSkillsTab();
+
+    expect(
+      await screen.findByRole("switch", {
+        name: /Toggle built-in multica-mentioning/i,
+      }),
+    ).toBeChecked();
+    expect(mockGetAgent).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("renders an excluded Multica built-in as off", () => {
+    renderSkillsTab({
+      builtin_skills: [
+        {
+          id: "builtin:multica-mentioning",
+          name: "multica-mentioning",
+          description: "Mention collaborators",
+          enabled: false,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole("switch", {
+        name: /Toggle built-in multica-mentioning/i,
+      }),
+    ).not.toBeChecked();
+  });
+
+  it("restores inherit-all defaults after the built-in set was customized", async () => {
+    const user = userEvent.setup();
+    renderSkillsTab({
+      enabled_builtin_skill_ids: [],
+      builtin_skills: [
+        {
+          id: "builtin:multica-mentioning",
+          name: "multica-mentioning",
+          description: "Mention collaborators",
+          enabled: false,
+        },
+      ],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Use defaults" }));
+
+    expect(mockResetAgentBuiltinSkills).toHaveBeenCalledWith("agent-1");
   });
 
   it("shows inherited skills discovered from the assigned runtime", async () => {

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -6,6 +6,7 @@ import {
   Plus,
   RefreshCw,
   Server,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 import { SkillIcon } from "../../../skills/lib/skill-icon";
@@ -25,6 +26,7 @@ import {
   runtimeDisplayLabel,
 } from "@multica/core/runtimes";
 import {
+  agentDetailOptions,
   skillDetailOptions,
   skillListOptions,
   workspaceKeys,
@@ -65,6 +67,15 @@ export function SkillsTab({
   const { data: workspaceSkills = [] } = useQuery(skillListOptions(wsId));
   const canReadRuntime =
     runtime != null && isRuntimeUsableForUser(runtime, currentUserId ?? null);
+  // The workspace agent list deliberately omits the built-in inventory to
+  // avoid multiplying every built-in description by every agent. Fetch the
+  // detail shape only while this tab is mounted and the caller supplied the
+  // lean list shape.
+  const builtinDetailQuery = useQuery({
+    ...agentDetailOptions(wsId, agent.id),
+    enabled: !!wsId && !!agent.id && agent.builtin_skills == null,
+  });
+  const effectiveAgent = builtinDetailQuery.data ?? agent;
   const runtimeId =
     runtime?.runtime_mode === "local" &&
     runtime.status === "online" &&
@@ -142,7 +153,43 @@ export function SkillsTab({
     }
   };
 
+  const handleBuiltinToggle = async (skillId: string, enabled: boolean) => {
+    setBusyId(skillId);
+    try {
+      await api.setAgentBuiltinSkillEnabled(agent.id, {
+        skill_id: skillId,
+        enabled,
+      });
+      await refreshAgent();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t(($) => $.tab_body.skills.builtin_toggle_failed_toast),
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleBuiltinReset = async () => {
+    setBusyId("builtin:reset");
+    try {
+      await api.resetAgentBuiltinSkills(agent.id);
+      await refreshAgent();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t(($) => $.tab_body.skills.builtin_reset_failed_toast),
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   const runtimeSkills = runtimeQuery.data?.skills ?? [];
+  const builtinSkills = effectiveAgent.builtin_skills ?? [];
 
   return (
     <div className="space-y-8">
@@ -229,6 +276,81 @@ export function SkillsTab({
                       </Button>
                     </>
                   )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CapabilitySection>
+
+      <CapabilitySection
+        title={t(($) => $.tab_body.skills.builtin_title)}
+        description={t(($) => $.tab_body.skills.builtin_hint)}
+        action={
+          canEdit && effectiveAgent.enabled_builtin_skill_ids != null ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleBuiltinReset}
+              disabled={busyId !== null}
+            >
+              {busyId === "builtin:reset" && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" />
+              )}
+              {t(($) => $.tab_body.skills.builtin_reset_action)}
+            </Button>
+          ) : null
+        }
+      >
+        {agent.builtin_skills == null && builtinDetailQuery.isPending ? (
+          <div className="flex justify-center py-6">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
+          </div>
+        ) : builtinSkills.length === 0 ? (
+          <RuntimeNotice text={t(($) => $.tab_body.skills.builtin_unavailable)} />
+        ) : (
+          <ul className="divide-y rounded-lg border bg-surface-raised/40">
+            {builtinSkills.map((skill) => {
+              const enabled = skill.enabled !== false;
+              const busy = busyId === skill.id;
+              return (
+                <li key={skill.id} className="flex items-center gap-3 p-3">
+                  <span
+                    className={cn(
+                      "flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground",
+                      !enabled && "opacity-50",
+                    )}
+                  >
+                    <Sparkles className="h-4 w-4" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span
+                      className={cn(
+                        "block text-body font-medium",
+                        !enabled && "text-muted-foreground",
+                      )}
+                    >
+                      {skill.name}
+                    </span>
+                    <span className="block truncate text-caption text-muted-foreground">
+                      {skill.description || t(($) => $.tab_body.skills.no_description)}
+                    </span>
+                  </span>
+                  {canEdit &&
+                    (busy ? (
+                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
+                    ) : (
+                      <Switch
+                        checked={enabled}
+                        onCheckedChange={(checked) =>
+                          handleBuiltinToggle(skill.id, checked)
+                        }
+                        aria-label={t(
+                          ($) => $.tab_body.skills.builtin_toggle_aria,
+                          { name: skill.name },
+                        )}
+                      />
+                    ))}
                 </li>
               );
             })}

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -318,7 +318,7 @@ export function SkillsTab({
                   <span
                     className={cn(
                       "flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground",
-                      !enabled && "opacity-50",
+                      !enabled && "text-faint-foreground",
                     )}
                   >
                     <Sparkles className="h-4 w-4" />

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -640,9 +640,16 @@
       "save_failed_toast": "Failed to save routing config"
     },
     "skills": {
-      "intro": "This is the agent's effective skill set. Workspace skills are managed here; inherited Codex and Claude Code skills can also be turned off per agent.",
+      "intro": "This is the agent's effective skill set. Manage workspace skills, Multica built-ins, and inherited Codex or Claude Code skills here.",
       "assigned_title": "Assigned to agent",
       "assigned_hint": "Workspace skills travel with the agent. Turn one off temporarily without removing it.",
+      "builtin_title": "Built into Multica",
+      "builtin_hint": "Platform workflows are enabled by default. Once changed, this becomes the exact set this agent receives, including after upgrades.",
+      "builtin_unavailable": "Built-in skill controls aren't available from this server.",
+      "builtin_toggle_aria": "Toggle built-in {{name}}",
+      "builtin_toggle_failed_toast": "Failed to change built-in skill status",
+      "builtin_reset_action": "Use defaults",
+      "builtin_reset_failed_toast": "Failed to restore default built-ins",
       "runtime_title": "Inherited from runtime",
       "runtime_hint": "Discovered automatically from {{runtime}} and available whenever this agent runs there.",
       "workspace_badge": "Workspace",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -522,8 +522,16 @@
       "save_failed_toast": "ルーティング設定の保存に失敗しました"
     },
     "skills": {
+      "intro": "このエージェントの有効なスキルセットです。ワークスペースのスキル、Multica 組み込みスキル、Codex または Claude Code から継承したスキルを管理できます。",
       "assigned_title": "エージェントに割り当て済み",
       "assigned_hint": "ワークスペースのスキルはエージェントと一緒に移動します。削除せず一時的に無効化できます。",
+      "builtin_title": "Multica 組み込み",
+      "builtin_hint": "プラットフォームのワークフローは既定で有効です。変更後は、アップグレード後もこの一覧がエージェントに渡される正確なセットになります。",
+      "builtin_unavailable": "このサーバーでは組み込みスキルの制御を利用できません。",
+      "builtin_toggle_aria": "組み込み {{name}} を切り替え",
+      "builtin_toggle_failed_toast": "組み込みスキルの状態を変更できませんでした",
+      "builtin_reset_action": "既定値を使用",
+      "builtin_reset_failed_toast": "組み込みスキルの既定値を復元できませんでした",
       "runtime_title": "ランタイムから継承",
       "runtime_hint": "{{runtime}} から自動検出され、このエージェントがそこで実行されるときに利用できます。",
       "workspace_badge": "ワークスペース",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -530,8 +530,16 @@
       "save_failed_toast": "라우팅 설정 저장 실패"
     },
     "skills": {
+      "intro": "이 에이전트의 유효한 스킬 집합입니다. 워크스페이스 스킬, Multica 기본 제공 스킬, Codex 또는 Claude Code에서 상속된 스킬을 관리할 수 있습니다.",
       "assigned_title": "에이전트에 할당됨",
       "assigned_hint": "워크스페이스 스킬은 에이전트와 함께 이동합니다. 제거하지 않고 일시적으로 끌 수 있습니다.",
+      "builtin_title": "Multica 기본 제공",
+      "builtin_hint": "플랫폼 워크플로는 기본으로 활성화됩니다. 변경 후에는 업그레이드 이후에도 이 목록이 에이전트에 제공되는 정확한 집합이 됩니다.",
+      "builtin_unavailable": "이 서버에서는 기본 제공 스킬 제어를 사용할 수 없습니다.",
+      "builtin_toggle_aria": "기본 제공 {{name}} 전환",
+      "builtin_toggle_failed_toast": "기본 제공 스킬 상태를 변경하지 못했습니다",
+      "builtin_reset_action": "기본값 사용",
+      "builtin_reset_failed_toast": "기본 제공 스킬 기본값을 복원하지 못했습니다",
       "runtime_title": "런타임에서 상속",
       "runtime_hint": "{{runtime}}에서 자동으로 탐색되며 이 에이전트가 해당 런타임에서 실행될 때 사용할 수 있습니다.",
       "workspace_badge": "워크스페이스",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -629,9 +629,16 @@
       "save_failed_toast": "保存路由配置失败"
     },
     "skills": {
-      "intro": "这里展示该智能体实际拥有的全部 skill。工作区 skill 可在此管理；从 Codex 和 Claude Code 继承的 skill 也可以按智能体单独关闭。",
+      "intro": "这里展示该智能体实际拥有的全部 skill。你可以在此管理工作区 skill、Multica 内置 skill，以及从 Codex 或 Claude Code 继承的 skill。",
       "assigned_title": "分配给智能体",
       "assigned_hint": "工作区 skill 会跟随智能体。你可以临时关闭，而不必将其移除。",
+      "builtin_title": "Multica 内置",
+      "builtin_hint": "平台工作流默认启用。更改后，此列表将成为该智能体收到的准确集合，升级后也不会自动增加。",
+      "builtin_unavailable": "此服务器不支持内置 skill 控制。",
+      "builtin_toggle_aria": "切换内置 {{name}}",
+      "builtin_toggle_failed_toast": "无法更改内置 skill 状态",
+      "builtin_reset_action": "使用默认设置",
+      "builtin_reset_failed_toast": "无法恢复默认内置 skill",
       "runtime_title": "从运行时继承",
       "runtime_hint": "自动从 {{runtime}} 发现；只要该智能体在这个运行时执行，就可以直接使用。",
       "workspace_badge": "工作区",

--- a/server/cmd/multica/cmd_agent_builtins.go
+++ b/server/cmd/multica/cmd_agent_builtins.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+type agentBuiltinSkillSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Enabled     bool   `json:"enabled"`
+}
+
+type agentBuiltinPolicy struct {
+	Mode                   string                     `json:"mode"`
+	EnabledBuiltinSkillIDs []string                   `json:"enabled_builtin_skill_ids"`
+	BuiltinSkills          []agentBuiltinSkillSummary `json:"builtin_skills"`
+}
+
+var agentBuiltinsCmd = &cobra.Command{
+	Use:   "builtins",
+	Short: "Manage the Multica built-in skills available to an agent",
+	Long: "Built-in skills are inherited by default. The first disable creates an " +
+		"exact per-agent allow-list, so future built-ins stay off until enabled. " +
+		"Use reset to restore inheritance of every current and future built-in.",
+}
+
+var agentBuiltinsListCmd = &cobra.Command{
+	Use:   "list <agent-id>",
+	Short: "List built-in skills and the agent's inheritance mode",
+	Args:  exactArgs(1),
+	RunE:  runAgentBuiltinsList,
+}
+
+var agentBuiltinsEnableCmd = &cobra.Command{
+	Use:   "enable <agent-id> <skill-id>",
+	Short: "Enable one Multica built-in skill for an agent",
+	Args:  exactArgs(2),
+	RunE:  runAgentBuiltinsEnable,
+}
+
+var agentBuiltinsDisableCmd = &cobra.Command{
+	Use:   "disable <agent-id> <skill-id>",
+	Short: "Disable one Multica built-in skill for an agent",
+	Args:  exactArgs(2),
+	RunE:  runAgentBuiltinsDisable,
+}
+
+var agentBuiltinsResetCmd = &cobra.Command{
+	Use:   "reset <agent-id>",
+	Short: "Restore inheritance of every current and future built-in skill",
+	Args:  exactArgs(1),
+	RunE:  runAgentBuiltinsReset,
+}
+
+func init() {
+	agentCmd.AddCommand(agentBuiltinsCmd)
+	agentBuiltinsCmd.AddCommand(
+		agentBuiltinsListCmd,
+		agentBuiltinsEnableCmd,
+		agentBuiltinsDisableCmd,
+		agentBuiltinsResetCmd,
+	)
+	for _, cmd := range []*cobra.Command{
+		agentBuiltinsListCmd,
+		agentBuiltinsEnableCmd,
+		agentBuiltinsDisableCmd,
+		agentBuiltinsResetCmd,
+	} {
+		cmd.Flags().String("output", "table", "Output format: table or json")
+	}
+}
+
+func agentBuiltinsPath(agentID string) string {
+	return "/api/agents/" + url.PathEscape(strings.TrimSpace(agentID)) + "/builtin-skills"
+}
+
+func fetchAgentBuiltinPolicy(ctx context.Context, client *cli.APIClient, agentID string) (agentBuiltinPolicy, error) {
+	var response struct {
+		EnabledBuiltinSkillIDs []string                   `json:"enabled_builtin_skill_ids"`
+		BuiltinSkills          []agentBuiltinSkillSummary `json:"builtin_skills"`
+	}
+	path := "/api/agents/" + url.PathEscape(strings.TrimSpace(agentID))
+	if err := client.GetJSON(ctx, path, &response); err != nil {
+		return agentBuiltinPolicy{}, err
+	}
+	if response.BuiltinSkills == nil {
+		return agentBuiltinPolicy{}, fmt.Errorf("built-in skill controls are not available from this server")
+	}
+	mode := "exact"
+	if response.EnabledBuiltinSkillIDs == nil {
+		mode = "inherit_all"
+	}
+	return agentBuiltinPolicy{
+		Mode:                   mode,
+		EnabledBuiltinSkillIDs: response.EnabledBuiltinSkillIDs,
+		BuiltinSkills:          response.BuiltinSkills,
+	}, nil
+}
+
+func runAgentBuiltinsList(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	policy, err := fetchAgentBuiltinPolicy(ctx, client, args[0])
+	if err != nil {
+		return fmt.Errorf("list agent built-ins: %w", err)
+	}
+	return printAgentBuiltinPolicy(cmd, policy)
+}
+
+func runAgentBuiltinsEnable(cmd *cobra.Command, args []string) error {
+	return setAgentBuiltinEnabled(cmd, args, true)
+}
+
+func runAgentBuiltinsDisable(cmd *cobra.Command, args []string) error {
+	return setAgentBuiltinEnabled(cmd, args, false)
+}
+
+func setAgentBuiltinEnabled(cmd *cobra.Command, args []string, enabled bool) error {
+	agentID, skillID := strings.TrimSpace(args[0]), strings.TrimSpace(args[1])
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body := map[string]any{"skill_id": skillID, "enabled": enabled}
+	if err := client.PutJSON(ctx, agentBuiltinsPath(agentID)+"/enabled", body, nil); err != nil {
+		return fmt.Errorf("update agent built-in skill: %w", err)
+	}
+	policy, err := fetchAgentBuiltinPolicy(ctx, client, agentID)
+	if err != nil {
+		return fmt.Errorf("built-in skill updated, but read-back failed: %w", err)
+	}
+	return printAgentBuiltinPolicy(cmd, policy)
+}
+
+func runAgentBuiltinsReset(cmd *cobra.Command, args []string) error {
+	agentID := strings.TrimSpace(args[0])
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	if err := client.DeleteJSON(ctx, agentBuiltinsPath(agentID)); err != nil {
+		return fmt.Errorf("reset agent built-ins: %w", err)
+	}
+	policy, err := fetchAgentBuiltinPolicy(ctx, client, agentID)
+	if err != nil {
+		return fmt.Errorf("built-in skills reset, but read-back failed: %w", err)
+	}
+	return printAgentBuiltinPolicy(cmd, policy)
+}
+
+func printAgentBuiltinPolicy(cmd *cobra.Command, policy agentBuiltinPolicy) error {
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, policy)
+	}
+
+	fmt.Fprintf(os.Stdout, "Policy: %s\n", policy.Mode)
+	headers := []string{"ID", "NAME", "STATUS", "DESCRIPTION"}
+	rows := make([][]string, 0, len(policy.BuiltinSkills))
+	for _, skill := range policy.BuiltinSkills {
+		status := "disabled"
+		if skill.Enabled {
+			status = "enabled"
+		}
+		rows = append(rows, []string{skill.ID, skill.Name, status, skill.Description})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}

--- a/server/cmd/multica/cmd_agent_builtins_test.go
+++ b/server/cmd/multica/cmd_agent_builtins_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	testBuiltinAgentID = "22222222-2222-2222-2222-222222222222"
+	testBuiltinSkillID = "builtin:multica-working-on-issues"
+)
+
+func newAgentBuiltinsTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "builtins"}
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("output", "table", "")
+	return cmd
+}
+
+func builtinPolicyTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+}
+
+func writeBuiltinAgentResponse(w http.ResponseWriter, enabledIDs any, targetEnabled bool) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":                        testBuiltinAgentID,
+		"enabled_builtin_skill_ids": enabledIDs,
+		"builtin_skills": []map[string]any{
+			{
+				"id":          testBuiltinSkillID,
+				"name":        "multica-working-on-issues",
+				"description": "Work on Multica issues",
+				"enabled":     targetEnabled,
+			},
+		},
+	})
+}
+
+func TestAgentBuiltinsCommandsAreRegistered(t *testing.T) {
+	for _, name := range []string{"list", "enable", "disable", "reset"} {
+		cmd, _, err := agentCmd.Find([]string{"builtins", name})
+		if err != nil {
+			t.Fatalf("find agent builtins %s: %v", name, err)
+		}
+		if cmd == nil || cmd.Name() != name {
+			t.Fatalf("agent builtins %s is not registered", name)
+		}
+	}
+}
+
+func TestRunAgentBuiltinsListShowsInheritedPolicy(t *testing.T) {
+	var gotMethod, gotPath string
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		writeBuiltinAgentResponse(w, nil, true)
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	out, err := captureStdout(t, func() error {
+		return runAgentBuiltinsList(cmd, []string{testBuiltinAgentID})
+	})
+	if err != nil {
+		t.Fatalf("runAgentBuiltinsList: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/api/agents/"+testBuiltinAgentID {
+		t.Fatalf("request = %s %s, want GET agent detail", gotMethod, gotPath)
+	}
+	for _, want := range []string{"Policy: inherit_all", testBuiltinSkillID, "enabled"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRunAgentBuiltinsListJSONPreservesExactEmptyPolicy(t *testing.T) {
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeBuiltinAgentResponse(w, []string{}, false)
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+	out, err := captureStdout(t, func() error {
+		return runAgentBuiltinsList(cmd, []string{testBuiltinAgentID})
+	})
+	if err != nil {
+		t.Fatalf("runAgentBuiltinsList: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, out)
+	}
+	if got["mode"] != "exact" {
+		t.Fatalf("mode = %v, want exact", got["mode"])
+	}
+	ids, ok := got["enabled_builtin_skill_ids"].([]any)
+	if !ok || len(ids) != 0 {
+		t.Fatalf("enabled_builtin_skill_ids = %#v, want explicit []", got["enabled_builtin_skill_ids"])
+	}
+}
+
+func TestRunAgentBuiltinsDisableAndEnableUseDedicatedEndpoint(t *testing.T) {
+	var gotMethods, gotPaths []string
+	var gotEnabled []bool
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethods = append(gotMethods, r.Method)
+		gotPaths = append(gotPaths, r.URL.Path)
+		if r.Method == http.MethodPut {
+			var body struct {
+				SkillID string `json:"skill_id"`
+				Enabled bool   `json:"enabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if body.SkillID != testBuiltinSkillID {
+				t.Fatalf("skill_id = %q, want %q", body.SkillID, testBuiltinSkillID)
+			}
+			gotEnabled = append(gotEnabled, body.Enabled)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeBuiltinAgentResponse(w, []string{}, false)
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	out, err := captureStdout(t, func() error {
+		return runAgentBuiltinsDisable(cmd, []string{testBuiltinAgentID, testBuiltinSkillID})
+	})
+	if err != nil {
+		t.Fatalf("runAgentBuiltinsDisable: %v", err)
+	}
+	if !strings.Contains(out, "Policy: exact") || !strings.Contains(out, "disabled") {
+		t.Fatalf("disable output did not read back exact policy: %q", out)
+	}
+	if len(gotMethods) != 2 || gotMethods[0] != http.MethodPut || gotMethods[1] != http.MethodGet {
+		t.Fatalf("methods = %v, want PUT then GET", gotMethods)
+	}
+	wantMutationPath := "/api/agents/" + testBuiltinAgentID + "/builtin-skills/enabled"
+	if gotPaths[0] != wantMutationPath || gotPaths[1] != "/api/agents/"+testBuiltinAgentID {
+		t.Fatalf("paths = %v", gotPaths)
+	}
+	if len(gotEnabled) != 1 || gotEnabled[0] {
+		t.Fatalf("disable enabled values = %v, want [false]", gotEnabled)
+	}
+
+	gotMethods, gotPaths = nil, nil
+	if _, err := captureStdout(t, func() error {
+		return runAgentBuiltinsEnable(cmd, []string{testBuiltinAgentID, testBuiltinSkillID})
+	}); err != nil {
+		t.Fatalf("runAgentBuiltinsEnable: %v", err)
+	}
+	if len(gotEnabled) != 2 || !gotEnabled[1] {
+		t.Fatalf("enable enabled values = %v, want final true", gotEnabled)
+	}
+}
+
+func TestRunAgentBuiltinsResetRestoresInheritance(t *testing.T) {
+	var gotMethods []string
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethods = append(gotMethods, r.Method)
+		if r.Method == http.MethodDelete {
+			if r.URL.Path != "/api/agents/"+testBuiltinAgentID+"/builtin-skills" {
+				t.Fatalf("reset path = %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeBuiltinAgentResponse(w, nil, true)
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	out, err := captureStdout(t, func() error {
+		return runAgentBuiltinsReset(cmd, []string{testBuiltinAgentID})
+	})
+	if err != nil {
+		t.Fatalf("runAgentBuiltinsReset: %v", err)
+	}
+	if len(gotMethods) != 2 || gotMethods[0] != http.MethodDelete || gotMethods[1] != http.MethodGet {
+		t.Fatalf("methods = %v, want DELETE then GET", gotMethods)
+	}
+	if !strings.Contains(out, "Policy: inherit_all") {
+		t.Fatalf("reset output did not show inherited policy: %q", out)
+	}
+}
+
+func TestRunAgentBuiltinsMutationSurfacesServerErrorWithoutReadback(t *testing.T) {
+	requests := 0
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.Error(w, `{"error":"unknown built-in skill"}`, http.StatusBadRequest)
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	_, err := captureStdout(t, func() error {
+		return runAgentBuiltinsDisable(cmd, []string{testBuiltinAgentID, "builtin:not-real"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown built-in skill") {
+		t.Fatalf("error = %v, want unknown built-in skill", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want no read-back after failed mutation", requests)
+	}
+}
+
+func TestRunAgentBuiltinsListRejectsUnsupportedServer(t *testing.T) {
+	builtinPolicyTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": testBuiltinAgentID})
+	})
+
+	cmd := newAgentBuiltinsTestCmd()
+	_, err := captureStdout(t, func() error {
+		return runAgentBuiltinsList(cmd, []string{testBuiltinAgentID})
+	})
+	if err == nil || !strings.Contains(err.Error(), "not available from this server") {
+		t.Fatalf("error = %v, want unsupported-server message", err)
+	}
+}

--- a/server/cmd/multica/cmd_agent_copy.go
+++ b/server/cmd/multica/cmd_agent_copy.go
@@ -257,6 +257,12 @@ func runAgentCopy(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	// Built-in policy is portable agent configuration, independent of runtime
+	// and distinct from workspace bindings. Preserve key presence so an exact
+	// empty set remains "all off" instead of becoming NULL/inherit-all.
+	if policy, ok := src["enabled_builtin_skill_ids"]; ok {
+		body["enabled_builtin_skill_ids"] = policy
+	}
 
 	// Secret / machine-local fields are never copied from the source (they are
 	// redacted or masked on GET). Set them only when supplied explicitly, via

--- a/server/cmd/multica/cmd_agent_copy_test.go
+++ b/server/cmd/multica/cmd_agent_copy_test.go
@@ -34,14 +34,15 @@ func fullSourceAgent() map[string]any {
 		"conversation_starters": []any{
 			map[string]any{"label": "Review a PR", "prompt": "Review the open pull request."},
 		},
-		"avatar_url":           "https://img.example/a.png",
-		"custom_args":          []any{"--foo", "--bar"},
-		"max_concurrent_tasks": 9,
-		"model":                "claude-sonnet-4-6",
-		"thinking_level":       "high",
-		"service_tier":         "priority",
-		"permission_mode":      "public_to",
-		"invocation_targets":   []any{map[string]any{"target_type": "workspace"}},
+		"avatar_url":                "https://img.example/a.png",
+		"custom_args":               []any{"--foo", "--bar"},
+		"max_concurrent_tasks":      9,
+		"model":                     "claude-sonnet-4-6",
+		"thinking_level":            "high",
+		"service_tier":              "priority",
+		"enabled_builtin_skill_ids": []any{},
+		"permission_mode":           "public_to",
+		"invocation_targets":        []any{map[string]any{"target_type": "workspace"}},
 		"skills": []any{
 			map[string]any{"id": "skill-1", "name": "One"},
 			map[string]any{"id": "skill-2", "name": "Two"},
@@ -147,6 +148,9 @@ func TestAgentCopySameRuntimeCopiesPortableFields(t *testing.T) {
 	// Skills bind in the same create request.
 	if !reflect.DeepEqual(gotBody["skill_ids"], []any{"skill-1", "skill-2"}) {
 		t.Errorf("skill_ids = %v, want [skill-1 skill-2]", gotBody["skill_ids"])
+	}
+	if policy, ok := gotBody["enabled_builtin_skill_ids"].([]any); !ok || len(policy) != 0 {
+		t.Errorf("enabled_builtin_skill_ids = %v, want explicit empty list", gotBody["enabled_builtin_skill_ids"])
 	}
 	// Secrets / machine-local config must never be copied.
 	for _, k := range []string{"custom_env", "mcp_config", "runtime_config", "has_custom_env"} {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -2036,6 +2036,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Post("/labels", h.AttachLabelToAgent)
 					r.Delete("/labels/{labelId}", h.DetachLabelFromAgent)
 					r.Put("/skills/{skillId}/enabled", h.SetAgentSkillEnabled)
+					r.Put("/builtin-skills/enabled", h.SetAgentBuiltinSkillEnabled)
+					r.Delete("/builtin-skills", h.ResetAgentBuiltinSkills)
 					r.Put("/runtime-skills/enabled", h.SetAgentRuntimeSkillEnabled)
 					r.Delete("/skills/{skillId}", h.RemoveAgentSkill)
 					// Workspace MCP servers assigned to this agent. Mirrors

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -122,15 +122,19 @@ type AgentResponse struct {
 	// members infer another member's integration footprint. Redacted to
 	// `nil` + `composio_toolkit_allowlist_redacted=true` for non-owners,
 	// mirroring the existing mcp_config redaction contract.
-	ComposioToolkitAllowlist         []string               `json:"composio_toolkit_allowlist,omitempty"`
-	ComposioToolkitAllowlistRedacted bool                   `json:"composio_toolkit_allowlist_redacted,omitempty"`
-	OwnerID                          *string                `json:"owner_id"`
-	Skills                           []AgentSkillSummary    `json:"skills"`
-	DisabledRuntimeSkills            []DisabledRuntimeSkill `json:"disabled_runtime_skills"`
-	CreatedAt                        string                 `json:"created_at"`
-	UpdatedAt                        string                 `json:"updated_at"`
-	ArchivedAt                       *string                `json:"archived_at"`
-	ArchivedBy                       *string                `json:"archived_by"`
+	ComposioToolkitAllowlist         []string            `json:"composio_toolkit_allowlist,omitempty"`
+	ComposioToolkitAllowlistRedacted bool                `json:"composio_toolkit_allowlist_redacted,omitempty"`
+	OwnerID                          *string             `json:"owner_id"`
+	Skills                           []AgentSkillSummary `json:"skills"`
+	BuiltinSkills                    []AgentSkillSummary `json:"builtin_skills,omitempty"`
+	// EnabledBuiltinSkillIDs is nil when the agent inherits every built-in.
+	// Once customized, the non-nil list is the exact enabled set.
+	EnabledBuiltinSkillIDs []string               `json:"enabled_builtin_skill_ids"`
+	DisabledRuntimeSkills  []DisabledRuntimeSkill `json:"disabled_runtime_skills"`
+	CreatedAt              string                 `json:"created_at"`
+	UpdatedAt              string                 `json:"updated_at"`
+	ArchivedAt             *string                `json:"archived_at"`
+	ArchivedBy             *string                `json:"archived_by"`
 }
 
 // runtimeConfigGatewayTokenMask is the placeholder the API substitutes for
@@ -227,6 +231,7 @@ func (h *Handler) agentToResponse(a db.Agent) AgentResponse {
 		ComposioToolkitAllowlist: composioAllowlist,
 		OwnerID:                  uuidToPtr(a.OwnerID),
 		Skills:                   []AgentSkillSummary{},
+		EnabledBuiltinSkillIDs:   a.EnabledBuiltinSkillIds,
 		DisabledRuntimeSkills:    decodeDisabledRuntimeSkills(a.DisabledRuntimeSkills),
 		CreatedAt:                timestampToString(a.CreatedAt),
 		UpdatedAt:                timestampToString(a.UpdatedAt),
@@ -1095,6 +1100,11 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := h.agentToResponse(agent)
+	// Built-in descriptions can be hundreds of characters each and are only
+	// consumed by the detail-page Skills tab. Keep the inventory on this detail
+	// endpoint instead of rebuilding and multiplying it across list, mutation,
+	// and WebSocket payloads.
+	resp.BuiltinSkills = h.builtinSkillSummaries(agent.EnabledBuiltinSkillIds)
 	if !h.enrichAgentResponseWithTargetsHTTP(w, r, &resp, agent.ID) {
 		return
 	}
@@ -1173,6 +1183,9 @@ type CreateAgentRequest struct {
 	// SkillIDs are attached inside the same transaction as the agent row so a
 	// create never becomes visible in a partially configured state.
 	SkillIDs []string `json:"skill_ids"`
+	// EnabledBuiltinSkillIDs is copied as portable agent configuration. Nil
+	// inherits all built-ins; a non-nil list, including empty, is exact.
+	EnabledBuiltinSkillIDs []string `json:"enabled_builtin_skill_ids"`
 }
 
 func decodeJSONBodyWithRawFields(body io.Reader, dst any) (map[string]json.RawMessage, error) {
@@ -1422,6 +1435,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		ServiceTier:              pgtype.Text{String: req.ServiceTier, Valid: req.ServiceTier != ""},
 		ConversationStarters:     sp,
 		ComposioToolkitAllowlist: allowlist,
+		EnabledBuiltinSkillIds:   req.EnabledBuiltinSkillIDs,
 	})
 	if err != nil {
 		// Unique constraint on (workspace_id, name) — return a clear conflict error

--- a/server/internal/handler/agent_builtin_skills.go
+++ b/server/internal/handler/agent_builtin_skills.go
@@ -86,6 +86,14 @@ func (h *Handler) SetAgentBuiltinSkillEnabled(w http.ResponseWriter, r *http.Req
 
 	current := locked.EnabledBuiltinSkillIds
 	if current == nil {
+		// In inherit-all mode every known built-in is already enabled. Keep a
+		// redundant enable idempotent instead of freezing today's inventory into
+		// an exact allow-list; this matters for scripted/API callers, which may
+		// safely repeat an enable operation without knowing the current mode.
+		if *req.Enabled {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		current = make([]string, 0, len(known))
 		for id := range known {
 			current = append(current, id)

--- a/server/internal/handler/agent_builtin_skills.go
+++ b/server/internal/handler/agent_builtin_skills.go
@@ -1,0 +1,181 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func (h *Handler) builtinSkillSummaries(enabledIDs []string) []AgentSkillSummary {
+	if h.TaskService == nil {
+		return []AgentSkillSummary{}
+	}
+	enabled := make(map[string]struct{}, len(enabledIDs))
+	if enabledIDs != nil {
+		for _, id := range enabledIDs {
+			enabled[id] = struct{}{}
+		}
+	}
+	skills := h.TaskService.BuiltinSkills()
+	result := make([]AgentSkillSummary, 0, len(skills))
+	for _, skill := range skills {
+		id := service.BuiltinSkillID(skill.Name)
+		_, explicitlyEnabled := enabled[id]
+		result = append(result, AgentSkillSummary{
+			ID:          id,
+			Name:        skill.Name,
+			Description: skill.Description,
+			Enabled:     enabledIDs == nil || explicitlyEnabled,
+		})
+	}
+	return result
+}
+
+// SetAgentBuiltinSkillEnabled turns the inherited-all default into an exact
+// allow-list on first edit, then toggles one stable built-in skill ID. Unknown
+// existing IDs are retained so an older server in a rolling deployment cannot
+// erase configuration written by a newer one.
+func (h *Handler) SetAgentBuiltinSkillEnabled(w http.ResponseWriter, r *http.Request) {
+	agentID := chi.URLParam(r, "id")
+	agent, ok := h.loadAgentForUser(w, r, agentID)
+	if !ok {
+		return
+	}
+	if !h.canManageAgent(w, r, agent) {
+		return
+	}
+
+	var req struct {
+		SkillID string `json:"skill_id"`
+		Enabled *bool  `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Enabled == nil {
+		writeError(w, http.StatusBadRequest, "skill_id and enabled are required")
+		return
+	}
+	req.SkillID = strings.TrimSpace(req.SkillID)
+	known := make(map[string]struct{})
+	for _, skill := range h.TaskService.BuiltinSkills() {
+		known[service.BuiltinSkillID(skill.Name)] = struct{}{}
+	}
+	if _, exists := known[req.SkillID]; !exists {
+		writeError(w, http.StatusBadRequest, "unknown built-in skill")
+		return
+	}
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to begin transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+	locked, err := qtx.GetAgentForUpdate(r.Context(), agent.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agent")
+		return
+	}
+
+	current := locked.EnabledBuiltinSkillIds
+	if current == nil {
+		current = make([]string, 0, len(known))
+		for id := range known {
+			current = append(current, id)
+		}
+	}
+	nextSet := make(map[string]struct{}, len(current)+1)
+	for _, id := range current {
+		if id != req.SkillID {
+			nextSet[id] = struct{}{}
+		}
+	}
+	if *req.Enabled {
+		nextSet[req.SkillID] = struct{}{}
+	}
+	next := make([]string, 0, len(nextSet))
+	for id := range nextSet {
+		next = append(next, id)
+	}
+	sort.Strings(next)
+
+	updated, err := qtx.UpdateAgentEnabledBuiltinSkillIDs(r.Context(), db.UpdateAgentEnabledBuiltinSkillIDsParams{
+		ID:                     locked.ID,
+		EnabledBuiltinSkillIds: next,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update built-in skill")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit")
+		return
+	}
+
+	h.publishBuiltinSkillAgentUpdate(r, updated)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ResetAgentBuiltinSkills restores inherit-all behavior. Future built-ins will
+// again be enabled automatically, unlike an explicit list containing every
+// built-in known to the current server.
+func (h *Handler) ResetAgentBuiltinSkills(w http.ResponseWriter, r *http.Request) {
+	agentID := chi.URLParam(r, "id")
+	agent, ok := h.loadAgentForUser(w, r, agentID)
+	if !ok {
+		return
+	}
+	if !h.canManageAgent(w, r, agent) {
+		return
+	}
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to begin transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+	locked, err := qtx.GetAgentForUpdate(r.Context(), agent.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load agent")
+		return
+	}
+	updated, err := qtx.UpdateAgentEnabledBuiltinSkillIDs(r.Context(), db.UpdateAgentEnabledBuiltinSkillIDsParams{
+		ID:                     locked.ID,
+		EnabledBuiltinSkillIds: nil,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reset built-in skills")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit")
+		return
+	}
+
+	h.publishBuiltinSkillAgentUpdate(r, updated)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) publishBuiltinSkillAgentUpdate(r *http.Request, updated db.Agent) {
+	resp := h.agentToResponse(updated)
+	if err := h.enrichAgentResponseWithTargets(r.Context(), &resp, updated.ID); err != nil {
+		slog.Warn("built-in skill toggle: load invocation targets for broadcast failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(updated.ID))...)
+	}
+	if err := h.attachAgentSkills(r.Context(), &resp, updated.ID); err != nil {
+		slog.Warn("built-in skill toggle: load agent skills for broadcast failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(updated.ID))...)
+	}
+	actorType, actorID := h.resolveActor(r, requestUserID(r), uuidToString(updated.WorkspaceID))
+	h.publish(protocol.EventAgentStatus, uuidToString(updated.WorkspaceID), actorType, actorID,
+		map[string]any{"agent": broadcastAgentResponse(resp)})
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2165,15 +2165,24 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		resp.Agent.Instructions = service.ComposeMikaInstructions(agent.Name, agent.Instructions)
 	}
 	if useSkillRefs {
-		_, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
-		agentSkillCount = len(skillRefs)
+		_, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID, agent.EnabledBuiltinSkillIds)
+		for _, skill := range skillRefs {
+			if skill.Source == skillbundle.SourceBuiltin {
+				builtinSkillCount++
+			} else {
+				agentSkillCount++
+			}
+		}
 		resp.Agent.SkillRefs = skillRefs
 	} else {
-		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
-		agentSkillCount = len(skills)
-		builtinSkills := h.TaskService.BuiltinSkills()
-		builtinSkillCount = len(builtinSkills)
-		skills = append(skills, builtinSkills...)
+		skills, _ := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID, agent.EnabledBuiltinSkillIds)
+		for _, skill := range skills {
+			if skill.Source == skillbundle.SourceBuiltin {
+				builtinSkillCount++
+			} else {
+				agentSkillCount++
+			}
+		}
 		resp.Agent.Skills = skills
 	}
 	if !claimResponseAgentIdentityMatches(resp) {
@@ -3420,7 +3429,12 @@ func (h *Handler) ResolveTaskSkillBundles(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	bundles, _ := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
+	agent, err := h.Queries.GetAgent(r.Context(), task.AgentID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load task agent")
+		return
+	}
+	bundles, _ := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID, agent.EnabledBuiltinSkillIds)
 	allowed := make(map[string]service.AgentSkillData, len(bundles))
 	for _, bundle := range bundles {
 		allowed[bundle.Source+"\x00"+bundle.ID] = bundle

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -627,6 +627,90 @@ func TestClaimTaskByRuntime_SkillBundleRefsAndResolve(t *testing.T) {
 	w = testutil.Call(t, testHandler.ResolveTaskSkillBundles, req).Want(http.StatusConflict)
 }
 
+func TestClaimTaskByRuntime_EmptyBuiltinPolicyReachesFullSlimAndResolve(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	builtins := testHandler.TaskService.BuiltinSkills()
+	if len(builtins) == 0 {
+		t.Fatal("no built-in skills available")
+	}
+	_, builtinRefs := service.BuildAgentSkillBundles([]service.AgentSkillData{builtins[0]})
+	disabledRef := builtinRefs[0]
+
+	claim := func(label, capability string) (string, string, *AgentTaskResponse) {
+		t.Helper()
+		runtimeID := createClaimReclaimRuntime(t, ctx, label+" runtime")
+		agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, label+" agent")
+		if _, err := testPool.Exec(ctx, `
+			UPDATE agent SET enabled_builtin_skill_ids = '{}'::text[] WHERE id = $1
+		`, agentID); err != nil {
+			t.Fatalf("setup: disable all built-ins: %v", err)
+		}
+
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+			VALUES ($1, $2, $3, 'queued', 0)
+			RETURNING id
+		`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+			t.Fatalf("setup: create task: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+		w := httptest.NewRecorder()
+		req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil, testWorkspaceID, label+"-daemon")
+		if capability != "" {
+			req.Header.Set("X-Client-Capabilities", capability)
+		}
+		req = withURLParam(req, "runtimeId", runtimeID)
+		testHandler.ClaimTaskByRuntime(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var response struct {
+			Task *AgentTaskResponse `json:"task"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode claim: %v", err)
+		}
+		if response.Task == nil || response.Task.Agent == nil {
+			t.Fatalf("missing task agent in response: %s", w.Body.String())
+		}
+		return runtimeID, taskID, response.Task
+	}
+
+	_, _, full := claim("empty-builtins-full", "")
+	for _, skill := range full.Agent.Skills {
+		if skill.Source == disabledRef.Source {
+			t.Fatalf("disabled built-in leaked into full claim: %+v", skill)
+		}
+	}
+
+	runtimeID, taskID, slim := claim(
+		"empty-builtins-slim",
+		protocol.DaemonCapabilitySkillBundlesV1,
+	)
+	for _, ref := range slim.Agent.SkillRefs {
+		if ref.Source == disabledRef.Source {
+			t.Fatalf("disabled built-in leaked into slim claim: %+v", ref)
+		}
+	}
+
+	resolveBody := resolveSkillBundlesRequest{Skills: []resolveSkillBundleRef{{
+		ID: disabledRef.ID, Source: disabledRef.Source, Hash: disabledRef.Hash,
+	}}}
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/"+taskID+"/skill-bundles/resolve", resolveBody, testWorkspaceID, "empty-builtins-slim-daemon")
+	req = withURLParams(req, "runtimeId", runtimeID, "taskId", taskID)
+	testHandler.ResolveTaskSkillBundles(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("disabled built-in resolve: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestClaimTaskByRuntime_PopulatesWorkspaceContext verifies the claim
 // response carries workspace.context so the daemon can inject the
 // workspace-level system prompt into every agent brief. Regression coverage

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -260,10 +260,21 @@ func TestSetAgentBuiltinSkillEnabledCreatesExactAllowlist(t *testing.T) {
 		return w
 	}
 
+	if w := setEnabled(targetID, true); w.Code != 204 {
+		t.Fatalf("redundant inherited enable: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err := testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	if err != nil {
+		t.Fatalf("load agent after redundant enable: %v", err)
+	}
+	if row.EnabledBuiltinSkillIds != nil {
+		t.Fatalf("redundant enable froze inherited policy: %v", row.EnabledBuiltinSkillIds)
+	}
+
 	if w := setEnabled(targetID, false); w.Code != 204 {
 		t.Fatalf("disable built-in: expected 204, got %d: %s", w.Code, w.Body.String())
 	}
-	row, err := testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	row, err = testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
 	if err != nil {
 		t.Fatalf("load agent: %v", err)
 	}

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/multica-ai/multica/server/internal/service"
 )
 
 // TestListSkills_OmitsContent guards the fix for GH multica-ai/multica#2174:
@@ -223,6 +224,145 @@ func TestSetAgentRuntimeSkillEnabledPersistsScopedOverride(t *testing.T) {
 	}
 	if disabled = decodeDisabledRuntimeSkills(row.DisabledRuntimeSkills); len(disabled) != 0 {
 		t.Fatalf("re-enabled skill still disabled: %+v", disabled)
+	}
+}
+
+func TestSetAgentBuiltinSkillEnabledCreatesExactAllowlist(t *testing.T) {
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			visibility, permission_mode, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'local', '{}'::jsonb, 'private', 'private', 1, $3)
+		RETURNING id
+	`, testWorkspaceID, "Built-in Skill Toggle "+t.Name(), testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	builtins := testHandler.TaskService.BuiltinSkills()
+	if len(builtins) < 2 {
+		t.Fatalf("need at least two built-ins, got %d", len(builtins))
+	}
+	targetID := service.BuiltinSkillID(builtins[0].Name)
+	setEnabled := func(skillID string, enabled bool) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("PUT", "/api/agents/"+agentID+"/builtin-skills/enabled", map[string]any{
+			"skill_id": skillID,
+			"enabled":  enabled,
+		})
+		req = withURLParam(req, "id", agentID)
+		testHandler.SetAgentBuiltinSkillEnabled(w, req)
+		return w
+	}
+
+	if w := setEnabled(targetID, false); w.Code != 204 {
+		t.Fatalf("disable built-in: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err := testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	if err != nil {
+		t.Fatalf("load agent: %v", err)
+	}
+	if row.EnabledBuiltinSkillIds == nil {
+		t.Fatal("first edit must replace inherit-all with an explicit allowlist")
+	}
+	if len(row.EnabledBuiltinSkillIds) != len(builtins)-1 {
+		t.Fatalf("enabled ids = %d, want %d", len(row.EnabledBuiltinSkillIds), len(builtins)-1)
+	}
+	for _, id := range row.EnabledBuiltinSkillIds {
+		if id == targetID {
+			t.Fatalf("disabled built-in %s remained enabled", targetID)
+		}
+	}
+	{
+		w := httptest.NewRecorder()
+		req := newRequest("GET", "/api/agents/"+agentID, nil)
+		req = withURLParam(req, "id", agentID)
+		testHandler.GetAgent(w, req)
+		if w.Code != 200 {
+			t.Fatalf("get customized agent: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var response AgentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode customized agent: %v", err)
+		}
+		if response.EnabledBuiltinSkillIDs == nil || len(response.BuiltinSkills) != len(builtins) {
+			t.Fatalf("agent detail omitted built-in policy/inventory: %+v", response)
+		}
+		for _, summary := range response.BuiltinSkills {
+			if summary.ID == targetID && summary.Enabled {
+				t.Fatalf("agent detail rendered disabled built-in %s as enabled", targetID)
+			}
+		}
+	}
+	resolved, refs := testHandler.TaskService.LoadAgentSkillBundles(
+		context.Background(), parseUUID(agentID), row.EnabledBuiltinSkillIds,
+	)
+	if len(resolved) != len(builtins)-1 || len(refs) != len(builtins)-1 {
+		t.Fatalf("execution resolved %d bundles/%d refs, want %d", len(resolved), len(refs), len(builtins)-1)
+	}
+	for _, ref := range refs {
+		if ref.ID == targetID {
+			t.Fatalf("disabled built-in %s leaked into execution refs", targetID)
+		}
+	}
+
+	// Preserve an unknown ID written by a newer server during rolling deploys.
+	const futureID = "builtin:future-skill"
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE agent SET enabled_builtin_skill_ids = array_append(enabled_builtin_skill_ids, $2)
+		WHERE id = $1
+	`, agentID, futureID); err != nil {
+		t.Fatalf("seed future built-in id: %v", err)
+	}
+	if w := setEnabled(targetID, true); w.Code != 204 {
+		t.Fatalf("re-enable built-in: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err = testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	if err != nil {
+		t.Fatalf("reload agent: %v", err)
+	}
+	foundTarget, foundFuture := false, false
+	for _, id := range row.EnabledBuiltinSkillIds {
+		foundTarget = foundTarget || id == targetID
+		foundFuture = foundFuture || id == futureID
+	}
+	if !foundTarget || !foundFuture {
+		t.Fatalf("re-enabled/forward-compatible ids missing: %v", row.EnabledBuiltinSkillIds)
+	}
+
+	before := append([]string(nil), row.EnabledBuiltinSkillIds...)
+	if w := setEnabled("builtin:not-real", false); w.Code != 400 {
+		t.Fatalf("unknown built-in: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err = testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	if err != nil || strings.Join(row.EnabledBuiltinSkillIds, "\x00") != strings.Join(before, "\x00") {
+		t.Fatalf("unknown built-in changed policy: before=%v after=%v err=%v", before, row.EnabledBuiltinSkillIds, err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/agents/"+agentID+"/builtin-skills", nil)
+	req = withURLParam(req, "id", agentID)
+	testHandler.ResetAgentBuiltinSkills(w, req)
+	if w.Code != 204 {
+		t.Fatalf("reset built-ins: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err = testHandler.Queries.GetAgent(context.Background(), parseUUID(agentID))
+	if err != nil {
+		t.Fatalf("reload reset agent: %v", err)
+	}
+	if row.EnabledBuiltinSkillIds != nil {
+		t.Fatalf("reset policy = %v, want nil inherit-all", row.EnabledBuiltinSkillIds)
+	}
+	resolved, refs = testHandler.TaskService.LoadAgentSkillBundles(
+		context.Background(), parseUUID(agentID), row.EnabledBuiltinSkillIds,
+	)
+	if len(resolved) != len(builtins) || len(refs) != len(builtins) {
+		t.Fatalf("reset execution resolved %d bundles/%d refs, want all %d", len(resolved), len(refs), len(builtins))
 	}
 }
 

--- a/server/internal/service/builtin_skills.go
+++ b/server/internal/service/builtin_skills.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+
+	internalSkill "github.com/multica-ai/multica/server/internal/skill"
 )
 
 //go:embed builtin_skills
@@ -12,10 +14,19 @@ var builtinSkillsFS embed.FS
 
 const builtinSkillsRoot = "builtin_skills"
 
+const builtinSkillIDPrefix = "builtin:"
+
+// BuiltinSkillID returns the stable public identity for a built-in skill.
+// Directory names are compile-time product identifiers; display names from
+// frontmatter must never change persisted agent controls.
+func BuiltinSkillID(name string) string {
+	return builtinSkillIDPrefix + name
+}
+
 // BuiltinSkills returns the platform's built-in skills, embedded at compile
-// time. Every agent receives these on top of its workspace-bound skills, so
-// they teach platform-wide "how to" workflows (e.g. mentioning) that the
-// runtime brief intentionally leaves to skills.
+// time. Agents inherit these on top of workspace-bound skills unless their
+// exact per-agent allow-list disables one, so they teach platform-wide "how
+// to" workflows (e.g. mentioning) that the runtime brief leaves to skills.
 //
 // Layout: builtin_skills/<name>/SKILL.md plus optional supporting files. The
 // <name> directory carries a "multica-" prefix so its on-disk slug can never
@@ -23,6 +34,27 @@ const builtinSkillsRoot = "builtin_skills"
 // derives the skill directory from AgentSkillData.Name).
 func (s *TaskService) BuiltinSkills() []AgentSkillData {
 	return loadBuiltinSkills()
+}
+
+// EnabledBuiltinSkills applies an agent's exact built-in allow-list. A nil
+// list means the agent has never customized built-ins and inherits all of
+// them. A non-nil list, including an empty list, is authoritative.
+func (s *TaskService) EnabledBuiltinSkills(enabledIDs []string) []AgentSkillData {
+	skills := s.BuiltinSkills()
+	if enabledIDs == nil {
+		return skills
+	}
+	enabled := make(map[string]struct{}, len(enabledIDs))
+	for _, id := range enabledIDs {
+		enabled[id] = struct{}{}
+	}
+	result := make([]AgentSkillData, 0, len(skills))
+	for _, skill := range skills {
+		if _, ok := enabled[BuiltinSkillID(skill.Name)]; ok {
+			result = append(result, skill)
+		}
+	}
+	return result
 }
 
 func loadBuiltinSkills() []AgentSkillData {
@@ -50,7 +82,8 @@ func loadBuiltinSkill(name string) (AgentSkillData, bool) {
 		// than ship an empty skill.
 		return AgentSkillData{}, false
 	}
-	skill := AgentSkillData{Name: name, Content: string(content)}
+	_, description := internalSkill.ParseSkillFrontmatter(string(content))
+	skill := AgentSkillData{Name: name, Description: description, Content: string(content)}
 	// Any other file in the directory becomes a supporting file, preserving
 	// its relative path so subdirectories (e.g. rules/styling.md) survive.
 	_ = fs.WalkDir(builtinSkillsFS, dir, func(p string, d fs.DirEntry, walkErr error) error {

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -20,6 +20,7 @@ These commands read state and have no side effects:
 ```bash
 multica agent get <agent-id> --output json      # full persisted agent record
 multica agent skills list <agent-id> --output json   # current skill bindings
+multica agent builtins list <agent-id> --output json # built-in inventory + inherit/exact policy
 multica agent env get <agent-id> --output json  # plaintext env (agent owner or ws owner/admin; agents denied)
 ```
 
@@ -82,6 +83,24 @@ The body accepts more than the CLI exposes. `conversation_starters` has no
 `agent copy`. Setting it for a new agent means either calling `/api/agents`
 directly or telling the human to use the web UI; see below for where they
 will find it.
+
+## Controlling built-in skills
+
+Built-ins are managed independently from workspace skill bindings:
+
+```bash
+multica agent builtins list <agent-id>
+multica agent builtins disable <agent-id> builtin:multica-working-on-issues
+multica agent builtins enable <agent-id> builtin:multica-working-on-issues
+multica agent builtins reset <agent-id>
+```
+
+`list` reads the agent detail endpoint and reports `mode: inherit_all` when
+`enabled_builtin_skill_ids` is `null`, otherwise `mode: exact`. `enable` and
+`disable` call the dedicated atomic toggle endpoint, then read the agent back;
+`reset` restores `null`, so every current and future built-in is inherited.
+Repeating `enable` for a skill that is already enabled by inheritance is a
+no-op and does not freeze the current inventory into an exact list.
 
 ## Copying an agent
 
@@ -343,7 +362,8 @@ that agent. If both stay enabled, both are available to the provider.
 
 ## Side effects needing approval
 
-Read-only (safe): `agent get`, `agent skills list`, `agent env get`.
+Read-only (safe): `agent get`, `agent skills list`, `agent builtins list`,
+`agent env get`.
 
 State-changing (require an explicit instruction — do not run speculatively):
 
@@ -352,6 +372,8 @@ State-changing (require an explicit instruction — do not run speculatively):
   the source is left untouched.
 - `multica agent skills add` / `set` — mutate bindings (`set` is destructive:
   it drops bindings not in the new list).
+- `multica agent builtins enable` / `disable` / `reset` — mutate the agent's
+  built-in allow-list; `reset` restores inherit-all behavior.
 - `multica agent env set` — overwrites the full `custom_env` map and writes an
   audit row.
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -74,6 +74,8 @@ The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 `instructions`, `conversation_starters`, `avatar_url`, `runtime_id`, `runtime_config`, `custom_env`,
 `custom_args`, `model`, `thinking_level`, `service_tier`, `visibility`,
 `max_concurrent_tasks`, `mcp_config`, `skill_ids`.
+`enabled_builtin_skill_ids` is also accepted for copy/restore callers: `null`
+or omission inherits every built-in, while an array is the exact enabled set.
 
 The body accepts more than the CLI exposes. `conversation_starters` has no
 `agent create` / `agent update` flag — the CLI can only carry it across an
@@ -88,7 +90,8 @@ configuration into a brand-new agent, leaving the source untouched. It is the
 CLI/headless equivalent of the web "Duplicate" action. No dedicated server API
 is involved: `runAgentCopy` reads the source with `GET /api/agents/<id>`, then
 POSTs a `CreateAgentRequest` — passing the source's skill ids in `skill_ids` so
-the bindings attach in the SAME create transaction (unlike `agent create`, which
+the bindings attach in the SAME create transaction and preserving its exact
+built-in policy in `enabled_builtin_skill_ids` (unlike `agent create`, which
 binds nothing). The mutation is therefore a single atomic create.
 
 ```bash
@@ -100,7 +103,7 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
 - Copied by default, each overridable with the matching flag: `name` (suffixed
   `" (copy)"`), `description`, `instructions`, avatar, `custom_args`,
   `max_concurrent_tasks`, invocation permission (`permission_mode` +
-  allow-list), and assigned workspace skills.
+  allow-list), assigned workspace skills, and the exact built-in skill policy.
 - A copied `max_concurrent_tasks` is included only when the source value is
   within 1–50. Historical out-of-range values are omitted so the new agent
   receives the server default (`6`); an explicit out-of-range
@@ -325,12 +328,18 @@ multica agent skills add <agent-id> --skill-ids <skill-id> --output json
 multica agent skills list <agent-id> --output json
 ```
 
-At claim time the daemon assembles the agent's skills as workspace-bound skills
-FIRST, then appends the platform built-in skills. `LoadAgentSkills` loads each
-bound skill's content plus its supporting files; built-in skills are embedded
-at compile time and loaded from `SKILL.md` + sibling files. Both reach the
-provider as skill content — which is why capability belongs in a bound skill,
-not pasted into `instructions`.
+At claim time the daemon assembles the agent's enabled workspace-bound skills
+plus its enabled platform built-ins. Built-ins default to inherit-all. The first
+per-agent built-in toggle snapshots an exact allow-list, so a later Multica
+upgrade does not silently add new built-ins to that customized agent.
+`LoadAgentSkills` loads each bound skill's content plus its supporting files;
+built-ins are embedded at compile time and loaded from `SKILL.md` + sibling
+files. Both reach the provider as skill content — which is why capability
+belongs in a bound skill, not pasted into `instructions`.
+
+A workspace skill never overrides a built-in by matching its name or purpose.
+To replace a built-in, assign the workspace skill and turn the built-in off for
+that agent. If both stay enabled, both are available to the provider.
 
 ## Side effects needing approval
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -31,9 +31,17 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | `agent skills set` = replace-all | 922 | `PUT /api/agents/{id}/skills` (940); `--skill-ids ''` clears all (928–931) | `multica agent skills set --help` |
 | `agent skills add` = additive | 947 | `POST /api/agents/{id}/skills/add` (968); requires ≥1 id (953–958) | `multica agent skills add --help` |
 | `agent skills list` | 890 | reads bindings, no side effect | `multica agent skills list --help` |
-| Per-agent built-in controls | `agent_builtin_skills.go` | `PUT /api/agents/{id}/builtin-skills/enabled` creates/updates the exact allow-list; `DELETE /api/agents/{id}/builtin-skills` restores inherit-all |
 | `agent env get` | 1024 | `GET /api/agents/{id}/env` (1034) | `multica agent env get --help` |
 | `agent env set` | 1059 | `PUT /api/agents/{id}/env` with full `custom_env` map (1079) | `multica agent env set --help` |
+
+## Built-in skill commands — `server/cmd/multica/cmd_agent_builtins.go`
+
+| Contract | Anchor | Behavior | Safe check |
+|---|---|---|---|
+| `agent builtins list` | `runAgentBuiltinsList` | Reads `GET /api/agents/{id}` and prints both the complete built-in inventory and `inherit_all` versus `exact` policy mode | `multica agent builtins list --help` |
+| `agent builtins enable` / `disable` | `setAgentBuiltinEnabled` | Sends one stable `builtin:<name>` ID to `PUT /api/agents/{id}/builtin-skills/enabled`, then reads the effective policy back | `multica agent builtins enable --help`; `multica agent builtins disable --help` |
+| `agent builtins reset` | `runAgentBuiltinsReset` | `DELETE /api/agents/{id}/builtin-skills`, then reads back `inherit_all` | `multica agent builtins reset --help` |
+| Per-agent built-in controls | `server/internal/handler/agent_builtin_skills.go` | Atomic row lock; redundant inherited enable preserves `NULL`; disable creates/updates the exact allow-list; reset restores inherit-all | `go test ./internal/handler -run TestSetAgentBuiltinSkillEnabledCreatesExactAllowlist` |
 
 ## Copy command — `server/cmd/multica/cmd_agent_copy.go`
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -31,6 +31,7 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | `agent skills set` = replace-all | 922 | `PUT /api/agents/{id}/skills` (940); `--skill-ids ''` clears all (928–931) | `multica agent skills set --help` |
 | `agent skills add` = additive | 947 | `POST /api/agents/{id}/skills/add` (968); requires ≥1 id (953–958) | `multica agent skills add --help` |
 | `agent skills list` | 890 | reads bindings, no side effect | `multica agent skills list --help` |
+| Per-agent built-in controls | `agent_builtin_skills.go` | `PUT /api/agents/{id}/builtin-skills/enabled` creates/updates the exact allow-list; `DELETE /api/agents/{id}/builtin-skills` restores inherit-all |
 | `agent env get` | 1024 | `GET /api/agents/{id}/env` (1034) | `multica agent env get --help` |
 | `agent env set` | 1059 | `PUT /api/agents/{id}/env` with full `custom_env` map (1079) | `multica agent env set --help` |
 
@@ -119,8 +120,7 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | Contract | Line | Behavior |
 |---|---|---|
 | Fresh agent re-read on claim | 1109–1111 | `GetAgent(task.AgentID)` — claim uses persisted fields, not create output |
-| Workspace skills FIRST | 1115 | `skills := h.TaskService.LoadAgentSkills(...)` |
-| Built-ins appended | 1116 | `skills = append(skills, h.TaskService.BuiltinSkills()...)` |
+| Effective skill set | `buildClaimedTaskResponse` | `LoadAgentSkillBundles` resolves enabled workspace skills plus the agent's exact built-in allow-list for both slim-ref and full-bundle daemon payloads |
 | Runtime payload | `daemon.go` `TaskAgentData` | Carries `Instructions`, `Skills`, `CustomEnv`, `CustomArgs`, `Model`, `ThinkingLevel`, `ServiceTier`, and `McpConfig`; metadata-only fields remain absent |
 | `custom_args` argv and safe launch log | `internal/daemon/daemon.go` `ExecOptions.CustomArgs`; `pkg/agent/launch.go` `Config.logAgentCommand` | Custom args normally reach the provider process argv. Launch logs preserve flag names but redact inline values and positional/value tokens; OS process-list exposure remains, so credentials belong in `custom_env`. |
 | ZeroClaw agent alias pseudo-args | `pkg/agent/zeroclaw.go` `takeZeroclawAgentAlias` / `zeroclawBlockedArgs` | `--agent` and `--agent-alias` (separate or `=value`) are consumed from `custom_args` and sent as `session/new.agentAlias`; neither token reaches argv because `zeroclaw acp` rejects those CLI flags. Omit the selector for sole-agent auto-selection; use it when multiple agents exist without `[acp].default_agent`. |
@@ -130,19 +130,21 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | Contract | Line | Behavior |
 |---|---|---|
 | `LoadAgentSkills` | 1685 | `ListAgentSkills` + per-skill `ListSkillFiles` → content + supporting files for execution |
+| `LoadAgentSkillBundles` | function body | Appends only `EnabledBuiltinSkills(enabled_builtin_skill_ids)`; nil means inherit-all and a non-nil list is exact |
 
 ## Built-in skills — `server/internal/service/builtin_skills.go`
 
 | Contract | Line | Behavior |
 |---|---|---|
-| `go:embed builtin_skills` | 10–11 | skills embedded at compile time |
-| `loadBuiltinSkill` | 45 | reads `<name>/SKILL.md` (47) + walks sibling files into `Files` (56–68) |
+| `go:embed builtin_skills` | 12–13 | skills embedded at compile time |
+| `loadBuiltinSkill` | 77 | reads `<name>/SKILL.md` (79) + walks sibling files into `Files` (89–103) |
+| Stable identity and policy | `BuiltinSkillID`, `EnabledBuiltinSkills` | IDs use `builtin:<directory-name>`; unknown IDs are harmless and an explicit empty list disables all built-ins |
 
 ## Persisted columns — `server/pkg/db/generated/agent.sql.go`
 
 | Contract | Line | Behavior |
 |---|---|---|
-| `CreateAgent` INSERT | generated from `queries/agent.sql` | columns include `runtime_config, runtime_id, instructions, conversation_starters, custom_env, custom_args, mcp_config, model, thinking_level, service_tier` |
-| `CreateAgentParams` | generated from `queries/agent.sql` | typed params include nullable `Model`, `ThinkingLevel`, and `ServiceTier` |
+| `CreateAgent` INSERT | generated from `queries/agent.sql` | columns include `runtime_config, runtime_id, instructions, conversation_starters, custom_env, custom_args, mcp_config, model, thinking_level, service_tier, enabled_builtin_skill_ids` |
+| `CreateAgentParams` | generated from `queries/agent.sql` | typed params include nullable `Model`, `ThinkingLevel`, `ServiceTier`, and exact `EnabledBuiltinSkillIds` |
 | `UpdateAgent` SET | generated from `queries/agent.sql` | COALESCE updates include model/thinking/service tier; dedicated clear queries restore each nullable override |
 | `UpdateAgentCustomEnv` (called by the `UpdateAgentEnv` handler) | 2652 | `SET custom_env = $2` — the only write path for env values |

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -80,6 +80,29 @@ func TestBuiltinSkillsConformToTemplate(t *testing.T) {
 	}
 }
 
+func TestEnabledBuiltinSkillsUsesNilAsInheritAndNonNilAsExactSet(t *testing.T) {
+	service := &TaskService{}
+	all := service.BuiltinSkills()
+	if len(all) < 2 {
+		t.Fatalf("need at least two built-in skills, got %d", len(all))
+	}
+	if got := service.EnabledBuiltinSkills(nil); len(got) != len(all) {
+		t.Fatalf("nil policy returned %d skills, want all %d", len(got), len(all))
+	}
+	if got := service.EnabledBuiltinSkills([]string{}); len(got) != 0 {
+		t.Fatalf("empty exact policy returned %d skills, want none", len(got))
+	}
+
+	wantID := BuiltinSkillID(all[1].Name)
+	got := service.EnabledBuiltinSkills([]string{wantID, "builtin:future-skill"})
+	if len(got) != 1 || BuiltinSkillID(got[0].Name) != wantID {
+		t.Fatalf("subset = %+v, want only %s", got, wantID)
+	}
+	if got[0].Description == "" {
+		t.Fatal("built-in summary must expose its frontmatter description")
+	}
+}
+
 // TestBuiltinSkillsFrontmatterIsStrictYAML is the regression guard for MUL-3100
 // / GitHub #3851: a built-in SKILL.md whose frontmatter is not valid YAML 1.2
 // (the canonical break is an unquoted `: ` inside the description) is silently

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6347,11 +6347,12 @@ func (s *TaskService) LoadAgentSkills(ctx context.Context, agentID pgtype.UUID) 
 	return result
 }
 
-// LoadAgentSkillBundles returns every skill visible to an agent, including
-// built-ins, with stable bundle hashes and lightweight refs for slim claims.
-func (s *TaskService) LoadAgentSkillBundles(ctx context.Context, agentID pgtype.UUID) ([]AgentSkillData, []AgentSkillRefData) {
+// LoadAgentSkillBundles returns every skill visible to an agent, including its
+// exact enabled built-in set, with stable bundle hashes and lightweight refs
+// for slim claims. A nil built-in list preserves legacy inherit-all behavior.
+func (s *TaskService) LoadAgentSkillBundles(ctx context.Context, agentID pgtype.UUID, enabledBuiltinSkillIDs []string) ([]AgentSkillData, []AgentSkillRefData) {
 	skills := s.LoadAgentSkills(ctx, agentID)
-	skills = append(skills, s.BuiltinSkills()...)
+	skills = append(skills, s.EnabledBuiltinSkills(enabledBuiltinSkillIDs)...)
 	return BuildAgentSkillBundles(skills)
 }
 
@@ -6369,7 +6370,7 @@ func BuildAgentSkillBundles(skills []AgentSkillData) ([]AgentSkillData, []AgentS
 			}
 		}
 		if id == "" && source == skillbundle.SourceBuiltin {
-			id = "builtin:" + skill.Name
+			id = BuiltinSkillID(skill.Name)
 		}
 		skill.Source = source
 		skill.ID = id

--- a/server/migrations/441_agent_enabled_builtin_skills.down.sql
+++ b/server/migrations/441_agent_enabled_builtin_skills.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent
+DROP COLUMN enabled_builtin_skill_ids;

--- a/server/migrations/441_agent_enabled_builtin_skills.up.sql
+++ b/server/migrations/441_agent_enabled_builtin_skills.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent
+ADD COLUMN enabled_builtin_skill_ids TEXT[];

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -110,7 +110,7 @@ func (q *Queries) AcknowledgeExhaustedDelegatedFailureRecovery(ctx context.Conte
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type ArchiveAgentParams struct {
@@ -151,6 +151,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -159,7 +160,7 @@ const archiveAgentsByIDs = `-- name: ArchiveAgentsByIDs :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type ArchiveAgentsByIDsParams struct {
@@ -214,6 +215,7 @@ func (q *Queries) ArchiveAgentsByIDs(ctx context.Context, arg ArchiveAgentsByIDs
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -230,7 +232,7 @@ UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE runtime_id = ANY($2::uuid[]) AND archived_at IS NULL
   AND (system_key IS NULL OR system_key = '')
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type ArchiveAgentsByRuntimeParams struct {
@@ -288,6 +290,7 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -1785,7 +1788,7 @@ func (q *Queries) ClaimChatFinalizeDeferred(ctx context.Context, id pgtype.UUID)
 const clearAgentComposioToolkitAllowlist = `-- name: ClearAgentComposioToolkitAllowlist :one
 UPDATE agent SET composio_toolkit_allowlist = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 // Explicit NULL-clear for composio_toolkit_allowlist. The COALESCE-based
@@ -1827,6 +1830,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -1834,7 +1838,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 const clearAgentMcpConfig = `-- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -1870,6 +1874,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -1877,7 +1882,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 const clearAgentServiceTier = `-- name: ClearAgentServiceTier :one
 UPDATE agent SET service_tier = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 // Explicit NULL-clear for service_tier. COALESCE-based UpdateAgent cannot
@@ -1915,6 +1920,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -1922,7 +1928,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 const clearAgentThinkingLevel = `-- name: ClearAgentThinkingLevel :one
 UPDATE agent SET thinking_level = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 // Explicit NULL-clear for thinking_level. COALESCE-based UpdateAgent cannot
@@ -1961,6 +1967,7 @@ func (q *Queries) ClearAgentThinkingLevel(ctx context.Context, id pgtype.UUID) (
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -2111,16 +2118,17 @@ INSERT INTO agent (
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
     service_tier, conversation_starters,
-    composio_toolkit_allowlist, permission_mode
+    composio_toolkit_allowlist, permission_mode, enabled_builtin_skill_ids
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15, $16,
     $17, COALESCE($18::jsonb, '[]'::jsonb),
     $19::text[],
-    COALESCE($20, 'private')
+    COALESCE($20, 'private'),
+    $21::text[]
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type CreateAgentParams struct {
@@ -2144,6 +2152,7 @@ type CreateAgentParams struct {
 	ConversationStarters     []byte      `json:"conversation_starters"`
 	ComposioToolkitAllowlist []string    `json:"composio_toolkit_allowlist"`
 	PermissionMode           interface{} `json:"permission_mode"`
+	EnabledBuiltinSkillIds   []string    `json:"enabled_builtin_skill_ids"`
 }
 
 func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent, error) {
@@ -2168,6 +2177,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.ConversationStarters,
 		arg.ComposioToolkitAllowlist,
 		arg.PermissionMode,
+		arg.EnabledBuiltinSkillIds,
 	)
 	var i Agent
 	err := row.Scan(
@@ -2200,6 +2210,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -2214,7 +2225,7 @@ INSERT INTO agent (
     'private', 'private', 1, $5, $6,
     '{}'::jsonb, '[]'::jsonb, $7, 'system', $8
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type CreateAgentBuilderParams struct {
@@ -2274,6 +2285,7 @@ func (q *Queries) CreateAgentBuilder(ctx context.Context, arg CreateAgentBuilder
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -3179,7 +3191,7 @@ INSERT INTO agent (
     $6, $7, $8, $9, $10,
     $11, '', '{}'::jsonb, '[]'::jsonb, 'user', $12
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type CreateSystemUserAgentParams struct {
@@ -3255,6 +3267,7 @@ func (q *Queries) CreateSystemUserAgent(ctx context.Context, arg CreateSystemUse
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -3987,7 +4000,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE id = $1
 `
 
@@ -4024,12 +4037,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
 
 const getAgentBySystemKey = `-- name: GetAgentBySystemKey :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE workspace_id = $1 AND system_key = $2 AND archived_at IS NULL
 ORDER BY created_at ASC, id ASC
 LIMIT 1
@@ -4076,12 +4090,13 @@ func (q *Queries) GetAgentBySystemKey(ctx context.Context, arg GetAgentBySystemK
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
 
 const getAgentForClaimUpdate = `-- name: GetAgentForClaimUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -4119,18 +4134,19 @@ func (q *Queries) GetAgentForClaimUpdate(ctx context.Context, id pgtype.UUID) (A
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
 
 const getAgentForUpdate = `-- name: GetAgentForUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE id = $1
 FOR UPDATE
 `
 
-// Serializes read-modify-write updates to disabled_runtime_skills so two
-// concurrent per-skill toggles cannot overwrite each other.
+// Serializes read-modify-write updates to per-agent skill controls so two
+// concurrent toggles cannot overwrite each other.
 func (q *Queries) GetAgentForUpdate(ctx context.Context, id pgtype.UUID) (Agent, error) {
 	row := q.db.QueryRow(ctx, getAgentForUpdate, id)
 	var i Agent
@@ -4164,12 +4180,13 @@ func (q *Queries) GetAgentForUpdate(ctx context.Context, id pgtype.UUID) (Agent,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
 `
 
@@ -4211,6 +4228,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -5049,7 +5067,7 @@ func (q *Queries) LinkTaskToIssue(ctx context.Context, arg LinkTaskToIssueParams
 }
 
 const listActiveAgentsByRuntime = `-- name: ListActiveAgentsByRuntime :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 `
@@ -5099,6 +5117,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -5111,7 +5130,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listActiveAgentsByRuntimeForUpdate = `-- name: ListActiveAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 FOR UPDATE
@@ -5163,6 +5182,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -5420,7 +5440,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -5464,6 +5484,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -5476,7 +5497,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE workspace_id = $1 AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -5520,6 +5541,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -5532,7 +5554,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listAllAgentsAnyKind = `-- name: ListAllAgentsAnyKind :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -5586,6 +5608,7 @@ func (q *Queries) ListAllAgentsAnyKind(ctx context.Context, workspaceID pgtype.U
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -6169,7 +6192,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 }
 
 const listUserAgentsByRuntimeForUpdate = `-- name: ListUserAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE runtime_id = $1 AND kind = 'user'
 ORDER BY id
 FOR UPDATE
@@ -6219,6 +6242,7 @@ func (q *Queries) ListUserAgentsByRuntimeForUpdate(ctx context.Context, runtimeI
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}
@@ -6527,7 +6551,7 @@ func (q *Queries) ListWorkspaceWorkingAgents(ctx context.Context, arg ListWorksp
 }
 
 const lockAgentForAutopilotAssignment = `-- name: LockAgentForAutopilotAssignment :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
 FOR SHARE
 `
@@ -6579,6 +6603,7 @@ func (q *Queries) LockAgentForAutopilotAssignment(ctx context.Context, arg LockA
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -7307,7 +7332,7 @@ SET runtime_id = $1,
     model = $3,
     updated_at = now()
 WHERE id = $4 AND kind = 'system' AND system_key LIKE 'agent_builder:%'
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type RebindAgentBuilderRuntimeParams struct {
@@ -7371,6 +7396,7 @@ func (q *Queries) RebindAgentBuilderRuntime(ctx context.Context, arg RebindAgent
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -7735,7 +7761,7 @@ SET status = desired.status,
     updated_at = now()
 FROM desired
 WHERE a.id = $1 AND a.status IS DISTINCT FROM desired.status
-RETURNING a.id, a.workspace_id, a.name, a.avatar_url, a.runtime_mode, a.runtime_config, a.visibility, a.status, a.max_concurrent_tasks, a.owner_id, a.created_at, a.updated_at, a.description, a.runtime_id, a.instructions, a.archived_at, a.archived_by, a.custom_env, a.custom_args, a.mcp_config, a.model, a.thinking_level, a.composio_toolkit_allowlist, a.permission_mode, a.kind, a.system_key, a.disabled_runtime_skills, a.service_tier, a.conversation_starters
+RETURNING a.id, a.workspace_id, a.name, a.avatar_url, a.runtime_mode, a.runtime_config, a.visibility, a.status, a.max_concurrent_tasks, a.owner_id, a.created_at, a.updated_at, a.description, a.runtime_id, a.instructions, a.archived_at, a.archived_by, a.custom_env, a.custom_args, a.mcp_config, a.model, a.thinking_level, a.composio_toolkit_allowlist, a.permission_mode, a.kind, a.system_key, a.disabled_runtime_skills, a.service_tier, a.conversation_starters, a.enabled_builtin_skill_ids
 `
 
 // Persisted agent.status has no queued/resource-wait bucket. Keep dispatched
@@ -7776,6 +7802,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -7939,7 +7966,7 @@ func (q *Queries) RequeueAgentTaskAfterClaimFailure(ctx context.Context, arg Req
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -7975,6 +8002,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -8235,7 +8263,7 @@ UPDATE agent SET
     composio_toolkit_allowlist = COALESCE($20::text[], composio_toolkit_allowlist),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type UpdateAgentParams struct {
@@ -8321,6 +8349,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -8329,7 +8358,7 @@ const updateAgentCustomEnv = `-- name: UpdateAgentCustomEnv :one
 UPDATE agent
 SET custom_env = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type UpdateAgentCustomEnvParams struct {
@@ -8375,6 +8404,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -8383,7 +8413,7 @@ const updateAgentDisabledRuntimeSkills = `-- name: UpdateAgentDisabledRuntimeSki
 UPDATE agent
 SET disabled_runtime_skills = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type UpdateAgentDisabledRuntimeSkillsParams struct {
@@ -8424,6 +8454,57 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
+	)
+	return i, err
+}
+
+const updateAgentEnabledBuiltinSkillIDs = `-- name: UpdateAgentEnabledBuiltinSkillIDs :one
+UPDATE agent
+SET enabled_builtin_skill_ids = $2, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
+`
+
+type UpdateAgentEnabledBuiltinSkillIDsParams struct {
+	ID                     pgtype.UUID `json:"id"`
+	EnabledBuiltinSkillIds []string    `json:"enabled_builtin_skill_ids"`
+}
+
+func (q *Queries) UpdateAgentEnabledBuiltinSkillIDs(ctx context.Context, arg UpdateAgentEnabledBuiltinSkillIDsParams) (Agent, error) {
+	row := q.db.QueryRow(ctx, updateAgentEnabledBuiltinSkillIDs, arg.ID, arg.EnabledBuiltinSkillIds)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.Kind,
+		&i.SystemKey,
+		&i.DisabledRuntimeSkills,
+		&i.ServiceTier,
+		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }
@@ -8431,7 +8512,7 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 type UpdateAgentStatusParams struct {
@@ -8472,6 +8553,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
 		&i.ConversationStarters,
+		&i.EnabledBuiltinSkillIds,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -47,12 +47,13 @@ type Agent struct {
 	// Composio toolkit slugs this agent is allowed to mount as MCP. NULL or empty array = no MCP overlay. Mounted for any run that passes the agent invocation-permission gate (MUL-3963); the overlay uses the agent OWNER's active Composio connection, so sharing the agent (public_to) shares these apps with whoever may invoke it. No longer gated on originator == owner. Stored as TEXT[] so the dispatch path can intersect against the owner's active connections with a single SQL ANY() filter.
 	ComposioToolkitAllowlist []string `json:"composio_toolkit_allowlist"`
 	// Agent invocation permission mode (MUL-3963). private = owner only; public_to = allow-list in agent_invocation_target. Replaces visibility as the authorization source for triggering runs; visibility is now a derived legacy field. Default private = deny-by-default.
-	PermissionMode        string      `json:"permission_mode"`
-	Kind                  string      `json:"kind"`
-	SystemKey             pgtype.Text `json:"system_key"`
-	DisabledRuntimeSkills []byte      `json:"disabled_runtime_skills"`
-	ServiceTier           pgtype.Text `json:"service_tier"`
-	ConversationStarters  []byte      `json:"conversation_starters"`
+	PermissionMode         string      `json:"permission_mode"`
+	Kind                   string      `json:"kind"`
+	SystemKey              pgtype.Text `json:"system_key"`
+	DisabledRuntimeSkills  []byte      `json:"disabled_runtime_skills"`
+	ServiceTier            pgtype.Text `json:"service_tier"`
+	ConversationStarters   []byte      `json:"conversation_starters"`
+	EnabledBuiltinSkillIds []string    `json:"enabled_builtin_skill_ids"`
 }
 
 type AgentBuilderDraft struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -1362,7 +1362,7 @@ const unbindUserAgentsFromRuntime = `-- name: UnbindUserAgentsFromRuntime :many
 UPDATE agent
 SET runtime_id = NULL, updated_at = now()
 WHERE runtime_id = $1 AND kind = 'user'
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, conversation_starters, enabled_builtin_skill_ids
 `
 
 // MUL-5559: the runtime-delete replacement for archive-then-hard-delete. Every
@@ -1414,6 +1414,7 @@ func (q *Queries) UnbindUserAgentsFromRuntime(ctx context.Context, runtimeID pgt
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
 			&i.ConversationStarters,
+			&i.EnabledBuiltinSkillIds,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -28,8 +28,8 @@ SELECT * FROM agent
 WHERE id = $1;
 
 -- name: GetAgentForUpdate :one
--- Serializes read-modify-write updates to disabled_runtime_skills so two
--- concurrent per-skill toggles cannot overwrite each other.
+-- Serializes read-modify-write updates to per-agent skill controls so two
+-- concurrent toggles cannot overwrite each other.
 SELECT * FROM agent
 WHERE id = $1
 FOR UPDATE;
@@ -58,14 +58,15 @@ INSERT INTO agent (
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
     service_tier, conversation_starters,
-    composio_toolkit_allowlist, permission_mode
+    composio_toolkit_allowlist, permission_mode, enabled_builtin_skill_ids
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15, $16,
     $17, COALESCE(sqlc.narg('conversation_starters')::jsonb, '[]'::jsonb),
     sqlc.narg('composio_toolkit_allowlist')::text[],
-    COALESCE(sqlc.narg('permission_mode'), 'private')
+    COALESCE(sqlc.narg('permission_mode'), 'private'),
+    sqlc.narg('enabled_builtin_skill_ids')::text[]
 )
 RETURNING *;
 
@@ -193,6 +194,12 @@ RETURNING *;
 -- name: UpdateAgentDisabledRuntimeSkills :one
 UPDATE agent
 SET disabled_runtime_skills = $2, updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: UpdateAgentEnabledBuiltinSkillIDs :one
+UPDATE agent
+SET enabled_builtin_skill_ids = $2, updated_at = now()
 WHERE id = $1
 RETURNING *;
 


### PR DESCRIPTION
## What does this PR do?

Adds per-agent controls for Multica’s platform-provided built-in skills.

Agents can already manage workspace skills and runtime-local skills, but platform built-ins are currently injected into every agent without an opt-out. This PR
extends the existing Skills tab, API, and CLI so users can disable built-ins that conflict with an agent’s instructions or replace them with their own workspace
skills.

The policy is backward-compatible:

- Existing and newly created agents inherit all current and future built-ins by default.
- The first disable creates an exact per-agent allow-list.
- An empty allow-list disables all built-ins.
- Resetting the policy restores inheritance of all current and future built-ins.
- Enabling an already inherited skill is a no-op, so it does not accidentally freeze the current built-in inventory.
- Unknown persisted skill IDs are retained for rolling-deployment compatibility.

Built-in skills use stable IDs based on their bundle directory, such as `builtin:multica-working-on-issues`. The policy is applied consistently to full skill
payloads, slim/deferred bundle references, agent drafts, and copied agents.

A workspace skill does not implicitly replace a built-in merely by sharing its name. Users explicitly disable the built-in and attach their preferred workspace
skill instead.

## Related Issue

Closes #7708

Related to #1216, which covers the broader problem of overriding platform-injected context. This PR specifically adds controls for Multica’s built-in skill bundles
and does not change generated `CLAUDE.md` sections.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added the nullable `agent.enabled_builtin_skill_ids` policy and regenerated sqlc bindings:
  - `server/migrations/441_agent_enabled_builtin_skills.*.sql`
  - `server/pkg/db/queries/agent.sql`
  - `server/pkg/db/generated/`
- Added permission-checked, transaction-safe API operations for toggling and resetting built-in skills:
  - `PUT /api/agents/{id}/builtin-skills/enabled`
  - `DELETE /api/agents/{id}/builtin-skills`
  - `server/internal/handler/agent_builtin_skills.go`
  - `server/cmd/server/router.go`
- Added stable built-in IDs, descriptions, policy filtering, and execution-path propagation:
  - `server/internal/service/builtin_skills.go`
  - `server/internal/service/task.go`
  - `server/internal/handler/daemon.go`
- Added defensive agent response parsing and API client methods:
  - `packages/core/api/schemas.ts`
  - `packages/core/api/client.ts`
  - `packages/core/types/agent.ts`
- Preserved the policy when duplicating agents through drafts and `multica agent copy`:
  - `packages/core/agents/draft.ts`
  - `server/cmd/multica/cmd_agent_copy.go`
- Added built-in skill toggles and a reset action to the existing agent Skills tab. Agent detail is loaded lazily because list responses intentionally omit the
built-in inventory:
  - `packages/views/agents/components/tabs/skills-tab.tsx`
- Added English, Japanese, Korean, and Simplified Chinese UI copy:
  - `packages/views/locales/*/agents.json`
- Added CLI commands:
  - `multica agent builtins list <agent-id>`
  - `multica agent builtins enable <agent-id> <skill-id>`
  - `multica agent builtins disable <agent-id> <skill-id>`
  - `multica agent builtins reset <agent-id>`
  - `server/cmd/multica/cmd_agent_builtins.go`
- Updated CLI documentation and the built-in agent-creation skill documentation:
  - `apps/docs/content/docs/cli*.mdx`
  - `server/internal/service/builtin_skills/multica-creating-agents/`

### Risks and compatibility

- The migration is additive and nullable. Existing agents therefore retain their current behavior.
- After the first disable, the agent uses an exact allow-list. Newly introduced built-ins remain disabled until explicitly enabled or the policy is reset. This is
intentional but is called out in the UI and CLI documentation.
- Built-in skill controls require a server version that exposes the built-in inventory. Older servers degrade to an unavailable state rather than causing the UI to
iterate malformed or missing data.
- This does not automatically resolve name collisions between built-in and workspace skills; replacement remains an explicit user decision.

## How to Test

1. Open an existing agent and select its **Skills** tab. Confirm that the **Multica built-ins** section appears and that all built-ins are initially enabled.
2. Disable one built-in. Refresh the page and confirm that:
   - the disabled state persists;
   - other built-ins remain enabled;
   - the policy is reported as `exact` by `multica agent builtins list <agent-id>`.
3. Run an agent task and confirm the disabled built-in is absent from both full skill payloads and deferred/slim skill-bundle resolution.
4. Select **Reset to defaults**, then confirm that all built-ins are enabled and the CLI reports `inherit_all`.
5. Verify the CLI directly:
   ```bash
   multica agent builtins list <agent-id>
   multica agent builtins disable <agent-id> builtin:multica-working-on-issues
   multica agent builtins enable <agent-id> builtin:multica-working-on-issues
   multica agent builtins reset <agent-id>

6. Run the focused automated tests:

   pnpm --filter @multica/core exec vitest run api/client.test.ts agents/draft.test.ts
   pnpm --filter @multica/views exec vitest run agents/components/tabs/skills-tab.test.tsx

   cd server
   go test ./cmd/migrate ./cmd/multica ./internal/service ./internal/handler ./internal/daemon

Focused validation completed locally:

- Core Vitest: 117 tests passed.
- Skills-tab Vitest: 12 tests passed.
- Relevant Go package suites passed.

pnpm typecheck was not completed in this checkout because its existing workspace dependency links are missing @multica/plugin-sdk. The dependency workspace should
be refreshed and the full typecheck run before requesting merge.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy (apps/web/features/landing/i18n/) and relevant docs (apps/docs/content/
  docs/) — N/A: this extends the existing Skills tab and adds no runtime, coding tool, or tab

- [x] If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (terminology, mixed-rule for task /
  issue / skill)

- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

AI tool used: OpenAI Codex

Prompt / approach:

I used Codex to inspect the existing skill architecture, compare the feature with current mainline behavior, resolve rebase conflicts, and trace built-in skill
delivery across the database, API, UI, CLI, agent-copy, and execution paths.

The implementation was reviewed around explicit policy invariants: inherited defaults versus an exact allow-list, preserving explicit empty arrays, stable built-in
identifiers, safe concurrent updates, rolling-deployment compatibility, and consistent behavior for full and deferred skill bundles. Codex also helped add and run
focused frontend and backend tests and update the relevant documentation.

## Screenshots (optional)

### Before
There is not multica built-in skill section currently

### After
<img width="1001" height="711" alt="image" src="https://github.com/user-attachments/assets/1dc1d2e0-c47f-4e83-a657-cd24bee907e9" />

