### PR TITLE
MUL-6841: feat(daemon): add native Codex working directory

### DIFF
--- a/server/cmd/multica/cmd_config.go
+++ b/server/cmd/multica/cmd_config.go
@@ -35,6 +35,7 @@ var configSetSupportedKeys = []string{
 	"device_name",
 	"runtime_name",
 	"workspaces_root",
+	"codex_native_workdir",
 	"max_concurrent_tasks",
 	"poll_interval",
 	"heartbeat_interval",
@@ -51,11 +52,11 @@ var configSetCmd = &cobra.Command{
 	Short: "Set a CLI configuration value",
 	Long: "Supported keys: " +
 		"server_url, app_url, workspace_id, " +
-		"device_name, runtime_name, workspaces_root, max_concurrent_tasks, poll_interval, " +
+		"device_name, runtime_name, workspaces_root, codex_native_workdir, max_concurrent_tasks, poll_interval, " +
 		"heartbeat_interval, agent_timeout, " +
 		"codex_semantic_inactivity_timeout, codex_handshake_timeout, " +
 		"disable_auto_update, auto_update_check_interval, disable_auto_reload.\n\n" +
-		"The daemon keys (device_name, runtime_name, workspaces_root, max_concurrent_tasks, " +
+		"The daemon keys (device_name, runtime_name, workspaces_root, codex_native_workdir, max_concurrent_tasks, " +
 		"poll_interval, heartbeat_interval, agent_timeout, " +
 		"codex_semantic_inactivity_timeout, codex_handshake_timeout, " +
 		"disable_auto_update, auto_update_check_interval, disable_auto_reload) mirror their " +
@@ -100,6 +101,7 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "device_name:", valueOrDefault(cfg.DeviceName, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "runtime_name:", valueOrDefault(cfg.RuntimeName, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "workspaces_root:", valueOrDefault(cfg.WorkspacesRoot, "(not set)"))
+	fmt.Fprintf(os.Stdout, "%-34s %s\n", "codex_native_workdir:", valueOrDefault(cfg.CodexNativeWorkDir, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "max_concurrent_tasks:", intOrDefault(cfg.MaxConcurrentTasks, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "poll_interval:", valueOrDefault(cfg.PollInterval, "(not set)"))
 	fmt.Fprintf(os.Stdout, "%-34s %s\n", "heartbeat_interval:", valueOrDefault(cfg.HeartbeatInterval, "(not set)"))
@@ -173,6 +175,17 @@ func applyConfigSet(cfg *cli.CLIConfig, key, value string) error {
 			return fmt.Errorf("resolve workspaces_root: %w", err)
 		}
 		cfg.WorkspacesRoot = root
+	case "codex_native_workdir":
+		value = strings.TrimSpace(value)
+		if value == "" {
+			cfg.CodexNativeWorkDir = ""
+			return nil
+		}
+		root, err := filepath.Abs(value)
+		if err != nil {
+			return fmt.Errorf("resolve codex_native_workdir: %w", err)
+		}
+		cfg.CodexNativeWorkDir = root
 	case "max_concurrent_tasks":
 		if value == "" {
 			cfg.MaxConcurrentTasks = 0

--- a/server/cmd/multica/cmd_config_test.go
+++ b/server/cmd/multica/cmd_config_test.go
@@ -201,10 +201,12 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 
 	cfg := cli.CLIConfig{}
 	workspacesRoot := filepath.Join(t.TempDir(), "multica")
+	codexNativeWorkDir := t.TempDir()
 	pairs := []struct{ key, val string }{
 		{"device_name", "vm-1-custom-name"},
 		{"runtime_name", "worker-a"},
 		{"workspaces_root", workspacesRoot},
+		{"codex_native_workdir", codexNativeWorkDir},
 		{"max_concurrent_tasks", "4"},
 		{"poll_interval", "10s"},
 		{"heartbeat_interval", "5s"},
@@ -222,6 +224,7 @@ func TestApplyConfigSetSupportsDaemonKeys(t *testing.T) {
 	if cfg.DeviceName != "vm-1-custom-name" ||
 		cfg.RuntimeName != "worker-a" ||
 		cfg.WorkspacesRoot != workspacesRoot ||
+		cfg.CodexNativeWorkDir != codexNativeWorkDir ||
 		cfg.MaxConcurrentTasks != 4 ||
 		cfg.PollInterval != "10s" ||
 		cfg.HeartbeatInterval != "5s" ||

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -98,6 +98,7 @@ func init() {
 	f.String("device-name", "", "Human-readable device name (env: MULTICA_DAEMON_DEVICE_NAME)")
 	f.String("runtime-name", "", "Runtime display name (env: MULTICA_AGENT_RUNTIME_NAME)")
 	f.String("workspaces-root", "", "Base directory for task workspaces (env: MULTICA_WORKSPACES_ROOT)")
+	f.String("codex-native-workdir", "", "Stable Codex cwd without Multica sidecar injection (env: MULTICA_CODEX_NATIVE_WORKDIR)")
 	f.Duration("poll-interval", 0, "Task poll interval (env: MULTICA_DAEMON_POLL_INTERVAL)")
 	f.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	f.Duration("agent-timeout", 0, "Absolute per-task wall-clock cap; 0 = no cap, rely on the watchdogs (env: MULTICA_AGENT_TIMEOUT)")
@@ -120,6 +121,7 @@ func init() {
 	rf.String("device-name", "", "Human-readable device name (env: MULTICA_DAEMON_DEVICE_NAME)")
 	rf.String("runtime-name", "", "Runtime display name (env: MULTICA_AGENT_RUNTIME_NAME)")
 	rf.String("workspaces-root", "", "Base directory for task workspaces (env: MULTICA_WORKSPACES_ROOT)")
+	rf.String("codex-native-workdir", "", "Stable Codex cwd without Multica sidecar injection (env: MULTICA_CODEX_NATIVE_WORKDIR)")
 	rf.Duration("poll-interval", 0, "Task poll interval (env: MULTICA_DAEMON_POLL_INTERVAL)")
 	rf.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	rf.Duration("agent-timeout", 0, "Absolute per-task wall-clock cap; 0 = no cap, rely on the watchdogs (env: MULTICA_AGENT_TIMEOUT)")
@@ -866,6 +868,9 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if v := flagString(cmd, "workspaces-root"); v != "" {
 		args = append(args, "--workspaces-root", v)
 	}
+	if v := flagString(cmd, "codex-native-workdir"); v != "" {
+		args = append(args, "--codex-native-workdir", v)
+	}
 	if d, _ := cmd.Flags().GetDuration("poll-interval"); d > 0 {
 		args = append(args, "--poll-interval", d.String())
 	}
@@ -971,15 +976,21 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	codexNativeWorkDir := resolveDaemonStringOverride(
+		flagString(cmd, "codex-native-workdir"),
+		"MULTICA_CODEX_NATIVE_WORKDIR",
+		fileCfg.CodexNativeWorkDir,
+	)
 
 	overrides := daemon.Overrides{
-		ServerURL:      serverURL,
-		DaemonID:       flagString(cmd, "daemon-id"),
-		DeviceName:     deviceNameFlag,
-		RuntimeName:    runtimeNameFlag,
-		WorkspacesRoot: workspacesRoot,
-		Profile:        profile,
-		HealthPort:     healthPortForProfile(profile),
+		ServerURL:          serverURL,
+		DaemonID:           flagString(cmd, "daemon-id"),
+		DeviceName:         deviceNameFlag,
+		RuntimeName:        runtimeNameFlag,
+		WorkspacesRoot:     workspacesRoot,
+		CodexNativeWorkDir: codexNativeWorkDir,
+		Profile:            profile,
+		HealthPort:         healthPortForProfile(profile),
 	}
 	pollFlag, _ := cmd.Flags().GetDuration("poll-interval")
 	pollOverride, err := resolveDaemonDurationOverride(pollFlag, "MULTICA_DAEMON_POLL_INTERVAL", fileCfg.PollInterval)

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -119,6 +119,20 @@ func TestBuildDaemonStartArgsForwardsWorkspacesRoot(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonStartArgsForwardsCodexNativeWorkDir(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("codex-native-workdir", "", "")
+	if err := cmd.Flags().Set("codex-native-workdir", "/Users/example/code"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	args := buildDaemonStartArgs(cmd)
+	want := []string{"daemon", "start", "--foreground", "--codex-native-workdir", "/Users/example/code"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("buildDaemonStartArgs() = %q, want %q", args, want)
+	}
+}
+
 // TestBuildDaemonStartArgsForwardsNoAutoReload matters because `daemon start`
 // re-execs itself as a foreground child: a flag the parent parsed but doesn't
 // forward is silently dropped, so the opt-out would appear to work and not.
@@ -155,6 +169,16 @@ func TestWorkspacesRootFlagRegisteredOnBothDaemonCommands(t *testing.T) {
 	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonRestartCmd} {
 		if cmd.Flags().Lookup("workspaces-root") == nil {
 			t.Errorf("daemon %s is missing --workspaces-root", cmd.Name())
+		}
+	}
+}
+
+func TestCodexNativeWorkDirFlagRegisteredOnBothDaemonCommands(t *testing.T) {
+	t.Parallel()
+
+	for _, cmd := range []*cobra.Command{daemonStartCmd, daemonRestartCmd} {
+		if cmd.Flags().Lookup("codex-native-workdir") == nil {
+			t.Errorf("daemon %s is missing --codex-native-workdir", cmd.Name())
 		}
 	}
 }

--- a/server/internal/cli/config.go
+++ b/server/internal/cli/config.go
@@ -55,6 +55,12 @@ type CLIConfig struct {
 	// profile-aware built-in default.
 	WorkspacesRoot string `json:"workspaces_root,omitempty"`
 
+	// CodexNativeWorkDir is an opt-in, machine-local cwd for Codex tasks. The
+	// daemon keeps logs, credentials, CODEX_HOME, and all generated context in
+	// per-task env roots; it only launches Codex from this directory. Empty
+	// preserves the managed per-task workdir behavior.
+	CodexNativeWorkDir string `json:"codex_native_workdir,omitempty"`
+
 	// MaxConcurrentTasks caps the number of task executions the daemon
 	// processes in parallel. Persist here to avoid re-passing
 	// --max-concurrent-tasks on every daemon start / auto-restart. 0 means

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	Profile                        string                // profile name (empty = default)
 	Agents                         map[string]AgentEntry // keyed by provider: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, reasonix, dsh, kiro, antigravity, qoder, qoderclicn, traecli, grok, qwen, qwenpaw, mcode, dim, zeroclaw (plus built-in runtime identities from agent.BuiltinRuntimes, e.g. omp)
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
+	CodexNativeWorkDir             string                // optional stable Codex cwd; task-owned files remain under WorkspacesRoot
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
 	MaxConcurrentTasks             int                   // max tasks running in parallel (default: 20)
@@ -155,10 +156,11 @@ type Config struct {
 // Overrides allows CLI flags to override environment variables and defaults.
 // Zero values are ignored and the env/default value is used instead.
 type Overrides struct {
-	ServerURL         string
-	WorkspacesRoot    string
-	PollInterval      time.Duration
-	HeartbeatInterval time.Duration
+	ServerURL          string
+	WorkspacesRoot     string
+	CodexNativeWorkDir string
+	PollInterval       time.Duration
+	HeartbeatInterval  time.Duration
 	// AgentTimeout is a pointer so an explicit `--agent-timeout 0` (no cap) is
 	// distinguishable from "flag not passed". nil = use env/default.
 	AgentTimeout                   *time.Duration
@@ -479,6 +481,23 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
+	// Optional native Codex cwd: explicit override > env > disabled. Validate
+	// at daemon startup so a typo never waits until a task is claimed to fail.
+	codexNativeWorkDir := strings.TrimSpace(os.Getenv("MULTICA_CODEX_NATIVE_WORKDIR"))
+	if strings.TrimSpace(overrides.CodexNativeWorkDir) != "" {
+		codexNativeWorkDir = strings.TrimSpace(overrides.CodexNativeWorkDir)
+	}
+	if codexNativeWorkDir != "" {
+		path, err := normalizeLocalPath(codexNativeWorkDir)
+		if err != nil {
+			return Config{}, fmt.Errorf("codex native workdir: %w", err)
+		}
+		if err := validateLocalPath(path); err != nil {
+			return Config{}, fmt.Errorf("codex native workdir: %w", err)
+		}
+		codexNativeWorkDir = path
+	}
+
 	// Health port: override > default
 	healthPort := DefaultHealthPort
 	if overrides.HealthPort > 0 {
@@ -577,6 +596,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		Profile:                         profile,
 		Agents:                          agents,
 		WorkspacesRoot:                  workspacesRoot,
+		CodexNativeWorkDir:              codexNativeWorkDir,
 		KeepEnvAfterTask:                keepEnv,
 		GCEnabled:                       gcEnabled,
 		GCInterval:                      gcInterval,

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -112,6 +112,43 @@ func TestDefaultGCIntervalIsTwoHours(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_CodexNativeWorkDirPrecedenceAndValidation(t *testing.T) {
+	stageFakeAgent(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "missing-shell"))
+
+	envDir := t.TempDir()
+	overrideDir := t.TempDir()
+	t.Setenv("MULTICA_CODEX_NATIVE_WORKDIR", envDir)
+	base := Overrides{ServerURL: "http://localhost:0", WorkspacesRoot: t.TempDir()}
+
+	cfg, err := LoadConfig(base)
+	if err != nil {
+		t.Fatalf("LoadConfig from env: %v", err)
+	}
+	if cfg.CodexNativeWorkDir != envDir {
+		t.Fatalf("CodexNativeWorkDir = %q, want env path %q", cfg.CodexNativeWorkDir, envDir)
+	}
+
+	base.CodexNativeWorkDir = overrideDir
+	cfg, err = LoadConfig(base)
+	if err != nil {
+		t.Fatalf("LoadConfig from override: %v", err)
+	}
+	if cfg.CodexNativeWorkDir != overrideDir {
+		t.Fatalf("CodexNativeWorkDir = %q, want override path %q", cfg.CodexNativeWorkDir, overrideDir)
+	}
+
+	notDir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base.CodexNativeWorkDir = notDir
+	if _, err := LoadConfig(base); err == nil || !strings.Contains(err.Error(), "codex native workdir") {
+		t.Fatalf("invalid native workdir error = %v", err)
+	}
+}
+
 // A localhost server URL is not the official cloud host, so this exercises the
 // self-host branch of defaultGCCompletedTaskTTL: retention stays unbounded until
 // an operator opts in, and a daemon upgrade never starts deleting on its own.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5762,13 +5762,21 @@ func sameExistingDir(a, b string) bool {
 	return os.SameFile(ai, bi)
 }
 
-func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, envWorkDir string, sessionHomeReachable bool, taskLog *slog.Logger) bool {
+func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, envWorkDir string, sessionHomeReachable, workdirIndependent bool, taskLog *slog.Logger) bool {
 	// Compare the directories, not the spelling. Reuse runs in the canonical
 	// path it validated and locked, which need not be character-identical to
 	// the PriorWorkDir the server sent — a symlinked workspaces root is enough
 	// to make them differ. A string compare would then silently drop the prior
 	// session on every follow-up task in that installation.
 	reused := task.PriorWorkDir != "" && sameExistingDir(envWorkDir, task.PriorWorkDir) && sessionHomeReachable
+	if workdirIndependent {
+		// A native Codex cwd deliberately migrates an existing thread away from
+		// its old task sandbox. The conversation store is addressed by thread ID
+		// and mounted into this task's CODEX_HOME, so cwd equality is not a
+		// prerequisite; the rollout-presence gate immediately after this call is
+		// the authoritative proof that the thread can actually resume.
+		reused = task.PriorSessionID != "" && sessionHomeReachable
+	}
 	if !reused && task.PriorSessionID != "" {
 		taskLog.Info("dropping prior session: session store not reachable from this run",
 			"session_id", task.PriorSessionID,
@@ -5861,8 +5869,19 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] != "workdir" {
 		return "", false
 	}
-	if task.AgentID == "" || (task.IssueID == "" && task.ChatSessionID == "") {
+	if !managedPriorWorkdirMatchesTask(task, workdir) {
 		return "", false
+	}
+	return workdir, true
+}
+
+// managedPriorWorkdirMatchesTask verifies the daemon-authored proofs inside a
+// resolved env workdir. Path containment and the expected three-segment shape
+// are intentionally left to callers because native-cwd migration may be
+// moving away from the daemon's newly configured workspaces root.
+func managedPriorWorkdirMatchesTask(task Task, workdir string) bool {
+	if task.AgentID == "" || (task.IssueID == "" && task.ChatSessionID == "") {
+		return false
 	}
 	// Managed-env provenance is written only for non-local resumable envs, so
 	// its presence (plus the workspace/scope/agent match) proves this is a
@@ -5871,12 +5890,12 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 	if err != nil || prov.ManagedBy != execenv.ManagedEnvProvenanceManagedBy ||
 		prov.WorkspaceID != task.WorkspaceID ||
 		prov.AgentID != task.AgentID {
-		return "", false
+		return false
 	}
 
 	data, err := os.ReadFile(filepath.Join(workdir, execenv.TaskContextMarkerRelPath))
 	if err != nil {
-		return "", false
+		return false
 	}
 	var marker struct {
 		ManagedBy     string `json:"managed_by"`
@@ -5885,18 +5904,50 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 		ChatSessionID string `json:"chat_session_id"`
 	}
 	if json.Unmarshal(data, &marker) != nil {
-		return "", false
+		return false
 	}
 	if marker.ManagedBy != execenv.TaskContextMarkerManagedBy || marker.AgentID != task.AgentID {
-		return "", false
+		return false
 	}
 	if task.IssueID != "" {
 		if prov.IssueID != task.IssueID || marker.IssueID != task.IssueID {
-			return "", false
+			return false
 		}
-		return workdir, true
+		return true
 	}
 	if prov.ChatSessionID != task.ChatSessionID || marker.ChatSessionID != task.ChatSessionID {
+		return false
+	}
+	return true
+}
+
+// nativeCodexMigrationWorkdir finds a prior daemon-owned workdir from which
+// one Codex rollout may be exposed. The normal current-root proof is preferred.
+// During a local switch the old workspaces root may have been the new native
+// cwd itself; accept that exact legacy shape too. Codex already has access to
+// the whole native cwd, and the provenance+marker pair still has to match this
+// conversation, so this does not broaden filesystem authority.
+func nativeCodexMigrationWorkdir(task Task, nativeWorkDir, workspacesRoot string) (string, bool) {
+	if workdir, ok := shouldReusePriorWorkdir(task, nil, workspacesRoot); ok {
+		return workdir, true
+	}
+	nativeRoot, err := filepath.EvalSymlinks(nativeWorkDir)
+	if err != nil {
+		return "", false
+	}
+	workdir, err := filepath.EvalSymlinks(task.PriorWorkDir)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(nativeRoot, workdir)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] != "workdir" {
+		return "", false
+	}
+	if !managedPriorWorkdirMatchesTask(task, workdir) {
 		return "", false
 	}
 	return workdir, true
@@ -6802,6 +6853,23 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// LocalWorkDir into execenv. handleTask already validated + locked the
 	// path for worker tasks; leader tasks intentionally skip the assignment.
 	localAssignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID)
+	// A project local_directory is an explicit task scope and therefore wins
+	// over the machine-local native Codex cwd. Otherwise native mode changes
+	// only the provider cwd; envRoot remains isolated task scratch.
+	codexNativeWorkDir := ""
+	if provider == "codex" && localAssignment == nil {
+		codexNativeWorkDir = d.cfg.CodexNativeWorkDir
+	}
+	codexResumeSessionsSource := ""
+	if codexNativeWorkDir != "" && task.PriorSessionID != "" {
+		// Only trust a prior session directory when the existing managed-env
+		// provenance and task marker prove it belongs to this conversation.
+		// This migrates one rollout without making arbitrary server-provided
+		// filesystem paths into read sources.
+		if priorWorkDir, ok := nativeCodexMigrationWorkdir(task, codexNativeWorkDir, d.cfg.WorkspacesRoot); ok {
+			codexResumeSessionsSource = filepath.Join(filepath.Dir(priorWorkDir), "codex-home", "sessions")
+		}
+	}
 	// Reuse intentionally skipped for local_directory tasks: the prior
 	// WorkDir is the user's own path (always present) but the reuse path
 	// loses the envRoot association the GC loop needs, and re-running
@@ -7002,7 +7070,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}
 	}
 	envReused := false
-	if priorClaim, priorWorkDir, lockedPriorInfo, ok := d.lockReusablePriorEnvRoot(task, localAssignment, envClaim.RootDir()); ok {
+	if priorClaim, priorWorkDir, lockedPriorInfo, ok := d.lockReusablePriorEnvRoot(task, localAssignment, envClaim.RootDir()); codexNativeWorkDir == "" && ok {
 		defer priorClaim.Release()
 		// Deterministic seam for the last-window regression: tests swap the
 		// directory here, after the claim is settled and before Reuse resolves
@@ -7068,21 +7136,24 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			AgentName:       agentName,
 			// This run already holds the claim (envClaim above) and the reset
 			// it implies; preparation must not try to take it again.
-			EnvRootPreclaimed:     true,
-			Provider:              provider,
-			CodexVersion:          codexVersion,
-			OpenclawBin:           openclawBin,
-			McpConfig:             effectiveMcpConfig,
-			CursorMcpAuthSource:   cursorMcpAuthSource,
-			OpenclawGateway:       openclawGateway,
-			HermesSourceHome:      hermesSourceHome,
-			HermesSourceMustExist: hermesSourceMustExist,
-			HermesEnv:             hermesEnv,
-			HermesMemoryStore:     hermesMemoryStore,
-			HermesSessionStore:    hermesSessionStore,
-			ReasonixEnv:           reasonixEnv,
-			CodexCustomArgs:       codexSandboxArgs,
-			Task:                  taskCtx,
+			EnvRootPreclaimed:         true,
+			Provider:                  provider,
+			CodexVersion:              codexVersion,
+			OpenclawBin:               openclawBin,
+			McpConfig:                 effectiveMcpConfig,
+			CursorMcpAuthSource:       cursorMcpAuthSource,
+			OpenclawGateway:           openclawGateway,
+			HermesSourceHome:          hermesSourceHome,
+			HermesSourceMustExist:     hermesSourceMustExist,
+			HermesEnv:                 hermesEnv,
+			HermesMemoryStore:         hermesMemoryStore,
+			HermesSessionStore:        hermesSessionStore,
+			ReasonixEnv:               reasonixEnv,
+			CodexCustomArgs:           codexSandboxArgs,
+			NativeWorkDir:             codexNativeWorkDir,
+			CodexResumeSessionID:      task.PriorSessionID,
+			CodexResumeSessionsSource: codexResumeSessionsSource,
+			Task:                      taskCtx,
 		}
 		if localAssignment.UsesWorktree() {
 			prepParams.LocalWorktree = &execenv.LocalWorktreeParams{LocalPath: localAssignment.AbsPath}
@@ -7327,7 +7398,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	cancelPrepare()
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
-	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, sessionHomeReachable(provider, env, envReused), taskLog)
+	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, sessionHomeReachable(provider, env, envReused), codexNativeWorkDir != "", taskLog)
 	// A reused workdir is necessary but not sufficient for a Codex resume: the
 	// prior thread's rollout must actually be present in this task's CODEX_HOME
 	// sessions (MUL-4424 isolates them). Drop the resume before the brief is
@@ -7337,10 +7408,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		gateCodexResumeToRolloutPresence(&task, &taskCtx, provider, env.CodexHome, taskLog)
 	}
 
-	// Inject runtime-specific config (meta skill) so the agent discovers .agent_context/.
-	runtimeBrief, err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx)
-	if err != nil {
-		d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
+	// Managed workdirs receive the runtime brief through their provider-native
+	// context file. Native Codex cwd must remain byte-for-byte user-owned, so
+	// render the same brief without writing and send it over app-server instead.
+	var runtimeBrief string
+	if codexNativeWorkDir != "" {
+		runtimeBrief = execenv.BuildRuntimeConfigContent(provider, taskCtx)
+	} else {
+		var err error
+		runtimeBrief, err = execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx)
+		if err != nil {
+			d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
+		}
 	}
 	// An exempt turn runs in the user's directory without having queued for it,
 	// so a sibling coding task may be writing to the same tree right now. That
@@ -7616,7 +7695,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// as always included, and a real kiro-cli 2.13.0 ACP smoke confirms it.
 	// Prepending the full runtime brief into the ACP user prompt duplicates that
 	// context and bloats every turn.
-	if providerNeedsInlineSystemPrompt(provider) {
+	if providerNeedsInlineSystemPrompt(provider) || codexNativeWorkDir != "" {
 		execOpts.SystemPrompt = runtimeBrief
 	}
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1967,6 +1967,7 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 		// local_directory case (GH #6806). Zero value keeps the cwd-keyed
 		// providers' behaviour.
 		sessionHomeUnreachable bool
+		workdirIndependent     bool
 		wantSession            string
 		wantReused             bool
 	}{
@@ -1985,6 +1986,15 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 			envDir:      "/ws/task-b/workdir",
 			wantSession: "",
 			wantReused:  false,
+		},
+		{
+			name:               "native codex cwd migration keeps session",
+			sessionID:          "sess-1",
+			priorDir:           "/ws/task-a/workdir",
+			envDir:             "/code",
+			workdirIndependent: true,
+			wantSession:        "sess-1",
+			wantReused:         true,
 		},
 		{
 			name:        "session without recorded workdir drops session",
@@ -2039,7 +2049,7 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 			task := Task{PriorSessionID: tt.sessionID, PriorWorkDir: priorDir}
 			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: tt.sessionID != ""}
 
-			reused := gateResumeToReusedWorkdir(&task, &taskCtx, envDir, !tt.sessionHomeUnreachable, slog.Default())
+			reused := gateResumeToReusedWorkdir(&task, &taskCtx, envDir, !tt.sessionHomeUnreachable, tt.workdirIndependent, slog.Default())
 
 			if reused != tt.wantReused {
 				t.Fatalf("reused = %v, want %v", reused, tt.wantReused)

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -63,6 +63,10 @@ type CodexHomeOptions struct {
 	// whole shared history back in. Empty means a fresh thread (no rollout to
 	// expose). See prepareCodexSessionsDir (MUL-4424).
 	ResumeSessionID string
+	// ResumeSessionsSource optionally names another scoped sessions directory
+	// that already contains ResumeSessionID. Native cwd migration uses the
+	// prior managed task home here; only that single rollout is exposed.
+	ResumeSessionsSource string
 	// IsLocalDirectory marks a task whose env root is never reused across task
 	// IDs — every local_directory task, in_place or worktree. Worktree tasks
 	// get a fresh env root per task just like in-place ones do
@@ -569,6 +573,10 @@ func dirStat(dir string) (newest time.Time, size int64) {
 func prepareCodexSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions, logger *slog.Logger) error {
 	dst := filepath.Join(codexHome, "sessions")
 	sharedSessions := filepath.Join(sharedHome, "sessions")
+	resumeSessions := sharedSessions
+	if opts.ResumeSessionsSource != "" && len(findCodexRollouts(opts.ResumeSessionsSource, opts.ResumeSessionID)) > 0 {
+		resumeSessions = opts.ResumeSessionsSource
+	}
 	storeDir := codexSessionStoreDir(sharedHome, opts.SessionStoreKey)
 
 	// local_directory tasks have no reusable envRoot, so their history can only
@@ -581,7 +589,7 @@ func prepareCodexSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions
 			// empty local dir rather than re-exposing the whole shared history.
 			return os.MkdirAll(dst, 0o755)
 		}
-		return linkCodexSessionsToStore(dst, storeDir, sharedSessions, opts.ResumeSessionID, logger)
+		return linkCodexSessionsToStore(dst, storeDir, resumeSessions, opts.ResumeSessionID, logger)
 	}
 
 	fi, err := os.Lstat(dst)
@@ -603,7 +611,7 @@ func prepareCodexSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions
 	// the store link and the resume rollout, then leave it.
 	if storeDir != "" {
 		if target, rlErr := os.Readlink(dst); rlErr == nil && sameCodexPath(target, storeDir) {
-			return linkCodexSessionsToStore(dst, storeDir, sharedSessions, opts.ResumeSessionID, logger)
+			return linkCodexSessionsToStore(dst, storeDir, resumeSessions, opts.ResumeSessionID, logger)
 		}
 	}
 
@@ -622,7 +630,7 @@ func prepareCodexSessionsDir(codexHome, sharedHome string, opts CodexHomeOptions
 	if opts.ResumeSessionID != "" && storeDir != "" {
 		logger.Info("execenv: migrated codex-home sessions from shared symlink to per-issue store",
 			"codex_home", codexHome, "resume_session", true)
-		return linkCodexSessionsToStore(dst, storeDir, sharedSessions, opts.ResumeSessionID, logger)
+		return linkCodexSessionsToStore(dst, storeDir, resumeSessions, opts.ResumeSessionID, logger)
 	}
 	logger.Info("execenv: migrated codex-home sessions from shared symlink to task-local dir",
 		"codex_home", codexHome, "resume_session", false)

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -81,6 +81,17 @@ type PrepareParams struct {
 	// substituted. Used by the local_directory project_resource flow
 	// (MUL-2663). When set, the envRoot/workdir directory is not created.
 	LocalWorkDir string
+	// NativeWorkDir is a stable, user-owned cwd used without adopting the
+	// local_directory lifecycle. The daemon must not write context files,
+	// markers, skills, or cleanup metadata into it. Task-private state remains
+	// under envRoot. Currently supported only for Codex.
+	NativeWorkDir string
+	// CodexResumeSessionID and CodexResumeSessionsSource migrate exactly one
+	// prior managed Codex rollout into the native cwd conversation store. The
+	// source is read-only and must already have passed the daemon's managed-env
+	// ownership checks. They are ignored outside native Codex mode.
+	CodexResumeSessionID      string
+	CodexResumeSessionsSource string
 	// LocalWorktree, when non-nil, is the worktree-mode counterpart of
 	// LocalWorkDir: instead of running in the user's directory, the task gets
 	// its own git worktree of that repo inside envRoot and delivers its work
@@ -283,6 +294,10 @@ type Environment struct {
 	// scratch that the GC should reclaim on the normal schedule, and the
 	// sidecar rollback that protects a user's directory is unnecessary.
 	LocalDirectory bool
+	// NativeWorkDir is true when WorkDir is a stable provider cwd that Multica
+	// must treat as read-only infrastructure: the agent may edit user files,
+	// but Prepare/Cleanup never injects or removes daemon sidecars there.
+	NativeWorkDir bool
 	// MulticaConfigRoot is the private per-task config directory exported to
 	// child CLI invocations. It prevents implicit discovery of the daemon
 	// owner's ~/.multica profile without changing the provider-facing HOME.
@@ -420,6 +435,21 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	if params.TaskID == "" {
 		return nil, fmt.Errorf("execenv: task ID is required")
 	}
+	if params.NativeWorkDir != "" {
+		if params.Provider != "codex" {
+			return nil, fmt.Errorf("execenv: native workdir is supported only for codex")
+		}
+		if params.LocalWorkDir != "" || params.LocalWorktree != nil {
+			return nil, fmt.Errorf("execenv: native workdir cannot be combined with local_directory")
+		}
+		info, err := os.Stat(params.NativeWorkDir)
+		if err != nil {
+			return nil, fmt.Errorf("execenv: stat native workdir: %w", err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("execenv: native workdir is not a directory: %s", params.NativeWorkDir)
+		}
+	}
 
 	envRoot, err := ResolveRootDir(RootDirParams{
 		WorkspacesRoot:  params.WorkspacesRoot,
@@ -495,10 +525,12 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// envRoot.
 	workDir := filepath.Join(envRoot, "workdir")
 	scratchDirs := []string{filepath.Join(envRoot, "output"), filepath.Join(envRoot, "logs")}
-	if params.LocalWorkDir == "" && params.LocalWorktree == nil {
+	if params.LocalWorkDir == "" && params.LocalWorktree == nil && params.NativeWorkDir == "" {
 		scratchDirs = append(scratchDirs, workDir)
 	} else if params.LocalWorkDir != "" {
 		workDir = params.LocalWorkDir
+	} else if params.NativeWorkDir != "" {
+		workDir = params.NativeWorkDir
 	}
 	for _, dir := range scratchDirs {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -555,6 +587,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		RootDir:           envRoot,
 		WorkDir:           workDir,
 		LocalDirectory:    params.LocalWorkDir != "",
+		NativeWorkDir:     params.NativeWorkDir != "",
 		LocalWorktree:     localWorktree,
 		MulticaConfigRoot: multicaConfigRoot,
 		logger:            logger,
@@ -600,11 +633,13 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		}()
 	}
 
-	if err := writeContextFiles(workDir, params.Provider, params.Task, manifest); err != nil {
-		return nil, fmt.Errorf("execenv: write context files: %w", err)
-	}
-	if err := prepareOmpMcpConfig(workDir, params.Provider, params.McpConfig, manifest); err != nil {
-		return nil, fmt.Errorf("execenv: prepare omp mcp config: %w", err)
+	if params.NativeWorkDir == "" {
+		if err := writeContextFiles(workDir, params.Provider, params.Task, manifest); err != nil {
+			return nil, fmt.Errorf("execenv: write context files: %w", err)
+		}
+		if err := prepareOmpMcpConfig(workDir, params.Provider, params.McpConfig, manifest); err != nil {
+			return nil, fmt.Errorf("execenv: prepare omp mcp config: %w", err)
+		}
 	}
 
 	// Persist managed-env provenance for non-local resumable envs at Prepare time
@@ -630,7 +665,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "" || params.LocalWorktree != nil, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.CodexResumeSessionID, ResumeSessionsSource: params.CodexResumeSessionsSource, IsLocalDirectory: params.LocalWorkDir != "" || params.LocalWorktree != nil || params.NativeWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
@@ -1208,9 +1243,9 @@ func ReadManagedEnvProvenance(envRoot string) (*ManagedEnvProvenance, error) {
 // If removeAll is true, the entire env root is deleted. Otherwise, workdir is
 // removed but output/ and logs/ are preserved for debugging.
 //
-// For local_directory tasks (env.LocalDirectory==true) WorkDir is the
-// user's own path — Cleanup MUST NEVER delete it, regardless of removeAll.
-// In that mode we only ever delete the envRoot scratch directory.
+// For local_directory and native-cwd tasks WorkDir is the user's own path —
+// Cleanup MUST NEVER delete it, regardless of removeAll. In those modes we
+// only ever delete the envRoot scratch directory.
 func (env *Environment) Cleanup(removeAll bool) error {
 	if env == nil {
 		return nil
@@ -1221,7 +1256,7 @@ func (env *Environment) Cleanup(removeAll bool) error {
 	// both paths are idempotent.
 	env.ReleaseLock()
 
-	if env.LocalDirectory {
+	if env.LocalDirectory || env.NativeWorkDir {
 		// Never touch the user's directory. RootDir is the daemon's own
 		// scratch; safe to remove when the caller asked for a full
 		// teardown.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -64,6 +64,65 @@ func TestPredictRootDir(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexNativeWorkDirLeavesUserDirectoryUntouched(t *testing.T) {
+	root := t.TempDir()
+	nativeDir := t.TempDir()
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+	resumeSource := filepath.Join(t.TempDir(), "sessions")
+	const resumeID = "01901234-5678-7abc-8def-0123456789ab"
+	rolloutDir := filepath.Join(resumeSource, "2026", "08", "29")
+	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolloutDir, "rollout-test-"+resumeID+".jsonl"), []byte("prior conversation\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(nativeDir, "AGENTS.md")
+	const original = "user-owned instructions\n"
+	if err := os.WriteFile(sentinel, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot:            root,
+		WorkspaceID:               "workspace-1",
+		TaskID:                    "task-1",
+		Provider:                  "codex",
+		NativeWorkDir:             nativeDir,
+		CodexResumeSessionID:      resumeID,
+		CodexResumeSessionsSource: resumeSource,
+		Task: TaskContextForEnv{
+			AgentID:       "agent-1",
+			ChatSessionID: "chat-1",
+		},
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if env.WorkDir != nativeDir || !env.NativeWorkDir || env.LocalDirectory {
+		t.Fatalf("unexpected environment: %+v", env)
+	}
+	if got, err := os.ReadFile(sentinel); err != nil || string(got) != original {
+		t.Fatalf("user AGENTS.md changed: got %q err=%v", got, err)
+	}
+	entries, err := os.ReadDir(nativeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "AGENTS.md" {
+		t.Fatalf("native workdir received daemon sidecars: %v", entries)
+	}
+	if env.CodexHome == "" || !strings.HasPrefix(env.CodexHome, env.RootDir+string(filepath.Separator)) {
+		t.Fatalf("CODEX_HOME %q is not task-private under %q", env.CodexHome, env.RootDir)
+	}
+	if !CodexResumeRolloutPresent(env.CodexHome, resumeID) {
+		t.Fatal("prior managed rollout was not migrated into the native conversation store")
+	}
+}
+
 func TestResolveRootDirFreezesReadableNamesBeforePrepare(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -179,13 +179,20 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Grok:        writes {workDir}/AGENTS.md  (Grok Build CLI reads AGENTS.md natively from the workdir)
 // For Qwen:        writes {workDir}/QWEN.md (Qwen Code's native context file; it also reads AGENTS.md, but QWEN.md avoids cross-runtime ambiguity)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (string, error) {
-	content := buildMetaSkillContent(provider, ctx)
+	content := BuildRuntimeConfigContent(provider, ctx)
 	path := runtimeConfigPath(workDir, provider)
 	if path == "" {
 		// Unknown provider — skip config injection, prompt-only mode.
 		return content, nil
 	}
 	return content, writeRuntimeConfigFile(path, content)
+}
+
+// BuildRuntimeConfigContent renders the provider brief without writing it to
+// the working directory. Native-cwd runtimes use this to deliver instructions
+// through the provider protocol while leaving the user's directory untouched.
+func BuildRuntimeConfigContent(provider string, ctx TaskContextForEnv) string {
+	return buildMetaSkillContent(provider, ctx)
 }
 
 // runtimeConfigPath returns the absolute path to the runtime config file that

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -134,6 +134,33 @@ func TestShouldReusePriorWorkdirChatAcceptsMatchingConversation(t *testing.T) {
 	}
 }
 
+func TestNativeCodexMigrationAcceptsProvenancedLegacyRootUnderNativeCwd(t *testing.T) {
+	t.Parallel()
+
+	nativeRoot := t.TempDir()
+	newWorkspacesRoot := t.TempDir()
+	workDir := filepath.Join(nativeRoot, "ws-chat", "12345678", "workdir")
+	writeChatTaskMarker(t, workDir, "agent-chat", "chat-session")
+	writeChatManagedEnvProvenance(t, workDir, "ws-chat", "chat-session", "agent-chat")
+
+	task := leaderReuseTestTask("task-chat")
+	task.WorkspaceID = "ws-chat"
+	task.IssueID = ""
+	task.ChatSessionID = "chat-session"
+	task.AgentID = "agent-chat"
+	task.PriorWorkDir = workDir
+
+	got, ok := nativeCodexMigrationWorkdir(task, nativeRoot, newWorkspacesRoot)
+	if !ok || !sameDir(t, got, workDir) {
+		t.Fatalf("native migration workdir = %q, %v; want %q, true", got, ok, workDir)
+	}
+
+	task.ChatSessionID = "another-chat"
+	if got, ok := nativeCodexMigrationWorkdir(task, nativeRoot, newWorkspacesRoot); ok {
+		t.Fatalf("accepted mismatched conversation workdir %q", got)
+	}
+}
+
 // TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance is the unit
 // positive: managed shape + matching Prepare-time provenance + matching marker.
 func TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance(t *testing.T) {

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1797,13 +1797,15 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 	if priorThreadID := opts.ResumeSessionID; priorThreadID != "" {
 		// thread/resume reuses the thread's persisted model and reasoning
 		// effort; only override fields the daemon actually cares about.
-		// developerInstructions stays nil for the reason given on thread/start
-		// below.
+		// Native-cwd runs cannot place a generated AGENTS.md in the user's
+		// directory, so their runtime brief travels as developer instructions.
+		// Managed workdirs leave SystemPrompt empty and preserve the historical
+		// nil field.
 		resumeParams := map[string]any{
 			"threadId":              priorThreadID,
 			"cwd":                   opts.Cwd,
 			"model":                 nilIfEmpty(opts.Model),
-			"developerInstructions": nil,
+			"developerInstructions": nilIfEmpty(opts.SystemPrompt),
 		}
 		// Explicit override of the persisted reasoning effort: without
 		// this, a Codex resume silently reuses whatever level the prior
@@ -1827,12 +1829,9 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		}
 	}
 
-	// developerInstructions is always nil: a thread started with this cwd loads
-	// the per-task AGENTS.md the daemon wrote there, so the runtime brief is
-	// already in context and inlining it would duplicate it on every turn.
-	// Confirmed end-to-end against codex-cli 0.144.6 driving the real
-	// app-server (thread/start -> turn/start) with developerInstructions unset
-	// (MUL-5392).
+	// Managed workdirs load the daemon-authored AGENTS.md and therefore leave
+	// SystemPrompt empty. Native-cwd runs deliberately write nothing into the
+	// user's directory, so they supply the same brief here instead.
 	startParams := map[string]any{
 		"model":                  nilIfEmpty(opts.Model),
 		"modelProvider":          nil,
@@ -1842,7 +1841,7 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		"sandbox":                nil,
 		"config":                 nil,
 		"baseInstructions":       nil,
-		"developerInstructions":  nil,
+		"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
 		"compactPrompt":          nil,
 		"includeApplyPatchTool":  nil,
 		"experimentalRawEvents":  false,

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2025,7 +2025,16 @@ func assertNoDeveloperInstructions(t *testing.T, params map[string]any) {
 	}
 }
 
-func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
+func assertDeveloperInstructions(expected string) func(*testing.T, map[string]any) {
+	return func(t *testing.T, params map[string]any) {
+		t.Helper()
+		if got := params["developerInstructions"]; got != expected {
+			t.Errorf("developerInstructions = %v, want %q", got, expected)
+		}
+	}
+}
+
+func TestCodexThreadStartForwardsNativeRuntimeBrief(t *testing.T) {
 	t.Parallel()
 
 	c, fs, _ := newTestCodexClient(t)
@@ -2034,12 +2043,11 @@ func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
 		{
 			method:   "thread/start",
 			result:   json.RawMessage(`{"thread":{"id":"thr_fresh"}}`),
-			assertFn: assertNoDeveloperInstructions,
+			assertFn: assertDeveloperInstructions(codexRuntimeBriefCanary),
 		},
 	})
 	defer wait()
 
-	// SystemPrompt is set deliberately; it must not reach the app-server.
 	if _, _, err := c.startOrResumeThread(
 		context.Background(),
 		ExecOptions{Cwd: "/work", SystemPrompt: codexRuntimeBriefCanary},
@@ -2049,7 +2057,7 @@ func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
 	}
 }
 
-func TestCodexThreadResumeNeverInlinesSystemPrompt(t *testing.T) {
+func TestCodexThreadResumeForwardsNativeRuntimeBrief(t *testing.T) {
 	t.Parallel()
 
 	c, fs, _ := newTestCodexClient(t)
@@ -2058,17 +2066,30 @@ func TestCodexThreadResumeNeverInlinesSystemPrompt(t *testing.T) {
 		{
 			method:   "thread/resume",
 			result:   json.RawMessage(`{"thread":{"id":"thr_prior"}}`),
-			assertFn: assertNoDeveloperInstructions,
+			assertFn: assertDeveloperInstructions(codexRuntimeBriefCanary),
 		},
 	})
 	defer wait()
 
-	// SystemPrompt is set deliberately; it must not reach the app-server.
 	if _, _, err := c.startOrResumeThread(
 		context.Background(),
 		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_prior", SystemPrompt: codexRuntimeBriefCanary},
 		slog.Default(),
 	); err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+}
+
+func TestCodexThreadStartKeepsDeveloperInstructionsNilByDefault(t *testing.T) {
+	t.Parallel()
+	c, fs, _ := newTestCodexClient(t)
+	wait := drainRPCScript(t, c, fs, []rpcResponse{{
+		method:   "thread/start",
+		result:   json.RawMessage(`{"thread":{"id":"thr_fresh"}}`),
+		assertFn: assertNoDeveloperInstructions,
+	}})
+	defer wait()
+	if _, _, err := c.startOrResumeThread(context.Background(), ExecOptions{Cwd: "/work"}, slog.Default()); err != nil {
 		t.Fatalf("startOrResumeThread: %v", err)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in machine-local Codex working directory (`codex_native_workdir` / `--codex-native-workdir` / `MULTICA_CODEX_NATIVE_WORKDIR`). Codex can run from a stable user directory while Multica keeps task logs, credentials, generated context, and `CODEX_HOME` in the isolated task env root.

The default remains unchanged. An explicitly assigned project `local_directory` still takes precedence.

This is intended for users who want Multica to remain the transport/task gateway while Codex keeps its native stable-cwd workflow. In native mode Multica does not write `AGENTS.md`, `.agent_context`, task markers, skills, or cleanup sidecars into the selected directory. The runtime brief is sent via Codex app-server `developerInstructions` instead.

Existing conversations can migrate safely: when a prior managed task workdir is proven to belong to the same agent and issue/chat, only the requested rollout is linked into the persistent per-conversation Codex session store. The existing rollout-presence gate remains authoritative, so a missing rollout is never presented as a successful resume.

## Related Issue

No linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add native Codex cwd configuration to the CLI config, daemon flags, env overrides, and startup validation.
- Keep native cwd preparation and cleanup sidecar-free while retaining a task-private env root and `CODEX_HOME`.
- Deliver the runtime brief through `developerInstructions` on both `thread/start` and `thread/resume` only when supplied; managed mode remains `nil`.
- Preserve Codex sessions across both task IDs and a one-time managed-workdir-to-native-cwd migration.
- Add coverage for configuration precedence, flag forwarding, cwd ownership, rollout migration, resume gating, and app-server parameters.

## How to Test

1. Configure a writable directory: `multica config set codex_native_workdir /absolute/path/to/code`.
2. Start/restart the daemon and run a Codex chat; verify the reported cwd is the configured directory and no Multica sidecars are created there.
3. Continue a chat whose prior turn used a managed task workdir; verify the same Codex thread resumes after the cwd change.
4. Clear the setting and verify managed per-task workdirs retain their previous behavior.

Automated verification run locally:

- `go test -p=1 ./internal/daemon ./internal/daemon/execenv`
- `go test ./pkg/agent`
- full `cmd/multica` test binary (run outside an existing workspaces-root marker)
- `go vet ./internal/daemon ./internal/daemon/execenv ./pkg/agent ./cmd/multica`
- `go build ./cmd/multica`

## Risks

- Native mode deliberately gives Codex the normal filesystem authority of the configured cwd. It is opt-in and Codex-only.
- A project `local_directory` remains higher priority, preserving explicit project scoping.
- Session migration accepts only an exact prior session rollout after managed provenance, task marker, directory shape, and conversation identity checks.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the convention (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex via Multica

**Prompt / approach:** Implemented from a stable-cwd gateway use case. Traced daemon workdir selection, execenv sidecar lifecycle, Codex app-server start/resume parameters, and rollout storage before adding an opt-in path. Kept the upstream default unchanged and verified both fresh and migration paths.
