### PR TITLE
fix(skills): enforce portable supporting-file paths

### DIFF
--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
 
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	"github.com/multica-ai/multica/server/pkg/skillbundle"
 )
 
@@ -155,14 +155,7 @@ func validateSkillBundle(ref SkillRefData, bundle SkillData) bool {
 }
 
 func safeSkillFilePath(p string) bool {
-	if p == "" || strings.Contains(p, "\x00") || strings.HasPrefix(p, "/") || strings.Contains(p, "\\") {
-		return false
-	}
-	clean := path.Clean(p)
-	if clean == "." || clean != p || strings.HasPrefix(clean, "../") || clean == ".." {
-		return false
-	}
-	return true
+	return skillpkg.IsSafeFilePath(p)
 }
 
 func safeCacheSegment(s string) string {

--- a/server/internal/daemon/skill_cache_test.go
+++ b/server/internal/daemon/skill_cache_test.go
@@ -74,6 +74,17 @@ func TestSkillBundleCacheRejectsCorruptBundle(t *testing.T) {
 	}
 }
 
+// The complete path matrix lives beside skill.IsSafeFilePath. This test only
+// verifies that the daemon wrapper uses the shared contract.
+func TestSafeSkillFilePathUsesSharedContract(t *testing.T) {
+	if !safeSkillFilePath("references/example.md") {
+		t.Fatal("expected canonical nested path to be accepted")
+	}
+	if safeSkillFilePath("C:/outside.txt") {
+		t.Fatal("expected Windows drive path to be rejected")
+	}
+}
+
 func testSkillBundle() SkillData {
 	bundle := SkillData{
 		ID:      "skill-1",

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -300,19 +300,9 @@ type AddAgentSkillsRequest struct {
 
 // --- Helpers ---
 
-// validateFilePath checks that a file path is safe (no traversal, no absolute paths).
+// validateFilePath checks that a file path uses the shared supporting-file contract.
 func validateFilePath(p string) bool {
-	if p == "" {
-		return false
-	}
-	if filepath.IsAbs(p) {
-		return false
-	}
-	cleaned := filepath.Clean(p)
-	if strings.HasPrefix(cleaned, "..") {
-		return false
-	}
-	return true
+	return skillpkg.IsSafeFilePath(p)
 }
 
 func (h *Handler) loadSkillForUser(w http.ResponseWriter, r *http.Request, id string) (db.Skill, bool) {

--- a/server/internal/handler/skill_path_test.go
+++ b/server/internal/handler/skill_path_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// The complete path matrix lives beside skill.IsSafeFilePath. These checks
+// prove that each public write route applies that shared contract.
+func TestSkillFileWriteEndpointsRejectNonCanonicalPaths(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+
+	skillID := dbfx.Insert(t, "skill", testutil.Cols{
+		"workspace_id": testWorkspaceID,
+		"name":         "skill-path-validation-fixture",
+		"description":  "fixture for path validation",
+		"content":      "# Skill path validation",
+		"created_by":   testUserID,
+	})
+
+	t.Run("create", func(t *testing.T) {
+		req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", CreateSkillRequest{
+			Name:    "skill-path-validation-create",
+			Content: "# Skill path validation",
+			Files: []CreateSkillFileRequest{
+				{Path: "references//guide.md", Content: "guide"},
+			},
+		})
+		testutil.Call(t, testHandler.CreateSkill, req).Want(http.StatusBadRequest)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		req := newRequest(http.MethodPut, "/api/skills/"+skillID, UpdateSkillRequest{
+			Files: []CreateSkillFileRequest{
+				{Path: "references/./guide.md", Content: "guide"},
+			},
+		})
+		req = withURLParam(req, "id", skillID)
+		testutil.Call(t, testHandler.UpdateSkill, req).Want(http.StatusBadRequest)
+	})
+
+	t.Run("upsert file", func(t *testing.T) {
+		req := newRequest(http.MethodPut, "/api/skills/"+skillID+"/files", CreateSkillFileRequest{
+			Path:    `references\guide.md`,
+			Content: "guide",
+		})
+		req = withURLParam(req, "id", skillID)
+		testutil.Call(t, testHandler.UpsertSkillFile, req).Want(http.StatusBadRequest)
+	})
+}

--- a/server/internal/skill/file_path.go
+++ b/server/internal/skill/file_path.go
@@ -1,0 +1,24 @@
+package skill
+
+import (
+	"path"
+	"strings"
+)
+
+// IsSafeFilePath reports whether filePath is a canonical, slash-delimited
+// supporting-file path accepted consistently by the server and daemon.
+func IsSafeFilePath(filePath string) bool {
+	if filePath == "" || strings.Contains(filePath, "\x00") || strings.HasPrefix(filePath, "/") || strings.Contains(filePath, "\\") {
+		return false
+	}
+	if len(filePath) >= 2 && filePath[1] == ':' && isASCIILetter(filePath[0]) {
+		return false
+	}
+
+	clean := path.Clean(filePath)
+	return clean != "." && clean == filePath && clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}

--- a/server/internal/skill/file_path_test.go
+++ b/server/internal/skill/file_path_test.go
@@ -1,0 +1,40 @@
+package skill
+
+import "testing"
+
+func TestIsSafeFilePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{name: "file", filePath: "reference.md", want: true},
+		{name: "nested file", filePath: "references/example.md", want: true},
+		{name: "dot-prefixed file", filePath: "..notes.md", want: true},
+		{name: "empty", filePath: "", want: false},
+		{name: "NUL", filePath: "file\x00.txt", want: false},
+		{name: "slash rooted", filePath: "/abs/file.txt", want: false},
+		{name: "slash UNC", filePath: "//server/share/file.txt", want: false},
+		{name: "relative backslash", filePath: `agents\openai.yaml`, want: false},
+		{name: "backslash rooted", filePath: `\abs\file.txt`, want: false},
+		{name: "Windows drive absolute with backslashes", filePath: `C:\abs\file.txt`, want: false},
+		{name: "Windows drive absolute with slashes", filePath: "C:/abs/file.txt", want: false},
+		{name: "Windows drive relative", filePath: `C:relative.txt`, want: false},
+		{name: "backslash UNC", filePath: `\\server\share\file.txt`, want: false},
+		{name: "parent traversal with slashes", filePath: "../escape.txt", want: false},
+		{name: "parent traversal with backslashes", filePath: `..\escape.txt`, want: false},
+		{name: "embedded traversal", filePath: "safe/../escape.txt", want: false},
+		{name: "duplicate separators", filePath: "safe//file.txt", want: false},
+		{name: "dot segment", filePath: "safe/./file.txt", want: false},
+		{name: "dot", filePath: ".", want: false},
+		{name: "trailing slash", filePath: "safe/", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSafeFilePath(tt.filePath); got != tt.want {
+				t.Fatalf("IsSafeFilePath(%q) = %v, want %v", tt.filePath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Skill supporting-file paths are written by the authoring API and later consumed by daemon bundle validation. Those two boundaries currently use different, host-dependent rules: the API uses path/filepath, while the daemon expects canonical slash-delimited paths. On a Linux server, direct create, update, and file-upsert requests can therefore persist backslashes or other non-canonical paths that the daemon later rejects.

This PR introduces one host-independent supporting-file path contract and applies it at both boundaries. It rejects absolute, drive-prefixed, backslash-delimited, traversal, NUL-containing, and non-canonical paths before persistence, while keeping daemon validation aligned with the same rule.

## Related Issue

Related to #6893.
Complementary to #6899, whose review identified the sibling authoring endpoints as another path that can persist daemon-invalid file paths.

This PR does not auto-close #6893 because it does not remediate already-persisted invalid paths or normalize CRLF file content.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add skill.IsSafeFilePath as the canonical slash-delimited supporting-file path contract.
- Reuse the shared contract in skill create, update, file-upsert, and daemon bundle validation.
- Add a platform-independent path matrix covering Windows drive paths, UNC/backslash paths, traversal, NUL bytes, and non-canonical segments.
- Add database-backed regression coverage for all three public authoring routes.

## How to Test

1. Run the shared path matrix:

       cd server
       go test ./internal/skill -run '^TestIsSafeFilePath$' -count=1

2. Run the daemon wiring regression:

       go test ./internal/daemon -run '^TestSafeSkillFilePathUsesSharedContract$' -count=1

3. With PostgreSQL available and migrations applied, run the authoring endpoint regressions:

       go test ./internal/handler -run '^TestSkillFileWriteEndpointsRejectNonCanonicalPaths$' -count=1 -v

4. Run static checks:

       go vet ./internal/skill ./internal/handler ./internal/daemon

All commands above pass locally on Windows. Root TypeScript typecheck also passes. The unrelated full frontend unit suite is not green in this native Windows checkout because the existing type-scale contract reports Windows path separators and a Vitest worker exits unexpectedly; this PR changes only server Go files, so PR CI will select the backend validation jobs.

## Risks

- Requests using previously accepted non-canonical paths will now receive a bad-request response.
- Existing database rows with invalid paths are not rewritten by this change.
- A dot-prefixed filename such as ..notes.md is accepted because it is a filename, not a traversal segment; this aligns the API with the daemon's existing slash-based rule.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] UI screenshots are not applicable because this change only affects server-side path validation
- [x] Documentation changes are not required because no public workflow or API shape changes
- [x] Landing copy and product documentation synchronization are not applicable
- [x] Chinese product copy review is not applicable
- [x] I have considered and documented the risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I used Codex to trace the path from skill authoring endpoints through database persistence to daemon bundle validation, compare the host-dependent and slash-based rules, build a shared validation contract, and add regression tests at the contract and public-route boundaries. I manually reviewed the final six-file diff for repository-local branding or environment data and verified the targeted tests against an isolated PostgreSQL worktree database.

## Screenshots (optional)

Not applicable.