### PR TITLE
fix(agents): preserve disabled skills when adding new skills (MUL-6847 / PUCK-71 / upstream #5988)

### DIFF
--- a/packages/views/agents/components/skill-add-dialog.tsx
+++ b/packages/views/agents/components/skill-add-dialog.tsx
@@ -79,11 +79,7 @@ export function SkillAddDialog({
     if (selectedIds.size === 0) return;
     setSaving(true);
     try {
-      const newIds = [
-        ...agent.skills.map((s) => s.id),
-        ...selectedIds,
-      ];
-      await api.setAgentSkills(agent.id, { skill_ids: newIds });
+      await api.addAgentSkills(agent.id, { skill_ids: [...selectedIds] });
       qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
       handleOpenChange(false);
     } catch (e) {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where adding a new skill to an agent re-enables all previously disabled skills.

Root cause: `SkillAddDialog` (`packages/views/agents/components/skill-add-dialog.tsx:78-86`) rebuilt the full skill list and called `api.setAgentSkills` (PUT `/api/agents/:id/skills`), which on the server does `DELETE + INSERT` with default `enabled=true`. Existing disabled skills were reset to enabled.

This PR switches the dialog to the additive endpoint `api.addAgentSkills` (POST `/api/agents/:id/skills/add`, `ON CONFLICT DO NOTHING`), which preserves the `enabled` flag of existing rows.

## Related Issue

https://github.com/multica-ai/multica/issues/5988

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/agents/components/skill-add-dialog.tsx`: `api.setAgentSkills` → `api.addAgentSkills` with `skill_ids: [...selectedIds]` only (1 file, +1/-5)

## How to Test

1. Assign skills A (enabled) and B (disabled) to an agent; verify B is disabled in Capabilities tab.
2. Open SkillAddDialog, add skill C.
3. Verify B remains disabled after the operation.
4. Verify `go vet ./...` and `go test ./internal/handler -run TestAddAgentSkills` pass (existing test `TestAddAgentSkillsPreservesExistingAssignments` covers the server invariant).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (existing server test covers the invariant)
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above (no breaking change; strictly additive)
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Muse Spark (Multica worker-opencode)

**Prompt / approach:** Traced SkillAddDialog → SetAgentSkills → server DELETE+INSERT; switched to additive endpoint and verified with local reproduction script and handler tests.
