### PR TITLE
MUL-6916: fix(chat): stabilize live-end following across task and gesture states

### DIFF
--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -437,7 +437,7 @@ describe("ChatMessageList auto-scroll", () => {
   // again. The loop swallowed the reader's wheel scrolls, leaving the list
   // shaking and immovable. Corrections must go through Virtuoso.
   it("corrects through Virtuoso rather than writing scrollTop on the container", () => {
-    const { scroll } = renderStreamingChat();
+    const { scroll } = renderChat();
 
     scroll.grow(180);
     scroll.shrinkViewport(72);
@@ -456,7 +456,7 @@ describe("ChatMessageList auto-scroll", () => {
   // newest row's own box, because during the estimate the scroll geometry
   // reports the viewport as being at the live end.
   it("stays hidden until the newest message has actually landed at the bottom", () => {
-    const { view, scroll } = renderStreamingChat();
+    const { view, scroll } = renderChat();
 
     const box = (el: Element, top: number, bottom: number) => {
       el.getBoundingClientRect = () => ({ top, bottom }) as DOMRect;
@@ -491,7 +491,7 @@ describe("ChatMessageList auto-scroll", () => {
   // highlighting — moves the content under a reader pinned to the bottom.
   // Reaching the live end once is not enough to reveal (MUL-6879).
   it("keeps waiting while rows are still changing size at the live end", () => {
-    const { view, scroll } = renderStreamingChat();
+    const { view, scroll } = renderChat();
 
     const box = (el: Element, top: number, bottom: number) => {
       el.getBoundingClientRect = () => ({ top, bottom }) as DOMRect;

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -3,7 +3,7 @@ import { act, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { chatKeys } from "@multica/core/chat/queries";
-import type { TaskMessagePayload } from "@multica/core/types";
+import type { ChatPendingTask, TaskMessagePayload } from "@multica/core/types";
 import type { ReactElement } from "react";
 import enChat from "../../locales/en/chat.json";
 import { ChatMessageList } from "./chat-message-list";
@@ -370,12 +370,12 @@ const RUNNING_TASK = { task_id: TASK_ID, status: "running" } as const;
 
 function renderChat({
   contentHeight = 2000,
-  pendingTask = RUNNING_TASK as typeof RUNNING_TASK | null,
+  pendingTask = RUNNING_TASK as ChatPendingTask | null,
 } = {}) {
   const qc = new QueryClient();
   qc.setQueryData(chatKeys.taskMessages(TASK_ID), [taskMsg(0, "Looking into it. ")]);
 
-  const ui = (pending: typeof RUNNING_TASK | null) => (
+  const ui = (pending: ChatPendingTask | null) => (
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <QueryClientProvider client={qc}>
         <ChatMessageList messages={[]} pendingTask={pending} availability={undefined} />
@@ -397,7 +397,7 @@ function renderChat({
       view.container
         .querySelector("[data-follow-at-bottom]")
         ?.getAttribute("data-follow-at-bottom"),
-    setPendingTask: (pending: typeof RUNNING_TASK | null) => {
+    setPendingTask: (pending: ChatPendingTask | null) => {
       act(() => {
         view.rerender(ui(pending));
       });
@@ -898,6 +898,26 @@ describe("ChatMessageList auto-scroll while idle", () => {
     const { followsAtBottom } = renderIdleChat();
 
     expect(followsAtBottom()).toBe("auto");
+  });
+
+  it.each(["queued", "waiting_local_directory", "deferred"])(
+    "does not pin content growth while the pending task is %s",
+    (status) => {
+      const { scroll } = renderChat({ pendingTask: { task_id: TASK_ID, status } });
+
+      scroll.grow(180);
+
+      expect(scroll.distanceFromBottom()).toBe(180);
+    },
+  );
+
+  it("stops pinning when a live task becomes idle", () => {
+    const { scroll, setPendingTask } = renderChat();
+
+    setPendingTask(null);
+    scroll.grow(180);
+
+    expect(scroll.distanceFromBottom()).toBe(180);
   });
 
   it("engages the follow when a task starts with the reader at the bottom", () => {

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -743,6 +743,21 @@ describe("ChatMessageList auto-scroll", () => {
     expect(scroll.distanceFromBottom()).toBe(560);
   });
 
+  // The frame-boundary re-judge fires only for pins a gesture actually
+  // deferred. An unconditional re-judge snapped back every sub-threshold
+  // reader scroll (touchpad tick, arrow key) one frame later, with no growth
+  // anywhere (TIM-65 review).
+  it("leaves a confirmed sub-threshold scroll alone at the frame boundary", () => {
+    const { scroll } = renderChat();
+
+    scroll.readerScrollsUp(60);
+    expect(scroll.distanceFromBottom()).toBe(60);
+
+    renderFrame();
+
+    expect(scroll.distanceFromBottom()).toBe(60);
+  });
+
   it("pins growth deferred by unconsumed input once the claim frame ends", () => {
     const { scroll, streamChunk } = renderChat();
 
@@ -755,6 +770,35 @@ describe("ChatMessageList auto-scroll", () => {
     renderFrame(); // claim discarded at the frame boundary: deferred pin fires
 
     expect(scroll.distanceFromBottom()).toBe(0);
+  });
+
+  // A deferral with no input frame left to consume it (growth deferred by
+  // carry residue after the gesture's rAF already fired) must be settled by
+  // the pin that eventually resolves it — not inherited by the next gesture's
+  // frame boundary, which would snap back a scroll that gesture never earned
+  // (TIM-65 review round 2).
+  it("does not inherit a stranded deferral into a later gesture's frame", () => {
+    const { scroll, streamChunk } = renderChat();
+
+    scroll.wheelInput(100);
+    scroll.browserScrollsListUp(40); // browser under-delivers: carry residue
+    renderFrame(); // this gesture's boundary: nothing deferred yet
+
+    streamChunk(1);
+    scroll.grow(180); // deferred by the residue
+
+    gestureSettles();
+    streamChunk(2);
+    scroll.grow(180); // settle window over: pins normally, settling the flag
+    expect(scroll.distanceFromBottom()).toBe(0);
+
+    gestureSettles();
+    scroll.readerScrollsUp(60); // brand new, fully confirmed, sub-threshold
+    expect(scroll.distanceFromBottom()).toBe(60);
+
+    renderFrame(); // nothing deferred this frame: nothing to re-judge
+
+    expect(scroll.distanceFromBottom()).toBe(60);
   });
 
   it("keeps following after a flick on a conversation too short to scroll", () => {

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -355,21 +355,24 @@ function taskMsg(seq: number, content: string): TaskMessagePayload {
   return { task_id: TASK_ID, seq, type: "text", content } as TaskMessagePayload;
 }
 
-function renderStreamingChat({ contentHeight = 2000 } = {}) {
+const RUNNING_TASK = { task_id: TASK_ID, status: "running" } as const;
+
+function renderChat({
+  contentHeight = 2000,
+  pendingTask = RUNNING_TASK as typeof RUNNING_TASK | null,
+} = {}) {
   const qc = new QueryClient();
   qc.setQueryData(chatKeys.taskMessages(TASK_ID), [taskMsg(0, "Looking into it. ")]);
 
-  const view = render(
+  const ui = (pending: typeof RUNNING_TASK | null) => (
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <QueryClientProvider client={qc}>
-        <ChatMessageList
-          messages={[]}
-          pendingTask={{ task_id: TASK_ID, status: "running" }}
-          availability={undefined}
-        />
+        <ChatMessageList messages={[]} pendingTask={pending} availability={undefined} />
       </QueryClientProvider>
-    </I18nProvider>,
+    </I18nProvider>
   );
+
+  const view = render(ui(pendingTask));
 
   const el = view.container.querySelector<HTMLElement>("[data-tab-scroll-root]");
   if (!el) throw new Error("chat list did not render a scroll container");
@@ -383,6 +386,11 @@ function renderStreamingChat({ contentHeight = 2000 } = {}) {
       view.container
         .querySelector("[data-follow-at-bottom]")
         ?.getAttribute("data-follow-at-bottom"),
+    setPendingTask: (pending: typeof RUNNING_TASK | null) => {
+      act(() => {
+        view.rerender(ui(pending));
+      });
+    },
     streamChunk: (seq: number) => {
       act(() => {
         qc.setQueryData<TaskMessagePayload[]>(
@@ -394,9 +402,12 @@ function renderStreamingChat({ contentHeight = 2000 } = {}) {
   };
 }
 
+const renderIdleChat = ({ contentHeight = 2000 } = {}) =>
+  renderChat({ contentHeight, pendingTask: null });
+
 describe("ChatMessageList auto-scroll", () => {
   it("follows a streaming reply whose row count never changes", () => {
-    const { scroll, streamChunk, rowCount } = renderStreamingChat();
+    const { scroll, streamChunk, rowCount } = renderChat();
 
     const rowsBefore = rowCount();
     for (let seq = 1; seq <= 30; seq++) {
@@ -493,7 +504,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("keeps the newest content clear of a composer that grew", () => {
-    const { scroll } = renderStreamingChat();
+    const { scroll } = renderChat();
 
     scroll.shrinkViewport(72);
 
@@ -501,7 +512,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("stays pinned when the composer collapses", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     streamChunk(1);
     scroll.grow(180);
@@ -516,7 +527,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("stays pinned when content shrinks", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     streamChunk(1);
     scroll.grow(180);
@@ -533,7 +544,7 @@ describe("ChatMessageList auto-scroll", () => {
   // The base behavior `atBottomThreshold` always granted: a trackpad nudge
   // inside the edge zone is not the reader leaving.
   it("keeps following after a small trackpad nudge near the live end", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.readerScrollsUp(2);
     gestureSettles();
@@ -545,7 +556,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("releases when touch momentum carries a flick past the threshold", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.touchStart(100);
     scroll.touchMove(180, 80);
@@ -560,7 +571,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("leaves a fractional touch drag in progress", () => {
-    const { scroll, streamChunk, followsAtBottom } = renderStreamingChat();
+    const { scroll, streamChunk, followsAtBottom } = renderChat();
 
     scroll.touchStart(100);
     scroll.touchMove(180, 80.5);
@@ -572,7 +583,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("resumes pinning after a sub-threshold touch ends", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.touchStart(100);
     scroll.touchMove(180, 80);
@@ -585,7 +596,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("releases on incremental upward scrolling during a fast stream", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     streamChunk(1);
     scroll.grow(180);
@@ -609,7 +620,7 @@ describe("ChatMessageList auto-scroll", () => {
   // Discrete mouse wheel at reading pace: one notch per event, spaced past
   // the intent window. Release must not require a single fast burst.
   it("releases for wheel notches spaced past the intent window", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.readerScrollsUp(100);
     gestureSettles();
@@ -626,7 +637,7 @@ describe("ChatMessageList auto-scroll", () => {
   // A reply's final chunk always exists and has a whole intent window to land
   // in after any small nudge; no later event will re-evaluate a declined pin.
   it("pins a chunk that lands inside the reader's intent window", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.readerScrollsUp(2);
     streamChunk(1);
@@ -636,7 +647,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("honors Shift+Space paging from a focused row control", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.shiftSpaceFromRowControl();
     scroll.browserScrollsListUp(VIEWPORT);
@@ -650,7 +661,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("leaves the viewport alone once the reader scrolls up to read history", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.readerScrollsTo(900);
     gestureSettles();
@@ -666,7 +677,7 @@ describe("ChatMessageList auto-scroll", () => {
   // Wheel over a capped code block scrolls the block; the event bubbles to
   // the list without moving it. Unconsumed input must not release the follow.
   it("keeps following through wheel input the list never consumed", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.wheelWithoutScroll(200);
     gestureSettles();
@@ -678,7 +689,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("pins a system shift after nested scrolling left input unconsumed", () => {
-    const { scroll } = renderStreamingChat();
+    const { scroll } = renderChat();
 
     scroll.wheelWithoutScroll(300);
     renderFrame();
@@ -688,7 +699,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("keeps following after a flick on a conversation too short to scroll", () => {
-    const { scroll, streamChunk } = renderStreamingChat({ contentHeight: 400 });
+    const { scroll, streamChunk } = renderChat({ contentHeight: 400 });
 
     scroll.wheelWithoutScroll(200);
     gestureSettles();
@@ -705,7 +716,7 @@ describe("ChatMessageList auto-scroll", () => {
   // scrolls the list. The scroll confirms the staged key intent: the reader
   // is released, not pinned back over their own keypress.
   it("honors keyboard paging from a focused row control", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.pageUpFromRowControl();
     scroll.browserScrollsListUp(VIEWPORT);
@@ -719,7 +730,7 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("re-engages when the reader scrolls back down to the live end", () => {
-    const { scroll, streamChunk } = renderStreamingChat();
+    const { scroll, streamChunk } = renderChat();
 
     scroll.readerScrollsTo(900);
     scroll.readerScrollsTo(0);
@@ -734,7 +745,7 @@ describe("ChatMessageList auto-scroll", () => {
   // `followOutput` is `atBottom && isFollowing()`: a released follow must turn
   // it off even while Virtuoso still reports the reader at the bottom.
   it("turns followOutput off while released, even when Virtuoso reports atBottom", () => {
-    const { scroll, streamChunk, followsAtBottom } = renderStreamingChat();
+    const { scroll, streamChunk, followsAtBottom } = renderChat();
 
     expect(followsAtBottom()).toBe("auto");
 
@@ -745,10 +756,67 @@ describe("ChatMessageList auto-scroll", () => {
   });
 
   it("stops measuring once the list unmounts", () => {
-    const { view } = renderStreamingChat();
+    const { view } = renderChat();
 
     view.unmount();
 
     expect(observedTargets()).toHaveLength(0);
+  });
+});
+
+// With no task in flight there is no live end: nothing may move the viewport
+// on the reader's behalf, whatever resizes or scrolls happen (TIM-65).
+describe("ChatMessageList auto-scroll while idle", () => {
+  it("does not pin when content grows under a reader at the bottom", () => {
+    const { scroll } = renderIdleChat();
+
+    scroll.grow(400);
+
+    expect(scroll.distanceFromBottom()).toBe(400);
+  });
+
+  it("does not pin when the composer grows", () => {
+    const { scroll } = renderIdleChat();
+
+    scroll.shrinkViewport(72);
+
+    expect(scroll.distanceFromBottom()).toBe(72);
+  });
+
+  it("does not fight a scroll it saw no input for", () => {
+    const { scroll } = renderIdleChat();
+
+    scroll.browserScrollsListUp(300);
+
+    expect(scroll.distanceFromBottom()).toBe(300);
+  });
+
+  it("still follows appended rows through plain atBottom", () => {
+    const { followsAtBottom } = renderIdleChat();
+
+    expect(followsAtBottom()).toBe("auto");
+  });
+
+  it("engages the follow when a task starts with the reader at the bottom", () => {
+    const { scroll, setPendingTask, streamChunk } = renderIdleChat();
+
+    setPendingTask(RUNNING_TASK);
+    streamChunk(1);
+    scroll.grow(180);
+
+    expect(scroll.distanceFromBottom()).toBe(0);
+  });
+
+  it("leaves a reader up in history alone when a task starts", () => {
+    const { scroll, setPendingTask, streamChunk } = renderIdleChat();
+
+    scroll.browserScrollsListUp(900);
+    const parked = scroll.scrollTop;
+
+    setPendingTask(RUNNING_TASK);
+    streamChunk(1);
+    scroll.grow(500);
+
+    expect(scroll.scrollTop).toBe(parked);
   });
 });

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -911,6 +911,24 @@ describe("ChatMessageList auto-scroll while idle", () => {
     },
   );
 
+  it("keeps following for an unknown pending-task status", () => {
+    const { scroll } = renderChat({
+      pendingTask: { task_id: TASK_ID, status: "some_future_streaming_status" },
+    });
+
+    scroll.grow(180);
+
+    expect(scroll.distanceFromBottom()).toBe(0);
+  });
+
+  it("keeps following when the pending-task status is absent", () => {
+    const { scroll } = renderChat({ pendingTask: { task_id: TASK_ID } });
+
+    scroll.grow(180);
+
+    expect(scroll.distanceFromBottom()).toBe(0);
+  });
+
   it("stops pinning when a live task becomes idle", () => {
     const { scroll, setPendingTask } = renderChat();
 

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -709,12 +709,11 @@ describe("ChatMessageList auto-scroll", () => {
     expect(scroll.distanceFromBottom()).toBe(0);
   });
 
-  // A mouse wheel tick delivers its input at once; the browser ANIMATES the
-  // scroll over the following frames. A pin landing mid-animation cancels the
-  // animation and reverts the tick, so wheel users were yanked back to the
-  // bottom continuously — every tick answered by a chunk or one of Virtuoso's
-  // re-measure height changes — while touchpads, whose displacement confirms
-  // per event, escaped normally (TIM-65 follow-up).
+  // A mouse wheel tick delivers its input at once, but the browser may animate
+  // its displacement over later frames. A pin landing mid-animation cancels
+  // and reverts the tick. Content growth and Virtuoso remeasurement can request
+  // pins during that interval; touchpads usually confirm displacement per event
+  // and therefore reach the release threshold before a pin can interrupt them.
   it("does not cancel an animated wheel tick with a mid-flight chunk pin", () => {
     const { scroll, streamChunk } = renderChat();
 
@@ -743,10 +742,9 @@ describe("ChatMessageList auto-scroll", () => {
     expect(scroll.distanceFromBottom()).toBe(560);
   });
 
-  // The frame-boundary re-judge fires only for pins a gesture actually
-  // deferred. An unconditional re-judge snapped back every sub-threshold
-  // reader scroll (touchpad tick, arrow key) one frame later, with no growth
-  // anywhere (TIM-65 review).
+  // Only a pin actually deferred by a gesture warrants a frame-boundary
+  // re-judge. Re-judging every input frame would snap back a sub-threshold
+  // touchpad tick or arrow-key scroll even when no growth requested a pin.
   it("leaves a confirmed sub-threshold scroll alone at the frame boundary", () => {
     const { scroll } = renderChat();
 
@@ -772,11 +770,10 @@ describe("ChatMessageList auto-scroll", () => {
     expect(scroll.distanceFromBottom()).toBe(0);
   });
 
-  // A deferral with no input frame left to consume it (growth deferred by
-  // carry residue after the gesture's rAF already fired) must be settled by
-  // the pin that eventually resolves it — not inherited by the next gesture's
-  // frame boundary, which would snap back a scroll that gesture never earned
-  // (TIM-65 review round 2).
+  // A deferral created after its input frame ended can outlive the gesture
+  // that caused it. The first resolved pin verdict must settle that deferral;
+  // otherwise the next gesture's frame boundary can inherit it and snap back
+  // a scroll that gesture never deferred.
   it("does not inherit a stranded deferral into a later gesture's frame", () => {
     const { scroll, streamChunk } = renderChat();
 
@@ -867,8 +864,8 @@ describe("ChatMessageList auto-scroll", () => {
   });
 });
 
-// With no task in flight there is no live end: nothing may move the viewport
-// on the reader's behalf, whatever resizes or scrolls happen (TIM-65).
+// With no streaming task there is no live end: resizes and system scrolls must
+// not move the viewport on the reader's behalf.
 describe("ChatMessageList auto-scroll while idle", () => {
   it("does not pin when content grows under a reader at the bottom", () => {
     const { scroll } = renderIdleChat();

--- a/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
+++ b/packages/views/chat/components/chat-message-list.autoscroll.test.tsx
@@ -164,6 +164,12 @@ interface Scroller {
   shrinkViewport(px: number): void;
   /** Reader wheel input scrolling up by `px`, and the scroll it causes. */
   readerScrollsUp(px: number): void;
+  /**
+   * Wheel input alone: the browser answers a mouse wheel tick with ANIMATED
+   * scrolling, so its displacement arrives over later frames (model those
+   * with `browserScrollsListUp`).
+   */
+  wheelInput(px: number): void;
   /** Starts a one-finger touch gesture at `clientY`. */
   touchStart(clientY: number): void;
   /** Moves that finger and then scrolls the list up by `scrollPx`. */
@@ -290,6 +296,11 @@ function scroller(el: HTMLElement, initialContent = 2000): Scroller {
     },
     readerScrollsUp(px) {
       wheelBy(px);
+    },
+    wheelInput(px) {
+      act(() => {
+        el.dispatchEvent(new WheelEvent("wheel", { deltaY: -px }));
+      });
     },
     touchStart(clientY) {
       act(() => {
@@ -694,6 +705,54 @@ describe("ChatMessageList auto-scroll", () => {
     scroll.wheelWithoutScroll(300);
     renderFrame();
     scroll.browserScrollsListUp(200);
+
+    expect(scroll.distanceFromBottom()).toBe(0);
+  });
+
+  // A mouse wheel tick delivers its input at once; the browser ANIMATES the
+  // scroll over the following frames. A pin landing mid-animation cancels the
+  // animation and reverts the tick, so wheel users were yanked back to the
+  // bottom continuously — every tick answered by a chunk or one of Virtuoso's
+  // re-measure height changes — while touchpads, whose displacement confirms
+  // per event, escaped normally (TIM-65 follow-up).
+  it("does not cancel an animated wheel tick with a mid-flight chunk pin", () => {
+    const { scroll, streamChunk } = renderChat();
+
+    scroll.wheelInput(100);
+    scroll.browserScrollsListUp(10); // first animation frame confirms the tick
+    streamChunk(1);
+    scroll.grow(180); // chunk lands mid-animation: must not pin
+
+    expect(scroll.distanceFromBottom()).toBe(190);
+  });
+
+  it("releases across two animated wheel ticks despite growth between them", () => {
+    const { scroll, streamChunk } = renderChat();
+
+    scroll.wheelInput(100);
+    scroll.browserScrollsListUp(20);
+    streamChunk(1);
+    scroll.grow(180); // deferred: the tick's animation is still in flight
+    scroll.browserScrollsListUp(80); // tick 1 finishes: 100px taken
+    scroll.wheelInput(100);
+    scroll.browserScrollsListUp(100); // tick 2: 200px taken, released
+    gestureSettles();
+    streamChunk(2);
+    scroll.grow(180);
+
+    expect(scroll.distanceFromBottom()).toBe(560);
+  });
+
+  it("pins growth deferred by unconsumed input once the claim frame ends", () => {
+    const { scroll, streamChunk } = renderChat();
+
+    scroll.wheelWithoutScroll(300);
+    streamChunk(1);
+    scroll.grow(180); // deferred: the claim might still confirm
+
+    expect(scroll.distanceFromBottom()).toBe(180);
+
+    renderFrame(); // claim discarded at the frame boundary: deferred pin fires
 
     expect(scroll.distanceFromBottom()).toBe(0);
   });

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -360,7 +360,7 @@ export function ChatMessageList({
         atBottomThreshold={FOLLOW_EDGE_THRESHOLD}
         // Follow appended rows only while Virtuoso says the reader is at the
         // live end. An in-flight smooth animation temporarily reports "not at
-        // bottom" on the next append and permanently drops the follow (#6697),
+        // bottom" on the next append and permanently drops the follow,
         // so live growth must use an immediate scroll. While a task can stream,
         // `isFollowing` narrows this further: the reader may have
         // scrolled away by input the 120px `atBottom` band forgives (see

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -55,6 +55,11 @@ import { splitTimeline, extractCopyText } from "../lib/copy-text";
 import { stripChatQuickActionsProtocol } from "../lib/quick-actions";
 import { useT } from "../../i18n";
 
+// These pending states can persist without producing any transcript growth.
+// Keep this a denylist: status is an optional, open server string, so a newer
+// streaming status must retain the existing follow behavior on older clients.
+const PARKED_TASK_STATUSES = new Set(["queued", "waiting_local_directory", "deferred"]);
+
 // ─── Public component ────────────────────────────────────────────────────
 
 interface ChatMessageListProps {
@@ -191,9 +196,11 @@ export function ChatMessageList({
     scrollRef.current = node;
     setScrollContainerEl(node);
   }, []);
-  // An idle chat has no live end, so the bottom-stick only runs while a task
-  // is pending.
-  const hasPendingTask = !!pendingTask;
+  // The bottom-stick runs only while the pending task can stream. Queued,
+  // directory-waiting and deferred tasks have no live end, so a fold, image or
+  // composer resize must not move the viewport on the reader's behalf.
+  const hasLiveTask =
+    !!pendingTask && !PARKED_TASK_STATUSES.has(pendingTask.status ?? "");
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   // The bottom-stick corrects through Virtuoso, never by writing `scrollTop`
   // on the container: `scrollHeight` is an estimate over the unrendered rows,
@@ -204,7 +211,7 @@ export function ChatMessageList({
   const { isFollowing, onContentHeightChanged, hasReachedLiveEnd } = useStickToBottom(
     scrollContainerEl,
     pinToLiveEnd,
-    hasPendingTask,
+    hasLiveTask,
   );
   // Soft edge fade hinting more content above/below. Kept small so it barely
   // grazes full-bleed previews (image / HTML) at the edges.
@@ -354,16 +361,16 @@ export function ChatMessageList({
         // Follow appended rows only while Virtuoso says the reader is at the
         // live end. An in-flight smooth animation temporarily reports "not at
         // bottom" on the next append and permanently drops the follow (#6697),
-        // so live growth must use an immediate scroll. While a task is in
-        // flight, `isFollowing` narrows this further: the reader may have
+        // so live growth must use an immediate scroll. While a task can stream,
+        // `isFollowing` narrows this further: the reader may have
         // scrolled away by input the 120px `atBottom` band forgives (see
-        // stick-to-bottom.ts). While idle the latch is off and plain
+        // stick-to-bottom.ts). While idle or parked the latch is off and plain
         // `atBottom` decides — a message arriving from another device still
         // scrolls a reader who is at the bottom.
         followOutput={(atBottom) =>
           !isFetchingOlderMessages &&
           atBottom &&
-          (hasPendingTask ? isFollowing() : true)
+          (hasLiveTask ? isFollowing() : true)
             ? "auto"
             : false
         }

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -191,6 +191,9 @@ export function ChatMessageList({
     scrollRef.current = node;
     setScrollContainerEl(node);
   }, []);
+  // An idle chat has no live end, so the bottom-stick only runs while a task
+  // is pending.
+  const hasPendingTask = !!pendingTask;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   // The bottom-stick corrects through Virtuoso, never by writing `scrollTop`
   // on the container: `scrollHeight` is an estimate over the unrendered rows,
@@ -201,6 +204,7 @@ export function ChatMessageList({
   const { isFollowing, onContentHeightChanged, hasReachedLiveEnd } = useStickToBottom(
     scrollContainerEl,
     pinToLiveEnd,
+    hasPendingTask,
   );
   // Soft edge fade hinting more content above/below. Kept small so it barely
   // grazes full-bleed previews (image / HTML) at the edges.
@@ -347,14 +351,21 @@ export function ChatMessageList({
         initialTopMostItemIndex={{ index: "LAST", align: "end" }}
         increaseViewportBy={{ top: 400, bottom: 600 }}
         atBottomThreshold={FOLLOW_EDGE_THRESHOLD}
-        // Follow rapid streamed output only while Virtuoso says the reader is
-        // at the live end. An in-flight smooth animation temporarily reports
-        // "not at bottom" on the next append and permanently drops the follow
-        // (#6697), so live growth must use an immediate scroll. `isFollowing`
-        // narrows this further: the reader may have scrolled away by input the
-        // 120px `atBottom` band forgives (see stick-to-bottom.ts).
+        // Follow appended rows only while Virtuoso says the reader is at the
+        // live end. An in-flight smooth animation temporarily reports "not at
+        // bottom" on the next append and permanently drops the follow (#6697),
+        // so live growth must use an immediate scroll. While a task is in
+        // flight, `isFollowing` narrows this further: the reader may have
+        // scrolled away by input the 120px `atBottom` band forgives (see
+        // stick-to-bottom.ts). While idle the latch is off and plain
+        // `atBottom` decides — a message arriving from another device still
+        // scrolls a reader who is at the bottom.
         followOutput={(atBottom) =>
-          !isFetchingOlderMessages && atBottom && isFollowing() ? "auto" : false
+          !isFetchingOlderMessages &&
+          atBottom &&
+          (hasPendingTask ? isFollowing() : true)
+            ? "auto"
+            : false
         }
         // `followOutput` never fires for a single row growing mid-stream, so
         // content resizes route to the bottom-stick through Virtuoso's own

--- a/packages/views/chat/components/stick-to-bottom.ts
+++ b/packages/views/chat/components/stick-to-bottom.ts
@@ -208,12 +208,13 @@ export function useStickToBottom(
       if (inputFrame !== null) cancelAnimationFrame(inputFrame);
       inputFrame = requestAnimationFrame(() => {
         inputFrame = null;
-        follow.endInputFrame();
         // A staged claim defers pins (a wheel tick's scroll is animated and a
         // pin mid-flight would cancel it). If the claim was never confirmed —
         // nested-scroller input the list did not consume — it is gone now, so
-        // re-judge: a pin deferred by it fires one frame late, not never.
-        onResize();
+        // re-judge a pin it deferred: it fires one frame late, not never.
+        // Only when one was actually deferred: an unconditional re-judge
+        // would snap back sub-threshold reader scrolls nothing had pinned.
+        if (follow.endInputFrame()) onResize();
       });
     };
     const onWheel = (e: WheelEvent) => {

--- a/packages/views/chat/components/stick-to-bottom.ts
+++ b/packages/views/chat/components/stick-to-bottom.ts
@@ -123,9 +123,10 @@ export interface StickToBottom {
  * scroll to the last row is what Virtuoso's own `followOutput` does, and it
  * converges because Virtuoso measures that row before deciding where to stop.
  *
- * `live` is whether a task is in flight. An idle chat has no live end to
- * follow, so while `live` is false nothing here moves the viewport: expanding
- * a fold, loading an image or resizing the composer must not move the reader.
+ * `live` is whether the pending task can currently stream. Idle and parked
+ * chats have no live end to follow, so while `live` is false nothing here
+ * moves the viewport: expanding a fold, loading an image or resizing the
+ * composer must not yank the reader to the bottom.
  */
 export function useStickToBottom(
   scrollEl: HTMLElement | null,
@@ -211,9 +212,9 @@ export function useStickToBottom(
         // A staged claim defers pins (a wheel tick's scroll is animated and a
         // pin mid-flight would cancel it). If the claim was never confirmed —
         // nested-scroller input the list did not consume — it is gone now, so
-        // re-judge a pin it deferred: it fires one frame late, not never.
-        // Only when one was actually deferred: an unconditional re-judge
-        // would snap back sub-threshold reader scrolls nothing had pinned.
+        // re-judge only if it deferred a pin. The pin then fires one frame
+        // late; an unconditional re-judge would instead snap back
+        // sub-threshold reader scrolls when nothing requested a pin.
         if (follow.endInputFrame()) onResize();
       });
     };

--- a/packages/views/chat/components/stick-to-bottom.ts
+++ b/packages/views/chat/components/stick-to-bottom.ts
@@ -122,23 +122,37 @@ export interface StickToBottom {
  * releases and the list cannot be scrolled at all (MUL-6879). An index-based
  * scroll to the last row is what Virtuoso's own `followOutput` does, and it
  * converges because Virtuoso measures that row before deciding where to stop.
+ *
+ * `live` is whether a task is in flight. An idle chat has no live end to
+ * follow, so while `live` is false nothing here moves the viewport: expanding
+ * a fold, loading an image or resizing the composer must not move the reader.
  */
 export function useStickToBottom(
   scrollEl: HTMLElement | null,
   pinToLiveEnd: () => void,
+  live: boolean,
 ): StickToBottom {
   const followRef = useRef<LiveEndFollow | null>(null);
   if (followRef.current === null) {
     followRef.current = createLiveEndFollow();
-    // Unlike the transcript, the chat list is always live. Activated at
-    // creation, not in an effect: `followOutput` reads the latch on the
-    // very first render.
-    followRef.current.setActive(true);
+    // Activated synchronously, not only in the effect below: `followOutput`
+    // reads the latch on the very first render.
+    followRef.current.setActive(live);
   }
   const follow = followRef.current;
 
   const pinRef = useRef(pinToLiveEnd);
   pinRef.current = pinToLiveEnd;
+
+  useEffect(() => {
+    follow.setActive(live);
+    if (!live) return;
+    // A task just started (or the list mounted mid-task): judge the follow
+    // from where the reader is NOW, not from latch state the previous task
+    // left behind. A reader up in history when a task starts stays there.
+    follow.reset();
+    if (scrollEl && !isAtLiveEnd(scrollEl)) follow.disengage();
+  }, [follow, live, scrollEl]);
   const pin = useCallback(() => {
     pinRef.current();
   }, []);

--- a/packages/views/chat/components/stick-to-bottom.ts
+++ b/packages/views/chat/components/stick-to-bottom.ts
@@ -209,6 +209,11 @@ export function useStickToBottom(
       inputFrame = requestAnimationFrame(() => {
         inputFrame = null;
         follow.endInputFrame();
+        // A staged claim defers pins (a wheel tick's scroll is animated and a
+        // pin mid-flight would cancel it). If the claim was never confirmed —
+        // nested-scroller input the list did not consume — it is gone now, so
+        // re-judge: a pin deferred by it fires one frame late, not never.
+        onResize();
       });
     };
     const onWheel = (e: WheelEvent) => {

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -27,18 +27,22 @@ vi.mock("@multica/ui/lib/clipboard", () => ({
 }));
 
 // Real react-virtuoso renders no data rows under jsdom's zero-height viewport,
-// so stub it with a flat render to make rows visible to these tests.
+// so stub it with a flat render to make rows visible to these tests. The
+// scroller element is forwarded through `scrollerRef` (identity-stable, so
+// React attaches it once) for the live-end follow wiring suite below.
 vi.mock("react-virtuoso", () => ({
   Virtuoso: ({
     data,
     itemContent,
     computeItemKey,
+    scrollerRef,
   }: {
     data: TimelineItem[];
     itemContent: (i: number, item: TimelineItem) => ReactNode;
     computeItemKey: (i: number, item: TimelineItem) => number;
+    scrollerRef?: (el: HTMLElement | null) => void;
   }) => (
-    <div>
+    <div data-testid="transcript-scroller" ref={scrollerRef}>
       {data.map((item, i) => (
         <div key={computeItemKey(i, item)}>{itemContent(i, item)}</div>
       ))}
@@ -919,5 +923,167 @@ describe("AgentTranscriptDialog — reason vs raw diagnostics", () => {
 
     expect(screen.queryByText("Technical details")).not.toBeInTheDocument();
     expect(screen.queryByText("Reason")).not.toBeInTheDocument();
+  });
+});
+
+// The follow wiring itself: input staging, the scroll-event pin, and the
+// frame-boundary re-judge. The latch decision table is canonical in
+// transcript-follow.test.ts; these tests drive the dialog's DOM wiring the
+// way the chat list's suite drives chat-message-list. This surface is
+// newest-first, so the live end is at the TOP: away from it is scrolling
+// DOWN (positive deltaY), and the pin writes scrollTop = 0.
+describe("AgentTranscriptDialog — live-end follow wiring", () => {
+  let animationFrames: Map<number, FrameRequestCallback>;
+  let nextFrameId = 1;
+  let now = 0;
+
+  beforeEach(() => {
+    animationFrames = new Map();
+    nextFrameId = 1;
+    now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      const id = nextFrameId++;
+      animationFrames.set(id, cb);
+      return id;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      animationFrames.delete(id);
+    });
+    // The latch only engages while live and newest-first.
+    useTranscriptViewStore.setState({ sortDirection: "newest_first" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.mocked(Date.now).mockRestore();
+  });
+
+  function renderFrame() {
+    const callbacks = [...animationFrames.values()];
+    animationFrames.clear();
+    now += 16;
+    for (const cb of callbacks) cb(now);
+  }
+
+  function gestureSettles() {
+    now += 301;
+  }
+
+  function liveScroller() {
+    renderDialog(items, { task: liveTask, isLive: true });
+    const el = screen.getByTestId("transcript-scroller");
+    const state = { scrollTop: 0, contentHeight: 2000, viewportHeight: 600 };
+    Object.defineProperties(el, {
+      scrollHeight: { configurable: true, get: () => state.contentHeight },
+      clientHeight: { configurable: true, get: () => state.viewportHeight },
+      scrollTop: {
+        configurable: true,
+        get: () => state.scrollTop,
+        set: (value: number) => {
+          state.scrollTop = value;
+        },
+      },
+    });
+    const scrollEvent = () =>
+      act(() => {
+        el.dispatchEvent(new Event("scroll"));
+      });
+    return {
+      get scrollTop() {
+        return state.scrollTop;
+      },
+      /** Reader wheel input away from the live end, and the scroll it causes. */
+      readerScrollsDown(px: number) {
+        act(() => {
+          el.dispatchEvent(new WheelEvent("wheel", { deltaY: px }));
+        });
+        state.scrollTop += px;
+        scrollEvent();
+      },
+      /** Wheel input alone; the browser animates the scroll over later frames. */
+      wheelInputDown(px: number) {
+        act(() => {
+          el.dispatchEvent(new WheelEvent("wheel", { deltaY: px }));
+        });
+      },
+      /** Wheel input a nested scroller consumed: no scroll event follows. */
+      wheelWithoutScroll(px: number) {
+        const nested = document.createElement("pre");
+        el.appendChild(nested);
+        act(() => {
+          nested.dispatchEvent(new WheelEvent("wheel", { deltaY: px, bubbles: true }));
+        });
+      },
+      /** The system moves the viewport (prepend compensation); no input. */
+      systemShiftDown(px: number) {
+        state.scrollTop += px;
+        scrollEvent();
+      },
+      /**
+       * A scrollTop write whose scroll event has not landed yet — Virtuoso's
+       * prepend compensation writes directly; the event fires a task later.
+       */
+      silentShiftDown(px: number) {
+        state.scrollTop += px;
+      },
+    };
+  }
+
+  it("pins a prepend shift straight back to the live end", () => {
+    const scroll = liveScroller();
+
+    scroll.systemShiftDown(400);
+
+    expect(scroll.scrollTop).toBe(0);
+  });
+
+  // Regression (TIM-65 review): an unconditional frame-boundary re-judge
+  // snapped back every confirmed sub-threshold reader scroll one frame later.
+  it("leaves a confirmed sub-threshold scroll alone at the frame boundary", () => {
+    const scroll = liveScroller();
+
+    scroll.readerScrollsDown(60);
+    expect(scroll.scrollTop).toBe(60);
+
+    renderFrame();
+
+    expect(scroll.scrollTop).toBe(60);
+  });
+
+  it("re-judges a pin deferred by unconsumed input at the frame boundary", () => {
+    const scroll = liveScroller();
+
+    scroll.readerScrollsDown(60); // parked inside the follow band
+    gestureSettles();
+    scroll.wheelWithoutScroll(-40); // toward-input a nested block consumed
+    scroll.systemShiftDown(50); // prepend shift mid-claim: deferred
+
+    expect(scroll.scrollTop).toBe(110);
+
+    renderFrame(); // claim discarded: the deferred pin fires
+
+    expect(scroll.scrollTop).toBe(0);
+  });
+
+  // Locks the re-judge to onResize. Re-judging through onScroll would read
+  // the distance moved since the last scroll event as continued reader
+  // motion, so a prepend compensation writing scrollTop in that gap would be
+  // credited against the wheel tick's carry and release the follow on pure
+  // system displacement (TIM-65 review round 2).
+  it("does not credit a silent prepend write against the tick at the re-judge", () => {
+    const scroll = liveScroller();
+
+    scroll.wheelInputDown(150);
+    scroll.systemShiftDown(110); // the tick's animation delivers 110 so far
+    scroll.systemShiftDown(300); // big prepend mid-animation: pin deferred
+    scroll.silentShiftDown(20); // compensation write, its scroll event pending
+
+    renderFrame(); // re-judge must not attribute the 20px to the reader
+
+    gestureSettles();
+    scroll.systemShiftDown(50); // still following: this pin must fire
+
+    expect(scroll.scrollTop).toBe(0);
   });
 });

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -1038,8 +1038,9 @@ describe("AgentTranscriptDialog — live-end follow wiring", () => {
     expect(scroll.scrollTop).toBe(0);
   });
 
-  // Regression (TIM-65 review): an unconditional frame-boundary re-judge
-  // snapped back every confirmed sub-threshold reader scroll one frame later.
+  // Only an actually deferred pin warrants a frame-boundary re-judge;
+  // re-judging every input frame would snap back a confirmed sub-threshold
+  // reader scroll one frame later.
   it("leaves a confirmed sub-threshold scroll alone at the frame boundary", () => {
     const scroll = liveScroller();
 
@@ -1066,11 +1067,11 @@ describe("AgentTranscriptDialog — live-end follow wiring", () => {
     expect(scroll.scrollTop).toBe(0);
   });
 
-  // Locks the re-judge to onResize. Re-judging through onScroll would read
+  // Re-judge through onResize. Routing through onScroll would read
   // the distance moved since the last scroll event as continued reader
   // motion, so a prepend compensation writing scrollTop in that gap would be
   // credited against the wheel tick's carry and release the follow on pure
-  // system displacement (TIM-65 review round 2).
+  // system displacement.
   it("does not credit a silent prepend write against the tick at the re-judge", () => {
     const scroll = liveScroller();
 

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -349,12 +349,12 @@ export function AgentTranscriptDialog({
           inputFrame = null;
           // A staged claim defers pins so a wheel tick's animated scroll is
           // not cancelled mid-flight. Once the unconfirmed claim is discarded,
-          // re-judge a pin it deferred so it fires one frame late, not never —
-          // and only such a pin, or sub-threshold reader scrolls get snapped
-          // back. Through onResize, never onScroll: a Virtuoso prepend
-          // compensation writing scrollTop in the gap since the last scroll
-          // event would run the continued-motion branch and credit a system
-          // shift as reader displacement.
+          // re-judge only if it deferred a pin. This lets the pin fire one frame
+          // late without snapping back sub-threshold reader scrolls. Re-judge
+          // through onResize, never onScroll: a Virtuoso prepend compensation
+          // writing scrollTop in the gap since the last scroll event would run
+          // the continued-motion branch and credit a system shift as reader
+          // displacement.
           if (followCtl.endInputFrame() && followCtl.onResize(el.scrollTop)) {
             el.scrollTop = 0;
           }

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -347,12 +347,17 @@ export function AgentTranscriptDialog({
         if (inputFrame !== null) cancelAnimationFrame(inputFrame);
         inputFrame = requestAnimationFrame(() => {
           inputFrame = null;
-          followCtl.endInputFrame();
           // A staged claim defers pins so a wheel tick's animated scroll is
-          // not cancelled mid-flight. An unconfirmed claim is discarded above,
-          // so re-judge: a pin it deferred fires one frame late, not never.
-          // (Zero movement, so this attributes nothing.)
-          if (followCtl.onScroll(el.scrollTop)) el.scrollTop = 0;
+          // not cancelled mid-flight. Once the unconfirmed claim is discarded,
+          // re-judge a pin it deferred so it fires one frame late, not never —
+          // and only such a pin, or sub-threshold reader scrolls get snapped
+          // back. Through onResize, never onScroll: a Virtuoso prepend
+          // compensation writing scrollTop in the gap since the last scroll
+          // event would run the continued-motion branch and credit a system
+          // shift as reader displacement.
+          if (followCtl.endInputFrame() && followCtl.onResize(el.scrollTop)) {
+            el.scrollTop = 0;
+          }
         });
       };
       const onWheel = (e: WheelEvent) => {

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -348,6 +348,11 @@ export function AgentTranscriptDialog({
         inputFrame = requestAnimationFrame(() => {
           inputFrame = null;
           followCtl.endInputFrame();
+          // A staged claim defers pins so a wheel tick's animated scroll is
+          // not cancelled mid-flight. An unconfirmed claim is discarded above,
+          // so re-judge: a pin it deferred fires one frame late, not never.
+          // (Zero movement, so this attributes nothing.)
+          if (followCtl.onScroll(el.scrollTop)) el.scrollTop = 0;
         });
       };
       const onWheel = (e: WheelEvent) => {

--- a/packages/views/common/task-transcript/transcript-follow.test.ts
+++ b/packages/views/common/task-transcript/transcript-follow.test.ts
@@ -218,14 +218,50 @@ describe("createLiveEndFollow", () => {
     expect(follow.onScroll(400)).toBe(false); // no pinning once disengaged
   });
 
-  it("input the surface never consumed does not release, and never blocks the pin", () => {
+  it("input the surface never consumed defers the pin only to the frame boundary", () => {
     // A wheel over a nested scroller (or a list too short to scroll) bubbles
-    // to the container without moving it: no scroll ever attributes it.
+    // to the container without moving it: no scroll ever attributes it. While
+    // the claim is staged the pin is deferred — it might be a real tick whose
+    // animated scroll has not arrived yet — but once the wiring discards the
+    // claim, the deferred pin fires.
     const { follow } = makeFollow();
     follow.input(300);
     expect(follow.isFollowing()).toBe(true);
-    expect(follow.onResize(180)).toBe(true); // growth pins straight away
+    expect(follow.onResize(180)).toBe(false); // deferred: claim may still confirm
+    follow.endInputFrame();
+    expect(follow.onResize(180)).toBe(true); // claim discarded: pin fires now
     expect(follow.isFollowing()).toBe(true);
+  });
+
+  it("defers pins while a wheel tick's animated scroll is in flight", () => {
+    // A mouse wheel tick delivers its input at once; the browser animates the
+    // displacement over the following frames. A pin landing mid-animation
+    // would cancel it and revert the tick — the reader could never accumulate
+    // a release against a stream. The pin waits until the carry is spent.
+    const { follow, tick } = makeFollow();
+    follow.input(100);
+    tick(16);
+    expect(follow.onScroll(10)).toBe(false); // first frame confirms the claim
+    follow.endInputFrame();
+    expect(follow.onResize(190)).toBe(false); // chunk mid-animation: deferred
+    tick(16);
+    expect(follow.onScroll(220)).toBe(false); // the rest of the tick still lands
+    tick(16);
+    expect(follow.onScroll(280)).toBe(false); // animation complete: 100px taken
+    tick(301); // gesture settles, carry spent
+    expect(follow.onResize(460)).toBe(true); // pinning resumes
+    expect(follow.isFollowing()).toBe(true); // 100px is inside the zone
+  });
+
+  it("accumulates a release across animated ticks despite mid-flight growth", () => {
+    const { follow } = makeFollow();
+    follow.input(100);
+    expect(follow.onScroll(20)).toBe(false);
+    expect(follow.onResize(200)).toBe(false); // chunk: deferred, tick survives
+    expect(follow.onScroll(280)).toBe(false); // tick 1 finishes: 100px taken
+    follow.input(100); // tick 2, overlapping the settle window
+    expect(follow.onScroll(380)).toBe(false); // 200px taken
+    expect(follow.isFollowing()).toBe(false);
   });
 
   it("pins a system shift after the surface left input unconsumed", () => {

--- a/packages/views/common/task-transcript/transcript-follow.test.ts
+++ b/packages/views/common/task-transcript/transcript-follow.test.ts
@@ -264,6 +264,56 @@ describe("createLiveEndFollow", () => {
     expect(follow.isFollowing()).toBe(false);
   });
 
+  it("reports no deferral for a scroll the reader fully confirmed", () => {
+    // The frame-boundary re-judge exists only for pins an in-flight gesture
+    // deferred. A confirmed sub-threshold scroll deferred nothing, so the
+    // wiring must not re-judge — that would snap the reader back one frame
+    // after a touchpad tick or arrow key the latch had left alone.
+    const { follow } = makeFollow();
+    follow.input(60);
+    expect(follow.onScroll(60)).toBe(false);
+    expect(follow.endInputFrame()).toBe(false);
+  });
+
+  it("reports a deferred pin at the frame boundary, once", () => {
+    const { follow } = makeFollow();
+    follow.input(300); // never consumed
+    expect(follow.onResize(180)).toBe(false); // deferred behind the claim
+    expect(follow.endInputFrame()).toBe(true); // the wiring re-judges now
+    expect(follow.onResize(180)).toBe(true); // and the pin fires
+    expect(follow.endInputFrame()).toBe(false); // flag does not linger
+  });
+
+  it("re-following through an over-claimed toward gesture leaves no stale carry", () => {
+    // End stages the whole scrollHeight; the scroll to the live end consumes
+    // only the real distance. Re-following must clear the leftover carry, or
+    // it defers every pin for the rest of the settle window.
+    const { follow } = makeFollow();
+    follow.disengage();
+    follow.onScroll(200);
+    follow.input(-300);
+    expect(follow.onScroll(0)).toBe(false); // arrives at the live end: re-follows
+    follow.endInputFrame();
+    expect(follow.onResize(180)).toBe(true); // growth pins immediately again
+  });
+
+  it("bounds carry-residue deferral by the settle window", () => {
+    // The browser can deliver less displacement than the claim (scroll extent
+    // reached, delta scaling off): the carry never drains, so pins stay
+    // deferred — but only until the settle window expires.
+    const { follow, tick } = makeFollow();
+    follow.input(100);
+    expect(follow.onScroll(40)).toBe(false); // only 40 of the 100 ever lands
+    follow.endInputFrame();
+    tick(100);
+    expect(follow.onResize(220)).toBe(false); // still deferred
+    tick(250);
+    expect(follow.onResize(400)).toBe(true); // settle window over: pin resumes
+    // The resolved pin settled the deferral: a later gesture's frame boundary
+    // must not inherit it and re-judge a pin that gesture never earned.
+    expect(follow.endInputFrame()).toBe(false);
+  });
+
   it("pins a system shift after the surface left input unconsumed", () => {
     const { follow, tick } = makeFollow();
     follow.input(300);

--- a/packages/views/common/task-transcript/transcript-follow.ts
+++ b/packages/views/common/task-transcript/transcript-follow.ts
@@ -22,8 +22,12 @@
 // - While following, displacement not attributed to the reader is pinned
 //   straight back to the live end (`onScroll` / `onResize` return the
 //   verdict) — immediately, with no intent-window timer for a final event to
-//   hide behind — but never during an active touch or while the mouse is held
-//   down (text selection autoscroll must not be fought).
+//   hide behind — but never during an active touch, while the mouse is held
+//   down (text selection autoscroll must not be fought), or while a reader
+//   gesture is still in flight: a pin mid-flight cancels the browser's wheel
+//   scroll animation and reverts the tick. A pin a staged-but-unconfirmed
+//   claim deferred is re-judged when the wiring discards that claim at the
+//   frame boundary, so it fires one frame late rather than never.
 // - Arriving back within the edge zone re-engages the follow.
 //
 // The state machine is direction-agnostic: callers feed it away-positive
@@ -116,8 +120,27 @@ export function createLiveEndFollow(now: () => number = () => Date.now()): LiveE
   const withinCarry = (amount: number) =>
     amount <= motionCarry + Math.max(1, motionCarry) * 1e-9;
 
+  // A reader gesture the surface has not finished answering: a claim staged
+  // this frame still awaiting its first confirming scroll, or a wheel/key
+  // scroll ANIMATION still spending its claim. A mouse wheel tick delivers
+  // its input at once but the browser animates the displacement over many
+  // frames, and a pin issued mid-flight cancels that animation — reverting
+  // the tick, so a wheel user could never accumulate a release against a
+  // stream or Virtuoso's re-measure resizes while a touchpad (which confirms
+  // per event) escaped easily. Deferring the pin lets the gesture finish;
+  // an unconsumed claim's deferral ends when the wiring discards the claim
+  // at the frame boundary and re-judges (see stick-to-bottom.ts).
+  const gestureInFlight = () =>
+    (inputFresh() && (awayBudget > 0 || towardBudget > 0)) ||
+    (motionFresh() && motionSource === "input" && motionCarry > 0);
+
   const pinVerdict = (distance: number): boolean =>
-    following && !mouseHeld && !scrollbarDrag && !touchHeld && distance > 0;
+    following &&
+    !mouseHeld &&
+    !scrollbarDrag &&
+    !touchHeld &&
+    !gestureInFlight() &&
+    distance > 0;
 
   return {
     setActive(a: boolean) {

--- a/packages/views/common/task-transcript/transcript-follow.ts
+++ b/packages/views/common/task-transcript/transcript-follow.ts
@@ -63,8 +63,13 @@ export interface LiveEndFollow {
    * budget the surface's own scroll can attribute displacement against.
    */
   input(delta: number): void;
-  /** Discards input the surface did not consume during its rendering frame. */
-  endInputFrame(): void;
+  /**
+   * Discards input the surface did not consume during its rendering frame.
+   * Returns whether a pin was deferred by an in-flight gesture since the
+   * previous frame boundary — the wiring must re-judge (via `onResize`) so a
+   * deferred pin fires one frame late rather than never.
+   */
+  endInputFrame(): boolean;
   /** An active touch prevents pinning while drag displacement is confirmed. */
   touchStart(): void;
   /** Ends the held state; confirmed momentum may continue within the settle window. */
@@ -130,17 +135,37 @@ export function createLiveEndFollow(now: () => number = () => Date.now()): LiveE
   // per event) escaped easily. Deferring the pin lets the gesture finish;
   // an unconsumed claim's deferral ends when the wiring discards the claim
   // at the frame boundary and re-judges (see stick-to-bottom.ts).
+  //
+  // Carry residue is the bounded cost: if the browser delivers less
+  // displacement than the claim (scroll extent reached, delta scaling off),
+  // the carry never drains and pins stay deferred until the settle window
+  // expires — at most MOTION_SETTLE_WINDOW_MS with the live end off-screen,
+  // corrected by the next scroll or resize after that.
   const gestureInFlight = () =>
     (inputFresh() && (awayBudget > 0 || towardBudget > 0)) ||
     (motionFresh() && motionSource === "input" && motionCarry > 0);
 
-  const pinVerdict = (distance: number): boolean =>
-    following &&
-    !mouseHeld &&
-    !scrollbarDrag &&
-    !touchHeld &&
-    !gestureInFlight() &&
-    distance > 0;
+  // Whether a wanted pin was suppressed by an in-flight gesture since the
+  // last frame boundary; endInputFrame reports and clears it so the wiring
+  // re-judges only pins that were actually deferred — an unconditional
+  // frame-boundary re-judge would snap back sub-threshold reader scrolls the
+  // latch had deliberately left alone.
+  let pinDeferred = false;
+
+  const pinVerdict = (distance: number): boolean => {
+    const wanted =
+      following && !mouseHeld && !scrollbarDrag && !touchHeld && distance > 0;
+    if (wanted && gestureInFlight()) {
+      pinDeferred = true;
+      return false;
+    }
+    // Judged for real: whatever was deferred is settled, so a later frame
+    // boundary must not inherit it — a deferral stranded by a gesture with
+    // no input frame left would otherwise be consumed by the next unrelated
+    // gesture and snap it back.
+    pinDeferred = false;
+    return wanted;
+  };
 
   return {
     setActive(a: boolean) {
@@ -159,6 +184,7 @@ export function createLiveEndFollow(now: () => number = () => Date.now()): LiveE
       motionSource = null;
       motionCarry = 0;
       lastMotionAt = -MOTION_SETTLE_WINDOW_MS;
+      pinDeferred = false;
     },
     isFollowing: () => active && following,
     disengage() {
@@ -179,6 +205,9 @@ export function createLiveEndFollow(now: () => number = () => Date.now()): LiveE
     endInputFrame() {
       awayBudget = 0;
       towardBudget = 0;
+      const deferred = pinDeferred;
+      pinDeferred = false;
+      return deferred;
     },
     touchStart() {
       if (active) touchHeld = true;
@@ -286,6 +315,11 @@ export function createLiveEndFollow(now: () => number = () => Date.now()): LiveE
             towardBudget = 0;
             awayTaken = 0;
             motionDirection = 0;
+            // Clear the carry too: an over-claimed toward gesture (End stages
+            // the whole scrollHeight) would otherwise defer pins for the rest
+            // of the settle window right after the follow re-engaged.
+            motionSource = null;
+            motionCarry = 0;
           }
           return false;
         }


### PR DESCRIPTION
## What does this PR do?

Keeps chat and transcript live-end following aligned with whether content can actually stream and whether the reader is actively moving away from the live end.

The chat list still uses Virtuoso's index-based correction and delayed reveal from current `main`. This change narrows when that correction may run and strengthens the shared input latch so browser-animated wheel scrolling is not cancelled by content or viewport changes.

### Thinking path

- Virtuoso's `followOutput` handles appended rows, but a streaming reply grows inside one row and composer changes resize the viewport without changing row count.
- Idle and parked tasks have no growing live end, so content, image, fold, and composer resizes must not move the reader.
- Mouse-wheel input can arrive in one event while its displacement is animated across later frames. Pinning during that animation cancels the gesture before it can cross the release threshold.
- The shared latch therefore defers only pins that overlap an in-flight gesture, re-judges only pins that were actually deferred, and clears carry/deferral state when a verdict resolves.
- Pending-task status is an open server string, so parked states are denied explicitly while unknown or absent future streaming statuses retain the existing follow behavior.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [x] Tests
- [ ] CI / infrastructure

## Changes Made

- Gate the chat bottom-stick on streaming-capable pending states while preserving plain `atBottom` handling for idle and parked chats.
- Preserve reader wheel, touch, and keyboard intent through streaming growth and Virtuoso remeasurement.
- Make deferred-pin and carry state settle at the correct gesture boundaries in the shared transcript-follow latch.
- Add component and latch coverage for idle/parked transitions, animated wheel input, deferred-pin lifecycle, transcript wiring, and forward-compatible task statuses.

## How to Test

1. Run the focused follow suites:
   `pnpm --filter @multica/views exec vitest run chat/components/chat-message-list.autoscroll.test.tsx common/task-transcript/agent-transcript-dialog.test.tsx common/task-transcript/transcript-follow.test.ts`
2. Run all views tests:
   `pnpm --filter @multica/views test`
3. Run views lint:
   `pnpm --filter @multica/views lint`

Local results:

- Focused follow suites: 116 tests passed.
- Full views suite: 411 files and 4,920 tests passed.
- Views lint: no errors; 27 existing warnings outside the changed files.
- Views typecheck still reports existing workspace errors outside the changed files.

## Risks

- The latch is shared with the newest-first transcript dialog; component-level wiring tests cover both top-pinned and bottom-pinned surfaces.
- Unknown pending statuses intentionally remain follow-enabled for forward compatibility; explicit tests prevent replacing the parked-state denylist with a closed allowlist.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the product conventions (not applicable)
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Rebased an approved chat-follow stack onto current `main`, reconciled it with the newer Virtuoso index-based correction and delayed-reveal behavior, then validated the shared latch and both component wirings with focused and full test suites.

## Screenshots (optional)

Not included. The change concerns scroll timing and input attribution rather than a stable visual state; deterministic DOM and latch tests cover the before/after behavior.
