### PR TITLE
fix(ci): unblock the release by fixing two flaky main failures (MUL-6890)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --port 4000",
-    "build": "fumadocs-mdx && next build",
+    "build": "next build",
     "start": "next start",
-    "typecheck": "fumadocs-mdx && tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "mdx": "fumadocs-mdx",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "sh -c 'next dev --webpack --port \"${FRONTEND_PORT:-3000}\"'",
-    "build": "fumadocs-mdx && next build --webpack",
+    "build": "next build --webpack",
     "start": "next start",
-    "typecheck": "fumadocs-mdx && tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
+    "mdx": "fumadocs-mdx",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/server/internal/integrations/wecom/relay_ordering_db_test.go
+++ b/server/internal/integrations/wecom/relay_ordering_db_test.go
@@ -37,7 +37,15 @@ import (
 // wecomTestRedis is the same gate the rest of the repository uses for
 // Redis-backed tests: REDIS_TEST_URL, a dedicated DB index, flushed around
 // each test so one run cannot see another's claims.
-const wecomRelayTestRedisDB = 12
+//
+// The index has to be unique across PACKAGES, not just within this one. `go
+// test ./...` runs packages concurrently, every Redis-backed suite flushes its
+// own DB on entry and exit, and a flush is indiscriminate: sharing an index
+// means another package can delete a live delivery claim mid-test, and the
+// outcome watch then reports a reply that was delivered as lost. Current
+// allocation — 11 internal/auth, 12 internal/service, 13 internal/middleware,
+// 14 internal/handler, 15 here.
+const wecomRelayTestRedisDB = 15
 
 // testClaimBudget is the claim round trip these tests give the real store. It
 // sizes outcomeGrace (once per offer), so the production 2s would make the

--- a/turbo.json
+++ b/turbo.json
@@ -21,8 +21,20 @@
     "DESKTOP_APP_SUFFIX"
   ],
   "tasks": {
+    // `fumadocs-mdx` regenerates `.source/` by removing the directory and
+    // writing it again, so two of them in the same package at once is a race:
+    // one process rm -rf's the tree the other has already mkdir'd, and the
+    // loser dies on `ENOENT .source/index.ts`. `build` and `typecheck` both
+    // needed those types and both used to shell out to it, which turbo is free
+    // to run concurrently — a red CI job on nothing but timing. One task the
+    // two depend on generates it once, and its output is cached like any
+    // other. Packages without an `mdx` script are unaffected: turbo skips a
+    // dependency no package implements.
+    "mdx": {
+      "outputs": [".source/**"]
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "mdx"],
       // No explicit `inputs`: turbo's default (every git-tracked file in the
       // package) is the only safe hash source now that the cache is actually
       // restored in CI. The previous narrow glob list matched neither
@@ -41,7 +53,7 @@
       "persistent": true
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^typecheck", "mdx"]
     },
     // Hash-only transit task. No package implements a `cache-inputs` script,
     // so every node resolves to <NONEXISTENT> and nothing is ever executed --


### PR DESCRIPTION
## Summary

Two failures on `main` are blocking the v0.4.37 release tag. Neither is caused by the code under test — both are infrastructure races that fail intermittently — and both are fixed here.

### 1. `backend-tests`: `TestRelay_ADeliveredReplyIsCountedOnceAndNotAlsoLost`

```
relay_ordering_db_test.go:390: outbound_dropped on the publisher = 1, want 0 — it was delivered
```

The WeCom relay tests keep their delivery claims in Redis DB **12**, and `server/internal/service` uses DB **12** for its own Redis-backed suite. Both flush that DB on entry and on cleanup, and `go test ./...` runs packages concurrently — so a flush from `internal/service` can delete a live claim held by a relay test. The publisher's outcome watch then finds no claim, concludes nobody took the delivery, and counts a drop for a reply the holder had already sent.

Fix: give the package an index nothing else uses (15), and write the current allocation down next to it (11 auth, 12 service, 13 middleware, 14 handler, 15 wecom) so the next suite does not collide either.

### 2. `frontend-build`: `ENOENT: no such file or directory, open '.source/index.ts'`

`@multica/web` ran `fumadocs-mdx && next build` and `fumadocs-mdx && tsc --noEmit`, and turbo may run those two tasks for the same package concurrently. `fumadocs-mdx` regenerates `.source/` with `rm -rf` → `mkdir` → `writeFile`, so two of them fight over one directory and the loser's write hits ENOENT.

Fix: move the generation into its own `mdx` turbo task that `build` and `typecheck` depend on. It runs once, its output is cached, and the two consumers still run in parallel. `apps/docs` had the same script pair and gets the same treatment.

## Verification

Backend — reproduced the failure first, then confirmed the fix under the same concurrency (local Postgres + Redis):

```
# before: service suite hammering DB 12 alongside the relay test
--- FAIL: TestRelay_ADeliveredReplyIsCountedOnceAndNotAlsoLost (0.66s)
    relay_ordering_db_test.go:390: outbound_dropped on the publisher = 1, want 0 — it was delivered

# after (same command, 8 iterations of every TestRelay_*)
ok      github.com/multica-ai/multica/server/internal/integrations/wecom
```

- `go test ./internal/integrations/wecom/ -race` alongside a full `go test ./internal/service/` — both pass.

Frontend (Node 22, matching CI):

- `pnpm exec turbo build typecheck lint --filter='!@multica/docs' --filter='!@multica/mobile'` — 15/15 tasks successful.
- `pnpm exec turbo build typecheck --filter='@multica/docs'` — 4/4 successful.
- `turbo --dry` confirms `@multica/web#build` and `@multica/web#typecheck` now share a single `@multica/web#mdx` dependency.
