### PR TITLE
fix(tasks): replay issue comments after cancellation

### DIFF
--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1270,6 +1270,28 @@ func TestBuildPromptResumedNoDeltaDoesNotForceThreadRead(t *testing.T) {
 	}
 }
 
+// TestBuildCommentPromptResumedInterventionKeepsInstruction verifies the
+// stop-then-resume path: the follow-up task carries the cancelled provider
+// session while the new member instruction remains the authoritative turn
+// input.
+func TestBuildCommentPromptResumedInterventionKeepsInstruction(t *testing.T) {
+	const instruction = "로그인 버튼은 modal 말고 page transition으로 바꿔"
+	out := BuildPrompt(Task{
+		IssueID:               "issue-intervention-1",
+		TriggerCommentID:      "comment-intervention-1",
+		TriggerCommentContent: instruction,
+		TriggerAuthorType:     "member",
+		PriorSessionID:        "cancelled-session-1",
+	}, "claude")
+
+	if !strings.Contains(out, instruction) {
+		t.Fatalf("resumed prompt dropped the intervention instruction:\n%s", out)
+	}
+	if !strings.Contains(out, "triggering comment is already included above") {
+		t.Fatalf("resumed prompt did not take the warm-session path:\n%s", out)
+	}
+}
+
 // TestBuildCommentPromptCoalescedCrossThread pins MUL-4195 review should-fix #3:
 // when a run coalesces comments that span MULTIPLE threads, the prompt must
 // embed each folded comment's content with its OWN thread id instead of

--- a/server/internal/handler/cancel_task_by_user_test.go
+++ b/server/internal/handler/cancel_task_by_user_test.go
@@ -228,6 +228,55 @@ func TestCancelTaskByUser_ReplaysIssueCommentForSessionResume(t *testing.T) {
 	}
 }
 
+// Deferred issue tasks have not received a claim, so cancelling one must not
+// reconcile comments that a later task already delivered.
+func TestCancelTaskByUser_DeferredIssueTaskDoesNotReplayConsumedComment(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+	issueID := dbfx.Issue(t, "deferred cancellation does not replay", testutil.Cols{
+		"status":        "in_progress",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	deferredTaskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id": runtimeID,
+		"issue_id":   issueID,
+		"status":     "deferred",
+		"created_at": testutil.Raw("now() - interval '10 minutes'"),
+		"fire_at":    testutil.Raw("now() + interval '1 hour'"),
+	})
+	commentID := dbfx.Comment(t, issueID, "already consumed by a newer task", testutil.Cols{
+		"created_at": testutil.Raw("now() - interval '1 minute'"),
+	})
+	dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id":            runtimeID,
+		"issue_id":              issueID,
+		"status":                "completed",
+		"created_at":            testutil.Raw("now() - interval '30 seconds'"),
+		"completed_at":          testutil.Raw("now() - interval '10 seconds'"),
+		"delivered_comment_ids": testutil.Raw("ARRAY['" + commentID + "']::uuid[]"),
+	})
+
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, deferredTaskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CancelTaskByUser: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var queued int
+	dbfx.QueryRow(t, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+	`, issueID, agentID).Scan(&queued)
+	if queued != 0 {
+		t.Fatalf("cancelling deferred task queued %d duplicate follow-up tasks", queued)
+	}
+}
+
 func TestCancelTaskByUser_QueuedEditPersistsDraftRestore(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/cancel_task_by_user_test.go
+++ b/server/internal/handler/cancel_task_by_user_test.go
@@ -169,6 +169,65 @@ func TestCancelTaskByUser_QueuedOnlyDoesNotCancelPromotedTask(t *testing.T) {
 	}
 }
 
+// TestCancelTaskByUser_ReplaysIssueCommentForSessionResume covers the
+// intervention path: a member posts an instruction while an issue task is
+// running, then stops that task. Cancellation has no completion callback, so
+// the handler must replay the undelivered comment and the next claim must keep
+// the cancelled provider session.
+func TestCancelTaskByUser_ReplaysIssueCommentForSessionResume(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+	issueID := dbfx.Issue(t, "cancelled issue intervention", testutil.Cols{
+		"status":        "in_progress",
+		"number":        999731,
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	triggerID := dbfx.Comment(t, issueID, "initial request", testutil.Cols{
+		"created_at": testutil.Raw("now() - interval '10 minutes'"),
+	})
+	var taskID string
+	dbfx.QueryRow(t, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id, status, priority,
+			created_at, started_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, $4, 'running', 0, now() - interval '10 minutes',
+		        now() - interval '5 minutes', 'intervention-session', '/tmp/intervention-workdir')
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerID).Scan(&taskID)
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
+
+	commentID := dbfx.Comment(t, issueID, "로그인 버튼은 modal 말고 page transition으로 바꿔", testutil.Cols{
+		"created_at": testutil.Raw("now() - interval '1 minute'"),
+	})
+
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CancelTaskByUser: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var queuedID, queuedTrigger string
+	dbfx.QueryRow(t, `
+		SELECT id, trigger_comment_id FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		ORDER BY created_at DESC LIMIT 1
+	`, issueID, agentID).Scan(&queuedID, &queuedTrigger)
+	if queuedID == "" || queuedTrigger != commentID {
+		t.Fatalf("cancel should queue the intervention comment, got task=%q trigger=%q want trigger=%q", queuedID, queuedTrigger, commentID)
+	}
+
+	claimed := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if claimed.PriorSessionID != "intervention-session" {
+		t.Fatalf("resumed claim session = %q, want intervention-session", claimed.PriorSessionID)
+	}
+}
+
 func TestCancelTaskByUser_QueuedEditPersistsDraftRestore(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1751,7 +1751,7 @@ func (h *Handler) ClearQueuedChatTasks(w http.ResponseWriter, r *http.Request) {
 
 func issueTaskCanReplayComments(status string) bool {
 	switch status {
-	case "dispatched", "running", "waiting_local_directory", "deferred":
+	case "dispatched", "running", "waiting_local_directory":
 		return true
 	default:
 		return false

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1749,6 +1749,15 @@ func (h *Handler) ClearQueuedChatTasks(w http.ResponseWriter, r *http.Request) {
 // Task cancellation (user-facing, with ownership check)
 // ---------------------------------------------------------------------------
 
+func issueTaskCanReplayComments(status string) bool {
+	switch status {
+	case "dispatched", "running", "waiting_local_directory", "deferred":
+		return true
+	default:
+		return false
+	}
+}
+
 // CancelTaskByUser cancels a task the caller is allowed to act on within the
 // current workspace.
 //
@@ -1870,6 +1879,14 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	// A member may have posted an instruction while this issue task was
+	// running. The normal comment path defers that input to terminal reconcile;
+	// cancellation has no completion callback, so replay it here. Cancellation
+	// keeps the provider session on the task row, letting the queued follow-up
+	// resume the interrupted conversation instead of losing the instruction.
+	if !queuedOnly && task.IssueID.Valid && issueTaskCanReplayComments(task.Status) {
+		h.reconcileCommentsOnCompletion(r.Context(), &cancelled.Task)
 	}
 
 	resp := CancelTaskByUserResponse{


### PR DESCRIPTION
## What does this PR do?

Fixes a cancellation-resume UX gap: when a user cancels a task and immediately leaves an issue comment for session resume, the follow-up task was losing that comment.

- `server/internal/handler/chat.go`: replay unconsumed `issue_comment` messages into the resumed session after `CancelTaskByUser`, and exclude deferred cancellation tasks that already consumed the comment (prevents double replay).
- `server/internal/daemon/prompt_test.go` and `server/internal/handler/cancel_task_by_user_test.go`: cover both paths (keeps instructor instruction, does not replay already-consumed comment).

Thinking path: project context is issue-based agent tasks with provider sessions; cancellation creates a new turn that should carry member intent. Tracing `CancelTaskByUser` → `BuildPrompt` showed the prior session resume was dropping the comment while deferred tasks had already consumed it. The fix threads the comment through the resume path with explicit tests marking the boundary.

Risk: low, isolated to cancellation-resume and deferred task paths. No migration, no API contract change. The deferred guard prevents duplicate insertion.

## Related Issue

No upstream issue yet. This is a fork contribution extracted from `makesomethingshit/multica` (PUCK-51 in the fork, not an upstream identifier). If this should be linked to a new upstream issue, happy to create one.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/chat.go:1` - replay unconsumed issue comments on cancellation resume, exclude deferred-consumed case
- `server/internal/daemon/prompt_test.go:1` - `TestBuildCommentPromptResumedInterventionKeepsInstruction` verifies stop-then-resume keeps instruction
- `server/internal/handler/cancel_task_by_user_test.go:1` - `TestCancelTaskByUser_ReplaysIssueCommentForSessionResume` and `TestCancelTaskByUser_DeferredIssueTaskDoesNotReplayConsumedComment`

Source commits from fork: `8cac25f41`, `81fa48ed5` cherry-picked onto `upstream/main` at `64ec7f541` without conflicts.

## How to Test

```bash
# from server/
go test ./internal/daemon -run TestBuildCommentPromptResumedInterventionKeepsInstruction -count=1
go test ./internal/handler -run TestCancelTaskByUser -count=1
```

Both passed locally on this branch. Manual reproduction:
1. Start an issue task, cancel via `CancelTaskByUser` while leaving an issue comment.
2. Resume session - comment should appear in the resumed prompt (not lost).
3. Deferred task that already consumed the comment should not replay it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - backend only)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Muse Spark (Multica Agent, opencode)

**Prompt / approach:**
Fork analysis identified PUCK-51 as the safest first upstream candidate (no migration, no rebase conflict). Cherry-picked the two commits onto latest `upstream/main`, verified with `go test ./internal/daemon` and `go test ./internal/handler`. PR description drafted with thinking path and risk per `.github/PULL_REQUEST_TEMPLATE.md`.

## Screenshots (optional)

N/A
