### PR TITLE
MUL-6863: fix(agent/cursor): add --trust for headless daemon launch

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -964,13 +964,14 @@ var cursorBlockedArgs = map[string]blockedArgMode{
 	"-p":              blockedStandalone, // non-interactive print mode
 	"--output-format": blockedWithValue,  // stream-json protocol
 	"--yolo":          blockedStandalone, // auto-approval for autonomous operation
+	"--trust":         blockedStandalone, // headless workspace trust (no TTY prompt)
 }
 
 // buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
 //
 // Usage: cursor-agent -p --output-format stream-json
 //
-//	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
+//	--workspace <cwd> --yolo --trust [--model <m>] [--resume <id>]
 //
 // The prompt is deliberately NOT part of argv. cursor-agent's -p is a boolean
 // print-mode switch and the prompt is a positional argument; when no positional
@@ -991,6 +992,7 @@ func buildCursorArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
+		"--trust",
 	}
 	if opts.Cwd != "" {
 		args = append(args, "--workspace", opts.Cwd)

--- a/server/pkg/agent/cursor_invocation_test.go
+++ b/server/pkg/agent/cursor_invocation_test.go
@@ -18,7 +18,7 @@ func TestChooseCursorInvocation_PassthroughForNonLauncher(t *testing.T) {
 
 	execName := "cursor-agent"
 	lookedUp := filepath.Join(t.TempDir(), "cursor-agent") // no .cmd / .bat
-	args := []string{"-p", "hello\nworld", "--output-format", "stream-json", "--yolo"}
+	args := []string{"-p", "hello\nworld", "--output-format", "stream-json", "--yolo", "--trust"}
 
 	gotExec, gotArgs := chooseCursorInvocation(execName, lookedUp, args, logger)
 

--- a/server/pkg/agent/cursor_invocation_windows_test.go
+++ b/server/pkg/agent/cursor_invocation_windows_test.go
@@ -48,6 +48,7 @@ func TestPlatformCursorInvocation_RewritesCmdLauncherToPowerShellFile(t *testing
 		"-p", "line1\nline2\nline3",
 		"--output-format", "stream-json",
 		"--yolo",
+		"--trust",
 		"--workspace", `C:\some\workspace`,
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/server/pkg/agent/cursor_stdin_unix_test.go
+++ b/server/pkg/agent/cursor_stdin_unix_test.go
@@ -95,7 +95,7 @@ func TestCursorExecuteSendsPromptOnStdinNotArgv(t *testing.T) {
 
 	// The fixed, content-free flags must still be present.
 	joined := strings.Join(argv, " ")
-	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo"} {
+	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo", "--trust"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("expected %q in argv, got %v", want, argv)
 		}

--- a/server/pkg/agent/cursor_stdin_windows_test.go
+++ b/server/pkg/agent/cursor_stdin_windows_test.go
@@ -171,7 +171,7 @@ func assertPromptSurvivesShim(t *testing.T) {
 	}
 	// The content-free flags must still survive the same hop.
 	gotArgv := string(argvRaw)
-	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo"} {
+	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo", "--trust"} {
 		if !strings.Contains(gotArgv, want) {
 			t.Errorf("expected %q to reach the native child; argv was %q", want, gotArgv)
 		}

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -31,6 +31,7 @@ func TestBuildCursorArgs(t *testing.T) {
 		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
+		"--trust",
 		"--workspace", "/tmp/work",
 		"--model", "composer-1.5",
 	}
@@ -67,7 +68,7 @@ func TestBuildCursorArgsMinimal(t *testing.T) {
 	t.Parallel()
 
 	args := buildCursorArgs(ExecOptions{}, slog.Default())
-	expected := []string{"-p", "--output-format", "stream-json", "--yolo"}
+	expected := []string{"-p", "--output-format", "stream-json", "--yolo", "--trust"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
@@ -98,23 +99,28 @@ func TestBuildCursorArgsCustomArgs(t *testing.T) {
 	t.Parallel()
 
 	args := buildCursorArgs(ExecOptions{
-		CustomArgs: []string{"--extra", "val", "--yolo", "--output-format", "text"},
+		CustomArgs: []string{"--extra", "val", "--yolo", "--trust", "--output-format", "text"},
 	}, slog.Default())
 
-	// --extra val should be present; --yolo and --output-format should be filtered out
+	// --extra val should be present; --yolo, --trust, and --output-format should be filtered out
 	hasExtra := false
 	hasBlockedYolo := false
+	hasBlockedTrust := false
 	hasBlockedFormat := false
 	for i, a := range args {
 		if a == "--extra" && i+1 < len(args) && args[i+1] == "val" {
 			hasExtra = true
 		}
 	}
-	// Count occurrences of --yolo (should be exactly 1 — the hardcoded one)
+	// Count occurrences of --yolo / --trust (should be exactly 1 each — the hardcoded ones)
 	yoloCount := 0
+	trustCount := 0
 	for _, a := range args {
 		if a == "--yolo" {
 			yoloCount++
+		}
+		if a == "--trust" {
+			trustCount++
 		}
 		if a == "text" {
 			hasBlockedFormat = true
@@ -123,14 +129,23 @@ func TestBuildCursorArgsCustomArgs(t *testing.T) {
 	if yoloCount > 1 {
 		hasBlockedYolo = true
 	}
+	if trustCount > 1 {
+		hasBlockedTrust = true
+	}
 	if !hasExtra {
 		t.Fatalf("expected --extra val in args, got %v", args)
 	}
 	if hasBlockedYolo {
 		t.Fatalf("--yolo from custom args should be filtered, got %v", args)
 	}
+	if hasBlockedTrust {
+		t.Fatalf("--trust from custom args should be filtered, got %v", args)
+	}
 	if hasBlockedFormat {
 		t.Fatalf("--output-format from custom args should be filtered, got %v", args)
+	}
+	if trustCount != 1 {
+		t.Fatalf("expected exactly one --trust (hardcoded), got %d in %v", trustCount, args)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Headless Cursor Agent runs started by the Multica daemon hang or fail because `buildCursorArgs` never passes `--trust`. Without a TTY, `cursor-agent` can block on the workspace-trust prompt and never emit a terminal `result` event.

`--yolo` only covers tool auto-approval (`--force`); it does not skip workspace trust. This adds `--trust` next to `--yolo`, and blocks user `custom_args` from overriding it the same way as the other daemon-owned flags.

Fixes #7791

## Related Issue

Closes #7791

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/cursor.go`: append `--trust` in `buildCursorArgs`; add it to `cursorBlockedArgs` as `blockedStandalone`
- argv / stdin / invocation tests updated to expect `--trust` (unix + windows)

## How to Test

1. `cd server && go test ./pkg/agent -run 'TestBuildCursor' -count=1`
2. Optional smoke: `cursor-agent -p "reply with exactly: pong" --output-format stream-json --yolo --trust --workspace /tmp` should finish without a trust prompt

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes, or not applicable
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Thinking path: daemon launches cursor with no TTY → CLI help lists `--trust` separately from `--yolo`/`--force` → missing `--trust` matches the hang in #7791 → add the flag beside `--yolo` and keep it daemon-owned via `cursorBlockedArgs`. Interactive sessions are unaffected beyond skipping a prompt they would normally accept for automation.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Used the argv gap and CLI help notes from #7791, patched `buildCursorArgs` / `cursorBlockedArgs`, and updated the existing argv tests so `--trust` stays next to `--yolo`.

## Screenshots (optional)

N/A