### PR TITLE
fix(daemon): restore issue scope for manual reruns

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1985,6 +1985,71 @@ func rerunSourceMatchesTaskScope(task, source db.AgentTaskQueue) bool {
 	return false
 }
 
+func restorableRerunIssueScope(task, source db.AgentTaskQueue) (pgtype.UUID, bool) {
+	if task.IssueID.Valid || task.ChatSessionID.Valid || task.AutopilotRunID.Valid || !task.RerunOfTaskID.Valid {
+		return pgtype.UUID{}, false
+	}
+	var quickCreate struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(task.Context, &quickCreate) == nil && quickCreate.Type == service.QuickCreateContextType {
+		return pgtype.UUID{}, false
+	}
+	if !source.IssueID.Valid || source.AgentID != task.AgentID {
+		return pgtype.UUID{}, false
+	}
+	return source.IssueID, true
+}
+
+// restoreMissingRerunIssueScope repairs the one manual-rerun state that must
+// never reach the daemon as a generic scratch task: a rerun row whose durable
+// lineage points at an issue task but whose own issue_id is NULL. The source
+// task is server-authored lineage and the agent match prevents a malformed row
+// from borrowing another agent's issue. Persist the repair before assembling
+// the claim so project context is resolved live from the issue's current
+// project resources and later progress/completion stays attached to the issue.
+//
+// Issue-less quick-create reruns are intentionally unchanged: their source has
+// no issue_id, so they continue through the quick-create context path below.
+func (h *Handler) restoreMissingRerunIssueScope(ctx context.Context, task *db.AgentTaskQueue) error {
+	if !task.RerunOfTaskID.Valid || task.IssueID.Valid || task.ChatSessionID.Valid || task.AutopilotRunID.Valid {
+		return nil
+	}
+
+	source, err := h.Queries.GetAgentTask(ctx, task.RerunOfTaskID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("load rerun source while restoring issue scope: %w", err)
+	}
+	issueID, ok := restorableRerunIssueScope(*task, source)
+	if !ok {
+		return nil
+	}
+
+	if err := h.Queries.LinkTaskToIssue(ctx, db.LinkTaskToIssueParams{
+		ID:      task.ID,
+		IssueID: issueID,
+	}); err != nil {
+		return fmt.Errorf("restore rerun issue scope: %w", err)
+	}
+	repaired, err := h.Queries.GetAgentTask(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("verify restored rerun issue scope: %w", err)
+	}
+	if !repaired.IssueID.Valid || repaired.IssueID != issueID {
+		return fmt.Errorf("verify restored rerun issue scope: issue_id was not persisted")
+	}
+	task.IssueID = repaired.IssueID
+	slog.Warn("daemon claim: restored missing issue scope from rerun source",
+		"task_id", uuidToString(task.ID),
+		"source_task_id", uuidToString(source.ID),
+		"issue_id", uuidToString(issueID),
+	)
+	return nil
+}
+
 func claimResponseAgentIdentityMatches(resp AgentTaskResponse) bool {
 	return resp.AgentID != "" && resp.Agent != nil && resp.Agent.ID == resp.AgentID
 }
@@ -1998,6 +2063,20 @@ func claimResponseAgentIdentityMatches(resp AgentTaskResponse) bool {
 // means the task must not be dispatched; the builder has already cancelled it
 // where the failure semantics require it.
 func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQueue, runtime db.AgentRuntime, runtimeID, runtimeWorkspaceID string) (resp AgentTaskResponse, deliveredCommentIDs []pgtype.UUID, agentSkillCount, builtinSkillCount int, failure *claimBuildFailure) {
+	if err := h.restoreMissingRerunIssueScope(r.Context(), task); err != nil {
+		slog.Error("daemon claim: failed to restore rerun issue scope; requeueing claim",
+			"task_id", uuidToString(task.ID), "error", err)
+		if _, requeueErr := h.TaskService.RequeueTaskAfterClaimFailure(r.Context(), *task); requeueErr != nil {
+			slog.Error("daemon claim: requeue after rerun issue-scope restore failed; stale reclaim will recover it",
+				"task_id", uuidToString(task.ID), "error", requeueErr)
+		}
+		return resp, nil, 0, 0, &claimBuildFailure{
+			outcome: "error_restore_rerun_issue_scope",
+			status:  http.StatusInternalServerError,
+			message: "failed to restore rerun issue context",
+		}
+	}
+
 	// Build response with fresh agent data (name + skills + custom_env + custom_args).
 	resp = taskToResponse(*task, runtimeWorkspaceID)
 	var issueNumber int32

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2009,8 +2009,9 @@ func restorableRerunIssueScope(task, source db.AgentTaskQueue) (pgtype.UUID, boo
 // the claim so project context is resolved live from the issue's current
 // project resources and later progress/completion stays attached to the issue.
 //
-// Issue-less quick-create reruns are intentionally unchanged: their source has
-// no issue_id, so they continue through the quick-create context path below.
+// Quick-create reruns are intentionally unchanged: even if the source task later
+// gets an issue_id via LinkTaskToIssue, quick-create runs should continue through
+// the quick-create context path below rather than borrowing issue scope.
 func (h *Handler) restoreMissingRerunIssueScope(ctx context.Context, task *db.AgentTaskQueue) error {
 	if !task.RerunOfTaskID.Valid || task.IssueID.Valid || task.ChatSessionID.Valid || task.AutopilotRunID.Valid {
 		return nil

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2667,27 +2667,73 @@ func TestClaimResponseAgentIdentityMatches(t *testing.T) {
 	}
 }
 
+func TestRestorableRerunIssueScope(t *testing.T) {
+	agentID := parseUUID("00000000-0000-0000-0000-000000000101")
+	otherAgentID := parseUUID("00000000-0000-0000-0000-000000000102")
+	issueID := parseUUID("00000000-0000-0000-0000-000000000201")
+	rerunID := parseUUID("00000000-0000-0000-0000-000000000301")
+
+	baseTask := db.AgentTaskQueue{AgentID: agentID, RerunOfTaskID: rerunID}
+	baseSource := db.AgentTaskQueue{AgentID: agentID, IssueID: issueID}
+	quickCreateTask := baseTask
+	quickCreateTask.Context = []byte(`{"type":"` + service.QuickCreateContextType + `"}`)
+	scopedTask := baseTask
+	scopedTask.IssueID = issueID
+	for _, tc := range []struct {
+		name   string
+		task   db.AgentTaskQueue
+		source db.AgentTaskQueue
+		want   bool
+	}{
+		{name: "lost issue scope", task: baseTask, source: baseSource, want: true},
+		{name: "ordinary issue rerun already scoped", task: scopedTask, source: baseSource},
+		{name: "quick-create context remains issue-less", task: quickCreateTask, source: baseSource},
+		{name: "quick-create source has no issue", task: baseTask, source: db.AgentTaskQueue{AgentID: agentID}},
+		{name: "different agent cannot lend scope", task: baseTask, source: db.AgentTaskQueue{AgentID: otherAgentID, IssueID: issueID}},
+		{name: "non-rerun cannot borrow scope", task: db.AgentTaskQueue{AgentID: agentID}, source: baseSource},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotIssueID, got := restorableRerunIssueScope(tc.task, tc.source)
+			if got != tc.want {
+				t.Fatalf("restorable = %v, want %v", got, tc.want)
+			}
+			if got && gotIssueID != issueID {
+				t.Fatalf("issue id = %s, want %s", uuidToString(gotIssueID), uuidToString(issueID))
+			}
+		})
+	}
+}
+
 type claimRuntimeGuardTask struct {
-	PriorSessionID                string          `json:"prior_session_id"`
-	PriorWorkDir                  string          `json:"prior_work_dir"`
-	PriorSessionResumeUnavailable bool            `json:"prior_session_resume_unavailable"`
-	ChatMessage                   string          `json:"chat_message"`
-	ThreadName                    string          `json:"thread_name"`
-	QuickCreateAttachmentIDs      []string        `json:"quick_create_attachment_ids"`
-	QuickCreatePriority           string          `json:"quick_create_priority"`
-	QuickCreateDueDate            string          `json:"quick_create_due_date"`
-	ProjectID                     string          `json:"project_id"`
-	ProjectDescription            string          `json:"project_description"`
-	ParentIssueID                 string          `json:"parent_issue_id"`
-	QuickCreateSourceContext      json.RawMessage `json:"quick_create_source_context"`
+	IssueID                       string                `json:"issue_id"`
+	PriorSessionID                string                `json:"prior_session_id"`
+	PriorWorkDir                  string                `json:"prior_work_dir"`
+	PriorSessionResumeUnavailable bool                  `json:"prior_session_resume_unavailable"`
+	ChatMessage                   string                `json:"chat_message"`
+	ThreadName                    string                `json:"thread_name"`
+	QuickCreateAttachmentIDs      []string              `json:"quick_create_attachment_ids"`
+	QuickCreatePriority           string                `json:"quick_create_priority"`
+	QuickCreateDueDate            string                `json:"quick_create_due_date"`
+	ProjectID                     string                `json:"project_id"`
+	ProjectDescription            string                `json:"project_description"`
+	ProjectResources              []ProjectResourceData `json:"project_resources"`
+	ParentIssueID                 string                `json:"parent_issue_id"`
+	QuickCreateSourceContext      json.RawMessage       `json:"quick_create_source_context"`
 }
 
 func claimTaskForRuntimeGuard(t *testing.T, runtimeID, daemonID string) *claimRuntimeGuardTask {
+	return claimTaskForRuntimeGuardWithCapabilities(t, runtimeID, daemonID)
+}
+
+func claimTaskForRuntimeGuardWithCapabilities(t *testing.T, runtimeID, daemonID string, capabilities ...string) *claimRuntimeGuardTask {
 	t.Helper()
 
 	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
 		testWorkspaceID, daemonID)
+	if len(capabilities) > 0 {
+		req.Header.Set("X-Client-Capabilities", strings.Join(capabilities, ","))
+	}
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("runtimeId", runtimeID)
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
@@ -3101,6 +3147,71 @@ func TestClaimTask_ManualRetryReusesWorkdir(t *testing.T) {
 		}
 		if task.PriorSessionID != "" {
 			t.Fatalf("PriorSessionID = %q, want empty (cross-runtime session cannot resolve)", task.PriorSessionID)
+		}
+	})
+
+	t.Run("missing_issue_scope_is_restored_before_resolving_current_project_resources", func(t *testing.T) {
+		issueNum++
+		projectID := dbfx.Project(t, "manual retry current resource fixture")
+		const originalPath = "/root/progetto-prova"
+		const updatedPath = "/home/agente/progetto-prova"
+		dbfx.Exec(t, `
+			INSERT INTO project_resource (
+				project_id, workspace_id, resource_type, resource_ref, position
+			) VALUES ($1, $2, 'local_directory', $3::jsonb, 0)
+		`, projectID, testWorkspaceID, `{"daemon_id":"`+daemonID+`","local_path":"`+originalPath+`","execution_mode":"worktree"}`)
+
+		issueID := dbfx.Issue(t, "manual retry restores project context", testutil.Cols{
+			"status":     "in_progress",
+			"number":     issueNum,
+			"project_id": projectID,
+		})
+		sourceID := dbfx.Task(t, agentID, testutil.Cols{
+			"runtime_id": runtimeID,
+			"issue_id":   issueID,
+			"status":     "failed",
+			"work_dir":   originalPath,
+		})
+		dbfx.Exec(t, `
+			UPDATE project_resource
+			SET resource_ref = $2::jsonb
+			WHERE project_id = $1 AND resource_type = 'local_directory'
+		`, projectID, `{"daemon_id":"`+daemonID+`","local_path":"`+updatedPath+`","execution_mode":"worktree"}`)
+
+		var rerunID string
+		dbfx.QueryRow(t, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, status, priority,
+				rerun_of_task_id, force_fresh_session
+			)
+			VALUES ($1, $2, 'queued', 0, $3, TRUE)
+			RETURNING id
+		`, agentID, runtimeID, sourceID).Scan(&rerunID)
+
+		task := claimTaskForRuntimeGuardWithCapabilities(t, runtimeID, daemonID, protocol.DaemonCapabilityLocalWorktreeV1)
+		if task.IssueID != issueID {
+			t.Fatalf("IssueID = %q, want restored source issue %q", task.IssueID, issueID)
+		}
+		if task.PriorWorkDir != originalPath {
+			t.Fatalf("PriorWorkDir = %q, want source workdir", task.PriorWorkDir)
+		}
+		if len(task.ProjectResources) != 1 {
+			t.Fatalf("ProjectResources = %+v, want updated local_directory", task.ProjectResources)
+		}
+		var localDirectory struct {
+			LocalPath string `json:"local_path"`
+		}
+		if err := json.Unmarshal(task.ProjectResources[0].ResourceRef, &localDirectory); err != nil {
+			t.Fatalf("decode local_directory resource: %v", err)
+		}
+		if localDirectory.LocalPath != updatedPath {
+			t.Fatalf("local_directory path = %q, want current path %q", localDirectory.LocalPath, updatedPath)
+		}
+
+		var persistedIssueID string
+		dbfx.QueryRow(t, `SELECT issue_id FROM agent_task_queue WHERE id = $1`, rerunID).Scan(&persistedIssueID)
+		if persistedIssueID != issueID {
+			t.Fatalf("persisted issue_id = %q, want %q", persistedIssueID, issueID)
 		}
 	})
 


### PR DESCRIPTION
## What does this PR do?

Fixes the failure mode reported in #7826, where a manually retried task can reach `ClaimAgentTask` without an `issue_id`.

Without issue scope, the claim path treats the rerun as an issue-less task. As a result, it does not resolve the project's current resources and the daemon starts the task in a generic scratch workdir instead of the configured `local_directory`.

Thinking path:

- Project resources are resolved during task claim from the task's issue and project scope.
- The daemon log in #7826 shows the retried task being claimed with `issue=""`.
- Manual reruns retain `rerun_of_task_id`, which provides durable lineage back to the source task.
- When a manual rerun is missing issue scope, this change restores the issue association from its same-agent source task before the claim response is built.
- The existing claim path can then resolve the project's current resources, including resource path updates made between attempts.
- The recovery is intentionally limited to manual reruns with missing issue scope. Existing issue-bound tasks, chat tasks, autopilot tasks, quick-create tasks, and cross-agent reruns keep their current behavior.

## Related Issue

Closes #7826

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add a conservative predicate for identifying manual reruns whose issue scope can be restored.
- Restore and persist the source task's issue association before resolving the claim response.
- Re-read the task after linking the issue to verify that the association was persisted.
- Add boundary coverage for issue-bound, chat, autopilot, quick-create, and cross-agent reruns.
- Add a database-backed regression test proving that a rerun uses the project's updated `local_directory` resource while retaining its prior workdir lineage.

## How to Test

From `server/`, with PostgreSQL available and migrations applied:

1. Run the focused scope and claim regression tests:

   ```bash
   go test ./internal/handler \
     -run '^(TestRestorableRerunIssueScope|TestClaimTask_ManualRetryReusesWorkdir)$' \
     -count=1