### PR TITLE
fix(runtimes): stack usage KPI cards on mobile widths

### DIFF
--- a/packages/views/runtimes/components/usage-section.test.tsx
+++ b/packages/views/runtimes/components/usage-section.test.tsx
@@ -259,3 +259,36 @@ describe("UsageSection — custom-pricing entry point", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("UsageSection — KPI row layout", () => {
+  // Regression (#7836): the KPI row was a hard `grid-cols-3`. At a 390px
+  // viewport each column is ~110px, and `KpiCard`'s p-5 leaves ~70px for a
+  // 36px `text-display` value. A compact token total ("960.1M") is a single
+  // unbreakable token, so it painted past the card's right edge rather than
+  // wrapping. The Analytics Usage/Errors tabs already stack their identical
+  // KPI rows below `sm`; this row is the one that never got it.
+  it("stacks below sm instead of forcing three columns", () => {
+    const { container } = render(<UsageSection runtime={RUNTIME} />, {
+      wrapper: Wrapper,
+    });
+
+    // Walk up from a KPI value to the row that lays the three cards out.
+    const row = container
+      .querySelector("number-flow-react")
+      ?.closest("div.grid");
+    expect(row).not.toBeNull();
+
+    const classes = row!.className;
+    expect(classes).toContain("grid-cols-1");
+    expect(classes).toContain("sm:grid-cols-3");
+    // The unprefixed `grid-cols-3` is the defect itself: it applies at every
+    // width. `sm:grid-cols-3` must not be mistaken for it.
+    expect(classes.split(/\s+/)).not.toContain("grid-cols-3");
+    // The separator has to follow the orientation, or the stacked cards run
+    // together with a vertical rule floating between columns that no longer
+    // exist.
+    expect(classes).toContain("divide-y");
+    expect(classes).toContain("sm:divide-x");
+    expect(classes).toContain("sm:divide-y-0");
+  });
+});

--- a/packages/views/runtimes/components/usage-section.tsx
+++ b/packages/views/runtimes/components/usage-section.tsx
@@ -224,7 +224,14 @@ export function UsageSection({ runtime }: { runtime: AgentRuntime }) {
           if the user has saved overrides, so those rates remain editable. */}
       <CustomPricingBar usage={filtered} />
 
-      <div className="grid grid-cols-3 divide-x rounded-lg border bg-card">
+      {/* Stacks below `sm`, matching the Analytics tabs' KPI rows. Three
+          fixed columns leave ~70px of content width inside `KpiCard`'s p-5 at
+          a 390px viewport, and a `text-display` value ("960.1M", "$1,234.56")
+          is far wider than that — it painted past the card's right edge
+          instead of wrapping, because a number is one unbreakable token
+          (#7836). `divide-y` carries the separator through the stacked
+          orientation so the row still reads as one grouped card. */}
+      <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
         <KpiCard
           label={t(($) => $.usage.kpi_cost_label, { days })}
           value={


### PR DESCRIPTION
## Problem

The runtime detail usage KPI row is a hard `grid-cols-3`:

```tsx
<div className="grid grid-cols-3 divide-x rounded-lg border bg-card">
```

At a 390px viewport each column is ~110px, and `KpiCard`'s `p-5` leaves ~70px of content width for a `text-display` (36px) value. A compact token total such as `960.1M` — or a four-figure cost — is one unbreakable token, so it painted past the card's right edge instead of wrapping, exactly as the screenshot in #7836 shows.

## Fix

Adopt the responsive pattern the Analytics **Usage** and **Errors** tabs already use for their identical `KpiCard` rows:

```tsx
<div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0">
```

- `packages/views/dashboard/components/errors-tab.tsx:119` — same three-tile row, already `grid-cols-1 … sm:grid-cols-3 sm:divide-x sm:divide-y-0`
- `packages/views/dashboard/components/dashboard-page.tsx:538` — the four-tile variant of the same row

so this is the one KPI row on that pattern that never got it, not a new convention. `divide-y` carries the separator through the stacked orientation, or the cards run together with a vertical rule floating between columns that no longer exist.

## Test

`packages/views/runtimes/components/usage-section.test.tsx` — `UsageSection — KPI row layout`, which fails before the change:

```
AssertionError: expected 'grid grid-cols-3 divide-x rounded-lg …' to contain 'grid-cols-1'
```

It walks up from a rendered KPI value to the row that lays the cards out and asserts the base/`sm:` split, checking `grid-cols-3` as a class *token* so `sm:grid-cols-3` cannot be mistaken for the unprefixed defect, plus the divider orientation.

```
npx vitest run runtimes/components/usage-section.test.tsx   # 7 passed
```

Scoped to the reported surface. `issues/components/issue-usage-dialog.tsx` has the same three-column row, but it sits inside a `!max-w-5xl` dialog built around a nine-column run table, so it wants its own look — happy to follow up there if you'd like it stacked too.

Fixes #7836
