### PR TITLE
MUL-6903: fix(processtree): terminate escaped Linux descendants

### DIFF
--- a/server/internal/daemon/processtree/controller_unix.go
+++ b/server/internal/daemon/processtree/controller_unix.go
@@ -13,23 +13,40 @@ import (
 
 const processTreeFinishTimeout = 5 * time.Second
 
-type controller struct{}
+type ownedDescendant struct {
+	pid      int
+	identity uint64
+}
+
+type controller struct {
+	descendants map[int]ownedDescendant
+}
 
 func newController(cmd *exec.Cmd) (*controller, error) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setpgid = true
-	return &controller{}, nil
+	return &controller{descendants: make(map[int]ownedDescendant)}, nil
 }
 
 func (*controller) attach(_ *exec.Cmd) error { return nil }
 
-func (*controller) interrupt(cmd *exec.Cmd) error {
-	if cmd.Process == nil {
-		return os.ErrProcessDone
+func (c *controller) rememberDescendants(rootPID int) {
+	refs, err := discoverOwnedDescendants(rootPID)
+	if err != nil {
+		// Process groups remain the portable Unix fallback. Descendant discovery
+		// is an additional Linux containment layer and must not make cancellation
+		// fail on hosts where procfs is unavailable or restricted.
+		return
 	}
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
+	for _, ref := range refs {
+		c.descendants[ref.pid] = ref
+	}
+}
+
+func signalProcessGroup(pid int, sig syscall.Signal) error {
+	if err := syscall.Kill(-pid, sig); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
 			return nil
 		}
@@ -38,17 +55,55 @@ func (*controller) interrupt(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (*controller) stop(cmd *exec.Cmd) error {
+func (c *controller) signalDescendants(sig syscall.Signal) error {
+	var result error
+	for _, ref := range c.descendants {
+		result = errors.Join(result, signalOwnedDescendant(ref, sig))
+	}
+	return result
+}
+
+func (c *controller) activeDescendantPIDs() []int {
+	active := make([]int, 0, len(c.descendants))
+	for _, ref := range c.descendants {
+		if ownedDescendantAlive(ref) {
+			active = append(active, ref.pid)
+		}
+	}
+	return active
+}
+
+func (c *controller) interrupt(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return nil
-		}
-		return cmd.Process.Kill()
+	pid := cmd.Process.Pid
+	// Snapshot descendants while the leader is still alive. A child may call
+	// setsid and leave the process group without changing its parent; retaining
+	// its process identity lets stop/finish reach it after the leader exits and
+	// it is reparented.
+	c.rememberDescendants(pid)
+	return errors.Join(
+		c.signalDescendants(syscall.SIGTERM),
+		signalProcessGroup(pid, syscall.SIGTERM),
+	)
+}
+
+func (c *controller) stop(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return os.ErrProcessDone
 	}
-	return nil
+	pid := cmd.Process.Pid
+	// Capture children created during the graceful-stop window before the
+	// process group is force-killed.
+	c.rememberDescendants(pid)
+	groupErr := signalProcessGroup(pid, syscall.SIGKILL)
+	if groupErr != nil {
+		if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			groupErr = errors.Join(groupErr, err)
+		}
+	}
+	return errors.Join(c.signalDescendants(syscall.SIGKILL), groupErr)
 }
 
 func (c *controller) finish(cmd *exec.Cmd) error {
@@ -56,23 +111,31 @@ func (c *controller) finish(cmd *exec.Cmd) error {
 		return nil
 	}
 	pid := cmd.Process.Pid
-	if err := syscall.Kill(-pid, 0); errors.Is(err, syscall.ESRCH) {
-		return nil
-	}
-	// A normally-exited leader can still leave a descendant holding inherited
-	// pipes or repository locks. Kill the remaining group before returning
-	// ownership of the repository to another operation.
-	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+	// The normal-exit path may still have group-bound descendants. The
+	// cancellation path also has remembered descendants that may now be in a
+	// different process group or reparented to init.
+	c.rememberDescendants(pid)
+	groupErr := signalProcessGroup(pid, syscall.SIGKILL)
+	descendantErr := c.signalDescendants(syscall.SIGKILL)
+	if err := errors.Join(groupErr, descendantErr); err != nil {
 		return err
 	}
+
 	deadline := time.Now().Add(processTreeFinishTimeout)
 	for time.Now().Before(deadline) {
-		if err := syscall.Kill(-pid, 0); errors.Is(err, syscall.ESRCH) {
+		groupActive := syscall.Kill(-pid, 0) == nil
+		activeDescendants := c.activeDescendantPIDs()
+		if !groupActive && len(activeDescendants) == 0 {
 			return nil
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return fmt.Errorf("process group %d still active after %s", pid, processTreeFinishTimeout)
+	return fmt.Errorf(
+		"process tree rooted at %d still active after %s (descendants=%v)",
+		pid,
+		processTreeFinishTimeout,
+		c.activeDescendantPIDs(),
+	)
 }
 
 func (*controller) close() {}

--- a/server/internal/daemon/processtree/descendants_linux.go
+++ b/server/internal/daemon/processtree/descendants_linux.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package processtree
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type linuxProcessStat struct {
+	ppid      int
+	startTime uint64
+}
+
+func readLinuxProcessStat(pid int) (linuxProcessStat, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return linuxProcessStat{}, err
+	}
+	// comm is enclosed in parentheses and may contain spaces or ')'. Split
+	// after the final ')' so field indexes from state onward remain stable.
+	closeParen := strings.LastIndexByte(string(data), ')')
+	if closeParen < 0 || closeParen+1 >= len(data) {
+		return linuxProcessStat{}, fmt.Errorf("malformed /proc/%d/stat", pid)
+	}
+	fields := strings.Fields(string(data[closeParen+1:]))
+	// fields[0] is state (field 3), fields[1] is ppid (field 4), and
+	// fields[19] is starttime (field 22).
+	if len(fields) <= 19 {
+		return linuxProcessStat{}, fmt.Errorf("short /proc/%d/stat", pid)
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return linuxProcessStat{}, fmt.Errorf("parse /proc/%d/stat ppid: %w", pid, err)
+	}
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return linuxProcessStat{}, fmt.Errorf("parse /proc/%d/stat starttime: %w", pid, err)
+	}
+	return linuxProcessStat{ppid: ppid, startTime: startTime}, nil
+}
+
+func discoverOwnedDescendants(rootPID int) ([]ownedDescendant, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	children := make(map[int][]ownedDescendant)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 || pid == rootPID {
+			continue
+		}
+		stat, err := readLinuxProcessStat(pid)
+		if err != nil {
+			// Processes can exit while /proc is scanned and hidepid mounts may
+			// deny unrelated entries. Both are expected; retain readable children.
+			continue
+		}
+		children[stat.ppid] = append(children[stat.ppid], ownedDescendant{
+			pid:      pid,
+			identity: stat.startTime,
+		})
+	}
+
+	seen := map[int]struct{}{rootPID: {}}
+	queue := []int{rootPID}
+	result := make([]ownedDescendant, 0)
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range children[parent] {
+			if _, ok := seen[child.pid]; ok {
+				continue
+			}
+			seen[child.pid] = struct{}{}
+			result = append(result, child)
+			queue = append(queue, child.pid)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].pid < result[j].pid })
+	return result, nil
+}
+
+func signalOwnedDescendant(ref ownedDescendant, sig syscall.Signal) error {
+	stat, err := readLinuxProcessStat(ref.pid)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		// Do not signal an unverified PID: it may have been recycled for an
+		// unrelated process after the original descendant exited.
+		return nil
+	}
+	if stat.startTime != ref.identity {
+		return nil
+	}
+	if err := syscall.Kill(ref.pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}
+
+func ownedDescendantAlive(ref ownedDescendant) bool {
+	stat, err := readLinuxProcessStat(ref.pid)
+	return err == nil && stat.startTime == ref.identity
+}

--- a/server/internal/daemon/processtree/descendants_linux.go
+++ b/server/internal/daemon/processtree/descendants_linux.go
@@ -13,6 +13,7 @@ import (
 )
 
 type linuxProcessStat struct {
+	state     byte
 	ppid      int
 	startTime uint64
 }
@@ -31,7 +32,7 @@ func readLinuxProcessStat(pid int) (linuxProcessStat, error) {
 	fields := strings.Fields(string(data[closeParen+1:]))
 	// fields[0] is state (field 3), fields[1] is ppid (field 4), and
 	// fields[19] is starttime (field 22).
-	if len(fields) <= 19 {
+	if len(fields) <= 19 || len(fields[0]) != 1 {
 		return linuxProcessStat{}, fmt.Errorf("short /proc/%d/stat", pid)
 	}
 	ppid, err := strconv.Atoi(fields[1])
@@ -42,7 +43,7 @@ func readLinuxProcessStat(pid int) (linuxProcessStat, error) {
 	if err != nil {
 		return linuxProcessStat{}, fmt.Errorf("parse /proc/%d/stat starttime: %w", pid, err)
 	}
-	return linuxProcessStat{ppid: ppid, startTime: startTime}, nil
+	return linuxProcessStat{state: fields[0][0], ppid: ppid, startTime: startTime}, nil
 }
 
 func discoverOwnedDescendants(rootPID int) ([]ownedDescendant, error) {
@@ -101,7 +102,7 @@ func signalOwnedDescendant(ref ownedDescendant, sig syscall.Signal) error {
 		// unrelated process after the original descendant exited.
 		return nil
 	}
-	if stat.startTime != ref.identity {
+	if stat.startTime != ref.identity || stat.state == 'Z' {
 		return nil
 	}
 	if err := syscall.Kill(ref.pid, sig); err != nil && !errors.Is(err, syscall.ESRCH) {
@@ -112,5 +113,5 @@ func signalOwnedDescendant(ref ownedDescendant, sig syscall.Signal) error {
 
 func ownedDescendantAlive(ref ownedDescendant) bool {
 	stat, err := readLinuxProcessStat(ref.pid)
-	return err == nil && stat.startTime == ref.identity
+	return err == nil && stat.startTime == ref.identity && stat.state != 'Z'
 }

--- a/server/internal/daemon/processtree/descendants_other.go
+++ b/server/internal/daemon/processtree/descendants_other.go
@@ -1,0 +1,14 @@
+//go:build !windows && !linux
+
+package processtree
+
+import "syscall"
+
+// Procfs descendant snapshots are a Linux containment layer. Other Unix
+// platforms retain the existing process-group behavior until they gain a
+// native process-table implementation.
+func discoverOwnedDescendants(_ int) ([]ownedDescendant, error) { return nil, nil }
+
+func signalOwnedDescendant(_ ownedDescendant, _ syscall.Signal) error { return nil }
+
+func ownedDescendantAlive(_ ownedDescendant) bool { return false }

--- a/server/internal/daemon/processtree/run.go
+++ b/server/internal/daemon/processtree/run.go
@@ -1,5 +1,7 @@
 // Package processtree runs bounded helper commands whose descendants must not
-// survive cancellation. It uses a Unix process group or a Windows Job Object.
+// survive cancellation. Windows uses a Job Object. Unix uses a process group;
+// Linux additionally snapshots procfs descendants at cancellation so a child
+// that calls setsid cannot escape merely by leaving that group.
 package processtree
 
 import (
@@ -14,7 +16,7 @@ import (
 const gracefulStopTimeout = time.Second
 
 // CombinedOutput runs an unstarted command and returns its combined output.
-// Cancellation terminates the entire process tree, waits for it to disappear,
+// Cancellation terminates the owned process tree, waits for it to disappear,
 // and returns the context cause rather than a platform-specific exit status.
 func CombinedOutput(ctx context.Context, cmd *exec.Cmd, waitDelay time.Duration) ([]byte, error) {
 	var output bytes.Buffer
@@ -36,7 +38,9 @@ func Output(ctx context.Context, cmd *exec.Cmd, waitDelay time.Duration) ([]byte
 	return stdout.Bytes(), err
 }
 
-// Run executes an unstarted command while owning its complete process tree.
+// Run executes an unstarted command while owning its platform-supported
+// process tree: a Job Object on Windows, a process group on Unix, and that
+// group plus descendants observed through procfs at cancellation on Linux.
 func Run(ctx context.Context, cmd *exec.Cmd, waitDelay time.Duration) error {
 	return run(ctx, cmd, waitDelay)
 }

--- a/server/internal/daemon/processtree/setsid_escape_repro_linux_test.go
+++ b/server/internal/daemon/processtree/setsid_escape_repro_linux_test.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package processtree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	if os.Getenv("PUCK_SETSID_HELPER2") == "1" {
+		pidFile := os.Getenv("PUCK_SETSID_HELPER2_PIDFILE")
+		if pidFile == "" {
+			os.Exit(2)
+		}
+		if _, err := syscall.Setsid(); err != nil {
+			if _, err2 := unix.Setsid(); err2 != nil {
+				os.Exit(3)
+			}
+		}
+		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+			os.Exit(4)
+		}
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+func waitForPid(path string) int {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(path)
+		if err == nil {
+			n := 0
+			for _, c := range b {
+				if c >= '0' && c <= '9' {
+					n = n*10 + int(c-'0')
+				}
+			}
+			if n > 0 {
+				return n
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	panic("helper never wrote pid to " + path)
+}
+
+// TestProcesstreeRunSetsidEscape reproduces the setsid escape via the public
+// Run path (run.go:65-85 Wait then finish with lifecycle error propagation).
+// Build tag linux only, uses Go re-exec helper without external setsid.
+func TestProcesstreeRunSetsidEscape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	leaderPidFile := filepath.Join(dir, "leader.pid")
+	childPidFile := filepath.Join(dir, "setsid-child.pid")
+	script := filepath.Join(dir, "leader.sh")
+	bin, _ := os.Executable()
+	content := "#!/bin/sh\necho $$ > \"" + leaderPidFile + "\"\nPUCK_SETSID_HELPER2=1 PUCK_SETSID_HELPER2_PIDFILE=\"" + childPidFile + "\" \"" + bin + "\" -test.run=^$ &\nsleep 300\n"
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.Command(script)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, cmd, 2*time.Second)
+	}()
+
+	childPID := waitForPid(childPidFile)
+	leaderPID := waitForPid(leaderPidFile)
+	leaderPGID, _ := unix.Getpgid(leaderPID)
+	childPGID, _ := unix.Getpgid(childPID)
+	leaderSID, _ := unix.Getsid(leaderPID)
+	childSID, _ := unix.Getsid(childPID)
+	t.Logf("leader pid=%d pgid=%d sid=%d", leaderPID, leaderPGID, leaderSID)
+	t.Logf("setsid child pid=%d pgid=%d sid=%d", childPID, childPGID, childSID)
+	if childPGID == leaderPGID {
+		t.Fatalf("child PGID %d == leader PGID %d — Setsid escape failed", childPGID, leaderPGID)
+	}
+
+	t.Cleanup(func() {
+		if leaderPID != 0 {
+			_ = syscall.Kill(-leaderPID, syscall.SIGKILL)
+			_ = syscall.Kill(leaderPID, syscall.SIGKILL)
+		}
+		_ = syscall.Kill(childPID, syscall.SIGKILL)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if syscall.Kill(childPID, 0) != nil {
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		if syscall.Kill(childPID, 0) == nil {
+			t.Logf("cleanup warning: child pid %d still alive after SIGKILL", childPID)
+		}
+		if leaderPID != 0 && syscall.Kill(-leaderPID, 0) == nil {
+			t.Logf("cleanup warning: leader pgid %d still alive", leaderPID)
+		}
+	})
+
+	cancel()
+	select {
+	case err := <-errCh:
+		t.Logf("Run returned err=%v", err)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run error = %v, want context.Canceled; lifecycle errors must not be misread as setsid reproduction", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Run did not return after cancel (wait+finish hung)")
+	}
+
+	alive := syscall.Kill(childPID, 0) == nil
+	t.Logf("after Run cancel+finish: child pid=%d alive=%v", childPID, alive)
+	if !alive {
+		t.Fatalf("child already gone — not reproducing escape")
+	}
+	t.Logf("REPRODUCED processtree Run: setsid child pid=%d pgid=%d sid=%d survived Run cancel+finish (leader pid=%d pgid=%d) — expected on main 11861145a", childPID, childPGID, childSID, leaderPID, leaderPGID)
+}

--- a/server/internal/daemon/processtree/setsid_escape_repro_linux_test.go
+++ b/server/internal/daemon/processtree/setsid_escape_repro_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -16,60 +17,97 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	setsidHelperEnv     = "MULTICA_TEST_SETSID_CHILD"
+	setsidHelperPIDFile = "MULTICA_TEST_SETSID_CHILD_PIDFILE"
+)
+
 func init() {
-	if os.Getenv("PUCK_SETSID_HELPER2") == "1" {
-		pidFile := os.Getenv("PUCK_SETSID_HELPER2_PIDFILE")
-		if pidFile == "" {
-			os.Exit(2)
-		}
-		if _, err := syscall.Setsid(); err != nil {
-			if _, err2 := unix.Setsid(); err2 != nil {
-				os.Exit(3)
-			}
-		}
-		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
-			os.Exit(4)
-		}
-		for {
-			time.Sleep(time.Second)
-		}
+	if os.Getenv(setsidHelperEnv) != "1" {
+		return
+	}
+	pidFile := os.Getenv(setsidHelperPIDFile)
+	if pidFile == "" {
+		os.Exit(2)
+	}
+	if _, err := unix.Setsid(); err != nil {
+		os.Exit(3)
+	}
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		os.Exit(4)
+	}
+	for {
+		time.Sleep(time.Second)
 	}
 }
 
-func waitForPid(path string) int {
+func readPIDFile(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		b, err := os.ReadFile(path)
-		if err == nil {
-			n := 0
-			for _, c := range b {
-				if c >= '0' && c <= '9' {
-					n = n*10 + int(c-'0')
-				}
-			}
-			if n > 0 {
-				return n
-			}
+		if pid := readPIDFile(path); pid > 0 {
+			return pid
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	panic("helper never wrote pid to " + path)
+	t.Fatalf("helper never wrote pid to %s", path)
+	return 0
 }
 
-// TestProcesstreeRunSetsidEscape reproduces the setsid escape via the public
-// Run path (run.go:65-85 Wait then finish with lifecycle error propagation).
-// Build tag linux only, uses Go re-exec helper without external setsid.
-func TestProcesstreeRunSetsidEscape(t *testing.T) {
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+// TestProcesstreeRunKillsSetsidEscape verifies that Linux cancellation retains
+// and terminates a descendant even after the child creates its own session and
+// leaves the leader's process group.
+func TestProcesstreeRunKillsSetsidEscape(t *testing.T) {
 	t.Parallel()
+
 	dir := t.TempDir()
-	leaderPidFile := filepath.Join(dir, "leader.pid")
-	childPidFile := filepath.Join(dir, "setsid-child.pid")
+	leaderPIDFile := filepath.Join(dir, "leader.pid")
+	childPIDFile := filepath.Join(dir, "setsid-child.pid")
 	script := filepath.Join(dir, "leader.sh")
-	bin, _ := os.Executable()
-	content := "#!/bin/sh\necho $$ > \"" + leaderPidFile + "\"\nPUCK_SETSID_HELPER2=1 PUCK_SETSID_HELPER2_PIDFILE=\"" + childPidFile + "\" \"" + bin + "\" -test.run=^$ &\nsleep 300\n"
-	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
-		t.Fatal(err)
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
 	}
+	content := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"echo $$ > " + shellQuote(leaderPIDFile) + "\n" +
+		setsidHelperEnv + "=1 " + setsidHelperPIDFile + "=" + shellQuote(childPIDFile) + " " + shellQuote(bin) + " -test.run=^$ &\n" +
+		"sleep 300\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write leader fixture: %v", err)
+	}
+
+	var leaderPID, leaderPGID, childPID int
+	var childRef ownedDescendant
+	t.Cleanup(func() {
+		if childPID == 0 {
+			childPID = readPIDFile(childPIDFile)
+		}
+		if childPID > 0 {
+			_ = syscall.Kill(childPID, syscall.SIGKILL)
+		}
+		if leaderPGID > 0 {
+			_ = syscall.Kill(-leaderPGID, syscall.SIGKILL)
+		} else if leaderPID > 0 {
+			_ = syscall.Kill(leaderPID, syscall.SIGKILL)
+		}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -80,54 +118,54 @@ func TestProcesstreeRunSetsidEscape(t *testing.T) {
 		errCh <- Run(ctx, cmd, 2*time.Second)
 	}()
 
-	childPID := waitForPid(childPidFile)
-	leaderPID := waitForPid(leaderPidFile)
-	leaderPGID, _ := unix.Getpgid(leaderPID)
-	childPGID, _ := unix.Getpgid(childPID)
-	leaderSID, _ := unix.Getsid(leaderPID)
-	childSID, _ := unix.Getsid(childPID)
-	t.Logf("leader pid=%d pgid=%d sid=%d", leaderPID, leaderPGID, leaderSID)
-	t.Logf("setsid child pid=%d pgid=%d sid=%d", childPID, childPGID, childSID)
-	if childPGID == leaderPGID {
-		t.Fatalf("child PGID %d == leader PGID %d — Setsid escape failed", childPGID, leaderPGID)
+	leaderPID = waitForPIDFile(t, leaderPIDFile)
+	leaderPGID, err = unix.Getpgid(leaderPID)
+	if err != nil {
+		t.Fatalf("get leader pgid: %v", err)
+	}
+	leaderSID, err := unix.Getsid(leaderPID)
+	if err != nil {
+		t.Fatalf("get leader sid: %v", err)
 	}
 
-	t.Cleanup(func() {
-		if leaderPID != 0 {
-			_ = syscall.Kill(-leaderPID, syscall.SIGKILL)
-			_ = syscall.Kill(leaderPID, syscall.SIGKILL)
-		}
-		_ = syscall.Kill(childPID, syscall.SIGKILL)
-		deadline := time.Now().Add(2 * time.Second)
-		for time.Now().Before(deadline) {
-			if syscall.Kill(childPID, 0) != nil {
-				break
-			}
-			time.Sleep(20 * time.Millisecond)
-		}
-		if syscall.Kill(childPID, 0) == nil {
-			t.Logf("cleanup warning: child pid %d still alive after SIGKILL", childPID)
-		}
-		if leaderPID != 0 && syscall.Kill(-leaderPID, 0) == nil {
-			t.Logf("cleanup warning: leader pgid %d still alive", leaderPID)
-		}
-	})
+	childPID = waitForPIDFile(t, childPIDFile)
+	childPGID, err := unix.Getpgid(childPID)
+	if err != nil {
+		t.Fatalf("get child pgid: %v", err)
+	}
+	childSID, err := unix.Getsid(childPID)
+	if err != nil {
+		t.Fatalf("get child sid: %v", err)
+	}
+	childStat, err := readLinuxProcessStat(childPID)
+	if err != nil {
+		t.Fatalf("read child process identity: %v", err)
+	}
+	childRef = ownedDescendant{pid: childPID, identity: childStat.startTime}
+
+	t.Logf("leader pid=%d pgid=%d sid=%d", leaderPID, leaderPGID, leaderSID)
+	t.Logf("setsid child pid=%d pgid=%d sid=%d", childPID, childPGID, childSID)
+	if childPGID == leaderPGID || childSID == leaderSID {
+		t.Fatalf(
+			"fixture did not escape leader group/session: leader=(pgid=%d sid=%d), child=(pgid=%d sid=%d)",
+			leaderPGID,
+			leaderSID,
+			childPGID,
+			childSID,
+		)
+	}
 
 	cancel()
 	select {
 	case err := <-errCh:
-		t.Logf("Run returned err=%v", err)
 		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("Run error = %v, want context.Canceled; lifecycle errors must not be misread as setsid reproduction", err)
+			t.Fatalf("Run error = %v, want context.Canceled", err)
 		}
 	case <-time.After(10 * time.Second):
-		t.Fatalf("Run did not return after cancel (wait+finish hung)")
+		t.Fatal("Run did not return after cancellation")
 	}
 
-	alive := syscall.Kill(childPID, 0) == nil
-	t.Logf("after Run cancel+finish: child pid=%d alive=%v", childPID, alive)
-	if !alive {
-		t.Fatalf("child already gone — not reproducing escape")
+	if ownedDescendantAlive(childRef) {
+		t.Fatalf("setsid descendant %d survived Run cancellation", childPID)
 	}
-	t.Logf("REPRODUCED processtree Run: setsid child pid=%d pgid=%d sid=%d survived Run cancel+finish (leader pid=%d pgid=%d) — expected on main 11861145a", childPID, childPGID, childSID, leaderPID, leaderPGID)
 }


### PR DESCRIPTION
## What does this PR do?

Linux only, best-effort procfs descendant retention; not a general Unix Job Object equivalent.

This fixes one Linux cleanup gap when a descendant calls `setsid()` and escapes the process group managed by `processtree`. While the root is still alive and `/proc` is readable, the controller remembers observed descendants by PID plus start time and signals them during interrupt, stop, and finish cleanup. Existing process-group signaling remains the portable fallback, and non-Linux Unix behavior is unchanged.

## Related Issues

Closes #7615

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Tests

## Changes Made

- Track Linux descendants observed through `/proc`, including descendants that leave the original process group with `setsid()`.
- Guard descendant signaling with `/proc` start-time identity checks to avoid acting on a reused PID.
- Treat reaped descendant zombies as inactive during cleanup.
- Preserve the existing process-group-only behavior on non-Linux Unix platforms.
- Document the platform-specific, best-effort ownership contract.
- Turn the Linux reproducer into a regression test that requires the observed escaped descendant to terminate.

## How to Test

Run on Linux:

```bash
cd server
go test -race ./internal/daemon/processtree -run '^TestProcesstreeRunSetsidEscape$' -count=1 -v
go test -race ./internal/daemon/processtree -count=1
cd ..
bash scripts/test-go.sh --race
```

## Screenshots (if applicable)

N/A — backend process-lifecycle change.

## Known Limits and Risks

- If `/proc` is unavailable or unreadable, cleanup falls back to the existing process-group behavior.
- A descendant that reparents or exits before it is observed may not be retained.
- PID namespaces can hide or remap descendants and are outside this best-effort contract.
- PID reuse is guarded only for observed processes by matching the recorded start time before signaling.
- This does not provide complete process-tree ownership or a general Unix equivalent of Windows Job Objects.
- Non-Linux Unix behavior is intentionally unchanged.

## Checklist

- [x] I have thought through the edge cases and failure modes
- [ ] I have run tests locally and they pass — the local host is Windows; the Linux-only regression is covered by CI
- [x] I have added tests that prove my fix is effective
- [x] If my change affects the UI, I have included screenshots — N/A, backend process-lifecycle change
- [x] I have made corresponding changes to the documentation
- [x] My changes do not introduce a new runtime, tool, or UI tab — N/A
- [x] User-facing text uses Chinese characters with a Traditional/Simplified conversion helper — N/A, no user-facing text added
- [x] I have documented known limits and risks
- [x] I have performed a self-review of my code

## AI Assistance Disclosure

### AI tool used

Multica Agent / ChatGPT

### Prompt / approach

Started from a Linux `setsid()` reproducer, traced the Unix controller lifecycle, then implemented the narrow Linux fix: best-effort retention of procfs-observed descendants by stable process identity while preserving process-group cleanup as the cross-platform fallback.
