### PR TITLE
MUL-6803: perf(handler): pool JSON response encode buffers

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -12,6 +13,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -492,43 +494,76 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 	return h
 }
 
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	// Marshal the body up front so we can advertise an accurate Content-Length
-	// header. Streaming straight into the ResponseWriter after WriteHeader forces
-	// net/http into chunked transfer encoding, which omits Content-Length; buffering
-	// first lets clients (and proxies) see the exact body size.
-	body, err := json.Marshal(v)
-	if err != nil {
-		// Fall back to a minimal, self-describing error payload rather than leaving
-		// the client with a half-written response.
-		body = []byte(`{"error":"failed to encode response"}`)
-		status = http.StatusInternalServerError
+// jsonBufPool recycles the encode buffers used by writeJSON / writeMeasuredJSON.
+// json.Marshal returns a length-exact slice, so the historical `append(body,
+// '\n')` reallocated and copied the whole body just to add one byte — costly on
+// large list responses. Encoding through a pooled bytes.Buffer with
+// json.Encoder (which writes the trailing newline itself) removes both that
+// realloc and the per-request marshal allocation.
+var jsonBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// maxPooledJSONBuf caps the buffer capacity we return to the pool. A one-off
+// large response (e.g. an unpaginated list) would otherwise pin megabytes in
+// the pool indefinitely; oversized buffers are dropped for the GC instead.
+const maxPooledJSONBuf = 1 << 20 // 1 MiB
+
+func putJSONBuf(buf *bytes.Buffer) {
+	if buf.Cap() > maxPooledJSONBuf {
+		return
 	}
-	// Match the trailing newline that json.Encoder.Encode historically appended.
-	body = append(body, '\n')
+	jsonBufPool.Put(buf)
+}
+
+// encodeJSONError is the body written when encoding fails: minimal and
+// self-describing, so a caller never gets a half-written response.
+var encodeJSONError = []byte(`{"error":"failed to encode response"}` + "\n")
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	// Buffer the body up front so we can advertise an accurate Content-Length.
+	// Streaming straight into the ResponseWriter after WriteHeader forces
+	// net/http into chunked transfer encoding, which omits Content-Length;
+	// buffering first lets clients (and proxies) see the exact body size.
+	buf := jsonBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer putJSONBuf(buf)
+
+	// json.Encoder.Encode appends the trailing newline writeJSON historically
+	// added by hand, and matches json.Marshal's default HTML escaping.
+	if err := json.NewEncoder(buf).Encode(v); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(encodeJSONError)))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(encodeJSONError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
 	w.WriteHeader(status)
-	_, _ = w.Write(body)
+	_, _ = w.Write(buf.Bytes())
 }
 
 // writeMeasuredJSON behaves like writeJSON but returns the encoded body size so
 // callers can record payload bytes in slow-endpoint diagnostics. It measures the
 // uncompressed JSON length and is unrelated to transport compression.
 func writeMeasuredJSON(w http.ResponseWriter, status int, v any) (int, error) {
-	body, err := json.Marshal(v)
-	if err != nil {
+	buf := jsonBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer putJSONBuf(buf)
+
+	if err := json.NewEncoder(buf).Encode(v); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to encode response")
 		return 0, err
 	}
-	body = append(body, '\n')
+	n := buf.Len()
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.Header().Set("Content-Length", strconv.Itoa(n))
 	w.WriteHeader(status)
-	if _, err := w.Write(body); err != nil {
-		return len(body), err
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return n, err
 	}
-	return len(body), nil
+	return n, nil
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/server/internal/handler/handler_writejson_test.go
+++ b/server/internal/handler/handler_writejson_test.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -12,11 +14,11 @@ import (
 // behind the F2 claim-observability patch: swapping writeJSON for writeMeasuredJSON
 // at the /tasks/claim response sites must not change a single byte on the wire.
 //
-// writeJSON encodes via json.NewEncoder(w).Encode (which appends a trailing
-// newline); writeMeasuredJSON marshals via json.Marshal and appends the newline
-// by hand. Both HTML-escape by default, so the emitted bytes must match for every
-// input. This table-driven test fails closed if that invariant ever drifts, so the
-// "no wire-behavior change" claim is provable rather than reasoned.
+// writeJSON and writeMeasuredJSON both encode via json.NewEncoder(buf).Encode
+// through a pooled buffer (which appends a trailing newline and HTML-escapes by
+// default), so the emitted bytes must match for every input. This table-driven
+// test fails closed if that invariant ever drifts, so the "no wire-behavior
+// change" claim is provable rather than reasoned.
 func TestWriteMeasuredJSONByteIdenticalToWriteJSON(t *testing.T) {
 	type skill struct {
 		Name        string            `json:"name"`
@@ -152,4 +154,81 @@ func TestWriteJSONSetsContentLength(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWriteJSONTrailingNewline pins the trailing newline that json.Encoder.Encode
+// emits. writeJSON used to append it by hand; after switching to a pooled
+// bytes.Buffer + json.Encoder the newline must still be there, byte-for-byte, so
+// existing clients and golden-file tests see no change.
+func TestWriteJSONTrailingNewline(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSON(rec, http.StatusOK, map[string]string{"hello": "world"})
+
+	body := rec.Body.Bytes()
+	if len(body) == 0 || body[len(body)-1] != '\n' {
+		t.Fatalf("writeJSON body must end in a newline, got %q", body)
+	}
+	// Exactly one trailing newline, not two.
+	if len(body) >= 2 && body[len(body)-2] == '\n' {
+		t.Fatalf("writeJSON emitted a double trailing newline: %q", body)
+	}
+	cl, _ := strconv.Atoi(rec.Header().Get("Content-Length"))
+	if cl != len(body) {
+		t.Fatalf("Content-Length %d excludes/miscounts the newline (body %d)", cl, len(body))
+	}
+}
+
+// TestWriteJSONEncodeErrorFallback covers the branch where json encoding fails
+// (a channel is unmarshalable). The response must be the self-describing error
+// body with a 500 and an accurate Content-Length, never a half-written payload.
+func TestWriteJSONEncodeErrorFallback(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSON(rec, http.StatusOK, map[string]any{"bad": make(chan int)})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if got, want := rec.Body.String(), `{"error":"failed to encode response"}`+"\n"; got != want {
+		t.Fatalf("fallback body = %q, want %q", got, want)
+	}
+	cl, err := strconv.Atoi(rec.Header().Get("Content-Length"))
+	if err != nil || cl != rec.Body.Len() {
+		t.Fatalf("Content-Length = %q, want %d", rec.Header().Get("Content-Length"), rec.Body.Len())
+	}
+
+	// writeMeasuredJSON reports zero bytes and surfaces the error on the same input.
+	recMeasured := httptest.NewRecorder()
+	n, err := writeMeasuredJSON(recMeasured, http.StatusOK, map[string]any{"bad": make(chan int)})
+	if err == nil {
+		t.Fatalf("writeMeasuredJSON should return an error for an unmarshalable value")
+	}
+	if n != 0 {
+		t.Fatalf("writeMeasuredJSON reported %d bytes on error, want 0", n)
+	}
+}
+
+// TestWriteJSONPoolReuseNoCorruption runs many concurrent writes with distinct
+// payloads through the shared buffer pool: each response must contain exactly its
+// own body, proving buffers are Reset on Get and never aliased across calls.
+func TestWriteJSONPoolReuseNoCorruption(t *testing.T) {
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			writeJSON(rec, http.StatusOK, map[string]int{"seq": i})
+
+			var got map[string]int
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Errorf("iter %d: body not valid JSON: %v (%q)", i, err, rec.Body.String())
+				return
+			}
+			if got["seq"] != i {
+				t.Errorf("iter %d: got seq=%d, buffer was reused without isolation", i, got["seq"])
+			}
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What does this PR do?

Reduces allocation and copy overhead in the shared `writeJSON` and `writeMeasuredJSON` response paths without changing their wire behavior.

Previously, both writers encoded with `json.Marshal` and then appended a newline. The marshal result is commonly length-exact, so adding one byte can allocate a second slice and copy the entire response. This PR instead encodes into a pooled `*bytes.Buffer` with `json.NewEncoder(buf).Encode(v)`, which writes the trailing newline as part of encoding and allows the buffer capacity to be reused by later requests.

The existing behavior is preserved:

- default HTML escaping remains enabled;
- responses end with exactly one newline;
- `Content-Length` is calculated from the complete encoded body;
- encoding failures still return a JSON 500 response; and
- `writeMeasuredJSON` still reports the encoded response size and write errors.

Buffers larger than 1 MiB are not returned to the pool, preventing an unusually large response from retaining oversized backing storage in the pool.

## Related Issue

Closes #7715

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/handler.go`: add a shared `sync.Pool` of JSON encoding buffers and encode responses with `json.NewEncoder`.
- `server/internal/handler/handler.go`: discard pooled buffers above 1 MiB and retain accurate `Content-Length` and error responses.
- `server/internal/handler/handler_writejson_test.go`: update the writer identity documentation and add coverage for one trailing newline, encoding-error responses, and concurrent pool reuse.

## How to Test

1. From `server/`, run `go build ./...`.
2. Run `go vet ./...`.
3. Run `go test -race ./internal/handler/...`.
4. Confirm the writer tests cover byte-identical output, default HTML escaping, exactly one trailing newline, accurate `Content-Length`, encode-error fallback, and concurrent reuse without cross-response corruption.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The main risk is accidental response-format drift or sharing a live buffer across concurrent responses. Existing byte-identity and escaping tests remain in place, while new tests pin the single newline, exact length, error fallback, and concurrent isolation. A buffer is returned to the pool only after the synchronous response write has finished, and oversized buffers are discarded.

## AI Disclosure

**AI tool used:** Claude Code and OpenAI Codex

**Prompt / approach:** Audited the shared JSON response writers for avoidable allocations, replaced the marshal-plus-append path with pooled buffered encoding, and retained the existing response format and length calculation. Added regression tests for output identity, error handling, and concurrent reuse. OpenAI Codex reviewed the final diff, tightened the performance claims, and prepared the issue and PR workflow.

## Screenshots (optional)

Not applicable; this is a backend response-encoding optimization with no UI change.
