### PR TITLE
MUL-6851: fix(chat): fall back to message.content when the task timeline has no trailing text

### DIFF
--- a/packages/views/chat/components/chat-message-list.test.tsx
+++ b/packages/views/chat/components/chat-message-list.test.tsx
@@ -1,11 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { chatKeys } from "@multica/core/chat/queries";
-import type { TaskMessagePayload } from "@multica/core/types";
+import { captureEvent } from "@multica/core/analytics";
+import type { ChatMessage, TaskMessagePayload } from "@multica/core/types";
 import type { ReactElement } from "react";
 import enChat from "../../locales/en/chat.json";
+
+vi.mock("@multica/core/analytics", () => ({ captureEvent: vi.fn() }));
 
 // The live timeline is a real list row rather than Virtuoso chrome (MUL-4922),
 // so it shares one identity with the persisted assistant row and keeps its
@@ -572,5 +575,136 @@ describe("ChatMessageList onboarding starter cards", () => {
       await screen.findByRole("button", { name: "Get a board up in minutes" }),
     ).toBeEnabled();
     expect(screen.getByRole("button", { name: "Later chip" })).toBeEnabled();
+  });
+});
+
+describe("ChatMessageList missing final text fallback", () => {
+  // The persisted assistant row renders its answer text ONLY from the task
+  // timeline's trailing text (splitTimeline's `final` segment) whenever the
+  // timeline is non-empty — `message.content` is gated off entirely. When the
+  // timeline's tail is missing (daemon tail-flush loss, sandwiched text, a
+  // client cache hole), the turn renders elapsed + quick actions but NO
+  // answer. extractCopyText already falls back to message.content for this
+  // exact shape; the render path must too.
+  beforeEach(() => {
+    vi.mocked(captureEvent).mockClear();
+  });
+  const ANSWER = "Task list updated: T-2001";
+
+  // Tool steps with NO trailing text after the last non-text item — the
+  // pathological shape where the whole answer is invisible today.
+  const TAILLESS_TIMELINE: TaskMessagePayload[] = [
+    taskMsg(0, "tool_use", { tool: "Bash", input: { command: "multica issue create" } }),
+    taskMsg(1, "tool_result", { tool: "Bash", output: "ok" }),
+  ];
+
+  function renderIs90(
+    messageOverrides: Partial<ChatMessage> = {},
+    timeline: TaskMessagePayload[] = TAILLESS_TIMELINE,
+  ) {
+    const qc = new QueryClient();
+    qc.setQueryData(chatKeys.taskMessages(TASK_ID), timeline);
+    return render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={qc}>
+          <ChatMessageList
+            messages={[
+              {
+                id: "m-is90",
+                chat_session_id: "s1",
+                role: "assistant" as const,
+                content: ANSWER,
+                task_id: TASK_ID,
+                created_at: new Date(0).toISOString(),
+                ...messageOverrides,
+              },
+            ]}
+            pendingTask={null}
+            availability="online"
+          />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+  }
+
+  it("renders message.content when the timeline has no trailing text", async () => {
+    renderIs90();
+    // The timeline itself still renders (the fold), and the authoritative
+    // answer text from the persisted row becomes visible below it.
+    expect(await screen.findByText("2 steps")).toBeInTheDocument();
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+  });
+
+  it("does not duplicate the answer when trailing text exists", async () => {
+    renderIs90(
+      {},
+      [
+        taskMsg(0, "tool_use", { tool: "Bash", input: { command: "ls" } }),
+        taskMsg(1, "tool_result", { tool: "Bash", output: "ok" }),
+        taskMsg(2, "text", { content: ANSWER }),
+      ],
+    );
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    expect(screen.getAllByText(ANSWER)).toHaveLength(1);
+  });
+
+  it("keeps the no_response placeholder instead of a fabricated answer", async () => {
+    renderIs90({ content: "", message_kind: "no_response" as const });
+    expect(await screen.findByText(enChat.message_list.no_response)).toBeInTheDocument();
+    expect(screen.queryByText(ANSWER)).toBeNull();
+  });
+
+  it("keeps the failure bubble for failed turns", async () => {
+    renderIs90({ failure_reason: "something_entirely_new" });
+    expect(
+      await screen.findByText(enChat.message_list.failure.fallback),
+    ).toBeInTheDocument();
+  });
+
+  it("fires assistant_reply_missing_final_text telemetry once per message", async () => {
+    const { rerender } = renderIs90();
+    await screen.findByText(ANSWER);
+    expect(vi.mocked(captureEvent)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureEvent)).toHaveBeenCalledWith(
+      "assistant_reply_missing_final_text",
+      expect.objectContaining({ message_id: "m-is90", task_id: TASK_ID }),
+    );
+
+    // A re-render of the same row (quick-actions patch, task:message tick)
+    // must not re-emit.
+    rerender(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={new QueryClient()}>
+          <ChatMessageList
+            messages={[
+              {
+                id: "m-is90",
+                chat_session_id: "s1",
+                role: "assistant" as const,
+                content: ANSWER,
+                task_id: TASK_ID,
+                created_at: new Date(0).toISOString(),
+              },
+            ]}
+            pendingTask={null}
+            availability="online"
+          />
+        </QueryClientProvider>
+      </I18nProvider>,
+    );
+    expect(vi.mocked(captureEvent)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire telemetry for turns that render their text normally", async () => {
+    renderIs90(
+      {},
+      [
+        taskMsg(0, "tool_use", { tool: "Bash", input: { command: "ls" } }),
+        taskMsg(1, "tool_result", { tool: "Bash", output: "ok" }),
+        taskMsg(2, "text", { content: ANSWER }),
+      ],
+    );
+    await screen.findByText(ANSWER);
+    expect(vi.mocked(captureEvent)).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/chat/components/chat-message-list.test.tsx
+++ b/packages/views/chat/components/chat-message-list.test.tsx
@@ -667,7 +667,11 @@ describe("ChatMessageList missing final text fallback", () => {
     expect(vi.mocked(captureEvent)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(captureEvent)).toHaveBeenCalledWith(
       "assistant_reply_missing_final_text",
-      expect.objectContaining({ message_id: "m-is90", task_id: TASK_ID }),
+      expect.objectContaining({
+        message_id: "m-is90",
+        task_id: TASK_ID,
+        reason: "empty_final",
+      }),
     );
 
     // A re-render of the same row (quick-actions patch, task:message tick)
@@ -706,5 +710,62 @@ describe("ChatMessageList missing final text fallback", () => {
     );
     await screen.findByText(ANSWER);
     expect(vi.mocked(captureEvent)).not.toHaveBeenCalled();
+  });
+
+  it("does not fire telemetry when final matches content modulo whitespace", async () => {
+    renderIs90(
+      {},
+      [
+        taskMsg(0, "tool_use", { tool: "Bash", input: { command: "ls" } }),
+        taskMsg(1, "tool_result", { tool: "Bash", output: "ok" }),
+        taskMsg(2, "text", { content: ANSWER + "\n\n" }),
+      ],
+    );
+    expect(await screen.findByText(ANSWER)).toBeInTheDocument();
+    expect(screen.getAllByText(ANSWER)).toHaveLength(1);
+    expect(vi.mocked(captureEvent)).not.toHaveBeenCalled();
+  });
+
+  it("renders content replacing a truncated final (strict prefix of content)", async () => {
+    const FULL = "Summary: the synthetic fallback answer renders end to end.";
+    renderIs90(
+      { content: FULL },
+      [
+        taskMsg(0, "tool_use", { tool: "Bash", input: { command: "ls" } }),
+        taskMsg(1, "tool_result", { tool: "Bash", output: "ok" }),
+        // Daemon tail-flush lost the last chunks: the timeline's trailing
+        // text is only a strict prefix of the persisted content.
+        taskMsg(2, "text", { content: "Summary: the" }),
+      ],
+    );
+    // The authoritative full answer renders, and the truncated tail does not
+    // survive as a separate duplicate fragment.
+    expect(await screen.findByText(FULL)).toBeInTheDocument();
+    expect(screen.queryByText("Summary: the")).toBeNull();
+    expect(vi.mocked(captureEvent)).toHaveBeenCalledWith(
+      "assistant_reply_missing_final_text",
+      expect.objectContaining({ message_id: "m-is90", reason: "final_mismatch" }),
+    );
+  });
+
+  it("renders content replacing an inconsistent final and keeps the fold", async () => {
+    const NARRATION = "Synthetic narration frame left over from a mid-run checkpoint.";
+    const ANSWER_ZH = "Summary: the synthetic fallback answer renders end to end.";
+    renderIs90(
+      { content: ANSWER_ZH },
+      [
+        taskMsg(0, "tool_use", { tool: "Bash", input: { command: "ls" } }),
+        taskMsg(1, "text", { content: NARRATION }),
+      ],
+    );
+    // The persisted answer wins; the stale surviving narration frame is
+    // replaced, while the process fold stays.
+    expect(await screen.findByText(ANSWER_ZH)).toBeInTheDocument();
+    expect(screen.queryByText(NARRATION)).toBeNull();
+    expect(screen.getByText("1 step")).toBeInTheDocument();
+    expect(vi.mocked(captureEvent)).toHaveBeenCalledWith(
+      "assistant_reply_missing_final_text",
+      expect.objectContaining({ message_id: "m-is90", reason: "final_mismatch" }),
+    );
   });
 });

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -52,7 +52,7 @@ import { CHAT_COLUMN, CHAT_GUTTER } from "./chat-column";
 import { FOLLOW_EDGE_THRESHOLD } from "../../common/task-transcript/transcript-follow";
 import { useStickToBottom } from "./stick-to-bottom";
 import { formatElapsedMs } from "../lib/format";
-import { splitTimeline, extractCopyText } from "../lib/copy-text";
+import { splitTimeline, extractCopyText, timelineFinalMatchesContent } from "../lib/copy-text";
 import { stripChatQuickActionsProtocol } from "../lib/quick-actions";
 import { useT } from "../../i18n";
 
@@ -564,23 +564,32 @@ function AssistantMessage({
 
   // The persisted row's own answer text renders only when the timeline
   // is empty; with a timeline, the answer must come from the timeline's
-  // trailing text (`final` — text after the last non-text item). When that
-  // tail is missing — a daemon tail-flush that failed to persist, the answer
-  // text sandwiched before a later thinking/tool frame, or a hole in the
-  // client's task-messages cache — the turn otherwise renders elapsed +
-  // quick actions but NO reply. extractCopyText already falls back to
-  // message.content for exactly this shape; the render path now does too.
-  const { final: finalTimelineItems } = useMemo(
+  // trailing text (`final` — text after the last non-text item). When the
+  // final text disagrees with message.content — an empty final (daemon
+  // tail-flush that failed to persist, the answer sandwiched before a later
+  // thinking/tool frame, a hole in the client's task-messages cache) or a
+  // non-empty final that is a truncated prefix of / entirely inconsistent
+  // with content (the real final answer never persisted; a mid-run narration
+  // frame sits after the last non-text item) — content is authoritative:
+  // replace the final text segment with it so the detail view's last sentence
+  // matches the list preview. The process fold is preserved either way.
+  // extractCopyText already falls back to message.content for exactly these
+  // shapes; the render path now does too.
+  const { preface, middle, final: finalTimelineItems } = useMemo(
     () => splitTimeline(timeline),
     [timeline],
   );
   const isNoResponse = message?.message_kind === "no_response";
-  const missingFinalText =
-    !!message &&
-    timeline.length > 0 &&
-    finalTimelineItems.length === 0 &&
-    !isNoResponse &&
-    (message.content?.trim().length ?? 0) > 0;
+  const finalFallbackReason: "empty_final" | "final_mismatch" | null = (() => {
+    if (!message || isNoResponse || timeline.length === 0) return null;
+    // Streaming rows (no persisted message yet) and turns without an answer
+    // to fall back to keep the plain render.
+    if ((message.content?.trim().length ?? 0) === 0) return null;
+    if (finalTimelineItems.length === 0) return "empty_final";
+    return timelineFinalMatchesContent(finalTimelineItems, message.content)
+      ? null
+      : "final_mismatch";
+  })();
 
   // Count every visibly-rendered turn that needed the fallback — this is the
   // direct measure of the user-facing missing-final-text symptom, whichever upstream path
@@ -589,7 +598,7 @@ function AssistantMessage({
   // invisible again.
   const missingFinalTelemetryFor = useRef<string | null>(null);
   useEffect(() => {
-    if (!missingFinalText || !message) return;
+    if (!finalFallbackReason || !message) return;
     if (missingFinalTelemetryFor.current === message.id) return;
     missingFinalTelemetryFor.current = message.id;
     captureEvent("assistant_reply_missing_final_text", {
@@ -597,8 +606,9 @@ function AssistantMessage({
       task_id: message.task_id ?? null,
       message_kind: message.message_kind ?? "message",
       timeline_items: timeline.length,
+      reason: finalFallbackReason,
     });
-  }, [missingFinalText, message, timeline.length]);
+  }, [finalFallbackReason, message, timeline.length]);
 
   // Failure bubble path: when the server's FailTask wrote a failure
   // chat_message (failure_reason set), render a destructive bubble with the
@@ -622,7 +632,14 @@ function AssistantMessage({
     <div className="w-full space-y-1.5">
       {timeline.length > 0 && (
         <TimelineView
-          items={timeline}
+          items={
+            finalFallbackReason
+              ? // Fallback active: the final text segment is replaced by
+                // message.content below — drop the tail so it is not rendered
+                // twice (or rendered stale). Preface + middle (the fold) stay.
+                [...preface, ...middle]
+              : timeline
+          }
           attachments={message?.attachments}
           phase={phase}
           isStreaming={!message}
@@ -638,10 +655,10 @@ function AssistantMessage({
           phase="settled"
           className="leading-relaxed"
         />
-      ) : missingFinalText ? (
-        // Fallback: the timeline carried no trailing text but the
-        // persisted row has the authoritative answer — render it rather than
-        // leaving the turn blank.
+      ) : finalFallbackReason && message ? (
+        // Fallback: the timeline's trailing text is empty or disagrees
+        // with the persisted row — render the authoritative message.content
+        // rather than a blank or stale answer.
         <RichContent
           content={message.content}
           attachments={message.attachments}

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { isTaskMessageTaskId, taskMessagesOptions } from "@multica/core/chat/queries";
+import { captureEvent } from "@multica/core/analytics";
 import { RichContent } from "../../rich-content";
 import { RichContentScrollRootProvider } from "../../rich-content/scroll-root";
 import { copyText } from "@multica/ui/lib/clipboard";
@@ -561,6 +562,44 @@ function AssistantMessage({
   // still arriving and a trailing fence may be half-written.
   const phase: "streaming" | "settled" = message ? "settled" : "streaming";
 
+  // The persisted row's own answer text renders only when the timeline
+  // is empty; with a timeline, the answer must come from the timeline's
+  // trailing text (`final` — text after the last non-text item). When that
+  // tail is missing — a daemon tail-flush that failed to persist, the answer
+  // text sandwiched before a later thinking/tool frame, or a hole in the
+  // client's task-messages cache — the turn otherwise renders elapsed +
+  // quick actions but NO reply. extractCopyText already falls back to
+  // message.content for exactly this shape; the render path now does too.
+  const { final: finalTimelineItems } = useMemo(
+    () => splitTimeline(timeline),
+    [timeline],
+  );
+  const isNoResponse = message?.message_kind === "no_response";
+  const missingFinalText =
+    !!message &&
+    timeline.length > 0 &&
+    finalTimelineItems.length === 0 &&
+    !isNoResponse &&
+    (message.content?.trim().length ?? 0) > 0;
+
+  // Count every visibly-rendered turn that needed the fallback — this is the
+  // direct measure of the user-facing missing-final-text symptom, whichever upstream path
+  // dropped the tail. Fired once per message id for the life of the mounted
+  // row; a remount (session revisit) re-emits, which is correct: the turn was
+  // invisible again.
+  const missingFinalTelemetryFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!missingFinalText || !message) return;
+    if (missingFinalTelemetryFor.current === message.id) return;
+    missingFinalTelemetryFor.current = message.id;
+    captureEvent("assistant_reply_missing_final_text", {
+      message_id: message.id,
+      task_id: message.task_id ?? null,
+      message_kind: message.message_kind ?? "message",
+      timeline_items: timeline.length,
+    });
+  }, [missingFinalText, message, timeline.length]);
+
   // Failure bubble path: when the server's FailTask wrote a failure
   // chat_message (failure_reason set), render a destructive bubble with the
   // human-readable reason label + collapsible raw errMsg + the same timeline
@@ -579,8 +618,6 @@ function AssistantMessage({
   // no_response path (MUL-4351): the agent completed this direct-chat turn
   // without any text. Keep whatever tool/thinking timeline the run produced and
   // show a localized "no text reply" notice instead of an empty markdown block.
-  const isNoResponse = message?.message_kind === "no_response";
-
   return (
     <div className="w-full space-y-1.5">
       {timeline.length > 0 && (
@@ -594,6 +631,17 @@ function AssistantMessage({
       {isNoResponse ? (
         <NoResponseNotice />
       ) : message && timeline.length === 0 ? (
+        <RichContent
+          content={message.content}
+          attachments={message.attachments}
+          density="compact"
+          phase="settled"
+          className="leading-relaxed"
+        />
+      ) : missingFinalText ? (
+        // Fallback: the timeline carried no trailing text but the
+        // persisted row has the authoritative answer — render it rather than
+        // leaving the turn blank.
         <RichContent
           content={message.content}
           attachments={message.attachments}

--- a/packages/views/chat/lib/copy-text.test.ts
+++ b/packages/views/chat/lib/copy-text.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest";
 import type { ChatMessage } from "@multica/core/types";
 import type { ChatTimelineItem } from "@multica/core/chat";
-import { splitTimeline, extractCopyText } from "./copy-text";
+import { splitTimeline, extractCopyText, timelineFinalMatchesContent } from "./copy-text";
 
 const text = (seq: number, content: string): ChatTimelineItem => ({
   seq,
@@ -131,5 +131,66 @@ describe("extractCopyText", () => {
         text(3, "para 2"),
       ]),
     ).toBe("para 1\n\npara 2");
+  });
+});
+
+describe("timelineFinalMatchesContent", () => {
+  it("matches when final text equals content", () => {
+    expect(timelineFinalMatchesContent([text(1, "final answer")], "final answer")).toBe(true);
+  });
+
+  it("matches when final is several segments that concatenate to content", () => {
+    expect(
+      timelineFinalMatchesContent(
+        [text(1, "para 1"), text(2, "para 2")],
+        "para 1para 2",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores whitespace-only differences (trailing newlines, CRLF, runs)", () => {
+    expect(
+      timelineFinalMatchesContent([text(1, "final answer \n\n")], "final answer"),
+    ).toBe(true);
+    expect(
+      timelineFinalMatchesContent([text(1, "line one\r\nline two")], "line one\nline two"),
+    ).toBe(true);
+    expect(
+      timelineFinalMatchesContent([text(1, "a  b")], "a b"),
+    ).toBe(true);
+  });
+
+  it("matches when both sides are empty", () => {
+    expect(timelineFinalMatchesContent([], "")).toBe(true);
+    expect(timelineFinalMatchesContent([], null)).toBe(true);
+    expect(timelineFinalMatchesContent([text(1, "   \n")], undefined)).toBe(true);
+  });
+
+  it("does not match when final is a strict prefix of content (truncated tail)", () => {
+    expect(
+      timelineFinalMatchesContent([text(1, "Summary: the")], "Summary: the answer is ready"),
+    ).toBe(false);
+  });
+
+  it("does not match when final and content are entirely different", () => {
+    expect(
+      timelineFinalMatchesContent(
+        [text(1, "Synthetic narration frame left over from a mid-run checkpoint.")],
+        "Summary: the answer is ready",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match when final is empty but content is not", () => {
+    expect(timelineFinalMatchesContent([], "final answer")).toBe(false);
+    expect(
+      timelineFinalMatchesContent([text(1, "   ")], "final answer"),
+    ).toBe(false);
+  });
+
+  it("does not match when content only extends final by whitespace", () => {
+    // Whitespace normalization means trailing whitespace in content cannot
+    // manufacture a mismatch for an otherwise-complete final.
+    expect(timelineFinalMatchesContent([text(1, "final answer")], "final answer\n")).toBe(true);
   });
 });

--- a/packages/views/chat/lib/copy-text.ts
+++ b/packages/views/chat/lib/copy-text.ts
@@ -52,3 +52,28 @@ export function extractCopyText(
   if (pieces.length === 0) return message.content ?? "";
   return pieces.join("\n\n");
 }
+
+/**
+ * Whether the timeline's trailing text (`final`) is the same answer the
+ * persisted row carries in `message.content`, compared after normalization.
+ *
+ * The two sources describe one turn, but they are produced by different write
+ * paths, so incidental formatting differences (trailing newlines, CRLF vs LF,
+ * blank-line separators between segments, whitespace runs) must not read as a
+ * divergence. Any real text difference does: a truncated tail (final is a
+ * strict prefix of content — a daemon tail-flush lost the last chunks) or a
+ * stale surviving frame (the final answer never persisted; a mid-run
+ * narration text sits after the last non-text item instead). This is the
+ * Fallback trigger: when the two disagree and content is non-empty, the
+ * render path uses content as the authoritative answer.
+ */
+export function timelineFinalMatchesContent(
+  finalItems: ChatTimelineItem[],
+  content: string | null | undefined,
+): boolean {
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim();
+  return (
+    normalize(finalItems.map((i) => i.content ?? "").join("")) ===
+    normalize(content ?? "")
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the client half of #7777: when a persisted assistant turn's task timeline is non-empty but has **no trailing text segment**, the turn rendered elapsed time and quick actions with **no reply body** — even though the authoritative answer text is right there in `chat_messages.content`.

The renderer only consults `message.content` when `timeline.length === 0`; with a timeline, the answer must come from the timeline's trailing text (`splitTimeline`'s `final`). When that tail is missing — a daemon tail-flush that never persisted (#7777), the answer sandwiched before a later thinking/tool frame, or a hole in the client's task-messages cache — the reply was invisible.

## Change

`AssistantMessage` (`packages/views/chat/components/chat-message-list.tsx`) now falls back to rendering `message.content` when:

- `timeline.length > 0` **and** `final` is empty,
- the turn is not `no_response` (its placeholder still wins),
- `message.content` is non-empty.

This mirrors the guard `extractCopyText` already had ("so Copy never produces an empty string") — previously a user could Copy the answer they could not see. The fallback covers every loss variant: daemon tail loss, sandwiched text, client cache holes — including historical sessions whose tail rows are already gone.

A second commit extends the fallback to the case where `final` is non-empty but **disagrees with `message.content`** (a truncated tail that is only a strict prefix of content, or a stale mid-run narration frame sitting after the last non-text item while the real answer never persisted). The trigger is now a normalized comparison of the timeline's final text vs `message.content`; on mismatch, content is authoritative — the final text segment is replaced, the process fold is kept. The analytics event payload gains a `reason` (`empty_final` | `final_mismatch`) to separate the two shapes.

Also fires an `assistant_reply_missing_final_text` analytics event (once per message id per mount; carries `message_id` / `task_id` / `message_kind` / `timeline_items` / `reason`) so the user-visible symptom is directly measurable and the historical hit rate is observable.

## Self-test

- New unit tests: fallback renders the authoritative text; no duplicate render when trailing text exists; truncated-tail and stale-narration mismatch cases render content without duplicates; `no_response` still shows the placeholder; failed turns still show the failure bubble; telemetry fires exactly once per message with the correct `reason`; whitespace-only differences never fire the fallback.
- Regression: `packages/views` chat + task-transcript suites green; `tsc --noEmit` clean. All run against a fresh `upstream/main` base.

## Notes

- The server/daemon half (retry + `(task_id, seq)` idempotency) is proposed in #7777 and intentionally out of scope here.
- Verified end-to-end on a production workspace: a previously invisible reply (preview showed it, detail did not) renders correctly with this build.
