### PR TITLE
feat(server): SDLC P6a governance pre-comment + pre-status hooks (VAN-178)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -436,6 +436,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		LLMDefaultModel:          strings.TrimSpace(os.Getenv("MULTICA_LLM_DEFAULT_MODEL")),
 		LLMMaxRetries:            opts.LLMMaxRetries,
 		ServerVersion:            normalizeServerVersion(version),
+		GovernanceRoot:           strings.TrimSpace(os.Getenv("MULTICA_GOVERNANCE_ROOT")),
+		GovernanceHookTimeout:    envDuration("MULTICA_GOVERNANCE_HOOK_TIMEOUT", 30*time.Second),
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	invitationRateLimits := handler.DefaultInvitationRateLimits()

--- a/server/internal/governance/hooks.go
+++ b/server/internal/governance/hooks.go
@@ -1,0 +1,174 @@
+// Package governance runs workspace-configured shell hooks before issue
+// comment and status mutations. Hook failure is fail-safe default-deny per
+// multica-org-governance ORGANIZATION.md §5.8.4.
+package governance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHookTimeout = 30 * time.Second
+	defaultPreComment  = "scripts/pre-comment"
+	defaultPreStatus   = "scripts/pre-status"
+)
+
+// Config carries server-level governance defaults (from deployment env).
+type Config struct {
+	Root    string
+	Timeout time.Duration
+}
+
+// WorkspaceHooks is the resolved hook contract for one workspace.
+type WorkspaceHooks struct {
+	PreComment string
+	PreStatus  string
+	Timeout    time.Duration
+}
+
+// HookDeniedError is returned when a hook exits non-zero. Stderr is surfaced
+// to API callers so the agent CLI can show actionable gate output.
+type HookDeniedError struct {
+	Hook   string
+	Stderr string
+}
+
+func (e *HookDeniedError) Error() string {
+	if strings.TrimSpace(e.Stderr) != "" {
+		return strings.TrimSpace(e.Stderr)
+	}
+	return fmt.Sprintf("governance hook %q denied the operation", e.Hook)
+}
+
+// HookFailedError is returned when a configured hook cannot be executed
+// (missing, not executable, timeout, spawn error). Fail-safe default-deny.
+type HookFailedError struct {
+	Hook string
+	Err  error
+}
+
+func (e *HookFailedError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("governance hook %q failed: %v", e.Hook, e.Err)
+	}
+	return fmt.Sprintf("governance hook %q failed", e.Hook)
+}
+
+func (e *HookFailedError) Unwrap() error { return e.Err }
+
+// ParseWorkspaceHooks resolves hook paths from workspace settings JSON with
+// server-level fallbacks. When no hook is configured, the corresponding path
+// is empty and the caller should skip invocation (allow).
+func ParseWorkspaceHooks(settingsJSON []byte, server Config) WorkspaceHooks {
+	hooks := WorkspaceHooks{Timeout: server.Timeout}
+	if hooks.Timeout <= 0 {
+		hooks.Timeout = defaultHookTimeout
+	}
+
+	var settings map[string]json.RawMessage
+	if len(settingsJSON) > 0 {
+		_ = json.Unmarshal(settingsJSON, &settings)
+	}
+
+	var gov struct {
+		Hooks struct {
+			PreComment string `json:"pre_comment"`
+			PreStatus  string `json:"pre_status"`
+		} `json:"hooks"`
+		TimeoutSeconds *int `json:"timeout_seconds"`
+	}
+	if raw, ok := settings["governance"]; ok {
+		_ = json.Unmarshal(raw, &gov)
+	}
+	if gov.TimeoutSeconds != nil && *gov.TimeoutSeconds > 0 {
+		hooks.Timeout = time.Duration(*gov.TimeoutSeconds) * time.Second
+	}
+
+	hooks.PreComment = resolveHookPath(gov.Hooks.PreComment, server.Root, defaultPreComment)
+	hooks.PreStatus = resolveHookPath(gov.Hooks.PreStatus, server.Root, defaultPreStatus)
+	return hooks
+}
+
+func resolveHookPath(explicit, root, defaultRel string) string {
+	path := strings.TrimSpace(explicit)
+	if path == "" && root != "" {
+		path = defaultRel
+	}
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, path)
+}
+
+// RunPreComment executes the workspace pre-comment hook when configured.
+func RunPreComment(ctx context.Context, ws WorkspaceHooks, env map[string]string, commentFile string) error {
+	if ws.PreComment == "" {
+		return nil
+	}
+	if commentFile == "" {
+		return &HookFailedError{Hook: "pre_comment", Err: errors.New("comment file path is required")}
+	}
+	args := []string{commentFile}
+	return runHook(ctx, "pre_comment", ws.PreComment, ws.Timeout, env, args)
+}
+
+// RunPreStatus executes the workspace pre-status hook when configured.
+func RunPreStatus(ctx context.Context, ws WorkspaceHooks, env map[string]string, args []string) error {
+	if ws.PreStatus == "" {
+		return nil
+	}
+	return runHook(ctx, "pre_status", ws.PreStatus, ws.Timeout, env, args)
+}
+
+func runHook(ctx context.Context, name, script string, timeout time.Duration, env map[string]string, args []string) error {
+	if timeout <= 0 {
+		timeout = defaultHookTimeout
+	}
+	info, err := os.Stat(script)
+	if err != nil {
+		return &HookFailedError{Hook: name, Err: fmt.Errorf("hook script not found: %w", err)}
+	}
+	if info.IsDir() {
+		return &HookFailedError{Hook: name, Err: fmt.Errorf("hook script is a directory")}
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "/bin/bash", script)
+	if len(args) > 0 {
+		cmd.Args = append(cmd.Args, args...)
+	}
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			return &HookFailedError{Hook: name, Err: fmt.Errorf("hook timed out after %s", timeout)}
+		}
+		if _, ok := err.(*exec.ExitError); ok {
+			return &HookDeniedError{Hook: name, Stderr: stderr.String()}
+		}
+		return &HookFailedError{Hook: name, Err: err}
+	}
+	return nil
+}

--- a/server/internal/governance/hooks_test.go
+++ b/server/internal/governance/hooks_test.go
@@ -1,0 +1,109 @@
+package governance
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeHook(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseWorkspaceHooks_ServerDefaults(t *testing.T) {
+	root := t.TempDir()
+	hooks := ParseWorkspaceHooks(nil, Config{Root: root, Timeout: 10 * time.Second})
+	wantComment := filepath.Join(root, defaultPreComment)
+	wantStatus := filepath.Join(root, defaultPreStatus)
+	if hooks.PreComment != wantComment {
+		t.Fatalf("PreComment = %q, want %q", hooks.PreComment, wantComment)
+	}
+	if hooks.PreStatus != wantStatus {
+		t.Fatalf("PreStatus = %q, want %q", hooks.PreStatus, wantStatus)
+	}
+	if hooks.Timeout != 10*time.Second {
+		t.Fatalf("Timeout = %v, want 10s", hooks.Timeout)
+	}
+}
+
+func TestParseWorkspaceHooks_NoConfigSkips(t *testing.T) {
+	hooks := ParseWorkspaceHooks([]byte(`{"foo":"bar"}`), Config{})
+	if hooks.PreComment != "" || hooks.PreStatus != "" {
+		t.Fatalf("expected empty hooks, got %+v", hooks)
+	}
+}
+
+func TestRunPreComment_AllowAndDeny(t *testing.T) {
+	dir := t.TempDir()
+	allow := writeHook(t, dir, "allow.sh", "#!/usr/bin/env bash\nexit 0\n")
+	deny := writeHook(t, dir, "deny.sh", "#!/usr/bin/env bash\necho blocked by gate >&2\nexit 1\n")
+
+	commentFile := filepath.Join(dir, "comment.md")
+	if err := os.WriteFile(commentFile, []byte("STATUS: DONE\nok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	env := map[string]string{
+		"MULTICA_COMMENT_FILE": commentFile,
+		"MULTICA_AUTHOR_ID":    "agent-1",
+	}
+
+	if err := RunPreComment(ctx, WorkspaceHooks{PreComment: allow, Timeout: time.Second}, env, commentFile); err != nil {
+		t.Fatalf("allow hook: %v", err)
+	}
+
+	err := RunPreComment(ctx, WorkspaceHooks{PreComment: deny, Timeout: time.Second}, env, commentFile)
+	var denied *HookDeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("deny hook: expected HookDeniedError, got %T: %v", err, err)
+	}
+	if !strings.Contains(denied.Stderr, "blocked by gate") {
+		t.Fatalf("stderr = %q", denied.Stderr)
+	}
+}
+
+func TestRunPreComment_MissingScriptFailsClosed(t *testing.T) {
+	err := RunPreComment(context.Background(), WorkspaceHooks{
+		PreComment: filepath.Join(t.TempDir(), "missing.sh"),
+		Timeout:    time.Second,
+	}, nil, filepath.Join(t.TempDir(), "c.md"))
+	var failed *HookFailedError
+	if !errors.As(err, &failed) {
+		t.Fatalf("expected HookFailedError, got %T: %v", err, err)
+	}
+}
+
+func TestRunPreComment_TimeoutFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	slow := writeHook(t, dir, "slow.sh", "#!/usr/bin/env bash\nsleep 2\n")
+	commentFile := filepath.Join(dir, "comment.md")
+	_ = os.WriteFile(commentFile, []byte("x"), 0o644)
+
+	err := RunPreComment(context.Background(), WorkspaceHooks{
+		PreComment: slow,
+		Timeout:    50 * time.Millisecond,
+	}, nil, commentFile)
+	var failed *HookFailedError
+	if !errors.As(err, &failed) {
+		t.Fatalf("expected HookFailedError, got %T: %v", err, err)
+	}
+	if !strings.Contains(failed.Error(), "timed out") {
+		t.Fatalf("error = %v", failed)
+	}
+}
+
+func TestRunPreComment_UnconfiguredSkips(t *testing.T) {
+	if err := RunPreComment(context.Background(), WorkspaceHooks{}, nil, ""); err != nil {
+		t.Fatalf("unconfigured hook should skip: %v", err)
+	}
+}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1871,6 +1871,15 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// entity-encode Markdown syntax characters (>, ", &, <) and corrupt the
 	// source. See issue #1303 / discussion in MUL-1119, MUL-1125.
 
+	if err := h.invokePreCommentHook(r.Context(), issue.WorkspaceID, issue, authorType, authorID, req.Content); err != nil {
+		if writeGovernanceHookError(w, err) {
+			return
+		}
+		slog.Warn("pre-comment hook failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
+		writeError(w, http.StatusInternalServerError, "governance hook check failed")
+		return
+	}
+
 	// parent_id stores the exact comment being replied to. Thread-level behavior
 	// (for example auto-unresolving a resolved thread) resolves the root
 	// separately so storing a reply-to-reply does not destroy the direct-parent
@@ -3342,6 +3351,14 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusInternalServerError, "failed to prepare comment edit")
 				return
 			}
+		}
+		if err := h.invokePreCommentHook(r.Context(), issue.WorkspaceID, issue, actorType, actorID, req.Content); err != nil {
+			if writeGovernanceHookError(w, err) {
+				return
+			}
+			slog.Warn("pre-comment hook failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentId)...)
+			writeError(w, http.StatusInternalServerError, "governance hook check failed")
+			return
 		}
 	}
 

--- a/server/internal/handler/governance_hooks.go
+++ b/server/internal/handler/governance_hooks.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/governance"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func governanceConfigFromHandler(h *Handler) governance.Config {
+	timeout := h.cfg.GovernanceHookTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return governance.Config{
+		Root:    strings.TrimSpace(h.cfg.GovernanceRoot),
+		Timeout: timeout,
+	}
+}
+
+func (h *Handler) workspaceGovernanceHooks(ctx context.Context, workspaceID pgtype.UUID) (governance.WorkspaceHooks, error) {
+	ws, err := h.Queries.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return governance.WorkspaceHooks{}, err
+	}
+	return governance.ParseWorkspaceHooks(ws.Settings, governanceConfigFromHandler(h)), nil
+}
+
+func writeGovernanceHookError(w http.ResponseWriter, err error) bool {
+	var denied *governance.HookDeniedError
+	if errors.As(err, &denied) {
+		writeErrorCode(w, http.StatusForbidden, "governance_hook_denied", denied.Error())
+		return true
+	}
+	var failed *governance.HookFailedError
+	if errors.As(err, &failed) {
+		writeErrorCode(w, http.StatusForbidden, "governance_hook_failed", failed.Error())
+		return true
+	}
+	return false
+}
+
+func (h *Handler) invokePreCommentHook(ctx context.Context, workspaceID pgtype.UUID, issue db.Issue, authorType, authorID, content string) error {
+	hooks, err := h.workspaceGovernanceHooks(ctx, workspaceID)
+	if err != nil {
+		return &governance.HookFailedError{Hook: "pre_comment", Err: err}
+	}
+	if hooks.PreComment == "" {
+		return nil
+	}
+
+	dir, err := os.MkdirTemp("", "multica-pre-comment-*")
+	if err != nil {
+		return &governance.HookFailedError{Hook: "pre_comment", Err: err}
+	}
+	defer os.RemoveAll(dir)
+
+	commentFile := filepath.Join(dir, "comment.md")
+	if err := os.WriteFile(commentFile, []byte(content), 0o600); err != nil {
+		return &governance.HookFailedError{Hook: "pre_comment", Err: err}
+	}
+
+	env := map[string]string{
+		"MULTICA_COMMENT_FILE": commentFile,
+		"MULTICA_AUTHOR_ID":    authorID,
+		"ISSUE_ID":             uuidToString(issue.ID),
+		"ISSUE_TITLE":          issue.Title,
+		"ISSUE_STATUS":         issue.Status,
+		"AUTHOR_TYPE":          authorType,
+	}
+	if issue.ParentIssueID.Valid {
+		env["PARENT_ISSUE_ID"] = uuidToString(issue.ParentIssueID)
+	}
+	return governance.RunPreComment(ctx, hooks, env, commentFile)
+}
+
+func (h *Handler) invokePreStatusHook(ctx context.Context, workspaceID pgtype.UUID, issue db.Issue, newStatus, authorType, authorID string) error {
+	hooks, err := h.workspaceGovernanceHooks(ctx, workspaceID)
+	if err != nil {
+		return &governance.HookFailedError{Hook: "pre_status", Err: err}
+	}
+	if hooks.PreStatus == "" {
+		return nil
+	}
+
+	env := map[string]string{
+		"ISSUE_ID":          uuidToString(issue.ID),
+		"STATUS":            newStatus,
+		"MULTICA_AUTHOR_ID": authorID,
+		"ISSUE_TITLE":       issue.Title,
+		"AUTHOR_TYPE":       authorType,
+	}
+	if issue.ParentIssueID.Valid {
+		env["PARENT_ISSUE_ID"] = uuidToString(issue.ParentIssueID)
+	}
+
+	args := []string{
+		"--issue-id", uuidToString(issue.ID),
+		"--status", newStatus,
+		"--author-id", authorID,
+		"--issue-title", issue.Title,
+	}
+	if issue.ParentIssueID.Valid {
+		args = append(args, "--parent-id", uuidToString(issue.ParentIssueID))
+	}
+	return governance.RunPreStatus(ctx, hooks, env, args)
+}

--- a/server/internal/handler/governance_hooks_test.go
+++ b/server/internal/handler/governance_hooks_test.go
@@ -1,21 +1,108 @@
 package handler
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/testutil"
 )
 
+// governanceTestMu serialises handler governance integration tests. They mutate
+// workspace.settings on a dedicated workspace, but the mutex keeps hook env
+// setup/teardown from racing other packages that share the process-wide pool.
+var governanceTestMu sync.Mutex
+
+type governanceTestEnv struct {
+	workspaceID string
+	fixture     *testutil.Fixture
+}
+
+func setupGovernanceTestWorkspace(t *testing.T) governanceTestEnv {
+	t.Helper()
+	ctx := context.Background()
+
+	slug := fmt.Sprintf("gov-hooks-%s", strings.ReplaceAll(t.Name(), "/", "-"))
+	var workspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, '', 'GOV')
+		RETURNING id
+	`, "Governance hook tests "+t.Name(), slug).Scan(&workspaceID); err != nil {
+		t.Fatalf("create governance test workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, workspaceID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'owner')
+	`, workspaceID, testUserID); err != nil {
+		t.Fatalf("add governance test member: %v", err)
+	}
+
+	return governanceTestEnv{
+		workspaceID: workspaceID,
+		fixture:     testutil.New(testPool, workspaceID, testUserID),
+	}
+}
+
+func newRequestForWorkspace(workspaceID, method, path string, body any) *http.Request {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", workspaceID)
+	return req
+}
+
+func setWorkspaceGovernanceHooks(t *testing.T, workspaceID string, hooks map[string]string, timeoutSeconds *int) {
+	t.Helper()
+	ctx := context.Background()
+
+	gov := map[string]any{"hooks": hooks}
+	if timeoutSeconds != nil {
+		gov["timeout_seconds"] = *timeoutSeconds
+	}
+	settings, err := json.Marshal(map[string]any{"governance": gov})
+	if err != nil {
+		t.Fatalf("marshal governance settings: %v", err)
+	}
+
+	var previous []byte
+	if err := testPool.QueryRow(ctx, `SELECT settings FROM workspace WHERE id = $1`, workspaceID).Scan(&previous); err != nil {
+		t.Fatalf("read workspace settings: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = $1 WHERE id = $2`, settings, workspaceID); err != nil {
+		t.Fatalf("update workspace governance settings: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `UPDATE workspace SET settings = $1 WHERE id = $2`, previous, workspaceID)
+	})
+}
+
 func TestCreateComment_GovernancePreCommentAllowAndDeny(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
+	governanceTestMu.Lock()
+	defer governanceTestMu.Unlock()
+
+	env := setupGovernanceTestWorkspace(t)
 
 	dir := t.TempDir()
 	allowHook := filepath.Join(dir, "allow.sh")
@@ -27,42 +114,23 @@ func TestCreateComment_GovernancePreCommentAllowAndDeny(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	configureWorkspaceGovernance := func(hookPath string) {
-		t.Helper()
-		settings, _ := json.Marshal(map[string]any{
-			"governance": map[string]any{
-				"hooks": map[string]string{
-					"pre_comment": hookPath,
-				},
-			},
-		})
-		if _, err := testPool.Exec(t.Context(), `UPDATE workspace SET settings = $1 WHERE id = $2`, settings, testWorkspaceID); err != nil {
-			t.Fatalf("update workspace settings: %v", err)
-		}
-		t.Cleanup(func() {
-			_, _ = testPool.Exec(t.Context(), `UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`, testWorkspaceID)
-		})
-	}
+	issueID := env.fixture.Issue(t, "governance pre-comment hook")
 
-	issueID := dbfx.Issue(t, "governance pre-comment hook")
-
-	configureWorkspaceGovernance(allowHook)
+	setWorkspaceGovernanceHooks(t, env.workspaceID, map[string]string{"pre_comment": allowHook}, nil)
 	w := httptest.NewRecorder()
-	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+	r := withURLParam(newRequestForWorkspace(env.workspaceID, "POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "STATUS: DONE\nallowed comment",
-	})
-	r = withURLParam(r, "id", issueID)
+	}), "id", issueID)
 	testHandler.CreateComment(w, r)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("allow hook: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
-	configureWorkspaceGovernance(denyHook)
+	setWorkspaceGovernanceHooks(t, env.workspaceID, map[string]string{"pre_comment": denyHook}, nil)
 	w = httptest.NewRecorder()
-	r = newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+	r = withURLParam(newRequestForWorkspace(env.workspaceID, "POST", "/api/issues/"+issueID+"/comments", map[string]any{
 		"content": "STATUS: DONE\nblocked comment",
-	})
-	r = withURLParam(r, "id", issueID)
+	}), "id", issueID)
 	testHandler.CreateComment(w, r)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("deny hook: expected 403, got %d: %s", w.Code, w.Body.String())
@@ -76,6 +144,10 @@ func TestUpdateIssue_GovernancePreStatusDeny(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
+	governanceTestMu.Lock()
+	defer governanceTestMu.Unlock()
+
+	env := setupGovernanceTestWorkspace(t)
 
 	dir := t.TempDir()
 	denyHook := filepath.Join(dir, "deny-status.sh")
@@ -83,24 +155,11 @@ func TestUpdateIssue_GovernancePreStatusDeny(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	settings, _ := json.Marshal(map[string]any{
-		"governance": map[string]any{
-			"hooks": map[string]string{
-				"pre_status": denyHook,
-			},
-		},
-	})
-	if _, err := testPool.Exec(t.Context(), `UPDATE workspace SET settings = $1 WHERE id = $2`, settings, testWorkspaceID); err != nil {
-		t.Fatalf("update workspace settings: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = testPool.Exec(t.Context(), `UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`, testWorkspaceID)
-	})
+	setWorkspaceGovernanceHooks(t, env.workspaceID, map[string]string{"pre_status": denyHook}, nil)
 
-	issueID := dbfx.Issue(t, "governance pre-status hook", testutil.Cols{"status": "todo"})
+	issueID := env.fixture.Issue(t, "governance pre-status hook", testutil.Cols{"status": "todo"})
 	w := httptest.NewRecorder()
-	r := newRequest("PATCH", "/api/issues/"+issueID, map[string]any{"status": "in_progress"})
-	r = withURLParam(r, "id", issueID)
+	r := withURLParam(newRequestForWorkspace(env.workspaceID, "PATCH", "/api/issues/"+issueID, map[string]any{"status": "in_progress"}), "id", issueID)
 	testHandler.UpdateIssue(w, r)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("deny hook: expected 403, got %d: %s", w.Code, w.Body.String())

--- a/server/internal/handler/governance_hooks_test.go
+++ b/server/internal/handler/governance_hooks_test.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+func TestCreateComment_GovernancePreCommentAllowAndDeny(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	dir := t.TempDir()
+	allowHook := filepath.Join(dir, "allow.sh")
+	if err := os.WriteFile(allowHook, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	denyHook := filepath.Join(dir, "deny.sh")
+	if err := os.WriteFile(denyHook, []byte("#!/usr/bin/env bash\necho governance gate blocked comment >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configureWorkspaceGovernance := func(hookPath string) {
+		t.Helper()
+		settings, _ := json.Marshal(map[string]any{
+			"governance": map[string]any{
+				"hooks": map[string]string{
+					"pre_comment": hookPath,
+				},
+			},
+		})
+		if _, err := testPool.Exec(t.Context(), `UPDATE workspace SET settings = $1 WHERE id = $2`, settings, testWorkspaceID); err != nil {
+			t.Fatalf("update workspace settings: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(t.Context(), `UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`, testWorkspaceID)
+		})
+	}
+
+	issueID := dbfx.Issue(t, "governance pre-comment hook")
+
+	configureWorkspaceGovernance(allowHook)
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "STATUS: DONE\nallowed comment",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("allow hook: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	configureWorkspaceGovernance(denyHook)
+	w = httptest.NewRecorder()
+	r = newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "STATUS: DONE\nblocked comment",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("deny hook: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "governance gate blocked comment") {
+		t.Fatalf("expected hook stderr in response, got %s", w.Body.String())
+	}
+}
+
+func TestUpdateIssue_GovernancePreStatusDeny(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	dir := t.TempDir()
+	denyHook := filepath.Join(dir, "deny-status.sh")
+	if err := os.WriteFile(denyHook, []byte("#!/usr/bin/env bash\necho status transition blocked >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings, _ := json.Marshal(map[string]any{
+		"governance": map[string]any{
+			"hooks": map[string]string{
+				"pre_status": denyHook,
+			},
+		},
+	})
+	if _, err := testPool.Exec(t.Context(), `UPDATE workspace SET settings = $1 WHERE id = $2`, settings, testWorkspaceID); err != nil {
+		t.Fatalf("update workspace settings: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(t.Context(), `UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`, testWorkspaceID)
+	})
+
+	issueID := dbfx.Issue(t, "governance pre-status hook", testutil.Cols{"status": "todo"})
+	w := httptest.NewRecorder()
+	r := newRequest("PATCH", "/api/issues/"+issueID, map[string]any{"status": "in_progress"})
+	r = withURLParam(r, "id", issueID)
+	testHandler.UpdateIssue(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("deny hook: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "status transition blocked") {
+		t.Fatalf("expected hook stderr in response, got %s", w.Body.String())
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -148,6 +148,15 @@ type Config struct {
 	// Surfaced through /api/config so self-hosted operators can confirm which
 	// server build is deployed. Empty in dev builds.
 	ServerVersion string
+	// GovernanceRoot is the deployment-level base path for workspace governance
+	// hook scripts (MULTICA_GOVERNANCE_ROOT). Workspace settings may override
+	// individual hook paths; when unset, hooks are skipped unless configured
+	// per-workspace with absolute paths.
+	GovernanceRoot string
+	// GovernanceHookTimeout caps pre-comment / pre-status hook execution
+	// (MULTICA_GOVERNANCE_HOOK_TIMEOUT, default 30s). Hook timeout is
+	// fail-safe default-deny.
+	GovernanceHookTimeout time.Duration
 }
 
 type cloudRuntimeProxy interface {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3546,6 +3546,18 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	if statusKeyForGuard != "" && statusKeyForGuard != prevIssue.Status {
+		if err := h.invokePreStatusHook(r.Context(), prevIssue.WorkspaceID, prevIssue, statusKeyForGuard, actorType, actorID); err != nil {
+			if writeGovernanceHookError(w, err) {
+				return
+			}
+			slog.Warn("pre-status hook failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id)...)
+			writeError(w, http.StatusInternalServerError, "governance hook check failed")
+			return
+		}
+	}
+
 	var issue db.Issue
 	attachmentsChanged := false
 	if req.Description != nil || req.TitleBase != nil || req.DescriptionBase != nil || len(attachmentIDs) > 0 {
@@ -3584,7 +3596,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Determine actor identity: agent (via X-Agent-ID header) or member.
-	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	// (resolved earlier when pre-status hook ran)
 
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
@@ -4128,6 +4140,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	updated := 0
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 	// One Resolver for the whole batch — a per-issue filler would query the
 	// catalog once per custom-status row. (MUL-6243)
 	fillBatch := h.newStatusCategoryFiller(r.Context(), wsUUID)
@@ -4286,6 +4299,17 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if batchStatusKey != "" && batchStatusKey != prevIssue.Status {
+			if err := h.invokePreStatusHook(r.Context(), prevIssue.WorkspaceID, prevIssue, batchStatusKey, actorType, actorID); err != nil {
+				if writeGovernanceHookError(w, err) {
+					return
+				}
+				slog.Warn("pre-status hook failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
+				writeError(w, http.StatusInternalServerError, "governance hook check failed")
+				return
+			}
+		}
+
 		var issue db.Issue
 		if req.Updates.Description != nil {
 			// One batch-level base cannot describe multiple issue documents.
@@ -4318,7 +4342,6 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 		resp := issueToResponse(issue, prefix)
-		actorType, actorID := h.resolveActor(r, userID, workspaceID)
 
 		fillBatch(&resp)
 		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&


### PR DESCRIPTION
## Summary
- Add `server/internal/governance` hook runner (workspace `settings.governance` + `MULTICA_GOVERNANCE_ROOT` deployment defaults)
- Invoke `pre_comment` before comment create/update and `pre_status` before issue status transitions (including batch updates)
- Fail-safe default-deny on hook timeout/spawn/missing script; hook stderr returned as `403 governance_hook_denied` to the CLI
- Unit + handler integration tests for allow/deny paths

## Test plan
- [x] `go test ./internal/governance/... -count=1`
- [x] `go build ./...`
- [ ] `go test ./internal/handler -run 'TestCreateComment_Governance|TestUpdateIssue_Governance' -count=1` (requires Postgres)

## Issue
VAN-178 / P6a


Made with [Cursor](https://cursor.com)