### PR TITLE
test(cli): guard issue list --output json against control chars

### DIFF
--- a/server/cmd/multica/cmd_issue_json_output_test.go
+++ b/server/cmd/multica/cmd_issue_json_output_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression guard for #7653: `issue list --output json` must always emit
+// valid JSON. Descriptions can contain newlines, tabs and other control
+// characters; the CLI decodes the server response and re-encodes it through
+// encoding/json (cli.PrintJSON), which escapes those characters. The existing
+// list-json test only asserts the command returns no error, not that its
+// stdout parses — this pins the stronger contract.
+
+func TestIssueListJSONEscapesControlCharsInDescription(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/issues" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []any{map[string]any{
+				"id": "issue-1", "identifier": "MUL-1", "title": "t",
+				"status": "todo", "priority": "none",
+				"description": "line1\nline2\twith tab\rand CR",
+			}},
+			"total": 1,
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+	out, err := captureStdout(t, func() error { return runIssueList(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runIssueList: %v", err)
+	}
+
+	var parsed struct {
+		Issues []struct {
+			Description string `json:"description"`
+		} `json:"issues"`
+	}
+	if uerr := json.Unmarshal([]byte(out), &parsed); uerr != nil {
+		t.Fatalf("output is not valid JSON: %v\n---\n%s", uerr, out)
+	}
+	// A raw newline inside a JSON string is the exact defect from #7653.
+	if strings.Contains(out, "line1\nline2") {
+		t.Fatalf("stdout contains an unescaped control character:\n%s", out)
+	}
+	if len(parsed.Issues) != 1 || parsed.Issues[0].Description != "line1\nline2\twith tab\rand CR" {
+		t.Fatalf("description did not round-trip: %+v", parsed.Issues)
+	}
+}
+
+// If the server itself sends a body with a raw control character inside a
+// string (invalid JSON on the wire), the CLI must fail cleanly rather than
+// forward invalid JSON to stdout.
+func TestIssueListJSONNeverForwardsInvalidServerJSON(t *testing.T) {
+	rawBody := "{\"issues\":[{\"id\":\"issue-1\",\"identifier\":\"MUL-1\",\"title\":\"t\",\"status\":\"todo\",\"priority\":\"none\",\"description\":\"line1\nline2\"}],\"total\":1}"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/issues" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(rawBody))
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+	out, err := captureStdout(t, func() error { return runIssueList(cmd, nil) })
+	if err == nil && out == "" {
+		t.Fatal("expected either an error or output, got neither")
+	}
+	if out != "" {
+		var parsed any
+		if uerr := json.Unmarshal([]byte(out), &parsed); uerr != nil {
+			t.Fatalf("CLI forwarded invalid JSON to stdout: %v\n---\n%s", uerr, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a regression test pinning the JSON-output contract of `issue list --output json`.

## Context

I could not reproduce the raw-`0x0A` defect on current `main`. The list path decodes the server response and re-encodes it through `encoding/json` (`cli.GetJSON` → `cli.PrintJSON`), which always escapes control characters, so a description containing newlines/tabs comes out as valid, escaped JSON. If a server ever sent a body with a raw control character inside a string (invalid JSON on the wire), `GetJSON` fails the decode and the command errors — it never forwards invalid JSON to stdout.

The existing list-json test only asserts the command returns no error, not that its stdout parses. This adds two focused tests:
- valid, parseable JSON output when a description holds `\n` / `\t` / `\r`, with a round-trip check on the value;
- the CLI never forwards an invalid server body to stdout.

## Testing

`go test ./server/cmd/multica/ -run TestIssueListJSON` — both pass.

Refs #7653. If anyone can still reproduce the raw-newline output, a `multica version` and a minimal sample on the issue would help pin which build/path it came from.
