### PR TITLE
MUL-6821: fix(codex): interrupt active turn before task handoff

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -66,6 +66,11 @@ const (
 	// their default separate without slowing failures for lightweight RPCs.
 	defaultCodexThreadHandshakeTimeout = 60 * time.Second
 	codexVersionDiagnosticTimeout      = 2 * time.Second
+	// codexTurnInterruptTimeout bounds the native app-server handoff when a
+	// Multica task is cancelled or times out. The process deliberately outlives
+	// the task context for this brief window so Codex can persist an interrupted
+	// turn before the replacement resumes the same thread.
+	codexTurnInterruptTimeout = 2 * time.Second
 	// codexGracefulShutdownTimeout bounds how long the lifecycle goroutine
 	// waits for codex to exit on its own after stdin is closed, before forcing
 	// a context-cancel kill. A clean exit lets codex run its shutdown path and
@@ -954,7 +959,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		semanticInactivityTimeout = defaultCodexSemanticInactivityTimeout
 	}
 	handshakeTimeout, threadHandshakeTimeout := resolveCodexHandshakeTimeouts(opts)
-	runCtx, cancel := runContext(ctx, timeout)
+	runCtx, cancelRun := runContext(ctx, timeout)
+	// Do not bind the app-server process directly to runCtx. Task cancellation
+	// must first travel through Codex's turn/interrupt RPC; wiring CommandContext
+	// to runCtx makes os/exec invoke cmd.Cancel (a process-group SIGKILL below)
+	// before the lifecycle goroutine can send that RPC. processCtx is cancelled
+	// only by bounded cleanup after the native interrupt attempt.
+	processCtx, cancelProcess := context.WithCancel(context.WithoutCancel(runCtx))
 
 	// Materialise the agent's MCP config into the per-task
 	// `$CODEX_HOME/config.toml`. Argv would be the simpler path, but
@@ -974,7 +985,8 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			// look indistinguishable from "the saved config was
 			// applied", which is exactly the surprise the MCP Tab is
 			// supposed to remove.
-			cancel()
+			cancelRun()
+			cancelProcess()
 			return nil, fmt.Errorf("apply codex mcp_config: %w", err)
 		}
 	} else if hasManagedCodexMcpConfig(opts.McpConfig) {
@@ -982,7 +994,8 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		// Same reasoning as above: silently launching would inherit
 		// whatever MCP setup the host user has, which is the wrong
 		// shape of failure.
-		cancel()
+		cancelRun()
+		cancelProcess()
 		return nil, fmt.Errorf("codex: mcp_config is set but CODEX_HOME env var is not configured; cannot apply managed MCP")
 	}
 
@@ -1018,7 +1031,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		})
 	}
 	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
-	cmd := runtimeCmd.exec(runCtx, codexArgs...)
+	cmd := runtimeCmd.exec(processCtx, codexArgs...)
 	hideAgentWindow(cmd)
 	// Run codex in its own process group so a cancel-on-stuck cleanup
 	// reaches the whole tree — the codex Node wrapper plus the native
@@ -1051,12 +1064,14 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		cancel()
+		cancelRun()
+		cancelProcess()
 		return nil, fmt.Errorf("codex stdout pipe: %w", err)
 	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		cancel()
+		cancelRun()
+		cancelProcess()
 		return nil, fmt.Errorf("codex stdin pipe: %w", err)
 	}
 	// Codex stderr can contain auth/provider diagnostics. Capture a bounded
@@ -1072,7 +1087,8 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	// Start. Ownership that cannot be taken is logged, not fatal; a child that
 	// cannot be resumed is killed and reported here.
 	if err := startOwnedProcessTree(cmd, b.cfg.Logger); err != nil {
-		cancel()
+		cancelRun()
+		cancelProcess()
 		return nil, fmt.Errorf("start codex: %w", err)
 	}
 	activeLaunches := activeCodexLaunches.Add(1)
@@ -1264,7 +1280,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 					"pid", cmd.Process.Pid,
 					"grace", grace.String(),
 				)
-				cancel()
+				cancelProcess()
 				// On Windows, Cancel terminates only the direct child. A
 				// descendant may keep inherited stdout open indefinitely. Start
 				// Wait now so os/exec's WaitDelay closes the pipe after its
@@ -1294,7 +1310,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 					"pid", cmd.Process.Pid,
 					"grace", grace.String(),
 				)
-				cancel()
+				cancelProcess()
 				// WaitDelay (10s) is the final backstop: even if the
 				// group-kill races with an open pipe held by a
 				// descendant, cmd.Wait() returns within WaitDelay of the
@@ -1338,7 +1354,8 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	// readerDone closes → lifecycle goroutine collects final output and sends Result.
 	go func() {
 		defer activeCodexLaunches.Add(-1)
-		defer cancel()
+		defer cancelRun()
+		defer cancelProcess()
 		defer close(msgCh)
 		defer close(resCh)
 		defer drainAndWait()
@@ -1503,18 +1520,71 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 				}
 			}
 		}
-		turnNotificationGate.arm()
-		_, err = c.request(runCtx, "turn/start", turnParams)
-		if err != nil {
-			select {
-			case aborted := <-turnDone:
-				finishTurn(aborted)
-			default:
-				drainAndWait() // flush os/exec stderr goroutine before sampling Tail
-				finalStatus = "failed"
-				finalError = withAgentStderr(fmt.Sprintf("codex turn/start failed: %v", err), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+		finishRunContextDone := func() {
+			waitingForTurn = false
+			if runCtx.Err() == context.DeadlineExceeded {
+				finishFirstItemWait("execution_timeout")
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("codex timed out after %s", timeout)
+			} else {
+				finishFirstItemWait("cancelled")
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			}
+		}
+		nativeInterruptAttempted := false
+		interruptActiveTurn := func() {
+			if nativeInterruptAttempted {
 				return
+			}
+			nativeInterruptAttempted = true
+			turnID := c.currentTurnID()
+			if turnID == "" {
+				b.cfg.Logger.Info("codex native interrupt skipped: active turn ID is not available",
+					"thread_id", threadID, "task_id", b.cfg.TaskID)
+				return
+			}
+			interruptCtx, cancelInterrupt := context.WithTimeout(context.Background(), codexTurnInterruptTimeout)
+			defer cancelInterrupt()
+			if err := c.interruptTurn(interruptCtx, threadID, turnID); err != nil {
+				b.cfg.Logger.Warn("codex native turn interrupt failed; falling back to process shutdown",
+					"thread_id", threadID, "turn_id", turnID, "error", err)
+				return
+			}
+			b.cfg.Logger.Info("codex native turn interrupt accepted",
+				"thread_id", threadID, "turn_id", turnID, "task_id", b.cfg.TaskID)
+			// The RPC acknowledgement means the request was accepted, while the
+			// terminal notification is the durable turn boundary the replacement
+			// should resume after. Give it the remainder of the same bounded window.
+			select {
+			case <-turnDone:
+				b.cfg.Logger.Info("codex interrupted turn completed",
+					"thread_id", threadID, "turn_id", turnID, "task_id", b.cfg.TaskID)
+			case <-interruptCtx.Done():
+				b.cfg.Logger.Warn("codex interrupt acknowledged without terminal notification; continuing shutdown",
+					"thread_id", threadID, "turn_id", turnID)
+			}
+		}
+		turnNotificationGate.arm()
+		turnStartResult, err := c.request(runCtx, "turn/start", turnParams)
+		if turnID := extractTurnID(turnStartResult); turnID != "" {
+			c.setTurnID(turnID)
+		}
+		if err != nil {
+			if runCtx.Err() != nil {
+				finishRunContextDone()
+				interruptActiveTurn()
+			} else {
+				select {
+				case aborted := <-turnDone:
+					finishTurn(aborted)
+				default:
+					drainAndWait() // flush os/exec stderr goroutine before sampling Tail
+					finalStatus = "failed"
+					finalError = withAgentStderr(fmt.Sprintf("codex turn/start failed: %v", err), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
+					resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+					return
+				}
 			}
 		}
 
@@ -1537,18 +1607,6 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		}
 		defer stopFirstTurnNoProgressTimer()
 
-		finishRunContextDone := func() {
-			waitingForTurn = false
-			if runCtx.Err() == context.DeadlineExceeded {
-				finishFirstItemWait("execution_timeout")
-				finalStatus = "timeout"
-				finalError = fmt.Sprintf("codex timed out after %s", timeout)
-			} else {
-				finishFirstItemWait("cancelled")
-				finalStatus = "aborted"
-				finalError = "execution cancelled"
-			}
-		}
 		for waitingForTurn {
 			select {
 			case aborted := <-turnDone:
@@ -1580,13 +1638,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 					Timeout:      firstTurnNoProgressTimeout,
 					LastActivity: lastSemanticActivityDescription,
 					ThreadID:     threadID,
-					TurnID:       c.turnID,
+					TurnID:       c.currentTurnID(),
 					Model:        opts.Model,
 				}
 				b.cfg.Logger.Warn(CodexFirstTurnNoProgressMarker,
 					"pid", cmd.Process.Pid,
 					"thread_id", threadID,
-					"turn_id", c.turnID,
+					"turn_id", c.currentTurnID(),
 					"timeout", firstTurnNoProgressTimeout.String(),
 					"last_activity", lastSemanticActivityDescription,
 				)
@@ -1599,13 +1657,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 					Timeout:      semanticInactivityTimeout,
 					LastActivity: lastSemanticActivityDescription,
 					ThreadID:     threadID,
-					TurnID:       c.turnID,
+					TurnID:       c.currentTurnID(),
 					Model:        opts.Model,
 				}
 				b.cfg.Logger.Warn(CodexSemanticInactivityMarker,
 					"pid", cmd.Process.Pid,
 					"thread_id", threadID,
-					"turn_id", c.turnID,
+					"turn_id", c.currentTurnID(),
 					"timeout", semanticInactivityTimeout.String(),
 					"last_activity", lastSemanticActivityDescription,
 					"idle_for", time.Since(lastSemanticActivity).Round(time.Millisecond).String(),
@@ -1631,6 +1689,9 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 					}
 				}
 			}
+		}
+		if finalStatus == "timeout" || runCtx.Err() != nil {
+			interruptActiveTurn()
 		}
 
 		duration := time.Since(startTime)
@@ -1692,7 +1753,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 				"active_launches", activeLaunches,
 				"method", "turn/start",
 				"thread_id", threadID,
-				"turn_id", c.turnID,
+				"turn_id", c.currentTurnID(),
 				"outcome", outcome,
 				"latency", waitLatency.Round(time.Millisecond).String(),
 				"latency_ms", waitLatency.Milliseconds(),
@@ -2194,6 +2255,7 @@ type codexClient struct {
 	threadSetupMethod      string
 	threadSetupStarted     time.Time
 	threadID               string
+	turnMu                 sync.RWMutex
 	turnID                 string
 	onMessage              func(Message)
 	onSemanticActivity     func(description string)
@@ -2444,6 +2506,32 @@ func (c *codexClient) request(ctx context.Context, method string, params any) (j
 		c.mu.Unlock()
 		return nil, codexRequestContextError(requestCtx)
 	}
+}
+
+func (c *codexClient) setTurnID(turnID string) {
+	if turnID == "" {
+		return
+	}
+	c.turnMu.Lock()
+	c.turnID = turnID
+	c.turnMu.Unlock()
+}
+
+func (c *codexClient) currentTurnID() string {
+	c.turnMu.RLock()
+	defer c.turnMu.RUnlock()
+	return c.turnID
+}
+
+func (c *codexClient) interruptTurn(ctx context.Context, threadID, turnID string) error {
+	if threadID == "" || turnID == "" {
+		return fmt.Errorf("codex turn/interrupt requires thread and turn IDs")
+	}
+	_, err := c.request(ctx, "turn/interrupt", map[string]any{
+		"threadId": threadID,
+		"turnId":   turnID,
+	})
+	return err
 }
 
 func (c *codexClient) notify(method string) {
@@ -3170,7 +3258,7 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 	switch method {
 	case "turn/started":
 		if turnID := extractNestedString(params, "turn", "id"); turnID != "" {
-			c.turnID = turnID
+			c.setTurnID(turnID)
 		}
 		if c.onMessage != nil {
 			c.onMessage(Message{Type: MessageStatus, Status: "running", SessionID: c.threadID})
@@ -3754,6 +3842,18 @@ func extractThreadID(result json.RawMessage) string {
 		return ""
 	}
 	return r.Thread.ID
+}
+
+func extractTurnID(result json.RawMessage) string {
+	var r struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(result, &r); err != nil {
+		return ""
+	}
+	return r.Turn.ID
 }
 
 func extractNestedString(m map[string]any, keys ...string) string {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -3678,6 +3679,86 @@ func TestCodexExecuteSurfacesUnsupportedServerRequestOnInterruptedTurn(t *testin
 	}
 	if !strings.Contains(result.Error, "unsupported codex app-server request: item/tool/call") {
 		t.Fatalf("expected unsupported request error, got %q", result.Error)
+	}
+}
+
+func TestCodexExecuteCancelsWithNativeTurnInterruptBeforeProcessShutdown(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	interruptCapture := filepath.Join(t.TempDir(), "turn-interrupt.json")
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+ // initialized notification
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-native-cancel"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{"turn":{"id":"turn-native-cancel"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-native-cancel","turn":{"id":"turn-native-cancel"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-native-cancel","turnId":"turn-native-cancel","item":{"type":"agentMessage","id":"msg-working","text":"working"}}}'`+"\n"+
+		`read line`+"\n"+
+		`printf '%s\n' "$line" > `+strconv.Quote(interruptCapture)+"\n"+
+		`echo '{"jsonrpc":"2.0","id":4,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-native-cancel","turn":{"id":"turn-native-cancel","status":"interrupted"}}}'`+"\n")
+
+	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	session, err := backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("execute: %v", err)
+	}
+	running := make(chan struct{})
+	var runningOnce sync.Once
+	go func() {
+		for msg := range session.Messages {
+			if msg.Type == MessageStatus && msg.Status == "running" {
+				runningOnce.Do(func() { close(running) })
+			}
+		}
+	}()
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("fake Codex turn never started")
+	}
+	cancel()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "aborted" {
+			t.Fatalf("cancelled result status = %q, want aborted (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled Codex session did not finish")
+	}
+
+	raw, err := os.ReadFile(interruptCapture)
+	if err != nil {
+		t.Fatalf("app-server never received turn/interrupt before shutdown: %v", err)
+	}
+	var request struct {
+		Method string `json:"method"`
+		Params struct {
+			ThreadID string `json:"threadId"`
+			TurnID   string `json:"turnId"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &request); err != nil {
+		t.Fatalf("decode captured interrupt request: %v", err)
+	}
+	if request.Method != "turn/interrupt" || request.Params.ThreadID != "thr-native-cancel" || request.Params.TurnID != "turn-native-cancel" {
+		t.Fatalf("native interrupt request = %+v, want current thread and turn", request)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes Multica stop an active Codex turn through the native app-server protocol before handing the conversation to a replacement task.

Today the Codex subprocess is created with the task context. Cancelling the task therefore triggers `exec.Cmd.Cancel`, which sends SIGKILL to the whole Codex process group before the backend can tell app-server to interrupt its active turn. The replacement has to recover whatever state survived that hard teardown.

This change separates the task deadline from the app-server process lifetime. On cancellation or timeout Multica now sends `turn/interrupt` with the current `threadId` and `turnId`, waits for the terminal turn notification within a bounded two-second window, and only then runs the existing graceful-close / process-group-kill cleanup. The replacement can resume the same persisted Codex thread and start the appended user message as the next turn.

This is intentionally Codex-only. Other providers keep their existing cancellation behavior.

## Relationship to #7818

This PR is rebased onto current `main`, which includes #7818. That merged change handles the lower-level workdir race by waiting for the previous execution to release its environment lock.

This PR covers the Codex protocol boundary: it interrupts the active Codex turn before the app-server process is closed. It no longer contains the separate environment-handoff registry from #7723.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement
- [ ] Documentation update
- [x] Tests

## Changes Made

- Split Codex's task context from its subprocess cleanup context so task cancellation cannot SIGKILL app-server before protocol shutdown.
- Capture the active turn ID from both `turn/start` responses and `turn/started` notifications.
- Send native `turn/interrupt(threadId, turnId)` on cancellation and watchdog timeout.
- Wait briefly for `turn/completed` so interrupted state is durable before closing stdio.
- Keep the existing bounded graceful shutdown and process-group SIGKILL fallback for old, crashed, or unresponsive app-servers.
- Add an end-to-end fake app-server regression that fails unless the interrupt RPC arrives before process shutdown with the exact active thread and turn IDs.

## How to Test

1. `cd server && go test ./pkg/agent -run 'TestCodex' -count=1`
2. `cd server && go test -race ./pkg/agent -run 'TestCodexExecute(CancelsWithNativeTurnInterruptBeforeProcessShutdown|TimeoutWinsOverProcessExitDuringActiveTurn|CleansUpWhenScannerOverflowsOnResume)' -count=1`
3. `cd server && go vet ./pkg/agent`

All three commands pass on the rebased head.

## Risk and fallback

Keeping app-server alive after task cancellation is bounded by the two-second interrupt context plus the existing bounded cleanup phases. If the active turn ID is unavailable, the method is unsupported, the process has already exited, or the RPC times out, Multica logs the reason and falls back to the existing process shutdown path. Non-Codex runtimes are untouched.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** The user asked for native Codex stop-and-continue semantics instead of killing a task and cold-starting a conversation. Codex traced task cancellation through the daemon and app-server backend, found that `CommandContext` killed the process group before any protocol interrupt was possible, implemented a bounded native turn handoff, and verified request ordering under race detection.
