### PR TITLE
MUL-6895, MUL-6586: fix(daemon,tasks): force a server-side re-check for woken runtimes to clear a stale empty-claim stall

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -265,20 +265,33 @@ const batchClaimRequestTimeout = 5 * time.Second
 // (batchClaimRequestTimeout) rather than the shared 30s control-plane timeout so
 // one slow claim cannot stall the whole batch; the deadline propagates to the
 // server and cancels the in-flight query there too.
-func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int) ([]*Task, error) {
+func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, batchClaimRequestTimeout)
 	defer cancel()
 	var resp struct {
 		Tasks []*Task `json:"tasks"`
 	}
-	if err := c.postJSON(reqCtx, "/api/daemon/tasks/claim", map[string]any{
-		"daemon_id":   daemonID,
-		"runtime_ids": runtimeIDs,
-		"max_tasks":   maxTasks,
-	}, &resp); err != nil {
+	if err := c.postJSON(reqCtx, "/api/daemon/tasks/claim", claimTasksBody(daemonID, runtimeIDs, maxTasks, forceRecheckIDs...), &resp); err != nil {
 		return nil, err
 	}
 	return resp.Tasks, nil
+}
+
+// claimTasksBody builds the batch-claim request body shared by the HTTP and
+// WS-first transports so both stay byte-identical. force_recheck_runtime_ids
+// (#7452) is an optional, additive field: it is omitted when no runtime was
+// woken so a steady-state poll is exactly the pre-#7452 request, and an older
+// server that does not know the field simply ignores it.
+func claimTasksBody(daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) map[string]any {
+	body := map[string]any{
+		"daemon_id":   daemonID,
+		"runtime_ids": runtimeIDs,
+		"max_tasks":   maxTasks,
+	}
+	if len(forceRecheckIDs) > 0 {
+		body["force_recheck_runtime_ids"] = forceRecheckIDs
+	}
+	return body
 }
 
 // isBatchClaimUnsupported reports whether err is a 404 from the batch claim

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -266,17 +266,19 @@ const batchClaimRequestTimeout = 5 * time.Second
 // one slow claim cannot stall the whole batch; the deadline propagates to the
 // server and cancels the in-flight query there too.
 //
-// The second return value is the server's force_rechecked_runtime_ids echo
-// (#7452): the forced runtimes the server actually scanned this cycle. The
-// caller consumes the wakeup hint only for those and re-notes the rest. An older
-// server omits the field, yielding an empty echo so every forced runtime is
-// re-noted (TTL remains the outer bound).
-func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, []string, error) {
+// The second return value is the server's force_rechecked_runtime_ids
+// acknowledgement (#7452): the forced runtimes the server observed genuinely
+// idle this cycle. It is a POINTER so absence is distinguishable from
+// emptiness: a non-nil empty slice means an upgraded server acknowledged
+// nothing (keep every forced runtime forced), while nil means the server
+// omitted the field entirely and cannot honour the hint at all, so the caller
+// drops it rather than re-forcing forever.
+func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, *[]string, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, batchClaimRequestTimeout)
 	defer cancel()
 	var resp struct {
-		Tasks                    []*Task  `json:"tasks"`
-		ForceRecheckedRuntimeIDs []string `json:"force_rechecked_runtime_ids"`
+		Tasks                    []*Task   `json:"tasks"`
+		ForceRecheckedRuntimeIDs *[]string `json:"force_rechecked_runtime_ids"`
 	}
 	if err := c.postJSON(reqCtx, "/api/daemon/tasks/claim", claimTasksBody(daemonID, runtimeIDs, maxTasks, forceRecheckIDs...), &resp); err != nil {
 		return nil, nil, err

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -265,16 +265,23 @@ const batchClaimRequestTimeout = 5 * time.Second
 // (batchClaimRequestTimeout) rather than the shared 30s control-plane timeout so
 // one slow claim cannot stall the whole batch; the deadline propagates to the
 // server and cancels the in-flight query there too.
-func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, error) {
+//
+// The second return value is the server's force_rechecked_runtime_ids echo
+// (#7452): the forced runtimes the server actually scanned this cycle. The
+// caller consumes the wakeup hint only for those and re-notes the rest. An older
+// server omits the field, yielding an empty echo so every forced runtime is
+// re-noted (TTL remains the outer bound).
+func (c *Client) ClaimTasks(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, []string, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, batchClaimRequestTimeout)
 	defer cancel()
 	var resp struct {
-		Tasks []*Task `json:"tasks"`
+		Tasks                    []*Task  `json:"tasks"`
+		ForceRecheckedRuntimeIDs []string `json:"force_rechecked_runtime_ids"`
 	}
 	if err := c.postJSON(reqCtx, "/api/daemon/tasks/claim", claimTasksBody(daemonID, runtimeIDs, maxTasks, forceRecheckIDs...), &resp); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return resp.Tasks, nil
+	return resp.Tasks, resp.ForceRecheckedRuntimeIDs, nil
 }
 
 // claimTasksBody builds the batch-claim request body shared by the HTTP and

--- a/server/internal/daemon/client_batch_claim_test.go
+++ b/server/internal/daemon/client_batch_claim_test.go
@@ -36,7 +36,7 @@ func TestClient_ClaimTasks_PostsRuntimeSetAndParsesTasks(t *testing.T) {
 	c := NewClient(srv.URL)
 	c.SetToken("tok")
 
-	tasks, err := c.ClaimTasks(context.Background(), "daemon-x", []string{"rt-a", "rt-b", "rt-c"}, 3)
+	tasks, _, err := c.ClaimTasks(context.Background(), "daemon-x", []string{"rt-a", "rt-b", "rt-c"}, 3)
 	if err != nil {
 		t.Fatalf("ClaimTasks: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestClient_ClaimTasks_EmptyResult(t *testing.T) {
 	c := NewClient(srv.URL)
 	c.SetToken("tok")
 
-	tasks, err := c.ClaimTasks(context.Background(), "daemon-x", []string{"rt-a"}, 1)
+	tasks, _, err := c.ClaimTasks(context.Background(), "daemon-x", []string{"rt-a"}, 1)
 	if err != nil {
 		t.Fatalf("ClaimTasks: %v", err)
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -520,6 +520,14 @@ type Daemon struct {
 	pendingWorkInflight map[string]struct{}  // runtime_id -> hint-driven heartbeat in flight
 	pendingWorkLastRun  map[string]time.Time // runtime_id -> when the last hint-driven heartbeat started
 
+	// forceRecheckMu guards forceRecheckRuntimes, the set of runtimes woken by a
+	// targeted `task_available` since the last batch claim (#7452). The next
+	// claim carries them so the server bypasses their cached "empty" verdict,
+	// repairing a stale verdict left by a lost EmptyClaim.Bump instead of
+	// stalling the queued task until the 3-minute TTL.
+	forceRecheckMu       sync.Mutex
+	forceRecheckRuntimes map[string]struct{} // runtime_id -> woken since last claim
+
 	cancelFunc context.CancelFunc // set by Run(); called by triggerRestart
 	rootCtx    context.Context    // set by Run(); used by long-running recoveries that must survive per-runtime ctx cancellation
 	// restartMu guards restartBinary. Two goroutines can reach triggerRestart —
@@ -4750,9 +4758,13 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan taskWakeup) er
 			// The batch poller re-derives allRuntimeIDs() each cycle; nudge it to
 			// pick up a registered/removed runtime promptly.
 			nudge()
-		case <-taskWakeups:
+		case wk := <-taskWakeups:
 			// Targeted-runtime and catch-up wakeups both trigger one batch claim
-			// across the whole runtime set.
+			// across the whole runtime set. A targeted wakeup also records its
+			// runtime so the next claim forces a server-side re-check that bypasses
+			// a stale cached "empty" verdict (#7452); a catch-up wakeup has no
+			// runtime id and only nudges.
+			d.noteWokenRuntime(wk.runtimeID)
 			nudge()
 		}
 	}
@@ -4815,10 +4827,19 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			continue
 		}
 
-		tasks, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots))
+		// Drain the runtimes woken since the last claim and force a server-side
+		// re-check for them so a stale cached "empty" verdict cannot strand their
+		// queued task until the TTL (#7452).
+		forceRecheck := d.drainWokenRuntimes()
+		tasks, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots), forceRecheck...)
 		if err != nil {
 			d.exitClaim()
 			releaseSlots(slots)
+			// Preserve the force signal across a transient claim failure so the
+			// woken runtime is still re-checked on the next cycle.
+			for _, rid := range forceRecheck {
+				d.noteWokenRuntime(rid)
+			}
 			if pollerCtx.Err() == nil {
 				d.logger.Warn("batch claim failed", "error", err)
 			}
@@ -4882,6 +4903,39 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			return
 		}
 	}
+}
+
+// noteWokenRuntime records a runtime woken by a targeted `task_available` so the
+// next batch claim forces a server-side re-check that bypasses its cached
+// "empty" verdict (#7452). A catch-up wakeup carries no runtime id and is a
+// no-op here — it still nudges the poller, which polls the whole set normally.
+func (d *Daemon) noteWokenRuntime(runtimeID string) {
+	if runtimeID == "" {
+		return
+	}
+	d.forceRecheckMu.Lock()
+	if d.forceRecheckRuntimes == nil {
+		d.forceRecheckRuntimes = make(map[string]struct{})
+	}
+	d.forceRecheckRuntimes[runtimeID] = struct{}{}
+	d.forceRecheckMu.Unlock()
+}
+
+// drainWokenRuntimes returns and clears the runtimes woken since the last claim.
+// The poller calls it immediately before issuing a claim; on a claim error the
+// caller re-notes them so a transient failure does not drop the force signal.
+func (d *Daemon) drainWokenRuntimes() []string {
+	d.forceRecheckMu.Lock()
+	defer d.forceRecheckMu.Unlock()
+	if len(d.forceRecheckRuntimes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(d.forceRecheckRuntimes))
+	for id := range d.forceRecheckRuntimes {
+		out = append(out, id)
+	}
+	d.forceRecheckRuntimes = nil
+	return out
 }
 
 func signalPollerWakeup(wakeup chan<- struct{}) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4831,7 +4831,7 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 		// re-check for them so a stale cached "empty" verdict cannot strand their
 		// queued task until the TTL (#7452).
 		forceRecheck := d.drainWokenRuntimes()
-		tasks, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots), forceRecheck...)
+		tasks, forceRechecked, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots), forceRecheck...)
 		if err != nil {
 			d.exitClaim()
 			releaseSlots(slots)
@@ -4848,6 +4848,8 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			}
 			continue
 		}
+
+		d.consumeForceRecheckHints(forceRecheck, forceRechecked)
 
 		// Dispatch each claimed task into a slot. activeTasks is incremented for
 		// every dispatched task BEFORE exitClaim so the auto-update barrier never
@@ -4919,6 +4921,33 @@ func (d *Daemon) noteWokenRuntime(runtimeID string) {
 	}
 	d.forceRecheckRuntimes[runtimeID] = struct{}{}
 	d.forceRecheckMu.Unlock()
+}
+
+// consumeForceRecheckHints implements the "consume the hint only on confirmed
+// execution" contract (#7452). After a successful claim it re-notes every
+// drained force-recheck runtime the server did NOT confirm scanning, so the next
+// claim forces its re-check again. confirmed is the server's
+// force_rechecked_runtime_ids echo:
+//   - a normal claim echoes the subset actually scanned, so a runtime skipped
+//     because reclaim already filled the batch (server early-return) is re-noted;
+//   - the send-nothing cooldown branch echoes nothing, so the whole drained set
+//     is re-noted;
+//   - the uncertain-after-send and legacy fallbacks echo the full drained set,
+//     so nothing is re-noted (an uncertain claim must not replay the hint, and an
+//     old server cannot honor it — TTL is the outer bound).
+func (d *Daemon) consumeForceRecheckHints(drained, confirmed []string) {
+	if len(drained) == 0 {
+		return
+	}
+	confirmedSet := make(map[string]struct{}, len(confirmed))
+	for _, rid := range confirmed {
+		confirmedSet[rid] = struct{}{}
+	}
+	for _, rid := range drained {
+		if _, ok := confirmedSet[rid]; !ok {
+			d.noteWokenRuntime(rid)
+		}
+	}
 }
 
 // drainWokenRuntimes returns and clears the runtimes woken since the last claim.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4831,7 +4831,7 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 		// re-check for them so a stale cached "empty" verdict cannot strand their
 		// queued task until the TTL (#7452).
 		forceRecheck := d.drainWokenRuntimes()
-		tasks, forceRechecked, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots), forceRecheck...)
+		tasks, acknowledged, err := d.ClaimTasksWSFirst(pollerCtx, d.cfg.DaemonID, runtimeIDs, len(slots), forceRecheck...)
 		if err != nil {
 			d.exitClaim()
 			releaseSlots(slots)
@@ -4849,7 +4849,7 @@ func (d *Daemon) runBatchPoller(pollerCtx, parentCtx context.Context, sem chan i
 			continue
 		}
 
-		d.consumeForceRecheckHints(forceRecheck, forceRechecked)
+		d.consumeForceRecheckHints(forceRecheck, acknowledged)
 
 		// Dispatch each claimed task into a slot. activeTasks is incremented for
 		// every dispatched task BEFORE exitClaim so the auto-update barrier never
@@ -4923,28 +4923,31 @@ func (d *Daemon) noteWokenRuntime(runtimeID string) {
 	d.forceRecheckMu.Unlock()
 }
 
-// consumeForceRecheckHints implements the "consume the hint only on confirmed
-// execution" contract (#7452). After a successful claim it re-notes every
-// drained force-recheck runtime the server did NOT confirm scanning, so the next
-// claim forces its re-check again. confirmed is the server's
-// force_rechecked_runtime_ids echo:
-//   - a normal claim echoes the subset actually scanned, so a runtime skipped
-//     because reclaim already filled the batch (server early-return) is re-noted;
-//   - the send-nothing cooldown branch echoes nothing, so the whole drained set
-//     is re-noted;
-//   - the uncertain-after-send and legacy fallbacks echo the full drained set,
-//     so nothing is re-noted (an uncertain claim must not replay the hint, and an
-//     old server cannot honor it — TTL is the outer bound).
-func (d *Daemon) consumeForceRecheckHints(drained, confirmed []string) {
-	if len(drained) == 0 {
+// consumeForceRecheckHints decides which drained force-recheck runtimes stay
+// forced after a claim (#7452). acknowledged is the server's
+// force_rechecked_runtime_ids, as a pointer so absence is distinguishable from
+// emptiness:
+//   - acknowledged == nil: the server never returned the field, so it is older
+//     than #7452 and can never act on the hint. Drop the drained hints (the
+//     pre-#7452 behaviour) rather than re-forcing forever; the empty-claim TTL
+//     remains the outer bound.
+//   - acknowledged non-nil: an upgraded server spoke. It lists only the forced
+//     runtimes it observed genuinely idle (a zero-candidate scan, cache
+//     re-armed). Every other drained runtime is re-noted and forced again next
+//     cycle, including when the list is empty. A forced runtime whose scan found
+//     candidates is deliberately in that group: it keeps its stale cached
+//     verdict until a scan comes back empty, so the fix never depends on a
+//     Redis repair write succeeding.
+func (d *Daemon) consumeForceRecheckHints(drained []string, acknowledged *[]string) {
+	if len(drained) == 0 || acknowledged == nil {
 		return
 	}
-	confirmedSet := make(map[string]struct{}, len(confirmed))
-	for _, rid := range confirmed {
-		confirmedSet[rid] = struct{}{}
+	acked := make(map[string]struct{}, len(*acknowledged))
+	for _, rid := range *acknowledged {
+		acked[rid] = struct{}{}
 	}
 	for _, rid := range drained {
-		if _, ok := confirmedSet[rid]; !ok {
+		if _, ok := acked[rid]; !ok {
 			d.noteWokenRuntime(rid)
 		}
 	}

--- a/server/internal/daemon/daemon_legacy_fallback_test.go
+++ b/server/internal/daemon/daemon_legacy_fallback_test.go
@@ -42,7 +42,7 @@ func TestClaimTasksWSFirst_LegacyFallbackWhenBatchRouteMissing(t *testing.T) {
 
 	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
 
-	tasks, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1", "rt2"}, 5)
+	tasks, _, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1", "rt2"}, 5)
 	if err != nil {
 		t.Fatalf("ClaimTasksWSFirst: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestClaimTasksWSFirst_LegacyFallbackWhenBatchRouteMissing(t *testing.T) {
 	}
 
 	// Second poll must skip the batch route entirely and go straight to legacy.
-	if _, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1", "rt2"}, 5); err != nil {
+	if _, _, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1", "rt2"}, 5); err != nil {
 		t.Fatalf("second ClaimTasksWSFirst: %v", err)
 	}
 	if batchCalls.Load() != 1 {
@@ -106,7 +106,7 @@ func TestClaimTasksWSFirst_NoDoubleClaimOnDetach(t *testing.T) {
 	var tasks []*Task
 	var err error
 	go func() {
-		tasks, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
+		tasks, _, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
 		close(done)
 	}()
 
@@ -170,7 +170,7 @@ func TestClaimTasksWSFirst_HTTPFallbackAfterUncertainCooldown(t *testing.T) {
 	var tasks []*Task
 	var err error
 	go func() {
-		tasks, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
+		tasks, _, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
 		close(done)
 	}()
 
@@ -205,7 +205,7 @@ func TestClaimTasksWSFirst_HTTPFallbackAfterUncertainCooldown(t *testing.T) {
 	})
 	d.wsRPC.markRPCV1Supported(reconnectGeneration)
 
-	tasks, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
+	tasks, _, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
 	if err != nil {
 		t.Fatalf("cooldown ClaimTasksWSFirst: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestClaimTasksWSFirst_HTTPFallbackAfterUncertainCooldown(t *testing.T) {
 	}
 
 	time.Sleep(2 * wsClaimUncertainFallbackDelay)
-	tasks, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
+	tasks, _, err = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2)
 	if err != nil {
 		t.Fatalf("post-cooldown ClaimTasksWSFirst: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestClaimTasksWSFirst_ReconnectToOldServerSkipsWSRPC(t *testing.T) {
 		return &wsOutbound{data: frame}, nil
 	})
 
-	tasks, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 1)
+	tasks, _, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 1)
 	if err != nil {
 		t.Fatalf("ClaimTasksWSFirst: %v", err)
 	}

--- a/server/internal/daemon/force_recheck_consume_test.go
+++ b/server/internal/daemon/force_recheck_consume_test.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConsumeForceRecheckHints_ReNotesOnlyUnconfirmed pins the "consume the hint
+// only on confirmed execution" contract (#7452). A drained force-recheck runtime
+// the server did NOT echo as scanned must be re-noted so the next claim forces
+// it again; a confirmed one is consumed.
+func TestConsumeForceRecheckHints_ReNotesOnlyUnconfirmed(t *testing.T) {
+	// A partial echo: the server scanned rt-1 but not rt-2 (e.g. rt-2's SELECT was
+	// skipped). rt-2 must be re-noted, rt-1 consumed.
+	d := &Daemon{}
+	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, []string{"rt-1"})
+	got := d.drainWokenRuntimes()
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "rt-2" {
+		t.Fatalf("re-noted set = %v, want [rt-2] (only the unconfirmed runtime)", got)
+	}
+
+	// A full echo (uncertain-after-send / legacy fallback): every drained runtime
+	// is confirmed, so nothing is re-noted.
+	d = &Daemon{}
+	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, []string{"rt-1", "rt-2"})
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("full echo re-noted %v, want nothing", got)
+	}
+}
+
+// TestConsumeForceRecheckHints_ReclaimFilledBatchReNotesAll is the reclaim-fills-
+// batch regression (#7452, requirement 4): when stale reclaim already fills the
+// batch the server returns before scanning the forced runtimes, so its echo is
+// empty. The daemon must re-note the whole drained set — the force signal is NOT
+// consumed — so the next cycle forces the re-check again.
+func TestConsumeForceRecheckHints_ReclaimFilledBatchReNotesAll(t *testing.T) {
+	d := &Daemon{}
+	drained := []string{"rt-1", "rt-2", "rt-3"}
+	// Empty echo == server scanned none of them (reclaim filled maxTasks first).
+	d.consumeForceRecheckHints(drained, nil)
+	got := d.drainWokenRuntimes()
+	sort.Strings(got)
+	want := []string{"rt-1", "rt-2", "rt-3"}
+	if len(got) != len(want) {
+		t.Fatalf("re-noted set = %v, want all drained %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("re-noted set = %v, want all drained %v", got, want)
+		}
+	}
+}
+
+// TestClaimTasksWSFirst_UncertainCooldownEchoesEmptyForceSet is the "targeted
+// wakeup during the uncertain-claim cooldown still forces a re-check next cycle"
+// regression (#7452). While the send-nothing cooldown is open ClaimTasksWSFirst
+// scans nothing, so it must echo an EMPTY force-rechecked set — driving the
+// daemon to re-note the whole drained set — even though a frame went out on the
+// earlier uncertain attempt.
+func TestClaimTasksWSFirst_UncertainCooldownEchoesEmptyForceSet(t *testing.T) {
+	originalDelay := wsClaimUncertainFallbackDelay
+	wsClaimUncertainFallbackDelay = time.Hour // keep the cooldown open for the test
+	t.Cleanup(func() { wsClaimUncertainFallbackDelay = originalDelay })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"tasks":[]}`))
+	}))
+	defer srv.Close()
+
+	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+
+	// Drive one uncertain sent-frame outcome so the HTTP-fallback cooldown opens.
+	var mu sync.Mutex
+	var item *wsOutbound
+	frameQueued := make(chan struct{})
+	generation := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		item = &wsOutbound{data: frame}
+		close(frameQueued)
+		return item, nil
+	})
+	d.wsRPC.markRPCV1Supported(generation)
+
+	done := make(chan struct{})
+	go func() {
+		d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, "rt1")
+		close(done)
+	}()
+	select {
+	case <-frameQueued:
+	case <-time.After(time.Second):
+		t.Fatal("WS claim frame was not queued")
+	}
+	mu.Lock()
+	item.beginWrite()
+	mu.Unlock()
+	d.wsRPC.attach(nil)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("uncertain ClaimTasksWSFirst did not return")
+	}
+
+	// The cooldown is now open. A claim that names a woken runtime scans nothing
+	// and must echo an empty force-rechecked set.
+	drained := []string{"rt1"}
+	tasks, forceRechecked, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
+	if err != nil {
+		t.Fatalf("cooldown ClaimTasksWSFirst: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("cooldown claim returned %d tasks, want 0", len(tasks))
+	}
+	if len(forceRechecked) != 0 {
+		t.Fatalf("cooldown echo = %v, want empty so the daemon re-notes the force set", forceRechecked)
+	}
+
+	// End to end: feeding that empty echo back re-notes the woken runtime.
+	d.consumeForceRecheckHints(drained, forceRechecked)
+	if got := d.drainWokenRuntimes(); len(got) != 1 || got[0] != "rt1" {
+		t.Fatalf("re-noted set after cooldown = %v, want [rt1]", got)
+	}
+}
+
+// TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet pins the opposite
+// branch (#7452): when a claim frame actually went out and its outcome is
+// uncertain, ClaimTasksWSFirst echoes the FULL drained force set so the daemon
+// re-notes nothing — replaying the hint could double-claim a task the WS frame
+// may have already committed.
+func TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"tasks":[]}`))
+	}))
+	defer srv.Close()
+
+	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+
+	var mu sync.Mutex
+	var item *wsOutbound
+	frameQueued := make(chan struct{})
+	generation := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		item = &wsOutbound{data: frame}
+		close(frameQueued)
+		return item, nil
+	})
+	d.wsRPC.markRPCV1Supported(generation)
+
+	drained := []string{"rt1", "rt2"}
+	done := make(chan struct{})
+	var forceRechecked []string
+	go func() {
+		_, forceRechecked, _ = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
+		close(done)
+	}()
+	select {
+	case <-frameQueued:
+	case <-time.After(time.Second):
+		t.Fatal("WS claim frame was not queued")
+	}
+	mu.Lock()
+	item.beginWrite() // frame on the wire — outcome is genuinely uncertain
+	mu.Unlock()
+	d.wsRPC.attach(nil)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("uncertain ClaimTasksWSFirst did not return")
+	}
+
+	sort.Strings(forceRechecked)
+	if len(forceRechecked) != 2 || forceRechecked[0] != "rt1" || forceRechecked[1] != "rt2" {
+		t.Fatalf("uncertain-after-send echo = %v, want the full drained set [rt1 rt2]", forceRechecked)
+	}
+	// Feeding it back re-notes nothing.
+	d.consumeForceRecheckHints(drained, forceRechecked)
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("uncertain-after-send re-noted %v, want nothing", got)
+	}
+}
+
+// TestSignalTaskWakeup_FullChannelCoalescesRuntimeID is the "wakeup channel full
+// → runtime id not lost" regression (#7452). signalTaskWakeup drops on a full
+// channel, but a targeted wakeup's runtime id is the force-recheck signal, so it
+// must be coalesced into the woken set instead of silently lost; the pending
+// nudge already queued still drives the next claim.
+func TestSignalTaskWakeup_FullChannelCoalescesRuntimeID(t *testing.T) {
+	d := New(Config{MaxConcurrentTasks: 1}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+
+	// An unbuffered channel with no receiver is always "full" for a non-blocking
+	// send, so the coalesce path runs.
+	full := make(chan taskWakeup)
+	d.signalTaskWakeup(full, "rt-burst")
+
+	got := d.drainWokenRuntimes()
+	if len(got) != 1 || got[0] != "rt-burst" {
+		t.Fatalf("woken set after dropped wakeup = %v, want [rt-burst]", got)
+	}
+
+	// A catch-up wakeup (empty runtime id) has nothing to preserve and must not
+	// enter the set.
+	d.signalTaskWakeup(full, "")
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("empty-id wakeup coalesced %v, want nothing", got)
+	}
+}

--- a/server/internal/daemon/force_recheck_consume_test.go
+++ b/server/internal/daemon/force_recheck_consume_test.go
@@ -11,40 +11,38 @@ import (
 	"time"
 )
 
-// TestConsumeForceRecheckHints_ReNotesOnlyUnconfirmed pins the "consume the hint
-// only on confirmed execution" contract (#7452). A drained force-recheck runtime
-// the server did NOT echo as scanned must be re-noted so the next claim forces
-// it again; a confirmed one is consumed.
-func TestConsumeForceRecheckHints_ReNotesOnlyUnconfirmed(t *testing.T) {
-	// A partial echo: the server scanned rt-1 but not rt-2 (e.g. rt-2's SELECT was
-	// skipped). rt-2 must be re-noted, rt-1 consumed.
+// TestConsumeForceRecheckHints_ReNotesEverythingUnacknowledged pins the
+// acknowledgement contract (#7452). The server acknowledges only the forced
+// runtimes it observed genuinely idle; every other drained runtime stays forced
+// so the next claim forces it again.
+func TestConsumeForceRecheckHints_ReNotesEverythingUnacknowledged(t *testing.T) {
+	// A partial acknowledgement: rt-1's scan came back empty, rt-2's did not
+	// (either it found candidates or it was never scanned). rt-2 stays forced.
 	d := &Daemon{}
-	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, []string{"rt-1"})
+	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, &[]string{"rt-1"})
 	got := d.drainWokenRuntimes()
 	sort.Strings(got)
 	if len(got) != 1 || got[0] != "rt-2" {
-		t.Fatalf("re-noted set = %v, want [rt-2] (only the unconfirmed runtime)", got)
+		t.Fatalf("re-noted set = %v, want [rt-2] (only the unacknowledged runtime)", got)
 	}
 
-	// A full echo (uncertain-after-send / legacy fallback): every drained runtime
-	// is confirmed, so nothing is re-noted.
+	// A full acknowledgement: every drained runtime was confirmed idle, so
+	// nothing stays forced.
 	d = &Daemon{}
-	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, []string{"rt-1", "rt-2"})
+	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, &[]string{"rt-1", "rt-2"})
 	if got := d.drainWokenRuntimes(); got != nil {
-		t.Fatalf("full echo re-noted %v, want nothing", got)
+		t.Fatalf("full acknowledgement re-noted %v, want nothing", got)
 	}
 }
 
-// TestConsumeForceRecheckHints_ReclaimFilledBatchReNotesAll is the reclaim-fills-
-// batch regression (#7452, requirement 4): when stale reclaim already fills the
-// batch the server returns before scanning the forced runtimes, so its echo is
-// empty. The daemon must re-note the whole drained set — the force signal is NOT
-// consumed — so the next cycle forces the re-check again.
-func TestConsumeForceRecheckHints_ReclaimFilledBatchReNotesAll(t *testing.T) {
+// TestConsumeForceRecheckHints_PresentButEmptyKeepsAllForced covers refinement 2
+// (#7452): a PRESENT but empty acknowledged set means an upgraded server
+// explicitly acknowledged nothing — reclaim filled the batch before the scan, or
+// every forced scan found candidates — so every drained runtime stays forced.
+func TestConsumeForceRecheckHints_PresentButEmptyKeepsAllForced(t *testing.T) {
 	d := &Daemon{}
 	drained := []string{"rt-1", "rt-2", "rt-3"}
-	// Empty echo == server scanned none of them (reclaim filled maxTasks first).
-	d.consumeForceRecheckHints(drained, nil)
+	d.consumeForceRecheckHints(drained, &[]string{})
 	got := d.drainWokenRuntimes()
 	sort.Strings(got)
 	want := []string{"rt-1", "rt-2", "rt-3"}
@@ -58,13 +56,26 @@ func TestConsumeForceRecheckHints_ReclaimFilledBatchReNotesAll(t *testing.T) {
 	}
 }
 
-// TestClaimTasksWSFirst_UncertainCooldownEchoesEmptyForceSet is the "targeted
+// TestConsumeForceRecheckHints_AbsentFieldConsumesHints is the other half of
+// refinement 2 (#7452): an ABSENT acknowledged set means a pre-#7452 server that
+// cannot act on the hint at all. Re-forcing it forever would be pointless churn,
+// so the drained hints are consumed and the empty-claim TTL stays the outer
+// bound — exactly the pre-#7452 behaviour.
+func TestConsumeForceRecheckHints_AbsentFieldConsumesHints(t *testing.T) {
+	d := &Daemon{}
+	d.consumeForceRecheckHints([]string{"rt-1", "rt-2"}, nil)
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("absent acknowledgement re-noted %v, want nothing (legacy server)", got)
+	}
+}
+
+// TestClaimTasksWSFirst_UncertainCooldownAcknowledgesNothing is the "targeted
 // wakeup during the uncertain-claim cooldown still forces a re-check next cycle"
 // regression (#7452). While the send-nothing cooldown is open ClaimTasksWSFirst
-// scans nothing, so it must echo an EMPTY force-rechecked set — driving the
-// daemon to re-note the whole drained set — even though a frame went out on the
-// earlier uncertain attempt.
-func TestClaimTasksWSFirst_UncertainCooldownEchoesEmptyForceSet(t *testing.T) {
+// scans nothing, so it must return a PRESENT but empty acknowledgement —
+// driving the daemon to keep the whole drained set forced — even though a frame
+// went out on the earlier uncertain attempt.
+func TestClaimTasksWSFirst_UncertainCooldownAcknowledgesNothing(t *testing.T) {
 	originalDelay := wsClaimUncertainFallbackDelay
 	wsClaimUncertainFallbackDelay = time.Hour // keep the cooldown open for the test
 	t.Cleanup(func() { wsClaimUncertainFallbackDelay = originalDelay })
@@ -113,30 +124,33 @@ func TestClaimTasksWSFirst_UncertainCooldownEchoesEmptyForceSet(t *testing.T) {
 	// The cooldown is now open. A claim that names a woken runtime scans nothing
 	// and must echo an empty force-rechecked set.
 	drained := []string{"rt1"}
-	tasks, forceRechecked, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
+	tasks, acknowledged, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
 	if err != nil {
 		t.Fatalf("cooldown ClaimTasksWSFirst: %v", err)
 	}
 	if len(tasks) != 0 {
 		t.Fatalf("cooldown claim returned %d tasks, want 0", len(tasks))
 	}
-	if len(forceRechecked) != 0 {
-		t.Fatalf("cooldown echo = %v, want empty so the daemon re-notes the force set", forceRechecked)
+	if acknowledged == nil {
+		t.Fatal("cooldown acknowledgement is absent, want present but empty so the force set is kept")
+	}
+	if len(*acknowledged) != 0 {
+		t.Fatalf("cooldown acknowledgement = %v, want empty so the daemon keeps the force set", *acknowledged)
 	}
 
-	// End to end: feeding that empty echo back re-notes the woken runtime.
-	d.consumeForceRecheckHints(drained, forceRechecked)
+	// End to end: feeding that empty acknowledgement back keeps the runtime forced.
+	d.consumeForceRecheckHints(drained, acknowledged)
 	if got := d.drainWokenRuntimes(); len(got) != 1 || got[0] != "rt1" {
 		t.Fatalf("re-noted set after cooldown = %v, want [rt1]", got)
 	}
 }
 
-// TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet pins the opposite
+// TestClaimTasksWSFirst_UncertainAfterSendAcknowledgesFullForceSet pins the opposite
 // branch (#7452): when a claim frame actually went out and its outcome is
-// uncertain, ClaimTasksWSFirst echoes the FULL drained force set so the daemon
-// re-notes nothing — replaying the hint could double-claim a task the WS frame
+// uncertain, ClaimTasksWSFirst acknowledges the FULL drained force set so the
+// daemon re-notes nothing — replaying the hint could double-claim a task the WS frame
 // may have already committed.
-func TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet(t *testing.T) {
+func TestClaimTasksWSFirst_UncertainAfterSendAcknowledgesFullForceSet(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"tasks":[]}`))
@@ -159,9 +173,9 @@ func TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet(t *testing.T) {
 
 	drained := []string{"rt1", "rt2"}
 	done := make(chan struct{})
-	var forceRechecked []string
+	var acknowledged *[]string
 	go func() {
-		_, forceRechecked, _ = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
+		_, acknowledged, _ = d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 2, drained...)
 		close(done)
 	}()
 	select {
@@ -179,12 +193,15 @@ func TestClaimTasksWSFirst_UncertainAfterSendEchoesFullForceSet(t *testing.T) {
 		t.Fatal("uncertain ClaimTasksWSFirst did not return")
 	}
 
-	sort.Strings(forceRechecked)
-	if len(forceRechecked) != 2 || forceRechecked[0] != "rt1" || forceRechecked[1] != "rt2" {
-		t.Fatalf("uncertain-after-send echo = %v, want the full drained set [rt1 rt2]", forceRechecked)
+	if acknowledged == nil {
+		t.Fatal("uncertain-after-send acknowledgement is absent, want the full drained set")
+	}
+	sort.Strings(*acknowledged)
+	if len(*acknowledged) != 2 || (*acknowledged)[0] != "rt1" || (*acknowledged)[1] != "rt2" {
+		t.Fatalf("uncertain-after-send acknowledgement = %v, want the full drained set [rt1 rt2]", *acknowledged)
 	}
 	// Feeding it back re-notes nothing.
-	d.consumeForceRecheckHints(drained, forceRechecked)
+	d.consumeForceRecheckHints(drained, acknowledged)
 	if got := d.drainWokenRuntimes(); got != nil {
 		t.Fatalf("uncertain-after-send re-noted %v, want nothing", got)
 	}
@@ -213,5 +230,62 @@ func TestSignalTaskWakeup_FullChannelCoalescesRuntimeID(t *testing.T) {
 	d.signalTaskWakeup(full, "")
 	if got := d.drainWokenRuntimes(); got != nil {
 		t.Fatalf("empty-id wakeup coalesced %v, want nothing", got)
+	}
+}
+
+// TestClaimTasks_AcknowledgementPresenceOverTheWire is the wire half of
+// refinement 2 (#7452): the acknowledged set must survive JSON decoding as
+// PRESENT-but-empty when an upgraded server returns an empty array, and as
+// ABSENT when an older server omits the field, so the daemon can tell the two
+// apart.
+func TestClaimTasks_AcknowledgementPresenceOverTheWire(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		body    string
+		present bool
+	}{
+		{name: "upgraded server acknowledges nothing", body: `{"tasks":[],"force_rechecked_runtime_ids":[]}`, present: true},
+		{name: "upgraded server acknowledges one", body: `{"tasks":[],"force_rechecked_runtime_ids":["rt1"]}`, present: true},
+		{name: "legacy server omits the field", body: `{"tasks":[]}`, present: false},
+		{name: "legacy server sends null", body: `{"tasks":[],"force_rechecked_runtime_ids":null}`, present: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL)
+			c.SetToken("tok")
+			_, acknowledged, err := c.ClaimTasks(context.Background(), "daemon-x", []string{"rt1"}, 1, "rt1")
+			if err != nil {
+				t.Fatalf("ClaimTasks: %v", err)
+			}
+			if tc.present != (acknowledged != nil) {
+				t.Fatalf("acknowledged presence = %v, want %v (body %s)", acknowledged != nil, tc.present, tc.body)
+			}
+
+			// The daemon's decision follows from that presence alone: absent consumes
+			// the drained hints, present keeps every unacknowledged runtime forced.
+			d := &Daemon{}
+			d.consumeForceRecheckHints([]string{"rt1", "rt2"}, acknowledged)
+			got := d.drainWokenRuntimes()
+			sort.Strings(got)
+			switch {
+			case !tc.present:
+				if got != nil {
+					t.Fatalf("absent acknowledgement kept %v forced, want nothing", got)
+				}
+			case len(*acknowledged) == 0:
+				if len(got) != 2 {
+					t.Fatalf("present-but-empty acknowledgement kept %v forced, want both runtimes", got)
+				}
+			default:
+				if len(got) != 1 || got[0] != "rt2" {
+					t.Fatalf("partial acknowledgement kept %v forced, want [rt2]", got)
+				}
+			}
+		})
 	}
 }

--- a/server/internal/daemon/force_recheck_test.go
+++ b/server/internal/daemon/force_recheck_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestDaemon_WokenRuntimeTracking pins the daemon side of #7452: a targeted
+// `task_available` records its runtime so the next claim can force a server-side
+// re-check, an empty wakeup (catch-up) is ignored, and draining clears the set
+// so a runtime is forced exactly once per wakeup.
+func TestDaemon_WokenRuntimeTracking(t *testing.T) {
+	d := &Daemon{}
+
+	// Nothing woken yet.
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("drain on empty set = %v, want nil", got)
+	}
+
+	// A catch-up wakeup carries no runtime id and must not enter the set.
+	d.noteWokenRuntime("")
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("drain after empty wakeup = %v, want nil", got)
+	}
+
+	// Two targeted wakeups (with a duplicate) collapse to the distinct set.
+	d.noteWokenRuntime("rt-1")
+	d.noteWokenRuntime("rt-2")
+	d.noteWokenRuntime("rt-1")
+	got := d.drainWokenRuntimes()
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "rt-1" || got[1] != "rt-2" {
+		t.Fatalf("drain = %v, want [rt-1 rt-2]", got)
+	}
+
+	// Draining clears the set: the same runtime is not force-rechecked again
+	// until it is woken anew.
+	if got := d.drainWokenRuntimes(); got != nil {
+		t.Fatalf("drain after clear = %v, want nil", got)
+	}
+}
+
+// TestClaimTasksBody_ForceRecheckIsOptional pins the request-compat contract of
+// #7452: with no woken runtime the body is byte-for-byte the pre-#7452 request
+// (so an older server sees no new field), and the field appears only when a
+// runtime was actually woken.
+func TestClaimTasksBody_ForceRecheckIsOptional(t *testing.T) {
+	base := claimTasksBody("daemon-x", []string{"rt-1"}, 3)
+	if _, present := base["force_recheck_runtime_ids"]; present {
+		t.Fatalf("force_recheck_runtime_ids must be omitted when no runtime is woken; body = %v", base)
+	}
+	if base["daemon_id"] != "daemon-x" || base["max_tasks"] != 3 {
+		t.Fatalf("base body lost its existing fields: %v", base)
+	}
+
+	withForce := claimTasksBody("daemon-x", []string{"rt-1"}, 3, "rt-1")
+	ids, ok := withForce["force_recheck_runtime_ids"].([]string)
+	if !ok || len(ids) != 1 || ids[0] != "rt-1" {
+		t.Fatalf("force_recheck_runtime_ids = %v, want [rt-1]", withForce["force_recheck_runtime_ids"])
+	}
+}

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -143,7 +143,7 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	defer d.clearWSHeartbeatAcks()
 
 	d.logger.Info("task wakeup websocket connected", "runtimes", len(runtimeIDs))
-	signalTaskWakeup(taskWakeups, "")
+	d.signalTaskWakeup(taskWakeups, "")
 	// signalTaskWakeup only wakes idle ClaimTask pollers. In-flight tasks and
 	// the workspace sync loop park on coarse tickers (5s and 30s) that do not
 	// observe the wakeup channel, so anything the server changed during the
@@ -397,7 +397,7 @@ func (d *Daemon) readTaskWakeupMessagesForConnection(conn *websocket.Conn, taskW
 			if payload.RuntimeID != "" {
 				d.logger.Debug("task wakeup received", "runtime_id", payload.RuntimeID, "task_id", payload.TaskID)
 			}
-			signalTaskWakeup(taskWakeups, payload.RuntimeID)
+			d.signalTaskWakeup(taskWakeups, payload.RuntimeID)
 		case protocol.EventDaemonRuntimeProfilesChanged:
 			var payload protocol.RuntimeProfilesChangedPayload
 			if err := json.Unmarshal(msg.Payload, &payload); err != nil {
@@ -476,10 +476,21 @@ func (d *Daemon) handleRuntimeProfilesChanged(payload protocol.RuntimeProfilesCh
 	}
 }
 
-func signalTaskWakeup(taskWakeups chan<- taskWakeup, runtimeID string) {
+// signalTaskWakeup delivers a targeted (or catch-up) task wakeup to the poller.
+// The channel is a coalescing nudge, so a full channel already carries a pending
+// wakeup — dropping the send loses only the runtime id it would have delivered.
+// For a targeted wakeup that id is the #7452 force-recheck signal, so on a full
+// channel record it directly in the woken set instead: the already-queued nudge
+// still drives the next claim, and the runtime is now forced there. A catch-up
+// wakeup (empty runtimeID) has nothing to preserve and is simply dropped.
+func (d *Daemon) signalTaskWakeup(taskWakeups chan<- taskWakeup, runtimeID string) {
 	select {
 	case taskWakeups <- taskWakeup{runtimeID: runtimeID}:
 	default:
+		if runtimeID != "" {
+			d.noteWokenRuntime(runtimeID)
+			d.logger.Debug("task wakeup channel full; coalesced runtime into force-recheck set", "runtime_id", runtimeID)
+		}
 	}
 }
 

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -312,7 +312,11 @@ func (c *wsRPCClient) deliver(resp protocol.RPCResponsePayload) {
 // retried over HTTP only after a short safety window. The request/response bodies
 // are identical to the HTTP endpoint so both transports are interchangeable.
 // Wired into the claim poller as part of the poller cutover.
-func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int) ([]*Task, error) {
+// forceRecheckIDs (#7452) names runtimes woken by a targeted `task_available`
+// since the last claim; it is forwarded unchanged over whichever transport
+// wins so the server bypasses their cached "empty" verdict. The legacy
+// per-runtime fallback ignores it (an un-upgraded server has no such route).
+func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, error) {
 	// Un-upgraded server without the batch route: a prior poll already learned
 	// this (via a 404), so go straight to the legacy per-runtime claim and skip
 	// the WS + batch attempts each cycle.
@@ -339,11 +343,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		}
 		// batchClaimRequestTimeout is the server-side execution budget; the
 		// daemon waits that plus the client's grace margin for the response.
-		_, err := d.wsRPC.CallIfRPCV1Supported(ctx, "tasks.claim", batchClaimRequestTimeout, map[string]any{
-			"daemon_id":   daemonID,
-			"runtime_ids": runtimeIDs,
-			"max_tasks":   maxTasks,
-		}, &resp)
+		_, err := d.wsRPC.CallIfRPCV1Supported(ctx, "tasks.claim", batchClaimRequestTimeout, claimTasksBody(daemonID, runtimeIDs, maxTasks, forceRecheckIDs...), &resp)
 		if err == nil {
 			return resp.Tasks, nil
 		}
@@ -364,7 +364,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		}
 		d.logger.Debug("ws claim failed; falling back to http", "error", err)
 	}
-	tasks, err := d.client.ClaimTasks(ctx, daemonID, runtimeIDs, maxTasks)
+	tasks, err := d.client.ClaimTasks(ctx, daemonID, runtimeIDs, maxTasks, forceRecheckIDs...)
 	if err == nil {
 		return tasks, nil
 	}

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -354,6 +354,11 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 			// execution budget plus response grace has elapsed. If the WS claim
 			// committed, the task is already dispatched and stale reclaim owns
 			// recovery; if it did not, HTTP regains liveness for the queued task.
+			// The drained forceRecheck set (#7452) is intentionally not re-noted
+			// here: the caller treats this nil error as success and does not
+			// restore it, so a runtime whose bypass rode this uncertain claim
+			// falls back to the next targeted wakeup or the empty-claim TTL rather
+			// than risk a double-claim by replaying the force signal immediately.
 			delay := wsClaimUncertainFallbackDelay
 			if delay < 0 {
 				delay = 0

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -316,12 +316,24 @@ func (c *wsRPCClient) deliver(resp protocol.RPCResponsePayload) {
 // since the last claim; it is forwarded unchanged over whichever transport
 // wins so the server bypasses their cached "empty" verdict. The legacy
 // per-runtime fallback ignores it (an un-upgraded server has no such route).
-func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, error) {
+//
+// The second return value tells the caller which forced runtimes were confirmed
+// scanned so it consumes the wakeup hint only for those (#7452):
+//   - a normal WS/HTTP claim returns the server's force_rechecked_runtime_ids
+//     echo (the subset actually scanned);
+//   - the send-nothing cooldown branch returns an EMPTY set, so the caller
+//     re-notes the whole drained set and re-forces next cycle;
+//   - the uncertain-after-send branch and the legacy/unsupported fallbacks
+//     return the full forceRecheckIDs, so the caller re-notes nothing (an
+//     uncertain claim must not replay the hint, and an old server cannot honor
+//     it — TTL is the outer bound for both).
+func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, []string, error) {
 	// Un-upgraded server without the batch route: a prior poll already learned
 	// this (via a 404), so go straight to the legacy per-runtime claim and skip
 	// the WS + batch attempts each cycle.
 	if d.batchClaimUnsupported.Load() {
-		return d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
+		tasks, err := d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
+		return tasks, forceRecheckIDs, err
 	}
 	bypassWSOnce := false
 	if retryAfterNanos := d.wsClaimHTTPFallbackAfter.Load(); retryAfterNanos > 0 {
@@ -330,7 +342,11 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		if now.Before(retryAfter) {
 			d.logger.Debug("ws claim outcome uncertain; delaying http fallback until safety window elapses",
 				"retry_after", retryAfter.Sub(now).Round(time.Millisecond))
-			return nil, nil
+			// Nothing was sent and nothing scanned this cycle: echo an empty set so
+			// the caller re-notes the whole drained force set and re-forces next
+			// cycle (unlike the uncertain-after-send branch below, no frame went
+			// out, so replaying the hint cannot double-claim).
+			return nil, nil, nil
 		}
 		if d.wsClaimHTTPFallbackAfter.CompareAndSwap(retryAfterNanos, 0) {
 			bypassWSOnce = true
@@ -339,13 +355,14 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 	}
 	if !bypassWSOnce && d.wsRPC.supportsRPCV1() {
 		var resp struct {
-			Tasks []*Task `json:"tasks"`
+			Tasks                    []*Task  `json:"tasks"`
+			ForceRecheckedRuntimeIDs []string `json:"force_rechecked_runtime_ids"`
 		}
 		// batchClaimRequestTimeout is the server-side execution budget; the
 		// daemon waits that plus the client's grace margin for the response.
 		_, err := d.wsRPC.CallIfRPCV1Supported(ctx, "tasks.claim", batchClaimRequestTimeout, claimTasksBody(daemonID, runtimeIDs, maxTasks, forceRecheckIDs...), &resp)
 		if err == nil {
-			return resp.Tasks, nil
+			return resp.Tasks, resp.ForceRecheckedRuntimeIDs, nil
 		}
 		if errors.Is(err, errWSRPCUncertain) {
 			// The WS claim may have committed server-side; claiming the same
@@ -355,23 +372,23 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 			// committed, the task is already dispatched and stale reclaim owns
 			// recovery; if it did not, HTTP regains liveness for the queued task.
 			// The drained forceRecheck set (#7452) is intentionally not re-noted
-			// here: the caller treats this nil error as success and does not
-			// restore it, so a runtime whose bypass rode this uncertain claim
-			// falls back to the next targeted wakeup or the empty-claim TTL rather
-			// than risk a double-claim by replaying the force signal immediately.
+			// here: a frame DID go out and may have committed server-side, so
+			// replaying the hint immediately could double-claim. Echo the full
+			// forced set as "confirmed" so the caller re-notes nothing; recovery
+			// falls to the next targeted wakeup or the empty-claim TTL.
 			delay := wsClaimUncertainFallbackDelay
 			if delay < 0 {
 				delay = 0
 			}
 			d.wsClaimHTTPFallbackAfter.Store(time.Now().Add(delay).UnixNano())
 			d.logger.Debug("ws claim outcome uncertain after disconnect; delaying http fallback", "retry_after", delay)
-			return nil, nil
+			return nil, forceRecheckIDs, nil
 		}
 		d.logger.Debug("ws claim failed; falling back to http", "error", err)
 	}
-	tasks, err := d.client.ClaimTasks(ctx, daemonID, runtimeIDs, maxTasks, forceRecheckIDs...)
+	tasks, forceRechecked, err := d.client.ClaimTasks(ctx, daemonID, runtimeIDs, maxTasks, forceRecheckIDs...)
 	if err == nil {
-		return tasks, nil
+		return tasks, forceRechecked, nil
 	}
 	// Server has no batch route (404): freeze the old API contract by falling
 	// back to the legacy per-runtime claim loop, and remember it so we don't
@@ -379,7 +396,8 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 	if isBatchClaimUnsupported(err) {
 		d.batchClaimUnsupported.Store(true)
 		d.logger.Info("batch claim route unsupported by server; using legacy per-runtime claim")
-		return d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
+		tasks, err := d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
+		return tasks, forceRecheckIDs, err
 	}
-	return nil, err
+	return nil, nil, err
 }

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -317,23 +317,29 @@ func (c *wsRPCClient) deliver(resp protocol.RPCResponsePayload) {
 // wins so the server bypasses their cached "empty" verdict. The legacy
 // per-runtime fallback ignores it (an un-upgraded server has no such route).
 //
-// The second return value tells the caller which forced runtimes were confirmed
-// scanned so it consumes the wakeup hint only for those (#7452):
-//   - a normal WS/HTTP claim returns the server's force_rechecked_runtime_ids
-//     echo (the subset actually scanned);
-//   - the send-nothing cooldown branch returns an EMPTY set, so the caller
-//     re-notes the whole drained set and re-forces next cycle;
-//   - the uncertain-after-send branch and the legacy/unsupported fallbacks
-//     return the full forceRecheckIDs, so the caller re-notes nothing (an
-//     uncertain claim must not replay the hint, and an old server cannot honor
-//     it — TTL is the outer bound for both).
-func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, []string, error) {
+// The second return value is the server's acknowledgement of the forced
+// runtimes (#7452). It is a POINTER so the caller can tell an explicit empty
+// acknowledgement from a missing one:
+//   - a normal WS/HTTP claim passes the server's force_rechecked_runtime_ids
+//     through verbatim: present (possibly empty) from an upgraded server,
+//     absent from an older one that does not know the field;
+//   - the send-nothing cooldown branch acknowledges nothing (present, empty),
+//     so the caller keeps the whole drained set forced and re-forces next cycle;
+//   - the uncertain-after-send branch acknowledges the full forced set, so the
+//     caller re-notes nothing: a frame DID go out and replaying the hint could
+//     double-claim, so recovery falls to the next wakeup or the TTL;
+//   - the legacy/unsupported fallbacks report ABSENT, so the caller drops the
+//     hint the way it did before #7452 instead of re-forcing a server that can
+//     never acknowledge it.
+func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtimeIDs []string, maxTasks int, forceRecheckIDs ...string) ([]*Task, *[]string, error) {
 	// Un-upgraded server without the batch route: a prior poll already learned
 	// this (via a 404), so go straight to the legacy per-runtime claim and skip
 	// the WS + batch attempts each cycle.
 	if d.batchClaimUnsupported.Load() {
 		tasks, err := d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
-		return tasks, forceRecheckIDs, err
+		// The legacy route cannot honour the hint, so report ABSENT: the caller
+		// drops it instead of re-forcing a server that will never acknowledge.
+		return tasks, nil, err
 	}
 	bypassWSOnce := false
 	if retryAfterNanos := d.wsClaimHTTPFallbackAfter.Load(); retryAfterNanos > 0 {
@@ -342,11 +348,11 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		if now.Before(retryAfter) {
 			d.logger.Debug("ws claim outcome uncertain; delaying http fallback until safety window elapses",
 				"retry_after", retryAfter.Sub(now).Round(time.Millisecond))
-			// Nothing was sent and nothing scanned this cycle: echo an empty set so
-			// the caller re-notes the whole drained force set and re-forces next
-			// cycle (unlike the uncertain-after-send branch below, no frame went
-			// out, so replaying the hint cannot double-claim).
-			return nil, nil, nil
+			// Nothing was sent and nothing scanned this cycle: acknowledge nothing
+			// (present but empty) so the caller keeps the whole drained force set and
+			// re-forces next cycle. Unlike the uncertain-after-send branch below, no
+			// frame went out, so replaying the hint cannot double-claim.
+			return nil, ackNone(), nil
 		}
 		if d.wsClaimHTTPFallbackAfter.CompareAndSwap(retryAfterNanos, 0) {
 			bypassWSOnce = true
@@ -355,8 +361,8 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 	}
 	if !bypassWSOnce && d.wsRPC.supportsRPCV1() {
 		var resp struct {
-			Tasks                    []*Task  `json:"tasks"`
-			ForceRecheckedRuntimeIDs []string `json:"force_rechecked_runtime_ids"`
+			Tasks                    []*Task   `json:"tasks"`
+			ForceRecheckedRuntimeIDs *[]string `json:"force_rechecked_runtime_ids"`
 		}
 		// batchClaimRequestTimeout is the server-side execution budget; the
 		// daemon waits that plus the client's grace margin for the response.
@@ -382,7 +388,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 			}
 			d.wsClaimHTTPFallbackAfter.Store(time.Now().Add(delay).UnixNano())
 			d.logger.Debug("ws claim outcome uncertain after disconnect; delaying http fallback", "retry_after", delay)
-			return nil, forceRecheckIDs, nil
+			return nil, ackAll(forceRecheckIDs), nil
 		}
 		d.logger.Debug("ws claim failed; falling back to http", "error", err)
 	}
@@ -397,7 +403,26 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		d.batchClaimUnsupported.Store(true)
 		d.logger.Info("batch claim route unsupported by server; using legacy per-runtime claim")
 		tasks, err := d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
-		return tasks, forceRecheckIDs, err
+		// An old server without the batch route can never acknowledge the hint,
+		// so report ABSENT and let the caller drop it (pre-#7452 behaviour) rather
+		// than re-force it forever.
+		return tasks, nil, err
 	}
 	return nil, nil, err
+}
+
+// ackNone is a present-but-empty acknowledgement (#7452): the transport knows
+// the server scanned nothing this cycle, so the caller keeps every drained
+// runtime forced. Distinct from a nil acknowledgement, which means the server
+// never spoke about the hint at all.
+func ackNone() *[]string {
+	acked := []string{}
+	return &acked
+}
+
+// ackAll acknowledges the whole drained set (#7452), so the caller re-notes
+// nothing.
+func ackAll(ids []string) *[]string {
+	acked := append([]string{}, ids...)
+	return &acked
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1587,6 +1587,14 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 		DaemonID   string   `json:"daemon_id"`
 		RuntimeIDs []string `json:"runtime_ids"`
 		MaxTasks   int      `json:"max_tasks"`
+		// ForceRecheckRuntimeIDs is an optional, additive signal (#7452): the
+		// daemon lists the runtimes woken by a targeted `task_available` since its
+		// last claim so the server bypasses their cached "empty" verdict and runs
+		// the real candidate SELECT, repairing a stale verdict left by a lost
+		// EmptyClaim.Bump. Absent/unknown on an older daemon → behaves exactly as
+		// before (TTL fallback). Parsed defensively; ids not in the authorized set
+		// are dropped.
+		ForceRecheckRuntimeIDs []string `json:"force_recheck_runtime_ids"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
@@ -1678,7 +1686,23 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claimed, err := h.TaskService.ClaimTasksForRuntimes(r.Context(), authorized, maxTasks)
+	// Restrict the force-recheck set (#7452) to runtimes this daemon is
+	// authorized for: an unknown or malformed id is skipped (matching this
+	// endpoint's "unknown id skipped" semantics), and an id for another daemon's
+	// runtime cannot force a cross-machine cache bypass.
+	forceRecheck := make([]pgtype.UUID, 0, len(req.ForceRecheckRuntimeIDs))
+	for _, rid := range req.ForceRecheckRuntimeIDs {
+		ruid, err := util.ParseUUID(rid)
+		if err != nil {
+			continue
+		}
+		if _, ok := runtimeByID[util.UUIDToString(ruid)]; !ok {
+			continue
+		}
+		forceRecheck = append(forceRecheck, ruid)
+	}
+
+	claimed, err := h.TaskService.ClaimTasksForRuntimes(r.Context(), authorized, maxTasks, forceRecheck...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to claim tasks: "+err.Error())
 		return

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1798,9 +1798,12 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 			"runtimes", len(authorized), "requested_max", maxTasks, "claimed", len(out),
 			"total_ms", time.Since(start).Milliseconds())
 	}
-	// force_rechecked_runtime_ids echoes the forced runtimes the service actually
-	// scanned (#7452), so the daemon consumes the wakeup hint only for those and
-	// re-notes the rest. Additive/optional: an older daemon ignores it.
+	// force_rechecked_runtime_ids acknowledges the forced runtimes whose scan came
+	// back with zero candidates (#7452): those are confirmed idle and cache-repaired,
+	// so the daemon drops the wakeup hint for them and keeps every other forced
+	// runtime forced. The field is ALWAYS emitted, even when empty, so a daemon can
+	// tell "acknowledged nothing" from an older server that omits it entirely.
+	// Additive/optional: an older daemon ignores it.
 	if forceRechecked == nil {
 		forceRechecked = []string{}
 	}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1702,7 +1702,7 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 		forceRecheck = append(forceRecheck, ruid)
 	}
 
-	claimed, err := h.TaskService.ClaimTasksForRuntimes(r.Context(), authorized, maxTasks, forceRecheck...)
+	claimed, forceRechecked, err := h.TaskService.ClaimTasksForRuntimes(r.Context(), authorized, maxTasks, forceRecheck...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to claim tasks: "+err.Error())
 		return
@@ -1798,7 +1798,16 @@ func (h *Handler) ClaimTasksByRuntime(w http.ResponseWriter, r *http.Request) {
 			"runtimes", len(authorized), "requested_max", maxTasks, "claimed", len(out),
 			"total_ms", time.Since(start).Milliseconds())
 	}
-	writeMeasuredJSON(w, http.StatusOK, map[string]any{"tasks": out})
+	// force_rechecked_runtime_ids echoes the forced runtimes the service actually
+	// scanned (#7452), so the daemon consumes the wakeup hint only for those and
+	// re-notes the rest. Additive/optional: an older daemon ignores it.
+	if forceRechecked == nil {
+		forceRechecked = []string{}
+	}
+	writeMeasuredJSON(w, http.StatusOK, map[string]any{
+		"tasks":                       out,
+		"force_rechecked_runtime_ids": forceRechecked,
+	})
 }
 
 // claimBuildFailure captures a pre-response failure from

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3718,9 +3718,25 @@ func (s *TaskService) RequeueTaskAfterClaimFailure(ctx context.Context, task db.
 // The returned slice contains both reclaimed and freshly-claimed tasks, each
 // already carrying its runtime_id so the daemon routes it to the matching
 // runtime locally.
-func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pgtype.UUID, maxTasks int) ([]db.AgentTaskQueue, error) {
+// forceRecheckRuntimeIDs, when non-empty, names runtimes whose empty-claim
+// verdict must be ignored for THIS call: a targeted daemon `task_available`
+// wakeup carries them so a queued task becomes claimable immediately even if a
+// prior enqueue's EmptyClaim.Bump was lost to a transient Redis failure and the
+// stale "empty" verdict would otherwise survive to its TTL (GitHub #7452). The
+// forced runtimes still MarkEmpty-repair on a zero-candidate result (step 5),
+// so a genuinely-idle runtime re-arms the cache instead of polling Postgres
+// every cycle. It is an optional, additive signal: an empty set reproduces the
+// exact pre-#7452 behavior, and ids not in runtimeIDs are ignored.
+func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pgtype.UUID, maxTasks int, forceRecheckRuntimeIDs ...pgtype.UUID) ([]db.AgentTaskQueue, error) {
 	if len(runtimeIDs) == 0 || maxTasks <= 0 {
 		return nil, nil
+	}
+
+	// Runtimes whose cached empty verdict is bypassed for this call. Keyed by
+	// canonical uuid string so it matches the per-runtime bookkeeping below.
+	forceRecheck := make(map[string]struct{}, len(forceRecheckRuntimeIDs))
+	for _, rid := range forceRecheckRuntimeIDs {
+		forceRecheck[util.UUIDToString(rid)] = struct{}{}
 	}
 
 	// De-dup runtime IDs defensively so MarkEmpty/version bookkeeping stays
@@ -3822,11 +3838,15 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	}
 
 	// 3. Empty-cache short-circuit + version sampling for the remaining runtimes.
+	// A runtime named in forceRecheck skips the IsEmpty short-circuit and always
+	// runs the real candidate SELECT (step 4), repairing a stale "empty" verdict
+	// left by a lost Bump (#7452). It still samples the version so step 5 can
+	// MarkEmpty-repair it when the SELECT confirms it is genuinely idle.
 	nonEmpty := make([]pgtype.UUID, 0, len(uniqueIDs))
 	versions := make(map[string]int64, len(uniqueIDs))
 	for _, rid := range uniqueIDs {
 		key := util.UUIDToString(rid)
-		if s.EmptyClaim.IsEmpty(ctx, key) {
+		if _, forced := forceRecheck[key]; !forced && s.EmptyClaim.IsEmpty(ctx, key) {
 			continue
 		}
 		versions[key] = s.EmptyClaim.CurrentVersion(ctx, key)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3834,6 +3834,11 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		)
 	}
 	if len(claimed) >= maxTasks {
+		// Reclaim (step 2) already filled the batch, so step 3 never runs and a
+		// forceRecheck runtime not among the reclaimed tasks keeps its stale
+		// "empty" verdict this cycle. That is self-healing: the daemon re-drives
+		// the same free slots on the next poll (and the wakeup that set the force
+		// signal recurs), so the bypass lands then; the TTL is the outer bound.
 		return claimed[:maxTasks], nil
 	}
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3728,13 +3728,28 @@ func (s *TaskService) RequeueTaskAfterClaimFailure(ctx context.Context, task db.
 // every cycle. It is an optional, additive signal: an empty set reproduces the
 // exact pre-#7452 behavior, and ids not in runtimeIDs are ignored.
 //
-// The second return value echoes the subset of forceRecheckRuntimeIDs that
-// actually reached the candidate SELECT this cycle (were in the non-empty set
-// step 4 queried), as canonical uuid strings. It drives the daemon's
-// "consume the hint only on confirmed execution" contract: a forced runtime the
-// server did NOT scan — because reclaim already filled the batch (step 2 early
-// return) or an error cut the cycle short — is absent from the echo, so the
-// daemon re-notes it and forces the re-check again next cycle.
+// The second return value ACKNOWLEDGES the subset of forceRecheckRuntimeIDs
+// whose candidate SELECT came back with ZERO candidates this cycle, as
+// canonical uuid strings. A forced runtime is acknowledged only once it has
+// been observed genuinely idle and MarkEmpty-repaired (step 5): its cache entry
+// is then freshly authoritative, so the hint has done its job and the daemon
+// can drop it.
+//
+// Everything else is deliberately NOT acknowledged, so the daemon keeps the
+// runtime forced and re-forces it next cycle:
+//   - a forced runtime whose SELECT found candidates. The batch's
+//     one-attempt-per-agent rule can claim one of two same-agent tasks and leave
+//     the second queued, and the stale verdict that made the runtime need
+//     forcing is still cached. Acknowledging here would depend on a repair write
+//     (a Bump/invalidate) succeeding, and that write can fail in the very Redis
+//     outage that lost the enqueue-side Bump, silently restoring the stale
+//     verdict. Staying forced until a scan is empty needs no such write.
+//   - a forced runtime the server never scanned, because reclaim already filled
+//     the batch (step 2 early return) or an error cut the cycle short.
+//
+// The set is meaningful even when empty, and the handler always emits the field,
+// so a daemon can tell "this server acknowledged nothing" from "this server does
+// not know the field at all".
 func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pgtype.UUID, maxTasks int, forceRecheckRuntimeIDs ...pgtype.UUID) ([]db.AgentTaskQueue, []string, error) {
 	if len(runtimeIDs) == 0 || maxTasks <= 0 {
 		return nil, nil, nil
@@ -3847,8 +3862,8 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		// "empty" verdict this cycle. That is self-healing: the daemon re-drives
 		// the same free slots on the next poll (and the wakeup that set the force
 		// signal recurs), so the bypass lands then; the TTL is the outer bound.
-		// The forced runtimes were never scanned, so the echo is empty and the
-		// daemon re-notes every one of them for the next cycle.
+		// Nothing was scanned, so nothing is acknowledged: the daemon keeps every
+		// forced runtime forced and the bypass lands on the next poll.
 		return claimed[:maxTasks], nil, nil
 	}
 
@@ -3856,20 +3871,18 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	// A runtime named in forceRecheck skips the IsEmpty short-circuit and always
 	// runs the real candidate SELECT (step 4), repairing a stale "empty" verdict
 	// left by a lost Bump (#7452). It still samples the version so step 5 can
-	// MarkEmpty-repair it when the SELECT confirms it is genuinely idle.
+	// MarkEmpty-repair it, and acknowledge it, when the SELECT confirms it is
+	// genuinely idle.
 	nonEmpty := make([]pgtype.UUID, 0, len(uniqueIDs))
 	versions := make(map[string]int64, len(uniqueIDs))
-	// forceRechecked echoes the forced runtimes that actually reach the SELECT
-	// below, so the daemon consumes the hint only for those (see the doc comment).
+	// forceRechecked acknowledges the forced runtimes that step 5 confirms idle,
+	// so every other forced runtime stays forced (see the doc comment).
 	forceRechecked := make([]string, 0, len(forceRecheck))
 	for _, rid := range uniqueIDs {
 		key := util.UUIDToString(rid)
 		_, forced := forceRecheck[key]
 		if !forced && s.EmptyClaim.IsEmpty(ctx, key) {
 			continue
-		}
-		if forced {
-			forceRechecked = append(forceRechecked, key)
 		}
 		versions[key] = s.EmptyClaim.CurrentVersion(ctx, key)
 		nonEmpty = append(nonEmpty, rid)
@@ -3892,8 +3905,8 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		if len(claimed) > 0 {
 			slog.Error("batch claim: candidate query failed after partial success; returning claimed tasks to avoid loss",
 				"error", err, "claimed", len(claimed))
-			// The SELECT errored, so the forced runtimes were not confirmed
-			// scanned — echo nothing so the daemon re-notes and retries them.
+			// The SELECT errored, so no forced runtime was observed idle:
+			// acknowledge none of them and let the daemon keep them forced.
 			return claimed, nil, nil
 		}
 		return nil, nil, fmt.Errorf("list queued claim candidates: %w", err)
@@ -3911,19 +3924,15 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		key := util.UUIDToString(rid)
 		if _, ok := withCandidates[key]; !ok {
 			s.EmptyClaim.MarkEmpty(ctx, key, versions[key])
-			continue
-		}
-		// Blocker 1 (#7452): a FORCED runtime that yielded ≥1 candidate still
-		// carries the stale "empty" verdict that made it need forcing (the lost
-		// Bump). The batch's one-attempt-per-agent rule can claim only one of two
-		// same-agent tasks and leave the second queued; without invalidating the
-		// verdict here the next NORMAL poll would short-circuit that runtime and
-		// strand the second task until the TTL. Bump so the stale verdict is
-		// rejected on the next read and the poll re-checks it (step 5 re-marks it
-		// empty if it is genuinely idle by then). Non-forced positives already
-		// passed IsEmpty, so they have no stale verdict to clear.
-		if _, forced := forceRecheck[key]; forced {
-			s.EmptyClaim.Bump(ctx, key)
+			// The runtime is confirmed idle and its cache entry has just been
+			// re-armed from a real SELECT, so the force hint has done its job:
+			// acknowledge it and let the daemon drop it (#7452). A forced runtime
+			// that DID yield candidates is intentionally left unacknowledged: it
+			// stays forced until a later scan comes back empty, which is what makes
+			// the contract independent of any Redis repair write succeeding.
+			if _, forced := forceRecheck[key]; forced {
+				forceRechecked = append(forceRechecked, key)
+			}
 		}
 	}
 
@@ -3950,9 +3959,8 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 			if len(claimed) > 0 {
 				slog.Error("batch claim: claim task failed after partial success; returning claimed tasks to avoid loss",
 					"error", err, "claimed", len(claimed))
-				// The candidate SELECT already ran and step 5 already invalidated
-				// forced-positive verdicts, so the forced runtimes were confirmed
-				// scanned this cycle — echo them.
+				// Step 5 already ran, so any forced runtime it confirmed idle is
+				// safely acknowledged; the rest stay forced.
 				return claimed, forceRechecked, nil
 			}
 			return nil, nil, fmt.Errorf("claim task: %w", err)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3727,9 +3727,17 @@ func (s *TaskService) RequeueTaskAfterClaimFailure(ctx context.Context, task db.
 // so a genuinely-idle runtime re-arms the cache instead of polling Postgres
 // every cycle. It is an optional, additive signal: an empty set reproduces the
 // exact pre-#7452 behavior, and ids not in runtimeIDs are ignored.
-func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pgtype.UUID, maxTasks int, forceRecheckRuntimeIDs ...pgtype.UUID) ([]db.AgentTaskQueue, error) {
+//
+// The second return value echoes the subset of forceRecheckRuntimeIDs that
+// actually reached the candidate SELECT this cycle (were in the non-empty set
+// step 4 queried), as canonical uuid strings. It drives the daemon's
+// "consume the hint only on confirmed execution" contract: a forced runtime the
+// server did NOT scan — because reclaim already filled the batch (step 2 early
+// return) or an error cut the cycle short — is absent from the echo, so the
+// daemon re-notes it and forces the re-check again next cycle.
+func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pgtype.UUID, maxTasks int, forceRecheckRuntimeIDs ...pgtype.UUID) ([]db.AgentTaskQueue, []string, error) {
 	if len(runtimeIDs) == 0 || maxTasks <= 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Runtimes whose cached empty verdict is bypassed for this call. Keyed by
@@ -3777,7 +3785,7 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		slog.Info("promote deferred tasks (batch): slot taken by a concurrent enqueue, skipping this tick")
 		promoted = nil
 	} else if err != nil {
-		return nil, fmt.Errorf("promote deferred tasks: %w", err)
+		return nil, nil, fmt.Errorf("promote deferred tasks: %w", err)
 	}
 	for _, task := range promoted {
 		slog.Info("deferred fallback task promoted (batch)",
@@ -3812,7 +3820,7 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 			MaxTasks:          int32(maxTasks),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("reclaim stale dispatched tasks: %w", err)
+			return nil, nil, fmt.Errorf("reclaim stale dispatched tasks: %w", err)
 		}
 		// The UPDATE's fixed setup/locking cost dominates array width. Query and
 		// advance the complete machine-level set together so per-runtime backstops
@@ -3839,7 +3847,9 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		// "empty" verdict this cycle. That is self-healing: the daemon re-drives
 		// the same free slots on the next poll (and the wakeup that set the force
 		// signal recurs), so the bypass lands then; the TTL is the outer bound.
-		return claimed[:maxTasks], nil
+		// The forced runtimes were never scanned, so the echo is empty and the
+		// daemon re-notes every one of them for the next cycle.
+		return claimed[:maxTasks], nil, nil
 	}
 
 	// 3. Empty-cache short-circuit + version sampling for the remaining runtimes.
@@ -3849,16 +3859,23 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 	// MarkEmpty-repair it when the SELECT confirms it is genuinely idle.
 	nonEmpty := make([]pgtype.UUID, 0, len(uniqueIDs))
 	versions := make(map[string]int64, len(uniqueIDs))
+	// forceRechecked echoes the forced runtimes that actually reach the SELECT
+	// below, so the daemon consumes the hint only for those (see the doc comment).
+	forceRechecked := make([]string, 0, len(forceRecheck))
 	for _, rid := range uniqueIDs {
 		key := util.UUIDToString(rid)
-		if _, forced := forceRecheck[key]; !forced && s.EmptyClaim.IsEmpty(ctx, key) {
+		_, forced := forceRecheck[key]
+		if !forced && s.EmptyClaim.IsEmpty(ctx, key) {
 			continue
+		}
+		if forced {
+			forceRechecked = append(forceRechecked, key)
 		}
 		versions[key] = s.EmptyClaim.CurrentVersion(ctx, key)
 		nonEmpty = append(nonEmpty, rid)
 	}
 	if len(nonEmpty) == 0 {
-		return claimed, nil
+		return claimed, forceRechecked, nil
 	}
 
 	// 4. One candidate SELECT across the non-empty set.
@@ -3875,9 +3892,11 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		if len(claimed) > 0 {
 			slog.Error("batch claim: candidate query failed after partial success; returning claimed tasks to avoid loss",
 				"error", err, "claimed", len(claimed))
-			return claimed, nil
+			// The SELECT errored, so the forced runtimes were not confirmed
+			// scanned — echo nothing so the daemon re-notes and retries them.
+			return claimed, nil, nil
 		}
-		return nil, fmt.Errorf("list queued claim candidates: %w", err)
+		return nil, nil, fmt.Errorf("list queued claim candidates: %w", err)
 	}
 
 	// 5. Mark runtimes with zero candidates empty so their next idle poll skips
@@ -3892,6 +3911,19 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		key := util.UUIDToString(rid)
 		if _, ok := withCandidates[key]; !ok {
 			s.EmptyClaim.MarkEmpty(ctx, key, versions[key])
+			continue
+		}
+		// Blocker 1 (#7452): a FORCED runtime that yielded ≥1 candidate still
+		// carries the stale "empty" verdict that made it need forcing (the lost
+		// Bump). The batch's one-attempt-per-agent rule can claim only one of two
+		// same-agent tasks and leave the second queued; without invalidating the
+		// verdict here the next NORMAL poll would short-circuit that runtime and
+		// strand the second task until the TTL. Bump so the stale verdict is
+		// rejected on the next read and the poll re-checks it (step 5 re-marks it
+		// empty if it is genuinely idle by then). Non-forced positives already
+		// passed IsEmpty, so they have no stale verdict to clear.
+		if _, forced := forceRecheck[key]; forced {
+			s.EmptyClaim.Bump(ctx, key)
 		}
 	}
 
@@ -3918,9 +3950,12 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 			if len(claimed) > 0 {
 				slog.Error("batch claim: claim task failed after partial success; returning claimed tasks to avoid loss",
 					"error", err, "claimed", len(claimed))
-				return claimed, nil
+				// The candidate SELECT already ran and step 5 already invalidated
+				// forced-positive verdicts, so the forced runtimes were confirmed
+				// scanned this cycle — echo them.
+				return claimed, forceRechecked, nil
 			}
-			return nil, fmt.Errorf("claim task: %w", err)
+			return nil, nil, fmt.Errorf("claim task: %w", err)
 		}
 		if task == nil {
 			continue
@@ -3934,7 +3969,7 @@ func (s *TaskService) ClaimTasksForRuntimes(ctx context.Context, runtimeIDs []pg
 		claimed = append(claimed, *task)
 	}
 
-	return claimed, nil
+	return claimed, forceRechecked, nil
 }
 
 // cancelSupersededDeferredRetries drops deferred auto-retry rows that an active

--- a/server/internal/service/task_batch_claim_deferred_test.go
+++ b/server/internal/service/task_batch_claim_deferred_test.go
@@ -45,7 +45,7 @@ func TestClaimTasksForRuntimes_PromotesDeferredAndEmitsQueuedEvent(t *testing.T)
 	svc := NewTaskService(db.New(pool), pool, nil, bus)
 	rt, deferredTaskID := deferredBatchFixture(t, ctx, pool)
 
-	got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(rt)}, 5)
+	got, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(rt)}, 5)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}

--- a/server/internal/service/task_batch_claim_force_recheck_test.go
+++ b/server/internal/service/task_batch_claim_force_recheck_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestClaimTasksForRuntimes_ForceRecheckBypassesStaleEmptyVerdict is the #7452
+// regression: a runtime with a queued task but a stale cached "empty" verdict
+// (as if the enqueue's EmptyClaim.Bump was lost to a transient Redis failure)
+// is stranded on a normal claim, yet a claim that names it in the force set
+// bypasses the short-circuit and claims the task immediately. A second runtime
+// that is NOT forced still short-circuits, proving the bypass is targeted.
+func TestClaimTasksForRuntimes_ForceRecheckBypassesStaleEmptyVerdict(t *testing.T) {
+	ctx := context.Background()
+	pool := newTaskClaimRacePool(t)
+	rdb := newRedisTestClient(t)
+
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.EmptyClaim = NewEmptyClaimCache(rdb)
+
+	rt1, rt2 := batchClaimFixture(t, ctx, pool)
+	rt1Key, rt2Key := rt1, rt2
+	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
+
+	// Simulate the missed-invalidation state on BOTH runtimes: a verdict tagged
+	// with the current version, so IsEmpty trusts it even though rows are queued.
+	svc.EmptyClaim.MarkEmpty(ctx, rt1Key, svc.EmptyClaim.CurrentVersion(ctx, rt1Key))
+	svc.EmptyClaim.MarkEmpty(ctx, rt2Key, svc.EmptyClaim.CurrentVersion(ctx, rt2Key))
+	if !svc.EmptyClaim.IsEmpty(ctx, rt1Key) || !svc.EmptyClaim.IsEmpty(ctx, rt2Key) {
+		t.Fatal("precondition: both runtimes must read as cached-empty")
+	}
+
+	// No force set: both runtimes short-circuit on the stale verdict → nothing
+	// is claimed even though tasks are queued.
+	got, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	if err != nil {
+		t.Fatalf("unforced claim: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("unforced claim returned %d tasks, want 0 (stale empty verdict must short-circuit)", len(got))
+	}
+
+	// Force only rt1: it bypasses the short-circuit and claims its queued task,
+	// while rt2 (not forced) stays short-circuited.
+	got, err = svc.ClaimTasksForRuntimes(ctx, ids, 5, util.MustParseUUID(rt1))
+	if err != nil {
+		t.Fatalf("forced claim: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("forced claim returned %d tasks, want exactly 1 (only rt1 bypassed)", len(got))
+	}
+	if util.UUIDToString(got[0].RuntimeID) != rt1 {
+		t.Fatalf("forced claim routed to %s, want rt1", util.UUIDToString(got[0].RuntimeID))
+	}
+}
+
+// TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates pins the
+// other half of #7452: forcing a re-check on a genuinely-idle runtime must not
+// leave the cache disabled — a zero-candidate result re-arms the empty verdict
+// (MarkEmpty), so subsequent idle polls skip Postgres again.
+func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testing.T) {
+	ctx := context.Background()
+	pool := newTaskClaimRacePool(t)
+	rdb := newRedisTestClient(t)
+
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.EmptyClaim = NewEmptyClaimCache(rdb)
+
+	_, rt2 := batchClaimFixture(t, ctx, pool)
+	rt2ID := util.MustParseUUID(rt2)
+
+	// Drain rt2's single queued task so it becomes genuinely idle in the DB.
+	if got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5); err != nil {
+		t.Fatalf("drain claim: %v", err)
+	} else if len(got) != 1 {
+		t.Fatalf("drain claim returned %d tasks, want 1", len(got))
+	}
+
+	// Invalidate any cached verdict so IsEmpty is false going into the forced call.
+	svc.EmptyClaim.Bump(ctx, rt2)
+	if svc.EmptyClaim.IsEmpty(ctx, rt2) {
+		t.Fatal("precondition: rt2 must not read as cached-empty after Bump")
+	}
+
+	// Force a re-check on the now-idle runtime: nothing to claim, but the empty
+	// verdict must be re-armed for the next idle poll.
+	got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5, rt2ID)
+	if err != nil {
+		t.Fatalf("forced idle claim: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("forced idle claim returned %d tasks, want 0", len(got))
+	}
+	if !svc.EmptyClaim.IsEmpty(ctx, rt2) {
+		t.Fatal("forced re-check on a zero-candidate runtime must re-arm the empty verdict")
+	}
+}

--- a/server/internal/service/task_batch_claim_force_recheck_test.go
+++ b/server/internal/service/task_batch_claim_force_recheck_test.go
@@ -38,7 +38,7 @@ func TestClaimTasksForRuntimes_ForceRecheckBypassesStaleEmptyVerdict(t *testing.
 
 	// No force set: both runtimes short-circuit on the stale verdict → nothing
 	// is claimed even though tasks are queued.
-	got, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	got, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("unforced claim: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestClaimTasksForRuntimes_ForceRecheckBypassesStaleEmptyVerdict(t *testing.
 
 	// Force only rt1: it bypasses the short-circuit and claims its queued task,
 	// while rt2 (not forced) stays short-circuited.
-	got, err = svc.ClaimTasksForRuntimes(ctx, ids, 5, util.MustParseUUID(rt1))
+	got, _, err = svc.ClaimTasksForRuntimes(ctx, ids, 5, util.MustParseUUID(rt1))
 	if err != nil {
 		t.Fatalf("forced claim: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testin
 	rt2ID := util.MustParseUUID(rt2)
 
 	// Drain rt2's single queued task so it becomes genuinely idle in the DB.
-	if got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5); err != nil {
+	if got, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5); err != nil {
 		t.Fatalf("drain claim: %v", err)
 	} else if len(got) != 1 {
 		t.Fatalf("drain claim returned %d tasks, want 1", len(got))
@@ -90,7 +90,7 @@ func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testin
 
 	// Force a re-check on the now-idle runtime: nothing to claim, but the empty
 	// verdict must be re-armed for the next idle poll.
-	got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5, rt2ID)
+	got, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5, rt2ID)
 	if err != nil {
 		t.Fatalf("forced idle claim: %v", err)
 	}
@@ -99,5 +99,65 @@ func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testin
 	}
 	if !svc.EmptyClaim.IsEmpty(ctx, rt2) {
 		t.Fatal("forced re-check on a zero-candidate runtime must re-arm the empty verdict")
+	}
+}
+
+// TestClaimTasksForRuntimes_ForcedPositiveReleasesSecondSameAgentTask is
+// blocker 1 of #7452: a forced runtime whose SELECT returns candidates must not
+// keep its stale "empty" verdict. The batch claims at most one task per agent
+// per call, so a forced claim on a runtime with TWO queued tasks for the same
+// agent takes only the first and leaves the second queued. Without invalidating
+// the verdict on that forced positive, the next NORMAL poll would short-circuit
+// the runtime and strand the second task until the empty key's TTL (~3 min). The
+// fix Bumps the verdict on a forced positive, so the very next normal claim
+// re-checks the runtime and takes the second task immediately.
+func TestClaimTasksForRuntimes_ForcedPositiveReleasesSecondSameAgentTask(t *testing.T) {
+	ctx := context.Background()
+	pool := newTaskClaimRacePool(t)
+	rdb := newRedisTestClient(t)
+
+	svc := NewTaskService(db.New(pool), pool, nil, events.New())
+	svc.EmptyClaim = NewEmptyClaimCache(rdb)
+
+	// batchClaimFixture gives rt1 an agent with TWO queued tasks on two issues.
+	rt1, _ := batchClaimFixture(t, ctx, pool)
+	rt1ID := util.MustParseUUID(rt1)
+
+	// Simulate the lost-Bump state: a verdict tagged with the current version, so
+	// IsEmpty trusts it even though two tasks are queued on rt1.
+	svc.EmptyClaim.MarkEmpty(ctx, rt1, svc.EmptyClaim.CurrentVersion(ctx, rt1))
+	if !svc.EmptyClaim.IsEmpty(ctx, rt1) {
+		t.Fatal("precondition: rt1 must read as cached-empty")
+	}
+
+	// Forced claim: bypasses the short-circuit, claims exactly one of the two
+	// same-agent tasks, and echoes rt1 as force-rechecked (it reached the SELECT).
+	forced, forceRechecked, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5, rt1ID)
+	if err != nil {
+		t.Fatalf("forced claim: %v", err)
+	}
+	if len(forced) != 1 || util.UUIDToString(forced[0].RuntimeID) != rt1 {
+		t.Fatalf("forced claim = %d tasks on %v, want exactly 1 on rt1", len(forced), forced)
+	}
+	if len(forceRechecked) != 1 || forceRechecked[0] != rt1 {
+		t.Fatalf("force-rechecked echo = %v, want [rt1]", forceRechecked)
+	}
+
+	// The stale verdict must now be invalidated so a plain poll re-checks rt1.
+	if svc.EmptyClaim.IsEmpty(ctx, rt1) {
+		t.Fatal("forced positive must invalidate the stale empty verdict, else the second task waits for TTL")
+	}
+
+	// Next NORMAL claim (no force set): it re-checks rt1 and takes the second
+	// same-agent task instead of stranding it.
+	second, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5)
+	if err != nil {
+		t.Fatalf("normal follow-up claim: %v", err)
+	}
+	if len(second) != 1 || util.UUIDToString(second[0].RuntimeID) != rt1 {
+		t.Fatalf("follow-up claim = %d tasks on %v, want the second task on rt1", len(second), second)
+	}
+	if forced[0].ID == second[0].ID {
+		t.Fatal("follow-up claim returned the same task, want the distinct second same-agent task")
 	}
 }

--- a/server/internal/service/task_batch_claim_force_recheck_test.go
+++ b/server/internal/service/task_batch_claim_force_recheck_test.go
@@ -90,7 +90,7 @@ func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testin
 
 	// Force a re-check on the now-idle runtime: nothing to claim, but the empty
 	// verdict must be re-armed for the next idle poll.
-	got, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5, rt2ID)
+	got, acknowledged, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt2ID}, 5, rt2ID)
 	if err != nil {
 		t.Fatalf("forced idle claim: %v", err)
 	}
@@ -100,18 +100,25 @@ func TestClaimTasksForRuntimes_ForceRecheckReArmsCacheOnZeroCandidates(t *testin
 	if !svc.EmptyClaim.IsEmpty(ctx, rt2) {
 		t.Fatal("forced re-check on a zero-candidate runtime must re-arm the empty verdict")
 	}
+	// A zero-candidate scan is the ONLY thing that acknowledges a forced runtime
+	// (#7452): the runtime is confirmed idle and its cache entry was just re-armed
+	// from a real SELECT, so the daemon may drop the hint.
+	if len(acknowledged) != 1 || acknowledged[0] != rt2 {
+		t.Fatalf("acknowledged set = %v, want [rt2] after a zero-candidate forced scan", acknowledged)
+	}
 }
 
-// TestClaimTasksForRuntimes_ForcedPositiveReleasesSecondSameAgentTask is
-// blocker 1 of #7452: a forced runtime whose SELECT returns candidates must not
-// keep its stale "empty" verdict. The batch claims at most one task per agent
-// per call, so a forced claim on a runtime with TWO queued tasks for the same
-// agent takes only the first and leaves the second queued. Without invalidating
-// the verdict on that forced positive, the next NORMAL poll would short-circuit
-// the runtime and strand the second task until the empty key's TTL (~3 min). The
-// fix Bumps the verdict on a forced positive, so the very next normal claim
-// re-checks the runtime and takes the second task immediately.
-func TestClaimTasksForRuntimes_ForcedPositiveReleasesSecondSameAgentTask(t *testing.T) {
+// TestClaimTasksForRuntimes_ForcedPositiveIsNotAcknowledged pins refinement 1 of
+// #7452: a forced runtime whose SELECT returns candidates is NOT acknowledged,
+// so the daemon keeps it forced and re-forces it next cycle. The batch claims at
+// most one task per agent per call, so a forced claim on a runtime with TWO
+// queued tasks for the same agent takes only the first and leaves the second
+// queued behind a stale "empty" verdict. Acknowledging here would have made
+// correctness depend on a Redis repair write landing — and that write can fail in
+// the very outage that lost the enqueue-side Bump. Staying forced until a scan
+// comes back empty needs no such write: the next forced claim takes the second
+// task immediately, without waiting for the ~3 minute TTL.
+func TestClaimTasksForRuntimes_ForcedPositiveIsNotAcknowledged(t *testing.T) {
 	ctx := context.Background()
 	pool := newTaskClaimRacePool(t)
 	rdb := newRedisTestClient(t)
@@ -130,34 +137,53 @@ func TestClaimTasksForRuntimes_ForcedPositiveReleasesSecondSameAgentTask(t *test
 		t.Fatal("precondition: rt1 must read as cached-empty")
 	}
 
-	// Forced claim: bypasses the short-circuit, claims exactly one of the two
-	// same-agent tasks, and echoes rt1 as force-rechecked (it reached the SELECT).
-	forced, forceRechecked, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5, rt1ID)
+	// Forced claim: bypasses the short-circuit and claims exactly one of the two
+	// same-agent tasks. Because the scan found candidates, rt1 is NOT acknowledged.
+	forced, acknowledged, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5, rt1ID)
 	if err != nil {
 		t.Fatalf("forced claim: %v", err)
 	}
 	if len(forced) != 1 || util.UUIDToString(forced[0].RuntimeID) != rt1 {
 		t.Fatalf("forced claim = %d tasks on %v, want exactly 1 on rt1", len(forced), forced)
 	}
-	if len(forceRechecked) != 1 || forceRechecked[0] != rt1 {
-		t.Fatalf("force-rechecked echo = %v, want [rt1]", forceRechecked)
+	if len(acknowledged) != 0 {
+		t.Fatalf("acknowledged set = %v, want empty: a forced scan that found candidates must stay forced", acknowledged)
 	}
 
-	// The stale verdict must now be invalidated so a plain poll re-checks rt1.
-	if svc.EmptyClaim.IsEmpty(ctx, rt1) {
-		t.Fatal("forced positive must invalidate the stale empty verdict, else the second task waits for TTL")
-	}
-
-	// Next NORMAL claim (no force set): it re-checks rt1 and takes the second
-	// same-agent task instead of stranding it.
-	second, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5)
-	if err != nil {
+	// A NORMAL poll still short-circuits on the stale verdict, which is exactly
+	// why the runtime must stay forced rather than be acknowledged here.
+	if stranded, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5); err != nil {
 		t.Fatalf("normal follow-up claim: %v", err)
+	} else if len(stranded) != 0 {
+		t.Fatalf("normal follow-up claim = %d tasks, want 0 (the stale verdict still short-circuits)", len(stranded))
+	}
+
+	// The daemon kept rt1 forced, so the next FORCED claim takes the second
+	// same-agent task instead of stranding it until the TTL.
+	second, secondAck, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5, rt1ID)
+	if err != nil {
+		t.Fatalf("second forced claim: %v", err)
 	}
 	if len(second) != 1 || util.UUIDToString(second[0].RuntimeID) != rt1 {
-		t.Fatalf("follow-up claim = %d tasks on %v, want the second task on rt1", len(second), second)
+		t.Fatalf("second forced claim = %d tasks on %v, want the second task on rt1", len(second), second)
 	}
 	if forced[0].ID == second[0].ID {
-		t.Fatal("follow-up claim returned the same task, want the distinct second same-agent task")
+		t.Fatal("second forced claim returned the same task, want the distinct second same-agent task")
+	}
+	if len(secondAck) != 0 {
+		t.Fatalf("acknowledged set = %v, want empty: this scan also found candidates", secondAck)
+	}
+
+	// Once the queue really is drained, a forced scan comes back empty and only
+	// THEN is rt1 acknowledged, so the daemon finally drops the hint.
+	drained, drainedAck, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{rt1ID}, 5, rt1ID)
+	if err != nil {
+		t.Fatalf("drained forced claim: %v", err)
+	}
+	if len(drained) != 0 {
+		t.Fatalf("drained forced claim = %d tasks, want 0", len(drained))
+	}
+	if len(drainedAck) != 1 || drainedAck[0] != rt1 {
+		t.Fatalf("acknowledged set = %v, want [rt1] once the forced scan is empty", drainedAck)
 	}
 }

--- a/server/internal/service/task_batch_claim_partial_test.go
+++ b/server/internal/service/task_batch_claim_partial_test.go
@@ -69,7 +69,7 @@ func TestClaimTasksForRuntimes_PartialSuccessOnSecondAgentClaimFailure(t *testin
 	rt1, rt2 := batchClaimFixture(t, ctx, pool)
 	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
 
-	claimed, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	claimed, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("expected partial success (nil error), got %v", err)
 	}
@@ -129,7 +129,7 @@ func TestClaimTasksForRuntimes_PartialSuccessOnCandidateQueryFailureAfterReclaim
 	})
 
 	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
-	claimed, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	claimed, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("expected partial success (nil error) despite candidate query failure, got %v", err)
 	}

--- a/server/internal/service/task_batch_claim_test.go
+++ b/server/internal/service/task_batch_claim_test.go
@@ -108,7 +108,7 @@ func TestClaimTasksForRuntimes_MultiRuntimeDrain(t *testing.T) {
 	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
 
 	// Call 1: one task per agent (agent1→rt1, agent2→rt2) => 2 tasks, one per runtime.
-	got1, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	got1, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("call1: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestClaimTasksForRuntimes_MultiRuntimeDrain(t *testing.T) {
 
 	// Call 2: agent1 still has a second queued task (different issue, capacity 5);
 	// agent2 is drained => exactly 1 task, on rt1.
-	got2, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	got2, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("call2: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestClaimTasksForRuntimes_MultiRuntimeDrain(t *testing.T) {
 	}
 
 	// Call 3: everything dispatched => empty.
-	got3, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	got3, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("call3: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestClaimTasksForRuntimes_MaxTasksCap(t *testing.T) {
 	rt1, rt2 := batchClaimFixture(t, ctx, pool)
 	ids := []pgtype.UUID{util.MustParseUUID(rt1), util.MustParseUUID(rt2)}
 
-	got, err := svc.ClaimTasksForRuntimes(ctx, ids, 1)
+	got, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 1)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestClaimTasksForRuntimes_AnyDueRuntimeChecksTheCompleteSet(t *testing.T) {
 		t.Fatalf("precondition due runtimes = %v, want [%s]", due, rt1)
 	}
 
-	claimed, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
+	claimed, _, err := svc.ClaimTasksForRuntimes(ctx, ids, 5)
 	if err != nil {
 		t.Fatalf("batch claim: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestClaimTasksForRuntimes_EmptyReclaimDefersHintForRetry(t *testing.T) {
 		t.Fatalf("precondition due runtimes = %v, want [%s]", due, rt1)
 	}
 
-	if claimed, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{runtimeID}, 5); err != nil {
+	if claimed, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{runtimeID}, 5); err != nil {
 		t.Fatalf("batch claim: %v", err)
 	} else if len(claimed) != 0 {
 		t.Fatalf("claimed tasks with stale runtime heartbeat: %v", claimed)
@@ -305,11 +305,11 @@ func TestClaimTasksForRuntimes_EmptyInputs(t *testing.T) {
 	pool := newTaskClaimRacePool(t)
 	svc := NewTaskService(db.New(pool), pool, nil, events.New())
 
-	if got, err := svc.ClaimTasksForRuntimes(ctx, nil, 5); err != nil || got != nil {
+	if got, _, err := svc.ClaimTasksForRuntimes(ctx, nil, 5); err != nil || got != nil {
 		t.Fatalf("nil runtimes: got=%v err=%v, want nil,nil", got, err)
 	}
 	rt1, _ := batchClaimFixture(t, ctx, pool)
-	if got, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(rt1)}, 0); err != nil || got != nil {
+	if got, _, err := svc.ClaimTasksForRuntimes(ctx, []pgtype.UUID{util.MustParseUUID(rt1)}, 0); err != nil || got != nil {
 		t.Fatalf("maxTasks=0: got=%v err=%v, want nil,nil", got, err)
 	}
 }


### PR DESCRIPTION
## What

A queued task for an idle runtime can stall for up to ~3 minutes. On enqueue the server bumps an empty-claim verdict cache (`empty_claim_cache.go`, 3m TTL) and the claim path short-circuits any runtime whose `EmptyClaim.IsEmpty` is true. When the invalidating `Bump` is lost to a transient Redis failure, the stale "empty" verdict survives to the TTL and the daemon's 30s idle polls keep getting nothing for that runtime — the failure #7452 reports (a task queued for an online, idle-capacity runtime dispatched only ~205s later).

This wires the issue's suggested direction #1: the daemon's targeted `task_available` wakeup now forces a server-side DB re-check that **bypasses the `IsEmpty` short-circuit for exactly the woken runtimes**, while still `MarkEmpty`-repairing on a zero-candidate result so the cache re-arms. The empty-claim optimization is untouched for every runtime that was not just woken.

## How

- **Server** (`service/task.go`, `ClaimTasksForRuntimes`): a variadic `forceRecheckRuntimeIDs`. At the step-3 empty-cache filter, forced runtimes skip `IsEmpty` but still flow through the step-5 `MarkEmpty` re-arm on zero candidates. Non-forced runtimes are byte-for-byte unchanged.
- **Transport** (`handler/daemon.go`, `daemon/client.go`, `daemon/wsrpc.go`): an **optional, additive** `force_recheck_runtime_ids` on the batch/WS claim request. Parsed defensively (`util.ParseUUID`, skip on error) and **intersected with the daemon's authorized runtime set**, so a daemon can never force a re-check for a runtime it does not own. The WS `tasks.claim` RPC reuses the same HTTP handler, so authorization is not duplicated.
- **Daemon** (`daemon/daemon.go`): a mutex-guarded woken-runtime set. `pollLoop` records the runtime id on each targeted wakeup; `runBatchPoller` drains the set into the next claim and re-notes it on claim error. The set is omitted from the request body entirely when empty, so a steady-state poll is identical to the pre-fix request.

## Testing

RED→GREEN, both directions:
- `service/task_batch_claim_force_recheck_test.go`: a forced runtime bypasses a stale empty verdict and claims while a non-forced runtime still short-circuits; a forced zero-candidate runtime re-arms the cache. (Reverting the step-3 bypass or the step-5 re-arm fails these.)
- `daemon/force_recheck_test.go`: the woken set is tracked, deduped and cleared; an empty wakeup is ignored; `claimTasksBody` omits the field with nothing woken and includes it otherwise.

`go build ./...`, `go vet`, `gofmt -l` clean; the daemon suite and the handler batch-claim tests pass.

## API compatibility

The field is additive/optional and safe in both directions. Newer daemon → older server: the unknown JSON field is ignored, behavior falls back to today's TTL. Older daemon → newer server: the field is absent, decodes to nil, and the non-forced path is unchanged. Empty woken set → the field is omitted, so the request is byte-identical to before.

## Known limitations (narrow, self-healing — flagged for a possible follow-up)

The common-case stall is closed. Two rare interleavings still fall back to the existing TTL for a single runtime (never a correctness regression, never a double-claim, always self-healing on the next wakeup/enqueue or the 3m TTL):

1. If a WS claim returns the "uncertain" outcome (request may not have reached the server), the already-drained woken set is not re-noted (the re-note is on the error path only), so that runtime is not force-rechecked that cycle.
2. If the step-2 stale-dispatch reclaim alone fills the batch's `maxTasks`, `ClaimTasksForRuntimes` returns before the step-3 forced bypass runs, consuming the signal without effect for that cycle.

The singular per-runtime `ClaimTaskForRuntime` path (legacy fallback for servers without the batch route, which therefore lack this feature) is intentionally not wired — threading force there would be dead code.

Addresses #7452.
