### PR TITLE
MUL-6864: KSL-72: enable native iPad support

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -31,7 +31,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     // iOS icon size from this single PNG.
     icon: "./assets/icon.png",
     ios: {
-      supportsTablet: false,
+      // Expo keeps the top-level portrait policy for iPhone while adding all
+      // iPad orientations required for multitasking when tablet support is on.
+      supportsTablet: true,
       // Pins DEVELOPMENT_TEAM on every prebuild. Leaving it unset is the normal
       // path — `expo run:ios` then resolves a signing identity from the Keychain
       // itself, which is right when the Apple ID owns exactly one team. With


### PR DESCRIPTION
## What does this PR do?

Enables native iPad builds for the mobile app by opting the iOS target into the iPad device family.

The top-level `orientation: "portrait"` setting remains unchanged, so iPhone behavior stays portrait-only. With tablet support enabled and iPad multitasking allowed, Expo generates all four iPad interface orientations; iPad can therefore rotate between portrait and landscape without broadening the iPhone support surface.

This is a config-only, latest-`main` alternative to #6329. It intentionally does not add an iPad-specific width constraint or navigation redesign, keeping the product/layout decision separate from enabling the native device family.

## Related Issue

- Related to #6328
- Alternative to #6329
- Workspace tracking: KSL-72

## Type of Change

- [ ] Bug fix (non-breaking change that fixes existing functionality)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `apps/mobile/app.config.ts`: enable `ios.supportsTablet` and document why iPhone remains portrait-only while iPad receives the multitasking orientation set.

## How to Test

1. Run `pnpm exec turbo typecheck lint test --filter=@multica/mobile`.
2. Run an iOS production prebuild and inspect the generated target: `TARGETED_DEVICE_FAMILY` should be `1,2`; `UISupportedInterfaceOrientations` should remain portrait-only; `UISupportedInterfaceOrientations~ipad` should contain portrait, upside-down portrait, landscape-left, and landscape-right.
3. Install the Release build on an iPad and confirm it launches natively and rotates in both portrait and landscape.

Validation completed:

- typecheck, lint, tests, and the iOS runner script passed on current `main`;
- 18 Vitest files / 113 tests passed;
- lint reported 0 errors and 7 pre-existing warnings outside this change;
- Expo prebuild generated `TARGETED_DEVICE_FAMILY = "1,2"`, portrait-only iPhone orientations, and all four iPad orientations;
- a universal Release build with the same iPad device-family/orientation output was signed, installed, launched, and observed running in landscape on a physical iPad mini (6th generation).

## Scope and Risk

- This enables native iPad presentation but does not claim a complete iPad-specific layout or split-view experience.
- Existing screens keep their current responsive behavior; any wider-screen layout refinements can be evaluated independently.
- iPhone orientation behavior is unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] Tests are not added because this is an Expo-to-native configuration contract; generated native output and a physical device were verified directly
- [ ] If this change affects the UI, I have included before/after screenshots — physical-device acceptance was completed; no screenshot is attached
- [x] The non-obvious orientation behavior is documented next to the configuration
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — not applicable
- [ ] If this PR touches Chinese product copy, I checked the terminology conventions — not applicable
- [x] I have considered and documented the risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex as a Multica coding agent

**Prompt / approach:** Reconstructed the device-build acceptance record, audited the current Expo config and generated iOS project, compared the existing upstream proposal, narrowed the change to the smallest latest-main alternative, reran the mobile verification suite, and verified the generated iPhone/iPad orientation split before opening this PR.

## Screenshots (optional)

Not attached. Acceptance was performed on a physical iPad and the generated native configuration is recorded above.
