### PR TITLE
fix(storage): honor context cancellation for local uploads

### DIFF
--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -153,7 +153,7 @@ func (s *LocalStorage) DeleteKeys(ctx context.Context, keys []string) {
 
 func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
 	dest := filepath.Join(s.uploadDir, key)
-	if err := writeAtomic(dest, bytes.NewReader(data)); err != nil {
+	if err := writeAtomic(ctx, dest, bytes.NewReader(data)); err != nil {
 		return "", err
 	}
 	// Best-effort sidecar so ServeFile can restore the original filename in
@@ -177,7 +177,7 @@ func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, cont
 
 func (s *LocalStorage) UploadStream(ctx context.Context, key string, data io.Reader, _ int64, contentType string, filename string) (string, error) {
 	dest := filepath.Join(s.uploadDir, key)
-	if err := writeAtomic(dest, data); err != nil {
+	if err := writeAtomic(ctx, dest, data); err != nil {
 		return "", err
 	}
 	if filename != "" {
@@ -200,8 +200,13 @@ func (s *LocalStorage) UploadStream(ctx context.Context, key string, data io.Rea
 // removed it outright) — an attachment row could then point at a file that no
 // longer exists. With rename-into-place a failed write only discards its own
 // temp file and the existing object survives untouched. Both upload paths go
-// through here so neither can reintroduce the destructive shape.
-func writeAtomic(dest string, src io.Reader) error {
+// through here so neither can reintroduce the destructive shape. Context
+// cancellation is checked before filesystem work, around each source read, and
+// before the staging file is renamed over the destination.
+func writeAtomic(ctx context.Context, dest string, src io.Reader) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("local storage stream copy: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return fmt.Errorf("local storage MkdirAll: %w", err)
 	}
@@ -212,20 +217,44 @@ func writeAtomic(dest string, src io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("local storage create temp: %w", err)
 	}
-	if _, err := io.Copy(f, src); err != nil {
+	_, copyErr := io.Copy(f, &contextReader{ctx: ctx, src: src})
+	if copyErr == nil {
+		copyErr = ctx.Err()
+	}
+	if copyErr != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
-		return fmt.Errorf("local storage stream copy: %w", err)
+		return fmt.Errorf("local storage stream copy: %w", copyErr)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("local storage Close: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("local storage stream copy: %w", err)
 	}
 	if err := os.Rename(tmp, dest); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("local storage Rename: %w", err)
 	}
 	return nil
+}
+
+type contextReader struct {
+	ctx context.Context
+	src io.Reader
+}
+
+func (r *contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := r.src.Read(p)
+	if ctxErr := r.ctx.Err(); ctxErr != nil {
+		return 0, ctxErr
+	}
+	return n, err
 }
 
 // tempPath is the staging file writeAtomic renames into place. It is derived
@@ -325,7 +354,7 @@ func readLocalMeta(filePath string) (localMeta, bool) {
 }
 
 func (s *LocalStorage) UploadFromReader(ctx context.Context, key string, reader io.Reader, contentType string, filename string) (string, error) {
-	data, err := io.ReadAll(reader)
+	data, err := io.ReadAll(&contextReader{ctx: ctx, src: reader})
 	if err != nil {
 		return "", fmt.Errorf("local storage ReadAll: %w", err)
 	}

--- a/server/internal/storage/local_atomic_test.go
+++ b/server/internal/storage/local_atomic_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type failingReader struct {
@@ -22,6 +23,193 @@ func (r *failingReader) Read(p []byte) (int, error) {
 		return n, nil
 	}
 	return 0, errors.New("injected stream failure")
+}
+
+type countingReader struct {
+	reads int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	r.reads++
+	return copy(p, "payload"), io.EOF
+}
+
+type blockingFirstReader struct {
+	started chan struct{}
+	release chan struct{}
+	reads   int
+}
+
+func (r *blockingFirstReader) Read(p []byte) (int, error) {
+	r.reads++
+	switch r.reads {
+	case 1:
+		close(r.started)
+		<-r.release
+		return copy(p, "new-first-"), nil
+	case 2:
+		return copy(p, "new-second"), nil
+	default:
+		return 0, io.EOF
+	}
+}
+
+func TestLocalStorageUploadsRejectCanceledContext(t *testing.T) {
+	tests := []struct {
+		name   string
+		upload func(*LocalStorage, context.Context, string, io.Reader) error
+	}{
+		{
+			name: "Upload",
+			upload: func(s *LocalStorage, ctx context.Context, key string, _ io.Reader) error {
+				_, err := s.Upload(ctx, key, []byte("payload"), "text/plain", "payload.txt")
+				return err
+			},
+		},
+		{
+			name: "UploadStream",
+			upload: func(s *LocalStorage, ctx context.Context, key string, reader io.Reader) error {
+				_, err := s.UploadStream(ctx, key, reader, 7, "text/plain", "payload.txt")
+				return err
+			},
+		},
+		{
+			name: "UploadFromReader",
+			upload: func(s *LocalStorage, ctx context.Context, key string, reader io.Reader) error {
+				_, err := s.UploadFromReader(ctx, key, reader, "text/plain", "payload.txt")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			s := &LocalStorage{uploadDir: dir}
+			key := "nested/cancelled.txt"
+			dest := filepath.Join(dir, key)
+			reader := &countingReader{}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := tt.upload(s, ctx, key, reader)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want errors.Is(context.Canceled)", err)
+			}
+			if reader.reads != 0 {
+				t.Fatalf("source reads = %d, want 0", reader.reads)
+			}
+			for _, path := range []string{dest, tempPath(dest), dest + metaSuffix} {
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Errorf("cancelled upload created %q (stat error = %v)", path, statErr)
+				}
+			}
+			if _, statErr := os.Stat(filepath.Dir(dest)); !os.IsNotExist(statErr) {
+				t.Errorf("cancelled upload started filesystem work (parent stat error = %v)", statErr)
+			}
+		})
+	}
+}
+
+func TestLocalStorageReaderUploadsStopOnContextCancellation(t *testing.T) {
+	methods := []struct {
+		name   string
+		upload func(*LocalStorage, context.Context, string, io.Reader) error
+	}{
+		{
+			name: "UploadStream",
+			upload: func(s *LocalStorage, ctx context.Context, key string, reader io.Reader) error {
+				_, err := s.UploadStream(ctx, key, reader, 21, "application/octet-stream", "payload.bin")
+				return err
+			},
+		},
+		{
+			name: "UploadFromReader",
+			upload: func(s *LocalStorage, ctx context.Context, key string, reader io.Reader) error {
+				_, err := s.UploadFromReader(ctx, key, reader, "application/octet-stream", "payload.bin")
+				return err
+			},
+		},
+	}
+
+	for _, method := range methods {
+		for _, deadline := range []bool{false, true} {
+			contextName := "canceled"
+			if deadline {
+				contextName = "deadline"
+			}
+			t.Run(method.name+"/"+contextName, func(t *testing.T) {
+				dir := t.TempDir()
+				s := &LocalStorage{uploadDir: dir}
+				key := "workspaces/ws/existing"
+				dest := filepath.Join(dir, key)
+				if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(dest, []byte("previous-object"), 0644); err != nil {
+					t.Fatal(err)
+				}
+
+				reader := &blockingFirstReader{
+					started: make(chan struct{}),
+					release: make(chan struct{}),
+				}
+				var ctx context.Context
+				var cancel context.CancelFunc
+				wantErr := context.Canceled
+				if deadline {
+					ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+					wantErr = context.DeadlineExceeded
+				} else {
+					ctx, cancel = context.WithCancel(context.Background())
+				}
+				defer cancel()
+
+				result := make(chan error, 1)
+				go func() {
+					result <- method.upload(s, ctx, key, reader)
+				}()
+				select {
+				case <-reader.started:
+				case <-time.After(5 * time.Second):
+					t.Fatal("upload did not start reading")
+				}
+				if deadline {
+					select {
+					case <-ctx.Done():
+					case <-time.After(5 * time.Second):
+						t.Fatal("context deadline did not expire")
+					}
+				} else {
+					cancel()
+				}
+				close(reader.release)
+
+				var uploadErr error
+				select {
+				case uploadErr = <-result:
+				case <-time.After(5 * time.Second):
+					t.Fatal("upload did not return after context cancellation")
+				}
+				if !errors.Is(uploadErr, wantErr) {
+					t.Errorf("error = %v, want errors.Is(%v)", uploadErr, wantErr)
+				}
+				if reader.reads != 1 {
+					t.Errorf("source reads = %d, want 1", reader.reads)
+				}
+				body, err := os.ReadFile(dest)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(body) != "previous-object" {
+					t.Errorf("destination = %q, want previous object intact", body)
+				}
+				if _, statErr := os.Stat(tempPath(dest)); !os.IsNotExist(statErr) {
+					t.Errorf("cancelled upload left staging file (stat error = %v)", statErr)
+				}
+			})
+		}
+	}
 }
 
 // A failed UploadStream must never destroy an object a previous successful


### PR DESCRIPTION
## Summary

- stop local buffered and streamed uploads when their context is cancelled or its deadline expires
- remove the staging file and preserve an existing destination when cancellation happens during a copy
- make `UploadFromReader` observe cancellation while reading its source

Fixes #7784

## Validation

- confirmed the new regression suite fails on the unmodified base: uploads returned `nil`, drained the source, and replaced the existing object after cancellation
- `go test ./internal/storage -run '^TestLocalStorage(UploadsRejectCanceledContext|ReaderUploadsStopOnContextCancellation)$' -count=1 -v`
- `go test ./internal/storage -count=1`
- `go test -race ./internal/storage -count=1`
- `go vet ./internal/storage`
- `go test ./internal/integrations/lark ./internal/integrations/wecom -count=1`
- `go test ./internal/integrations/lark ./internal/integrations/wecom ./internal/handler -run '^$' -count=1`

The tests ran on Linux x86_64 with Go 1.26.6. The database-backed full `make test` suite was not run in this isolated environment.