### PR TITLE
MUL-6781: perf(server): compress JSON API responses

### DIFF
--- a/server/cmd/server/compression_test.go
+++ b/server/cmd/server/compression_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+)
+
+func TestMainRouterCompressesJSONWhenRequested(t *testing.T) {
+	router := NewRouter(nil, realtime.NewHub(), events.New(), analytics.NoopClient{}, nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	router.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	var body liveResponse
+	if err := json.NewDecoder(zr).Decode(&body); err != nil {
+		t.Fatalf("decode compressed /health response: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status = %q, want ok", body.Status)
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1230,6 +1230,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		r.Use(opts.HTTPMetrics.Middleware)
 	}
 	r.Use(chimw.Recoverer)
+	r.Use(chimw.Compress(5, "application/json"))
 	r.Use(h.PluginSurfaceHostBoundary)
 	r.Use(middleware.ContentSecurityPolicy)
 


### PR DESCRIPTION

## What does this PR do?

Enables gzip compression for JSON API responses when clients advertise support through `Accept-Encoding`.

The change adds Chi's existing compression middleware at the shared server boundary, immediately after recovery middleware, and restricts it to `application/json`. Clients that do not request a supported encoding continue to receive uncompressed responses, and non-JSON responses are unchanged.

Thinking path: the server already centralizes cross-cutting HTTP behavior in `NewRouterWithOptions`. Applying compression there avoids modifying individual handlers and gives web, daemon, and CLI clients consistent negotiation. A regression test exercises the production router through `/health`, verifies `Content-Encoding: gzip`, decompresses the response, and confirms the JSON payload remains valid.

## Related Issue

Closes #7677

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/server/router.go`: add `chimw.Compress(5, "application/json")` after `chimw.Recoverer`.
- `server/cmd/server/compression_test.go`: add a production-router regression test covering gzip negotiation and JSON round-trip decoding.

## How to Test

1. From `server/`, run:

   ```bash
   go test ./cmd/server -run TestMainRouterCompressesJSONWhenRequested -count=1