### PR TITLE
MUL-6849: fix(runtime): remove duplicate Runtime Brief context

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1093,6 +1093,10 @@ func TestBuildPromptAutopilotRunOnly(t *testing.T) {
 		AutopilotTitle:       "Daily dependency check",
 		AutopilotDescription: "Check dependencies and report outdated packages.",
 		AutopilotSource:      "manual",
+		AutopilotTriggerPayload: json.RawMessage(`{
+			"repository": "multica-ai/multica",
+			"action": "scheduled"
+		}`),
 	}, "claude")
 
 	for _, want := range []string{
@@ -1100,6 +1104,8 @@ func TestBuildPromptAutopilotRunOnly(t *testing.T) {
 		"Autopilot run ID: run-1",
 		"Daily dependency check",
 		"Check dependencies and report outdated packages.",
+		"Trigger source: manual",
+		`"repository": "multica-ai/multica"`,
 		"multica autopilot get autopilot-1 --output json",
 	} {
 		if !strings.Contains(prompt, want) {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -697,15 +697,16 @@ func TestChatProjectContextInjectedIntoRuntimeBrief(t *testing.T) {
 	}
 }
 
-// When the issue's project has its own github_repo resources, those should be
-// the only repos rendered in the meta-skill — workspace-level repos must not
-// leak into the agent prompt to avoid confusing it about which repo to use.
+// When the issue's project has its own github_repo resources, the claim lifts
+// them into Repos for checkout authorization as well as retaining their richer
+// ProjectResources representation. The brief must render each URL only once,
+// in Project Context, without changing the underlying runtime repo list.
 //
 // The handler-side override is exercised in handler tests; this test confirms
 // the rendering side: given a TaskContextForEnv where Repos was already
 // narrowed by the server to project repos only, the meta skill renders just
 // those.
-func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
+func TestProjectReposRenderedOnceInMetaSkill(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	ctx := TaskContextForEnv{
@@ -719,7 +720,8 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 			{
 				ID:           "33333333-4444-5555-6666-777777777777",
 				ResourceType: "github_repo",
-				ResourceRef:  []byte(`{"url":"https://github.com/org/project-repo"}`),
+				ResourceRef:  []byte(`{"url":"https://github.com/org/project-repo","ref":"release/v2","default_branch_hint":"main"}`),
+				Label:        "Primary repository",
 			},
 		},
 	}
@@ -731,11 +733,39 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
 	s := string(content)
-	if !strings.Contains(s, "https://github.com/org/project-repo") {
-		t.Errorf("CLAUDE.md missing project repo URL")
+	if count := strings.Count(s, "https://github.com/org/project-repo"); count != 1 {
+		t.Errorf("CLAUDE.md project repo URL count = %d, want exactly one\n---\n%s", count, s)
 	}
-	if strings.Contains(s, "https://github.com/org/workspace-repo") {
-		t.Errorf("CLAUDE.md should not contain workspace repo when project has its own")
+	for _, want := range []string{"## Project Context", "**GitHub repo**", "release/v2", "Primary repository"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing richer project repo context %q", want)
+		}
+	}
+	if strings.Contains(s, "## Repositories") {
+		t.Errorf("CLAUDE.md should omit Repositories when every repo is already rendered in Project Context\n---\n%s", s)
+	}
+}
+
+func TestProjectContextKeepsUnmatchedWorkspaceRepoInMetaSkill(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID:   "11111111-2222-3333-4444-555555555555",
+		ProjectID: "22222222-3333-4444-5555-666666666666",
+		Repos: []RepoContextForEnv{
+			{URL: "https://github.com/org/workspace-repo"},
+		},
+		ProjectResources: []ProjectResourceForEnv{
+			{
+				ID:           "33333333-4444-5555-6666-777777777777",
+				ResourceType: "local_directory",
+				ResourceRef:  []byte(`{"local_path":"/srv/project"}`),
+			},
+		},
+	}
+
+	s := buildMetaSkillContent("claude", ctx)
+	if !strings.Contains(s, "## Repositories") || !strings.Contains(s, "https://github.com/org/workspace-repo") {
+		t.Errorf("brief dropped a workspace repo not represented by Project Context\n---\n%s", s)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2614,9 +2614,8 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 
 	for _, want := range []string{
 		"Autopilot in run-only mode",
-		"Autopilot run ID: `run-1`",
-		"Check dependencies and report outdated packages.",
-		"multica autopilot get autopilot-1 --output json",
+		"Complete the autopilot instructions directly",
+		AutopilotIssueCommandsGuard,
 		"Your final assistant output is captured automatically as the autopilot run result",
 	} {
 		if !strings.Contains(s, want) {
@@ -2625,6 +2624,11 @@ func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 	}
 
 	for _, absent := range []string{
+		"Autopilot run ID: `run-1`",
+		"autopilot-1",
+		"Daily dependency check",
+		"Check dependencies and report outdated packages.",
+		"Trigger source: manual",
 		"Run `multica issue get",
 		"Final results MUST be delivered via `multica issue comment add`",
 	} {

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -554,37 +554,17 @@ func writeWorkflowQuickCreate(b *strings.Builder) {
 	b.WriteString("- If the CLI returns an error, exit with that error as the only output. Do not retry.\n\n")
 }
 
-// AutopilotIssueCommandsGuard is the run-only autopilot issue-command boundary,
-// shared verbatim by the runtime brief (writeWorkflowAutopilot) and the
-// per-turn prompt (daemon.buildAutopilotPrompt). Both land in the same context
-// window; MUL-5696 found the two hand-maintained copies had drifted into an
-// unconditional ban on one surface and a conditional one on the other.
+// AutopilotIssueCommandsGuard is the run-only autopilot issue-command boundary.
+// The runtime brief is its single emission point; the per-turn prompt defers to
+// this stable, higher-priority copy. MUL-5696 found that two hand-maintained
+// copies had drifted into conflicting instructions.
 const AutopilotIssueCommandsGuard = "Do not run `multica issue get`, `multica issue comment add`, or `multica issue status` for this run unless the autopilot instructions explicitly tell you to create or update an issue"
 
-// writeWorkflowAutopilot emits the autopilot run-only workflow.
-func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
+// writeWorkflowAutopilot emits only stable run-only policy. Per-run Autopilot
+// data belongs to daemon.buildAutopilotPrompt so it appears once, at user-turn
+// priority, without changing the runtime brief's cache prefix (issue #7773).
+func writeWorkflowAutopilot(b *strings.Builder) {
 	b.WriteString("**This task was triggered by an Autopilot in run-only mode.** There is no assigned Multica issue for this run.\n\n")
-	fmt.Fprintf(b, "- Autopilot run ID: `%s`\n", ctx.AutopilotRunID)
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(b, "- Autopilot ID: `%s`\n", ctx.AutopilotID)
-	}
-	if ctx.AutopilotTitle != "" {
-		fmt.Fprintf(b, "- Autopilot title: %s\n", ctx.AutopilotTitle)
-	}
-	if ctx.AutopilotSource != "" {
-		fmt.Fprintf(b, "- Trigger source: %s\n", ctx.AutopilotSource)
-	}
-	if ctx.AutopilotTriggerPayload != "" {
-		fmt.Fprintf(b, "- Trigger payload:\n\n```json\n%s\n```\n", ctx.AutopilotTriggerPayload)
-	}
-	if strings.TrimSpace(ctx.AutopilotDescription) != "" {
-		b.WriteString("\nAutopilot instructions:\n\n")
-		b.WriteString(ctx.AutopilotDescription)
-		b.WriteString("\n\n")
-	}
-	if ctx.AutopilotID != "" {
-		fmt.Fprintf(b, "- Run `multica autopilot get %s --output json` if you need the full autopilot configuration\n", ctx.AutopilotID)
-	}
 	b.WriteString("- Complete the autopilot instructions directly\n")
 	b.WriteString("- " + AutopilotIssueCommandsGuard + "\n\n")
 }
@@ -952,7 +932,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	case kindQuickCreate:
 		writeWorkflowQuickCreate(&b)
 	case kindAutopilotRunOnly:
-		writeWorkflowAutopilot(&b, ctx)
+		writeWorkflowAutopilot(&b)
 	case kindIssue:
 		writeWorkflowIssue(&b, ctx)
 	}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -391,16 +392,42 @@ func writeCommentFormatting(b *strings.Builder) {
 	b.WriteString("For issue comments, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`**. Never use inline `--content` for agent-authored comments (MUL-2904); never use `--content-stdin` HEREDOCs alongside other flags (#4182). Write the file inside your working directory, never `/tmp` or shared paths (MUL-4252). Keep the same `--parent` value from the trigger comment when replying; delete the temp file (`rm ./reply.md`) after posting; do not rely on `\\n` escapes.\n\n")
 }
 
-// writeRepositories emits the Repositories section when at least one repo
-// is configured. The closing paragraph from the legacy version is dropped
-// (it re-stated the opening); intro is tightened into one line.
+// writeRepositories emits workspace repos that are not already represented by
+// a richer github_repo entry in Project Context. The claim deliberately lifts
+// project github_repo resources into ctx.Repos for checkout authorization and
+// caching, but rendering both lists repeated the same URL in the brief. This is
+// a presentation-only filter: ctx.Repos remains unchanged for runtime behavior
+// (issue #7773).
 func writeRepositories(b *strings.Builder, ctx TaskContextForEnv) {
-	if len(ctx.Repos) == 0 {
+	projectRepoURLs := make(map[string]struct{})
+	for _, resource := range ctx.ProjectResources {
+		if resource.ResourceType != "github_repo" {
+			continue
+		}
+		var ref struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(resource.ResourceRef, &ref); err != nil {
+			continue
+		}
+		if url := strings.TrimSpace(ref.URL); url != "" {
+			projectRepoURLs[url] = struct{}{}
+		}
+	}
+
+	repos := make([]RepoContextForEnv, 0, len(ctx.Repos))
+	for _, repo := range ctx.Repos {
+		if _, duplicatedByProjectContext := projectRepoURLs[strings.TrimSpace(repo.URL)]; duplicatedByProjectContext {
+			continue
+		}
+		repos = append(repos, repo)
+	}
+	if len(repos) == 0 {
 		return
 	}
 	b.WriteString("## Repositories\n\n")
 	b.WriteString("Available in this workspace — `multica repo checkout <url> [--ref <branch-or-sha>]` to fetch (creates a repository checkout on a dedicated branch).\n\n")
-	for _, repo := range ctx.Repos {
+	for _, repo := range repos {
 		if repo.Description != "" {
 			fmt.Fprintf(b, "- %s — %s\n", repo.URL, repo.Description)
 		} else {

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1973,6 +1973,20 @@ func TestBriefByteIdenticalAcrossRunsForEveryKind(t *testing.T) {
 			// stated by the per-turn chat prompt and never here.
 			c.ChatChannelDeliversFiles = true
 		}},
+		{"autopilot-run", func(c *TaskContextForEnv) {
+			if c.AutopilotRunID != "" {
+				c.AutopilotRunID = "run-2"
+			}
+		}},
+		{"autopilot-config", func(c *TaskContextForEnv) {
+			if c.AutopilotRunID != "" {
+				c.AutopilotID = "ap-2"
+				c.AutopilotTitle = "Different title"
+				c.AutopilotDescription = "Different instructions"
+				c.AutopilotSource = "webhook"
+				c.AutopilotTriggerPayload = `{"request":{"receivedAt":"2026-08-30T00:00:00Z"}}`
+			}
+		}},
 	}
 
 	for kindName, baseCtx := range kinds {


### PR DESCRIPTION
## Summary

- keep only stable run-only workflow policy and the issue-command guard in the Autopilot Runtime Brief
- keep all per-run Autopilot IDs, instructions, source, and trigger payload in the current user-turn prompt
- render project GitHub repositories once in the richer Project Context section instead of repeating their URLs under `## Repositories`
- preserve unmatched workspace repos and the complete runtime repo list used for checkout authorization and caching
- add regression coverage for Brief byte stability, prompt completeness, project repo deduplication, and workspace repo fallback

## Why

The Runtime Brief is part of the model's prompt prefix. Repeating content there increases input tokens and makes the cached prefix larger than necessary. Per-run Autopilot data also makes the Brief vary between runs, while project GitHub resources were printed twice inside the same Brief.

This change gives each value one canonical prompt location without changing task behavior or repository access.

## Tests

- `go test ./internal/daemon/execenv -run 'Test(ProjectReposRenderedOnceInMetaSkill|ProjectContextKeepsUnmatchedWorkspaceRepoInMetaSkill|PrepareWithRepoContext|ChatProjectContextInjectedIntoRuntimeBrief|BriefByteIdenticalAcrossRunsForEveryKind|InjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow|BriefOwnsAutopilotIssueCommandsGuard)$' -count=1`
- `go test ./internal/daemon -run '^TestBuildPromptAutopilotRunOnly$' -count=1`

A full `go test ./internal/daemon/execenv ./internal/daemon` run was also attempted. It is blocked on this Windows host by unrelated environment-dependent tests (local CLI and skill discovery, filesystem locking, and long path behavior); the focused affected tests pass.

Closes #7773
