### PR TITLE
MUL-6809: fix(daemon): hand off chat environment on explicit release

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -574,6 +574,15 @@ type Daemon struct {
 	activeEnvRoots     map[string]int  // env root path -> reference count (handles reuse paths marked twice)
 	deletingEnvRoots   map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
 
+	// envRootClaims pairs every environment lock held by this daemon with a
+	// one-shot release signal. A replacement chat turn can therefore wait for
+	// the exact execution it superseded instead of polling the filesystem for
+	// an arbitrary amount of time. The mutex also closes the gap between taking
+	// an OS lock and publishing its signal (and between observing busy and
+	// subscribing to it).
+	envRootClaimsMu sync.Mutex
+	envRootClaims   map[string]*envRootClaimHandoff
+
 	activeStoresMu   sync.Mutex
 	activeStoresCond *sync.Cond      // signalled when an in-flight store deletion finishes, so a blocked markActive can proceed
 	activeStores     map[string]int  // persistent store path (per-conversation Codex sessions, per-agent Hermes memories) -> live-task refcount; guards the store from GC mid-task (MUL-4424)
@@ -645,6 +654,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		wsHBLastAck:               make(map[string]time.Time),
 		activeEnvRoots:            make(map[string]int),
 		deletingEnvRoots:          make(map[string]bool),
+		envRootClaims:             make(map[string]*envRootClaimHandoff),
 		activeStores:              make(map[string]int),
 		deletingStores:            make(map[string]bool),
 		localPathLocks:            NewLocalPathLocker(),
@@ -6264,7 +6274,7 @@ func (d *Daemon) startTaskPrepareLeaseExtender(ctx context.Context, task Task, t
 // The re-check under the lock closes the gap between proving eligibility and
 // acting on it. Declining is always safe: the caller falls back to a fresh
 // Prepare, which costs session continuity, not correctness.
-func (d *Daemon) lockReusablePriorEnvRoot(task Task, localAssignment *localDirectoryAssignment, heldRoot string) (*execenv.EnvRootClaim, string, os.FileInfo, bool) {
+func (d *Daemon) lockReusablePriorEnvRoot(ctx context.Context, task Task, localAssignment *localDirectoryAssignment, heldRoot string) (*execenv.EnvRootClaim, string, os.FileInfo, bool) {
 	// Pin the workspaces root BEFORE validating anything. Opening it after,
 	// from a name validation just approved, would re-resolve that name: rename
 	// the root aside, leave a symlink to a look-alike tree, and os.Root
@@ -6316,7 +6326,27 @@ func (d *Daemon) lockReusablePriorEnvRoot(task Task, localAssignment *localDirec
 		reuseLockTestHook()
 	}
 
-	claim, lockedInfo, err := execenv.LockEnvRootForReuse(wsRoot, rel, priorRoot)
+	claim, lockedInfo, released, err := d.lockEnvRootForReuse(wsRoot, rel, priorRoot)
+	// Sending a new chat message cancels the active turn, but the replacement
+	// can reach this point before the cancelled process has observed that state
+	// and released its environment lock. Falling back immediately creates a new
+	// task root, which makes the recorded provider session unreachable and turns
+	// an ordinary follow-up into a cold start. Wait only when this daemon can
+	// identify the exact holder and give us its one-shot release signal; an
+	// untracked lock may belong to another process and retains the existing
+	// fresh-environment fallback. The preparation context is the only timeout.
+	if errors.Is(err, execenv.ErrEnvRootBusy) && released != nil && task.ChatSessionID != "" && task.PriorSessionID != "" {
+		d.logger.Info("prior chat workdir is still shutting down; waiting to preserve session continuity",
+			"task", shortID(task.ID), "prior_root", filepath.Base(priorRoot))
+		for errors.Is(err, execenv.ErrEnvRootBusy) && released != nil {
+			select {
+			case <-ctx.Done():
+				return nil, "", nil, false
+			case <-released:
+				claim, lockedInfo, released, err = d.lockEnvRootForReuse(wsRoot, rel, priorRoot)
+			}
+		}
+	}
 	switch {
 	case errors.Is(err, execenv.ErrEnvRootBusy):
 		d.logger.Info("prior workdir is in use by another execution; starting a fresh environment",
@@ -6333,7 +6363,7 @@ func (d *Daemon) lockReusablePriorEnvRoot(task Task, localAssignment *localDirec
 	if !os.SameFile(validatedInfo, lockedInfo) {
 		d.logger.Info("prior workdir changed identity before it could be claimed; starting a fresh environment",
 			"task", shortID(task.ID))
-		claim.Release()
+		d.releaseEnvRootClaim(claim)
 		return nil, "", nil, false
 	}
 
@@ -6345,7 +6375,7 @@ func (d *Daemon) lockReusablePriorEnvRoot(task Task, localAssignment *localDirec
 	// not spelling.
 	recheckedWorkDir, stillOK := shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot)
 	if !stillOK || recheckedWorkDir != workDir {
-		claim.Release()
+		d.releaseEnvRootClaim(claim)
 		return nil, "", nil, false
 	}
 	// ...and the directory we are about to hand to Reuse has to be that same
@@ -6354,7 +6384,7 @@ func (d *Daemon) lockReusablePriorEnvRoot(task Task, localAssignment *localDirec
 	if err != nil || !os.SameFile(lockedInfo, currentInfo) {
 		d.logger.Info("prior workdir changed identity while being claimed; starting a fresh environment",
 			"task", shortID(task.ID))
-		claim.Release()
+		d.releaseEnvRootClaim(claim)
 		return nil, "", nil, false
 	}
 	return claim, workDir, lockedInfo, true
@@ -6776,11 +6806,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// *os.File cannot cross its JSON response back to us. Claiming there would
 	// leave the agent running with no protection at all — which is exactly the
 	// re-dispatch window this guards.
-	envClaim, err := execenv.ClaimEnvRoot(taskRootDirParams(d.cfg.WorkspacesRoot, task))
+	envClaim, err := d.claimEnvRoot(taskRootDirParams(d.cfg.WorkspacesRoot, task))
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("claim execution environment: %w", err)
 	}
-	defer envClaim.Release()
+	defer d.releaseEnvRootClaim(envClaim)
 
 	// Try to reuse the workdir from a previous task on the same (agent, issue) pair.
 	var env *execenv.Environment
@@ -7002,8 +7032,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}
 	}
 	envReused := false
-	if priorClaim, priorWorkDir, lockedPriorInfo, ok := d.lockReusablePriorEnvRoot(task, localAssignment, envClaim.RootDir()); ok {
-		defer priorClaim.Release()
+	if priorClaim, priorWorkDir, lockedPriorInfo, ok := d.lockReusablePriorEnvRoot(prepareCtx, task, localAssignment, envClaim.RootDir()); ok {
+		defer d.releaseEnvRootClaim(priorClaim)
 		// Deterministic seam for the last-window regression: tests swap the
 		// directory here, after the claim is settled and before Reuse resolves
 		// the path by name.
@@ -8689,6 +8719,84 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 		}
 	}
 	return result
+}
+
+type envRootClaimHandoff struct {
+	claim    *execenv.EnvRootClaim
+	released chan struct{}
+}
+
+// claimEnvRoot takes and publishes a fresh-root claim atomically with respect
+// to reuse attempts in this daemon. Publishing under the same mutex used by
+// lockEnvRootForReuse means a waiter can never observe ErrEnvRootBusy before
+// the matching release signal exists.
+func (d *Daemon) claimEnvRoot(params execenv.RootDirParams) (*execenv.EnvRootClaim, error) {
+	d.envRootClaimsMu.Lock()
+	defer d.envRootClaimsMu.Unlock()
+	claim, err := execenv.ClaimEnvRoot(params)
+	if err != nil {
+		return nil, err
+	}
+	d.trackEnvRootClaimLocked(claim)
+	return claim, nil
+}
+
+// lockEnvRootForReuse takes a reusable-root claim or, when this daemon already
+// owns the busy root, returns the current owner's exact release signal.
+func (d *Daemon) lockEnvRootForReuse(wsRoot *os.Root, rel, envRoot string) (*execenv.EnvRootClaim, os.FileInfo, <-chan struct{}, error) {
+	d.envRootClaimsMu.Lock()
+	defer d.envRootClaimsMu.Unlock()
+	claim, info, err := execenv.LockEnvRootForReuse(wsRoot, rel, envRoot)
+	if err == nil && claim != nil {
+		d.trackEnvRootClaimLocked(claim)
+		return claim, info, nil, nil
+	}
+	if errors.Is(err, execenv.ErrEnvRootBusy) {
+		if handoff := d.envRootClaims[envRootClaimKey(envRoot)]; handoff != nil {
+			return nil, info, handoff.released, err
+		}
+	}
+	return claim, info, nil, err
+}
+
+func (d *Daemon) trackEnvRootClaimLocked(claim *execenv.EnvRootClaim) {
+	if claim == nil || claim.RootDir() == "" {
+		return
+	}
+	if d.envRootClaims == nil {
+		d.envRootClaims = make(map[string]*envRootClaimHandoff)
+	}
+	d.envRootClaims[envRootClaimKey(claim.RootDir())] = &envRootClaimHandoff{
+		claim:    claim,
+		released: make(chan struct{}),
+	}
+}
+
+func envRootClaimKey(envRoot string) string {
+	canonical, err := filepath.EvalSymlinks(envRoot)
+	if err == nil {
+		return canonical
+	}
+	return filepath.Clean(envRoot)
+}
+
+// releaseEnvRootClaim drops the OS lock before waking its waiter. Holding the
+// registry mutex across both operations prevents a replacement from missing
+// the release and subscribing to stale state.
+func (d *Daemon) releaseEnvRootClaim(claim *execenv.EnvRootClaim) {
+	if claim == nil {
+		return
+	}
+	d.envRootClaimsMu.Lock()
+	defer d.envRootClaimsMu.Unlock()
+	root := envRootClaimKey(claim.RootDir())
+	handoff := d.envRootClaims[root]
+	claim.Release()
+	if handoff == nil || handoff.claim != claim {
+		return
+	}
+	delete(d.envRootClaims, root)
+	close(handoff.released)
 }
 
 // markActiveEnvRoot records that a task is currently using the given env root,

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -469,7 +470,7 @@ func TestLockReusablePriorEnvRootNeverWritesOutsideWorkspacesRoot(t *testing.T) 
 			d := &Daemon{logger: discardLogger()}
 			d.cfg.WorkspacesRoot = workspacesRoot
 
-			claim, _, _, ok := d.lockReusablePriorEnvRoot(Task{
+			claim, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), Task{
 				ID:           "01a01ec0-e69d-7000-8000-0123456789ab",
 				WorkspaceID:  "ws-1",
 				AgentID:      "agent-1",
@@ -533,7 +534,7 @@ func TestLockReusablePriorEnvRootLocksAValidatedRoot(t *testing.T) {
 	d := &Daemon{logger: discardLogger()}
 	d.cfg.WorkspacesRoot = root
 
-	claim, canonical, _, ok := d.lockReusablePriorEnvRoot(task, nil, "")
+	claim, canonical, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
 	if !ok {
 		t.Fatal("a fully provenanced managed workdir was refused for reuse")
 	}
@@ -559,17 +560,172 @@ func TestLockReusablePriorEnvRootLocksAValidatedRoot(t *testing.T) {
 	}
 
 	// A concurrent continuation of the same task must not get the same root.
-	if second, _, _, ok := d.lockReusablePriorEnvRoot(task, nil, ""); ok {
+	if second, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, ""); ok {
 		second.Release()
 		t.Fatal("two continuations locked the same prior workdir at once")
 	}
 
 	claim.Release()
-	again, _, _, ok := d.lockReusablePriorEnvRoot(task, nil, "")
+	again, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
 	if !ok {
 		t.Fatal("prior workdir stayed locked after release")
 	}
 	again.Release()
+}
+
+// TestLockReusablePriorEnvRootWaitsForSupersededChatTurn covers the handoff
+// race between a cancelled chat turn and its replacement. The replacement may
+// be claimed before the old process has observed cancellation and released the
+// shared environment. It must wait for that execution's explicit release
+// signal and preserve the provider session, rather than immediately falling
+// back to a fresh root and transcript replay.
+func TestLockReusablePriorEnvRootWaitsForSupersededChatTurn(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "ws-chat", "0123456789ab", "workdir")
+	writeChatTaskMarker(t, workDir, "agent-chat", "chat-session")
+	writeChatManagedEnvProvenance(t, workDir, "ws-chat", "chat-session", "agent-chat")
+
+	task := Task{
+		ID:             "task-chat-follow-up",
+		WorkspaceID:    "ws-chat",
+		AgentID:        "agent-chat",
+		ChatSessionID:  "chat-session",
+		PriorSessionID: "provider-session",
+		PriorWorkDir:   workDir,
+	}
+	d := &Daemon{logger: discardLogger()}
+	d.cfg.WorkspacesRoot = root
+
+	active, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
+	if !ok || active == nil {
+		t.Fatal("failed to lock the active chat environment")
+	}
+	type lockResult struct {
+		claim     *execenv.EnvRootClaim
+		canonical string
+		ok        bool
+	}
+	result := make(chan lockResult, 1)
+	go func() {
+		continuation, canonical, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
+		result <- lockResult{claim: continuation, canonical: canonical, ok: ok}
+	}()
+
+	select {
+	case got := <-result:
+		if got.claim != nil {
+			d.releaseEnvRootClaim(got.claim)
+		}
+		t.Fatal("chat continuation returned before the active turn released its environment")
+	case <-time.After(50 * time.Millisecond):
+	}
+	d.releaseEnvRootClaim(active)
+
+	got := <-result
+	if !got.ok || got.claim == nil {
+		t.Fatal("chat continuation fell back instead of waiting for the active turn")
+	}
+	defer d.releaseEnvRootClaim(got.claim)
+	if got.canonical == "" {
+		t.Fatal("chat continuation lost the reusable workdir")
+	}
+}
+
+// TestLockReusablePriorEnvRootStopsWaitingOnCancellation pins the other side
+// of the signal handoff: there is no fixed five-second timer, but the task's
+// preparation deadline/cancellation still stops the wait immediately.
+func TestLockReusablePriorEnvRootStopsWaitingOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "ws-chat", "0123456789ab", "workdir")
+	writeChatTaskMarker(t, workDir, "agent-chat", "chat-session")
+	writeChatManagedEnvProvenance(t, workDir, "ws-chat", "chat-session", "agent-chat")
+	task := Task{
+		ID:             "task-chat-follow-up",
+		WorkspaceID:    "ws-chat",
+		AgentID:        "agent-chat",
+		ChatSessionID:  "chat-session",
+		PriorSessionID: "provider-session",
+		PriorWorkDir:   workDir,
+	}
+	d := &Daemon{logger: discardLogger()}
+	d.cfg.WorkspacesRoot = root
+
+	active, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
+	if !ok || active == nil {
+		t.Fatal("failed to lock the active chat environment")
+	}
+	defer d.releaseEnvRootClaim(active)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	claim, _, _, ok := d.lockReusablePriorEnvRoot(ctx, task, nil, "")
+	if claim != nil {
+		d.releaseEnvRootClaim(claim)
+	}
+	if ok {
+		t.Fatal("cancelled chat continuation acquired the active environment")
+	}
+}
+
+// TestEnvRootClaimHandoffUsesCanonicalIdentity covers the production shape on
+// macOS, where a configured workspaces root may contain a symlink component
+// (/tmp -> /private/tmp). Fresh claims retain the configured spelling while
+// reuse validation returns a canonical path; both must still address the same
+// release signal.
+func TestEnvRootClaimHandoffUsesCanonicalIdentity(t *testing.T) {
+	t.Parallel()
+
+	realRoot := t.TempDir()
+	aliasParent := t.TempDir()
+	aliasRoot := filepath.Join(aliasParent, "workspaces")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	d := &Daemon{logger: discardLogger()}
+	claim, err := d.claimEnvRoot(execenv.RootDirParams{
+		WorkspacesRoot: aliasRoot,
+		WorkspaceID:    "ws-chat",
+		TaskID:         "01a01ec0-e69d-7000-8000-0123456789ab",
+	})
+	if err != nil {
+		t.Fatalf("claim fresh env root: %v", err)
+	}
+
+	canonicalRoot, err := filepath.EvalSymlinks(claim.RootDir())
+	if err != nil {
+		t.Fatalf("resolve claimed root: %v", err)
+	}
+	canonicalWorkspace, err := filepath.EvalSymlinks(aliasRoot)
+	if err != nil {
+		t.Fatalf("resolve workspace root: %v", err)
+	}
+	rel, err := filepath.Rel(canonicalWorkspace, canonicalRoot)
+	if err != nil {
+		t.Fatalf("relative root: %v", err)
+	}
+	wsRoot, err := os.OpenRoot(canonicalWorkspace)
+	if err != nil {
+		t.Fatalf("open workspace root: %v", err)
+	}
+	defer wsRoot.Close()
+
+	second, _, released, err := d.lockEnvRootForReuse(wsRoot, rel, canonicalRoot)
+	if second != nil {
+		d.releaseEnvRootClaim(second)
+	}
+	if !errors.Is(err, execenv.ErrEnvRootBusy) || released == nil {
+		t.Fatalf("busy canonical path did not return the fresh claim's release signal: claim=%v signal=%v err=%v", second, released != nil, err)
+	}
+	d.releaseEnvRootClaim(claim)
+	select {
+	case <-released:
+	default:
+		t.Fatal("fresh claim release did not close the canonical handoff signal")
+	}
 }
 
 // TestLockReusablePriorEnvRootSurvivesRetargetAfterValidation is the TOCTOU
@@ -610,7 +766,7 @@ func TestLockReusablePriorEnvRootSurvivesRetargetAfterValidation(t *testing.T) {
 	}
 	t.Cleanup(func() { reuseLockTestHook = nil })
 
-	claim, _, _, ok := d.lockReusablePriorEnvRoot(task, nil, "")
+	claim, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
 	if claim != nil {
 		claim.Release()
 	}
@@ -656,7 +812,7 @@ func TestLockReusablePriorEnvRootRejectsIdentitySwap(t *testing.T) {
 	}
 	t.Cleanup(func() { reuseLockTestHook = nil })
 
-	claim, used, _, ok := d.lockReusablePriorEnvRoot(task, nil, "")
+	claim, used, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
 	if claim != nil {
 		claim.Release()
 	}
@@ -724,7 +880,7 @@ func TestLockReusablePriorEnvRootSurvivesWorkspacesRootSwap(t *testing.T) {
 	}
 	t.Cleanup(func() { reuseLockTestHook = nil })
 
-	claim, _, _, ok := d.lockReusablePriorEnvRoot(task, nil, "")
+	claim, _, _, ok := d.lockReusablePriorEnvRoot(context.Background(), task, nil, "")
 	if claim != nil {
 		claim.Release()
 	}


### PR DESCRIPTION
## What does this PR do?

Preserves provider-session continuity when a replacement chat turn is claimed just before the cancelled turn releases its managed environment.

Instead of polling the prior env-root lock every 50ms for an arbitrary five-second window, the daemon now registers every env-root claim with a one-shot release signal. A replacement chat turn carrying a resume pointer waits for the exact in-process holder to release the root, then immediately claims it and resumes the provider session.

Untracked locks may belong to another daemon process, so they keep the existing safe fresh-environment fallback. The wait remains bounded and cancellable through the existing task preparation context.

### Thinking path

1. Runtime logs showed the replacement task being claimed while the prior task was still executing tools.
2. The replacement hit `prior workdir is in use`, created a fresh environment, and invoked Codex with `resume_session=false`; the prior task released the environment shortly afterward.
3. Source tracing connected that sequence through `lockReusablePriorEnvRoot`, `gateResumeToReusedWorkdir`, and `SessionContinuityNoticeChatTranscript`.
4. A fixed polling window reduces the race but cannot express the actual lifecycle boundary: it can be too short, or add needless retry latency.
5. The fix therefore publishes the real env-root claim lifecycle and preserves every existing recovery fallback.

## Related Issue

Closes #7722

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Track daemon-owned env-root claims by canonical filesystem identity.
- Publish a one-shot signal after the exact holder releases its OS lock.
- Make Codex chat continuations wait on that signal instead of polling or sleeping.
- Keep cancellation, external-lock fallback, canonical-path handling, and TOCTOU identity checks intact.
- Add regression tests for explicit handoff, cancellation, and symlink/canonical path identity.

## How to Test

1. `cd server && go test -race ./internal/daemon -run 'Test(LockReusablePriorEnvRoot|EnvRootClaimHandoff)' -count=1`
2. `cd server && env -u MULTICA_TASK_CONFIG_ROOT -u MULTICA_TASK_WORKSPACES_ROOT go test ./internal/daemon -count=1`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; daemon-only change)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no user-facing contract change)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the copy conventions (not applicable)
- [x] I have considered and documented any risks below

### Risk

The replacement may wait until the existing task preparation deadline if a tracked holder never releases. Normal cancellation closes the provider process and releases the claim; explicit preparation cancellation stops the waiter immediately. Locks not tracked by this daemon never enter the wait path.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** The user asked to replace the fixed five-second retry with an explicit old-execution release handoff. Codex traced the env-root lock lifecycle, introduced an in-process one-shot release registry with canonical filesystem keys, and verified the handoff under race detection and daemon package tests.
