### PR TITLE
MUL-6931: feat(agent): integrate Prime Agent as a pi-family builtin runtime

### DIFF
--- a/packages/core/runtimes/display.test.ts
+++ b/packages/core/runtimes/display.test.ts
@@ -116,6 +116,13 @@ describe("runtimeDisplayLabel", () => {
     ).toBe("box (MiniMax Code)");
     expect(
       runtimeDisplayLabel({
+        name: "Prime Agent (host)",
+        custom_name: "box",
+        provider: "prime",
+      }),
+    ).toBe("box (Prime Agent)");
+    expect(
+      runtimeDisplayLabel({
         name: "ZeroClaw (host)",
         custom_name: "box",
         provider: "zeroclaw",

--- a/packages/core/runtimes/display.ts
+++ b/packages/core/runtimes/display.ts
@@ -49,6 +49,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   qwenpaw: "QwenPaw",
   mcode: "MiniMax Code",
   omp: "Oh-My-Pi",
+  prime: "Prime Agent",
   zeroclaw: "ZeroClaw",
 };
 

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -404,6 +404,9 @@ export function ProviderLogo({
       return <PiLogo className={className} />;
     case "omp":
       return <PiLogo className={className} />;
+    case "prime":
+      // Prime Agent is a hard fork of pi — reuse the Pi wordmark, like omp.
+      return <PiLogo className={className} />;
     case "copilot":
       return <CopilotLogo className={className} />;
     case "cursor":

--- a/server/pkg/agent/builtin_runtimes.go
+++ b/server/pkg/agent/builtin_runtimes.go
@@ -59,6 +59,12 @@ type BuiltinRuntime struct {
 	// piBackend.providerLabel).
 	ProviderLabel string
 
+	// SessionMode is the pi-family session-persistence strategy. Zero is
+	// piSessionModeFile (pi/omp): the daemon creates a transcript file and
+	// reuses its path as the session id. Forks that own their session
+	// directory (prime) set piSessionModeDir.
+	SessionMode piSessionMode
+
 	// ModelDiscovery is the strategy for discovering available models.
 	// When set, it replaces the protocol family's discovery entirely — omp
 	// uses `omp models --json`, a different command and output shape from
@@ -82,8 +88,9 @@ type ModelDiscoveryFunc func(ctx context.Context, runtimeCmd Command) ([]Model, 
 // to its protocol family's backend.
 //
 // A runtime identity appears here when it needs its own probe/display/skills
-// but reuses an existing backend's protocol. The first entry is omp (oh-my-pi):
-// a separate CLI that speaks the pi JSON event protocol.
+// but reuses an existing backend's protocol. omp (oh-my-pi) is a separate CLI
+// that speaks the pi JSON event protocol; prime (Prime Agent) is a hard fork
+// of pi that keeps the same event protocol but owns its session directory.
 var BuiltinRuntimes = []BuiltinRuntime{
 	{
 		ID:                "omp",
@@ -97,6 +104,24 @@ var BuiltinRuntimes = []BuiltinRuntime{
 		DefaultExecutable: "omp",
 		ProviderLabel:     "omp",
 		ModelDiscovery:    discoverOmpModels,
+	},
+	{
+		ID:                "prime",
+		ProtocolFamily:    "pi",
+		DefaultCommand:    "prime-agent",
+		EnvPrefix:         "MULTICA_PRIME",
+		DisplayName:       "Prime Agent",
+		SkillsDir:         ".prime/agent/skills",
+		UserSkillsDir:     ".prime/agent/skills",
+		LaunchHeader:      "prime-agent (json mode)",
+		DefaultExecutable: "prime-agent",
+		ProviderLabel:     "prime",
+		// prime refuses pi's --session flag (verified against v0.8.0) and
+		// manages its own session directory; it resumes by the session event's
+		// id via --resume. File mode would break it, so the descriptor pins
+		// dir mode.
+		SessionMode:    piSessionModeDir,
+		ModelDiscovery: discoverPrimeModels,
 	},
 }
 
@@ -143,6 +168,7 @@ type backendOverrideApplicator interface {
 func (b *piBackend) applyBuiltinRuntimeOverrides(desc BuiltinRuntime) {
 	b.defaultExecutable = desc.DefaultExecutable
 	b.providerLabel = desc.ProviderLabel
+	b.sessionMode = desc.SessionMode
 }
 
 // ResolveBackend is the single production entry point the daemon uses to

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -1376,6 +1376,41 @@ func parseOmpModels(data []byte) ([]Model, error) {
 	return models, nil
 }
 
+// discoverPrimeModels runs `prime-agent model list` and parses the text table
+// with the same parser as pi's `--list-models`. prime removed `--list-models`
+// (v0.8.0: "Error: --list-models was removed. Use \"prime-agent model list\".")
+// The `model list` output is a `provider  model  context  max-out  thinking
+//
+//	images` table whose rows are structurally identical to pi's table, so
+//
+// parsePiModels normalises them; prime's leading `provider` header line is
+// skipped by the same no-op. An empty catalog (no provider credentials) or a
+// non-zero exit (binary missing / too old) falls back to an empty list so the
+// UI degrades to manual entry instead of erroring.
+func discoverPrimeModels(ctx context.Context, runtimeCmd Command) ([]Model, error) {
+	if runtimeCmd.Path == "" {
+		runtimeCmd.Path = "prime-agent"
+	}
+	if _, err := exec.LookPath(runtimeCmd.Path); err != nil {
+		return []Model{}, nil
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := runtimeCmd.exec(runCtx, "model", "list")
+	hideAgentWindow(cmd)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := outputOwned(cmd, runtimeCmd.logger)
+	if err != nil && len(stdout) == 0 && stderr.Len() == 0 {
+		return []Model{}, nil
+	}
+	text := string(stdout)
+	if strings.TrimSpace(text) == "" {
+		text = stderr.String()
+	}
+	return parsePiModels(text), nil
+}
+
 // discoverHermesModels spins up a throwaway `hermes acp` process,
 // drives just enough of the protocol to receive the model list
 // advertised in the `session/new` response, and shuts it down. The

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -15,23 +15,46 @@ import (
 	"time"
 )
 
+// piSessionMode selects the session-persistence strategy a pi-family runtime
+// speaks. They are not interchangeable: pi pre-creates a transcript file and
+// reuses it with --session, while its forks may own the session directory and
+// resume by id. The mode is fixed by the runtime, never negotiated per turn.
+type piSessionMode int
+
+const (
+	// piSessionModeFile is pi's contract: the daemon pre-creates a JSONL
+	// transcript file, passes it via --session, and reuses the path as the
+	// opaque SessionID / ResumeSessionID. The file lock serialises turns.
+	piSessionModeFile piSessionMode = iota
+	// piSessionModeDir is prime-agent's contract: the daemon passes a
+	// --session-dir and lets prime create/name the JSONL. Resumption is by
+	// --resume <id>, where <id> is the session event's id (not the filename).
+	// prime refuses --session outright (verified against v0.8.0).
+	piSessionModeDir
+)
+
 // piBackend implements Backend by spawning the Pi CLI in non-interactive
 // JSON mode (`pi -p --mode json --session <path>`) and parsing its event
 // stream on stdout.
 //
-// It also backs the "omp" (oh-my-pi) provider — omp is a separate CLI
-// (https://omp.sh) that is a drop-in fork of pi and speaks the same JSON
-// event protocol. The daemon probes a separate `omp` binary and registers
-// it under the "omp" key; piBackend uses defaultExecutable so the fallback
-// binary name matches the provider key (pi → "pi", omp → "omp") when
+// It also backs the "omp" (oh-my-pi) and "prime" providers — separate CLIs
+// that are drop-in forks of pi and speak the same JSON event protocol. The
+// daemon probes a separate binary for each and registers it under its own
+// key; piBackend uses defaultExecutable so the fallback binary name matches
+// the provider key (pi → "pi", omp → "omp", prime → "prime-agent") when
 // cfg.ExecutablePath is empty.
 type piBackend struct {
 	cfg               Config
 	defaultExecutable string
 	// providerLabel is the human-facing name used in log messages and error
-	// strings ("pi" or "omp"). Defaults to "pi" when empty so existing callers
-	// that construct piBackend directly (tests) keep their original output.
+	// strings ("pi", "omp" or "prime"). Defaults to "pi" when empty so existing
+	// callers that construct piBackend directly (tests) keep their original
+	// output.
 	providerLabel string
+	// sessionMode is the session-persistence strategy for this runtime. Zero
+	// value (piSessionModeFile) preserves pi/omp behaviour; the prime variant
+	// is selected by the BuiltinRuntime descriptor.
+	sessionMode piSessionMode
 }
 
 var (
@@ -212,34 +235,57 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 	timeout := opts.Timeout
 
-	// Pi's --session flag expects a file path where events are appended.
-	// The path doubles as our opaque session identifier: we return it as
-	// SessionID and expect it back as ResumeSessionID on the next turn.
-	sessionPath := opts.ResumeSessionID
-	if sessionPath == "" {
-		p, err := newPiSessionPath()
+	// Session model depends on the runtime family (pi session mode).
+	// - piSessionModeFile (pi, omp): the daemon pre-creates a JSONL transcript
+	//   file, passes it via --session, and reuses the path as the opaque
+	//   SessionID / ResumeSessionID. A file lock serialises turns.
+	// - piSessionModeDir (prime): the daemon points prime at a --session-dir
+	//   and lets prime create/name the JSONL. Resumption is by --resume <id>,
+	//   where <id> is the session event's id. prime manages its own
+	//   concurrency (it refuses to resume an already-active session).
+	sessionValue := opts.ResumeSessionID
+	sessionLock := (*os.File)(nil)
+	if b.sessionMode == piSessionModeDir {
+		dir, err := piSessionDir()
 		if err != nil {
-			return nil, fmt.Errorf("%s session path: %w", label, err)
+			return nil, fmt.Errorf("%s session dir: %w", label, err)
 		}
-		sessionPath = p
-	}
-	if err := ensurePiSessionFile(sessionPath); err != nil {
-		return nil, fmt.Errorf("%s session file: %w", label, err)
-	}
-	sessionLock, locked, err := tryLockPiSessionFile(sessionPath)
-	if err != nil {
-		return nil, fmt.Errorf("%s session lock: %w", label, err)
-	}
-	if !locked {
-		if opts.ResumeSessionID != "" {
-			return piSessionBusyResult(label, sessionPath), nil
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("%s session dir: %w", label, err)
 		}
-		return nil, fmt.Errorf("%s session file %q is already in use", label, sessionPath)
+		sessionValue = dir
+	} else {
+		if sessionValue == "" {
+			p, err := newPiSessionPath()
+			if err != nil {
+				return nil, fmt.Errorf("%s session path: %w", label, err)
+			}
+			sessionValue = p
+		}
+		if err := ensurePiSessionFile(sessionValue); err != nil {
+			return nil, fmt.Errorf("%s session file: %w", label, err)
+		}
+		var locked bool
+		sessionLock, locked, err = tryLockPiSessionFile(sessionValue)
+		if err != nil {
+			return nil, fmt.Errorf("%s session lock: %w", label, err)
+		}
+		if !locked {
+			if opts.ResumeSessionID != "" {
+				return piSessionBusyResult(label, sessionValue), nil
+			}
+			return nil, fmt.Errorf("%s session file %q is already in use", label, sessionValue)
+		}
 	}
 
 	runCtx, cancel := runContext(ctx, timeout)
 
-	args := buildPiArgs(sessionPath, opts, b.cfg.Logger)
+	var args []string
+	if b.sessionMode == piSessionModeDir {
+		args = buildPrimeArgs(sessionValue, opts, b.cfg.Logger)
+	} else {
+		args = buildPiArgs(sessionValue, opts, b.cfg.Logger)
+	}
 	cmd, _, _ := b.cfg.commandAt(execName).execVia(runCtx, choosePiInvocation, lookedUp, args, b.cfg.Logger)
 	hideAgentWindow(cmd)
 	b.cfg.logAgentCommand(cmd, newAgentCommandLogArgs(args))
@@ -313,6 +359,9 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		var finalError string
 		var lastTurnError string
 		usage := make(map[string]TokenUsage)
+		// For piSessionModeDir (prime) the resumable session id is emitted in
+		// the leading `session` event; in file mode the path is the id.
+		resumableSessionID := sessionValue
 
 		// Pi message_update events can be large (they embed the full message
 		// partial on each delta); the shared stream bound covers that.
@@ -330,6 +379,15 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			}
 
 			switch evt.Type {
+			case "session":
+				// prime emits a leading `session` event carrying the resumable
+				// session id (distinct from the on-disk filename). In dir mode
+				// this id is what --resume needs on a later turn.
+				if b.sessionMode == piSessionModeDir && evt.ID != "" {
+					resumableSessionID = evt.ID
+				}
+				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
+
 			case "agent_start":
 				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 
@@ -482,7 +540,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			Output:     output.String(),
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
-			SessionID:  sessionPath,
+			SessionID:  resumableSessionID,
 			Usage:      usage,
 		}
 	}()
@@ -511,6 +569,12 @@ func piSessionBusyResult(label, sessionPath string) *Session {
 // demand by the switch arms.
 type piStreamEvent struct {
 	Type string `json:"type"`
+
+	// session: the first event emitted in print/JSON mode. Its `id` is the
+	// runtime-owned session id. In piSessionModeDir (prime) this id — NOT the
+	// filename on disk — is the value to hand back for --resume, so we capture
+	// it and surface it as Result.SessionID.
+	ID string `json:"id,omitempty"`
 
 	// message_update
 	AssistantMessageEvent *piAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
@@ -594,11 +658,13 @@ func decodePiResult(raw json.RawMessage) string {
 // overridden by user-configured custom_args. Overriding these would
 // break the daemon↔Pi communication protocol.
 var piBlockedArgs = map[string]blockedArgMode{
-	"-p":         blockedStandalone, // non-interactive mode
-	"--print":    blockedStandalone, // alias for -p
-	"--mode":     blockedWithValue,  // "json" event stream protocol
-	"--session":  blockedWithValue,  // daemon manages the session path
-	"--thinking": blockedWithValue,  // owned by agent.thinking_level
+	"-p":            blockedStandalone, // non-interactive mode
+	"--print":       blockedStandalone, // alias for -p
+	"--mode":        blockedWithValue,  // "json" event stream protocol
+	"--session":     blockedWithValue,  // daemon manages the session path
+	"--session-dir": blockedWithValue,  // prime: daemon manages the session dir
+	"--resume":      blockedWithValue,  // prime: daemon manages resume (session id)
+	"--thinking":    blockedWithValue,  // owned by agent.thinking_level
 }
 
 // piCustomArgModes mirrors Pi 0.83's built-in parser closely enough to
@@ -706,6 +772,34 @@ func buildPiArgs(sessionPath string, opts ExecOptions, logger *slog.Logger) []st
 	// Pi loads the per-task AGENTS.md the daemon writes into the workdir, so
 	// inlining the same runtime brief would duplicate it on every turn.
 	// Verified against Pi 0.67.2 (MUL-5392).
+	args = append(args, filterPiCustomArgs(opts.CustomArgs, logger)...)
+	return args
+}
+
+// buildPrimeArgs assembles argv for a Prime Agent one-shot run. It is pi's
+// JSON protocol with the session flags prime actually accepts: prime removed
+// `--session` (v0.8.0: "Error: Unknown option: --session") and instead owns a
+// session directory (`--session-dir`), resuming a prior conversation via
+// `--resume <id>` where <id> is the session event's id. The rest (model,
+// thinking, tool registry, custom args) matches buildPiArgs so the same
+// filtered custom-args handling applies.
+func buildPrimeArgs(sessionDir string, opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{
+		"-p",
+		"--mode", "json",
+	}
+	if sessionDir != "" {
+		args = append(args, "--session-dir", sessionDir)
+		if resume := strings.TrimSpace(opts.ResumeSessionID); resume != "" {
+			args = append(args, "--resume", resume)
+		}
+	}
+	if model := strings.TrimSpace(opts.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	if opts.ThinkingLevel != "" {
+		args = append(args, "--thinking", opts.ThinkingLevel)
+	}
 	args = append(args, filterPiCustomArgs(opts.CustomArgs, logger)...)
 	return args
 }

--- a/server/pkg/agent/prime_test.go
+++ b/server/pkg/agent/prime_test.go
@@ -1,0 +1,233 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPrimeNewDispatchesToPiBackend asserts that ResolveBackend("prime")
+// dispatches to the pi backend via the descriptor registry — the core
+// contract that prime is a runtime identity on the pi protocol (hard fork of
+// pi), not a separate protocol family. IsSupportedType("prime") is false (it
+// is not a protocol family), but New resolves it through BuiltinRuntimes to
+// the pi backend with the correct executable, label, and session-mode
+// overrides.
+func TestPrimeNewDispatchesToPiBackend(t *testing.T) {
+	if IsSupportedType("prime") {
+		t.Error("prime must not be in SupportedTypes (it is a runtime identity, not a protocol family)")
+	}
+	b, err := ResolveBackend("prime", Config{Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("ResolveBackend(prime): %v", err)
+	}
+	pb, ok := b.(*piBackend)
+	if !ok {
+		t.Fatalf("ResolveBackend(prime) returned %T, want *piBackend", b)
+	}
+	if pb.defaultExecutable != "prime-agent" {
+		t.Errorf("defaultExecutable = %q, want %q", pb.defaultExecutable, "prime-agent")
+	}
+	if pb.providerLabel != "prime" {
+		t.Errorf("providerLabel = %q, want %q", pb.providerLabel, "prime")
+	}
+	if pb.sessionMode != piSessionModeDir {
+		t.Errorf("sessionMode = %v, want piSessionModeDir (prime owns its session dir)", pb.sessionMode)
+	}
+}
+
+// TestPrimeOmitsSessionAndUsesSessionDir verifies that the prime arg builder
+// emits --session-dir and --resume instead of --session. prime removed
+// --session (v0.8.0) — this is the compatibility contract.
+func TestPrimeArgsUseSessionDirAndResume(t *testing.T) {
+	args := buildPrimeArgs("/tmp/prime-sessions", ExecOptions{ResumeSessionID: "01a05c2d-3221-71ab-99b8-1a2f6d968114"}, slog.Default())
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-p", "--mode json", "--session-dir /tmp/prime-sessions", "--resume 01a05c2d-3221-71ab-99b8-1a2f6d968114"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("buildPrimeArgs missing %q; args: %v", want, args)
+		}
+	}
+	if strings.Contains(joined, "--session ") {
+		t.Errorf("buildPrimeArgs must not emit --session (prime rejects it); args: %v", args)
+	}
+}
+
+// TestPrimeArgsNoResumeOnFreshSession verifies a fresh prime session (empty
+// ResumeSessionID) omits --resume altogether.
+func TestPrimeArgsNoResumeOnFreshSession(t *testing.T) {
+	args := buildPrimeArgs("/tmp/prime-sessions", ExecOptions{}, slog.Default())
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--session-dir /tmp/prime-sessions") {
+		t.Fatalf("expected --session-dir in args: %v", args)
+	}
+	if strings.Contains(joined, "--resume") {
+		t.Errorf("fresh prime session must not emit --resume; args: %v", args)
+	}
+}
+
+// TestPrimeArgsKeepsModelThinkingCustomArgs verifies buildPrimeArgs forwards
+// the same model/thinking/custom-arg options buildPiArgs does.
+func TestPrimeArgsKeepsModelThinkingCustomArgs(t *testing.T) {
+	args := buildPrimeArgs("/tmp/prime-sessions", ExecOptions{
+		Model:         "omlx6/Qwen3.6-35B-A3B-oQ4-fp16-mtp",
+		ThinkingLevel: "low",
+		CustomArgs:    []string{"--offline"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"--model omlx6/Qwen3.6-35B-A3B-oQ4-fp16-mtp", "--thinking low", "--offline"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("buildPrimeArgs missing %q; args: %v", want, args)
+		}
+	}
+}
+
+// TestPrimeExecuteUsesSessionDir verifies the dir-mode execute path launches
+// with --session-dir (not --session) end to end, using a fake prime binary
+// that emits the pi JSON event stream. The result carries the session event's
+// id as SessionID (the value --resume needs on the next turn).
+func TestPrimeExecuteUsesSessionDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	events := []string{
+		`{"type":"session","version":3,"id":"01a05c2d-prime-test-abcd","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp","rlmDepth":0}`,
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello from prime"}}`,
+		`{"type":"turn_end","message":{"role":"assistant","model":"prime-test","usage":{"input":10,"output":5}}}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "prime-agent")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
+
+	backend, err := ResolveBackend("prime", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("ResolveBackend(prime): %v", err)
+	}
+	pb := backend.(*piBackend)
+	if pb.sessionMode != piSessionModeDir {
+		t.Fatalf("backend sessionMode = %v, want piSessionModeDir", pb.sessionMode)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "hello from prime" {
+			t.Errorf("Output = %q, want %q", result.Output, "hello from prime")
+		}
+		// In dir mode the SessionID must be the session event's id, not a path.
+		if result.SessionID != "01a05c2d-prime-test-abcd" {
+			t.Errorf("SessionID = %q, want the session event id %q (prime resumes by id)", result.SessionID, "01a05c2d-prime-test-abcd")
+		}
+		if len(result.Usage) != 1 {
+			t.Fatalf("expected 1 usage entry, got %d", len(result.Usage))
+		}
+		u, ok := result.Usage["prime-test"]
+		if !ok {
+			t.Fatalf("expected usage for model %q, got %v", "prime-test", result.Usage)
+		}
+		if u.InputTokens != 10 || u.OutputTokens != 5 {
+			t.Errorf("usage: input=%d output=%d, want input=10 output=5", u.InputTokens, u.OutputTokens)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestPrimeAndPiCanCoexist verifies both "pi" and "prime" backends construct
+// side by side, with prime defaulting to dir mode and pi to file mode.
+func TestPrimeAndPiCanCoexist(t *testing.T) {
+	piBe, err := New("pi", Config{ExecutablePath: "/fake/pi", Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(pi): %v", err)
+	}
+	primeBe, err := ResolveBackend("prime", Config{ExecutablePath: "/fake/prime-agent", Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("ResolveBackend(prime): %v", err)
+	}
+	pb := piBe.(*piBackend)
+	primeb := primeBe.(*piBackend)
+	if pb.sessionMode != piSessionModeFile {
+		t.Errorf("pi sessionMode = %v, want piSessionModeFile", pb.sessionMode)
+	}
+	if primeb.sessionMode != piSessionModeDir {
+		t.Errorf("prime sessionMode = %v, want piSessionModeDir", primeb.sessionMode)
+	}
+}
+
+// TestPrimeDescriptorFieldsAreConsumed guards that the prime descriptor's
+// fields are all populated (the descriptor-driven probe and UI read them).
+func TestPrimeDescriptorFieldsAreConsumed(t *testing.T) {
+	desc, ok := BuiltinRuntimeByID("prime")
+	if !ok {
+		t.Fatal("prime descriptor not found")
+	}
+	checks := map[string]string{
+		"ID":                desc.ID,
+		"ProtocolFamily":    desc.ProtocolFamily,
+		"DefaultCommand":    desc.DefaultCommand,
+		"EnvPrefix":         desc.EnvPrefix,
+		"DisplayName":       desc.DisplayName,
+		"SkillsDir":         desc.SkillsDir,
+		"UserSkillsDir":     desc.UserSkillsDir,
+		"LaunchHeader":      desc.LaunchHeader,
+		"DefaultExecutable": desc.DefaultExecutable,
+		"ProviderLabel":     desc.ProviderLabel,
+	}
+	for name, val := range checks {
+		if val == "" {
+			t.Errorf("descriptor field %s is empty", name)
+		}
+	}
+	if desc.ModelDiscovery == nil {
+		t.Error("descriptor field ModelDiscovery is nil")
+	}
+	if desc.SessionMode != piSessionModeDir {
+		t.Errorf("descriptor SessionMode = %v, want piSessionModeDir", desc.SessionMode)
+	}
+}
+
+// TestDiscoverPrimeModelsTable verifies `prime-agent model list` output (the
+// same table shape as pi) is parsed through parsePiModels.
+func TestDiscoverPrimeModelsTable(t *testing.T) {
+	table := "provider  model                       context  max-out  thinking  images\n" +
+		"litellm   opencode-jj-deepseek-v4-flash   131.1K   16.4K    no        no\n" +
+		"omlx6     Qwen3.6-35B-A3B-oQ4-fp16-mtp    131.1K   16.4K    yes       no\n"
+	models, err := discoverPrimeModelsTable(table)
+	if err != nil {
+		t.Fatalf("discoverPrimeModelsTable: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "litellm/opencode-jj-deepseek-v4-flash" || models[0].Provider != "litellm" {
+		t.Errorf("models[0] = %+v", models[0])
+	}
+	if models[1].ID != "omlx6/Qwen3.6-35B-A3B-oQ4-fp16-mtp" || models[1].Provider != "omlx6" {
+		t.Errorf("models[1] = %+v", models[1])
+	}
+}
+
+// discoverPrimeModelsTable is a thin wrapper so the table-parsing path is
+// testable without spawning a binary. It mirrors discoverPrimeModels' final
+// parse step.
+func discoverPrimeModelsTable(output string) ([]Model, error) {
+	return parsePiModels(output), nil
+}


### PR DESCRIPTION
## NRA-961: Integrate Prime Agent into Multica (pi-family builtin runtime)

Prime Agent (v0.8.0) is a **hard fork of pi** ("began as a hard fork of pi-mono... retains the inherited `pi` bin entry"). It emits the same JSON event stream as pi (`session`, `agent_start`, `turn_start`, `message_update` with `assistantMessageEvent`, `turn_end` with `usage`/`stopReason`, `agent_end`), so it integrates as a **builtin runtime identity** on the `pi` protocol family, exactly like `omp`.

### What changes

- **`BuiltinRuntime` descriptor `prime`** (`builtin_runtimes.go`) — ProtocolFamily `pi`, binary `prime-agent`, env `MULTICA_PRIME`, display "Prime Agent", skills under `.prime/agent/skills`. No DB migration needed (a runtime identity is not in `SupportedTypes`, same as `omp`).
- **Dir-mode sessions** (`pi.go`): prime **rejects `--session`** (v0.8.0) and manages its own session directory. Added `piSessionMode` (`file` = pi/omp, `dir` = prime): in dir mode we pass `--session-dir` and resume with `--resume <id>`, where `<id>` is the id of the leading `session` event (not the on-disk filename). That id is captured from the stream and surfaced as `Result.SessionID`.
- **Model discovery** (`models.go`): `prime-agent model list` (pi removed `--list-models`). Its output is a `provider model context …` table with the **same shape `parsePiModels` already normalises**, so the pi parser is reused.
- **Frontend**: logo (`provider-logo.tsx`, reuses the Pi wordmark like omp) and display name "Prime Agent" (`display.ts`).
- **Tests** (`prime_test.go`): dispatch to piBackend, dir-mode arg builder, end-to-end execution with a fake binary emitting the `session` event + pi stream, pi/prime coexistence, and model-table parsing.

### Verification

- `go build ./...` OK.
- `go test ./pkg/agent/ -run 'Prime|Omp|Pi|BuiltinRuntime|ParsePi'` — PASS. (The 4 codex/mcode failures in the full suite are pre-existing on `main`, confirmed via stash.)
- TS changes mirror the existing `omp` case exactly; the monorepo TS tests need `pnpm install` and were not run.
- **Verified empirically against `prime-agent` v0.8.0 on the N100**: `--mode json` emits a `session` event whose id differs from the filename, and `--resume <id>` / `--resume <filepath>` continues context.

> Note: this PR is opened from a fork (`nicolasramos/multica`) because the daemon's `multica-ai/multica` push access returns 403 for this account.

Closes NRA-961
