### PR TITLE
fix(repocache): resolve pull-request refs and unfetched commits for repo checkout --ref

### DIFF
--- a/server/cmd/multica/cmd_repo.go
+++ b/server/cmd/multica/cmd_repo.go
@@ -67,7 +67,7 @@ func init() {
 	repoRemoveCmd.Flags().StringArray("url", nil, "Repository URL to remove (may be repeated)")
 	repoRemoveCmd.Flags().String("output", "json", "Output format: table or json")
 
-	repoCheckoutCmd.Flags().StringVar(&repoCheckoutRef, "ref", "", "branch, tag, or commit to check out instead of the remote default branch")
+	repoCheckoutCmd.Flags().StringVar(&repoCheckoutRef, "ref", "", "branch, tag, commit, or fully-qualified ref such as refs/pull/12/head, to check out instead of the remote default branch")
 
 	repoCmd.AddCommand(repoListCmd)
 	repoCmd.AddCommand(repoAddCmd)

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -1333,8 +1333,44 @@ func resolveBaseRefContext(ctx context.Context, barePath, requestedRef string) (
 		return getRemoteDefaultBranchContext(ctx, barePath), nil
 	}
 
-	// Prefer remote-tracking branches for human branch names. Then allow full
-	// local refs, tags, and raw commits that exist in the fetched bare cache.
+	if resolved, ok := lookupCachedBaseRefContext(ctx, barePath, ref); ok {
+		return resolved, nil
+	}
+
+	// The cache only ever fetches modernFetchRefspec, so its refs are
+	// refs/remotes/origin/* plus tags — nothing else the remote publishes. Two
+	// documented `--ref` inputs therefore can never be in the cache no matter
+	// how recently Sync ran: a fully-qualified ref outside refs/heads/*
+	// (refs/pull/N/head on GitHub, refs/merge-requests/N/head on GitLab), and
+	// a commit no fetched head reaches — a PR head being the usual one. Both
+	// used to fail as "cannot resolve", which reads as a typo rather than as
+	// "this ref exists but we never asked for it" (#6153).
+	//
+	// So ask origin for exactly the one thing that was requested. This stays
+	// bounded: a single refspec (or a single object), --no-tags, and no
+	// widening of the cache's standing refspec — a second full fetch has
+	// already happened in CreateWorktree just above.
+	refspec, localRef, ok := targetedFetchRefspec(ref)
+	if !ok {
+		return "", fmt.Errorf("cannot resolve requested ref %q in repo cache at %s: it is not a branch, tag, or commit in the cache, and it is neither a fully-qualified ref (refs/...) nor a commit id, so there is nothing specific to fetch from origin", ref, barePath)
+	}
+	if out, err := runGitCombinedOutputContext(ctx, "-C", barePath, "fetch", "--no-tags", "origin", refspec); err != nil {
+		if ctx.Err() != nil {
+			return "", context.Cause(ctx)
+		}
+		return "", fmt.Errorf("cannot resolve requested ref %q in repo cache at %s: fetching it from origin failed: %s: %w", ref, barePath, strings.TrimSpace(string(out)), err)
+	}
+	if gitRefExistsContext(ctx, barePath, localRef+"^{commit}") {
+		return localRef, nil
+	}
+	return "", fmt.Errorf("cannot resolve requested ref %q in repo cache at %s: origin accepted the fetch but %s does not name a commit (an annotated object or a deleted ref)", ref, barePath, localRef)
+}
+
+// lookupCachedBaseRefContext resolves a requested ref against what the bare
+// cache already holds. Remote-tracking branches come first so a human branch
+// name never collides with a same-named tag; then tags, then anything that is
+// already a full ref or a raw commit in the cache.
+func lookupCachedBaseRefContext(ctx context.Context, barePath, ref string) (string, bool) {
 	candidates := []string{
 		"refs/remotes/origin/" + ref,
 		"refs/tags/" + ref,
@@ -1342,10 +1378,62 @@ func resolveBaseRefContext(ctx context.Context, barePath, requestedRef string) (
 	}
 	for _, candidate := range candidates {
 		if gitRefExistsContext(ctx, barePath, candidate+"^{commit}") {
-			return candidate, nil
+			return candidate, true
 		}
 	}
-	return "", fmt.Errorf("cannot resolve requested ref %q in repo cache at %s", ref, barePath)
+	return "", false
+}
+
+// targetedFetchRefspec maps a requested ref onto the single refspec that would
+// bring it into the bare cache, plus the local name it lands under. It returns
+// ok=false for anything that would turn into an unbounded or ambiguous ask.
+//
+// Only two shapes qualify, and both are self-fencing as git arguments: a
+// "refs/"-prefixed ref and a hex commit id can never start with "-", so an
+// agent-supplied --ref cannot smuggle an option (--upload-pack=...) into the
+// fetch. A bare name is deliberately excluded: Sync already fetched every head
+// and tag, so a bare name that is still missing is a typo, and guessing at
+// namespaces for it is exactly the unbounded resolution #6153 asks us to avoid.
+func targetedFetchRefspec(ref string) (refspec, localRef string, ok bool) {
+	switch {
+	case strings.HasPrefix(ref, "refs/heads/"):
+		// Keep the standard remote-tracking layout so the ref stays where the
+		// bare cache's own refspec would have put it.
+		local := "refs/remotes/origin/" + strings.TrimPrefix(ref, "refs/heads/")
+		return "+" + ref + ":" + local, local, true
+	case strings.HasPrefix(ref, "refs/tags/"):
+		return "+" + ref + ":" + ref, ref, true
+	case strings.HasPrefix(ref, "refs/"):
+		// refs/pull/12/head → refs/remotes/origin/pull/12/head. Never
+		// refs/heads/*: that namespace is reserved for the agent/* branches
+		// worktree creation locks, and a fetch into it can abort on a locked
+		// ref (see modernFetchRefspec).
+		local := "refs/remotes/origin/" + strings.TrimPrefix(ref, "refs/")
+		return "+" + ref + ":" + local, local, true
+	case isCommitID(ref):
+		// No refspec: ask for the object itself. It lands in the cache's
+		// object store (and FETCH_HEAD), and the caller resolves the id
+		// directly. Remotes that refuse unadvertised objects fail here with
+		// their own message, which is more actionable than "cannot resolve".
+		return ref, ref, true
+	default:
+		return "", "", false
+	}
+}
+
+// isCommitID reports whether ref is an abbreviated or full hex object id.
+// Seven is git's own minimum unambiguous abbreviation; 64 covers SHA-256
+// repositories.
+func isCommitID(ref string) bool {
+	if len(ref) < 7 || len(ref) > 64 {
+		return false
+	}
+	for _, r := range ref {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 func gitRefExists(repoPath, ref string) bool {

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -2250,3 +2250,204 @@ func TestBranchNameDistinctForSharedUUIDv7Prefix(t *testing.T) {
 		t.Fatalf("both tasks resolved to branch %q", a)
 	}
 }
+
+// createPullRequestRef publishes commit under refs/pull/<number>/head in the
+// source repo and leaves it unreachable from every branch — the shape GitHub
+// gives a pull request from a fork. The bare cache's standing refspec
+// (refs/heads/* only) never brings such a ref across.
+func createPullRequestRef(t *testing.T, repoPath, number string) string {
+	t.Helper()
+	defaultBranch := strings.TrimSpace(gitRefCommitName(t, repoPath))
+	runGitAuthored(t, repoPath, "checkout", "-q", "-b", "pr-work")
+	addEmptyCommit(t, repoPath, "pull request head")
+	prCommit := gitHead(t, repoPath)
+	runGitAuthored(t, repoPath, "checkout", "-q", defaultBranch)
+	runGitAuthored(t, repoPath, "branch", "-q", "-D", "pr-work")
+	runGitAuthored(t, repoPath, "update-ref", "refs/pull/"+number+"/head", prCommit)
+	return prCommit
+}
+
+// gitRefCommitName returns the checked-out branch name of a working repo.
+func gitRefCommitName(t *testing.T, repoPath string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse --abbrev-ref HEAD failed in %s: %v", repoPath, err)
+	}
+	return string(out)
+}
+
+// Regression (#6153): `repo checkout --ref refs/pull/N/head` failed with
+// "cannot resolve requested ref". The ref is real and the remote publishes it,
+// but the cache only ever fetches refs/heads/* into refs/remotes/origin/*, so
+// no amount of syncing could ever make it resolvable. The requested ref is now
+// fetched on demand, as one bounded refspec.
+func TestCreateWorktreeResolvesPullRequestRef(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	prCommit := createPullRequestRef(t, sourceRepo, "1")
+
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	// Precondition: a plain sync leaves the PR head unresolvable by name, so
+	// the checkout below can only pass by fetching it.
+	barePath := cache.Lookup("ws-1", sourceRepo)
+	if gitRefExists(barePath, "refs/pull/1/head") {
+		t.Fatal("bare cache already holds refs/pull/1/head; the test no longer covers the on-demand fetch")
+	}
+
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "Reviewer",
+		TaskID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		Ref:         "refs/pull/1/head",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree with a pull-request ref failed: %v", err)
+	}
+	if got := gitHead(t, result.Path); got != prCommit {
+		t.Fatalf("worktree is at %s, want the pull request head %s", got, prCommit)
+	}
+	// The fetch lands in the remote-tracking namespace, never in refs/heads/*
+	// where worktree creation locks the agent/* branches.
+	if !gitRefExists(barePath, "refs/remotes/origin/pull/1/head") {
+		t.Error("expected the fetched pull-request ref under refs/remotes/origin/pull/1/head")
+	}
+}
+
+// The isolated-metadata checkout resolves the base through its own local clone
+// of the cache, so the on-demand fetch has to be visible there too.
+func TestCreateWorktreeResolvesPullRequestRefWithIsolatedGitMetadata(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	prCommit := createPullRequestRef(t, sourceRepo, "7")
+
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID:         "ws-1",
+		RepoURL:             sourceRepo,
+		WorkDir:             t.TempDir(),
+		AgentName:           "Reviewer",
+		TaskID:              "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		Ref:                 "refs/pull/7/head",
+		IsolatedGitMetadata: true,
+	})
+	if err != nil {
+		t.Fatalf("isolated CreateWorktree with a pull-request ref failed: %v", err)
+	}
+	if got := gitHead(t, result.Path); got != prCommit {
+		t.Fatalf("worktree is at %s, want the pull request head %s", got, prCommit)
+	}
+}
+
+// A bare name that no head or tag matches is a typo, not a namespace we should
+// go guessing at. It must fail without a fetch, and say why.
+func TestCreateWorktreeUnknownBareRefFailsWithoutFetching(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	_, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		AgentName:   "Reviewer",
+		TaskID:      "c1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		Ref:         "no-such-branch",
+	})
+	if err == nil {
+		t.Fatal("expected an unresolvable ref to fail")
+	}
+	if !strings.Contains(err.Error(), "no-such-branch") {
+		t.Errorf("error should name the requested ref, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "nothing specific to fetch") {
+		t.Errorf("error should explain why nothing was fetched, got: %v", err)
+	}
+}
+
+func TestTargetedFetchRefspec(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		ref      string
+		refspec  string
+		localRef string
+		ok       bool
+	}{
+		{
+			name:     "pull request head lands in the remote-tracking namespace",
+			ref:      "refs/pull/12/head",
+			refspec:  "+refs/pull/12/head:refs/remotes/origin/pull/12/head",
+			localRef: "refs/remotes/origin/pull/12/head",
+			ok:       true,
+		},
+		{
+			name:     "gitlab merge request head",
+			ref:      "refs/merge-requests/3/head",
+			refspec:  "+refs/merge-requests/3/head:refs/remotes/origin/merge-requests/3/head",
+			localRef: "refs/remotes/origin/merge-requests/3/head",
+			ok:       true,
+		},
+		{
+			// refs/heads/* in the bare cache is reserved for the agent/*
+			// branches worktree creation locks; a fetch into it can abort on a
+			// locked ref, so a qualified head keeps the standard layout.
+			name:     "qualified head keeps the standard remote-tracking layout",
+			ref:      "refs/heads/feature",
+			refspec:  "+refs/heads/feature:refs/remotes/origin/feature",
+			localRef: "refs/remotes/origin/feature",
+			ok:       true,
+		},
+		{
+			name:     "qualified tag stays a tag",
+			ref:      "refs/tags/v1.2.3",
+			refspec:  "+refs/tags/v1.2.3:refs/tags/v1.2.3",
+			localRef: "refs/tags/v1.2.3",
+			ok:       true,
+		},
+		{
+			name:     "full commit id is asked for as an object",
+			ref:      "0123456789abcdef0123456789abcdef01234567",
+			refspec:  "0123456789abcdef0123456789abcdef01234567",
+			localRef: "0123456789abcdef0123456789abcdef01234567",
+			ok:       true,
+		},
+		{name: "bare branch name", ref: "feature", ok: false},
+		{name: "short hex below git's abbreviation floor", ref: "abc12", ok: false},
+		{name: "hex-looking but too long", ref: strings.Repeat("a", 65), ok: false},
+		{name: "not hex", ref: "deadbeefz", ok: false},
+		{name: "empty", ref: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			refspec, localRef, ok := targetedFetchRefspec(tt.ref)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if refspec != tt.refspec {
+				t.Errorf("refspec = %q, want %q", refspec, tt.refspec)
+			}
+			if localRef != tt.localRef {
+				t.Errorf("localRef = %q, want %q", localRef, tt.localRef)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`multica repo checkout <url> --ref <x>` fails for two of the three shapes its own help text documents.

The bare cache fetches exactly one refspec — `modernFetchRefspec` = `+refs/heads/*:refs/remotes/origin/*` — so its refs are `refs/remotes/origin/*` plus tags, and nothing else the remote publishes. `resolveBaseRef` then looks the requested ref up against only what is already in the cache:

```go
candidates := []string{"refs/remotes/origin/" + ref, "refs/tags/" + ref, ref}
```

Two documented inputs can therefore never resolve, no matter how recently `Sync` ran:

- **A fully-qualified ref outside `refs/heads/*`** — `refs/pull/N/head` on GitHub, `refs/merge-requests/N/head` on GitLab. It was never fetched, so none of the three candidates matches.
- **A commit no fetched head reaches** — a PR head being the usual one.

Both surfaced as `cannot resolve requested ref "refs/pull/12/head" in repo cache at …`, which reads like a typo rather than "this ref exists on the remote, we just never asked for it". That is what sent #6153 to the workaround of checking out with no `--ref` and running `git checkout --detach <sha>` by hand.

## Fix

When — and only when — the cache cannot resolve the requested ref, ask origin for exactly that one ref before giving up.

This stays bounded, which is what the issue asks for: a single refspec (or a single object), `--no-tags`, and no widening of the cache's standing refspec. A full fetch has already happened in `CreateWorktree` immediately above, so this is not a second one.

`targetedFetchRefspec` maps the request onto one destination:

| requested `--ref` | fetched as | lands at |
|---|---|---|
| `refs/pull/12/head` | `+refs/pull/12/head:refs/remotes/origin/pull/12/head` | `refs/remotes/origin/pull/12/head` |
| `refs/merge-requests/3/head` | `+…:refs/remotes/origin/merge-requests/3/head` | same layout |
| `refs/heads/feature` | `+refs/heads/feature:refs/remotes/origin/feature` | the standard remote-tracking layout |
| `refs/tags/v1.2.3` | `+refs/tags/v1.2.3:refs/tags/v1.2.3` | stays a tag |
| `0123…4567` (hex id) | the object itself | resolved directly |

Three properties worth calling out:

- **Never into `refs/heads/*`.** That namespace is reserved for the `agent/*` branches worktree creation locks — the very reason `modernFetchRefspec` exists — so a qualified head keeps the standard remote-tracking destination instead.
- **Bare names are deliberately excluded.** `Sync` already fetched every head and tag, so a bare name that is still missing is a typo; guessing at namespaces for it is exactly the unbounded resolution the issue asks us to avoid. It now fails without a fetch, and says why.
- **The two accepted shapes are self-fencing as git arguments.** A `refs/`-prefixed ref and a hex object id can never begin with `-`, so an agent-supplied `--ref` cannot smuggle an option (`--upload-pack=…`) into the fetch.

Remotes that refuse unadvertised objects fail with their own message, which is still more actionable than `cannot resolve`.

## Tests

`server/internal/daemon/repocache/cache_test.go`, all four new and all failing before the change:

- `TestCreateWorktreeResolvesPullRequestRef` — publishes `refs/pull/1/head` in the source repo unreachable from any branch (the fork-PR shape), asserts the checkout lands on that commit, and asserts the ref arrived under `refs/remotes/origin/pull/1/head` rather than `refs/heads/*`. It also asserts the precondition — that a plain `Sync` leaves the ref unresolvable — so the test cannot silently stop covering the on-demand fetch.
- `TestCreateWorktreeResolvesPullRequestRefWithIsolatedGitMetadata` — the isolated-metadata checkout resolves its base through its own local clone of the cache, so the fetch has to be visible there too.
- `TestCreateWorktreeUnknownBareRefFailsWithoutFetching` — a bare name still fails, naming the ref and explaining why nothing was fetched.
- `TestTargetedFetchRefspec` — the mapping table above, plus the rejected shapes (bare name, hex below git's 7-char abbreviation floor, over-long, non-hex, empty).

```
go test ./internal/daemon/repocache/   # ok, full package
```

The `--ref` flag help now mentions the qualified-ref form.

Fixes #6153
