### PR TITLE
fix(chat): open first conversation on entry

### DIFF
--- a/packages/views/chat/chat-page.test.tsx
+++ b/packages/views/chat/chat-page.test.tsx
@@ -42,7 +42,17 @@ vi.mock("./components/chat-thread-list", () => ({
   ),
 }));
 vi.mock("./components/chat-session-header", () => ({
-  ChatSessionHeader: () => <div>chat-session-header</div>,
+  ChatSessionHeader: ({
+    session,
+    onArchive,
+  }: {
+    session: ChatSession;
+    onArchive: (session: ChatSession) => void;
+  }) => (
+    <button type="button" onClick={() => onArchive(session)}>
+      archive-current
+    </button>
+  ),
 }));
 vi.mock("./components/chat-empty-state", () => ({
   EmptyState: () => <div>chat-empty-state</div>,
@@ -101,7 +111,6 @@ const agentsSettledRef = vi.hoisted(() => ({ current: true }));
 const sessionsRef = vi.hoisted(() => ({ current: [] as ChatSession[] }));
 const sessionsLoadedRef = vi.hoisted(() => ({ current: true }));
 const mockStartNewChat = vi.hoisted(() => vi.fn());
-const mockHandleSelectSession = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
 const mockSetActiveSession = vi.hoisted(() =>
   vi.fn((id: string | null) => {
@@ -109,6 +118,19 @@ const mockSetActiveSession = vi.hoisted(() =>
     storeListeners.forEach((l) => l());
   }),
 );
+const mockHandleSelectSession = vi.hoisted(() =>
+  vi.fn((session: ChatSession) => mockSetActiveSession(session.id)),
+);
+const mockAdvanceSelectionAfterArchive = vi.hoisted(() =>
+  vi.fn((archived: ChatSession) => {
+    const next = sessionsRef.current.find(
+      (candidate) =>
+        candidate.status === "active" && candidate.id !== archived.id,
+    );
+    mockSetActiveSession(next?.id ?? null);
+  }),
+);
+const mockArchiveSession = vi.hoisted(() => vi.fn());
 const subscribeToStore = vi.hoisted(() => (cb: () => void) => {
   storeListeners.add(cb);
   return () => storeListeners.delete(cb);
@@ -142,7 +164,10 @@ vi.mock("./components/use-chat-controller", async () => {
         () => storeRef.current,
       ).activeSessionId,
       selectedAgentId: null,
-      currentSession: null,
+      currentSession:
+        sessionsRef.current.find(
+          (session) => session.id === storeRef.current.activeSessionId,
+        ) ?? null,
       isSessionArchived: false,
       isAgentArchived: false,
       isAgentRuntimeBound: true,
@@ -167,8 +192,8 @@ vi.mock("./components/use-chat-controller", async () => {
       handleNewChat: vi.fn(),
       handleStartNewChat: mockStartNewChat,
       handleSelectSession: mockHandleSelectSession,
-      advanceSelectionAfterArchive: vi.fn(),
-      archiveSession: vi.fn(),
+      advanceSelectionAfterArchive: mockAdvanceSelectionAfterArchive,
+      archiveSession: mockArchiveSession,
       setActiveSession: mockSetActiveSession,
       setSelectedAgentId: vi.fn(),
     }),
@@ -225,15 +250,16 @@ function session(
 
 function renderPage(search: string, { strict = false } = {}) {
   const replace = vi.fn();
-  const navigation: NavigationAdapter = {
+  let currentSearch = search;
+  const navigation = (): NavigationAdapter => ({
     push: vi.fn(),
     replace,
     back: vi.fn(),
     pathname: "/acme/chat",
-    searchParams: new URLSearchParams(search),
+    searchParams: new URLSearchParams(currentSearch),
     hash: "",
     getShareableUrl: (path) => path,
-  };
+  });
   // A fresh element per render — reusing one element object lets React bail
   // out of re-rendering, which would make the rerender-based tests vacuous.
   // ChatPage reads the client-only quick-actions pending marker via useQuery,
@@ -243,7 +269,7 @@ function renderPage(search: string, { strict = false } = {}) {
     const page = (
       <QueryClientProvider client={qc}>
         <I18nProvider locale="en" resources={TEST_RESOURCES}>
-          <NavigationProvider value={navigation}>
+          <NavigationProvider value={navigation()}>
             <ChatPage />
           </NavigationProvider>
         </I18nProvider>
@@ -252,7 +278,13 @@ function renderPage(search: string, { strict = false } = {}) {
     return strict ? <StrictMode>{page}</StrictMode> : page;
   };
   const view = render(makeUi());
-  return { replace, rerender: () => view.rerender(makeUi()) };
+  return {
+    replace,
+    rerender: (nextSearch?: string) => {
+      if (nextSearch !== undefined) currentSearch = nextSearch;
+      view.rerender(makeUi());
+    },
+  };
 }
 
 beforeEach(() => {
@@ -283,6 +315,17 @@ describe("ChatPage default session", () => {
     expect(mockHandleSelectSession).toHaveBeenCalledWith(pinned);
   });
 
+  it("keeps the default selection under StrictMode effect replay", () => {
+    const latest = session("latest", "2026-08-29T12:00:00Z");
+    sessionsRef.current = [latest];
+
+    const { replace } = renderPage("", { strict: true });
+
+    expect(mockHandleSelectSession).toHaveBeenCalledOnce();
+    expect(storeRef.current.activeSessionId).toBe("latest");
+    expect(replace).toHaveBeenCalledWith("/acme/chat?session=latest");
+  });
+
   it("waits for sessions to load before choosing the default", () => {
     sessionsLoadedRef.current = false;
     sessionsRef.current = [];
@@ -310,6 +353,26 @@ describe("ChatPage default session", () => {
     renderPage("agent=agent-1");
     expect(mockHandleSelectSession).not.toHaveBeenCalled();
     expect(mockStartNewChat).toHaveBeenCalledWith(agent);
+  });
+
+  it("does not open another chat after archiving an explicit compact deep link", () => {
+    layout.width = FOLD_INNER;
+    const explicit = session("explicit", "2026-08-29T12:00:00Z");
+    const unrelated = session("unrelated", "2026-08-28T12:00:00Z");
+    sessionsRef.current = [explicit, unrelated];
+    storeRef.current = { activeSessionId: explicit.id };
+    const { replace, rerender } = renderPage("session=explicit");
+
+    fireEvent.click(screen.getByRole("button", { name: "archive-current" }));
+    expect(mockArchiveSession).toHaveBeenCalledWith("explicit");
+    expect(storeRef.current.activeSessionId).toBeNull();
+    expect(replace).toHaveBeenCalledWith("/acme/chat");
+
+    // Simulate the navigation adapter committing replace(). The explicit
+    // intent consumed the one-shot, so the remaining history stays closed.
+    rerender("");
+    expect(storeRef.current.activeSessionId).toBeNull();
+    expect(mockHandleSelectSession).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/chat/chat-page.test.tsx
+++ b/packages/views/chat/chat-page.test.tsx
@@ -4,7 +4,7 @@ import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { Agent } from "@multica/core/types";
+import type { Agent, ChatSession } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../locales/en/common.json";
 import enChat from "../locales/en/chat.json";
@@ -98,7 +98,10 @@ const storeRef = vi.hoisted(() => ({
 const storeListeners = vi.hoisted(() => new Set<() => void>());
 const availableAgentsRef = vi.hoisted(() => ({ current: [] as Agent[] }));
 const agentsSettledRef = vi.hoisted(() => ({ current: true }));
+const sessionsRef = vi.hoisted(() => ({ current: [] as ChatSession[] }));
+const sessionsLoadedRef = vi.hoisted(() => ({ current: true }));
 const mockStartNewChat = vi.hoisted(() => vi.fn());
+const mockHandleSelectSession = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
 const mockSetActiveSession = vi.hoisted(() =>
   vi.fn((id: string | null) => {
@@ -132,7 +135,8 @@ vi.mock("./components/use-chat-controller", async () => {
       agents: availableAgentsRef.current,
       availableAgents: availableAgentsRef.current,
       agentsSettled: agentsSettledRef.current,
-      sessions: [],
+      sessions: sessionsRef.current,
+      sessionsLoaded: sessionsLoadedRef.current,
       activeSessionId: useSyncExternalStore(
         subscribeToStore,
         () => storeRef.current,
@@ -162,7 +166,7 @@ vi.mock("./components/use-chat-controller", async () => {
       handleUploadFile: vi.fn(),
       handleNewChat: vi.fn(),
       handleStartNewChat: mockStartNewChat,
-      handleSelectSession: vi.fn(),
+      handleSelectSession: mockHandleSelectSession,
       advanceSelectionAfterArchive: vi.fn(),
       archiveSession: vi.fn(),
       setActiveSession: mockSetActiveSession,
@@ -199,6 +203,25 @@ const agent: Agent = {
 };
 
 const NO_ACCESS_MSG = "You don't have access to chat with this agent.";
+
+function session(
+  id: string,
+  updatedAt: string,
+  options: { status?: "active" | "archived"; pinned?: boolean } = {},
+): ChatSession {
+  return {
+    id,
+    workspace_id: "ws-1",
+    agent_id: "agent-1",
+    creator_id: "user-1",
+    title: id,
+    status: options.status ?? "active",
+    has_unread: false,
+    pinned: options.pinned,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  };
+}
 
 function renderPage(search: string, { strict = false } = {}) {
   const replace = vi.fn();
@@ -238,7 +261,56 @@ beforeEach(() => {
   storeListeners.clear();
   availableAgentsRef.current = [agent];
   agentsSettledRef.current = true;
+  sessionsRef.current = [];
+  sessionsLoadedRef.current = true;
   layout.width = DESKTOP;
+});
+
+describe("ChatPage default session", () => {
+  it("opens the first active history row when entering bare Chat", () => {
+    const recent = session("recent", "2026-08-29T12:00:00Z");
+    const pinned = session("pinned", "2026-08-28T12:00:00Z", { pinned: true });
+    sessionsRef.current = [
+      session("archived", "2026-08-30T12:00:00Z", { status: "archived" }),
+      recent,
+      pinned,
+    ];
+
+    renderPage("");
+
+    // The same pinned-first ordering as ChatThreadList defines its first row.
+    expect(mockHandleSelectSession).toHaveBeenCalledOnce();
+    expect(mockHandleSelectSession).toHaveBeenCalledWith(pinned);
+  });
+
+  it("waits for sessions to load before choosing the default", () => {
+    sessionsLoadedRef.current = false;
+    sessionsRef.current = [];
+    const { rerender } = renderPage("");
+    expect(mockHandleSelectSession).not.toHaveBeenCalled();
+
+    const recent = session("recent", "2026-08-29T12:00:00Z");
+    sessionsLoadedRef.current = true;
+    sessionsRef.current = [recent];
+    rerender();
+
+    expect(mockHandleSelectSession).toHaveBeenCalledWith(recent);
+  });
+
+  it("does not replace an explicit session deep link", () => {
+    sessionsRef.current = [session("recent", "2026-08-29T12:00:00Z")];
+
+    renderPage("session=explicit");
+    expect(mockHandleSelectSession).not.toHaveBeenCalled();
+  });
+
+  it("does not replace a new-agent deep link", () => {
+    sessionsRef.current = [session("recent", "2026-08-29T12:00:00Z")];
+
+    renderPage("agent=agent-1");
+    expect(mockHandleSelectSession).not.toHaveBeenCalled();
+    expect(mockStartNewChat).toHaveBeenCalledWith(agent);
+  });
 });
 
 describe("ChatPage ?agent= deep link", () => {

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -13,7 +13,10 @@ import {
 import { useIsCompact } from "@multica/ui/hooks/use-mobile";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useChatStore } from "@multica/core/chat";
-import { chatQuickActionsPendingOptions } from "@multica/core/chat/queries";
+import {
+  chatQuickActionsPendingOptions,
+  sortChatSessions,
+} from "@multica/core/chat/queries";
 import { useRegenerateChatQuickActions } from "@multica/core/chat/mutations";
 import { useQuickActionsPendingTimeout } from "@multica/core/chat/use-quick-actions-pending-timeout";
 import { useQuickActionsFailureToast } from "./components/use-quick-actions-failure-toast";
@@ -62,6 +65,11 @@ export function ChatPage() {
   const isCompact = useIsCompact();
 
   const c = useChatController({ isActive: true });
+  const {
+    sessions: chatSessions,
+    sessionsLoaded,
+    handleSelectSession: selectSession,
+  } = c;
   const { data: quickActionsPending = null } = useQuery(
     chatQuickActionsPendingOptions(c.activeSessionId ?? ""),
   );
@@ -117,6 +125,30 @@ export function ChatPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- react to store only
   }, [c.activeSessionId]);
 
+  // A bare Chat navigation should be immediately useful: once the list has
+  // loaded, open the first active row instead of leaving the detail pane on a
+  // second-click prompt. Explicit `?session=` and `?agent=` intents always win.
+  // The one-shot ref is also load-bearing on compact layouts: after the user
+  // presses Back to return to the thread list, the resulting bare URL must not
+  // immediately reopen the same conversation.
+  const defaultSelectionHandled = useRef(false);
+  useEffect(() => {
+    if (
+      defaultSelectionHandled.current ||
+      urlSession ||
+      urlAgent ||
+      !sessionsLoaded
+    ) {
+      return;
+    }
+    defaultSelectionHandled.current = true;
+    if (useChatStore.getState().activeSessionId) return;
+    const latest = sortChatSessions(
+      chatSessions.filter((session) => session.status === "active"),
+    )[0];
+    if (latest) selectSession(latest);
+  }, [urlSession, urlAgent, sessionsLoaded, chatSessions, selectSession]);
+
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_chat_layout",
   });
@@ -134,6 +166,7 @@ export function ChatPage() {
   };
 
   const handleSelect = (session: ChatSession) => {
+    defaultSelectionHandled.current = true;
     supersedeAgentIntent();
     c.handleSelectSession(session);
     setComposingNew(false);
@@ -158,6 +191,7 @@ export function ChatPage() {
   };
 
   const startNewChat = (agent: Agent | null) => {
+    defaultSelectionHandled.current = true;
     // A manual ⊕ pick outranks a pending deep link; when called FROM the
     // intent effect the ref is already set to this param, so this is a no-op.
     supersedeAgentIntent();
@@ -357,6 +391,7 @@ export function ChatPage() {
               variant="ghost"
               size="sm"
               onClick={() => {
+                defaultSelectionHandled.current = true;
                 c.setActiveSession(null);
                 setComposingNew(false);
               }}

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -62,6 +62,7 @@ export function ChatPage() {
   const { t } = useT("chat");
   const { searchParams, replace } = useNavigation();
   const wsPaths = useWorkspacePaths();
+  const chatPath = wsPaths.chat();
   const isCompact = useIsCompact();
 
   const c = useChatController({ isActive: true });
@@ -69,6 +70,7 @@ export function ChatPage() {
     sessions: chatSessions,
     sessionsLoaded,
     handleSelectSession: selectSession,
+    setActiveSession,
   } = c;
   const { data: quickActionsPending = null } = useQuery(
     chatQuickActionsPendingOptions(c.activeSessionId ?? ""),
@@ -87,6 +89,12 @@ export function ChatPage() {
   // conversation pane is always mounted so it only needs to reset itself once a
   // real session takes over.
   const [composingNew, setComposingNew] = useState(false);
+  // Both refs belong to the URL/store reconciliation below. Explicit URL
+  // intents and manual navigation consume the default selection for this page
+  // visit; the session-intent ref additionally prevents an async URL replace
+  // from restoring a chat the user just archived or left.
+  const defaultSelectionHandled = useRef(false);
+  const consumedSessionIntent = useRef<string | null>(null);
   useEffect(() => {
     // Read the LIVE store value for the same reason as the session sync
     // effects below: under StrictMode's double-invoke this effect replays
@@ -96,58 +104,59 @@ export function ChatPage() {
     if (useChatStore.getState().activeSessionId) setComposingNew(false);
   }, [c.activeSessionId]);
 
-  // Two-way sync between the URL (`?session=`) and the chat store's
-  // activeSessionId. Both effects read the LIVE store value via
-  // `useChatStore.getState()` rather than the render-captured `c.activeSessionId`.
-  // That is what keeps them from fighting on mount: a naive mirror effect fires
-  // with the stale (null) snapshot and "corrects" the URL by stripping the
-  // session before the URL→store effect has applied — breaking deep links and
-  // making selection / new-chat feel unresponsive. Reading getState() sees the
-  // value the sibling effect just wrote, so the reconciliation converges in one
-  // pass and is idempotent under StrictMode's double-invoke.
-
-  // URL → store: deep link, refresh, notification click, back/forward.
-  useEffect(() => {
-    if (urlSession !== useChatStore.getState().activeSessionId) {
-      c.setActiveSession(urlSession);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- react to URL only
-  }, [urlSession]);
-
-  // store → URL: thread selection, "new chat", and sessions created by sending.
+  // Reconcile the URL, store, and one-shot default in one effect. Splitting the
+  // directions lets StrictMode replay URL → store with the mount snapshot after
+  // default selection has already updated the live store, clearing the session
+  // the default just chose. The consumed intent also matters after an explicit
+  // deep link: while replace() is still committing, a later archive/project
+  // action must update the URL instead of re-applying the stale parameter.
   useEffect(() => {
     const live = useChatStore.getState().activeSessionId;
-    const current = searchParams.get("session") || null;
-    if (live !== current) {
-      const base = wsPaths.chat();
-      replace(live ? `${base}?session=${live}` : base);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- react to store only
-  }, [c.activeSessionId]);
+    const base = chatPath;
 
-  // A bare Chat navigation should be immediately useful: once the list has
-  // loaded, open the first active row instead of leaving the detail pane on a
-  // second-click prompt. Explicit `?session=` and `?agent=` intents always win.
-  // The one-shot ref is also load-bearing on compact layouts: after the user
-  // presses Back to return to the thread list, the resulting bare URL must not
-  // immediately reopen the same conversation.
-  const defaultSelectionHandled = useRef(false);
-  useEffect(() => {
-    if (
-      defaultSelectionHandled.current ||
-      urlSession ||
-      urlAgent ||
-      !sessionsLoaded
-    ) {
+    if (urlSession) {
+      defaultSelectionHandled.current = true;
+      if (consumedSessionIntent.current !== urlSession) {
+        consumedSessionIntent.current = urlSession;
+        if (live !== urlSession) setActiveSession(urlSession);
+        return;
+      }
+      if (live !== urlSession) {
+        replace(live ? `${base}?session=${live}` : base);
+      }
       return;
     }
+
+    consumedSessionIntent.current = null;
+    if (urlAgent) {
+      defaultSelectionHandled.current = true;
+      if (live) setActiveSession(null);
+      return;
+    }
+
+    if (live) {
+      defaultSelectionHandled.current = true;
+      replace(`${base}?session=${live}`);
+      return;
+    }
+    if (defaultSelectionHandled.current || !sessionsLoaded) return;
+
     defaultSelectionHandled.current = true;
-    if (useChatStore.getState().activeSessionId) return;
     const latest = sortChatSessions(
       chatSessions.filter((session) => session.status === "active"),
     )[0];
     if (latest) selectSession(latest);
-  }, [urlSession, urlAgent, sessionsLoaded, chatSessions, selectSession]);
+  }, [
+    urlSession,
+    urlAgent,
+    sessionsLoaded,
+    chatSessions,
+    selectSession,
+    c.activeSessionId,
+    setActiveSession,
+    replace,
+    chatPath,
+  ]);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_chat_layout",

--- a/packages/views/chat/components/use-chat-controller.ts
+++ b/packages/views/chat/components/use-chat-controller.ts
@@ -830,6 +830,7 @@ export function useChatController(opts?: { isActive?: boolean }) {
     availableAgents,
     agentsSettled,
     sessions,
+    sessionsLoaded,
     projects,
     activeSessionId,
     selectedAgentId,


### PR DESCRIPTION
## What does this PR do?

Opens the first active conversation automatically when a user enters the bare Chat route, so the detail pane is useful without a second click.

## Behavior

- Waits until the chat-session query has settled before choosing a default.
- Uses the same pinned-first, then recent-activity ordering as the thread list.
- Skips archived conversations.
- Preserves explicit `?session=` deep links.
- Preserves `?agent=` new-chat intents.
- Runs only once per Chat page mount, so compact-layout users can still press Back and remain on the thread list.
- Keeps the selected session URL-addressable through the existing store-to-URL synchronization.

## Validation

- `packages/views`: ChatPage tests (14/14)
- `packages/views`: TypeScript check
- ESLint on all changed files
- `packages/views`: 4,859/4,862 tests passed in the host timezone; the remaining three unchanged Billing tests assert UTC calendar dates and pass with `TZ=UTC` (50/50)
- Desktop production build (`electron-vite build`)

## AI Disclosure

**AI tool used:** Codex

**Approach:** Traced the Chat page's URL/store reconciliation and responsive list-detail behavior, added a one-shot default-selection effect after session loading, and covered loading, archived rows, ordering, and both deep-link forms with page-level regressions.
