### PR TITLE
feat(skills): add Workspace Skill slash picker to Chat, comments, and task creation

### DIFF
--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -192,8 +192,8 @@ interface ContentEditorBaseProps {
   enableSlashCommands?: boolean;
   /**
    * Which `/` menu to show when enableSlashCommands is true: "skill" (default)
-   * lists the active agent's skills (chat); "command" shows the fixed built-in
-   * command menu (issue comments), e.g. /note.
+   * lists Workspace Skills (chat); "command" adds Quick Actions and built-ins
+   * such as /note (issue comments) to the same Workspace Skill library.
    */
   slashCommandMode?: "skill" | "command";
   /**

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -170,8 +170,9 @@ export interface EditorExtensionsOptions {
   enableSlashCommands?: boolean;
   /**
    * Which `/` menu to attach when enableSlashCommands is true:
-   * - "skill" (default) — the chat picker listing the active agent's skills.
-   * - "command" — the fixed built-in command menu (issue comments), e.g. /note.
+   * - "skill" (default) — the chat picker listing Workspace Skills.
+   * - "command" — Workspace Skills plus Quick Actions and built-ins (issue
+   *   comments), e.g. /note.
    */
   slashCommandMode?: "skill" | "command";
   /**
@@ -283,7 +284,7 @@ export function createEditorExtensions(
       suggestion: !options.enableSlashCommands
         ? { char: "/", allow: () => false }
         : options.slashCommandMode === "command"
-          ? createBuiltinCommandSuggestion(options.quickActionMenu)
+          ? createBuiltinCommandSuggestion(options.quickActionMenu, options.queryClient)
           : options.queryClient
             ? createSlashCommandSuggestion(options.queryClient)
             : { char: "/", allow: () => false },

--- a/packages/views/editor/extensions/slash-command-suggestion.test.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.test.tsx
@@ -3,7 +3,7 @@ import { createRef, type ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { workspaceKeys } from "@multica/core/workspace/queries";
-import type { Agent, MemberWithUser } from "@multica/core/types";
+import type { SkillSummary } from "@multica/core/types";
 import type { QueryClient } from "@tanstack/react-query";
 import enEditor from "../../locales/en/editor.json";
 
@@ -27,16 +27,6 @@ vi.mock("@multica/core/platform", () => ({
   getCurrentWsId: () => "ws-1",
 }));
 
-const authState = { user: { id: "u1" } as { id: string } | null };
-vi.mock("@multica/core/auth", () => ({
-  useAuthStore: { getState: () => authState },
-}));
-
-const chatState = { selectedAgentId: "agent-1" as string | null };
-vi.mock("@multica/core/chat", () => ({
-  useChatStore: { getState: () => chatState },
-}));
-
 import {
   SlashCommandList,
   type SlashCommandListRef,
@@ -48,300 +38,112 @@ import {
   QUICK_ACTION_ITEM_PREFIX,
 } from "./slash-command-suggestion";
 
-function agent(overrides: Partial<Agent>): Agent {
+function skill(overrides: Partial<SkillSummary>): SkillSummary {
   return {
-    id: "agent-1",
+    id: "skill-1",
     workspace_id: "ws-1",
-    runtime_id: "runtime-1",
-    name: "Agent",
+    name: "deploy",
     description: "",
-    instructions: "",
-    avatar_url: null,
-    runtime_mode: "local",
-    runtime_config: {},
-    custom_args: [],
-    visibility: "workspace",
-    permission_mode: "public_to",
-    invocation_targets: [{ target_type: "workspace", target_id: null }],
-    status: "idle",
-    max_concurrent_tasks: 1,
-    model: "",
-    owner_id: null,
-    skills: [],
+    config: {},
+    created_by: "u1",
     created_at: "",
     updated_at: "",
-    archived_at: null,
-    archived_by: null,
     ...overrides,
   };
 }
 
 function fakeQc(data: {
-  members?: Array<Pick<MemberWithUser, "user_id" | "name" | "role">>;
-  agents?: Agent[];
+  skills?: SkillSummary[];
+  fetchedSkills?: SkillSummary[];
 }): QueryClient {
   const map = new Map<string, unknown>();
-  map.set(JSON.stringify(workspaceKeys.members("ws-1")), data.members ?? []);
-  map.set(JSON.stringify(workspaceKeys.agents("ws-1")), data.agents ?? []);
+  if (data.skills) {
+    map.set(JSON.stringify(workspaceKeys.skills("ws-1")), data.skills);
+  }
   return {
     getQueryData: (key: readonly unknown[]) => map.get(JSON.stringify(key)),
+    fetchQuery: () => Promise.resolve(data.fetchedSkills ?? []),
   } as unknown as QueryClient;
 }
 
-function items(qc: QueryClient, query = ""): SlashCommandItem[] {
+function itemResult(
+  qc: QueryClient,
+  query = "",
+): SlashCommandItem[] | Promise<SlashCommandItem[]> {
   const config = createSlashCommandSuggestion(qc);
   return config.items!({
     query,
     editor: {} as never,
     signal: new AbortController().signal,
-  }) as SlashCommandItem[];
+  });
+}
+
+function items(qc: QueryClient, query = ""): SlashCommandItem[] {
+  return itemResult(qc, query) as SlashCommandItem[];
 }
 
 describe("slash command suggestion items", () => {
-  it("returns all active agent skills when query is empty", () => {
-    chatState.selectedAgentId = "agent-1";
+  it("returns the Workspace Skill library without requiring Agent assignments", () => {
     const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "deploy", description: "Ship changes" },
-            { id: "s2", name: "review", description: "Review code" },
-          ],
-        }),
+      skills: [
+        skill({ id: "s1", name: "deploy", description: "Ship changes" }),
+        skill({ id: "s2", name: "review", description: "Review code" }),
       ],
     });
 
-    expect(items(qc).map((i) => i.label)).toEqual(["deploy", "review"]);
-  });
-
-  it("filters skills by name case-insensitively", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "Deploy", description: "" },
-            { id: "s2", name: "Review", description: "" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "dep").map((i) => i.id)).toEqual(["s1"]);
-  });
-
-  it("filters skills by description", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "deploy", description: "Ship changes" },
-            { id: "s2", name: "review", description: "Read a pull request" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "pull").map((i) => i.id)).toEqual(["s2"]);
-  });
-
-  it("ranks name prefix matches above description-only matches", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "grilling", description: "Grill the user about a plan" },
-            { id: "s2", name: "prototype", description: "Build a throwaway prototype" },
-            { id: "s3", name: "wayfinder", description: "Plan a huge chunk of work" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "wa").map((i) => i.id)).toEqual(["s3", "s2"]);
-  });
-
-  it("ranks an exact name match ahead of a longer prefix match", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "reviewer", description: "" },
-            { id: "s2", name: "review", description: "" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "review").map((i) => i.id)).toEqual(["s2", "s1"]);
-  });
-
-  it("ranks a name prefix above a mid-name match", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "pr-review", description: "" },
-            { id: "s2", name: "review", description: "" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "rev").map((i) => i.id)).toEqual(["s2", "s1"]);
-  });
-
-  it("keeps the configured skill order within a match tier", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "deploy-web", description: "" },
-            { id: "s2", name: "deploy-api", description: "" },
-          ],
-        }),
-      ],
-    });
-
-    expect(items(qc, "deploy").map((i) => i.id)).toEqual(["s1", "s2"]);
-  });
-
-  it("keeps a name match inside the 20-item cap when description hits fill it", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            ...Array.from({ length: 25 }, (_, i) => ({
-              id: `d${i}`,
-              name: `skill-${i}`,
-              description: "Build a throwaway prototype",
-            })),
-            { id: "s-named", name: "wayfinder", description: "" },
-          ],
-        }),
-      ],
-    });
-
-    const result = items(qc, "wa");
-    expect(result).toHaveLength(20);
-    expect(result[0]?.id).toBe("s-named");
-  });
-
-  it("tolerates skills with missing descriptions from cached API data", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [
-            { id: "s1", name: "deploy" } as Agent["skills"][number],
-          ],
-        }),
-      ],
-    });
-
-    expect(() => items(qc, "dep")).not.toThrow();
-    expect(items(qc, "dep")).toEqual([
-      { id: "s1", label: "deploy", description: "" },
+    expect(items(qc)).toEqual([
+      { id: "s1", skillId: "s1", label: "deploy", description: "Ship changes" },
+      { id: "s2", skillId: "s2", label: "review", description: "Review code" },
     ]);
   });
 
-  it("returns empty when the active agent has no skills", () => {
-    chatState.selectedAgentId = "agent-1";
+  it("filters by name or description and ranks exact/prefix matches first", () => {
     const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [agent({ id: "agent-1", skills: [] })],
-    });
-
-    expect(items(qc)).toEqual([]);
-  });
-
-  it("caps results at 20", () => {
-    chatState.selectedAgentId = "agent-1";
-    const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: Array.from({ length: 25 }, (_, i) => ({
-            id: `s${i}`,
-            name: `skill-${i}`,
-            description: "",
-          })),
-        }),
+      skills: [
+        skill({ id: "s1", name: "reviewer", description: "" }),
+        skill({ id: "s2", name: "review", description: "" }),
+        skill({ id: "s3", name: "prototype", description: "Review a pull request" }),
       ],
     });
 
-    expect(items(qc)).toHaveLength(20);
+    expect(items(qc, "review").map((item) => item.id)).toEqual(["s2", "s1", "s3"]);
+    expect(items(qc, "pull").map((item) => item.id)).toEqual(["s3"]);
   });
 
-  it("falls back to the first available agent when selectedAgentId is stale", () => {
-    chatState.selectedAgentId = "missing";
+  it("keeps a name match inside the 20-item cap", () => {
     const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [
-        agent({
-          id: "agent-1",
-          skills: [{ id: "s1", name: "deploy", description: "" }],
-        }),
+      skills: [
+        ...Array.from({ length: 25 }, (_, i) =>
+          skill({ id: `d${i}`, name: `skill-${i}`, description: "wayfinder helper" }),
+        ),
+        skill({ id: "named", name: "wayfinder" }),
       ],
     });
 
-    expect(items(qc).map((i) => i.id)).toEqual(["s1"]);
+    const result = items(qc, "way");
+    expect(result).toHaveLength(20);
+    expect(result[0]?.id).toBe("named");
   });
 
-  it("returns empty when no agents exist", () => {
+  it("tolerates a missing description from stale cached API data", () => {
     const qc = fakeQc({
-      members: [{ user_id: "u1", name: "Alice", role: "member" }],
-      agents: [],
+      skills: [skill({ id: "s1", name: "deploy", description: undefined as never })],
     });
 
-    expect(items(qc)).toEqual([]);
+    expect(items(qc, "dep")).toEqual([
+      { id: "s1", skillId: "s1", label: "deploy", description: "" },
+    ]);
   });
 
-  it("excludes skills from private agents the user cannot access", () => {
-    chatState.selectedAgentId = "private-agent";
-    const qc = fakeQc({
-      members: [
-        { user_id: "u1", name: "Alice", role: "member" },
-        { user_id: "u2", name: "Bob", role: "member" },
-      ],
-      agents: [
-        agent({
-          id: "private-agent",
-          visibility: "private",
-          permission_mode: "private",
-          invocation_targets: [],
-          owner_id: "u2",
-          skills: [{ id: "private-skill", name: "secret", description: "" }],
-        }),
-      ],
-    });
+  it("fetches a cold Workspace Skill cache lazily", async () => {
+    const qc = fakeQc({ fetchedSkills: [skill({ id: "s1", name: "deploy" })] });
+    await expect(itemResult(qc)).resolves.toEqual([
+      { id: "s1", skillId: "s1", label: "deploy", description: "" },
+    ]);
+  });
 
-    expect(items(qc)).toEqual([]);
+  it("returns an empty picker for an empty Workspace Skill library", () => {
+    expect(items(fakeQc({ skills: [] }))).toEqual([]);
   });
 });
 
@@ -570,6 +372,35 @@ describe("buildBuiltinCommandItems", () => {
   it("returns nothing for a query that matches no command", () => {
     expect(buildBuiltinCommandItems("deploy")).toEqual([]);
   });
+
+  it("merges Quick Actions, Workspace Skills, and built-ins", () => {
+    const result = buildBuiltinCommandItems(
+      "",
+      [{ id: "qa-1", name: "summarize", description: "Summarize the issue" }],
+      [skill({ id: "skill-1", name: "architecture-sweep", description: "Audit structure" })],
+    );
+
+    expect(result.map((item) => item.id)).toEqual([
+      `${QUICK_ACTION_ITEM_PREFIX}qa-1`,
+      "skill-1",
+      "note",
+    ]);
+    expect(result[1]).toMatchObject({ skillId: "skill-1", label: "architecture-sweep" });
+  });
+
+  it("reserves a slot for /note when 20 or more Workspace Skills match", () => {
+    const result = buildBuiltinCommandItems(
+      "",
+      [{ id: "qa-1", name: "summarize" }],
+      Array.from({ length: 25 }, (_, index) =>
+        skill({ id: `skill-${index}`, name: `skill-${index}` }),
+      ),
+    );
+
+    expect(result).toHaveLength(20);
+    expect(result[0]?.id).toBe(`${QUICK_ACTION_ITEM_PREFIX}qa-1`);
+    expect(result.at(-1)?.id).toBe("note");
+  });
 });
 
 describe("SlashCommandList built-in command rendering", () => {
@@ -589,6 +420,73 @@ describe("SlashCommandList built-in command rendering", () => {
     expect(
       getByText("Add a note — won't trigger any agents"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("issue comment `/` menu — Workspace Skills", () => {
+  it("loads Workspace Skills through the same Query cache as Chat", () => {
+    const qc = fakeQc({ skills: [skill({ id: "skill-1", name: "architecture-sweep" })] });
+    const suggestion = createBuiltinCommandSuggestion({}, qc);
+    const result = suggestion.items!({
+      query: "arch",
+      editor: {} as never,
+      signal: new AbortController().signal,
+    }) as SlashCommandItem[];
+
+    expect(result).toEqual([
+      {
+        id: "skill-1",
+        skillId: "skill-1",
+        label: "architecture-sweep",
+        description: "",
+      },
+    ]);
+  });
+
+  it("inserts a selected Skill as the durable rich Markdown marker", () => {
+    const getSelection = vi
+      .spyOn(window, "getSelection")
+      .mockReturnValue({ collapseToEnd: vi.fn() } as unknown as Selection);
+    const inserts: unknown[] = [];
+    const chain = {
+      focus: () => chain,
+      insertContentAt: (_range: unknown, content: unknown) => {
+        inserts.push(content);
+        return chain;
+      },
+      run: () => true,
+    };
+    const editor = {
+      chain: () => chain,
+      view: { state: { selection: { $to: { nodeAfter: null } } } },
+    };
+    const suggestion = createBuiltinCommandSuggestion();
+
+    suggestion.command!({
+      editor,
+      range: { from: 0, to: 5 },
+      props: {
+        id: "skill-1",
+        skillId: "skill-1",
+        label: "review",
+        description: "Review code",
+      },
+    } as never);
+
+    expect(inserts).toEqual([
+      [
+        {
+          type: "slashCommand",
+          attrs: {
+            id: "skill-1",
+            label: "review",
+            mentionSuggestionChar: "/",
+          },
+        },
+        { type: "text", text: " " },
+      ],
+    ]);
+    getSelection.mockRestore();
   });
 });
 

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -11,13 +11,13 @@ import {
 import type { QueryClient } from "@tanstack/react-query";
 import type { SuggestionOptions } from "@tiptap/suggestion";
 import { PluginKey } from "@tiptap/pm/state";
-import { useAuthStore } from "@multica/core/auth";
-import { useChatStore } from "@multica/core/chat";
 import { getCurrentWsId } from "@multica/core/platform";
-import { canAssignAgentToIssue } from "@multica/core/permissions";
 import { isImeComposing } from "@multica/core/utils";
-import { workspaceKeys } from "@multica/core/workspace/queries";
-import type { Agent, MemberWithUser } from "@multica/core/types";
+import {
+  skillListOptions,
+  workspaceKeys,
+} from "@multica/core/workspace/queries";
+import type { SkillSummary } from "@multica/core/types";
 import { useT } from "../../i18n";
 import {
   createSuggestionPopupRender,
@@ -36,6 +36,8 @@ export type BuiltinCommandKey = "note";
 export interface SlashCommandItem {
   id: string;
   label: string;
+  /** Present only for a workspace Skill. The item id remains its stable UUID. */
+  skillId?: string;
   /** Raw description (skill picker). Built-in commands use descriptionKey. */
   description?: string;
   /**
@@ -192,33 +194,65 @@ function rankSkillMatches<T extends { name: string; description?: string }>(
     .map((entry) => entry.skill);
 }
 
-function buildItems(qc: QueryClient, query: string): SlashCommandItem[] {
+function workspaceSkillItems(
+  skills: SkillSummary[],
+  query: string,
+): SlashCommandItem[] {
+  const q = query.toLowerCase();
+  return rankSkillMatches(skills, q)
+    .slice(0, MAX_ITEMS)
+    .map((skill) => ({
+      id: skill.id,
+      skillId: skill.id,
+      label: skill.name,
+      description: skill.description ?? "",
+    }));
+}
+
+function buildItems(
+  qc: QueryClient,
+  query: string,
+): SlashCommandItem[] | Promise<SlashCommandItem[]> {
   const wsId = getCurrentWsId();
   if (!wsId) return [];
 
-  const agents: Agent[] = qc.getQueryData(workspaceKeys.agents(wsId)) ?? [];
-  const members: MemberWithUser[] =
-    qc.getQueryData(workspaceKeys.members(wsId)) ?? [];
-  // Tiptap calls suggestion items outside React render, so direct store reads
-  // are intentional here.
-  const { selectedAgentId } = useChatStore.getState();
-  const userId = useAuthStore.getState().user?.id ?? null;
-  const memberRole = members.find((m) => m.user_id === userId)?.role ?? null;
+  // Prefer the cache so every keystroke stays synchronous after the first
+  // open. A cold picker fetches the workspace library lazily; Suggestion
+  // accepts a Promise and discards stale query results for us.
+  const cached = qc.getQueryData<SkillSummary[]>(workspaceKeys.skills(wsId));
+  if (cached) return workspaceSkillItems(cached, query);
+  return qc
+    .fetchQuery(skillListOptions(wsId))
+    .then((skills) => workspaceSkillItems(skills, query))
+    .catch(() => []);
+}
 
-  const availableAgents = agents.filter(
-    (a) =>
-      !a.archived_at &&
-      canAssignAgentToIssue(a, { userId, role: memberRole }).allowed,
-  );
-  const activeAgent =
-    availableAgents.find((a) => a.id === selectedAgentId) ??
-    availableAgents[0] ??
-    null;
+function insertSlashSkill(
+  editor: Parameters<NonNullable<SuggestionOptions<SlashCommandItem>["command"]>>[0]["editor"],
+  range: { from: number; to: number },
+  item: SlashCommandItem,
+) {
+  const nodeAfter = editor.view.state.selection.$to.nodeAfter;
+  const overrideSpace = nodeAfter?.text?.startsWith(" ");
+  if (overrideSpace) range.to += 1;
 
-  const q = query.toLowerCase();
-  return rankSkillMatches(activeAgent?.skills ?? [], q)
-    .slice(0, MAX_ITEMS)
-    .map((s) => ({ id: s.id, label: s.name, description: s.description ?? "" }));
+  editor
+    .chain()
+    .focus()
+    .insertContentAt(range, [
+      {
+        type: "slashCommand",
+        attrs: {
+          id: item.skillId ?? item.id,
+          label: item.label,
+          mentionSuggestionChar: "/",
+        },
+      },
+      { type: "text", text: " " },
+    ])
+    .run();
+
+  window.getSelection()?.collapseToEnd();
 }
 
 export function createSlashCommandSuggestion(qc: QueryClient): Omit<
@@ -235,29 +269,7 @@ export function createSlashCommandSuggestion(qc: QueryClient): Omit<
     shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
     items: ({ query }) => buildItems(qc, query),
     command: ({ editor, range, props }) => {
-      const nodeAfter = editor.view.state.selection.$to.nodeAfter;
-      const overrideSpace = nodeAfter?.text?.startsWith(" ");
-      if (overrideSpace) {
-        range.to += 1;
-      }
-
-      editor
-        .chain()
-        .focus()
-        .insertContentAt(range, [
-          {
-            type: "slashCommand",
-            attrs: {
-              id: props.id,
-              label: props.label,
-              mentionSuggestionChar: "/",
-            },
-          },
-          { type: "text", text: " " },
-        ])
-        .run();
-
-      window.getSelection()?.collapseToEnd();
+      insertSlashSkill(editor, range, props);
     },
     render: createSuggestionPopupRender<SlashCommandItem, SlashCommandItem, SlashCommandListRef, SlashCommandListProps>({
       pluginKey,
@@ -277,9 +289,8 @@ export function createSlashCommandSuggestion(qc: QueryClient): Omit<
 // ---------------------------------------------------------------------------
 
 /**
- * Built-in slash commands offered in the issue comment composer. Unlike the
- * chat `/` picker (which lists the active agent's skills), these are a fixed,
- * hand-curated set. Currently only `/note`, which marks a comment as a
+ * Built-in slash commands offered alongside Workspace Skills in the issue
+ * comment composer. Currently only `/note`, which marks a comment as a
  * human-only note that won't trigger the assigned agent — mirrors the backend
  * `noteCommentPrefix` in server/internal/handler/comment.go.
  */
@@ -304,6 +315,7 @@ export function quickActionIdFromItem(item: SlashCommandItem): string {
 export function buildBuiltinCommandItems(
   query: string,
   quickActions: { id: string; name: string; description?: string }[] = [],
+  skills: SkillSummary[] = [],
 ): SlashCommandItem[] {
   const q = query.toLowerCase();
   // Quick actions lead: on an issue they are the reason a user reaches for
@@ -313,9 +325,26 @@ export function buildBuiltinCommandItems(
     label: a.name,
     description: a.description || undefined,
   }));
-  return [...actionItems, ...BUILTIN_COMMANDS]
-    .filter((c) => c.label.toLowerCase().startsWith(q))
-    .slice(0, MAX_ITEMS);
+  const matchingActions = actionItems.filter((item) =>
+    item.label.toLowerCase().startsWith(q),
+  );
+  const matchingSkills = workspaceSkillItems(skills, query);
+  const matchingBuiltins = BUILTIN_COMMANDS.filter((item) =>
+    item.label.toLowerCase().startsWith(q),
+  );
+  // Keep built-ins reachable even in Skill-heavy workspaces. Quick Actions
+  // retain their leading position; Skills use only the remaining budget.
+  const actionBudget = Math.max(0, MAX_ITEMS - matchingBuiltins.length);
+  const visibleActions = matchingActions.slice(0, actionBudget);
+  const skillBudget = Math.max(
+    0,
+    MAX_ITEMS - visibleActions.length - matchingBuiltins.length,
+  );
+  return [
+    ...visibleActions,
+    ...matchingSkills.slice(0, skillBudget),
+    ...matchingBuiltins,
+  ];
 }
 
 export interface BuiltinCommandSuggestionOptions {
@@ -342,6 +371,7 @@ export interface BuiltinCommandSuggestionOptions {
 
 export function createBuiltinCommandSuggestion(
   options: BuiltinCommandSuggestionOptions = {},
+  qc?: QueryClient,
 ): Omit<SuggestionOptions<SlashCommandItem>, "editor"> {
   const pluginKey = new PluginKey("builtinCommandSuggestion");
 
@@ -351,8 +381,22 @@ export function createBuiltinCommandSuggestion(
     // Only open over a `/` the user actually typed, so a pasted path
     // (`/usr/local/bin`) never opens the command menu (MUL-5429).
     shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
-    items: ({ query }) => buildBuiltinCommandItems(query, options.getQuickActions?.() ?? []),
+    items: ({ query }) => {
+      const quickActions = options.getQuickActions?.() ?? [];
+      const wsId = getCurrentWsId();
+      if (!qc || !wsId) return buildBuiltinCommandItems(query, quickActions);
+      const cached = qc.getQueryData<SkillSummary[]>(workspaceKeys.skills(wsId));
+      if (cached) return buildBuiltinCommandItems(query, quickActions, cached);
+      return qc
+        .fetchQuery(skillListOptions(wsId))
+        .then((skills) => buildBuiltinCommandItems(query, quickActions, skills))
+        .catch(() => buildBuiltinCommandItems(query, quickActions));
+    },
     command: ({ editor, range, props }) => {
+      if (props.skillId) {
+        insertSlashSkill(editor, range, props);
+        return;
+      }
       if (isQuickActionItem(props)) {
         const render = options.renderQuickAction;
         if (!render) return;

--- a/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
@@ -92,6 +92,26 @@ function type(editor: Editor, text: string): void {
   }
 }
 
+/**
+ * Chrome can route the first printable key after a handled select-all/delete
+ * through ProseMirror's keydown + DOM reconciliation path without calling
+ * `handleTextInput`. This mirrors that path: the keyboard hook runs, then the
+ * browser's DOM change becomes a normal insertion transaction.
+ */
+function typeFromKeyDown(editor: Editor, text: string): void {
+  for (const ch of text) {
+    const event = new KeyboardEvent("keydown", {
+      key: ch,
+      bubbles: true,
+      cancelable: true,
+    });
+    editor.view.dom.dispatchEvent(event);
+    if (!event.defaultPrevented) {
+      editor.view.dispatch(editor.state.tr.insertText(ch));
+    }
+  }
+}
+
 function picker(editor: Editor, pluginKey: PluginKey = key) {
   const state = pluginKey.getState(editor.state);
   return { active: state?.active, query: state?.query };
@@ -154,6 +174,18 @@ describe("suggestion trigger arming", () => {
       expect(picker(editor).active).toBe(false);
     });
 
+    it("does not reuse an uncommitted keydown arm for a later paste", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      editor.view.dom.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "/", bubbles: true, cancelable: true }),
+      );
+
+      paste(editor, "/usr/local/bin");
+
+      expect(picker(editor, slashKey).active).toBe(false);
+    });
+
     it("text already in the document when the editor mounts", () => {
       // No paste at all — a loaded draft, an undo, a collaborative edit. Tiptap
       // matches on document content alone, so this opened the picker too.
@@ -187,6 +219,24 @@ describe("suggestion trigger arming", () => {
       type(editor, "/shi");
 
       expect(picker(editor, slashKey)).toEqual({ active: true, query: "shi" });
+    });
+
+    it("reopens after select-all deletion when Chrome skips handleTextInput", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      type(editor, "/");
+      expect(picker(editor, slashKey).active).toBe(true);
+
+      editor.commands.selectAll();
+      editor.commands.deleteSelection();
+      editor.commands.focus("end");
+      expect(picker(editor, slashKey).active).toBe(false);
+
+      typeFromKeyDown(editor, "/");
+
+      expect(editor.getText()).toBe("/");
+      expect(isTriggerArmedAt(editor, 1)).toBe(true);
+      expect(picker(editor, slashKey)).toEqual({ active: true, query: "" });
     });
 
     it("keeps multi-word queries alive, so allowSpaces issue search survives", () => {

--- a/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
@@ -93,12 +93,11 @@ function type(editor: Editor, text: string): void {
 }
 
 /**
- * Chrome can route the first printable key after a handled select-all/delete
- * through ProseMirror's keydown + DOM reconciliation path without calling
- * `handleTextInput`. This mirrors that path: the keyboard hook runs, then the
- * browser's DOM change becomes a normal insertion transaction.
+ * Chrome routes the first printable key after a handled select-all/delete
+ * through a native keydown, then calls `handleTextInput` with the still-stale
+ * AllSelection range before reconciling the DOM insertion transaction.
  */
-function typeFromKeyDown(editor: Editor, text: string): void {
+function typeFromKeyDownAndTextInput(editor: Editor, text: string): void {
   for (const ch of text) {
     const event = new KeyboardEvent("keydown", {
       key: ch,
@@ -106,9 +105,21 @@ function typeFromKeyDown(editor: Editor, text: string): void {
       cancelable: true,
     });
     editor.view.dom.dispatchEvent(event);
-    if (!event.defaultPrevented) {
-      editor.view.dispatch(editor.state.tr.insertText(ch));
-    }
+    const { from, to } = editor.state.selection;
+    const armingPlugin = editor.state.plugins.find((plugin) =>
+      (plugin as unknown as { key: string }).key.startsWith(
+        "suggestionTriggerArming",
+      ),
+    );
+    armingPlugin?.props.handleTextInput?.call(
+      armingPlugin,
+      editor.view,
+      from,
+      to,
+      ch,
+      () => editor.state.tr.insertText(ch),
+    );
+    editor.view.dispatch(editor.state.tr.insertText(ch));
   }
 }
 
@@ -234,7 +245,7 @@ describe("suggestion trigger arming", () => {
       expect(picker(editor, slashKey)).toEqual({ active: true, query: "shi" });
     });
 
-    it("reopens after select-all deletion when Chrome skips handleTextInput", () => {
+    it("reopens after select-all deletion with Chrome's stale input range", () => {
       const editor = makeEditor();
       editor.commands.focus("end");
       type(editor, "/");
@@ -246,7 +257,7 @@ describe("suggestion trigger arming", () => {
       expect(editor.state.selection.toJSON().type).toBe("all");
       expect(picker(editor, slashKey).active).toBe(false);
 
-      typeFromKeyDown(editor, "/");
+      typeFromKeyDownAndTextInput(editor, "/");
 
       expect(editor.getText()).toBe("/");
       expect(isTriggerArmedAt(editor, 1)).toBe(true);

--- a/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
@@ -115,10 +115,10 @@ function typeFromKeyDown(editor: Editor, text: string): void {
 /** Keep ProseMirror's stale AllSelection while moving only the live DOM caret. */
 function placeDomCaretAtStart(editor: Editor): void {
   editor.view.dom.focus();
-  const paragraph = editor.view.dom.querySelector("p");
-  if (!paragraph) throw new Error("expected an editor paragraph");
   const range = document.createRange();
-  range.setStart(paragraph, 0);
+  // Chrome anchors the caret on the contenteditable root after it removes the
+  // selected slash; the schema-preserved empty paragraph is still its child.
+  range.setStart(editor.view.dom, 0);
   range.collapse(true);
   const selection = window.getSelection();
   selection?.removeAllRanges();

--- a/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
@@ -112,6 +112,19 @@ function typeFromKeyDown(editor: Editor, text: string): void {
   }
 }
 
+/** Keep ProseMirror's stale AllSelection while moving only the live DOM caret. */
+function placeDomCaretAtStart(editor: Editor): void {
+  editor.view.dom.focus();
+  const paragraph = editor.view.dom.querySelector("p");
+  if (!paragraph) throw new Error("expected an editor paragraph");
+  const range = document.createRange();
+  range.setStart(paragraph, 0);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
 function picker(editor: Editor, pluginKey: PluginKey = key) {
   const state = pluginKey.getState(editor.state);
   return { active: state?.active, query: state?.query };
@@ -229,7 +242,8 @@ describe("suggestion trigger arming", () => {
 
       editor.commands.selectAll();
       editor.commands.deleteSelection();
-      editor.commands.focus("end");
+      placeDomCaretAtStart(editor);
+      expect(editor.state.selection.toJSON().type).toBe("all");
       expect(picker(editor, slashKey).active).toBe(false);
 
       typeFromKeyDown(editor, "/");

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -1,5 +1,5 @@
 import { Extension, type Editor } from "@tiptap/core";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { AllSelection, Plugin, PluginKey, Selection } from "@tiptap/pm/state";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { EditorView } from "@tiptap/pm/view";
 
@@ -91,6 +91,13 @@ function stillHoldsTrigger(doc: ProseMirrorNode, pos: number): boolean {
  */
 function domInsertionPosition(view: EditorView): number {
   const fallback = view.state.selection.from;
+  // Chrome leaves the ProseMirror selection stale at AllSelection after the
+  // browser empties the contenteditable. Its next printable key is placed in
+  // the schema-preserved first paragraph, not at AllSelection.from (0).
+  if (view.state.selection instanceof AllSelection) {
+    return Selection.atStart(view.state.doc).from;
+  }
+
   const selection = view.dom.ownerDocument.getSelection();
   if (!selection?.anchorNode || !selection.focusNode) return fallback;
   if (

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -1,6 +1,7 @@
 import { Extension, type Editor } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { EditorView } from "@tiptap/pm/view";
 
 /**
  * Records that the user *typed* a suggestion trigger character, so a picker can
@@ -32,9 +33,11 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
  * input — paste goes through `handlePaste`/`doPaste` and drop through
  * `handleDrop`, neither of which reaches it. Chrome has one exception: after a
  * handled select-all/delete in a contenteditable, the next printable key can be
- * reconciled from the DOM without calling `handleTextInput`. `handleKeyDown`
- * supplies that missing provenance; the following transaction must still prove
- * that the trigger character was actually inserted before it is armed.
+ * reconciled from the DOM without calling `handleTextInput`. A raw
+ * `handleDOMEvents.keydown` hook supplies that missing provenance even when
+ * ProseMirror skips its higher-level `handleKeyDown` chain; the following
+ * transaction must still prove that the trigger character was actually
+ * inserted before it is armed.
  *
  * Typing a trigger character arms its document position. The pickers' `shouldShow`
  * then opens only for a match anchored at the armed position. Anything the user
@@ -74,6 +77,38 @@ function lastTriggerIndex(text: string): number {
 function stillHoldsTrigger(doc: ProseMirrorNode, pos: number): boolean {
   if (pos < 0 || pos + 1 > doc.content.size) return false;
   return TRIGGER_CHARS.has(doc.textBetween(pos, pos + 1));
+}
+
+/**
+ * Position where a printable key will replace/insert text according to the
+ * browser's live selection.
+ *
+ * After Chrome handles select-all + Backspace, the DOM caret is already back
+ * inside the empty paragraph while ProseMirror can still expose an
+ * `AllSelection` at position 0 until its DOM observer reconciles. The next key
+ * is inserted at position 1, so arming from `view.state.selection.from` would
+ * record the wrong position and reject a genuine trigger.
+ */
+function domInsertionPosition(view: EditorView): number {
+  const fallback = view.state.selection.from;
+  const selection = view.dom.ownerDocument.getSelection();
+  if (!selection?.anchorNode || !selection.focusNode) return fallback;
+  if (
+    !view.dom.contains(selection.anchorNode) ||
+    !view.dom.contains(selection.focusNode)
+  ) {
+    return fallback;
+  }
+
+  try {
+    const anchor = view.posAtDOM(selection.anchorNode, selection.anchorOffset, -1);
+    const focus = view.posAtDOM(selection.focusNode, selection.focusOffset, -1);
+    return Math.min(anchor, focus);
+  } catch {
+    // A transient detached DOM node must not break typing. The following
+    // document-change verification still rejects a mismatched fallback.
+    return fallback;
+  }
 }
 
 export const SuggestionTriggerArmingExtension = Extension.create({
@@ -150,22 +185,25 @@ export const SuggestionTriggerArmingExtension = Extension.create({
         },
 
         props: {
-          handleKeyDown(view, event) {
-            // `handleTextInput` remains authoritative for IME and modified-key
-            // layouts. This fallback is only for an unmodified printable
-            // trigger that Chrome may commit through DOM reconciliation.
-            if (
-              !event.isComposing &&
-              !event.ctrlKey &&
-              !event.metaKey &&
-              !event.altKey &&
-              TRIGGER_CHARS.has(event.key)
-            ) {
-              pendingArm = view.state.selection.from;
-            } else {
-              pendingArm = null;
-            }
-            return false;
+          handleDOMEvents: {
+            keydown(view, event) {
+              // `handleTextInput` remains authoritative for IME and
+              // modified-key layouts. This raw fallback is only for an
+              // unmodified printable trigger that Chrome may commit through
+              // DOM reconciliation.
+              if (
+                !event.isComposing &&
+                !event.ctrlKey &&
+                !event.metaKey &&
+                !event.altKey &&
+                TRIGGER_CHARS.has(event.key)
+              ) {
+                pendingArm = domInsertionPosition(view);
+              } else {
+                pendingArm = null;
+              }
+              return false;
+            },
           },
           handleTextInput(_view, from, _to, text) {
             const index = lastTriggerIndex(text);

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -28,12 +28,13 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
  *
  * ## How it works
  *
- * `handleTextInput` is the one ProseMirror hook that fires for real keyboard and
- * IME input only — paste goes through `handlePaste`/`doPaste` and drop through
- * `handleDrop`, neither of which reaches it. This is the same signal Tiptap's own
- * InputRules run on, which is why typing `- ` makes a list but pasting it does
- * not. Suggestion is the one Tiptap feature that does not use it; this plugin
- * supplies it.
+ * `handleTextInput` is ProseMirror's primary hook for real keyboard and IME
+ * input — paste goes through `handlePaste`/`doPaste` and drop through
+ * `handleDrop`, neither of which reaches it. Chrome has one exception: after a
+ * handled select-all/delete in a contenteditable, the next printable key can be
+ * reconciled from the DOM without calling `handleTextInput`. `handleKeyDown`
+ * supplies that missing provenance; the following transaction must still prove
+ * that the trigger character was actually inserted before it is armed.
  *
  * Typing a trigger character arms its document position. The pickers' `shouldShow`
  * then opens only for a match anchored at the armed position. Anything the user
@@ -100,9 +101,30 @@ export const SuggestionTriggerArmingExtension = Extension.create({
           },
 
           apply(tr, prev, _oldState, newState) {
+            const armCandidate = pendingArm;
+            // `handleTextInput` is followed immediately by a document change.
+            // The keydown fallback may first be followed by an internal
+            // selection/meta transaction, so keep that candidate only while
+            // the caret remains at its insertion point. A document change
+            // always consumes it, whether or not it proves valid.
+            if (armCandidate !== null) {
+              if (tr.docChanged || (tr.selectionSet && newState.selection.from !== armCandidate)) {
+                pendingArm = null;
+              }
+            }
+
             const next = ((): number | null => {
-              // A trigger character was just typed — arm it unconditionally.
-              if (pendingArm !== null) return pendingArm;
+              // A trigger character was just typed. The keydown fallback can
+              // run even when a later plugin consumes the key, so only accept
+              // the candidate on a document change that really inserted a
+              // trigger at that position.
+              if (
+                armCandidate !== null &&
+                tr.docChanged &&
+                stillHoldsTrigger(newState.doc, armCandidate)
+              ) {
+                return armCandidate;
+              }
               if (prev === null) return null;
 
               // A deliberate caret move (click, arrow key) abandons the trigger.
@@ -122,17 +144,45 @@ export const SuggestionTriggerArmingExtension = Extension.create({
               return mapped;
             })();
 
-            pendingArm = null;
             armedPositions.set(editor, next);
             return next;
           },
         },
 
         props: {
+          handleKeyDown(view, event) {
+            // `handleTextInput` remains authoritative for IME and modified-key
+            // layouts. This fallback is only for an unmodified printable
+            // trigger that Chrome may commit through DOM reconciliation.
+            if (
+              !event.isComposing &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey &&
+              TRIGGER_CHARS.has(event.key)
+            ) {
+              pendingArm = view.state.selection.from;
+            } else {
+              pendingArm = null;
+            }
+            return false;
+          },
           handleTextInput(_view, from, _to, text) {
             const index = lastTriggerIndex(text);
-            if (index !== -1) pendingArm = from + index;
+            pendingArm = index === -1 ? null : from + index;
             // Never handle the input — every other plugin must still see it.
+            return false;
+          },
+          handlePaste() {
+            pendingArm = null;
+            return false;
+          },
+          handleDrop() {
+            pendingArm = null;
+            return false;
+          },
+          handleClick() {
+            pendingArm = null;
             return false;
           },
         },

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -33,11 +33,11 @@ import type { EditorView } from "@tiptap/pm/view";
  * input — paste goes through `handlePaste`/`doPaste` and drop through
  * `handleDrop`, neither of which reaches it. Chrome has one exception: after a
  * handled select-all/delete in a contenteditable, the next printable key can be
- * reconciled from the DOM without calling `handleTextInput`. A raw
- * `handleDOMEvents.keydown` hook supplies that missing provenance even when
- * ProseMirror skips its higher-level `handleKeyDown` chain; the following
- * transaction must still prove that the trigger character was actually
- * inserted before it is armed.
+ * reconciled from the DOM without calling `handleTextInput`. A native capture
+ * listener on the editor DOM supplies that missing provenance even when
+ * ProseMirror skips its own event-routing chain; the following transaction
+ * must still prove that the trigger character was actually inserted before it
+ * is armed.
  *
  * Typing a trigger character arms its document position. The pickers' `shouldShow`
  * then opens only for a match anchored at the armed position. Anything the user
@@ -136,10 +136,39 @@ export const SuggestionTriggerArmingExtension = Extension.create({
     // consumed by the very next `apply`. Holds a position in the NEW document:
     // text typed at `from` puts its i-th character at `from + i`.
     let pendingArm: number | null = null;
+    const recordKeyDown = (view: EditorView, event: KeyboardEvent) => {
+      // `handleTextInput` remains authoritative for IME and modified-key
+      // layouts. This raw fallback is only for an unmodified printable trigger
+      // that Chrome may commit through DOM reconciliation.
+      if (
+        !event.isComposing &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        TRIGGER_CHARS.has(event.key)
+      ) {
+        pendingArm = domInsertionPosition(view);
+      } else {
+        pendingArm = null;
+      }
+    };
 
     return [
       new Plugin<number | null>({
         key: new PluginKey("suggestionTriggerArming"),
+
+        view(view) {
+          // ProseMirror can decline a keydown when its state selection is
+          // temporarily behind the browser DOM selection. Capture on the DOM
+          // itself so provenance survives that exact reconciliation gap.
+          const onKeyDown = (event: KeyboardEvent) => recordKeyDown(view, event);
+          view.dom.addEventListener("keydown", onKeyDown, true);
+          return {
+            destroy() {
+              view.dom.removeEventListener("keydown", onKeyDown, true);
+            },
+          };
+        },
 
         state: {
           init() {
@@ -197,26 +226,6 @@ export const SuggestionTriggerArmingExtension = Extension.create({
         },
 
         props: {
-          handleDOMEvents: {
-            keydown(view, event) {
-              // `handleTextInput` remains authoritative for IME and
-              // modified-key layouts. This raw fallback is only for an
-              // unmodified printable trigger that Chrome may commit through
-              // DOM reconciliation.
-              if (
-                !event.isComposing &&
-                !event.ctrlKey &&
-                !event.metaKey &&
-                !event.altKey &&
-                TRIGGER_CHARS.has(event.key)
-              ) {
-                pendingArm = domInsertionPosition(view);
-              } else {
-                pendingArm = null;
-              }
-              return false;
-            },
-          },
           handleTextInput(_view, from, _to, text) {
             const index = lastTriggerIndex(text);
             pendingArm = index === -1 ? null : from + index;

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -1,5 +1,5 @@
 import { Extension, type Editor } from "@tiptap/core";
-import { AllSelection, Plugin, PluginKey, Selection } from "@tiptap/pm/state";
+import { Plugin, PluginKey, Selection } from "@tiptap/pm/state";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { EditorView } from "@tiptap/pm/view";
 
@@ -94,7 +94,12 @@ function domInsertionPosition(view: EditorView): number {
   // Chrome leaves the ProseMirror selection stale at AllSelection after the
   // browser empties the contenteditable. Its next printable key is placed in
   // the schema-preserved first paragraph, not at AllSelection.from (0).
-  if (view.state.selection instanceof AllSelection) {
+  const { selection: stateSelection, doc } = view.state;
+  const selectsWholeDocument =
+    !stateSelection.empty &&
+    stateSelection.from === 0 &&
+    stateSelection.to === doc.content.size;
+  if (selectsWholeDocument) {
     return Selection.atStart(view.state.doc).from;
   }
 

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -79,6 +79,15 @@ function stillHoldsTrigger(doc: ProseMirrorNode, pos: number): boolean {
   return TRIGGER_CHARS.has(doc.textBetween(pos, pos + 1));
 }
 
+function selectsWholeDocument(view: EditorView): boolean {
+  const { selection, doc } = view.state;
+  return (
+    !selection.empty &&
+    selection.from === 0 &&
+    selection.to === doc.content.size
+  );
+}
+
 /**
  * Position where a printable key will replace/insert text according to the
  * browser's live selection.
@@ -94,12 +103,7 @@ function domInsertionPosition(view: EditorView): number {
   // Chrome leaves the ProseMirror selection stale at AllSelection after the
   // browser empties the contenteditable. Its next printable key is placed in
   // the schema-preserved first paragraph, not at AllSelection.from (0).
-  const { selection: stateSelection, doc } = view.state;
-  const selectsWholeDocument =
-    !stateSelection.empty &&
-    stateSelection.from === 0 &&
-    stateSelection.to === doc.content.size;
-  if (selectsWholeDocument) {
+  if (selectsWholeDocument(view)) {
     return Selection.atStart(view.state.doc).from;
   }
 
@@ -226,9 +230,12 @@ export const SuggestionTriggerArmingExtension = Extension.create({
         },
 
         props: {
-          handleTextInput(_view, from, _to, text) {
+          handleTextInput(view, from, _to, text) {
             const index = lastTriggerIndex(text);
-            pendingArm = index === -1 ? null : from + index;
+            const base = selectsWholeDocument(view)
+              ? Selection.atStart(view.state.doc).from
+              : from;
+            pendingArm = index === -1 ? null : base + index;
             // Never handle the input — every other plugin must still see it.
             return false;
           },

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -345,7 +345,7 @@ vi.mock("../editor", async () => {
   const composer = await vi.importActual<typeof import("../editor/use-composer-submit")>(
     "../editor/use-composer-submit",
   );
-  const ContentEditor = forwardRef(({ defaultValue, onUpdate, onSubmit, onUploadFile, onUploadingChange, placeholder, attachments }: any, ref: any) => {
+  const ContentEditor = forwardRef(({ defaultValue, onUpdate, onSubmit, onUploadFile, onUploadingChange, placeholder, attachments, enableSlashCommands }: any, ref: any) => {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
     // Mirrors the real editor's `uploading` node attrs: the placeholder is in
@@ -381,6 +381,7 @@ vi.mock("../editor", async () => {
           value={value}
           placeholder={placeholder}
           data-attachments-count={attachments?.length ?? 0}
+          data-slash-commands={enableSlashCommands ? "skill" : "off"}
           onChange={(e) => {
             valueRef.current = e.target.value;
             setValue(e.target.value);
@@ -714,6 +715,15 @@ describe("CreateIssueModal", () => {
     renderModal(<CreateIssueModal onClose={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Upload file" })).toHaveAttribute("data-size", "sm");
+  });
+
+  it("enables Workspace Skill slash suggestions in the manual description", () => {
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("Add description...")).toHaveAttribute(
+      "data-slash-commands",
+      "skill",
+    );
   });
 
   it("shows success feedback with a direct path to the new issue", async () => {

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -947,6 +947,7 @@ export function ManualCreatePanel({
               <ContentEditor
                 ref={descEditorRef}
                 defaultValue={draft.manual.description}
+                enableSlashCommands
                 placeholder={t(($) => $.create_issue.description_placeholder)}
                 onUpdate={(md) => setManual({ description: md })}
                 onSubmit={handleSubmit}

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -324,7 +324,7 @@ vi.mock("../editor", async () => {
   const composer = await vi.importActual<typeof import("../editor/use-composer-submit")>(
     "../editor/use-composer-submit",
   );
-  const ContentEditor = forwardRef(({ defaultValue, onUpdate, onSubmit, onUploadFile, onUploadingChange, placeholder }: any, ref: any) => {
+  const ContentEditor = forwardRef(({ defaultValue, onUpdate, onSubmit, onUploadFile, onUploadingChange, placeholder, enableSlashCommands }: any, ref: any) => {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
     // Mirrors the real editor's `uploading` node attrs: the placeholder sits
@@ -363,6 +363,7 @@ vi.mock("../editor", async () => {
         <textarea
           value={value}
           placeholder={placeholder}
+          data-slash-commands={enableSlashCommands ? "skill" : "off"}
           onChange={(e) => {
             valueRef.current = e.target.value;
             setValue(e.target.value);
@@ -554,6 +555,16 @@ describe("AgentCreatePanel", () => {
         'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
       ),
     ).toHaveValue("Persisted draft prompt");
+  });
+
+  it("enables Workspace Skill slash suggestions in the create-task prompt", () => {
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(
+      screen.getByPlaceholderText(
+        'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+      ),
+    ).toHaveAttribute("data-slash-commands", "skill");
   });
 
   it("restores unfinished actor, project, priority, and due-date selections after remount", async () => {

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -681,6 +681,7 @@ export function AgentCreatePanel({
           <ContentEditor
             ref={editorRef}
             defaultValue={initialPrompt}
+            enableSlashCommands
             placeholder={anchorCommentId
               ? t(($) => $.create_issue.agent.source_context_prompt_placeholder)
               : t(($) => $.create_issue.agent.prompt_placeholder)}

--- a/server/internal/daemon/execenv/codex_user_skills_test.go
+++ b/server/internal/daemon/execenv/codex_user_skills_test.go
@@ -187,6 +187,28 @@ func TestHydrateCodexSkillsWipeKeepsUserSkillContent(t *testing.T) {
 	}
 }
 
+func TestHydrateCodexSkillsRemovesPriorOneRunGrant(t *testing.T) {
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+	codexHome := t.TempDir()
+
+	granted := []SkillContextForEnv{{Name: "One Run", Content: "available once"}}
+	if err := hydrateCodexSkills(codexHome, granted, nil, testLogger()); err != nil {
+		t.Fatalf("hydrate selected Skill: %v", err)
+	}
+	grantedPath := filepath.Join(codexHome, "skills", "one-run", "SKILL.md")
+	if _, err := os.Stat(grantedPath); err != nil {
+		t.Fatalf("selected Skill was not materialized: %v", err)
+	}
+
+	if err := hydrateCodexSkills(codexHome, nil, nil, testLogger()); err != nil {
+		t.Fatalf("hydrate next task without selected Skill: %v", err)
+	}
+	if _, err := os.Stat(grantedPath); !os.IsNotExist(err) {
+		t.Fatalf("one-run Skill survived into the next task: %v", err)
+	}
+}
+
 // A workspace skill whose name only collides after directory naming — the
 // sanitized-name pre-filter does not catch it — must land in a sibling
 // directory instead of being written through the user's link.

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -310,6 +310,48 @@ func buildQuickCreatePrompt(task Task) string {
 	return b.String()
 }
 
+// writeExplicitlySelectedSkills validates durable slash markers against the
+// Skills materialized for this exact task, then emits canonical names. Labels
+// in user-authored Markdown are display text only and never trusted.
+func writeExplicitlySelectedSkills(
+	b *strings.Builder,
+	agent *AgentData,
+	markdowns ...string,
+) {
+	if agent == nil || len(agent.Skills) == 0 {
+		return
+	}
+	available := make(map[string]string, len(agent.Skills))
+	for _, skill := range agent.Skills {
+		available[skill.ID] = skill.Name
+	}
+
+	seen := make(map[string]struct{})
+	selected := make([]string, 0)
+	for _, markdown := range markdowns {
+		for _, ref := range ExtractSlashSkills(markdown) {
+			name, ok := available[ref.ID]
+			if !ok {
+				continue
+			}
+			if _, ok := seen[ref.ID]; ok {
+				continue
+			}
+			seen[ref.ID] = struct{}{}
+			selected = append(selected, name)
+		}
+	}
+	if len(selected) == 0 {
+		return
+	}
+
+	b.WriteString("Explicitly selected skills:\n")
+	for _, name := range selected {
+		fmt.Fprintf(b, "- %s\n", name)
+	}
+	b.WriteString("\n")
+}
+
 // buildCommentPrompt constructs a prompt for comment-triggered tasks.
 // The triggering comment content is embedded directly so the agent cannot
 // miss it, even when stale output files exist in a reused workdir.
@@ -409,6 +451,16 @@ func buildCommentPrompt(task Task, provider string) string {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise. The comment prohibition is conditional on that call SUCCEEDING: if it exits non-zero, your decision has no trace anywhere, so post exactly ONE short comment stating the outcome and the error instead of exiting silently. That failure comment is this turn's only comment — it does not license a second one.\n\n", task.IssueID)
 		}
 	}
+	selectedSkillMarkdown := make([]string, 0, len(task.CoalescedComments)+1)
+	if task.TriggerAuthorType == "member" {
+		selectedSkillMarkdown = append(selectedSkillMarkdown, task.TriggerCommentContent)
+	}
+	for _, comment := range task.CoalescedComments {
+		if comment.AuthorType == "member" {
+			selectedSkillMarkdown = append(selectedSkillMarkdown, comment.Content)
+		}
+	}
+	writeExplicitlySelectedSkills(&b, task.Agent, selectedSkillMarkdown...)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
 	// Comment-reading pointer. Warm path with new comments: issue-wide
 	// since-delta count, but steer the agent to read the triggering thread
@@ -575,37 +627,7 @@ func buildChatPrompt(task Task) string {
 		fmt.Fprintf(&b, "Reply to %s with the final outcome only. Do NOT narrate planned or in-progress steps (\"我先读取…\"); completed actions are part of the outcome.\n", platform)
 		b.WriteString("\n")
 	}
-	if task.Agent != nil && len(task.Agent.Skills) > 0 {
-		refs := ExtractSlashSkills(task.ChatMessage)
-		if len(refs) > 0 {
-			agentSkills := make(map[string]string, len(task.Agent.Skills))
-			for _, s := range task.Agent.Skills {
-				agentSkills[s.ID] = s.Name
-			}
-
-			selected := make([]string, 0, len(refs))
-			seen := make(map[string]struct{}, len(refs))
-			for _, ref := range refs {
-				name, ok := agentSkills[ref.ID]
-				if !ok {
-					continue
-				}
-				if _, ok := seen[ref.ID]; ok {
-					continue
-				}
-				seen[ref.ID] = struct{}{}
-				selected = append(selected, name)
-			}
-
-			if len(selected) > 0 {
-				b.WriteString("Explicitly selected skills:\n")
-				for _, name := range selected {
-					fmt.Fprintf(&b, "- %s\n", name)
-				}
-				b.WriteString("\n")
-			}
-		}
-	}
+	writeExplicitlySelectedSkills(&b, task.Agent, task.ChatMessage)
 	fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
 	// List attachments by id + filename so the agent can fetch them via
 	// the CLI. We deliberately do NOT inline the URL: chat attachments

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1022,6 +1022,35 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 	})
 }
 
+func TestBuildCommentPromptSlashSkills(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-1",
+		TriggerCommentID:      "comment-2",
+		TriggerCommentContent: "please [/review](slash://skill/skill-review)",
+		TriggerAuthorType:     "member",
+		CoalescedComments: []CoalescedCommentData{
+			{ID: "comment-agent", AuthorType: "agent", Content: "[/hidden](slash://skill/skill-hidden)"},
+			{ID: "comment-1", AuthorType: "member", Content: "also [/deploy](slash://skill/skill-deploy)"},
+		},
+		Agent: &AgentData{Skills: []SkillData{
+			{ID: "skill-review", Name: "architecture-sweep"},
+			{ID: "skill-deploy", Name: "autotrigger"},
+			{ID: "skill-hidden", Name: "agent-escalation"},
+		}},
+	}
+
+	out := buildCommentPrompt(task, "codex")
+	if !strings.Contains(out, "Explicitly selected skills:\n- architecture-sweep\n- autotrigger\n") {
+		t.Fatalf("comment prompt missing selected Skills block:\n%s", out)
+	}
+	if strings.Count(out, "Explicitly selected skills:") != 1 {
+		t.Fatalf("comment prompt emitted duplicate selected Skills blocks:\n%s", out)
+	}
+	if strings.Contains(out, "- agent-escalation\n") {
+		t.Fatalf("comment prompt trusted an agent-authored Skill marker:\n%s", out)
+	}
+}
+
 // TestBuildPromptDefaultScansRootsFirst pins that the catch-all fallback
 // prompt (no trigger comment, no chat, no autopilot, no quick-create)
 // starts assignment-triggered comment catch-up with a bounded roots scan and

--- a/server/internal/daemon/slash_skill.go
+++ b/server/internal/daemon/slash_skill.go
@@ -1,35 +1,9 @@
 package daemon
 
-import (
-	"regexp"
-	"strings"
-)
+import "github.com/multica-ai/multica/server/pkg/slashskill"
 
-var slashSkillRe = regexp.MustCompile(
-	`\[/((?:[^\]\\]|\\.)+)\]\(slash://skill/([^)]+)\)`,
-)
+type SlashSkillRef = slashskill.Ref
 
-type SlashSkillRef struct {
-	Label string
-	ID    string
-}
-
-func ExtractSlashSkills(md string) []SlashSkillRef {
-	matches := slashSkillRe.FindAllStringSubmatch(md, -1)
-	seen := make(map[string]struct{}, len(matches))
-	refs := make([]SlashSkillRef, 0, len(matches))
-
-	for _, m := range matches {
-		id := m[2]
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-
-		label := strings.ReplaceAll(m[1], `\[`, "[")
-		label = strings.ReplaceAll(label, `\]`, "]")
-		refs = append(refs, SlashSkillRef{Label: label, ID: id})
-	}
-
-	return refs
+func ExtractSlashSkills(markdown string) []SlashSkillRef {
+	return slashskill.Extract(markdown)
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -354,6 +354,10 @@ type TaskIssueStatusData struct {
 }
 
 type AgentTaskResponse struct {
+	// selectedSkillIDs is the validated, same-workspace grant frozen with claim
+	// finalization. It never crosses the wire directly; Agent.SkillRefs/Skills
+	// carry the executable bundles while the task context authorizes resolution.
+	selectedSkillIDs     []pgtype.UUID
 	ID                   string                 `json:"id"`
 	AgentID              string                 `json:"agent_id"`
 	RuntimeID            string                 `json:"runtime_id"`

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1753,7 +1753,7 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 			WorkspaceID: parseUUID(resp.WorkspaceID),
 			UserID:      rt.OwnerID,
 			ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true},
-		}, deliveredCommentIDs, commentBackedTask, daemonTokens...)
+		}, deliveredCommentIDs, commentBackedTask, resp.selectedSkillIDs, daemonTokens...)
 		if ferr != nil {
 			slog.Error("batch claim: finalize task claim failed; requeueing claim",
 				"task_id", uuidToString(task.ID), "error", ferr)
@@ -2163,18 +2163,6 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	// place a claimed task's agent payload is assembled.
 	if agent.SystemKey.String == service.MikaSystemKey {
 		resp.Agent.Instructions = service.ComposeMikaInstructions(agent.Name, agent.Instructions)
-	}
-	if useSkillRefs {
-		_, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
-		agentSkillCount = len(skillRefs)
-		resp.Agent.SkillRefs = skillRefs
-	} else {
-		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
-		agentSkillCount = len(skills)
-		builtinSkills := h.TaskService.BuiltinSkills()
-		builtinSkillCount = len(builtinSkills)
-		skills = append(skills, builtinSkills...)
-		resp.Agent.Skills = skills
 	}
 	if !claimResponseAgentIdentityMatches(resp) {
 		responseAgentID := ""
@@ -3014,6 +3002,18 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, failure
 	}
 
+	// Skill selection is payload-scoped, so hydrate it only after the task's
+	// exact chat/comment input and owning workspace have both been resolved.
+	// This keeps a `/skill` pick one-run-only while attached Skills and built-ins
+	// retain their existing always-available behavior.
+	var skillFailure *claimBuildFailure
+	agentSkillCount, builtinSkillCount, skillFailure = h.applyClaimTaskSkills(
+		r.Context(), *task, &resp, useSkillRefs,
+	)
+	if skillFailure != nil {
+		return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, skillFailure
+	}
+
 	// Surface a bounded snapshot of the same agent's other in-flight issue
 	// tasks. Queued tasks cannot coordinate yet and are intentionally omitted.
 	// This is advisory context, not a queue gate: cross-issue parallelism and
@@ -3340,7 +3340,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		WorkspaceID: parseUUID(resp.WorkspaceID),
 		UserID:      runtime.OwnerID,
 		ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true},
-	}, deliveredCommentIDs, commentBackedTask, daemonTokens...)
+	}, deliveredCommentIDs, commentBackedTask, resp.selectedSkillIDs, daemonTokens...)
 	if ferr != nil {
 		outcome = "error_claim_finalize"
 		slog.Error("task claim: failed to finalize token and comment delivery receipt",
@@ -3420,7 +3420,11 @@ func (h *Handler) ResolveTaskSkillBundles(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	bundles, _ := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
+	bundles, err := h.taskSkillBundlesForResolve(r.Context(), task, parseUUID(taskWorkspaceID))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load skill bundles")
+		return
+	}
 	allowed := make(map[string]service.AgentSkillData, len(bundles))
 	for _, bundle := range bundles {
 		allowed[bundle.Source+"\x00"+bundle.ID] = bundle

--- a/server/internal/handler/daemon_comment_delivery_test.go
+++ b/server/internal/handler/daemon_comment_delivery_test.go
@@ -977,7 +977,7 @@ func TestFinalizeTaskClaim_ReceiptCASFailureRollsBackInsertedToken(t *testing.T)
 		WorkspaceID: parseUUID(testWorkspaceID),
 		UserID:      parseUUID(testUserID),
 		ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true},
-	}, []pgtype.UUID{parseUUID("00000000-0000-0000-0000-000000000099")}, true, db.CreateDaemonTokenParams{
+	}, []pgtype.UUID{parseUUID("00000000-0000-0000-0000-000000000099")}, true, nil, db.CreateDaemonTokenParams{
 		TokenHash:   daemonTokenHash,
 		WorkspaceID: parseUUID(testWorkspaceID),
 		DaemonID:    "daemon-claim-rollback",
@@ -1030,7 +1030,7 @@ func TestFinalizeTaskClaim_TriggerDeletedAfterClaimRejectsStaleProvenance(t *tes
 		WorkspaceID: parseUUID(testWorkspaceID),
 		UserID:      parseUUID(testUserID),
 		ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true},
-	}, []pgtype.UUID{parseUUID(fixture.commentID[0]), parseUUID(fixture.commentID[1])}, true)
+	}, []pgtype.UUID{parseUUID(fixture.commentID[0]), parseUUID(fixture.commentID[1])}, true, nil)
 	if err == nil {
 		t.Fatalf("FinalizeTaskClaim accepted a receipt after persisted trigger changed")
 	}

--- a/server/internal/handler/daemon_slash_skill.go
+++ b/server/internal/handler/daemon_slash_skill.go
@@ -1,0 +1,189 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/slashskill"
+)
+
+// Matches the editor's display cap. The server still owns this ceiling so a
+// hand-written Markdown payload cannot inflate a claim with unbounded Skills.
+const maxSelectedSlashSkillsPerTask = 20
+
+func selectedSlashSkillIDs(markdowns ...string) []string {
+	ids := make([]string, 0, maxSelectedSlashSkillsPerTask)
+	seen := make(map[string]struct{}, maxSelectedSlashSkillsPerTask)
+	for _, markdown := range markdowns {
+		for _, ref := range slashskill.Extract(markdown) {
+			if _, ok := seen[ref.ID]; ok {
+				continue
+			}
+			seen[ref.ID] = struct{}{}
+			ids = append(ids, ref.ID)
+			if len(ids) == maxSelectedSlashSkillsPerTask {
+				return ids
+			}
+		}
+	}
+	return ids
+}
+
+// selectedSlashSkillIDsForClaim reads only immutable/task-owned chat input or
+// comment bodies actually admitted into this claim. Legacy chat tasks have no
+// durable input owner, so they retain the existing attached-Skills behavior.
+func selectedSlashSkillIDsForClaim(task db.AgentTaskQueue, resp AgentTaskResponse) []string {
+	markdowns := make([]string, 0, len(resp.CoalescedComments)+2)
+	if task.ChatInputTaskID.Valid {
+		markdowns = append(markdowns, resp.ChatMessage)
+	}
+	// A slash marker grants executable task authority, so only attributable
+	// human input may create it. Agent/system comments remain prompt context but
+	// cannot expand another run's Skill set.
+	if task.TriggerCommentID.Valid && resp.TriggerAuthorType == "member" {
+		markdowns = append(markdowns, resp.TriggerCommentContent)
+	}
+	if len(task.CoalescedCommentIds) > 0 {
+		for _, comment := range resp.CoalescedComments {
+			if comment.AuthorType == "member" {
+				markdowns = append(markdowns, comment.Content)
+			}
+		}
+	}
+	return selectedSlashSkillIDs(markdowns...)
+}
+
+func mergeTaskSkills(
+	configured []service.AgentSkillData,
+	selected []service.AgentSkillData,
+) []service.AgentSkillData {
+	merged := make([]service.AgentSkillData, 0, len(configured)+len(selected))
+	seen := make(map[string]struct{}, len(configured)+len(selected))
+	add := func(skill service.AgentSkillData) {
+		key := skill.Source + "\x00" + skill.ID
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, skill)
+	}
+	for _, skill := range configured {
+		add(skill)
+	}
+	for _, skill := range selected {
+		add(skill)
+	}
+	return merged
+}
+
+func selectedSkillUUIDs(skills []service.AgentSkillData) []pgtype.UUID {
+	ids := make([]pgtype.UUID, 0, len(skills))
+	for _, skill := range skills {
+		id, err := util.ParseUUID(skill.ID)
+		if err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// applyClaimTaskSkills merges attached Skills with same-workspace Skills the
+// user explicitly selected in this exact payload. Built-ins remain available
+// as before. Only the validated selected UUIDs are retained for transactional
+// claim finalization and later bundle-resolution authorization.
+func (h *Handler) applyClaimTaskSkills(
+	ctx context.Context,
+	task db.AgentTaskQueue,
+	resp *AgentTaskResponse,
+	useSkillRefs bool,
+) (agentSkillCount int, builtinSkillCount int, failure *claimBuildFailure) {
+	if resp.Agent == nil {
+		return 0, 0, nil
+	}
+
+	workspaceID, err := util.ParseUUID(resp.WorkspaceID)
+	if err != nil {
+		return 0, 0, &claimBuildFailure{
+			outcome: "error_selected_skills",
+			status:  http.StatusInternalServerError,
+			message: "failed to resolve task workspace Skills",
+		}
+	}
+	selected, err := h.TaskService.LoadWorkspaceSkillsByIDs(
+		ctx,
+		workspaceID,
+		selectedSlashSkillIDsForClaim(task, *resp),
+	)
+	if err != nil {
+		return 0, 0, &claimBuildFailure{
+			outcome: "error_selected_skills",
+			status:  http.StatusInternalServerError,
+			message: "failed to load selected workspace Skills",
+		}
+	}
+
+	resp.selectedSkillIDs = selectedSkillUUIDs(selected)
+	configured := h.TaskService.LoadAgentSkills(ctx, task.AgentID)
+	workspaceSkills := mergeTaskSkills(configured, selected)
+	builtins := h.TaskService.BuiltinSkills()
+	if useSkillRefs {
+		_, refs := service.BuildAgentSkillBundles(append(workspaceSkills, builtins...))
+		resp.Agent.SkillRefs = refs
+		return len(refs), 0, nil
+	}
+
+	resp.Agent.Skills = append(workspaceSkills, builtins...)
+	return len(workspaceSkills), len(builtins), nil
+}
+
+type persistedSelectedSkillContext struct {
+	SelectedSkillIDs []string `json:"selected_skill_ids"`
+}
+
+func selectedSkillIDsFromTaskContext(raw []byte) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var stored persistedSelectedSkillContext
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		// Older/custom tasks may carry a non-object context. That shape cannot
+		// contain a server-owned selected-Skill grant, so attached/built-in
+		// bundle resolution must retain its pre-feature behavior.
+		var typeErr *json.UnmarshalTypeError
+		if errors.As(err, &typeErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("decode selected skill grant: %w", err)
+	}
+	if len(stored.SelectedSkillIDs) > maxSelectedSlashSkillsPerTask {
+		stored.SelectedSkillIDs = stored.SelectedSkillIDs[:maxSelectedSlashSkillsPerTask]
+	}
+	return stored.SelectedSkillIDs, nil
+}
+
+func (h *Handler) taskSkillBundlesForResolve(
+	ctx context.Context,
+	task db.AgentTaskQueue,
+	workspaceID pgtype.UUID,
+) ([]service.AgentSkillData, error) {
+	selectedIDs, err := selectedSkillIDsFromTaskContext(task.Context)
+	if err != nil {
+		return nil, err
+	}
+	selected, err := h.TaskService.LoadWorkspaceSkillsByIDs(ctx, workspaceID, selectedIDs)
+	if err != nil {
+		return nil, err
+	}
+	configured := h.TaskService.LoadAgentSkills(ctx, task.AgentID)
+	all := mergeTaskSkills(configured, selected)
+	all = append(all, h.TaskService.BuiltinSkills()...)
+	bundles, _ := service.BuildAgentSkillBundles(all)
+	return bundles, nil
+}

--- a/server/internal/handler/daemon_slash_skill.go
+++ b/server/internal/handler/daemon_slash_skill.go
@@ -16,7 +16,7 @@ import (
 
 // Matches the editor's display cap. The server still owns this ceiling so a
 // hand-written Markdown payload cannot inflate a claim with unbounded Skills.
-const maxSelectedSlashSkillsPerTask = 20
+const maxSelectedSlashSkillsPerTask = slashskill.MaxSelectedPerPayload
 
 func selectedSlashSkillIDs(markdowns ...string) []string {
 	ids := make([]string, 0, maxSelectedSlashSkillsPerTask)
@@ -40,9 +40,15 @@ func selectedSlashSkillIDs(markdowns ...string) []string {
 // comment bodies actually admitted into this claim. Legacy chat tasks have no
 // durable input owner, so they retain the existing attached-Skills behavior.
 func selectedSlashSkillIDsForClaim(task db.AgentTaskQueue, resp AgentTaskResponse) []string {
-	markdowns := make([]string, 0, len(resp.CoalescedComments)+2)
+	markdowns := make([]string, 0, len(resp.CoalescedComments)+3)
 	if task.ChatInputTaskID.Valid {
 		markdowns = append(markdowns, resp.ChatMessage)
+	}
+	// Quick-create's prompt is immutable, server-owned task context submitted
+	// by the accountable member. It is the exact create-task payload this run
+	// is claiming, so its slash markers have the same authority as chat input.
+	if resp.QuickCreatePrompt != "" {
+		markdowns = append(markdowns, resp.QuickCreatePrompt)
 	}
 	// A slash marker grants executable task authority, so only attributable
 	// human input may create it. Agent/system comments remain prompt context but
@@ -58,6 +64,24 @@ func selectedSlashSkillIDsForClaim(task db.AgentTaskQueue, resp AgentTaskRespons
 		}
 	}
 	return selectedSlashSkillIDs(markdowns...)
+}
+
+func mergeSelectedSkillIDs(groups ...[]string) []string {
+	ids := make([]string, 0, maxSelectedSlashSkillsPerTask)
+	seen := make(map[string]struct{}, maxSelectedSlashSkillsPerTask)
+	for _, group := range groups {
+		for _, id := range group {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+			if len(ids) == maxSelectedSlashSkillsPerTask {
+				return ids
+			}
+		}
+	}
+	return ids
 }
 
 func mergeTaskSkills(
@@ -116,10 +140,22 @@ func (h *Handler) applyClaimTaskSkills(
 			message: "failed to resolve task workspace Skills",
 		}
 	}
+	storedSelectedIDs, err := selectedSkillIDsFromTaskContext(task.Context)
+	if err != nil {
+		return 0, 0, &claimBuildFailure{
+			outcome: "error_selected_skills",
+			status:  http.StatusInternalServerError,
+			message: "failed to resolve task workspace Skills",
+		}
+	}
+	selectedIDs := mergeSelectedSkillIDs(
+		storedSelectedIDs,
+		selectedSlashSkillIDsForClaim(task, *resp),
+	)
 	selected, err := h.TaskService.LoadWorkspaceSkillsByIDs(
 		ctx,
 		workspaceID,
-		selectedSlashSkillIDsForClaim(task, *resp),
+		selectedIDs,
 	)
 	if err != nil {
 		return 0, 0, &claimBuildFailure{

--- a/server/internal/handler/daemon_slash_skill_test.go
+++ b/server/internal/handler/daemon_slash_skill_test.go
@@ -1,0 +1,164 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func TestSelectedSlashSkillIDs(t *testing.T) {
+	markdown := make([]string, 0, maxSelectedSlashSkillsPerTask+2)
+	markdown = append(markdown, "[/first](slash://skill/a) [/again](slash://skill/a)")
+	for i := 0; i < maxSelectedSlashSkillsPerTask+1; i++ {
+		markdown = append(markdown, "[/skill](slash://skill/id-"+strings.Repeat("x", i+1)+")")
+	}
+
+	ids := selectedSlashSkillIDs(markdown...)
+	if len(ids) != maxSelectedSlashSkillsPerTask {
+		t.Fatalf("selected ids count = %d, want cap %d", len(ids), maxSelectedSlashSkillsPerTask)
+	}
+	if ids[0] != "a" {
+		t.Fatalf("first-occurrence order lost: %v", ids)
+	}
+}
+
+func TestSelectedSlashSkillIDsForClaimTrustsOnlyMemberComments(t *testing.T) {
+	task := db.AgentTaskQueue{
+		TriggerCommentID:    pgtype.UUID{Valid: true},
+		CoalescedCommentIds: []pgtype.UUID{{Valid: true}, {Valid: true}},
+	}
+	resp := AgentTaskResponse{
+		TriggerAuthorType:     "agent",
+		TriggerCommentContent: "[/agent](slash://skill/agent-skill)",
+		CoalescedComments: []CoalescedCommentData{
+			{AuthorType: "system", Content: "[/system](slash://skill/system-skill)"},
+			{AuthorType: "member", Content: "[/member](slash://skill/member-skill)"},
+		},
+	}
+
+	ids := selectedSlashSkillIDsForClaim(task, resp)
+	if len(ids) != 1 || ids[0] != "member-skill" {
+		t.Fatalf("selected ids = %v, want only member-authored marker", ids)
+	}
+}
+
+func TestMergeTaskSkillsDoesNotMutateConfiguredBackingArray(t *testing.T) {
+	configured := make([]service.AgentSkillData, 2, 4)
+	configured[0] = service.AgentSkillData{ID: "configured-1"}
+	configured[1] = service.AgentSkillData{ID: "configured-2"}
+	selected := []service.AgentSkillData{{ID: "selected-1"}}
+
+	merged := mergeTaskSkills(configured, selected)
+	if len(merged) != 3 {
+		t.Fatalf("merged count = %d, want 3", len(merged))
+	}
+	if configured[:cap(configured)][2].ID != "" {
+		t.Fatal("mergeTaskSkills wrote selected data into configured backing array")
+	}
+}
+
+func TestClaimTaskByRuntime_SelectedWorkspaceSkillGrant(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Selected Skill runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Selected Skill agent")
+	selectedID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         "selected-workspace-skill",
+		"description":  "Selected only for this run",
+		"content":      "selected content",
+		"config":       testutil.Raw("'{}'::jsonb"),
+		"created_by":   testUserID,
+	})
+	unselectedID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         "unselected-workspace-skill",
+		"description":  "Must remain unavailable",
+		"content":      "unselected content",
+		"config":       testutil.Raw("'{}'::jsonb"),
+		"created_by":   testUserID,
+	})
+	triggerID := dbfx.Comment(
+		t,
+		issueID,
+		"please [/selected-workspace-skill](slash://skill/"+selectedID+")",
+	)
+	taskID := dbfx.Task(t, agentID, testutil.Cols{
+		"runtime_id":         runtimeID,
+		"issue_id":           issueID,
+		"trigger_comment_id": triggerID,
+	})
+
+	req := newDaemonTokenRequest(
+		http.MethodPost,
+		"/api/daemon/runtimes/"+runtimeID+"/tasks/claim",
+		nil,
+		testWorkspaceID,
+		"selected-skill-daemon",
+	)
+	req.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilitySkillBundlesV1)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	w := testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
+
+	var claim struct {
+		Task *AgentTaskResponse `json:"task"`
+	}
+	w.JSON(&claim)
+	if claim.Task == nil || claim.Task.Agent == nil {
+		t.Fatalf("missing claimed task Agent: %s", w.Body.String())
+	}
+	var selectedRef service.AgentSkillRefData
+	for _, ref := range claim.Task.Agent.SkillRefs {
+		if ref.ID == selectedID {
+			selectedRef = ref
+		}
+		if ref.ID == unselectedID {
+			t.Fatalf("unselected workspace Skill leaked into claim: %+v", ref)
+		}
+	}
+	if selectedRef.ID == "" || selectedRef.Hash == "" {
+		t.Fatalf("selected workspace Skill missing from claim refs: %+v", claim.Task.Agent.SkillRefs)
+	}
+
+	var persistedContext string
+	dbfx.QueryRow(t, `SELECT context::text FROM agent_task_queue WHERE id = $1`, taskID).Scan(&persistedContext)
+	if !strings.Contains(persistedContext, selectedID) || strings.Contains(persistedContext, unselectedID) {
+		t.Fatalf("persisted selected-Skill grant is not exact: %s", persistedContext)
+	}
+
+	resolveSelected := resolveSkillBundlesRequest{Skills: []resolveSkillBundleRef{{
+		ID: selectedRef.ID, Source: selectedRef.Source, Hash: selectedRef.Hash,
+	}}}
+	req = newDaemonTokenRequest(
+		http.MethodPost,
+		"/api/daemon/runtimes/"+runtimeID+"/tasks/"+taskID+"/skill-bundles/resolve",
+		resolveSelected,
+		testWorkspaceID,
+		"selected-skill-daemon",
+	)
+	req = withURLParams(req, "runtimeId", runtimeID, "taskId", taskID)
+	testutil.Call(t, testHandler.ResolveTaskSkillBundles, req).Want(http.StatusOK)
+
+	resolveUnselected := resolveSkillBundlesRequest{Skills: []resolveSkillBundleRef{{
+		ID: unselectedID, Source: selectedRef.Source, Hash: selectedRef.Hash,
+	}}}
+	req = newDaemonTokenRequest(
+		http.MethodPost,
+		"/api/daemon/runtimes/"+runtimeID+"/tasks/"+taskID+"/skill-bundles/resolve",
+		resolveUnselected,
+		testWorkspaceID,
+		"selected-skill-daemon",
+	)
+	req = withURLParams(req, "runtimeId", runtimeID, "taskId", taskID)
+	testutil.Call(t, testHandler.ResolveTaskSkillBundles, req).Want(http.StatusNotFound)
+}

--- a/server/internal/handler/daemon_slash_skill_test.go
+++ b/server/internal/handler/daemon_slash_skill_test.go
@@ -49,6 +49,18 @@ func TestSelectedSlashSkillIDsForClaimTrustsOnlyMemberComments(t *testing.T) {
 	}
 }
 
+func TestSelectedSlashSkillIDsForClaimIncludesQuickCreatePrompt(t *testing.T) {
+	task := db.AgentTaskQueue{Context: []byte(`{"type":"quick_create"}`)}
+	resp := AgentTaskResponse{
+		QuickCreatePrompt: "please [/architecture-sweep](slash://skill/11111111-1111-4111-8111-111111111111)",
+	}
+
+	ids := selectedSlashSkillIDsForClaim(task, resp)
+	if len(ids) != 1 || ids[0] != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("selected ids = %v, want quick-create prompt marker", ids)
+	}
+}
+
 func TestMergeTaskSkillsDoesNotMutateConfiguredBackingArray(t *testing.T) {
 	configured := make([]service.AgentSkillData, 2, 4)
 	configured[0] = service.AgentSkillData{ID: "configured-1"}
@@ -61,6 +73,102 @@ func TestMergeTaskSkillsDoesNotMutateConfiguredBackingArray(t *testing.T) {
 	}
 	if configured[:cap(configured)][2].ID != "" {
 		t.Fatal("mergeTaskSkills wrote selected data into configured backing array")
+	}
+}
+
+func TestCreateIssueFreezesSelectedWorkspaceSkillForInitialRun(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Create Issue Selected Skill runtime")
+	agentID := dbfx.Agent(t, "Create Issue Selected Skill agent", runtimeID)
+	selectedID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         "architecture-sweep",
+		"description":  "Selected in the create-task description",
+		"content":      "selected content",
+		"config":       testutil.Raw("'{}'::jsonb"),
+		"created_by":   testUserID,
+	})
+	unselectedID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         "later-description-skill",
+		"description":  "Added only after the initial task was created",
+		"content":      "must not be selected",
+		"config":       testutil.Raw("'{}'::jsonb"),
+		"created_by":   testUserID,
+	})
+
+	w := testutil.Call(t, testHandler.CreateIssue, newRequest(
+		http.MethodPost,
+		"/api/issues?workspace_id="+testWorkspaceID,
+		map[string]any{
+			"title":         "Create task with selected Skill",
+			"description":   "please [/architecture-sweep](slash://skill/" + selectedID + ")",
+			"status":        "todo",
+			"priority":      "none",
+			"assignee_type": "agent",
+			"assignee_id":   agentID,
+		},
+	)).Want(http.StatusCreated)
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	w.JSON(&created)
+	if created.ID == "" {
+		t.Fatalf("missing created issue id: %s", w.Body.String())
+	}
+	dbfx.Cleanup(t, `DELETE FROM issue WHERE id = $1`, created.ID)
+	dbfx.Cleanup(t, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+
+	var taskID, persistedContext string
+	dbfx.QueryRow(t, `
+		SELECT id::text, COALESCE(context::text, 'null')
+		FROM agent_task_queue
+		WHERE issue_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, created.ID).Scan(&taskID, &persistedContext)
+	if !strings.Contains(persistedContext, selectedID) {
+		t.Fatalf("initial task %s did not freeze selected Skill %s: %s", taskID, selectedID, persistedContext)
+	}
+
+	// The issue body is mutable after creation. Replacing its marker must not
+	// revoke the original grant or smuggle a different Skill into this run.
+	dbfx.Exec(t, `UPDATE issue SET description = $2 WHERE id = $1`, created.ID,
+		"later [/later-description-skill](slash://skill/"+unselectedID+")")
+	req := newDaemonTokenRequest(
+		http.MethodPost,
+		"/api/daemon/runtimes/"+runtimeID+"/tasks/claim",
+		nil,
+		testWorkspaceID,
+		"create-issue-selected-skill-daemon",
+	)
+	req.Header.Set("X-Client-Capabilities", protocol.DaemonCapabilitySkillBundlesV1)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	w = testutil.Call(t, testHandler.ClaimTaskByRuntime, req).Want(http.StatusOK)
+
+	var claim struct {
+		Task *AgentTaskResponse `json:"task"`
+	}
+	w.JSON(&claim)
+	if claim.Task == nil || claim.Task.Agent == nil {
+		t.Fatalf("missing claimed task Agent: %s", w.Body.String())
+	}
+	selectedFound := false
+	for _, ref := range claim.Task.Agent.SkillRefs {
+		if ref.ID == selectedID {
+			selectedFound = true
+		}
+		if ref.ID == unselectedID {
+			t.Fatalf("Skill added to mutable issue description leaked into initial run: %+v", ref)
+		}
+	}
+	if !selectedFound {
+		t.Fatalf("create-time selected Skill missing from initial claim refs: %+v", claim.Task.Agent.SkillRefs)
 	}
 }
 

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -22,6 +22,7 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/dbid"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/multica-ai/multica/server/pkg/slashskill"
 )
 
 // IssueService is the single service-layer entry point for creating issues.
@@ -382,6 +383,11 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 	if err != nil {
 		return IssueCreateResult{}, fmt.Errorf("create issue: %w", err)
 	}
+	// Freeze member-authored selections from the exact create payload before
+	// any task can claim. The visible marker remains in the issue description,
+	// but only this server-owned task context grants the initial run access;
+	// later reruns do not re-read mutable issue content.
+	initialSelectedSkillIDs := selectedSkillIDsForMemberIssueCreate(issue)
 
 	if p.SourceContext != nil {
 		if _, err := PersistSourceContext(ctx, qtx, *p.SourceContext, issue.ID, pgtype.UUID{}); err != nil {
@@ -461,7 +467,7 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 		// task. Inserting both rows through qtx makes the unique-index winner
 		// deterministic: any observer that can discover the committed issue also
 		// sees the inert deferred task and must merge into it.
-		assignedTask, err = s.TaskService.createDeferredChannelIssueTaskWithQueries(ctx, qtx, issue, opts.AssignedAgentRunFireAt)
+		assignedTask, err = s.TaskService.createDeferredChannelIssueTaskWithQueries(ctx, qtx, issue, opts.AssignedAgentRunFireAt, initialSelectedSkillIDs)
 		if err != nil {
 			return IssueCreateResult{}, fmt.Errorf("create deferred channel issue task: %w", err)
 		}
@@ -495,14 +501,14 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 			// AssignedAgentRunFireAt currently belongs to channel /issue, which
 			// always resolves an agent assignee. Preserve the ordinary squad path
 			// for any future caller that supplies the option with a squad.
-			s.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, p.CreatorType, actorID)
+			s.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, p.CreatorType, actorID, initialSelectedSkillIDs)
 		}
 	}
 
 	s.publishIssueCreated(issue, attachments, labels, p.CreatorType, actorID, opts)
 	s.captureCreatedAnalytics(issue, p.CreatorType, actorID, opts)
 	if opts.AssignedAgentRunFireAt.IsZero() {
-		assignedTaskID = s.maybeEnqueueOnAssign(ctx, issue, p.CreatorType, actorID, opts.AssignedAgentRunFireAt)
+		assignedTaskID = s.maybeEnqueueOnAssign(ctx, issue, p.CreatorType, actorID, opts.AssignedAgentRunFireAt, initialSelectedSkillIDs)
 	}
 
 	return IssueCreateResult{Issue: issue, Attachments: attachments, Labels: labels, AssignedTaskID: assignedTaskID}, nil
@@ -721,7 +727,26 @@ func classifyOrigin(issue db.Issue, opts IssueCreateOpts) (source, taskID, autop
 	}
 }
 
-func (s *IssueService) maybeEnqueueOnAssign(ctx context.Context, issue db.Issue, creatorType, actorID string, agentRunFireAt time.Time) pgtype.UUID {
+func selectedSkillIDsForMemberIssueCreate(issue db.Issue) []pgtype.UUID {
+	if issue.CreatorType != "member" || !issue.Description.Valid {
+		return nil
+	}
+	refs := slashskill.Extract(issue.Description.String)
+	selected := make([]pgtype.UUID, 0, min(len(refs), slashskill.MaxSelectedPerPayload))
+	for _, ref := range refs {
+		id, err := util.ParseUUID(ref.ID)
+		if err != nil {
+			continue
+		}
+		selected = append(selected, id)
+		if len(selected) == slashskill.MaxSelectedPerPayload {
+			break
+		}
+	}
+	return selected
+}
+
+func (s *IssueService) maybeEnqueueOnAssign(ctx context.Context, issue db.Issue, creatorType, actorID string, agentRunFireAt time.Time, initialSelectedSkillIDs []pgtype.UUID) pgtype.UUID {
 	if !issue.AssigneeType.Valid || !issue.AssigneeID.Valid {
 		return pgtype.UUID{}
 	}
@@ -744,7 +769,7 @@ func (s *IssueService) maybeEnqueueOnAssign(ctx context.Context, issue db.Issue,
 		var task db.AgentTaskQueue
 		var err error
 		if agentRunFireAt.IsZero() {
-			task, err = s.TaskService.EnqueueTaskForIssue(ctx, issue)
+			task, err = s.TaskService.EnqueueTaskForIssueWithSelectedSkills(ctx, issue, initialSelectedSkillIDs)
 		} else {
 			task, err = s.TaskService.EnqueueDeferredChannelIssueTask(ctx, issue, agentRunFireAt)
 		}
@@ -757,7 +782,7 @@ func (s *IssueService) maybeEnqueueOnAssign(ctx context.Context, issue db.Issue,
 		}
 	}
 	if s.shouldEnqueueSquadLeaderOnAssign(ctx, issue) {
-		s.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, creatorType, actorID)
+		s.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, creatorType, actorID, initialSelectedSkillIDs)
 	}
 	return pgtype.UUID{}
 }
@@ -835,7 +860,7 @@ func (s *IssueService) isSquadLeaderReady(ctx context.Context, issue db.Issue) b
 	return verdict.Ready()
 }
 
-func (s *IssueService) enqueueSquadLeaderTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, authorType, authorID string) {
+func (s *IssueService) enqueueSquadLeaderTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, authorType, authorID string, initialSelectedSkillIDs []pgtype.UUID) {
 	squad, err := s.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
 		ID:          issue.AssigneeID,
 		WorkspaceID: issue.WorkspaceID,
@@ -852,7 +877,7 @@ func (s *IssueService) enqueueSquadLeaderTask(ctx context.Context, issue db.Issu
 	if err != nil || hasPending {
 		return
 	}
-	if _, err := s.TaskService.EnqueueTaskForSquadLeader(ctx, issue, squad.LeaderID, squad.ID, triggerCommentID); err != nil {
+	if _, err := s.TaskService.EnqueueTaskForSquadLeaderWithSelectedSkills(ctx, issue, squad.LeaderID, squad.ID, triggerCommentID, initialSelectedSkillIDs); err != nil {
 		slog.Warn("enqueue squad leader task on create failed",
 			"issue_id", util.UUIDToString(issue.ID),
 			"squad_id", util.UUIDToString(squad.ID),

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3620,16 +3620,20 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 
 // FinalizeTaskClaim atomically persists the task-scoped agent token, an
 // optional short-lived daemon token used by the Remote MCP broker, and, for a
-// comment-backed task, the exact comment ids embedded in the response. The
-// handler must call this only after the full payload has been built and before
-// writing any response bytes. A failure rolls every write back so the claim can
-// be safely returned to the queue.
+// comment-backed task, the exact comment ids embedded in the response. It also
+// freezes the workspace Skill IDs explicitly selected in that payload so the
+// later bundle resolver never has to trust a daemon ref or re-read mutable
+// source text. Empty grants avoid a new claim CAS unless a stale grant needs to
+// be cleared. The handler must call this only after the full payload has been
+// built and before writing any response bytes. A failure rolls every write back
+// so the claim can be safely returned to the queue.
 func (s *TaskService) FinalizeTaskClaim(
 	ctx context.Context,
 	task db.AgentTaskQueue,
 	token db.CreateTaskTokenParams,
 	deliveredCommentIDs []pgtype.UUID,
 	recordCommentReceipt bool,
+	selectedSkillIDs []pgtype.UUID,
 	daemonTokens ...db.CreateDaemonTokenParams,
 ) ([]pgtype.UUID, error) {
 	if len(daemonTokens) > 1 {
@@ -3648,6 +3652,21 @@ func (s *TaskService) FinalizeTaskClaim(
 			}
 			if _, err := qtx.CreateDaemonToken(ctx, daemonTokens[0]); err != nil {
 				return fmt.Errorf("create remote MCP daemon token: %w", err)
+			}
+		}
+		if len(selectedSkillIDs) > 0 || taskContextHasSelectedSkillGrant(task.Context) {
+			// pgx encodes a nil slice as SQL NULL. jsonb_set is strict, so always
+			// pass a concrete empty array when clearing an earlier task grant.
+			if selectedSkillIDs == nil {
+				selectedSkillIDs = []pgtype.UUID{}
+			}
+			if _, err := qtx.SetTaskClaimSelectedSkillIDs(ctx, db.SetTaskClaimSelectedSkillIDsParams{
+				SelectedSkillIds: selectedSkillIDs,
+				TaskID:           task.ID,
+				RuntimeID:        task.RuntimeID,
+				DispatchedAt:     task.DispatchedAt,
+			}); err != nil {
+				return fmt.Errorf("set selected skill ids: %w", err)
 			}
 		}
 		if !recordCommentReceipt {
@@ -3670,6 +3689,18 @@ func (s *TaskService) FinalizeTaskClaim(
 		return nil, err
 	}
 	return receipt, nil
+}
+
+func taskContextHasSelectedSkillGrant(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return false
+	}
+	_, ok := object["selected_skill_ids"]
+	return ok
 }
 
 // RequeueTaskAfterClaimFailure immediately releases an exact dispatched claim
@@ -6345,6 +6376,62 @@ func (s *TaskService) LoadAgentSkills(ctx context.Context, agentID pgtype.UUID) 
 		result = append(result, data)
 	}
 	return result
+}
+
+// LoadWorkspaceSkillsByIDs loads explicitly selected Skills through the
+// workspace boundary. Invalid, deleted, or cross-workspace IDs are omitted;
+// infrastructure failures are returned so a claim can be retried instead of
+// silently running without a Skill the user selected.
+func (s *TaskService) LoadWorkspaceSkillsByIDs(
+	ctx context.Context,
+	workspaceID pgtype.UUID,
+	skillIDs []string,
+) ([]AgentSkillData, error) {
+	if !workspaceID.Valid || len(skillIDs) == 0 {
+		return nil, nil
+	}
+
+	result := make([]AgentSkillData, 0, len(skillIDs))
+	seen := make(map[string]struct{}, len(skillIDs))
+	for _, rawID := range skillIDs {
+		skillID, err := util.ParseUUID(rawID)
+		if err != nil {
+			continue
+		}
+		canonicalID := util.UUIDToString(skillID)
+		if _, ok := seen[canonicalID]; ok {
+			continue
+		}
+		seen[canonicalID] = struct{}{}
+
+		skill, err := s.Queries.GetSkillInWorkspace(ctx, db.GetSkillInWorkspaceParams{
+			ID:          skillID,
+			WorkspaceID: workspaceID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("load selected workspace skill %s: %w", canonicalID, err)
+		}
+
+		data := AgentSkillData{
+			ID:          canonicalID,
+			Name:        skill.Name,
+			Description: skill.Description,
+			Content:     skill.Content,
+		}
+		files, err := s.Queries.ListSkillFiles(ctx, skill.ID)
+		if err != nil {
+			return nil, fmt.Errorf("load selected workspace skill files %s: %w", canonicalID, err)
+		}
+		for _, file := range files {
+			data.Files = append(data.Files, AgentSkillFileData{Path: file.Path, Content: file.Content})
+		}
+		result = append(result, data)
+	}
+
+	return result, nil
 }
 
 // LoadAgentSkillBundles returns every skill visible to an agent, including

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1041,7 +1041,15 @@ func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, t
 	if len(triggerCommentID) > 0 {
 		commentID = triggerCommentID[0]
 	}
-	return s.enqueueIssueTask(ctx, issue, commentID, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{})
+	return s.enqueueIssueTask(ctx, issue, commentID, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{}, nil)
+}
+
+// EnqueueTaskForIssueWithSelectedSkills is the create-time variant. The IDs
+// came from the exact member-authored issue description and are frozen into
+// the new task's server-owned context; later runs never re-read the mutable
+// issue body for executable authority.
+func (s *TaskService) EnqueueTaskForIssueWithSelectedSkills(ctx context.Context, issue db.Issue, selectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{}, selectedSkillIDs)
 }
 
 // EnqueueDeferredChannelIssueTask persists the assigned task for a media-backed
@@ -1049,7 +1057,7 @@ func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, t
 // crash-safe fallback; the channel router promotes the task as soon as the
 // detached attachment transaction settles.
 func (s *TaskService) EnqueueDeferredChannelIssueTask(ctx context.Context, issue db.Issue, fireAt time.Time) (db.AgentTaskQueue, error) {
-	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{Time: fireAt, Valid: true})
+	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{Time: fireAt, Valid: true}, nil)
 }
 
 // createDeferredChannelIssueTaskWithQueries inserts the inert media-gated task
@@ -1058,9 +1066,9 @@ func (s *TaskService) EnqueueDeferredChannelIssueTask(ctx context.Context, issue
 // intentionally absent from the transaction-scoped service: the task cannot be
 // claimed while deferred, so the optional external overlay is hydrated after
 // commit without holding database locks across a network call.
-func (s *TaskService) createDeferredChannelIssueTaskWithQueries(ctx context.Context, q *db.Queries, issue db.Issue, fireAt time.Time) (db.AgentTaskQueue, error) {
+func (s *TaskService) createDeferredChannelIssueTaskWithQueries(ctx context.Context, q *db.Queries, issue db.Issue, fireAt time.Time, selectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
 	txService := &TaskService{Queries: q}
-	return txService.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{Time: fireAt, Valid: true})
+	return txService.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, pgtype.Timestamptz{Time: fireAt, Valid: true}, selectedSkillIDs)
 }
 
 // hydrateDeferredChannelIssueTaskOverlay fills the optional Composio overlay
@@ -1102,7 +1110,7 @@ func (s *TaskService) hydrateDeferredChannelIssueTaskOverlay(ctx context.Context
 // member who performed the assign/promote and becomes the accountable human for
 // the run (MUL-4302 §4); invalid when the caller has no member actor.
 func (s *TaskService) EnqueueTaskForIssueWithHandoff(ctx context.Context, issue db.Issue, handoffNote string, actorUserID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, handoffNote, actorUserID, pgtype.UUID{}, pgtype.Timestamptz{})
+	return s.enqueueIssueTask(ctx, issue, pgtype.UUID{}, false, handoffNote, actorUserID, pgtype.UUID{}, pgtype.Timestamptz{}, nil)
 }
 
 // enqueueIssueTask is the shared implementation behind EnqueueTaskForIssue
@@ -1150,11 +1158,11 @@ func (s *TaskService) ResolveIssueReviewSHAParam(ctx context.Context, issueID pg
 	return headShaText(s.ResolveIssueReviewSHA(ctx, issueID))
 }
 
-func (s *TaskService) enqueueIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz) (db.AgentTaskQueue, error) {
-	return s.enqueueIssueTaskWithCommentPlan(ctx, issue, triggerCommentID, nil, forceFreshSession, handoffNote, actorUserID, rerunOfTaskID, fireAt)
+func (s *TaskService) enqueueIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz, initialSelectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueIssueTaskWithCommentPlan(ctx, issue, triggerCommentID, nil, forceFreshSession, handoffNote, actorUserID, rerunOfTaskID, fireAt, initialSelectedSkillIDs)
 }
 
-func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz) (db.AgentTaskQueue, error) {
+func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, fireAt pgtype.Timestamptz, initialSelectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
 	if !issue.AssigneeID.Valid {
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", "issue has no assignee")
 		return db.AgentTaskQueue{}, fmt.Errorf("issue has no assignee")
@@ -1191,26 +1199,27 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	attrSource, attrDelegatedFrom, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
 	createParams := db.CreateAgentTaskParams{
-		ID:                   dbid.NewV7(),
-		AgentID:              issue.AssigneeID,
-		RuntimeID:            agent.RuntimeID,
-		IssueID:              issue.ID,
-		Priority:             priorityToInt(issue.Priority),
-		TriggerCommentID:     triggerCommentID,
-		CoalescedCommentIds:  coalescedCommentIDs,
-		TriggerSummary:       s.buildCommentTriggerSummary(ctx, issue.WorkspaceID, triggerCommentID),
-		ForceFreshSession:    pgtype.Bool{Bool: forceFreshSession, Valid: forceFreshSession},
-		HandoffNote:          pgtype.Text{String: handoffNote, Valid: handoffNote != ""},
-		OriginatorUserID:     originatorUserID,
-		AccountableUserID:    attr.AccountableUserID,
-		RuleVersionID:        attr.RuleVersionID,
-		RerunOfTaskID:        rerunOfTaskID,
-		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
-		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
-		OriginatorSource:     attrSource,
-		DelegatedFromTaskID:  attrDelegatedFrom,
-		TriggerEvidenceKind:  attrEvidenceKind,
-		TriggerEvidenceRefID: attrEvidenceRef,
+		ID:                      dbid.NewV7(),
+		AgentID:                 issue.AssigneeID,
+		RuntimeID:               agent.RuntimeID,
+		IssueID:                 issue.ID,
+		Priority:                priorityToInt(issue.Priority),
+		TriggerCommentID:        triggerCommentID,
+		CoalescedCommentIds:     coalescedCommentIDs,
+		TriggerSummary:          s.buildCommentTriggerSummary(ctx, issue.WorkspaceID, triggerCommentID),
+		ForceFreshSession:       pgtype.Bool{Bool: forceFreshSession, Valid: forceFreshSession},
+		HandoffNote:             pgtype.Text{String: handoffNote, Valid: handoffNote != ""},
+		OriginatorUserID:        originatorUserID,
+		AccountableUserID:       attr.AccountableUserID,
+		RuleVersionID:           attr.RuleVersionID,
+		RerunOfTaskID:           rerunOfTaskID,
+		RuntimeMcpOverlay:       runtimeMCPOverlay.Overlay,
+		RuntimeConnectedApps:    runtimeMCPOverlay.ConnectedApps,
+		OriginatorSource:        attrSource,
+		DelegatedFromTaskID:     attrDelegatedFrom,
+		TriggerEvidenceKind:     attrEvidenceKind,
+		TriggerEvidenceRefID:    attrEvidenceRef,
+		InitialSelectedSkillIds: initialSelectedSkillIDs,
 		// Stamp the reviewed head so dedup can distinguish this run's target
 		// from a later request against a new HEAD (TEN-356).
 		HeadSha: headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
@@ -1218,30 +1227,31 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 	var task db.AgentTaskQueue
 	if fireAt.Valid {
 		task, err = s.Queries.CreateDeferredChannelIssueTask(ctx, db.CreateDeferredChannelIssueTaskParams{
-			ID:                   dbid.NewV7(),
-			AgentID:              createParams.AgentID,
-			RuntimeID:            createParams.RuntimeID,
-			IssueID:              createParams.IssueID,
-			Priority:             createParams.Priority,
-			TriggerCommentID:     createParams.TriggerCommentID,
-			CoalescedCommentIds:  createParams.CoalescedCommentIds,
-			TriggerSummary:       createParams.TriggerSummary,
-			ForceFreshSession:    createParams.ForceFreshSession,
-			IsLeaderTask:         createParams.IsLeaderTask,
-			HandoffNote:          createParams.HandoffNote,
-			SquadID:              createParams.SquadID,
-			HeadSha:              createParams.HeadSha,
-			OriginatorUserID:     createParams.OriginatorUserID,
-			AccountableUserID:    createParams.AccountableUserID,
-			RuntimeMcpOverlay:    createParams.RuntimeMcpOverlay,
-			RuntimeConnectedApps: createParams.RuntimeConnectedApps,
-			OriginatorSource:     createParams.OriginatorSource,
-			DelegatedFromTaskID:  createParams.DelegatedFromTaskID,
-			RuleVersionID:        createParams.RuleVersionID,
-			RerunOfTaskID:        createParams.RerunOfTaskID,
-			TriggerEvidenceKind:  createParams.TriggerEvidenceKind,
-			TriggerEvidenceRefID: createParams.TriggerEvidenceRefID,
-			FireAt:               fireAt,
+			ID:                      dbid.NewV7(),
+			AgentID:                 createParams.AgentID,
+			RuntimeID:               createParams.RuntimeID,
+			IssueID:                 createParams.IssueID,
+			Priority:                createParams.Priority,
+			TriggerCommentID:        createParams.TriggerCommentID,
+			CoalescedCommentIds:     createParams.CoalescedCommentIds,
+			TriggerSummary:          createParams.TriggerSummary,
+			ForceFreshSession:       createParams.ForceFreshSession,
+			IsLeaderTask:            createParams.IsLeaderTask,
+			HandoffNote:             createParams.HandoffNote,
+			SquadID:                 createParams.SquadID,
+			HeadSha:                 createParams.HeadSha,
+			OriginatorUserID:        createParams.OriginatorUserID,
+			AccountableUserID:       createParams.AccountableUserID,
+			RuntimeMcpOverlay:       createParams.RuntimeMcpOverlay,
+			RuntimeConnectedApps:    createParams.RuntimeConnectedApps,
+			OriginatorSource:        createParams.OriginatorSource,
+			DelegatedFromTaskID:     createParams.DelegatedFromTaskID,
+			RuleVersionID:           createParams.RuleVersionID,
+			RerunOfTaskID:           createParams.RerunOfTaskID,
+			TriggerEvidenceKind:     createParams.TriggerEvidenceKind,
+			TriggerEvidenceRefID:    createParams.TriggerEvidenceRefID,
+			InitialSelectedSkillIds: createParams.InitialSelectedSkillIds,
+			FireAt:                  fireAt,
 		})
 	} else {
 		task, err = s.Queries.CreateAgentTask(ctx, createParams)
@@ -1275,13 +1285,13 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 // Unlike EnqueueTaskForIssue, this takes an explicit agent ID rather than
 // deriving it from the issue assignee.
 func (s *TaskService) EnqueueTaskForMention(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueMentionTask(ctx, issue, agentID, triggerCommentID, false, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{})
+	return s.enqueueMentionTask(ctx, issue, agentID, triggerCommentID, false, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, nil)
 }
 
 // EnqueueTaskForThreadParent creates a queued task for the agent who authored
 // the direct parent comment a member replied to.
 func (s *TaskService) EnqueueTaskForThreadParent(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueMentionTask(ctx, issue, agentID, triggerCommentID, false, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{})
+	return s.enqueueMentionTask(ctx, issue, agentID, triggerCommentID, false, pgtype.UUID{}, false, "", pgtype.UUID{}, pgtype.UUID{}, nil)
 }
 
 // EnqueueTaskForSquadLeader is the leader-role variant of EnqueueTaskForMention.
@@ -1296,7 +1306,14 @@ func (s *TaskService) EnqueueTaskForThreadParent(ctx context.Context, issue db.I
 // leader task was triggered (comment @squad, issue assign, autopilot,
 // sub-issue done callback). See migration 127.
 func (s *TaskService) EnqueueTaskForSquadLeader(ctx context.Context, issue db.Issue, leaderID pgtype.UUID, squadID pgtype.UUID, triggerCommentID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueMentionTask(ctx, issue, leaderID, triggerCommentID, true, squadID, false, "", pgtype.UUID{}, pgtype.UUID{})
+	return s.enqueueMentionTask(ctx, issue, leaderID, triggerCommentID, true, squadID, false, "", pgtype.UUID{}, pgtype.UUID{}, nil)
+}
+
+// EnqueueTaskForSquadLeaderWithSelectedSkills is the create-time squad
+// variant of EnqueueTaskForSquadLeader. It grants only the member-selected
+// Skills frozen from that issue creation payload to the leader's initial run.
+func (s *TaskService) EnqueueTaskForSquadLeaderWithSelectedSkills(ctx context.Context, issue db.Issue, leaderID pgtype.UUID, squadID pgtype.UUID, triggerCommentID pgtype.UUID, selectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueMentionTask(ctx, issue, leaderID, triggerCommentID, true, squadID, false, "", pgtype.UUID{}, pgtype.UUID{}, selectedSkillIDs)
 }
 
 // EnqueueTaskForSquadLeaderWithHandoff is the assign/promote variant carrying a
@@ -1305,14 +1322,14 @@ func (s *TaskService) EnqueueTaskForSquadLeader(ctx context.Context, issue db.Is
 // performed the assign/promote and becomes the accountable human (MUL-4302 §4);
 // invalid when the caller has no member actor.
 func (s *TaskService) EnqueueTaskForSquadLeaderWithHandoff(ctx context.Context, issue db.Issue, leaderID pgtype.UUID, squadID pgtype.UUID, handoffNote string, actorUserID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueMentionTask(ctx, issue, leaderID, pgtype.UUID{}, true, squadID, false, handoffNote, actorUserID, pgtype.UUID{})
+	return s.enqueueMentionTask(ctx, issue, leaderID, pgtype.UUID{}, true, squadID, false, handoffNote, actorUserID, pgtype.UUID{}, nil)
 }
 
-func (s *TaskService) enqueueMentionTask(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID) (db.AgentTaskQueue, error) {
-	return s.enqueueMentionTaskWithCommentPlan(ctx, issue, agentID, triggerCommentID, nil, isLeader, squadID, forceFreshSession, handoffNote, actorUserID, rerunOfTaskID)
+func (s *TaskService) enqueueMentionTask(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, initialSelectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueMentionTaskWithCommentPlan(ctx, issue, agentID, triggerCommentID, nil, isLeader, squadID, forceFreshSession, handoffNote, actorUserID, rerunOfTaskID, initialSelectedSkillIDs)
 }
 
-func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID) (db.AgentTaskQueue, error) {
+func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID, initialSelectedSkillIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
 		slog.Error("mention task enqueue failed: agent not found", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID), "error", err)
@@ -1343,28 +1360,29 @@ func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, iss
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	attrSource, attrDelegatedFrom, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
 	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
-		ID:                   dbid.NewV7(),
-		AgentID:              agentID,
-		RuntimeID:            agent.RuntimeID,
-		IssueID:              issue.ID,
-		Priority:             priorityToInt(issue.Priority),
-		TriggerCommentID:     triggerCommentID,
-		CoalescedCommentIds:  coalescedCommentIDs,
-		TriggerSummary:       s.buildCommentTriggerSummary(ctx, issue.WorkspaceID, triggerCommentID),
-		IsLeaderTask:         pgtype.Bool{Bool: isLeader, Valid: isLeader},
-		ForceFreshSession:    pgtype.Bool{Bool: forceFreshSession, Valid: forceFreshSession},
-		HandoffNote:          pgtype.Text{String: handoffNote, Valid: handoffNote != ""},
-		SquadID:              squadID,
-		OriginatorUserID:     originatorUserID,
-		AccountableUserID:    attr.AccountableUserID,
-		RuleVersionID:        attr.RuleVersionID,
-		RerunOfTaskID:        rerunOfTaskID,
-		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
-		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
-		OriginatorSource:     attrSource,
-		DelegatedFromTaskID:  attrDelegatedFrom,
-		TriggerEvidenceKind:  attrEvidenceKind,
-		TriggerEvidenceRefID: attrEvidenceRef,
+		ID:                      dbid.NewV7(),
+		AgentID:                 agentID,
+		RuntimeID:               agent.RuntimeID,
+		IssueID:                 issue.ID,
+		Priority:                priorityToInt(issue.Priority),
+		TriggerCommentID:        triggerCommentID,
+		CoalescedCommentIds:     coalescedCommentIDs,
+		TriggerSummary:          s.buildCommentTriggerSummary(ctx, issue.WorkspaceID, triggerCommentID),
+		IsLeaderTask:            pgtype.Bool{Bool: isLeader, Valid: isLeader},
+		ForceFreshSession:       pgtype.Bool{Bool: forceFreshSession, Valid: forceFreshSession},
+		HandoffNote:             pgtype.Text{String: handoffNote, Valid: handoffNote != ""},
+		SquadID:                 squadID,
+		OriginatorUserID:        originatorUserID,
+		AccountableUserID:       attr.AccountableUserID,
+		RuleVersionID:           attr.RuleVersionID,
+		RerunOfTaskID:           rerunOfTaskID,
+		RuntimeMcpOverlay:       runtimeMCPOverlay.Overlay,
+		RuntimeConnectedApps:    runtimeMCPOverlay.ConnectedApps,
+		OriginatorSource:        attrSource,
+		DelegatedFromTaskID:     attrDelegatedFrom,
+		TriggerEvidenceKind:     attrEvidenceKind,
+		TriggerEvidenceRefID:    attrEvidenceRef,
+		InitialSelectedSkillIds: initialSelectedSkillIDs,
 		// Stamp the reviewed head so dedup can distinguish this run's target
 		// from a later request against a new HEAD (TEN-356).
 		HeadSha: headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
@@ -5632,9 +5650,9 @@ func (s *TaskService) promoteNewestSurvivingComment(ctx context.Context, ids []p
 func (s *TaskService) enqueueRerunTask(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, isLeader bool, squadID pgtype.UUID, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID) (db.AgentTaskQueue, error) {
 	if issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid &&
 		util.UUIDToString(issue.AssigneeID) == util.UUIDToString(agentID) {
-		return s.enqueueIssueTaskWithCommentPlan(ctx, issue, triggerCommentID, coalescedCommentIDs, true, "", actorUserID, rerunOfTaskID, pgtype.Timestamptz{})
+		return s.enqueueIssueTaskWithCommentPlan(ctx, issue, triggerCommentID, coalescedCommentIDs, true, "", actorUserID, rerunOfTaskID, pgtype.Timestamptz{}, nil)
 	}
-	return s.enqueueMentionTaskWithCommentPlan(ctx, issue, agentID, triggerCommentID, coalescedCommentIDs, isLeader, squadID, true, "", actorUserID, rerunOfTaskID)
+	return s.enqueueMentionTaskWithCommentPlan(ctx, issue, agentID, triggerCommentID, coalescedCommentIDs, isLeader, squadID, true, "", actorUserID, rerunOfTaskID, nil)
 }
 
 // HandleFailedTasks runs the post-failure side effects for a batch of

--- a/server/internal/service/task_finalize_failure_test.go
+++ b/server/internal/service/task_finalize_failure_test.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +38,7 @@ func TestFinalizeTaskClaimFailureRollsBackTokenThenRequeue(t *testing.T) {
 	// A delivered id outside the task's plan (no trigger/coalesced match) makes
 	// SetTaskDeliveredCommentIDs match zero rows → FinalizeTaskClaim errors.
 	bogus := util.MustParseUUID("11111111-1111-1111-1111-111111111111")
+	selectedSkill := util.MustParseUUID("22222222-2222-2222-2222-222222222222")
 	_, ferr := svc.FinalizeTaskClaim(ctx, task, db.CreateTaskTokenParams{
 		TokenHash:   fmt.Sprintf("finalize-fail-hash-%d", time.Now().UnixNano()),
 		TaskID:      task.ID,
@@ -43,7 +46,7 @@ func TestFinalizeTaskClaimFailureRollsBackTokenThenRequeue(t *testing.T) {
 		WorkspaceID: util.MustParseUUID(workspaceID),
 		UserID:      util.MustParseUUID(userID),
 		ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true},
-	}, []pgtype.UUID{bogus}, true)
+	}, []pgtype.UUID{bogus}, true, []pgtype.UUID{selectedSkill})
 	if ferr == nil {
 		t.Fatal("expected FinalizeTaskClaim to fail for an out-of-plan delivery receipt")
 	}
@@ -59,6 +62,13 @@ func TestFinalizeTaskClaimFailureRollsBackTokenThenRequeue(t *testing.T) {
 	if tokenCount != 0 {
 		t.Fatalf("expected token rolled back, found %d task_token rows", tokenCount)
 	}
+	var selectedGrantPersisted bool
+	if err := pool.QueryRow(ctx, `SELECT context ? 'selected_skill_ids' FROM agent_task_queue WHERE id = $1`, taskID).Scan(&selectedGrantPersisted); err != nil {
+		t.Fatalf("read selected Skill grant: %v", err)
+	}
+	if selectedGrantPersisted {
+		t.Fatal("selected Skill grant survived failed claim finalization")
+	}
 
 	// The exact dispatched claim is released back to queued.
 	if _, err := svc.RequeueTaskAfterClaimFailure(ctx, task); err != nil {
@@ -70,6 +80,83 @@ func TestFinalizeTaskClaimFailureRollsBackTokenThenRequeue(t *testing.T) {
 	}
 	if status != "queued" {
 		t.Fatalf("task status = %s, want queued after requeue", status)
+	}
+}
+
+func TestFinalizeTaskClaimWithoutSelectedSkillsPreservesContext(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialContext    string
+		wantObject        bool
+		wantSelectedCount int
+	}{
+		{name: "ordinary object skips grant CAS", initialContext: `{"keep":"value"}`, wantObject: true, wantSelectedCount: -1},
+		{name: "stale grant is cleared safely", initialContext: `{"keep":"value","selected_skill_ids":["22222222-2222-2222-2222-222222222222"]}`, wantObject: true, wantSelectedCount: 0},
+		{name: "legacy non-object context remains claimable", initialContext: `null`, wantObject: false, wantSelectedCount: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			pool := newTaskClaimRacePool(t)
+			svc := NewTaskService(db.New(pool), pool, nil, events.New())
+			queries := db.New(pool)
+
+			taskID, userID, workspaceID := dispatchedCommentTaskFixture(t, ctx, pool)
+			if _, err := pool.Exec(ctx, `UPDATE agent_task_queue SET context = $2::jsonb WHERE id = $1`, taskID, tt.initialContext); err != nil {
+				t.Fatalf("seed task context: %v", err)
+			}
+			task, err := queries.GetAgentTask(ctx, util.MustParseUUID(taskID))
+			if err != nil {
+				t.Fatalf("load task: %v", err)
+			}
+
+			if _, err := svc.FinalizeTaskClaim(ctx, task, db.CreateTaskTokenParams{
+				TokenHash:   fmt.Sprintf("finalize-empty-skill-%s-%d", strings.ReplaceAll(tt.name, " ", "-"), time.Now().UnixNano()),
+				TaskID:      task.ID,
+				AgentID:     task.AgentID,
+				WorkspaceID: util.MustParseUUID(workspaceID),
+				UserID:      util.MustParseUUID(userID),
+				ExpiresAt:   pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true},
+			}, nil, false, nil); err != nil {
+				t.Fatalf("FinalizeTaskClaim with no selected Skills: %v", err)
+			}
+
+			var raw []byte
+			if err := pool.QueryRow(ctx, `SELECT context FROM agent_task_queue WHERE id = $1`, taskID).Scan(&raw); err != nil {
+				t.Fatalf("read task context: %v", err)
+			}
+			if !tt.wantObject {
+				if string(raw) != "null" {
+					t.Fatalf("non-object context = %s, want null", raw)
+				}
+				return
+			}
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &object); err != nil {
+				t.Fatalf("decode preserved context: %v", err)
+			}
+			if string(object["keep"]) != `"value"` {
+				t.Fatalf("pre-existing context key lost: %s", raw)
+			}
+			selectedRaw, present := object["selected_skill_ids"]
+			if tt.wantSelectedCount < 0 {
+				if present {
+					t.Fatalf("empty grant unexpectedly added a context key: %s", raw)
+				}
+				return
+			}
+			var selected []string
+			if !present {
+				t.Fatalf("stale grant key was not cleared: %s", raw)
+			}
+			if err := json.Unmarshal(selectedRaw, &selected); err != nil {
+				t.Fatalf("decode selected skill ids: %v", err)
+			}
+			if len(selected) != tt.wantSelectedCount {
+				t.Fatalf("selected skill count = %d, want %d", len(selected), tt.wantSelectedCount)
+			}
+		})
 	}
 }
 

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -8087,6 +8087,46 @@ func (q *Queries) SetDeferredChannelIssueTaskRuntimeOverlay(ctx context.Context,
 	return result.RowsAffected(), nil
 }
 
+const setTaskClaimSelectedSkillIDs = `-- name: SetTaskClaimSelectedSkillIDs :one
+UPDATE agent_task_queue
+SET context = jsonb_set(
+    COALESCE(context, '{}'::jsonb),
+    '{selected_skill_ids}',
+    to_jsonb(COALESCE($1::uuid[], ARRAY[]::uuid[])),
+    true
+)
+WHERE id = $2
+  AND runtime_id = $3
+  AND status = 'dispatched'
+  AND started_at IS NULL
+  AND dispatched_at = $4
+  AND (context IS NULL OR jsonb_typeof(context) = 'object')
+RETURNING context
+`
+
+type SetTaskClaimSelectedSkillIDsParams struct {
+	SelectedSkillIds []pgtype.UUID      `json:"selected_skill_ids"`
+	TaskID           pgtype.UUID        `json:"task_id"`
+	RuntimeID        pgtype.UUID        `json:"runtime_id"`
+	DispatchedAt     pgtype.Timestamptz `json:"dispatched_at"`
+}
+
+// Freeze the workspace Skills explicitly selected in the exact payload this
+// claim is about to deliver. Keeping the grant in the task's server-owned
+// context lets the later bundle resolver authorize the same IDs without
+// trusting a daemon-supplied ref or re-reading mutable chat/comment bodies.
+func (q *Queries) SetTaskClaimSelectedSkillIDs(ctx context.Context, arg SetTaskClaimSelectedSkillIDsParams) ([]byte, error) {
+	row := q.db.QueryRow(ctx, setTaskClaimSelectedSkillIDs,
+		arg.SelectedSkillIds,
+		arg.TaskID,
+		arg.RuntimeID,
+		arg.DispatchedAt,
+	)
+	var context []byte
+	err := row.Scan(&context)
+	return context, err
+}
+
 const setTaskDeliveredCommentIDs = `-- name: SetTaskDeliveredCommentIDs :one
 UPDATE agent_task_queue
 SET delivered_comment_ids = $1::uuid[]

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2296,10 +2296,17 @@ SELECT
     $11,
     CASE
         WHEN COALESCE($12::text, '') <> ''
-        THEN jsonb_build_object('head_sha', $12::text)
+          OR cardinality(COALESCE($13::uuid[], ARRAY[]::uuid[])) > 0
+        THEN jsonb_strip_nulls(jsonb_build_object(
+            'head_sha', NULLIF(COALESCE($12::text, ''), ''),
+            'selected_skill_ids', CASE
+                WHEN cardinality(COALESCE($13::uuid[], ARRAY[]::uuid[])) > 0
+                THEN to_jsonb(COALESCE($13::uuid[], ARRAY[]::uuid[]))
+                ELSE NULL
+            END
+        ))
         ELSE NULL
     END,
-    $13,
     $14,
     $15,
     $16,
@@ -2309,35 +2316,37 @@ SELECT
     $20,
     $21,
     $22,
-    COALESCE($23::uuid, gen_random_uuid())
+    $23,
+    COALESCE($24::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, $3, $2)
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
 `
 
 type CreateAgentTaskParams struct {
-	AgentID              pgtype.UUID   `json:"agent_id"`
-	RuntimeID            pgtype.UUID   `json:"runtime_id"`
-	IssueID              pgtype.UUID   `json:"issue_id"`
-	Priority             int32         `json:"priority"`
-	TriggerCommentID     pgtype.UUID   `json:"trigger_comment_id"`
-	CoalescedCommentIds  []pgtype.UUID `json:"coalesced_comment_ids"`
-	TriggerSummary       pgtype.Text   `json:"trigger_summary"`
-	ForceFreshSession    pgtype.Bool   `json:"force_fresh_session"`
-	IsLeaderTask         pgtype.Bool   `json:"is_leader_task"`
-	HandoffNote          pgtype.Text   `json:"handoff_note"`
-	SquadID              pgtype.UUID   `json:"squad_id"`
-	HeadSha              pgtype.Text   `json:"head_sha"`
-	OriginatorUserID     pgtype.UUID   `json:"originator_user_id"`
-	AccountableUserID    pgtype.UUID   `json:"accountable_user_id"`
-	RuntimeMcpOverlay    []byte        `json:"runtime_mcp_overlay"`
-	RuntimeConnectedApps []byte        `json:"runtime_connected_apps"`
-	OriginatorSource     pgtype.Text   `json:"originator_source"`
-	DelegatedFromTaskID  pgtype.UUID   `json:"delegated_from_task_id"`
-	RuleVersionID        pgtype.UUID   `json:"rule_version_id"`
-	RerunOfTaskID        pgtype.UUID   `json:"rerun_of_task_id"`
-	TriggerEvidenceKind  pgtype.Text   `json:"trigger_evidence_kind"`
-	TriggerEvidenceRefID pgtype.UUID   `json:"trigger_evidence_ref_id"`
-	ID                   pgtype.UUID   `json:"id"`
+	AgentID                 pgtype.UUID   `json:"agent_id"`
+	RuntimeID               pgtype.UUID   `json:"runtime_id"`
+	IssueID                 pgtype.UUID   `json:"issue_id"`
+	Priority                int32         `json:"priority"`
+	TriggerCommentID        pgtype.UUID   `json:"trigger_comment_id"`
+	CoalescedCommentIds     []pgtype.UUID `json:"coalesced_comment_ids"`
+	TriggerSummary          pgtype.Text   `json:"trigger_summary"`
+	ForceFreshSession       pgtype.Bool   `json:"force_fresh_session"`
+	IsLeaderTask            pgtype.Bool   `json:"is_leader_task"`
+	HandoffNote             pgtype.Text   `json:"handoff_note"`
+	SquadID                 pgtype.UUID   `json:"squad_id"`
+	HeadSha                 pgtype.Text   `json:"head_sha"`
+	InitialSelectedSkillIds []pgtype.UUID `json:"initial_selected_skill_ids"`
+	OriginatorUserID        pgtype.UUID   `json:"originator_user_id"`
+	AccountableUserID       pgtype.UUID   `json:"accountable_user_id"`
+	RuntimeMcpOverlay       []byte        `json:"runtime_mcp_overlay"`
+	RuntimeConnectedApps    []byte        `json:"runtime_connected_apps"`
+	OriginatorSource        pgtype.Text   `json:"originator_source"`
+	DelegatedFromTaskID     pgtype.UUID   `json:"delegated_from_task_id"`
+	RuleVersionID           pgtype.UUID   `json:"rule_version_id"`
+	RerunOfTaskID           pgtype.UUID   `json:"rerun_of_task_id"`
+	TriggerEvidenceKind     pgtype.Text   `json:"trigger_evidence_kind"`
+	TriggerEvidenceRefID    pgtype.UUID   `json:"trigger_evidence_ref_id"`
+	ID                      pgtype.UUID   `json:"id"`
 }
 
 // Fenced against workspace teardown: lock_task_owner_rows (migration 284)
@@ -2347,10 +2356,11 @@ type CreateAgentTaskParams struct {
 // head_sha stamps the commit under review into the task's context JSONB so the
 // reviewer-loop dedup (HasPendingTaskForIssueAndAgent) can tell a pending run
 // against an OLD head apart from a fresh request against a NEW head (TEN-356).
-// Empty/absent head_sha leaves context NULL, preserving pre-TEN-356 behavior for
-// issues with no linked PR. Issue-linked tasks never hit quick-create context
-// parsing (parseQuickCreateContext short-circuits on IssueID.Valid), so this
-// key rides harmlessly alongside.
+// initial_selected_skill_ids freezes the member-authored `/skill` markers from
+// an issue's exact create payload for its first run. Empty inputs, together
+// with an empty head_sha, leave context NULL. Issue-linked tasks never hit
+// quick-create context parsing (parseQuickCreateContext short-circuits on
+// IssueID.Valid), so these keys ride harmlessly alongside.
 // id is minted by the application as a UUIDv7 (pkg/dbid) so consecutive
 // enqueues cluster in a narrow contiguous primary-key range instead of
 // scattering across the B-tree. On a table with existing v4 ids, that range
@@ -2372,6 +2382,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.HandoffNote,
 		arg.SquadID,
 		arg.HeadSha,
+		arg.InitialSelectedSkillIds,
 		arg.OriginatorUserID,
 		arg.AccountableUserID,
 		arg.RuntimeMcpOverlay,
@@ -2607,9 +2618,13 @@ SELECT
     $11,
     jsonb_strip_nulls(jsonb_build_object(
         'head_sha', NULLIF(COALESCE($12::text, ''), ''),
+        'selected_skill_ids', CASE
+            WHEN cardinality(COALESCE($13::uuid[], ARRAY[]::uuid[])) > 0
+            THEN to_jsonb(COALESCE($13::uuid[], ARRAY[]::uuid[]))
+            ELSE NULL
+        END,
         'channel_issue_media_pending', TRUE
     )),
-    $13,
     $14,
     $15,
     $16,
@@ -2620,36 +2635,38 @@ SELECT
     $21,
     $22,
     $23,
-    COALESCE($24::uuid, gen_random_uuid())
+    $24,
+    COALESCE($25::uuid, gen_random_uuid())
 WHERE lock_task_owner_rows($1, $3, $2)
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for, branch_name, durable_work_dir, channel_context_revision
 `
 
 type CreateDeferredChannelIssueTaskParams struct {
-	AgentID              pgtype.UUID        `json:"agent_id"`
-	RuntimeID            pgtype.UUID        `json:"runtime_id"`
-	IssueID              pgtype.UUID        `json:"issue_id"`
-	Priority             int32              `json:"priority"`
-	TriggerCommentID     pgtype.UUID        `json:"trigger_comment_id"`
-	CoalescedCommentIds  []pgtype.UUID      `json:"coalesced_comment_ids"`
-	TriggerSummary       pgtype.Text        `json:"trigger_summary"`
-	ForceFreshSession    pgtype.Bool        `json:"force_fresh_session"`
-	IsLeaderTask         pgtype.Bool        `json:"is_leader_task"`
-	HandoffNote          pgtype.Text        `json:"handoff_note"`
-	SquadID              pgtype.UUID        `json:"squad_id"`
-	HeadSha              pgtype.Text        `json:"head_sha"`
-	OriginatorUserID     pgtype.UUID        `json:"originator_user_id"`
-	AccountableUserID    pgtype.UUID        `json:"accountable_user_id"`
-	RuntimeMcpOverlay    []byte             `json:"runtime_mcp_overlay"`
-	RuntimeConnectedApps []byte             `json:"runtime_connected_apps"`
-	OriginatorSource     pgtype.Text        `json:"originator_source"`
-	DelegatedFromTaskID  pgtype.UUID        `json:"delegated_from_task_id"`
-	RuleVersionID        pgtype.UUID        `json:"rule_version_id"`
-	RerunOfTaskID        pgtype.UUID        `json:"rerun_of_task_id"`
-	TriggerEvidenceKind  pgtype.Text        `json:"trigger_evidence_kind"`
-	TriggerEvidenceRefID pgtype.UUID        `json:"trigger_evidence_ref_id"`
-	FireAt               pgtype.Timestamptz `json:"fire_at"`
-	ID                   pgtype.UUID        `json:"id"`
+	AgentID                 pgtype.UUID        `json:"agent_id"`
+	RuntimeID               pgtype.UUID        `json:"runtime_id"`
+	IssueID                 pgtype.UUID        `json:"issue_id"`
+	Priority                int32              `json:"priority"`
+	TriggerCommentID        pgtype.UUID        `json:"trigger_comment_id"`
+	CoalescedCommentIds     []pgtype.UUID      `json:"coalesced_comment_ids"`
+	TriggerSummary          pgtype.Text        `json:"trigger_summary"`
+	ForceFreshSession       pgtype.Bool        `json:"force_fresh_session"`
+	IsLeaderTask            pgtype.Bool        `json:"is_leader_task"`
+	HandoffNote             pgtype.Text        `json:"handoff_note"`
+	SquadID                 pgtype.UUID        `json:"squad_id"`
+	HeadSha                 pgtype.Text        `json:"head_sha"`
+	InitialSelectedSkillIds []pgtype.UUID      `json:"initial_selected_skill_ids"`
+	OriginatorUserID        pgtype.UUID        `json:"originator_user_id"`
+	AccountableUserID       pgtype.UUID        `json:"accountable_user_id"`
+	RuntimeMcpOverlay       []byte             `json:"runtime_mcp_overlay"`
+	RuntimeConnectedApps    []byte             `json:"runtime_connected_apps"`
+	OriginatorSource        pgtype.Text        `json:"originator_source"`
+	DelegatedFromTaskID     pgtype.UUID        `json:"delegated_from_task_id"`
+	RuleVersionID           pgtype.UUID        `json:"rule_version_id"`
+	RerunOfTaskID           pgtype.UUID        `json:"rerun_of_task_id"`
+	TriggerEvidenceKind     pgtype.Text        `json:"trigger_evidence_kind"`
+	TriggerEvidenceRefID    pgtype.UUID        `json:"trigger_evidence_ref_id"`
+	FireAt                  pgtype.Timestamptz `json:"fire_at"`
+	ID                      pgtype.UUID        `json:"id"`
 }
 
 // Fenced against workspace teardown: lock_task_owner_rows (migration 284)
@@ -2673,6 +2690,7 @@ func (q *Queries) CreateDeferredChannelIssueTask(ctx context.Context, arg Create
 		arg.HandoffNote,
 		arg.SquadID,
 		arg.HeadSha,
+		arg.InitialSelectedSkillIds,
 		arg.OriginatorUserID,
 		arg.AccountableUserID,
 		arg.RuntimeMcpOverlay,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -861,6 +861,26 @@ WHERE id = @task_id
   )
 RETURNING delivered_comment_ids;
 
+-- name: SetTaskClaimSelectedSkillIDs :one
+-- Freeze the workspace Skills explicitly selected in the exact payload this
+-- claim is about to deliver. Keeping the grant in the task's server-owned
+-- context lets the later bundle resolver authorize the same IDs without
+-- trusting a daemon-supplied ref or re-reading mutable chat/comment bodies.
+UPDATE agent_task_queue
+SET context = jsonb_set(
+    COALESCE(context, '{}'::jsonb),
+    '{selected_skill_ids}',
+    to_jsonb(COALESCE(@selected_skill_ids::uuid[], ARRAY[]::uuid[])),
+    true
+)
+WHERE id = @task_id
+  AND runtime_id = @runtime_id
+  AND status = 'dispatched'
+  AND started_at IS NULL
+  AND dispatched_at = @dispatched_at
+  AND (context IS NULL OR jsonb_typeof(context) = 'object')
+RETURNING context;
+
 -- name: RequeueAgentTaskAfterClaimFailure :one
 -- Claim finalization (task token + optional comment receipt) failed before any
 -- response bytes were written. Return only that exact claim generation to the

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -317,10 +317,11 @@ LIMIT 5;
 -- head_sha stamps the commit under review into the task's context JSONB so the
 -- reviewer-loop dedup (HasPendingTaskForIssueAndAgent) can tell a pending run
 -- against an OLD head apart from a fresh request against a NEW head (TEN-356).
--- Empty/absent head_sha leaves context NULL, preserving pre-TEN-356 behavior for
--- issues with no linked PR. Issue-linked tasks never hit quick-create context
--- parsing (parseQuickCreateContext short-circuits on IssueID.Valid), so this
--- key rides harmlessly alongside.
+-- initial_selected_skill_ids freezes the member-authored `/skill` markers from
+-- an issue's exact create payload for its first run. Empty inputs, together
+-- with an empty head_sha, leave context NULL. Issue-linked tasks never hit
+-- quick-create context parsing (parseQuickCreateContext short-circuits on
+-- IssueID.Valid), so these keys ride harmlessly alongside.
 -- id is minted by the application as a UUIDv7 (pkg/dbid) so consecutive
 -- enqueues cluster in a narrow contiguous primary-key range instead of
 -- scattering across the B-tree. On a table with existing v4 ids, that range
@@ -345,7 +346,15 @@ SELECT
     sqlc.narg(squad_id),
     CASE
         WHEN COALESCE(sqlc.narg('head_sha')::text, '') <> ''
-        THEN jsonb_build_object('head_sha', sqlc.narg('head_sha')::text)
+          OR cardinality(COALESCE(sqlc.narg('initial_selected_skill_ids')::uuid[], ARRAY[]::uuid[])) > 0
+        THEN jsonb_strip_nulls(jsonb_build_object(
+            'head_sha', NULLIF(COALESCE(sqlc.narg('head_sha')::text, ''), ''),
+            'selected_skill_ids', CASE
+                WHEN cardinality(COALESCE(sqlc.narg('initial_selected_skill_ids')::uuid[], ARRAY[]::uuid[])) > 0
+                THEN to_jsonb(COALESCE(sqlc.narg('initial_selected_skill_ids')::uuid[], ARRAY[]::uuid[]))
+                ELSE NULL
+            END
+        ))
         ELSE NULL
     END,
     sqlc.narg(originator_user_id),
@@ -388,6 +397,11 @@ SELECT
     sqlc.narg(squad_id),
     jsonb_strip_nulls(jsonb_build_object(
         'head_sha', NULLIF(COALESCE(sqlc.narg('head_sha')::text, ''), ''),
+        'selected_skill_ids', CASE
+            WHEN cardinality(COALESCE(sqlc.narg('initial_selected_skill_ids')::uuid[], ARRAY[]::uuid[])) > 0
+            THEN to_jsonb(COALESCE(sqlc.narg('initial_selected_skill_ids')::uuid[], ARRAY[]::uuid[]))
+            ELSE NULL
+        END,
         'channel_issue_media_pending', TRUE
     )),
     sqlc.narg(originator_user_id),

--- a/server/pkg/slashskill/slash_skill.go
+++ b/server/pkg/slashskill/slash_skill.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+// MaxSelectedPerPayload is the server-owned ceiling for one task-scoped
+// Skill selection. The UI mirrors this value for display, while every backend
+// admission path uses it as the authoritative cap.
+const MaxSelectedPerPayload = 20
+
 var markerRE = regexp.MustCompile(
 	`\[/((?:[^\]\\]|\\.)+)\]\(slash://skill/([^)]+)\)`,
 )

--- a/server/pkg/slashskill/slash_skill.go
+++ b/server/pkg/slashskill/slash_skill.go
@@ -1,0 +1,40 @@
+// Package slashskill parses the durable Markdown marker emitted by Multica's
+// slash-command editor. Both the claim handler and the daemon prompt consume
+// this package so UI selection, task authorization, and prompt disclosure use
+// one parser rather than security-sensitive lookalikes.
+package slashskill
+
+import (
+	"regexp"
+	"strings"
+)
+
+var markerRE = regexp.MustCompile(
+	`\[/((?:[^\]\\]|\\.)+)\]\(slash://skill/([^)]+)\)`,
+)
+
+type Ref struct {
+	Label string
+	ID    string
+}
+
+// Extract returns distinct Skill refs in first-occurrence order.
+func Extract(markdown string) []Ref {
+	matches := markerRE.FindAllStringSubmatch(markdown, -1)
+	seen := make(map[string]struct{}, len(matches))
+	refs := make([]Ref, 0, len(matches))
+
+	for _, match := range matches {
+		id := match[2]
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		label := strings.ReplaceAll(match[1], `\[`, "[")
+		label = strings.ReplaceAll(label, `\]`, "]")
+		refs = append(refs, Ref{Label: label, ID: id})
+	}
+
+	return refs
+}

--- a/server/pkg/slashskill/slash_skill_test.go
+++ b/server/pkg/slashskill/slash_skill_test.go
@@ -1,0 +1,24 @@
+package slashskill
+
+import "testing"
+
+func TestExtract(t *testing.T) {
+	t.Run("parses and deduplicates durable markers", func(t *testing.T) {
+		refs := Extract(`please [/deploy\[prod\]](slash://skill/a) and [/again](slash://skill/a)`)
+		if len(refs) != 1 || refs[0].ID != "a" || refs[0].Label != "deploy[prod]" {
+			t.Fatalf("unexpected refs: %+v", refs)
+		}
+	})
+
+	t.Run("ignores adjacent protocols", func(t *testing.T) {
+		for _, markdown := range []string{
+			"[/x](slash://action/y)",
+			"[/x](slash://skills/y)",
+			"[docs](https://example.com)",
+		} {
+			if refs := Extract(markdown); len(refs) != 0 {
+				t.Fatalf("expected no refs for %q, got %+v", markdown, refs)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Adds a Workspace Skill slash picker to Chat, issue comments/replies, and both new-task editors.

Typing `/` lists the current workspace Skills while preserving Quick Actions and reserved `/note` behavior. A selected Skill is encoded with a stable UUID marker, validated by the server, and granted only to the exact Run.

For task creation, the member-authored selection is frozen into the initial task context before the task can be claimed. Editing the issue description afterward cannot revoke that selection or substitute a different Skill.

## Related Issue

Closes #7729

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Tests
- [ ] Documentation update

## Changes Made

- Added Workspace Skill suggestions to Chat, issue comments/replies, quick create, and manual issue creation.
- Kept labels presentation-only and used UUID-backed markers for server authorization.
- Added same-workspace, exact-payload, member-authored, and maximum-selection validation.
- Included immutable quick-create prompts in claim-time Skill selection.
- Persisted manual-create Skill selections in the initial task's server-owned context.
- Merged frozen create-time selections with task-owned member input at claim.
- Denied unselected Skill bundles while preserving attached and built-in Skill behavior.
- Cleaned one-run Codex Skill materialization on the next execution.
- Hardened slash-trigger arming for Chrome's stale whole-document selection after `Ctrl+A` and `Delete`.
- Added frontend, parser, handler, service, prompt, SQL, and execution-environment coverage.

## How to Test

- Type `/` in Chat, an issue comment/reply, the quick-create prompt, and the manual issue description; verify Workspace Skills are listed and filterable.
- Select a Skill during assigned manual task creation and verify the initial claim contains that Skill.
- Change the issue description before claim and verify it cannot replace the create-time grant.
- Verify an unselected Workspace Skill cannot be resolved for the task.

Local validation includes:

- 160 relevant editor/modal Vitest tests.
- `@multica/views` TypeScript typecheck and focused ESLint.
- PostgreSQL-backed create/claim/authorization integration tests, including post-create description mutation.
- All `TestCreateIssue*` handler tests.
- The service and slash-skill package suites; Windows bind-mount CRLF-only built-in-Skill fixture checks were excluded locally and remain covered by Linux CI.

## Security and Risk Notes

- Selected Skill IDs are server-validated; client labels do not grant access.
- Grants require exact task-owned input or a member-authored comment in the same workspace.
- Create-time selections are frozen before claim; mutable issue content is not re-read for authority.
- A Run accepts at most 20 selected Skills.
- Unselected Workspace Skills remain inaccessible.
- Legacy/non-object task context remains claimable.
- The create-time selection is intentionally scoped to the initial Run; a rerun must select its own Skills from its triggering comment.

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have added tests that prove the feature works
- [x] New and existing focused tests pass locally
- [x] Documentation impact assessed; no documentation change is required for the current behavior
- [x] UI screenshot added

## AI Disclosure

AI tooling was used: OpenAI Codex for implementation and deterministic testing, with independent Claude Opus review for each frozen high-risk authorization diff. The latest review found no P0/P1 findings; P2/P3 observations were checked against all current issue-create callers, explicit one-Run grant semantics, and captured non-skipped database test evidence.

## Screenshots

See the [live acceptance screenshot and results](https://github.com/multica-ai/multica/pull/7730#issuecomment-5462599552).
