### PR TITLE
MUL-6825 refactor(redact): drop home-directory masking from agent output

### DIFF
--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -148,10 +148,14 @@ exit 1
 			t.Errorf("error = %q, want substring %q", result.Error, want)
 		}
 	}
-	for _, secret := range []string{"cursor-secret-token-value", homeDir} {
-		if strings.Contains(result.Error, secret) {
-			t.Errorf("error leaked %q: %q", secret, result.Error)
-		}
+	if strings.Contains(result.Error, "cursor-secret-token-value") {
+		t.Errorf("error leaked the bearer token: %q", result.Error)
+	}
+	// Host paths are deliberately NOT masked: a crash diagnostic is only
+	// actionable if the path it names is the real one, and masking a path
+	// segment never was an access-control boundary. See redact.Text.
+	if !strings.Contains(result.Error, homeDir+"/private") {
+		t.Errorf("error = %q, want the home path preserved verbatim", result.Error)
 	}
 	if result.Output != "" {
 		t.Fatalf("output = %q, want empty failed output", result.Output)

--- a/server/pkg/agent/stderr_tail.go
+++ b/server/pkg/agent/stderr_tail.go
@@ -22,10 +22,11 @@ var (
 	agentDiagnosticSecretRe    = regexp.MustCompile(`(?i)(authorization|auth|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
 )
 
-// sanitizeAgentDiagnostic removes terminal control characters, common secret
-// shapes, and local home-directory details before a child-process diagnostic is
-// persisted in Result.Error. stderr is still forwarded to the local daemon log;
-// this helper protects the task row and user-visible failure comment.
+// sanitizeAgentDiagnostic removes terminal control characters and common secret
+// shapes before a child-process diagnostic is persisted in Result.Error. stderr
+// is still forwarded to the local daemon log; this helper protects the task row
+// and user-visible failure comment. Local paths are left intact — they are what
+// makes a crash diagnostic actionable, and hiding them was never a boundary.
 func sanitizeAgentDiagnostic(value string) string {
 	value = strings.Map(func(r rune) rune {
 		if r < 0x20 && r != '\n' && r != '\t' {

--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -3,10 +3,7 @@
 package redact
 
 import (
-	"os"
-	"os/user"
 	"regexp"
-	"strings"
 )
 
 // secretPattern pairs a compiled regex with its replacement text.
@@ -152,30 +149,21 @@ func redactValue(v any, depth int) any {
 	}
 }
 
-// homeDir is resolved once at init for path redaction.
-var homeDir string
-var username string
-
-func init() {
-	homeDir, _ = os.UserHomeDir()
-	if u, err := user.Current(); err == nil {
-		username = u.Username
-	}
-}
-
 // Text scans the input string for known secret patterns and replaces
-// matches with safe placeholders. It also masks the local user's home
-// directory path to prevent leaking the username.
+// matches with safe placeholders.
+//
+// It deliberately does NOT mask the local home directory. That masking used to
+// live here, but it was never a boundary: anyone who can read a transcript
+// already sees repository paths, file contents, commands and diffs, so hiding
+// one path segment protected nothing while making paths unusable for copy-paste
+// and debugging. It was also incoherent about whose home directory it hid —
+// Content/Output are redacted in the server's ingest handler, so a hosted
+// deployment matched them against the *server's* home, never the machine
+// running the agent. Transcript visibility is an authorization concern and is
+// handled at that layer, not by string replacement here.
 func Text(s string) string {
 	for _, p := range patterns {
 		s = p.re.ReplaceAllString(s, p.replacement)
 	}
-
-	// Redact home directory paths (e.g. /Users/john/ → /Users/****/).
-	if homeDir != "" && username != "" {
-		masked := strings.Replace(homeDir, username, "****", 1)
-		s = strings.ReplaceAll(s, homeDir, masked)
-	}
-
 	return s
 }

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -3,7 +3,6 @@ package redact
 import (
 	"encoding/json"
 	"os"
-	"os/user"
 	"strings"
 	"testing"
 )
@@ -197,21 +196,6 @@ func TestRedactGenericCredentials(t *testing.T) {
 	}
 }
 
-func TestRedactHomeDirectory(t *testing.T) {
-	t.Parallel()
-	if homeDir == "" || username == "" {
-		t.Skip("cannot determine home dir or username")
-	}
-	input := "Reading file at " + homeDir + "/Documents/secret.txt"
-	got := Text(input)
-	if strings.Contains(got, username) {
-		t.Fatalf("home directory username not redacted: %s", got)
-	}
-	if !strings.Contains(got, "****") {
-		t.Fatalf("expected **** in path, got: %s", got)
-	}
-}
-
 func TestNoFalsePositivesOnNormalText(t *testing.T) {
 	t.Parallel()
 	inputs := []string{
@@ -362,27 +346,26 @@ func TestInputMapRedactsDeeplyNestedMaps(t *testing.T) {
 	}
 }
 
-func TestInputMapRedactsNestedHomePath(t *testing.T) {
+// Home directory paths are intentionally left intact — see Text's doc comment.
+// This guards the removal: a path under $HOME must survive verbatim, so nobody
+// reintroduces host-path masking as an incidental side effect of another fix.
+func TestTextLeavesHomePathIntact(t *testing.T) {
 	t.Parallel()
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		t.Skip("no home directory resolved in this environment")
 	}
-	u, err := user.Current()
-	if err != nil || u.Username == "" {
-		t.Skip("no current user resolved in this environment")
+	path := home + "/secret/app.go"
+
+	if got := Text(path); got != path {
+		t.Fatalf("home path was rewritten:\n  input:  %s\n  output: %s", path, got)
 	}
-	m := map[string]any{
-		"changes": []any{
-			map[string]any{"path": home + "/secret/app.go"},
-		},
-	}
-	got := InputMap(m)
-	changes, _ := got["changes"].([]any)
+
+	m := map[string]any{"changes": []any{map[string]any{"path": path}}}
+	changes, _ := InputMap(m)["changes"].([]any)
 	first, _ := changes[0].(map[string]any)
-	path, _ := first["path"].(string)
-	if strings.Contains(path, u.Username) {
-		t.Fatalf("username leaked from nested path: %s", path)
+	if got, _ := first["path"].(string); got != path {
+		t.Fatalf("nested home path was rewritten:\n  input:  %s\n  output: %s", path, got)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes home-directory masking from `redact.Text`. Agent output is no longer rewritten from `/Users/alice/repo/main.go` to `/Users/****/repo/main.go` before it is persisted and broadcast.

Follow-up to the discussion on #7744, which proposed making that masking more thorough. We decided to remove the behaviour instead.

**Why remove it rather than fix it:**

1. **It was never an access-control boundary.** Anyone who can read a task transcript already sees repository paths, file contents, commands, diffs and error output. Masking one path segment out of all that protected nothing, while it did make paths non-copy-pasteable and harder to line up when debugging a run.
2. **It was incoherent about whose home directory it hid.** `homeDir` / `username` were resolved from the process running `Text`, and the main transcript fields (`Content` / `Output`) are only redacted in the server's ingest handler (`server/internal/handler/daemon.go`) — so a hosted deployment matched them against the *server's* home directory, never the machine actually running the agent. Only tool inputs (`redact.InputMap` in the daemon) and stderr diagnostics went through a call site where the resolved home was the right one.
3. **Transcript visibility belongs in authorization.** We treat workspace members as trusted; finer-grained isolation is planned as a first-class concept rather than as output masking.

Secret redaction — API keys, tokens, PEM blocks, connection strings — is a real boundary and is untouched by this PR. So is `relative_work_dir`, which is a UI choice about showing short paths, not a privacy mechanism.

## Related Issue

No public issue. This follows from the review of #7744 (closed in favour of this change).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

Behaviour does change for the masked paths; nothing else in the redaction pipeline moves.

## Changes Made

- `server/pkg/redact/redact.go`: drop the `homeDir` / `username` package vars, the `init()` that resolved them, and the masking branch in `Text`. `os` / `os/user` / `strings` imports go with them. `Text`'s doc comment records why the behaviour is intentionally absent.
- `server/pkg/redact/redact_test.go`: replace `TestRedactHomeDirectory` and `TestInputMapRedactsNestedHomePath` with `TestTextLeavesHomePathIntact`, which asserts a `$HOME` path survives verbatim through both `Text` and `InputMap`.
- `server/pkg/agent/stderr_tail.go`: `sanitizeAgentDiagnostic`'s comment no longer claims it strips home-directory details.
- `server/pkg/agent/cursor_execute_unix_test.go`: `TestCursorExecuteReportsSanitizedStderrOnProcessFailure` keeps its bearer-token assertion and now asserts the home path is preserved instead of masked.

The two rewritten tests are the point of the test churn: they pin the removal so host-path masking cannot come back as an incidental side effect of a later redaction fix.

## How to Test

1. `cd server && go test ./pkg/redact/... -count=1` — passes, including `TestTextLeavesHomePathIntact`.
2. `cd server && go test ./pkg/agent/... -run 'Stderr|Sanitize|Diagnostic' -count=1` — passes.
3. `cd server && go vet ./... && go build ./...` — clean.

Verified locally on macOS: all three commands above pass on this branch. The full `make test` suite (DB-backed) was not run here; CI covers it.

This also resolves the Windows failure reported in #7744. `TestRedactHomeDirectory` failed there because Windows can return a `DOMAIN\user` account name that is not a substring of the home path, so the `strings.Replace` never fired. CI only runs Go tests on ubuntu, which is why `main` stayed green. Deleting the branch deletes the failure.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against the Chinese conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

No UI change, no documentation referenced the masking (grepped), no new runtime, no Chinese copy.

**Risk:** low and one-directional — strictly less rewriting of persisted text. Existing rows already written with `****` are unaffected; they simply stop being produced going forward. There is no migration and no API shape change.

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** Reviewed #7744, traced every `redact.Text` / `redact.InputMap` call site to establish which process resolves the home directory at each one, and confirmed with the maintainers that removal — not a more thorough mask — was the intended direction. Then removed the branch, updated the two tests that asserted the old behaviour into guards against its return, and ran vet/build plus the affected package tests.
