### PR TITLE
MUL-6835 fix(i18n): localize status and priority values

### DIFF
--- a/packages/views/inbox/components/inbox-detail-label.test.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.test.tsx
@@ -27,6 +27,13 @@ vi.mock("@multica/core/issue-statuses/hooks", () => ({
     isLoaded: true,
   }),
 }));
+// Scope note: stubbing the resolver keeps this suite about the ONE thing this
+// component owns — which resolver it asks. The catalog stub above still hands
+// back the English seed name for `in_progress`, so a component that went back
+// to reading `entryOf(...).name` renders "In Progress" and fails here. What
+// the real `useStatusLabel` does with a key (built-in through i18n, custom
+// through the catalog) is its own contract, covered by `run-confirm.test.tsx`
+// and `issues/utils/status-options.test.tsx`.
 vi.mock("../../issues/utils/status-label", () => ({
   useStatusLabel: () => (key: string) =>
     key === "in_progress" ? "进行中" : key,

--- a/packages/views/inbox/components/inbox-detail-label.test.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.test.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { InboxItem } from "@multica/core/types";
 import en from "../../locales/en/inbox.json";
+import zhHansIssues from "../../locales/zh-Hans/issues.json";
 import { InboxDetailLabel } from "./inbox-detail-label";
 
 vi.mock("../../issues/components", () => ({
@@ -18,20 +19,26 @@ vi.mock("@multica/core/issue-statuses/hooks", () => ({
     statuses: [],
     activeStatuses: [],
     categoryOf: (key: string) => key,
+    colorOf: () => null,
     labelOf: (key: string) => key,
-    entryOf: () => undefined,
+    entryOf: (key: string) =>
+      key === "in_progress" ? { key, name: "In Progress" } : undefined,
     inCategory: () => [],
     isLoaded: true,
   }),
+}));
+vi.mock("../../issues/utils/status-label", () => ({
+  useStatusLabel: () => (key: string) =>
+    key === "in_progress" ? "进行中" : key,
 }));
 
 // Resolve accessors against the REAL en locale rather than a stub, so this
 // test fails if the unconfirmed case is ever re-pointed at a label that
 // carries failure wording.
 vi.mock("../../i18n", () => ({
-  useT: () => ({
+  useT: (namespace: string) => ({
     t: (accessor: (dict: unknown) => string, params?: Record<string, string>) => {
-      const template = accessor(en);
+      const template = accessor(namespace === "issues" ? zhHansIssues : en);
       if (!params) return template;
       return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => params[key] ?? "");
     },
@@ -96,5 +103,29 @@ describe("InboxDetailLabel quick-create outcomes", () => {
 
     expect(container.textContent).toBe(en.types.quick_create_unconfirmed);
     expect(container.textContent).not.toMatch(/failed/i);
+  });
+});
+
+describe("InboxDetailLabel localized values", () => {
+  it("uses the localized built-in status instead of the English catalog seed", () => {
+    const { container } = render(
+      <InboxDetailLabel
+        item={item({ type: "status_changed", details: { to: "in_progress" } })}
+      />,
+    );
+
+    expect(container.textContent).toContain("进行中");
+    expect(container.textContent).not.toContain("In Progress");
+  });
+
+  it("uses the translated priority label", () => {
+    const { container } = render(
+      <InboxDetailLabel
+        item={item({ type: "priority_changed", details: { to: "high" } })}
+      />,
+    );
+
+    expect(container.textContent).toContain("高");
+    expect(container.textContent).not.toContain("High");
   });
 });

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -8,6 +8,7 @@ import { StatusIcon, PriorityIcon } from "../../issues/components";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@multica/core/types";
 import { getQuickCreateOutcomeDetail } from "./inbox-display";
 import { useT } from "../../i18n";
+import { useStatusLabel } from "../../issues/utils/status-label";
 
 // Hook returning the inbox-item type → human label map. Replaces the
 // previous static `typeLabels` const so the labels can flow through
@@ -45,17 +46,18 @@ function shortDate(dateStr: string): string {
 
 export function InboxDetailLabel({ item }: { item: InboxItem }) {
   const { t } = useT("inbox");
+  const { t: tIssues } = useT("issues");
   const typeLabels = useTypeLabels();
   const { getActorName } = useActorName();
   // Inbox is a cross-workspace surface, so the catalog is read per item's own
   // workspace rather than from the route. (MUL-6243)
-  const { categoryOf, entryOf, colorOf } = useIssueStatuses(item.workspace_id);
+  const { categoryOf, colorOf } = useIssueStatuses(item.workspace_id);
+  const statusLabelOf = useStatusLabel(item.workspace_id);
   const details = item.details ?? {};
 
   switch (item.type) {
     case "status_changed": {
       if (!details.to) return <span>{typeLabels[item.type]}</span>;
-      const entry = entryOf(details.to);
       return (
         <span className="inline-flex items-center gap-1">
           {t(($) => $.labels.set_status_to)}
@@ -65,13 +67,17 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
             color={colorOf(details.to)}
             className="h-3 w-3"
           />
-          {entry?.name ?? details.to}
+          {statusLabelOf(details.to)}
         </span>
       );
     }
     case "priority_changed": {
       if (!details.to) return <span>{typeLabels[item.type]}</span>;
-      const label = PRIORITY_CONFIG[details.to as IssuePriority]?.label ?? details.to;
+      const priority = details.to as IssuePriority;
+      const label =
+        priority in PRIORITY_CONFIG
+          ? tIssues(($) => $.priority[priority])
+          : details.to;
       return (
         <span className="inline-flex items-center gap-1">
           {t(($) => $.labels.set_priority_to)}

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { formatDateOnly } from "@multica/core/issues/date";
 import { useActorName } from "@multica/core/workspace/hooks";
@@ -9,6 +8,7 @@ import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@mult
 import { getQuickCreateOutcomeDetail } from "./inbox-display";
 import { useT } from "../../i18n";
 import { useStatusLabel } from "../../issues/utils/status-label";
+import { priorityLabel } from "../../issues/utils/priority-label";
 
 // Hook returning the inbox-item type → human label map. Replaces the
 // previous static `typeLabels` const so the labels can flow through
@@ -73,11 +73,7 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
     }
     case "priority_changed": {
       if (!details.to) return <span>{typeLabels[item.type]}</span>;
-      const priority = details.to as IssuePriority;
-      const label =
-        priority in PRIORITY_CONFIG
-          ? tIssues(($) => $.priority[priority])
-          : details.to;
+      const label = priorityLabel(details.to, tIssues);
       return (
         <span className="inline-flex items-center gap-1">
           {t(($) => $.labels.set_priority_to)}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -7,6 +7,7 @@ import {
   statusCategoryOfKey,
 } from "@multica/core/issues";
 import { useStatusLabel } from "../utils/status-label";
+import { priorityLabel } from "../utils/priority-label";
 import { useIssueStatuses } from "@multica/core/issue-statuses/hooks";
 import { useState, useEffect, useCallback, useMemo, useRef, Fragment, type ReactNode } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
@@ -62,7 +63,7 @@ import { PropRow } from "../../common/prop-row";
 import { PropertyIcon } from "../../common/property-icon";
 import type { Attachment, Issue, IssueProperty, IssueStatus, IssueStatusCategory, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
-import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
+import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { toast } from "sonner";
@@ -283,13 +284,6 @@ function statusLabel(
     return t(($) => $.status[statusCategoryOfKey(status)]);
   }
   return status;
-}
-
-function priorityLabel(priority: string, t: ActivityT): string {
-  if (priority in PRIORITY_CONFIG) {
-    return t(($) => $.priority[priority as IssuePriority]);
-  }
-  return priority;
 }
 
 function formatActivity(

--- a/packages/views/issues/utils/priority-label.ts
+++ b/packages/views/issues/utils/priority-label.ts
@@ -1,0 +1,23 @@
+import { PRIORITY_CONFIG } from "@multica/core/issues/config";
+import type { IssuePriority } from "@multica/core/types";
+import { useT } from "../../i18n";
+
+/** The `t` of the issues namespace, where every priority name lives. */
+export type IssuesT = ReturnType<typeof useT<"issues">>["t"];
+
+/**
+ * Names a priority VALUE. The five built-ins are localized from the key, so a
+ * non-English member never reads `PRIORITY_CONFIG`'s English seed; a value
+ * this client is too old to know falls back to the raw value rather than
+ * rendering blank. The status counterpart is `useStatusLabel`.
+ *
+ * Pure rather than a hook, so the issue activity formatter — which is a plain
+ * function holding a `t` it was handed — shares it with components that call
+ * `useT("issues")` themselves.
+ */
+export function priorityLabel(priority: string, t: IssuesT): string {
+  if (priority in PRIORITY_CONFIG) {
+    return t(($) => $.priority[priority as IssuePriority]);
+  }
+  return priority;
+}

--- a/packages/views/projects/components/labels.ts
+++ b/packages/views/projects/components/labels.ts
@@ -5,9 +5,11 @@ import { useT } from "../../i18n";
 
 // Hooks returning the i18n-aware label maps for project status / priority.
 // They replace the static `.label` field on PROJECT_STATUS_CONFIG /
-// PROJECT_PRIORITY_CONFIG for view-layer rendering. Core's `.label` stays
-// for non-translated callers (search, create-project modal) — those will
-// flip when their namespaces translate. Mirror of inbox `useTypeLabels`.
+// PROJECT_PRIORITY_CONFIG, and search — the last caller still rendering
+// `PROJECT_STATUS_CONFIG.label` — now resolves through here too, so nothing
+// in the repo reads either `.label` any more. Name a project status through
+// these hooks; the core field is a leftover, not a second source of truth.
+// Mirror of inbox `useTypeLabels`.
 
 export function useProjectStatusLabels(): Record<ProjectStatus, string> {
   const { t } = useT("projects");

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -27,6 +27,11 @@ const TEST_RESOURCES = {
   },
 };
 
+// Deliberately NOT a full zh-Hans bundle: only `projects` is translated, and
+// every other namespace stays on its English bundle under the zh-Hans key.
+// The one thing under test is whether a project row names its status through
+// the projects namespace, and keeping the chrome in English lets these tests
+// go on addressing the palette by its English placeholder and group headings.
 const ZH_TEST_RESOURCES = {
   "zh-Hans": {
     common: enCommon,

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -13,6 +13,8 @@ import enSearch from "../locales/en/search.json";
 // The palette labels its Pages group from the sidebar's own nav strings, so
 // the layout namespace is part of its contract, not incidental setup.
 import enLayout from "../locales/en/layout.json";
+import enProjects from "../locales/en/projects.json";
+import zhHansProjects from "../locales/zh-Hans/projects.json";
 
 const TEST_RESOURCES = {
   en: {
@@ -21,6 +23,18 @@ const TEST_RESOURCES = {
     settings: enSettings,
     search: enSearch,
     layout: enLayout,
+    projects: enProjects,
+  },
+};
+
+const ZH_TEST_RESOURCES = {
+  "zh-Hans": {
+    common: enCommon,
+    auth: enAuth,
+    settings: enSettings,
+    search: enSearch,
+    layout: enLayout,
+    projects: zhHansProjects,
   },
 };
 
@@ -33,6 +47,17 @@ function I18nWrapper({ children }: { children: ReactNode }) {
 }
 
 const renderSearch = () => render(<SearchCommand />, { wrapper: I18nWrapper });
+
+function ChineseI18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="zh-Hans" resources={ZH_TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+const renderSearchInChinese = () =>
+  render(<SearchCommand />, { wrapper: ChineseI18nWrapper });
 
 const {
   mockPush,
@@ -1031,6 +1056,31 @@ describe("SearchCommand", () => {
       Array.from(
         document.querySelectorAll<HTMLElement>("[cmdk-group-heading]"),
       ).map((el) => el.textContent ?? "");
+
+    it("renders project status in the selected UI language", async () => {
+      const user = userEvent.setup();
+      mockSearchProjects.mockResolvedValue({
+        projects: [
+          fixtureProject({
+            id: "proj-localized",
+            title: "localized project",
+            status: "in_progress",
+          }),
+        ],
+        total: 1,
+      });
+
+      renderSearchInChinese();
+      await user.type(
+        screen.getByPlaceholderText("Type a command or search..."),
+        "localized",
+      );
+
+      await waitFor(() => expect(screen.getByText("进行中")).toBeInTheDocument(), {
+        timeout: 2000,
+      });
+      expect(screen.queryByText("In Progress")).toBeNull();
+    });
 
     it("keeps a cancelled project below a live issue instead of first", async () => {
       const user = userEvent.setup();

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -47,6 +47,7 @@ import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { StatusIcon } from "../issues/components";
 import { resolvedThreadRootIds, rootCommentIds } from "../issues/components/thread-utils";
 import { ProjectIcon } from "../projects/components/project-icon";
+import { useProjectStatusLabels } from "../projects/components/labels";
 import { routeIconForPath } from "../layout/route-icon-components";
 import { PROJECT_STATUS_CONFIG } from "@multica/core/projects/config";
 import type { ProjectStatus } from "@multica/core/types";
@@ -184,6 +185,9 @@ function ProjectResultRow({
   disabled?: boolean;
   onSelect: (value: string) => void;
 }) {
+  const projectStatusLabels = useProjectStatusLabels();
+  const status = project.status as ProjectStatus;
+
   return (
     <CommandPrimitive.Item
       key={`project:${project.id}`}
@@ -198,9 +202,9 @@ function ProjectResultRow({
           <HighlightText text={project.title} query={query} />
         </span>
         <span
-          className={`ml-auto text-caption shrink-0 ${PROJECT_STATUS_CONFIG[project.status as ProjectStatus]?.color ?? "text-muted-foreground"}`}
+          className={`ml-auto text-caption shrink-0 ${PROJECT_STATUS_CONFIG[status]?.color ?? "text-muted-foreground"}`}
         >
-          {PROJECT_STATUS_CONFIG[project.status as ProjectStatus]?.label ?? project.status}
+          {projectStatusLabels[status] ?? project.status}
         </span>
       </div>
       {project.match_source === "description" && project.matched_snippet && (


### PR DESCRIPTION
## What does this PR do?

Fixes localized UI surfaces that still displayed English labels from server/config data:

- Inbox status changes used the built-in catalog's English seed name.
- Inbox priority changes used the English label from `PRIORITY_CONFIG`.
- Project search results used the English label from `PROJECT_STATUS_CONFIG`.

The UI now reuses the existing status, priority, and project-status localization helpers. Unknown or custom values still fall back to their original server value, and existing icons, colors, and behavior are unchanged.

## Related Issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [x] Tests

## Changes

- Localize built-in status labels in Inbox activity details.
- Localize known priority labels in Inbox activity details.
- Localize project status labels in search results.
- Add regression coverage using Simplified Chinese resources.

## How has this been tested?

- `corepack pnpm --filter @multica/views typecheck`
- `corepack pnpm --filter @multica/views exec vitest run inbox/components/inbox-detail-label.test.tsx search/search-command.test.tsx` (37 tests)
- `corepack pnpm --filter @multica/views lint` (0 errors; existing repository warnings only)

Manual scenario covered by tests: in a Simplified Chinese UI, Inbox status/priority changes and project search results show translated values instead of English config seeds.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I checked that the staged diff contains no downstream branding, private paths, or product-specific behavior.

## Screenshots

Not included because this is a copy-only localization correction with no layout changes.

## Risk

Low. The change only affects display labels and preserves raw-value fallback for unknown/custom values. It does not change API payloads, persisted state, status transitions, sorting, or styling.

## AI assistance

Codex was used to inventory the affected UI paths, reuse the repository's existing localization helpers, add focused regression tests, and audit the staged diff for downstream branding.