### PR TITLE
MUL-6840 fix(pi): preserve sessions across workdir changes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5769,14 +5769,16 @@ func sameExistingDir(a, b string) bool {
 }
 
 func gateResumeToReachableSession(task *Task, taskCtx *execenv.TaskContextForEnv, provider, envWorkDir string, sessionHomeReachable bool, taskLog *slog.Logger) bool {
-	// Compare the directories, not the spelling. Reuse runs in the canonical
-	// path it validated and locked, which need not be character-identical to
-	// the PriorWorkDir the server sent — a symlinked workspaces root is enough
-	// to make them differ. A string compare would then silently drop the prior
-	// session on every follow-up task in that installation.
-	reachable := task.PriorWorkDir != "" && sameExistingDir(envWorkDir, task.PriorWorkDir) && sessionHomeReachable
-	if provider == "pi" || provider == "omp" {
+	var reachable bool
+	if providerUsesPiSessionFile(provider) {
 		reachable = piSessionFilePresent(task.PriorSessionID)
+	} else {
+		// Compare the directories, not the spelling. Reuse runs in the canonical
+		// path it validated and locked, which need not be character-identical to
+		// the PriorWorkDir the server sent — a symlinked workspaces root is enough
+		// to make them differ. A string compare would then silently drop the prior
+		// session on every follow-up task in that installation.
+		reachable = task.PriorWorkDir != "" && sameExistingDir(envWorkDir, task.PriorWorkDir) && sessionHomeReachable
 	}
 	if !reachable && task.PriorSessionID != "" {
 		taskLog.Info("dropping prior session: session store not reachable from this run",
@@ -5798,12 +5800,24 @@ func gateResumeToReachableSession(task *Task, taskCtx *execenv.TaskContextForEnv
 	return reachable
 }
 
+func providerUsesPiSessionFile(provider string) bool {
+	if provider == "pi" {
+		return true
+	}
+	desc, ok := agent.BuiltinRuntimeByID(provider)
+	return ok && desc.ProtocolFamily == "pi"
+}
+
+// piSessionFilePresent proves there is persisted history to resume. It does
+// not claim the transcript is idle: the Pi backend takes an exclusive lock for
+// the complete child-process lifetime and reports a busy resume as rejected so
+// runTask falls back to its existing one-shot fresh-session path.
 func piSessionFilePresent(sessionID string) bool {
 	if sessionID == "" {
 		return false
 	}
 	info, err := os.Stat(sessionID)
-	return err == nil && info.Mode().IsRegular()
+	return err == nil && info.Mode().IsRegular() && info.Size() > 0
 }
 
 // sessionHomeReachable reports whether a session recorded by a prior task on

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5721,16 +5721,22 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 	}
 }
 
-// gateResumeToReusedWorkdir clears the task's prior session unless this run
+// gateResumeToReachableSession clears the task's prior session unless this run
 // can actually reach the store the session lives in, and reports whether that
-// held. CLI backends key their session stores to the cwd (Claude Code looks
-// sessions up under ~/.claude/projects/<encoded-cwd>/), so a session id from a
-// different workdir can never resolve: the CLI exits within a second and the
-// run fails before doing any work — permanently, because the failed run
-// records no session and the next claim serves the same stale pointer again.
-// This fires whenever the prior workdir no longer exists (GC'd after the issue
-// went done, daemon reinstall, manual cleanup) and execenv.Reuse fell back to a
-// fresh Prepare (GitHub #3854).
+// held. Most CLI backends key their session stores to the cwd (Claude Code
+// looks sessions up under ~/.claude/projects/<encoded-cwd>/), so a session id
+// from a different workdir can never resolve: the CLI exits within a second
+// and the run fails before doing any work — permanently, because the failed
+// run records no session and the next claim serves the same stale pointer
+// again. This fires whenever the prior workdir no longer exists (GC'd after
+// the issue went done, daemon reinstall, manual cleanup) and execenv.Reuse fell
+// back to a fresh Prepare (GitHub #3854).
+//
+// Pi and OMP are the exception. Their opaque session id is an absolute JSONL
+// path under ~/.multica/pi-sessions, and the backend passes that path directly
+// to --session. The transcript remains resumable when only the task workdir
+// changes, so binding it to workdir reuse discards healthy conversation history
+// and forces the model to reconstruct it through `multica chat history`.
 //
 // A matching workdir is not sufficient on its own. Hermes keys its sessions to
 // HERMES_HOME — the per-task overlay under envRoot — not to the cwd, and the
@@ -5745,8 +5751,8 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 // HermesSessionStore) — and false drops the resume with the same disclosure as
 // a workdir mismatch.
 // sameExistingDir reports whether two paths name the same existing directory.
-// False when either cannot be stat'd, which is the safe answer here: an absent
-// prior workdir means there is nothing to resume from.
+// False when either cannot be stat'd, which is the safe answer for cwd-keyed
+// providers: an absent prior workdir means there is nothing to resume from.
 func sameExistingDir(a, b string) bool {
 	if a == "" || b == "" {
 		return false
@@ -5762,15 +5768,19 @@ func sameExistingDir(a, b string) bool {
 	return os.SameFile(ai, bi)
 }
 
-func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, envWorkDir string, sessionHomeReachable bool, taskLog *slog.Logger) bool {
+func gateResumeToReachableSession(task *Task, taskCtx *execenv.TaskContextForEnv, provider, envWorkDir string, sessionHomeReachable bool, taskLog *slog.Logger) bool {
 	// Compare the directories, not the spelling. Reuse runs in the canonical
 	// path it validated and locked, which need not be character-identical to
 	// the PriorWorkDir the server sent — a symlinked workspaces root is enough
 	// to make them differ. A string compare would then silently drop the prior
 	// session on every follow-up task in that installation.
-	reused := task.PriorWorkDir != "" && sameExistingDir(envWorkDir, task.PriorWorkDir) && sessionHomeReachable
-	if !reused && task.PriorSessionID != "" {
+	reachable := task.PriorWorkDir != "" && sameExistingDir(envWorkDir, task.PriorWorkDir) && sessionHomeReachable
+	if provider == "pi" || provider == "omp" {
+		reachable = piSessionFilePresent(task.PriorSessionID)
+	}
+	if !reachable && task.PriorSessionID != "" {
 		taskLog.Info("dropping prior session: session store not reachable from this run",
+			"provider", provider,
 			"session_id", task.PriorSessionID,
 			"prior_workdir", task.PriorWorkDir,
 			"workdir", envWorkDir,
@@ -5785,7 +5795,15 @@ func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, e
 		taskCtx.PriorSessionResumeUnavailable = true
 		task.PriorSessionResumeUnavailable = true
 	}
-	return reused
+	return reachable
+}
+
+func piSessionFilePresent(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	info, err := os.Stat(sessionID)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // sessionHomeReachable reports whether a session recorded by a prior task on
@@ -5807,9 +5825,8 @@ func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, e
 //   - With no store, the transcript is the overlay's own task-local file, which
 //     survives exactly when this run reused the prior task's env root.
 //
-// Every other provider is keyed by cwd (or resolves its own store), so the
-// workdir comparison in gateResumeToReusedWorkdir remains the whole answer and
-// this returns true.
+// Every other provider is keyed by cwd or handles its independently addressed
+// store in gateResumeToReachableSession, so this predicate returns true.
 func sessionHomeReachable(provider string, env *execenv.Environment, envReused bool) bool {
 	if provider != "hermes" {
 		return true
@@ -5904,7 +5921,7 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 
 // gateCodexResumeToRolloutPresence drops the prior Codex session when its
 // rollout is not actually present in the task's CODEX_HOME sessions. A reused
-// workdir keeps PriorSessionID (gateResumeToReusedWorkdir), but Codex session
+// workdir keeps PriorSessionID (gateResumeToReachableSession), but Codex session
 // isolation (MUL-4424) means the rollout may be missing: a migrated legacy home
 // that could not locate it, or a local_directory task whose shared history was
 // pruned. Codex would then silently thread/start from scratch, so we clear the
@@ -7327,13 +7344,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	cancelPrepare()
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
-	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, sessionHomeReachable(provider, env, envReused), taskLog)
+	resumeReachable := gateResumeToReachableSession(&task, &taskCtx, provider, env.WorkDir, sessionHomeReachable(provider, env, envReused), taskLog)
 	// A reused workdir is necessary but not sufficient for a Codex resume: the
 	// prior thread's rollout must actually be present in this task's CODEX_HOME
 	// sessions (MUL-4424 isolates them). Drop the resume before the brief is
 	// generated below if it isn't, so we never tell the agent it is continuing a
 	// conversation Codex will silently restart from scratch.
-	if reused {
+	if resumeReachable {
 		gateCodexResumeToRolloutPresence(&task, &taskCtx, provider, env.CodexHome, taskLog)
 	}
 
@@ -7523,7 +7540,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"provider", provider,
 		"workdir", env.WorkDir,
 		"model", model,
-		"reused", reused,
+		"resume_reachable", resumeReachable,
 	)
 	if task.PriorSessionID != "" {
 		taskLog.Info("resuming session", "session_id", task.PriorSessionID)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -7714,7 +7714,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		firstResult := result
 		firstUsage := result.Usage
 		firstTools := tools
-		retiredSessionID = task.PriorSessionID
+		if !result.ResumeRejectedTransient {
+			retiredSessionID = task.PriorSessionID
+		}
 		taskLog.Warn("session resume failed, retrying with fresh session", "error", result.Error)
 
 		// Rebuild cold-session context before the single retry. The prior
@@ -8014,9 +8016,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 // how this went wrong before:
 //
 //  1. Would a fresh session even fix this? Only if the resume itself was
-//     refused — the transcript is gone, or it belongs to another provider
-//     account. result.ResumeRejected is the backend's positive evidence of
-//     that, and where a backend can produce it, it is the whole answer.
+//     refused — permanently because the transcript is gone or belongs to
+//     another provider account, or transiently because another live run owns
+//     it. result.ResumeRejected and result.ResumeRejectedTransient are the
+//     backend's positive evidence of those two cases. Both allow a fresh retry,
+//     but only the permanent signal retires the prior session from later
+//     lookups.
 //     Answering by exclusion alone would invert the burden of proof: the
 //     failures a new session cures are a small enumerable set, while the
 //     ones it cannot are open-ended. A network drop, a 429, a quota trip or
@@ -8047,7 +8052,7 @@ func shouldRetryWithFreshSession(result agent.Result, priorSessionID string, too
 		return false
 	}
 	// Positive evidence: the backend proved the resume was refused.
-	if result.ResumeRejected {
+	if result.ResumeRejected || result.ResumeRejectedTransient {
 		return true
 	}
 	// Positive evidence of a different kind: the resume was NOT refused —

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2736,6 +2736,12 @@ func TestShouldRetryWithFreshSession(t *testing.T) {
 			want:           true,
 		},
 		{
+			name:           "temporarily busy resume retries without declaring the session dead",
+			result:         agent.Result{Status: "failed", Error: "session already in use", ResumeRejectedTransient: true},
+			priorSessionID: "healthy-id",
+			want:           true,
+		},
+		{
 			// The reported bug: the session belongs to another provider
 			// account and the backend echoes the requested id back on the
 			// rejection, so SessionID stays non-empty. The backend still

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1954,7 +1954,7 @@ func TestExecuteAndDrain_PinsWhenRolloutAppearsAfterStatus(t *testing.T) {
 	t.Fatalf("expected the codex session to be pinned once its rollout appeared mid-run, got %+v", rec.snapshot())
 }
 
-func TestGateResumeToReusedWorkdir(t *testing.T) {
+func TestGateResumeToReachableSession(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -2019,7 +2019,7 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// gateResumeToReusedWorkdir compares directory IDENTITY, not path
+			// gateResumeToReachableSession compares directory IDENTITY, not path
 			// spelling, so the table's paths have to exist on disk. Mapping
 			// them under one temp root preserves each case's same/different
 			// relationship while making them real.
@@ -2039,7 +2039,7 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 			task := Task{PriorSessionID: tt.sessionID, PriorWorkDir: priorDir}
 			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: tt.sessionID != ""}
 
-			reused := gateResumeToReusedWorkdir(&task, &taskCtx, envDir, !tt.sessionHomeUnreachable, slog.Default())
+			reused := gateResumeToReachableSession(&task, &taskCtx, "claude", envDir, !tt.sessionHomeUnreachable, slog.Default())
 
 			if reused != tt.wantReused {
 				t.Fatalf("reused = %v, want %v", reused, tt.wantReused)
@@ -2057,6 +2057,76 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 				t.Fatalf("PriorSessionResumeUnavailable = %v, want %v", taskCtx.PriorSessionResumeUnavailable, wantUnavailable)
 			}
 		})
+	}
+}
+
+func TestGatePiResumeToSessionFile(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{"pi", "omp"} {
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+
+			base := t.TempDir()
+			priorDir := filepath.Join(base, "prior-workdir")
+			envDir := filepath.Join(base, "fresh-workdir")
+			for _, dir := range []string{priorDir, envDir} {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatalf("create %s: %v", dir, err)
+				}
+			}
+
+			sessionFile := filepath.Join(base, "pi-session.jsonl")
+			if err := os.WriteFile(sessionFile, []byte("{}\n"), 0o644); err != nil {
+				t.Fatalf("create session file: %v", err)
+			}
+
+			task := Task{PriorSessionID: sessionFile, PriorWorkDir: priorDir}
+			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+
+			reachable := gateResumeToReachableSession(&task, &taskCtx, provider, envDir, true, slog.Default())
+
+			if !reachable {
+				t.Fatal("Pi-family session file should remain reachable across workdirs")
+			}
+			if task.PriorSessionID != sessionFile {
+				t.Fatalf("PriorSessionID = %q, want %q", task.PriorSessionID, sessionFile)
+			}
+			if !taskCtx.PriorSessionResumed {
+				t.Fatal("PriorSessionResumed was cleared for a reachable Pi-family session")
+			}
+			if taskCtx.PriorSessionResumeUnavailable {
+				t.Fatal("reachable Pi-family session was reported unavailable")
+			}
+		})
+	}
+}
+
+func TestGatePiResumeDropsMissingSessionFile(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	workDir := filepath.Join(base, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("create workdir: %v", err)
+	}
+	missingSession := filepath.Join(base, "missing.jsonl")
+	task := Task{PriorSessionID: missingSession, PriorWorkDir: workDir}
+	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+
+	reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", workDir, true, slog.Default())
+
+	if reachable {
+		t.Fatal("missing Pi session file was treated as reachable")
+	}
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+	}
+	if taskCtx.PriorSessionResumed {
+		t.Fatal("PriorSessionResumed stayed true for a missing Pi session")
+	}
+	if !taskCtx.PriorSessionResumeUnavailable {
+		t.Fatal("missing Pi session was not reported unavailable")
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2039,10 +2039,10 @@ func TestGateResumeToReachableSession(t *testing.T) {
 			task := Task{PriorSessionID: tt.sessionID, PriorWorkDir: priorDir}
 			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: tt.sessionID != ""}
 
-			reused := gateResumeToReachableSession(&task, &taskCtx, "claude", envDir, !tt.sessionHomeUnreachable, slog.Default())
+			reachable := gateResumeToReachableSession(&task, &taskCtx, "claude", envDir, !tt.sessionHomeUnreachable, slog.Default())
 
-			if reused != tt.wantReused {
-				t.Fatalf("reused = %v, want %v", reused, tt.wantReused)
+			if reachable != tt.wantReused {
+				t.Fatalf("reachable = %v, want %v", reachable, tt.wantReused)
 			}
 			if task.PriorSessionID != tt.wantSession {
 				t.Fatalf("PriorSessionID = %q, want %q", task.PriorSessionID, tt.wantSession)
@@ -2102,31 +2102,77 @@ func TestGatePiResumeToSessionFile(t *testing.T) {
 	}
 }
 
-func TestGatePiResumeDropsMissingSessionFile(t *testing.T) {
+func TestGatePiResumeDropsUnusableSessionFile(t *testing.T) {
 	t.Parallel()
 
-	base := t.TempDir()
-	workDir := filepath.Join(base, "workdir")
-	if err := os.MkdirAll(workDir, 0o755); err != nil {
-		t.Fatalf("create workdir: %v", err)
-	}
-	missingSession := filepath.Join(base, "missing.jsonl")
-	task := Task{PriorSessionID: missingSession, PriorWorkDir: workDir}
-	taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, path string)
+	}{
+		{name: "missing"},
+		{
+			name: "empty",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, nil, 0o644); err != nil {
+					t.Fatalf("create empty session: %v", err)
+				}
+			},
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatalf("create session directory: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", workDir, true, slog.Default())
+			base := t.TempDir()
+			workDir := filepath.Join(base, "workdir")
+			if err := os.MkdirAll(workDir, 0o755); err != nil {
+				t.Fatalf("create workdir: %v", err)
+			}
+			sessionPath := filepath.Join(base, "session.jsonl")
+			if test.setup != nil {
+				test.setup(t, sessionPath)
+			}
+			task := Task{PriorSessionID: sessionPath, PriorWorkDir: workDir}
+			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: true}
 
-	if reachable {
-		t.Fatal("missing Pi session file was treated as reachable")
+			reachable := gateResumeToReachableSession(&task, &taskCtx, "pi", workDir, true, slog.Default())
+
+			if reachable {
+				t.Fatalf("%s Pi session was treated as reachable", test.name)
+			}
+			if task.PriorSessionID != "" {
+				t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+			}
+			if taskCtx.PriorSessionResumed {
+				t.Fatalf("PriorSessionResumed stayed true for a %s Pi session", test.name)
+			}
+			if !taskCtx.PriorSessionResumeUnavailable {
+				t.Fatalf("%s Pi session was not reported unavailable", test.name)
+			}
+		})
 	}
-	if task.PriorSessionID != "" {
-		t.Fatalf("PriorSessionID = %q, want empty", task.PriorSessionID)
+}
+
+func TestProviderUsesPiSessionFileFollowsBuiltinRuntimeDescriptors(t *testing.T) {
+	t.Parallel()
+
+	if !providerUsesPiSessionFile("pi") {
+		t.Fatal("pi protocol family did not use Pi session-file reachability")
 	}
-	if taskCtx.PriorSessionResumed {
-		t.Fatal("PriorSessionResumed stayed true for a missing Pi session")
-	}
-	if !taskCtx.PriorSessionResumeUnavailable {
-		t.Fatal("missing Pi session was not reported unavailable")
+	for _, desc := range agent.BuiltinRuntimes {
+		want := desc.ProtocolFamily == "pi"
+		if got := providerUsesPiSessionFile(desc.ID); got != want {
+			t.Errorf("providerUsesPiSessionFile(%q) = %v, want %v for protocol family %q", desc.ID, got, want, desc.ProtocolFamily)
+		}
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -336,7 +336,7 @@ type Environment struct {
 	// GC reclaimed between turns, a switched Hermes profile and an operator's
 	// `rm` all mount cleanly onto nothing. The daemon reads THIS, not the store
 	// path, as the answer to "can a prior session id still resolve here?" — see
-	// gateResumeToReusedWorkdir.
+	// gateResumeToReachableSession.
 	HermesSessionHistoryPresent bool
 	// QwenpawWorkspace is the path to the per-task QwenPaw workspace directory
 	// (set only for the qwenpaw provider). It is populated with the bound skills

--- a/server/internal/daemon/pi_busy_retry_unix_test.go
+++ b/server/internal/daemon/pi_busy_retry_unix_test.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestRunTaskPiBusyRetryDoesNotRetireHealthySession pins the distinction
+// between a permanently rejected resume and a healthy transcript that another
+// execution owns temporarily. The busy attempt must still fall back to a fresh
+// session for this turn, but that fallback must not remove the original JSONL
+// from every future session lookup.
+func TestRunTaskPiBusyRetryDoesNotRetireHealthySession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	priorSessionID := filepath.Join(t.TempDir(), "busy-session.jsonl")
+	claim, err := os.OpenFile(priorSessionID, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open prior session: %v", err)
+	}
+	defer claim.Close()
+	if _, err := claim.WriteString("{}\n"); err != nil {
+		t.Fatalf("seed prior session: %v", err)
+	}
+	if err := unix.Flock(int(claim.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		t.Fatalf("lock prior session: %v", err)
+	}
+	defer unix.Flock(int(claim.Fd()), unix.LOCK_UN) //nolint:errcheck -- best-effort test cleanup
+
+	fakeBin := filepath.Join(t.TempDir(), "pi")
+	script := `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"agent_start"}'
+printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"done"}}'
+printf '%s\n' '{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}'
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		logger:         logger,
+		workspaces:     make(map[string]*workspaceState),
+		runtimeIndex:   map[string]Runtime{"rt-pi": {ID: "rt-pi", Provider: "pi"}},
+		activeEnvRoots: make(map[string]int),
+		cfg: Config{
+			WorkspacesRoot: t.TempDir(),
+			AgentTimeout:   5 * time.Second,
+			ServerBaseURL:  srv.URL,
+			Agents: map[string]AgentEntry{
+				"pi": {Path: fakeBin},
+			},
+		},
+	}
+	task := Task{
+		ID:             "task-pi-busy",
+		WorkspaceID:    "ws-pi",
+		RuntimeID:      "rt-pi",
+		IssueID:        "issue-pi",
+		AgentID:        "agent-pi",
+		AuthToken:      "mat_pi_busy",
+		PriorSessionID: priorSessionID,
+		Agent: &AgentData{
+			ID:   "agent-pi",
+			Name: "pi-agent",
+		},
+	}
+
+	result, err := d.runTask(context.Background(), task, "pi", 0, logger)
+	if err != nil {
+		t.Fatalf("runTask: %v", err)
+	}
+	if result.Status != "completed" || result.Comment != "done" {
+		t.Fatalf("result = %+v, want successful fresh-session retry", result)
+	}
+	if result.SessionID == "" || result.SessionID == priorSessionID {
+		t.Fatalf("SessionID = %q, want a new session", result.SessionID)
+	}
+	if result.RetiredSessionID != "" {
+		t.Fatalf("RetiredSessionID = %q, want empty for a temporarily busy healthy session", result.RetiredSessionID)
+	}
+}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -200,9 +200,8 @@ type Result struct {
 	SessionID  string
 	Usage      map[string]TokenUsage // keyed by model name
 	// ResumeRejected is positive evidence that this run's requested resume
-	// was itself refused — the transcript is gone, the session belongs to
-	// another provider account, a live execution already owns the same
-	// single-writer transcript, OR the session still exists but its history
+	// was permanently refused — the transcript is gone, the session belongs to
+	// another provider account, OR the session still exists but its history
 	// can no longer be replayed to the provider (e.g. GH #5975: a stored
 	// image now exceeds the provider's max dimensions, so every resumed
 	// session/prompt is rejected before the turn runs). What unites these is
@@ -230,6 +229,12 @@ type Result struct {
 	// shouldRetryWithFreshSession, where "was this run a resume?" is already
 	// known. Do not encode it here.
 	ResumeRejected bool
+	// ResumeRejectedTransient is positive evidence that this run's requested
+	// resume cannot proceed right now, but the session itself remains healthy.
+	// The daemon may use a fresh session for this turn, but must not retire the
+	// requested session from future lookups. Backends must not set this together
+	// with ResumeRejected; the latter means the session is permanently unusable.
+	ResumeRejectedTransient bool
 	// codexInitializeRetrySafe is provider-internal evidence that an
 	// initialize timeout happened before semantic activity and after the
 	// process tree was reaped. It is intentionally not part of the public

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -201,7 +201,8 @@ type Result struct {
 	Usage      map[string]TokenUsage // keyed by model name
 	// ResumeRejected is positive evidence that this run's requested resume
 	// was itself refused — the transcript is gone, the session belongs to
-	// another provider account, OR the session still exists but its history
+	// another provider account, a live execution already owns the same
+	// single-writer transcript, OR the session still exists but its history
 	// can no longer be replayed to the provider (e.g. GH #5975: a stored
 	// image now exceeds the provider's max dimensions, so every resumed
 	// session/prompt is rejected before the turn runs). What unites these is

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -495,9 +495,9 @@ func piSessionBusyResult(label, sessionPath string) *Session {
 	close(msgCh)
 	resCh := make(chan Result, 1)
 	resCh <- Result{
-		Status:         "failed",
-		Error:          fmt.Sprintf("%s session file %q is already in use by another execution", label, sessionPath),
-		ResumeRejected: true,
+		Status:                  "failed",
+		Error:                   fmt.Sprintf("%s session file %q is already in use by another execution", label, sessionPath),
+		ResumeRejectedTransient: true,
 	}
 	close(resCh)
 	return &Session{Messages: msgCh, Result: resCh}

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -226,6 +226,16 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	if err := ensurePiSessionFile(sessionPath); err != nil {
 		return nil, fmt.Errorf("%s session file: %w", label, err)
 	}
+	sessionLock, locked, err := tryLockPiSessionFile(sessionPath)
+	if err != nil {
+		return nil, fmt.Errorf("%s session lock: %w", label, err)
+	}
+	if !locked {
+		if opts.ResumeSessionID != "" {
+			return piSessionBusyResult(label, sessionPath), nil
+		}
+		return nil, fmt.Errorf("%s session file %q is already in use", label, sessionPath)
+	}
 
 	runCtx, cancel := runContext(ctx, timeout)
 
@@ -241,6 +251,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		releasePiSessionFileLock(sessionLock)
 		cancel()
 		return nil, fmt.Errorf("%s stdout pipe: %w", label, err)
 	}
@@ -251,6 +262,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	// Pi has been observed to wait indefinitely when stdin never reaches EOF.
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
+		releasePiSessionFileLock(sessionLock)
 		cancel()
 		return nil, fmt.Errorf("%s stdin pipe: %w", label, err)
 	}
@@ -260,6 +272,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 	if err := startOwnedProcessTree(cmd, b.cfg.Logger); err != nil {
 		closeStdin()
+		releasePiSessionFileLock(sessionLock)
 		cancel()
 		return nil, fmt.Errorf("start %s: %w", label, err)
 	}
@@ -289,6 +302,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	}()
 
 	go func() {
+		defer func() { releasePiSessionFileLock(sessionLock) }()
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
@@ -457,6 +471,12 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 		b.cfg.Logger.Info(label+" finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		// Publish the terminal result only after the transcript is available to
+		// a follow-up run. The result channel is buffered, so relying on a defer
+		// would let the receiver race ahead and spuriously treat the session as
+		// still busy after Pi had already exited.
+		releasePiSessionFileLock(sessionLock)
+		sessionLock = nil
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     output.String(),
@@ -468,6 +488,19 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func piSessionBusyResult(label, sessionPath string) *Session {
+	msgCh := make(chan Message)
+	close(msgCh)
+	resCh := make(chan Result, 1)
+	resCh <- Result{
+		Status:         "failed",
+		Error:          fmt.Sprintf("%s session file %q is already in use by another execution", label, sessionPath),
+		ResumeRejected: true,
+	}
+	close(resCh)
+	return &Session{Messages: msgCh, Result: resCh}
 }
 
 // ── Pi event types ──

--- a/server/pkg/agent/pi_session_lock_unix.go
+++ b/server/pkg/agent/pi_session_lock_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryLockPiSessionFile takes a non-blocking exclusive lock on the transcript.
+// The daemon can launch more than one task at a time, and Pi appends directly
+// to this JSONL, so the lock must cover the complete child-process lifetime.
+// The kernel releases it if the daemon dies.
+func tryLockPiSessionFile(path string) (*os.File, bool, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == unix.EWOULDBLOCK {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return f, true, nil
+}
+
+func releasePiSessionFileLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	_ = f.Close()
+}

--- a/server/pkg/agent/pi_session_lock_windows.go
+++ b/server/pkg/agent/pi_session_lock_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLockPiSessionFile is the Windows equivalent of flock(LOCK_EX|LOCK_NB).
+// FILE_SHARE_DELETE keeps a held lock from pinning the session directory when
+// cleanup races a cancelled execution.
+func tryLockPiSessionFile(path string) (*os.File, bool, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, false, err
+	}
+	h, err := windows.CreateFile(
+		p,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	f := os.NewFile(uintptr(h), path)
+	overlapped := new(windows.Overlapped)
+	err = windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, overlapped,
+	)
+	if err == nil {
+		return f, true, nil
+	}
+	_ = f.Close()
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
+
+func releasePiSessionFileLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	overlapped := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, overlapped)
+	_ = f.Close()
+}

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -161,6 +162,51 @@ func TestPiExecuteRejectsEmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestPiExecuteRejectsConcurrentSessionWriter(t *testing.T) {
+	t.Parallel()
+
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("create session file: %v", err)
+	}
+	claim, locked, err := tryLockPiSessionFile(sessionPath)
+	if err != nil {
+		t.Fatalf("lock session file: %v", err)
+	}
+	if !locked {
+		t.Fatal("first session-file lock was unexpectedly busy")
+	}
+	defer releasePiSessionFileLock(claim)
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test executable: %v", err)
+	}
+	backend, err := New("pi", Config{ExecutablePath: executable, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(pi): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), "follow-up", ExecOptions{ResumeSessionID: sessionPath})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for range session.Messages {
+	}
+	result, ok := <-session.Result
+	if !ok {
+		t.Fatal("result channel closed without a value")
+	}
+	if result.Status != "failed" || !result.ResumeRejected {
+		t.Fatalf("result = %+v, want failed ResumeRejected", result)
+	}
+	if result.SessionID != "" {
+		t.Fatalf("SessionID = %q, want empty so the live transcript is not republished", result.SessionID)
+	}
+	if !strings.Contains(result.Error, "already in use") {
+		t.Fatalf("error = %q, want session-in-use diagnostic", result.Error)
+	}
+}
+
 // TestPiExecuteAttachesStdinPipe verifies that the Pi backend spawns the child
 // with an explicit stdin pipe, writes the task prompt, and closes it. Closing
 // delivers both the end-of-prompt signal and the EOF that keeps Pi from
@@ -225,6 +271,14 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
 	}
+	claim, locked, err := tryLockPiSessionFile(sessionPath)
+	if err != nil {
+		t.Fatalf("lock completed session: %v", err)
+	}
+	if !locked {
+		t.Fatal("Pi backend returned its result before releasing the session-file lock")
+	}
+	releasePiSessionFileLock(claim)
 }
 
 // piEventStreamScript builds a sh script that prints each JSON event on

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -196,8 +196,11 @@ func TestPiExecuteRejectsConcurrentSessionWriter(t *testing.T) {
 	if !ok {
 		t.Fatal("result channel closed without a value")
 	}
-	if result.Status != "failed" || !result.ResumeRejected {
-		t.Fatalf("result = %+v, want failed ResumeRejected", result)
+	if result.Status != "failed" || !result.ResumeRejectedTransient {
+		t.Fatalf("result = %+v, want failed ResumeRejectedTransient", result)
+	}
+	if result.ResumeRejected {
+		t.Fatal("a busy session is still healthy and must not be permanently rejected")
 	}
 	if result.SessionID != "" {
 		t.Fatalf("SessionID = %q, want empty so the live transcript is not republished", result.SessionID)


### PR DESCRIPTION
## What does this PR do?

Keeps Pi and OMP provider sessions resumable when a follow-up task receives a different workdir.

### Thinking path

Pi's backend uses an absolute JSONL file path as its opaque session ID and passes it directly to `--session`. That session store lives under `~/.multica/pi-sessions`, not under the task workdir.

The daemon's shared resume gate nevertheless required every provider to reuse the previous workdir. When workdir reuse failed or changed, it cleared Pi's still-valid session path, started a new provider conversation, and injected a continuity notice that made the agent reconstruct context through `multica chat history`.

This PR makes reachability match the provider's actual storage model: Pi/OMP resume whenever their recorded session file still exists, independently of workdir identity. Cwd-keyed providers and Hermes retain their existing gates.

## Related Issue

N/A — reported from a live Pi chat where the Multica transcript and workdir survived but the provider session restarted.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update the daemon resume gate to recognize Pi/OMP's independently addressed JSONL session store.
- Preserve a Pi/OMP `PriorSessionID` across workdir changes when the session file exists.
- Continue dropping the pointer and surfacing the continuity gap when the session file is actually missing.
- Add regression coverage for both Pi and OMP and for the missing-file fallback.

## How to Test

1. Run `cd server && go test ./internal/daemon -run 'TestGate(ResumeToReachableSession|PiResume)' -count=1`.
2. Run `cd server && go test ./internal/daemon -count=1`.
3. Run `cd server && go vet ./internal/daemon`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (inline runtime documentation updated; no user-facing docs affected)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risk

The exception is limited to the two providers backed by `piBackend`. The server already scopes prior session IDs to the same runtime; the daemon additionally requires the recorded path to resolve to a regular file. Every other provider keeps the existing workdir/session-store checks.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Traced a live Pi context-loss report through chat-session selection, daemon resume gating, and Pi's JSONL session implementation; wrote the failing cross-workdir regression first, then made the smallest provider-scoped change and ran focused package tests plus vet.
