### PR TITLE
fix(autopilot): route accountable member issues

### DIFF
--- a/server/internal/handler/agent_access.go
+++ b/server/internal/handler/agent_access.go
@@ -372,8 +372,9 @@ func (h *Handler) autopilotAssignAuthorityFromRequest(r *http.Request, scope ass
 //   - the assignment is bound to work this run verifiably owns —
 //     issueBoundToAutopilotTask for an existing issue (which for a run_only-created
 //     issue re-proves the run_only lineage, so a create_issue task cannot escape
-//     its same-issue bound via a fresh top-level issue), or the task's own
-//     verified autopilot run when creating a parentless issue;
+//     its same-issue bound via a fresh top-level issue), an existing member-created
+//     issue whose creator is exactly the run's accountable human, or the task's
+//     own verified autopilot run when creating a parentless issue;
 //   - the issue (when there is one) is in the request's workspace;
 //   - the accountable human is STILL a member of that workspace.
 //
@@ -401,9 +402,13 @@ func (h *Handler) autopilotTaskAssignAuthority(ctx context.Context, scope assign
 	default:
 		return ""
 	}
+	accountable := uuidToString(task.AccountableUserID)
+	if accountable == "" {
+		return ""
+	}
 
 	switch scope.Kind {
-	case scopeKindChildOf, scopeKindExistingIssue:
+	case scopeKindChildOf:
 		if scope.Issue == nil {
 			return ""
 		}
@@ -411,6 +416,21 @@ func (h *Handler) autopilotTaskAssignAuthority(ctx context.Context, scope assign
 			return ""
 		}
 		if !h.issueBoundToAutopilotTask(ctx, *scope.Issue, task, workspaceID) {
+			return ""
+		}
+	case scopeKindExistingIssue:
+		if scope.Issue == nil {
+			return ""
+		}
+		if uuidToString(scope.Issue.WorkspaceID) != workspaceID {
+			return ""
+		}
+		boundToTask := h.issueBoundToAutopilotTask(ctx, *scope.Issue, task, workspaceID)
+		ownedByAccountableMember := scope.Issue.CreatorType == "member" &&
+			scope.Issue.CreatorID.Valid &&
+			uuidToString(scope.Issue.CreatorID) == accountable &&
+			h.taskRunsAutopilotInWorkspace(ctx, task, workspaceID)
+		if !boundToTask && !ownedByAccountableMember {
 			return ""
 		}
 	case scopeKindNewTopLevelIssue:
@@ -421,10 +441,6 @@ func (h *Handler) autopilotTaskAssignAuthority(ctx context.Context, scope assign
 		return ""
 	}
 
-	accountable := uuidToString(task.AccountableUserID)
-	if accountable == "" {
-		return ""
-	}
 	if _, err := h.getWorkspaceMember(ctx, accountable, workspaceID); err != nil {
 		return ""
 	}
@@ -450,9 +466,11 @@ func (h *Handler) autopilotTaskAssignAuthority(ctx context.Context, scope assign
 //     runs of the same autopilot from borrowing on each other's issues, and needs
 //     no migration or backfill.
 //
-// A run_only leader therefore reaches only the issues it created (and, through
-// the child scope, their children) — never a pre-existing or foreign issue. A
-// create_issue leader reaches only the autopilot's own issue.
+// A run_only leader therefore reaches the issues it created and, only for the
+// assign-existing operation, pre-existing issues created by its accountable
+// human. It never reaches another member's or another run's issue. Through the
+// child scope it reaches only its own issue tree. A create_issue leader reaches
+// only the autopilot's own issue.
 func (h *Handler) issueBoundToAutopilotTask(ctx context.Context, issue db.Issue, task db.AgentTaskQueue, workspaceID string) bool {
 	if !issue.OriginType.Valid || !issue.OriginID.Valid || !issue.ID.Valid {
 		return false

--- a/server/internal/handler/issue_autopilot_run_only_assignment_test.go
+++ b/server/internal/handler/issue_autopilot_run_only_assignment_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sync/atomic"
@@ -89,6 +90,23 @@ func newRunOnlyAutopilotFixture(t *testing.T, targetAgentID, accountableUserID s
 		RunID:         runID,
 		RuntimeID:     runtimeID,
 	}
+}
+
+func seedMemberIssue(t *testing.T, creatorMemberID string) string {
+	t.Helper()
+	var issueID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title, status, number)
+		VALUES ($1, 'member', $2, 'MUL-6691 member-created issue', 'todo', $3) RETURNING id
+	`, testWorkspaceID, creatorMemberID, nextWorkspaceIssueNumber(t)).Scan(&issueID); err != nil {
+		t.Fatalf("seed member issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+	return issueID
 }
 
 // topLevelIssueRequest is a parentless `issue create` with an assignee, spoken by
@@ -480,6 +498,36 @@ func TestUpdateIssue_AutopilotLeaderAssignsPrivateWorker(t *testing.T) {
 		}
 	})
 
+	t.Run("run_only run assigns an issue created by its accountable member", func(t *testing.T) {
+		workerID, ownerID, _ := privateAgentTestFixture(t)
+		fx := newRunOnlyAutopilotFixture(t, workerID, ownerID)
+		issueID := seedMemberIssue(t, ownerID)
+
+		agentAssigns(t, fx.LeaderAgentID, fx.LeaderTaskID, issueID, workerID).Want(http.StatusOK)
+
+		if got := assigneeOf(t, issueID); got != workerID {
+			t.Fatalf("accountable member issue assignee = %q, want %q", got, workerID)
+		}
+		if total, _ := tasksFor(t, issueID, workerID); total != 1 {
+			t.Fatalf("accountable member issue enqueued %d tasks, want 1", total)
+		}
+	})
+
+	t.Run("run_only run cannot assign another member's issue", func(t *testing.T) {
+		workerID, ownerID, otherMemberID := privateAgentTestFixture(t)
+		fx := newRunOnlyAutopilotFixture(t, workerID, ownerID)
+		issueID := seedMemberIssue(t, otherMemberID)
+
+		agentAssigns(t, fx.LeaderAgentID, fx.LeaderTaskID, issueID, workerID).Want(http.StatusForbidden)
+
+		if got := assigneeOf(t, issueID); got != "" {
+			t.Fatalf("foreign member issue was assigned to %q", got)
+		}
+		if total, _ := tasksFor(t, issueID, workerID); total != 0 {
+			t.Fatalf("foreign member issue enqueued %d tasks", total)
+		}
+	})
+
 	t.Run("run_only run cannot assign an issue created by a sibling run", func(t *testing.T) {
 		workerID, ownerID, _ := privateAgentTestFixture(t)
 		owning := newRunOnlyAutopilotFixture(t, workerID, ownerID)
@@ -565,6 +613,26 @@ func TestBatchUpdateIssues_AutopilotAuthorityIsPerIssue(t *testing.T) {
 		}
 		if total, _ := tasksFor(t, foreignIssueID, workerID); total != 0 {
 			t.Fatalf("foreign issue enqueued %d tasks", total)
+		}
+	})
+
+	t.Run("accountable member issue is updated and another member issue is not", func(t *testing.T) {
+		workerID, ownerID, otherMemberID := privateAgentTestFixture(t)
+		fx := newRunOnlyAutopilotFixture(t, workerID, ownerID)
+		ownIssueID := seedMemberIssue(t, ownerID)
+		foreignIssueID := seedMemberIssue(t, otherMemberID)
+
+		batchAssignAsRun(t, otherMemberID, fx.LeaderAgentID, fx.LeaderTaskID, workerID, ownIssueID, foreignIssueID).
+			Want(http.StatusOK)
+
+		if got := assigneeOf(t, ownIssueID); got != workerID {
+			t.Fatalf("accountable member issue assignee = %q, want %q", got, workerID)
+		}
+		if got := assigneeOf(t, foreignIssueID); got != "" {
+			t.Fatalf("foreign member issue in the same batch was assigned to %q", got)
+		}
+		if total, _ := tasksFor(t, foreignIssueID, workerID); total != 0 {
+			t.Fatalf("foreign member issue enqueued %d tasks", total)
 		}
 	})
 


### PR DESCRIPTION
## Problem

A `run_only` autopilot can create and route a new issue, but cannot assign a pre-existing canonical issue created by the human who owns the run. Promoter-style automations therefore create duplicate execution-wrapper issues instead of routing the canonical record.

## Fix

Allow the existing-issue assignment scope only when all existing autopilot authority checks pass and either:

- the issue is already bound to this exact task, or
- the issue was created by the run's accountable member and the task independently proves active `run_only` lineage in the same workspace.

The authority remains unavailable for another member's issue, a sibling run's issue, completed tasks, untrusted attribution sources, and unrelated issues in the same batch.

## Verification

Real PostgreSQL 17:

- focused assignment positive/negative suite: PASS
- full `server/internal/handler` package: PASS (`36.716s`)
- mixed batch regression proves an allowed member issue cannot lend authority to another member's issue.
