### PR TITLE
MUL-6935: fix(execenv): recognize OpenClaw 2026.8.x 'Unknown config path' wording

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -1443,14 +1443,40 @@ func isOpenclawKeyMissing(err error) bool {
 const openclawJSONErrorMaxRunes = 1024
 
 func openclawJSONErrorMessage(stdout string) (string, bool) {
-	var envelope struct {
-		Error string `json:"error"`
-	}
-	if json.Unmarshal([]byte(strings.TrimSpace(stdout)), &envelope) != nil {
+	// Older OpenClaw builds emitted a flat `{"error":"..."}` envelope. From
+	// 2026.8.x the `error` field became an object with a `message` field
+	// (e.g. {"ok":false,"error":{"type":"cli_error","message":"..."}}).
+	// Unmarshalling a non-string into a string field makes json.Unmarshal
+	// return an error, which would silently drop the message and reclassify a
+	// graceful missing-key fallback as a hard failure. Accept both shapes.
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
 		return "", false
 	}
-	message := strings.Join(strings.Fields(envelope.Error), " ")
-	return message, message != ""
+	var envelope struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return "", false
+	}
+	if len(envelope.Error) == 0 {
+		return "", false
+	}
+	// error may be a plain string ("Config path not found: ...") or an
+	// object with a message field ({"type":"cli_error","message":"..."}).
+	var flat string
+	if err := json.Unmarshal(envelope.Error, &flat); err == nil {
+		message := strings.Join(strings.Fields(flat), " ")
+		return message, message != ""
+	}
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(envelope.Error, &payload); err == nil && payload.Message != "" {
+		message := strings.Join(strings.Fields(payload.Message), " ")
+		return message, message != ""
+	}
+	return "", false
 }
 
 // annotateOpenclawJSONError restores diagnostics for JSON-mode commands whose
@@ -1527,11 +1553,15 @@ func isOpenclawKeyMissingMessage(msg string) bool {
 	// strings.Contains on "Path not found" silently stopped matching the
 	// 2026.6.x string, turning the intended graceful-skip into a fail-closed
 	// error that broke every OpenClaw 2026.6.x runtime (see upstream #3028).
+	// OpenClaw 2026.8.x reworded it again to "Unknown config path:
+	// agents.list"; treat that as missing too so the registry fallback still
+	// engages instead of failing closed.
 	msg = strings.ToLower(msg)
 	return strings.Contains(msg, "no value at ") ||
 		strings.Contains(msg, "not set") ||
 		strings.Contains(msg, "missing key") ||
-		strings.Contains(msg, "path not found")
+		strings.Contains(msg, "path not found") ||
+		strings.Contains(msg, "unknown config path")
 }
 
 // isOpenclawUnknownSubcommand returns true when the CLI error indicates the

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1640,6 +1640,11 @@ func TestIsOpenclawKeyMissing(t *testing.T) {
 			errors.New("openclaw config get agents.list --json: exit status 1 (stderr: Config path not found: agents.list. Run openclaw config validate to inspect config shape.)"),
 			true,
 		},
+		{
+			"2026.8.x Unknown config path",
+			errors.New("openclaw config get agents.list --json: exit status 1 (stderr: Unknown config path: agents.list. Run openclaw config schema to inspect valid paths.)"),
+			true,
+		},
 		{"real failure stays an error", errors.New("openclaw: failed to read config: permission denied"), false},
 		{"malformed json is not a missing key", errors.New("parse output: invalid character 'x'"), false},
 	}
@@ -1669,6 +1674,12 @@ func TestIsOpenclawKeyMissingResult(t *testing.T) {
 		{
 			name:   "2026.7.2-beta.7 stdout json missing path",
 			stdout: `{"error":"Config path not found: agents.list"}`,
+			err:    errors.New("openclaw config get agents.list --json: exit status 1"),
+			want:   true,
+		},
+		{
+			name:   "2026.8.x stdout json unknown config path",
+			stdout: `{"ok":false,"error":{"type":"cli_error","message":"Unknown config path: agents.list. Run openclaw config schema to inspect valid paths."}}`,
 			err:    errors.New("openclaw config get agents.list --json: exit status 1"),
 			want:   true,
 		},


### PR DESCRIPTION
## Problem

OpenClaw `2026.8.x` reworded the missing-config-path error for `openclaw config get agents.list --json`:

- **2026.6.x**: `Config path not found: agents.list`
- **2026.8.x**: `Unknown config path: agents.list. Run openclaw config schema to inspect valid paths.`

`isOpenclawKeyMissingMessage` only matched the older phrasing (`"no value at "`, `"not set"`, `"missing key"`, `"path not found"`). Because `unknown config path` is not in that set, `isOpenclawKeyMissingResult` returned `false`, so the registry fallback in `openclawResolvedAgentsList` never engaged. Result: every OpenClaw `2026.8.x` runtime failed closed during execenv preparation with:

```
read openclaw agents.list: openclaw config get agents.list --json: exit status 1
```

## Second bug

OpenClaw `2026.8.x` also changed the JSON error envelope's `error` field from a **plain string** to an **object carrying `message`**:

```json
{"ok":false,"error":{"type":"cli_error","message":"Unknown config path: agents.list. Run openclaw config schema to inspect valid paths."}}
```

`openclawJSONErrorMessage` unmarshalled `error` into a `string` field, so `json.Unmarshal` failed on the object shape and silently dropped the message even when the exit path looked for it.

## Fix

1. `isOpenclawKeyMissingMessage`: also match `unknown config path` so the graceful registry fallback engages instead of failing closed.
2. `openclawJSONErrorMessage`: accept `error` as either a flat string **or** an object with a `message` field (via `json.RawMessage`).

Both changes are backward-compatible with pre-2026.6 and 2026.6.x phrasing.

## Tests

Added regression cases covering the `2026.8.x` wording to:
- `TestIsOpenclawKeyMissing` (stderr path)
- `TestIsOpenclawKeyMissingResult` (JSON envelope with nested `error.message`)

## Evidence

Verified against a real OpenClaw `2026.8.1` (`ea80657`) install:

- `openclaw config get agents.list --json` returns `{"ok":false,"error":{"type":"cli_error","message":"Unknown config path: agents.list. Run openclaw config schema to inspect valid paths."}}`, exit 1
- `openclaw agents list --json` returns `[{"id":...,"identityName":...,"workspace":...,"model":...}]`, exit 0 (the registry fallback target)

The registry fallback path already existed (`openclawRegistryAgentsList`); these changes restore the intended graceful switch to it.
