### PR TITLE
MUL-6943 feat(agent): add Claude Fable 5.1 model and pricing

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -146,6 +146,20 @@ describe("estimateCost", () => {
     expect(cost).toBeCloseTo(10 + 50 + 1 + 12.5, 5);
   });
 
+  it("prices Claude Fable 5.1 at the Mythos-class tier with quarter-rate cache reads", () => {
+    // Same $10 / $50 and $12.50 cache write as Fable 5, but cache reads are
+    // 0.025x input ($0.25) rather than the usual 0.1x.
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "claude-fable-5-1",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_read_tokens: 1_000_000,
+      cache_write_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(10 + 50 + 0.25 + 12.5, 5);
+  });
+
   it("prices Claude Sonnet 5 at Anthropic's intro $2 / $10 tier", () => {
     const cost = estimateCost({
       ...zeroUsage,
@@ -886,6 +900,7 @@ describe("isModelPriced", () => {
   it("recognises both Claude and Codex/GPT families", () => {
     expect(isModelPriced("claude-sonnet-5")).toBe(true);
     expect(isModelPriced("claude-fable-5")).toBe(true);
+    expect(isModelPriced("claude-fable-5-1")).toBe(true);
     expect(isModelPriced("claude-sonnet-4-6")).toBe(true);
     expect(isModelPriced("gpt-5-codex")).toBe(true);
     expect(isModelPriced("gpt-5-mini")).toBe(true);
@@ -899,6 +914,7 @@ describe("isModelPriced", () => {
     // hit the same catalog row, otherwise Copilot-routed usage gets bucketed
     // as "unmapped" and the user has to type the price in by hand.
     expect(isModelPriced("claude-sonnet-5")).toBe(true);
+    expect(isModelPriced("claude-fable-5.1")).toBe(true);
     expect(isModelPriced("claude-haiku-4.5")).toBe(true);
     expect(isModelPriced("claude-sonnet-4.5")).toBe(true);
     expect(isModelPriced("claude-sonnet-4.6")).toBe(true);
@@ -912,6 +928,7 @@ describe("isModelPriced", () => {
     // The provider prefix is routing metadata, not part of the SKU.
     expect(isModelPriced("anthropic/claude-sonnet-5")).toBe(true);
     expect(isModelPriced("anthropic/claude-fable-5")).toBe(true);
+    expect(isModelPriced("anthropic/claude-fable-5-1")).toBe(true);
     expect(isModelPriced("anthropic/claude-opus-4.7")).toBe(true);
     expect(isModelPriced("anthropic/claude-sonnet-4-6")).toBe(true);
   });

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -195,9 +195,11 @@ const MODEL_PRICING: Record<
   // -- Anthropic: current generation. Sonnet 5 uses Anthropic's published
   //    intro launch rate ($2 / $10 through 2026-08-31). This static map has
   //    no future-dated pricing support yet, so update the row when the
-  //    post-intro $3 / $15 rate takes effect. Fable 5 is a Mythos-class SKU
-  //    at 10/50; Opus 4.5 through Opus 5 stay on the lower 5/25 Opus tier. --
+  //    post-intro $3 / $15 rate takes effect. Fable 5 and 5.1 are Mythos-class
+  //    SKUs at 10/50 (5.1 prices cache reads at 0.025x input, a quarter of the
+  //    usual 0.1x); Opus 4.5 through Opus 5 stay on the lower 5/25 Opus tier. --
   "claude-sonnet-5":     { input: 2,    output: 10,   cacheRead: 0.20, cacheWrite: 2.50 },
+  "claude-fable-5-1":   { input: 10,   output: 50,   cacheRead: 0.25, cacheWrite: 12.50 },
   "claude-fable-5":     { input: 10,   output: 50,   cacheRead: 1.00, cacheWrite: 12.50 },
   "claude-opus-5":      { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
   "claude-haiku-4-5":   { input: 1,    output: 5,    cacheRead: 0.10, cacheWrite: 1.25 },

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -104,6 +104,22 @@ var modelPrices = map[string]ModelPrice{
 	// a guessed rate (same convention as xAI's `grok-composer-*`).
 }
 
+// claudeVersionEnd matches what is allowed to follow a Claude version inside
+// a reported model id. Appending it to a rule keeps that rule from swallowing
+// a later SKU in the same family: without it, `claude-fable-5` also matches
+// `claude-fable-5-1`, whose cache reads are a quarter of Fable 5's, so those
+// reads bill at 4x.
+//
+// What it admits is exactly what the frontend resolver normalizes away before
+// its exact-key lookup (`stripContextTag` and `stripDate` in
+// packages/views/runtimes/utils.ts), so both sides resolve the same strings:
+// end of id, a `[1m]`-style context tag, a trailing date snapshot in either
+// spelling, and `-latest`. Anything else — another version digit, a
+// `-preview`-style qualifier — is a distinct SKU at an unknown rate and stays
+// unmapped until it gets a row of its own, the same "every catalog SKU needs
+// its own row" rule the frontend table states.
+const claudeVersionEnd = `($|\[|-20\d{6}|-20\d{2}-\d{2}-\d{2}|-latest)`
+
 var modelAliasRules = []struct {
 	re       *regexp.Regexp
 	priceKey string
@@ -126,11 +142,10 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`claude-sonnet-5|claude-5-sonnet`), "anthropic:claude-sonnet-5"},
 	// Fable 5.1 shares Fable 5's $10 / $50 and $12.50 cache write but prices
 	// cache reads at 0.025x input ($0.25) instead of the standard 0.1x, so it
-	// needs its own row. It is listed before Fable 5, and the Fable 5 rule
-	// stops at the version so `claude-fable-5-1` cannot fall through to it
-	// (the `[1m]` context tag and end-of-string are still admitted).
-	{regexp.MustCompile(`claude-fable-5[-.]1`), "anthropic:claude-fable-5-1"},
-	{regexp.MustCompile(`claude-fable-5($|[^-.0-9])`), "anthropic:claude-fable-5"},
+	// needs its own row, and both rules end at their own version
+	// (claudeVersionEnd) so neither can swallow the other's ids.
+	{regexp.MustCompile(`claude-fable-5[-.]1` + claudeVersionEnd), "anthropic:claude-fable-5-1"},
+	{regexp.MustCompile(`claude-fable-5` + claudeVersionEnd), "anthropic:claude-fable-5"},
 	{regexp.MustCompile(`claude-opus-5`), "anthropic:claude-opus-5"},
 	{regexp.MustCompile(`claude-opus-4[-.]8`), "anthropic:claude-opus-4.8"},
 	{regexp.MustCompile(`claude-opus-4[-.]7`), "anthropic:claude-opus-4.7"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -104,21 +104,30 @@ var modelPrices = map[string]ModelPrice{
 	// a guessed rate (same convention as xAI's `grok-composer-*`).
 }
 
-// claudeVersionEnd matches what is allowed to follow a Claude version inside
-// a reported model id. Appending it to a rule keeps that rule from swallowing
-// a later SKU in the same family: without it, `claude-fable-5` also matches
-// `claude-fable-5-1`, whose cache reads are a quarter of Fable 5's, so those
-// reads bill at 4x.
+// claudeVersionEnd terminates a Claude family rule: at most one suffix that
+// the frontend resolver normalizes away, and then the END of the id. Appending
+// it keeps a rule from swallowing a later SKU in the same family — without it
+// `claude-fable-5` also matches `claude-fable-5-1`, whose cache reads are a
+// quarter of Fable 5's, so those reads bill at 4x.
 //
-// What it admits is exactly what the frontend resolver normalizes away before
-// its exact-key lookup (`stripContextTag` and `stripDate` in
-// packages/views/runtimes/utils.ts), so both sides resolve the same strings:
-// end of id, a `[1m]`-style context tag, a trailing date snapshot in either
-// spelling, and `-latest`. Anything else — another version digit, a
-// `-preview`-style qualifier — is a distinct SKU at an unknown rate and stays
-// unmapped until it gets a row of its own, the same "every catalog SKU needs
-// its own row" rule the frontend table states.
-const claudeVersionEnd = `($|\[|-20\d{6}|-20\d{2}-\d{2}-\d{2}|-latest)`
+// The admitted suffixes are exactly what `stripContextTag` and `stripDate`
+// remove in packages/views/runtimes/utils.ts before its exact-key lookup, so
+// both sides resolve the same set of strings. The trailing `$` is what makes
+// that true and is not optional: these rules are substring matches, so an
+// alternative that merely starts a suffix still matches when arbitrary text
+// follows it (`claude-fable-5-1-latest-preview`, `claude-fable-5-1[1m]junk`),
+// which is the silent tier-borrowing this constant exists to prevent. The
+// bracket form requires a complete tag for the same reason.
+//
+// A date snapshot carrying a context tag (`claude-fable-5-20260401[1m]`) is
+// covered by the tag-stripping retry in PriceForModelAlias, so it does not
+// need a combined alternative here.
+//
+// Anything else — another version digit, a `-preview`-style qualifier — is a
+// distinct SKU at an unknown rate and stays unmapped until it gets a row of
+// its own, the same "every catalog SKU needs its own row" rule the frontend
+// table states.
+const claudeVersionEnd = `(?:-20\d{6}|-20\d{2}-\d{2}-\d{2}|-latest|\[[^\]]+\])?$`
 
 var modelAliasRules = []struct {
 	re       *regexp.Regexp

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -41,6 +41,7 @@ var modelPrices = map[string]ModelPrice{
 	// static table cannot schedule the published post-intro $3 / $15 change yet,
 	// so keep the intro rate here and update the row when catalog support exists.
 	"anthropic:claude-sonnet-5":   {Provider: "anthropic", Model: "claude-sonnet-5", InputPerM: 2.00, CacheReadPerM: 0.20, CacheWritePerM: 2.50, OutputPerM: 10.00},
+	"anthropic:claude-fable-5-1":  {Provider: "anthropic", Model: "claude-fable-5-1", InputPerM: 10.00, CacheReadPerM: 0.25, CacheWritePerM: 12.50, OutputPerM: 50.00},
 	"anthropic:claude-fable-5":    {Provider: "anthropic", Model: "claude-fable-5", InputPerM: 10.00, CacheReadPerM: 1.00, CacheWritePerM: 12.50, OutputPerM: 50.00},
 	"anthropic:claude-opus-5":     {Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
 	"anthropic:claude-opus-4.8":   {Provider: "anthropic", Model: "claude-opus-4.8", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
@@ -123,7 +124,13 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]3-codex$`), "openai:gpt-5.3-codex"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]2-codex$`), "openai:gpt-5.2-codex"},
 	{regexp.MustCompile(`claude-sonnet-5|claude-5-sonnet`), "anthropic:claude-sonnet-5"},
-	{regexp.MustCompile(`claude-fable-5`), "anthropic:claude-fable-5"},
+	// Fable 5.1 shares Fable 5's $10 / $50 and $12.50 cache write but prices
+	// cache reads at 0.025x input ($0.25) instead of the standard 0.1x, so it
+	// needs its own row. It is listed before Fable 5, and the Fable 5 rule
+	// stops at the version so `claude-fable-5-1` cannot fall through to it
+	// (the `[1m]` context tag and end-of-string are still admitted).
+	{regexp.MustCompile(`claude-fable-5[-.]1`), "anthropic:claude-fable-5-1"},
+	{regexp.MustCompile(`claude-fable-5($|[^-.0-9])`), "anthropic:claude-fable-5"},
 	{regexp.MustCompile(`claude-opus-5`), "anthropic:claude-opus-5"},
 	{regexp.MustCompile(`claude-opus-4[-.]8`), "anthropic:claude-opus-4.8"},
 	{regexp.MustCompile(`claude-opus-4[-.]7`), "anthropic:claude-opus-4.7"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -112,8 +112,9 @@ var modelPrices = map[string]ModelPrice{
 //
 // The admitted suffixes are exactly what `stripContextTag` and `stripDate`
 // remove in packages/views/runtimes/utils.ts before its exact-key lookup, so
-// both sides resolve the same set of strings. The trailing `$` is what makes
-// that true and is not optional: these rules are substring matches, so an
+// both sides accept the same suffix forms. (Only the suffixes: the Claude
+// rules are still substring matches, so a malformed PREFIX is out of scope
+// here.) The trailing `$` is what makes that true and is not optional: these rules are substring matches, so an
 // alternative that merely starts a suffix still matches when arbitrary text
 // follows it (`claude-fable-5-1-latest-preview`, `claude-fable-5-1[1m]junk`),
 // which is the silent tier-borrowing this constant exists to prevent. The
@@ -232,7 +233,18 @@ func PriceForModelAlias(model string) (ModelPrice, bool) {
 	// `$`, so without this a bracketed variant would take the unpriced branch
 	// in RecordLLMUsage. Only ever turns a miss into a hit — the raw form is
 	// tried first, so an explicit bracketed rule still wins.
+	//
+	// Exactly ONE tag, matching the frontend: `canonicalCandidates` in
+	// packages/views/runtimes/utils.ts strips a single trailing tag and does
+	// not re-strip the result. Retrying a doubly-tagged id would peel `[2m]`
+	// off `claude-fable-5[1m][2m]` and let the leftover `[1m]` satisfy a rule
+	// that already, correctly, rejected the raw form — the dashboard leaves
+	// that id unmapped, so pricing it here would put two different costs on
+	// one usage row. A second tag means the id is not a shape we recognise.
 	if stripped := contextTagRe.ReplaceAllString(model, ""); stripped != model {
+		if contextTagRe.MatchString(stripped) {
+			return ModelPrice{}, false
+		}
 		return matchModelAlias(stripped)
 	}
 	return ModelPrice{}, false

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -392,3 +392,38 @@ func TestPriceForModelAliasContextTagStripping(t *testing.T) {
 		}
 	}
 }
+
+func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
+	// Fable 5.1 is its own SKU on the same Mythos-class tier as Fable 5, but
+	// with cache reads at 0.025x input ($0.25) instead of the usual 0.1x. The
+	// unanchored Fable 5 alias would otherwise swallow the `-1` suffix and
+	// bill those reads at 4x, so every spelling below must land on the
+	// Fable 5.1 row specifically.
+	fable51 := ModelPrice{Provider: "anthropic", Model: "claude-fable-5-1", InputPerM: 10, CacheReadPerM: 0.25, CacheWritePerM: 12.5, OutputPerM: 50}
+	fable5 := ModelPrice{Provider: "anthropic", Model: "claude-fable-5", InputPerM: 10, CacheReadPerM: 1, CacheWritePerM: 12.5, OutputPerM: 50}
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{model: "claude-fable-5-1", want: fable51},
+		{model: "anthropic/claude-fable-5-1", want: fable51},
+		{model: "anthropic:claude-fable-5-1", want: fable51},
+		// Copilot reports Claude models dotted.
+		{model: "claude-fable-5.1", want: fable51},
+		// Claude Code reports the 1M-context variant with a bracketed suffix.
+		{model: "claude-fable-5-1[1m]", want: fable51},
+		// Fable 5 must keep resolving to its own row, including its 1M form.
+		{model: "claude-fable-5", want: fable5},
+		{model: "claude-fable-5[1m]", want: fable5},
+	}
+
+	for _, tc := range cases {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", tc.model)
+		}
+		if got != tc.want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+}

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -474,4 +474,18 @@ func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 			t.Errorf("PriceForModelAlias(%q) resolved to %+v; want unmapped", model, got)
 		}
 	}
+
+	// A doubly-tagged id must not sneak back in through the tag-stripping
+	// retry: peeling `[2m]` leaves `[1m]`, which the rule above rejected on
+	// the raw form for good reason. The frontend strips one tag and does not
+	// re-strip, so pricing these here would put two different costs on one
+	// usage row.
+	for _, model := range []string{
+		"claude-fable-5[1m][2m]",
+		"claude-fable-5-1[1m][2m]",
+	} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Errorf("PriceForModelAlias(%q) resolved to %+v; want unmapped", model, got)
+		}
+	}
 }

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -426,6 +426,7 @@ func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 		{model: "claude-fable-5-20260401[1m]", want: fable5},
 		{model: "claude-fable-5-1-20260901", want: fable51},
 		{model: "claude-fable-5-1-latest", want: fable51},
+		{model: "claude-fable-5-1-20260901[1m]", want: fable51},
 	}
 
 	for _, tc := range cases {
@@ -448,6 +449,26 @@ func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 		"claude-fable-5-10",
 		"claude-fable-5.10",
 		"claude-fable-5-1x",
+	} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Errorf("PriceForModelAlias(%q) resolved to %+v; want unmapped", model, got)
+		}
+	}
+
+	// An admitted suffix only counts when it ENDS the id. These rules are
+	// substring matches, so a terminator whose alternatives are not anchored
+	// still fires on anything that merely starts with one — an unknown
+	// qualifier would silently borrow the tier of whichever row it prefixed,
+	// while the frontend (which anchors both `stripDate` and the bracket tag)
+	// leaves it unmapped. Same id, two different costs.
+	for _, model := range []string{
+		"claude-fable-5-1-latest-preview",
+		"claude-fable-5-1-20260901x",
+		"claude-fable-5-1-2026-09-01-preview",
+		"claude-fable-5-1[1m]junk",
+		"claude-fable-5-latest-preview",
+		"claude-fable-5-20260401-preview",
+		"claude-fable-5[1m]junk",
 	} {
 		if got, ok := PriceForModelAlias(model); ok {
 			t.Errorf("PriceForModelAlias(%q) resolved to %+v; want unmapped", model, got)

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -395,10 +395,10 @@ func TestPriceForModelAliasContextTagStripping(t *testing.T) {
 
 func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 	// Fable 5.1 is its own SKU on the same Mythos-class tier as Fable 5, but
-	// with cache reads at 0.025x input ($0.25) instead of the usual 0.1x. The
-	// unanchored Fable 5 alias would otherwise swallow the `-1` suffix and
-	// bill those reads at 4x, so every spelling below must land on the
-	// Fable 5.1 row specifically.
+	// with cache reads at 0.025x input ($0.25) instead of the usual 0.1x. A
+	// Fable 5 alias that did not stop at the version would swallow the `-1`
+	// suffix and bill those reads at 4x, so every spelling below must land on
+	// the Fable 5.1 row specifically.
 	fable51 := ModelPrice{Provider: "anthropic", Model: "claude-fable-5-1", InputPerM: 10, CacheReadPerM: 0.25, CacheWritePerM: 12.5, OutputPerM: 50}
 	fable5 := ModelPrice{Provider: "anthropic", Model: "claude-fable-5", InputPerM: 10, CacheReadPerM: 1, CacheWritePerM: 12.5, OutputPerM: 50}
 	cases := []struct {
@@ -415,6 +415,17 @@ func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 		// Fable 5 must keep resolving to its own row, including its 1M form.
 		{model: "claude-fable-5", want: fable5},
 		{model: "claude-fable-5[1m]", want: fable5},
+		// The frontend resolver strips a trailing date snapshot / `-latest`
+		// before its exact-key lookup (`stripDate` in
+		// packages/views/runtimes/utils.ts), so these forms price there. Both
+		// rules have to admit them too, otherwise the dashboard and
+		// RecordLLMUsage disagree on the same id.
+		{model: "claude-fable-5-20260401", want: fable5},
+		{model: "claude-fable-5-2026-04-01", want: fable5},
+		{model: "claude-fable-5-latest", want: fable5},
+		{model: "claude-fable-5-20260401[1m]", want: fable5},
+		{model: "claude-fable-5-1-20260901", want: fable51},
+		{model: "claude-fable-5-1-latest", want: fable51},
 	}
 
 	for _, tc := range cases {
@@ -424,6 +435,22 @@ func TestPriceForModelAliasAnthropicFable51(t *testing.T) {
 		}
 		if got != tc.want {
 			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+
+	// A later Fable minor is a distinct SKU at an unknown rate: it must stay
+	// unmapped and surface in the unpriced diagnostic rather than borrow a
+	// neighbour's tier. This is the same failure the `-1` suffix had against
+	// the Fable 5 rule, so guard it on the 5.1 rule as well.
+	for _, model := range []string{
+		"claude-fable-5-2",
+		"claude-fable-5.2",
+		"claude-fable-5-10",
+		"claude-fable-5.10",
+		"claude-fable-5-1x",
+	} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Errorf("PriceForModelAlias(%q) resolved to %+v; want unmapped", model, got)
 		}
 	}
 }

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -542,6 +542,7 @@ func claudeStaticModels() []Model {
 	return []Model{
 		{ID: "claude-sonnet-5", Label: "Claude Sonnet 5", Provider: "anthropic"},
 		{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Provider: "anthropic", Default: true},
+		{ID: "claude-fable-5-1", Label: "Claude Fable 5.1", Provider: "anthropic"},
 		{ID: "claude-fable-5", Label: "Claude Fable 5", Provider: "anthropic"},
 		{ID: "claude-opus-5", Label: "Claude Opus 5", Provider: "anthropic"},
 		{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Provider: "anthropic"},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -489,6 +489,29 @@ func TestClaudeStaticModelsExposesFable5(t *testing.T) {
 	}
 }
 
+func TestClaudeStaticModelsExposesFable51(t *testing.T) {
+	models := claudeStaticModels()
+	ids := map[string]Model{}
+	defaults := 0
+	for _, m := range models {
+		ids[m.ID] = m
+		if m.Default {
+			defaults++
+		}
+	}
+
+	fable, ok := ids["claude-fable-5-1"]
+	if !ok {
+		t.Fatalf("missing Claude Fable 5.1 in: %+v", models)
+	}
+	if fable.Label != "Claude Fable 5.1" || fable.Provider != "anthropic" || fable.Default {
+		t.Errorf("unexpected Fable 5.1 entry: %+v", fable)
+	}
+	if defaults != 1 || !ids["claude-sonnet-4-6"].Default {
+		t.Errorf("expected Sonnet 4.6 to remain the sole default, got defaults=%d models=%+v", defaults, models)
+	}
+}
+
 func TestClaudeStaticModelsExposesSonnet5(t *testing.T) {
 	models := claudeStaticModels()
 	ids := map[string]Model{}

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -1390,3 +1390,30 @@ func argIndexOf(slice []string, target string) int {
 	}
 	return -1
 }
+
+func TestValidateThinkingLevel_ClaudeFable51AcceptsFullEffortRange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+	// This test resets the package-global thinking cache, so it must remain serial.
+
+	// A model missing from the Claude catalog never gets a Thinking entry, so
+	// the daemon's pre-execution guard silently drops any persisted effort for
+	// it. Fable 5.1 supports the full low..max range, so once it is in the
+	// catalog every level must round-trip.
+	fakeClaude := writeFakeClaudeHelpBinary(t)
+	resetThinkingCacheForTests()
+	defer resetThinkingCacheForTests()
+
+	ctx := context.Background()
+
+	for _, level := range []string{"low", "medium", "high", "xhigh", "max"} {
+		ok, err := ValidateThinkingLevel(ctx, "claude", Command{Path: fakeClaude}, "claude-fable-5-1", level)
+		if err != nil {
+			t.Fatalf("unexpected err for %q: %v", level, err)
+		}
+		if !ok {
+			t.Errorf("level %q must be valid on claude-fable-5-1; got false", level)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds Claude Fable 5.1 (`claude-fable-5-1`, released 2026-09-01) to the Claude Code runtime's static model catalog and to the backend and frontend pricing tables. Same shape as #3982, which added Fable 5.

Today the model is reachable only by typing the ID into the picker's manual-entry field, and that path has three gaps:

- The daemon's pre-execution guard validates `thinking_level` against the catalog. A model that is not in it has no effort entry, so any persisted effort is dropped with a warning and Claude Code runs at its own default.
- The frontend pricing resolver cannot map the `-1` suffix, so usage rows for Fable 5.1 show as unmapped in the dashboard.
- The backend alias rule for Fable 5 is unanchored, so `claude-fable-5-1` silently resolved to the Fable 5 row. That was harmless for input and output, but Fable 5.1 prices cache reads at $0.25 / MTok (0.025x input) versus Fable 5's $1.00, so cached reads were billed at 4x in metrics.

Pricing source: https://platform.claude.com/docs/en/about-claude/pricing (Fable 5.1: $10 input, $50 output, $12.50 5m cache write, $0.25 cache read).

## Related Issue

No issue filed for Fable 5.1 yet. Fable 5 was tracked in #3980.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/models.go`: add `claude-fable-5-1` to `claudeStaticModels()`. Sonnet 4.6 stays the sole default. No change to `claudeModelEffortAllow`: a model absent from the allow-list gets the full `low..max` superset from `claude --help`, which matches Fable 5.1 (same as Fable 5 today).
- `server/internal/metrics/pricing.go`: add the `anthropic:claude-fable-5-1` row; add a `claude-fable-5[-.]1` alias rule ahead of Fable 5; anchor the Fable 5 rule to `claude-fable-5($|[^-.0-9])` so it keeps matching the bare ID and `[1m]` form but no longer swallows `-1`.
- `packages/views/runtimes/utils.ts`: add the `claude-fable-5-1` pricing row.
- Tests:
  - `server/pkg/agent/models_test.go`: `TestClaudeStaticModelsExposesFable51`.
  - `server/pkg/agent/thinking_test.go`: `TestValidateThinkingLevel_ClaudeFable51AcceptsFullEffortRange` (guards the effort-dropping symptom above).
  - `server/internal/metrics/pricing_test.go`: `TestPriceForModelAliasAnthropicFable51` (bare, `/`- and `:`-prefixed, dotted, and `[1m]` spellings resolve to the 5.1 row; Fable 5 and `claude-fable-5[1m]` still resolve to the Fable 5 row).
  - `packages/views/runtimes/utils.test.ts`: `estimateCost` and `isModelPriced` cases for the dashed, dotted, and provider-prefixed forms.

Not touched here, noted for a follow-up: the Sonnet 5 comments in both pricing tables still describe the $2 / $10 rate as introductory pricing ending 2026-08-31. Anthropic's pricing page now says that rate is permanent and the increase will not occur, so the rows are correct and only the comments are stale.

## How to Test

1. `cd server && go test ./pkg/agent ./internal/metrics`
2. `pnpm -C packages/views exec vitest run runtimes/utils.test.ts dashboard/utils.test.ts`
3. With a daemon built from this branch, open an agent's model picker on a Claude Code runtime: "Claude Fable 5.1" appears with the effort picker enabled, and a task launched with an effort set logs `--effort` on the `claude` command line instead of the `thinking_level: not valid for this (provider, model); skipping injection` warning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

Thinking path: Fable 5.1 shipped 2026-09-01 and no release (v0.4.37 is the latest) or `main` commit mentions it. The Claude catalog is static by design (`ListModels` comment: "Claude's catalog is static by design, not by failure"), so the only path is a catalog entry, and #3982 established the file set for that. Reading `ValidateThinkingLevelWith` and the daemon's `thinking_level` guard showed the user-visible cost of a missing entry is silently dropped effort, hence the extra `thinking_test.go` case. Reading `modelAliasRules` showed the unanchored Fable 5 regex would misprice 5.1's cheaper cache reads, hence the anchoring and the regression cases for both models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
