### PR TITLE
MUL-6861: fix(daemon): serialize Codex session store writers

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6749,6 +6749,45 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ConnectedApps:                    task.ConnectedApps,
 	}
 
+	// A local_directory task gets a fresh CODEX_HOME but mounts the same
+	// per-conversation sessions store as the task it replaces. Codex scopes its
+	// own thread writer lock to CODEX_HOME, so those two processes otherwise use
+	// different locks while appending to the same rollout. Hold a store-scoped,
+	// cross-process lock for the complete task lifetime. Take it before the env
+	// root claim so shutdown releases that claim first; the next task can then
+	// safely reuse the prior environment after it acquires this lock.
+	if provider == "codex" {
+		if store := execenv.CodexSessionStorePath(d.cfg.Profile, taskCtx); store != "" {
+			// Mark before waiting so the session-store GC cannot remove the store
+			// between this task being queued behind its predecessor and mounting it.
+			d.markActiveStore(store)
+			defer d.unmarkActiveStore(store)
+
+			waitCtx, waitCancel := context.WithCancel(prepareCtx)
+			var cancelledByPoll <-chan struct{}
+			writerLock, lockErr := execenv.AcquireCodexSessionWriterLock(waitCtx, store, func() {
+				taskLog.Info("codex: waiting for prior task to release conversation session writer")
+				pollInterval := d.cancelPollInterval
+				if pollInterval == 0 {
+					pollInterval = 5 * time.Second
+				}
+				cancelledByPoll = d.watchTaskCancellation(waitCtx, task.ID, pollInterval, taskLog)
+				go func() {
+					select {
+					case <-cancelledByPoll:
+						waitCancel()
+					case <-waitCtx.Done():
+					}
+				}()
+			})
+			waitCancel()
+			if lockErr != nil {
+				return TaskResult{}, fmt.Errorf("acquire Codex conversation session writer: %w", lockErr)
+			}
+			defer writerLock.Release()
+		}
+	}
+
 	// Mark candidate env roots as active before any env work so the GC loop
 	// can't reclaim artifacts inside them mid-execution. We mark both the
 	// stable root for a fresh Prepare and the prior root for Reuse — they
@@ -6990,16 +7029,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	var reasonixEnv map[string]string
 	if provider == "reasonix" {
 		reasonixEnv = sanitizeAgentEnv(agentEnvOverrides)
-	}
-	// Guard this task's per-issue Codex session store from the GC for the whole
-	// task, starting before Prepare/Reuse mounts it — so a prune that samples the
-	// store's stale (pre-remount) mtime cannot reclaim it out from under a resume
-	// of a long-idle issue (MUL-4424). No-op for non-Codex tasks / no stable key.
-	if provider == "codex" {
-		if store := execenv.CodexSessionStorePath(d.cfg.Profile, taskCtx); store != "" {
-			d.markActiveStore(store)
-			defer d.unmarkActiveStore(store)
-		}
 	}
 	envReused := false
 	if priorClaim, priorWorkDir, lockedPriorInfo, ok := d.lockReusablePriorEnvRoot(task, localAssignment, envClaim.RootDir()); ok {

--- a/server/internal/daemon/execenv/codex_session_writer_lock.go
+++ b/server/internal/daemon/execenv/codex_session_writer_lock.go
@@ -1,0 +1,97 @@
+package execenv
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	codexSessionWriterLockRoot = "multica-session-writer-locks"
+	codexSessionWriterLockPoll = 25 * time.Millisecond
+)
+
+// CodexSessionWriterLock serializes writers to one persistent Codex session
+// store. Each local_directory task gets a fresh CODEX_HOME, so Codex's own
+// writer lock (which lives under CODEX_HOME/thread-writer-locks) cannot see a
+// sibling task that mounts the same persistent sessions directory. Without a
+// store-scoped lock, a replacement task can append to the same rollout while
+// the cancelled task is still unwinding and corrupt its ordinal sequence.
+type CodexSessionWriterLock struct {
+	file *os.File
+	once sync.Once
+}
+
+// AcquireCodexSessionWriterLock waits until no other Multica task is writing
+// store. The lock is cross-process and crash-safe: the OS releases it when the
+// daemon exits even if Release is not called.
+//
+// The lock file deliberately lives outside the session store. Store GC may
+// remove and recreate the store; putting the lock inside it would let a waiter
+// lock a new inode while the old writer still held the unlinked one. Lock files
+// are stable coordination objects and must not be deleted as stale markers.
+// onWait is called at most once, when another writer is first observed.
+func AcquireCodexSessionWriterLock(ctx context.Context, store string, onWait func()) (*CodexSessionWriterLock, error) {
+	if store == "" {
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	path := codexSessionWriterLockPath(store)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create Codex session writer lock directory: %w", err)
+	}
+	f, err := openLockFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("open Codex session writer lock %s: %w", path, err)
+	}
+
+	announced := false
+	ticker := time.NewTicker(codexSessionWriterLockPoll)
+	defer ticker.Stop()
+	for {
+		locked, lockErr := lockFileExclusiveNonBlocking(f)
+		if lockErr != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("lock Codex session store %s: %w", store, lockErr)
+		}
+		if locked {
+			return &CodexSessionWriterLock{file: f}, nil
+		}
+		if !announced {
+			announced = true
+			if onWait != nil {
+				onWait()
+			}
+		}
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, fmt.Errorf("wait for Codex session writer lock: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// Release drops the store writer lock. It is safe to call more than once.
+func (l *CodexSessionWriterLock) Release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		releaseLockFile(l.file)
+		l.file = nil
+	})
+}
+
+func codexSessionWriterLockPath(store string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(store)))
+	return filepath.Join(resolveSharedCodexHome(), codexSessionWriterLockRoot, hex.EncodeToString(sum[:])+".lock")
+}

--- a/server/internal/daemon/execenv/codex_session_writer_lock_test.go
+++ b/server/internal/daemon/execenv/codex_session_writer_lock_test.go
@@ -1,0 +1,109 @@
+package execenv
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCodexSessionWriterLockSerializesOneStore(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	store := filepath.Join(t.TempDir(), "sessions")
+
+	first, err := AcquireCodexSessionWriterLock(context.Background(), store, nil)
+	if err != nil {
+		t.Fatalf("acquire first lock: %v", err)
+	}
+	defer first.Release()
+
+	waiting := make(chan struct{})
+	acquired := make(chan *CodexSessionWriterLock, 1)
+	errs := make(chan error, 1)
+	go func() {
+		lock, err := AcquireCodexSessionWriterLock(context.Background(), store, func() { close(waiting) })
+		if err != nil {
+			errs <- err
+			return
+		}
+		acquired <- lock
+	}()
+
+	select {
+	case <-waiting:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second writer never reported waiting")
+	}
+	select {
+	case lock := <-acquired:
+		lock.Release()
+		t.Fatal("second writer acquired while the first still held the store")
+	case err := <-errs:
+		t.Fatalf("second writer failed while waiting: %v", err)
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	first.Release()
+	select {
+	case lock := <-acquired:
+		lock.Release()
+	case err := <-errs:
+		t.Fatalf("second writer failed after release: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second writer did not acquire after release")
+	}
+}
+
+func TestCodexSessionWriterLockCancellationStopsWait(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	store := filepath.Join(t.TempDir(), "sessions")
+
+	first, err := AcquireCodexSessionWriterLock(context.Background(), store, nil)
+	if err != nil {
+		t.Fatalf("acquire first lock: %v", err)
+	}
+	defer first.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waiting := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := AcquireCodexSessionWriterLock(ctx, store, func() { close(waiting) })
+		done <- err
+	}()
+
+	select {
+	case <-waiting:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second writer never reported waiting")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("wait error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled writer did not stop waiting")
+	}
+}
+
+func TestCodexSessionWriterLockDoesNotSerializeDifferentStores(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	root := t.TempDir()
+
+	first, err := AcquireCodexSessionWriterLock(context.Background(), filepath.Join(root, "one"), nil)
+	if err != nil {
+		t.Fatalf("acquire first store: %v", err)
+	}
+	defer first.Release()
+
+	second, err := AcquireCodexSessionWriterLock(context.Background(), filepath.Join(root, "two"), func() {
+		t.Fatal("different stores must not contend")
+	})
+	if err != nil {
+		t.Fatalf("acquire second store: %v", err)
+	}
+	second.Release()
+}


### PR DESCRIPTION
## Summary

- serialize Codex tasks that write the same persistent conversation session store
- use a cross-process, crash-safe OS file lock outside the GC-managed store
- keep replacement-task waits cancellable and release the env-root claim before handing the session writer to the next task

## Problem

`local_directory` tasks receive a fresh `CODEX_HOME` for every task ID while their `sessions/` directories point to the same persistent conversation store. Codex keeps its own thread writer locks under `CODEX_HOME/thread-writer-locks`, so two replacement tasks can hold different locks and append to the same rollout while the cancelled task is still unwinding.

In a reproduced failure, the shared rollout contained ordinal `301` twice. Codex then rejected the history projection with `expected ordinal 302, got 301`, leaving subsequent turns unhealthy.

## Fix

The daemon now acquires one writer lock keyed by the persistent Codex session store before environment preparation and holds it for the entire task. The lock file lives outside the session store so store GC cannot replace the locked inode. Waiting tasks poll server-side cancellation and stop cleanly when cancelled.

## Tests

- `go test ./internal/daemon/execenv -run "TestCodexSessionWriterLock" -count=1`
- `env -u MULTICA_TASK_CONFIG_ROOT -u MULTICA_DAEMON_PORT -u MULTICA_TOKEN go test ./internal/daemon/execenv -run "TestCodexSessionWriterLock|TestPrepareCodexLocalDirectoryChatKeepsRolloutAcrossTaskIDs|TestPruneCodexSessionStores" -count=1`
- `env -u MULTICA_TASK_CONFIG_ROOT -u MULTICA_DAEMON_PORT -u MULTICA_TOKEN go test ./internal/daemon -run "^$" -count=1`