### PR TITLE
MUL-6883 perf(server): run the delegated-failure recovery outbox on its own leased worker

### DIFF
--- a/server/cmd/server/delegated_failure_recovery_sweeper_test.go
+++ b/server/cmd/server/delegated_failure_recovery_sweeper_test.go
@@ -141,6 +141,88 @@ func TestDelegatedFailureRecoveryLeaseTimings(t *testing.T) {
 	}
 }
 
+// The bound is six minutes, not the five the cadence suggests, and that is
+// accepted rather than papered over (MUL-6883). Pin the composition so that
+// moving either input has to move the recorded decision with it: a holder that
+// dies straight after a round leaves a cadence-long cooldown behind, and its
+// successor only notices the reopening on its next poll.
+func TestWorstCaseRecoveryHandoffIsTheConfirmedBound(t *testing.T) {
+	const confirmed = 6 * time.Minute
+	if delegatedFailureRecoveryWorstCaseHandoff != confirmed {
+		t.Fatalf("worst-case handoff = %s, but %s is what was confirmed as acceptable",
+			delegatedFailureRecoveryWorstCaseHandoff, confirmed)
+	}
+	if got := delegatedFailureRecoverySweepCadence + delegatedFailureRecoveryPollInterval; got != delegatedFailureRecoveryWorstCaseHandoff {
+		t.Fatalf("cadence %s + poll %s = %s, which no longer matches the documented bound %s",
+			delegatedFailureRecoverySweepCadence, delegatedFailureRecoveryPollInterval,
+			got, delegatedFailureRecoveryWorstCaseHandoff)
+	}
+}
+
+// What makes that bound a cadence plus a POLL rather than a cadence plus a
+// cadence: the successor is watching finer than the rate it is enforcing. A
+// replica ticking at the cadence would miss a reopening it fell a hair short of
+// and wait out another full window — which is the shape this measures, by
+// setting the successor's phase just before the cooldown begins.
+func TestDeadHolderHandsOverWithinOnePollOfTheCooldown(t *testing.T) {
+	const (
+		cooldown = 400 * time.Millisecond
+		poll     = 60 * time.Millisecond
+		// Scheduler slack only. The bound under test is cooldown + poll; a
+		// cadence-ticking successor would need up to cooldown + cooldown.
+		slack = 120 * time.Millisecond
+	)
+
+	for attempt := range 3 {
+		shared := &cadenceLease{cooldown: cooldown}
+		finishA, ok := (replicaLease{shared: shared, name: "replica-a"}).Acquire(context.Background())
+		if !ok {
+			t.Fatalf("attempt %d: the first replica could not acquire", attempt)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		swept := make(chan time.Time, 1)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			runLeasedSweep(ctx, poll, cooldown, replicaLease{shared: shared, name: "replica-b"}, func() {
+				select {
+				case swept <- time.Now():
+				default:
+				}
+			})
+		}()
+		// B's startup attempt is refused while A still holds the round, so B's
+		// poll phase is fixed just before the cooldown starts.
+		time.Sleep(2 * time.Millisecond)
+		completedAt := time.Now()
+		// A completes and is then never heard from again: its cooldown is
+		// shared state and outlives it.
+		finishA(true)
+
+		var sweptAt time.Time
+		select {
+		case sweptAt = <-swept:
+		case <-time.After(cooldown + poll + slack + time.Second):
+			cancel()
+			<-done
+			t.Fatalf("attempt %d: the window was never picked up after its holder stopped", attempt)
+		}
+		cancel()
+		<-done
+
+		delay := sweptAt.Sub(completedAt)
+		if delay < cooldown {
+			t.Fatalf("attempt %d: the next round started %s after the last one, inside the %s cooldown",
+				attempt, delay, cooldown)
+		}
+		if delay > cooldown+poll+slack {
+			t.Fatalf("attempt %d: handover took %s, past the cooldown plus one poll (%s)",
+				attempt, delay, cooldown+poll)
+		}
+	}
+}
+
 // The point of the gate: the number of scans the deployment performs must be
 // set by the cadence, not by how many replicas are running. Deleting the key at
 // the end of a round would satisfy the concurrency test below and still fail

--- a/server/cmd/server/delegated_failure_recovery_sweeper_test.go
+++ b/server/cmd/server/delegated_failure_recovery_sweeper_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	redismock "github.com/go-redis/redismock/v9"
+)
+
+type stubSweepLease struct {
+	grant    bool
+	attempts atomic.Int32
+	lastTTL  atomic.Int64
+}
+
+func (l *stubSweepLease) Acquire(_ context.Context, ttl time.Duration) bool {
+	l.attempts.Add(1)
+	l.lastTTL.Store(int64(ttl))
+	return l.grant
+}
+
+// The recovery outbox is a crash backstop, not a liveness signal. Leaving it in
+// the 30-second loop is what made a scan that usually finds nothing the most
+// frequent caller of the most expensive query in the sweeper.
+func TestDelegatedFailureRecoveryRunsOutsideTheLivenessLoop(t *testing.T) {
+	if delegatedFailureRecoverySweepInterval != 5*time.Minute {
+		t.Fatalf("recovery sweep interval = %s, want 5m", delegatedFailureRecoverySweepInterval)
+	}
+
+	source, err := os.ReadFile("runtime_sweeper.go")
+	if err != nil {
+		t.Fatalf("read runtime_sweeper.go: %v", err)
+	}
+	start := strings.Index(string(source), "func runRuntimeSweeper(")
+	end := strings.Index(string(source), "func runRuntimeGCSweeper(")
+	if start < 0 || end <= start {
+		t.Fatal("could not isolate runtime sweeper loops")
+	}
+	if strings.Contains(string(source[start:end]), "sweepPendingDelegatedFailureRecoveries(") {
+		t.Fatal("delegated failure recovery is still invoked from the 30-second liveness loop")
+	}
+}
+
+// The per-replica call rate is the whole point of the change, so pin it rather
+// than leaving it to be re-derived from a constant someone may retune.
+func TestDelegatedFailureRecoveryDailyCallRate(t *testing.T) {
+	const wantCallsPerDay = 288
+	got := int(24 * time.Hour / delegatedFailureRecoverySweepInterval)
+	if got != wantCallsPerDay {
+		t.Fatalf("recovery sweep rate = %d/day/replica, want %d/day/replica", got, wantCallsPerDay)
+	}
+}
+
+// A lease that outlives its round would let a replica that died holding it
+// suppress the next one; a lease far shorter than the round would let a second
+// replica start the same work while the first is still in it.
+func TestDelegatedFailureRecoveryLeaseTTLFitsInsideTheInterval(t *testing.T) {
+	if delegatedFailureRecoveryLeaseTTL >= delegatedFailureRecoverySweepInterval {
+		t.Fatalf("lease TTL %s must be shorter than the %s interval, or a dead holder suppresses the next round",
+			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoverySweepInterval)
+	}
+	if delegatedFailureRecoveryLeaseTTL < delegatedFailureRecoverySweepInterval/2 {
+		t.Fatalf("lease TTL %s is short enough that a slow round could run twice concurrently", delegatedFailureRecoveryLeaseTTL)
+	}
+}
+
+// The startup scan is the one that matters: a process that just started is the
+// aftermath of the exit this sweep repairs. Waiting a full interval for it
+// would make the new cadence strictly worse than the old one.
+func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lease := &stubSweepLease{grant: true}
+	swept := make(chan struct{}, 4)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// An interval no test can wait out, so only the startup round can fire.
+		runLeasedSweep(ctx, time.Hour, delegatedFailureRecoveryLeaseTTL, lease, func() {
+			swept <- struct{}{}
+		})
+	}()
+
+	select {
+	case <-swept:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup round never ran; the sweep waited for the first tick")
+	}
+	if got := lease.lastTTL.Load(); time.Duration(got) != delegatedFailureRecoveryLeaseTTL {
+		t.Fatalf("startup round took the lease for %s, want %s", time.Duration(got), delegatedFailureRecoveryLeaseTTL)
+	}
+	cancel()
+	<-done
+	if extra := len(swept); extra != 0 {
+		t.Fatalf("%d extra rounds ran before the first tick", extra)
+	}
+}
+
+// Losing the lease must skip the work, not just the logging.
+func TestLeasedSweepSkipsRoundsItDoesNotWin(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lease := &stubSweepLease{grant: false}
+	var rounds atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runLeasedSweep(ctx, 5*time.Millisecond, delegatedFailureRecoveryLeaseTTL, lease, func() {
+			rounds.Add(1)
+		})
+	}()
+
+	deadline := time.After(time.Second)
+	for lease.attempts.Load() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d lease attempts observed", lease.attempts.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+	if got := rounds.Load(); got != 0 {
+		t.Fatalf("ran %d rounds without holding the lease, want 0", got)
+	}
+}
+
+func TestLeasedSweepStopsWithItsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	lease := &stubSweepLease{grant: true}
+	stopped := make(chan struct{})
+	go func() {
+		runLeasedSweep(ctx, 5*time.Millisecond, delegatedFailureRecoveryLeaseTTL, lease, func() {})
+		close(stopped)
+	}()
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leased sweep did not stop with its context")
+	}
+}
+
+func TestRedisSweepLeaseAdmitsExactlyTheClaimingReplica(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	lease := newRedisSweepLease(client, "test:lease")
+
+	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetVal(true)
+	if !lease.Acquire(context.Background(), time.Minute) {
+		t.Fatal("claiming replica was not admitted")
+	}
+	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetVal(false)
+	if lease.Acquire(context.Background(), time.Minute) {
+		t.Fatal("replica was admitted to a round another replica already holds")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("redis expectations: %v", err)
+	}
+}
+
+// Failing closed here would let a Redis outage silently switch off crash
+// recovery. Running the round twice only repeats work that is already
+// idempotent; never running it strands an obligation.
+func TestRedisSweepLeaseFailsOpen(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	lease := newRedisSweepLease(client, "test:lease")
+	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetErr(errors.New("redis is down"))
+	if !lease.Acquire(context.Background(), time.Minute) {
+		t.Fatal("an unreachable Redis switched off the recovery round")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("redis expectations: %v", err)
+	}
+}
+
+// No Redis is the Helm default. It must keep the pre-change behaviour of every
+// replica running every round, at the new cadence.
+func TestUnleasedAlwaysRuns(t *testing.T) {
+	if !(unleased{}).Acquire(context.Background(), time.Minute) {
+		t.Fatal("the no-Redis deployment stopped running the recovery sweep")
+	}
+}

--- a/server/cmd/server/delegated_failure_recovery_sweeper_test.go
+++ b/server/cmd/server/delegated_failure_recovery_sweeper_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,14 +17,60 @@ import (
 type stubSweepLease struct {
 	grant    bool
 	attempts atomic.Int32
-	lastTTL  atomic.Int64
+	held     atomic.Int32
 }
 
-func (l *stubSweepLease) Acquire(_ context.Context, ttl time.Duration) bool {
+func (l *stubSweepLease) Acquire(context.Context) (func(), bool) {
 	l.attempts.Add(1)
-	l.lastTTL.Store(int64(ttl))
-	return l.grant
+	if !l.grant {
+		return nil, false
+	}
+	l.held.Add(1)
+	return func() { l.held.Add(-1) }, true
 }
+
+// expiringLease models the guarantee the Redis implementation provides —
+// exclusive admission that survives exactly as long as it is renewed — without
+// depending on wall-clock expiry inside Redis. It is what lets the concurrency
+// tests below be deterministic; the redismock tests cover the wire protocol
+// that produces this behaviour against a real server.
+type expiringLease struct {
+	mu     sync.Mutex
+	holder string
+	// renewals counts successful token-compared renewals.
+	renewals atomic.Int32
+}
+
+func (l *expiringLease) acquire(who string) (func(), bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holder != "" {
+		return nil, false
+	}
+	l.holder = who
+	return func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		// Token compare: only the holder may release.
+		if l.holder == who {
+			l.holder = ""
+		}
+	}, true
+}
+
+// expire drops the admission the way a missed renewal would.
+func (l *expiringLease) expire() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.holder = ""
+}
+
+type replicaLease struct {
+	shared *expiringLease
+	name   string
+}
+
+func (r replicaLease) Acquire(context.Context) (func(), bool) { return r.shared.acquire(r.name) }
 
 // The recovery outbox is a crash backstop, not a liveness signal. Leaving it in
 // the 30-second loop is what made a scan that usually finds nothing the most
@@ -56,16 +104,93 @@ func TestDelegatedFailureRecoveryDailyCallRate(t *testing.T) {
 	}
 }
 
-// A lease that outlives its round would let a replica that died holding it
-// suppress the next one; a lease far shorter than the round would let a second
-// replica start the same work while the first is still in it.
-func TestDelegatedFailureRecoveryLeaseTTLFitsInsideTheInterval(t *testing.T) {
+// With renewal, the TTL bounds how long the admission survives WITHOUT one, not
+// how long a round may take. It therefore has to leave room for a missed
+// renewal to be retried, and stay short enough that a replica which died
+// holding the lease frees it well inside one interval.
+func TestDelegatedFailureRecoveryLeaseTimings(t *testing.T) {
+	if delegatedFailureRecoveryLeaseRenew > delegatedFailureRecoveryLeaseTTL/2 {
+		t.Fatalf("renew %s leaves no room to retry inside a %s TTL",
+			delegatedFailureRecoveryLeaseRenew, delegatedFailureRecoveryLeaseTTL)
+	}
 	if delegatedFailureRecoveryLeaseTTL >= delegatedFailureRecoverySweepInterval {
-		t.Fatalf("lease TTL %s must be shorter than the %s interval, or a dead holder suppresses the next round",
+		t.Fatalf("a dead holder would suppress the next round: TTL %s, interval %s",
 			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoverySweepInterval)
 	}
-	if delegatedFailureRecoveryLeaseTTL < delegatedFailureRecoverySweepInterval/2 {
-		t.Fatalf("lease TTL %s is short enough that a slow round could run twice concurrently", delegatedFailureRecoveryLeaseTTL)
+}
+
+// The must-fix from review: a round has no deadline of its own, so a fixed TTL
+// could expire mid-round and let a second replica re-run the sweeper's most
+// expensive query exactly when the database is already slow. Holding the
+// admission for the whole round is what closes that window.
+func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shared := &expiringLease{}
+
+	roundStarted := make(chan struct{})
+	finishRound := make(chan struct{})
+	var firstRounds atomic.Int32
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		runLeasedSweep(ctx, time.Hour, replicaLease{shared: shared, name: "replica-a"}, func() {
+			if firstRounds.Add(1) == 1 {
+				close(roundStarted)
+			}
+			<-finishRound
+		})
+	}()
+	<-roundStarted
+
+	// While replica A is still inside its round, replica B ticks.
+	var secondRounds atomic.Int32
+	secondCtx, stopSecond := context.WithCancel(ctx)
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		runLeasedSweep(secondCtx, 5*time.Millisecond, replicaLease{shared: shared, name: "replica-b"}, func() {
+			secondRounds.Add(1)
+		})
+	}()
+	time.Sleep(100 * time.Millisecond)
+	if got := secondRounds.Load(); got != 0 {
+		t.Fatalf("second replica ran %d concurrent rounds during a slow round, want 0", got)
+	}
+
+	// Once the slow round ends the admission is released, not left to expire,
+	// so the next tick can take it immediately.
+	close(finishRound)
+	deadline := time.After(2 * time.Second)
+	for secondRounds.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("released admission was never handed to the waiting replica")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	stopSecond()
+	<-secondDone
+	cancel()
+	<-firstDone
+}
+
+// A replica that loses its admission mid-round (a renewal that never landed)
+// must not delete or extend whatever the next holder wrote.
+func TestReleaseAfterLosingTheLeaseDoesNotEvictTheNewHolder(t *testing.T) {
+	shared := &expiringLease{}
+	releaseA, ok := shared.acquire("replica-a")
+	if !ok {
+		t.Fatal("first replica could not acquire")
+	}
+	shared.expire()
+	if _, ok := shared.acquire("replica-b"); !ok {
+		t.Fatal("second replica could not take the expired admission")
+	}
+
+	releaseA()
+	if _, ok := shared.acquire("replica-c"); ok {
+		t.Fatal("a stale release evicted the new holder")
 	}
 }
 
@@ -81,9 +206,7 @@ func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
 	go func() {
 		defer close(done)
 		// An interval no test can wait out, so only the startup round can fire.
-		runLeasedSweep(ctx, time.Hour, delegatedFailureRecoveryLeaseTTL, lease, func() {
-			swept <- struct{}{}
-		})
+		runLeasedSweep(ctx, time.Hour, lease, func() { swept <- struct{}{} })
 	}()
 
 	select {
@@ -91,13 +214,13 @@ func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("startup round never ran; the sweep waited for the first tick")
 	}
-	if got := lease.lastTTL.Load(); time.Duration(got) != delegatedFailureRecoveryLeaseTTL {
-		t.Fatalf("startup round took the lease for %s, want %s", time.Duration(got), delegatedFailureRecoveryLeaseTTL)
-	}
 	cancel()
 	<-done
 	if extra := len(swept); extra != 0 {
 		t.Fatalf("%d extra rounds ran before the first tick", extra)
+	}
+	if held := lease.held.Load(); held != 0 {
+		t.Fatalf("%d admissions still held after the sweep stopped", held)
 	}
 }
 
@@ -110,9 +233,7 @@ func TestLeasedSweepSkipsRoundsItDoesNotWin(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runLeasedSweep(ctx, 5*time.Millisecond, delegatedFailureRecoveryLeaseTTL, lease, func() {
-			rounds.Add(1)
-		})
+		runLeasedSweep(ctx, 5*time.Millisecond, lease, func() { rounds.Add(1) })
 	}()
 
 	deadline := time.After(time.Second)
@@ -135,7 +256,7 @@ func TestLeasedSweepStopsWithItsContext(t *testing.T) {
 	lease := &stubSweepLease{grant: true}
 	stopped := make(chan struct{})
 	go func() {
-		runLeasedSweep(ctx, 5*time.Millisecond, delegatedFailureRecoveryLeaseTTL, lease, func() {})
+		runLeasedSweep(ctx, 5*time.Millisecond, lease, func() {})
 		close(stopped)
 	}()
 	cancel()
@@ -146,20 +267,97 @@ func TestLeasedSweepStopsWithItsContext(t *testing.T) {
 	}
 }
 
-func TestRedisSweepLeaseAdmitsExactlyTheClaimingReplica(t *testing.T) {
-	client, mock := redismock.NewClientMock()
-	lease := newRedisSweepLease(client, "test:lease")
+// captureToken records the holder token the lease generated, so the renew and
+// release expectations can assert the SAME token is compared.
+func captureToken(into *string) func(expected, actual []interface{}) error {
+	return func(_, actual []interface{}) error {
+		for _, arg := range actual {
+			s, ok := arg.(string)
+			if ok && len(s) == 36 {
+				*into = s
+				return nil
+			}
+		}
+		return fmt.Errorf("no holder token in %v", actual)
+	}
+}
 
-	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetVal(true)
-	if !lease.Acquire(context.Background(), time.Minute) {
+// The Redis half of the guarantee tested above: while the round runs the lease
+// is renewed with a token compare, and when it ends the lease is released with
+// the same compare rather than being left to expire.
+func TestRedisSweepLeaseRenewsDuringTheRoundAndReleasesAfter(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	const ttl = 300 * time.Millisecond
+	const renew = 10 * time.Millisecond
+	lease := newRedisSweepLease(client, "test:lease", ttl, renew)
+
+	var token string
+	mock.CustomMatch(captureToken(&token)).ExpectSetNX("test:lease", "", ttl).SetVal(true)
+
+	renewed := make(chan struct{}, 16)
+	for range 3 {
+		mock.CustomMatch(func(_, actual []interface{}) error {
+			if !containsString(actual, token) {
+				return fmt.Errorf("renewal did not compare the holder token %q: %v", token, actual)
+			}
+			select {
+			case renewed <- struct{}{}:
+			default:
+			}
+			return nil
+		}).ExpectEval(redisRenewSweepLeaseSource, []string{"test:lease"}, "", ttl.Milliseconds()).SetVal(int64(1))
+	}
+	released := make(chan struct{}, 1)
+	mock.CustomMatch(func(_, actual []interface{}) error {
+		if !containsString(actual, token) {
+			return fmt.Errorf("release did not compare the holder token %q: %v", token, actual)
+		}
+		released <- struct{}{}
+		return nil
+	}).ExpectEval(redisReleaseSweepLeaseSource, []string{"test:lease"}, "").SetVal(int64(1))
+
+	release, ok := lease.Acquire(context.Background())
+	if !ok {
 		t.Fatal("claiming replica was not admitted")
 	}
-	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetVal(false)
-	if lease.Acquire(context.Background(), time.Minute) {
-		t.Fatal("replica was admitted to a round another replica already holds")
+	if token == "" {
+		t.Fatal("no holder token was written")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("redis expectations: %v", err)
+	// Stay inside the round past several renew intervals, the way a slow round
+	// would, then end it.
+	for range 3 {
+		select {
+		case <-renewed:
+		case <-time.After(2 * time.Second):
+			t.Fatal("the admission was not renewed while the round was still running")
+		}
+	}
+	release()
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the admission was not released when the round ended")
+	}
+}
+
+func containsString(args []interface{}, want string) bool {
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRedisSweepLeaseRefusesARoundAnotherReplicaHolds(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second)
+	mock.CustomMatch(func(_, _ []interface{}) error { return nil }).
+		ExpectSetNX("test:lease", "", time.Minute).SetVal(false)
+
+	if release, ok := lease.Acquire(context.Background()); ok {
+		release()
+		t.Fatal("replica was admitted to a round another replica already holds")
 	}
 }
 
@@ -168,20 +366,25 @@ func TestRedisSweepLeaseAdmitsExactlyTheClaimingReplica(t *testing.T) {
 // idempotent; never running it strands an obligation.
 func TestRedisSweepLeaseFailsOpen(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	lease := newRedisSweepLease(client, "test:lease")
-	mock.ExpectSetNX("test:lease", lease.holder, time.Minute).SetErr(errors.New("redis is down"))
-	if !lease.Acquire(context.Background(), time.Minute) {
+	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second)
+	mock.CustomMatch(func(_, _ []interface{}) error { return nil }).
+		ExpectSetNX("test:lease", "", time.Minute).SetErr(errors.New("redis is down"))
+
+	release, ok := lease.Acquire(context.Background())
+	if !ok {
 		t.Fatal("an unreachable Redis switched off the recovery round")
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("redis expectations: %v", err)
-	}
+	// There is no admission to give back, so release must be a safe no-op
+	// rather than a compare-and-delete against a key this replica never wrote.
+	release()
 }
 
 // No Redis is the Helm default. It must keep the pre-change behaviour of every
 // replica running every round, at the new cadence.
 func TestUnleasedAlwaysRuns(t *testing.T) {
-	if !(unleased{}).Acquire(context.Background(), time.Minute) {
+	release, ok := (unleased{}).Acquire(context.Background())
+	if !ok {
 		t.Fatal("the no-Redis deployment stopped running the recovery sweep")
 	}
+	release()
 }

--- a/server/cmd/server/delegated_failure_recovery_sweeper_test.go
+++ b/server/cmd/server/delegated_failure_recovery_sweeper_test.go
@@ -15,69 +15,86 @@ import (
 )
 
 type stubSweepLease struct {
-	grant    bool
-	attempts atomic.Int32
-	held     atomic.Int32
+	grant     bool
+	attempts  atomic.Int32
+	held      atomic.Int32
+	completed atomic.Int32
+	abandoned atomic.Int32
 }
 
-func (l *stubSweepLease) Acquire(context.Context) (func(), bool) {
+func (l *stubSweepLease) Acquire(context.Context) (func(bool), bool) {
 	l.attempts.Add(1)
 	if !l.grant {
 		return nil, false
 	}
 	l.held.Add(1)
-	return func() { l.held.Add(-1) }, true
+	return func(completed bool) {
+		l.held.Add(-1)
+		if completed {
+			l.completed.Add(1)
+		} else {
+			l.abandoned.Add(1)
+		}
+	}, true
 }
 
-// expiringLease models the guarantee the Redis implementation provides —
-// exclusive admission that survives exactly as long as it is renewed — without
-// depending on wall-clock expiry inside Redis. It is what lets the concurrency
-// tests below be deterministic; the redismock tests cover the wire protocol
-// that produces this behaviour against a real server.
-type expiringLease struct {
-	mu     sync.Mutex
+// cadenceLease models the guarantee the Redis implementation provides: an
+// admission that excludes other replicas for the round, and then for the rest
+// of the cadence window once the round succeeds. It is what lets the
+// multi-replica tests below be deterministic; the redismock tests cover the
+// wire protocol that produces this behaviour against a real server.
+type cadenceLease struct {
+	mu       sync.Mutex
+	cooldown time.Duration
+	// holder is the replica currently mid-round, empty between rounds.
 	holder string
-	// renewals counts successful token-compared renewals.
-	renewals atomic.Int32
+	// coolUntil blocks every replica until the cadence window reopens.
+	coolUntil time.Time
+	rounds    atomic.Int32
 }
 
-func (l *expiringLease) acquire(who string) (func(), bool) {
+func (l *cadenceLease) acquire(who string) (func(bool), bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.holder != "" {
+	if l.holder != "" || time.Now().Before(l.coolUntil) {
 		return nil, false
 	}
 	l.holder = who
-	return func() {
+	l.rounds.Add(1)
+	return func(completed bool) {
 		l.mu.Lock()
 		defer l.mu.Unlock()
-		// Token compare: only the holder may release.
-		if l.holder == who {
-			l.holder = ""
+		// Token compare: only the holder may finish its own round.
+		if l.holder != who {
+			return
+		}
+		l.holder = ""
+		if completed {
+			l.coolUntil = time.Now().Add(l.cooldown)
 		}
 	}, true
 }
 
 // expire drops the admission the way a missed renewal would.
-func (l *expiringLease) expire() {
+func (l *cadenceLease) expire() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.holder = ""
 }
 
 type replicaLease struct {
-	shared *expiringLease
+	shared *cadenceLease
 	name   string
 }
 
-func (r replicaLease) Acquire(context.Context) (func(), bool) { return r.shared.acquire(r.name) }
+func (r replicaLease) Acquire(context.Context) (func(bool), bool) { return r.shared.acquire(r.name) }
 
 // The recovery outbox is a crash backstop, not a liveness signal. Leaving it in
 // the 30-second loop is what made a scan that usually finds nothing the most
 // frequent caller of the most expensive query in the sweeper.
 func TestDelegatedFailureRecoveryRunsOutsideTheLivenessLoop(t *testing.T) {
-	if delegatedFailureRecoverySweepInterval != 5*time.Minute {
-		t.Fatalf("recovery sweep interval = %s, want 5m", delegatedFailureRecoverySweepInterval)
+	if delegatedFailureRecoverySweepCadence != 5*time.Minute {
+		t.Fatalf("recovery sweep cadence = %s, want 5m", delegatedFailureRecoverySweepCadence)
 	}
 
 	source, err := os.ReadFile("runtime_sweeper.go")
@@ -94,39 +111,115 @@ func TestDelegatedFailureRecoveryRunsOutsideTheLivenessLoop(t *testing.T) {
 	}
 }
 
-// The per-replica call rate is the whole point of the change, so pin it rather
-// than leaving it to be re-derived from a constant someone may retune.
-func TestDelegatedFailureRecoveryDailyCallRate(t *testing.T) {
-	const wantCallsPerDay = 288
-	got := int(24 * time.Hour / delegatedFailureRecoverySweepInterval)
-	if got != wantCallsPerDay {
-		t.Fatalf("recovery sweep rate = %d/day/replica, want %d/day/replica", got, wantCallsPerDay)
+// The saving is a GLOBAL rate, so pin it as one, and pin the poll as finer than
+// the cadence — ticking at the cadence would let each replica's phase decide
+// who runs and how long an unclaimed window stays unclaimed.
+func TestDelegatedFailureRecoveryGlobalCallRate(t *testing.T) {
+	const wantScansPerDay = 288
+	got := int(24 * time.Hour / delegatedFailureRecoverySweepCadence)
+	if got != wantScansPerDay {
+		t.Fatalf("recovery scan rate = %d/day for the whole deployment, want %d/day", got, wantScansPerDay)
+	}
+	if delegatedFailureRecoveryPollInterval >= delegatedFailureRecoverySweepCadence {
+		t.Fatalf("poll %s must be finer than the %s cadence",
+			delegatedFailureRecoveryPollInterval, delegatedFailureRecoverySweepCadence)
 	}
 }
 
 // With renewal, the TTL bounds how long the admission survives WITHOUT one, not
-// how long a round may take. It therefore has to leave room for a missed
-// renewal to be retried, and stay short enough that a replica which died
-// holding the lease frees it well inside one interval.
+// how long a round may take. It has to leave room for a missed renewal to be
+// retried, and stay short enough that a replica which died holding the lease
+// frees it well inside one cadence window.
 func TestDelegatedFailureRecoveryLeaseTimings(t *testing.T) {
 	if delegatedFailureRecoveryLeaseRenew > delegatedFailureRecoveryLeaseTTL/2 {
 		t.Fatalf("renew %s leaves no room to retry inside a %s TTL",
 			delegatedFailureRecoveryLeaseRenew, delegatedFailureRecoveryLeaseTTL)
 	}
-	if delegatedFailureRecoveryLeaseTTL >= delegatedFailureRecoverySweepInterval {
-		t.Fatalf("a dead holder would suppress the next round: TTL %s, interval %s",
-			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoverySweepInterval)
+	if delegatedFailureRecoveryLeaseTTL >= delegatedFailureRecoverySweepCadence {
+		t.Fatalf("a dead holder would suppress the next window: TTL %s, cadence %s",
+			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoverySweepCadence)
 	}
 }
 
-// The must-fix from review: a round has no deadline of its own, so a fixed TTL
-// could expire mid-round and let a second replica re-run the sweeper's most
-// expensive query exactly when the database is already slow. Holding the
-// admission for the whole round is what closes that window.
-func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
+// The point of the gate: the number of scans the deployment performs must be
+// set by the cadence, not by how many replicas are running. Deleting the key at
+// the end of a round would satisfy the concurrency test below and still fail
+// this one, because out-of-phase replicas would take turns.
+func TestScanRateDoesNotGrowWithReplicaCount(t *testing.T) {
+	const (
+		cadence = 60 * time.Millisecond
+		poll    = 5 * time.Millisecond
+		run     = 420 * time.Millisecond
+	)
+	countRounds := func(replicas int) int32 {
+		shared := &cadenceLease{cooldown: cadence}
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		for i := range replicas {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Stagger startups so no two replicas share a tick phase —
+				// the rolling-restart shape, and the one a delete-on-finish
+				// protocol silently doubles.
+				time.Sleep(time.Duration(i) * 17 * time.Millisecond)
+				runLeasedSweep(ctx, poll, cadence, replicaLease{shared: shared, name: fmt.Sprint(i)}, func() {})
+			}()
+		}
+		time.Sleep(run)
+		cancel()
+		wg.Wait()
+		return shared.rounds.Load()
+	}
+
+	one := countRounds(1)
+	many := countRounds(4)
+	if one == 0 {
+		t.Fatal("a single replica ran no rounds at all")
+	}
+	// Four replicas may claim a window marginally sooner than one can, but they
+	// must not multiply the work. Anything near 4x is the turn-taking bug.
+	if many > one+2 {
+		t.Fatalf("4 replicas ran %d rounds vs %d for a single replica: the scan rate is scaling with replica count", many, one)
+	}
+}
+
+// A rolling restart is the case where phases are guaranteed to differ: each
+// replica runs its startup round and only then starts its ticker. One effective
+// startup scan must cover the deployment.
+func TestRollingRestartProducesOneStartupScan(t *testing.T) {
+	shared := &cadenceLease{cooldown: time.Hour}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	shared := &expiringLease{}
+
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Duration(i) * 20 * time.Millisecond)
+			// A poll interval no test can wait out, so only the startup round
+			// of each replica can fire.
+			runLeasedSweep(ctx, time.Hour, time.Hour, replicaLease{shared: shared, name: fmt.Sprint(i)}, func() {})
+		}()
+	}
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	if got := shared.rounds.Load(); got != 1 {
+		t.Fatalf("a rolling restart of 5 replicas produced %d startup scans, want 1", got)
+	}
+}
+
+// A round has no deadline of its own, so a fixed TTL could expire mid-round and
+// let a second replica re-run the sweeper's most expensive query exactly when
+// the database is already slow. Holding the admission for the whole round
+// closes that window; the cooldown then keeps the next replica out afterwards.
+func TestSlowRoundExcludesOtherReplicasDuringAndAfter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shared := &cadenceLease{cooldown: time.Hour}
 
 	roundStarted := make(chan struct{})
 	finishRound := make(chan struct{})
@@ -134,7 +227,7 @@ func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
 	firstDone := make(chan struct{})
 	go func() {
 		defer close(firstDone)
-		runLeasedSweep(ctx, time.Hour, replicaLease{shared: shared, name: "replica-a"}, func() {
+		runLeasedSweep(ctx, time.Hour, time.Hour, replicaLease{shared: shared, name: "replica-a"}, func() {
 			if firstRounds.Add(1) == 1 {
 				close(roundStarted)
 			}
@@ -143,13 +236,12 @@ func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
 	}()
 	<-roundStarted
 
-	// While replica A is still inside its round, replica B ticks.
 	var secondRounds atomic.Int32
 	secondCtx, stopSecond := context.WithCancel(ctx)
 	secondDone := make(chan struct{})
 	go func() {
 		defer close(secondDone)
-		runLeasedSweep(secondCtx, 5*time.Millisecond, replicaLease{shared: shared, name: "replica-b"}, func() {
+		runLeasedSweep(secondCtx, 5*time.Millisecond, time.Hour, replicaLease{shared: shared, name: "replica-b"}, func() {
 			secondRounds.Add(1)
 		})
 	}()
@@ -158,16 +250,12 @@ func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
 		t.Fatalf("second replica ran %d concurrent rounds during a slow round, want 0", got)
 	}
 
-	// Once the slow round ends the admission is released, not left to expire,
-	// so the next tick can take it immediately.
+	// Finishing must NOT hand the window straight over: the cadence window this
+	// round covered is done, and B has to wait for the next one.
 	close(finishRound)
-	deadline := time.After(2 * time.Second)
-	for secondRounds.Load() == 0 {
-		select {
-		case <-deadline:
-			t.Fatal("released admission was never handed to the waiting replica")
-		case <-time.After(time.Millisecond):
-		}
+	time.Sleep(100 * time.Millisecond)
+	if got := secondRounds.Load(); got != 0 {
+		t.Fatalf("second replica ran %d rounds inside a window the first replica had already covered, want 0", got)
 	}
 	stopSecond()
 	<-secondDone
@@ -175,28 +263,45 @@ func TestSlowRoundKeepsASecondReplicaOut(t *testing.T) {
 	<-firstDone
 }
 
+// The other direction: a round cut short by shutdown did NOT cover its window,
+// so it must be handed back rather than cooled down.
+func TestAbandonedRoundIsHandedBackImmediately(t *testing.T) {
+	shared := &cadenceLease{cooldown: time.Hour}
+	lease := replicaLease{shared: shared, name: "replica-a"}
+
+	finish, ok := lease.Acquire(context.Background())
+	if !ok {
+		t.Fatal("first replica could not acquire")
+	}
+	finish(false)
+
+	if _, ok := (replicaLease{shared: shared, name: "replica-b"}).Acquire(context.Background()); !ok {
+		t.Fatal("an abandoned round was cooled down instead of handed back")
+	}
+}
+
 // A replica that loses its admission mid-round (a renewal that never landed)
-// must not delete or extend whatever the next holder wrote.
-func TestReleaseAfterLosingTheLeaseDoesNotEvictTheNewHolder(t *testing.T) {
-	shared := &expiringLease{}
-	releaseA, ok := shared.acquire("replica-a")
+// must not cool down or delete whatever the next holder wrote.
+func TestFinishAfterLosingTheLeaseDoesNotAffectTheNewHolder(t *testing.T) {
+	shared := &cadenceLease{cooldown: time.Hour}
+	finishA, ok := (replicaLease{shared: shared, name: "replica-a"}).Acquire(context.Background())
 	if !ok {
 		t.Fatal("first replica could not acquire")
 	}
 	shared.expire()
-	if _, ok := shared.acquire("replica-b"); !ok {
+	if _, ok := (replicaLease{shared: shared, name: "replica-b"}).Acquire(context.Background()); !ok {
 		t.Fatal("second replica could not take the expired admission")
 	}
 
-	releaseA()
-	if _, ok := shared.acquire("replica-c"); ok {
-		t.Fatal("a stale release evicted the new holder")
+	finishA(true)
+	if _, ok := (replicaLease{shared: shared, name: "replica-c"}).Acquire(context.Background()); ok {
+		t.Fatal("a stale finish evicted the new holder")
 	}
 }
 
 // The startup scan is the one that matters: a process that just started is the
-// aftermath of the exit this sweep repairs. Waiting a full interval for it
-// would make the new cadence strictly worse than the old one.
+// aftermath of the exit this sweep repairs. Waiting a full poll for it would
+// make the new cadence strictly worse than the old one.
 func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -205,8 +310,7 @@ func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		// An interval no test can wait out, so only the startup round can fire.
-		runLeasedSweep(ctx, time.Hour, lease, func() { swept <- struct{}{} })
+		runLeasedSweep(ctx, time.Hour, time.Hour, lease, func() { swept <- struct{}{} })
 	}()
 
 	select {
@@ -222,10 +326,33 @@ func TestLeasedSweepRunsAtStartupBeforeTheFirstTick(t *testing.T) {
 	if held := lease.held.Load(); held != 0 {
 		t.Fatalf("%d admissions still held after the sweep stopped", held)
 	}
+	if lease.completed.Load() != 1 {
+		t.Fatalf("startup round finished as completed %d times, want 1", lease.completed.Load())
+	}
+}
+
+// The local floor is what bounds the no-Redis deployment, where there is no
+// shared cooldown to consult. Without it a poll finer than the cadence would
+// turn fail-open into a hot loop against the database.
+func TestLocalCadenceFloorHoldsWithoutALease(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var rounds atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runLeasedSweep(ctx, time.Millisecond, time.Hour, unleased{}, func() { rounds.Add(1) })
+	}()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+	if got := rounds.Load(); got != 1 {
+		t.Fatalf("an ungated replica ran %d rounds in one cadence window, want 1", got)
+	}
 }
 
 // Losing the lease must skip the work, not just the logging.
-func TestLeasedSweepSkipsRoundsItDoesNotWin(t *testing.T) {
+func TestLeasedSweepSkipsWindowsItDoesNotWin(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lease := &stubSweepLease{grant: false}
@@ -233,7 +360,7 @@ func TestLeasedSweepSkipsRoundsItDoesNotWin(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runLeasedSweep(ctx, 5*time.Millisecond, lease, func() { rounds.Add(1) })
+		runLeasedSweep(ctx, 5*time.Millisecond, time.Hour, lease, func() { rounds.Add(1) })
 	}()
 
 	deadline := time.After(time.Second)
@@ -256,7 +383,7 @@ func TestLeasedSweepStopsWithItsContext(t *testing.T) {
 	lease := &stubSweepLease{grant: true}
 	stopped := make(chan struct{})
 	go func() {
-		runLeasedSweep(ctx, 5*time.Millisecond, lease, func() {})
+		runLeasedSweep(ctx, 5*time.Millisecond, time.Hour, lease, func() {})
 		close(stopped)
 	}()
 	cancel()
@@ -267,13 +394,10 @@ func TestLeasedSweepStopsWithItsContext(t *testing.T) {
 	}
 }
 
-// captureToken records the holder token the lease generated, so the renew and
-// release expectations can assert the SAME token is compared.
 func captureToken(into *string) func(expected, actual []interface{}) error {
 	return func(_, actual []interface{}) error {
 		for _, arg := range actual {
-			s, ok := arg.(string)
-			if ok && len(s) == 36 {
+			if s, ok := arg.(string); ok && len(s) == 36 {
 				*into = s
 				return nil
 			}
@@ -282,14 +406,27 @@ func captureToken(into *string) func(expected, actual []interface{}) error {
 	}
 }
 
-// The Redis half of the guarantee tested above: while the round runs the lease
-// is renewed with a token compare, and when it ends the lease is released with
-// the same compare rather than being left to expire.
-func TestRedisSweepLeaseRenewsDuringTheRoundAndReleasesAfter(t *testing.T) {
+func containsString(args []interface{}, want string) bool {
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The Redis half of the guarantee: while the round runs the lease is renewed
+// with a token compare, and when it succeeds the key is CONVERTED to a cooldown
+// rather than deleted — deleting is what would let the next replica start
+// another round inside the same window.
+func TestRedisSweepLeaseRenewsDuringTheRoundAndCoolsDownAfter(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	const ttl = 300 * time.Millisecond
-	const renew = 10 * time.Millisecond
-	lease := newRedisSweepLease(client, "test:lease", ttl, renew)
+	const (
+		ttl      = 300 * time.Millisecond
+		renew    = 10 * time.Millisecond
+		cooldown = 5 * time.Second
+	)
+	lease := newRedisSweepLease(client, "test:lease", ttl, renew, cooldown)
 
 	var token string
 	mock.CustomMatch(captureToken(&token)).ExpectSetNX("test:lease", "", ttl).SetVal(true)
@@ -307,6 +444,47 @@ func TestRedisSweepLeaseRenewsDuringTheRoundAndReleasesAfter(t *testing.T) {
 			return nil
 		}).ExpectEval(redisRenewSweepLeaseSource, []string{"test:lease"}, "", ttl.Milliseconds()).SetVal(int64(1))
 	}
+	cooled := make(chan struct{}, 1)
+	mock.CustomMatch(func(_, actual []interface{}) error {
+		if !containsString(actual, token) {
+			return fmt.Errorf("cooldown did not compare the holder token %q: %v", token, actual)
+		}
+		if !containsString(actual, sweepCooldownMarker) {
+			return fmt.Errorf("cooldown did not write the marker: %v", actual)
+		}
+		cooled <- struct{}{}
+		return nil
+	}).ExpectEval(redisCooldownSweepLeaseSource, []string{"test:lease"}, "", sweepCooldownMarker, cooldown.Milliseconds()).SetVal(int64(1))
+
+	finish, ok := lease.Acquire(context.Background())
+	if !ok {
+		t.Fatal("claiming replica was not admitted")
+	}
+	if token == "" {
+		t.Fatal("no holder token was written")
+	}
+	for range 3 {
+		select {
+		case <-renewed:
+		case <-time.After(2 * time.Second):
+			t.Fatal("the admission was not renewed while the round was still running")
+		}
+	}
+	finish(true)
+	select {
+	case <-cooled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a completed round did not convert its admission into a cadence cooldown")
+	}
+}
+
+// A round cut short releases instead, so the window is contested again at once.
+func TestRedisSweepLeaseReleasesAnAbandonedRound(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	lease := newRedisSweepLease(client, "test:lease", time.Minute, 30*time.Second, 5*time.Minute)
+
+	var token string
+	mock.CustomMatch(captureToken(&token)).ExpectSetNX("test:lease", "", time.Minute).SetVal(true)
 	released := make(chan struct{}, 1)
 	mock.CustomMatch(func(_, actual []interface{}) error {
 		if !containsString(actual, token) {
@@ -316,48 +494,27 @@ func TestRedisSweepLeaseRenewsDuringTheRoundAndReleasesAfter(t *testing.T) {
 		return nil
 	}).ExpectEval(redisReleaseSweepLeaseSource, []string{"test:lease"}, "").SetVal(int64(1))
 
-	release, ok := lease.Acquire(context.Background())
+	finish, ok := lease.Acquire(context.Background())
 	if !ok {
 		t.Fatal("claiming replica was not admitted")
 	}
-	if token == "" {
-		t.Fatal("no holder token was written")
-	}
-	// Stay inside the round past several renew intervals, the way a slow round
-	// would, then end it.
-	for range 3 {
-		select {
-		case <-renewed:
-		case <-time.After(2 * time.Second):
-			t.Fatal("the admission was not renewed while the round was still running")
-		}
-	}
-	release()
+	finish(false)
 	select {
 	case <-released:
 	case <-time.After(2 * time.Second):
-		t.Fatal("the admission was not released when the round ended")
+		t.Fatal("an abandoned round did not release its admission")
 	}
 }
 
-func containsString(args []interface{}, want string) bool {
-	for _, arg := range args {
-		if s, ok := arg.(string); ok && s == want {
-			return true
-		}
-	}
-	return false
-}
-
-func TestRedisSweepLeaseRefusesARoundAnotherReplicaHolds(t *testing.T) {
+func TestRedisSweepLeaseRefusesACoveredWindow(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second)
+	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second, 5*time.Minute)
 	mock.CustomMatch(func(_, _ []interface{}) error { return nil }).
 		ExpectSetNX("test:lease", "", time.Minute).SetVal(false)
 
-	if release, ok := lease.Acquire(context.Background()); ok {
-		release()
-		t.Fatal("replica was admitted to a round another replica already holds")
+	if finish, ok := lease.Acquire(context.Background()); ok {
+		finish(false)
+		t.Fatal("replica was admitted to a window another replica already covered")
 	}
 }
 
@@ -366,25 +523,25 @@ func TestRedisSweepLeaseRefusesARoundAnotherReplicaHolds(t *testing.T) {
 // idempotent; never running it strands an obligation.
 func TestRedisSweepLeaseFailsOpen(t *testing.T) {
 	client, mock := redismock.NewClientMock()
-	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second)
+	lease := newRedisSweepLease(client, "test:lease", time.Minute, 20*time.Second, 5*time.Minute)
 	mock.CustomMatch(func(_, _ []interface{}) error { return nil }).
 		ExpectSetNX("test:lease", "", time.Minute).SetErr(errors.New("redis is down"))
 
-	release, ok := lease.Acquire(context.Background())
+	finish, ok := lease.Acquire(context.Background())
 	if !ok {
 		t.Fatal("an unreachable Redis switched off the recovery round")
 	}
-	// There is no admission to give back, so release must be a safe no-op
-	// rather than a compare-and-delete against a key this replica never wrote.
-	release()
+	// There is no admission to convert or drop, so finish must be a safe no-op
+	// rather than a compare-and-write against a key this replica never wrote.
+	finish(true)
 }
 
 // No Redis is the Helm default. It must keep the pre-change behaviour of every
-// replica running every round, at the new cadence.
+// replica running on its own cadence.
 func TestUnleasedAlwaysRuns(t *testing.T) {
-	release, ok := (unleased{}).Acquire(context.Background())
+	finish, ok := (unleased{}).Acquire(context.Background())
 	if !ok {
 		t.Fatal("the no-Redis deployment stopped running the recovery sweep")
 	}
-	release()
+	finish(true)
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -653,12 +653,14 @@ func main() {
 	go runRuntimeGCSweeper(sweepCtx, pool, queries, taskSvc.Metrics, h)
 	// The durable delegated-failure recovery outbox is a crash backstop, not a
 	// liveness signal, so it gets its own low-frequency loop and a Redis lease
-	// that admits one replica per round. Without Redis every replica runs every
-	// round, which is what it did before at ten times the rate.
+	// that admits ONE scan per cadence window across every replica. Without
+	// Redis each replica keeps its own cadence, which is what it did before at
+	// a tenth of the rate.
 	var recoverySweepLease sweepLease = unleased{}
 	if storeRedis != nil {
 		recoverySweepLease = newRedisSweepLease(storeRedis, delegatedFailureRecoveryLeaseKey,
-			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoveryLeaseRenew)
+			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoveryLeaseRenew,
+			delegatedFailureRecoverySweepCadence)
 	}
 	go runDelegatedFailureRecoverySweeper(sweepCtx, taskSvc, recoverySweepLease)
 	// Source-context cleanup is object-store work, so it gets its own goroutine

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -651,6 +651,15 @@ func main() {
 	// its bounded transactions run independently once per hour, so a slow GC
 	// round cannot delay offline detection or task recovery.
 	go runRuntimeGCSweeper(sweepCtx, pool, queries, taskSvc.Metrics, h)
+	// The durable delegated-failure recovery outbox is a crash backstop, not a
+	// liveness signal, so it gets its own low-frequency loop and a Redis lease
+	// that admits one replica per round. Without Redis every replica runs every
+	// round, which is what it did before at ten times the rate.
+	var recoverySweepLease sweepLease = unleased{}
+	if storeRedis != nil {
+		recoverySweepLease = newRedisSweepLease(storeRedis, delegatedFailureRecoveryLeaseKey)
+	}
+	go runDelegatedFailureRecoverySweeper(sweepCtx, taskSvc, recoverySweepLease)
 	// Source-context cleanup is object-store work, so it gets its own goroutine
 	// instead of a slot in the runtime sweep tick.
 	go runSourceContextSweeper(sweepCtx, taskSvc)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -657,7 +657,8 @@ func main() {
 	// round, which is what it did before at ten times the rate.
 	var recoverySweepLease sweepLease = unleased{}
 	if storeRedis != nil {
-		recoverySweepLease = newRedisSweepLease(storeRedis, delegatedFailureRecoveryLeaseKey)
+		recoverySweepLease = newRedisSweepLease(storeRedis, delegatedFailureRecoveryLeaseKey,
+			delegatedFailureRecoveryLeaseTTL, delegatedFailureRecoveryLeaseRenew)
 	}
 	go runDelegatedFailureRecoverySweeper(sweepCtx, taskSvc, recoverySweepLease)
 	// Source-context cleanup is object-store work, so it gets its own goroutine

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -111,6 +111,10 @@ const (
 	// decouples the two — the cadence is enforced by the shared cooldown, while
 	// the poll only decides how promptly a live replica notices. A poll that
 	// loses costs one Redis SETNX and touches no database.
+	//
+	// It is therefore also the second term of
+	// delegatedFailureRecoveryWorstCaseHandoff: the finer it is, the sooner a
+	// surviving replica picks up a window whose previous holder died.
 	delegatedFailureRecoveryPollInterval = time.Minute
 	// delegatedFailureRecoveryLeaseTTL is how long the admission survives
 	// WITHOUT a renewal, not how long a round may take. Because the lease is
@@ -124,6 +128,29 @@ const (
 	// (a GC pause, a brief Redis blip) to be retried before the TTL runs out,
 	// so it stays at a third of it.
 	delegatedFailureRecoveryLeaseRenew = 10 * time.Second
+	// delegatedFailureRecoveryWorstCaseHandoff is how long a stranded
+	// obligation can go unrepaired in the worst case, and it is the SUM of the
+	// two waits above rather than the cadence alone.
+	//
+	// The path that produces it: a replica completes a round, converts its
+	// admission into the cadence cooldown, and then dies. The cooldown is
+	// global and outlives it, so nobody may start the next round until the
+	// window reopens a cadence later; the replica that takes over only notices
+	// that it reopened on its next poll. Cadence + poll = 6m, and no shorter
+	// bound is available while the cooldown is what enforces the global rate.
+	//
+	// Confirmed acceptable for MUL-6883 rather than derived from an SLA. What
+	// this bound governs is a double fault: a dispatch lost after its recovery
+	// comment committed, AND no process restart afterwards — a restart runs the
+	// scan immediately, and that is the dominant shape of the failure this
+	// repairs. Every other route to a recovery is unchanged and still
+	// immediate, and the 30 seconds this replaced was a side effect of sharing
+	// the liveness tick, never a requirement of the repair.
+	//
+	// Tightening it is a one-line change to the poll: the poll costs one Redis
+	// SETNX per replica and touches no database, so 30s of poll would buy a
+	// 5m30s bound. It was not taken because nothing is waiting on this path.
+	delegatedFailureRecoveryWorstCaseHandoff = delegatedFailureRecoverySweepCadence + delegatedFailureRecoveryPollInterval
 	// delegatedFailureRecoveryBatchSize bounds the durable recovery-outbox
 	// replay so a historical backlog cannot monopolise one round.
 	delegatedFailureRecoveryBatchSize = 100
@@ -216,12 +243,19 @@ func runRuntimeGCSweeper(ctx context.Context, txStarter runtimeGCTxStarter, quer
 //
 // Two changes replace that cadence. The scan runs once at startup, because a
 // process that just started is precisely the aftermath of the exit this repairs
-// and is when a stranded obligation is most likely to exist. It then runs every
-// five minutes, gated so one replica per round does the work.
+// and is when a stranded obligation is most likely to exist. It then runs on a
+// five-minute global cadence, gated so one round per window runs across the
+// whole deployment rather than one per replica.
 //
 // The tradeoff is the worst-case age of an obligation stranded by a crash that
-// is NOT followed by a restart: previously 30 seconds, now five minutes. Every
-// other path to a recovery is unchanged and still immediate.
+// is NOT followed by a restart: previously 30 seconds, now
+// delegatedFailureRecoveryWorstCaseHandoff — the five-minute cooldown a dead
+// holder leaves standing, plus the poll its successor needs to notice the
+// window reopened. That is six minutes, not five; the derivation and the
+// decision to accept it are recorded on that constant, and
+// TestWorstCaseRecoveryHandoffIsTheConfirmedBound fails if either input drifts
+// away from it. Every other path to a recovery is unchanged and still
+// immediate.
 func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.TaskService, lease sweepLease) {
 	runLeasedSweep(ctx, delegatedFailureRecoveryPollInterval, delegatedFailureRecoverySweepCadence, lease, func() {
 		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -99,12 +99,18 @@ const (
 	// recovery outbox, which is a crash backstop rather than a liveness signal
 	// (see runDelegatedFailureRecoverySweeper).
 	delegatedFailureRecoverySweepInterval = 5 * time.Minute
-	// delegatedFailureRecoveryLeaseTTL admits one replica per round. It is
-	// shorter than the interval so a replica that dies holding it delays at
-	// most one round, and long enough to cover a round that is slow rather than
-	// hung — a bounded batch of at most delegatedFailureRecoveryBatchSize
-	// dispatches.
-	delegatedFailureRecoveryLeaseTTL = 4 * time.Minute
+	// delegatedFailureRecoveryLeaseTTL is how long the admission survives
+	// WITHOUT a renewal, not how long a round may take. Because the lease is
+	// renewed for as long as the round runs, this no longer has to be guessed
+	// large enough to cover the slowest plausible round — the batch size bounds
+	// how many recoveries a round dispatches, never how long the database takes
+	// to answer. Keeping it short is what lets a replica that dies holding the
+	// lease hand the next round over in seconds instead of minutes.
+	delegatedFailureRecoveryLeaseTTL = 30 * time.Second
+	// delegatedFailureRecoveryLeaseRenew must leave room for a missed renewal
+	// (a GC pause, a brief Redis blip) to be retried before the TTL runs out,
+	// so it stays at a third of it.
+	delegatedFailureRecoveryLeaseRenew = 10 * time.Second
 	// delegatedFailureRecoveryBatchSize bounds the durable recovery-outbox
 	// replay so a historical backlog cannot monopolise one round.
 	delegatedFailureRecoveryBatchSize = 100
@@ -204,7 +210,7 @@ func runRuntimeGCSweeper(ctx context.Context, txStarter runtimeGCTxStarter, quer
 // is NOT followed by a restart: previously 30 seconds, now five minutes. Every
 // other path to a recovery is unchanged and still immediate.
 func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.TaskService, lease sweepLease) {
-	runLeasedSweep(ctx, delegatedFailureRecoverySweepInterval, delegatedFailureRecoveryLeaseTTL, lease, func() {
+	runLeasedSweep(ctx, delegatedFailureRecoverySweepInterval, lease, func() {
 		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
 	})
 }
@@ -212,22 +218,28 @@ func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.Ta
 // runLeasedSweep runs sweep once immediately and then on every interval tick,
 // skipping any round this replica does not win the lease for.
 //
+// The admission is held for the whole round and released when it ends, so a
+// round that runs long cannot be joined by a second replica, and a round that
+// finishes early does not reserve the key it no longer needs.
+//
 // The startup round is deliberately leased too. What it repairs is global
 // database state, not anything owned by this process, so one replica covering
 // the round covers it for all of them — and during a rolling deploy that is the
 // difference between one scan and one scan per replica restarted.
-func runLeasedSweep(ctx context.Context, interval, leaseTTL time.Duration, lease sweepLease, sweep func()) {
+func runLeasedSweep(ctx context.Context, interval time.Duration, lease sweepLease, sweep func()) {
 	guarded := func() {
 		if ctx.Err() != nil {
 			return
 		}
-		if !lease.Acquire(ctx, leaseTTL) {
+		release, ok := lease.Acquire(ctx)
+		if !ok {
 			// Deliberately not observed as a sweep stage: a zero-duration,
 			// zero-candidate sample would be indistinguishable from a round
 			// that ran and found nothing.
 			slog.Debug("leased sweep: another replica holds this round")
 			return
 		}
+		defer release()
 		sweep()
 	}
 	guarded()

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -95,8 +95,18 @@ const (
 	chatFinalizeGraceSeconds = 60.0
 	// chatFinalizeBatchSize caps deferred finalizations per tick.
 	chatFinalizeBatchSize = 100
+	// delegatedFailureRecoverySweepInterval is the cadence of the durable
+	// recovery outbox, which is a crash backstop rather than a liveness signal
+	// (see runDelegatedFailureRecoverySweeper).
+	delegatedFailureRecoverySweepInterval = 5 * time.Minute
+	// delegatedFailureRecoveryLeaseTTL admits one replica per round. It is
+	// shorter than the interval so a replica that dies holding it delays at
+	// most one round, and long enough to cover a round that is slow rather than
+	// hung — a bounded batch of at most delegatedFailureRecoveryBatchSize
+	// dispatches.
+	delegatedFailureRecoveryLeaseTTL = 4 * time.Minute
 	// delegatedFailureRecoveryBatchSize bounds the durable recovery-outbox
-	// replay so a historical backlog cannot monopolise the runtime sweep tick.
+	// replay so a historical backlog cannot monopolise one round.
 	delegatedFailureRecoveryBatchSize = 100
 )
 
@@ -155,16 +165,16 @@ func runPeriodicSweep(ctx context.Context, interval time.Duration, sweep func())
 // stale window — that is the original behavior.
 func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handler.LivenessStore, taskSvc *service.TaskService, bus *events.Bus, reconnectGrace time.Duration) {
 	runPeriodicSweep(ctx, sweepInterval, func() {
-		// These stages retain the existing cadence and ordering in PR1 so the
-		// rollout changes no business predicate or recovery semantics. Runtime
-		// GC is the one exception: its seven-day retention work now runs in the
-		// independent hourly loop below and cannot delay this liveness path.
+		// These stages retain the existing cadence and ordering so the rollout
+		// changes no business predicate or recovery semantics. Two exceptions
+		// have moved to independent loops below because neither is a liveness
+		// signal: runtime GC's seven-day retention scan, and the durable
+		// delegated-failure recovery outbox.
 		sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 		sweepOfflineRuntimeTasks(ctx, queries, taskSvc, reconnectGrace)
 		sweepExpiredRuntimeReconnectRetries(ctx, queries, taskSvc, reconnectGrace)
 		sweepStaleTasks(ctx, queries, taskSvc, bus, reconnectGrace)
 		sweepExpiredQueuedTasks(ctx, queries, taskSvc, reconnectGrace)
-		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
 		sweepDeferredChatFinalizations(ctx, queries, taskSvc)
 	})
 }
@@ -175,10 +185,59 @@ func runRuntimeGCSweeper(ctx context.Context, txStarter runtimeGCTxStarter, quer
 	})
 }
 
+// runDelegatedFailureRecoverySweeper owns the durable recovery outbox on its
+// own cadence.
+//
+// The 30-second liveness tick was never this scan's requirement. The normal
+// terminal-failure path dispatches the coordinator handoff immediately; this
+// sweep exists only to repair the narrow window where the recovery comment
+// committed but its dispatch did not — a transient database error, or a process
+// that exited in between. Running that repair 2,880 times a day per replica
+// bought latency nobody was waiting on.
+//
+// Two changes replace that cadence. The scan runs once at startup, because a
+// process that just started is precisely the aftermath of the exit this repairs
+// and is when a stranded obligation is most likely to exist. It then runs every
+// five minutes, gated so one replica per round does the work.
+//
+// The tradeoff is the worst-case age of an obligation stranded by a crash that
+// is NOT followed by a restart: previously 30 seconds, now five minutes. Every
+// other path to a recovery is unchanged and still immediate.
+func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.TaskService, lease sweepLease) {
+	runLeasedSweep(ctx, delegatedFailureRecoverySweepInterval, delegatedFailureRecoveryLeaseTTL, lease, func() {
+		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
+	})
+}
+
+// runLeasedSweep runs sweep once immediately and then on every interval tick,
+// skipping any round this replica does not win the lease for.
+//
+// The startup round is deliberately leased too. What it repairs is global
+// database state, not anything owned by this process, so one replica covering
+// the round covers it for all of them — and during a rolling deploy that is the
+// difference between one scan and one scan per replica restarted.
+func runLeasedSweep(ctx context.Context, interval, leaseTTL time.Duration, lease sweepLease, sweep func()) {
+	guarded := func() {
+		if ctx.Err() != nil {
+			return
+		}
+		if !lease.Acquire(ctx, leaseTTL) {
+			// Deliberately not observed as a sweep stage: a zero-duration,
+			// zero-candidate sample would be indistinguishable from a round
+			// that ran and found nothing.
+			slog.Debug("leased sweep: another replica holds this round")
+			return
+		}
+		sweep()
+	}
+	guarded()
+	runPeriodicSweep(ctx, interval, guarded)
+}
+
 // sweepPendingDelegatedFailureRecoveries retries durable coordinator handoffs
-// that were not acquired by an executable task. It runs even when no stale
-// task was found in this tick, which is what repairs a recovery dispatch lost
-// before a server restart.
+// that were not acquired by an executable task. It is unconditional — nothing
+// earlier has to have found stale work — because what it repairs is a dispatch
+// lost before a server restart, which leaves no other trace.
 func sweepPendingDelegatedFailureRecoveries(ctx context.Context, taskSvc *service.TaskService) (stats runtimeSweepStageStats) {
 	startedAt := time.Now()
 	defer func() {

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -95,10 +95,23 @@ const (
 	chatFinalizeGraceSeconds = 60.0
 	// chatFinalizeBatchSize caps deferred finalizations per tick.
 	chatFinalizeBatchSize = 100
-	// delegatedFailureRecoverySweepInterval is the cadence of the durable
-	// recovery outbox, which is a crash backstop rather than a liveness signal
-	// (see runDelegatedFailureRecoverySweeper).
-	delegatedFailureRecoverySweepInterval = 5 * time.Minute
+	// delegatedFailureRecoverySweepCadence is the GLOBAL rate of the durable
+	// recovery outbox: at most one scan per cadence across the whole
+	// deployment, not per replica. It is a crash backstop rather than a
+	// liveness signal (see runDelegatedFailureRecoverySweeper).
+	delegatedFailureRecoverySweepCadence = 5 * time.Minute
+	// delegatedFailureRecoveryPollInterval is how often a replica CHECKS
+	// whether the cadence window has reopened, which is deliberately finer than
+	// the cadence itself.
+	//
+	// Ticking at the cadence would make the phase of each replica's ticker
+	// decide who runs: the window would be claimed by whichever replica happens
+	// to tick first after it opens, and if that replica then died the window
+	// could stay unclaimed for nearly a second full cadence. Polling finer
+	// decouples the two — the cadence is enforced by the shared cooldown, while
+	// the poll only decides how promptly a live replica notices. A poll that
+	// loses costs one Redis SETNX and touches no database.
+	delegatedFailureRecoveryPollInterval = time.Minute
 	// delegatedFailureRecoveryLeaseTTL is how long the admission survives
 	// WITHOUT a renewal, not how long a round may take. Because the lease is
 	// renewed for as long as the round runs, this no longer has to be guessed
@@ -210,37 +223,55 @@ func runRuntimeGCSweeper(ctx context.Context, txStarter runtimeGCTxStarter, quer
 // is NOT followed by a restart: previously 30 seconds, now five minutes. Every
 // other path to a recovery is unchanged and still immediate.
 func runDelegatedFailureRecoverySweeper(ctx context.Context, taskSvc *service.TaskService, lease sweepLease) {
-	runLeasedSweep(ctx, delegatedFailureRecoverySweepInterval, lease, func() {
+	runLeasedSweep(ctx, delegatedFailureRecoveryPollInterval, delegatedFailureRecoverySweepCadence, lease, func() {
 		sweepPendingDelegatedFailureRecoveries(ctx, taskSvc)
 	})
 }
 
-// runLeasedSweep runs sweep once immediately and then on every interval tick,
-// skipping any round this replica does not win the lease for.
+// runLeasedSweep polls every interval and runs sweep in any cadence window this
+// replica claims, starting with one attempt at startup.
 //
-// The admission is held for the whole round and released when it ends, so a
-// round that runs long cannot be joined by a second replica, and a round that
-// finishes early does not reserve the key it no longer needs.
+// Two guards decide that, and both are needed:
 //
-// The startup round is deliberately leased too. What it repairs is global
+//   - the lease, which is what makes the cadence GLOBAL. It excludes other
+//     replicas for the duration of the round and then, on success, for the rest
+//     of the cadence window. Without the second half the lease would only stop
+//     replicas overlapping, and out-of-phase replicas would still take turns
+//     running one scan each per window.
+//   - lastCompleted, the local floor. It bounds the no-Redis deployment, where
+//     there is no shared cooldown to consult, and it is what lets the poll be
+//     finer than the cadence without turning fail-open into a hot loop.
+//
+// The startup round goes through the same gate. What it repairs is global
 // database state, not anything owned by this process, so one replica covering
-// the round covers it for all of them — and during a rolling deploy that is the
+// the window covers it for all of them — during a rolling restart that is the
 // difference between one scan and one scan per replica restarted.
-func runLeasedSweep(ctx context.Context, interval time.Duration, lease sweepLease, sweep func()) {
+func runLeasedSweep(ctx context.Context, interval, cadence time.Duration, lease sweepLease, sweep func()) {
+	var lastCompleted time.Time
 	guarded := func() {
 		if ctx.Err() != nil {
 			return
 		}
-		release, ok := lease.Acquire(ctx)
+		if !lastCompleted.IsZero() && time.Since(lastCompleted) < cadence {
+			return
+		}
+		finish, ok := lease.Acquire(ctx)
 		if !ok {
 			// Deliberately not observed as a sweep stage: a zero-duration,
 			// zero-candidate sample would be indistinguishable from a round
 			// that ran and found nothing.
-			slog.Debug("leased sweep: another replica holds this round")
+			slog.Debug("leased sweep: this cadence window is already covered")
 			return
 		}
-		defer release()
 		sweep()
+		// A shutdown mid-round leaves the window uncovered, so hand it back
+		// instead of cooling down: the replica that takes over should not have
+		// to wait out a cadence this one did not finish.
+		completed := ctx.Err() == nil
+		finish(completed)
+		if completed {
+			lastCompleted = time.Now()
+		}
 	}
 	guarded()
 	runPeriodicSweep(ctx, interval, guarded)

--- a/server/cmd/server/sweep_lease.go
+++ b/server/cmd/server/sweep_lease.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// sweepLease admits one replica per round to a sweep that only needs to happen
+// once across the deployment. It is an efficiency gate, not a correctness one:
+// the work behind it is idempotent, so a round run twice costs duplicated
+// database work while a round never run loses a recovery. Every implementation
+// therefore fails OPEN.
+type sweepLease interface {
+	// Acquire reports whether this replica should run the round. ttl bounds
+	// how long the admission is held, so a replica that dies mid-round cannot
+	// suppress later rounds.
+	Acquire(ctx context.Context, ttl time.Duration) bool
+}
+
+// unleased is the no-Redis deployment: every replica runs every round, which is
+// what the sweep did before it was gated. A single-replica install — the Helm
+// default — is already exactly one runner, and a multi-replica install without
+// Redis keeps the amplification it has today at the new, lower cadence.
+type unleased struct{}
+
+func (unleased) Acquire(context.Context, time.Duration) bool { return true }
+
+// redisSweepLease admits the first replica to claim the key each round.
+//
+// SET NX PX is the whole protocol: there is no renewal and no release. The
+// admission simply expires, so the next round is contested from scratch and a
+// replica that crashes holding it delays at most one round. That is the right
+// shape for a rare, bounded, idempotent sweep — a renewed lease would add a
+// failure mode (a live holder that has stopped sweeping) with nothing to gain.
+type redisSweepLease struct {
+	client *redis.Client
+	key    string
+	// holder identifies this process only for operators reading the key; the
+	// protocol never compares it, because nothing here releases the lease.
+	holder string
+}
+
+func newRedisSweepLease(client *redis.Client, key string) *redisSweepLease {
+	return &redisSweepLease{client: client, key: key, holder: uuid.NewString()}
+}
+
+func (l *redisSweepLease) Acquire(ctx context.Context, ttl time.Duration) bool {
+	acquired, err := l.client.SetNX(ctx, l.key, l.holder, ttl).Result()
+	if err != nil {
+		// Fail open. Redis being unreachable must not silently switch off a
+		// recovery path; the cost of guessing wrong in this direction is a
+		// duplicate scan that finds the same rows already handled.
+		slog.Warn("sweep lease: redis unavailable, running this round unguarded",
+			"key", l.key, "error", err)
+		return true
+	}
+	return acquired
+}
+
+// delegatedFailureRecoveryLeaseKey is versioned so a future change to the round
+// protocol cannot be confused by a key left behind by an older replica.
+const delegatedFailureRecoveryLeaseKey = "multica:sweep-lease:v1:delegated-failure-recovery"

--- a/server/cmd/server/sweep_lease.go
+++ b/server/cmd/server/sweep_lease.go
@@ -9,40 +9,68 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// sweepLease admits one replica per round to a sweep that only needs to happen
-// once across the deployment, and keeps that admission for as long as the round
-// actually runs.
+// sweepLease enforces a global cadence for a sweep that only needs to happen
+// once across the deployment, no matter how many replicas are running.
+//
+// Two separate exclusions are needed, and getting only the first is the trap:
+//
+//   - while a round runs, no other replica may join it
+//   - after a round SUCCEEDS, no replica may start another until the cadence
+//     window reopens
+//
+// Holding a key for the duration of the round and deleting it at the end gives
+// only the first. Replicas whose ticks are out of phase — which they always are
+// after a rolling restart, because each starts its ticker when its own startup
+// round finishes — then simply take turns, and the deployment still runs one
+// scan per replica per window. The admission therefore does not end at DEL; on
+// success it converts into a cooldown that blocks everyone.
 //
 // It is an efficiency gate, not a correctness one: the work behind it is
 // idempotent, so a round run twice costs duplicated database work while a round
 // never run loses a recovery. Every implementation therefore fails OPEN.
 type sweepLease interface {
-	// Acquire reports whether this replica should run the round. The returned
-	// release must be called when the round ends and is never nil when ok is
-	// true; it stays safe to call after the caller's context is cancelled,
-	// which is what lets a shutdown hand the next round over immediately.
-	Acquire(ctx context.Context) (release func(), ok bool)
+	// Acquire reports whether this replica should run the round now. The
+	// returned finish must be called when the round ends and is never nil when
+	// ok is true.
+	//
+	// finish(true) means the round completed, and starts the cadence cooldown.
+	// finish(false) means it was cut short — a shutdown mid-round — and hands
+	// the window back so another replica can cover it immediately. Both stay
+	// safe to call after the caller's context is cancelled.
+	Acquire(ctx context.Context) (finish func(completed bool), ok bool)
 }
 
-// unleased is the no-Redis deployment: every replica runs every round, which is
-// what the sweep did before it was gated. A single-replica install — the Helm
-// default — is already exactly one runner, and a multi-replica install without
-// Redis keeps the amplification it has today at the new, lower cadence.
+// unleased is the no-Redis deployment. There is no cross-replica state to
+// consult, so every replica runs on its own cadence — which is what the sweep
+// did before it was gated, and is exactly one runner on the Helm default of a
+// single backend replica. The caller's local cadence guard is what keeps this
+// from degenerating into a poll.
 type unleased struct{}
 
-func (unleased) Acquire(context.Context) (func(), bool) { return func() {}, true }
+func (unleased) Acquire(context.Context) (func(bool), bool) { return func(bool) {}, true }
 
-// Renew and release compare the holder token before acting, so a replica can
-// only extend or drop the admission it still owns. Without that compare, a
+// Every mutation compares the holder token before acting, so a replica can only
+// extend, convert or drop the admission it still owns. Without that compare, a
 // replica whose lease had already expired and been taken by someone else would
-// renew or delete the new holder's key.
+// renew, cool down or delete the new holder's key.
 //
-// Sent as plain EVAL rather than a cached script: at one renewal per renew
+// Sent as plain EVAL rather than a cached script: at one call per renew
 // interval the extra script bytes are irrelevant, and it keeps each lease
 // mutation a single observable command with no NOSCRIPT fallback path.
 const redisRenewSweepLeaseSource = `
 if redis.call('GET', KEYS[1]) == ARGV[1] then
   return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+`
+
+// Converting rather than deleting is what makes this a cadence gate. The key
+// stays present, now holding the cooldown marker instead of a holder token, so
+// the next replica to poll is refused until it expires.
+const redisCooldownSweepLeaseSource = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+  return 1
 end
 return 0
 `
@@ -54,38 +82,37 @@ end
 return 0
 `
 
-// releaseTimeout bounds the compare-and-delete on the shutdown path, where the
-// caller's context is already cancelled. Failing to release is not harmful —
-// the key expires on its own — so this only decides how long shutdown waits
-// before giving up on handing the round over early.
-const releaseTimeout = 5 * time.Second
+// sweepCooldownMarker is what the key holds between rounds. Holder tokens are
+// UUIDs, so this can never be mistaken for one.
+const sweepCooldownMarker = "cooldown"
 
-// redisSweepLease admits the first replica to claim the key each round and
-// holds the admission for the whole round.
+// finishTimeout bounds the compare-and-write on the shutdown path, where the
+// caller's context is already cancelled. Failing here is not harmful — the key
+// expires on its own — so it only decides how long shutdown waits.
+const finishTimeout = 5 * time.Second
+
+// redisSweepLease admits the first replica to claim the key, holds the
+// admission for as long as the round runs, and converts it into a cadence
+// cooldown when the round succeeds.
 //
-// A fixed TTL cannot do that. The round has no deadline of its own: its batch
-// size bounds how many recoveries it dispatches, not how long the database
-// takes to answer, so a slow round can outlive any TTL picked in advance —
-// and precisely when the database is already struggling, a second replica
-// would then enter and re-run the sweeper's most expensive query. The lease is
-// therefore renewed on a timer while the round runs, and released when it ends
-// so the next round is contested immediately rather than after a timeout.
-//
-// Every mutation compares a per-round holder token, so a replica that lost its
-// lease (a renewal that arrived too late, a pause long enough for the key to
-// expire) can neither extend nor delete whatever the new holder wrote.
+// A fixed TTL cannot cover the round: it has no deadline of its own, since its
+// batch size bounds how many recoveries it dispatches and not how long the
+// database takes to answer. So the admission is renewed on a timer while the
+// round runs. The cooldown then bounds the other direction — how soon anyone
+// may start the next round — which the renewal alone does not.
 type redisSweepLease struct {
-	client *redis.Client
-	key    string
-	ttl    time.Duration
-	renew  time.Duration
+	client   *redis.Client
+	key      string
+	ttl      time.Duration
+	renew    time.Duration
+	cooldown time.Duration
 }
 
-func newRedisSweepLease(client *redis.Client, key string, ttl, renew time.Duration) *redisSweepLease {
-	return &redisSweepLease{client: client, key: key, ttl: ttl, renew: renew}
+func newRedisSweepLease(client *redis.Client, key string, ttl, renew, cooldown time.Duration) *redisSweepLease {
+	return &redisSweepLease{client: client, key: key, ttl: ttl, renew: renew, cooldown: cooldown}
 }
 
-func (l *redisSweepLease) Acquire(ctx context.Context) (func(), bool) {
+func (l *redisSweepLease) Acquire(ctx context.Context) (func(bool), bool) {
 	// A fresh token per round: nothing here re-acquires an admission it already
 	// holds, so reusing one across rounds would only make a stale renewal look
 	// legitimate.
@@ -95,12 +122,15 @@ func (l *redisSweepLease) Acquire(ctx context.Context) (func(), bool) {
 		// Fail open. Redis being unreachable must not silently switch off a
 		// recovery path; the cost of guessing wrong in this direction is a
 		// duplicate scan that finds the same rows already handled. There is no
-		// admission to hold, so nothing to renew or release either.
+		// admission to hold, so nothing to renew, cool down or release. The
+		// caller's local cadence guard still bounds how often this happens.
 		slog.Warn("sweep lease: redis unavailable, running this round unguarded",
 			"key", l.key, "error", err)
-		return func() {}, true
+		return func(bool) {}, true
 	}
 	if !acquired {
+		// Either another replica is mid-round, or the cadence window this
+		// round belongs to has already been covered.
 		return nil, false
 	}
 
@@ -111,15 +141,29 @@ func (l *redisSweepLease) Acquire(ctx context.Context) (func(), bool) {
 		l.keepAlive(renewCtx, token)
 	}()
 
-	return func() {
+	return func(completed bool) {
 		stopRenewing()
 		<-renewalStopped
-		// Detached from the caller's context so a shutdown still hands the
-		// round over instead of leaving the key to expire on its own.
-		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+		// Detached from the caller's context so a shutdown still records the
+		// outcome instead of leaving the key to expire on its own.
+		finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finishTimeout)
 		defer cancel()
-		if err := l.client.Eval(releaseCtx, redisReleaseSweepLeaseSource, []string{l.key}, token).Err(); err != nil && err != redis.Nil {
-			slog.Warn("sweep lease: release failed; the round will be contested again when the key expires",
+
+		if !completed {
+			// The round was cut short, so this window is NOT covered. Drop the
+			// admission rather than cooling down, and let another replica take
+			// it on its next poll.
+			if err := l.client.Eval(finishCtx, redisReleaseSweepLeaseSource, []string{l.key}, token).Err(); err != nil && err != redis.Nil {
+				slog.Warn("sweep lease: release failed; the round will be contested again when the key expires",
+					"key", l.key, "error", err)
+			}
+			return
+		}
+		if err := l.client.Eval(finishCtx, redisCooldownSweepLeaseSource,
+			[]string{l.key}, token, sweepCooldownMarker, l.cooldown.Milliseconds()).Err(); err != nil && err != redis.Nil {
+			// The admission expires on its own, so the worst case is that the
+			// next window opens early and one extra scan runs.
+			slog.Warn("sweep lease: cooldown failed; another replica may repeat this round",
 				"key", l.key, "error", err)
 		}
 	}, true
@@ -148,7 +192,8 @@ func (l *redisSweepLease) keepAlive(ctx context.Context, token string) {
 				// The key is gone or now belongs to someone else. The round
 				// keeps running — stopping it half-done would strand the work
 				// it has already started, and the dispatch it performs is
-				// idempotent — but it is no longer the single holder.
+				// idempotent — but it is no longer the single holder, and its
+				// finish will no longer match the token.
 				slog.Warn("sweep lease: lost mid-round; another replica may run this round concurrently",
 					"key", l.key)
 				return

--- a/server/cmd/server/sweep_lease.go
+++ b/server/cmd/server/sweep_lease.go
@@ -10,15 +10,18 @@ import (
 )
 
 // sweepLease admits one replica per round to a sweep that only needs to happen
-// once across the deployment. It is an efficiency gate, not a correctness one:
-// the work behind it is idempotent, so a round run twice costs duplicated
-// database work while a round never run loses a recovery. Every implementation
-// therefore fails OPEN.
+// once across the deployment, and keeps that admission for as long as the round
+// actually runs.
+//
+// It is an efficiency gate, not a correctness one: the work behind it is
+// idempotent, so a round run twice costs duplicated database work while a round
+// never run loses a recovery. Every implementation therefore fails OPEN.
 type sweepLease interface {
-	// Acquire reports whether this replica should run the round. ttl bounds
-	// how long the admission is held, so a replica that dies mid-round cannot
-	// suppress later rounds.
-	Acquire(ctx context.Context, ttl time.Duration) bool
+	// Acquire reports whether this replica should run the round. The returned
+	// release must be called when the round ends and is never nil when ok is
+	// true; it stays safe to call after the caller's context is cancelled,
+	// which is what lets a shutdown hand the next round over immediately.
+	Acquire(ctx context.Context) (release func(), ok bool)
 }
 
 // unleased is the no-Redis deployment: every replica runs every round, which is
@@ -27,38 +30,131 @@ type sweepLease interface {
 // Redis keeps the amplification it has today at the new, lower cadence.
 type unleased struct{}
 
-func (unleased) Acquire(context.Context, time.Duration) bool { return true }
+func (unleased) Acquire(context.Context) (func(), bool) { return func() {}, true }
 
-// redisSweepLease admits the first replica to claim the key each round.
+// Renew and release compare the holder token before acting, so a replica can
+// only extend or drop the admission it still owns. Without that compare, a
+// replica whose lease had already expired and been taken by someone else would
+// renew or delete the new holder's key.
 //
-// SET NX PX is the whole protocol: there is no renewal and no release. The
-// admission simply expires, so the next round is contested from scratch and a
-// replica that crashes holding it delays at most one round. That is the right
-// shape for a rare, bounded, idempotent sweep — a renewed lease would add a
-// failure mode (a live holder that has stopped sweeping) with nothing to gain.
+// Sent as plain EVAL rather than a cached script: at one renewal per renew
+// interval the extra script bytes are irrelevant, and it keeps each lease
+// mutation a single observable command with no NOSCRIPT fallback path.
+const redisRenewSweepLeaseSource = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+`
+
+const redisReleaseSweepLeaseSource = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`
+
+// releaseTimeout bounds the compare-and-delete on the shutdown path, where the
+// caller's context is already cancelled. Failing to release is not harmful —
+// the key expires on its own — so this only decides how long shutdown waits
+// before giving up on handing the round over early.
+const releaseTimeout = 5 * time.Second
+
+// redisSweepLease admits the first replica to claim the key each round and
+// holds the admission for the whole round.
+//
+// A fixed TTL cannot do that. The round has no deadline of its own: its batch
+// size bounds how many recoveries it dispatches, not how long the database
+// takes to answer, so a slow round can outlive any TTL picked in advance —
+// and precisely when the database is already struggling, a second replica
+// would then enter and re-run the sweeper's most expensive query. The lease is
+// therefore renewed on a timer while the round runs, and released when it ends
+// so the next round is contested immediately rather than after a timeout.
+//
+// Every mutation compares a per-round holder token, so a replica that lost its
+// lease (a renewal that arrived too late, a pause long enough for the key to
+// expire) can neither extend nor delete whatever the new holder wrote.
 type redisSweepLease struct {
 	client *redis.Client
 	key    string
-	// holder identifies this process only for operators reading the key; the
-	// protocol never compares it, because nothing here releases the lease.
-	holder string
+	ttl    time.Duration
+	renew  time.Duration
 }
 
-func newRedisSweepLease(client *redis.Client, key string) *redisSweepLease {
-	return &redisSweepLease{client: client, key: key, holder: uuid.NewString()}
+func newRedisSweepLease(client *redis.Client, key string, ttl, renew time.Duration) *redisSweepLease {
+	return &redisSweepLease{client: client, key: key, ttl: ttl, renew: renew}
 }
 
-func (l *redisSweepLease) Acquire(ctx context.Context, ttl time.Duration) bool {
-	acquired, err := l.client.SetNX(ctx, l.key, l.holder, ttl).Result()
+func (l *redisSweepLease) Acquire(ctx context.Context) (func(), bool) {
+	// A fresh token per round: nothing here re-acquires an admission it already
+	// holds, so reusing one across rounds would only make a stale renewal look
+	// legitimate.
+	token := uuid.NewString()
+	acquired, err := l.client.SetNX(ctx, l.key, token, l.ttl).Result()
 	if err != nil {
 		// Fail open. Redis being unreachable must not silently switch off a
 		// recovery path; the cost of guessing wrong in this direction is a
-		// duplicate scan that finds the same rows already handled.
+		// duplicate scan that finds the same rows already handled. There is no
+		// admission to hold, so nothing to renew or release either.
 		slog.Warn("sweep lease: redis unavailable, running this round unguarded",
 			"key", l.key, "error", err)
-		return true
+		return func() {}, true
 	}
-	return acquired
+	if !acquired {
+		return nil, false
+	}
+
+	renewCtx, stopRenewing := context.WithCancel(ctx)
+	renewalStopped := make(chan struct{})
+	go func() {
+		defer close(renewalStopped)
+		l.keepAlive(renewCtx, token)
+	}()
+
+	return func() {
+		stopRenewing()
+		<-renewalStopped
+		// Detached from the caller's context so a shutdown still hands the
+		// round over instead of leaving the key to expire on its own.
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+		defer cancel()
+		if err := l.client.Eval(releaseCtx, redisReleaseSweepLeaseSource, []string{l.key}, token).Err(); err != nil && err != redis.Nil {
+			slog.Warn("sweep lease: release failed; the round will be contested again when the key expires",
+				"key", l.key, "error", err)
+		}
+	}, true
+}
+
+// keepAlive extends the admission until the round ends or the lease is lost.
+func (l *redisSweepLease) keepAlive(ctx context.Context, token string) {
+	ticker := time.NewTicker(l.renew)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			renewed, err := l.client.Eval(ctx, redisRenewSweepLeaseSource, []string{l.key}, token, l.ttl.Milliseconds()).Int64()
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				// Transient: the admission is still ours until the key
+				// expires, so keep trying on the next tick.
+				slog.Warn("sweep lease: renewal failed, retrying", "key", l.key, "error", err)
+				continue
+			}
+			if renewed == 0 {
+				// The key is gone or now belongs to someone else. The round
+				// keeps running — stopping it half-done would strand the work
+				// it has already started, and the dispatch it performs is
+				// idempotent — but it is no longer the single holder.
+				slog.Warn("sweep lease: lost mid-round; another replica may run this round concurrently",
+					"key", l.key)
+				return
+			}
+		}
+	}
 }
 
 // delegatedFailureRecoveryLeaseKey is versioned so a future change to the round

--- a/server/cmd/server/sweep_lease.go
+++ b/server/cmd/server/sweep_lease.go
@@ -37,6 +37,13 @@ type sweepLease interface {
 	// finish(false) means it was cut short — a shutdown mid-round — and hands
 	// the window back so another replica can cover it immediately. Both stay
 	// safe to call after the caller's context is cancelled.
+	//
+	// The cooldown is shared state, so it deliberately outlives the replica
+	// that set it: a holder that dies right after completing a round keeps
+	// everyone else out for the rest of that window. That is the cost of making
+	// the cadence global, and it is what makes the caller's worst-case handoff
+	// a cadence plus a poll rather than a cadence
+	// (delegatedFailureRecoveryWorstCaseHandoff records the accepted bound).
 	Acquire(ctx context.Context) (finish func(completed bool), ok bool)
 }
 


### PR DESCRIPTION
Step 5 of MUL-6883. Independent of #7820 — no overlapping files — but see **Merge order** below.

## Summary

The recovery outbox scan sat inside the 30-second runtime-liveness loop, so every backend replica ran the sweeper's most expensive query **2,880 times a day**. That cadence was never its requirement: the normal terminal-failure path dispatches the coordinator handoff immediately, and this sweep exists only to repair the narrow window where the recovery comment committed but its dispatch did not — a transient database error, or a process that exited in between.

It now has its own five-minute loop, runs **once at startup**, and each round is gated on a Redis lease so one round happens per window across the whole deployment. Per replica: **2,880 → 288 calls/day**, and the `× N` amplification is gone rather than reshuffled between replicas.

## The startup round is the one that matters

A process that just started is precisely the aftermath of the exit this sweep repairs, so scanning then covers the dominant case without waiting an interval. Reducing the cadence *without* it would have made the new arrangement strictly worse than the old one.

It is leased too, deliberately: what it repairs is global database state rather than anything this process owns, so during a rolling deploy one scan covers every replica restarted, not one scan per restart.

## The lease: two exclusions, not one

The gate needs **both** halves, and having only the first is the trap:

1. while a round runs, no other replica may join it;
2. after a round **succeeds**, no replica may start another until the cadence window reopens.

Holding a key for the round and `DEL`-ing it at the end gives only (1). Replica phases always differ — each starts its ticker when its own startup round finishes, and a rolling restart staggers them further — so replicas would simply take turns and the deployment would still run one scan per replica per window.

So the protocol is:

| | |
|---|---|
| **acquire** | `SET NX PX` with a per-round holder token |
| **renew** | every 10s while the round runs, token-compared in Lua |
| **succeed** | the admission is **converted** (not deleted) into a `cooldown` marker for the rest of the window, under the same token compare |
| **cut short** | released, token-compared — an interrupted round did not cover its window, so the replica taking over should not wait out a cadence someone else abandoned |

A round has no deadline of its own — the batch size bounds how many recoveries it dispatches, never how long the database takes to answer — so a fixed TTL could expire mid-round and let a second replica re-run the expensive query exactly when the database is already slow. Renewal removes the need to guess: **TTL (30s) is how long the admission survives *without* a renewal**, renewed at 10s so a single missed renewal is retried, and a replica that dies holding it frees the round in seconds rather than minutes.

The tick is a **1-minute poll, finer than the 5-minute cadence**. Ticking at the cadence would let each replica's ticker phase decide who runs, and a window whose claimant then died could sit unclaimed for nearly a full cadence. The cooldown enforces the rate; the poll only decides how promptly a live replica notices. A poll that loses costs one Redis `SETNX` and touches no database.

A **local floor** completes it: a replica will not start a round within a cadence of its own last completed one. That bounds the no-Redis deployment, which has no shared cooldown to consult, and keeps fail-open from turning the finer poll into a hot loop against the database.

**It fails open.** An unreachable Redis must not silently switch off a recovery path: a duplicated round repeats work that is already idempotent — concurrent sweepers are serialised by `AcknowledgeExhaustedDelegatedFailureRecovery`'s `FOR UPDATE` — while a skipped round strands an obligation. With no Redis configured at all (the Helm default `backend.replicas: 1`) every replica runs every round, exactly as today, at a tenth of the rate.

## Tradeoff: worst case is ~6 minutes, and that is accepted

The worst-case age of an obligation stranded by a crash that is **not** followed by a restart goes from 30 seconds to **six minutes** — `delegatedFailureRecoveryWorstCaseHandoff`, which is the cadence plus one poll, not the cadence alone.

The path that produces it: a replica completes a round, converts its admission into the cooldown, and then dies. The cooldown is shared state and outlives it, so nobody may start the next round until the window reopens five minutes later, and the successor notices on its next poll — up to a minute after that. No tighter bound exists while a shared cooldown is what enforces the global rate.

Accepted rather than reshaped, because what it governs is a **double fault**: a dispatch lost after its recovery comment committed **and** no restart afterwards — a restart scans immediately, and that is the dominant shape of this failure. Every other route to a recovery is unchanged and still immediate, and the 30 seconds this replaces was a side effect of sharing the liveness tick, never a requirement of the repair.

It is cheap to tighten if that ever changes: the poll is one line and costs one Redis `SETNX` per replica per interval, so a 30s poll would buy a 5m30s bound.

## Observability

The `delegated_failure_recovery` stage of `multica_runtime_sweeper_stage_duration_seconds` is unchanged, so existing dashboards keep working — it is simply emitted by whichever replica held the round. A skipped round emits nothing rather than a zero-duration, zero-candidate sample, which would be indistinguishable from a round that ran and found nothing.

## Merge order

Sequenced after #7820's backfill is verified in production. Dropping the call rate first would mask whether the settled-marker index actually reduced per-call cost — you would see total load fall either way. Nothing here depends on #7820's code, so the two can merge in either order technically; this is a measurement constraint, not a build one.

## Testing

```
go test -race ./cmd/server/     # pass (clean, migrated database)
go test ./internal/service/     # pass
go vet ./cmd/server/            # pass
```

Coverage of the global property, which is what a mutex-shaped implementation passes and a cadence gate must:

- `TestScanRateDoesNotGrowWithReplicaCount` — 4 staggered replicas vs 1, across several windows; 27 vs 7 rounds under delete-on-finish
- `TestRollingRestartProducesOneStartupScan` — 5 staggered starts, exactly 1 effective scan; 5 under delete-on-finish
- `TestSlowRoundExcludesOtherReplicasDuringAndAfter` — no second replica during a round that outlives the old fixed TTL, **and** none after it in the same window
- `TestWorstCaseRecoveryHandoffIsTheConfirmedBound` — pins cadence + poll = the documented 6m, so moving either input has to move the recorded decision
- `TestDeadHolderHandsOverWithinOnePollOfTheCooldown` — after its holder stops, the window is picked up no earlier than the cooldown and within one poll of it; a cadence-ticking successor takes 799ms against a 460ms bound in the same setup
- `TestAbandonedRoundIsHandedBackImmediately`, `TestFinishAfterLosingTheLeaseDoesNotAffectTheNewHolder`, `TestLocalCadenceFloorHoldsWithoutALease`
- `TestRedisSweepLeaseRenewsDuringTheRoundAndCoolsDownAfter`, `TestRedisSweepLeaseReleasesAnAbandonedRound`, `TestRedisSweepLeaseRefusesACoveredWindow`, `TestRedisSweepLeaseFailsOpen`, `TestUnleasedAlwaysRuns` — the wire protocol behind the above
- `TestDelegatedFailureRecoveryRunsOutsideTheLivenessLoop`, `TestDelegatedFailureRecoveryGlobalCallRate`, `TestDelegatedFailureRecoveryLeaseTimings`, `TestLeasedSweepRunsAtStartupBeforeTheFirstTick`, `TestLeasedSweepSkipsWindowsItDoesNotWin`, `TestLeasedSweepStopsWithItsContext`

Timing-sensitive cases were also run `-count=8 -race` for jitter.

`cmd/multica`, `internal/cli`, `internal/daemon` and `internal/daemon/execenv` fail in my sandbox because it runs inside an agent task context (`daemon_task_context.json` present, task-scoped `MULTICA_TOKEN`). They fail identically on unmodified `main`, so they are environmental, not caused by this change.
