### PR TITLE
MUL-6817: fix(selfhost): bound container logs with json-file rotation

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -32,6 +32,12 @@
 
 name: multica
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   postgres:
     image: pgvector/pgvector:pg17
@@ -42,6 +48,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     restart: unless-stopped
+    logging: *default-logging
     healthcheck:
       test:
         [
@@ -195,6 +202,7 @@ services:
       # what it records is user message content.
       MULTICA_WECOM_TRACE: ${MULTICA_WECOM_TRACE:-}
     restart: unless-stopped
+    logging: *default-logging
 
   frontend:
     image: ${MULTICA_WEB_IMAGE:-ghcr.io/multica-ai/multica-web}:${MULTICA_IMAGE_TAG:-latest}
@@ -209,6 +217,7 @@ services:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
       NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-}
     restart: unless-stopped
+    logging: *default-logging
 
 volumes:
   pgdata:


### PR DESCRIPTION
All three services inherit Docker's unlimited `json-file` default. On a long-running self-host the backend log reached 80 MB, and past that point `docker logs` stopped returning new lines while the file itself kept growing. On an instance with no SMTP or Resend backend this also hides the login verification code, which is only ever printed to stdout.

Adds an `x-logging` anchor (`max-size: 10m`, `max-file: 3`) applied to `postgres`, `backend` and `frontend`.

Takes effect when containers are recreated; an already-oversized log still needs truncating once.
