### PR TITLE
fix(desktop): preserve explicit bundled CLI release versions (MUL-6858)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@ docker/entrypoint.sh text eol=lf
 
 # Default behavior
 * text=auto
+
+# Vite's SSR hashbang matcher requires LF when this CLI is imported by Vitest.
+apps/desktop/scripts/package.mjs text eol=lf

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify bundled CLI release version
+        working-directory: apps/desktop
+        run: node --test scripts/bundle-cli.integration.mjs
+
       - name: Package Desktop installers (${{ matrix.target }})
         working-directory: apps/desktop
         env:

--- a/apps/desktop/scripts/bundle-cli.integration.mjs
+++ b/apps/desktop/scripts/bundle-cli.integration.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+
+const source = new URL("./bundle-cli.mjs", import.meta.url);
+const goCaches = JSON.parse(execFileSync("go", ["env", "-json", "GOCACHE", "GOMODCACHE"], {
+  encoding: "utf8", windowsHide: true, timeout: 15_000,
+}));
+
+function fixture(t) {
+  const directory = mkdtempSync(join(tmpdir(), "multica-bundle-version-"));
+  t.after(() => {
+    assert.equal(resolve(directory), directory);
+    assert.ok(directory.startsWith(join(tmpdir(), "multica-bundle-version-")));
+    rmSync(directory, { recursive: true, force: true });
+  });
+  const scripts = join(directory, "apps/desktop/scripts");
+  const server = join(directory, "server");
+  mkdirSync(scripts, { recursive: true });
+  mkdirSync(join(server, "cmd/multica"), { recursive: true });
+  mkdirSync(join(directory, "empty-hooks"));
+  copyFileSync(source, join(scripts, "bundle-cli.mjs"));
+  writeFileSync(join(server, "go.mod"), "module version-fixture\n\ngo 1.26.0\n");
+  // Compile only this tiny local program: no real agent, account or network.
+  writeFileSync(join(server, "cmd/multica/main.go"), [
+    "package main",
+    'import ("fmt"; "os"; "runtime")',
+    'var version = "dev"',
+    'var commit = "unknown"',
+    'var date = "unknown"',
+    'func main() { if len(os.Args) != 2 || os.Args[1] != "--version" { os.Exit(2) };',
+    'fmt.Printf("multica %s (commit: %s, built: %s)\\ngo: %s, os/arch: %s/%s\\n", version, commit, date, runtime.Version(), runtime.GOOS, runtime.GOARCH) }',
+    "",
+  ].join("\n"));
+  const env = {
+    ...process.env, ...goCaches, HOME: directory, USERPROFILE: directory,
+    GOWORK: "off", GOTOOLCHAIN: "local", GOPROXY: "off", GOENV: "off",
+    GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: join(directory, "empty-gitconfig"),
+  };
+  delete env.MULTICA_CLI_VERSION;
+  const git = (...args) => execFileSync("git", args, {
+    cwd: directory, env, encoding: "utf8", windowsHide: true, timeout: 15_000,
+  }).trim();
+  git("init", "--quiet");
+  git("-c", "user.name=Version fixture", "-c", "user.email=fixture@example.invalid",
+    "-c", "commit.gpgsign=false", "-c", "core.hooksPath=" + join(directory, "empty-hooks"),
+    "commit", "--quiet", "--allow-empty", "-m", "fixture");
+  const build = (version, { withoutGo = false } = {}) => {
+    const buildEnv = { ...env };
+    if (version !== undefined) buildEnv.MULTICA_CLI_VERSION = version;
+    if (withoutGo) {
+      for (const key of Object.keys(buildEnv)) if (key.toUpperCase() === "PATH") delete buildEnv[key];
+      buildEnv.PATH = "";
+    }
+    return spawnSync(process.execPath, [join(scripts, "bundle-cli.mjs")], {
+      cwd: directory, env: buildEnv, encoding: "utf8", windowsHide: true, timeout: 120_000,
+    });
+  };
+  const output = () => execFileSync(join(directory, "apps/desktop/resources/bin",
+    process.platform === "win32" ? "multica.exe" : "multica"), ["--version"], {
+    cwd: directory, env, encoding: "utf8", windowsHide: true, timeout: 15_000,
+  });
+  return { git, build, output };
+}
+
+test("tagless custom checkout links the explicit release version into the actual CLI", (t) => {
+  const repo = fixture(t);
+  assert.equal(repo.git("tag", "--list"), "");
+  const version = "0.4.36-custom.123";
+  const result = repo.build(version);
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+  const output = repo.output();
+  assert.equal(output.split(/\s+/)[1], version);
+  assert.ok(output.startsWith("multica " + version + " (commit: " + repo.git("rev-parse", "--short", "HEAD") + ","));
+});
+
+test("invalid explicit versions fail instead of silently reverting to git describe", (t) => {
+  const repo = fixture(t);
+  repo.git("tag", "v0.4.36");
+  for (const version of ["", "3ed46eeed", "00.4.36", "0.4.36-custom.0", "0.4.36-custom.01", "0.4.36\n", "0.4.36 -X main.commit=wrong"]) {
+    const result = repo.build(version);
+    assert.ifError(result.error);
+    assert.notEqual(result.status, 0, "Accepted invalid MULTICA_CLI_VERSION: " + JSON.stringify(version));
+    assert.match(result.stderr, /MULTICA_CLI_VERSION/);
+  }
+});
+
+test("an explicit release version requires Go instead of reusing a stale binary", (t) => {
+  const repo = fixture(t);
+  const result = repo.build("0.4.36-custom.123", { withoutGo: true });
+  assert.ifError(result.error);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /MULTICA_CLI_VERSION requires Go/);
+});
+
+test("normal tagged builds preserve their git-derived CLI version", (t) => {
+  const repo = fixture(t);
+  repo.git("tag", "v0.4.36");
+  const result = repo.build();
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(repo.output().startsWith("multica v0.4.36 (commit: "));
+});

--- a/apps/desktop/scripts/bundle-cli.mjs
+++ b/apps/desktop/scripts/bundle-cli.mjs
@@ -6,8 +6,8 @@
 // source — no more stale binary surprises. Go's build cache makes the
 // no-op case (nothing changed) effectively free.
 //
-// ldflags mirror `make build` so `multica --version` reports a meaningful
-// version / commit / date.
+// ldflags mirror `make build`. Custom release checkouts may have no CLI tags,
+// so MULTICA_CLI_VERSION supplies the validated release-plan version explicitly.
 //
 // Graceful: if `go` is not installed (e.g. frontend-only contributor), we
 // skip the build and fall through to auto-install at runtime. A genuine
@@ -81,15 +81,25 @@ const destBinary = join(destDir, binName);
 // 0.0.0-g<hash> fallback.
 function git(...args) {
   try {
-    return execFileSync("git", args, { encoding: "utf-8" }).trim();
+    return execFileSync("git", args, { encoding: "utf-8", windowsHide: true }).trim();
   } catch {
     return "";
   }
 }
 
+const explicitVersion = process.env.MULTICA_CLI_VERSION;
+if (
+  explicitVersion !== undefined &&
+  !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-custom\.[1-9]\d*)?$/.test(explicitVersion)
+) {
+  throw new Error(
+    "[bundle-cli] MULTICA_CLI_VERSION must be a stable or custom Desktop semantic version",
+  );
+}
+
 function hasGo() {
   try {
-    execSync("go version", { stdio: "pipe" });
+    execSync("go version", { stdio: "pipe", windowsHide: true });
     return true;
   } catch {
     return false;
@@ -107,8 +117,8 @@ async function exists(p) {
 
 if (hasGo()) {
   const version =
-    git("describe", "--tags", "--match", "v[0-9]*", "--always", "--dirty") ||
-    "dev";
+    explicitVersion ??
+    (git("describe", "--tags", "--match", "v[0-9]*", "--always", "--dirty") || "dev");
   const commit = git("rev-parse", "--short", "HEAD") || "unknown";
   const date = new Date().toISOString().replace(/\.\d+Z$/, "Z");
   const ldflags = `-X main.version=${version} -X main.commit=${commit} -X main.date=${date}`;
@@ -130,6 +140,7 @@ if (hasGo()) {
     {
       cwd: serverDir,
       stdio: "inherit",
+      windowsHide: true,
       env: {
         ...process.env,
         CGO_ENABLED: "0",
@@ -139,6 +150,9 @@ if (hasGo()) {
     },
   );
 } else {
+  if (explicitVersion !== undefined) {
+    throw new Error("[bundle-cli] MULTICA_CLI_VERSION requires Go; refusing to reuse a stale CLI");
+  }
   console.warn(
     "[bundle-cli] `go` not found in PATH — skipping CLI build. " +
       "Desktop will use whatever is already in resources/bin/, or fall back " +

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Keep this hashbang LF-terminated; .gitattributes pins it for Vite's SSR loader.
 // Wrapper around `electron-builder` that keeps the Desktop version in
 // lockstep with the CLI. Both are derived from `git describe --tags
 // --match 'v[0-9]*' --always --dirty` — the same source GoReleaser reads
@@ -84,7 +85,7 @@ const MAC_ALL_PLATFORM_TARGETS = [
 // escaped to a GitHub Release.
 function git(args, cwd) {
   try {
-    return execFileSync("git", args, { encoding: "utf-8", cwd }).trim();
+    return execFileSync("git", args, { encoding: "utf-8", cwd, windowsHide: true }).trim();
   } catch {
     return "";
   }
@@ -396,6 +397,7 @@ function main() {
     cwd: desktopRoot,
     env: envWithLocalBins(),
     shell: true,
+    windowsHide: true,
   });
   if (viteResult.error) {
     console.error(
@@ -444,6 +446,7 @@ function main() {
       {
         stdio: "inherit",
         cwd: desktopRoot,
+        windowsHide: true,
       },
     );
 
@@ -461,6 +464,7 @@ function main() {
       cwd: desktopRoot,
       env: envWithLocalBins(),
       shell: true,
+      windowsHide: true,
     });
 
     if (result.error) {

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -449,6 +450,15 @@ describe("electron-builder.yml packaging config", () => {
     resolve(process.cwd(), "electron-builder.yml"),
     resolve(process.cwd(), "apps/desktop/electron-builder.yml"),
   ].find((candidate) => existsSync(candidate));
+
+  it("keeps the imported CLI hashbang LF-terminated on Windows", () => {
+    expect(configPath, "electron-builder.yml not found").toBeTruthy();
+    const scriptPath = resolve(configPath, "..", "scripts/package.mjs");
+    expect(
+      readFileSync(scriptPath, "utf-8").split("\n")[0],
+      "Keep package.mjs LF-terminated per .gitattributes: CRLF breaks Vite's hashbang transform.",
+    ).toBe("#!/usr/bin/env node");
+  });
 
   // Extract the entries of the top-level `files:` block sequence without a
   // YAML dependency: collect the `  - "…"` items that follow `files:` up to


### PR DESCRIPTION
## Summary

- Allow the Go CLI bundler to receive an explicit `MULTICA_CLI_VERSION` for a stable or `X.Y.Z-custom.N` Desktop release built from a checkout without reachable CLI tags. Invalid explicit values or missing Go fail closed instead of silently packaging a stale/mis-versioned binary; ordinary builds retain their existing git-derived behavior.
- Keep packaging subprocess windows hidden on Windows and pin the imported package script's hashbang to LF for Vite/Vitest.
- Add a tiny native Go regression fixture and run it in the existing read-only Linux/Windows Desktop Smoke workflow. No real agent, account, network dependency or microphone is exercised by that fixture.

## Reproduction

In a tagless checkout the bundler used `git describe --always`, embedding a bare commit hash as `main.version`. A Desktop whose Electron version was set through `-c.extraMetadata.version=...` could therefore ship with a CLI that fails the runtime/UI semantic-version gate.

The native regression failed against current upstream (`15280617b`): actual CLI version was a bare SHA instead of `0.4.36-custom.123`. It passes with this change. Custom release callers must pass the same immutable release version to the bundler and Electron's metadata override.

## Validation

- `node --test apps/desktop/scripts/bundle-cli.integration.mjs`: 4 passed (Windows x64, Go 1.26.7).
- `pnpm --filter @multica/desktop test scripts/package.test.mjs`: 31 passed.
- actionlint 1.7.12 for the changed Desktop Smoke workflow: passed.
- `git diff --check`: passed.

This is a focused extraction of the packaging repair already validated in a custom Windows installer. A fresh upstream installer was not published or installed for this PR. Publisher/feed configuration, signing behavior, package versions, native dictation and the skill-picker PR #7730 are unchanged.
