### PR TITLE
feat(desktop): add native Codex dictation for Windows composers

### DIFF
--- a/apps/desktop/docs/native-dictation.md
+++ b/apps/desktop/docs/native-dictation.md
@@ -11,16 +11,37 @@ The mic in Chat, ticket comments/replies, and both ticket-creation composers del
 
 A success notice means only that the shortcut was dispatched, not that audio recording or transcription succeeded. Account eligibility, subscription usage, microphone permission, availability and future compatibility remain controlled by Codex; this feature promises no free or unlimited usage. A missing app, unavailable account feature or failed bridge does not enable an API fallback.
 
+The exact configuration shape checked by this bridge is a JSON array containing
+one `{ "command": "globalDictationToggle", "key": "Ctrl+Alt+Shift+D" }` object,
+with no `when` property and no second binding using that chord. Modifier order
+and `Control`/`Ctrl` spelling are normalized. This is a third-party Desktop
+configuration contract, not a public transcription API or proof of global
+hotkey registration. A future Codex schema change fails closed; do not infer
+compatibility from the Codex CLI version. Validate recording/insertion against
+the actual Desktop version and keyboard layout before relying on it.
+
 ## Boundaries
 
-- The renderer exposes a parameterless adapter. The main process admits only a registered, focused, trusted top-level renderer with an active user gesture and an editable input.
+- The renderer exposes a parameterless adapter. The main process admits only a registered, focused, trusted top-level renderer. Sandboxed preload captures a trusted mic click or completed Enter/Space activation, and exposes its one-shot consumer only in a dedicated isolated world. Admission expires after two seconds, clears on window blur, and requires a connected mic and focused editable input. Main-world property overrides, synthetic clicks and direct IPC cannot mint an activation.
+- The mic DOM marker is UI routing, not proof of human intent against a compromised renderer that deceives the user with a fake button. The renderer still controls DOM content; do not describe this as complete renderer-compromise containment.
+- Windows Desktop reserves exactly `Ctrl+Alt+Shift+D` before renderer dispatch, including an AltGr `KeyD` event. If Codex does not consume the OS hotkey, it cannot insert a stray chord character into a Multica draft. Other chords/platforms are unchanged. Dispatch success still does not prove that Codex owns the hotkey.
 - Multica reads only the bounded keybindings file. It does not read Codex auth files, sessions, cookies, credentials or a keychain, and does not send anything to a Multica server for dictation.
 - The bundled Multica CLI implements the private `--desktop-dictation-v1` helper before ordinary CLI profile/update handling. It accepts only a read-only `probe`, or `toggle` with a canonical nonzero decimal native window handle.
 - The Windows helper verifies the current foreground window, official Codex package identity and interactive session, and rejects held modifiers/submit keys. It sends only the fixed chord, with bounded partial-injection cleanup and no toggle retry. It does not elevate, change permissions, start/stop agents or execute user scripts.
 - Only one toggle can be pending across all Multica windows. Unknown state, a missing/old bundled helper or a timeout fails closed.
+- If a partial SendInput cleanup also fails, the UI asks the user to press/release Ctrl, Alt, Shift and D before typing and check Codex's state before toggling again. There is one cleanup attempt, never a second toggle.
 
 ## Verification
 
-Automated tests use mocked Electron/IPC/editor adapters and fake native platforms. Windows ABI tests encode INPUT structures without sending keyboard input. They cover focus, frame/origin, gesture, configuration, native identity, held-key, partial-input, lazy editor and no-network/no-audio behavior.
+Unit tests use mocked Electron/IPC and fake native platforms. A real lazy comment/reply + mic + Tiptap test uses only a fake host adapter. Windows ABI tests encode INPUT structures without sending keyboard input. They cover focus, frame/origin, gesture, configuration, native identity, held-key, partial-input, lazy editor and no-network/no-audio behavior.
+
+Run `pnpm --filter @multica/desktop exec electron scripts/native-dictation-smoke.mjs`
+for a separate hidden Electron/Chromium fixture. It loads the actual isolated
+preload and main guard with config/native calls forbidden, proves a trusted
+Chromium mic activation is one-shot, rejects main-world property spoofing and
+synthetic clicks, and intercepts the unconsumed chord. It uses a temporary
+profile and Chromium-local input events, never OS SendInput, installed app
+profiles, credentials, microphone access or audio. Tested on Windows x64 with
+Electron 39.8.7. This is boundary evidence, not recording acceptance.
 
 Real recording and transcript insertion require a manual acceptance check with an eligible signed-in Codex account and microphone permission. Do not treat the read-only helper probe or the automated tests as end-to-end audio verification.

--- a/apps/desktop/docs/native-dictation.md
+++ b/apps/desktop/docs/native-dictation.md
@@ -1,0 +1,26 @@
+# Native dictation (Windows Desktop)
+
+The mic in Chat, ticket comments/replies, and both ticket-creation composers delegates to the user's running Codex Desktop global dictation UI. Multica does not record audio or call a transcription API. Web, mobile, macOS and Linux do not receive this adapter or a mic entry.
+
+## Setup and behavior
+
+1. Run the official packaged Codex Desktop in the same Windows interactive session. The helper validates its Windows package identity, not just its executable name. An unpackaged build is deliberately not supported.
+2. In Codex, configure the global dictation toggle as `Ctrl+Alt+Shift+D`, with no conflicting binding. This bridge expects one unconditional `globalDictationToggle` entry in Codex's `keybindings.json`; it never edits that file. `CODEX_HOME`, when set, must be absolute.
+3. Focus a Multica composer, release keyboard modifiers, and click the mic. The editor preserves its selection while taking focus. Lazy comment/reply editors are mounted before dispatch.
+4. Finish dictation in the native Codex UI. Text insertion and recording are owned by Codex. Multica does not submit the resulting text automatically.
+
+A success notice means only that the shortcut was dispatched, not that audio recording or transcription succeeded. Account eligibility, subscription usage, microphone permission, availability and future compatibility remain controlled by Codex; this feature promises no free or unlimited usage. A missing app, unavailable account feature or failed bridge does not enable an API fallback.
+
+## Boundaries
+
+- The renderer exposes a parameterless adapter. The main process admits only a registered, focused, trusted top-level renderer with an active user gesture and an editable input.
+- Multica reads only the bounded keybindings file. It does not read Codex auth files, sessions, cookies, credentials or a keychain, and does not send anything to a Multica server for dictation.
+- The bundled Multica CLI implements the private `--desktop-dictation-v1` helper before ordinary CLI profile/update handling. It accepts only a read-only `probe`, or `toggle` with a canonical nonzero decimal native window handle.
+- The Windows helper verifies the current foreground window, official Codex package identity and interactive session, and rejects held modifiers/submit keys. It sends only the fixed chord, with bounded partial-injection cleanup and no toggle retry. It does not elevate, change permissions, start/stop agents or execute user scripts.
+- Only one toggle can be pending across all Multica windows. Unknown state, a missing/old bundled helper or a timeout fails closed.
+
+## Verification
+
+Automated tests use mocked Electron/IPC/editor adapters and fake native platforms. Windows ABI tests encode INPUT structures without sending keyboard input. They cover focus, frame/origin, gesture, configuration, native identity, held-key, partial-input, lazy editor and no-network/no-audio behavior.
+
+Real recording and transcript insertion require a manual acceptance check with an eligible signed-in Codex account and microphone permission. Do not treat the read-only helper probe or the automated tests as end-to-end audio verification.

--- a/apps/desktop/scripts/native-dictation-smoke.mjs
+++ b/apps/desktop/scripts/native-dictation-smoke.mjs
@@ -1,0 +1,106 @@
+// Run with Electron, not Node: electron scripts/native-dictation-smoke.mjs
+// A hidden, isolated Chromium fixture; no app profile, agent, audio or SendInput.
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { app, BrowserWindow } from "electron";
+import ts from "typescript";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+const fixture = mkdtempSync(join(tmpdir(), "multica-dictation-smoke-"));
+app.setPath("userData", join(fixture, "profile"));
+const compile = (relative) => ts.transpileModule(readFileSync(join(root, relative), "utf8"), {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+}).outputText;
+const load = (relative, dependencies = {}) => {
+  const module = { exports: {} };
+  new Function("require", "module", "exports", compile(relative))(
+    (id) => Object.hasOwn(dependencies, id) ? dependencies[id] : require(id), module, module.exports,
+  );
+  return module.exports;
+};
+const shared = load("src/shared/dictation.ts");
+const preload = join(fixture, "preload.cjs");
+writeFileSync(preload, `
+  const electron = require("electron");
+  const fixtureModule = { exports: {} };
+  (function(require, module, exports) { ${compile("src/preload/dictation-activation.ts")} }) (
+    (id) => id === "electron" ? electron : ${JSON.stringify(shared)}, fixtureModule, fixtureModule.exports
+  );
+  fixtureModule.exports.installCodexDictationActivation();
+`);
+const html = join(fixture, "index.html");
+writeFileSync(html, '<button data-native-dictation id="mic">Mic</button><div id="editor" contenteditable="true">draft</div>');
+
+async function run() {
+ let window;
+ const timeout = setTimeout(() => { console.error("Dictation smoke timed out"); app.exit(1); }, 30000);
+ try {
+  await app.whenReady();
+  window = new BrowserWindow({ show: false, webPreferences: { preload, sandbox: true, contextIsolation: true, webSecurity: false } });
+  const handlers = new Map();
+  let configReads = 0;
+  let nativeDispatches = 0;
+  // Native focus/HWND are unit-tested separately. This hidden fixture supplies
+  // focus admission so a renderer-world rejection, not background focus, is
+  // what protects the config/native boundaries tested below.
+  const host = { webContents: window.webContents, isDestroyed: () => false, isFocused: () => true };
+  const main = load("src/main/codex-dictation.ts", {
+    electron: { BrowserWindow: { fromWebContents: () => host }, ipcMain: { handle: (channel, handler) => handlers.set(channel, handler) } },
+    "node:fs/promises": { open: () => { configReads++; throw new Error("fixture prohibits config access"); } },
+    "node:child_process": { execFile: () => { nativeDispatches++; throw new Error("fixture prohibits native dispatch"); } },
+    "./bundled-cli": { bundledCliPath: () => { throw new Error("fixture prohibits helper lookup"); } },
+    "../shared/dictation": shared,
+    "./navigation-guard": load("src/main/navigation-guard.ts"),
+  });
+  main.setupCodexDictation();
+  main.registerCodexDictationWindow(host, pathToFileURL(html).toString());
+  await window.loadFile(html);
+  const wc = window.webContents;
+  assert.equal(await wc.executeJavaScript("typeof globalThis.multicaDictationActivation"), "undefined");
+  await wc.executeJavaScript('globalThis.fixtureClick = new Promise(resolve => document.addEventListener("click", e => resolve({ trusted: e.isTrusted, target: e.target.id }), { once: true })); void 0');
+  wc.focus();
+  wc.sendInputEvent({ type: "mouseDown", x: 15, y: 15, button: "left", clickCount: 1 });
+  wc.sendInputEvent({ type: "mouseUp", x: 15, y: 15, button: "left", clickCount: 1 });
+  assert.deepEqual(await wc.executeJavaScript("globalThis.fixtureClick"), { trusted: true, target: "mic" });
+  await wc.executeJavaScript('document.getElementById("editor").focus()');
+  const consume = () => wc.executeJavaScriptInIsolatedWorld(shared.CODEX_DICTATION_WORLD, [{ code: "globalThis.multicaDictationActivation.consume()" }], false);
+  assert.equal(await consume(), true, "a Chromium mic click can arm the isolated gate");
+  assert.equal(await consume(), false, "the grant is one-shot");
+  await wc.executeJavaScript(`
+    Object.defineProperty(navigator, "userActivation", { value: { isActive: true } });
+    Object.defineProperty(document, "activeElement", { value: { isContentEditable: true } });
+    globalThis.multicaDictationActivation = { consume: () => true };
+    document.getElementById("mic").click();
+    document.getElementById("editor").focus();
+  `);
+  assert.equal(await wc.executeJavaScript("navigator.userActivation.isActive === true && document.activeElement?.isContentEditable === true"), true,
+    "the old main-world probe is spoofable");
+  assert.equal(await consume(), false);
+  if (process.platform === "win32") {
+    assert.deepEqual(await handlers.get(shared.CODEX_DICTATION_CHANNEL)({ sender: wc, senderFrame: wc.mainFrame }), { ok: false, reason: "unavailable" });
+    const prevented = new Promise((resolve) => wc.once("before-input-event", (event) => resolve(event.defaultPrevented)));
+    wc.sendInputEvent({ type: "keyDown", keyCode: "D", modifiers: ["control", "alt", "shift"] });
+    assert.equal(await prevented, true, "Chromium's fixed-chord event must be intercepted before renderer dispatch");
+    assert.equal(await wc.executeJavaScript('document.getElementById("editor").textContent'), "draft");
+  }
+  assert.equal(configReads, 0);
+  assert.equal(nativeDispatches, 0);
+  console.log(JSON.stringify({ passed: true, electron: process.versions.electron, platform: process.platform, checks: ["one-shot Chromium mic activation", "main-world spoof rejected", "synthetic click rejected", "private isolated bridge", "config/native boundaries untouched", "fixed chord intercepted (Windows)"] }));
+  window.destroy();
+  app.exit(0);
+ } catch (error) {
+  console.error(error);
+  window?.destroy();
+  app.exit(1);
+ } finally {
+  clearTimeout(timeout);
+ }
+}
+
+// Do not await app.ready at ESM top level: Electron waits for entry evaluation.
+void run();

--- a/apps/desktop/src/main/bundled-cli.ts
+++ b/apps/desktop/src/main/bundled-cli.ts
@@ -1,0 +1,12 @@
+import { app } from "electron";
+import { join } from "node:path";
+
+/** The CLI built with this Desktop version; never resolve a downloaded or PATH
+ * binary here. In a packaged app, resources are unpacked next to app.asar. */
+export function bundledCliPath(): string {
+  const binName = process.platform === "win32" ? "multica.exe" : "multica";
+  return join(app.getAppPath(), "resources", "bin", binName).replace(
+    "app.asar",
+    "app.asar.unpacked",
+  );
+}

--- a/apps/desktop/src/main/codex-dictation.test.ts
+++ b/apps/desktop/src/main/codex-dictation.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow, IpcMainInvokeEvent } from "electron";
+import { CODEX_DICTATION_CHANNEL } from "../shared/dictation";
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  fromWebContents: vi.fn(),
+  open: vi.fn(),
+  execFile: vi.fn(),
+  getAppPath: vi.fn(),
+}));
+vi.mock("electron", () => ({
+  app: { getAppPath: mocks.getAppPath },
+  BrowserWindow: { fromWebContents: mocks.fromWebContents },
+  ipcMain: { handle: mocks.handle },
+}));
+vi.mock("node:fs/promises", () => ({ open: mocks.open }));
+vi.mock("node:child_process", () => ({ execFile: mocks.execFile }));
+
+import {
+  hasCodexDictationBinding,
+  registerCodexDictationWindow,
+  setupCodexDictation,
+} from "./codex-dictation";
+
+const binding = JSON.stringify([
+  { command: "globalDictationToggle", key: "Ctrl+Alt+Shift+D" },
+]);
+
+describe("dictation keybindings", () => {
+  it("accepts only the explicitly configured global toggle chord", () => {
+    expect(hasCodexDictationBinding(binding)).toBe(true);
+    expect(hasCodexDictationBinding(JSON.stringify([
+      { command: "globalDictationToggle", key: "Shift+Control+Alt+d" },
+    ]))).toBe(true);
+  });
+
+  it.each([
+    "not json", "{}", "[]", "null",
+    JSON.stringify([{ command: "startDictation", key: "Ctrl+Alt+Shift+D" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Shift+D" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Alt+Shift+Q" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Alt+Shift+D", when: "editor" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Alt+Shift+D" }, { command: "globalDictationToggle", key: "" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Alt+Shift+D" }, { command: "anotherCommand", key: "Control+Alt+Shift+D" }]),
+    JSON.stringify([{ command: "globalDictationToggle", key: "Ctrl+Alt+Shift+D; Remove-Item x" }]),
+    " ".repeat(65537),
+  ])("rejects missing, ambiguous and unsafe bindings", (raw) => {
+    expect(hasCodexDictationBinding(raw)).toBe(false);
+  });
+});
+
+describe("dictation IPC", () => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+  let focused: boolean;
+  let raw: string;
+  let fakeWindow: BrowserWindow;
+  let event: IpcMainInvokeEvent;
+  let invoke: (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+  const close = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    vi.stubEnv("CODEX_HOME", "/CodexHome");
+    mocks.getAppPath.mockReturnValue("/Multica/resources/app.asar");
+    focused = true;
+    raw = binding;
+    const handle = Buffer.alloc(8);
+    handle.writeBigUInt64LE(42n);
+    fakeWindow = {
+      isDestroyed: () => false,
+      isFocused: () => focused,
+      getNativeWindowHandle: () => handle,
+    } as unknown as BrowserWindow;
+    const frame = { url: "file:///C:/Multica/out/renderer/index.html" };
+    event = {
+      senderFrame: frame,
+      sender: {
+        isDestroyed: () => false,
+        mainFrame: frame,
+        executeJavaScript: vi.fn().mockResolvedValue(true),
+      },
+    } as unknown as IpcMainInvokeEvent;
+    mocks.fromWebContents.mockReturnValue(fakeWindow);
+    registerCodexDictationWindow(fakeWindow, frame.url);
+    mocks.open.mockResolvedValue({
+      stat: async () => ({ isFile: () => true, size: Buffer.byteLength(raw) }),
+      read: async (buffer: Buffer) => ({ bytesRead: buffer.write(raw) }),
+      close,
+    });
+    mocks.execFile.mockImplementation((_path, _args, _options, callback) => {
+      callback(null, "sent\n", "");
+    });
+    setupCodexDictation();
+    expect(mocks.handle).toHaveBeenCalledWith(CODEX_DICTATION_CHANNEL, expect.any(Function));
+    invoke = mocks.handle.mock.calls[0]![1];
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", platformDescriptor);
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("reads only keybindings and dispatches a bounded hidden fixed-key helper", async () => {
+    expect(await invoke(event)).toEqual({ ok: true, shortcut: "Ctrl+Alt+Shift+D" });
+    expect(mocks.open).toHaveBeenCalledOnce();
+    expect(mocks.open.mock.calls[0]![0]).toMatch(/keybindings\.json$/);
+    expect(mocks.open.mock.calls[0]![1]).toBe("r");
+    expect(close).toHaveBeenCalledOnce();
+    const [path, args, options] = mocks.execFile.mock.calls[0]!;
+    expect(path).toMatch(/app\.asar\.unpacked[\\/]resources[\\/]bin[\\/]multica\.exe$/);
+    expect(args).toEqual(["--desktop-dictation-v1", "toggle", "42"]);
+    expect(options).toMatchObject({ windowsHide: true, shell: false, timeout: 5000, maxBuffer: 4096 });
+  });
+
+  it("rejects renderer-supplied payloads, even a plausible chord", async () => {
+    expect(await invoke(event, "Ctrl+Alt+Shift+D")).toMatchObject({ ok: false });
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["unregistered", "background", "subframe", "foreign", "missing-frame"])(
+    "rejects a %s sender before filesystem or OS access", async (kind) => {
+      if (kind === "unregistered") mocks.fromWebContents.mockReturnValue({ isDestroyed: () => false, isFocused: () => true });
+      if (kind === "background") focused = false;
+      if (kind === "subframe") event = { ...event, senderFrame: { url: event.senderFrame!.url } } as IpcMainInvokeEvent;
+      if (kind === "foreign") Object.defineProperty(event.senderFrame, "url", { value: "https://evil.example/" });
+      if (kind === "missing-frame") event = { ...event, senderFrame: null } as IpcMainInvokeEvent;
+      expect(await invoke(event)).toEqual({ ok: false, reason: "not_focused" });
+      expect(mocks.open).not.toHaveBeenCalled();
+      expect(mocks.execFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires a recent user gesture and an editable input", async () => {
+    vi.mocked(event.sender.executeJavaScript).mockResolvedValue(false);
+    expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it("times out a stalled renderer instead of locking dictation forever", async () => {
+    vi.useFakeTimers();
+    vi.mocked(event.sender.executeJavaScript).mockReturnValue(new Promise(() => {}));
+    const result = invoke(event);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(await result).toEqual({ ok: false, reason: "unavailable" });
+    vi.mocked(event.sender.executeJavaScript).mockResolvedValue(true);
+    expect(await invoke(event)).toMatchObject({ ok: true });
+  });
+
+  it("does not emit any chord if configuration is absent or too large", async () => {
+    mocks.open.mockRejectedValueOnce(new Error("ENOENT"));
+    expect(await invoke(event)).toEqual({ ok: false, reason: "not_configured" });
+    raw = " ".repeat(65537);
+    expect(await invoke(event)).toEqual({ ok: false, reason: "not_configured" });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it("rechecks focus after asynchronous configuration access", async () => {
+    mocks.open.mockImplementationOnce(async () => {
+      focused = false;
+      return {
+        stat: async () => ({ isFile: () => true, size: binding.length }),
+        read: async (buffer: Buffer) => ({ bytesRead: buffer.write(binding) }),
+        close,
+      };
+    });
+    expect(await invoke(event)).toEqual({ ok: false, reason: "not_focused" });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it("allows only one in-flight toggle across all windows", async () => {
+    let complete!: (error: null, stdout: string) => void;
+    mocks.execFile.mockImplementation((_path, _args, _options, callback) => { complete = callback; });
+    const first = invoke(event);
+    await vi.waitFor(() => expect(mocks.execFile).toHaveBeenCalledOnce());
+    expect(await invoke(event)).toEqual({ ok: false, reason: "busy" });
+    complete(null, "sent");
+    expect(await first).toMatchObject({ ok: true });
+  });
+
+  it.each(["app_not_running", "not_focused", "busy"])("preserves native failure %s", async (reason) => {
+    mocks.execFile.mockImplementation((_path, _args, _options, callback) => callback(null, reason, ""));
+    expect(await invoke(event)).toEqual({ ok: false, reason });
+  });
+
+  it("never returns subprocess details or retries after a helper failure", async () => {
+    mocks.execFile.mockImplementation((_path, _args, _options, callback) => callback(new Error("private path"), "private output", "private stderr"));
+    expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    expect(mocks.execFile).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the bundled CLI is missing or too old", async () => {
+    mocks.execFile.mockImplementationOnce((_path, _args, _options, callback) => callback(new Error("ENOENT"), "", ""));
+    expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    mocks.execFile.mockImplementationOnce((_path, _args, _options, callback) => callback(null, "unknown command", ""));
+    expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    expect(mocks.execFile).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([Buffer.alloc(8), Buffer.alloc(3)])("rejects a zero or malformed native window handle", async (handle) => {
+    vi.spyOn(fakeWindow, "getNativeWindowHandle").mockReturnValue(handle);
+    expect(await invoke(event)).toEqual({ ok: false, reason: "not_focused" });
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on unsupported platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    expect(mocks.open).not.toHaveBeenCalled();
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/codex-dictation.test.ts
+++ b/apps/desktop/src/main/codex-dictation.test.ts
@@ -58,6 +58,7 @@ describe("dictation IPC", () => {
   let fakeWindow: BrowserWindow;
   let event: IpcMainInvokeEvent;
   let invoke: (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+  let windowEvents: ReturnType<typeof vi.fn>;
   const close = vi.fn();
 
   beforeEach(() => {
@@ -69,19 +70,24 @@ describe("dictation IPC", () => {
     raw = binding;
     const handle = Buffer.alloc(8);
     handle.writeBigUInt64LE(42n);
+    const contents = {
+      on: vi.fn(),
+      isDestroyed: () => false,
+      mainFrame: { url: "file:///C:/Multica/out/renderer/index.html" },
+      executeJavaScript: vi.fn().mockResolvedValue(true),
+      executeJavaScriptInIsolatedWorld: vi.fn().mockResolvedValue(true),
+    };
+    windowEvents = contents.on;
     fakeWindow = {
       isDestroyed: () => false,
       isFocused: () => focused,
       getNativeWindowHandle: () => handle,
+      webContents: contents,
     } as unknown as BrowserWindow;
-    const frame = { url: "file:///C:/Multica/out/renderer/index.html" };
+    const frame = contents.mainFrame;
     event = {
       senderFrame: frame,
-      sender: {
-        isDestroyed: () => false,
-        mainFrame: frame,
-        executeJavaScript: vi.fn().mockResolvedValue(true),
-      },
+      sender: contents,
     } as unknown as IpcMainInvokeEvent;
     mocks.fromWebContents.mockReturnValue(fakeWindow);
     registerCodexDictationWindow(fakeWindow, frame.url);
@@ -135,20 +141,21 @@ describe("dictation IPC", () => {
     },
   );
 
-  it("requires a recent user gesture and an editable input", async () => {
-    vi.mocked(event.sender.executeJavaScript).mockResolvedValue(false);
+  it("ignores spoofed main-world activation and requires the isolated mic grant", async () => {
+    vi.mocked(event.sender.executeJavaScriptInIsolatedWorld).mockResolvedValue(false);
     expect(await invoke(event)).toEqual({ ok: false, reason: "unavailable" });
+    expect(event.sender.executeJavaScript).not.toHaveBeenCalled();
     expect(mocks.open).not.toHaveBeenCalled();
     expect(mocks.execFile).not.toHaveBeenCalled();
   });
 
   it("times out a stalled renderer instead of locking dictation forever", async () => {
     vi.useFakeTimers();
-    vi.mocked(event.sender.executeJavaScript).mockReturnValue(new Promise(() => {}));
+    vi.mocked(event.sender.executeJavaScriptInIsolatedWorld).mockReturnValue(new Promise(() => {}));
     const result = invoke(event);
     await vi.advanceTimersByTimeAsync(1000);
     expect(await result).toEqual({ ok: false, reason: "unavailable" });
-    vi.mocked(event.sender.executeJavaScript).mockResolvedValue(true);
+    vi.mocked(event.sender.executeJavaScriptInIsolatedWorld).mockResolvedValue(true);
     expect(await invoke(event)).toMatchObject({ ok: true });
   });
 
@@ -174,16 +181,44 @@ describe("dictation IPC", () => {
   });
 
   it("allows only one in-flight toggle across all windows", async () => {
+    const secondWindow = {
+      ...fakeWindow,
+      webContents: { ...event.sender, on: vi.fn(), executeJavaScriptInIsolatedWorld: vi.fn().mockResolvedValue(true) },
+    } as unknown as BrowserWindow;
+    const secondEvent = { ...event, sender: secondWindow.webContents } as IpcMainInvokeEvent;
+    registerCodexDictationWindow(secondWindow, event.senderFrame!.url);
+    mocks.fromWebContents.mockImplementation((sender) =>
+      sender === secondEvent.sender ? secondWindow : fakeWindow,
+    );
     let complete!: (error: null, stdout: string) => void;
     mocks.execFile.mockImplementation((_path, _args, _options, callback) => { complete = callback; });
     const first = invoke(event);
     await vi.waitFor(() => expect(mocks.execFile).toHaveBeenCalledOnce());
-    expect(await invoke(event)).toEqual({ ok: false, reason: "busy" });
+    expect(await invoke(secondEvent)).toEqual({ ok: false, reason: "busy" });
+    expect(secondEvent.sender.executeJavaScriptInIsolatedWorld).not.toHaveBeenCalled();
     complete(null, "sent");
     expect(await first).toMatchObject({ ok: true });
   });
 
-  it.each(["app_not_running", "not_focused", "busy"])("preserves native failure %s", async (reason) => {
+  it("blocks the unconsumed fixed chord before it can edit a draft, including AltGr layouts", () => {
+    const registration = windowEvents.mock.calls.find(
+      ([name]) => name === "before-input-event",
+    );
+    expect(registration).toBeDefined();
+    const listener = registration![1] as (event: { preventDefault: () => void }, input: object) => void;
+    for (const key of ["D", "Đ"]) {
+      const preventDefault = vi.fn();
+      listener({ preventDefault }, { type: "keyDown", key, code: "KeyD", control: true, alt: true, shift: true, meta: false });
+      expect(preventDefault).toHaveBeenCalledOnce();
+    }
+    for (const change of [{ control: false }, { alt: false }, { shift: false }, { meta: true }, { code: "KeyE", key: "E" }]) {
+      const preventDefault = vi.fn();
+      listener({ preventDefault }, { type: "keyDown", key: "D", code: "KeyD", control: true, alt: true, shift: true, meta: false, ...change });
+      expect(preventDefault).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each(["app_not_running", "not_focused", "busy", "cleanup_failed"])("preserves native failure %s", async (reason) => {
     mocks.execFile.mockImplementation((_path, _args, _options, callback) => callback(null, reason, ""));
     expect(await invoke(event)).toEqual({ ok: false, reason });
   });

--- a/apps/desktop/src/main/codex-dictation.ts
+++ b/apps/desktop/src/main/codex-dictation.ts
@@ -1,0 +1,145 @@
+import { execFile } from "node:child_process";
+import { open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from "electron";
+import type { DictationResult } from "@multica/core/types/dictation";
+import { CODEX_DICTATION_CHANNEL } from "../shared/dictation";
+import { isTrustedRendererURL } from "./navigation-guard";
+import { bundledCliPath } from "./bundled-cli";
+
+export const CODEX_DICTATION_SHORTCUT = "Ctrl+Alt+Shift+D";
+const MAX_KEYBINDINGS_BYTES = 64 * 1024;
+const trustedWindows = new WeakMap<BrowserWindow, string>();
+
+function isDictationChord(key: unknown): boolean {
+  if (typeof key !== "string") return false;
+  const parts = key.toLowerCase().split("+").map((part) => part.trim());
+  const normalized = parts.map((part) => part === "control" ? "ctrl" : part);
+  return normalized.length === 4 &&
+    [...new Set(normalized)].sort().join("+") === "alt+ctrl+d+shift";
+}
+
+/** The first bridge deliberately supports one safe, explicit chord, not an
+ * arbitrary keyboard injector. Duplicate/conditional/conflicting bindings fail
+ * closed instead of guessing which command the external app registered. */
+export function hasCodexDictationBinding(raw: string): boolean {
+  if (Buffer.byteLength(raw, "utf8") > MAX_KEYBINDINGS_BYTES) return false;
+  try {
+    const data: unknown = JSON.parse(raw);
+    if (!Array.isArray(data)) return false;
+    const entries = data.filter((entry): entry is Record<string, unknown> =>
+      !!entry && typeof entry === "object" && !Array.isArray(entry),
+    );
+    const toggles = entries.filter((entry) => entry.command === "globalDictationToggle");
+    const binding = toggles[0];
+    return toggles.length === 1 && !!binding && binding.when === undefined &&
+      isDictationChord(binding.key) &&
+      !entries.some((entry) => entry !== binding && isDictationChord(entry.key));
+  } catch {
+    return false;
+  }
+}
+
+async function isShortcutConfigured(): Promise<boolean> {
+  const codexDir = process.env.CODEX_HOME || join(homedir(), ".codex");
+  if (!isAbsolute(codexDir)) return false;
+  // This is the only OpenAI file we read. Never inspect auth.json, sessions,
+  // global state, keychains, browser cookies, or network traffic.
+  let file;
+  try {
+    file = await open(join(codexDir, "keybindings.json"), "r");
+    const stat = await file.stat();
+    if (!stat.isFile() || stat.size > MAX_KEYBINDINGS_BYTES) return false;
+    const buffer = Buffer.alloc(MAX_KEYBINDINGS_BYTES + 1);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > MAX_KEYBINDINGS_BYTES) return false;
+    return hasCodexDictationBinding(buffer.subarray(0, bytesRead).toString("utf8"));
+  } catch {
+    return false;
+  } finally {
+    await file?.close();
+  }
+}
+
+function trustedFocusedWindow(event: IpcMainInvokeEvent): BrowserWindow | null {
+  const frame = event.senderFrame;
+  if (!frame || event.sender.isDestroyed() || frame !== event.sender.mainFrame) return null;
+  const window = BrowserWindow.fromWebContents(event.sender);
+  if (!window || window.isDestroyed() || !window.isFocused()) return null;
+  const trustedURL = trustedWindows.get(window);
+  if (!trustedURL || !isTrustedRendererURL(frame.url, trustedURL)) return null;
+  return window;
+}
+
+async function hasInputGesture(event: IpcMainInvokeEvent): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      event.sender.executeJavaScript(
+        "navigator.userActivation.isActive === true && document.activeElement?.isContentEditable === true",
+      ).then((value: unknown) => value === true),
+      new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), 1000); }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function sendDictationChord(window: BrowserWindow): Promise<DictationResult> {
+  const handle = window.getNativeWindowHandle();
+  const hwnd = handle.length === 8 ? handle.readBigUInt64LE() :
+    handle.length === 4 ? BigInt(handle.readUInt32LE()) : 0n;
+  if (hwnd === 0n) return { ok: false, reason: "not_focused" };
+  return new Promise((resolve) => {
+    execFile(
+      bundledCliPath(),
+      ["--desktop-dictation-v1", "toggle", hwnd.toString()],
+      { windowsHide: true, shell: false, timeout: 5000, maxBuffer: 4096, encoding: "utf8" },
+      (error, stdout) => {
+        if (error) { resolve({ ok: false, reason: "unavailable" }); return; }
+        switch (stdout.trim()) {
+          case "sent":
+            resolve({ ok: true, shortcut: CODEX_DICTATION_SHORTCUT });
+            break;
+          case "app_not_running":
+          case "not_focused":
+          case "busy":
+            resolve({ ok: false, reason: stdout.trim() as "app_not_running" | "not_focused" | "busy" });
+            break;
+          default:
+            resolve({ ok: false, reason: "unavailable" });
+        }
+      },
+    );
+  });
+}
+
+/** Register only windows created by our main/issue renderer loader. */
+export function registerCodexDictationWindow(window: BrowserWindow, rendererURL: string): void {
+  trustedWindows.set(window, rendererURL);
+}
+
+export function setupCodexDictation(): void {
+  let pending = false;
+  ipcMain.handle(CODEX_DICTATION_CHANNEL, async (event, ...args): Promise<DictationResult> => {
+    if (process.platform !== "win32" || args.length !== 0) return { ok: false, reason: "unavailable" };
+    if (pending) return { ok: false, reason: "busy" };
+    const window = trustedFocusedWindow(event);
+    if (!window) return { ok: false, reason: "not_focused" };
+    pending = true;
+    try {
+      // Main, not renderer payload, checks that the parameterless call follows
+      // a user gesture. The preload exposes no arbitrary-key or command API.
+      if (!await hasInputGesture(event)) return { ok: false, reason: "unavailable" };
+      if (!await isShortcutConfigured()) return { ok: false, reason: "not_configured" };
+      if (trustedFocusedWindow(event) !== window) return { ok: false, reason: "not_focused" };
+      return await sendDictationChord(window);
+    } catch {
+      // Never forward process output, local paths, or config contents to UI/logs.
+      return { ok: false, reason: "unavailable" };
+    } finally {
+      pending = false;
+    }
+  });
+}

--- a/apps/desktop/src/main/codex-dictation.ts
+++ b/apps/desktop/src/main/codex-dictation.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from "electron";
 import type { DictationResult } from "@multica/core/types/dictation";
-import { CODEX_DICTATION_CHANNEL } from "../shared/dictation";
+import { CODEX_DICTATION_CHANNEL, CODEX_DICTATION_WORLD } from "../shared/dictation";
 import { isTrustedRendererURL } from "./navigation-guard";
 import { bundledCliPath } from "./bundled-cli";
 
@@ -76,9 +76,9 @@ async function hasInputGesture(event: IpcMainInvokeEvent): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      event.sender.executeJavaScript(
-        "navigator.userActivation.isActive === true && document.activeElement?.isContentEditable === true",
-      ).then((value: unknown) => value === true),
+      event.sender.executeJavaScriptInIsolatedWorld(CODEX_DICTATION_WORLD, [{
+        code: "globalThis.multicaDictationActivation?.consume() === true",
+      }], false).then((value: unknown) => value === true),
       new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), 1000); }),
     ]);
   } finally {
@@ -105,7 +105,8 @@ async function sendDictationChord(window: BrowserWindow): Promise<DictationResul
           case "app_not_running":
           case "not_focused":
           case "busy":
-            resolve({ ok: false, reason: stdout.trim() as "app_not_running" | "not_focused" | "busy" });
+          case "cleanup_failed":
+            resolve({ ok: false, reason: stdout.trim() as "app_not_running" | "not_focused" | "busy" | "cleanup_failed" });
             break;
           default:
             resolve({ ok: false, reason: "unavailable" });
@@ -117,7 +118,16 @@ async function sendDictationChord(window: BrowserWindow): Promise<DictationResul
 
 /** Register only windows created by our main/issue renderer loader. */
 export function registerCodexDictationWindow(window: BrowserWindow, rendererURL: string): void {
+  const registered = trustedWindows.has(window);
   trustedWindows.set(window, rendererURL);
+  if (registered || process.platform !== "win32") return;
+  // A registered OS hotkey consumes this before Chromium sees it. If Codex
+  // failed to register/consume it, reserve the exact chord rather than letting
+  // AltGr layouts turn it into draft text. Other shortcuts are unchanged.
+  window.webContents.on("before-input-event", (event, input) => {
+    if (input.control && input.alt && input.shift && !input.meta &&
+      (input.code === "KeyD" || input.key.toLowerCase() === "d")) event.preventDefault();
+  });
 }
 
 export function setupCodexDictation(): void {
@@ -129,8 +139,8 @@ export function setupCodexDictation(): void {
     if (!window) return { ok: false, reason: "not_focused" };
     pending = true;
     try {
-      // Main, not renderer payload, checks that the parameterless call follows
-      // a user gesture. The preload exposes no arbitrary-key or command API.
+      // Consume one mic activation in the isolated preload. Page-wide user
+      // activation and page-owned DOM wrappers cannot authorize this call.
       if (!await hasInputGesture(event)) return { ok: false, reason: "unavailable" };
       if (!await isShortcutConfigured()) return { ok: false, reason: "not_configured" };
       if (trustedFocusedWindow(event) !== window) return { ok: false, reason: "not_focused" };

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -23,6 +23,7 @@ import type {
 } from "../shared/daemon-types";
 import { daemonStatusAlive } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
+import { bundledCliPath } from "./bundled-cli";
 import { decideVersionAction } from "./version-decision";
 import {
   deriveProfileName,
@@ -385,24 +386,6 @@ function findCliOnPath(): string | null {
     }
   }
   return null;
-}
-
-/**
- * Returns the path to the CLI binary bundled inside the Desktop app.
- *
- * - Dev (`electron-vite dev`): `app.getAppPath()` → `apps/desktop`, resolving
- *   to `apps/desktop/resources/bin/multica`. `bundle-cli.mjs` populates this
- *   before dev starts, so iterating on Go changes is "make build → restart".
- * - Packaged: `app.getAppPath()` → `<Multica.app>/Contents/Resources/app.asar`.
- *   electron-builder's `asarUnpack: resources/**` extracts the binary to
- *   `app.asar.unpacked/`, so we swap the path segment to execute it.
- */
-function bundledCliPath(): string {
-  const binName = process.platform === "win32" ? "multica.exe" : "multica";
-  return join(app.getAppPath(), "resources", "bin", binName).replace(
-    "app.asar",
-    "app.asar.unpacked",
-  );
 }
 
 async function probeCliBinary(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { setupLocalDirectory } from "./local-directory";
+import { registerCodexDictationWindow, setupCodexDictation } from "./codex-dictation";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
@@ -232,6 +233,7 @@ function loadRenderer(window: BrowserWindow): void {
   // this one site covers both — see navigation-guard.ts for what is and is not
   // in scope (it is origin hardening; in-app routing never reaches it).
   installNavigationGuard(window, rendererURL);
+  registerCodexDictationWindow(window, rendererURL);
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
     void window.loadURL(process.env["ELECTRON_RENDERER_URL"]);
@@ -832,6 +834,7 @@ if (!gotTheLock) {
     setupAutoUpdater(() => mainWindow);
     setupDaemonManager(() => mainWindow);
     setupLocalDirectory(() => mainWindow);
+    setupCodexDictation();
 
     app.on("activate", () => {
       const window = ensureMainWindow();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -829,12 +829,12 @@ if (!gotTheLock) {
     });
 
     desktopInitialized = true;
+    setupCodexDictation();
     createWindow();
 
     setupAutoUpdater(() => mainWindow);
     setupDaemonManager(() => mainWindow);
     setupLocalDirectory(() => mainWindow);
-    setupCodexDictation();
 
     app.on("activate", () => {
       const window = ensureMainWindow();

--- a/apps/desktop/src/preload/dictation-activation.test.ts
+++ b/apps/desktop/src/preload/dictation-activation.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CODEX_DICTATION_WORLD } from "../shared/dictation";
+
+const expose = vi.hoisted(() => vi.fn());
+vi.mock("electron", () => ({ contextBridge: { exposeInIsolatedWorld: expose } }));
+import { installCodexDictationActivation } from "./dictation-activation";
+
+describe("isolated mic activation", () => {
+  let listeners: Map<string, (event: Event) => void>;
+  let consume: () => boolean;
+  let button: HTMLButtonElement;
+  let editor: HTMLDivElement;
+  let time: number;
+
+  beforeEach(() => {
+    expose.mockReset();
+    listeners = new Map();
+    vi.spyOn(document, "addEventListener").mockImplementation((name, listener) => {
+      listeners.set(name, listener as (event: Event) => void);
+    });
+    vi.spyOn(window, "addEventListener").mockImplementation((name, listener) => {
+      listeners.set(name, listener as (event: Event) => void);
+    });
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    time = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => time);
+    button = document.createElement("button");
+    button.setAttribute("data-native-dictation", "");
+    editor = document.createElement("div");
+    editor.tabIndex = 0;
+    Object.defineProperty(editor, "isContentEditable", { value: true });
+    document.body.append(button, editor);
+    editor.focus();
+    installCodexDictationActivation();
+    expect(expose).toHaveBeenCalledExactlyOnceWith(CODEX_DICTATION_WORLD, "multicaDictationActivation", { consume: expect.any(Function) });
+    consume = expose.mock.calls[0]![2].consume;
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); document.body.replaceChildren(); });
+
+  // This suite tests the grant state machine through captured callbacks. Real
+  // Chromium isTrusted and cross-world isolation are exercised by the separate
+  // Electron fixture; a jsdom synthetic event cannot attest a trusted gesture.
+  function trusted(type: string, values: object = {}) {
+    listeners.get(type)!({ isTrusted: true, target: button, ...values } as unknown as Event);
+  }
+
+  it("does not expose admission through a main-world API or accept synthetic clicks", () => {
+    expect(consume()).toBe(false);
+    const event = new MouseEvent("click", { bubbles: true });
+    Object.defineProperty(event, "target", { value: button });
+    listeners.get("click")!(event);
+    expect(consume()).toBe(false);
+  });
+
+  it("consumes one trusted mic click exactly once", () => {
+    trusted("click");
+    expect(consume()).toBe(true);
+    expect(consume()).toBe(false);
+  });
+
+  it.each(["Enter", " "])("requires completed %s activation on the same mic", (key) => {
+    trusted("keyup", { key });
+    expect(consume()).toBe(false);
+    trusted("keydown", { key });
+    expect(consume()).toBe(false);
+    trusted("keyup", { key });
+    expect(consume()).toBe(true);
+    expect(consume()).toBe(false);
+  });
+
+  it.each(["expired", "detached", "blurred", "non-editable", "other-click"])("consumes but rejects a %s grant", (reason) => {
+    trusted("click");
+    if (reason === "expired") time += 2000;
+    if (reason === "detached") button.remove();
+    if (reason === "blurred") listeners.get("blur")!(new Event("blur"));
+    if (reason === "non-editable") button.focus();
+    if (reason === "other-click") trusted("click", { target: editor });
+    expect(consume()).toBe(false);
+    editor.focus();
+    expect(consume()).toBe(false);
+  });
+
+  it("does not arm disabled buttons or repeated/modified keyboard activation", () => {
+    button.disabled = true;
+    trusted("click");
+    expect(consume()).toBe(false);
+    button.disabled = false;
+    for (const modifier of ["repeat", "ctrlKey", "altKey", "shiftKey", "metaKey"]) {
+      trusted("keydown", { key: "Enter", [modifier]: true });
+      trusted("keyup", { key: "Enter" });
+      expect(consume()).toBe(false);
+    }
+  });
+});

--- a/apps/desktop/src/preload/dictation-activation.ts
+++ b/apps/desktop/src/preload/dictation-activation.ts
@@ -1,0 +1,45 @@
+import { contextBridge } from "electron";
+import { CODEX_DICTATION_WORLD } from "../shared/dictation";
+
+/** Runs in the isolated preload, never the page's mutable JavaScript world. */
+export function installCodexDictationActivation(): void {
+  let activation: { button: HTMLButtonElement; at: number } | undefined;
+  let keyPress: { button: HTMLButtonElement; key: string } | undefined;
+
+  const micButton = (event: Event): HTMLButtonElement | undefined => {
+    if (!event.isTrusted || !(event.target instanceof Element)) return undefined;
+    const button = event.target.closest("button[data-native-dictation]");
+    if (button instanceof HTMLButtonElement && button.isConnected && !button.disabled) return button;
+    return undefined;
+  };
+  const arm = (button: HTMLButtonElement | undefined) => {
+    activation = button ? { button, at: performance.now() } : undefined;
+  };
+  document.addEventListener("click", (event) => arm(micButton(event)), true);
+  document.addEventListener("keydown", (event) => {
+    keyPress = undefined;
+    if (event.repeat || event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const button = micButton(event);
+    if (button) keyPress = { button, key: event.key };
+  }, true);
+  document.addEventListener("keyup", (event) => {
+    const pressed = keyPress;
+    keyPress = undefined;
+    if (pressed && pressed.key === event.key && pressed.button === micButton(event)) arm(pressed.button);
+  }, true);
+  window.addEventListener("blur", () => { activation = undefined; keyPress = undefined; });
+
+  // No equivalent API is exposed in the main world. Even the generic renderer
+  // IPC bridge cannot mint a grant. The marker is UI routing, not protection
+  // against a compromised renderer deceiving the user with a fake mic button.
+  contextBridge.exposeInIsolatedWorld(CODEX_DICTATION_WORLD, "multicaDictationActivation", {
+    consume: (): boolean => {
+      const grant = activation;
+      activation = undefined;
+      return !!grant && grant.button.isConnected && performance.now() - grant.at < 2000 &&
+        document.hasFocus() && document.activeElement instanceof HTMLElement &&
+        document.activeElement.isContentEditable === true;
+    },
+  });
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,4 +1,5 @@
 import { ElectronAPI } from "@electron-toolkit/preload";
+import type { DictationAdapter } from "@multica/core/types/dictation";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
 import type { NavigationGesture } from "../shared/navigation-gestures";
 import type { RendererRouteContextInput } from "../shared/renderer-route-context";
@@ -18,6 +19,8 @@ import type {
 } from "../shared/daemon-types";
 
 interface DesktopAPI {
+  /** Delegates to the user's native Codex dictation UI without audio transport. */
+  dictation: DictationAdapter;
   /** App version + normalized OS, captured synchronously at preload time. */
   appInfo: {
     version: string;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,7 @@ import {
 } from "../shared/issue-window";
 import { AUTH_SESSION_STATE_CHANNEL } from "../shared/auth-session";
 import { CODEX_DICTATION_CHANNEL } from "../shared/dictation";
+import { installCodexDictationActivation } from "./dictation-activation";
 import type {
   DaemonStatus,
   LocalRuntimeProbe,
@@ -321,6 +322,7 @@ const updaterAPI = {
 };
 
 if (process.contextIsolated) {
+  if (process.platform === "win32") installCodexDictationActivation();
   contextBridge.exposeInMainWorld("electron", electronAPI);
   contextBridge.exposeInMainWorld("desktopAPI", desktopAPI);
   contextBridge.exposeInMainWorld("daemonAPI", daemonAPI);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
+import type { DictationResult } from "@multica/core/types/dictation";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
 import type { FreezeBreadcrumb } from "../shared/freeze-breadcrumb";
 import type {
@@ -20,6 +21,7 @@ import {
   type IssueWindowRequest,
 } from "../shared/issue-window";
 import { AUTH_SESSION_STATE_CHANNEL } from "../shared/auth-session";
+import { CODEX_DICTATION_CHANNEL } from "../shared/dictation";
 import type {
   DaemonStatus,
   LocalRuntimeProbe,
@@ -98,6 +100,10 @@ function subscribeToMainRendererChannel<T>(
 }
 
 const desktopAPI = {
+  /** Parameterless native dictation delegation; never accepts audio or keys. */
+  dictation: {
+    toggle: (): Promise<DictationResult> => ipcRenderer.invoke(CODEX_DICTATION_CHANNEL),
+  },
   /** App version + normalized OS. Read once at preload time so the renderer
    *  can use it synchronously when initializing the API client. */
   appInfo,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -23,6 +23,7 @@ import { useOpenSettingsShortcut } from "./hooks/use-open-settings-shortcut";
 import { useDaemonIPCBridge } from "./platform/daemon-ipc-bridge";
 import { syncDaemonOnLogin } from "./platform/daemon-login-sync";
 import { createDesktopLocaleAdapter } from "./platform/i18n-adapter";
+import { desktopDictationAdapter } from "./platform/dictation-adapter";
 import { captureEvent } from "@multica/core/analytics";
 import { RESOURCES } from "@multica/views/locales";
 import { DesktopClientUsageReporter } from "./platform/client-usage-reporter";
@@ -461,6 +462,7 @@ export default function App() {
           locale={locale}
           resources={resources}
           localeAdapter={localeAdapter}
+          dictationAdapter={os === "windows" ? desktopDictationAdapter : undefined}
         >
           <DesktopAuthSessionBridge />
           {windowContext.kind === "main" && <DiagnosticRouteReporter />}

--- a/apps/desktop/src/renderer/src/platform/dictation-adapter.test.ts
+++ b/apps/desktop/src/renderer/src/platform/dictation-adapter.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { desktopDictationAdapter } from "./dictation-adapter";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("desktop dictation adapter", () => {
+  it("fails closed when the installed preload has no native bridge", async () => {
+    vi.stubGlobal("window", { desktopAPI: {} });
+    expect(await desktopDictationAdapter.toggle()).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("delegates only a parameterless toggle without acquiring audio", async () => {
+    const toggle = vi.fn().mockResolvedValue({ ok: true, shortcut: "Ctrl+Alt+Shift+D" });
+    vi.stubGlobal("window", { desktopAPI: { dictation: { toggle } } });
+    expect(await desktopDictationAdapter.toggle()).toMatchObject({ ok: true });
+    expect(toggle).toHaveBeenCalledExactlyOnceWith();
+  });
+});

--- a/apps/desktop/src/renderer/src/platform/dictation-adapter.ts
+++ b/apps/desktop/src/renderer/src/platform/dictation-adapter.ts
@@ -1,0 +1,11 @@
+import type { DictationAdapter } from "@multica/core/types/dictation";
+
+// Keep Windows on the native path even during a mismatched preload/HMR boot.
+// An unavailable native bridge must never turn into a paid API fallback.
+export const desktopDictationAdapter: DictationAdapter = {
+  async toggle() {
+    const bridge = window.desktopAPI?.dictation;
+    if (!bridge) return { ok: false, reason: "unavailable" };
+    return bridge.toggle();
+  },
+};

--- a/apps/desktop/src/shared/dictation.ts
+++ b/apps/desktop/src/shared/dictation.ts
@@ -1,0 +1,2 @@
+/** Parameterless IPC shared by main and preload; never accepts keys or audio. */
+export const CODEX_DICTATION_CHANNEL = "dictation:toggle-codex";

--- a/apps/desktop/src/shared/dictation.ts
+++ b/apps/desktop/src/shared/dictation.ts
@@ -1,2 +1,5 @@
 /** Parameterless IPC shared by main and preload; never accepts keys or audio. */
 export const CODEX_DICTATION_CHANNEL = "dictation:toggle-codex";
+
+/** Private bridge world, distinct from the page (0) and Electron preload (999). */
+export const CODEX_DICTATION_WORLD = 1004;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -145,6 +145,7 @@
     "./constants/*": "./constants/*.ts",
     "./feature-flags": "./feature-flags/index.ts",
     "./platform": "./platform/index.ts",
+    "./platform/dictation": "./platform/dictation.tsx",
     "./drafts": "./drafts/index.ts",
     "./drafts/*": "./drafts/*.ts",
     "./shortcuts": "./shortcuts/index.ts",

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -16,6 +16,7 @@ import { QueryProvider } from "../provider";
 import { createLogger } from "../logger";
 import { defaultStorage } from "./storage";
 import { AuthInitializer } from "./auth-initializer";
+import { DictationProvider } from "./dictation";
 import type { CoreProviderProps, ClientIdentity } from "./types";
 import type { StorageAdapter } from "../types/storage";
 import { ClientUsageReporter } from "../client-usage";
@@ -94,6 +95,7 @@ export function CoreProvider({
   locale,
   resources,
   localeAdapter,
+  dictationAdapter,
 }: CoreProviderProps) {
   // Initialize singletons on first render only. Dependencies are read-once:
   // apiBaseUrl, storage, and callbacks are set at app boot and never change at runtime.
@@ -130,7 +132,9 @@ export function CoreProvider({
           cookieAuth={cookieAuth}
           identity={identity}
         >
-          {children}
+          <DictationProvider adapter={dictationAdapter}>
+            {children}
+          </DictationProvider>
         </WSProvider>
       </AuthInitializer>
     </QueryProvider>

--- a/packages/core/platform/dictation.tsx
+++ b/packages/core/platform/dictation.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import type { DictationAdapter } from "../types/dictation";
+
+const DictationContext = createContext<DictationAdapter | undefined>(undefined);
+
+/** A provided host adapter is authoritative: consumers must not fall back to
+ * paid/server transcription when it rejects a request. */
+export function DictationProvider({
+  adapter,
+  children,
+}: {
+  adapter?: DictationAdapter;
+  children: ReactNode;
+}) {
+  return (
+    <DictationContext.Provider value={adapter}>
+      {children}
+    </DictationContext.Provider>
+  );
+}
+
+export function useDictationAdapter(): DictationAdapter | undefined {
+  return useContext(DictationContext);
+}

--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -1,4 +1,5 @@
 export { CoreProvider } from "./core-provider";
+export { DictationProvider, useDictationAdapter } from "./dictation";
 export type { CoreProviderProps, ClientIdentity } from "./types";
 export { AuthInitializer } from "./auth-initializer";
 export { defaultStorage } from "./storage";

--- a/packages/core/platform/types.ts
+++ b/packages/core/platform/types.ts
@@ -4,6 +4,7 @@ import type {
   SupportedLocale,
 } from "../i18n";
 import type { StorageAdapter } from "../types/storage";
+import type { DictationAdapter } from "../types/dictation";
 
 /** Identifies the calling client to the server. Threaded through to
  *  ApiClient and WSClient so all HTTP requests and WS connections from
@@ -40,4 +41,6 @@ export interface CoreProviderProps {
   /** Locale adapter for persisting user choice (used by Settings switcher).
    *  Optional because some shells (e.g. CLI auth pages) don't need switching. */
   localeAdapter?: LocaleAdapter;
+  /** Optional host-owned dictation UI; no audio or transcript crosses this adapter. */
+  dictationAdapter?: DictationAdapter;
 }

--- a/packages/core/types/dictation.ts
+++ b/packages/core/types/dictation.ts
@@ -1,0 +1,18 @@
+/** A host-owned dictation UI pastes into the focused editor. Audio, credentials
+ * and transcript transport never cross this adapter. Success means the toggle
+ * was dispatched, not that recording or transcription succeeded. */
+export type DictationResult =
+  | { ok: true; shortcut: string }
+  | {
+      ok: false;
+      reason:
+        | "not_configured"
+        | "app_not_running"
+        | "not_focused"
+        | "busy"
+        | "unavailable";
+    };
+
+export interface DictationAdapter {
+  toggle: () => Promise<DictationResult>;
+}

--- a/packages/core/types/dictation.ts
+++ b/packages/core/types/dictation.ts
@@ -10,6 +10,7 @@ export type DictationResult =
         | "app_not_running"
         | "not_focused"
         | "busy"
+        | "cleanup_failed"
         | "unavailable";
     };
 

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -84,6 +84,7 @@ vi.mock("../../editor", async () => ({
     return { isDragOver: false, dropZoneProps: { "data-testid": "drop-zone" } };
   },
   FileDropOverlay: () => null,
+  VoiceInputButton: () => null,
   ContentEditor: forwardRef(function MockContentEditor(
     props: {
       defaultValue?: string;

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -11,6 +11,7 @@ import {
   FileDropOverlay,
   useUploadGate,
   useComposerSubmit,
+  VoiceInputButton,
 } from "../../editor";
 import { PASTE_AS_FILE_THRESHOLD } from "../../editor/paste-as-file";
 import {
@@ -29,6 +30,7 @@ import type { Attachment, Project } from "@multica/core/types";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { ClearablePillButton } from "../../common/pill-button";
 import { useT } from "../../i18n";
+import { useDictationAdapter } from "@multica/core/platform/dictation";
 
 const logger = createLogger("chat.ui");
 const EMPTY_UPLOADS: DraftUpload[] = [];
@@ -176,6 +178,7 @@ export function ChatInput({
   const { t } = useT("chat");
   const { t: tEditor } = useT("editor");
   const sendShortcut = useShortcut("send");
+  const dictationAdapter = useDictationAdapter();
   const editorRef = useRef<ContentEditorRef>(null);
   const composerRef = useRef<HTMLDivElement>(null);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
@@ -715,7 +718,7 @@ export function ChatInput({
             showBubbleMenu
           />
         </div>
-        {(uploadEnabled || projectSelectionEnabled || leftAdornment) && (
+        {(uploadEnabled || projectSelectionEnabled || dictationAdapter || leftAdornment) && (
           <div className="absolute bottom-1.5 left-1.5 flex items-center gap-1">
             {(uploadEnabled || projectSelectionEnabled) && (
               <ChatAddMenu
@@ -728,6 +731,10 @@ export function ChatInput({
                 projectContextUnsupported={projectContextUnsupported}
               />
             )}
+            <VoiceInputButton
+              editorRef={editorRef}
+              disabled={!!disabled || !!noAgent || submitting}
+            />
             {leftAdornment}
           </div>
         )}

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -5,6 +5,10 @@ import type { Attachment } from "@multica/core/types";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 
 const mockFocus = vi.hoisted(() => vi.fn());
+const mockNativeFocus = vi.hoisted(() => vi.fn());
+const mockHasFocus = vi.hoisted(() => vi.fn(() => true));
+const mockClientRects = vi.hoisted(() => vi.fn(() => [{}]));
+const mockInsertContent = vi.hoisted(() => vi.fn(() => true));
 const mockSetContent = vi.hoisted(() => vi.fn());
 const mockSetTextSelection = vi.hoisted(() => vi.fn());
 const mockDispatch = vi.hoisted(() => vi.fn());
@@ -18,6 +22,8 @@ const capturedExtOptions = vi.hoisted<{
 const editorState = vi.hoisted(() => ({
   isFocused: false,
   isDestroyed: false,
+  isEditable: true,
+  isConnected: true,
   markdown: "",
   // Nodes the mocked doc reports via `descendants`. The content-sync effect
   // walks these to detect in-flight uploads; default empty = nothing uploading.
@@ -107,8 +113,12 @@ vi.mock("@tiptap/react", () => ({
         get isDestroyed() {
           return editorState.isDestroyed;
         },
+        get isEditable() {
+          return editorState.isEditable;
+        },
         commands: {
           focus: mockFocus,
+          insertContent: mockInsertContent,
           clearContent: vi.fn(),
           setContent: mockSetContent,
           setTextSelection: mockSetTextSelection,
@@ -123,7 +133,15 @@ vi.mock("@tiptap/react", () => ({
             (listener) => listener !== cb,
           );
         },
-        view: { dispatch: mockDispatch },
+        view: {
+          dispatch: mockDispatch,
+          focus: mockNativeFocus,
+          hasFocus: mockHasFocus,
+          dom: {
+            get isConnected() { return editorState.isConnected; },
+            getClientRects: mockClientRects,
+          },
+        },
         state: {
           get tr() {
             return emptyTr;
@@ -160,6 +178,10 @@ describe("ContentEditor", () => {
     vi.clearAllMocks();
     editorState.isFocused = false;
     editorState.isDestroyed = false;
+    editorState.isEditable = true;
+    editorState.isConnected = true;
+    mockHasFocus.mockReturnValue(true);
+    mockClientRects.mockReturnValue([{}]);
     editorState.markdown = "";
     editorState.uploadingNodes = [];
     editorRef.current = null;
@@ -184,6 +206,27 @@ describe("ContentEditor", () => {
     fireEvent.mouseDown(shell!);
 
     expect(mockFocus).toHaveBeenCalledWith("end");
+  });
+
+  it("focuses native input synchronously without inserting text or moving selection", () => {
+    const ref = createRef<ContentEditorRef>();
+    render(<ContentEditor ref={ref} />);
+    expect(ref.current?.focusForNativeInput()).toBe(true);
+    expect(mockNativeFocus).toHaveBeenCalledOnce();
+    expect(mockFocus).not.toHaveBeenCalled();
+    expect(mockSetTextSelection).not.toHaveBeenCalled();
+    expect(mockInsertContent).not.toHaveBeenCalled();
+  });
+
+  it.each(["destroyed", "readonly", "detached", "hidden"])("rejects a %s native input target", (state) => {
+    const ref = createRef<ContentEditorRef>();
+    render(<ContentEditor ref={ref} />);
+    if (state === "destroyed") editorState.isDestroyed = true;
+    if (state === "readonly") editorState.isEditable = false;
+    if (state === "detached") editorState.isConnected = false;
+    if (state === "hidden") mockClientRects.mockReturnValue([]);
+    expect(ref.current?.focusForNativeInput()).toBe(false);
+    expect(mockNativeFocus).not.toHaveBeenCalled();
   });
 
   it("does not hijack clicks that land inside the ProseMirror node", () => {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -253,6 +253,8 @@ interface ContentEditorRef {
   getMarkdown: () => string;
   clearContent: () => void;
   focus: () => void;
+  /** Focus a live visible editor synchronously without changing its selection. */
+  focusForNativeInput: () => boolean;
   /**
    * Focus and place the caret at the document position under the given
    * viewport coordinates. Used by readonly-first hosts so the click that
@@ -907,6 +909,14 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         if (editor) editor.commands.focus();
         // Editor not mounted yet — defer the focus to `onCreate`.
         else focusOnReadyRef.current = true;
+      },
+      focusForNativeInput: () => {
+        if (!editor || editor.isDestroyed || !editor.isEditable) return false;
+        const { view } = editor;
+        if (!view.dom.isConnected || view.dom.getClientRects().length === 0) return false;
+        // ProseMirror focuses synchronously; Tiptap defers to an animation frame.
+        view.focus();
+        return view.hasFocus();
       },
       focusAtCoords: (coords: { x: number; y: number }) => {
         if (!editor) {

--- a/packages/views/editor/index.ts
+++ b/packages/views/editor/index.ts
@@ -9,6 +9,7 @@ export {
   type TitleEditorRef,
 } from "./title-editor";
 export { ReadonlyContent } from "./readonly-content";
+export { VoiceInputButton, type VoiceInputButtonProps } from "./voice-input-button";
 export { useFileDropZone } from "./use-file-drop-zone";
 export { useUploadGate, type UploadGate } from "./use-upload-gate";
 export {

--- a/packages/views/editor/native-dictation-button.tsx
+++ b/packages/views/editor/native-dictation-button.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { LoaderCircle, Mic } from "lucide-react";
+import { toast } from "sonner";
+import type { DictationAdapter } from "@multica/core/types/dictation";
+import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
+import { useT } from "../i18n";
+import type { VoiceInputButtonProps } from "./voice-input-button";
+
+export function NativeDictationButton({
+  adapter,
+  editorRef,
+  disabled = false,
+  className,
+  size = "default",
+  onBeforeRecord,
+}: VoiceInputButtonProps & { adapter: DictationAdapter }) {
+  const { t } = useT("editor");
+  const [pending, setPending] = useState(false);
+  const pendingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  const toggle = async () => {
+    if (pendingRef.current || disabledRef.current) return;
+    pendingRef.current = true;
+    setPending(true);
+    try {
+      onBeforeRecord?.();
+      // Readonly-first composers mount Tiptap after this click. Wait only for
+      // the live visible editor, and fail closed if it unmounts or stays hidden.
+      const deadline = Date.now() + 1500;
+      let focused = false;
+      while (mountedRef.current && !disabledRef.current && Date.now() < deadline) {
+        if (editorRef.current?.focusForNativeInput()) {
+          focused = true;
+          break;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 16));
+      }
+      if (!mountedRef.current || disabledRef.current) return;
+      if (!focused) {
+        toast.error(t(($) => $.desktop.dictation.editor_not_ready));
+        return;
+      }
+
+      const result = await adapter.toggle();
+      if (!mountedRef.current) return;
+      if (result.ok) {
+        toast.info(t(($) => $.desktop.dictation.sent, { shortcut: result.shortcut }));
+      } else {
+        switch (result.reason) {
+          case "not_configured":
+            toast.error(t(($) => $.desktop.dictation.not_configured));
+            break;
+          case "app_not_running":
+            toast.error(t(($) => $.desktop.dictation.app_not_running));
+            break;
+          case "not_focused":
+            toast.error(t(($) => $.desktop.dictation.not_focused));
+            break;
+          case "busy":
+            toast.error(t(($) => $.desktop.dictation.busy));
+            break;
+          default:
+            toast.error(t(($) => $.desktop.dictation.unavailable));
+        }
+      }
+    } catch {
+      if (mountedRef.current) toast.error(t(($) => $.desktop.dictation.unavailable));
+    } finally {
+      pendingRef.current = false;
+      if (mountedRef.current) setPending(false);
+    }
+  };
+
+  const label = pending
+    ? t(($) => $.desktop.dictation.opening)
+    : t(($) => $.desktop.dictation.toggle);
+  const iconClassName = size === "sm" ? "size-3.5" : "size-4";
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size={size === "sm" ? "icon-xs" : "icon-sm"}
+      aria-label={label}
+      aria-busy={pending || undefined}
+      title={label}
+      disabled={disabled || pending}
+      onPointerDown={(event) => event.preventDefault()}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter") return;
+        // Native buttons click on Enter keydown; the helper correctly refuses
+        // a chord while Enter is still held. Dispatch only after its release.
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onKeyUp={(event) => {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        event.stopPropagation();
+        void toggle();
+      }}
+      onClick={() => void toggle()}
+      className={cn("text-muted-foreground", className)}
+    >
+      {pending ? (
+        <LoaderCircle className={cn(iconClassName, "animate-spin")} />
+      ) : (
+        <Mic className={iconClassName} />
+      )}
+    </Button>
+  );
+}

--- a/packages/views/editor/native-dictation-button.tsx
+++ b/packages/views/editor/native-dictation-button.tsx
@@ -70,6 +70,9 @@ export function NativeDictationButton({
           case "busy":
             toast.error(t(($) => $.desktop.dictation.busy));
             break;
+          case "cleanup_failed":
+            toast.error(t(($) => $.desktop.dictation.cleanup_failed));
+            break;
           default:
             toast.error(t(($) => $.desktop.dictation.unavailable));
         }
@@ -89,6 +92,7 @@ export function NativeDictationButton({
   return (
     <Button
       type="button"
+      data-native-dictation=""
       variant="ghost"
       size={size === "sm" ? "icon-xs" : "icon-sm"}
       aria-label={label}

--- a/packages/views/editor/voice-input-button.test.tsx
+++ b/packages/views/editor/voice-input-button.test.tsx
@@ -1,0 +1,186 @@
+import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DictationProvider } from "@multica/core/platform/dictation";
+import type { DictationAdapter } from "@multica/core/types/dictation";
+import { renderWithI18n } from "../test/i18n";
+import type { ContentEditorRef } from "./content-editor";
+import { VoiceInputButton } from "./voice-input-button";
+
+const mocks = vi.hoisted(() => ({ toastInfo: vi.fn(), toastError: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { info: mocks.toastInfo, error: mocks.toastError } }));
+const getUserMedia = vi.fn();
+const fetchSpy = vi.fn();
+
+function editorRef() {
+  return {
+    ref: {
+      current: { focusForNativeInput: vi.fn(() => true) } as unknown as ContentEditorRef,
+    },
+    insert: vi.fn(),
+  };
+}
+
+describe("VoiceInputButton native-only bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchSpy);
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia }, configurable: true,
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders no mic without a host adapter", () => {
+    renderWithI18n(<VoiceInputButton editorRef={editorRef().ref} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  function nativeButton(
+    ref: { current: ContentEditorRef | null },
+    adapter: DictationAdapter,
+    props: { disabled?: boolean; onBeforeRecord?: () => void } = {},
+  ) {
+    return (
+      <DictationProvider adapter={adapter}>
+        <VoiceInputButton editorRef={ref} {...props} />
+      </DictationProvider>
+    );
+  }
+
+  it("delegates to native dictation without capturing, fetching, inserting, or submitting", async () => {
+    const { ref, insert } = editorRef();
+    const toggle = vi.fn().mockResolvedValue({ ok: true, shortcut: "Ctrl+Alt+Shift+D" });
+    const submit = vi.fn((event) => event.preventDefault());
+    renderWithI18n(<form onSubmit={submit}>{nativeButton(ref, { toggle })}</form>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    await waitFor(() => expect(toggle).toHaveBeenCalledExactlyOnceWith());
+    expect(ref.current.focusForNativeInput).toHaveBeenCalledOnce();
+    expect(mocks.toastInfo).toHaveBeenCalledWith(expect.stringContaining("Sent Ctrl+Alt+Shift+D"));
+    expect(submit).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Native recording state is unknown; don't invent a pressed/recording UI.
+    expect(screen.getByRole("button", { name: "Dictate with Codex" })).not.toHaveAttribute("aria-pressed");
+  });
+
+  it.each(["not_configured", "app_not_running", "not_focused", "busy", "unavailable"])(
+    "never falls back to API or microphone capture on native %s", async (reason) => {
+      const { ref, insert } = editorRef();
+      const toggle = vi.fn().mockResolvedValue({ ok: false, reason });
+      renderWithI18n(nativeButton(ref, { toggle }));
+      fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+      await waitFor(() => expect(mocks.toastError).toHaveBeenCalledOnce());
+      expect(getUserMedia).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(insert).not.toHaveBeenCalled();
+    },
+  );
+
+  it("waits for Enter release before native dictation without submitting", async () => {
+    const user = userEvent.setup();
+    const { ref, insert } = editorRef();
+    const toggle = vi.fn().mockResolvedValue({ ok: true, shortcut: "Ctrl+Alt+Shift+D" });
+    const submit = vi.fn((event) => event.preventDefault());
+    renderWithI18n(<form onSubmit={submit}>{nativeButton(ref, { toggle })}</form>);
+    screen.getByRole("button", { name: "Dictate with Codex" }).focus();
+
+    await user.keyboard("{Enter>}");
+    expect(toggle).not.toHaveBeenCalled();
+    await user.keyboard("{/Enter}");
+
+    await waitFor(() => expect(toggle).toHaveBeenCalledExactlyOnceWith());
+    expect(submit).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles IPC rejection without any paid fallback", async () => {
+    const { ref } = editorRef();
+    const toggle = vi.fn().mockRejectedValue(new Error("bridge disconnected"));
+    renderWithI18n(nativeButton(ref, { toggle }));
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledOnce());
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("waits for a readonly-first composer to become visible and focused", async () => {
+    vi.useFakeTimers();
+    const { ref } = editorRef();
+    vi.mocked(ref.current.focusForNativeInput).mockReturnValueOnce(false).mockReturnValueOnce(false);
+    const toggle = vi.fn().mockResolvedValue({ ok: true, shortcut: "Ctrl+Alt+Shift+D" });
+    const activate = vi.fn();
+    renderWithI18n(nativeButton(ref, { toggle }, { onBeforeRecord: activate }));
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    expect(activate).toHaveBeenCalledOnce();
+    expect(toggle).not.toHaveBeenCalled();
+    await act(async () => { await vi.advanceTimersByTimeAsync(40); });
+    expect(toggle).toHaveBeenCalledOnce();
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch if the lazy editor never becomes ready", async () => {
+    vi.useFakeTimers();
+    const { ref } = editorRef();
+    vi.mocked(ref.current.focusForNativeInput).mockReturnValue(false);
+    const toggle = vi.fn();
+    renderWithI18n(nativeButton(ref, { toggle }));
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+    expect(toggle).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith("The editor isn't ready yet. Try again.");
+  });
+
+  it("cancels preparation when the composer unmounts", async () => {
+    vi.useFakeTimers();
+    const ref = { current: null };
+    const toggle = vi.fn();
+    const view = renderWithI18n(nativeButton(ref, { toggle }));
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    view.unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+    expect(toggle).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("cancels preparation when the composer becomes disabled", async () => {
+    vi.useFakeTimers();
+    const ref = { current: null };
+    const toggle = vi.fn();
+    const adapter = { toggle };
+    const view = renderWithI18n(nativeButton(ref, adapter));
+    fireEvent.click(screen.getByRole("button", { name: "Dictate with Codex" }));
+    view.rerender(nativeButton(ref, adapter, { disabled: true }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600); });
+    expect(toggle).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates rapid clicks while the native request is pending", async () => {
+    const { ref } = editorRef();
+    let resolve!: (value: { ok: true; shortcut: string }) => void;
+    const toggle = vi.fn(() => new Promise<{ ok: true; shortcut: string }>((complete) => { resolve = complete; }));
+    renderWithI18n(nativeButton(ref, { toggle }));
+    const button = screen.getByRole("button", { name: "Dictate with Codex" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(toggle).toHaveBeenCalledOnce();
+    await act(async () => { resolve({ ok: true, shortcut: "Ctrl+Alt+Shift+D" }); });
+  });
+
+  it("localizes the native mic entry", () => {
+    const { ref } = editorRef();
+    renderWithI18n(nativeButton(ref, { toggle: vi.fn() }), { locale: "zh-Hans" });
+    expect(screen.getByRole("button", { name: "使用 Codex 语音输入" })).toBeInTheDocument();
+  });
+});

--- a/packages/views/editor/voice-input-button.test.tsx
+++ b/packages/views/editor/voice-input-button.test.tsx
@@ -72,7 +72,7 @@ describe("VoiceInputButton native-only bridge", () => {
     expect(screen.getByRole("button", { name: "Dictate with Codex" })).not.toHaveAttribute("aria-pressed");
   });
 
-  it.each(["not_configured", "app_not_running", "not_focused", "busy", "unavailable"])(
+  it.each(["not_configured", "app_not_running", "not_focused", "busy", "cleanup_failed", "unavailable"])(
     "never falls back to API or microphone capture on native %s", async (reason) => {
       const { ref, insert } = editorRef();
       const toggle = vi.fn().mockResolvedValue({ ok: false, reason });

--- a/packages/views/editor/voice-input-button.tsx
+++ b/packages/views/editor/voice-input-button.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import type { RefObject } from "react";
+import { useDictationAdapter } from "@multica/core/platform/dictation";
+import type { ContentEditorRef } from "./content-editor";
+import { NativeDictationButton } from "./native-dictation-button";
+
+export interface VoiceInputButtonProps {
+  editorRef: RefObject<ContentEditorRef | null>;
+  disabled?: boolean;
+  className?: string;
+  size?: "sm" | "default";
+  /** Mount readonly-first composers before focusing the native paste target. */
+  onBeforeRecord?: () => void;
+}
+
+/** Only the host's native dictation UI records audio. Web/mobile have no mic
+ * entry; a missing or failed native bridge never enables an API fallback. */
+export function VoiceInputButton(props: VoiceInputButtonProps) {
+  const adapter = useDictationAdapter();
+  return adapter ? <NativeDictationButton {...props} adapter={adapter} /> : null;
+}

--- a/packages/views/issues/components/comment-card-edit-gate.test.tsx
+++ b/packages/views/issues/components/comment-card-edit-gate.test.tsx
@@ -65,6 +65,7 @@ vi.mock("../../editor", async () => ({
     "../../editor/use-composer-submit",
   )),
   useEditorUpload: () => ({ uploadWithToast, upload: vi.fn(), uploading: false }),
+  VoiceInputButton: () => null,
   useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
   FileDropOverlay: () => null,
   ReadonlyContent: ({ content }: { content: string }) => <div>{content}</div>,

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -99,6 +99,7 @@ vi.mock("../../editor", async () => ({
     dropZoneProps: { "data-testid": "drop-zone" },
   }),
   FileDropOverlay: () => null,
+  VoiceInputButton: () => null,
   ContentEditor: forwardRef(function MockContentEditor(
     {
       defaultValue,

--- a/packages/views/issues/components/comment-dictation.test.tsx
+++ b/packages/views/issues/components/comment-dictation.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DictationProvider } from "@multica/core/platform/dictation";
+import { useCommentDraftStore } from "@multica/core/issues/stores";
+import { WorkspaceSlugProvider } from "@multica/core/paths";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import { renderWithI18n } from "../../test/i18n";
+import { CommentInput } from "./comment-input";
+import { ReplyInput } from "./reply-input";
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    getBaseUrl: () => "https://fixture.invalid",
+    listWorkspaces: vi.fn().mockResolvedValue([{ id: "test-ws", slug: "test", name: "Test" }]),
+    listMembers: vi.fn().mockResolvedValue([]),
+    listAgents: vi.fn().mockResolvedValue([]),
+    listSquads: vi.fn().mockResolvedValue([]),
+    listQuickActions: vi.fn().mockResolvedValue({ quick_actions: [] }),
+    previewCommentTriggers: vi.fn().mockResolvedValue({ agents: [], blocked: [] }),
+  },
+}));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
+
+// The composer, lazy controller, mic and Tiptap editor are real. Only the host
+// adapter and unrelated API/avatar plumbing are fake: no account, native
+// shortcut or microphone is accessed.
+describe("native dictation in real lazy composers", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+    useCommentDraftStore.setState({ drafts: {} });
+    vi.spyOn(HTMLElement.prototype, "getClientRects").mockImplementation(function (this: HTMLElement) {
+      return (this.closest(".hidden") ? [] : [new DOMRect(0, 0, 300, 40)]) as unknown as DOMRectList;
+    });
+  });
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+  it.each(["comment", "reply"])("mounts the %s editor from the mic and keeps click/Enter separate from submit", async (kind) => {
+    const submit = vi.fn().mockResolvedValue(true);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(workspaceKeys.list(), [{ id: "test-ws", slug: "test", name: "Test" }]);
+    const toggle = vi.fn(async () => {
+      expect(document.activeElement).toHaveAttribute("contenteditable", "true");
+      expect(document.activeElement?.closest(".hidden")).toBeNull();
+      return { ok: true as const, shortcut: "Ctrl+Alt+Shift+D" };
+    });
+    const { container, unmount } = renderWithI18n(
+      <QueryClientProvider client={client}>
+        <WorkspaceSlugProvider slug="test">
+        <DictationProvider adapter={{ toggle }}>
+          {kind === "comment" ? <CommentInput issueId="test-issue" onSubmit={submit} /> : (
+            <ReplyInput issueId="test-issue" parentId="test-comment" avatarType="member" avatarId="test-user" onSubmit={submit} />
+          )}
+        </DictationProvider>
+        </WorkspaceSlugProvider>
+      </QueryClientProvider>,
+    );
+    expect(container.querySelector("[contenteditable=true]")).toBeNull();
+    const mic = screen.getByRole("button", { name: "Dictate with Codex" });
+    expect(mic).toHaveAttribute("data-native-dictation");
+    fireEvent.click(mic);
+    await waitFor(() => expect(toggle).toHaveBeenCalledOnce());
+    expect(submit).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(mic).not.toBeDisabled());
+    mic.focus();
+    const user = userEvent.setup();
+    await user.keyboard("{Enter>}");
+    expect(toggle).toHaveBeenCalledOnce();
+    await user.keyboard("{/Enter}");
+    await waitFor(() => expect(toggle).toHaveBeenCalledTimes(2));
+    expect(submit).not.toHaveBeenCalled();
+    expect(container.querySelector("[contenteditable=true]")?.textContent).toBe("");
+    unmount();
+    client.clear();
+  });
+});

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useCallback, useEffect } from "react";
 import { cn } from "@multica/ui/lib/utils";
-import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit } from "../../editor";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit, VoiceInputButton } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { contentReferencesAttachment } from "@multica/core/types";
@@ -278,6 +278,12 @@ function CommentInput({ issueId, onSubmit, onAccepted }: CommentInputProps) {
         />
       </div>
       <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
+        <VoiceInputButton
+          size="sm"
+          editorRef={editorRef}
+          disabled={submitting}
+          onBeforeRecord={lazy.activate}
+        />
         <FileUploadButton
           size="sm"
           multiple

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -146,6 +146,7 @@ vi.mock("../../editor", async () => ({
     upload: vi.fn(),
     uploading: false,
   }),
+  VoiceInputButton: () => null,
   useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
   FileDropOverlay: () => null,
   // No-op so comment-card's AttachmentList can render without hitting the

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useCallback, useEffect } from "react";
-import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit } from "../../editor";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit, VoiceInputButton } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -295,6 +295,12 @@ function ReplyInput({
           />
         </div>
         <div className="absolute bottom-0 right-0 flex items-center gap-1">
+          <VoiceInputButton
+            size="sm"
+            editorRef={editorRef}
+            disabled={submitting}
+            onBeforeRecord={lazy.activate}
+          />
           <FileUploadButton
             size="sm"
             multiple

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -96,6 +96,19 @@
     "show_source": "Show source",
     "fullscreen": "Fullscreen"
   },
+  "desktop": {
+    "dictation": {
+      "toggle": "Dictate with Codex",
+      "opening": "Opening Codex dictation…",
+      "sent": "Sent {{shortcut}} to Codex. Finish in its dictation overlay, keep this input selected, and review the text before sending.",
+      "not_configured": "In the Codex/ChatGPT desktop app, set Toggle dictation hotkey to Ctrl+Alt+Shift+D. Use a unique global shortcut, not the in-app Start dictation shortcut.",
+      "app_not_running": "Open the Codex/ChatGPT Windows desktop app and stay signed in, then try again. The Codex CLI alone cannot provide global dictation.",
+      "not_focused": "Keep this Multica window and input focused, then try again.",
+      "busy": "Release any held shortcut keys, wait a moment, and try again.",
+      "unavailable": "Couldn't open Codex dictation. Try Ctrl+Alt+Shift+D manually. No audio was sent to a Multica transcription API.",
+      "editor_not_ready": "The editor isn't ready yet. Try again."
+    }
+  },
   "file_card": {
     "uploading": "Uploading {{filename}}"
   },

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -105,6 +105,7 @@
       "app_not_running": "Open the Codex/ChatGPT Windows desktop app and stay signed in, then try again. The Codex CLI alone cannot provide global dictation.",
       "not_focused": "Keep this Multica window and input focused, then try again.",
       "busy": "Release any held shortcut keys, wait a moment, and try again.",
+      "cleanup_failed": "Some shortcut keys could not be released. Press and release Ctrl, Alt, Shift and D before typing. Check Codex dictation before toggling again.",
       "unavailable": "Couldn't open Codex dictation. Try Ctrl+Alt+Shift+D manually. No audio was sent to a Multica transcription API.",
       "editor_not_ready": "The editor isn't ready yet. Try again."
     }

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -89,6 +89,19 @@
     "show_source": "ソースを表示",
     "fullscreen": "全画面"
   },
+  "desktop": {
+    "dictation": {
+      "toggle": "Codex で音声入力",
+      "opening": "Codex の音声入力を開いています…",
+      "sent": "Codex に {{shortcut}} を送りました。音声入力ウィンドウで録音を終了し、この入力欄を選択したまま、文字を確認してから送信してください。",
+      "not_configured": "Codex/ChatGPT デスクトップアプリで Toggle dictation hotkey を Ctrl+Alt+Shift+D に設定してください。アプリ内の Start dictation ではなく、重複のないグローバルショートカットを使用します。",
+      "app_not_running": "Windows 版 Codex/ChatGPT デスクトップアプリを開いてログインし、もう一度お試しください。Codex CLI だけではグローバル音声入力を利用できません。",
+      "not_focused": "この Multica ウィンドウと入力欄を選択して、もう一度お試しください。",
+      "busy": "押しているショートカットキーを離し、少し待ってからお試しください。",
+      "unavailable": "Codex の音声入力を開けませんでした。Ctrl+Alt+Shift+D を手動でお試しください。Multica の文字起こし API には音声を送信していません。",
+      "editor_not_ready": "入力欄の準備ができていません。もう一度お試しください。"
+    }
+  },
   "file_card": {
     "uploading": "{{filename}} をアップロード中"
   },

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -98,6 +98,7 @@
       "app_not_running": "Windows 版 Codex/ChatGPT デスクトップアプリを開いてログインし、もう一度お試しください。Codex CLI だけではグローバル音声入力を利用できません。",
       "not_focused": "この Multica ウィンドウと入力欄を選択して、もう一度お試しください。",
       "busy": "押しているショートカットキーを離し、少し待ってからお試しください。",
+      "cleanup_failed": "一部のキーを解放できませんでした。入力前に Ctrl、Alt、Shift、D を押して離してください。再度切り替える前に Codex の音声入力状態を確認してください。",
       "unavailable": "Codex の音声入力を開けませんでした。Ctrl+Alt+Shift+D を手動でお試しください。Multica の文字起こし API には音声を送信していません。",
       "editor_not_ready": "入力欄の準備ができていません。もう一度お試しください。"
     }

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -89,6 +89,19 @@
     "show_source": "소스 표시",
     "fullscreen": "전체 화면"
   },
+  "desktop": {
+    "dictation": {
+      "toggle": "Codex로 음성 입력",
+      "opening": "Codex 음성 입력 여는 중…",
+      "sent": "Codex에 {{shortcut}}을 보냈습니다. 음성 입력 창에서 녹음을 마치고, 이 입력란을 선택한 상태로 텍스트를 확인한 뒤 전송하세요.",
+      "not_configured": "Codex/ChatGPT 데스크톱 앱에서 Toggle dictation hotkey를 Ctrl+Alt+Shift+D로 설정하세요. 앱 내부의 Start dictation이 아닌, 충돌 없는 전역 단축키를 사용해야 합니다.",
+      "app_not_running": "Windows용 Codex/ChatGPT 데스크톱 앱을 열어 로그인한 뒤 다시 시도하세요. Codex CLI만으로는 전역 음성 입력을 사용할 수 없습니다.",
+      "not_focused": "현재 Multica 창과 입력란을 선택한 상태에서 다시 시도하세요.",
+      "busy": "누르고 있는 단축키를 놓고 잠시 후 다시 시도하세요.",
+      "unavailable": "Codex 음성 입력을 열지 못했습니다. Ctrl+Alt+Shift+D를 직접 눌러 보세요. Multica 전사 API로 오디오를 보내지 않았습니다.",
+      "editor_not_ready": "입력란이 아직 준비되지 않았습니다. 다시 시도하세요."
+    }
+  },
   "file_card": {
     "uploading": "{{filename}} 업로드 중"
   },

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -98,6 +98,7 @@
       "app_not_running": "Windows용 Codex/ChatGPT 데스크톱 앱을 열어 로그인한 뒤 다시 시도하세요. Codex CLI만으로는 전역 음성 입력을 사용할 수 없습니다.",
       "not_focused": "현재 Multica 창과 입력란을 선택한 상태에서 다시 시도하세요.",
       "busy": "누르고 있는 단축키를 놓고 잠시 후 다시 시도하세요.",
+      "cleanup_failed": "일부 단축키를 해제하지 못했습니다. 입력 전에 Ctrl, Alt, Shift, D를 눌렀다 놓으세요. 다시 전환하기 전에 Codex 음성 입력 상태를 확인하세요.",
       "unavailable": "Codex 음성 입력을 열지 못했습니다. Ctrl+Alt+Shift+D를 직접 눌러 보세요. Multica 전사 API로 오디오를 보내지 않았습니다.",
       "editor_not_ready": "입력란이 아직 준비되지 않았습니다. 다시 시도하세요."
     }

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -105,6 +105,7 @@
       "app_not_running": "请打开 Windows 版 Codex/ChatGPT 桌面应用并保持登录，然后重试。仅安装 Codex CLI 无法提供全局语音输入。",
       "not_focused": "请保持当前 Multica 窗口和输入框处于选中状态，然后重试。",
       "busy": "请松开按住的快捷键，稍等片刻后重试。",
+      "cleanup_failed": "部分 shortcut keys 未能释放。输入前请分别按下并松开 Ctrl、Alt、Shift 和 D。再次 toggle 前，请检查 Codex dictation 状态。",
       "unavailable": "无法打开 Codex 语音输入，请手动尝试 Ctrl+Alt+Shift+D。未向 Multica 转写 API 发送音频。",
       "editor_not_ready": "输入框尚未准备好，请重试。"
     }

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -96,6 +96,19 @@
     "show_source": "显示源码",
     "fullscreen": "放大"
   },
+  "desktop": {
+    "dictation": {
+      "toggle": "使用 Codex 语音输入",
+      "opening": "正在打开 Codex 语音输入...",
+      "sent": "已向 Codex 发送 {{shortcut}}。请在它的语音浮窗中完成录音，保持选中当前输入框，检查文字后再发送。",
+      "not_configured": "请在 Codex/ChatGPT 桌面应用中，将 Toggle dictation hotkey 设为 Ctrl+Alt+Shift+D。请使用无冲突的全局快捷键，而非应用内的 Start dictation。",
+      "app_not_running": "请打开 Windows 版 Codex/ChatGPT 桌面应用并保持登录，然后重试。仅安装 Codex CLI 无法提供全局语音输入。",
+      "not_focused": "请保持当前 Multica 窗口和输入框处于选中状态，然后重试。",
+      "busy": "请松开按住的快捷键，稍等片刻后重试。",
+      "unavailable": "无法打开 Codex 语音输入，请手动尝试 Ctrl+Alt+Shift+D。未向 Multica 转写 API 发送音频。",
+      "editor_not_ready": "输入框尚未准备好，请重试。"
+    }
+  },
   "file_card": {
     "uploading": "正在上传 {{filename}}"
   },

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -434,6 +434,7 @@ vi.mock("../editor", async () => {
     ...composer,
     useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
     FileDropOverlay: () => null,
+    VoiceInputButton: () => null,
     ContentEditor,
     TitleEditor,
   };

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -51,7 +51,7 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { Switch } from "@multica/ui/components/ui/switch";
-import { ContentEditor, type ContentEditorRef, TitleEditor, type TitleEditorRef, useFileDropZone, FileDropOverlay, useUploadGate, useComposerSubmit } from "../editor";
+import { ContentEditor, type ContentEditorRef, TitleEditor, type TitleEditorRef, useFileDropZone, FileDropOverlay, useUploadGate, useComposerSubmit, VoiceInputButton } from "../editor";
 import { useIssueCreateUploads } from "./use-issue-create-uploads";
 import { useShortcut } from "@multica/core/shortcuts";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
@@ -1367,6 +1367,11 @@ export function ManualCreatePanel({
                 grid child in both branches below. */}
             <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-2.5 border-t px-4 py-3 shrink-0 sm:flex sm:flex-wrap">
               <div className="flex min-h-7 items-center gap-2 sm:mr-auto">
+                <VoiceInputButton
+                  size="sm"
+                  editorRef={descEditorRef}
+                  disabled={submitBusy}
+                />
                 <FileUploadButton
                   size="sm"
                   multiple

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -389,6 +389,7 @@ vi.mock("../editor", async () => {
     ...uploadGate,
     ...composer,
     ContentEditor,
+    VoiceInputButton: () => null,
     useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
     FileDropOverlay: () => null,
   };

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -78,6 +78,7 @@ import {
   FileDropOverlay,
   useUploadGate,
   useComposerSubmit,
+  VoiceInputButton,
 } from "../editor";
 import { useIssueCreateUploads } from "./use-issue-create-uploads";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -849,6 +850,11 @@ export function AgentCreatePanel({
             {/* Deliberately NOT disabled while uploading: each file is its
                 own queue entry, so queueing a second one is safe and waiting
                 for the first to land just to attach the next is busywork. */}
+            <VoiceInputButton
+              size="sm"
+              editorRef={editorRef}
+              disabled={submitting}
+            />
             <FileUploadButton
               size="sm"
               multiple

--- a/server/cmd/multica/cmd_desktop_dictation_test.go
+++ b/server/cmd/multica/cmd_desktop_dictation_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/desktopdictation"
+)
+
+func TestDesktopDictationHelperRunsBeforeNormalCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Ordinary CLI config resolution rejects this root. The private helper
+	// must never reach that path, even when rejecting an invalid HWND.
+	t.Setenv("MULTICA_TASK_CONFIG_ROOT", "not-an-absolute-path")
+	previousArgs := os.Args
+	os.Args = []string{"multica", desktopdictation.HelperArg, "toggle", "0"}
+	t.Cleanup(func() { os.Args = previousArgs })
+	output, err := captureStdout(t, func() error {
+		main()
+		return nil
+	})
+	if err != nil || output != "unavailable\n" {
+		t.Fatalf("helper output = %q, error = %v", output, err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".multica")); !os.IsNotExist(err) {
+		t.Fatal("helper created ordinary CLI state")
+	}
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/desktopdictation"
 )
 
 var (
@@ -97,6 +98,12 @@ func init() {
 }
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == desktopdictation.HelperArg {
+		// A bundled Desktop helper must not load a profile, access an account,
+		// start the daemon, or run the CLI updater just to dispatch a shortcut.
+		fmt.Fprintln(os.Stdout, desktopdictation.Run(os.Args[2:]))
+		return
+	}
 	if len(os.Args) == 2 && os.Args[1] == execenv.PreparationHelperArg {
 		logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 		if err := execenv.RunPreparationHelper(os.Stdin, os.Stdout, logger); err != nil {

--- a/server/internal/desktopdictation/dictation.go
+++ b/server/internal/desktopdictation/dictation.go
@@ -93,7 +93,9 @@ func run(args []string, p platform) string {
 		for i := len(held) - 1; i >= 0; i-- {
 			release = append(release, keyEvent{key: held[i], up: true})
 		}
-		p.sendKeys(release)
+		if p.sendKeys(release) != len(release) {
+			return "cleanup_failed"
+		}
 	}
 	return "unavailable"
 }

--- a/server/internal/desktopdictation/dictation.go
+++ b/server/internal/desktopdictation/dictation.go
@@ -1,0 +1,99 @@
+// Package desktopdictation owns the Desktop-only, fixed global dictation chord.
+// It has no daemon, account, audio, credential, or network dependency.
+package desktopdictation
+
+import "strconv"
+
+// HelperArg is private to the matching bundled Desktop client. Version the
+// protocol rather than falling back to arbitrary commands or an older CLI.
+const HelperArg = "--desktop-dictation-v1"
+
+type keyEvent struct {
+	key uint16
+	up  bool
+}
+
+type platform interface {
+	available() bool
+	desktopRunning() bool
+	foregroundWindow() uintptr
+	keyDown(uint16) bool
+	sendKeys([]keyEvent) int
+}
+
+var guardedKeys = [...]uint16{
+	0x10, 0x11, 0x12, // Shift, Ctrl, Alt (either side).
+	0x5B, 0x5C, // Windows keys.
+	0x44, 0x0D, 0x20, // D, Enter, Space; never combine with an active submit key.
+}
+
+// Run returns only a bounded status token. "probe" is read-only; "toggle" takes
+// exactly one decimal HWND chosen by Electron main, never a key or script.
+// Electron owns trusted-frame/user-gesture admission. This helper rechecks the
+// actual foreground HWND immediately before sending one fixed chord.
+func Run(args []string) string {
+	return run(args, nativePlatform())
+}
+
+func run(args []string, p platform) string {
+	probe := len(args) == 1 && args[0] == "probe"
+	var hwnd uint64
+	if !probe {
+		if len(args) != 2 || args[0] != "toggle" {
+			return "unavailable"
+		}
+		var err error
+		hwnd, err = strconv.ParseUint(args[1], 10, strconv.IntSize)
+		if err != nil || hwnd == 0 || strconv.FormatUint(hwnd, 10) != args[1] {
+			return "unavailable"
+		}
+	}
+	if p == nil || !p.available() {
+		return "unavailable"
+	}
+	if !probe && p.foregroundWindow() != uintptr(hwnd) {
+		return "not_focused"
+	}
+	if !p.desktopRunning() {
+		return "app_not_running"
+	}
+	if probe {
+		return "ready"
+	}
+	for _, key := range guardedKeys {
+		if p.keyDown(key) {
+			return "busy"
+		}
+	}
+	// Process enumeration can take time. Do not steal focus or send into a
+	// different application if the user moved away in the meantime.
+	if p.foregroundWindow() != uintptr(hwnd) {
+		return "not_focused"
+	}
+	chord := []keyEvent{
+		{key: 0x11}, {key: 0x12}, {key: 0x10}, {key: 0x44},
+		{key: 0x44, up: true}, {key: 0x10, up: true}, {key: 0x12, up: true}, {key: 0x11, up: true},
+	}
+	sent := p.sendKeys(chord)
+	if sent == len(chord) {
+		return "sent"
+	}
+	if sent > 0 && sent < len(chord) {
+		// No retry: a partially sent toggle may already have started dictation.
+		// Release only keys left down by the inserted prefix, in reverse order.
+		var held []uint16
+		for _, event := range chord[:sent] {
+			if event.up {
+				held = held[:len(held)-1]
+			} else {
+				held = append(held, event.key)
+			}
+		}
+		release := make([]keyEvent, 0, len(held))
+		for i := len(held) - 1; i >= 0; i-- {
+			release = append(release, keyEvent{key: held[i], up: true})
+		}
+		p.sendKeys(release)
+	}
+	return "unavailable"
+}

--- a/server/internal/desktopdictation/dictation_other.go
+++ b/server/internal/desktopdictation/dictation_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package desktopdictation
+
+func nativePlatform() platform { return nil }

--- a/server/internal/desktopdictation/dictation_test.go
+++ b/server/internal/desktopdictation/dictation_test.go
@@ -7,14 +7,15 @@ import (
 )
 
 type fakePlatform struct {
-	ready    bool
-	running  bool
-	window   uintptr
-	down     uint16
-	sent     int
-	calls    [][]keyEvent
-	checks   int
-	switchAt int
+	ready       bool
+	running     bool
+	window      uintptr
+	down        uint16
+	sent        int
+	calls       [][]keyEvent
+	checks      int
+	switchAt    int
+	cleanupSent *int
 }
 
 func (f *fakePlatform) available() bool         { return f.ready }
@@ -31,6 +32,9 @@ func (f *fakePlatform) sendKeys(keys []keyEvent) int {
 	f.calls = append(f.calls, append([]keyEvent(nil), keys...))
 	if len(f.calls) == 1 {
 		return f.sent
+	}
+	if f.cleanupSent != nil {
+		return *f.cleanupSent
 	}
 	return len(keys)
 }
@@ -145,5 +149,18 @@ func TestPartialInjectionReleasesOnlyOutstandingKeysWithoutRetry(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFailedCleanupReportsHeldKeysWithoutAnotherToggle(t *testing.T) {
+	f := healthyPlatform()
+	f.sent = 4
+	count := 2
+	f.cleanupSent = &count
+	if got := run([]string{"toggle", "42"}, f); got != "cleanup_failed" {
+		t.Fatalf("status = %q, want cleanup_failed", got)
+	}
+	if len(f.calls) != 2 {
+		t.Fatalf("got %d calls; want one chord and one release attempt", len(f.calls))
 	}
 }

--- a/server/internal/desktopdictation/dictation_test.go
+++ b/server/internal/desktopdictation/dictation_test.go
@@ -1,0 +1,149 @@
+package desktopdictation
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type fakePlatform struct {
+	ready    bool
+	running  bool
+	window   uintptr
+	down     uint16
+	sent     int
+	calls    [][]keyEvent
+	checks   int
+	switchAt int
+}
+
+func (f *fakePlatform) available() bool         { return f.ready }
+func (f *fakePlatform) desktopRunning() bool    { return f.running }
+func (f *fakePlatform) keyDown(key uint16) bool { return key == f.down }
+func (f *fakePlatform) foregroundWindow() uintptr {
+	f.checks++
+	if f.switchAt != 0 && f.checks >= f.switchAt {
+		return 99
+	}
+	return f.window
+}
+func (f *fakePlatform) sendKeys(keys []keyEvent) int {
+	f.calls = append(f.calls, append([]keyEvent(nil), keys...))
+	if len(f.calls) == 1 {
+		return f.sent
+	}
+	return len(keys)
+}
+
+func healthyPlatform() *fakePlatform {
+	return &fakePlatform{ready: true, running: true, window: 42, sent: 8}
+}
+
+func TestInvalidRequestsNeverReachNativeCode(t *testing.T) {
+	for _, args := range [][]string{
+		nil, {"toggle"}, {"probe", "42"}, {"record", "42"},
+		{"toggle", "0"}, {"toggle", "-1"}, {"toggle", "+42"},
+		{"toggle", " 42"}, {"toggle", "0x2a"}, {"toggle", "042"},
+		{"toggle", "18446744073709551616"}, {"toggle", "42", "extra"},
+	} {
+		t.Run(fmt.Sprint(args), func(t *testing.T) {
+			if got := run(args, nil); got != "unavailable" {
+				t.Fatalf("status = %q, want unavailable", got)
+			}
+		})
+	}
+}
+
+func TestProbeNeverFocusesOrSendsInput(t *testing.T) {
+	f := healthyPlatform()
+	if got := run([]string{"probe"}, f); got != "ready" {
+		t.Fatalf("status = %q, want ready", got)
+	}
+	if len(f.calls) != 0 || f.checks != 0 {
+		t.Fatal("a probe must not inspect the target or send input")
+	}
+}
+
+func TestNativeAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*fakePlatform)
+		want   string
+	}{
+		{"unsupported", func(f *fakePlatform) { f.ready = false }, "unavailable"},
+		{"no desktop", func(f *fakePlatform) { f.running = false }, "app_not_running"},
+		{"wrong window", func(f *fakePlatform) { f.window = 99 }, "not_focused"},
+		{"focus changed", func(f *fakePlatform) { f.switchAt = 2 }, "not_focused"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := healthyPlatform()
+			tc.mutate(f)
+			if got := run([]string{"toggle", "42"}, f); got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+			if len(f.calls) != 0 {
+				t.Fatal("rejected requests must not send input")
+			}
+		})
+	}
+}
+
+func TestHeldKeysPreventModifiedChordsOrAccidentalSubmit(t *testing.T) {
+	for _, key := range guardedKeys {
+		f := healthyPlatform()
+		f.down = key
+		if got := run([]string{"toggle", "42"}, f); got != "busy" || len(f.calls) != 0 {
+			t.Fatalf("held key %#x: status = %q, sends = %d", key, got, len(f.calls))
+		}
+	}
+}
+
+func TestToggleSendsOnlyTheFixedChordInOneBatch(t *testing.T) {
+	f := healthyPlatform()
+	if got := run([]string{"toggle", "42"}, f); got != "sent" {
+		t.Fatalf("status = %q, want sent", got)
+	}
+	want := [][]keyEvent{{
+		{key: 0x11}, {key: 0x12}, {key: 0x10}, {key: 0x44},
+		{key: 0x44, up: true}, {key: 0x10, up: true}, {key: 0x12, up: true}, {key: 0x11, up: true},
+	}}
+	if !reflect.DeepEqual(f.calls, want) {
+		t.Fatalf("input = %#v, want %#v", f.calls, want)
+	}
+}
+
+func TestPartialInjectionReleasesOnlyOutstandingKeysWithoutRetry(t *testing.T) {
+	for sent := 0; sent < 8; sent++ {
+		t.Run(fmt.Sprint(sent), func(t *testing.T) {
+			f := healthyPlatform()
+			f.sent = sent
+			if got := run([]string{"toggle", "42"}, f); got != "unavailable" {
+				t.Fatalf("status = %q, want unavailable", got)
+			}
+			if sent == 0 {
+				if len(f.calls) != 1 {
+					t.Fatal("no keys were inserted, so no release should be sent")
+				}
+				return
+			}
+			if len(f.calls) != 2 {
+				t.Fatalf("got %d calls; want chord and one cleanup batch", len(f.calls))
+			}
+			held := map[uint16]bool{}
+			for _, key := range f.calls[0][:sent] {
+				held[key.key] = !key.up
+			}
+			for _, key := range f.calls[1] {
+				if !key.up || !held[key.key] {
+					t.Fatalf("unexpected cleanup key %#v", key)
+				}
+				held[key.key] = false
+			}
+			for key, down := range held {
+				if down {
+					t.Fatalf("key %#x left down", key)
+				}
+			}
+		})
+	}
+}

--- a/server/internal/desktopdictation/dictation_windows.go
+++ b/server/internal/desktopdictation/dictation_windows.go
@@ -1,0 +1,142 @@
+//go:build windows
+
+package desktopdictation
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const codexPackageFamily = "OpenAI.Codex_2p2nqsd0c76g0"
+
+var (
+	dictationUser32   = windows.NewLazySystemDLL("user32.dll")
+	sendInputProc     = dictationUser32.NewProc("SendInput")
+	keyStateProc      = dictationUser32.NewProc("GetAsyncKeyState")
+	packageFamilyProc = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetPackageFamilyName")
+)
+
+// INPUT's union is sized/aligned for MOUSEINPUT, even when sending KEYBDINPUT.
+// A keyboard-only struct would pass the wrong cbSize (40 on x64, 28 on x86).
+type mouseInput struct {
+	X, Y      int32
+	MouseData uint32
+	Flags     uint32
+	Time      uint32
+	ExtraInfo uintptr
+}
+
+type keyboardInput struct {
+	VirtualKey uint16
+	Scan       uint16
+	Flags      uint32
+	Time       uint32
+	ExtraInfo  uintptr
+}
+
+type nativeInput struct {
+	Kind uint32
+	Data mouseInput
+}
+
+type windowsPlatform struct{}
+
+func nativePlatform() platform { return windowsPlatform{} }
+
+func (windowsPlatform) available() bool {
+	return sendInputProc.Find() == nil && keyStateProc.Find() == nil && packageFamilyProc.Find() == nil
+}
+
+func (windowsPlatform) foregroundWindow() uintptr {
+	return uintptr(windows.GetForegroundWindow())
+}
+
+func (windowsPlatform) keyDown(key uint16) bool {
+	state, _, _ := keyStateProc.Call(uintptr(key))
+	return state&0x8000 != 0
+}
+
+func isCodexDesktop(name, imagePath, family string) bool {
+	return family == codexPackageFamily &&
+		(strings.EqualFold(name, "ChatGPT.exe") || strings.EqualFold(name, "Codex.exe")) &&
+		strings.EqualFold(filepath.Base(imagePath), name) &&
+		strings.EqualFold(filepath.Base(filepath.Dir(imagePath)), "app")
+}
+
+func processIsCodexDesktop(pid uint32, name string, session uint32) bool {
+	var candidateSession uint32
+	if windows.ProcessIdToSessionId(pid, &candidateSession) != nil || candidateSession != session {
+		return false
+	}
+	process, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(process)
+	// Ask Windows for package identity; a lookalike executable name/path alone
+	// is not proof that the official app owns the global shortcut.
+	var family [128]uint16
+	familyLength := uint32(len(family))
+	status, _, _ := packageFamilyProc.Call(uintptr(process), uintptr(unsafe.Pointer(&familyLength)), uintptr(unsafe.Pointer(&family[0])))
+	if status != 0 {
+		return false
+	}
+	var image [32768]uint16
+	imageLength := uint32(len(image))
+	if windows.QueryFullProcessImageName(process, 0, &image[0], &imageLength) != nil {
+		return false
+	}
+	return isCodexDesktop(name, windows.UTF16ToString(image[:]), windows.UTF16ToString(family[:]))
+}
+
+func (windowsPlatform) desktopRunning() bool {
+	var session uint32
+	if windows.ProcessIdToSessionId(uint32(os.Getpid()), &session) != nil {
+		return false
+	}
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(snapshot)
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	for err = windows.Process32First(snapshot, &entry); err == nil; err = windows.Process32Next(snapshot, &entry) {
+		name := windows.UTF16ToString(entry.ExeFile[:])
+		if (strings.EqualFold(name, "ChatGPT.exe") || strings.EqualFold(name, "Codex.exe")) &&
+			processIsCodexDesktop(entry.ProcessID, name, session) {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeKeys(keys []keyEvent) []nativeInput {
+	inputs := make([]nativeInput, len(keys))
+	for i, key := range keys {
+		inputs[i].Kind = 1 // INPUT_KEYBOARD
+		keyboard := (*keyboardInput)(unsafe.Pointer(&inputs[i].Data))
+		keyboard.VirtualKey = key.key
+		if key.up {
+			keyboard.Flags = 2 // KEYEVENTF_KEYUP
+		}
+	}
+	return inputs
+}
+
+func (windowsPlatform) sendKeys(keys []keyEvent) int {
+	if len(keys) == 0 {
+		return 0
+	}
+	inputs := encodeKeys(keys)
+	// Windows enforces UIPI; a blocked call fails closed. No elevation or
+	// accessibility/security setting changes are attempted by this helper.
+	sent, _, _ := sendInputProc.Call(uintptr(len(inputs)), uintptr(unsafe.Pointer(&inputs[0])), unsafe.Sizeof(nativeInput{}))
+	runtime.KeepAlive(inputs)
+	return int(sent)
+}

--- a/server/internal/desktopdictation/dictation_windows_test.go
+++ b/server/internal/desktopdictation/dictation_windows_test.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package desktopdictation
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// These tests only encode memory and inspect fake identities; never enumerate
+// user processes or call SendInput during the default test suite.
+func TestWindowsInputLayout(t *testing.T) {
+	wantSize, wantOffset := uintptr(28), uintptr(4)
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		wantSize, wantOffset = 40, 8
+	}
+	if unsafe.Sizeof(nativeInput{}) != wantSize || unsafe.Offsetof(nativeInput{}.Data) != wantOffset {
+		t.Fatal("INPUT size/alignment does not match the Windows ABI")
+	}
+	inputs := encodeKeys([]keyEvent{{key: 0x11}, {key: 0x11, up: true}})
+	for i := range inputs {
+		keyboard := (*keyboardInput)(unsafe.Pointer(&inputs[i].Data))
+		if inputs[i].Kind != 1 || keyboard.VirtualKey != 0x11 || keyboard.Flags != uint32(i*2) ||
+			keyboard.Scan != 0 || keyboard.Time != 0 || keyboard.ExtraInfo != 0 {
+			t.Fatalf("unexpected keyboard encoding %#v / %#v", inputs[i], keyboard)
+		}
+	}
+}
+
+func TestOnlyVerifiedPackagedDesktopIsEligible(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, family string
+		want               bool
+	}{
+		{"ChatGPT.exe", `C:\Program Files\WindowsApps\OpenAI.Codex_version\app\ChatGPT.exe`, codexPackageFamily, true},
+		{"Codex.exe", `C:\Program Files\WindowsApps\OpenAI.Codex_version\app\Codex.exe`, codexPackageFamily, true},
+		{"ChatGPT.exe", `C:\fake\app\ChatGPT.exe`, "", false},
+		{"ChatGPT.exe", `C:\fake\app\ChatGPT.exe`, "OpenAI.Codex_otherpublisher", false},
+		{"codex.exe", `C:\Program Files\WindowsApps\OpenAI.Codex_version\app\resources\codex.exe`, codexPackageFamily, false},
+		{"Other.exe", `C:\Program Files\WindowsApps\OpenAI.Codex_version\app\Other.exe`, codexPackageFamily, false},
+	} {
+		if got := isCodexDesktop(tc.name, tc.path, tc.family); got != tc.want {
+			t.Errorf("identity %q / %q: got %v, want %v", tc.name, tc.family, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add an optional host-owned dictation adapter and a mic entry to Windows Desktop Chat, ticket comments/replies, manual ticket creation, and agent-assisted ticket creation. The adapter delegates a fixed, explicitly configured global dictation shortcut to the user's running Codex Desktop. Multica never records audio or calls a transcription API.

This standalone upstream port is separate from the Workspace Skill slash picker in #7730. No custom release feed, self-hosted URL, fork publisher, or disabled API-transcription draft is included.

## Behavior and safety

- Preserve the editor selection, mount lazy comment/reply editors before focusing, and never submit automatically. Web/mobile/macOS/Linux have no adapter or mic entry.
- Sandboxed preload captures a trusted mic click or completed Enter/Space activation. Its one-shot consumer is exposed only in a dedicated isolated world, expires after two seconds, clears on blur, and requires a focused editable target. Main admits only a focused, registered, trusted top-level renderer. IPC accepts no arguments.
- Main-world property overrides, synthetic clicks and direct IPC cannot mint activation. The DOM mic marker is UI routing, **not complete renderer-compromise containment**: a compromised renderer can still deceive a user with its content.
- Require one unconditional `globalDictationToggle` binding for `Ctrl+Alt+Shift+D` in a bounded `keybindings.json`. No credential, session or cookie reads. This third-party configuration contract is not proof that Codex registered the hotkey.
- Intercept exactly the fixed chord before renderer dispatch, including an AltGr `KeyD` event, so an unconsumed hotkey cannot type a stray character into the Multica draft. Other chords/platforms are unchanged.
- Use the bundled Multica CLI's private fixed-key helper. Validate foreground HWND, official Codex Windows package identity, interactive session and held modifier/submit keys. Fail closed on unavailable configuration, focus, identity, old helper or timeout; no API fallback or automatic toggle retry. Report failed partial-key cleanup with explicit release guidance.
- Success means **shortcut dispatch only**. Recording, microphone permission, text insertion, account eligibility and usage remain owned by Codex. This does not promise free/unlimited usage or provide an independent transcription API.

Setup, exact keybindings schema, compatibility limits and manual acceptance are documented in `apps/desktop/docs/native-dictation.md`. en/ja/ko/zh-Hans strings are included without replacing upstream locale keys.

## Review disposition

The first native Claude Opus/high review of `eb8024f` reported 0 P0, 0 P1, 2 P2 and 5 P3 findings. No API/credit fallback was used. Follow-up commit `351d3e70b` addresses those findings:

- [x] Replace the main-world gesture probe with isolated preload activation and make the actual guarantee explicit.
- [x] Prevent unconsumed fixed-chord draft edits.
- [x] Report failed partial-key cleanup without retrying the toggle.
- [x] Exercise two distinct registered windows for process-wide single flight.
- [x] Exercise real mic + lazy comment/reply + editor integration instead of stubbing the mic everywhere.
- [x] Document the exact third-party schema and distinguish Desktop compatibility from CLI version.
- [x] Register IPC before the first renderer is created.

This is deterministic disposition of the original review, **not a claim that the follow-up SHA received a second independent model approval**. Safe failing regressions were reproduced before the fixes.

## Validation

- Desktop IPC/preload/adapter: **47 tests passed**.
- Mic/editor and real lazy comment/reply integration: **58 tests passed**.
- Existing Chat/comment/reply/manual/agent-assisted composer regressions: **244 tests passed** (**349 total Vitest tests**).
- Windows helper and CLI early-dispatch tests passed using isolated test state. Linux amd64 helper test binary cross-compiles; it was not executed.
- Core/views/Desktop node+web typechecks, changed-file ESLint and staged diff check passed.
- `electron-vite build` passed; existing CSS highlight and mixed emoji import warnings remain.
- Opt-in `scripts/native-dictation-smoke.mjs` passed on Windows x64 / Electron 39.8.7: real Chromium trusted activation is one-shot; main-world overrides and synthetic clicks are rejected; the fixed chord is intercepted. It uses a hidden fixture with config/native calls forbidden, never OS SendInput or a microphone.
- GitHub checks on `351d3e70b1fd849ef7b13b9b72714f49d2a24f4b` passed (image-budget was skipped).

## Remaining manual acceptance / release boundary

The implementation is available for maintainer review; **Ready for review does not mean approved, merged, deployed, or audio-certified**.

- [ ] On an eligible signed-in Codex Desktop with microphone permission, verify actual recording, insertion into each composer, preserved draft/selection, and no automatic submission. Record the Desktop version and keyboard layout. Automated boundary tests do not establish this.

No new installer was deployed, no running agent was stopped, and no installed app/profile was changed while preparing these review fixes. There is no paid transcription fallback.
