### PR TITLE
fix(redact): mask custom home directory paths

### DIFF
--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -172,10 +172,31 @@ func Text(s string) string {
 	}
 
 	// Redact home directory paths (e.g. /Users/john/ → /Users/****/).
-	if homeDir != "" && username != "" {
-		masked := strings.Replace(homeDir, username, "****", 1)
+	if homeDir != "" {
+		masked := maskHomeDirectory(homeDir, username)
 		s = strings.ReplaceAll(s, homeDir, masked)
 	}
 
 	return s
+}
+
+func maskHomeDirectory(home, currentUsername string) string {
+	if currentUsername != "" {
+		masked := strings.Replace(home, currentUsername, "****", 1)
+		if masked != home {
+			return masked
+		}
+	}
+
+	// A container may override HOME without changing the process account.
+	// Mask the final path component so that setup remains privacy-safe.
+	trimmed := strings.TrimRight(home, `/\`)
+	if trimmed == "" {
+		return home
+	}
+	separator := strings.LastIndexAny(trimmed, `/\`)
+	if separator < 0 {
+		return "****" + home[len(trimmed):]
+	}
+	return trimmed[:separator+1] + "****" + home[len(trimmed):]
 }

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -212,6 +212,27 @@ func TestRedactHomeDirectory(t *testing.T) {
 	}
 }
 
+func TestMaskHomeDirectoryWithOverriddenHome(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		home     string
+		username string
+		want     string
+	}{
+		{name: "matching username", home: "/home/runner", username: "runner", want: "/home/****"},
+		{name: "different process user", home: "/home/runner", username: "multica", want: "/home/****"},
+		{name: "windows home", home: `C:\Users\runner`, username: "multica", want: `C:\Users\****`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maskHomeDirectory(tc.home, tc.username); got != tc.want {
+				t.Fatalf("maskHomeDirectory(%q, %q) = %q, want %q", tc.home, tc.username, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNoFalsePositivesOnNormalText(t *testing.T) {
 	t.Parallel()
 	inputs := []string{


### PR DESCRIPTION
## What does this PR do?

Multica already intends to redact the local home directory from agent output, but the current implementation only masks it when os.UserHomeDir() contains os/user.Current().Username as an exact, case-sensitive substring.

That assumption does not hold when Windows returns a differently shaped account name or when a container overrides HOME without changing the process account. In those environments, the full home path remains visible.

Thinking path:

- Keep the existing redaction boundary in Text rather than adding a second caller-specific scrubber.
- Preserve the current exact username replacement when it succeeds.
- Fall back to masking the final home-directory component when the account name and resolved home path differ.
- Cover matching, overridden Unix, and Windows-shaped home paths with a table-driven regression test.

## Related Issue

No public issue exists. This is a small, self-contained bug reproduced by the existing redaction test on Windows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- server/pkg/redact/redact.go: mask resolved home paths even when the process username is absent from the path.
- server/pkg/redact/redact_test.go: cover matching usernames, overridden HOME values, and Windows paths.

## How to Test

1. On upstream/main before this patch, run go test ./pkg/redact -count=1 on Windows. TestRedactHomeDirectory fails because the home path remains unchanged.
2. On this branch, run go test ./pkg/redact -count=1. The package passes.
3. Run go vet ./pkg/redact and git diff --check upstream/main...HEAD.

Additional validation:

- go test ./pkg/redact -count=1 passed.
- go vet ./pkg/redact passed.
- git diff --check upstream/main...HEAD passed.
- go test ./pkg/... -count=1 was also attempted. Unrelated server/pkg/agent failures involving Windows process behavior and missing fake CLI executables reproduced on an unmodified upstream worktree. pkg/redact failed only before this patch and passed after it.
- make check-worktree was not run because GNU Make is unavailable in this Windows environment.

Risk is low: the change only affects how the already-resolved local home path is replaced in redacted text. It does not change APIs, persistence, or UI behavior.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The conditional UI, documentation, runtime, and Chinese-copy checklist items are not applicable to this backend-only fix.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Codex was used to audit an existing downstream fix, reproduce the failure on the latest upstream main before modification, manually port only the minimal Go helper and regression test, review the complete diff for downstream-specific content, and run targeted tests plus an unmodified-upstream baseline comparison. I reviewed and authorized the resulting contribution.

## Screenshots (optional)

Not applicable; there is no visual change.