### PR TITLE
MUL-6826 fix(core): widen React peer dependency range

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -171,7 +171,7 @@
     "zustand": "catalog:"
   },
   "peerDependencies": {
-    "react": "catalog:"
+    "react": ">=19.2.0 <20"
   },
   "devDependencies": {
     "@multica/eslint-config": "workspace:*",


### PR DESCRIPTION
## What does this PR do?

`@multica/core` currently declares React through the workspace catalog in `peerDependencies`. When the package is packed, pnpm resolves that entry to the exact catalog version (`19.2.3`). The first-party Mobile app consumes `@multica/core` while pinning React `19.2.0`, so the packed Core package reports an unmet peer for a React version already used in this repository.

This changes the peer contract to `>=19.2.0 <20`. Core keeps `catalog:` in `devDependencies`, so its own development and test runtime remains unchanged.

Thinking path:

1. Core is the shared package consumed by Web, Desktop, and Mobile.
2. A peer dependency should describe compatible consumer versions, while the development dependency selects the version used to validate Core itself.
3. The repository's first-party consumers establish React `19.2.0` as the compatibility floor, while `<20` avoids claiming support for an untested major version.
4. The fix is limited to package metadata; it does not change runtime code or the lockfile.

Risk is limited to accepting other React 19 patch/minor versions. Core tests still run with the catalog version, and Mobile typechecks with React `19.2.0`.

## Related Issue

None. The mismatch is directly reproducible from the repository's first-party manifests and packed package metadata.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/core/package.json` so the React peer accepts supported React 19 versions from `19.2.0` onward.

## How to Test

1. Pack the baseline Core package and inspect `package/package.json`; its React peer resolves to exactly `19.2.3`.
2. Install that tarball beside React `19.2.0` with pnpm `10.28.2`; pnpm reports `unmet peer react@19.2.3: found 19.2.0`.
3. Pack this branch and repeat the same installation; the React peer is `>=19.2.0 <20` and the warning is gone.
4. Run:
   - `corepack pnpm install --frozen-lockfile --strict-peer-dependencies --ignore-scripts`
   - `corepack pnpm --filter @multica/core lint`
   - `corepack pnpm --filter @multica/core typecheck`
   - `corepack pnpm --filter @multica/core test` (139 files, 1,671 tests)
   - `corepack pnpm --filter @multica/mobile typecheck`

All listed checks pass locally with pnpm `10.28.2`. GNU Make and Node 22 are not available in this Windows environment (local Node is `24.20.0`), so `make check-worktree` was not run; GitHub CI remains the Node 22/full-suite validation gate.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (not applicable: manifest-only change; verified through packed consumer metadata and existing suites)
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable: no documented behavior changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** I used Codex to trace the React versions across the workspace manifests, inspect pnpm's packed peer metadata before and after the change, search for duplicate contributions, apply the one-line manifest fix, and run the package-level verification listed above. I manually reviewed the final diff and contribution scope before submission.

## Screenshots (optional)

Not applicable; this change has no UI effect.