### PR TITLE
MUL-6904: fix: make task transcript delivery loss-detecting

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -298,6 +298,7 @@ var concurrentIndexCleanups = map[string]string{
 	"443_issue_project_status_index":                            "idx_issue_project_status",
 	"445_comment_delegated_failure_unsettled_index":             "idx_comment_delegated_failure_unsettled",
 	"446_issue_properties_bigm_index":                           "idx_issue_properties_bigm",
+	"449_task_message_task_seq_unique_index":                    "task_message_task_id_seq_uidx",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction
@@ -321,6 +322,7 @@ var concurrentDownIndexCleanups = map[string]string{
 	"375_drop_issue_last_activity_index":                    "idx_issue_workspace_last_activity",
 	"391_drop_agent_task_queue_dispatched_prepare_index":    "idx_agent_task_queue_dispatched_prepare",
 	"437_drop_agent_runtime_last_seen_at_index":             "idx_agent_runtime_last_seen_at",
+	"450_drop_task_message_task_seq_index":                  "idx_task_message_task_id_seq",
 }
 
 var preMigrationHooks = func() map[string]preMigrationHook {

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -1015,10 +1015,12 @@ var defaultTerminalRetrySchedule = []time.Duration{
 	64 * time.Second,
 }
 
-// taskMessageRetrySchedule is deliberately shorter than the terminal callback
-// schedule: transcript batches are emitted throughout a run, so a long outage
-// must fail the task instead of stacking minutes of blocked flushes. Replays
+// taskMessageRetrySchedule spends at most 1.75s sleeping inside the existing
+// 5s transcript-delivery deadline. That leaves 3.25s for four fast-failing
+// requests while bounding every flush at the same 5s latency ceiling. Replays
 // are safe because the server de-duplicates each message by (task_id, seq).
+const taskMessageDeliveryTimeout = 5 * time.Second
+
 var taskMessageRetrySchedule = []time.Duration{
 	250 * time.Millisecond,
 	500 * time.Millisecond,

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -494,7 +494,17 @@ func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages
 	}, nil)
 }
 
+func (c *Client) ReportTaskMessagesWithRetry(ctx context.Context, taskID string, messages []TaskMessageData) error {
+	return c.postJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/messages", taskID), map[string]any{
+		"messages": messages,
+	}, nil, taskMessageRetrySchedule)
+}
+
 func (c *Client) CompleteTask(ctx context.Context, taskID, output, branchName, sessionID, workDir string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string) error {
+	return c.CompleteTaskWithTranscript(ctx, taskID, output, branchName, sessionID, workDir, sessionRolloutMissing, retiredSessionID, durableWorkDir, nil)
+}
+
+func (c *Client) CompleteTaskWithTranscript(ctx context.Context, taskID, output, branchName, sessionID, workDir string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string, expectedMessageSeq *int32) error {
 	body := map[string]any{"output": output}
 	if branchName != "" {
 		body["branch_name"] = branchName
@@ -514,6 +524,9 @@ func (c *Client) CompleteTask(ctx context.Context, taskID, output, branchName, s
 	if retiredSessionID != "" {
 		body["retired_session_id"] = retiredSessionID
 	}
+	if expectedMessageSeq != nil {
+		body["expected_message_seq"] = *expectedMessageSeq
+	}
 	return c.postJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/complete", taskID), body, nil, defaultTerminalRetrySchedule)
 }
 
@@ -527,6 +540,10 @@ func (c *Client) ReportTaskUsage(ctx context.Context, taskID string, usage []Tas
 }
 
 func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string) error {
+	return c.FailTaskWithTranscript(ctx, taskID, errMsg, sessionID, workDir, branchName, failureReason, sessionRolloutMissing, retiredSessionID, durableWorkDir, nil)
+}
+
+func (c *Client) FailTaskWithTranscript(ctx context.Context, taskID, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string, expectedMessageSeq *int32) error {
 	body := map[string]any{"error": errMsg}
 	if sessionID != "" {
 		body["session_id"] = sessionID
@@ -551,6 +568,9 @@ func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDi
 	}
 	if retiredSessionID != "" {
 		body["retired_session_id"] = retiredSessionID
+	}
+	if expectedMessageSeq != nil {
+		body["expected_message_seq"] = *expectedMessageSeq
 	}
 	return c.postJSONWithRetry(ctx, fmt.Sprintf("/api/daemon/tasks/%s/fail", taskID), body, nil, defaultTerminalRetrySchedule)
 }
@@ -993,6 +1013,16 @@ var defaultTerminalRetrySchedule = []time.Duration{
 	16 * time.Second,
 	32 * time.Second,
 	64 * time.Second,
+}
+
+// taskMessageRetrySchedule is deliberately shorter than the terminal callback
+// schedule: transcript batches are emitted throughout a run, so a long outage
+// must fail the task instead of stacking minutes of blocked flushes. Replays
+// are safe because the server de-duplicates each message by (task_id, seq).
+var taskMessageRetrySchedule = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
 }
 
 // skillBundleResolveRetrySchedule rides out brief transport blips on a single

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -333,6 +334,87 @@ func TestPostJSONWithRetry_TransientThenSuccess(t *testing.T) {
 	}
 	if got := calls.Load(); got != 3 {
 		t.Fatalf("expected 3 attempts (2 transient + 1 success), got %d", got)
+	}
+}
+
+func TestReportTaskMessagesRetriesIdenticalBatch(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var calls atomic.Int32
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies = append(bodies, string(body))
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	batch := []TaskMessageData{{Seq: 1, Type: "text", Content: "kept"}}
+	if err := c.ReportTaskMessagesWithRetry(context.Background(), "task-1", batch); err != nil {
+		t.Fatalf("ReportTaskMessages: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+	if len(bodies) != 2 || bodies[0] != bodies[1] {
+		t.Fatalf("retry bodies differ: %q", bodies)
+	}
+}
+
+func TestReportTaskMessagesDoesNotRetryWithoutServerCapability(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	err := NewClient(srv.URL).ReportTaskMessages(context.Background(), "task-1",
+		[]TaskMessageData{{Seq: 1, Type: "text", Content: "legacy-safe"}})
+	if err == nil {
+		t.Fatal("legacy one-shot report unexpectedly succeeded")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("legacy message attempts = %d, want 1", got)
+	}
+}
+
+func TestTerminalTranscriptReceiptIsSentOnCompleteAndFail(t *testing.T) {
+	wantSeq := int32(7)
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		bodies = append(bodies, body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	if err := c.CompleteTaskWithTranscript(context.Background(), "complete", "done", "", "", "", false, "", "", &wantSeq); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if err := c.FailTaskWithTranscript(context.Background(), "fail", "boom", "", "", "", "agent_error", false, "", "", &wantSeq); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("terminal bodies = %d, want 2", len(bodies))
+	}
+	for i, body := range bodies {
+		if got := body["expected_message_seq"]; got != float64(wantSeq) {
+			t.Fatalf("body %d expected_message_seq = %#v, want %d", i, got, wantSeq)
+		}
 	}
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5441,6 +5441,10 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	case <-cancelledByPoll:
 		taskLog.Info("task cancelled during execution, discarding result",
 			"branch_name", result.BranchName, "error", err)
+		if errors.Is(err, errTranscriptIncomplete) {
+			taskLog.Error("cancelled task transcript is incomplete; withholding flush acknowledgement", "error", err)
+			return
+		}
 		// runner.run has returned, so the transcript flush is complete —
 		// tell the server it can settle its deferred chat finalization
 		// (#5219). The sweeper grace period covers a lost ack's chat settle,
@@ -8616,6 +8620,7 @@ func freshSessionMayHelp(errText string) bool {
 var (
 	transcriptDrainGrace       = 10 * time.Second
 	transcriptDrainStopTimeout = 12 * time.Second
+	errTranscriptIncomplete    = errors.New("transcript delivery incomplete")
 )
 
 func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID, codexHome string, msgSeq *atomic.Int32, transcriptBatchReplaySafe ...bool) (agent.Result, int32, error) {
@@ -8734,7 +8739,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 			mu.Unlock()
 
 			if len(toSend) > 0 {
-				sendCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				sendCtx, cancel := context.WithTimeout(context.Background(), taskMessageDeliveryTimeout)
 				var err error
 				if len(transcriptBatchReplaySafe) > 0 && transcriptBatchReplaySafe[0] {
 					err = d.client.ReportTaskMessagesWithRetry(sendCtx, taskID, toSend)
@@ -8948,13 +8953,13 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		transcriptErrMu.Lock()
 		defer transcriptErrMu.Unlock()
 		if transcriptErr != nil {
-			return fmt.Errorf("transcript delivery failed: %w", transcriptErr)
+			return fmt.Errorf("%w: transcript delivery failed: %v", errTranscriptIncomplete, transcriptErr)
 		}
 		if drainTruncated.Load() {
-			return errors.New("transcript drain was force-stopped before the message stream closed")
+			return fmt.Errorf("%w: transcript drain was force-stopped before the message stream closed", errTranscriptIncomplete)
 		}
 		if deliveryTracker.Abandoned() {
-			return errors.New("transcript delivery abandoned during agent cancellation")
+			return fmt.Errorf("%w: transcript delivery abandoned during agent cancellation", errTranscriptIncomplete)
 		}
 		return nil
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -229,7 +229,8 @@ type terminalTaskReport struct {
 	// abandoned as unresumable (GH #6066). The server records it so no later
 	// run on the issue or chat can select it again, however many clean rows
 	// still reference it.
-	retiredSessionID string
+	retiredSessionID   string
+	expectedMessageSeq *int32
 }
 
 type executionEnvironmentCommand func() ([]string, error)
@@ -5803,6 +5804,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			durableWorkDir:        result.DurableWorkDir,
 			sessionRolloutMissing: result.SessionRolloutMissing,
 			retiredSessionID:      result.RetiredSessionID,
+			expectedMessageSeq:    result.ExpectedMessageSeq,
 		})
 		if err == nil {
 			return
@@ -5846,6 +5848,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			failureReason:         taskfailure.Classify(fallbackErrMsg).String(),
 			sessionRolloutMissing: result.SessionRolloutMissing,
 			retiredSessionID:      result.RetiredSessionID,
+			expectedMessageSeq:    result.ExpectedMessageSeq,
 		}); failErr != nil {
 			taskLog.Error("fail task fallback also failed", "error", failErr)
 		}
@@ -5884,6 +5887,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			failureReason:         failureReason,
 			sessionRolloutMissing: result.SessionRolloutMissing,
 			retiredSessionID:      result.RetiredSessionID,
+			expectedMessageSeq:    result.ExpectedMessageSeq,
 		}); err != nil {
 			taskLog.Error("report failed task failed", "error", err)
 		}
@@ -5901,9 +5905,9 @@ func (d *Daemon) reportTerminalTask(parentCtx context.Context, report terminalTa
 
 	switch report.kind {
 	case terminalTaskReportComplete:
-		return d.client.CompleteTask(ctx, report.taskID, report.output, report.branchName, report.sessionID, report.workDir, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir)
+		return d.client.CompleteTaskWithTranscript(ctx, report.taskID, report.output, report.branchName, report.sessionID, report.workDir, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir, report.expectedMessageSeq)
 	case terminalTaskReportFail:
-		return d.client.FailTask(ctx, report.taskID, report.errorMessage, report.sessionID, report.workDir, report.branchName, report.failureReason, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir)
+		return d.client.FailTaskWithTranscript(ctx, report.taskID, report.errorMessage, report.sessionID, report.workDir, report.branchName, report.failureReason, report.sessionRolloutMissing, report.retiredSessionID, report.durableWorkDir, report.expectedMessageSeq)
 	default:
 		return fmt.Errorf("unsupported terminal task report kind %d", report.kind)
 	}
@@ -8095,7 +8099,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Shared across the resume-retry below so the retry's transcript rows
 	// keep ascending seq values for the same task.
 	var msgSeq atomic.Int32
-	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq)
+	defer func() {
+		if returnErr == nil {
+			expected := msgSeq.Load()
+			taskResult.ExpectedMessageSeq = &expected
+		}
+	}()
+	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq, task.TranscriptBatchReplaySafe)
 	if err != nil {
 		return TaskResult{}, err
 	}
@@ -8151,7 +8161,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}
 		freshPrompt := BuildPrompt(task, provider, promptOptions...)
 
-		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, freshPrompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq)
+		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, freshPrompt, execOpts, taskLog, task.ID, env.CodexHome, &msgSeq, task.TranscriptBatchReplaySafe)
 		if retryErr != nil {
 			taskLog.Error("fresh session also failed to start; keeping the original poisoned result", "error", retryErr)
 		} else if retryResult.Status != "completed" && retryResult.SessionID == "" {
@@ -8603,7 +8613,12 @@ func freshSessionMayHelp(errText string) bool {
 // messages and is owned by the caller so a same-task retry continues the
 // sequence instead of restarting at 1 — the server orders the transcript by
 // seq alone, and duplicate seqs would interleave the two attempts' rows.
-func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID, codexHome string, msgSeq *atomic.Int32) (agent.Result, int32, error) {
+var (
+	transcriptDrainGrace       = 10 * time.Second
+	transcriptDrainStopTimeout = 12 * time.Second
+)
+
+func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID, codexHome string, msgSeq *atomic.Int32, transcriptBatchReplaySafe ...bool) (agent.Result, int32, error) {
 	// Wrap the caller's ctx so the idle watchdog (below) can interrupt both
 	// the agent subprocess (via the ctx passed to backend.Execute) AND the
 	// drain loop with a single cancel. Without this layer the backend would
@@ -8611,6 +8626,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	// drain, leaving the subprocess running.
 	agentCtx, agentCancel := context.WithCancel(ctx)
 	defer agentCancel()
+	agentCtx, deliveryTracker := agent.WithMessageDeliveryTracker(agentCtx)
 
 	session, err := backend.Execute(agentCtx, prompt, opts)
 	if err != nil {
@@ -8681,6 +8697,10 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	// message batch, so the result hand-off below can wait for the transcript
 	// tail to be persisted.
 	drainFinished := make(chan struct{})
+	forceDrainStop := make(chan struct{})
+	var drainTruncated atomic.Bool
+	var transcriptErrMu sync.Mutex
+	var transcriptErr error
 	go func() {
 		defer close(drainFinished)
 		var mu sync.Mutex
@@ -8715,8 +8735,24 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 
 			if len(toSend) > 0 {
 				sendCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				if err := d.client.ReportTaskMessages(sendCtx, taskID, toSend); err != nil {
-					taskLog.Debug("failed to report task messages", "error", err)
+				var err error
+				if len(transcriptBatchReplaySafe) > 0 && transcriptBatchReplaySafe[0] {
+					err = d.client.ReportTaskMessagesWithRetry(sendCtx, taskID, toSend)
+				} else {
+					err = d.client.ReportTaskMessages(sendCtx, taskID, toSend)
+				}
+				if err != nil {
+					transcriptErrMu.Lock()
+					if transcriptErr == nil {
+						transcriptErr = err
+					}
+					transcriptErrMu.Unlock()
+					taskLog.Warn("failed to report task messages after retries",
+						"error", err,
+						"count", len(toSend),
+						"first_seq", toSend[0].Seq,
+						"last_seq", toSend[len(toSend)-1].Seq,
+					)
 				} else {
 					taskLog.Debug("reported task messages", "count", len(toSend), "last_seq", toSend[len(toSend)-1].Seq)
 				}
@@ -8874,7 +8910,8 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 					})
 					mu.Unlock()
 				}
-			case <-drainCtx.Done():
+			case <-forceDrainStop:
+				drainTruncated.Store(true)
 				goto drainDone
 			}
 		}
@@ -8893,26 +8930,40 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	// terminal transition would otherwise see a transcript that is non-empty
 	// but truncated, indistinguishable from a complete one. Bounded so a
 	// backend that never closes its message channel cannot stall the terminal
-	// transition: after 10s the drain loop is cancelled and given a window
+	// transition: after 10s the drain loop is force-stopped and given a window
 	// wide enough for its worst-case exit — an in-flight tick flush plus the
 	// final one, each capped by the 5s ReportTaskMessages timeout and neither
 	// interruptible by the cancel (they post on context.Background()).
-	waitForDrain := func() {
+	waitForDrain := func() error {
 		select {
 		case <-drainFinished:
-		case <-time.After(10 * time.Second):
-			drainCancel()
+		case <-time.After(transcriptDrainGrace):
+			close(forceDrainStop)
 			select {
 			case <-drainFinished:
-			case <-time.After(12 * time.Second):
-				taskLog.Warn("transcript drain did not stop after cancel; completing anyway")
+			case <-time.After(transcriptDrainStopTimeout):
+				return errors.New("transcript drain did not stop after cancellation")
 			}
 		}
+		transcriptErrMu.Lock()
+		defer transcriptErrMu.Unlock()
+		if transcriptErr != nil {
+			return fmt.Errorf("transcript delivery failed: %w", transcriptErr)
+		}
+		if drainTruncated.Load() {
+			return errors.New("transcript drain was force-stopped before the message stream closed")
+		}
+		if deliveryTracker.Abandoned() {
+			return errors.New("transcript delivery abandoned during agent cancellation")
+		}
+		return nil
 	}
 
 	select {
 	case result := <-session.Result:
-		waitForDrain()
+		if err := waitForDrain(); err != nil {
+			return result, toolCount.Load(), err
+		}
 		if idleWatchdogFired.Load() {
 			// The backend's wait goroutine (e.g. claude.go) translates the
 			// SIGKILL we delivered via agentCancel into Status="aborted".
@@ -8926,11 +8977,12 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		}
 		return result, toolCount.Load(), nil
 	case <-drainCtx.Done():
-		// The drain loop is exiting on this same Done signal; wait for its
-		// final flush so the timeout/watchdog/cancel terminals below cannot
-		// hand back (and let runTask fail-and-broadcast) a still-flushing
-		// transcript either.
-		waitForDrain()
+		// Backend cancellation may race with buffered terminal messages. Keep
+		// draining until the backend closes Messages, then flush before handing
+		// back; waitForDrain fails closed if that close never arrives.
+		if err := waitForDrain(); err != nil {
+			return agent.Result{}, toolCount.Load(), err
+		}
 		// Idle watchdog cancels via agentCancel(), which propagates here as
 		// context.Canceled. Check this BEFORE the generic cancelled/timeout
 		// classifiers so a watchdog-induced stop isn't misreported as

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2495,8 +2495,21 @@ func TestExecuteAndDrain_FailsWhenTranscriptRetriesExhausted(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "transcript delivery failed") {
 		t.Fatalf("executeAndDrain error = %v, want transcript delivery failure", err)
 	}
-	if got := calls.Load(); got != int32(len(taskMessageRetrySchedule)+1) {
-		t.Fatalf("message attempts = %d, want %d", got, len(taskMessageRetrySchedule)+1)
+	if !errors.Is(err, errTranscriptIncomplete) {
+		t.Fatalf("executeAndDrain error = %v, want incomplete-transcript classification", err)
+	}
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("message attempts = %d, want 4", got)
+	}
+	var backoffBudget time.Duration
+	for _, delay := range taskMessageRetrySchedule {
+		backoffBudget += delay
+	}
+	if backoffBudget != 1750*time.Millisecond {
+		t.Fatalf("message retry backoff budget = %s, want 1.75s", backoffBudget)
+	}
+	if backoffBudget >= taskMessageDeliveryTimeout {
+		t.Fatalf("message retry backoff budget %s consumes 5s delivery deadline", backoffBudget)
 	}
 }
 
@@ -2519,6 +2532,9 @@ func TestExecuteAndDrain_FailsWhenMessageStreamNeverCloses(t *testing.T) {
 	_, _, err := d.executeAndDrain(context.Background(), backend, "p", agent.ExecOptions{}, slog.Default(), "task-open-stream", "", new(atomic.Int32))
 	if err == nil || !strings.Contains(err.Error(), "force-stopped before the message stream closed") {
 		t.Fatalf("executeAndDrain error = %v, want force-stopped transcript failure", err)
+	}
+	if !errors.Is(err, errTranscriptIncomplete) {
+		t.Fatalf("executeAndDrain error = %v, want incomplete-transcript classification", err)
 	}
 	if got := rec.snapshot(); len(got) != 1 || got[0].Content != "persist before refusing receipt" {
 		t.Fatalf("persisted transcript before refusing receipt = %+v", got)
@@ -4834,6 +4850,7 @@ func TestHandleTask_ReportsUsageWhenCancelledByPoll(t *testing.T) {
 	// statusCallCount lets the poll goroutine return "cancelled" on first call
 	// while still handling later calls from the post-run status check.
 	var statusCallCount atomic.Int64
+	var cancelAckCalls atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -4857,6 +4874,9 @@ func TestHandleTask_ReportsUsageWhenCancelledByPoll(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"status":"running"}`))
 			}
+		case strings.HasSuffix(r.URL.Path, "/cancel-ack"):
+			cancelAckCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
 		default:
 			w.WriteHeader(http.StatusOK)
 		}
@@ -4880,7 +4900,7 @@ func TestHandleTask_ReportsUsageWhenCancelledByPoll(t *testing.T) {
 			Usage: []TaskUsageEntry{
 				{Provider: "anthropic", Model: "claude-opus-4-6", InputTokens: 200, OutputTokens: 80},
 			},
-		}, nil
+		}, fmt.Errorf("%w: injected cancellation-path gap", errTranscriptIncomplete)
 	})
 
 	task := Task{
@@ -4921,6 +4941,9 @@ func TestHandleTask_ReportsUsageWhenCancelledByPoll(t *testing.T) {
 	// given that the runner blocks on runCtx.Done().
 	if usageIdx < pollStatusIdx {
 		t.Fatalf("usage reported before poll-status (order: %v) — poll-status must come first", order)
+	}
+	if got := cancelAckCalls.Load(); got != 0 {
+		t.Fatalf("cancel acknowledgements = %d, want 0 for incomplete transcript", got)
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -3467,14 +3467,18 @@ type idleWatchdogBackend struct {
 	emitOne bool // when true, emit one message before going silent; when false, never emit anything
 }
 
-func (b idleWatchdogBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+func (b idleWatchdogBackend) Execute(ctx context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
 	msgCh := make(chan agent.Message, 1)
 	resCh := make(chan agent.Result)
 	if b.emitOne {
 		msgCh <- agent.Message{Type: agent.MessageText, Content: "hello"}
 	}
-	// Deliberately do NOT close msgCh and never write to resCh — this models
-	// a backend whose subprocess is hung and will never naturally complete.
+	// The subprocess is hung and never completes naturally, but a real backend
+	// still closes Messages after executeAndDrain cancels its process context.
+	go func() {
+		<-ctx.Done()
+		close(msgCh)
+	}()
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 
@@ -3815,11 +3819,14 @@ func TestExecuteAndDrain_IdleWatchdog_PerRunOverrideStillUsesToolWindow(t *testi
 // (the MUL-3064 default), AgentToolWatchdog is the only thing that ends it.
 type stuckInFlightToolBackend struct{}
 
-func (stuckInFlightToolBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+func (stuckInFlightToolBackend) Execute(ctx context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
 	msgCh := make(chan agent.Message, 2)
 	resCh := make(chan agent.Result)
 	msgCh <- agent.Message{Type: agent.MessageToolUse, Tool: "Bash", CallID: "c1"}
-	// Deliberately leave msgCh open, never emit tool_result, never write resCh.
+	go func() {
+		<-ctx.Done()
+		close(msgCh)
+	}()
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 
@@ -3854,12 +3861,15 @@ func TestExecuteAndDrain_IdleWatchdog_FiresOnStuckInFlightTool(t *testing.T) {
 // fresh; the watchdog should fire exactly one window later, not earlier.
 type tailIdleAfterToolBackend struct{}
 
-func (tailIdleAfterToolBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+func (tailIdleAfterToolBackend) Execute(ctx context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
 	msgCh := make(chan agent.Message, 4)
 	resCh := make(chan agent.Result)
 	msgCh <- agent.Message{Type: agent.MessageToolUse, Tool: "Bash", CallID: "c1"}
 	msgCh <- agent.Message{Type: agent.MessageToolResult, Tool: "Bash", CallID: "c1", Output: "ok"}
-	// Deliberately leave msgCh open and never write to resCh.
+	go func() {
+		<-ctx.Done()
+		close(msgCh)
+	}()
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2476,6 +2476,55 @@ func TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult(t *testing.T) {
 	}
 }
 
+func TestExecuteAndDrain_FailsWhenTranscriptRetriesExhausted(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/messages") {
+			calls.Add(1)
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	_, _, err := d.executeAndDrain(context.Background(), &transcriptBackend{}, "p", agent.ExecOptions{}, slog.Default(), "task-transcript-fail", "", new(atomic.Int32), true)
+	if err == nil || !strings.Contains(err.Error(), "transcript delivery failed") {
+		t.Fatalf("executeAndDrain error = %v, want transcript delivery failure", err)
+	}
+	if got := calls.Load(); got != int32(len(taskMessageRetrySchedule)+1) {
+		t.Fatalf("message attempts = %d, want %d", got, len(taskMessageRetrySchedule)+1)
+	}
+}
+
+func TestExecuteAndDrain_FailsWhenMessageStreamNeverCloses(t *testing.T) {
+	oldGrace, oldStop := transcriptDrainGrace, transcriptDrainStopTimeout
+	transcriptDrainGrace = 20 * time.Millisecond
+	transcriptDrainStopTimeout = 500 * time.Millisecond
+	t.Cleanup(func() {
+		transcriptDrainGrace = oldGrace
+		transcriptDrainStopTimeout = oldStop
+	})
+
+	d, rec := newTranscriptRecorder(t)
+	msgCh := make(chan agent.Message, 1)
+	msgCh <- agent.Message{Type: agent.MessageText, Content: "persist before refusing receipt"}
+	resultCh := make(chan agent.Result, 1)
+	resultCh <- agent.Result{Status: "completed", Output: "done"}
+	backend := sessionBackend{session: &agent.Session{Messages: msgCh, Result: resultCh}}
+
+	_, _, err := d.executeAndDrain(context.Background(), backend, "p", agent.ExecOptions{}, slog.Default(), "task-open-stream", "", new(atomic.Int32))
+	if err == nil || !strings.Contains(err.Error(), "force-stopped before the message stream closed") {
+		t.Fatalf("executeAndDrain error = %v, want force-stopped transcript failure", err)
+	}
+	if got := rec.snapshot(); len(got) != 1 || got[0].Content != "persist before refusing receipt" {
+		t.Fatalf("persisted transcript before refusing receipt = %+v", got)
+	}
+}
+
 // TestExecuteAndDrain_SeqContinuesAcrossRetry pins the transcript's ordering
 // key: the server sorts a task's messages by seq alone, so a same-task resume
 // retry must keep numbering upwards instead of restarting at 1 and
@@ -2555,6 +2604,7 @@ func TestExecuteAndDrain_ContextCancelled_FlushesPendingTranscript(t *testing.T)
 
 	msgCh <- agent.Message{Type: agent.MessageText, Content: "pending tail"}
 	cancel()
+	close(msgCh)
 
 	r := <-retCh
 	if r.err != nil {
@@ -2567,6 +2617,45 @@ func TestExecuteAndDrain_ContextCancelled_FlushesPendingTranscript(t *testing.T)
 	got := rec.snapshot()
 	if len(got) != 1 || got[0].Type != "text" || got[0].Content != "pending tail" {
 		t.Fatalf("expected the pending tail flushed before the cancelled return, got %+v", got)
+	}
+}
+
+func TestExecuteAndDrain_ContextCancelled_DrainsTailUntilStreamCloses(t *testing.T) {
+	t.Parallel()
+
+	d, rec := newTranscriptRecorder(t)
+	msgCh := make(chan agent.Message, 1)
+	b := sessionBackend{session: &agent.Session{Messages: msgCh, Result: make(chan agent.Result)}}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type ret struct {
+		result agent.Result
+		err    error
+	}
+	retCh := make(chan ret, 1)
+	go func() {
+		result, _, err := d.executeAndDrain(ctx, b, "p", agent.ExecOptions{}, slog.Default(), "task-cancel-buffered-tail", "", new(atomic.Int32))
+		retCh <- ret{result, err}
+	}()
+
+	// Cancellation asks the backend to stop, but adapters may still emit their
+	// buffered tail before closing Messages. The daemon must keep draining that
+	// tail instead of treating the cancellation signal itself as EOF.
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+	msgCh <- agent.Message{Type: agent.MessageText, Content: "tail after cancel"}
+	close(msgCh)
+
+	r := <-retCh
+	if r.err != nil {
+		t.Fatalf("executeAndDrain: %v", r.err)
+	}
+	if r.result.Status != "cancelled" {
+		t.Fatalf("expected status=cancelled, got %q (err=%q)", r.result.Status, r.result.Error)
+	}
+	got := rec.snapshot()
+	if len(got) != 1 || got[0].Content != "tail after cancel" {
+		t.Fatalf("expected buffered cancellation tail to be persisted, got %+v", got)
 	}
 }
 

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -119,6 +119,7 @@ type Task struct {
 	ProjectResources              []ProjectResourceData  `json:"project_resources,omitempty"`                // project-scoped resources to expose to the agent
 	IsLeaderTask                  bool                   `json:"is_leader_task,omitempty"`                   // true when executing in the squad-leader coordinator role
 	LeaderRoleResolved            bool                   `json:"leader_role_resolved,omitempty"`             // server capability: IsLeaderTask/SquadID authoritatively answer "is this a leader run". Absent on servers predating it — those before #4951 never sent is_leader_task at all, later ones send it without this guarantee — so taskIsSquadLeader falls back to the briefing marker for both (MUL-5811)
+	TranscriptBatchReplaySafe     bool                   `json:"transcript_batch_replay_safe,omitempty"`     // server capability: message batches may be retried idempotently. False on old servers, where retry after a lost response would duplicate rows.
 	PriorSessionID                string                 `json:"prior_session_id,omitempty"`                 // Claude session ID from a previous task on this issue
 	PriorWorkDir                  string                 `json:"prior_work_dir,omitempty"`                   // work_dir from a previous task on this issue
 	PriorSessionResumeUnavailable bool                   `json:"prior_session_resume_unavailable,omitempty"` // MUL-5305: server signals a more recent Codex session was withheld (rollout missing) and PriorSessionID (if any) is an older fallback; the run must disclose the continuity gap even if that older session resumes cleanly. Absent/false on old servers.
@@ -318,8 +319,12 @@ type TaskResult struct {
 	// abandoned as unresumable (GH #6066). Forwarded on every terminal path,
 	// including the completed one: a fresh-session retry that SUCCEEDS is
 	// precisely when the abandoned id would otherwise stay selectable.
-	RetiredSessionID string           `json:"-"`
-	Usage            []TaskUsageEntry `json:"usage,omitempty"` // per-model token usage
+	RetiredSessionID string `json:"-"`
+	// ExpectedMessageSeq is the last contiguous transcript sequence the daemon
+	// acknowledged before producing this result. Nil means the run could not
+	// prove transcript completeness and must not claim it at the terminal API.
+	ExpectedMessageSeq *int32           `json:"-"`
+	Usage              []TaskUsageEntry `json:"usage,omitempty"` // per-model token usage
 }
 
 // PluginHookTool is one agent-trigger plugin hook, as the agent will see it.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -389,32 +389,33 @@ type AgentTaskResponse struct {
 	// IssueStatusesOmitted is how many active custom statuses were dropped by
 	// the cap, so the brief can say the list is incomplete instead of
 	// presenting a truncated catalog as the whole one.
-	IssueStatusesOmitted int                    `json:"issue_statuses_omitted,omitempty"`
-	ActiveSiblingRuns    []ActiveSiblingRunData `json:"active_sibling_runs,omitempty"`
-	ThreadName           string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
-	Status               string                 `json:"status"`
-	Priority             int32                  `json:"priority"`
-	DispatchedAt         *string                `json:"dispatched_at"`
-	StartedAt            *string                `json:"started_at"`
-	CompletedAt          *string                `json:"completed_at"`
-	Result               any                    `json:"result"`
-	Error                *string                `json:"error"`
-	FailureReason        string                 `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt              int32                  `json:"attempt"`
-	MaxAttempts          int32                  `json:"max_attempts"`
-	ParentTaskID         *string                `json:"parent_task_id,omitempty"`
-	IsLeaderTask         bool                   `json:"is_leader_task,omitempty"`
-	LeaderRoleResolved   bool                   `json:"leader_role_resolved,omitempty"` // claim-only capability, always true here: IsLeaderTask/SquadID authoritatively answer "is this a leader run", so the daemon must not infer the role from briefing text. Servers predating it make no such promise — before #4951 they sent no is_leader_task at all, after it they sent the flag without guaranteeing a briefing — so a daemon seeing no capability keeps the legacy inference. Never rendered into a prompt; see daemon.taskIsSquadLeader (MUL-5811). Mirror field: internal/daemon/types.go, same JSON name
-	Agent                *TaskAgentData         `json:"agent,omitempty"`
-	ConnectedApps        []ConnectedAppData     `json:"connected_apps,omitempty"` // daemon-claim only: per-run app capabilities mounted through runtime MCP overlays
-	Repos                []RepoData             `json:"repos,omitempty"`
-	ProjectID            string                 `json:"project_id,omitempty"`          // issue's project, when present
-	ProjectTitle         string                 `json:"project_title,omitempty"`       // for surfacing in agent context
-	ProjectDescription   string                 `json:"project_description,omitempty"` // durable project-level context injected into the brief
-	ProjectResources     []ProjectResourceData  `json:"project_resources,omitempty"`   // resources attached to the project
-	CreatedAt            string                 `json:"created_at"`
-	PriorSessionID       string                 `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
-	PriorWorkDir         string                 `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
+	IssueStatusesOmitted      int                    `json:"issue_statuses_omitted,omitempty"`
+	ActiveSiblingRuns         []ActiveSiblingRunData `json:"active_sibling_runs,omitempty"`
+	ThreadName                string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
+	Status                    string                 `json:"status"`
+	Priority                  int32                  `json:"priority"`
+	DispatchedAt              *string                `json:"dispatched_at"`
+	StartedAt                 *string                `json:"started_at"`
+	CompletedAt               *string                `json:"completed_at"`
+	Result                    any                    `json:"result"`
+	Error                     *string                `json:"error"`
+	FailureReason             string                 `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt                   int32                  `json:"attempt"`
+	MaxAttempts               int32                  `json:"max_attempts"`
+	ParentTaskID              *string                `json:"parent_task_id,omitempty"`
+	IsLeaderTask              bool                   `json:"is_leader_task,omitempty"`
+	LeaderRoleResolved        bool                   `json:"leader_role_resolved,omitempty"`         // claim-only capability, always true here: IsLeaderTask/SquadID authoritatively answer "is this a leader run", so the daemon must not infer the role from briefing text. Servers predating it make no such promise — before #4951 they sent no is_leader_task at all, after it they sent the flag without guaranteeing a briefing — so a daemon seeing no capability keeps the legacy inference. Never rendered into a prompt; see daemon.taskIsSquadLeader (MUL-5811). Mirror field: internal/daemon/types.go, same JSON name
+	TranscriptBatchReplaySafe bool                   `json:"transcript_batch_replay_safe,omitempty"` // claim-only capability: this server de-duplicates message retries by (task_id, seq). Old servers omit it, so upgraded daemons keep one-shot delivery instead of duplicating rows after a lost response.
+	Agent                     *TaskAgentData         `json:"agent,omitempty"`
+	ConnectedApps             []ConnectedAppData     `json:"connected_apps,omitempty"` // daemon-claim only: per-run app capabilities mounted through runtime MCP overlays
+	Repos                     []RepoData             `json:"repos,omitempty"`
+	ProjectID                 string                 `json:"project_id,omitempty"`          // issue's project, when present
+	ProjectTitle              string                 `json:"project_title,omitempty"`       // for surfacing in agent context
+	ProjectDescription        string                 `json:"project_description,omitempty"` // durable project-level context injected into the brief
+	ProjectResources          []ProjectResourceData  `json:"project_resources,omitempty"`   // resources attached to the project
+	CreatedAt                 string                 `json:"created_at"`
+	PriorSessionID            string                 `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
+	PriorWorkDir              string                 `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
 	// PriorSessionResumeUnavailable is set when a more recent Codex session was
 	// withheld because its rollout was missing (MUL-5305); PriorSessionID (if
 	// any) is then an older fallback. The daemon surfaces the continuity gap in

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3796,6 +3796,19 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	// same commit creates and wakes can never observe the withheld pointer or a
 	// missing continuity-gap flag.
 	task, err := h.TaskService.CompleteTaskWithTranscript(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir, req.BranchName, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir, req.ExpectedMessageSeq)
+	if errors.Is(err, service.ErrTaskTranscriptIncomplete) {
+		h.failTask(w, r, taskID, workspaceID, TaskFailRequest{
+			Error:                 err.Error(),
+			FailureReason:         taskfailure.ReasonTranscriptIncomplete.String(),
+			SessionID:             req.SessionID,
+			WorkDir:               req.WorkDir,
+			DurableWorkDir:        req.DurableWorkDir,
+			BranchName:            req.BranchName,
+			SessionRolloutMissing: req.SessionRolloutMissing,
+			RetiredSessionID:      req.RetiredSessionID,
+		})
+		return
+	}
 	if err != nil {
 		// A CompleteTask error is an infrastructure failure (transaction /
 		// assistant-outcome write), not a bad request: an already-finalized
@@ -3804,6 +3817,10 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 		// including the single chat outcome row — lands exactly once (MUL-4351).
 		slog.Warn("complete task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if task.Status == "failed" && task.FailureReason.Valid && task.FailureReason.String == taskfailure.ReasonTranscriptIncomplete.String() {
+		writeJSON(w, http.StatusOK, map[string]string{"status": task.Status})
 		return
 	}
 
@@ -4493,6 +4510,12 @@ func (h *Handler) failTask(w http.ResponseWriter, r *http.Request, taskID, works
 	// creates and wakes the auto-retry, so the retry can never claim the withheld
 	// pointer or miss the continuity gap.
 	task, err := h.TaskService.FailTaskWithTranscript(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.BranchName, req.FailureReason, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir, req.ExpectedMessageSeq)
+	if errors.Is(err, service.ErrTaskTranscriptIncomplete) {
+		req.Error = err.Error()
+		req.FailureReason = taskfailure.ReasonTranscriptIncomplete.String()
+		req.ExpectedMessageSeq = nil
+		task, err = h.TaskService.FailTaskWithTranscript(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.BranchName, req.FailureReason, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir, nil)
+	}
 	if err != nil {
 		// A FailTask error is an infrastructure failure (the terminal
 		// transaction that also clears the withheld session, writes the
@@ -4504,6 +4527,10 @@ func (h *Handler) failTask(w http.ResponseWriter, r *http.Request, taskID, works
 		slog.Warn("fail task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	if task.FailureReason.Valid && task.FailureReason.String == taskfailure.ReasonTranscriptIncomplete.String() {
+		req.Error = task.Error.String
+		req.FailureReason = task.FailureReason.String
 	}
 	h.TaskService.NotifyTaskFinished(*task)
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -2007,6 +2008,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	// not — because its absence is what tells an upgraded daemon it is talking
 	// to a server too old to have answered the question (MUL-5811).
 	resp.LeaderRoleResolved = true
+	resp.TranscriptBatchReplaySafe = true
 	// Agent-trigger plugin hooks, as tools. A failure here degrades to no
 	// tools rather than failing the claim: a plugin that cannot be listed must
 	// not stop an agent from working on the issue.
@@ -3695,6 +3697,12 @@ type TaskCompleteRequest struct {
 	// to report" — this says "never hand this id to a later run". Older
 	// daemons omit it, which is exactly the pre-fix behaviour.
 	RetiredSessionID string `json:"retired_session_id,omitempty"`
+	// ExpectedMessageSeq is supplied by current daemons after every transcript
+	// batch has been acknowledged. Nil preserves compatibility with older hosts.
+	ExpectedMessageSeq *int32 `json:"expected_message_seq,omitempty"`
+	// TranscriptComplete is server-authored: client input is ignored and the
+	// terminal transaction succeeds only after verifying the contiguous range.
+	TranscriptComplete bool `json:"transcript_complete,omitempty"`
 }
 
 // sanitizeTaskCompleteRequest / sanitizeTaskFailRequest scrub every
@@ -3747,6 +3755,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	// re-route below feeds req.Output into the failure classifier, and that
 	// classifier must see exactly the text we are going to persist.
 	sanitizeTaskCompleteRequest(&req)
+	req.TranscriptComplete = req.ExpectedMessageSeq != nil
 
 	// GH #6402: a daemon whose backend does not (yet) read the provider's
 	// structured terminal reason reports a context-exhausted run as a clean
@@ -3776,6 +3785,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 			BranchName:            req.BranchName,
 			SessionRolloutMissing: req.SessionRolloutMissing,
 			RetiredSessionID:      req.RetiredSessionID,
+			ExpectedMessageSeq:    req.ExpectedMessageSeq,
 		})
 		return
 	}
@@ -3785,7 +3795,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	// transaction (force session_id NULL + flag the row), so an auto-retry the
 	// same commit creates and wakes can never observe the withheld pointer or a
 	// missing continuity-gap flag.
-	task, err := h.TaskService.CompleteTask(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir, req.BranchName, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir)
+	task, err := h.TaskService.CompleteTaskWithTranscript(r.Context(), parseUUID(taskID), result, req.SessionID, req.WorkDir, req.BranchName, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir, req.ExpectedMessageSeq)
 	if err != nil {
 		// A CompleteTask error is an infrastructure failure (transaction /
 		// assistant-outcome write), not a bad request: an already-finalized
@@ -4445,7 +4455,8 @@ type TaskFailRequest struct {
 	// (GH #6066). Distinct from an empty SessionID, which only means "nothing
 	// to report" — this says "never hand this id to a later run". Older
 	// daemons omit it, which is exactly the pre-fix behaviour.
-	RetiredSessionID string `json:"retired_session_id,omitempty"`
+	RetiredSessionID   string `json:"retired_session_id,omitempty"`
+	ExpectedMessageSeq *int32 `json:"expected_message_seq,omitempty"`
 }
 
 func (h *Handler) FailTask(w http.ResponseWriter, r *http.Request) {
@@ -4481,7 +4492,7 @@ func (h *Handler) failTask(w http.ResponseWriter, r *http.Request, taskID, works
 	// keep a stale mid-flight pin) and flagging the row in the same commit that
 	// creates and wakes the auto-retry, so the retry can never claim the withheld
 	// pointer or miss the continuity gap.
-	task, err := h.TaskService.FailTask(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.BranchName, req.FailureReason, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir)
+	task, err := h.TaskService.FailTaskWithTranscript(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.BranchName, req.FailureReason, req.SessionRolloutMissing, req.RetiredSessionID, req.DurableWorkDir, req.ExpectedMessageSeq)
 	if err != nil {
 		// A FailTask error is an infrastructure failure (the terminal
 		// transaction that also clears the withheld session, writes the
@@ -4565,6 +4576,7 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 	// the large messages that are already the most expensive (MUL-6523). Empty
 	// string means SQL NULL, applied by the query's NULLIF.
 	n := len(req.Messages)
+	seenSeq := make(map[int]struct{}, n)
 	params := db.CreateTaskMessagesParams{
 		TaskID:   parseUUID(taskID),
 		Ids:      make([]pgtype.UUID, 0, n),
@@ -4576,6 +4588,16 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		Outputs:  make([]string, 0, n),
 	}
 	for _, msg := range req.Messages {
+		if msg.Seq <= 0 || msg.Seq > math.MaxInt32 {
+			writeError(w, http.StatusBadRequest, "message seq must be between 1 and 2147483647")
+			return
+		}
+		if _, exists := seenSeq[msg.Seq]; exists {
+			writeError(w, http.StatusBadRequest, "message seq must be unique within a batch")
+			return
+		}
+		seenSeq[msg.Seq] = struct{}{}
+
 		id, err := uuid.NewV7()
 		if err != nil {
 			slog.Error("failed to generate task message id", "task_id", taskID, "error", err)
@@ -4592,8 +4614,10 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		// bytes PostgreSQL refuses to store. Tool output is the likeliest
 		// carrier of a stray NUL in the whole system — an agent that cats a
 		// binary, or a Windows tool emitting UTF-16 — and this endpoint has no
-		// retry on the daemon side, so an unsanitized batch is silently lost
-		// (GH #7098). Input is a JSONB column, so it needs the deep walk: the
+		// retry on the daemon side used to make an unsanitized batch disappear;
+		// the current retry still needs sanitization because a permanent bad
+		// payload must not consume the whole retry budget (GH #7098). Input is a
+		// JSONB column, so it needs the deep walk: the
 		// offending byte can sit at any depth of a tool's arguments. Batching
 		// raises the stakes: one bad byte now fails the whole statement rather
 		// than a single row, which is inherent to one-statement writes.
@@ -4631,9 +4655,49 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		params.Outputs = append(params.Outputs, msg.Output)
 	}
 
-	created, err := h.Queries.CreateTaskMessages(r.Context(), params)
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist task message")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	status, err := qtx.LockTaskForTranscriptWrite(r.Context(), params.TaskID)
+	if err != nil {
+		slog.Error("failed to lock task for transcript write", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist task message")
+		return
+	}
+	// Cancellation is a two-phase protocol: the server marks the task
+	// cancelled first, then the daemon drains its transcript and sends
+	// cancel-ack. Keep accepting that final drain, but seal completed and
+	// failed tasks against late writes.
+	if status != "running" && status != "cancelled" {
+		writeError(w, http.StatusConflict, "task is no longer accepting transcript messages")
+		return
+	}
+
+	created, err := qtx.CreateTaskMessages(r.Context(), params)
 	if err != nil {
 		slog.Error("failed to create task messages", "task_id", taskID, "count", n, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist task message")
+		return
+	}
+	if len(created) != n {
+		// A concurrent first writer may not be visible to this statement's
+		// snapshot. Roll back and let the daemon retry against a fresh snapshot.
+		writeError(w, http.StatusInternalServerError, "failed to resolve task message replay")
+		return
+	}
+	for _, m := range created {
+		if !m.PayloadMatches {
+			writeError(w, http.StatusConflict, "message seq already exists with different payload")
+			return
+		}
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("failed to commit task messages", "task_id", taskID, "count", n, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to persist task message")
 		return
 	}
@@ -4645,12 +4709,19 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		// guarantee, and subscribers render these events as they arrive, so the
 		// ordering lives in the query rather than in the clients.
 		for _, m := range created {
+			if !m.WasInserted {
+				continue
+			}
 			// The ordered CTE makes sqlc name the row type after the query
 			// rather than reusing the table model; the columns are the table's,
 			// in order, so the conversion is checked by the compiler and breaks
 			// loudly if the query ever stops returning the whole row.
 			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID,
-				taskMessageToPayload(db.TaskMessage(m), taskID, uuidToString(task.IssueID)))
+				taskMessageToPayload(db.TaskMessage{
+					ID: m.ID, TaskID: m.TaskID, Seq: m.Seq, Type: m.Type,
+					Tool: m.Tool, Content: m.Content, Input: m.Input,
+					Output: m.Output, CreatedAt: m.CreatedAt,
+				}, taskID, uuidToString(task.IssueID)))
 		}
 	}
 

--- a/server/internal/handler/squad_briefing_claim_test.go
+++ b/server/internal/handler/squad_briefing_claim_test.go
@@ -29,10 +29,11 @@ func claimAgentInstructionsForTest(t *testing.T, runtimeID string) (taskID strin
 
 	var resp struct {
 		Task *struct {
-			ID                 string `json:"id"`
-			IsLeaderTask       bool   `json:"is_leader_task"`
-			LeaderRoleResolved bool   `json:"leader_role_resolved"`
-			Agent              *struct {
+			ID                        string `json:"id"`
+			IsLeaderTask              bool   `json:"is_leader_task"`
+			LeaderRoleResolved        bool   `json:"leader_role_resolved"`
+			TranscriptBatchReplaySafe bool   `json:"transcript_batch_replay_safe"`
+			Agent                     *struct {
 				Instructions string `json:"instructions"`
 			} `json:"agent"`
 		} `json:"task"`
@@ -49,6 +50,9 @@ func claimAgentInstructionsForTest(t *testing.T, runtimeID string) (taskID strin
 	// from instructions text — the bug MUL-5811 removed.
 	if !resp.Task.LeaderRoleResolved {
 		t.Fatalf("claim response must set leader_role_resolved=true: %s", w.Body.String())
+	}
+	if !resp.Task.TranscriptBatchReplaySafe {
+		t.Fatalf("claim response must set transcript_batch_replay_safe=true: %s", w.Body.String())
 	}
 	var instr string
 	if resp.Task.Agent != nil {

--- a/server/internal/handler/task_message_batch_test.go
+++ b/server/internal/handler/task_message_batch_test.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -170,15 +172,260 @@ func TestReportTaskMessagesPublishesInSeqOrder(t *testing.T) {
 	}
 }
 
+func TestReportTaskMessagesReplayIsIdempotent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "batch-replay")
+
+	sharedBus := testHandler.Bus
+	testHandler.Bus = events.New()
+	t.Cleanup(func() { testHandler.Bus = sharedBus })
+
+	var mu sync.Mutex
+	published := 0
+	testHandler.Bus.Subscribe(protocol.EventTaskMessage, func(e events.Event) {
+		if e.TaskID == taskID {
+			mu.Lock()
+			published++
+			mu.Unlock()
+		}
+	})
+
+	messages := []any{
+		map[string]any{"seq": 1, "type": "tool_use", "tool": "exec", "input": map[string]any{"cmd": "true", "nested": map[string]any{"ok": true}}},
+		map[string]any{"seq": 2, "type": "text", "content": "second"},
+	}
+	for range 2 {
+		testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, messages)).Want(http.StatusOK)
+	}
+
+	if count := dbfx.Count(t, `SELECT COUNT(*) FROM task_message WHERE task_id = $1`, taskID); count != 2 {
+		t.Fatalf("persisted rows = %d, want 2", count)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if published != 2 {
+		t.Fatalf("published events = %d, want 2 (replay must publish none)", published)
+	}
+}
+
+func TestReportTaskMessagesRejectsConflictingReplayAtomically(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "batch-conflicting-replay")
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "original"},
+	})).Want(http.StatusOK)
+
+	// The new seq must roll back with the altered replay; accepting only the
+	// new row would turn one rejected batch into a partial transcript.
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "tool_use", "tool": "exec", "content": "altered"},
+		map[string]any{"seq": 2, "type": "text", "content": "must roll back"},
+	})).Want(http.StatusConflict)
+
+	stored, err := testHandler.Queries.ListTaskMessages(context.Background(), util.MustParseUUID(taskID))
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Type != "text" || stored[0].Content.String != "original" {
+		t.Fatalf("conflicting replay changed transcript: %+v", stored)
+	}
+}
+
+func TestReportTaskMessagesRejectsInvalidBatchSeq(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "batch-invalid-seq")
+
+	tests := []struct {
+		name     string
+		messages []any
+	}{
+		{"zero", []any{map[string]any{"seq": 0, "type": "text", "content": "bad"}}},
+		{"overflow", []any{map[string]any{"seq": 2147483648, "type": "text", "content": "bad"}}},
+		{"duplicate", []any{
+			map[string]any{"seq": 1, "type": "text", "content": "first"},
+			map[string]any{"seq": 1, "type": "text", "content": "different"},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, tt.messages)).Want(http.StatusBadRequest)
+		})
+	}
+	if count := dbfx.Count(t, `SELECT COUNT(*) FROM task_message WHERE task_id = $1`, taskID); count != 0 {
+		t.Fatalf("persisted rows = %d, want 0", count)
+	}
+}
+
+func TestCompleteTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	taskID := seedBatchTask(t, "terminal-transcript-receipt")
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "first"},
+		map[string]any{"seq": 3, "type": "text", "content": "third"},
+	})).Want(http.StatusOK)
+
+	complete := func() *http.Request {
+		return daemonTaskRequest(t, "/api/daemon/tasks/"+taskID+"/complete", taskID, map[string]any{
+			"output":               "done",
+			"expected_message_seq": 3,
+		})
+	}
+	w := testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusInternalServerError)
+	if !strings.Contains(w.Body.String(), "transcript incomplete") {
+		t.Fatalf("missing receipt error: %s", w.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+		t.Fatalf("read task after rejected completion: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("status after rejected completion = %q, want running", status)
+	}
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 2, "type": "text", "content": "second"},
+	})).Want(http.StatusOK)
+	testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusOK)
+	// A lost HTTP response makes the daemon replay the exact terminal callback.
+	// The sealed receipt must make that retry idempotent, while a different
+	// terminal payload must not be mistaken for the same completion.
+	testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusOK)
+	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+taskID+"/complete", taskID, map[string]any{
+			"output": "different", "expected_message_seq": 3,
+		})).Want(http.StatusInternalServerError)
+
+	var resultJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, result FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status, &resultJSON); err != nil {
+		t.Fatalf("read completed task: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("status = %q, want completed", status)
+	}
+	var result TaskCompleteRequest
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !result.TranscriptComplete || result.ExpectedMessageSeq == nil || *result.ExpectedMessageSeq != 3 {
+		t.Fatalf("transcript receipt = %+v, want complete at seq 3", result)
+	}
+}
+
+func TestCompleteTaskReceiptRejectsLateTranscriptWrite(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "terminal-transcript-seal")
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "only"},
+	})).Want(http.StatusOK)
+	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+taskID+"/complete", taskID, map[string]any{
+			"output": "done", "expected_message_seq": 1,
+		})).Want(http.StatusOK)
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 2, "type": "text", "content": "late"},
+	})).Want(http.StatusConflict)
+	if count := dbfx.Count(t, `SELECT COUNT(*) FROM task_message WHERE task_id = $1`, taskID); count != 1 {
+		t.Fatalf("late write changed sealed transcript row count to %d", count)
+	}
+}
+
+func TestReportTaskMessagesAcceptsCancelledTaskFinalDrain(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	taskID := seedBatchTask(t, "cancelled-transcript-final-drain")
+	dbfx.Exec(t, `UPDATE agent_task_queue SET status = 'cancelled' WHERE id = $1`, taskID)
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "final drain"},
+	})).Want(http.StatusOK)
+	if count := dbfx.Count(t, `SELECT COUNT(*) FROM task_message WHERE task_id = $1`, taskID); count != 1 {
+		t.Fatalf("cancelled task final drain persisted %d rows, want 1", count)
+	}
+}
+
+func TestCompleteTaskAcceptsEmptyTranscriptReceipt(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	emptyTaskID := seedBatchTask(t, "empty-transcript-receipt")
+	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+emptyTaskID+"/complete", emptyTaskID, map[string]any{
+			"output": "done", "expected_message_seq": 0,
+		})).Want(http.StatusOK)
+
+	nonemptyTaskID := seedBatchTask(t, "invalid-empty-transcript-receipt")
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, nonemptyTaskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "present"},
+	})).Want(http.StatusOK)
+	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+nonemptyTaskID+"/complete", nonemptyTaskID, map[string]any{
+			"output": "done", "expected_message_seq": 0,
+		})).Want(http.StatusInternalServerError)
+}
+
+func TestFailTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	taskID := seedBatchTask(t, "failed-transcript-receipt")
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 2, "type": "text", "content": "second"},
+	})).Want(http.StatusOK)
+
+	fail := func() *http.Request {
+		return daemonTaskRequest(t, "/api/daemon/tasks/"+taskID+"/fail", taskID, map[string]any{
+			"error":                "agent failed",
+			"failure_reason":       "agent_error.unknown",
+			"expected_message_seq": 2,
+		})
+	}
+	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusInternalServerError)
+
+	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
+		map[string]any{"seq": 1, "type": "text", "content": "first"},
+	})).Want(http.StatusOK)
+	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusOK)
+	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusOK)
+	testutil.Call(t, testHandler.FailTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+taskID+"/fail", taskID, map[string]any{
+			"error": "different", "failure_reason": "agent_error.unknown", "expected_message_seq": 2,
+		})).Want(http.StatusInternalServerError)
+	testutil.Call(t, testHandler.FailTask, daemonTaskRequest(t,
+		"/api/daemon/tasks/"+taskID+"/fail", taskID, map[string]any{
+			"error": "agent failed", "failure_reason": "agent_error.unknown", "expected_message_seq": 2,
+			"session_rollout_missing": true,
+		})).Want(http.StatusInternalServerError)
+
+	var status string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+		t.Fatalf("read failed task: %v", err)
+	}
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+}
+
 // TestCreateTaskMessagesBatchIsAtomic exercises the production query, not a copy
 // of it: a batch that violates the primary key must persist nothing. This is the
-// property the single statement buys over the per-message loop, which could
-// leave a prefix of the batch behind and no way to complete it (the daemon does
-// not retry this endpoint).
-//
-// Note what this does and does not guarantee: the batch is consistent, not
-// complete. A failing batch is now lost whole. Closing that gap needs a retry
-// plus a (task_id, seq) uniqueness rule, which is not part of this change.
+// property the single statement buys over the per-message loop. Delivery
+// completeness is covered separately by retry, (task_id, seq) uniqueness and
+// the terminal contiguous-sequence receipt.
 func TestCreateTaskMessagesBatchIsAtomic(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/task_message_batch_test.go
+++ b/server/internal/handler/task_message_batch_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
@@ -15,6 +14,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
 // seedBatchTask builds the running, issue-backed task the /messages endpoint
@@ -262,7 +262,7 @@ func TestReportTaskMessagesRejectsInvalidBatchSeq(t *testing.T) {
 	}
 }
 
-func TestCompleteTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
+func TestCompleteTaskFinalizesIncompleteTranscriptAsFailure(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
@@ -280,45 +280,20 @@ func TestCompleteTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
 			"expected_message_seq": 3,
 		})
 	}
-	w := testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusInternalServerError)
-	if !strings.Contains(w.Body.String(), "transcript incomplete") {
-		t.Fatalf("missing receipt error: %s", w.Body.String())
-	}
-
-	var status string
-	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
-		t.Fatalf("read task after rejected completion: %v", err)
-	}
-	if status != "running" {
-		t.Fatalf("status after rejected completion = %q, want running", status)
-	}
-
-	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
-		map[string]any{"seq": 2, "type": "text", "content": "second"},
-	})).Want(http.StatusOK)
 	testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusOK)
-	// A lost HTTP response makes the daemon replay the exact terminal callback.
-	// The sealed receipt must make that retry idempotent, while a different
-	// terminal payload must not be mistaken for the same completion.
+	// A lost response replays the original completion callback. Once the
+	// transcript gap has been persisted as a terminal failure, that replay is
+	// idempotent rather than returning 5xx forever.
 	testutil.Call(t, testHandler.CompleteTask, complete()).Want(http.StatusOK)
-	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
-		"/api/daemon/tasks/"+taskID+"/complete", taskID, map[string]any{
-			"output": "different", "expected_message_seq": 3,
-		})).Want(http.StatusInternalServerError)
 
-	var resultJSON []byte
-	if err := testPool.QueryRow(ctx, `SELECT status, result FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status, &resultJSON); err != nil {
-		t.Fatalf("read completed task: %v", err)
+	var status, taskErr, failureReason string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, error, failure_reason FROM agent_task_queue WHERE id = $1
+	`, taskID).Scan(&status, &taskErr, &failureReason); err != nil {
+		t.Fatalf("read task after incomplete completion: %v", err)
 	}
-	if status != "completed" {
-		t.Fatalf("status = %q, want completed", status)
-	}
-	var result TaskCompleteRequest
-	if err := json.Unmarshal(resultJSON, &result); err != nil {
-		t.Fatalf("decode result: %v", err)
-	}
-	if !result.TranscriptComplete || result.ExpectedMessageSeq == nil || *result.ExpectedMessageSeq != 3 {
-		t.Fatalf("transcript receipt = %+v, want complete at seq 3", result)
+	if status != "failed" || failureReason != taskfailure.ReasonTranscriptIncomplete.String() || !strings.Contains(taskErr, "transcript incomplete") {
+		t.Fatalf("terminal task = status %q error %q reason %q", status, taskErr, failureReason)
 	}
 }
 
@@ -375,10 +350,10 @@ func TestCompleteTaskAcceptsEmptyTranscriptReceipt(t *testing.T) {
 	testutil.Call(t, testHandler.CompleteTask, daemonTaskRequest(t,
 		"/api/daemon/tasks/"+nonemptyTaskID+"/complete", nonemptyTaskID, map[string]any{
 			"output": "done", "expected_message_seq": 0,
-		})).Want(http.StatusInternalServerError)
+		})).Want(http.StatusOK)
 }
 
-func TestFailTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
+func TestFailTaskFinalizesIncompleteTranscriptAsFailure(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
@@ -395,29 +370,18 @@ func TestFailTaskRequiresContiguousTranscriptReceipt(t *testing.T) {
 			"expected_message_seq": 2,
 		})
 	}
-	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusInternalServerError)
-
-	testutil.Call(t, testHandler.ReportTaskMessages, batchMessagesRequest(t, taskID, []any{
-		map[string]any{"seq": 1, "type": "text", "content": "first"},
-	})).Want(http.StatusOK)
 	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusOK)
+	// Retry the exact callback to cover a lost successful HTTP response.
 	testutil.Call(t, testHandler.FailTask, fail()).Want(http.StatusOK)
-	testutil.Call(t, testHandler.FailTask, daemonTaskRequest(t,
-		"/api/daemon/tasks/"+taskID+"/fail", taskID, map[string]any{
-			"error": "different", "failure_reason": "agent_error.unknown", "expected_message_seq": 2,
-		})).Want(http.StatusInternalServerError)
-	testutil.Call(t, testHandler.FailTask, daemonTaskRequest(t,
-		"/api/daemon/tasks/"+taskID+"/fail", taskID, map[string]any{
-			"error": "agent failed", "failure_reason": "agent_error.unknown", "expected_message_seq": 2,
-			"session_rollout_missing": true,
-		})).Want(http.StatusInternalServerError)
 
-	var status string
-	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+	var status, taskErr, failureReason string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, error, failure_reason FROM agent_task_queue WHERE id = $1
+	`, taskID).Scan(&status, &taskErr, &failureReason); err != nil {
 		t.Fatalf("read failed task: %v", err)
 	}
-	if status != "failed" {
-		t.Fatalf("status = %q, want failed", status)
+	if status != "failed" || failureReason != taskfailure.ReasonTranscriptIncomplete.String() || !strings.Contains(taskErr, "transcript incomplete") {
+		t.Fatalf("terminal task = status %q error %q reason %q", status, taskErr, failureReason)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4259,6 +4259,10 @@ func failedTerminalPayloadMatches(existing db.AgentTaskQueue, errMsg, sessionID,
 		optionalTerminalTextMatches(existing.DurableWorkDir, durableWorkDir)
 }
 
+// ErrTaskTranscriptIncomplete marks a terminal callback whose claimed final
+// sequence cannot be verified against the stored contiguous transcript.
+var ErrTaskTranscriptIncomplete = errors.New("transcript incomplete")
+
 func verifyTaskTranscript(ctx context.Context, qtx *db.Queries, taskID pgtype.UUID, expectedMessageSeq *int32) error {
 	if expectedMessageSeq == nil {
 		return nil // Legacy daemon: completeness remains unknown.
@@ -4281,8 +4285,13 @@ func verifyTaskTranscript(ctx context.Context, qtx *db.Queries, taskID pgtype.UU
 	if err != nil {
 		return fmt.Errorf("read transcript sequence summary: %w", err)
 	}
-	return fmt.Errorf("transcript incomplete: expected contiguous seq 1..%d, got count=%d min=%d max=%d",
+	return fmt.Errorf("%w: expected contiguous seq 1..%d, got count=%d min=%d max=%d", ErrTaskTranscriptIncomplete,
 		*expectedMessageSeq, summary.MessageCount, summary.MinSeq, summary.MaxSeq)
+}
+
+func failedForIncompleteTranscript(task db.AgentTaskQueue) bool {
+	return task.Status == "failed" && task.FailureReason.Valid &&
+		task.FailureReason.String == taskfailure.ReasonTranscriptIncomplete.String()
 }
 
 // CompleteTask marks a task as completed.
@@ -4389,6 +4398,9 @@ func (s *TaskService) CompleteTaskWithTranscript(ctx context.Context, taskID pgt
 		// Treat it as an idempotent success — same pattern as CancelTask.
 		if existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID); lookupErr == nil {
 			idempotent := expectedMessageSeq == nil && errors.Is(err, pgx.ErrNoRows)
+			if expectedMessageSeq != nil && failedForIncompleteTranscript(existing) {
+				idempotent = true
+			}
 			if expectedMessageSeq != nil && existing.Status == "completed" && jsonPayloadEqual(existing.Result, result) {
 				matches, matchErr := taskTranscriptMatches(ctx, s.Queries, taskID, *expectedMessageSeq)
 				idempotent = matchErr == nil && matches
@@ -5007,6 +5019,9 @@ func (s *TaskService) FailTaskWithTranscript(ctx context.Context, taskID pgtype.
 	}); err != nil {
 		if existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID); lookupErr == nil {
 			idempotent := expectedMessageSeq == nil && errors.Is(err, pgx.ErrNoRows)
+			if expectedMessageSeq != nil && failedForIncompleteTranscript(existing) {
+				idempotent = true
+			}
 			if expectedMessageSeq != nil && failedTerminalPayloadMatches(existing,
 				errMsg, sessionID, workDir, branchName, failureReason,
 				sessionRolloutMissing, retiredSessionID, durableWorkDir) {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -4213,6 +4214,77 @@ func startsWithAbsolutePath(s string) bool {
 	return false
 }
 
+func taskTranscriptMatches(ctx context.Context, queries *db.Queries, taskID pgtype.UUID, expected int32) (bool, error) {
+	if expected < 0 {
+		return false, fmt.Errorf("invalid expected transcript sequence %d", expected)
+	}
+	summary, err := queries.GetTaskMessageSeqSummary(ctx, taskID)
+	if err != nil {
+		return false, fmt.Errorf("read transcript sequence summary: %w", err)
+	}
+	if expected == 0 {
+		return summary.MessageCount == 0, nil
+	}
+	return summary.MessageCount == expected && summary.MinSeq == 1 && summary.MaxSeq == expected, nil
+}
+
+func jsonPayloadEqual(a, b []byte) bool {
+	var left, right any
+	if json.Unmarshal(a, &left) != nil || json.Unmarshal(b, &right) != nil {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func optionalTerminalTextMatches(stored pgtype.Text, incoming string) bool {
+	return incoming == "" || stored.Valid && stored.String == incoming
+}
+
+func failedTerminalPayloadMatches(existing db.AgentTaskQueue, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string) bool {
+	if existing.Status != "failed" || !existing.Error.Valid || existing.Error.String != errMsg ||
+		!existing.FailureReason.Valid || existing.FailureReason.String != failureReason ||
+		existing.SessionRolloutMissing != sessionRolloutMissing {
+		return false
+	}
+	if sessionRolloutMissing {
+		if existing.SessionID.Valid {
+			return false
+		}
+	} else if !optionalTerminalTextMatches(existing.SessionID, sessionID) {
+		return false
+	}
+	return optionalTerminalTextMatches(existing.WorkDir, workDir) &&
+		optionalTerminalTextMatches(existing.BranchName, branchName) &&
+		optionalTerminalTextMatches(existing.RetiredSessionID, retiredSessionID) &&
+		optionalTerminalTextMatches(existing.DurableWorkDir, durableWorkDir)
+}
+
+func verifyTaskTranscript(ctx context.Context, qtx *db.Queries, taskID pgtype.UUID, expectedMessageSeq *int32) error {
+	if expectedMessageSeq == nil {
+		return nil // Legacy daemon: completeness remains unknown.
+	}
+	status, err := qtx.LockTaskForTranscriptWrite(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("lock task for transcript verification: %w", err)
+	}
+	if status != "running" {
+		return fmt.Errorf("task is not running while verifying transcript: %s", status)
+	}
+	matches, err := taskTranscriptMatches(ctx, qtx, taskID, *expectedMessageSeq)
+	if err != nil {
+		return err
+	}
+	if matches {
+		return nil
+	}
+	summary, err := qtx.GetTaskMessageSeqSummary(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("read transcript sequence summary: %w", err)
+	}
+	return fmt.Errorf("transcript incomplete: expected contiguous seq 1..%d, got count=%d min=%d max=%d",
+		*expectedMessageSeq, summary.MessageCount, summary.MinSeq, summary.MaxSeq)
+}
+
 // CompleteTask marks a task as completed.
 // Issue status is NOT changed here — the agent manages it via the CLI.
 //
@@ -4224,6 +4296,10 @@ func startsWithAbsolutePath(s string) bool {
 // durableWorkDir is terminal delivery metadata, not a resume pointer: it is
 // populated only after the daemon confirms a disposable worktree is gone.
 func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir, branchName string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string) (*db.AgentTaskQueue, error) {
+	return s.CompleteTaskWithTranscript(ctx, taskID, result, sessionID, workDir, branchName, sessionRolloutMissing, retiredSessionID, durableWorkDir, nil)
+}
+
+func (s *TaskService) CompleteTaskWithTranscript(ctx context.Context, taskID pgtype.UUID, result []byte, sessionID, workDir, branchName string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string, expectedMessageSeq *int32) (*db.AgentTaskQueue, error) {
 	var task db.AgentTaskQueue
 	// chatAssistantMsg is the single assistant outcome row written for a chat
 	// task inside the completion transaction below. It is broadcast (chat:done)
@@ -4231,6 +4307,9 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	var chatAssistantMsg *db.ChatMessage
 	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
 		if err := lockChatSessionForTaskWrite(ctx, qtx, taskID); err != nil {
+			return err
+		}
+		if err := verifyTaskTranscript(ctx, qtx, taskID, expectedMessageSeq); err != nil {
 			return err
 		}
 		t, err := qtx.CompleteAgentTask(ctx, db.CompleteAgentTaskParams{
@@ -4309,7 +4388,12 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		// … WHERE status = 'running' returns no rows in that case.
 		// Treat it as an idempotent success — same pattern as CancelTask.
 		if existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID); lookupErr == nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			idempotent := expectedMessageSeq == nil && errors.Is(err, pgx.ErrNoRows)
+			if expectedMessageSeq != nil && existing.Status == "completed" && jsonPayloadEqual(existing.Result, result) {
+				matches, matchErr := taskTranscriptMatches(ctx, s.Queries, taskID, *expectedMessageSeq)
+				idempotent = matchErr == nil && matches
+			}
+			if idempotent {
 				slog.Info("complete task: already finalized",
 					"task_id", util.UUIDToString(taskID),
 					"current_status", existing.Status,
@@ -4639,6 +4723,10 @@ func (s *TaskService) observeChatOutputLocalPath(task db.AgentTaskQueue, body st
 // (via classifyPoisonedError, the timeout / runtime classifier, etc.)
 // will have their value preserved untouched.
 func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string) (*db.AgentTaskQueue, error) {
+	return s.FailTaskWithTranscript(ctx, taskID, errMsg, sessionID, workDir, branchName, failureReason, sessionRolloutMissing, retiredSessionID, durableWorkDir, nil)
+}
+
+func (s *TaskService) FailTaskWithTranscript(ctx context.Context, taskID pgtype.UUID, errMsg, sessionID, workDir, branchName, failureReason string, sessionRolloutMissing bool, retiredSessionID, durableWorkDir string, expectedMessageSeq *int32) (*db.AgentTaskQueue, error) {
 	// Strip bytes PostgreSQL cannot store before anything else reads errMsg, so
 	// the classifier, the transaction and every downstream consumer see the one
 	// text we will actually persist (GH #7098). Kept at the service boundary
@@ -4711,6 +4799,9 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	var retried *db.AgentTaskQueue
 	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
 		if err := lockChatSessionForTaskWrite(ctx, qtx, taskID); err != nil {
+			return err
+		}
+		if err := verifyTaskTranscript(ctx, qtx, taskID, expectedMessageSeq); err != nil {
 			return err
 		}
 		t, err := qtx.FailAgentTask(ctx, db.FailAgentTaskParams{
@@ -4915,7 +5006,14 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		return nil
 	}); err != nil {
 		if existing, lookupErr := s.Queries.GetAgentTask(ctx, taskID); lookupErr == nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			idempotent := expectedMessageSeq == nil && errors.Is(err, pgx.ErrNoRows)
+			if expectedMessageSeq != nil && failedTerminalPayloadMatches(existing,
+				errMsg, sessionID, workDir, branchName, failureReason,
+				sessionRolloutMissing, retiredSessionID, durableWorkDir) {
+				matches, matchErr := taskTranscriptMatches(ctx, s.Queries, taskID, *expectedMessageSeq)
+				idempotent = matchErr == nil && matches
+			}
+			if idempotent {
 				slog.Info("fail task: already finalized",
 					"task_id", util.UUIDToString(taskID),
 					"current_status", existing.Status,

--- a/server/migrations/449_task_message_task_seq_unique_index.down.sql
+++ b/server/migrations/449_task_message_task_seq_unique_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS task_message_task_id_seq_uidx;

--- a/server/migrations/449_task_message_task_seq_unique_index.up.sql
+++ b/server/migrations/449_task_message_task_seq_unique_index.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS task_message_task_id_seq_uidx ON task_message (task_id, seq);

--- a/server/migrations/450_drop_task_message_task_seq_index.down.sql
+++ b/server/migrations/450_drop_task_message_task_seq_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_message_task_id_seq ON task_message (task_id, seq);

--- a/server/migrations/450_drop_task_message_task_seq_index.up.sql
+++ b/server/migrations/450_drop_task_message_task_seq_index.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_task_message_task_id_seq;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -11,14 +11,17 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 // Backend is the unified interface for executing prompts via coding agents.
 type Backend interface {
 	// Execute runs a prompt and returns a Session for streaming results.
-	// The caller should read from Session.Messages (optional) and wait on
-	// Session.Result for the final outcome.
+	// The caller must drain Session.Messages concurrently while waiting on
+	// Session.Result. Message delivery applies backpressure instead of dropping
+	// events when the channel buffer fills; cancelling ctx releases a blocked
+	// producer.
 	Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error)
 }
 
@@ -142,7 +145,9 @@ func runContext(ctx context.Context, timeout time.Duration) (context.Context, co
 // Session represents a running agent execution.
 type Session struct {
 	// Messages streams events as the agent works. The channel is closed
-	// when the agent finishes (before Result is sent).
+	// when the agent finishes (before Result is sent). Callers must keep draining
+	// it while the execution is active; waiting on Result alone can backpressure
+	// the producer once this channel's buffer fills.
 	Messages <-chan Message
 	// Result receives exactly one value — the final outcome — then closes.
 	Result <-chan Result
@@ -172,6 +177,53 @@ type Message struct {
 	Status    string         // agent status string (Status)
 	Level     string         // log level (Log)
 	SessionID string         // backend session id (Status), for early resume-pointer pinning
+}
+
+type messageDeliveryTrackerKey struct{}
+
+// MessageDeliveryTracker records an execution event that could not be handed
+// to the daemon because the execution context was cancelled while the message
+// channel was backpressured. A terminal receipt must stay unknown in that case.
+type MessageDeliveryTracker struct {
+	abandoned atomic.Bool
+}
+
+func WithMessageDeliveryTracker(ctx context.Context) (context.Context, *MessageDeliveryTracker) {
+	tracker := &MessageDeliveryTracker{}
+	return context.WithValue(ctx, messageDeliveryTrackerKey{}, tracker), tracker
+}
+
+func (t *MessageDeliveryTracker) Abandoned() bool {
+	return t != nil && t.abandoned.Load()
+}
+
+func markMessageDeliveryAbandoned(ctx context.Context) {
+	if tracker, ok := ctx.Value(messageDeliveryTrackerKey{}).(*MessageDeliveryTracker); ok {
+		tracker.abandoned.Store(true)
+	}
+}
+
+func messageReaderClosedBefore(ctx context.Context, readerDone <-chan struct{}) bool {
+	select {
+	case <-readerDone:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// sendMessage delivers an execution event without silently dropping it when
+// the consumer is briefly behind. The execution context is the escape hatch:
+// cancellation releases a producer blocked on a full channel so shutdown does
+// not leak the backend goroutine.
+func sendMessage(ctx context.Context, ch chan<- Message, msg Message) bool {
+	select {
+	case ch <- msg:
+		return true
+	case <-ctx.Done():
+		markMessageDeliveryAbandoned(ctx)
+		return false
+	}
 }
 
 // TokenUsage tracks token consumption for a single model.

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -250,3 +250,17 @@ func TestRunContextPositiveTimeoutHasDeadline(t *testing.T) {
 		t.Fatalf("unexpected deadline remaining: %s", remaining)
 	}
 }
+
+func TestMessageReaderClosedBefore(t *testing.T) {
+	closed := make(chan struct{})
+	close(closed)
+	if !messageReaderClosedBefore(context.Background(), closed) {
+		t.Fatal("closed reader was reported open")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if messageReaderClosedBefore(ctx, make(chan struct{})) {
+		t.Fatal("open reader was reported closed after timeout")
+	}
+}

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -126,7 +126,7 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 
 		scanner := newAgentStreamScanner(stdout)
 
-		trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+		sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running"})
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -145,7 +145,7 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 			}
 			output.WriteString(line)
 			if chunk != "" {
-				trySend(msgCh, Message{Type: MessageText, Content: chunk})
+				sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: chunk})
 			}
 		}
 		if err := scanner.Err(); err != nil {
@@ -201,7 +201,7 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 			// final comment while the execution transcript remains blank.
 			if recovered := readAntigravityTranscriptOutput(logPath, sessionID); recovered != "" {
 				finalOutput = recovered
-				trySend(msgCh, Message{Type: MessageText, Content: recovered})
+				sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: recovered})
 				b.cfg.Logger.Info("agy recovered empty stdout from transcript", "bytes", len(recovered))
 			}
 		}

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -227,21 +227,21 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				turn := b.handleAssistant(msg, msgCh, usage)
+				turn := b.handleAssistant(runCtx, msg, msgCh, usage)
 				toolUseCount += turn.toolUses
 				if !turn.understood {
 					unreadableAssistantCount++
 				}
 				lastAssistantText = turn.resolveFallback(lastAssistantText)
 			case "user":
-				if b.handleUser(msg, msgCh) {
+				if b.handleUser(runCtx, msg, msgCh) {
 					sawAsyncLaunch = true
 				}
 			case "system":
 				if msg.SessionID != "" {
 					sessionID = msg.SessionID
 				}
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+				sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 			case "result":
 				sawResult = true
 				finalResultText = msg.ResultText
@@ -254,7 +254,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				closeStdin()
 			case "log":
 				if msg.Log != nil {
-					trySend(msgCh, Message{
+					sendMessage(runCtx, msgCh, Message{
 						Type:    MessageLog,
 						Level:   msg.Log.Level,
 						Content: msg.Log.Message,
@@ -363,7 +363,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
+func (b *claudeBackend) handleAssistant(ctx context.Context, msg claudeSDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
 	var content claudeMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
 		// Unreadable body: understood stays false so the caller drops any
@@ -389,11 +389,11 @@ func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message,
 		case "text":
 			if block.Text != "" {
 				assistantText.WriteString(block.Text)
-				trySend(ch, Message{Type: MessageText, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageText, Content: block.Text})
 			}
 		case "thinking":
 			if block.Text != "" {
-				trySend(ch, Message{Type: MessageThinking, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageThinking, Content: block.Text})
 			}
 		case "tool_use":
 			toolUseCount++
@@ -401,7 +401,7 @@ func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message,
 			if block.Input != nil {
 				_ = json.Unmarshal(block.Input, &input)
 			}
-			trySend(ch, Message{
+			sendMessage(ctx, ch, Message{
 				Type:   MessageToolUse,
 				Tool:   block.Name,
 				CallID: block.ID,
@@ -420,7 +420,7 @@ func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message,
 	return turn
 }
 
-func (b *claudeBackend) handleUser(msg claudeSDKMessage, ch chan<- Message) bool {
+func (b *claudeBackend) handleUser(ctx context.Context, msg claudeSDKMessage, ch chan<- Message) bool {
 	var content claudeMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
 		return false
@@ -436,7 +436,7 @@ func (b *claudeBackend) handleUser(msg claudeSDKMessage, ch chan<- Message) bool
 					sawAsyncLaunch = true
 				}
 			}
-			trySend(ch, Message{
+			sendMessage(ctx, ch, Message{
 				Type:   MessageToolResult,
 				CallID: block.ToolUseID,
 				Output: resultStr,
@@ -680,17 +680,6 @@ type claudeControlRequestPayload struct {
 	Subtype  string          `json:"subtype"`
 	ToolName string          `json:"tool_name,omitempty"`
 	Input    json.RawMessage `json:"input,omitempty"`
-}
-
-// ── Shared helpers ──
-
-func trySend(ch chan<- Message, msg Message) {
-	select {
-	case ch <- msg:
-	default:
-		// Channel full — drop message. Result.Output is finalized independently,
-		// so only live transcript consumers are affected.
-	}
 }
 
 // claudeBlockedArgs are flags hardcoded by the daemon that must not be

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -30,7 +30,7 @@ func TestClaudeHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(context.Background(), msg, ch, make(map[string]TokenUsage))
 	output, tools := turn.text, turn.toolUses
 
 	if output != "Hello world" {
@@ -70,7 +70,7 @@ func TestClaudeHandleAssistantToolUse(t *testing.T) {
 		}),
 	}
 
-	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(context.Background(), msg, ch, make(map[string]TokenUsage))
 	output, tools := turn.text, turn.toolUses
 
 	if output != "" {
@@ -112,7 +112,7 @@ func TestClaudeHandleUserToolResult(t *testing.T) {
 		}),
 	}
 
-	if b.handleUser(msg, ch) {
+	if b.handleUser(context.Background(), msg, ch) {
 		t.Fatal("did not expect async launch in ordinary tool result")
 	}
 
@@ -237,7 +237,7 @@ func TestClaudeHandleUserDetectsAsyncLaunchedToolResult(t *testing.T) {
 		}),
 	}
 
-	if !b.handleUser(msg, ch) {
+	if !b.handleUser(context.Background(), msg, ch) {
 		t.Fatal("expected async launch to be detected")
 	}
 }
@@ -264,7 +264,7 @@ func TestClaudeHandleUserIgnoresAsyncLaunchedTextOutput(t *testing.T) {
 		}),
 	}
 
-	if b.handleUser(msg, ch) {
+	if b.handleUser(context.Background(), msg, ch) {
 		t.Fatal("did not expect async launch to be detected in ordinary text output")
 	}
 }
@@ -281,7 +281,7 @@ func TestClaudeHandleAssistantInvalidJSON(t *testing.T) {
 	}
 
 	// Should not panic
-	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(context.Background(), msg, ch, make(map[string]TokenUsage))
 	output, tools := turn.text, turn.toolUses
 
 	if output != "" {
@@ -297,23 +297,70 @@ func TestClaudeHandleAssistantInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestTrySendDropsWhenFull(t *testing.T) {
+func TestSendMessageBackpressuresUntilRead(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan Message, 1)
-	// Fill the channel
-	trySend(ch, Message{Type: MessageText, Content: "first"})
-	// This should not block
-	trySend(ch, Message{Type: MessageText, Content: "second"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if !sendMessage(ctx, ch, Message{Type: MessageText, Content: "first"}) {
+		t.Fatal("first send was abandoned")
+	}
+	done := make(chan bool, 1)
+	go func() {
+		done <- sendMessage(ctx, ch, Message{Type: MessageText, Content: "second"})
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("second send completed while the channel was full")
+	case <-time.After(25 * time.Millisecond):
+	}
 
 	m := <-ch
 	if m.Content != "first" {
 		t.Fatalf("expected 'first', got %q", m.Content)
 	}
 	select {
-	case m := <-ch:
-		t.Fatalf("expected empty channel, got %+v", m)
-	default:
+	case ok := <-done:
+		if !ok {
+			t.Fatal("second send was abandoned after capacity became available")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second send stayed blocked after capacity became available")
+	}
+	if m = <-ch; m.Content != "second" {
+		t.Fatalf("expected 'second', got %q", m.Content)
+	}
+}
+
+func TestSendMessageCancellationReleasesBackpressure(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan Message, 1)
+	ch <- Message{Type: MessageText, Content: "first"}
+	ctx, tracker := WithMessageDeliveryTracker(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan bool, 1)
+	go func() {
+		done <- sendMessage(ctx, ch, Message{Type: MessageText, Content: "second"})
+	}()
+	cancel()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("send succeeded even though cancellation was the only ready path")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled send stayed blocked")
+	}
+	if m := <-ch; m.Content != "first" {
+		t.Fatalf("queued message changed after cancellation: %+v", m)
+	}
+	if !tracker.Abandoned() {
+		t.Fatal("cancelled delivery did not mark the task-scoped tracker abandoned")
 	}
 }
 

--- a/server/pkg/agent/codearts.go
+++ b/server/pkg/agent/codearts.go
@@ -237,7 +237,7 @@ func (b *codeartsBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processEvents(stdout, msgCh)
+		scanResult := b.processEvents(runCtx, stdout, msgCh)
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
@@ -333,7 +333,7 @@ type codeArtsEventResult struct {
 
 // processEvents reads JSON lines from r, dispatches events to ch, and returns
 // the accumulated result. This is the core scanner loop, extracted for testability.
-func (b *codeartsBackend) processEvents(r io.Reader, ch chan<- Message) codeArtsEventResult {
+func (b *codeartsBackend) processEvents(ctx context.Context, r io.Reader, ch chan<- Message) codeArtsEventResult {
 	var output strings.Builder
 	var unparsedOutput strings.Builder
 	var sessionID string
@@ -410,24 +410,24 @@ func (b *codeartsBackend) processEvents(r io.Reader, ch chan<- Message) codeArts
 
 		switch event.Type {
 		case "text":
-			b.handleTextEvent(event, ch, &output)
+			b.handleTextEvent(ctx, event, ch, &output)
 			if event.Part.Text != "" {
 				stepProducedOutput = true
 			}
 		case "tool_use":
-			b.handleToolUseEvent(event, ch)
+			b.handleToolUseEvent(ctx, event, ch)
 			stepProducedOutput = true
 			if event.Part.Metadata == nil || !event.Part.Metadata.ProviderExecuted {
 				stepHasContinuationTool = true
 			}
 		case "error":
-			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
+			b.handleErrorEvent(ctx, event, ch, &finalStatus, &finalError)
 		case "step_start":
 			openStep = true
 			stepHasContinuationTool = false
 			awaitingContinuation = false
 			stepProducedOutput = false
-			trySend(ch, Message{Type: MessageStatus, Status: "running"})
+			sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
 			openStep = false
 			sawStepFinish = true
@@ -534,18 +534,18 @@ func codeArtsStepReportedUsage(part *codeartsEventPart) bool {
 	return t.Cache != nil && (t.Cache.Read > 0 || t.Cache.Write > 0)
 }
 
-func (b *codeartsBackend) handleTextEvent(event codeartsEvent, ch chan<- Message, output *strings.Builder) {
+func (b *codeartsBackend) handleTextEvent(ctx context.Context, event codeartsEvent, ch chan<- Message, output *strings.Builder) {
 	text := event.Part.Text
 	if text != "" {
 		output.WriteString(text)
-		trySend(ch, Message{Type: MessageText, Content: text})
+		sendMessage(ctx, ch, Message{Type: MessageText, Content: text})
 	}
 }
 
 // handleToolUseEvent processes "tool_use" events from codearts. A single
 // tool_use event contains both the call and result in part.state when the
 // tool reaches a terminal state (state.status is "completed" or "error").
-func (b *codeartsBackend) handleToolUseEvent(event codeartsEvent, ch chan<- Message) {
+func (b *codeartsBackend) handleToolUseEvent(ctx context.Context, event codeartsEvent, ch chan<- Message) {
 	// Extract input from state.input (the tool invocation parameters).
 	var input map[string]any
 	if event.Part.State != nil && event.Part.State.Input != nil {
@@ -553,7 +553,7 @@ func (b *codeartsBackend) handleToolUseEvent(event codeartsEvent, ch chan<- Mess
 	}
 
 	// Emit the tool-use message.
-	trySend(ch, Message{
+	sendMessage(ctx, ch, Message{
 		Type:   MessageToolUse,
 		Tool:   event.Part.Tool,
 		CallID: event.Part.CallID,
@@ -569,7 +569,7 @@ func (b *codeartsBackend) handleToolUseEvent(event codeartsEvent, ch chan<- Mess
 		if state.Status == "error" && state.Error != "" {
 			outputStr = state.Error
 		}
-		trySend(ch, Message{
+		sendMessage(ctx, ch, Message{
 			Type:   MessageToolResult,
 			Tool:   event.Part.Tool,
 			CallID: event.Part.CallID,
@@ -581,7 +581,7 @@ func (b *codeartsBackend) handleToolUseEvent(event codeartsEvent, ch chan<- Mess
 // handleErrorEvent processes "error" events from codearts. CodeArts can exit
 // with RC=0 even on errors (e.g. invalid model), so error events are the
 // reliable signal for failures.
-func (b *codeartsBackend) handleErrorEvent(event codeartsEvent, ch chan<- Message, finalStatus, finalError *string) {
+func (b *codeartsBackend) handleErrorEvent(ctx context.Context, event codeartsEvent, ch chan<- Message, finalStatus, finalError *string) {
 	errMsg := ""
 	if event.Error != nil {
 		errMsg = event.Error.Message()
@@ -591,7 +591,7 @@ func (b *codeartsBackend) handleErrorEvent(event codeartsEvent, ch chan<- Messag
 	}
 
 	b.cfg.Logger.Warn("codearts error event", "error", errMsg)
-	trySend(ch, Message{Type: MessageError, Content: errMsg})
+	sendMessage(ctx, ch, Message{Type: MessageError, Content: errMsg})
 
 	*finalStatus = "failed"
 	*finalError = errMsg

--- a/server/pkg/agent/codearts_test.go
+++ b/server/pkg/agent/codearts_test.go
@@ -103,7 +103,7 @@ func TestCodeArtsExecuteUsesNativeRunFlagsAndStdin(t *testing.T) {
 func TestCodeArtsRejectsNonJSONSuccessOutput(t *testing.T) {
 	backend := &codeartsBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 8)
-	result := backend.processEvents(strings.NewReader("\x1b[31mError: CODEARTS_CLI_AK is not configured\x1b[0m\n"), ch)
+	result := backend.processEvents(context.Background(), strings.NewReader("\x1b[31mError: CODEARTS_CLI_AK is not configured\x1b[0m\n"), ch)
 	if result.status != "failed" {
 		t.Fatalf("status = %q, want failed", result.status)
 	}
@@ -119,7 +119,7 @@ func TestCodeArtsRejectsNonJSONSuccessOutput(t *testing.T) {
 func TestCodeArtsStreamErrorsUseCodeArtsLabel(t *testing.T) {
 	backend := &codeartsBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 8)
-	result := backend.processEvents(strings.NewReader(`{"type":"step_start","sessionID":"ses","part":{}}`+"\n"), ch)
+	result := backend.processEvents(context.Background(), strings.NewReader(`{"type":"step_start","sessionID":"ses","part":{}}`+"\n"), ch)
 	if result.status != "failed" || !strings.HasPrefix(result.errMsg, "codearts stream ended") {
 		t.Fatalf("result = %+v", result)
 	}

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -234,19 +234,19 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				turn := b.handleAssistant(msg, msgCh, usage)
+				turn := b.handleAssistant(runCtx, msg, msgCh, usage)
 				toolUseCount += turn.toolUses
 				if !turn.understood {
 					unreadableAssistantCount++
 				}
 				lastAssistantText = turn.resolveFallback(lastAssistantText)
 			case "user":
-				b.handleUser(msg, msgCh)
+				b.handleUser(runCtx, msg, msgCh)
 			case "system":
 				if msg.SessionID != "" {
 					sessionID = msg.SessionID
 				}
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+				sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 			case "result":
 				sawResult = true
 				finalResultText = msg.ResultText
@@ -258,7 +258,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 				closeStdin()
 			case "log":
 				if msg.Log != nil {
-					trySend(msgCh, Message{
+					sendMessage(runCtx, msgCh, Message{
 						Type:    MessageLog,
 						Level:   msg.Log.Level,
 						Content: msg.Log.Message,
@@ -349,7 +349,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
+func (b *codebuddyBackend) handleAssistant(ctx context.Context, msg codebuddySDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
 	var content codebuddyMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
 		// Unreadable body: understood stays false so the caller drops any
@@ -375,11 +375,11 @@ func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Me
 		case "text":
 			if block.Text != "" {
 				assistantText.WriteString(block.Text)
-				trySend(ch, Message{Type: MessageText, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageText, Content: block.Text})
 			}
 		case "thinking":
 			if block.Text != "" {
-				trySend(ch, Message{Type: MessageThinking, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageThinking, Content: block.Text})
 			}
 		case "tool_use":
 			toolUseCount++
@@ -387,7 +387,7 @@ func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Me
 			if block.Input != nil {
 				_ = json.Unmarshal(block.Input, &input)
 			}
-			trySend(ch, Message{
+			sendMessage(ctx, ch, Message{
 				Type:   MessageToolUse,
 				Tool:   block.Name,
 				CallID: block.ID,
@@ -406,7 +406,7 @@ func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Me
 	return turn
 }
 
-func (b *codebuddyBackend) handleUser(msg codebuddySDKMessage, ch chan<- Message) {
+func (b *codebuddyBackend) handleUser(ctx context.Context, msg codebuddySDKMessage, ch chan<- Message) {
 	var content codebuddyMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
 		return
@@ -418,7 +418,7 @@ func (b *codebuddyBackend) handleUser(msg codebuddySDKMessage, ch chan<- Message
 			if block.Content != nil {
 				resultStr = string(block.Content)
 			}
-			trySend(ch, Message{
+			sendMessage(ctx, ch, Message{
 				Type:   MessageToolResult,
 				CallID: block.ToolUseID,
 				Output: resultStr,

--- a/server/pkg/agent/codebuddy_test.go
+++ b/server/pkg/agent/codebuddy_test.go
@@ -384,7 +384,7 @@ func TestCodebuddyHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(context.Background(), msg, ch, make(map[string]TokenUsage))
 	output, tools := turn.text, turn.toolUses
 
 	if output != "codebuddy says hi" {
@@ -450,7 +450,7 @@ func TestCodebuddyHandleUserToolResult(t *testing.T) {
 		}),
 	}
 
-	b.handleUser(msg, ch)
+	b.handleUser(context.Background(), msg, ch)
 
 	select {
 	case m := <-ch:

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -871,7 +871,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			holdingPins := true
 			flushHeldPins := func() {
 				for _, held := range heldPins {
-					msgCh <- held
+					sendMessage(ctx, msgCh, held)
 				}
 				heldPins = nil
 				holdingPins = false
@@ -884,7 +884,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				if holdingPins {
 					flushHeldPins()
 				}
-				msgCh <- msg
+				sendMessage(ctx, msgCh, msg)
 			}
 			result, ok := <-session.Result
 			if !ok {
@@ -1139,7 +1139,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			if activity == "status:running" {
 				firstItemWait.start(time.Now())
 			}
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 			trySendString(semanticActivityCh, activity)
 			if activity != "" {
 				semanticObserved.Store(true)

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -407,7 +407,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			}
 
 			for _, m := range handleCopilotEvent(evt, st) {
-				trySend(msgCh, m)
+				sendMessage(runCtx, msgCh, m)
 			}
 		}
 		if err := scanner.Err(); err != nil {

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -162,19 +162,19 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch evt.Type {
 			case "system":
 				if evt.Subtype == "init" {
-					trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+					sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running"})
 				}
 				if evt.Subtype == "error" {
 					errMsg := cursorErrorText(&evt)
 					if errMsg != "" {
 						protocolError = errMsg
-						trySend(msgCh, Message{Type: MessageError, Content: errMsg})
+						sendMessage(runCtx, msgCh, Message{Type: MessageError, Content: errMsg})
 					}
 				}
 
 			case "assistant":
 				assistantEventCount++
-				assistantBytes += b.handleCursorAssistant(&evt, msgCh, &output)
+				assistantBytes += b.handleCursorAssistant(runCtx, &evt, msgCh, &output)
 
 			case "thinking":
 				// Reasoning is a top-level event streamed as deltas, not a
@@ -187,7 +187,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				switch evt.Subtype {
 				case "delta":
 					if content := thinking.delta(evt.Text); content != "" {
-						trySend(msgCh, Message{Type: MessageThinking, Content: content})
+						sendMessage(runCtx, msgCh, Message{Type: MessageThinking, Content: content})
 					}
 				case "completed":
 					thinking.complete()
@@ -207,7 +207,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				case "started":
 					call := parseCursorToolCall(&evt)
 					toolUseCount++
-					trySend(msgCh, Message{
+					sendMessage(runCtx, msgCh, Message{
 						Type:   MessageToolUse,
 						Tool:   call.Name,
 						CallID: call.CallID,
@@ -215,7 +215,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					})
 				case "completed":
 					call := parseCursorToolCall(&evt)
-					trySend(msgCh, Message{
+					sendMessage(runCtx, msgCh, Message{
 						Type:   MessageToolResult,
 						Tool:   call.Name,
 						CallID: call.CallID,
@@ -231,7 +231,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				if evt.Parameters != nil {
 					_ = json.Unmarshal(evt.Parameters, &params)
 				}
-				trySend(msgCh, Message{
+				sendMessage(runCtx, msgCh, Message{
 					Type:   MessageToolUse,
 					Tool:   evt.ToolName,
 					CallID: evt.ToolID,
@@ -239,7 +239,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				})
 
 			case "tool_result":
-				trySend(msgCh, Message{
+				sendMessage(runCtx, msgCh, Message{
 					Type:   MessageToolResult,
 					CallID: evt.ToolID,
 					Output: evt.Output,
@@ -255,7 +255,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				resultBytes = len(evt.ResultText)
 				if evt.ResultText != "" && output.Len() == 0 {
 					output.WriteString(evt.ResultText)
-					trySend(msgCh, Message{Type: MessageText, Content: evt.ResultText})
+					sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: evt.ResultText})
 				}
 				b.accumulateResultUsage(resultUsage, &evt, configuredModel)
 				if evt.hasResultUsage() {
@@ -271,7 +271,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				if errMsg != "" {
 					protocolError = errMsg
 				}
-				trySend(msgCh, Message{Type: MessageError, Content: errMsg})
+				sendMessage(runCtx, msgCh, Message{Type: MessageError, Content: errMsg})
 
 			case "text":
 				if evt.Part != nil {
@@ -280,7 +280,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					if part.Text != "" {
 						output.WriteString(part.Text)
 						assistantBytes += len(part.Text)
-						trySend(msgCh, Message{Type: MessageText, Content: part.Text})
+						sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: part.Text})
 					}
 				}
 
@@ -583,7 +583,7 @@ func (t *cursorUnhandledTypeTally) summary() string {
 // returns how many bytes of model-authored text it appended to output. The
 // caller tracks that separately from output.Len(), which also absorbs the
 // terminal result text.
-func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) int {
+func (b *cursorBackend) handleCursorAssistant(ctx context.Context, evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) int {
 	if evt.Message == nil {
 		return 0
 	}
@@ -604,18 +604,18 @@ func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- 
 			if block.Text != "" {
 				output.WriteString(block.Text)
 				written += len(block.Text)
-				trySend(ch, Message{Type: MessageText, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageText, Content: block.Text})
 			}
 		case "thinking":
 			if block.Text != "" {
-				trySend(ch, Message{Type: MessageThinking, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageThinking, Content: block.Text})
 			}
 		case "tool_use":
 			var input map[string]any
 			if block.Input != nil {
 				_ = json.Unmarshal(block.Input, &input)
 			}
-			trySend(ch, Message{
+			sendMessage(ctx, ch, Message{
 				Type:   MessageToolUse,
 				Tool:   block.Name,
 				CallID: block.ID,

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -203,7 +204,7 @@ func TestCursorHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	b.handleCursorAssistant(evt, ch, &output)
+	b.handleCursorAssistant(context.Background(), evt, ch, &output)
 
 	if output.String() != "Hello from Cursor" {
 		t.Fatalf("expected output 'Hello from Cursor', got %q", output.String())
@@ -240,7 +241,7 @@ func TestCursorHandleAssistantToolUse(t *testing.T) {
 		}),
 	}
 
-	b.handleCursorAssistant(evt, ch, &output)
+	b.handleCursorAssistant(context.Background(), evt, ch, &output)
 
 	select {
 	case m := <-ch:
@@ -432,7 +433,7 @@ func TestCursorUsageOnlyFromResult(t *testing.T) {
 		}),
 	}
 
-	b.handleCursorAssistant(evt, ch, &output)
+	b.handleCursorAssistant(context.Background(), evt, ch, &output)
 
 	if output.String() != "hello" {
 		t.Fatalf("expected 'hello', got %q", output.String())

--- a/server/pkg/agent/deveco.go
+++ b/server/pkg/agent/deveco.go
@@ -7,7 +7,7 @@ package agent
 // decoupled from the OpenCode backend: it owns its own backend struct, event
 // types, blocked-args table, and process lifecycle, so a change to either agent
 // can never affect the other. The two share only the package-wide generic
-// process helpers (configureProcessGroup, filterCustomArgs, trySend, …) that
+// process helpers (configureProcessGroup, filterCustomArgs, sendMessage, …) that
 // every backend in this package reuses.
 //
 // DevEco speaks the same `run --format json` protocol and emits the same NDJSON
@@ -194,7 +194,7 @@ func (b *devecoBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processEvents(stdout, msgCh)
+		scanResult := b.processEvents(runCtx, stdout, msgCh)
 
 		exitErr := cmd.Wait()
 		close(procDone)
@@ -302,7 +302,7 @@ type devecoEventResult struct {
 
 // processEvents reads JSON lines from r, dispatches events to ch, and returns
 // the accumulated result. This is the core scanner loop, extracted for testability.
-func (b *devecoBackend) processEvents(r io.Reader, ch chan<- Message) devecoEventResult {
+func (b *devecoBackend) processEvents(ctx context.Context, r io.Reader, ch chan<- Message) devecoEventResult {
 	var output strings.Builder
 	var sessionID string
 	var usage TokenUsage
@@ -328,13 +328,13 @@ func (b *devecoBackend) processEvents(r io.Reader, ch chan<- Message) devecoEven
 
 		switch event.Type {
 		case "text":
-			b.handleTextEvent(event, ch, &output)
+			b.handleTextEvent(ctx, event, ch, &output)
 		case "tool_use":
-			b.handleToolUseEvent(event, ch)
+			b.handleToolUseEvent(ctx, event, ch)
 		case "error":
-			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
+			b.handleErrorEvent(ctx, event, ch, &finalStatus, &finalError)
 		case "step_start":
-			trySend(ch, Message{Type: MessageStatus, Status: "running"})
+			sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
 			// Accumulate token usage from step_finish events.
 			if t := event.Part.Tokens; t != nil {
@@ -365,24 +365,24 @@ func (b *devecoBackend) processEvents(r io.Reader, ch chan<- Message) devecoEven
 	}
 }
 
-func (b *devecoBackend) handleTextEvent(event devecoEvent, ch chan<- Message, output *strings.Builder) {
+func (b *devecoBackend) handleTextEvent(ctx context.Context, event devecoEvent, ch chan<- Message, output *strings.Builder) {
 	text := event.Part.Text
 	if text != "" {
 		output.WriteString(text)
-		trySend(ch, Message{Type: MessageText, Content: text})
+		sendMessage(ctx, ch, Message{Type: MessageText, Content: text})
 	}
 }
 
 // handleToolUseEvent processes "tool_use" events. A single tool_use event
 // contains both the call and result in part.state when the tool reaches a
 // terminal state (state.status is "completed" or "error").
-func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message) {
+func (b *devecoBackend) handleToolUseEvent(ctx context.Context, event devecoEvent, ch chan<- Message) {
 	var input map[string]any
 	if event.Part.State != nil && event.Part.State.Input != nil {
 		_ = json.Unmarshal(event.Part.State.Input, &input)
 	}
 
-	trySend(ch, Message{
+	sendMessage(ctx, ch, Message{
 		Type:   MessageToolUse,
 		Tool:   event.Part.Tool,
 		CallID: event.Part.CallID,
@@ -398,7 +398,7 @@ func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message)
 		if state.Status == "error" && state.Error != "" {
 			outputStr = state.Error
 		}
-		trySend(ch, Message{
+		sendMessage(ctx, ch, Message{
 			Type:   MessageToolResult,
 			Tool:   event.Part.Tool,
 			CallID: event.Part.CallID,
@@ -409,7 +409,7 @@ func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message)
 
 // handleErrorEvent processes "error" events. DevEco can exit with RC=0 even on
 // errors (e.g. invalid model), so error events are the reliable failure signal.
-func (b *devecoBackend) handleErrorEvent(event devecoEvent, ch chan<- Message, finalStatus, finalError *string) {
+func (b *devecoBackend) handleErrorEvent(ctx context.Context, event devecoEvent, ch chan<- Message, finalStatus, finalError *string) {
 	errMsg := ""
 	if event.Error != nil {
 		errMsg = event.Error.Message()
@@ -419,7 +419,7 @@ func (b *devecoBackend) handleErrorEvent(event devecoEvent, ch chan<- Message, f
 	}
 
 	b.cfg.Logger.Warn("deveco error event", "error", errMsg)
-	trySend(ch, Message{Type: MessageError, Content: errMsg})
+	sendMessage(ctx, ch, Message{Type: MessageError, Content: errMsg})
 
 	*finalStatus = "failed"
 	*finalError = errMsg

--- a/server/pkg/agent/deveco_test.go
+++ b/server/pkg/agent/deveco_test.go
@@ -182,7 +182,7 @@ func TestDevecoProcessEventsHappyPath(t *testing.T) {
 		`{"type":"step_finish","timestamp":1003,"sessionID":"ses_happy","part":{"type":"step-finish","tokens":{"total":10,"input":7,"output":3,"cache":{"read":0,"write":0}}}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -220,7 +220,7 @@ func TestDevecoProcessEventsToolErrorEmitsResult(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_toolerr","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
 	}
@@ -260,7 +260,7 @@ func TestDevecoProcessEventsErrorCausesFailedStatus(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_err","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -280,7 +280,7 @@ func TestDevecoHandleErrorEventNilError(t *testing.T) {
 	status := "completed"
 	errMsg := ""
 
-	b.handleErrorEvent(devecoEvent{Type: "error"}, ch, &status, &errMsg)
+	b.handleErrorEvent(context.Background(), devecoEvent{Type: "error"}, ch, &status, &errMsg)
 
 	if errMsg != "unknown deveco error" {
 		t.Errorf("error: got %q, want %q", errMsg, "unknown deveco error")

--- a/server/pkg/agent/dim.go
+++ b/server/pkg/agent/dim.go
@@ -140,22 +140,24 @@ func dimVersionSupported(version string) bool {
 // dimMessageStream serializes sends and the final close so a late stdout
 // reader cannot send on a closed channel. Mirrors grok/traecli/qoder.
 type dimMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newDimMessageStream(size int) *dimMessageStream {
-	return &dimMessageStream{ch: make(chan Message, size)}
+func newDimMessageStream(ctx context.Context, size int) *dimMessageStream {
+	return &dimMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *dimMessageStream) send(msg Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, msg)
+	sendMessage(s.ctx, s.ch, msg)
 }
 
 func (s *dimMessageStream) close() {
@@ -239,7 +241,7 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 
 	b.cfg.Logger.Info("dim acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
 
-	msgStream := newDimMessageStream(256)
+	msgStream := newDimMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 
 	// Dim streams interim narration and the final answer as the same
@@ -294,7 +296,6 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 	}()
 
 	go func() {
-		defer cancel()
 		defer msgStream.close()
 		defer close(resCh)
 		// Cleanup ordering matters: cancel the run context first so
@@ -325,6 +326,7 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 			// so the OS can finalize any processes that were attached to it.
 			releaseProcessGroup(cmd)
 		}()
+		defer cancel()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -636,9 +638,8 @@ func (b *dimBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 		// Dim's ACP server may keep the process — and the stdout/stderr
 		// pipes — open briefly after session/prompt returns. Bound the drain.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), dimReaderDrainGrace)
-		select {
-		case <-readerDone:
-		case <-drainCtx.Done():
+		if !messageReaderClosedBefore(drainCtx, readerDone) {
+			markMessageDeliveryAbandoned(runCtx)
 		}
 		select {
 		case <-stderrDone:

--- a/server/pkg/agent/dsh.go
+++ b/server/pkg/agent/dsh.go
@@ -315,7 +315,7 @@ func (b *dshBackend) Execute(ctx context.Context, prompt string, opts ExecOption
 				continue
 			}
 			state.frameCount++
-			handleDshFrame(frame, requestID, msgCh, &state)
+			handleDshFrame(runCtx, frame, requestID, msgCh, &state)
 		}
 		scanErr := scanner.Err()
 		if scanErr != nil {
@@ -370,7 +370,7 @@ type dshRunState struct {
 	result        *Result
 }
 
-func handleDshFrame(frame dshFrame, requestID string, ch chan<- Message, state *dshRunState) {
+func handleDshFrame(ctx context.Context, frame dshFrame, requestID string, ch chan<- Message, state *dshRunState) {
 	if frame.Version != dshProtocolVersion {
 		state.protocolError = fmt.Sprintf("dsh returned unsupported protocol version %d", frame.Version)
 		return
@@ -383,23 +383,23 @@ func handleDshFrame(frame dshFrame, requestID string, ch chan<- Message, state *
 		state.ready = frame.Runtime == "dsh"
 	case "session":
 		state.sessionID = frame.SessionID
-		trySend(ch, Message{Type: MessageStatus, Status: "running", SessionID: frame.SessionID})
+		sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running", SessionID: frame.SessionID})
 	case "text":
 		if frame.Content != "" {
-			trySend(ch, Message{Type: MessageText, Content: frame.Content})
+			sendMessage(ctx, ch, Message{Type: MessageText, Content: frame.Content})
 		}
 	case "thinking":
 		if frame.Content != "" {
-			trySend(ch, Message{Type: MessageThinking, Content: frame.Content})
+			sendMessage(ctx, ch, Message{Type: MessageThinking, Content: frame.Content})
 		}
 	case "tool_call":
 		input := map[string]any{}
 		if frame.Arguments != "" && json.Unmarshal([]byte(frame.Arguments), &input) != nil {
 			input = map[string]any{"raw": frame.Arguments}
 		}
-		trySend(ch, Message{Type: MessageToolUse, Tool: frame.Name, CallID: frame.CallID, Input: input})
+		sendMessage(ctx, ch, Message{Type: MessageToolUse, Tool: frame.Name, CallID: frame.CallID, Input: input})
 	case "tool_result":
-		trySend(ch, Message{Type: MessageToolResult, Tool: frame.Name, CallID: frame.CallID, Output: frame.Output})
+		sendMessage(ctx, ch, Message{Type: MessageToolResult, Tool: frame.Name, CallID: frame.CallID, Output: frame.Output})
 	case "usage":
 		key := frame.Model
 		if frame.Provider != "" {

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -79,22 +79,24 @@ var (
 // grokMessageStream serializes sends and the final close so a late stdout
 // reader cannot send on a closed channel. Mirrors traecli/qoder.
 type grokMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newGrokMessageStream(size int) *grokMessageStream {
-	return &grokMessageStream{ch: make(chan Message, size)}
+func newGrokMessageStream(ctx context.Context, size int) *grokMessageStream {
+	return &grokMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *grokMessageStream) send(msg Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, msg)
+	sendMessage(s.ctx, s.ch, msg)
 }
 
 func (s *grokMessageStream) close() {
@@ -189,7 +191,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 
 	b.cfg.Logger.Info("grok acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
 
-	msgStream := newGrokMessageStream(256)
+	msgStream := newGrokMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 
 	// Grok streams interim narration and the final answer as the same
@@ -253,7 +255,6 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	}()
 
 	go func() {
-		defer cancel()
 		defer msgStream.close()
 		defer close(resCh)
 		defer func() {
@@ -261,6 +262,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			_ = cmd.Wait()
 			releaseProcessGroup(cmd)
 		}()
+		defer cancel()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -470,9 +472,8 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// Grok ACP may keep the process — and the stdout/stderr pipes — open
 		// briefly after session/prompt returns. Bound the drain.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), grokReaderDrainGrace)
-		select {
-		case <-readerDone:
-		case <-drainCtx.Done():
+		if !messageReaderClosedBefore(drainCtx, readerDone) {
+			markMessageDeliveryAbandoned(runCtx)
 		}
 		select {
 		case <-stderrDone:

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -397,7 +397,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			}
 			turnActivity.Add(1)
 			deliverable.observe(msg)
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
 			if !streamingCurrentTurn.Load() {
@@ -554,7 +554,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("hermes session created", "session_id", sessionID)
 		// Mid-flight pin: daemon PinTaskSession keys off MessageStatus+SessionID.
-		trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+		sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 
 		// 3. If the caller picked a model (via agent.model from the
 		// UI dropdown), ask hermes to switch the session to it

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -169,7 +169,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
 			deliverable.observe(msg)
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
 			if !streamingCurrentTurn.Load() {

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -188,7 +188,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				}
 			}
 			deliverable.observe(msg)
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
 			if !streamingCurrentTurn.Load() {

--- a/server/pkg/agent/mcode.go
+++ b/server/pkg/agent/mcode.go
@@ -47,22 +47,24 @@ var mcodeSessionStartupReadyDelay = 100 * time.Millisecond
 var errMcodeProcessExited = errors.New("mcode process exited")
 
 type mcodeMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newMcodeMessageStream(size int) *mcodeMessageStream {
-	return &mcodeMessageStream{ch: make(chan Message, size)}
+func newMcodeMessageStream(ctx context.Context, size int) *mcodeMessageStream {
+	return &mcodeMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *mcodeMessageStream) send(message Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, message)
+	sendMessage(s.ctx, s.ch, message)
 }
 
 func (s *mcodeMessageStream) close() {
@@ -137,7 +139,7 @@ func (b *mcodeBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}()
 
 	b.cfg.Logger.Info("mcode acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
-	msgStream := newMcodeMessageStream(256)
+	msgStream := newMcodeMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 	var deliverable acpDeliverableTracker
 	var streamingCurrentTurn atomic.Bool

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -132,7 +132,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processOutput(stdout, msgCh)
+		scanResult := b.processOutput(runCtx, stdout, msgCh)
 
 		// openclaw delivered a complete result but would not exit. Cancel the
 		// run context so CommandContext kills it and cmd.Wait can return —
@@ -411,7 +411,7 @@ type openclawEventResult struct {
 // fails do we fall through to the line-by-line NDJSON scanner. This makes
 // the dominant happy path (one pretty-printed JSON blob) deterministic
 // while keeping NDJSON event support intact.
-func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclawEventResult {
+func (b *openclawBackend) processOutput(ctx context.Context, r io.Reader, ch chan<- Message) openclawEventResult {
 	buf, cutShort, readErr := readOpenclawStdout(r, openclawResultIdleGrace)
 	if readErr != nil {
 		return openclawEventResult{status: "failed", errMsg: fmt.Sprintf("read stdout: %v", readErr)}
@@ -423,7 +423,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 	// matches, we're done — no need to involve the line scanner at all.
 	if result, ok := parseWholeBufferOpenclawResult(buf); ok {
 		var output strings.Builder
-		res := b.buildOpenclawEventResult(result, ch, &output)
+		res := b.buildOpenclawEventResult(ctx, result, ch, &output)
 		res.cutShort = cutShort
 		return res
 	}
@@ -463,21 +463,21 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 			case "text":
 				if event.Text != "" {
 					output.WriteString(event.Text)
-					trySend(ch, Message{Type: MessageText, Content: event.Text})
+					sendMessage(ctx, ch, Message{Type: MessageText, Content: event.Text})
 				}
 			case "tool_use":
 				var input map[string]any
 				if event.Input != nil {
 					_ = json.Unmarshal(event.Input, &input)
 				}
-				trySend(ch, Message{
+				sendMessage(ctx, ch, Message{
 					Type:   MessageToolUse,
 					Tool:   event.Tool,
 					CallID: event.CallID,
 					Input:  input,
 				})
 			case "tool_result":
-				trySend(ch, Message{
+				sendMessage(ctx, ch, Message{
 					Type:   MessageToolResult,
 					Tool:   event.Tool,
 					CallID: event.CallID,
@@ -486,7 +486,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 			case "error":
 				errMsg := event.errorMessage()
 				b.cfg.Logger.Warn("openclaw error event", "error", errMsg)
-				trySend(ch, Message{Type: MessageError, Content: errMsg})
+				sendMessage(ctx, ch, Message{Type: MessageError, Content: errMsg})
 				finalStatus = "failed"
 				finalError = errMsg
 			case "lifecycle":
@@ -494,12 +494,12 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 				if phase == "error" || phase == "failed" || phase == "cancelled" {
 					errMsg := event.errorMessage()
 					b.cfg.Logger.Warn("openclaw lifecycle failure", "phase", phase, "error", errMsg)
-					trySend(ch, Message{Type: MessageError, Content: errMsg})
+					sendMessage(ctx, ch, Message{Type: MessageError, Content: errMsg})
 					finalStatus = "failed"
 					finalError = errMsg
 				}
 			case "step_start":
-				trySend(ch, Message{Type: MessageStatus, Status: "running"})
+				sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running"})
 			case "step_finish":
 				if event.Usage != nil {
 					u := parseOpenclawUsage(event.Usage)
@@ -515,7 +515,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 		// Try parsing as a final result blob (legacy format).
 		if result, ok := tryParseOpenclawResult(line); ok {
 			gotEvents = true
-			res := b.buildOpenclawEventResult(result, ch, &output)
+			res := b.buildOpenclawEventResult(ctx, result, ch, &output)
 			if res.sessionID != "" {
 				sessionID = res.sessionID
 			}
@@ -633,11 +633,11 @@ func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 
 // buildOpenclawEventResult extracts text and metadata from a final result blob.
 // Text payloads are appended to the shared output builder and emitted to ch.
-func (b *openclawBackend) buildOpenclawEventResult(result openclawResult, ch chan<- Message, output *strings.Builder) openclawEventResult {
+func (b *openclawBackend) buildOpenclawEventResult(ctx context.Context, result openclawResult, ch chan<- Message, output *strings.Builder) openclawEventResult {
 	for _, p := range result.Payloads {
 		if p.Text != "" {
 			output.WriteString(p.Text)
-			trySend(ch, Message{Type: MessageText, Content: p.Text})
+			sendMessage(ctx, ch, Message{Type: MessageText, Content: p.Text})
 		}
 	}
 

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -48,7 +48,7 @@ func TestOpenclawProcessOutputHappyPath(t *testing.T) {
 	}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -93,7 +93,7 @@ func TestOpenclawProcessOutputMultiplePayloads(t *testing.T) {
 	}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.output != "FirstSecond" {
 		t.Errorf("output: got %q, want %q", res.output, "FirstSecond")
@@ -124,7 +124,7 @@ func TestOpenclawProcessOutputEmptyPayloads(t *testing.T) {
 	result := openclawResult{Payloads: []openclawPayload{}}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -155,7 +155,7 @@ func TestOpenclawProcessOutputWithLeadingLogLines(t *testing.T) {
 	data, _ := json.Marshal(result)
 	input := "some log line\nanother log\n" + string(data)
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -179,7 +179,7 @@ func TestOpenclawProcessOutputIgnoresTrailingLogLinesAfterJSON(t *testing.T) {
 	data, _ := json.Marshal(result)
 	input := string(data) + "\npost-result log line that should not block parsing"
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -197,7 +197,7 @@ func TestOpenclawProcessOutputNoJSON(t *testing.T) {
 	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	res := b.processOutput(strings.NewReader("not json at all"), ch)
+	res := b.processOutput(context.Background(), strings.NewReader("not json at all"), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -215,7 +215,7 @@ func TestOpenclawProcessOutputEmptyInput(t *testing.T) {
 	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	res := b.processOutput(strings.NewReader(""), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(""), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -233,7 +233,7 @@ func TestOpenclawProcessOutputReadError(t *testing.T) {
 	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	res := b.processOutput(&ioErrReader{data: ""}, ch)
+	res := b.processOutput(context.Background(), &ioErrReader{data: ""}, ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -260,7 +260,7 @@ func TestOpenclawProcessOutputWithBracesInLogLines(t *testing.T) {
 	// with '{' are considered. The result blob on its own line is still parsed.
 	input := `[tools] exec failed: complex interpreter invocation detected. raw_params={"command":"echo hello"}` + "\n" + string(data)
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -287,7 +287,7 @@ func TestOpenclawResultBlobWithLeadingPrefixRejected(t *testing.T) {
 	data, _ := json.Marshal(result)
 	input := "some prefix " + string(data)
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	// Should fall back to raw output since the JSON has a prefix.
 	if res.status != "completed" {
@@ -314,7 +314,7 @@ func TestOpenclawStreamingTextEvents(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -352,7 +352,7 @@ func TestOpenclawStreamingToolUseEvents(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -410,7 +410,7 @@ func TestOpenclawStreamingErrorEvent(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -445,7 +445,7 @@ func TestOpenclawStreamingStepFinishUsage(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.usage.InputTokens != 200 {
 		t.Errorf("input tokens: got %d, want 200", res.usage.InputTokens)
@@ -474,7 +474,7 @@ func TestOpenclawStreamingSessionID(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.sessionID != "ses_stream_123" {
 		t.Errorf("sessionID: got %q, want %q", res.sessionID, "ses_stream_123")
@@ -497,7 +497,7 @@ func TestOpenclawStreamingMixedWithLogLines(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -530,7 +530,7 @@ func TestOpenclawLifecycleErrorPhase(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -563,7 +563,7 @@ func TestOpenclawLifecycleFailedPhase(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -586,7 +586,7 @@ func TestOpenclawLifecycleCancelledPhase(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -611,7 +611,7 @@ func TestOpenclawLifecycleRunningPhaseIgnored(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -633,7 +633,7 @@ func TestOpenclawStructuredErrorObject(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -656,7 +656,7 @@ func TestOpenclawStructuredErrorNameOnly(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.errMsg != "AuthenticationError" {
 		t.Errorf("errMsg: got %q, want %q", res.errMsg, "AuthenticationError")
@@ -676,7 +676,7 @@ func TestOpenclawStructuredErrorMessageField(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.errMsg != "rate limit exceeded" {
 		t.Errorf("errMsg: got %q, want %q", res.errMsg, "rate limit exceeded")
@@ -773,7 +773,7 @@ func TestOpenclawUsageAccumulationAcrossSteps(t *testing.T) {
 	}
 	input := strings.Join(lines, "\n")
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.usage.InputTokens != 300 {
 		t.Errorf("InputTokens: got %d, want 300", res.usage.InputTokens)
@@ -809,7 +809,7 @@ func TestOpenclawUsageFinalResultAlternativeFields(t *testing.T) {
 	}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.usage.InputTokens != 400 {
 		t.Errorf("InputTokens: got %d, want 400", res.usage.InputTokens)
@@ -846,7 +846,7 @@ func TestOpenclawProcessOutputMultilineJSON(t *testing.T) {
 	// Marshal with indentation to simulate openclaw's pretty-printed output.
 	data, _ := json.MarshalIndent(result, "", "  ")
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -881,7 +881,7 @@ func TestOpenclawProcessOutputMultilineJSONWithLeadingLogs(t *testing.T) {
 	data, _ := json.MarshalIndent(result, "", "  ")
 	input := "some startup log\nanother log line\n" + string(data)
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -1170,7 +1170,7 @@ func TestOpenclawProcessOutputExtractsModelFromAgentMeta(t *testing.T) {
 	}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.model != "deepseek-chat" {
 		t.Errorf("model: got %q, want %q", res.model, "deepseek-chat")
@@ -1208,7 +1208,7 @@ func TestOpenclawProcessOutputModelEmptyWhenAgentMetaOmitsIt(t *testing.T) {
 	}
 	data, _ := json.Marshal(result)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.model != "" {
 		t.Errorf("model: got %q, want empty", res.model)
@@ -1257,7 +1257,7 @@ func TestOpenclawProcessOutputWholeBufferPrettyJSON(t *testing.T) {
 }
 `
 
-	res := b.processOutput(strings.NewReader(input), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(input), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")
@@ -1339,7 +1339,7 @@ func TestOpenclawProcessOutputEmptyBufferCanonicalError(t *testing.T) {
 	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	res := b.processOutput(strings.NewReader(""), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(""), ch)
 
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
@@ -1384,7 +1384,7 @@ func TestOpenclawProcessOutputStdoutFixture(t *testing.T) {
 	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	res := b.processOutput(strings.NewReader(string(data)), ch)
+	res := b.processOutput(context.Background(), strings.NewReader(string(data)), ch)
 
 	if res.status != "completed" {
 		t.Errorf("status: got %q, want %q", res.status, "completed")

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -245,7 +245,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processEvents(stdout, msgCh)
+		scanResult := b.processEvents(runCtx, stdout, msgCh)
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
@@ -341,7 +341,7 @@ type eventResult struct {
 
 // processEvents reads JSON lines from r, dispatches events to ch, and returns
 // the accumulated result. This is the core scanner loop, extracted for testability.
-func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventResult {
+func (b *opencodeBackend) processEvents(ctx context.Context, r io.Reader, ch chan<- Message) eventResult {
 	var output strings.Builder
 	var sessionID string
 	var usage TokenUsage
@@ -405,24 +405,24 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 
 		switch event.Type {
 		case "text":
-			b.handleTextEvent(event, ch, &output)
+			b.handleTextEvent(ctx, event, ch, &output)
 			if event.Part.Text != "" {
 				stepProducedOutput = true
 			}
 		case "tool_use":
-			b.handleToolUseEvent(event, ch)
+			b.handleToolUseEvent(ctx, event, ch)
 			stepProducedOutput = true
 			if event.Part.Metadata == nil || !event.Part.Metadata.ProviderExecuted {
 				stepHasContinuationTool = true
 			}
 		case "error":
-			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
+			b.handleErrorEvent(ctx, event, ch, &finalStatus, &finalError)
 		case "step_start":
 			openStep = true
 			stepHasContinuationTool = false
 			awaitingContinuation = false
 			stepProducedOutput = false
-			trySend(ch, Message{Type: MessageStatus, Status: "running"})
+			sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
 			openStep = false
 			sawStepFinish = true
@@ -521,18 +521,18 @@ func stepReportedUsage(part *opencodeEventPart) bool {
 	return t.Cache != nil && (t.Cache.Read > 0 || t.Cache.Write > 0)
 }
 
-func (b *opencodeBackend) handleTextEvent(event opencodeEvent, ch chan<- Message, output *strings.Builder) {
+func (b *opencodeBackend) handleTextEvent(ctx context.Context, event opencodeEvent, ch chan<- Message, output *strings.Builder) {
 	text := event.Part.Text
 	if text != "" {
 		output.WriteString(text)
-		trySend(ch, Message{Type: MessageText, Content: text})
+		sendMessage(ctx, ch, Message{Type: MessageText, Content: text})
 	}
 }
 
 // handleToolUseEvent processes "tool_use" events from opencode. A single
 // tool_use event contains both the call and result in part.state when the
 // tool reaches a terminal state (state.status is "completed" or "error").
-func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Message) {
+func (b *opencodeBackend) handleToolUseEvent(ctx context.Context, event opencodeEvent, ch chan<- Message) {
 	// Extract input from state.input (the tool invocation parameters).
 	var input map[string]any
 	if event.Part.State != nil && event.Part.State.Input != nil {
@@ -540,7 +540,7 @@ func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Mess
 	}
 
 	// Emit the tool-use message.
-	trySend(ch, Message{
+	sendMessage(ctx, ch, Message{
 		Type:   MessageToolUse,
 		Tool:   event.Part.Tool,
 		CallID: event.Part.CallID,
@@ -556,7 +556,7 @@ func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Mess
 		if state.Status == "error" && state.Error != "" {
 			outputStr = state.Error
 		}
-		trySend(ch, Message{
+		sendMessage(ctx, ch, Message{
 			Type:   MessageToolResult,
 			Tool:   event.Part.Tool,
 			CallID: event.Part.CallID,
@@ -568,7 +568,7 @@ func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Mess
 // handleErrorEvent processes "error" events from opencode. OpenCode can exit
 // with RC=0 even on errors (e.g. invalid model), so error events are the
 // reliable signal for failures.
-func (b *opencodeBackend) handleErrorEvent(event opencodeEvent, ch chan<- Message, finalStatus, finalError *string) {
+func (b *opencodeBackend) handleErrorEvent(ctx context.Context, event opencodeEvent, ch chan<- Message, finalStatus, finalError *string) {
 	errMsg := ""
 	if event.Error != nil {
 		errMsg = event.Error.Message()
@@ -578,7 +578,7 @@ func (b *opencodeBackend) handleErrorEvent(event opencodeEvent, ch chan<- Messag
 	}
 
 	b.cfg.Logger.Warn("opencode error event", "error", errMsg)
-	trySend(ch, Message{Type: MessageError, Content: errMsg})
+	sendMessage(ctx, ch, Message{Type: MessageError, Content: errMsg})
 
 	*finalStatus = "failed"
 	*finalError = errMsg

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -42,7 +42,7 @@ func TestOpencodeHandleTextEvent(t *testing.T) {
 		},
 	}
 
-	b.handleTextEvent(event, ch, &output)
+	b.handleTextEvent(context.Background(), event, ch, &output)
 
 	if output.String() != "Hello from opencode" {
 		t.Errorf("output: got %q, want %q", output.String(), "Hello from opencode")
@@ -68,7 +68,7 @@ func TestOpencodeHandleTextEventEmpty(t *testing.T) {
 		Part: opencodeEventPart{Type: "text", Text: ""},
 	}
 
-	b.handleTextEvent(event, ch, &output)
+	b.handleTextEvent(context.Background(), event, ch, &output)
 
 	if output.String() != "" {
 		t.Errorf("expected empty output, got %q", output.String())
@@ -101,7 +101,7 @@ func TestOpencodeHandleToolUseEventCompleted(t *testing.T) {
 		},
 	}
 
-	b.handleToolUseEvent(event, ch)
+	b.handleToolUseEvent(context.Background(), event, ch)
 
 	// Should emit both a tool-use and a tool-result message.
 	if len(ch) != 2 {
@@ -155,7 +155,7 @@ func TestOpencodeHandleToolUseEventPending(t *testing.T) {
 		},
 	}
 
-	b.handleToolUseEvent(event, ch)
+	b.handleToolUseEvent(context.Background(), event, ch)
 
 	if len(ch) != 1 {
 		t.Fatalf("expected 1 message for pending tool, got %d", len(ch))
@@ -189,7 +189,7 @@ func TestOpencodeHandleToolUseEventStructuredOutput(t *testing.T) {
 		},
 	}
 
-	b.handleToolUseEvent(event, ch)
+	b.handleToolUseEvent(context.Background(), event, ch)
 
 	// tool-use + tool-result
 	if len(ch) != 2 {
@@ -220,7 +220,7 @@ func TestOpencodeHandleToolUseEventNilState(t *testing.T) {
 		},
 	}
 
-	b.handleToolUseEvent(event, ch)
+	b.handleToolUseEvent(context.Background(), event, ch)
 
 	if len(ch) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(ch))
@@ -252,7 +252,7 @@ func TestOpencodeHandleErrorEvent(t *testing.T) {
 		},
 	}
 
-	b.handleErrorEvent(event, ch, &status, &errMsg)
+	b.handleErrorEvent(context.Background(), event, ch, &status, &errMsg)
 
 	if status != "failed" {
 		t.Errorf("status: got %q, want %q", status, "failed")
@@ -285,7 +285,7 @@ func TestOpencodeHandleErrorEventNameOnly(t *testing.T) {
 		},
 	}
 
-	b.handleErrorEvent(event, ch, &status, &errMsg)
+	b.handleErrorEvent(context.Background(), event, ch, &status, &errMsg)
 
 	if errMsg != "RateLimitError" {
 		t.Errorf("error: got %q, want %q", errMsg, "RateLimitError")
@@ -302,7 +302,7 @@ func TestOpencodeHandleErrorEventNilError(t *testing.T) {
 
 	event := opencodeEvent{Type: "error"}
 
-	b.handleErrorEvent(event, ch, &status, &errMsg)
+	b.handleErrorEvent(context.Background(), event, ch, &status, &errMsg)
 
 	if errMsg != "unknown opencode error" {
 		t.Errorf("error: got %q, want %q", errMsg, "unknown opencode error")
@@ -509,7 +509,7 @@ func TestOpencodeProcessEventsHappyPath(t *testing.T) {
 		`{"type":"step_finish","timestamp":1004,"sessionID":"ses_happy","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	// Verify result.
 	if result.status != "completed" {
@@ -568,7 +568,7 @@ func TestOpencodeProcessEventsErrorCausesFailedStatus(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_err","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -604,7 +604,7 @@ func TestOpencodeProcessEventsSessionIDExtracted(t *testing.T) {
 		`{"type":"text","timestamp":1001,"sessionID":"ses_updated","part":{"type":"text","text":"hi"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.sessionID != "ses_updated" {
 		t.Errorf("sessionID: got %q, want %q (should use last seen)", result.sessionID, "ses_updated")
@@ -621,7 +621,7 @@ func TestOpencodeProcessEventsScannerError(t *testing.T) {
 
 	// Use an ioErrReader that returns valid data then an I/O error, which
 	// triggers scanner.Err() and should set status to "failed".
-	result := b.processEvents(&ioErrReader{
+	result := b.processEvents(context.Background(), &ioErrReader{
 		data: `{"type":"text","sessionID":"ses_scan","part":{"text":"before error"}}` + "\n",
 	}, ch)
 
@@ -669,7 +669,7 @@ func TestOpencodeProcessEventsEmptyLines(t *testing.T) {
 		"",
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -703,7 +703,7 @@ func TestOpencodeProcessEventsErrorDoesNotRevertToCompleted(t *testing.T) {
 		`{"type":"text","sessionID":"ses_x","part":{"text":"recovered?"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q (error should stick)", result.status, "failed")
@@ -730,7 +730,7 @@ func TestOpencodeProcessEventsStreamEndsMidStep(t *testing.T) {
 		`{"type":"text","timestamp":1001,"sessionID":"ses_midstep","part":{"type":"text","text":"Let me plan the work..."}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -761,7 +761,7 @@ func TestOpencodeProcessEventsStreamEndsAfterToolBeforeStepFinish(t *testing.T) 
 		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_tool","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"go test ./..."},"output":"ok\n"}}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -793,7 +793,7 @@ func TestOpencodeProcessEventsMultiStepHappyPath(t *testing.T) {
 		`{"type":"step_finish","timestamp":1006,"sessionID":"ses_multi","part":{"type":"step-finish","reason":"stop"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -824,7 +824,7 @@ func TestOpencodeProcessEventsStreamEndsAfterToolCallsStepFinish(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_toolcalls","part":{"type":"step-finish","reason":"tool-calls"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -855,7 +855,7 @@ func TestOpencodeProcessEventsStreamEndsAfterToolWithStopFinish(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_stop_tool","part":{"type":"step-finish","reason":"stop"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q", result.status, "failed")
@@ -887,7 +887,7 @@ func TestOpencodeProcessEventsToolWithStopFinishThenContinuation(t *testing.T) {
 		`{"type":"step_finish","timestamp":1005,"sessionID":"ses_stop_continue","part":{"type":"step-finish","reason":"stop"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -913,7 +913,7 @@ func TestOpencodeProcessEventsProviderExecutedToolWithStopFinish(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_provider_tool","part":{"type":"step-finish","reason":"stop"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -941,7 +941,7 @@ func TestOpencodeProcessEventsStepFinishWithoutReasonBackcompat(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_noreason","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q", result.status, "completed")
@@ -972,7 +972,7 @@ func TestOpencodeProcessEventsToolErrorThenCleanFinish(t *testing.T) {
 		`{"type":"step_finish","timestamp":1003,"sessionID":"ses_toolerr","part":{"type":"step-finish"}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q (recovered tool error must not fail a healthy run)", result.status, "completed")
@@ -1034,7 +1034,7 @@ func TestOpencodeProcessEventsEmptyFinalStepFails(t *testing.T) {
 		`{"type":"step_finish","timestamp":1006,"sessionID":"ses_void","part":{"type":"step-finish","reason":"unknown","tokens":{"input":0,"output":0,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "failed" {
 		t.Errorf("status: got %q, want %q (an empty final step must not complete the run)", result.status, "failed")
@@ -1080,7 +1080,7 @@ func TestOpencodeProcessEventsEmptyStepMidRunRecovers(t *testing.T) {
 		`{"type":"step_finish","timestamp":1004,"sessionID":"ses_recover","part":{"type":"step-finish","reason":"stop","tokens":{"input":120,"output":8,"cache":{"write":0,"read":0}}}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q (a recovered void step must not fail the run)", result.status, "completed")
@@ -1108,7 +1108,7 @@ func TestOpencodeProcessEventsToolOnlyFinalStepStaysCompleted(t *testing.T) {
 		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_toolonly","part":{"type":"step-finish","reason":"stop","tokens":{"input":0,"output":0,"cache":{"write":0,"read":0}}}}`,
 	}, "\n")
 
-	result := b.processEvents(strings.NewReader(lines), ch)
+	result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 	if result.status != "completed" {
 		t.Errorf("status: got %q, want %q (a tool call is a productive step)", result.status, "completed")
@@ -1171,7 +1171,7 @@ func TestOpencodeProcessEventsUsageOnlyFinalStepStaysCompleted(t *testing.T) {
 				tc.final,
 			}, "\n")
 
-			result := b.processEvents(strings.NewReader(lines), ch)
+			result := b.processEvents(context.Background(), strings.NewReader(lines), ch)
 
 			if result.status != "completed" {
 				t.Errorf("status: got %q, want %q (reported usage proves the provider round-trip happened)", result.status, "completed")

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -331,7 +331,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 			switch evt.Type {
 			case "agent_start":
-				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+				sendMessage(runCtx, msgCh, Message{Type: MessageStatus, Status: "running"})
 
 			case "turn_start":
 				output.Reset()
@@ -346,11 +346,11 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				case "text_delta":
 					if d := drainPiTextBuffer(&textBuffer, evt.AssistantMessageEvent.Delta); d != "" {
 						output.WriteString(d)
-						trySend(msgCh, Message{Type: MessageText, Content: d})
+						sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: d})
 					}
 				case "thinking_delta":
 					if d := evt.AssistantMessageEvent.Delta; d != "" {
-						trySend(msgCh, Message{Type: MessageThinking, Content: d})
+						sendMessage(runCtx, msgCh, Message{Type: MessageThinking, Content: d})
 					}
 				}
 
@@ -359,7 +359,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				if len(evt.Args) > 0 {
 					_ = json.Unmarshal(evt.Args, &params)
 				}
-				trySend(msgCh, Message{
+				sendMessage(runCtx, msgCh, Message{
 					Type:   MessageToolUse,
 					Tool:   evt.ToolName,
 					CallID: evt.ToolCallID,
@@ -367,7 +367,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				})
 
 			case "tool_execution_end":
-				trySend(msgCh, Message{
+				sendMessage(runCtx, msgCh, Message{
 					Type:   MessageToolResult,
 					CallID: evt.ToolCallID,
 					Output: decodePiResult(evt.Result),
@@ -406,7 +406,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 			case "error":
 				errText := decodePiString(evt.Message)
-				trySend(msgCh, Message{Type: MessageError, Content: errText})
+				sendMessage(runCtx, msgCh, Message{Type: MessageError, Content: errText})
 				if finalStatus == "completed" {
 					finalStatus = "failed"
 					finalError = errText
@@ -425,7 +425,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		}
 		if d := flushPiTextBuffer(&textBuffer); d != "" {
 			output.WriteString(d)
-			trySend(msgCh, Message{Type: MessageText, Content: d})
+			sendMessage(runCtx, msgCh, Message{Type: MessageText, Content: d})
 		}
 
 		waitErr := cmd.Wait()

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -46,22 +46,24 @@ func qoderDefaultBinary(providerType string) string {
 var qoderReaderDrainGrace = 2 * time.Second
 
 type qoderMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newQoderMessageStream(size int) *qoderMessageStream {
-	return &qoderMessageStream{ch: make(chan Message, size)}
+func newQoderMessageStream(ctx context.Context, size int) *qoderMessageStream {
+	return &qoderMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *qoderMessageStream) send(msg Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, msg)
+	sendMessage(s.ctx, s.ch, msg)
 }
 
 func (s *qoderMessageStream) close() {
@@ -145,7 +147,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	b.cfg.Logger.Info("qoder acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
 
-	msgStream := newQoderMessageStream(256)
+	msgStream := newQoderMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 
 	// Qoder emits interim narration and the final answer as the same ACP
@@ -207,7 +209,6 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}()
 
 	go func() {
-		defer cancel()
 		defer msgStream.close()
 		defer close(resCh)
 		defer func() {
@@ -215,6 +216,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			_ = cmd.Wait()
 			releaseProcessGroup(cmd)
 		}()
+		defer cancel()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -399,9 +401,8 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		// makes the provider-error promotion below see a terminal marker before
 		// we decide the final status.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), qoderReaderDrainGrace)
-		select {
-		case <-readerDone:
-		case <-drainCtx.Done():
+		if !messageReaderClosedBefore(drainCtx, readerDone) {
+			markMessageDeliveryAbandoned(runCtx)
 		}
 		select {
 		case <-stderrDone:

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -637,8 +637,9 @@ func TestQoderBackendDoesNotWaitForeverForReaderAfterPromptDone(t *testing.T) {
 	}
 }
 
-func TestQoderMessageStreamDropsSendAfterClose(t *testing.T) {
-	stream := newQoderMessageStream(1)
+func TestQoderMessageStreamSendAfterCloseMarksDeliveryAbandoned(t *testing.T) {
+	ctx, tracker := WithMessageDeliveryTracker(context.Background())
+	stream := newQoderMessageStream(ctx, 1)
 	stream.close()
 
 	defer func() {
@@ -650,6 +651,45 @@ func TestQoderMessageStreamDropsSendAfterClose(t *testing.T) {
 
 	if _, ok := <-stream.ch; ok {
 		t.Fatal("message channel should be closed")
+	}
+	if !tracker.Abandoned() {
+		t.Fatal("late send after stream close was not marked abandoned")
+	}
+}
+
+func TestQoderMessageStreamCancellationUnblocksSendAndClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := newQoderMessageStream(ctx, 1)
+	stream.send(Message{Type: MessageText, Content: "first"})
+
+	sendDone := make(chan struct{})
+	go func() {
+		stream.send(Message{Type: MessageText, Content: "second"})
+		close(sendDone)
+	}()
+	cancel()
+
+	select {
+	case <-sendDone:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled stream send stayed blocked")
+	}
+	closeDone := make(chan struct{})
+	go func() {
+		stream.close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("stream close stayed blocked behind cancelled send")
+	}
+
+	if msg, ok := <-stream.ch; !ok || msg.Content != "first" {
+		t.Fatalf("queued message = %+v, open=%v; want first", msg, ok)
+	}
+	if _, ok := <-stream.ch; ok {
+		t.Fatal("message channel remained open after close")
 	}
 }
 

--- a/server/pkg/agent/qwen.go
+++ b/server/pkg/agent/qwen.go
@@ -190,7 +190,7 @@ func (b *qwenBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			}
 			state.eventCount++
 			state.lastEventType = event.Type
-			handleQwenEvent(event, msgCh, &state)
+			handleQwenEvent(runCtx, event, msgCh, &state)
 		}
 		scanErr := scanner.Err()
 		if scanErr != nil {
@@ -277,7 +277,7 @@ type qwenStreamState struct {
 	unreadableAssistantCount                                            int
 }
 
-func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStreamState) {
+func handleQwenEvent(ctx context.Context, event qwenStreamEvent, ch chan<- Message, state *qwenStreamState) {
 	if event.SessionID != "" {
 		state.sessionID = event.SessionID
 	}
@@ -286,10 +286,10 @@ func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStream
 	}
 	switch event.Type {
 	case "system":
-		trySend(ch, Message{Type: MessageStatus, Status: "running", SessionID: state.sessionID})
+		sendMessage(ctx, ch, Message{Type: MessageStatus, Status: "running", SessionID: state.sessionID})
 	case "assistant":
 		state.assistantEventCount++
-		turn, model := handleQwenAssistant(event.Message, ch, state.usage)
+		turn, model := handleQwenAssistant(ctx, event.Message, ch, state.usage)
 		if model != "" {
 			state.model = model
 		}
@@ -299,7 +299,7 @@ func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStream
 		}
 		state.lastAssistantText = turn.resolveFallback(state.lastAssistantText)
 	case "user":
-		handleQwenUser(event.Message, ch)
+		handleQwenUser(ctx, event.Message, ch)
 	case "result":
 		state.sawResult = true
 		state.resultIsError = event.IsError || event.Subtype == "error" || event.Subtype == "failed"
@@ -321,7 +321,7 @@ func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStream
 	}
 }
 
-func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[string]TokenUsage) (assistantTurn, string) {
+func handleQwenAssistant(ctx context.Context, raw json.RawMessage, ch chan<- Message, usage map[string]TokenUsage) (assistantTurn, string) {
 	var message qwenMessage
 	if json.Unmarshal(raw, &message) != nil {
 		// Unreadable body: understood stays false so the caller drops any
@@ -338,12 +338,12 @@ func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[strin
 		switch block.Type {
 		case "thinking":
 			if block.Thinking != "" {
-				trySend(ch, Message{Type: MessageThinking, Content: block.Thinking})
+				sendMessage(ctx, ch, Message{Type: MessageThinking, Content: block.Thinking})
 			}
 		case "text":
 			if block.Text != "" {
 				text.WriteString(block.Text)
-				trySend(ch, Message{Type: MessageText, Content: block.Text})
+				sendMessage(ctx, ch, Message{Type: MessageText, Content: block.Text})
 			}
 		case "tool_use":
 			tools++
@@ -351,7 +351,7 @@ func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[strin
 			if len(block.Input) > 0 {
 				_ = json.Unmarshal(block.Input, &input)
 			}
-			trySend(ch, Message{Type: MessageToolUse, Tool: block.Name, CallID: block.ID, Input: input})
+			sendMessage(ctx, ch, Message{Type: MessageToolUse, Tool: block.Name, CallID: block.ID, Input: input})
 		default:
 			// A block type we do not render may be carrying the model's answer
 			// in a shape we cannot read, so we must not claim this turn was
@@ -365,14 +365,14 @@ func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[strin
 	return turn, message.Model
 }
 
-func handleQwenUser(raw json.RawMessage, ch chan<- Message) {
+func handleQwenUser(ctx context.Context, raw json.RawMessage, ch chan<- Message) {
 	var message qwenMessage
 	if json.Unmarshal(raw, &message) != nil {
 		return
 	}
 	for _, block := range message.Content {
 		if block.Type == "tool_result" {
-			trySend(ch, Message{Type: MessageToolResult, CallID: block.ToolUseID, Output: qwenToolResultOutput(block.Content)})
+			sendMessage(ctx, ch, Message{Type: MessageToolResult, CallID: block.ToolUseID, Output: qwenToolResultOutput(block.Content)})
 		}
 	}
 }

--- a/server/pkg/agent/qwen_test.go
+++ b/server/pkg/agent/qwen_test.go
@@ -329,7 +329,7 @@ func TestQwenCode020FixtureParses(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			t.Fatalf("fixture event: %v\n%s", err, line)
 		}
-		handleQwenEvent(event, messages, &state)
+		handleQwenEvent(context.Background(), event, messages, &state)
 	}
 	if !state.sawResult || state.resultIsError || state.sessionID != "session-redacted" || state.finalResultText != "DONE" {
 		t.Fatalf("unexpected fixture state: %+v", state)
@@ -352,7 +352,7 @@ func TestQwenCode020ErrorFixturePreservesErrorMessage(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			t.Fatalf("fixture event: %v\n%s", err, line)
 		}
-		handleQwenEvent(event, messages, &state)
+		handleQwenEvent(context.Background(), event, messages, &state)
 	}
 	if !state.sawResult || !state.resultIsError {
 		t.Fatalf("unexpected terminal state: %+v", state)

--- a/server/pkg/agent/qwenpaw.go
+++ b/server/pkg/agent/qwenpaw.go
@@ -148,7 +148,7 @@ func (b *qwenpawBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				output.WriteString(msg.Content)
 				outputMu.Unlock()
 			}
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
 			select {

--- a/server/pkg/agent/reasonix.go
+++ b/server/pkg/agent/reasonix.go
@@ -198,7 +198,7 @@ func (b *reasonixBackend) Execute(ctx context.Context, prompt string, opts ExecO
 				msg.Tool = reasonixToolNameFromTitle(msg.Tool)
 			}
 			deliverable.observe(msg)
-			trySend(msgCh, msg)
+			sendMessage(runCtx, msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
 			if !streamingCurrentTurn.Load() {

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -58,22 +58,24 @@ var traecliReaderDrainGrace = 2 * time.Second
 // reader (traecli may keep the process and its pipes open briefly after
 // session/prompt returns) cannot send on a closed channel. Mirrors qoder.
 type traecliMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newTraecliMessageStream(size int) *traecliMessageStream {
-	return &traecliMessageStream{ch: make(chan Message, size)}
+func newTraecliMessageStream(ctx context.Context, size int) *traecliMessageStream {
+	return &traecliMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *traecliMessageStream) send(msg Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, msg)
+	sendMessage(s.ctx, s.ch, msg)
 }
 
 func (s *traecliMessageStream) close() {
@@ -157,7 +159,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 
 	b.cfg.Logger.Info("traecli acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
 
-	msgStream := newTraecliMessageStream(256)
+	msgStream := newTraecliMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 
 	// Traecli streams interim narration and the final answer as the same
@@ -219,7 +221,6 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	}()
 
 	go func() {
-		defer cancel()
 		defer msgStream.close()
 		defer close(resCh)
 		defer func() {
@@ -227,6 +228,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			_ = cmd.Wait()
 			releaseProcessGroup(cmd)
 		}()
+		defer cancel()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -400,9 +402,8 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 		// cancellation tears the process down). Draining stderr is what makes
 		// the provider-error promotion below see a terminal marker.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), traecliReaderDrainGrace)
-		select {
-		case <-readerDone:
-		case <-drainCtx.Done():
+		if !messageReaderClosedBefore(drainCtx, readerDone) {
+			markMessageDeliveryAbandoned(runCtx)
 		}
 		select {
 		case <-stderrDone:

--- a/server/pkg/agent/zeroclaw.go
+++ b/server/pkg/agent/zeroclaw.go
@@ -193,22 +193,24 @@ var (
 // zeroclawMessageStream serializes sends and the final close so a late
 // stdout reader cannot send on a closed channel. Mirrors dim/grok/traecli.
 type zeroclawMessageStream struct {
+	ctx    context.Context
 	ch     chan Message
 	mu     sync.Mutex
 	closed bool
 }
 
-func newZeroclawMessageStream(size int) *zeroclawMessageStream {
-	return &zeroclawMessageStream{ch: make(chan Message, size)}
+func newZeroclawMessageStream(ctx context.Context, size int) *zeroclawMessageStream {
+	return &zeroclawMessageStream{ctx: ctx, ch: make(chan Message, size)}
 }
 
 func (s *zeroclawMessageStream) send(msg Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
+		markMessageDeliveryAbandoned(s.ctx)
 		return
 	}
-	trySend(s.ch, msg)
+	sendMessage(s.ctx, s.ch, msg)
 }
 
 func (s *zeroclawMessageStream) close() {
@@ -291,7 +293,7 @@ func (b *zeroclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 	b.cfg.Logger.Info("zeroclaw acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
 
-	msgStream := newZeroclawMessageStream(256)
+	msgStream := newZeroclawMessageStream(runCtx, 256)
 	resCh := make(chan Result, 1)
 
 	// ZeroClaw streams interim narration and the final answer as the same
@@ -363,7 +365,6 @@ func (b *zeroclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}()
 
 	go func() {
-		defer cancel()
 		defer msgStream.close()
 		defer close(resCh)
 		defer func() {
@@ -371,6 +372,7 @@ func (b *zeroclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 			_ = cmd.Wait()
 			releaseProcessGroup(cmd)
 		}()
+		defer cancel()
 
 		startTime := time.Now()
 		finalStatus := "completed"
@@ -553,9 +555,8 @@ func (b *zeroclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		// ZeroClaw's ACP server may keep the process — and the stdout/stderr
 		// pipes — open briefly after session/prompt returns. Bound the drain.
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), zeroclawReaderDrainGrace)
-		select {
-		case <-readerDone:
-		case <-drainCtx.Done():
+		if !messageReaderClosedBefore(drainCtx, readerDone) {
+			markMessageDeliveryAbandoned(runCtx)
 		}
 		select {
 		case <-stderrDone:

--- a/server/pkg/db/generated/task_message.sql.go
+++ b/server/pkg/db/generated/task_message.sql.go
@@ -55,7 +55,7 @@ func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessagePa
 }
 
 const createTaskMessages = `-- name: CreateTaskMessages :many
-WITH incoming AS (
+WITH raw_incoming AS (
     -- Several single-argument unnest calls in one SELECT list expand in
     -- lockstep (PostgreSQL 10+ set-returning-function semantics), which is the
     -- same row-wise zip the multi-argument unnest(a, b, ...) form gives — but
@@ -69,6 +69,16 @@ WITH incoming AS (
         unnest($5::text[]) AS content,
         unnest($6::text[]) AS input,
         unnest($7::text[]) AS output
+), incoming AS (
+    SELECT
+        id,
+        seq,
+        type,
+        NULLIF(tool, '') AS tool,
+        NULLIF(content, '') AS content,
+        NULLIF(input, '')::jsonb AS input,
+        NULLIF(output, '') AS output
+    FROM raw_incoming
 ), inserted AS (
     INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
     SELECT
@@ -76,14 +86,34 @@ WITH incoming AS (
         $8::uuid,
         m.seq,
         m.type,
-        NULLIF(m.tool, ''),
-        NULLIF(m.content, ''),
-        NULLIF(m.input, '')::jsonb,
-        NULLIF(m.output, '')
+        m.tool,
+        m.content,
+        m.input,
+        m.output
     FROM incoming AS m
+    ON CONFLICT (task_id, seq) DO NOTHING
     RETURNING id, task_id, seq, type, tool, content, input, output, created_at
+), resolved AS (
+    SELECT inserted.id, inserted.task_id, inserted.seq, inserted.type, inserted.tool, inserted.content, inserted.input, inserted.output, inserted.created_at, true AS was_inserted, true AS payload_matches
+    FROM inserted
+
+    UNION ALL
+
+    SELECT
+        existing.id, existing.task_id, existing.seq, existing.type, existing.tool, existing.content, existing.input, existing.output, existing.created_at,
+        false AS was_inserted,
+        existing.type = incoming.type
+            AND existing.tool IS NOT DISTINCT FROM incoming.tool
+            AND existing.content IS NOT DISTINCT FROM incoming.content
+            AND existing.input IS NOT DISTINCT FROM incoming.input
+            AND existing.output IS NOT DISTINCT FROM incoming.output
+            AS payload_matches
+    FROM incoming
+    JOIN task_message AS existing
+      ON existing.task_id = $8::uuid
+     AND existing.seq = incoming.seq
 )
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM inserted ORDER BY seq ASC
+SELECT id, task_id, seq, type, tool, content, input, output, created_at, was_inserted, payload_matches FROM resolved ORDER BY seq ASC
 `
 
 type CreateTaskMessagesParams struct {
@@ -98,15 +128,17 @@ type CreateTaskMessagesParams struct {
 }
 
 type CreateTaskMessagesRow struct {
-	ID        pgtype.UUID        `json:"id"`
-	TaskID    pgtype.UUID        `json:"task_id"`
-	Seq       int32              `json:"seq"`
-	Type      string             `json:"type"`
-	Tool      pgtype.Text        `json:"tool"`
-	Content   pgtype.Text        `json:"content"`
-	Input     []byte             `json:"input"`
-	Output    pgtype.Text        `json:"output"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID             pgtype.UUID        `json:"id"`
+	TaskID         pgtype.UUID        `json:"task_id"`
+	Seq            int32              `json:"seq"`
+	Type           string             `json:"type"`
+	Tool           pgtype.Text        `json:"tool"`
+	Content        pgtype.Text        `json:"content"`
+	Input          []byte             `json:"input"`
+	Output         pgtype.Text        `json:"output"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	WasInserted    bool               `json:"was_inserted"`
+	PayloadMatches bool               `json:"payload_matches"`
 }
 
 // Batch variant of CreateTaskMessage: persists a whole daemon-reported batch in
@@ -136,11 +168,9 @@ type CreateTaskMessagesRow struct {
 // into one statement, not to the parameter shape.
 //
 // Atomicity is a deliberate side effect, not just a speedup: the per-message
-// loop this replaces could persist part of a batch and then fail, leaving the
-// transcript with a prefix of the batch and no way to complete it — the daemon
-// does not retry this endpoint. One statement makes the batch all-or-nothing,
-// which buys consistency; a batch that fails is still lost whole, so closing
-// the gap for real needs a retry plus a (task_id, seq) uniqueness rule.
+// loop this replaces could persist part of a batch and then fail. The daemon
+// now retries the exact batch, while (task_id, seq) uniqueness and DO NOTHING
+// make a lost-response replay idempotent and keep realtime events single-shot.
 //
 // The ORDER BY is a contract, not decoration. A bare `INSERT ... RETURNING`
 // has no defined row order, and the caller republishes these rows as realtime
@@ -176,6 +206,8 @@ func (q *Queries) CreateTaskMessages(ctx context.Context, arg CreateTaskMessages
 			&i.Input,
 			&i.Output,
 			&i.CreatedAt,
+			&i.WasInserted,
+			&i.PayloadMatches,
 		); err != nil {
 			return nil, err
 		}
@@ -195,6 +227,28 @@ WHERE task_id = $1
 func (q *Queries) DeleteTaskMessages(ctx context.Context, taskID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, deleteTaskMessages, taskID)
 	return err
+}
+
+const getTaskMessageSeqSummary = `-- name: GetTaskMessageSeqSummary :one
+SELECT
+    COUNT(*)::int AS message_count,
+    COALESCE(MIN(seq), 0)::int AS min_seq,
+    COALESCE(MAX(seq), 0)::int AS max_seq
+FROM task_message
+WHERE task_id = $1
+`
+
+type GetTaskMessageSeqSummaryRow struct {
+	MessageCount int32 `json:"message_count"`
+	MinSeq       int32 `json:"min_seq"`
+	MaxSeq       int32 `json:"max_seq"`
+}
+
+func (q *Queries) GetTaskMessageSeqSummary(ctx context.Context, taskID pgtype.UUID) (GetTaskMessageSeqSummaryRow, error) {
+	row := q.db.QueryRow(ctx, getTaskMessageSeqSummary, taskID)
+	var i GetTaskMessageSeqSummaryRow
+	err := row.Scan(&i.MessageCount, &i.MinSeq, &i.MaxSeq)
+	return i, err
 }
 
 const listTaskMessages = `-- name: ListTaskMessages :many
@@ -272,4 +326,17 @@ func (q *Queries) ListTaskMessagesSince(ctx context.Context, arg ListTaskMessage
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockTaskForTranscriptWrite = `-- name: LockTaskForTranscriptWrite :one
+SELECT status FROM agent_task_queue
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockTaskForTranscriptWrite(ctx context.Context, id pgtype.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, lockTaskForTranscriptWrite, id)
+	var status string
+	err := row.Scan(&status)
+	return status, err
 }

--- a/server/pkg/db/queries/task_message.sql
+++ b/server/pkg/db/queries/task_message.sql
@@ -31,11 +31,9 @@ RETURNING *;
 -- into one statement, not to the parameter shape.
 --
 -- Atomicity is a deliberate side effect, not just a speedup: the per-message
--- loop this replaces could persist part of a batch and then fail, leaving the
--- transcript with a prefix of the batch and no way to complete it — the daemon
--- does not retry this endpoint. One statement makes the batch all-or-nothing,
--- which buys consistency; a batch that fails is still lost whole, so closing
--- the gap for real needs a retry plus a (task_id, seq) uniqueness rule.
+-- loop this replaces could persist part of a batch and then fail. The daemon
+-- now retries the exact batch, while (task_id, seq) uniqueness and DO NOTHING
+-- make a lost-response replay idempotent and keep realtime events single-shot.
 --
 -- The ORDER BY is a contract, not decoration. A bare `INSERT ... RETURNING`
 -- has no defined row order, and the caller republishes these rows as realtime
@@ -43,7 +41,7 @@ RETURNING *;
 -- published in request order, so the ordering has to be restored explicitly or
 -- subscribers can see a batch out of order. seq is assigned by the daemon and
 -- increases within a batch, so it is the request order.
-WITH incoming AS (
+WITH raw_incoming AS (
     -- Several single-argument unnest calls in one SELECT list expand in
     -- lockstep (PostgreSQL 10+ set-returning-function semantics), which is the
     -- same row-wise zip the multi-argument unnest(a, b, ...) form gives — but
@@ -57,6 +55,16 @@ WITH incoming AS (
         unnest(sqlc.arg('contents')::text[]) AS content,
         unnest(sqlc.arg('inputs')::text[]) AS input,
         unnest(sqlc.arg('outputs')::text[]) AS output
+), incoming AS (
+    SELECT
+        id,
+        seq,
+        type,
+        NULLIF(tool, '') AS tool,
+        NULLIF(content, '') AS content,
+        NULLIF(input, '')::jsonb AS input,
+        NULLIF(output, '') AS output
+    FROM raw_incoming
 ), inserted AS (
     INSERT INTO task_message (id, task_id, seq, type, tool, content, input, output)
     SELECT
@@ -64,14 +72,39 @@ WITH incoming AS (
         sqlc.arg('task_id')::uuid,
         m.seq,
         m.type,
-        NULLIF(m.tool, ''),
-        NULLIF(m.content, ''),
-        NULLIF(m.input, '')::jsonb,
-        NULLIF(m.output, '')
+        m.tool,
+        m.content,
+        m.input,
+        m.output
     FROM incoming AS m
+    ON CONFLICT (task_id, seq) DO NOTHING
     RETURNING *
+), resolved AS (
+    SELECT inserted.*, true AS was_inserted, true AS payload_matches
+    FROM inserted
+
+    UNION ALL
+
+    SELECT
+        existing.*,
+        false AS was_inserted,
+        existing.type = incoming.type
+            AND existing.tool IS NOT DISTINCT FROM incoming.tool
+            AND existing.content IS NOT DISTINCT FROM incoming.content
+            AND existing.input IS NOT DISTINCT FROM incoming.input
+            AND existing.output IS NOT DISTINCT FROM incoming.output
+            AS payload_matches
+    FROM incoming
+    JOIN task_message AS existing
+      ON existing.task_id = sqlc.arg('task_id')::uuid
+     AND existing.seq = incoming.seq
 )
-SELECT * FROM inserted ORDER BY seq ASC;
+SELECT * FROM resolved ORDER BY seq ASC;
+
+-- name: LockTaskForTranscriptWrite :one
+SELECT status FROM agent_task_queue
+WHERE id = $1
+FOR UPDATE;
 
 -- name: ListTaskMessages :many
 SELECT * FROM task_message
@@ -82,6 +115,14 @@ ORDER BY seq ASC;
 SELECT * FROM task_message
 WHERE task_id = $1 AND seq > $2
 ORDER BY seq ASC;
+
+-- name: GetTaskMessageSeqSummary :one
+SELECT
+    COUNT(*)::int AS message_count,
+    COALESCE(MIN(seq), 0)::int AS min_seq,
+    COALESCE(MAX(seq), 0)::int AS max_seq
+FROM task_message
+WHERE task_id = $1;
 
 -- name: DeleteTaskMessages :exec
 DELETE FROM task_message

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -138,6 +138,11 @@ const (
 	// only repeat an isolation failure.
 	ReasonInvalidTaskIdentity Reason = "invalid_task_identity"
 
+	// ReasonTranscriptIncomplete: the daemon claimed a terminal transcript
+	// sequence that the server could not verify as contiguous. The task is
+	// failed rather than left running after terminal callback retries exhaust.
+	ReasonTranscriptIncomplete Reason = "transcript_incomplete"
+
 	// Agent process side: failure surfaced by the agent CLI / SDK as
 	// an error string. Classify(rawError) is responsible for picking
 	// the right sub-reason from the string. IsAgentError returns true
@@ -213,7 +218,7 @@ const (
 	ReasonAgentUnknown Reason = "agent_error.unknown"
 )
 
-// allReasons is the canonical ordered list of the 25 reasons. Order is
+// allReasons is the canonical ordered list of the 26 reasons. Order is
 // stable so callers (e.g. Prometheus collectors that pre-warm series via
 // AllReasons) can build deterministic label sets across restarts.
 //
@@ -235,6 +240,7 @@ var allReasons = []Reason{
 	ReasonSkillBundleUnavailable,
 	ReasonRuntimeCLITimeout,
 	ReasonInvalidTaskIdentity,
+	ReasonTranscriptIncomplete,
 
 	// Agent process side: provider errors.
 	ReasonAgentProviderAuthOrAccess,

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -30,6 +30,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonSkillBundleUnavailable, "skill_bundle_unavailable"},
 		{ReasonRuntimeCLITimeout, "runtime_cli_timeout"},
 		{ReasonInvalidTaskIdentity, "invalid_task_identity"},
+		{ReasonTranscriptIncomplete, "transcript_incomplete"},
 		// Agent-side.
 		{ReasonAgentProviderAuthOrAccess, "agent_error.provider_auth_or_access"},
 		{ReasonAgentProviderQuotaLimit, "agent_error.provider_quota_limit"},
@@ -47,7 +48,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonAgentUnknown, "agent_error.unknown"},
 	}
 
-	if got, want := len(cases), 25; got != want {
+	if got, want := len(cases), 26; got != want {
 		t.Fatalf("constant count = %d, want %d (canonical taxonomy size)", got, want)
 	}
 
@@ -78,6 +79,7 @@ func TestIsAgentError(t *testing.T) {
 		ReasonSkillBundleUnavailable,
 		ReasonRuntimeCLITimeout,
 		ReasonInvalidTaskIdentity,
+		ReasonTranscriptIncomplete,
 	}
 	for _, r := range platformSide {
 		if r.IsAgentError() {
@@ -118,8 +120,8 @@ func TestAllReasonsContents(t *testing.T) {
 	t.Parallel()
 
 	got := AllReasons()
-	if len(got) != 25 {
-		t.Fatalf("AllReasons() returned %d entries, want 25", len(got))
+	if len(got) != 26 {
+		t.Fatalf("AllReasons() returned %d entries, want 26", len(got))
 	}
 
 	seen := make(map[Reason]bool, len(got))
@@ -136,8 +138,8 @@ func TestAllReasonsContents(t *testing.T) {
 		}
 	}
 
-	if platformCount != 11 {
-		t.Errorf("AllReasons(): platform-side count = %d, want 11", platformCount)
+	if platformCount != 12 {
+		t.Errorf("AllReasons(): platform-side count = %d, want 12", platformCount)
 	}
 	if agentCount != 14 {
 		t.Errorf("AllReasons(): agent-side count = %d, want 14", agentCount)
@@ -152,7 +154,7 @@ func TestAllReasonsContents(t *testing.T) {
 		ReasonRuntimeRecovery,
 		ReasonTimeout, ReasonIterationLimit, ReasonAgentBlocked,
 		ReasonAPIInvalidRequest, ReasonSkillBundleUnavailable,
-		ReasonRuntimeCLITimeout, ReasonInvalidTaskIdentity,
+		ReasonRuntimeCLITimeout, ReasonInvalidTaskIdentity, ReasonTranscriptIncomplete,
 		ReasonAgentProviderAuthOrAccess, ReasonAgentProviderQuotaLimit,
 		ReasonAgentProviderCapacityOrRateLimit, ReasonAgentProviderServerError,
 		ReasonAgentProviderNetwork, ReasonAgentProcessFailure,


### PR DESCRIPTION
Supersedes #7649. This branch reapplies the original two commits to the current `main`. The migration conflict is resolved by renumbering `441/442` to the next free versions, `444/445`. It also updates the CodeArts backend added after #7649 was opened to use the same context-aware message delivery instead of the removed `trySend` helper.

## Summary

- replace silent agent message drops with context-aware backpressure and task-scoped abandonment detection across every backend
- make transcript batch delivery retry-safe through an advertised server capability, `(task_id, seq)` uniqueness, atomic idempotent replay, and conflicting-payload rejection
- verify a contiguous transcript high-watermark in the same task-row transaction that completes or fails a task
- drain buffered cancellation tails before returning; fail closed when a stream never closes or delivery is truncated

## Why

The daemon previously cleared each in-memory batch before a one-shot HTTP request. A transient request or insert failure could therefore leave a task terminal while its persisted transcript was incomplete. Agent adapters could also silently drop messages whenever their 256-entry channel filled.

This change fixes the shared delivery boundary instead of adding adapter-specific guards. New daemons retry only when the claimed task advertises `transcript_batch_replay_safe`; old servers retain the existing one-shot behavior, avoiding duplicate rows during mixed-version operation.

## Verification

- pinned `sqlc/sqlc:1.31.1 generate`
- DB-backed replay, conflicting replay rollback, invalid sequence, cancelled final drain, complete/fail receipt, exact terminal replay, and late-write seal tests
- daemon retry, drain, cancellation-tail, and never-closing-stream regressions
- agent backpressure and late-reader regressions across affected stream wrappers
- migration cleanup-map contract tests
- targeted daemon/agent tests under `-race`
- compile-only check and `go vet` for all changed packages
- `git diff --check`

## Upgrade notes

Migration 444 deliberately fails closed if historical duplicates already exist. Before production migration, check:

```sql
SELECT task_id, seq, COUNT(*)
FROM task_message
GROUP BY task_id, seq
HAVING COUNT(*) > 1;
```

If rows are returned, inspect and reconcile them before retrying the migration; do not delete them automatically.

The official Helm backend uses `Recreate`, which avoids a mixed server fleet. Custom multi-replica deployments should roll the server capability fleet-wide before relying on daemon retries.

## Scope boundary

The receipt proves persistence of every `agent.Message` formed during the current process lifetime. Crash-durable daemon restart replay, raw provider-byte preservation, and first-class failed/cancelled receipt storage remain separate follow-up work.
