### PR TITLE
MUL-6920 fix(server): disclose the provider session dropped by a runtime move

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2550,8 +2550,15 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 					resp.PriorWorkDir = src.WorkDir.String
 				}
 				if !service.ResumeUnsafeFailure(src.FailureReason.String, src.Error.String) &&
-					src.SessionID.Valid && src.RuntimeID == task.RuntimeID {
-					resp.PriorSessionID = src.SessionID.String
+					src.SessionID.Valid {
+					if src.RuntimeID == task.RuntimeID {
+						resp.PriorSessionID = src.SessionID.String
+					} else {
+						// MUL-6920: the source has a resumable session, it just
+						// is not reachable from this runtime. Same silent-drop
+						// as the follow-up branch below — say so.
+						resp.PriorSessionResumeUnavailable = true
+					}
 				}
 				// MUL-5305: if the source task withheld its Codex session because
 				// the rollout was missing, this rerun has nothing resumable from it
@@ -2582,6 +2589,15 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			}); err == nil && prior.SessionID.Valid {
 				if prior.RuntimeID == task.RuntimeID {
 					resp.PriorSessionID = prior.SessionID.String
+				} else {
+					// MUL-6920: the runtime gate above drops a session that
+					// really exists — the conversation moved to a different
+					// machine, where that provider session is not reachable.
+					// Dropping it silently is what makes the next turn answer
+					// as if the earlier turns never happened; disclosing it
+					// routes the run through the continuity notice, which tells
+					// it to read the record back instead of assuming.
+					resp.PriorSessionResumeUnavailable = true
 				}
 				if prior.WorkDir.Valid {
 					resp.PriorWorkDir = prior.WorkDir.String
@@ -2664,6 +2680,14 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			}
 		}
 		projectCtx.applyTo(&resp)
+		// MUL-6920: a session pointer this claim SAW but could not hand back.
+		// Both resume sources below are runtime-gated, so a chat that moved to
+		// another runtime resolves to no PriorSessionID while the conversation
+		// it belongs to is very much still there. Recording that the candidate
+		// existed is what separates "this chat has no history yet" (nothing to
+		// disclose) from "the history is unreachable from here" (the run must
+		// be told, or it answers the next message as a brand-new conversation).
+		chatResumeCandidateExists := false
 		if !task.ForceFreshSession && !task.ChannelContextRevision.Valid {
 			// Resume chat sessions only when the stored pointer was produced
 			// by the same runtime as the claiming task. When the chat_session
@@ -2673,8 +2697,11 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			// otherwise a single failed turn would silently drop the entire
 			// conversation memory on the next message. The fallback also
 			// requires runtime to match.
-			if cs.SessionID.Valid && cs.RuntimeID.Valid && cs.RuntimeID == task.RuntimeID {
-				resp.PriorSessionID = cs.SessionID.String
+			if cs.SessionID.Valid {
+				chatResumeCandidateExists = true
+				if cs.RuntimeID.Valid && cs.RuntimeID == task.RuntimeID {
+					resp.PriorSessionID = cs.SessionID.String
+				}
 			}
 			if cs.WorkDir.Valid {
 				resp.PriorWorkDir = cs.WorkDir.String
@@ -2744,6 +2771,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				switch {
 				case err == nil && prior.SessionID.Valid:
 					h.Metrics.RecordChatClaimSessionFallbackHit()
+					chatResumeCandidateExists = true
 					if resp.PriorSessionID == "" && prior.RuntimeID == task.RuntimeID {
 						resp.PriorSessionID = prior.SessionID.String
 					}
@@ -2771,6 +2799,26 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			})
 			h.Metrics.ObserveChatClaimRolloutMissingQuery(time.Since(started).Seconds())
 			if err == nil && missing {
+				resp.PriorSessionResumeUnavailable = true
+			}
+
+			// MUL-6920: both resume sources above were runtime-gated, so a
+			// candidate that survived every poison filter can still end up
+			// unusable purely because the chat moved runtimes. Judge the
+			// OUTCOME rather than re-testing each gate: whatever dropped it,
+			// this turn starts fresh on a conversation that does have history,
+			// and the continuity notice is the only thing that says so — and
+			// names the read-back command for this surface.
+			//
+			// Fires at most once per move: the first turn on the new runtime
+			// writes its own session_id + runtime_id back via
+			// UpdateChatSessionSession, so the next claim matches and stays
+			// quiet. A user who explicitly asked for a fresh start never gets
+			// here — ForceFreshSession short-circuits the whole block — and a
+			// rotated channel context only ever considers candidates from its
+			// own generation, so the rotation itself is never reported as a
+			// loss.
+			if resp.PriorSessionID == "" && chatResumeCandidateExists {
 				resp.PriorSessionResumeUnavailable = true
 			}
 		}

--- a/server/internal/handler/daemon_claim_runtime_move_test.go
+++ b/server/internal/handler/daemon_claim_runtime_move_test.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/testutil"
+)
+
+// MUL-6920. Every resume pointer the claim hands back is runtime-gated: a
+// session id belongs to a provider process on one machine and means nothing on
+// another. Moving an agent to a different runtime therefore drops the pointer —
+// correctly — but until now it dropped it in silence, and silence is
+// indistinguishable from "this conversation has no history". The run started
+// fresh, answered as if the earlier turns had never happened, and the user had
+// to notice and tell it to go read the record (GitHub #7738).
+//
+// The disclosure flag already existed for the MUL-5305 rollout-missing case and
+// already routes the run to the surface-correct continuity notice — the issue's
+// comment history, Slack's channel, or `multica chat history` for a stored
+// transcript. These tests pin the runtime-move case onto it, and pin the
+// negatives that keep the notice from becoming per-turn noise.
+func TestClaimTask_RuntimeMoveDisclosesDroppedSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	t.Run("issue follow-up across runtimes discloses", func(t *testing.T) {
+		agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+		oldRuntimeID := createRuntimeGuardRuntime(t, ctx, "kimi")
+
+		issueID := dbfx.Issue(t, "runtime move issue", testutil.Cols{
+			"status": "in_progress",
+			"number": 81301,
+		})
+		// A healthy, resume-safe turn — on the machine the agent no longer runs on.
+		dbfx.Task(t, agentID, testutil.Cols{
+			"runtime_id": oldRuntimeID,
+			"issue_id":   issueID,
+			"status":     "completed",
+			"session_id": "moved-issue-session",
+			"work_dir":   "/tmp/moved-issue-workdir",
+		})
+		dbfx.Exec(t, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+			VALUES ($1, $2, $3, 'queued', 1000)
+		`, agentID, runtimeID, issueID)
+
+		task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+		if task.PriorSessionID != "" {
+			t.Fatalf("PriorSessionID = %q, want empty (the session lives on the old runtime)", task.PriorSessionID)
+		}
+		// The workdir is still offered — a shared mount may resolve it — so the
+		// response alone cannot tell the daemon whether context carried over.
+		if task.PriorWorkDir != "/tmp/moved-issue-workdir" {
+			t.Fatalf("PriorWorkDir = %q, want /tmp/moved-issue-workdir", task.PriorWorkDir)
+		}
+		if !task.PriorSessionResumeUnavailable {
+			t.Fatal("issue follow-up on a new runtime must disclose the session it could not resume")
+		}
+	})
+
+	t.Run("issue follow-up on the same runtime stays quiet", func(t *testing.T) {
+		agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+		issueID := dbfx.Issue(t, "runtime stay issue", testutil.Cols{
+			"status": "in_progress",
+			"number": 81302,
+		})
+		dbfx.Task(t, agentID, testutil.Cols{
+			"runtime_id": runtimeID,
+			"issue_id":   issueID,
+			"status":     "completed",
+			"session_id": "same-issue-session",
+			"work_dir":   "/tmp/same-issue-workdir",
+		})
+		dbfx.Exec(t, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+			VALUES ($1, $2, $3, 'queued', 1000)
+		`, agentID, runtimeID, issueID)
+
+		task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+		if task.PriorSessionID != "same-issue-session" {
+			t.Fatalf("PriorSessionID = %q, want same-issue-session", task.PriorSessionID)
+		}
+		if task.PriorSessionResumeUnavailable {
+			t.Fatal("a resume that worked must not disclose a gap")
+		}
+	})
+
+	// A first turn has nothing to lose. Without this the flag would fire on
+	// every brand-new conversation, and a notice that always appears teaches
+	// the agent to ignore the one that matters.
+	t.Run("chat with no prior session stays quiet", func(t *testing.T) {
+		agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+		chatID := dbfx.ChatSession(t, agentID, testutil.Cols{
+			"title": "first turn chat",
+		})
+		dbfx.Exec(t, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+			VALUES ($1, $2, $3, 'queued', 1000)
+		`, agentID, runtimeID, chatID)
+
+		task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+		if task.PriorSessionResumeUnavailable {
+			t.Fatal("a chat with no history must not disclose a continuity gap")
+		}
+	})
+
+	// "Start a new context" is the user asking for the fresh session, not the
+	// platform losing one. Telling the agent its context could not be restored
+	// there would be a false alarm about a loss the user chose.
+	t.Run("chat force-fresh across runtimes stays quiet", func(t *testing.T) {
+		agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+		oldRuntimeID := createRuntimeGuardRuntime(t, ctx, "kimi")
+
+		chatID := dbfx.ChatSession(t, agentID, testutil.Cols{
+			"title":      "force fresh chat",
+			"session_id": "force-fresh-old-session",
+			"work_dir":   "/tmp/force-fresh-workdir",
+			"runtime_id": oldRuntimeID,
+		})
+		dbfx.Exec(t, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, chat_session_id, status, priority, force_fresh_session
+			)
+			VALUES ($1, $2, $3, 'queued', 1000, TRUE)
+		`, agentID, runtimeID, chatID)
+
+		task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+		if task.PriorSessionID != "" {
+			t.Fatalf("PriorSessionID = %q, want empty on an explicit fresh start", task.PriorSessionID)
+		}
+		if task.PriorSessionResumeUnavailable {
+			t.Fatal("an explicitly requested fresh session is not a continuity gap")
+		}
+	})
+}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3068,6 +3068,9 @@ func TestClaimTask_ManualRetryReusesWorkdir(t *testing.T) {
 		if task.PriorSessionID != "safe-session" {
 			t.Fatalf("PriorSessionID = %q, want safe-session (transient failure resumes)", task.PriorSessionID)
 		}
+		if task.PriorSessionResumeUnavailable {
+			t.Fatal("a rerun that resumed its source session must not disclose a gap")
+		}
 	})
 
 	t.Run("poisoned_reason_same_runtime_reuses_workdir_fresh_session", func(t *testing.T) {
@@ -3101,6 +3104,13 @@ func TestClaimTask_ManualRetryReusesWorkdir(t *testing.T) {
 		}
 		if task.PriorSessionID != "" {
 			t.Fatalf("PriorSessionID = %q, want empty (cross-runtime session cannot resolve)", task.PriorSessionID)
+		}
+		// MUL-6920: the source session was resume-SAFE — only the machine is
+		// wrong. Nothing else in the response distinguishes that from "the
+		// source never had a session", so the disclosure is the only signal
+		// the rerun gets that it is not continuing what the user clicked on.
+		if !task.PriorSessionResumeUnavailable {
+			t.Fatal("cross-runtime rerun must disclose the session it could not reach")
 		}
 	})
 
@@ -3176,6 +3186,13 @@ func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 	if task.PriorWorkDir != "/tmp/old-chat-workdir" {
 		t.Fatalf("chat runtime mismatch: expected PriorWorkDir='/tmp/old-chat-workdir', got %q", task.PriorWorkDir)
 	}
+	// MUL-6920: dropping the pointer is correct; dropping it SILENTLY is the
+	// bug. The chat's transcript is intact and readable, so the run has to be
+	// told its own memory of it is not — otherwise it answers the next message
+	// as a brand-new conversation and the user has to notice and say so.
+	if !task.PriorSessionResumeUnavailable {
+		t.Fatal("chat runtime mismatch: expected the claim to disclose the dropped session")
+	}
 	dbfx.Exec(t, `
 		UPDATE agent_task_queue
 		SET status = 'completed', completed_at = now()
@@ -3203,6 +3220,13 @@ func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 	}
 	if task.PriorWorkDir != "/tmp/same-chat-workdir" {
 		t.Fatalf("chat runtime match: expected PriorWorkDir='/tmp/same-chat-workdir', got %q", task.PriorWorkDir)
+	}
+	// The other half of MUL-6920: a resume that actually worked must stay
+	// quiet. This is what bounds the notice to one appearance per move —
+	// after the first turn on the new runtime writes its pointer back, every
+	// later claim lands here.
+	if task.PriorSessionResumeUnavailable {
+		t.Fatal("chat runtime match: a successful resume must not disclose a continuity gap")
 	}
 }
 


### PR DESCRIPTION
Fixes the silent context loss reported in #7738.

## The problem

Every resume pointer the claim handler hands back is runtime-gated — a provider
session id names a process on one machine and means nothing on another. So when
an agent moves to a different runtime, the claim drops the pointer. That is
correct. What was not correct is that it dropped it *silently*: the response
looked exactly like a conversation with no history at all, so the next run
opened a fresh session and answered as though the earlier turns had never
happened. The user had to notice the amnesia and manually tell the agent to go
read the history back.

Everything needed to handle this already existed and was simply never wired to
this case:

- `multica chat history` reads the transcript back regardless of which runtime
  the task lands on — the session is resolved server-side from the task token
  (`server/internal/handler/chat_history.go`).
- `PriorSessionResumeUnavailable` already makes `BuildPrompt` append a
  continuity notice, and `sessionContinuityNoticeFor` already picks the variant
  matching what *that* surface can read back: the issue's comment history,
  Slack's channel, or `multica chat history` for a stored transcript.
- But the flag was only ever set for the MUL-5305 rollout-missing case. The
  runtime gate never set it.

## The change

Set the flag on every claim path that saw a resumable session and could not hand
it back because of the runtime gate:

- **Chat** — judged on the *outcome* (a candidate pointer existed, no session
  resolved) rather than by re-testing each gate, so a future source that drops a
  pointer behind this cannot go silent again. Covers both the chat-wide
  `chat_session` pointer and the `GetLastChatTaskSession` task-row fallback.
- **Issue follow-up** — `GetLastTaskSession` returned a session belonging to
  another runtime.
- **Manual rerun** — the source task's session was resume-*safe*; only the
  machine was wrong. Nothing else in the response distinguished that from "the
  source never had a session".

No new copy and no new prompt plumbing: this is purely the missing trigger.

## Bounded, not chatty

- **Once per move.** The first turn on the new runtime writes its own
  `session_id` + `runtime_id` back via `UpdateChatSessionSession`, so the next
  claim matches and stays quiet.
- **Never on an explicit fresh start.** `ForceFreshSession` short-circuits the
  block, and a rotated channel context only considers candidates from its own
  generation, so the rotation itself is never reported as a loss.
- **Never on a first turn.** No candidate pointer, no disclosure.
- **No prompt-cache cost.** The notice lives in the per-turn user message, not
  the runtime brief (MUL-5377).
- **No routine noise.** A task's `runtime_id` comes from `agent.runtime_id`, so
  a mismatch means the agent's runtime actually changed.

## Out of scope

Switching *harness* on the same runtime (Claude → Codex) produces the same
context loss but is not detectable server-side: neither `chat_session` nor
`agent_task_queue` records which provider produced a session id. Providers that
explicitly reject a foreign resume are already covered downstream by
`shouldRetryWithFreshSession`; ones that silently restart are not. Covering that
needs a provider column on the pointer and belongs in its own change.

## Verification

`(cd server && go test ./internal/handler/ -count=1)` — full package green
(47s). Each new assertion was confirmed to fail against the unpatched handler
before the fix landed.

New/extended tests:

- `TestClaimTask_RuntimeMoveDisclosesDroppedSession` — issue follow-up across
  runtimes discloses; same runtime stays quiet; a chat with no prior session
  stays quiet; a force-fresh chat across runtimes stays quiet.
- `TestClaimTask_ChatPriorSessionRuntimeGuard` — the existing "mismatch yields
  an empty `PriorSessionID`" assertion is unchanged; added that the mismatch
  discloses and that a successful resume does not.
- `TestClaimTask_ManualRetryReusesWorkdir` — cross-runtime rerun discloses; a
  rerun that resumed its source does not.

Pre-existing failures in `internal/daemon` / `internal/daemon/execenv` on this
machine (HOME/profile path tests) reproduce on a clean checkout of `main` and
are unrelated to this change.
