### PR TITLE
MUL-6838 fix(i18n): localize squad and editor labels

### DIFF
--- a/packages/views/editor/extensions/code-block-view.test.tsx
+++ b/packages/views/editor/extensions/code-block-view.test.tsx
@@ -29,6 +29,7 @@ vi.mock("../../i18n", () => ({
     t: (sel: (s: Record<string, Record<string, string>>) => string) =>
       sel({
         code_block: {
+          html_preview: "Localized HTML preview",
           copy_code: "Copy code",
           show_preview: "Show preview",
           show_source: "Show source",
@@ -65,6 +66,7 @@ describe("CodeBlockView — html language toggle", () => {
     });
     const frame = document.querySelector("iframe");
     expect(frame).toBeTruthy();
+    expect(frame?.getAttribute("title")).toBe("Localized HTML preview");
     expect(frame?.getAttribute("sandbox")).toBe("allow-scripts");
     // NodeViewContent (and its enclosing <pre>) MUST remain mounted —
     // unmounting would break Tiptap's bindings and prevent editing.

--- a/packages/views/editor/extensions/code-block-view.tsx
+++ b/packages/views/editor/extensions/code-block-view.tsx
@@ -73,7 +73,7 @@ function CodeBlockView({ node }: NodeViewProps) {
         <div contentEditable={false} className="mb-1">
           <CodeBlockIframe
             html={debouncedHtml}
-            title="HTML preview"
+            title={t(($) => $.code_block.html_preview)}
             heightClassName={HTML_PREVIEW_HEIGHT}
           />
         </div>

--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -11,6 +11,11 @@ import enAuth from "../../locales/en/auth.json";
 import enSettings from "../../locales/en/settings.json";
 import enEditor from "../../locales/en/editor.json";
 import enIssues from "../../locales/en/issues.json";
+import zhCommon from "../../locales/zh-Hans/common.json";
+import zhAuth from "../../locales/zh-Hans/auth.json";
+import zhSettings from "../../locales/zh-Hans/settings.json";
+import zhEditor from "../../locales/zh-Hans/editor.json";
+import zhIssues from "../../locales/zh-Hans/issues.json";
 
 const TEST_RESOURCES = {
   en: {
@@ -20,11 +25,26 @@ const TEST_RESOURCES = {
     editor: enEditor,
     issues: enIssues,
   },
+  "zh-Hans": {
+    common: zhCommon,
+    auth: zhAuth,
+    settings: zhSettings,
+    editor: zhEditor,
+    issues: zhIssues,
+  },
 };
 
 function I18nWrapper({ children }: { children: ReactNode }) {
   return (
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+function ZhI18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="zh-Hans" resources={TEST_RESOURCES}>
       {children}
     </I18nProvider>
   );
@@ -688,6 +708,26 @@ describe("createMentionSuggestion", () => {
     expect(screen.getByText("Recently viewed")).toBeInTheDocument();
     expect(screen.getByText("MUL-1")).toBeInTheDocument();
     expect(screen.getByText("Roadmap")).toBeInTheDocument();
+  });
+
+  it("localizes agent and squad badges", () => {
+    render(
+      <ZhI18nWrapper>
+        <MentionList
+          items={[
+            { id: "a1", label: "Aegis", type: "agent" },
+            { id: "s1", label: "Core team", type: "squad" },
+          ]}
+          query=""
+          command={vi.fn()}
+        />
+      </ZhI18nWrapper>,
+    );
+
+    expect(screen.getByText("智能体")).toBeInTheDocument();
+    expect(screen.getByText("小队")).toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Squad")).not.toBeInTheDocument();
   });
 
   it("includes squads with a runnable leader in the mention list", () => {

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -624,14 +624,14 @@ function MentionRow({
         {item.type === "all" ? t(($) => $.mention.all_members) : item.label}
       </span>
       {item.type === "agent" && (
-        // "Agent" is a glossary-protected product term — kept un-translated.
-        // eslint-disable-next-line i18next/no-literal-string
-        <Badge variant="outline" className="ml-auto text-micro h-4 px-1.5">Agent</Badge>
+        <Badge variant="outline" className="ml-auto text-micro h-4 px-1.5">
+          {t(($) => $.mention.agent_badge)}
+        </Badge>
       )}
       {item.type === "squad" && (
-        // "Squad" is a glossary-protected product term — kept un-translated.
-        // eslint-disable-next-line i18next/no-literal-string
-        <Badge variant="outline" className="ml-auto text-micro h-4 px-1.5">Squad</Badge>
+        <Badge variant="outline" className="ml-auto text-micro h-4 px-1.5">
+          {t(($) => $.mention.squad_badge)}
+        </Badge>
       )}
     </button>
   );

--- a/packages/views/editor/html-block-preview.test.tsx
+++ b/packages/views/editor/html-block-preview.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../i18n", () => ({
     t: (sel: (s: Record<string, Record<string, string>>) => string) =>
       sel({
         code_block: {
+          html_preview: "Localized HTML preview",
           copy_code: "Copy code",
           show_preview: "Show preview",
           show_source: "Show source",
@@ -36,6 +37,7 @@ describe("HtmlBlockPreview — preview / source toggle", () => {
     const frames = document.querySelectorAll("iframe");
     expect(frames.length).toBeGreaterThanOrEqual(1);
     const frame = frames[0]!;
+    expect(frame.getAttribute("title")).toBe("Localized HTML preview");
     expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
     const srcdoc = frame.getAttribute("srcdoc") ?? "";
     expect(srcdoc.startsWith("<p>hi</p>")).toBe(true);

--- a/packages/views/editor/html-block-preview.tsx
+++ b/packages/views/editor/html-block-preview.tsx
@@ -125,7 +125,7 @@ export function HtmlBlockPreview({ html, className }: HtmlBlockPreviewProps) {
       {view === "preview" ? (
         <HtmlPreviewBody
           source={{ kind: "inline", html }}
-          title="HTML preview"
+          title={t(($) => $.code_block.html_preview)}
           className={CODE_BLOCK_IFRAME_HEIGHT}
         />
       ) : (
@@ -138,7 +138,7 @@ export function HtmlBlockPreview({ html, className }: HtmlBlockPreviewProps) {
         >
           <HtmlPreviewBody
             source={{ kind: "inline", html }}
-            title="HTML preview"
+            title={t(($) => $.code_block.html_preview)}
             className="h-full w-full"
             iframeClassName="rounded-none border-0"
           />

--- a/packages/views/editor/mermaid-diagram.test.tsx
+++ b/packages/views/editor/mermaid-diagram.test.tsx
@@ -255,6 +255,8 @@ describe("MermaidDiagram inline presentation", () => {
   it("renders the diagram in an empty sandbox at its natural size", async () => {
     render(<MermaidDiagram chart={CHART} />);
 
+    expect(screen.getByLabelText("Mermaid diagram")).toBeInTheDocument();
+
     const frame = await waitFor(() => {
       const found = document.querySelector<HTMLIFrameElement>(".mermaid-diagram-frame");
       expect(found).not.toBeNull();
@@ -264,6 +266,7 @@ describe("MermaidDiagram inline presentation", () => {
     expect(frame.getAttribute("sandbox")).toBe("");
     expect(frame.style.width).toBe("1000px");
     expect(frame.style.height).toBe("500px");
+    expect(frame.title).toBe("Mermaid diagram");
   });
 
   it("copies the source straight from the inline toolbar", async () => {

--- a/packages/views/editor/mermaid-diagram.tsx
+++ b/packages/views/editor/mermaid-diagram.tsx
@@ -469,7 +469,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
     <div
       ref={containerRef}
       className="mermaid-diagram"
-      aria-label={t(($) => $.mermaid.diagram_aria)}
+      aria-label={t(($) => $.mermaid.diagram_label)}
       style={containerStyle}
       data-overflow-start={overflow.start ? "" : undefined}
       data-overflow-end={overflow.end ? "" : undefined}
@@ -496,7 +496,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
                 height: rendered.layout ? `${rendered.layout.height}px` : undefined,
                 width: rendered.layout ? `${rendered.layout.width}px` : undefined,
               }}
-              title={t(($) => $.mermaid.diagram_aria)}
+              title={t(($) => $.mermaid.diagram_label)}
             />
           </div>
           <div className="mermaid-diagram-toolbar">

--- a/packages/views/editor/mermaid-diagram.tsx
+++ b/packages/views/editor/mermaid-diagram.tsx
@@ -469,7 +469,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
     <div
       ref={containerRef}
       className="mermaid-diagram"
-      aria-label="Mermaid diagram"
+      aria-label={t(($) => $.mermaid.diagram_aria)}
       style={containerStyle}
       data-overflow-start={overflow.start ? "" : undefined}
       data-overflow-end={overflow.end ? "" : undefined}
@@ -496,7 +496,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
                 height: rendered.layout ? `${rendered.layout.height}px` : undefined,
                 width: rendered.layout ? `${rendered.layout.width}px` : undefined,
               }}
-              title="Mermaid diagram"
+              title={t(($) => $.mermaid.diagram_aria)}
             />
           </div>
           <div className="mermaid-diagram-toolbar">

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -73,6 +73,8 @@
     "group_users": "Users",
     "group_issues": "Issues",
     "all_members": "All members",
+    "agent_badge": "Agent",
+    "squad_badge": "Squad",
     "searching": "Searching...",
     "no_results": "No results",
     "group_current": "Current page",
@@ -88,6 +90,7 @@
     }
   },
   "code_block": {
+    "html_preview": "HTML preview",
     "copy_code": "Copy code",
     "show_preview": "Show preview",
     "show_source": "Show source",
@@ -108,6 +111,7 @@
     "title_aria_label": "Title"
   },
   "mermaid": {
+    "diagram_aria": "Mermaid diagram",
     "render_error": "Unable to render Mermaid diagram.",
     "rendering": "Rendering diagram…",
     "viewer_title": "Diagram",

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -111,7 +111,7 @@
     "title_aria_label": "Title"
   },
   "mermaid": {
-    "diagram_aria": "Mermaid diagram",
+    "diagram_label": "Mermaid diagram",
     "render_error": "Unable to render Mermaid diagram.",
     "rendering": "Rendering diagram…",
     "viewer_title": "Diagram",

--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -19,6 +19,10 @@
     "details_section": "Details",
     "archive_button": "Archive"
   },
+  "member_type": {
+    "agent": "Agent",
+    "member": "Member"
+  },
   "archive_dialog": {
     "title": "Archive this squad?",
     "description": "\"{{name}}\" will be archived. Issues currently assigned to this squad will be transferred to its leader. This can't be undone — create a new squad if you need the routing back.",
@@ -28,7 +32,13 @@
     "success": "Squad archived"
   },
   "name_editor": {
-    "cancel": "Cancel"
+    "title": "Rename squad",
+    "placeholder": "Squad name",
+    "required": "Name is required",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saved": "Saved",
+    "save_failed": "Failed to save"
   },
   "add_member_dialog": {
     "title": "Add Member",
@@ -37,12 +47,21 @@
     "label_role": "Role",
     "label_optional": "(optional)",
     "placeholder_role_inline": "Add role…",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "select_target": "Select a member or agent",
+    "search_placeholder": "Search members or agents...",
+    "members_section": "Members",
+    "agents_section": "Agents",
+    "role_placeholder": "e.g. Reviewer, Frontend Lead",
+    "role_inline_placeholder": "Role (e.g. Reviewer)",
+    "add": "Add"
   },
   "description_dialog": {
     "title": "Edit description",
     "placeholder_empty": "Add a description",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "responsibility_placeholder": "What is this squad responsible for?",
+    "save": "Save"
   },
   "discard_changes_dialog": {
     "title": "Discard unsaved changes?",
@@ -69,6 +88,29 @@
     "active_issue_more": "and {{count}} more",
     "last_active_label": "last active {{time}}"
   },
+  "detail_tabs": {
+    "members": "Members",
+    "instructions": "Instructions"
+  },
+  "details": {
+    "leader": "Leader",
+    "members": "Members",
+    "created_by": "Created by",
+    "created": "Created",
+    "updated": "Updated"
+  },
+  "toasts": {
+    "member_added": "Member added",
+    "member_add_failed": "Failed to add member",
+    "member_removed": "Member removed",
+    "member_remove_failed": "Failed to remove member",
+    "role_updated": "Role updated",
+    "role_update_failed": "Failed to update role",
+    "leader_updated": "Leader updated",
+    "leader_update_failed": "Failed to update leader",
+    "archive_failed": "Failed to archive squad",
+    "instructions_saved": "Instructions saved"
+  },
   "profile_card": {
     "unavailable": "Squad unavailable",
     "detail_link": "Detail →",
@@ -82,7 +124,8 @@
   "instructions_tab": {
     "description": "Squad instructions are injected into the leader agent's prompt whenever it works on an issue assigned to this squad. Use them to give the leader squad-wide guidance, working agreements, or context the leader should follow on every task.",
     "unsaved_changes": "Unsaved changes",
-    "save_button": "Save"
+    "save_button": "Save",
+    "placeholder": "e.g. Always start by writing a failing test. Prefer small, atomic commits."
   },
   "scope": {
     "mine": "Mine",

--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -46,15 +46,17 @@
     "label_member": "Member",
     "label_role": "Role",
     "label_optional": "(optional)",
-    "placeholder_role_inline": "Add role…",
     "cancel": "Cancel",
     "select_target": "Select a member or agent",
     "search_placeholder": "Search members or agents...",
     "members_section": "Members",
     "agents_section": "Agents",
     "role_placeholder": "e.g. Reviewer, Frontend Lead",
-    "role_inline_placeholder": "Role (e.g. Reviewer)",
     "add": "Add"
+  },
+  "role_editor": {
+    "empty": "Add role…",
+    "placeholder": "Role (e.g. Reviewer)"
   },
   "description_dialog": {
     "title": "Edit description",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -104,7 +104,7 @@
     "title_aria_label": "タイトル"
   },
   "mermaid": {
-    "diagram_aria": "Mermaid 図",
+    "diagram_label": "Mermaid 図",
     "render_error": "Mermaid ダイアグラムを描画できません。",
     "rendering": "ダイアグラムを描画中…",
     "viewer_title": "ダイアグラム",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -73,6 +73,8 @@
     "group_users": "ユーザー",
     "group_issues": "タスク",
     "all_members": "すべてのメンバー",
+    "agent_badge": "エージェント",
+    "squad_badge": "スクワッド",
     "searching": "検索中...",
     "no_results": "結果なし",
     "group_current": "現在のページ",
@@ -81,6 +83,7 @@
     "group_cancelled": "キャンセル済み"
   },
   "code_block": {
+    "html_preview": "HTML プレビュー",
     "copy_code": "コードをコピー",
     "show_preview": "プレビューを表示",
     "show_source": "ソースを表示",
@@ -101,6 +104,7 @@
     "title_aria_label": "タイトル"
   },
   "mermaid": {
+    "diagram_aria": "Mermaid 図",
     "render_error": "Mermaid ダイアグラムを描画できません。",
     "rendering": "ダイアグラムを描画中…",
     "viewer_title": "ダイアグラム",

--- a/packages/views/locales/ja/squads.json
+++ b/packages/views/locales/ja/squads.json
@@ -46,15 +46,17 @@
     "label_member": "メンバー",
     "label_role": "役割",
     "label_optional": "（任意）",
-    "placeholder_role_inline": "役割を追加…",
     "cancel": "キャンセル",
     "select_target": "メンバーまたはエージェントを選択",
     "search_placeholder": "メンバーまたはエージェントを検索...",
     "members_section": "メンバー",
     "agents_section": "エージェント",
     "role_placeholder": "例：レビュアー、フロントエンドリード",
-    "role_inline_placeholder": "役割（例：レビュアー）",
     "add": "追加"
+  },
+  "role_editor": {
+    "empty": "役割を追加…",
+    "placeholder": "役割（例：レビュアー）"
   },
   "description_dialog": {
     "title": "説明を編集",

--- a/packages/views/locales/ja/squads.json
+++ b/packages/views/locales/ja/squads.json
@@ -19,6 +19,10 @@
     "details_section": "詳細",
     "archive_button": "アーカイブ"
   },
+  "member_type": {
+    "agent": "エージェント",
+    "member": "メンバー"
+  },
   "archive_dialog": {
     "title": "このスクワッドをアーカイブしますか？",
     "description": "\"{{name}}\" がアーカイブされます。現在このスクワッドに割り当てられているタスクはリーダーに引き継がれます。この操作は取り消せません。ルーティングを元に戻すには、新しいスクワッドを作成してください。",
@@ -28,7 +32,13 @@
     "success": "スカッドをアーカイブしました"
   },
   "name_editor": {
-    "cancel": "キャンセル"
+    "title": "スクワッド名を変更",
+    "placeholder": "スクワッド名",
+    "required": "名前を入力してください",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "saved": "保存しました",
+    "save_failed": "保存できませんでした"
   },
   "add_member_dialog": {
     "title": "メンバーを追加",
@@ -37,12 +47,21 @@
     "label_role": "役割",
     "label_optional": "（任意）",
     "placeholder_role_inline": "役割を追加…",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "select_target": "メンバーまたはエージェントを選択",
+    "search_placeholder": "メンバーまたはエージェントを検索...",
+    "members_section": "メンバー",
+    "agents_section": "エージェント",
+    "role_placeholder": "例：レビュアー、フロントエンドリード",
+    "role_inline_placeholder": "役割（例：レビュアー）",
+    "add": "追加"
   },
   "description_dialog": {
     "title": "説明を編集",
     "placeholder_empty": "説明を追加",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "responsibility_placeholder": "このスクワッドの担当は何ですか？",
+    "save": "保存"
   },
   "discard_changes_dialog": {
     "title": "保存していない変更を破棄しますか？",
@@ -68,6 +87,29 @@
     "last_active_label": "最終アクティブ {{time}}",
     "status_archived": "アーカイブ済み"
   },
+  "detail_tabs": {
+    "members": "メンバー",
+    "instructions": "指示"
+  },
+  "details": {
+    "leader": "リーダー",
+    "members": "メンバー",
+    "created_by": "作成者",
+    "created": "作成日時",
+    "updated": "更新日時"
+  },
+  "toasts": {
+    "member_added": "メンバーを追加しました",
+    "member_add_failed": "メンバーを追加できませんでした",
+    "member_removed": "メンバーを削除しました",
+    "member_remove_failed": "メンバーを削除できませんでした",
+    "role_updated": "役割を更新しました",
+    "role_update_failed": "役割を更新できませんでした",
+    "leader_updated": "リーダーを更新しました",
+    "leader_update_failed": "リーダーを更新できませんでした",
+    "archive_failed": "スクワッドをアーカイブできませんでした",
+    "instructions_saved": "指示を保存しました"
+  },
   "profile_card": {
     "unavailable": "スクワッドを利用できません",
     "detail_link": "詳細 →",
@@ -79,7 +121,8 @@
   "instructions_tab": {
     "description": "スクワッドの指示は、リーダーエージェントがこのスクワッドに割り当てられたタスクに取り組むたびに、そのプロンプトに挿入されます。スクワッド全体の方針、進め方の取り決め、リーダーがすべての作業で従うべきコンテキストを伝えるために使用します。",
     "unsaved_changes": "保存していない変更",
-    "save_button": "保存"
+    "save_button": "保存",
+    "placeholder": "例：必ず失敗するテストから始める。コミットは小さく独立させる。"
   },
   "scope": {
     "mine": "自分",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -73,6 +73,8 @@
     "group_users": "사용자",
     "group_issues": "태스크",
     "all_members": "모든 멤버",
+    "agent_badge": "에이전트",
+    "squad_badge": "스쿼드",
     "searching": "검색 중...",
     "no_results": "결과 없음",
     "group_current": "현재 페이지",
@@ -81,6 +83,7 @@
     "group_cancelled": "취소됨"
   },
   "code_block": {
+    "html_preview": "HTML 미리보기",
     "copy_code": "코드 복사",
     "show_preview": "미리보기 표시",
     "show_source": "소스 표시",
@@ -101,6 +104,7 @@
     "title_aria_label": "제목"
   },
   "mermaid": {
+    "diagram_aria": "Mermaid 다이어그램",
     "render_error": "Mermaid 다이어그램을 렌더링할 수 없습니다.",
     "rendering": "다이어그램 렌더링 중...",
     "viewer_title": "다이어그램",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -104,7 +104,7 @@
     "title_aria_label": "제목"
   },
   "mermaid": {
-    "diagram_aria": "Mermaid 다이어그램",
+    "diagram_label": "Mermaid 다이어그램",
     "render_error": "Mermaid 다이어그램을 렌더링할 수 없습니다.",
     "rendering": "다이어그램 렌더링 중...",
     "viewer_title": "다이어그램",

--- a/packages/views/locales/ko/squads.json
+++ b/packages/views/locales/ko/squads.json
@@ -19,6 +19,10 @@
     "details_section": "세부 정보",
     "archive_button": "보관"
   },
+  "member_type": {
+    "agent": "에이전트",
+    "member": "멤버"
+  },
   "archive_dialog": {
     "title": "이 스쿼드를 보관할까요?",
     "description": "\"{{name}}\"이(가) 보관됩니다. 현재 이 스쿼드에 할당된 태스크는 리더에게 이전됩니다. 이 작업은 되돌릴 수 없습니다. 라우팅을 다시 쓰려면 새 스쿼드를 만드세요.",
@@ -28,7 +32,13 @@
     "success": "스쿼드를 보관했습니다"
   },
   "name_editor": {
-    "cancel": "취소"
+    "title": "스쿼드 이름 변경",
+    "placeholder": "스쿼드 이름",
+    "required": "이름을 입력하세요",
+    "cancel": "취소",
+    "save": "저장",
+    "saved": "저장했습니다",
+    "save_failed": "저장하지 못했습니다"
   },
   "add_member_dialog": {
     "title": "멤버 추가",
@@ -37,12 +47,21 @@
     "label_role": "역할",
     "label_optional": "(선택 사항)",
     "placeholder_role_inline": "역할 추가...",
-    "cancel": "취소"
+    "cancel": "취소",
+    "select_target": "멤버 또는 에이전트 선택",
+    "search_placeholder": "멤버 또는 에이전트 검색...",
+    "members_section": "멤버",
+    "agents_section": "에이전트",
+    "role_placeholder": "예: 리뷰어, 프런트엔드 리드",
+    "role_inline_placeholder": "역할(예: 리뷰어)",
+    "add": "추가"
   },
   "description_dialog": {
     "title": "설명 수정",
     "placeholder_empty": "설명 추가",
-    "cancel": "취소"
+    "cancel": "취소",
+    "responsibility_placeholder": "이 스쿼드는 무엇을 담당하나요?",
+    "save": "저장"
   },
   "discard_changes_dialog": {
     "title": "저장하지 않은 변경사항을 버릴까요?",
@@ -68,6 +87,29 @@
     "active_issue_more": "외 {{count}}개",
     "last_active_label": "마지막 활동 {{time}}"
   },
+  "detail_tabs": {
+    "members": "멤버",
+    "instructions": "지침"
+  },
+  "details": {
+    "leader": "리더",
+    "members": "멤버",
+    "created_by": "생성자",
+    "created": "생성일",
+    "updated": "수정일"
+  },
+  "toasts": {
+    "member_added": "멤버를 추가했습니다",
+    "member_add_failed": "멤버를 추가하지 못했습니다",
+    "member_removed": "멤버를 제거했습니다",
+    "member_remove_failed": "멤버를 제거하지 못했습니다",
+    "role_updated": "역할을 업데이트했습니다",
+    "role_update_failed": "역할을 업데이트하지 못했습니다",
+    "leader_updated": "리더를 업데이트했습니다",
+    "leader_update_failed": "리더를 업데이트하지 못했습니다",
+    "archive_failed": "스쿼드를 보관하지 못했습니다",
+    "instructions_saved": "지침을 저장했습니다"
+  },
   "profile_card": {
     "unavailable": "스쿼드를 사용할 수 없습니다",
     "detail_link": "자세히 →",
@@ -79,7 +121,8 @@
   "instructions_tab": {
     "description": "스쿼드에 할당된 태스크를 리더 에이전트가 처리할 때마다 스쿼드 지침이 리더 프롬프트에 포함됩니다. 스쿼드 전체의 방향, 협업 규칙, 매 작업마다 따라야 할 맥락을 리더에게 전달할 때 사용하세요.",
     "unsaved_changes": "저장하지 않은 변경사항",
-    "save_button": "저장"
+    "save_button": "저장",
+    "placeholder": "예: 항상 실패하는 테스트부터 작성합니다. 커밋은 작고 독립적으로 유지합니다."
   },
   "scope": {
     "mine": "내 스쿼드",

--- a/packages/views/locales/ko/squads.json
+++ b/packages/views/locales/ko/squads.json
@@ -46,15 +46,17 @@
     "label_member": "멤버",
     "label_role": "역할",
     "label_optional": "(선택 사항)",
-    "placeholder_role_inline": "역할 추가...",
     "cancel": "취소",
     "select_target": "멤버 또는 에이전트 선택",
     "search_placeholder": "멤버 또는 에이전트 검색...",
     "members_section": "멤버",
     "agents_section": "에이전트",
     "role_placeholder": "예: 리뷰어, 프런트엔드 리드",
-    "role_inline_placeholder": "역할(예: 리뷰어)",
     "add": "추가"
+  },
+  "role_editor": {
+    "empty": "역할 추가...",
+    "placeholder": "역할(예: 리뷰어)"
   },
   "description_dialog": {
     "title": "설명 수정",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -111,7 +111,7 @@
     "title_aria_label": "标题"
   },
   "mermaid": {
-    "diagram_aria": "Mermaid 图表",
+    "diagram_label": "Mermaid 图表",
     "render_error": "无法渲染 Mermaid 图。",
     "rendering": "渲染中…",
     "viewer_title": "图表",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -73,6 +73,8 @@
     "group_users": "用户",
     "group_issues": "任务",
     "all_members": "所有成员",
+    "agent_badge": "智能体",
+    "squad_badge": "小队",
     "searching": "搜索中...",
     "no_results": "无结果",
     "group_current": "当前页面",
@@ -88,6 +90,7 @@
     }
   },
   "code_block": {
+    "html_preview": "HTML 预览",
     "copy_code": "复制代码",
     "show_preview": "显示预览",
     "show_source": "显示源码",
@@ -108,6 +111,7 @@
     "title_aria_label": "标题"
   },
   "mermaid": {
+    "diagram_aria": "Mermaid 图表",
     "render_error": "无法渲染 Mermaid 图。",
     "rendering": "渲染中…",
     "viewer_title": "图表",

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -46,15 +46,17 @@
     "label_member": "成员",
     "label_role": "角色",
     "label_optional": "（可选）",
-    "placeholder_role_inline": "添加角色…",
     "cancel": "取消",
     "select_target": "选择成员或智能体",
     "search_placeholder": "搜索成员或智能体...",
     "members_section": "成员",
     "agents_section": "智能体",
     "role_placeholder": "例如：审查者、前端负责人",
-    "role_inline_placeholder": "角色（例如：审查者）",
     "add": "添加"
+  },
+  "role_editor": {
+    "empty": "添加角色…",
+    "placeholder": "角色（例如：审查者）"
   },
   "description_dialog": {
     "title": "编辑描述",

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -19,6 +19,10 @@
     "details_section": "详情",
     "archive_button": "归档"
   },
+  "member_type": {
+    "agent": "智能体",
+    "member": "成员"
+  },
   "archive_dialog": {
     "title": "归档这个小队？",
     "description": "“{{name}}” 将被归档，该小队当前承接的任务会转交给小队负责人。此操作无法撤销，如需恢复路由请新建小队。",
@@ -28,7 +32,13 @@
     "success": "已归档小队"
   },
   "name_editor": {
-    "cancel": "取消"
+    "title": "重命名小队",
+    "placeholder": "小队名称",
+    "required": "名称不能为空",
+    "cancel": "取消",
+    "save": "保存",
+    "saved": "已保存",
+    "save_failed": "保存失败"
   },
   "add_member_dialog": {
     "title": "添加成员",
@@ -37,12 +47,21 @@
     "label_role": "角色",
     "label_optional": "（可选）",
     "placeholder_role_inline": "添加角色…",
-    "cancel": "取消"
+    "cancel": "取消",
+    "select_target": "选择成员或智能体",
+    "search_placeholder": "搜索成员或智能体...",
+    "members_section": "成员",
+    "agents_section": "智能体",
+    "role_placeholder": "例如：审查者、前端负责人",
+    "role_inline_placeholder": "角色（例如：审查者）",
+    "add": "添加"
   },
   "description_dialog": {
     "title": "编辑描述",
     "placeholder_empty": "添加描述",
-    "cancel": "取消"
+    "cancel": "取消",
+    "responsibility_placeholder": "这个小队负责什么？",
+    "save": "保存"
   },
   "discard_changes_dialog": {
     "title": "放弃未保存的修改？",
@@ -68,6 +87,29 @@
     "active_issue_more": "还有 {{count}} 个",
     "last_active_label": "最近活动 {{time}}"
   },
+  "detail_tabs": {
+    "members": "成员",
+    "instructions": "指引"
+  },
+  "details": {
+    "leader": "队长",
+    "members": "成员",
+    "created_by": "创建者",
+    "created": "创建时间",
+    "updated": "更新时间"
+  },
+  "toasts": {
+    "member_added": "已添加成员",
+    "member_add_failed": "添加成员失败",
+    "member_removed": "已移除成员",
+    "member_remove_failed": "移除成员失败",
+    "role_updated": "角色已更新",
+    "role_update_failed": "更新角色失败",
+    "leader_updated": "队长已更新",
+    "leader_update_failed": "更新队长失败",
+    "archive_failed": "归档小队失败",
+    "instructions_saved": "指引已保存"
+  },
   "profile_card": {
     "unavailable": "小队不可用",
     "detail_link": "详情 →",
@@ -79,7 +121,8 @@
   "instructions_tab": {
     "description": "小队指引会在 Leader 智能体处理分配给该小队的任务时注入到它的 prompt 中。可用来给 Leader 提供贯穿全队的指导、协作规范，或每次 task 都应遵循的上下文。",
     "unsaved_changes": "有未保存的修改",
-    "save_button": "保存"
+    "save_button": "保存",
+    "placeholder": "例如：始终先编写失败测试。提交应保持小而独立。"
   },
   "scope": {
     "mine": "我的",

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -134,16 +134,16 @@ export function SquadDetailPage() {
         member_id: input.id,
         role: input.role?.trim() || undefined,
       }),
-    onSuccess: () => { refetchMembers(); toast.success("Member added"); },
+    onSuccess: () => { refetchMembers(); toast.success(t(($) => $.toasts.member_added)); },
     onError: (err) =>
-      toast.error(err instanceof Error && err.message ? err.message : "Failed to add member"),
+      toast.error(err instanceof Error && err.message ? err.message : t(($) => $.toasts.member_add_failed)),
   });
 
   const removeMemberMut = useMutation({
     mutationFn: (m: SquadMember) => api.removeSquadMember(squadId, { member_type: m.member_type, member_id: m.member_id }),
-    onSuccess: () => { refetchMembers(); toast.success("Member removed"); },
+    onSuccess: () => { refetchMembers(); toast.success(t(($) => $.toasts.member_removed)); },
     onError: (err) =>
-      toast.error(err instanceof Error && err.message ? err.message : "Failed to remove member"),
+      toast.error(err instanceof Error && err.message ? err.message : t(($) => $.toasts.member_remove_failed)),
   });
 
   const updateRoleMut = useMutation({
@@ -153,9 +153,9 @@ export function SquadDetailPage() {
         member_id: input.member.member_id,
         role: input.role,
       }),
-    onSuccess: () => { refetchMembers(); toast.success("Role updated"); },
+    onSuccess: () => { refetchMembers(); toast.success(t(($) => $.toasts.role_updated)); },
     onError: (err) =>
-      toast.error(err instanceof Error && err.message ? err.message : "Failed to update role"),
+      toast.error(err instanceof Error && err.message ? err.message : t(($) => $.toasts.role_update_failed)),
   });
 
   const setLeaderMut = useMutation({
@@ -164,17 +164,17 @@ export function SquadDetailPage() {
       refetchSquad();
       refetchMembers();
       queryClient.invalidateQueries({ queryKey: workspaceKeys.squads(wsId) });
-      toast.success("Leader updated");
+      toast.success(t(($) => $.toasts.leader_updated));
     },
     onError: (err) =>
-      toast.error(err instanceof Error && err.message ? err.message : "Failed to update leader"),
+      toast.error(err instanceof Error && err.message ? err.message : t(($) => $.toasts.leader_update_failed)),
   });
 
   const deleteMut = useMutation({
     mutationFn: () => api.deleteSquad(squadId),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: workspaceKeys.squads(wsId) }); push(p.squads()); toast.success("Squad archived"); },
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: workspaceKeys.squads(wsId) }); push(p.squads()); toast.success(t(($) => $.archive_dialog.success)); },
     onError: (err) =>
-      toast.error(err instanceof Error && err.message ? err.message : "Failed to archive squad"),
+      toast.error(err instanceof Error && err.message ? err.message : t(($) => $.toasts.archive_failed)),
   });
 
   const getEntityName = (type: string, id: string) => {
@@ -247,7 +247,7 @@ export function SquadDetailPage() {
           onSetLeader={(id) => setLeaderMut.mutate(id)}
           onRemoveMember={(m) => removeMemberMut.mutate(m)}
           onUpdateRole={async (m, role) => { await updateRoleMut.mutateAsync({ member: m, role }); }}
-          onSaveInstructions={async (next) => { await updateSquadMut.mutateAsync({ instructions: next }); toast.success("Instructions saved"); }}
+          onSaveInstructions={async (next) => { await updateSquadMut.mutateAsync({ instructions: next }); toast.success(t(($) => $.toasts.instructions_saved)); }}
           setLeaderPending={setLeaderMut.isPending}
         />
       </div>
@@ -378,13 +378,16 @@ function SquadNameEditor({
   value: string;
   onSave: (next: string) => Promise<void>;
 }) {
+  const { t } = useT("squads");
   return (
     <InlineEditPopover
       value={value}
       onSave={onSave}
-      title="Rename squad"
-      placeholder="Squad name"
-      validate={(v) => (v.trim().length > 0 ? null : "Name is required")}
+      title={t(($) => $.name_editor.title)}
+      placeholder={t(($) => $.name_editor.placeholder)}
+      validate={(v) =>
+        v.trim().length > 0 ? null : t(($) => $.name_editor.required)
+      }
     >
       {(triggerProps) => (
         <button
@@ -442,9 +445,9 @@ function InlineEditPopover({
     try {
       await onSave(draft);
       setOpen(false);
-      toast.success("Saved");
+      toast.success(t(($) => $.name_editor.saved));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Failed to save");
+      toast.error(e instanceof Error ? e.message : t(($) => $.name_editor.save_failed));
     } finally {
       setSaving(false);
     }
@@ -485,7 +488,7 @@ function InlineEditPopover({
               {t(($) => $.name_editor.cancel)}
             </Button>
             <Button size="sm" onClick={() => void commit()} disabled={saving || draft === value}>
-              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t(($) => $.name_editor.save)}
             </Button>
           </div>
         </div>
@@ -555,10 +558,12 @@ function AddMemberDialog({
                 )}
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-medium">
-                    {target?.name ?? "Select a member or agent"}
+                    {target?.name ?? t(($) => $.add_member_dialog.select_target)}
                   </div>
                   {target && (
-                    <div className="truncate text-caption text-muted-foreground capitalize">{target.type}</div>
+                    <div className="truncate text-caption text-muted-foreground">
+                      {t(($) => $.member_type[target.type])}
+                    </div>
                   )}
                 </div>
                 <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${pickerOpen ? "rotate-180" : ""}`} />
@@ -570,13 +575,13 @@ function AddMemberDialog({
                     type="text"
                     value={pickerFilter}
                     onChange={(e) => setPickerFilter(e.target.value)}
-                    placeholder="Search members or agents..."
+                    placeholder={t(($) => $.add_member_dialog.search_placeholder)}
                     className="w-full bg-transparent text-body placeholder:text-muted-foreground outline-none"
                   />
                 </div>
                 <div className="p-1 max-h-72 overflow-y-auto">
                   {filteredMembers.length > 0 && (
-                    <PickerSection label="Members">
+                    <PickerSection label={t(($) => $.add_member_dialog.members_section)}>
                       {filteredMembers.map((m) => (
                         <PickerItem
                           key={m.user_id}
@@ -594,7 +599,7 @@ function AddMemberDialog({
                     </PickerSection>
                   )}
                   {filteredAgents.length > 0 && (
-                    <PickerSection label="Agents">
+                    <PickerSection label={t(($) => $.add_member_dialog.agents_section)}>
                       {filteredAgents.map((a) => (
                         <PickerItem
                           key={a.id}
@@ -626,7 +631,7 @@ function AddMemberDialog({
               type="text"
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              placeholder="e.g. Reviewer, Frontend Lead"
+              placeholder={t(($) => $.add_member_dialog.role_placeholder)}
               className="mt-1"
               onKeyDown={(e) => {
                 if (isImeComposing(e)) return;
@@ -639,7 +644,7 @@ function AddMemberDialog({
         <DialogFooter>
           <Button variant="ghost" onClick={onClose}>{t(($) => $.add_member_dialog.cancel)}</Button>
           <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {submitting ? <Loader2 className="size-3.5 animate-spin" /> : "Add"}
+            {submitting ? <Loader2 className="size-3.5 animate-spin" /> : t(($) => $.add_member_dialog.add)}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -686,7 +691,7 @@ function RoleEditor({ value, onSave }: { value: string; onSave: (next: string) =
           else if (e.key === "Escape") { setDraft(value); setEditing(false); }
         }}
         disabled={saving}
-        placeholder="Role (e.g. Reviewer)"
+        placeholder={t(($) => $.add_member_dialog.role_inline_placeholder)}
         className="h-6 mt-0.5 text-caption px-1.5"
       />
     );
@@ -785,25 +790,25 @@ function SquadDetailInspector({
           {t(($) => $.inspector.details_section)}
         </div>
         <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
-          <InspectorRow label="Leader">
+          <InspectorRow label={t(($) => $.details.leader)}>
             <span className="flex min-w-0 items-center gap-1.5">
               <ActorAvatar actorType="agent" actorId={squad.leader_id} size="xs" />
               <span className="truncate">{leaderName}</span>
             </span>
           </InspectorRow>
-          <InspectorRow label="Members">
+          <InspectorRow label={t(($) => $.details.members)}>
             <span className="text-muted-foreground tabular-nums">{memberCount}</span>
           </InspectorRow>
-          <InspectorRow label="Created by">
+          <InspectorRow label={t(($) => $.details.created_by)}>
             <span className="flex min-w-0 items-center gap-1.5">
               <ActorAvatar actorType="member" actorId={squad.creator_id} size="xs" />
               <span className="truncate">{creatorName}</span>
             </span>
           </InspectorRow>
-          <InspectorRow label="Created">
+          <InspectorRow label={t(($) => $.details.created)}>
             <span className="text-muted-foreground">{timeAgo(squad.created_at)}</span>
           </InspectorRow>
-          <InspectorRow label="Updated">
+          <InspectorRow label={t(($) => $.details.updated)}>
             <span className="text-muted-foreground">{timeAgo(squad.updated_at)}</span>
           </InspectorRow>
         </div>
@@ -904,7 +909,7 @@ function SquadDescriptionEditorBody({
         autoFocus
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
-        placeholder="What is this squad responsible for?"
+        placeholder={t(($) => $.description_dialog.responsibility_placeholder)}
         rows={6}
         onKeyDown={(e) => {
           if (e.key === "Escape") { onClose(); return; }
@@ -919,7 +924,7 @@ function SquadDescriptionEditorBody({
       <DialogFooter>
         <Button variant="ghost" size="sm" onClick={onClose} disabled={saving}>{t(($) => $.description_dialog.cancel)}</Button>
         <Button size="sm" onClick={() => void commit()} disabled={saving || !dirty}>
-          {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
+          {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t(($) => $.description_dialog.save)}
         </Button>
       </DialogFooter>
     </>
@@ -933,9 +938,9 @@ function SquadDescriptionEditorBody({
 // ---------------------------------------------------------------------------
 type SquadDetailTab = "members" | "instructions";
 
-const squadDetailTabs: { id: SquadDetailTab; label: string; icon: typeof FileText }[] = [
-  { id: "members", label: "Members", icon: Users },
-  { id: "instructions", label: "Instructions", icon: FileText },
+const squadDetailTabs: { id: SquadDetailTab; icon: typeof FileText }[] = [
+  { id: "members", icon: Users },
+  { id: "instructions", icon: FileText },
 ];
 
 function SquadOverviewPane({
@@ -1009,7 +1014,9 @@ function SquadOverviewPane({
             }`}
           >
             <tab.icon className="h-3.5 w-3.5" />
-            {tab.label}
+            {tab.id === "members"
+              ? t(($) => $.detail_tabs.members)
+              : t(($) => $.detail_tabs.instructions)}
           </button>
         ))}
       </div>
@@ -1181,7 +1188,9 @@ function SquadMembersTab({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="text-body font-medium">{getEntityName(m.member_type, m.member_id)}</span>
-                  <span className="text-caption text-muted-foreground capitalize">{m.member_type}</span>
+                  <span className="text-caption text-muted-foreground">
+                    {t(($) => $.member_type[m.member_type])}
+                  </span>
                   {isLeader(m) && (
                     <span className="inline-flex items-center gap-0.5 text-caption bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1.5 py-0.5 rounded">
                       <Crown className="size-3" />
@@ -1362,7 +1371,7 @@ function SquadInstructionsTab({
           onUpdate={canManage ? setValue : () => {}}
           placeholder={
             canManage
-              ? "e.g. Always start by writing a failing test. Prefer small, atomic commits."
+              ? t(($) => $.instructions_tab.placeholder)
               : ""
           }
           debounceMs={150}

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -691,7 +691,7 @@ function RoleEditor({ value, onSave }: { value: string; onSave: (next: string) =
           else if (e.key === "Escape") { setDraft(value); setEditing(false); }
         }}
         disabled={saving}
-        placeholder={t(($) => $.add_member_dialog.role_inline_placeholder)}
+        placeholder={t(($) => $.role_editor.placeholder)}
         className="h-6 mt-0.5 text-caption px-1.5"
       />
     );
@@ -703,7 +703,7 @@ function RoleEditor({ value, onSave }: { value: string; onSave: (next: string) =
       onClick={() => setEditing(true)}
       className="text-caption text-muted-foreground mt-0.5 text-left hover:text-foreground transition-colors"
     >
-      {value || <span className="italic opacity-60">{t(($) => $.add_member_dialog.placeholder_role_inline)}</span>}
+      {value || <span className="italic opacity-60">{t(($) => $.role_editor.empty)}</span>}
     </button>
   );
 }
@@ -1014,9 +1014,7 @@ function SquadOverviewPane({
             }`}
           >
             <tab.icon className="h-3.5 w-3.5" />
-            {tab.id === "members"
-              ? t(($) => $.detail_tabs.members)
-              : t(($) => $.detail_tabs.instructions)}
+            {t(($) => $.detail_tabs[tab.id])}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## What does this PR do?

Removes hard-coded English from the squad detail and editor surfaces so user-facing labels, feedback, placeholders, enum values, iframe titles, and accessible names follow the selected locale. The change uses the existing typed `useT` selectors and keeps API payloads, state, and behavior unchanged.

The implementation was scoped by tracing each visible literal to its owning component and locale namespace, checking the Chinese copy against the repository terminology contract, and excluding downstream-only branding or product behavior.

## Related Issue

N/A — this is a self-contained localization bug fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Route squad detail toasts, fields, tabs, placeholders, and `agent` / `member` display values through the `squads` namespace.
- Localize editor mention badges, HTML preview iframe titles, and Mermaid accessible names.
- Add matching English, Japanese, Korean, and Simplified Chinese resources.
- Add regression coverage for localized editor output and locale key parity.
- No downstream branding, private paths, API changes, or business-logic changes are included.

## How to Test

1. Run `corepack pnpm --filter @multica/views typecheck`.
2. Run `corepack pnpm --filter @multica/views exec vitest run locales/parity.test.ts editor/extensions/code-block-view.test.tsx editor/extensions/mention-suggestion.test.tsx editor/html-block-preview.test.tsx editor/mermaid-diagram.test.tsx`.
3. Run `corepack pnpm --filter @multica/views lint`.

Local results: typecheck passed; 5 test files / 230 tests passed; lint completed with 0 errors (27 pre-existing warnings).

Risk is limited to presentation copy and accessible labels. Translation key parity and typed selectors cover missing-resource regressions.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) — not applicable; no runtime, tool, or tab was added
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Screenshots are not included because this only replaces existing labels with locale-backed equivalents and does not alter layout.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Audited the downstream localization diff against current upstream main, isolated upstream-generic untranslated UI, removed downstream-only scope, implemented typed locale lookups, added focused regression tests, and validated the result locally before opening this Draft PR.

## Screenshots (optional)

Not included; no layout or visual styling changes.