### PR TITLE
DEV-6: Add outbound GitHub PR polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -501,6 +501,13 @@ GITHUB_WEBHOOK_SECRET=
 #   -----END RSA PRIVATE KEY-----"
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
+# Optional outbound PR polling for private/self-hosted Multica deployments that
+# cannot receive GitHub webhooks. Explicitly enable it; it reuses the GitHub App
+# credentials above and polls workspace/project GitHub repository resources.
+GITHUB_PR_POLLING_ENABLED=false
+GITHUB_PR_POLL_INTERVAL=5m
+# Go duration syntax; 720h is 30 days.
+GITHUB_PR_POLL_INITIAL_LOOKBACK=720h
 
 # Self-hosted Git provider integration (Settings → Integrations): Forgejo, Gitea,
 # and GitLab. This is a SELF-HOSTED-MULTICA-ONLY feature (not offered on the

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -109,16 +109,18 @@ services:
       MULTICA_CLOUD_URL: ${MULTICA_CLOUD_URL:-}
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
-      # App API credentials. The pull_request webhook is what mirrors a PR
-      # onto a card; these are what let the server authenticate as the App
-      # and pull the CI / mergeability snapshot that enriches it, plus
-      # Settings -> Repositories -> Choose from GitHub. Left unset,
-      # ghsnapshot.NewClientFromEnv returns a nil client and the enrichment
-      # degrades off silently - no error and no log line to notice.
+      # App API credentials. Webhooks mirror PRs by default; the optional
+      # outbound poller below uses the same credentials when inbound GitHub
+      # delivery is unavailable. They also power PR-card CI / mergeability and
+      # Settings -> Repositories -> Choose from GitHub. Left unset, App API
+      # features remain disabled.
       # GITHUB_APP_PRIVATE_KEY is a PEM block: double-quote it in .env so
       # its newlines survive into the container.
       GITHUB_APP_ID: ${GITHUB_APP_ID:-}
       GITHUB_APP_PRIVATE_KEY: ${GITHUB_APP_PRIVATE_KEY:-}
+      GITHUB_PR_POLLING_ENABLED: ${GITHUB_PR_POLLING_ENABLED:-false}
+      GITHUB_PR_POLL_INTERVAL: ${GITHUB_PR_POLL_INTERVAL:-5m}
+      GITHUB_PR_POLL_INITIAL_LOOKBACK: ${GITHUB_PR_POLL_INITIAL_LOOKBACK:-720h}
       # Public URL the API is reachable at from the open internet, no
       # trailing slash. Used to mint absolute webhook URLs for autopilot
       # webhook triggers. Leave unset behind a same-origin reverse proxy

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -204,6 +204,17 @@ func envDuration(name string, def time.Duration) time.Duration {
 	return v
 }
 
+func githubPRPollConfigFromEnv() (handler.GitHubPRPollConfig, bool) {
+	if !envBool("GITHUB_PR_POLLING_ENABLED", false) {
+		return handler.GitHubPRPollConfig{}, false
+	}
+	return handler.GitHubPRPollConfig{
+		Interval:        envDuration("GITHUB_PR_POLL_INTERVAL", 5*time.Minute),
+		InitialLookback: envDuration("GITHUB_PR_POLL_INITIAL_LOOKBACK", 30*24*time.Hour),
+		Overlap:         5 * time.Minute,
+	}, true
+}
+
 func envNonNegativeDuration(name string, def time.Duration) time.Duration {
 	raw := os.Getenv(name)
 	if raw == "" {
@@ -629,6 +640,11 @@ func main() {
 	// GitHub PR-card API snapshot pipeline (MUL-5265): worker pool + TTL sweeper.
 	// No-op when unconfigured (no App private key).
 	h.PRRefresh.Start(sweepCtx)
+	if pollConfig, enabled := githubPRPollConfigFromEnv(); enabled {
+		go h.RunGitHubPRPoller(sweepCtx, pollConfig)
+	} else {
+		slog.Info("github PR poller: disabled")
+	}
 
 	// Channel inbound supervisor (MUL-3620): holds the §4.4 WS lease per
 	// installation and drives each channel.Channel. It is channel-agnostic,

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -386,6 +386,28 @@ func TestEnvBool(t *testing.T) {
 	}
 }
 
+func TestGitHubPRPollConfigFromEnv(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv("GITHUB_PR_POLLING_ENABLED", "")
+		config, enabled := githubPRPollConfigFromEnv()
+		if enabled || config.Interval != 0 || config.InitialLookback != 0 || config.Overlap != 0 {
+			t.Fatalf("disabled config = %+v, enabled=%v", config, enabled)
+		}
+	})
+	t.Run("enabled with configured interval and lookback", func(t *testing.T) {
+		t.Setenv("GITHUB_PR_POLLING_ENABLED", "true")
+		t.Setenv("GITHUB_PR_POLL_INTERVAL", "2m")
+		t.Setenv("GITHUB_PR_POLL_INITIAL_LOOKBACK", "48h")
+		config, enabled := githubPRPollConfigFromEnv()
+		if !enabled {
+			t.Fatal("poller was not enabled")
+		}
+		if config.Interval != 2*time.Minute || config.InitialLookback != 48*time.Hour || config.Overlap != 5*time.Minute {
+			t.Fatalf("enabled config = %+v", config)
+		}
+	})
+}
+
 func TestEnvNonNegativeDuration(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1215,35 +1215,37 @@ func (h *Handler) handleInstallationEvent(ctx context.Context, body []byte) {
 	}
 }
 
+type ghPullRequest struct {
+	Number         int32  `json:"number"`
+	HTMLURL        string `json:"html_url"`
+	Title          string `json:"title"`
+	Body           string `json:"body"`
+	State          string `json:"state"`
+	Draft          bool   `json:"draft"`
+	Merged         bool   `json:"merged"`
+	MergedAt       string `json:"merged_at"`
+	ClosedAt       string `json:"closed_at"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+	MergeableState string `json:"mergeable_state"`
+	Additions      int32  `json:"additions"`
+	Deletions      int32  `json:"deletions"`
+	ChangedFiles   int32  `json:"changed_files"`
+	Head           struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	User struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"user"`
+}
+
 type ghPullRequestPayload struct {
-	Action      string `json:"action"`
-	PullRequest struct {
-		Number         int32  `json:"number"`
-		HTMLURL        string `json:"html_url"`
-		Title          string `json:"title"`
-		Body           string `json:"body"`
-		State          string `json:"state"`
-		Draft          bool   `json:"draft"`
-		Merged         bool   `json:"merged"`
-		MergedAt       string `json:"merged_at"`
-		ClosedAt       string `json:"closed_at"`
-		CreatedAt      string `json:"created_at"`
-		UpdatedAt      string `json:"updated_at"`
-		MergeableState string `json:"mergeable_state"`
-		Additions      int32  `json:"additions"`
-		Deletions      int32  `json:"deletions"`
-		ChangedFiles   int32  `json:"changed_files"`
-		Head           struct {
-			Ref string `json:"ref"`
-			SHA string `json:"sha"`
-		} `json:"head"`
-		User struct {
-			Login     string `json:"login"`
-			AvatarURL string `json:"avatar_url"`
-		} `json:"user"`
-	} `json:"pull_request"`
-	Changes    *ghPRChanges `json:"changes"`
-	Repository struct {
+	Action      string        `json:"action"`
+	PullRequest ghPullRequest `json:"pull_request"`
+	Changes     *ghPRChanges  `json:"changes"`
+	Repository  struct {
 		Name  string `json:"name"`
 		Owner struct {
 			Login string `json:"login"`
@@ -1273,29 +1275,33 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 		// can attribute to a workspace, so drop it silently.
 		return
 	}
-	// #4855 lets one GitHub App installation bind to several workspaces. A
-	// repo's events belong to every bound workspace, so fan the delivery out:
-	// each workspace independently mirrors the PR and auto-links it against its
-	// own issues (its own prefix + github toggle). Repo scope is whatever GitHub
-	// authorized the installation for; we deliberately don't gate on the
-	// workspace.repos registry — that list is "code the agent clones", not a
-	// webhook subscription (MUL-4343).
-	//
-	// Fanning out means an identifier can resolve in more than one workspace at
-	// once (issue prefixes are not globally unique and issue numbers restart at
-	// 1 per workspace, so two bound workspaces can both own a real "ABC-100").
-	// Settle who — if anyone — may act on a closing keyword BEFORE any workspace
-	// links, and treat that verdict as authoritative for the whole delivery, so
-	// the mirror pass cannot re-derive a different answer. See closeIntentPolicy.
-	closePolicy := h.resolveCloseIntentPolicy(ctx, insts, &p)
-	for _, inst := range insts {
-		h.mirrorPullRequestForWorkspace(ctx, inst.WorkspaceID, inst.InstallationID, &p, closePolicy)
+	if err := h.processGitHubPullRequest(ctx, &p, insts, insts); err != nil {
+		slog.Warn("github: process pull request failed", "err", err)
+	}
+}
+
+// processGitHubPullRequest is the shared webhook/poller ingestion path. Callers
+// provide the workspace bindings to mirror and every binding used to resolve
+// cross-workspace close-intent ambiguity; storage, linking, terminal status
+// changes, and refresh triggers remain identical.
+func (h *Handler) processGitHubPullRequest(
+	ctx context.Context,
+	p *ghPullRequestPayload,
+	mirrorBindings []db.GithubInstallation,
+	closePolicyBindings []db.GithubInstallation,
+) error {
+	closePolicy := h.resolveCloseIntentPolicy(ctx, closePolicyBindings, p)
+	var processErrs []error
+	for _, inst := range mirrorBindings {
+		if err := h.mirrorPullRequestForWorkspace(ctx, inst.WorkspaceID, inst.InstallationID, p, closePolicy); err != nil {
+			processErrs = append(processErrs, fmt.Errorf("workspace %s: %w", uuidToString(inst.WorkspaceID), err))
+		}
 	}
 	// The PR row(s) now carry the new head; ask the API pipeline for the
-	// authoritative CI + mergeability snapshot for that head. The webhook is
-	// only the doorbell — its own mergeable/checks payload is not used for
-	// display anymore (MUL-5265).
+	// authoritative CI + mergeability snapshot for that head. The delivery is
+	// only the doorbell — its own checks payload is not used for display.
 	h.PRRefresh.Enqueue(p.Installation.ID, p.Repository.Owner.Login, p.Repository.Name, p.PullRequest.Number)
+	return errors.Join(processErrs...)
 }
 
 // closeIntentPolicy decides which (closing identifier, workspace) pairs this
@@ -1519,19 +1525,18 @@ func (h *Handler) triggerPRRefreshFromCIEvent(ctx context.Context, body []byte) 
 	}
 }
 
-// mirrorPullRequestForWorkspace mirrors a pull_request webhook into a single
-// workspace: it upserts the PR row, replays any check_suite events that
-// arrived before the PR was mirrored, auto-links referenced issues (gated by
-// the workspace's github toggles), advances issues on terminal events, and
-// broadcasts the change. Invoked once per workspace bound to the delivering
-// installation.
+// mirrorPullRequestForWorkspace mirrors one GitHub PR into a single workspace:
+// it upserts the PR row, replays any check_suite events that arrived before the
+// PR was mirrored, auto-links referenced issues (gated by the workspace's
+// GitHub toggles), advances issues on terminal events, and broadcasts the
+// change. Invoked once per workspace binding selected by a webhook or poll.
 //
 // closePolicy is the delivery-wide verdict on which closing identifiers this
 // workspace may act on; identifiers it does not permit still link, but never
 // carry close_intent, so they can never advance an issue to done. This function
 // only ever narrows that verdict — it cannot grant close intent the policy
 // withheld.
-func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype.UUID, installationID int64, p *ghPullRequestPayload, closePolicy closeIntentPolicy) {
+func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype.UUID, installationID int64, p *ghPullRequestPayload, closePolicy closeIntentPolicy) error {
 	state := derivePRState(p.PullRequest.State, p.PullRequest.Draft, p.PullRequest.Merged)
 	mergeable, clearMergeable := derivePRMergeableState(p.Action, p.PullRequest.MergeableState, baseRefChanged(p.Changes))
 	pr, err := h.Queries.UpsertGitHubPullRequest(ctx, db.UpsertGitHubPullRequestParams{
@@ -1558,8 +1563,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		ChangedFiles:        p.PullRequest.ChangedFiles,
 	})
 	if err != nil {
-		slog.Warn("github: upsert pr failed", "err", err)
-		return
+		return fmt.Errorf("upsert pull request: %w", err)
 	}
 
 	workspaceID := uuidToString(wsID)
@@ -1576,7 +1580,16 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 	// flag (which itself short-circuits when the master `github_enabled`
 	// switch is off).
 	linkedIssueIDs := make([]string, 0)
-	if h.workspaceAutoLinkPRsEnabled(ctx, wsID) {
+	ws, err := h.Queries.GetWorkspace(ctx, wsID)
+	if err != nil {
+		return fmt.Errorf("load workspace: %w", err)
+	}
+	autoLink, settingsErr := autoLinkPRsEnabledForWorkspace(ws)
+	if settingsErr != nil {
+		slog.Warn("github: invalid workspace settings; using auto-link default",
+			"err", settingsErr, "workspace_id", workspaceID)
+	}
+	if autoLink {
 		idents := extractIdentifiers(p.PullRequest.Title, p.PullRequest.Body, p.PullRequest.Head.Ref)
 		// closingIdents is the subset of identifiers that this PR explicitly
 		// declared via a closing keyword ("Closes/Fixes/Resolves MUL-X").
@@ -1609,7 +1622,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		// a terminal event, later edit/synchronize webhooks must not rewrite
 		// the merge-time close decision.
 		preserveCloseIntent := p.Action != "closed" && (state == "merged" || state == "closed")
-		prefix := h.getIssuePrefix(ctx, wsID)
+		prefix := issuePrefixForWorkspace(ws)
 		// reevalIssues collects each issue whose link row we just touched so
 		// we can re-run the auto-advance gate against the persisted aggregate
 		// after every link upsert in this event. Driving the gate off
@@ -1621,7 +1634,10 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		// MUL-1 still advances.
 		reevalIssues := make([]db.Issue, 0, len(idents))
 		for _, id := range idents {
-			issue, ok := h.lookupIssueByIdentifier(ctx, wsID, prefix, id)
+			issue, ok, err := h.lookupIssueByIdentifierWithError(ctx, wsID, prefix, id)
+			if err != nil {
+				return fmt.Errorf("lookup issue %s: %w", id, err)
+			}
 			if !ok {
 				continue
 			}
@@ -1646,8 +1662,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 				LinkedByType:        strToText("system"),
 				LinkedByID:          pgtype.UUID{},
 			}); err != nil {
-				slog.Warn("github: link failed", "err", err)
-				continue
+				return fmt.Errorf("link issue %s: %w", id, err)
 			}
 			linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))
 			reevalIssues = append(reevalIssues, issue)
@@ -1678,11 +1693,12 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 				// an open GitHub PR blocks it on the VCS webhook path.
 				counts, err := h.Queries.GetIssueCombinedPullRequestCloseAggregate(ctx, issue.ID)
 				if err != nil {
-					slog.Warn("github: count linked pr states failed", "err", err, "issue_id", uuidToString(issue.ID))
-					continue
+					return fmt.Errorf("count linked pull requests for issue %s: %w", uuidToString(issue.ID), err)
 				}
 				if counts.OpenCount == 0 && counts.MergedWithCloseIntentCount > 0 {
-					h.advanceIssueToDone(ctx, issue, workspaceID)
+					if err := h.advanceIssueToDone(ctx, issue, workspaceID); err != nil {
+						return fmt.Errorf("advance issue %s: %w", uuidToString(issue.ID), err)
+					}
 				}
 			}
 		}
@@ -1694,6 +1710,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		"pull_request":     resp,
 		"linked_issue_ids": linkedIssueIDs,
 	})
+	return nil
 }
 
 // derivePRMergeableState resolves the upsert behaviour for the PR row's
@@ -1879,29 +1896,36 @@ func issueNumberForPrefix(identifier, prefix string) (int32, bool) {
 // "PREFIX-NUMBER" identifier. Returns the row + true if the prefix matches
 // the workspace's configured prefix and the number resolves to a real issue.
 func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtype.UUID, prefix, identifier string) (db.Issue, bool) {
+	issue, ok, _ := h.lookupIssueByIdentifierWithError(ctx, workspaceID, prefix, identifier)
+	return issue, ok
+}
+
+func (h *Handler) lookupIssueByIdentifierWithError(ctx context.Context, workspaceID pgtype.UUID, prefix, identifier string) (db.Issue, bool, error) {
 	number, ok := issueNumberForPrefix(identifier, prefix)
 	if !ok {
-		return db.Issue{}, false
+		return db.Issue{}, false, nil
 	}
 	issue, err := h.Queries.GetIssueByNumber(ctx, db.GetIssueByNumberParams{
 		WorkspaceID: workspaceID,
 		Number:      number,
 	})
-	if err != nil {
-		return db.Issue{}, false
+	if errors.Is(err, pgx.ErrNoRows) {
+		return db.Issue{}, false, nil
 	}
-	return issue, true
+	if err != nil {
+		return db.Issue{}, false, err
+	}
+	return issue, true, nil
 }
 
-func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, workspaceID string) {
+func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, workspaceID string) error {
 	updated, err := h.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 		ID:          issue.ID,
 		Status:      "done",
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil {
-		slog.Warn("github: advance issue to done failed", "err", err)
-		return
+		return err
 	}
 
 	// Fire the platform parent-notification path on the same transition the
@@ -1923,6 +1947,7 @@ func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, worksp
 		"creator_id":     uuidToString(issue.CreatorID),
 		"source":         "github_pr_merged",
 	})
+	return nil
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/server/internal/handler/github_poll.go
+++ b/server/internal/handler/github_poll.go
@@ -1,0 +1,275 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+const githubPRPollPageSize = 100
+
+// GitHubPRPollConfig controls the optional in-process outbound poller.
+type GitHubPRPollConfig struct {
+	Interval        time.Duration
+	InitialLookback time.Duration
+	Overlap         time.Duration
+}
+
+// RunGitHubPRPoller polls once immediately, then at the configured interval.
+// It is started only when GITHUB_PR_POLLING_ENABLED is explicitly true.
+func (h *Handler) RunGitHubPRPoller(ctx context.Context, cfg GitHubPRPollConfig) {
+	if cfg.Interval <= 0 || cfg.InitialLookback <= 0 || cfg.Overlap < 0 {
+		slog.Error("github PR poller: invalid configuration",
+			"interval", cfg.Interval, "initial_lookback", cfg.InitialLookback, "overlap", cfg.Overlap)
+		return
+	}
+	if h.githubAPIGet == nil {
+		slog.Error("github PR poller: enabled but GitHub App API credentials are unavailable")
+		return
+	}
+	slog.Info("github PR poller: starting",
+		"interval", cfg.Interval, "initial_lookback", cfg.InitialLookback, "overlap", cfg.Overlap)
+
+	run := func() {
+		if err := h.pollGitHubPullRequestsOnce(ctx, cfg); err != nil && ctx.Err() == nil {
+			slog.Error("github PR poller: poll failed; cursor unchanged for failed repositories", "err", err)
+		}
+	}
+	run()
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}
+
+type githubPRPollTarget struct {
+	workspaceID   pgtype.UUID
+	owner         string
+	repo          string
+	installations []int64
+}
+
+func (h *Handler) pollGitHubPullRequestsOnce(ctx context.Context, cfg GitHubPRPollConfig) error {
+	rows, err := h.Queries.ListGitHubPRPollingTargets(ctx)
+	if err != nil {
+		return fmt.Errorf("list polling targets: %w", err)
+	}
+	targets := make([]githubPRPollTarget, 0, len(rows))
+	byKey := make(map[string]int, len(rows))
+	for _, row := range rows {
+		owner, repo, ok := parseGitHubRepositoryURL(row.RepoUrl)
+		if !ok {
+			continue
+		}
+		key := uuidToString(row.WorkspaceID) + "/" + strings.ToLower(owner) + "/" + strings.ToLower(repo)
+		if i, exists := byKey[key]; exists {
+			targets[i].installations = appendUniqueInt64(targets[i].installations, row.InstallationID)
+			continue
+		}
+		byKey[key] = len(targets)
+		targets = append(targets, githubPRPollTarget{
+			workspaceID:   row.WorkspaceID,
+			owner:         owner,
+			repo:          repo,
+			installations: []int64{row.InstallationID},
+		})
+	}
+
+	var pollErrs []error
+	for _, target := range targets {
+		if err := h.pollGitHubRepository(ctx, cfg, target); err != nil {
+			pollErrs = append(pollErrs, fmt.Errorf("workspace %s repository %s/%s: %w",
+				uuidToString(target.workspaceID), target.owner, target.repo, err))
+		}
+	}
+	return errors.Join(pollErrs...)
+}
+
+func (h *Handler) pollGitHubRepository(ctx context.Context, cfg GitHubPRPollConfig, target githubPRPollTarget) error {
+	startedAt := time.Now().UTC()
+	cursorOwner := strings.ToLower(target.owner)
+	cursorRepo := strings.ToLower(target.repo)
+	cursor, err := h.Queries.GetGitHubPRPollCursor(ctx, db.GetGitHubPRPollCursorParams{
+		WorkspaceID: target.workspaceID,
+		RepoOwner:   cursorOwner,
+		RepoName:    cursorRepo,
+	})
+	cutoff := startedAt.Add(-cfg.InitialLookback)
+	if err == nil {
+		cutoff = cursor.Time.Add(-cfg.Overlap)
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("load cursor: %w", err)
+	}
+
+	var (
+		pullRequests   []ghPullRequestPayload
+		installationID int64
+		fetchErrs      []error
+	)
+	for _, candidate := range target.installations {
+		pullRequests, err = h.fetchUpdatedGitHubPullRequests(ctx, candidate, target.owner, target.repo, cutoff)
+		if err == nil {
+			installationID = candidate
+			break
+		}
+		fetchErrs = append(fetchErrs, fmt.Errorf("installation %d: %w", candidate, err))
+	}
+	if installationID == 0 {
+		return fmt.Errorf("fetch pull requests: %w", errors.Join(fetchErrs...))
+	}
+
+	closePolicyBindings, err := h.Queries.ListGitHubInstallationsByInstallationID(ctx, installationID)
+	if err != nil {
+		return fmt.Errorf("load installation bindings: %w", err)
+	}
+	if len(closePolicyBindings) == 0 {
+		return errors.New("selected GitHub installation has no workspace bindings")
+	}
+
+	binding := db.GithubInstallation{WorkspaceID: target.workspaceID, InstallationID: installationID}
+	for i := range pullRequests {
+		if err := h.processGitHubPullRequest(ctx, &pullRequests[i], []db.GithubInstallation{binding}, closePolicyBindings); err != nil {
+			return fmt.Errorf("process pull request #%d: %w", pullRequests[i].PullRequest.Number, err)
+		}
+	}
+	if err := h.Queries.UpsertGitHubPRPollCursor(ctx, db.UpsertGitHubPRPollCursorParams{
+		WorkspaceID:     target.workspaceID,
+		RepoOwner:       cursorOwner,
+		RepoName:        cursorRepo,
+		CursorUpdatedAt: pgtype.Timestamptz{Time: startedAt, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("save cursor: %w", err)
+	}
+	slog.Info("github PR poller: repository poll complete",
+		"workspace_id", uuidToString(target.workspaceID),
+		"repository", target.owner+"/"+target.repo,
+		"pull_requests", len(pullRequests))
+	return nil
+}
+
+func (h *Handler) fetchUpdatedGitHubPullRequests(ctx context.Context, installationID int64, owner, repo string, cutoff time.Time) ([]ghPullRequestPayload, error) {
+	pullRequests := make([]ghPullRequestPayload, 0)
+	for page := 1; ; page++ {
+		var listed []struct {
+			Number    int32  `json:"number"`
+			UpdatedAt string `json:"updated_at"`
+		}
+		listPath := fmt.Sprintf("/repos/%s/%s/pulls?state=all&sort=updated&direction=desc&per_page=%d&page=%d",
+			url.PathEscape(owner), url.PathEscape(repo), githubPRPollPageSize, page)
+		if err := h.githubAPIGet(ctx, installationID, listPath, &listed); err != nil {
+			return nil, fmt.Errorf("list page %d: %w", page, err)
+		}
+		stop := false
+		for _, item := range listed {
+			updatedAt, err := time.Parse(time.RFC3339, item.UpdatedAt)
+			if err != nil {
+				return nil, fmt.Errorf("pull request #%d has invalid updated_at", item.Number)
+			}
+			if updatedAt.Before(cutoff) {
+				stop = true
+				break
+			}
+			var pr ghPullRequest
+			detailPath := fmt.Sprintf("/repos/%s/%s/pulls/%d", url.PathEscape(owner), url.PathEscape(repo), item.Number)
+			if err := h.githubAPIGet(ctx, installationID, detailPath, &pr); err != nil {
+				return nil, fmt.Errorf("fetch pull request #%d: %w", item.Number, err)
+			}
+			if err := validatePolledGitHubPullRequest(pr, item.Number); err != nil {
+				return nil, err
+			}
+			pr.Merged = pr.Merged || pr.MergedAt != ""
+			payload := ghPullRequestPayload{Action: "poll", PullRequest: pr}
+			if pr.State == "closed" || pr.Merged {
+				payload.Action = "closed"
+			}
+			payload.Installation.ID = installationID
+			payload.Repository.Owner.Login = owner
+			payload.Repository.Name = repo
+			pullRequests = append(pullRequests, payload)
+		}
+		if stop || len(listed) < githubPRPollPageSize {
+			break
+		}
+	}
+
+	// Backfills must mirror every current open sibling before terminal PRs can
+	// evaluate the existing close-intent aggregate.
+	sort.SliceStable(pullRequests, func(i, j int) bool {
+		iTerminal := polledPRTerminal(pullRequests[i].PullRequest)
+		jTerminal := polledPRTerminal(pullRequests[j].PullRequest)
+		return !iTerminal && jTerminal
+	})
+	return pullRequests, nil
+}
+
+func validatePolledGitHubPullRequest(pr ghPullRequest, wantNumber int32) error {
+	if pr.Number != wantNumber || pr.Number == 0 {
+		return fmt.Errorf("github pull request number mismatch: got %d, want %d", pr.Number, wantNumber)
+	}
+	if pr.HTMLURL == "" || pr.Title == "" || pr.Head.SHA == "" {
+		return fmt.Errorf("github pull request #%d is missing required fields", pr.Number)
+	}
+	if _, err := time.Parse(time.RFC3339, pr.CreatedAt); err != nil {
+		return fmt.Errorf("github pull request #%d has invalid created_at", pr.Number)
+	}
+	if _, err := time.Parse(time.RFC3339, pr.UpdatedAt); err != nil {
+		return fmt.Errorf("github pull request #%d has invalid updated_at", pr.Number)
+	}
+	return nil
+}
+
+func polledPRTerminal(pr ghPullRequest) bool {
+	return pr.State == "closed" || pr.Merged || pr.MergedAt != ""
+}
+
+func appendUniqueInt64(values []int64, value int64) []int64 {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func parseGitHubRepositoryURL(raw string) (owner, repo string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "git@github.com:") {
+		return splitGitHubRepositoryPath(raw[len("git@github.com:"):])
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return "", "", false
+	}
+	return splitGitHubRepositoryPath(parsed.Path)
+}
+
+func splitGitHubRepositoryPath(path string) (owner, repo string, ok bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	owner = strings.TrimSpace(parts[0])
+	repo = strings.TrimSuffix(strings.TrimSpace(parts[1]), ".git")
+	if owner == "" || repo == "" || owner == "." || owner == ".." || repo == "." || repo == ".." {
+		return "", "", false
+	}
+	return owner, repo, true
+}

--- a/server/internal/handler/github_poll_test.go
+++ b/server/internal/handler/github_poll_test.go
@@ -1,0 +1,312 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/testutil"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestGitHubPRPollerBackfillSharesWebhookSemantics(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	const repoURL = "https://github.com/acme/widget"
+	workspaceID := dbfx.Insert(t, "workspace", testutil.Cols{
+		"name":         "GitHub PR polling backfill",
+		"slug":         fmt.Sprintf("github-pr-polling-%d", time.Now().UnixNano()),
+		"description":  "",
+		"issue_prefix": "DEV",
+		"repos":        `[{"url":"` + repoURL + `"}]`,
+	})
+	projectID := dbfx.Project(t, "GitHub PR polling backfill", testutil.Cols{"workspace_id": workspaceID})
+	dbfx.Insert(t, "project_resource", testutil.Cols{
+		"project_id": projectID, "workspace_id": workspaceID,
+		"resource_type": "github_repo", "resource_ref": `{"url":"` + repoURL + `"}`,
+		"position": 0,
+	})
+	installationID := time.Now().UnixNano()
+	dbfx.Insert(t, "github_installation", testutil.Cols{
+		"workspace_id": workspaceID, "installation_id": installationID,
+		"account_login": "acme", "account_type": "Organization",
+	})
+
+	mergedIssueID := dbfx.Issue(t, "DEV-6 equivalent", testutil.Cols{
+		"workspace_id": workspaceID, "number": 6, "status": "in_progress",
+	})
+	secondIssueID := dbfx.Issue(t, "DEV-9 equivalent", testutil.Cols{
+		"workspace_id": workspaceID, "number": 9, "status": "in_progress",
+	})
+	referenceIssueID := dbfx.Issue(t, "Reference-only equivalent", testutil.Cols{
+		"workspace_id": workspaceID, "number": 10, "status": "in_progress",
+	})
+	dbfx.Cleanup(t, `DELETE FROM activity_log WHERE issue_id = ANY($1::uuid[])`, []string{mergedIssueID, secondIssueID, referenceIssueID})
+	dbfx.Cleanup(t, `DELETE FROM issue_pull_request WHERE issue_id = ANY($1::uuid[])`, []string{mergedIssueID, secondIssueID, referenceIssueID})
+	dbfx.Cleanup(t, `DELETE FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'widget'`, workspaceID)
+	dbfx.Cleanup(t, `DELETE FROM github_pr_poll_cursor WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'widget'`, workspaceID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	prs := map[int32]ghPullRequest{
+		19: pollingTestPR(19, "OPE-734: Receipt保存失敗と商品売上集計エラーを修正", "Closes DEV-6", "dev-6-receipt-summary-fix", "closed", now.Add(-time.Minute), true),
+		20: pollingTestPR(20, "DEV-9: Receipt転送をdurable outboxで耐障害化する", "Closes DEV-9", "agent/dev-9-receipt-transfer-outbox", "closed", now.Add(-30*time.Second), true),
+		21: pollingTestPR(21, "Documentation", "Related DEV-10", "docs", "open", now.Add(-90*time.Second), false),
+	}
+	var listCalls atomic.Int32
+	h := *testHandler
+	h.githubAPIGet = func(_ context.Context, gotInstallation int64, path string, out any) error {
+		if gotInstallation != installationID {
+			return fmt.Errorf("installation = %d", gotInstallation)
+		}
+		switch {
+		case strings.HasPrefix(path, "/repos/acme/widget/pulls?"):
+			listCalls.Add(1)
+			return marshalPollingResponse(out, []map[string]any{
+				{"number": 20, "updated_at": prs[20].UpdatedAt},
+				{"number": 19, "updated_at": prs[19].UpdatedAt},
+				{"number": 21, "updated_at": prs[21].UpdatedAt},
+			})
+		case strings.HasPrefix(path, "/repos/acme/widget/pulls/"):
+			var number int32
+			if _, err := fmt.Sscanf(path, "/repos/acme/widget/pulls/%d", &number); err != nil {
+				return err
+			}
+			return marshalPollingResponse(out, prs[number])
+		default:
+			return fmt.Errorf("unexpected path %s", path)
+		}
+	}
+	cfg := GitHubPRPollConfig{Interval: time.Minute, InitialLookback: 30 * 24 * time.Hour, Overlap: 5 * time.Minute}
+	if err := h.pollGitHubPullRequestsOnce(ctx, cfg); err != nil {
+		t.Fatalf("initial poll: %v", err)
+	}
+	if err := h.pollGitHubPullRequestsOnce(ctx, cfg); err != nil {
+		t.Fatalf("overlap poll: %v", err)
+	}
+	if listCalls.Load() != 2 {
+		t.Fatalf("list calls = %d, want duplicate-resource target polled once per round", listCalls.Load())
+	}
+
+	mergedRows, err := h.Queries.ListPullRequestsByIssue(ctx, parseUUID(mergedIssueID))
+	if err != nil || len(mergedRows) != 1 || mergedRows[0].PrNumber != 19 {
+		t.Fatalf("merged issue PRs = %+v, err=%v", mergedRows, err)
+	}
+	secondRows, err := h.Queries.ListPullRequestsByIssue(ctx, parseUUID(secondIssueID))
+	if err != nil || len(secondRows) != 1 || secondRows[0].PrNumber != 20 {
+		t.Fatalf("DEV-9 issue PRs = %+v, err=%v", secondRows, err)
+	}
+	referenceRows, err := h.Queries.ListPullRequestsByIssue(ctx, parseUUID(referenceIssueID))
+	if err != nil || len(referenceRows) != 0 {
+		t.Fatalf("reference-only issue PRs = %+v, err=%v", referenceRows, err)
+	}
+	var referenceOnly bool
+	dbfx.QueryRow(t, `SELECT reference_only FROM issue_pull_request WHERE issue_id = $1`, referenceIssueID).Scan(&referenceOnly)
+	if !referenceOnly {
+		t.Fatal("bare body reference was not stored as reference_only")
+	}
+	mergedIssue, err := h.Queries.GetIssue(ctx, parseUUID(mergedIssueID))
+	if err != nil || mergedIssue.Status != "done" {
+		t.Fatalf("DEV-6 merged close-intent status = %q, err=%v", mergedIssue.Status, err)
+	}
+	secondIssue, err := h.Queries.GetIssue(ctx, parseUUID(secondIssueID))
+	if err != nil || secondIssue.Status != "done" {
+		t.Fatalf("DEV-9 merged close-intent status = %q, err=%v", secondIssue.Status, err)
+	}
+	if got := dbfx.Count(t, `SELECT count(*) FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'widget'`, workspaceID); got != 3 {
+		t.Fatalf("PR rows after repeated poll = %d, want 3", got)
+	}
+	if got := dbfx.Count(t, `SELECT count(*) FROM issue_pull_request WHERE issue_id = ANY($1::uuid[])`, []string{mergedIssueID, secondIssueID, referenceIssueID}); got != 3 {
+		t.Fatalf("link rows after repeated poll = %d, want 3", got)
+	}
+}
+
+func TestGitHubPRPollerPreservesCrossWorkspaceCloseIntentPolicy(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	installationID := time.Now().UnixNano()
+	workspaceIDs := make([]string, 2)
+	issueIDs := make([]string, 2)
+	for i := range workspaceIDs {
+		workspaceIDs[i] = dbfx.Insert(t, "workspace", testutil.Cols{
+			"name":         fmt.Sprintf("Polling close policy %d", i),
+			"slug":         fmt.Sprintf("polling-close-policy-%d-%d", i, installationID),
+			"description":  "",
+			"issue_prefix": "DEV",
+		})
+		dbfx.Insert(t, "github_installation", testutil.Cols{
+			"workspace_id": workspaceIDs[i], "installation_id": installationID,
+			"account_login": "acme", "account_type": "Organization",
+		})
+		issueIDs[i] = dbfx.Issue(t, "Ambiguous DEV-6", testutil.Cols{
+			"workspace_id": workspaceIDs[i], "number": 6, "status": "in_progress",
+		})
+	}
+	dbfx.Cleanup(t, `DELETE FROM activity_log WHERE issue_id = ANY($1::uuid[])`, issueIDs)
+	dbfx.Cleanup(t, `DELETE FROM issue_pull_request WHERE issue_id = ANY($1::uuid[])`, issueIDs)
+	dbfx.Cleanup(t, `DELETE FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'widget'`, workspaceIDs[0])
+	dbfx.Cleanup(t, `DELETE FROM github_pr_poll_cursor WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'widget'`, workspaceIDs[0])
+
+	pr := pollingTestPR(19, "Receipt save fix", "Closes DEV-6", "dev-6-receipt-summary-fix", "closed", time.Now().UTC(), true)
+	h := *testHandler
+	h.githubAPIGet = func(_ context.Context, _ int64, path string, out any) error {
+		if strings.HasPrefix(path, "/repos/acme/widget/pulls?") {
+			return marshalPollingResponse(out, []map[string]any{{"number": 19, "updated_at": pr.UpdatedAt}})
+		}
+		if path == "/repos/acme/widget/pulls/19" {
+			return marshalPollingResponse(out, pr)
+		}
+		return fmt.Errorf("unexpected path %s", path)
+	}
+	target := githubPRPollTarget{
+		workspaceID: parseUUID(workspaceIDs[0]), owner: "acme", repo: "widget",
+		installations: []int64{installationID},
+	}
+	if err := h.pollGitHubRepository(ctx, GitHubPRPollConfig{
+		Interval: time.Minute, InitialLookback: 30 * 24 * time.Hour, Overlap: 5 * time.Minute,
+	}, target); err != nil {
+		t.Fatal(err)
+	}
+	firstIssue, err := h.Queries.GetIssue(ctx, parseUUID(issueIDs[0]))
+	if err != nil || firstIssue.Status != "in_progress" {
+		t.Fatalf("ambiguous close-intent issue status = %q, err=%v", firstIssue.Status, err)
+	}
+	var closeIntent bool
+	dbfx.QueryRow(t, `SELECT close_intent FROM issue_pull_request WHERE issue_id = $1`, issueIDs[0]).Scan(&closeIntent)
+	if closeIntent {
+		t.Fatal("poller granted close intent ambiguous across installation bindings")
+	}
+	if got := dbfx.Count(t, `SELECT count(*) FROM issue_pull_request WHERE issue_id = $1`, issueIDs[1]); got != 0 {
+		t.Fatalf("poller mirrored PR into unselected workspace: links=%d", got)
+	}
+}
+
+func TestGitHubPRPollerFailurePreservesCursorThenRetriesOverlap(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	installationID := time.Now().UnixNano()
+	dbfx.Insert(t, "github_installation", testutil.Cols{
+		"workspace_id": testWorkspaceID, "installation_id": installationID,
+		"account_login": "acme", "account_type": "Organization",
+	})
+	dbfx.Cleanup(t, `DELETE FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'retry'`, testWorkspaceID)
+	dbfx.Cleanup(t, `DELETE FROM github_pr_poll_cursor WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'retry'`, testWorkspaceID)
+
+	oldCursor := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
+	if err := testHandler.Queries.UpsertGitHubPRPollCursor(ctx, db.UpsertGitHubPRPollCursorParams{
+		WorkspaceID: parseUUID(testWorkspaceID), RepoOwner: "acme", RepoName: "retry",
+		CursorUpdatedAt: pgtype.Timestamptz{Time: oldCursor, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	insideOverlap := pollingTestPR(30, "Incremental PR", "", "incremental", "open", oldCursor.Add(-4*time.Minute), false)
+	outsideOverlap := pollingTestPR(31, "Old PR", "", "old", "open", oldCursor.Add(-6*time.Minute), false)
+	insideOverlap.HTMLURL = "https://github.com/acme/retry/pull/30"
+	outsideOverlap.HTMLURL = "https://github.com/acme/retry/pull/31"
+	var fail atomic.Bool
+	fail.Store(true)
+	var detailCalls atomic.Int32
+	h := *testHandler
+	h.githubAPIGet = func(_ context.Context, _ int64, path string, out any) error {
+		switch {
+		case strings.HasPrefix(path, "/repos/acme/retry/pulls?"):
+			if fail.Load() {
+				return errors.New("temporary GitHub API failure")
+			}
+			return marshalPollingResponse(out, []map[string]any{
+				{"number": 30, "updated_at": insideOverlap.UpdatedAt},
+				{"number": 31, "updated_at": outsideOverlap.UpdatedAt},
+			})
+		case path == "/repos/acme/retry/pulls/30":
+			detailCalls.Add(1)
+			return marshalPollingResponse(out, insideOverlap)
+		case path == "/repos/acme/retry/pulls/31":
+			return errors.New("poller fetched beyond overlap cutoff")
+		default:
+			return fmt.Errorf("unexpected path %s", path)
+		}
+	}
+	target := githubPRPollTarget{
+		workspaceID: parseUUID(testWorkspaceID), owner: "acme", repo: "retry",
+		installations: []int64{installationID},
+	}
+	cfg := GitHubPRPollConfig{Interval: time.Minute, InitialLookback: 30 * 24 * time.Hour, Overlap: 5 * time.Minute}
+	if err := h.pollGitHubRepository(ctx, cfg, target); err == nil {
+		t.Fatal("API failure unexpectedly succeeded")
+	}
+	cursor, err := h.Queries.GetGitHubPRPollCursor(ctx, db.GetGitHubPRPollCursorParams{
+		WorkspaceID: target.workspaceID, RepoOwner: "acme", RepoName: "retry",
+	})
+	if err != nil || !cursor.Time.Equal(oldCursor) {
+		t.Fatalf("cursor after failure = %s, err=%v; want %s", cursor.Time, err, oldCursor)
+	}
+
+	fail.Store(false)
+	if err := h.pollGitHubRepository(ctx, cfg, target); err != nil {
+		t.Fatalf("retry poll: %v", err)
+	}
+	if detailCalls.Load() != 1 {
+		t.Fatalf("detail calls = %d, want only the PR inside overlap", detailCalls.Load())
+	}
+	cursor, err = h.Queries.GetGitHubPRPollCursor(ctx, db.GetGitHubPRPollCursorParams{
+		WorkspaceID: target.workspaceID, RepoOwner: "acme", RepoName: "retry",
+	})
+	if err != nil || !cursor.Time.After(oldCursor) {
+		t.Fatalf("cursor after successful retry = %s, err=%v; want after %s", cursor.Time, err, oldCursor)
+	}
+	if got := dbfx.Count(t, `SELECT count(*) FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = 'acme' AND repo_name = 'retry'`, testWorkspaceID); got != 1 {
+		t.Fatalf("incremental PR rows = %d, want 1", got)
+	}
+}
+
+func TestParseGitHubRepositoryURL(t *testing.T) {
+	for _, raw := range []string{
+		"https://github.com/multica-ai/multica",
+		"ssh://git@github.com/multica-ai/multica.git",
+		"git@github.com:multica-ai/multica.git",
+	} {
+		owner, repo, ok := parseGitHubRepositoryURL(raw)
+		if !ok || owner != "multica-ai" || repo != "multica" {
+			t.Fatalf("parse %q = %q/%q, %v", raw, owner, repo, ok)
+		}
+	}
+	if _, _, ok := parseGitHubRepositoryURL("https://gitlab.com/multica-ai/multica"); ok {
+		t.Fatal("non-GitHub repository was accepted")
+	}
+}
+
+func pollingTestPR(number int32, title, body, branch, state string, updatedAt time.Time, merged bool) ghPullRequest {
+	pr := ghPullRequest{
+		Number: number, HTMLURL: fmt.Sprintf("https://github.com/acme/widget/pull/%d", number),
+		Title: title, Body: body, State: state, Merged: merged,
+		CreatedAt: updatedAt.Add(-time.Hour).Format(time.RFC3339), UpdatedAt: updatedAt.Format(time.RFC3339),
+		Additions: 3, Deletions: 1, ChangedFiles: 1,
+	}
+	pr.Head.Ref = branch
+	pr.Head.SHA = fmt.Sprintf("head-%d", number)
+	pr.User.Login = "octocat"
+	if merged {
+		pr.MergedAt = updatedAt.Format(time.RFC3339)
+		pr.ClosedAt = updatedAt.Format(time.RFC3339)
+	}
+	return pr
+}
+
+func marshalPollingResponse(out, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, out)
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -381,7 +381,10 @@ type Handler struct {
 	// so the feature degrades cleanly on deployments without a private key.
 	// Wired in cmd/server/router.go after New.
 	PRRefresh *ghsnapshot.Manager
-	cfg       Config
+	// githubAPIGet is bound to the same installation-token client as PRRefresh.
+	// Kept as the concrete Get method so tests can supply a deterministic API.
+	githubAPIGet func(context.Context, int64, string, any) error
+	cfg          Config
 }
 
 func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *events.Bus, emailService *service.EmailService, store storage.Storage, cfSigner *auth.CloudFrontSigner, analyticsClient analytics.Client, cfg Config, daemonHubs ...*daemonws.Hub) *Handler {
@@ -488,6 +491,9 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		slog.Warn("github: PR snapshot pipeline disabled (invalid App private key)", "err", err)
 	}
 	h.PRRefresh = ghsnapshot.NewManager(ghClient, queries, txStarter, h.broadcastPRSnapshotApplied)
+	if ghClient != nil {
+		h.githubAPIGet = ghClient.Get
+	}
 
 	return h
 }

--- a/server/internal/handler/workspace_delete_manifest_test.go
+++ b/server/internal/handler/workspace_delete_manifest_test.go
@@ -64,6 +64,7 @@ var workspaceDeletionManifest = map[string]workspaceDeleteAction{
 	"github_installation":                workspaceDelete,
 	"github_pending_check_suite":         workspaceDelete,
 	"github_pending_installation":        workspaceDeleteKeep,
+	"github_pr_poll_cursor":              workspaceDelete,
 	"github_pull_request":                workspaceDelete,
 	"github_pull_request_check_run":      workspaceDelete,
 	"github_pull_request_check_suite":    workspaceDelete,

--- a/server/internal/integrations/ghsnapshot/client.go
+++ b/server/internal/integrations/ghsnapshot/client.go
@@ -209,6 +209,45 @@ func (c *Client) mintInstallationToken(ctx context.Context, installationID int64
 	return parsed.Token, nil
 }
 
+// Get decodes one installation-authenticated GitHub REST response. apiPath
+// must be a path on api.github.com; rejecting absolute/network paths prevents
+// an installation token from being forwarded to another host.
+func (c *Client) Get(ctx context.Context, installationID int64, apiPath string, out any) error {
+	if !c.Enabled() {
+		return errors.New("github App API is not configured")
+	}
+	if !strings.HasPrefix(apiPath, "/") || strings.HasPrefix(apiPath, "//") {
+		return errors.New("github REST path must be absolute")
+	}
+	token, err := c.installationToken(ctx, installationID)
+	if err != nil {
+		return err
+	}
+	endpoint := strings.TrimRight(c.apiBase, "/") + apiPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		return rateLimitFromResponse(resp, c.now())
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("github REST GET %s: unexpected status %d", apiPath, resp.StatusCode)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(out); err != nil {
+		return fmt.Errorf("github REST GET %s: malformed response: %w", apiPath, err)
+	}
+	return nil
+}
+
 // graphQL runs a single GraphQL query as the given installation and returns the
 // raw `data` object. GitHub returns HTTP 200 even for query-level errors, so we
 // inspect the `errors` array too, mapping a RATE_LIMITED error type to a

--- a/server/internal/integrations/ghsnapshot/client_test.go
+++ b/server/internal/integrations/ghsnapshot/client_test.go
@@ -203,3 +203,45 @@ func TestNewClientFromEnv(t *testing.T) {
 		}
 	})
 }
+
+func TestGetUsesInstallationTokenAndDecodes(t *testing.T) {
+	var mints int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			atomic.AddInt32(&mints, 1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"ghs_poll","expires_at":"` +
+				time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"}`))
+		case r.URL.Path == "/repos/acme/widget/pulls":
+			if got := r.Header.Get("Authorization"); got != "Bearer ghs_poll" {
+				t.Errorf("Authorization = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"name":"widget"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	var got struct {
+		Name string `json:"name"`
+	}
+	if err := c.Get(context.Background(), 42, "/repos/acme/widget/pulls", &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "widget" {
+		t.Fatalf("decoded name = %q", got.Name)
+	}
+	if atomic.LoadInt32(&mints) != 1 {
+		t.Fatalf("token mints = %d, want 1", mints)
+	}
+}
+
+func TestGetRejectsAbsolutePath(t *testing.T) {
+	c := newTestClient(t, "https://api.github.com")
+	if err := c.Get(context.Background(), 42, "https://example.com/token", &struct{}{}); err == nil {
+		t.Fatal("absolute API path was accepted")
+	}
+}

--- a/server/migrations/441_github_pr_poll_cursor.down.sql
+++ b/server/migrations/441_github_pr_poll_cursor.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS github_pr_poll_cursor;

--- a/server/migrations/441_github_pr_poll_cursor.up.sql
+++ b/server/migrations/441_github_pr_poll_cursor.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE github_pr_poll_cursor (
+    workspace_id UUID NOT NULL,
+    repo_owner TEXT NOT NULL,
+    repo_name TEXT NOT NULL,
+    cursor_updated_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (workspace_id, repo_owner, repo_name)
+);

--- a/server/pkg/db/generated/github.sql.go
+++ b/server/pkg/db/generated/github.sql.go
@@ -137,6 +137,25 @@ func (q *Queries) GetGitHubInstallationByID(ctx context.Context, id pgtype.UUID)
 	return i, err
 }
 
+const getGitHubPRPollCursor = `-- name: GetGitHubPRPollCursor :one
+SELECT cursor_updated_at
+FROM github_pr_poll_cursor
+WHERE workspace_id = $1 AND repo_owner = $2 AND repo_name = $3
+`
+
+type GetGitHubPRPollCursorParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	RepoOwner   string      `json:"repo_owner"`
+	RepoName    string      `json:"repo_name"`
+}
+
+func (q *Queries) GetGitHubPRPollCursor(ctx context.Context, arg GetGitHubPRPollCursorParams) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getGitHubPRPollCursor, arg.WorkspaceID, arg.RepoOwner, arg.RepoName)
+	var cursor_updated_at pgtype.Timestamptz
+	err := row.Scan(&cursor_updated_at)
+	return cursor_updated_at, err
+}
+
 const getGitHubPullRequest = `-- name: GetGitHubPullRequest :one
 SELECT id, workspace_id, installation_id, repo_owner, repo_name, pr_number, title, state, html_url, branch, author_login, author_avatar_url, merged_at, closed_at, pr_created_at, pr_updated_at, created_at, updated_at, head_sha, mergeable_state, additions, deletions, changed_files, api_mergeable, api_merge_state_status, checks_rollup_state, snapshot_head_sha, snapshot_fetched_at FROM github_pull_request
 WHERE workspace_id = $1 AND repo_owner = $2 AND repo_name = $3 AND pr_number = $4
@@ -417,6 +436,55 @@ func (q *Queries) ListGitHubInstallationsByWorkspace(ctx context.Context, worksp
 	return items, nil
 }
 
+const listGitHubPRPollingTargets = `-- name: ListGitHubPRPollingTargets :many
+
+WITH repository_urls AS (
+    SELECT workspace_id, btrim(resource_ref->>'url') AS repo_url
+    FROM project_resource
+    WHERE resource_type = 'github_repo'
+    UNION
+    SELECT w.id AS workspace_id, btrim(repo->>'url') AS repo_url
+    FROM workspace w
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(w.repos) = 'array' THEN w.repos ELSE '[]'::jsonb END
+    ) AS repo
+)
+SELECT DISTINCT r.workspace_id, i.installation_id, r.repo_url
+FROM repository_urls r
+JOIN github_installation i ON i.workspace_id = r.workspace_id
+WHERE r.repo_url IS NOT NULL AND r.repo_url <> ''
+ORDER BY r.workspace_id, r.repo_url, i.installation_id
+`
+
+type ListGitHubPRPollingTargetsRow struct {
+	WorkspaceID    pgtype.UUID `json:"workspace_id"`
+	InstallationID int64       `json:"installation_id"`
+	RepoUrl        string      `json:"repo_url"`
+}
+
+// =====================
+// GitHub Pull Request Polling
+// =====================
+func (q *Queries) ListGitHubPRPollingTargets(ctx context.Context) ([]ListGitHubPRPollingTargetsRow, error) {
+	rows, err := q.db.Query(ctx, listGitHubPRPollingTargets)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListGitHubPRPollingTargetsRow{}
+	for rows.Next() {
+		var i ListGitHubPRPollingTargetsRow
+		if err := rows.Scan(&i.WorkspaceID, &i.InstallationID, &i.RepoUrl); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listIssueIDsForPullRequest = `-- name: ListIssueIDsForPullRequest :many
 SELECT issue_id FROM issue_pull_request
 WHERE pull_request_id = $1
@@ -660,6 +728,37 @@ func (q *Queries) UpdateGitHubInstallationAccountByInstallationID(ctx context.Co
 		return nil, err
 	}
 	return items, nil
+}
+
+const upsertGitHubPRPollCursor = `-- name: UpsertGitHubPRPollCursor :exec
+INSERT INTO github_pr_poll_cursor (
+    workspace_id, repo_owner, repo_name, cursor_updated_at
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT (workspace_id, repo_owner, repo_name) DO UPDATE SET
+    cursor_updated_at = GREATEST(
+        github_pr_poll_cursor.cursor_updated_at,
+        EXCLUDED.cursor_updated_at
+    ),
+    updated_at = now()
+`
+
+type UpsertGitHubPRPollCursorParams struct {
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	RepoOwner       string             `json:"repo_owner"`
+	RepoName        string             `json:"repo_name"`
+	CursorUpdatedAt pgtype.Timestamptz `json:"cursor_updated_at"`
+}
+
+func (q *Queries) UpsertGitHubPRPollCursor(ctx context.Context, arg UpsertGitHubPRPollCursorParams) error {
+	_, err := q.db.Exec(ctx, upsertGitHubPRPollCursor,
+		arg.WorkspaceID,
+		arg.RepoOwner,
+		arg.RepoName,
+		arg.CursorUpdatedAt,
+	)
+	return err
 }
 
 const upsertGitHubPullRequest = `-- name: UpsertGitHubPullRequest :one

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -677,6 +677,15 @@ type GithubPendingInstallation struct {
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 }
 
+type GithubPrPollCursor struct {
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	RepoOwner       string             `json:"repo_owner"`
+	RepoName        string             `json:"repo_name"`
+	CursorUpdatedAt pgtype.Timestamptz `json:"cursor_updated_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+}
+
 type GithubPullRequest struct {
 	ID                  pgtype.UUID        `json:"id"`
 	WorkspaceID         pgtype.UUID        `json:"workspace_id"`

--- a/server/pkg/db/generated/workspace_delete.sql.go
+++ b/server/pkg/db/generated/workspace_delete.sql.go
@@ -214,7 +214,11 @@ func (q *Queries) DeleteWorkspaceCommunicationRoots(ctx context.Context, workspa
 }
 
 const deleteWorkspaceConnections = `-- name: DeleteWorkspaceConnections :exec
-WITH deleted_github_installations AS (
+WITH deleted_github_pr_poll_cursors AS (
+    DELETE FROM github_pr_poll_cursor
+    WHERE github_pr_poll_cursor.workspace_id = $1
+),
+deleted_github_installations AS (
     DELETE FROM github_installation
     WHERE github_installation.workspace_id = $1
 )

--- a/server/pkg/db/queries/github.sql
+++ b/server/pkg/db/queries/github.sql
@@ -76,6 +76,46 @@ SELECT * FROM github_pending_installation WHERE installation_id = $1
 ;
 
 -- =====================
+-- GitHub Pull Request Polling
+-- =====================
+
+-- name: ListGitHubPRPollingTargets :many
+WITH repository_urls AS (
+    SELECT workspace_id, btrim(resource_ref->>'url') AS repo_url
+    FROM project_resource
+    WHERE resource_type = 'github_repo'
+    UNION
+    SELECT w.id AS workspace_id, btrim(repo->>'url') AS repo_url
+    FROM workspace w
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(w.repos) = 'array' THEN w.repos ELSE '[]'::jsonb END
+    ) AS repo
+)
+SELECT DISTINCT r.workspace_id, i.installation_id, r.repo_url
+FROM repository_urls r
+JOIN github_installation i ON i.workspace_id = r.workspace_id
+WHERE r.repo_url IS NOT NULL AND r.repo_url <> ''
+ORDER BY r.workspace_id, r.repo_url, i.installation_id;
+
+-- name: GetGitHubPRPollCursor :one
+SELECT cursor_updated_at
+FROM github_pr_poll_cursor
+WHERE workspace_id = $1 AND repo_owner = $2 AND repo_name = $3;
+
+-- name: UpsertGitHubPRPollCursor :exec
+INSERT INTO github_pr_poll_cursor (
+    workspace_id, repo_owner, repo_name, cursor_updated_at
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT (workspace_id, repo_owner, repo_name) DO UPDATE SET
+    cursor_updated_at = GREATEST(
+        github_pr_poll_cursor.cursor_updated_at,
+        EXCLUDED.cursor_updated_at
+    ),
+    updated_at = now();
+
+-- =====================
 -- GitHub Pull Request
 -- =====================
 

--- a/server/pkg/db/queries/workspace_delete.sql
+++ b/server/pkg/db/queries/workspace_delete.sql
@@ -584,7 +584,11 @@ WITH deleted_github_prs AS (
 DELETE FROM vcs_pull_request WHERE vcs_pull_request.workspace_id = $1;
 
 -- name: DeleteWorkspaceConnections :exec
-WITH deleted_github_installations AS (
+WITH deleted_github_pr_poll_cursors AS (
+    DELETE FROM github_pr_poll_cursor
+    WHERE github_pr_poll_cursor.workspace_id = $1
+),
+deleted_github_installations AS (
     DELETE FROM github_installation
     WHERE github_installation.workspace_id = $1
 )


### PR DESCRIPTION
## Summary
- add an explicitly enabled in-process worker that polls workspace/project `github_repo` resources with the existing GitHub App installation-token client
- route polled PRs through the webhook ingestion path, preserving normal links, close intent, `reference_only`, merged transitions, and cross-workspace ambiguity protection
- persist per-workspace/repository cursors with a 5-minute overlap and advance only after a complete successful repository poll

## Configuration
- `GITHUB_PR_POLLING_ENABLED=false`
- `GITHUB_PR_POLL_INTERVAL=5m`
- `GITHUB_PR_POLL_INITIAL_LOOKBACK=720h` (30 days)
- existing `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` remain required

The worker starts in `cmd/server` only when explicitly enabled, polls immediately, then at the configured interval. No route, scheduler service, queue, or external cron was added.

## Migration
Migration `441_github_pr_poll_cursor` creates the per-workspace/repository cursor table. Workspace teardown deletes cursor rows.

## Verification
- `go test -race ./internal/handler ./internal/integrations/ghsnapshot ./cmd/server -run 'Test(GitHubPRPoll|ParseGitHubRepositoryURL|GetUsesInstallationToken|GetRejectsAbsolutePath)' -count=1`
- `go vet ./...`
- `pnpm lint`
- `make build`
- migration 441 applied successfully to a fresh local database

The DB-backed backfill fixture uses the verified title/head/body/merged state from `empathyLtd/emposserver` PRs #19 and #20 and confirms DEV-6/DEV-9 linking and terminal transitions. Live Multica backfill is intentionally deployment-gated: running an unreviewed Draft migration/worker against production would be unsafe and could auto-close the active issue.

Closes DEV-6