### PR TITLE
MUL-6800: perf(handler): reuse HTTP clients instead of per-request allocation

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -34,6 +34,11 @@ import (
 // point App-authenticated calls at an httptest server without touching GitHub.
 var githubAPIBase = "https://api.github.com"
 
+// githubTokenHTTPClient is reused across installation-token exchanges (a hot
+// path against api.github.com) so they share one keep-alive connection pool
+// instead of building a throwaway client — and its idle connections — per call.
+var githubTokenHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
 const (
 	githubReturnToGitHub       = "github"
 	githubReturnToRepositories = "repositories"
@@ -824,7 +829,6 @@ func fetchGitHubInstallationRepositories(
 		return GitHubRepositoriesResponse{}, errors.New("github App JWT credentials unavailable")
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
 	tokenEndpoint := fmt.Sprintf(
 		"%s/app/installations/%d/access_tokens",
 		strings.TrimRight(githubAPIBase, "/"),
@@ -841,7 +845,7 @@ func fetchGitHubInstallationRepositories(
 	}
 	setGitHubAPIHeaders(tokenReq, appJWT)
 	tokenReq.Header.Set("Content-Type", "application/json")
-	tokenResp, err := client.Do(tokenReq)
+	tokenResp, err := githubTokenHTTPClient.Do(tokenReq)
 	if err != nil {
 		return GitHubRepositoriesResponse{}, fmt.Errorf("create installation token: %w", err)
 	}
@@ -859,7 +863,7 @@ func fetchGitHubInstallationRepositories(
 	if tokenBody.Token == "" {
 		return GitHubRepositoriesResponse{}, errors.New("github returned an empty installation token")
 	}
-	defer revokeGitHubInstallationToken(client, tokenBody.Token)
+	defer revokeGitHubInstallationToken(githubTokenHTTPClient, tokenBody.Token)
 
 	repositoriesEndpoint := fmt.Sprintf(
 		"%s/installation/repositories?page=%d&per_page=%d",
@@ -872,7 +876,7 @@ func fetchGitHubInstallationRepositories(
 		return GitHubRepositoriesResponse{}, err
 	}
 	setGitHubAPIHeaders(repositoriesReq, tokenBody.Token)
-	repositoriesResp, err := client.Do(repositoriesReq)
+	repositoriesResp, err := githubTokenHTTPClient.Do(repositoriesReq)
 	if err != nil {
 		return GitHubRepositoriesResponse{}, fmt.Errorf("list installation repositories: %w", err)
 	}

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -367,8 +367,7 @@ func (h *Handler) SearchSkills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	candidates, err := searchClawHubSkills(httpClient, query)
+	candidates, err := searchClawHubSkills(skillHTTPClient, query)
 	if err != nil {
 		writeJSON(w, http.StatusBadGateway, map[string]string{
 			"code":  "upstream_unavailable",
@@ -789,6 +788,13 @@ func (s *importedSkill) addFile(path, content string) error {
 // --- ClawHub types ---
 
 var clawHubAPIBase = "https://clawhub.ai/api/v1"
+
+// skillHTTPClient is shared across the skill search / import / refresh paths so
+// they reuse one keep-alive connection pool instead of paying a fresh TCP+TLS
+// handshake per request. The per-request deadline is applied via context
+// (importFetchTimeout / the caller's request context), so this client-level
+// Timeout is only an outer safety bound.
+var skillHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 const clawHubSearchStatsLimit = 10
 
@@ -2301,8 +2307,6 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-
 	// Bound the whole server-side fetch under an overall deadline that is
 	// shorter than the reverse-proxy / CDN gateway timeout in front of the API.
 	// If an upstream is slow, the import returns a clear error instead of the
@@ -2314,11 +2318,11 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	var imported *importedSkill
 	switch source {
 	case sourceClawHub:
-		imported, err = fetchFromClawHub(ctx, httpClient, normalized)
+		imported, err = fetchFromClawHub(ctx, skillHTTPClient, normalized)
 	case sourceSkillsSh:
-		imported, err = fetchFromSkillsSh(ctx, httpClient, normalized)
+		imported, err = fetchFromSkillsSh(ctx, skillHTTPClient, normalized)
 	case sourceGitHub:
-		imported, err = fetchFromGitHub(ctx, httpClient, normalized)
+		imported, err = fetchFromGitHub(ctx, skillHTTPClient, normalized)
 	}
 	if err != nil {
 		status, msg := importFetchErrorResponse(ctx, err)

--- a/server/internal/handler/skill_refresh.go
+++ b/server/internal/handler/skill_refresh.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -148,11 +147,10 @@ func (h *Handler) RefreshSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpClient := &http.Client{Timeout: 30 * time.Second}
 	ctx, cancel := context.WithTimeout(r.Context(), importFetchTimeout)
 	defer cancel()
 
-	imported, err := fetchImportedSkillFromOrigin(ctx, httpClient, origin)
+	imported, err := fetchImportedSkillFromOrigin(ctx, skillHTTPClient, origin)
 	if err != nil {
 		if errors.Is(err, errSkillNotRefreshable) {
 			writeError(w, http.StatusUnprocessableEntity, err.Error())


### PR DESCRIPTION
## What does this PR do?

The skill search/import/refresh handlers and the GitHub installation-token exchange each constructed a fresh `*http.Client` per request. Every throwaway client carries its own transport with an empty connection pool, so repeated calls cannot reuse TCP/TLS keep-alive connections and pay unnecessary handshake/allocation cost on existing user-facing flows.

This hoists those clients to package-level vars with the same timeout values, matching the existing long-lived client pattern in `integrations/vcs/forgejo.go`, without changing request deadlines or response behavior.

## Related Issue

Closes #7712

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/skill.go`: add `skillHTTPClient` with the existing 30s timeout and reuse it for `SearchSkills` and `ImportSkill`.
- `server/internal/handler/skill_refresh.go`: reuse `skillHTTPClient` for `RefreshSkill` and remove the now-unused `time` import.
- `server/internal/handler/github.go`: add `githubTokenHTTPClient` with the existing 15s timeout and reuse it across the GitHub installation-token exchange, repository listing, and token revocation path.
- Leave `plugin_hook.go` unchanged because hooks already run under per-call `context.WithTimeout`, and a fixed client-level timeout would incorrectly truncate hooks with longer configured `TimeoutMs`.

## How to Test

1. `cd server && gofmt -w internal/handler/github.go internal/handler/skill.go internal/handler/skill_refresh.go`
2. `cd server && go build ./internal/handler/...`
3. `cd server && go vet ./internal/handler/...`
4. `cd server && go test ./internal/handler/ -run 'Skill|GitHub'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Audited outbound HTTP client allocation in existing handler paths, compared against the repository's Forgejo integration pattern, and kept the change scoped to call sites with fixed timeout requirements. Also checked `plugin_hook.go` and intentionally left it unchanged because that path has configurable per-hook context deadlines.
