### PR TITLE
MUL-6837: fix(i18n): respect locale for formatted values

### DIFF
--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -73,7 +73,7 @@ import {
   AgentListToolbar,
   countActiveFilterDimensions,
 } from "./agent-list-toolbar";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 // Column template — single source of truth for header, rows, and skeletons.
@@ -768,6 +768,7 @@ function LoadingSkeleton() {
 
 export function AgentsPage(_props: AgentsPageProps = {}) {
   const { t } = useT("agents");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   const paths = useWorkspacePaths();
   const navigation = useNavigation();
@@ -1140,7 +1141,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
                       )}
                       {isColVisible("runs") ? (
                         <ListGridCell className="hidden justify-end font-mono text-caption tabular-nums text-muted-foreground @2xl:flex">
-                          {row.runCount.toLocaleString()}
+                          {row.runCount.toLocaleString(locale)}
                         </ListGridCell>
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />
@@ -1158,7 +1159,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
                         <ListGridCell className="hidden whitespace-nowrap text-caption tabular-nums text-muted-foreground @2xl:flex">
                           {new Date(
                             row.agent.created_at,
-                          ).toLocaleDateString()}
+                          ).toLocaleDateString(locale)}
                         </ListGridCell>
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -59,7 +59,7 @@ import {
   AutopilotRowActions,
 } from "./autopilot-list-actions";
 import type { ScheduleConfig } from "./schedule-editor/model";
-import { useT, useTimeAgo } from "../../i18n";
+import { useLocale, useT, useTimeAgo } from "../../i18n";
 
 // Column template — single source of truth for header, rows, and skeletons.
 // Same conventions as the skills list (see list-grid.tsx and the comment
@@ -600,6 +600,7 @@ function LoadingSkeleton() {
 
 export function AutopilotsPage() {
   const { t } = useT("autopilots");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   const wsPaths = useWorkspacePaths();
   const rowLink = useRowLink();
@@ -937,7 +938,7 @@ export function AutopilotsPage() {
                       )}
                       {isColVisible("created") ? (
                         <ListGridCell className="hidden whitespace-nowrap text-caption tabular-nums text-muted-foreground @2xl:flex">
-                          {new Date(autopilot.created_at).toLocaleDateString()}
+                          {new Date(autopilot.created_at).toLocaleDateString(locale)}
                         </ListGridCell>
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />

--- a/packages/views/autopilots/components/webhook-deliveries-section.tsx
+++ b/packages/views/autopilots/components/webhook-deliveries-section.tsx
@@ -31,7 +31,7 @@ import {
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { toast } from "sonner";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import type {
   WebhookDelivery,
   WebhookDeliveryStatus,
@@ -72,9 +72,9 @@ function visualForStatus(status: string): StatusVisual {
 
 // --- Helpers --------------------------------------------------------------
 
-function formatDate(value: string): string {
+function formatDate(value: string, locale: string): string {
   if (!value) return "—";
-  return new Date(value).toLocaleString(undefined, {
+  return new Date(value).toLocaleString(locale, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -158,6 +158,7 @@ function DeliveryRow({
   autopilotId: string;
 }) {
   const { t } = useT("autopilots");
+  const locale = useLocale();
   const [open, setOpen] = useState(false);
 
   const visual = visualForStatus(delivery.status);
@@ -204,7 +205,7 @@ function DeliveryRow({
           </Badge>
         )}
         <span className="w-32 shrink-0 text-right text-caption text-muted-foreground tabular-nums">
-          {formatDate(delivery.received_at || delivery.created_at)}
+          {formatDate(delivery.received_at || delivery.created_at, locale)}
         </span>
       </button>
       {open && (
@@ -233,6 +234,7 @@ function DeliveryDetailDialog({
   delivery: WebhookDelivery;
 }) {
   const { t } = useT("autopilots");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   const { data: detail, isLoading } = useQuery(
     autopilotDeliveryOptions(wsId, autopilotId, delivery.id, { enabled: open }),
@@ -283,11 +285,11 @@ function DeliveryDetailDialog({
           <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-caption">
             <MetaRow
               label={t(($) => $.deliveries.detail.received_at)}
-              value={formatDate(full.received_at)}
+              value={formatDate(full.received_at, locale)}
             />
             <MetaRow
               label={t(($) => $.deliveries.detail.last_attempt_at)}
-              value={formatDate(full.last_attempt_at)}
+              value={formatDate(full.last_attempt_at, locale)}
             />
             <MetaRow
               label={t(($) => $.deliveries.detail.attempt_count)}
@@ -300,7 +302,7 @@ function DeliveryDetailDialog({
             {full.status === "queued" && (
               <MetaRow
                 label={t(($) => $.deliveries.detail.available_at)}
-                value={formatDate(full.available_at)}
+                value={formatDate(full.available_at, locale)}
               />
             )}
             <MetaRow

--- a/packages/views/billing/billing-test-page.tsx
+++ b/packages/views/billing/billing-test-page.tsx
@@ -51,7 +51,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@multica/ui/components/ui/card";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
 import { useNavigation } from "../navigation";
 
 // 1 credit = 1_000_000 micro-credit; cents → dollars factor for the
@@ -116,6 +116,7 @@ function CheckoutSessionStatusBanner({
   onDismiss: () => void;
 }) {
   const { t } = useT("billing");
+  const locale = useLocale();
   const { data, isLoading, isError, error } = useQuery(
     billingCheckoutSessionOptions(sessionId),
   );
@@ -178,13 +179,13 @@ function CheckoutSessionStatusBanner({
             <dd>
               {data.bonus_credits > 0
                 ? t(($) => $.checkout.charged_with_bonus, {
-                    money: formatMoney(data.amount_cents, data.currency),
-                    credits: data.credits.toLocaleString(),
-                    bonus: data.bonus_credits.toLocaleString(),
+                    money: formatMoney(data.amount_cents, data.currency, locale),
+                    credits: data.credits.toLocaleString(locale),
+                    bonus: data.bonus_credits.toLocaleString(locale),
                   })
                 : t(($) => $.checkout.charged_value, {
-                    money: formatMoney(data.amount_cents, data.currency),
-                    credits: data.credits.toLocaleString(),
+                    money: formatMoney(data.amount_cents, data.currency, locale),
+                    credits: data.credits.toLocaleString(locale),
                   })}
             </dd>
           </dl>
@@ -208,6 +209,7 @@ function CheckoutSessionStatusBanner({
 
 function BalanceCard() {
   const { t } = useT("billing");
+  const locale = useLocale();
   const balance = useQuery(billingBalanceOptions());
 
   return (
@@ -232,16 +234,16 @@ function BalanceCard() {
         ) : (
           <div className="space-y-1 text-body">
             <div className="text-display-sm font-semibold tabular-nums">
-              {balance.data?.balance_credit.toLocaleString() ?? 0}
+              {balance.data?.balance_credit.toLocaleString(locale) ?? 0}
               <span className="ml-1 text-body font-normal text-muted-foreground">
                 {t(($) => $.balance.credits_suffix)}
               </span>
             </div>
             <div className="text-caption text-muted-foreground">
               {t(($) => $.balance.meta, {
-                micro: balance.data?.balance_micro.toLocaleString() ?? 0,
+                micro: balance.data?.balance_micro.toLocaleString(locale) ?? 0,
                 owner: balance.data?.owner_id.slice(0, 8) ?? "",
-                updated: formatDate(balance.data?.updated_at, t),
+                updated: formatDate(balance.data?.updated_at, t, locale),
               })}
             </div>
           </div>
@@ -368,19 +370,20 @@ function TierButton({
   onClick: () => void;
 }) {
   const { t } = useT("billing");
+  const locale = useLocale();
   const display = tier.display_name || tier.id;
   const baseLine = t(($) => $.buy.tier_money_to_credits, {
-    money: formatMoney(tier.amount_cents, "usd"),
-    credits: tier.credits.toLocaleString(),
+    money: formatMoney(tier.amount_cents, "usd", locale),
+    credits: tier.credits.toLocaleString(locale),
   });
   const bonusLine = tier.bonus_credits
     ? tier.bonus_expires_in
       ? t(($) => $.buy.tier_bonus_with_expiry, {
-          credits: tier.bonus_credits.toLocaleString(),
+          credits: tier.bonus_credits.toLocaleString(locale),
           expiry: tier.bonus_expires_in,
         })
       : t(($) => $.buy.tier_bonus, {
-          credits: tier.bonus_credits.toLocaleString(),
+          credits: tier.bonus_credits.toLocaleString(locale),
         })
     : "";
   return (
@@ -450,6 +453,7 @@ function TransactionsCard() {
 
 function TransactionRow({ row }: { row: BillingTransaction }) {
   const { t } = useT("billing");
+  const locale = useLocale();
   const credit = row.amount_micro / MICRO_PER_CREDIT;
   return (
     <li className="rounded-md border bg-background p-2.5">
@@ -468,7 +472,7 @@ function TransactionRow({ row }: { row: BillingTransaction }) {
           }`}
         >
           {t(($) => $.transactions.credits_value, {
-            value: `${credit >= 0 ? "+" : ""}${credit.toLocaleString()}`,
+            value: `${credit >= 0 ? "+" : ""}${credit.toLocaleString(locale)}`,
           })}
         </span>
       </div>
@@ -477,8 +481,8 @@ function TransactionRow({ row }: { row: BillingTransaction }) {
       )}
       <div className="mt-1 font-mono text-micro text-muted-foreground">
         {t(($) => $.transactions.row_meta, {
-          date: formatDate(row.created_at, t),
-          balance: (row.balance_after / MICRO_PER_CREDIT).toLocaleString(),
+          date: formatDate(row.created_at, t, locale),
+          balance: (row.balance_after / MICRO_PER_CREDIT).toLocaleString(locale),
           ref: row.reference_id || t(($) => $.transactions.ref_empty),
         })}
       </div>
@@ -529,6 +533,7 @@ function BatchesCard() {
 
 function BatchRow({ row }: { row: BillingBatch }) {
   const { t } = useT("billing");
+  const locale = useLocale();
   const total = row.total_micro / MICRO_PER_CREDIT;
   const remaining = row.remaining_micro / MICRO_PER_CREDIT;
   const consumed = total - remaining;
@@ -543,15 +548,15 @@ function BatchRow({ row }: { row: BillingBatch }) {
         </span>
         <span className="text-body tabular-nums">
           {t(($) => $.batches.remaining_over_total, {
-            remaining: remaining.toLocaleString(),
-            total: total.toLocaleString(),
+            remaining: remaining.toLocaleString(locale),
+            total: total.toLocaleString(locale),
           })}
         </span>
       </div>
       <div className="mt-1 text-caption text-muted-foreground">
-        {t(($) => $.batches.consumed, { value: consumed.toLocaleString() })}
+        {t(($) => $.batches.consumed, { value: consumed.toLocaleString(locale) })}
         {row.expires_at
-          ? t(($) => $.batches.expires_suffix, { value: formatDate(row.expires_at, t) })
+          ? t(($) => $.batches.expires_suffix, { value: formatDate(row.expires_at, t, locale) })
           : t(($) => $.batches.never_expires_suffix)}
       </div>
     </li>
@@ -601,6 +606,7 @@ function TopupsCard() {
 
 function TopupRow({ row }: { row: BillingTopup }) {
   const { t } = useT("billing");
+  const locale = useLocale();
   return (
     <li className="rounded-md border bg-background p-2.5">
       <div className="flex items-center justify-between gap-2">
@@ -621,19 +627,19 @@ function TopupRow({ row }: { row: BillingTopup }) {
         <span className="text-body tabular-nums">
           {row.bonus_credits > 0
             ? t(($) => $.topups.amount_to_credits_with_bonus, {
-                money: formatMoney(row.amount_cents, row.currency),
-                credits: row.credits.toLocaleString(),
-                bonus: row.bonus_credits,
+                money: formatMoney(row.amount_cents, row.currency, locale),
+                credits: row.credits.toLocaleString(locale),
+                bonus: row.bonus_credits.toLocaleString(locale),
               })
             : t(($) => $.topups.amount_to_credits, {
-                money: formatMoney(row.amount_cents, row.currency),
-                credits: row.credits.toLocaleString(),
+                money: formatMoney(row.amount_cents, row.currency, locale),
+                credits: row.credits.toLocaleString(locale),
               })}
         </span>
       </div>
       <div className="mt-1 font-mono text-micro text-muted-foreground">
         {t(($) => $.topups.row_meta, {
-          date: formatDate(row.created_at, t),
+          date: formatDate(row.created_at, t, locale),
           checkout: row.stripe_checkout_id || t(($) => $.topups.stripe_empty),
         })}
       </div>
@@ -701,13 +707,15 @@ function EmptyText({ children }: { children: React.ReactNode }) {
   return <p className="text-caption text-muted-foreground">{children}</p>;
 }
 
-function formatMoney(amountCents: number, currency: string): string {
-  // Intl is fine here — no currency conversion happening, just
-  // canonical display. Defaults to en-US to match the rest of the
-  // dev UI; the produced string is then passed into a t() interpolation
-  // so the surrounding sentence still gets translated.
+function formatMoney(
+  amountCents: number,
+  currency: string,
+  locale: string,
+): string {
+  // Intl is fine here — no currency conversion happening, just canonical
+  // display in the same locale as the surrounding translated sentence.
   try {
-    return new Intl.NumberFormat("en-US", {
+    return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: currency.toUpperCase(),
     }).format(amountCents / CENTS_PER_DOLLAR);
@@ -725,9 +733,10 @@ function formatMoney(amountCents: number, currency: string): string {
 function formatDate(
   value: string | undefined,
   t: ReturnType<typeof useT<"billing">>["t"],
+  locale: string,
 ): string {
   if (!value) return t(($) => $.shared.date_dash);
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleString();
+  return d.toLocaleString(locale);
 }

--- a/packages/views/chat/components/chat-thread-list.tsx
+++ b/packages/views/chat/components/chat-thread-list.tsx
@@ -36,21 +36,21 @@ import {
 import { resolveClickIntent, useOptionalNavigation } from "../../navigation";
 import { createLogger } from "@multica/core/logger";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 const apiLogger = createLogger("chat.api");
 
 // IM-style timestamp: today → clock, this year → M/D, else full date.
-function formatChatTime(dateStr: string): string {
+function formatChatTime(dateStr: string, locale: string): string {
   const d = new Date(dateStr);
   const now = new Date();
   if (d.toDateString() === now.toDateString()) {
-    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return d.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" });
   }
   if (d.getFullYear() === now.getFullYear()) {
-    return d.toLocaleDateString([], { month: "numeric", day: "numeric" });
+    return d.toLocaleDateString(locale, { month: "numeric", day: "numeric" });
   }
-  return d.toLocaleDateString();
+  return d.toLocaleDateString(locale);
 }
 
 // Collapse a (possibly markdown / multi-line) message into a one-line preview.
@@ -95,6 +95,7 @@ export function ChatThreadList({
   onArchive: (session: ChatSession) => void;
 }) {
   const { t } = useT("chat");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   // Null-safe slug (not useWorkspacePaths, which throws): the list renders in
   // tests outside a workspace route; without a slug the web modifier-click
@@ -220,7 +221,9 @@ export function ChatThreadList({
     const isConfirmingAction = isConfirmingDelete || isConfirmingStop;
     const titleText = session.title?.trim() || t(($) => $.window.untitled);
     const last = session.last_message ?? null;
-    const timeText = last ? formatChatTime(last.created_at) : formatChatTime(session.updated_at);
+    const timeText = last
+      ? formatChatTime(last.created_at, locale)
+      : formatChatTime(session.updated_at, locale);
 
     // The second line: typing/waiting → failed → preview.
     let previewNode: React.ReactNode;

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -89,7 +89,7 @@ import {
 import { useChatProjectContextSupport } from "./use-chat-project-context-support";
 import { createLogger } from "@multica/core/logger";
 import type { Agent, Attachment, ChatMessage, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
@@ -1639,6 +1639,7 @@ function SessionDropdown({
 
 function useFormatTimeAgo(): (dateStr: string) => string {
   const { t } = useT("chat");
+  const locale = useLocale();
   return (dateStr: string) => {
     const date = new Date(dateStr);
     const now = new Date();
@@ -1651,6 +1652,6 @@ function useFormatTimeAgo(): (dateStr: string) => string {
     if (diffMins < 60) return t(($) => $.session_history.time.minutes, { count: diffMins });
     if (diffHours < 24) return t(($) => $.session_history.time.hours, { count: diffHours });
     if (diffDays < 7) return t(($) => $.session_history.time.days, { count: diffDays });
-    return date.toLocaleDateString();
+    return date.toLocaleDateString(locale);
   };
 }

--- a/packages/views/common/date-only-picker.tsx
+++ b/packages/views/common/date-only-picker.tsx
@@ -15,6 +15,7 @@ import {
   PopoverContent,
 } from "@multica/ui/components/ui/popover";
 import { DeferredPopup } from "./deferred-popup";
+import { useLocale } from "../i18n";
 
 /**
  * Default class of the date pill trigger — shared with the deferred lookalike
@@ -90,6 +91,7 @@ function DateTriggerContent({
   placeholder,
   highlightOverdue = false,
 }: Pick<DateOnlyPickerProps, "value" | "icon" | "placeholder" | "highlightOverdue">) {
+  const locale = useLocale();
   const date = dateOnlyToLocalDate(value);
   const overdue = highlightOverdue && isPastDateOnly(value);
   return (
@@ -97,7 +99,7 @@ function DateTriggerContent({
       {icon}
       {date ? (
         <span className={overdue ? "text-destructive" : ""}>
-          {formatDateOnly(value, { month: "short", day: "numeric" }, "en-US")}
+          {formatDateOnly(value, { month: "short", day: "numeric" }, locale)}
         </span>
       ) : (
         <span className="text-muted-foreground">{placeholder}</span>

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -95,7 +95,7 @@ import {
   ToolDetailSurface,
 } from "./detail-surfaces";
 import { languageForPath } from "./diff-highlight";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import {
   formatTokens,
   formatUsd,
@@ -159,8 +159,8 @@ function formatOffset(ms: number): string {
   return `+${hours}:${String(minutes % 60).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
-function formatRunTime(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+function formatRunTime(iso: string, locale: string): string {
+  return new Date(iso).toLocaleString(locale, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -307,6 +307,7 @@ export function AgentTranscriptDialog({
   headerSlot,
 }: AgentTranscriptDialogProps) {
   const { t } = useT("agents");
+  const locale = useLocale();
   const [selectedSeq, setSelectedSeq] = useState<number | null>(null);
   const [expandedGroups, setExpandedGroups] = useState<Set<number>>(() => new Set());
   const [query, setQuery] = useState("");
@@ -807,9 +808,9 @@ export function AgentTranscriptDialog({
   // Diagnostic detail for the ⓘ popover: everything a reader needs only when
   // debugging this specific run, kept off the always-visible surface.
   const providerLabel = runtimeInfo?.provider ? transcriptProviderLabel(runtimeInfo.provider) : null;
-  const createdLabel = task.created_at ? formatRunTime(task.created_at) : null;
-  const startedLabel = task.started_at ? formatRunTime(task.started_at) : null;
-  const completedLabel = task.completed_at ? formatRunTime(task.completed_at) : null;
+  const createdLabel = task.created_at ? formatRunTime(task.created_at, locale) : null;
+  const startedLabel = task.started_at ? formatRunTime(task.started_at, locale) : null;
+  const completedLabel = task.completed_at ? formatRunTime(task.completed_at, locale) : null;
   const hasTriggeredBy = !!task.attribution?.initiator;
   // This run's own spend. Present on transcripts opened from the issue
   // execution log (the endpoint that hydrates usage); absent elsewhere, where
@@ -1372,12 +1373,13 @@ function TranscriptRow(props: TranscriptRowProps) {
 
 /** The offset column: where in the run this happened. */
 function OffsetCell({ startedAt, runStartMs }: { startedAt?: string; runStartMs?: number }) {
+  const locale = useLocale();
   const at = timeMs(startedAt);
   const label = at !== undefined && runStartMs !== undefined ? formatOffset(at - runStartMs) : "";
   return (
     <span
       className="w-11 shrink-0 pt-0.5 text-right font-mono text-micro tabular-nums text-faint-foreground"
-      title={startedAt ? new Date(startedAt).toLocaleString() : undefined}
+      title={startedAt ? new Date(startedAt).toLocaleString(locale) : undefined}
     >
       {label}
     </span>

--- a/packages/views/inbox/components/inbox-detail-label.test.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.test.tsx
@@ -43,6 +43,7 @@ vi.mock("../../issues/utils/status-label", () => ({
 // test fails if the unconfirmed case is ever re-pointed at a label that
 // carries failure wording.
 vi.mock("../../i18n", () => ({
+  useLocale: () => "zh-Hans",
   useT: (namespace: string) => ({
     t: (accessor: (dict: unknown) => string, params?: Record<string, string>) => {
       const template = accessor(namespace === "issues" ? zhHansIssues : en);
@@ -134,5 +135,16 @@ describe("InboxDetailLabel localized values", () => {
 
     expect(container.textContent).toContain("高");
     expect(container.textContent).not.toContain("High");
+  });
+
+  it("formats calendar dates with the selected UI locale", () => {
+    const { container } = render(
+      <InboxDetailLabel
+        item={item({ type: "due_date_changed", details: { to: "2026-08-21" } })}
+      />,
+    );
+
+    expect(container.textContent).toContain("8月21日");
+    expect(container.textContent).not.toContain("Aug");
   });
 });

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -6,7 +6,7 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { StatusIcon, PriorityIcon } from "../../issues/components";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@multica/core/types";
 import { getQuickCreateOutcomeDetail } from "./inbox-display";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { useStatusLabel } from "../../issues/utils/status-label";
 import { priorityLabel } from "../../issues/utils/priority-label";
 
@@ -40,13 +40,14 @@ export function useTypeLabels(): Record<InboxItemType, string> {
 
 // start_date / due_date are calendar days — format timezone-safely so the day
 // never shifts with the viewer's offset (see @multica/core/issues/date).
-function shortDate(dateStr: string): string {
-  return formatDateOnly(dateStr, { month: "short", day: "numeric" }, "en-US");
+function shortDate(dateStr: string, locale: string): string {
+  return formatDateOnly(dateStr, { month: "short", day: "numeric" }, locale);
 }
 
 export function InboxDetailLabel({ item }: { item: InboxItem }) {
   const { t } = useT("inbox");
   const { t: tIssues } = useT("issues");
+  const locale = useLocale();
   const typeLabels = useTypeLabels();
   const { getActorName } = useActorName();
   // Inbox is a cross-workspace surface, so the catalog is read per item's own
@@ -97,11 +98,11 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
       return <span>{typeLabels[item.type]}</span>;
     }
     case "start_date_changed": {
-      if (details.to) return <span>{t(($) => $.labels.set_start_date_to, { date: shortDate(details.to) })}</span>;
+      if (details.to) return <span>{t(($) => $.labels.set_start_date_to, { date: shortDate(details.to, locale) })}</span>;
       return <span>{t(($) => $.labels.removed_start_date)}</span>;
     }
     case "due_date_changed": {
-      if (details.to) return <span>{t(($) => $.labels.set_due_date_to, { date: shortDate(details.to) })}</span>;
+      if (details.to) return <span>{t(($) => $.labels.set_due_date_to, { date: shortDate(details.to, locale) })}</span>;
       return <span>{t(($) => $.labels.removed_due_date)}</span>;
     }
     case "new_comment": {

--- a/packages/views/issues/components/board-card-assignee-picker.test.tsx
+++ b/packages/views/issues/components/board-card-assignee-picker.test.tsx
@@ -67,6 +67,7 @@ vi.mock("@multica/core/workspace/hooks", () => ({
 }));
 
 vi.mock("../../i18n", () => ({
+  useLocale: () => "en",
   useT: () => ({ t: () => "Translated" }),
   useTimeAgo: () => () => "now",
 }));

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -17,7 +17,7 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { PropertyIcon } from "../../common/property-icon";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { useTimeAgo } from "../../i18n";
+import { useLocale, useT, useTimeAgo } from "../../i18n";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { PriorityIcon } from "./priority-icon";
 import { PriorityPicker, AssigneePicker, StartDatePicker, DueDatePicker } from "./pickers";
@@ -29,10 +29,8 @@ import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { CustomStatusChip, useIsCustomStatus } from "./custom-status-chip";
 import { useIssueSurfaceActionsOptional } from "../surface/actions-context";
-import { useT } from "../../i18n";
-
-function formatDate(date: string): string {
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
+function formatDate(date: string, locale: string): string {
+  return formatDateOnly(date, { month: "short", day: "numeric" }, locale);
 }
 
 /** Stops event from bubbling to Link/drag handlers */
@@ -60,6 +58,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   project?: Project;
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const timeAgo = useTimeAgo();
   const storeProperties = useViewStore((s) => s.cardProperties);
   const cardPropertyIds = useViewStore((s) => s.cardPropertyIds);
@@ -246,7 +245,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                       trigger={
                         <span className="flex items-center gap-1 text-caption text-muted-foreground">
                           <CalendarClock className="size-3" />
-                          {formatDate(issue.start_date!)}
+                          {formatDate(issue.start_date!, locale)}
                         </span>
                       }
                     />
@@ -254,7 +253,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                 ) : (
                   <span className="flex shrink-0 items-center gap-1 text-caption text-muted-foreground">
                     <CalendarClock className="size-3" />
-                    {formatDate(issue.start_date!)}
+                    {formatDate(issue.start_date!, locale)}
                   </span>
                 )
               )}
@@ -273,7 +272,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                           }`}
                         >
                           <CalendarDays className="size-3" />
-                          {formatDate(issue.due_date!)}
+                          {formatDate(issue.due_date!, locale)}
                         </span>
                       }
                     />
@@ -287,7 +286,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                     }`}
                   >
                     <CalendarDays className="size-3" />
-                    {formatDate(issue.due_date!)}
+                    {formatDate(issue.due_date!, locale)}
                   </span>
                 )
               )}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -28,7 +28,7 @@ import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { useTimeAgo } from "../../i18n";
+import { useLocale, useTimeAgo } from "../../i18n";
 import { ContentEditor, type ContentEditorRef, ReadonlyContent, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider, useUploadGate, useComposerSubmit } from "../../editor";
 import { useCommentUploads } from "./use-comment-uploads";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -613,6 +613,7 @@ function CommentRow({
   onResolveToggle?: (commentId: string, resolved: boolean) => void;
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
 
@@ -649,7 +650,7 @@ function CommentRow({
             }
           />
           <TooltipContent side="top">
-            {new Date(entry.created_at).toLocaleString()}
+            {new Date(entry.created_at).toLocaleString(locale)}
           </TooltipContent>
         </Tooltip>
 
@@ -866,6 +867,7 @@ function CommentCardImpl({
   highlightedCommentId,
 }: CommentCardProps) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
   const isCollapsed = useCommentCollapseStore((s) => s.isCollapsed(issueId, entry.id));
@@ -971,7 +973,7 @@ function CommentCardImpl({
                   }
                 />
                 <TooltipContent side="top">
-                  {new Date(entry.created_at).toLocaleString()}
+                  {new Date(entry.created_at).toLocaleString(locale)}
                 </TooltipContent>
               </Tooltip>
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -124,7 +124,7 @@ import { useIssueTimeline } from "../hooks/use-issue-timeline";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
 import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
-import { useTimeAgo } from "../../i18n";
+import { useLocale, useTimeAgo } from "../../i18n";
 import {
   useRestoredScrollOffset,
   useRestoredScrollRef,
@@ -261,9 +261,9 @@ function SubscriberPopoverContent({
   );
 }
 
-function shortDate(date: string | null): string {
+function shortDate(date: string | null, locale: string): string {
   if (!date) return "—";
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
+  return formatDateOnly(date, { month: "short", day: "numeric" }, locale);
 }
 
 type ActivityT = ReturnType<typeof useT<"issues">>["t"];
@@ -289,6 +289,7 @@ function statusLabel(
 function formatActivity(
   entry: TimelineEntry,
   t: ActivityT,
+  locale: string,
   resolveActorName?: (type: string, id: string) => string,
   resolveStatusLabel?: (statusKey: string) => string,
 ): string {
@@ -318,12 +319,12 @@ function formatActivity(
     }
     case "start_date_changed": {
       if (!details.to) return t(($) => $.activity.start_date_removed);
-      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, "en-US");
+      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, locale);
       return t(($) => $.activity.start_date_set, { date: formatted });
     }
     case "due_date_changed": {
       if (!details.to) return t(($) => $.activity.due_date_removed);
-      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, "en-US");
+      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, locale);
       return t(($) => $.activity.due_date_set, { date: formatted });
     }
     case "title_changed":
@@ -532,6 +533,7 @@ function ActivityBlock({
   resolveStatusColor,
   t,
   timeAgo,
+  locale,
 }: {
   entries: TimelineEntry[];
   expanded: boolean;
@@ -549,6 +551,7 @@ function ActivityBlock({
   resolveStatusColor: (statusKey: string) => string | null;
   t: ActivityT;
   timeAgo: (dateStr: string) => string;
+  locale: string;
 }) {
   if (!expanded) {
     const count = entries.length;
@@ -634,7 +637,7 @@ function ActivityBlock({
             </div>
             <div className="flex min-w-0 flex-1 items-center gap-1">
               <span className="shrink-0 font-medium">{getActorName(entry.actor_type, entry.actor_id)}</span>
-              <span className="truncate">{formatActivity(entry, t, getActorName, resolveStatusLabel)}</span>
+              <span className="truncate">{formatActivity(entry, t, locale, getActorName, resolveStatusLabel)}</span>
               {(entry.coalesced_count ?? 1) > 1 &&
                 entry.action !== "task_completed" &&
                 entry.action !== "task_failed" && (
@@ -651,7 +654,7 @@ function ActivityBlock({
                   }
                 />
                 <TooltipContent side="top">
-                  {new Date(entry.created_at).toLocaleString()}
+                  {new Date(entry.created_at).toLocaleString(locale)}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -681,6 +684,7 @@ function SubIssueRow({
   customProperties: IssueProperty[];
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const paths = useWorkspacePaths();
   const updateIssue = useUpdateIssue();
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(child.id));
@@ -843,7 +847,7 @@ function SubIssueRow({
                 )}
               >
                 <CalendarDays className="size-3" />
-                {shortDate(child.due_date)}
+                {shortDate(child.due_date, locale)}
               </span>
             }
           />
@@ -1118,6 +1122,7 @@ export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
 
 export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId, highlightRequestToken, leadingAction }: IssueDetailProps) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const timeAgo = useTimeAgo();
   const id = issueId;
   const user = useAuthStore((s) => s.user);
@@ -2592,10 +2597,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             <span className="cursor-pointer truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_created)}>
-            <span className="text-muted-foreground">{shortDate(issue.created_at)}</span>
+            <span className="text-muted-foreground">{shortDate(issue.created_at, locale)}</span>
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_updated)}>
-            <span className="text-muted-foreground">{shortDate(issue.updated_at)}</span>
+            <span className="text-muted-foreground">{shortDate(issue.updated_at, locale)}</span>
           </PropRow>
         </div>}
       </div>
@@ -2702,6 +2707,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         resolveStatusColor={resolveStatusColor}
         t={t}
         timeAgo={timeAgo}
+        locale={locale}
       />
     );
   };

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -25,14 +25,15 @@ import { LabelChip } from "../../labels/label-chip";
 import { CustomStatusChip } from "./custom-status-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { useIssueSurfaceSelection } from "../surface/selection-context";
+import { useLocale } from "../../i18n";
 
 export interface ChildProgress {
   done: number;
   total: number;
 }
 
-function formatDate(date: string): string {
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
+function formatDate(date: string, locale: string): string {
+  return formatDateOnly(date, { month: "short", day: "numeric" }, locale);
 }
 
 function ListRowContent({
@@ -54,6 +55,7 @@ function ListRowContent({
   containerProps?: Record<string, unknown>;
   checkboxProps?: Pick<React.HTMLAttributes<HTMLDivElement>, "onClick" | "onMouseDown" | "onPointerDown">;
 }) {
+  const locale = useLocale();
   const selection = useIssueSurfaceSelection();
   const selected = selection.selectedIds.has(issue.id);
   const toggle = selection.toggle;
@@ -160,12 +162,12 @@ function ListRowContent({
           )}
           {showStartDate && (
             <span className="shrink-0 text-caption text-muted-foreground">
-              {formatDate(issue.start_date!)}
+              {formatDate(issue.start_date!, locale)}
             </span>
           )}
           {showDueDate && (
             <span className="shrink-0 text-caption text-muted-foreground">
-              {formatDate(issue.due_date!)}
+              {formatDate(issue.due_date!, locale)}
             </span>
           )}
           {showAssignee && (

--- a/packages/views/issues/components/pickers/custom-property-picker.tsx
+++ b/packages/views/issues/components/pickers/custom-property-picker.tsx
@@ -22,7 +22,7 @@ import {
 } from "@multica/ui/components/ui/popover";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 import { PropertyPicker, PickerItem } from "./property-picker";
 import { ActorPropertyPicker, ActorPropertyDisplay } from "./actor-property-picker";
 
@@ -473,6 +473,7 @@ export function CustomPropertyValueDisplay({
   value: IssuePropertyValue | undefined;
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   if (value === undefined) {
     return (
       <span className="text-muted-foreground">
@@ -539,7 +540,7 @@ export function CustomPropertyValueDisplay({
         <span className="flex items-center gap-1.5">
           <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
           {typeof value === "string"
-            ? formatDateOnly(value, { month: "short", day: "numeric" }, "en-US")
+            ? formatDateOnly(value, { month: "short", day: "numeric" }, locale)
             : String(value)}
         </span>
       );

--- a/packages/views/issues/components/thread-nav-panel.test.tsx
+++ b/packages/views/issues/components/thread-nav-panel.test.tsx
@@ -208,19 +208,25 @@ describe("formatStamp", () => {
   const at = (iso: string) => new Date(iso).toISOString();
 
   it("shows a clock time under today and yesterday", () => {
-    expect(formatStamp(at("2026-08-05T14:20:00"), "today")).toMatch(/\d/);
-    expect(formatStamp(at("2026-08-05T14:20:00"), "today")).not.toMatch(/[A-Za-z]{3}/);
-    expect(formatStamp(at("2026-08-04T14:20:00"), "yesterday")).not.toMatch(/[A-Za-z]{3}/);
+    expect(formatStamp(at("2026-08-05T14:20:00"), "today", "en")).toMatch(/\d/);
+    expect(formatStamp(at("2026-08-05T14:20:00"), "today", "en")).not.toMatch(/[A-Za-z]{3}/);
+    expect(formatStamp(at("2026-08-04T14:20:00"), "yesterday", "en")).not.toMatch(/[A-Za-z]{3}/);
   });
 
   it("always shows a date under earlier, even when it is under 48 hours old", () => {
     // The regression: 23:41 the day before yesterday is < 48h but groups as
     // "earlier", and used to render as a bare clock time.
-    expect(formatStamp(at("2026-08-03T23:41:00"), "earlier")).toMatch(/[A-Za-z]{3}|\d+\/\d+|月/);
+    expect(formatStamp(at("2026-08-03T23:41:00"), "earlier", "en")).toMatch(/[A-Za-z]{3}|\d+\/\d+|月/);
+  });
+
+  it("formats earlier entries with the selected UI language", () => {
+    expect(
+      formatStamp(at("2026-08-03T23:41:00"), "earlier", "zh-Hans"),
+    ).toContain("月");
   });
 
   it("returns an empty string for an unparseable timestamp", () => {
-    expect(formatStamp("not-a-date", "today")).toBe("");
+    expect(formatStamp("not-a-date", "today", "en")).toBe("");
   });
 });
 

--- a/packages/views/issues/components/thread-nav-panel.tsx
+++ b/packages/views/issues/components/thread-nav-panel.tsx
@@ -22,7 +22,7 @@ import {
 import { ActorAvatar } from "../../common/actor-avatar";
 import { pickerNavigationDirection } from "../../common/picker-keys";
 import { ShortcutKeycaps } from "../../common/shortcut-keycaps";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { commentPreview } from "./thread-minimap";
 
 // ---------------------------------------------------------------------------
@@ -204,6 +204,7 @@ function ThreadRow({
   onHover: (threadId: string | null) => void;
 }) {
   const { t } = useT("issues");
+  const locale = useLocale();
   const { thread, title, excerpt, authorName } = prepared;
   return (
     <button
@@ -245,7 +246,7 @@ function ThreadRow({
             {highlightMatches(title, query)}
           </span>
           <span className="shrink-0 text-micro tabular-nums text-faint-foreground">
-            {formatStamp(prepared.thread.entry.created_at, prepared.group)}
+            {formatStamp(prepared.thread.entry.created_at, prepared.group, locale)}
           </span>
         </span>
         <span className="mt-1 flex min-w-0 items-center gap-1.5 text-caption text-muted-foreground">
@@ -284,13 +285,13 @@ function ThreadRow({
  * "earlier", and it rendered as a bare `11:41 PM` with nothing saying which
  * day. One boundary, decided once, cannot drift from itself.
  */
-export function formatStamp(createdAt: string, group: ThreadDayGroup): string {
+export function formatStamp(createdAt: string, group: ThreadDayGroup, locale: string): string {
   const ts = Date.parse(createdAt);
   if (Number.isNaN(ts)) return "";
   const d = new Date(ts);
   return group === "earlier"
-    ? d.toLocaleDateString(undefined, { month: "short", day: "numeric" })
-    : d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+    ? d.toLocaleDateString(locale, { month: "short", day: "numeric" })
+    : d.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" });
 }
 
 interface ThreadNavPanelProps {

--- a/packages/views/issues/surface/issue-surface.test.tsx
+++ b/packages/views/issues/surface/issue-surface.test.tsx
@@ -77,6 +77,7 @@ vi.mock("@multica/core/auth", () => ({
 }));
 
 vi.mock("../../i18n", () => ({
+  useLocale: () => "en",
   // TableView also reads `i18n.language` for its date formatting.
   useT: () => ({ t: mockTranslate, i18n: { language: "en" } }),
   useTimeAgo: () => () => "now",

--- a/packages/views/runtimes/components/charts/daily-tasks-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tasks-chart.tsx
@@ -11,7 +11,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 
 // Three-segment stack — completed runs at the bottom (chart-1, primary
 // brand), then cancelled (chart-3, muted: a manual stop is an outcome, not
@@ -33,6 +33,7 @@ export interface DailyTasksData {
 
 export function DailyTasksChart({ data }: { data: DailyTasksData[] }) {
   const { t } = useT("runtimes");
+  const locale = useLocale();
   return (
     <ChartContainer config={tasksChartConfig} className="aspect-[3/1] w-full">
       <BarChart data={data} margin={{ left: 0, right: 0, top: 4, bottom: 0 }}>
@@ -66,7 +67,7 @@ export function DailyTasksChart({ data }: { data: DailyTasksData[] }) {
                   <div className="flex items-center justify-between gap-2 font-medium">
                     <span>{t(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
-                      {total.toLocaleString()}
+                      {total.toLocaleString(locale)}
                     </span>
                   </div>
                 );

--- a/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
@@ -12,7 +12,7 @@ import {
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
 import { formatTokens, type DailyTokenData } from "../../utils";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 
 // Four-segment stack — input / output / cache read / cache write. Unlike the
 // cost chart, cache reads ARE visible here: a typical day on Claude shows
@@ -34,6 +34,7 @@ export const tokenStackConfig = {
 
 export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
   const { t } = useT("runtimes");
+  const locale = useLocale();
   // No internal empty-state — same convention as DailyCostChart: the parent
   // decides what to render when there's nothing to show.
   return (
@@ -73,7 +74,7 @@ export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
                   <div className="flex items-center justify-between gap-2 font-medium">
                     <span>{t(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
-                      {total.toLocaleString()}
+                      {total.toLocaleString(locale)}
                     </span>
                   </div>
                 );

--- a/packages/views/runtimes/components/charts/weekly-tasks-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-tasks-chart.tsx
@@ -12,7 +12,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 
 // Weekly counterpart of DailyTasksChart — same completed/cancelled/failed
 // stacked bar, but each bar groups a Mon–Sun calendar week. Partial-week
@@ -39,6 +39,7 @@ export interface WeeklyTasksData {
 export function WeeklyTasksChart({ data }: { data: WeeklyTasksData[] }) {
   const { t } = useT("usage");
   const { t: tRuntimes } = useT("runtimes");
+  const locale = useLocale();
   return (
     <ChartContainer
       config={weeklyTasksChartConfig}
@@ -86,7 +87,7 @@ export function WeeklyTasksChart({ data }: { data: WeeklyTasksData[] }) {
                   <div className="flex items-center justify-between gap-2 font-medium">
                     <span>{tRuntimes(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
-                      {total.toLocaleString()}
+                      {total.toLocaleString(locale)}
                     </span>
                   </div>
                 );

--- a/packages/views/runtimes/components/charts/weekly-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-tokens-chart.tsx
@@ -13,7 +13,7 @@ import {
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
 import { formatTokens, type WeeklyTokenData } from "../../utils";
-import { useT } from "../../../i18n";
+import { useLocale, useT } from "../../../i18n";
 
 // Mirror of DailyTokensChart's four-segment stack — same series and colours
 // keep the Weekly view legible as a coarser cut of the Daily one.
@@ -26,6 +26,7 @@ export const weeklyTokenStackConfig = {
 
 export function WeeklyTokensChart({ data }: { data: WeeklyTokenData[] }) {
   const { t } = useT("runtimes");
+  const locale = useLocale();
   return (
     <ChartContainer config={weeklyTokenStackConfig} className="aspect-[3/1] w-full">
       <BarChart data={data} margin={{ left: 0, right: 0, top: 4, bottom: 0 }}>
@@ -73,7 +74,7 @@ export function WeeklyTokensChart({ data }: { data: WeeklyTokenData[] }) {
                   <div className="flex items-center justify-between gap-2 font-medium">
                     <span>{t(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
-                      {total.toLocaleString()}
+                      {total.toLocaleString(locale)}
                     </span>
                   </div>
                 );

--- a/packages/views/settings/components/labels-tab.tsx
+++ b/packages/views/settings/components/labels-tab.tsx
@@ -42,7 +42,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { cn } from "@multica/ui/lib/utils";
 import { ColorPicker, COLOR_PICKER_PRESETS } from "../../common/color-picker";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
 /**
@@ -68,6 +68,7 @@ const EMPTY_DRAFT: LabelDraft = {
 
 export function LabelsTab() {
   const { t } = useT("settings");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
 
   const [resourceType, setResourceType] = useState<LabelScope>("issue");
@@ -181,7 +182,7 @@ export function LabelsTab() {
                     {t(($) => $.labels.usage_count, { count: label.usage_count ?? 0 })}
                   </span>
                   <span className="text-caption text-muted-foreground">
-                    {new Date(label.updated_at).toLocaleDateString()}
+                    {new Date(label.updated_at).toLocaleDateString(locale)}
                   </span>
                   <DropdownMenu>
                     <DropdownMenuTrigger

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -41,7 +41,7 @@ import { larkInstallationsOptions, larkKeys } from "@multica/core/lark";
 import { api, ApiError } from "@multica/core/api";
 import type { LarkInstallation, LarkInstallStatusResponse } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 // MUL-3083: the Lark (international, open.larksuite.com) "connect a Bot"
 // entry is temporarily hidden while its install → inbound pipeline is
@@ -214,6 +214,7 @@ function InstallationRow({
   onDisconnect: () => void;
 }) {
   const { t } = useT("settings");
+  const locale = useLocale();
   // The bot is bound 1:1 to a Multica Agent (per the (workspace_id,
   // agent_id) UNIQUE in lark_installation). Render the Multica agent's
   // identity here rather than the raw Lark app_id / bot_open_id — those
@@ -249,7 +250,7 @@ function InstallationRow({
           </p>
           <p className="text-micro text-muted-foreground">
             {t(($) => $.lark.installed_at_label, {
-              when: new Date(installation.installed_at).toLocaleString(),
+              when: new Date(installation.installed_at).toLocaleString(locale),
             })}
           </p>
         </div>

--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -315,6 +315,7 @@ function ShareLinkRow({
   onCopy: () => void;
 }) {
   const { t } = useT("settings");
+  const locale = useLocale();
   const roleConfig = useRoleLabels();
   const rc = roleConfig[link.role];
   const navigation = useOptionalNavigation();
@@ -328,7 +329,7 @@ function ShareLinkRow({
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-1 text-body font-medium">
           <span>{t(($) => $.members.share_link_uses, { used: link.use_count, max: link.max_uses ?? "∞" })}</span>
-          {link.expires_at && <span>· {t(($) => $.members.share_link_expires, { date: new Date(link.expires_at).toLocaleDateString() })}</span>}
+          {link.expires_at && <span>· {t(($) => $.members.share_link_expires, { date: new Date(link.expires_at).toLocaleDateString(locale) })}</span>}
         </div>
         <div
           className="truncate font-mono text-caption text-muted-foreground"

--- a/packages/views/settings/components/properties-tab.tsx
+++ b/packages/views/settings/components/properties-tab.tsx
@@ -76,7 +76,7 @@ import {
   PropertyIconGlyph,
   PropertyIconPicker,
 } from "../../common/property-icon";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
 const MAX_ACTIVE_PROPERTIES = 20;
@@ -109,6 +109,7 @@ function typeHasOptions(type: string): boolean {
 
 export function PropertiesTab() {
   const { t } = useT("settings");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   const user = useAuthStore((s) => s.user);
 
@@ -255,7 +256,7 @@ export function PropertiesTab() {
                     {t(($) => $.properties.usage_count, { count: property.usage_count ?? 0 })}
                   </span>
                   <span className="text-caption text-muted-foreground">
-                    {new Date(property.updated_at).toLocaleDateString()}
+                    {new Date(property.updated_at).toLocaleDateString(locale)}
                   </span>
                   {canManage ? (
                     <DropdownMenu>

--- a/packages/views/settings/components/quick-actions-tab.tsx
+++ b/packages/views/settings/components/quick-actions-tab.tsx
@@ -61,7 +61,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { cn } from "@multica/ui/lib/utils";
 import { AgentPicker } from "../../autopilots/components/pickers/agent-picker";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
 // Quick Actions catalog (MUL-5465).
@@ -187,6 +187,7 @@ function toFormState(action: QuickAction): FormState {
 
 export function QuickActionsTab() {
   const { t } = useT("settings");
+  const locale = useLocale();
   const wsId = useWorkspaceId();
   const { data: actions = [], isLoading } = useQuery(quickActionListOptions(wsId, true));
 
@@ -331,7 +332,7 @@ export function QuickActionsTab() {
                         : t(($) => $.quick_actions.used_count, { count: action.use_count })}
                     </span>
                     <span className="text-caption text-muted-foreground">
-                      {new Date(action.updated_at).toLocaleDateString()}
+                      {new Date(action.updated_at).toLocaleDateString(locale)}
                     </span>
                     <DropdownMenu>
                       <DropdownMenuTrigger

--- a/packages/views/settings/components/slack-tab.tsx
+++ b/packages/views/settings/components/slack-tab.tsx
@@ -36,7 +36,7 @@ import { api } from "@multica/core/api";
 import type { SlackInstallation } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { openExternal } from "../../platform";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 // SlackTab is the workspace settings panel for Slack bot installations.
 // Listing is member-visible; the disconnect action is admin-only (the backend
@@ -192,6 +192,7 @@ function InstallationRow({
   onDisconnect: () => void;
 }) {
   const { t } = useT("settings");
+  const locale = useLocale();
   const { getAgentName } = useActorName();
   const isActive = installation.status === "active";
   const agentName = getAgentName(installation.agent_id);
@@ -216,7 +217,7 @@ function InstallationRow({
           </p>
           <p className="text-micro text-muted-foreground">
             {t(($) => $.slack.installed_at_label, {
-              when: new Date(installation.installed_at).toLocaleString(),
+              when: new Date(installation.installed_at).toLocaleString(locale),
             })}
           </p>
         </div>

--- a/packages/views/settings/components/telegram-tab.tsx
+++ b/packages/views/settings/components/telegram-tab.tsx
@@ -36,7 +36,7 @@ import { api } from "@multica/core/api";
 import type { TelegramInstallation } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { openExternal } from "../../platform";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 
 // TelegramTab is the workspace settings panel for Telegram bot installations,
 // mirroring SlackTab: listing is member-visible; the disconnect action is
@@ -186,6 +186,7 @@ function InstallationRow({
   onDisconnect: () => void;
 }) {
   const { t } = useT("settings");
+  const locale = useLocale();
   const { getAgentName } = useActorName();
   const isActive = installation.status === "active";
   const agentName = getAgentName(installation.agent_id);
@@ -215,7 +216,7 @@ function InstallationRow({
           </p>
           <p className="text-micro text-muted-foreground">
             {t(($) => $.telegram.installed_at_label, {
-              when: new Date(installation.installed_at).toLocaleString(),
+              when: new Date(installation.installed_at).toLocaleString(locale),
             })}
           </p>
         </div>

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -37,13 +37,14 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { SettingsSection, SettingsTab } from "./settings-layout";
 
 const EXPIRY_KEYS = ["30", "90", "365", "never"] as const;
 
 export function TokensTab() {
   const { t } = useT("settings");
+  const locale = useLocale();
   const expiryItems = EXPIRY_KEYS.map((value) => ({
     value,
     label: t(($) => $.tokens.expiry[value]),
@@ -205,15 +206,15 @@ export function TokensTab() {
                     <div className="text-caption text-muted-foreground">
                       {t(($) => $.tokens.metadata_prefix, {
                         prefix: token.token_prefix,
-                        created: new Date(token.created_at).toLocaleDateString(),
+                        created: new Date(token.created_at).toLocaleDateString(locale),
                         lastUsed: token.last_used_at
                           ? t(($) => $.tokens.last_used_with_date, {
-                              date: new Date(token.last_used_at!).toLocaleDateString(),
+                              date: new Date(token.last_used_at!).toLocaleDateString(locale),
                             })
                           : t(($) => $.tokens.last_used_never),
                       })}
                       {token.expires_at && t(($) => $.tokens.expires_with_date, {
-                        date: new Date(token.expires_at!).toLocaleDateString(),
+                        date: new Date(token.expires_at!).toLocaleDateString(locale),
                       })}
                     </div>
                   </div>

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -89,7 +89,7 @@ import {
   CollectionPageHeaderAction,
   CollectionPageState,
 } from "../../layout/collection-page";
-import { useT } from "../../i18n";
+import { useLocale, useT } from "../../i18n";
 import { PAGE_TOOLBAR } from "../../layout/page-header";
 
 // Column template — the simplest member of the ListGrid family (squads are
@@ -772,6 +772,7 @@ function SquadListToolbar({
 
 export function SquadsPage() {
   const { t } = useT("squads");
+  const locale = useLocale();
   const workspace = useCurrentWorkspace();
   const wsId = workspace?.id ?? "";
   const p = useWorkspacePaths();
@@ -1011,7 +1012,7 @@ export function SquadsPage() {
                     )}
                     {isColVisible("created") ? (
                       <ListGridCell className="hidden whitespace-nowrap text-caption tabular-nums text-muted-foreground @2xl:flex">
-                        {new Date(squad.created_at).toLocaleDateString()}
+                        {new Date(squad.created_at).toLocaleDateString(locale)}
                       </ListGridCell>
                     ) : (
                       <ListGridCell className="hidden px-0 @2xl:flex" />


### PR DESCRIPTION
## What does this PR do?

Makes user-visible dates, times, numbers, currency values, and chart totals follow the selected Multica UI locale instead of the browser/OS default or a hard-coded en-US locale.

The affected surfaces include agent/autopilot/squad lists, webhook deliveries, chat history, issue dates and activity, comments and transcripts, Inbox date changes, runtime charts, billing diagnostics, and settings metadata.

This is formatting-only: no locale resources, product terminology, API payloads, persisted state, sorting, date arithmetic, or business behavior are changed. The timezone picker keeps its deliberate en-US formatter because that code parses the stable GMT offset shape.

## Related Issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [x] Tests

## Changes

- Pass the existing useLocale() value to Intl, toLocaleString, toLocaleDateString, toLocaleTimeString, and formatDateOnly calls.
- Keep calendar-day formatting timezone-safe while using the selected language.
- Localize numeric totals and currency output in chart and billing surfaces.
- Rebase onto the latest main and combine the Inbox changes with main's useStatusLabel and priorityLabel behavior.
- Retain focused Inbox regressions for status labels, priority labels, and calendar dates, plus thread-navigation date coverage.
- Update focused test mocks for the existing locale hook.

## How has this been tested?

- pnpm --filter @multica/views exec vitest run on 4 focused files: 72 tests passed.
- pnpm --filter @multica/views typecheck passed.
- pnpm --filter @multica/views lint completed with 0 errors and only existing repository warnings.
- The final upstream range contains 32 files and 197 added lines.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the locale formatting fix is effective.
- [x] Relevant unit tests pass locally with my changes.
- [x] I checked the final upstream range for downstream branding, private paths, and product-specific behavior.

## Screenshots

Not included because this is a cross-surface formatting correction with no layout or styling changes.

## Risk

Low to moderate because many display surfaces are touched, but each change is limited to choosing the existing UI locale for presentation. Stored timestamps, calendar-day values, numeric values, calculations, and server data remain unchanged.

## AI assistance

Codex was used to audit implicit and hard-coded locale formatting calls, apply the repository's existing useLocale() pattern, preserve the latest main behavior during rebase, add focused regression tests, run the local validation suite, and scan the final upstream range for downstream branding.
