### PR TITLE
MUL-6863: fix(agent/cursor): trust the workspace so headless runs cannot hang on a prompt

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -964,13 +964,14 @@ var cursorBlockedArgs = map[string]blockedArgMode{
 	"-p":              blockedStandalone, // non-interactive print mode
 	"--output-format": blockedWithValue,  // stream-json protocol
 	"--yolo":          blockedStandalone, // auto-approval for autonomous operation
+	"--trust":         blockedStandalone, // headless runs cannot answer a trust prompt
 }
 
 // buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
 //
 // Usage: cursor-agent -p --output-format stream-json
 //
-//	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
+//	--workspace <cwd> --yolo --trust [--model <m>] [--resume <id>]
 //
 // The prompt is deliberately NOT part of argv. cursor-agent's -p is a boolean
 // print-mode switch and the prompt is a positional argument; when no positional
@@ -991,6 +992,13 @@ func buildCursorArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
+		// A workspace cursor-agent has not seen before raises an interactive
+		// trust prompt. The daemon runs it without a TTY, so the prompt has no
+		// answer and the run hangs until its deadline instead of failing —
+		// --yolo governs command approval and does not cover it. Trust is
+		// implied here anyway: the workdir is one the daemon prepared for this
+		// task.
+		"--trust",
 	}
 	if opts.Cwd != "" {
 		args = append(args, "--workspace", opts.Cwd)

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -31,6 +31,7 @@ func TestBuildCursorArgs(t *testing.T) {
 		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
+		"--trust",
 		"--workspace", "/tmp/work",
 		"--model", "composer-1.5",
 	}
@@ -67,10 +68,40 @@ func TestBuildCursorArgsMinimal(t *testing.T) {
 	t.Parallel()
 
 	args := buildCursorArgs(ExecOptions{}, slog.Default())
-	expected := []string{"-p", "--output-format", "stream-json", "--yolo"}
+	expected := []string{"-p", "--output-format", "stream-json", "--yolo", "--trust"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+}
+
+// A workspace cursor-agent has not seen raises an interactive trust prompt,
+// which a daemon-launched run has no TTY to answer: it hangs to its deadline
+// rather than failing. --yolo does not cover it — that governs command
+// approval, not workspace trust — so --trust has to be in every argv.
+func TestBuildCursorArgsAlwaysTrustsTheWorkspace(t *testing.T) {
+	t.Parallel()
+
+	for name, opts := range map[string]ExecOptions{
+		"minimal":  {},
+		"with cwd": {Cwd: "/tmp/work"},
+		"resume":   {ResumeSessionID: "ses_1"},
+		// A user cannot opt out of it either: dropping --trust from a headless
+		// run brings back the hang this flag exists to prevent.
+		"custom args try to drop it": {CustomArgs: []string{"--trust"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			args := buildCursorArgs(opts, slog.Default())
+			seen := 0
+			for _, a := range args {
+				if a == "--trust" {
+					seen++
+				}
+			}
+			if seen != 1 {
+				t.Fatalf("expected exactly one --trust in %v, got %d", args, seen)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #7791.

`cursor-agent` raises an interactive workspace-trust prompt the first time it is pointed at a directory it has not seen. The daemon launches it without a TTY, so nothing can answer it: the run sits there until its deadline instead of failing, and the task looks stuck rather than broken. `--yolo` does not cover this — that governs command approval, not workspace trust.

Trust is implied at this call site anyway: the workdir is one the daemon prepared for this task, and the operator already consented to autonomous execution when they configured the runtime.

`--trust` joins `cursorBlockedArgs` for the same reason the other protocol flags are there — `custom_args` that dropped it would reintroduce the hang.

**Verification**: flag confirmed against a real `cursor-agent 2026.08.25-3e8eec8` (the version in the report):

```
--trust    Trust the current workspace without prompting
```

The new test asserts exactly one `--trust` across minimal / cwd / resume / "custom args try to drop it" argv shapes; the two existing argv-shape tests are updated.

The issue also notes the obsolete `chat` subcommand, already removed in #3077 / #3092 — this PR is only the remaining `--trust` gap.
