### PR TITLE
MUL-6939 fix(util): preserve JSON keys during NUL sanitization

### DIFF
--- a/server/internal/util/text.go
+++ b/server/internal/util/text.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"unicode/utf8"
 )
@@ -109,8 +111,8 @@ func sanitizeJSONValue(v any, depth int) any {
 		return SanitizeTextForPostgres(t)
 	case map[string]any:
 		out := make(map[string]any, len(t))
-		for k, val := range t {
-			out[SanitizeTextForPostgres(k)] = sanitizeJSONValue(val, depth+1)
+		for k, safeKey := range sanitizePostgresJSONMapKeys(t) {
+			out[safeKey] = sanitizeJSONValue(t[k], depth+1)
 		}
 		return out
 	case []any:
@@ -123,4 +125,43 @@ func sanitizeJSONValue(v any, depth int) any {
 		// Numbers, bools, nil — nothing a TEXT/JSONB column can choke on.
 		return v
 	}
+}
+
+// sanitizePostgresJSONMapKeys returns a stable one-to-one mapping from raw
+// object keys to PostgreSQL-safe keys. Unchanged keys reserve their spelling
+// first; transformed keys that would collide receive the first free numeric
+// suffix instead of silently overwriting another entry.
+func sanitizePostgresJSONMapKeys(values map[string]any) map[string]string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	mapped := make(map[string]string, len(keys))
+	used := make(map[string]struct{}, len(keys))
+	changed := make([]string, 0, len(keys))
+	for _, key := range keys {
+		candidate := SanitizeTextForPostgres(key)
+		if candidate == key {
+			mapped[key] = key
+			used[key] = struct{}{}
+			continue
+		}
+		changed = append(changed, key)
+	}
+
+	for _, key := range changed {
+		base := SanitizeTextForPostgres(key)
+		candidate := base
+		for suffix := 2; ; suffix++ {
+			if _, exists := used[candidate]; !exists {
+				break
+			}
+			candidate = fmt.Sprintf("%s#%d", base, suffix)
+		}
+		mapped[key] = candidate
+		used[candidate] = struct{}{}
+	}
+	return mapped
 }

--- a/server/internal/util/text.go
+++ b/server/internal/util/text.go
@@ -140,6 +140,7 @@ func sanitizePostgresJSONMapKeys(values map[string]any) map[string]string {
 
 	mapped := make(map[string]string, len(keys))
 	used := make(map[string]struct{}, len(keys))
+	nextSuffix := make(map[string]int)
 	changed := make([]string, 0, len(keys))
 	for _, key := range keys {
 		candidate := SanitizeTextForPostgres(key)
@@ -154,11 +155,19 @@ func sanitizePostgresJSONMapKeys(values map[string]any) map[string]string {
 	for _, key := range changed {
 		base := SanitizeTextForPostgres(key)
 		candidate := base
-		for suffix := 2; ; suffix++ {
-			if _, exists := used[candidate]; !exists {
-				break
+		if _, exists := used[candidate]; exists {
+			suffix := nextSuffix[base]
+			if suffix == 0 {
+				suffix = 2
 			}
-			candidate = fmt.Sprintf("%s#%d", base, suffix)
+			for {
+				candidate = fmt.Sprintf("%s#%d", base, suffix)
+				if _, exists := used[candidate]; !exists {
+					nextSuffix[base] = suffix + 1
+					break
+				}
+				suffix++
+			}
 		}
 		mapped[key] = candidate
 		used[candidate] = struct{}{}

--- a/server/internal/util/text_postgres_test.go
+++ b/server/internal/util/text_postgres_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -120,6 +121,60 @@ func TestSanitizeJSONForPostgres(t *testing.T) {
 		}
 	})
 
+	t.Run("assigns multiple collisions deterministically after reserved suffixes", func(t *testing.T) {
+		entries := []struct {
+			key   string
+			value string
+		}{
+			{key: "tool", value: "unchanged base"},
+			{key: "tool#2", value: "unchanged suffix two"},
+			{key: "tool#3", value: "unchanged suffix three"},
+			{key: "\x00tool", value: "leading NUL"},
+			{key: "to\x00ol", value: "middle NUL"},
+			{key: "tool\x00", value: "trailing NUL"},
+			{key: "tool\x00\x00", value: "two trailing NULs"},
+		}
+		want := map[string]any{
+			"tool":   "unchanged base",
+			"tool#2": "unchanged suffix two",
+			"tool#3": "unchanged suffix three",
+			"tool#4": "leading NUL",
+			"tool#5": "middle NUL",
+			"tool#6": "trailing NUL",
+			"tool#7": "two trailing NULs",
+		}
+
+		var first map[string]any
+		for _, reverse := range []bool{false, true} {
+			in := make(map[string]any, len(entries))
+			for i := range entries {
+				index := i
+				if reverse {
+					index = len(entries) - 1 - i
+				}
+				in[entries[index].key] = entries[index].value
+			}
+
+			out := SanitizeJSONForPostgres(in).(map[string]any)
+			if !reflect.DeepEqual(out, want) {
+				t.Fatalf("reverse=%v: output = %#v, want %#v", reverse, out, want)
+			}
+			if first == nil {
+				first = out
+			} else if !reflect.DeepEqual(out, first) {
+				t.Fatalf("output changed with insertion order: first=%#v, reversed=%#v", first, out)
+			}
+
+			encoded, err := json.Marshal(out)
+			if err != nil {
+				t.Fatalf("marshal sanitized value: %v", err)
+			}
+			if strings.Contains(string(encoded), "\\u0000") {
+				t.Fatalf("sanitized JSON still carries a NUL escape: %s", encoded)
+			}
+		}
+	})
+
 	t.Run("cleans strings at every depth, keys included", func(t *testing.T) {
 		in := map[string]any{
 			"cmd\x00": "cat\x00 binary",
@@ -192,4 +247,39 @@ func TestSanitizeJSONForPostgres(t *testing.T) {
 			t.Fatalf("got %v, want nil", got)
 		}
 	})
+}
+
+func TestSanitizePostgresJSONMapKeysCollisionAllocationScalesLinearly(t *testing.T) {
+	makeCollisions := func(size int) map[string]any {
+		const base = "abcdefghijklmnop"
+		values := make(map[string]any, size)
+		for mask := 0; mask < size; mask++ {
+			var key strings.Builder
+			key.Grow(len(base) * 2)
+			for index := range len(base) {
+				if mask&(1<<index) != 0 {
+					key.WriteByte(0)
+				}
+				key.WriteByte(base[index])
+			}
+			values[key.String()] = mask
+		}
+		return values
+	}
+
+	small := makeCollisions(128)
+	large := makeCollisions(256)
+	smallAllocs := testing.AllocsPerRun(3, func() {
+		sanitizePostgresJSONMapKeys(small)
+	})
+	largeAllocs := testing.AllocsPerRun(3, func() {
+		sanitizePostgresJSONMapKeys(large)
+	})
+
+	// Doubling a collision group may roughly double allocation work. A
+	// quadratic suffix scan instead grows close to fourfold because it rebuilds
+	// every already-rejected candidate for every later key.
+	if largeAllocs > smallAllocs*3 {
+		t.Fatalf("allocations grew superlinearly: size 128=%0.f, size 256=%0.f", smallAllocs, largeAllocs)
+	}
 }

--- a/server/internal/util/text_postgres_test.go
+++ b/server/internal/util/text_postgres_test.go
@@ -80,6 +80,46 @@ func TestSanitizeTextForPostgresToValidUTF8IsNotEnough(t *testing.T) {
 }
 
 func TestSanitizeJSONForPostgres(t *testing.T) {
+	t.Run("preserves distinct keys that collide after sanitization", func(t *testing.T) {
+		in := map[string]any{
+			"tool":     "unchanged",
+			"tool\x00": "contained a NUL",
+		}
+
+		out, ok := SanitizeJSONForPostgres(in).(map[string]any)
+		if !ok {
+			t.Fatalf("SanitizeJSONForPostgres returned %T, want map[string]any", SanitizeJSONForPostgres(in))
+		}
+		if len(out) != 2 {
+			t.Fatalf("sanitized key collision dropped an entry: got %v", out)
+		}
+		if got := out["tool"]; got != "unchanged" {
+			t.Fatalf("out[tool] = %v, want unchanged value", got)
+		}
+		if got := out["tool#2"]; got != "contained a NUL" {
+			t.Fatalf("out[tool#2] = %v, want sanitized collision value", got)
+		}
+	})
+
+	t.Run("does not overwrite an existing collision suffix", func(t *testing.T) {
+		in := map[string]any{
+			"tool":     "unchanged",
+			"tool#2":   "existing suffix",
+			"tool\x00": "contained a NUL",
+		}
+
+		out := SanitizeJSONForPostgres(in).(map[string]any)
+		if len(out) != 3 {
+			t.Fatalf("sanitized key collision dropped an entry: got %v", out)
+		}
+		if got := out["tool#2"]; got != "existing suffix" {
+			t.Fatalf("out[tool#2] = %v, want existing suffix value", got)
+		}
+		if got := out["tool#3"]; got != "contained a NUL" {
+			t.Fatalf("out[tool#3] = %v, want sanitized collision value", got)
+		}
+	})
+
 	t.Run("cleans strings at every depth, keys included", func(t *testing.T) {
 		in := map[string]any{
 			"cmd\x00": "cat\x00 binary",


### PR DESCRIPTION
## What does this PR do?

Prevents `SanitizeJSONForPostgres` from silently dropping decoded JSON object entries when distinct keys collide after PostgreSQL NUL sanitization.

Unchanged keys reserve their original spelling. Transformed keys are processed deterministically and receive the first free `#2`, `#3`, ... suffix when needed. The allocator remembers the next candidate per sanitized base, so collision handling is amortized linear after the existing key sort. Non-colliding keys keep the existing output.

### Thinking path

The PostgreSQL defense already recursively sanitizes decoded JSON values, but its map branch writes each normalized key directly into a new Go map. That makes normalization non-injective: `"tool"` and `"tool\u0000"` both target `"tool"`. Preserving the existing recursive contract while allocating collision-free output keys is the smallest change that removes the data-loss path. Sorting raw keys makes the allocation deterministic, and reserving unchanged keys avoids renaming valid input because of malformed input.

Risk is limited to malformed objects whose keys collide after sanitization. Those objects now retain data under suffixed keys instead of losing one value. No database schema or API shape changes are involved.

## Related Issue

Closes #7888

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `server/internal/util/text.go` to allocate stable, collision-free sanitized object keys.
- Add regressions for a direct NUL collision, reserved numeric suffixes, deterministic multi-collision assignment across insertion orders, and linear allocation growth in `server/internal/util/text_postgres_test.go`.

## How to Test

1. `cd server && go test ./internal/util ./internal/service ./internal/handler -count=1`
2. `cd server && go vet ./internal/util`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI, so screenshots are not applicable
- [x] This internal defensive fix does not require documentation changes
- [x] This change does not add a runtime, coding tool, or UI tab
- [x] This change does not touch Chinese product copy
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Inspected the current sanitizer and callers, reproduced the key-collision loss with a failing regression test, implemented deterministic collision-free mapping, then followed review feedback by reproducing the quadratic allocation growth, retaining the next suffix per sanitized base, and pinning multi-collision behavior across insertion orders and reserved suffixes. Ran related package tests plus `go vet`.

## Screenshots (optional)

Not applicable.
