### PR TITLE
fix(storage): observe context cancellation in local uploads

### DIFF
--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -153,7 +154,7 @@ func (s *LocalStorage) DeleteKeys(ctx context.Context, keys []string) {
 
 func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
 	dest := filepath.Join(s.uploadDir, key)
-	if err := writeAtomic(dest, bytes.NewReader(data)); err != nil {
+	if err := writeAtomic(ctx, dest, bytes.NewReader(data)); err != nil {
 		return "", err
 	}
 	// Best-effort sidecar so ServeFile can restore the original filename in
@@ -177,7 +178,7 @@ func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, cont
 
 func (s *LocalStorage) UploadStream(ctx context.Context, key string, data io.Reader, _ int64, contentType string, filename string) (string, error) {
 	dest := filepath.Join(s.uploadDir, key)
-	if err := writeAtomic(dest, data); err != nil {
+	if err := writeAtomic(ctx, dest, data); err != nil {
 		return "", err
 	}
 	if filename != "" {
@@ -201,7 +202,12 @@ func (s *LocalStorage) UploadStream(ctx context.Context, key string, data io.Rea
 // longer exists. With rename-into-place a failed write only discards its own
 // temp file and the existing object survives untouched. Both upload paths go
 // through here so neither can reintroduce the destructive shape.
-func writeAtomic(dest string, src io.Reader) error {
+func writeAtomic(ctx context.Context, dest string, src io.Reader) error {
+	// Checked before anything is created so an already-cancelled caller leaves
+	// no staging file behind, and again on every read below.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return fmt.Errorf("local storage MkdirAll: %w", err)
 	}
@@ -212,9 +218,15 @@ func writeAtomic(dest string, src io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("local storage create temp: %w", err)
 	}
-	if _, err := io.Copy(f, src); err != nil {
+	if _, err := io.Copy(f, &contextReader{ctx: ctx, r: src}); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
+		// A cancellation must stay recognizable to errors.Is: callers above
+		// distinguish "the client went away" from a real storage failure, and
+		// the rename never ran, so the existing object at this key is intact.
+		if cause := ctx.Err(); cause != nil && errors.Is(err, cause) {
+			return err
+		}
 		return fmt.Errorf("local storage stream copy: %w", err)
 	}
 	if err := f.Close(); err != nil {
@@ -325,10 +337,34 @@ func readLocalMeta(filePath string) (localMeta, bool) {
 }
 
 func (s *LocalStorage) UploadFromReader(ctx context.Context, key string, reader io.Reader, contentType string, filename string) (string, error) {
-	data, err := io.ReadAll(reader)
+	// Read through the context so a cancelled caller stops this copy too.
+	// Buffering the whole source first and only then consulting ctx (inside
+	// Upload) would keep reading a stalled or endless reader long after the
+	// request it belongs to has gone away.
+	data, err := io.ReadAll(&contextReader{ctx: ctx, r: reader})
 	if err != nil {
+		if cause := ctx.Err(); cause != nil && errors.Is(err, cause) {
+			return "", err
+		}
 		return "", fmt.Errorf("local storage ReadAll: %w", err)
 	}
 
 	return s.Upload(ctx, key, data, contentType, filename)
+}
+
+// contextReader makes an io.Reader observe cancellation. io.Copy and
+// io.ReadAll have no context of their own, so without this a cancelled upload
+// runs to EOF: the goroutine and its filesystem writes outlive the caller.
+// The check sits before each Read, so an in-flight read still completes —
+// that is the granularity the caller gets, and it is bounded by the source.
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *contextReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
 }

--- a/server/internal/storage/local_test.go
+++ b/server/internal/storage/local_test.go
@@ -2,12 +2,16 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLocalStorage_Upload(t *testing.T) {
@@ -516,5 +520,153 @@ func TestLocalStorage_GetReader_MissingKey(t *testing.T) {
 	if rc, err := store.GetReader(context.Background(), "nonexistent.txt"); err == nil {
 		rc.Close()
 		t.Fatal("GetReader should error on missing key")
+	}
+}
+
+// endlessReader never reaches EOF: every Read hands back another byte, and
+// the first one signals that a copy is genuinely in flight so the test can
+// cancel mid-stream rather than racing the goroutine's start.
+//
+// A source that ends on its own would let a broken implementation look
+// correct — it would simply finish. Cancellation has to be the only thing
+// that can stop this one. It never blocks, so nothing here can deadlock if
+// the implementation regresses; readCap turns that case into a failed
+// assertion instead of an out-of-memory test binary.
+type endlessReader struct {
+	started   chan struct{}
+	startOnce sync.Once
+	reads     atomic.Int64
+}
+
+const endlessReaderCap = 1 << 20
+
+func newEndlessReader() *endlessReader {
+	return &endlessReader{started: make(chan struct{})}
+}
+
+func (r *endlessReader) Read(p []byte) (int, error) {
+	r.startOnce.Do(func() { close(r.started) })
+	if r.reads.Add(1) > endlessReaderCap {
+		return 0, errors.New("reader exhausted: cancellation never stopped the copy")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = 'x'
+	return 1, nil
+}
+
+func newTestLocalStorage(t *testing.T) (*LocalStorage, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("LOCAL_UPLOAD_DIR", dir)
+	t.Setenv("LOCAL_UPLOAD_BASE_URL", "")
+	store := NewLocalStorageFromEnv()
+	if store == nil {
+		t.Fatal("NewLocalStorageFromEnv returned nil")
+	}
+	return store, dir
+}
+
+// A cancelled caller must not start writing at all. Without the check the
+// upload ran to completion and reported success, so a request the client had
+// already abandoned still produced an object.
+func TestLocalStorage_UploadRejectsCancelledContext(t *testing.T) {
+	store, dir := newTestLocalStorage(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := store.Upload(ctx, "cancelled.txt", []byte("data"), "text/plain", ""); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Upload error = %v, want context.Canceled", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("a cancelled upload left files behind: %v", entries)
+	}
+}
+
+// Cancelling mid-copy has to stop the copy, drop the staging file, and leave
+// any previously stored object at that key untouched — the whole reason
+// writeAtomic stages through a temp file.
+func TestLocalStorage_UploadStreamCancelMidCopyKeepsExistingObject(t *testing.T) {
+	store, dir := newTestLocalStorage(t)
+	key := "doc.txt"
+	if _, err := store.Upload(context.Background(), key, []byte("original"), "text/plain", ""); err != nil {
+		t.Fatalf("seed upload: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := newEndlessReader()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := store.UploadStream(ctx, key, reader, 0, "text/plain", "")
+		errCh <- err
+	}()
+
+	// Wait for the first Read so the cancellation lands mid-copy rather than
+	// before the copy starts — that is a different code path with its own test.
+	<-reader.started
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UploadStream error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UploadStream ignored cancellation and is still copying")
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, key))
+	if err != nil {
+		t.Fatalf("existing object went missing: %v", err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("existing object = %q, want it untouched (%q)", got, "original")
+	}
+	if _, err := os.Stat(tempPath(filepath.Join(dir, key))); !os.IsNotExist(err) {
+		t.Fatalf("staging file survived a cancelled copy (stat err = %v)", err)
+	}
+}
+
+// UploadFromReader buffers its source before handing it to Upload, so without
+// a context-aware read it drains a stalled reader in full before anyone looks
+// at ctx.
+func TestLocalStorage_UploadFromReaderStopsReadingOnCancel(t *testing.T) {
+	store, _ := newTestLocalStorage(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := newEndlessReader()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := store.UploadFromReader(ctx, "stream.txt", reader, "text/plain", "")
+		errCh <- err
+	}()
+
+	<-reader.started
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UploadFromReader error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UploadFromReader ignored cancellation and is still reading")
+	}
+}
+
+// A deadline is the other half of the contract: callers use errors.Is on
+// DeadlineExceeded to tell a timeout from a storage failure.
+func TestLocalStorage_UploadPreservesDeadlineExceeded(t *testing.T) {
+	store, _ := newTestLocalStorage(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+
+	if _, err := store.Upload(ctx, "late.txt", []byte("data"), "text/plain", ""); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Upload error = %v, want context.DeadlineExceeded", err)
 	}
 }


### PR DESCRIPTION
Fixes #7784.

`LocalStorage.Upload`, `UploadStream` and `UploadFromReader` take a `context.Context` and never look at it. `io.Copy` and `io.ReadAll` have no context of their own, so a cancelled request keeps reading its source to EOF: the goroutine and its filesystem writes outlive the caller, and a client that hung up still ends up with a stored object. `UploadFromReader` is the worst of the three — it buffers the entire source before `Upload` is even called, so a stalled reader is drained in full before anything consults `ctx`.

Reads now go through a `contextReader` that checks `ctx` before each `Read`, which bounds the overshoot at one in-flight read rather than the whole body. Cancellation is reported as the context error itself rather than wrapped in a storage message, because callers use `errors.Is` to tell "the client went away" from a real storage failure.

Nothing is destroyed on the way out: `writeAtomic` already stages through a temp file, so an aborted copy removes its own staging file and leaves any existing object at that key intact. The pre-flight check means an already-cancelled caller never creates one.

This matches the expected behaviour listed in the issue point for point:

| Expected | Test |
| --- | --- |
| pre-cancelled context prevents the upload from starting | `TestLocalStorage_UploadRejectsCancelledContext` (also asserts the directory stays empty) |
| cancellation during a copy stops after the current read | `TestLocalStorage_UploadStreamCancelMidCopyKeepsExistingObject` |
| staging file is removed | same test (`tempPath` must not exist) |
| existing object at the same key remains intact | same test (content still `original`) |
| error preserves `context.Canceled` / `DeadlineExceeded` | all four, incl. `TestLocalStorage_UploadPreservesDeadlineExceeded` |

`UploadFromReader` gets its own test since its failure mode is distinct (drains before delegating).

**These are real regression tests** — on the current implementation all four fail: two by completing the upload and returning `nil`, two by copying past cancellation for the full 5s timeout.
