### PR TITLE
MUL-6804 fix(settings): stop claiming workspace delete removes all data

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -688,7 +688,7 @@
   },
   "delete_workspace_dialog": {
     "title": "Delete workspace",
-    "description": "This cannot be undone. All issues, agents, and data will be permanently removed.",
+    "description": "This cannot be undone. All issues, agents, chats, and task history will be permanently removed.",
     "type_to_confirm_prefix": "To confirm, type",
     "type_to_confirm_suffix": " below.",
     "cancel": "Cancel",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -686,7 +686,7 @@
   },
   "delete_workspace_dialog": {
     "title": "ワークスペースを削除",
-    "description": "この操作は元に戻せません。すべてのタスク、エージェント、データが完全に削除されます。",
+    "description": "この操作は元に戻せません。すべてのタスク、エージェント、チャット、実行履歴が完全に削除されます。",
     "type_to_confirm_prefix": "確認するには、下に",
     "type_to_confirm_suffix": " と入力してください。",
     "cancel": "キャンセル",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -686,7 +686,7 @@
   },
   "delete_workspace_dialog": {
     "title": "워크스페이스 삭제",
-    "description": "이 작업은 되돌릴 수 없습니다. 모든 태스크, 에이전트, 데이터가 영구 삭제됩니다.",
+    "description": "이 작업은 되돌릴 수 없습니다. 모든 태스크, 에이전트, 채팅, 실행 기록이 영구 삭제됩니다.",
     "type_to_confirm_prefix": "확인하려면 아래에",
     "type_to_confirm_suffix": "을(를) 입력하세요.",
     "cancel": "취소",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -686,7 +686,7 @@
   },
   "delete_workspace_dialog": {
     "title": "删除工作区",
-    "description": "此操作不可撤销。所有任务、智能体和数据都将被永久删除。",
+    "description": "此操作不可撤销。所有任务、智能体、聊天记录和执行历史都将被永久删除。",
     "type_to_confirm_prefix": "确认请输入",
     "type_to_confirm_suffix": "。",
     "cancel": "取消",


### PR DESCRIPTION
## Summary

The delete-workspace confirmation dialog told users:

> This cannot be undone. All issues, agents, and data will be permanently removed.

The "and data" part is not accurate. Workspace deletion does clear every database row — tasks, chat, issues, agents, integrations, memberships, and the `attachment` rows — but it does not remove the uploaded file objects from object storage.

`DeleteWorkspace` (`server/internal/handler/workspace.go:1313`) calls `deleteS3Objects` exactly once, with `sourceContextAttachmentURLs + sourceContextIntentURLs`, and `ListSourceContextAttachmentURLsByWorkspace` filters on `source_context_id IS NOT NULL`. So only source-context snapshot objects are deleted; regular issue / comment / chat uploads stay in the bucket under `workspaces/<workspace-id>/` (`file.go:439`) as orphans. There is no fallback sweeper either — `source_context_sweeper.go` only covers source contexts.

Reported in #7717 by a self-host operator asking whether deleting a workspace deletes all associated data.

This PR only corrects the copy so it stops overstating the scope. The object-storage cleanup is tracked separately; it is not a one-line change because `DeleteKeys` deletes objects serially after the transaction commits and before the HTTP response, so doing it properly needs batched `DeleteObjects` or an async sweeper.

## Changes

Updated `delete_workspace_dialog.description` in all four locales (en, zh-Hans, ja, ko) to name what the teardown actually guarantees instead of claiming "all data":

> This cannot be undone. All issues, agents, chats, and task history will be permanently removed.

No keys added or removed, so locale parity is unaffected.

## Verification

- `npx vitest run locales/parity.test.ts settings/components/delete-workspace-dialog.test.tsx` in `packages/views` — 169 tests pass
- All four JSON bundles re-parsed to confirm they are still valid
