### PR TITLE
MUL-6827: fix(usage): include live token tail in reports

### DIFF
--- a/server/internal/handler/dashboard_test.go
+++ b/server/internal/handler/dashboard_test.go
@@ -703,6 +703,98 @@ func TestRollupTaskUsageHourlyIdempotentAndWatermark(t *testing.T) {
 	}
 }
 
+// TestUsageReportsReadTheLiveTail proves a just-finished task is visible
+// before the five-minute-safe rollup watermark reaches it. A stale materialized
+// row is seeded in the same current-hour bucket as well: the live view must
+// replace that whole bucket from raw task_usage, not add both copies together.
+func TestUsageReportsReadTheLiveTail(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	var runtimeID, agentID string
+	dbfx.QueryRow(t, `SELECT id FROM agent_runtime WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&runtimeID)
+	dbfx.QueryRow(t, `SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID)
+
+	const model = "live-tail-regression-model"
+	taskID := dbfx.Insert(t, "agent_task_queue", testutil.Cols{
+		"agent_id":     agentID,
+		"runtime_id":   runtimeID,
+		"status":       "completed",
+		"created_at":   testutil.Raw("now()"),
+		"started_at":   testutil.Raw("now() - interval '1 minute'"),
+		"completed_at": testutil.Raw("now()"),
+	})
+	dbfx.Insert(t, "task_usage", testutil.Cols{
+		"task_id":       taskID,
+		"provider":      "codex",
+		"model":         model,
+		"input_tokens":  4242,
+		"output_tokens": 58,
+		"created_at":    testutil.Raw("now()"),
+		"updated_at":    testutil.Raw("now()"),
+	})
+	dbfx.InsertNoID(t, "task_usage_hourly", testutil.Cols{
+		"bucket_hour":   testutil.Raw("task_usage_hour_bucket(now())"),
+		"workspace_id":  testWorkspaceID,
+		"runtime_id":    runtimeID,
+		"agent_id":      agentID,
+		"project_id":    nil,
+		"provider":      "codex",
+		"model":         model,
+		"input_tokens":  999,
+		"output_tokens": 1,
+		"task_count":    1,
+		"event_count":   1,
+	}, "workspace_id = $1 AND runtime_id = $2 AND agent_id = $3 AND provider = $4 AND model = $5",
+		testWorkspaceID, runtimeID, agentID, "codex", model)
+
+	daily := testutil.Call(t, testHandler.GetDashboardUsageDaily,
+		newRequest("GET", "/api/dashboard/usage/daily?days=1&tz=UTC", nil)).Want(http.StatusOK)
+	var dailyRows []DashboardUsageDailyResponse
+	daily.JSON(&dailyRows)
+	var dailyInput int64
+	for _, row := range dailyRows {
+		if row.Model == model {
+			dailyInput += row.InputTokens
+		}
+	}
+	if dailyInput != 4242 {
+		t.Fatalf("dashboard daily live-tail input = %d, want 4242", dailyInput)
+	}
+
+	byAgent := testutil.Call(t, testHandler.GetDashboardUsageByAgent,
+		newRequest("GET", "/api/dashboard/usage/by-agent?days=1&tz=UTC", nil)).Want(http.StatusOK)
+	var agentRows []DashboardUsageByAgentResponse
+	byAgent.JSON(&agentRows)
+	var agentInput int64
+	for _, row := range agentRows {
+		if row.Model == model {
+			agentInput += row.InputTokens
+		}
+	}
+	if agentInput != 4242 {
+		t.Fatalf("dashboard by-agent live-tail input = %d, want 4242", agentInput)
+	}
+
+	runtimeReq := withURLParam(
+		newRequest("GET", "/api/runtimes/"+runtimeID+"/usage?days=1&tz=UTC", nil),
+		"runtimeId", runtimeID,
+	)
+	runtimeUsage := testutil.Call(t, testHandler.GetRuntimeUsage, runtimeReq).Want(http.StatusOK)
+	var runtimeRows []RuntimeUsageResponse
+	runtimeUsage.JSON(&runtimeRows)
+	var runtimeInput int64
+	for _, row := range runtimeRows {
+		if row.Model == model {
+			runtimeInput += row.InputTokens
+		}
+	}
+	if runtimeInput != 4242 {
+		t.Fatalf("runtime live-tail input = %d, want 4242", runtimeInput)
+	}
+}
+
 // TestRollupTaskUsageHourlyReassignBetweenRuntimes ports the invalidation
 // coverage the deleted runtime_rollup_test.go held for the legacy daily
 // rollup. Reassigning a task between runtimes (the runtime-merge path) must

--- a/server/migrations/441_task_usage_hourly_live.down.sql
+++ b/server/migrations/441_task_usage_hourly_live.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS task_usage_hourly_live;

--- a/server/migrations/441_task_usage_hourly_live.up.sql
+++ b/server/migrations/441_task_usage_hourly_live.up.sql
@@ -1,0 +1,72 @@
+-- Keep usage reports current without weakening the hourly rollup's five-minute
+-- safety lag. Historical buckets continue to come from task_usage_hourly; the
+-- bucket that contains the lag boundary (and every newer bucket) is rebuilt
+-- from raw task_usage rows at read time.
+--
+-- The boundary is rounded down to an hour. At most 65 minutes of raw rows are
+-- scanned in steady state: five minutes of intentional lag plus the remainder
+-- of the boundary hour. Splitting on a whole bucket is what prevents a row
+-- already present in the rollup from being counted again in the live tail.
+CREATE VIEW task_usage_hourly_live AS
+WITH boundary AS (
+    SELECT task_usage_hour_bucket(now() - INTERVAL '5 minutes') AS cutoff
+),
+rolled AS (
+    SELECT
+        h.bucket_hour,
+        h.workspace_id,
+        h.runtime_id,
+        h.agent_id,
+        h.project_id,
+        h.provider,
+        h.model,
+        h.input_tokens,
+        h.output_tokens,
+        h.cache_read_tokens,
+        h.cache_write_tokens,
+        h.cost_usd_ticks,
+        COALESCE(h.uncosted_input_tokens, h.input_tokens)::bigint AS uncosted_input_tokens,
+        COALESCE(h.uncosted_output_tokens, h.output_tokens)::bigint AS uncosted_output_tokens,
+        COALESCE(h.uncosted_cache_read_tokens, h.cache_read_tokens)::bigint AS uncosted_cache_read_tokens,
+        COALESCE(h.uncosted_cache_write_tokens, h.cache_write_tokens)::bigint AS uncosted_cache_write_tokens,
+        h.task_count,
+        h.event_count
+    FROM task_usage_hourly h
+    CROSS JOIN boundary b
+    WHERE h.bucket_hour < b.cutoff
+),
+live_tail AS (
+    SELECT
+        task_usage_hour_bucket(tu.created_at) AS bucket_hour,
+        a.workspace_id,
+        atq.runtime_id,
+        atq.agent_id,
+        i.project_id,
+        tu.provider,
+        tu.model,
+        SUM(tu.input_tokens)::bigint AS input_tokens,
+        SUM(tu.output_tokens)::bigint AS output_tokens,
+        SUM(tu.cache_read_tokens)::bigint AS cache_read_tokens,
+        SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens,
+        COALESCE(SUM(tu.cost_usd_ticks), 0)::bigint AS cost_usd_ticks,
+        COALESCE(SUM(tu.input_tokens) FILTER (WHERE tu.cost_usd_ticks IS NULL), 0)::bigint AS uncosted_input_tokens,
+        COALESCE(SUM(tu.output_tokens) FILTER (WHERE tu.cost_usd_ticks IS NULL), 0)::bigint AS uncosted_output_tokens,
+        COALESCE(SUM(tu.cache_read_tokens) FILTER (WHERE tu.cost_usd_ticks IS NULL), 0)::bigint AS uncosted_cache_read_tokens,
+        COALESCE(SUM(tu.cache_write_tokens) FILTER (WHERE tu.cost_usd_ticks IS NULL), 0)::bigint AS uncosted_cache_write_tokens,
+        COUNT(DISTINCT tu.task_id)::bigint AS task_count,
+        COUNT(*)::bigint AS event_count
+    FROM task_usage tu
+    JOIN agent_task_queue atq ON atq.id = tu.task_id
+    JOIN agent a ON a.id = atq.agent_id
+    LEFT JOIN issue i ON i.id = atq.issue_id
+    CROSS JOIN boundary b
+    WHERE atq.runtime_id IS NOT NULL
+      AND tu.created_at >= b.cutoff
+    GROUP BY 1, 2, 3, 4, 5, 6, 7
+)
+SELECT * FROM rolled
+UNION ALL
+SELECT * FROM live_tail;
+
+COMMENT ON VIEW task_usage_hourly_live IS
+    'Hourly usage with a raw live tail for the rollup safety-lag window. Use for reports; keep task_usage_hourly as the materialized storage table.';

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -1376,6 +1376,28 @@ type TaskUsageHourlyDirty struct {
 	EnqueuedAt  pgtype.Timestamptz `json:"enqueued_at"`
 }
 
+// Hourly usage with a raw live tail for the rollup safety-lag window. Use for reports; keep task_usage_hourly as the materialized storage table.
+type TaskUsageHourlyLive struct {
+	BucketHour               pgtype.Timestamptz `json:"bucket_hour"`
+	WorkspaceID              pgtype.UUID        `json:"workspace_id"`
+	RuntimeID                pgtype.UUID        `json:"runtime_id"`
+	AgentID                  pgtype.UUID        `json:"agent_id"`
+	ProjectID                pgtype.UUID        `json:"project_id"`
+	Provider                 string             `json:"provider"`
+	Model                    string             `json:"model"`
+	InputTokens              int64              `json:"input_tokens"`
+	OutputTokens             int64              `json:"output_tokens"`
+	CacheReadTokens          int64              `json:"cache_read_tokens"`
+	CacheWriteTokens         int64              `json:"cache_write_tokens"`
+	CostUsdTicks             int64              `json:"cost_usd_ticks"`
+	UncostedInputTokens      int64              `json:"uncosted_input_tokens"`
+	UncostedOutputTokens     int64              `json:"uncosted_output_tokens"`
+	UncostedCacheReadTokens  int64              `json:"uncosted_cache_read_tokens"`
+	UncostedCacheWriteTokens int64              `json:"uncosted_cache_write_tokens"`
+	TaskCount                int64              `json:"task_count"`
+	EventCount               int64              `json:"event_count"`
+}
+
 type TaskUsageHourlyRollupState struct {
 	ID                int16              `json:"id"`
 	WatermarkAt       pgtype.Timestamptz `json:"watermark_at"`

--- a/server/pkg/db/generated/runtime_usage.sql.go
+++ b/server/pkg/db/generated/runtime_usage.sql.go
@@ -151,7 +151,7 @@ SELECT
     SUM(COALESCE(uncosted_output_tokens, output_tokens))::bigint         AS uncosted_output_tokens,
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE runtime_id = $1
   AND bucket_hour >= $3::timestamptz
 GROUP BY DATE(bucket_hour AT TIME ZONE $2::text), LOWER(provider), model

--- a/server/pkg/db/generated/task_usage.sql.go
+++ b/server/pkg/db/generated/task_usage.sql.go
@@ -418,7 +418,7 @@ SELECT
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens,
     SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE workspace_id = $1
   AND bucket_hour >= $2::timestamptz
   AND ($3::uuid IS NULL OR project_id = $3)
@@ -511,7 +511,7 @@ SELECT
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens,
     SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE workspace_id = $1
   AND bucket_hour >= $3::timestamptz
   AND ($4::uuid IS NULL OR project_id = $4)

--- a/server/pkg/db/queries/runtime_usage.sql
+++ b/server/pkg/db/queries/runtime_usage.sql
@@ -23,7 +23,7 @@ SELECT
     SUM(COALESCE(uncosted_output_tokens, output_tokens))::bigint         AS uncosted_output_tokens,
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE runtime_id = $1
   AND bucket_hour >= sqlc.arg('since')::timestamptz
 GROUP BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text), LOWER(provider), model

--- a/server/pkg/db/queries/task_usage.sql
+++ b/server/pkg/db/queries/task_usage.sql
@@ -97,7 +97,7 @@ SELECT
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens,
     SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE workspace_id = $1
   AND bucket_hour >= sqlc.arg('since')::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
@@ -133,7 +133,7 @@ SELECT
     SUM(COALESCE(uncosted_cache_read_tokens, cache_read_tokens))::bigint AS uncosted_cache_read_tokens,
     SUM(COALESCE(uncosted_cache_write_tokens, cache_write_tokens))::bigint AS uncosted_cache_write_tokens,
     SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
+FROM task_usage_hourly_live
 WHERE workspace_id = $1
   AND bucket_hour >= @since::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))


### PR DESCRIPTION
## Summary

- add a `task_usage_hourly_live` view that keeps materialized historical buckets but rebuilds the boundary and recent buckets from raw `task_usage`
- switch daily, by-agent, and by-runtime usage reports to the live view
- add a regression test proving a completed task's raw usage wins over a stale materialized bucket

## Why

`task_usage_hourly` intentionally excludes the newest five minutes while its hourly rollup refreshes. Reports that read it directly can therefore show zero or stale token usage immediately after a task finishes.

The live view preserves the rollup for older data and scans at most the last 65 minutes of raw events. It replaces whole boundary/recent buckets instead of adding both sources, so it does not double-count usage.

## Validation

- `make sqlc`
- `go test ./internal/handler -run '^TestUsageReportsReadTheLiveTail$' -count=1`
- migration `441_task_usage_hourly_live` applied and tested against a temporary PostgreSQL database
