### PR TITLE
refactor(execenv): list a repository in one prompt section, not two

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_dedup_test.go
+++ b/server/internal/daemon/execenv/runtime_config_dedup_test.go
@@ -1,0 +1,124 @@
+package execenv
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func githubResource(url, label string) ProjectResourceForEnv {
+	ref, _ := json.Marshal(map[string]string{"url": url})
+	return ProjectResourceForEnv{ResourceType: "github_repo", ResourceRef: ref, Label: label}
+}
+
+// A repo carried by a project resource is already rendered in Project
+// Context with its ref, branch hint and label. The bare URL in
+// ## Repositories says strictly less and costs tokens twice.
+func TestRepositoriesOmitsReposAlreadyInProjectContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := TaskContextForEnv{
+		IssueID: "i1",
+		Repos: []RepoContextForEnv{
+			{URL: "https://github.com/acme/api", Description: "workspace copy"},
+			{URL: "https://github.com/acme/tools"},
+		},
+		ProjectID:        "p1",
+		ProjectResources: []ProjectResourceForEnv{githubResource("https://github.com/acme/api", "API")},
+	}
+	brief := buildMetaSkillContentSlim("claude", ctx)
+
+	if strings.Count(brief, "https://github.com/acme/api") != 1 {
+		t.Errorf("the project repo appears %d times, want exactly 1:\n%s",
+			strings.Count(brief, "https://github.com/acme/api"), brief)
+	}
+	// Unmatched workspace repos are still reachable and must survive.
+	if !strings.Contains(brief, "https://github.com/acme/tools") {
+		t.Errorf("an unmatched workspace repo was dropped:\n%s", brief)
+	}
+	if !strings.Contains(brief, "## Repositories") {
+		t.Errorf("the section vanished even though a repo was left to list:\n%s", brief)
+	}
+}
+
+// Whole-section elision: with nothing left after dedup, a heading and its
+// one-line preamble would be pure overhead.
+func TestRepositoriesSectionElidedWhenEveryRepoIsAProjectResource(t *testing.T) {
+	t.Parallel()
+
+	brief := buildMetaSkillContentSlim("claude", TaskContextForEnv{
+		IssueID:          "i1",
+		Repos:            []RepoContextForEnv{{URL: "https://github.com/acme/api"}},
+		ProjectID:        "p1",
+		ProjectResources: []ProjectResourceForEnv{githubResource("https://github.com/acme/api", "API")},
+	})
+
+	if strings.Contains(brief, "## Repositories") {
+		t.Errorf("empty Repositories section still rendered:\n%s", brief)
+	}
+	if strings.Count(brief, "https://github.com/acme/api") != 1 {
+		t.Errorf("project repo should still appear once, in Project Context:\n%s", brief)
+	}
+}
+
+// The two sides store the same repository differently in practice. Matching
+// only exact strings would miss the pair that motivated the dedup.
+func TestProjectRepoDedupIgnoresGitSuffixAndTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	for name, resourceURL := range map[string]string{
+		"git suffix":     "https://github.com/acme/api.git",
+		"trailing slash": "https://github.com/acme/api/",
+		"mixed case":     "https://github.com/Acme/API",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			brief := buildMetaSkillContentSlim("claude", TaskContextForEnv{
+				IssueID:          "i1",
+				Repos:            []RepoContextForEnv{{URL: "https://github.com/acme/api"}},
+				ProjectID:        "p1",
+				ProjectResources: []ProjectResourceForEnv{githubResource(resourceURL, "API")},
+			})
+			if strings.Contains(brief, "## Repositories") {
+				t.Errorf("%s was not recognized as the same repo:\n%s", name, brief)
+			}
+		})
+	}
+}
+
+// Narrow on purpose: normalization must never merge two repositories that
+// only look alike.
+func TestProjectRepoDedupKeepsDistinctRepos(t *testing.T) {
+	t.Parallel()
+
+	brief := buildMetaSkillContentSlim("claude", TaskContextForEnv{
+		IssueID:          "i1",
+		Repos:            []RepoContextForEnv{{URL: "https://github.com/acme/api-v2"}},
+		ProjectID:        "p1",
+		ProjectResources: []ProjectResourceForEnv{githubResource("https://github.com/acme/api", "API")},
+	})
+
+	if !strings.Contains(brief, "https://github.com/acme/api-v2") {
+		t.Errorf("a different repo was deduped away:\n%s", brief)
+	}
+}
+
+// A non-github resource carries no URL to match on; it must not silently
+// hide a workspace repo.
+func TestRepositoriesUnaffectedByNonGithubResources(t *testing.T) {
+	t.Parallel()
+
+	ref, _ := json.Marshal(map[string]string{"path": "/srv/app"})
+	brief := buildMetaSkillContentSlim("claude", TaskContextForEnv{
+		IssueID:   "i1",
+		Repos:     []RepoContextForEnv{{URL: "https://github.com/acme/api"}},
+		ProjectID: "p1",
+		ProjectResources: []ProjectResourceForEnv{
+			{ResourceType: "local_directory", ResourceRef: ref, Label: "app"},
+		},
+	})
+
+	if !strings.Contains(brief, "https://github.com/acme/api") {
+		t.Errorf("workspace repo dropped by an unrelated resource type:\n%s", brief)
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -392,16 +393,32 @@ func writeCommentFormatting(b *strings.Builder) {
 	b.WriteString("For issue comments, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`**. Never use inline `--content` for agent-authored comments (MUL-2904); never use `--content-stdin` HEREDOCs alongside other flags (#4182). Write the file inside your working directory, never `/tmp` or shared paths (MUL-4252). Keep the same `--parent` value from the trigger comment when replying; delete the temp file (`rm ./reply.md`) after posting; do not rely on `\\n` escapes.\n\n")
 }
 
-// writeRepositories emits the Repositories section when at least one repo
-// is configured. The closing paragraph from the legacy version is dropped
-// (it re-stated the opening); intro is tightened into one line.
+// writeRepositories emits the Repositories section for the workspace repos
+// this task does not already see through its project.
+//
+// A repo that is also a github_repo project resource is rendered by
+// writeProjectContext, with its ref, default-branch hint and label. Listing
+// the bare URL again here spends tokens on a line that says strictly less
+// than the one above it, and leaves the agent to work out that the two are
+// the same repository. Everything unmatched still belongs here — a workspace
+// repo is reachable whether or not a project points at it. Only the prompt
+// changes: the runtime repo list used for checkout authorization is
+// untouched.
 func writeRepositories(b *strings.Builder, ctx TaskContextForEnv) {
-	if len(ctx.Repos) == 0 {
+	inProject := projectRepoURLs(ctx.ProjectResources)
+	repos := make([]RepoContextForEnv, 0, len(ctx.Repos))
+	for _, repo := range ctx.Repos {
+		if _, ok := inProject[normalizeRepoURL(repo.URL)]; ok {
+			continue
+		}
+		repos = append(repos, repo)
+	}
+	if len(repos) == 0 {
 		return
 	}
 	b.WriteString("## Repositories\n\n")
 	b.WriteString("Available in this workspace — `multica repo checkout <url> [--ref <branch-or-sha>]` to fetch (creates a repository checkout on a dedicated branch).\n\n")
-	for _, repo := range ctx.Repos {
+	for _, repo := range repos {
 		if repo.Description != "" {
 			fmt.Fprintf(b, "- %s — %s\n", repo.URL, repo.Description)
 		} else {
@@ -409,6 +426,39 @@ func writeRepositories(b *strings.Builder, ctx TaskContextForEnv) {
 		}
 	}
 	b.WriteString("\n")
+}
+
+// projectRepoURLs indexes the github_repo resources by normalized URL.
+func projectRepoURLs(resources []ProjectResourceForEnv) map[string]struct{} {
+	out := make(map[string]struct{}, len(resources))
+	for _, r := range resources {
+		if r.ResourceType != "github_repo" {
+			continue
+		}
+		var payload struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(r.ResourceRef, &payload); err != nil {
+			continue
+		}
+		if key := normalizeRepoURL(payload.URL); key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+
+// normalizeRepoURL is the identity two prompt sections agree on. The same
+// repository is written both ways in practice — a project resource stored
+// with the `.git` suffix and a workspace repo without it are one repo, and
+// deduping only exact strings would leave the pair that motivated this.
+// Deliberately narrow: it never rewrites the host or path, so two genuinely
+// different URLs cannot collapse into one.
+func normalizeRepoURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	u = strings.TrimSuffix(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	return strings.ToLower(strings.TrimSuffix(u, "/"))
 }
 
 // writeProjectContext emits the Project Context section when the task carries


### PR DESCRIPTION
Fixes the repository half of #7773. The autopilot half landed upstream independently as MUL-6984 (#7971) — this PR is rebased on top of it and now carries only what remains.

A `github_repo` project resource is rendered by Project Context with its ref, default-branch hint and label. `## Repositories` then listed the bare URL again — a line that says strictly less than the one above it, and leaves the agent to work out that the two are the same repository. Those repos are skipped there now, and the section is elided when nothing is left. Unmatched workspace repos still appear: a workspace repo is reachable whether or not a project points at it.

URL matching ignores a `.git` suffix, a trailing slash and case, because the two sides store the same repository both ways in practice; it never rewrites host or path, so two genuinely different URLs cannot collapse into one.

**Out of scope, verified untouched**: the runtime repository list used for checkout authorization and caching, and the sidecar context files.

| Acceptance | Test |
| --- | --- |
| project repo appears once, metadata kept in Project Context | `TestRepositoriesOmitsReposAlreadyInProjectContext` |
| section elided when nothing is left | `TestRepositoriesSectionElidedWhenEveryRepoIsAProjectResource` |
| unmatched workspace repos survive | same, plus `TestProjectRepoDedupKeepsDistinctRepos` |
| `.git` / trailing slash / case are the same repo | `TestProjectRepoDedupIgnoresGitSuffixAndTrailingSlash` |
| non-github resources hide nothing | `TestRepositoriesUnaffectedByNonGithubResources` |
