### PR TITLE
MUL-6801: fix(runtime): wake daemon for local skill requests

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3994,11 +3994,11 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 //
 // The HTTP heartbeat is used on purpose rather than queueing a WS frame: the
 // hint arrives on the read pump, the WS write path may be backed up or tearing
-// down, and this is a human-interactive, low-frequency path (a user opened a
-// model picker) where one extra request is cheaper than a missed wakeup. Note it
-// intentionally bypasses the wsHeartbeatRecentlyAcked suppression that the
-// scheduled HTTP tick honours — that suppression exists to avoid duplicate
-// periodic writes, not to block an explicitly requested pull.
+// down, and this is a human-interactive, low-frequency path where one extra
+// request is cheaper than a missed wakeup. Note it intentionally bypasses the
+// wsHeartbeatRecentlyAcked suppression that the scheduled HTTP tick honours —
+// that suppression exists to avoid duplicate periodic writes, not to block an
+// explicitly requested pull.
 func (d *Daemon) handlePendingWorkHint(runtimeID, kind string) {
 	if runtimeID == "" {
 		return
@@ -4026,10 +4026,10 @@ func (d *Daemon) handlePendingWorkHint(runtimeID, kind string) {
 		d.pendingWorkMu.Unlock()
 		return
 	}
-	// Rate limit per runtime. The hint is caller-triggered (any workspace member
-	// hitting the list-models endpoint), so without a floor a request loop would
-	// become a heartbeat amplifier. A suppressed hint costs nothing but the
-	// pre-existing wait for the scheduled heartbeat.
+	// Rate limit per runtime. The hint is caller-triggered by interactive model
+	// or capability endpoints, so without a floor a request loop would become a
+	// heartbeat amplifier. A suppressed hint costs nothing but the pre-existing
+	// wait for the scheduled heartbeat.
 	if last, ok := d.pendingWorkLastRun[runtimeID]; ok && time.Since(last) < pendingWorkHintMinInterval {
 		d.pendingWorkMu.Unlock()
 		d.logger.Debug("pending work hint throttled", "runtime_id", runtimeID, "kind", kind)
@@ -4044,10 +4044,12 @@ func (d *Daemon) handlePendingWorkHint(runtimeID, kind string) {
 		d.pendingWorkMu.Unlock()
 	}()
 
-	// Root context: handleHeartbeatActions hands this ctx to the actual work
-	// (model discovery shells out to a CLI, for up to ~40s on the slowest
-	// provider — see agent.hermesDiscoveryTimeout), so it must outlive this
-	// function. Only the heartbeat request itself is time-bounded.
+	// Root context: handleHeartbeatActions hands this ctx to the actual work, so
+	// it must outlive this function. Capability discovery and local-skill imports
+	// are normally quick filesystem operations, while model discovery may shell
+	// out to a CLI for up to ~40s on the slowest provider (see
+	// agent.hermesDiscoveryTimeout). Only the heartbeat request itself is
+	// time-bounded.
 	ctx := d.recoveryContext()
 	if ctx.Err() != nil {
 		return

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -164,8 +164,9 @@ type WorkspaceSetRefreshNotifier interface {
 }
 
 // DaemonPendingWorkNotifier pushes a runtime-scoped "heartbeat now" hint to the
-// daemon so a queued heartbeat-carried request (model discovery) is picked up
-// immediately instead of on the daemon's next scheduled tick (MUL-5444).
+// daemon so a queued heartbeat-carried request (model discovery, capability
+// discovery, or local-skill import) is picked up immediately instead of on the
+// daemon's next scheduled tick (MUL-5444).
 // Satisfied by both *daemonws.Hub (single-node) and *daemonws.RelayNotifier
 // (multi-node, fans out through Redis).
 type DaemonPendingWorkNotifier interface {

--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -606,6 +606,7 @@ func (h *Handler) InitiateListLocalSkills(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "failed to enqueue local skills request: "+err.Error())
 		return
 	}
+	h.requestDaemonPendingWork(rt.runtimeID, protocol.PendingWorkKindLocalSkills)
 	writeJSON(w, http.StatusOK, req)
 }
 
@@ -690,6 +691,7 @@ func (h *Handler) InitiateImportLocalSkill(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "failed to enqueue local skill import: "+err.Error())
 		return
 	}
+	h.requestDaemonPendingWork(rt.runtimeID, protocol.PendingWorkKindLocalSkillImport)
 	writeJSON(w, http.StatusOK, importReq)
 }
 

--- a/server/internal/handler/runtime_local_skills_test.go
+++ b/server/internal/handler/runtime_local_skills_test.go
@@ -9,7 +9,17 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
+
+type runtimeLocalSkillPendingWorkRecorder struct {
+	hints []string
+}
+
+func (r *runtimeLocalSkillPendingWorkRecorder) NotifyPendingWork(runtimeID, kind string) {
+	r.hints = append(r.hints, runtimeID+":"+kind)
+}
 
 func newRequestAsUser(userID, method, path string, body any) *http.Request {
 	var buf bytes.Buffer
@@ -265,6 +275,32 @@ func TestListLocalSkills_AllowsNonOwnerForPublicRuntime(t *testing.T) {
 	}
 }
 
+func TestInitiateListLocalSkills_WakesDaemon(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
+	recorder := &runtimeLocalSkillPendingWorkRecorder{}
+	h := *testHandler
+	h.DaemonPendingWork = recorder
+
+	w := httptest.NewRecorder()
+	req := withURLParams(
+		newRequestAsUser(testUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills", nil),
+		"runtimeId", runtimeID,
+	)
+
+	h.InitiateListLocalSkills(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	want := runtimeID + ":" + protocol.PendingWorkKindLocalSkills
+	if len(recorder.hints) != 1 || recorder.hints[0] != want {
+		t.Fatalf("pending-work hints = %v, want [%s]", recorder.hints, want)
+	}
+}
+
 func TestListLocalSkills_RejectsNonMember(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
@@ -316,6 +352,49 @@ func TestInitiateImportLocalSkill_RequiresRuntimeOwner(t *testing.T) {
 	testHandler.InitiateImportLocalSkill(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInitiateImportLocalSkill_WakesDaemonAfterValidEnqueue(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID := createRuntimeLocalSkillTestRuntime(t, testUserID)
+	recorder := &runtimeLocalSkillPendingWorkRecorder{}
+	h := *testHandler
+	h.DaemonPendingWork = recorder
+
+	w := httptest.NewRecorder()
+	req := withURLParams(
+		newRequestAsUser(testUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills/import", map[string]any{
+			"skill_key": "review-helper",
+		}),
+		"runtimeId", runtimeID,
+	)
+
+	h.InitiateImportLocalSkill(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	want := runtimeID + ":" + protocol.PendingWorkKindLocalSkillImport
+	if len(recorder.hints) != 1 || recorder.hints[0] != want {
+		t.Fatalf("pending-work hints = %v, want [%s]", recorder.hints, want)
+	}
+
+	w = httptest.NewRecorder()
+	req = withURLParams(
+		newRequestAsUser(testUserID, http.MethodPost, "/api/runtimes/"+runtimeID+"/local-skills/import", map[string]any{
+			"skill_key": "",
+		}),
+		"runtimeId", runtimeID,
+	)
+	h.InitiateImportLocalSkill(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(recorder.hints) != 1 {
+		t.Fatalf("rejected enqueue must not send another hint, got %v", recorder.hints)
 	}
 }
 

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -150,10 +150,11 @@ const (
 	EventDaemonRuntimeProfilesChanged = "daemon:runtime_profiles_changed"
 	EventDaemonWorkspacesChanged      = "daemon:workspaces_changed"
 	// EventDaemonPendingWork is a runtime-scoped hint that a heartbeat-carried
-	// request (today: model-list discovery) is queued for that runtime. Without
-	// it the daemon only learns about the request on its next scheduled
-	// heartbeat, which adds up to one HeartbeatInterval (15s by default) of
-	// dead wait to an interactive UI flow (MUL-5444). The hint carries no work
+	// request (model discovery, capability discovery, or local-skill import) is
+	// queued for that runtime. Without it the daemon only learns about the
+	// request on its next scheduled heartbeat, adding up to one HeartbeatInterval
+	// (15s by default) of dead wait to an interactive UI flow (MUL-5444). The
+	// hint carries no work
 	// itself: the daemon still pulls the request through the normal heartbeat
 	// claim, so a lost or duplicated hint is harmless.
 	EventDaemonPendingWork = "daemon:pending_work"

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -117,7 +117,9 @@ type WorkspacesChangedPayload struct{}
 // heartbeat, which claims whatever is queued) — so an unknown value from a
 // newer server stays safe on an older daemon.
 const (
-	PendingWorkKindModelList = "model_list"
+	PendingWorkKindModelList        = "model_list"
+	PendingWorkKindLocalSkills      = "local_skills"
+	PendingWorkKindLocalSkillImport = "local_skill_import"
 )
 
 // PendingWorkPayload is sent from server to daemon as a wakeup hint when a


### PR DESCRIPTION
 ## What does this PR do?

Fixes unnecessary latency when discovering or importing skills from an online local runtime.

Local skill requests are queued through the server and retrieved by the daemon through its heartbeat. Previously, these operations did not notify the daemon that new work was available, so an interactive request could wait until the next scheduled heartbeat—up to roughly 15 seconds by default.

After successfully queuing either a local skill discovery or import request, the server now sends the runtime-scoped `daemon:pending_work` hint already used for model discovery. The daemon responds by performing the normal heartbeat request immediately.

The notification carries no work payload and does not change queue ownership or claim semantics. Scheduled heartbeat polling remains the reliability fallback, so lost or duplicate notifications are harmless. Existing per-runtime coalescing and throttling prevent repeated requests from becoming a heartbeat amplifier.

### Risks and compatibility

- The change can produce an additional heartbeat request after an interactive local-skill operation. Existing per-runtime throttling and coalescing limit this behavior.
- Notifications are sent only after work is enqueued successfully.
- The heartbeat remains authoritative and continues to claim the queued work.
- Older daemons safely ignore unknown pending-work kinds and still retrieve the request through their scheduled heartbeat.
- Multi-node deployments continue using the existing pending-work relay mechanism.

## Related Issue

Closes #7711

Builds on the runtime-scoped pending-work notification mechanism introduced in #6098.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Send a `local_skills` pending-work hint after successfully queuing runtime-local skill discovery:
  - `server/internal/handler/runtime_local_skills.go`
- Send a `local_skill_import` hint after successfully queuing a runtime-local skill import:
  - `server/internal/handler/runtime_local_skills.go`
- Add explicit pending-work kind constants for discovery and import:
  - `server/pkg/protocol/messages.go`
- Generalize the existing pending-work protocol and daemon documentation beyond model discovery:
  - `server/pkg/protocol/events.go`
  - `server/internal/handler/handler.go`
  - `server/internal/daemon/daemon.go`
- Add regression coverage confirming that:
  - successful discovery requests wake the target daemon;
  - successful imports wake the target daemon;
  - rejected imports do not send a wake hint:
  - `server/internal/handler/runtime_local_skills_test.go`

## How to Test

1. Run the focused regression tests:

   ```bash
   cd server
   go test ./internal/handler ./internal/daemon \
     -run 'Test(InitiateListLocalSkills_WakesDaemon|InitiateImportLocalSkill_WakesDaemonAfterValidEnqueue|HandlePendingWorkHint)'
   ```

2. Connect an online local runtime and wait for a scheduled daemon heartbeat to complete.
3. Request runtime-local skill discovery from the Skills UI.
4. Verify that the daemon performs an immediate heartbeat and begins discovery without waiting for the next scheduled interval.
5. Import a runtime-local skill and verify that the daemon likewise begins processing promptly.
6. Submit an invalid import request and verify that it is rejected without sending a pending-work hint.

Focused validation completed locally:

- Handler wake-notification tests passed.
- Daemon pending-work hint tests passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A: this changes request latency without changing the UI
- [x] I have updated relevant documentation to reflect my changes — N/A: no user-facing API, configuration, or workflow changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/
docs/content/docs/`) — N/A
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` — N/A: no product copy changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

I used Codex to trace the runtime-local skill discovery and import request paths from server enqueue through daemon heartbeat processing. The existing runtime-scoped pending-work mechanism used by model discovery was identified as the appropriate wake-up path.

The implementation extends that mechanism with explicit local-skill discovery and import kinds while preserving the heartbeat as the authoritative pull and reliability fallback. Codex also helped separate this fix from unrelated feature work, rebase it onto current mainline, and add focused regression coverage for successful and rejected enqueue paths.

## Screenshots (optional)

Not applicable; this changes daemon wake-up latency without changing the UI.
