### PR TITLE
fix(issues): wake parent when child enters review

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -350,15 +350,22 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
 }
 
-// isTerminalChildStatus reports whether a child issue status counts as
-// "finished" for stage-barrier purposes. Cancelled counts as terminal: a
-// cancelled sibling will never complete, so it must not hold a stage open.
+// isChildCompletedStatus reports whether a child handed work back to its
+// parent. `in_review` is an agent-completion signal; `done` and `cancelled`
+// also close a stage because they require no further child work.
+func isChildCompletedStatus(status string) bool {
+	return status == "in_review" || status == "done" || status == "cancelled"
+}
+
+// isTerminalChildStatus is retained for callers that use the historic name.
+// A stage is complete when its children are ready for review, done, or
+// cancelled; a child agent conventionally enters in_review before acceptance.
 //
 // Takes a CANONICAL status. Callers that hold a raw `issue.status` must pass it
-// through terminalChildPredicate first, so a custom status in the done or
-// cancelled category closes a stage exactly like Done and Cancelled do.
+// through terminalChildPredicate first, so a custom completion status closes a
+// stage exactly like the built-in completion statuses do.
 func isTerminalChildStatus(status string) bool {
-	return status == "done" || status == "cancelled"
+	return isChildCompletedStatus(status)
 }
 
 // terminalChildPredicate returns the terminal test for a sibling set, resolving

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -154,6 +154,45 @@ func TestChildDoneNotifiesParent(t *testing.T) {
 	}
 }
 
+// TestChildInReviewNotifiesParent keeps serial staged workflows moving when a
+// child agent hands work back for review. `in_review` is the normal agent
+// completion status, so it must close a one-child stage just like `done`.
+func TestChildInReviewNotifiesParent(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("expected exactly 1 system comment on parent after in_review, got %d", got)
+	}
+}
+
+// TestChildInReviewThenDoneDoesNotRefire ensures accepting an already reviewed
+// child does not enqueue the parent a second time.
+func TestChildInReviewThenDoneDoesNotRefire(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+	updateChildStatus(t, fx.child.ID, "done")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("expected one system comment after in_review then done, got %d", got)
+	}
+}
+
+func TestChildCompletedStatusIncludesReview(t *testing.T) {
+	for _, status := range []string{"in_review", "done", "cancelled"} {
+		if !isChildCompletedStatus(status) {
+			t.Errorf("%q should close a child stage", status)
+		}
+	}
+	for _, status := range []string{"backlog", "todo", "in_progress"} {
+		if isChildCompletedStatus(status) {
+			t.Errorf("%q must not close a child stage", status)
+		}
+	}
+}
+
 // TestChildDoneNotificationIsIdempotent — re-saving an already-done child
 // must NOT fire a second notification. UpdateIssue is called with the same
 // status='done' twice; only the first call is a transition and should


### PR DESCRIPTION
## Summary
- Treat a child transition to `in_review` as a completed stage transition.
- Wake the parent assignee once so its coordinator can evaluate and promote the next ready backlog stage.
- Keep `in_review` → `done` idempotent, preventing a duplicate parent wake.

## Validation
- `go test ./internal/handler -run 'TestChild(InReviewNotifiesParent|InReviewThenDoneDoesNotRefire|CompletedStatusIncludesReview)$' -count=1 -v`
- `go test ./internal/handler -count=1`
- `git diff --check`

`make test` exercised the handler suite successfully, including the new database-backed regression cases. The aggregate command has unrelated CLI test failures caused by the daemon-managed task marker in this environment.
