### PR TITLE
MUL-6781: perf(server): compress JSON API responses

### DIFF
--- a/server/cmd/server/compression_test.go
+++ b/server/cmd/server/compression_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+)
+
+func TestMainRouterCompressesJSONWhenRequested(t *testing.T) {
+	router := NewRouter(nil, realtime.NewHub(), events.New(), analytics.NoopClient{}, nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	router.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	var body liveResponse
+	if err := json.NewDecoder(zr).Decode(&body); err != nil {
+		t.Fatalf("decode compressed /health response: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status = %q, want ok", body.Status)
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1230,6 +1230,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		r.Use(opts.HTTPMetrics.Middleware)
 	}
 	r.Use(chimw.Recoverer)
+	r.Use(chimw.Compress(5, "application/json"))
 	r.Use(h.PluginSurfaceHostBoundary)
 	r.Use(middleware.ContentSecurityPolicy)
 


### PR DESCRIPTION
## What does this PR do?

Adds Chi's existing compression middleware to the global server router so clients that advertise gzip support receive compressed JSON API responses. The middleware is scoped to `application/json`, keeps responses uncompressed when clients do not request a supported encoding, and preserves `http.Hijacker` for WebSocket upgrades.

The implementation stays at the shared HTTP boundary instead of changing individual handlers.

## Related Issue

Closes #7677

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add `chimw.Compress(5, "application/json")` after the global recovery middleware.
- Verify the real main router negotiates gzip and returns decodable JSON.

## How to Test

1. `cd server`
2. `go test ./cmd/server -run TestMainRouterCompressesJSONWhenRequested -count=1`
3. `go test ./cmd/server -skip TestReadinessEndpoints -count=1`

The unfiltered package suite was also run. Only `TestReadinessEndpoints` failed because this checkout's shared local test database migration ledger is behind current upstream; all remaining `cmd/server` tests passed with that environment-dependent readiness test skipped.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex via Multica

**Prompt / approach:** Reviewed the upstream issue, excluded candidates with active implementation PRs, traced the global router and existing Chi dependency, then applied the smallest shared-boundary change and added one regression test against the production router.

## Screenshots (optional)

Not applicable.
