### PR TITLE
NAT-1068: restore Feishu delivery for member inbox reports

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -276,6 +276,8 @@ var concurrentIndexCleanups = map[string]string{
 	"440_github_pr_head_sha_index":                              "idx_github_pull_request_head_sha",
 	"443_issue_project_status_index":                            "idx_issue_project_status",
 	"445_comment_delegated_failure_unsettled_index":             "idx_comment_delegated_failure_unsettled",
+	"447_channel_inbox_delivery_identity_index":                 "channel_inbox_delivery_identity_uidx",
+	"448_channel_inbox_delivery_workspace_index":                "idx_channel_inbox_delivery_workspace",
 }
 
 // concurrentDownIndexCleanups covers every migration whose down direction

--- a/server/internal/handler/autopilot_subscriber_test.go
+++ b/server/internal/handler/autopilot_subscriber_test.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/testutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -739,6 +741,126 @@ func TestAutopilotDispatchNotifiesSubscribersOnCreate(t *testing.T) {
 	}
 	if inboxTitle != title {
 		t.Fatalf("inbox title = %q, want %q (issue title)", inboxTitle, title)
+	}
+}
+
+// TestAutopilotReportInboxQueryExcludesCreateNotice pins the single-message
+// delivery boundary used by Feishu: create_issue first emits a durable
+// issue_subscribed Inbox item, but only the later comment produced by the
+// Autopilot run's own task is a report eligible for direct-room delivery.
+func TestAutopilotReportInboxQueryExcludesCreateNotice(t *testing.T) {
+	ctx := context.Background()
+	title := fmt.Sprintf("Synthetic Autopilot report %d", time.Now().UnixNano())
+	var autopilotID, issueID string
+	defer func() {
+		if issueID != "" {
+			testPool.Exec(ctx, `DELETE FROM inbox_item WHERE issue_id = $1`, issueID)
+			testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		}
+		if autopilotID != "" {
+			testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+		}
+	}()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("load test agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
+		"title":                "Single-message report contract",
+		"assignee_id":          agentID,
+		"execution_mode":       "create_issue",
+		"issue_title_template": title,
+		"subscribers": []map[string]any{
+			{"user_type": "member", "user_id": testUserID},
+		},
+	})
+	testHandler.CreateAutopilot(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var autopilot AutopilotResponse
+	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
+		t.Fatalf("decode autopilot: %v", err)
+	}
+	autopilotID = autopilot.ID
+
+	queries := db.New(testPool)
+	ap, err := queries.GetAutopilot(ctx, parseUUID(autopilotID))
+	if err != nil {
+		t.Fatalf("GetAutopilot: %v", err)
+	}
+	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "manual", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if run == nil || !run.IssueID.Valid {
+		t.Fatalf("dispatch run = %+v, want linked issue", run)
+	}
+	issueID = uuidToString(run.IssueID)
+
+	var createNoticeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM inbox_item
+		WHERE issue_id = $1 AND recipient_id = $2 AND type = 'issue_subscribed'
+	`, issueID, testUserID).Scan(&createNoticeID); err != nil {
+		t.Fatalf("load create notice: %v", err)
+	}
+	if _, err := queries.GetAutopilotReportInboxItemInWorkspace(ctx, db.GetAutopilotReportInboxItemInWorkspaceParams{
+		ID: parseUUID(createNoticeID), WorkspaceID: parseUUID(testWorkspaceID),
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("create notice report lookup error = %v, want pgx.ErrNoRows", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, issueID, agentID).Scan(&taskID); err != nil {
+		t.Fatalf("load Autopilot task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE autopilot_run SET task_id = $2 WHERE id = $1`, uuidToString(run.ID), taskID); err != nil {
+		t.Fatalf("link Autopilot task: %v", err)
+	}
+
+	reportCommentID := dbfx.Insert(t, "comment", testutil.Cols{
+		"issue_id":       issueID,
+		"workspace_id":   testWorkspaceID,
+		"author_type":    "agent",
+		"author_id":      agentID,
+		"content":        "【Mock】Feishu delivery smoke。",
+		"source_task_id": taskID,
+	})
+	details, err := json.Marshal(map[string]string{"comment_id": reportCommentID})
+	if err != nil {
+		t.Fatalf("marshal report details: %v", err)
+	}
+	reportInboxID := dbfx.Insert(t, "inbox_item", testutil.Cols{
+		"workspace_id":   testWorkspaceID,
+		"recipient_type": "member",
+		"recipient_id":   testUserID,
+		"type":           "new_comment",
+		"severity":       "info",
+		"issue_id":       issueID,
+		"title":          title,
+		"body":           "【Mock】Feishu delivery smoke。",
+		"actor_type":     "agent",
+		"actor_id":       agentID,
+		"details":        details,
+	})
+	item, err := queries.GetAutopilotReportInboxItemInWorkspace(ctx, db.GetAutopilotReportInboxItemInWorkspaceParams{
+		ID: parseUUID(reportInboxID), WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("load report Inbox item: %v", err)
+	}
+	if got := uuidToString(item.ID); got != reportInboxID {
+		t.Fatalf("report Inbox id = %s, want %s", got, reportInboxID)
 	}
 }
 

--- a/server/internal/handler/workspace_delete_manifest_test.go
+++ b/server/internal/handler/workspace_delete_manifest_test.go
@@ -41,6 +41,7 @@ var workspaceDeletionManifest = map[string]workspaceDeleteAction{
 	"channel_chat_session_binding":       workspaceDelete,
 	"channel_inbound_audit":              workspaceDelete,
 	"channel_inbound_message_dedup":      workspaceDelete,
+	"channel_inbox_delivery":             workspaceDelete,
 	"channel_installation":               workspaceDelete,
 	"channel_media_pending_object":       workspaceDeleteSettle,
 	"channel_outbound_card_message":      workspaceDelete,

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -530,6 +530,7 @@ RETURNING id
 `, neighborSlug).Scan(&neighborWorkspaceID)
 	t.Cleanup(func() {
 		for _, workspaceID := range []string{targetWorkspaceID, neighborWorkspaceID} {
+			_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_inbox_delivery WHERE workspace_id = $1`, workspaceID)
 			_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, workspaceID)
 			_, _ = testPool.Exec(context.Background(), `DELETE FROM task_usage_hourly_dirty WHERE workspace_id = $1`, workspaceID)
 			_, _ = testPool.Exec(context.Background(), `DELETE FROM runtime_profile WHERE workspace_id = $1`, workspaceID)
@@ -546,6 +547,7 @@ VALUES ($1, $2, 'owner')
 		workspaceID string
 		mediaKey    string
 		issueID     string
+		inboxItemID string
 	}
 	fixtures := []*tenantFixture{
 		{workspaceID: targetWorkspaceID, mediaKey: targetMediaKey},
@@ -561,12 +563,20 @@ RETURNING id
 INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content)
 VALUES ($1, $2, 'member', $3, 'Workspace delete tenant isolation')
 `, fixture.issueID, fixture.workspaceID, testUserID)
-		dbfx.Exec(t, `
+		dbfx.QueryRow(t, `
 INSERT INTO inbox_item (
 	workspace_id, recipient_type, recipient_id, type, issue_id, title
 )
 VALUES ($1, 'member', $2, 'workspace-delete-test', $3, 'Workspace delete tenant isolation')
-`, fixture.workspaceID, testUserID, fixture.issueID)
+RETURNING id
+`, fixture.workspaceID, testUserID, fixture.issueID).Scan(&fixture.inboxItemID)
+		dbfx.Exec(t, `
+INSERT INTO channel_inbox_delivery (
+	inbox_item_id, workspace_id, channel_type, status, target_type,
+	provider_message_id, idempotency_key, finished_at
+)
+VALUES ($1, $2, 'feishu', 'delivered', 'direct_room', 'om_workspace_delete', $3, now())
+`, fixture.inboxItemID, fixture.workspaceID, fixture.inboxItemID)
 		dbfx.Exec(t, `
 INSERT INTO runtime_profile (
 	workspace_id, display_name, protocol_family, command_name, created_by
@@ -595,6 +605,7 @@ VALUES ($1, $2, gen_random_uuid(), 's3://workspace-delete/tenant-isolation')
 		"workspace":                    "id",
 		"issue":                        "workspace_id",
 		"comment":                      "workspace_id",
+		"channel_inbox_delivery":       "workspace_id",
 		"inbox_item":                   "workspace_id",
 		"runtime_profile":              "workspace_id",
 		"task_usage_hourly_dirty":      "workspace_id",

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -292,7 +292,15 @@ type PatchCardParams struct {
 type SendTextParams struct {
 	InstallationID InstallationCredentials
 	ChatID         ChatID
-	Text           string
+	// OpenID sends a proactive 1:1 message to a bound member. Exactly one of
+	// ChatID and OpenID must be set. This is used by the Inbox delivery path;
+	// normal channel replies continue to use ChatID.
+	OpenID OpenID
+	Text   string
+	// IdempotencyKey is forwarded as Lark's message uuid. Replaying an Inbox
+	// event with the same key returns the original provider message instead of
+	// creating a duplicate direct-room message.
+	IdempotencyKey string
 	// ReplyTarget threads the text reply back into a Lark topic; see
 	// ReplyTarget. Empty keeps the chat-level send.
 	ReplyTarget ReplyTarget

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -370,15 +370,19 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	return resp.Data.MessageID, nil
 }
 
-// SendTextMessage posts a plain text IM message into a Lark chat.
-// This is the Patcher's primary outbound for agent chat replies —
+// SendTextMessage posts a plain text IM message into a Lark chat or directly
+// to an open_id. This is the Patcher's primary outbound for agent chat replies —
 // using a normal text bubble instead of an interactive card makes
 // free-form replies feel like a native Lark conversation. The
 // content envelope Lark expects is a JSON-encoded `{"text": "..."}`
-// blob; we encode it here so callers pass raw text.
+// blob; we encode it here so callers pass raw text. Direct sends may provide
+// a stable uuid so Lark deduplicates retries of one durable Inbox event.
 func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (string, error) {
-	if p.ChatID == "" {
-		return "", errors.New("lark http client: missing chat_id")
+	if (p.ChatID == "") == (p.OpenID == "") {
+		return "", errors.New("lark http client: exactly one of chat_id or open_id is required")
+	}
+	if p.OpenID != "" && p.ReplyTarget.IsSet() {
+		return "", errors.New("lark http client: direct open_id send cannot be a thread reply")
 	}
 	if p.Text == "" {
 		return "", errors.New("lark http client: missing text")
@@ -390,7 +394,23 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode text content: %w", err)
 	}
-	path, body := outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.ReplyTarget)
+	var path string
+	var body map[string]any
+	if p.OpenID != "" {
+		q := url.Values{}
+		q.Set("receive_id_type", "open_id")
+		path = "/open-apis/im/v1/messages?" + q.Encode()
+		body = map[string]any{
+			"receive_id": string(p.OpenID),
+			"msg_type":   "text",
+			"content":    string(contentBytes),
+		}
+		if p.IdempotencyKey != "" {
+			body["uuid"] = p.IdempotencyKey
+		}
+	} else {
+		path, body = outboundMessageRequest(p.ChatID, "text", string(contentBytes), p.ReplyTarget)
+	}
 	var resp struct {
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -635,6 +635,43 @@ func TestHTTPClient_SendTextMessage_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPClient_SendTextMessage_DirectOpenIDWithIdempotencyKey(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_direct", 7200)
+	fake.stubSend(
+		map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]string{"message_id": "om_direct_1"},
+		},
+		func(r *http.Request, body map[string]string) {
+			if got := r.URL.Query().Get("receive_id_type"); got != "open_id" {
+				t.Errorf("receive_id_type: got %q want open_id", got)
+			}
+			if body["receive_id"] != "ou_member_1" {
+				t.Errorf("receive_id: got %q want ou_member_1", body["receive_id"])
+			}
+			if body["uuid"] != "44444444-4444-4444-4444-444444444444" {
+				t.Errorf("uuid: got %q", body["uuid"])
+			}
+		},
+	)
+
+	c := newTestClient(fake, time.Now)
+	msgID, err := c.SendTextMessage(context.Background(), SendTextParams{
+		InstallationID: testCreds(),
+		OpenID:         OpenID("ou_member_1"),
+		Text:           "daily report",
+		IdempotencyKey: "44444444-4444-4444-4444-444444444444",
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if msgID != "om_direct_1" {
+		t.Fatalf("message id: got %q want om_direct_1", msgID)
+	}
+}
+
 // TestHTTPClient_SendTextMessage_ReplyInThread pins the wire shape of a
 // threaded reply: when ReplyTarget is set the client must POST to the
 // reply endpoint (/messages/<id>/reply), carry reply_in_thread=true, and

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -155,7 +155,7 @@ type PatcherQueries interface {
 	CreateLarkOutboundCardMessage(ctx context.Context, arg CreateOutboundCardMessageParams) (OutboundCardMessage, error)
 	UpdateLarkOutboundCardStatus(ctx context.Context, arg UpdateOutboundCardStatusParams) error
 	FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error)
-	GetInboxItemInWorkspace(ctx context.Context, arg db.GetInboxItemInWorkspaceParams) (db.InboxItem, error)
+	GetAutopilotReportInboxItemInWorkspace(ctx context.Context, arg db.GetAutopilotReportInboxItemInWorkspaceParams) (db.InboxItem, error)
 	GetChannelInboxDelivery(ctx context.Context, arg db.GetChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error)
 	UpsertChannelInboxDelivery(ctx context.Context, arg db.UpsertChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error)
 }
@@ -193,8 +193,8 @@ func (c PatcherConfig) withDefaults() PatcherConfig {
 }
 
 // Patcher reacts to task-lifecycle and Inbox events on the event bus. It
-// forwards chat replies and member notifications to Lark. It is the outbound
-// side of §4.5 — but the original "thinking → streaming → final card"
+// forwards chat replies and Autopilot report notifications to Lark. It is the
+// outbound side of §4.5 — but the original "thinking → streaming → final card"
 // lifecycle was reduced to a single plain-text reply on EventChatDone
 // after Bohan reported the card chrome made replies feel like system
 // notifications. The error path is the one survivor of card rendering:
@@ -203,9 +203,9 @@ func (c PatcherConfig) withDefaults() PatcherConfig {
 //
 // Scope:
 //
-//   - Task events require a lark_chat_session_binding. Member Inbox events
-//     instead resolve the recipient's active channel_user_binding, which lets
-//     non-chat work such as Autopilots reach the member's direct room.
+//   - Task events require a lark_chat_session_binding. Autopilot report Inbox
+//     events instead resolve the recipient's active channel_user_binding so
+//     non-chat reports reach the member's direct room.
 //
 //   - Each EventChatDone yields one Lark text message; there is no
 //     streaming, no throttling, no DB row to track card-state.
@@ -281,9 +281,11 @@ func (p *Patcher) SetTypingIndicatorManager(m *TypingIndicatorManager) {
 //     and task-failed race the add the same way — and closing it needs a
 //     per-session generation the add can check when its call returns.
 //
-//   - EventInboxNew — a durable member notification was created. When the
-//     member has an active Feishu binding, its body is sent to their direct
-//     room and the provider receipt is persisted on that Inbox item.
+//   - EventInboxNew — a durable notification was created. Only a report
+//     comment produced by an Autopilot run's own task is eligible; creation
+//     notices and unrelated Inbox activity stay in Multica. When the report's
+//     member recipient has an active Feishu binding, its body is sent to their
+//     direct room and the provider receipt is persisted on that Inbox item.
 //
 // We deliberately do NOT subscribe to EventTaskQueued / EventTaskRunning
 // (no thinking-card lifecycle anymore — adds noise without value) or to
@@ -299,11 +301,10 @@ func (p *Patcher) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventInboxNew, p.handleInboxNew)
 }
 
-// handleInboxNew mirrors the already-shipped WeCom Inbox delivery edge for
-// Feishu/Lark. The notification remains durable in Multica; when its member
-// recipient has an active Feishu binding, the same body is additionally sent
-// to that member's direct room and the provider receipt is stored in the
-// dedicated channel delivery table.
+// handleInboxNew is the report-only Feishu/Lark delivery edge. Every
+// notification remains durable in Multica, but only an Autopilot report Inbox
+// item is additionally sent to a bound member's direct room and recorded in
+// the dedicated channel delivery table.
 func (p *Patcher) handleInboxNew(e events.Event) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -322,9 +323,6 @@ func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
 	if !ok {
 		return nil
 	}
-	if recipientType, _ := itemPayload["recipient_type"].(string); recipientType != "member" {
-		return nil
-	}
 	itemID, err := util.ParseUUID(stringField(itemPayload, "id"))
 	if err != nil || !itemID.Valid {
 		return nil
@@ -333,19 +331,17 @@ func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
 	if err != nil || !workspaceID.Valid {
 		return nil
 	}
-	recipientID, err := util.ParseUUID(stringField(itemPayload, "recipient_id"))
-	if err != nil || !recipientID.Valid {
-		return nil
-	}
-
-	item, err := p.queries.GetInboxItemInWorkspace(ctx, db.GetInboxItemInWorkspaceParams{
+	item, err := p.queries.GetAutopilotReportInboxItemInWorkspace(ctx, db.GetAutopilotReportInboxItemInWorkspaceParams{
 		ID: itemID, WorkspaceID: workspaceID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return fmt.Errorf("load inbox item: %w", err)
+		return fmt.Errorf("load autopilot report inbox item: %w", err)
+	}
+	if item.RecipientType != "member" || !item.RecipientID.Valid {
+		return nil
 	}
 	receipt, err := p.queries.GetChannelInboxDelivery(ctx, db.GetChannelInboxDeliveryParams{
 		InboxItemID: item.ID, WorkspaceID: item.WorkspaceID, ChannelType: channelTypeFeishu,
@@ -358,7 +354,7 @@ func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
 	}
 
 	binding, err := p.queries.FindChannelBindingForMember(ctx, db.FindChannelBindingForMemberParams{
-		WorkspaceID: workspaceID, MulticaUserID: recipientID, ChannelType: channelTypeFeishu,
+		WorkspaceID: item.WorkspaceID, MulticaUserID: item.RecipientID, ChannelType: channelTypeFeishu,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -386,7 +382,7 @@ func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
 	}
 
 	key := util.UUIDToString(item.ID)
-	messageID, sendErr := p.client.SendTextMessage(ctx, SendTextParams{
+	messageID, sendErr := p.sendInboxText(ctx, SendTextParams{
 		InstallationID: creds,
 		OpenID:         OpenID(binding.ChannelUserID),
 		Text:           content,
@@ -420,6 +416,26 @@ func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
 		"provider_message_id", messageID,
 		"idempotency_key", key)
 	return nil
+}
+
+// sendInboxText makes one bounded repair attempt for an ambiguous transport
+// failure. Both calls carry the same provider uuid, so a response lost after a
+// successful first send cannot create a duplicate. Lark business errors are
+// durable failures and are not retried immediately.
+func (p *Patcher) sendInboxText(ctx context.Context, params SendTextParams) (string, error) {
+	messageID, err := p.client.SendTextMessage(ctx, params)
+	if err == nil || !inboxDeliveryRetryable(err) {
+		return messageID, err
+	}
+	return p.client.SendTextMessage(ctx, params)
+}
+
+func inboxDeliveryRetryable(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var apiErr *APIError
+	return !errors.As(err, &apiErr)
 }
 
 func stringField(item map[string]any, key string) string {

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -152,6 +154,10 @@ type PatcherQueries interface {
 	GetLarkOutboundCardByTask(ctx context.Context, taskID pgtype.UUID) (OutboundCardMessage, error)
 	CreateLarkOutboundCardMessage(ctx context.Context, arg CreateOutboundCardMessageParams) (OutboundCardMessage, error)
 	UpdateLarkOutboundCardStatus(ctx context.Context, arg UpdateOutboundCardStatusParams) error
+	FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error)
+	GetInboxItemInWorkspace(ctx context.Context, arg db.GetInboxItemInWorkspaceParams) (db.InboxItem, error)
+	GetChannelInboxDelivery(ctx context.Context, arg db.GetChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error)
+	UpsertChannelInboxDelivery(ctx context.Context, arg db.UpsertChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error)
 }
 
 // CredentialsResolver decrypts an installation's app_secret for the
@@ -186,8 +192,8 @@ func (c PatcherConfig) withDefaults() PatcherConfig {
 	return c
 }
 
-// Patcher reacts to task-lifecycle events on the event bus and forwards
-// chat replies to Lark as plain text IM messages. It is the outbound
+// Patcher reacts to task-lifecycle and Inbox events on the event bus. It
+// forwards chat replies and member notifications to Lark. It is the outbound
 // side of §4.5 — but the original "thinking → streaming → final card"
 // lifecycle was reduced to a single plain-text reply on EventChatDone
 // after Bohan reported the card chrome made replies feel like system
@@ -197,9 +203,9 @@ func (c PatcherConfig) withDefaults() PatcherConfig {
 //
 // Scope:
 //
-//   - Only tasks whose chat_session has a lark_chat_session_binding
-//     produce outbound. Tasks born from the web UI or autopilot pass
-//     through unchanged.
+//   - Task events require a lark_chat_session_binding. Member Inbox events
+//     instead resolve the recipient's active channel_user_binding, which lets
+//     non-chat work such as Autopilots reach the member's direct room.
 //
 //   - Each EventChatDone yields one Lark text message; there is no
 //     streaming, no throttling, no DB row to track card-state.
@@ -275,6 +281,10 @@ func (p *Patcher) SetTypingIndicatorManager(m *TypingIndicatorManager) {
 //     and task-failed race the add the same way — and closing it needs a
 //     per-session generation the add can check when its call returns.
 //
+//   - EventInboxNew — a durable member notification was created. When the
+//     member has an active Feishu binding, its body is sent to their direct
+//     room and the provider receipt is persisted on that Inbox item.
+//
 // We deliberately do NOT subscribe to EventTaskQueued / EventTaskRunning
 // (no thinking-card lifecycle anymore — adds noise without value) or to
 // EventTaskCompleted (chat tasks always emit EventChatDone first, which
@@ -286,6 +296,143 @@ func (p *Patcher) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventTaskFailed, p.handleEvent)
 	bus.Subscribe(protocol.EventChatDone, p.handleEvent)
 	bus.Subscribe(protocol.EventTaskCancelled, p.handleEvent)
+	bus.Subscribe(protocol.EventInboxNew, p.handleInboxNew)
+}
+
+// handleInboxNew mirrors the already-shipped WeCom Inbox delivery edge for
+// Feishu/Lark. The notification remains durable in Multica; when its member
+// recipient has an active Feishu binding, the same body is additionally sent
+// to that member's direct room and the provider receipt is stored in the
+// dedicated channel delivery table.
+func (p *Patcher) handleInboxNew(e events.Event) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := p.processInboxNew(ctx, e); err != nil {
+		p.cfg.Logger.WarnContext(ctx, "lark outbound: inbox delivery failed",
+			"workspace_id", e.WorkspaceID, "error", err)
+	}
+}
+
+func (p *Patcher) processInboxNew(ctx context.Context, e events.Event) error {
+	payload, ok := e.Payload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	itemPayload, ok := payload["item"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if recipientType, _ := itemPayload["recipient_type"].(string); recipientType != "member" {
+		return nil
+	}
+	itemID, err := util.ParseUUID(stringField(itemPayload, "id"))
+	if err != nil || !itemID.Valid {
+		return nil
+	}
+	workspaceID, err := util.ParseUUID(stringField(itemPayload, "workspace_id"))
+	if err != nil || !workspaceID.Valid {
+		return nil
+	}
+	recipientID, err := util.ParseUUID(stringField(itemPayload, "recipient_id"))
+	if err != nil || !recipientID.Valid {
+		return nil
+	}
+
+	item, err := p.queries.GetInboxItemInWorkspace(ctx, db.GetInboxItemInWorkspaceParams{
+		ID: itemID, WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("load inbox item: %w", err)
+	}
+	receipt, err := p.queries.GetChannelInboxDelivery(ctx, db.GetChannelInboxDeliveryParams{
+		InboxItemID: item.ID, WorkspaceID: item.WorkspaceID, ChannelType: channelTypeFeishu,
+	})
+	if err == nil && receipt.Status == "delivered" {
+		return nil
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("load inbox delivery receipt: %w", err)
+	}
+
+	binding, err := p.queries.FindChannelBindingForMember(ctx, db.FindChannelBindingForMemberParams{
+		WorkspaceID: workspaceID, MulticaUserID: recipientID, ChannelType: channelTypeFeishu,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("lookup member binding: %w", err)
+	}
+	inst, err := p.queries.GetLarkInstallation(ctx, binding.InstallationID)
+	if err != nil {
+		return fmt.Errorf("load installation: %w", err)
+	}
+	if InstallationStatus(inst.Status) != InstallationActive {
+		return nil
+	}
+	creds, err := p.installationCredentials(inst)
+	if err != nil {
+		return err
+	}
+	content := strings.TrimSpace(item.Body.String)
+	if content == "" {
+		content = strings.TrimSpace(item.Title)
+	}
+	if content == "" {
+		return nil
+	}
+
+	key := util.UUIDToString(item.ID)
+	messageID, sendErr := p.client.SendTextMessage(ctx, SendTextParams{
+		InstallationID: creds,
+		OpenID:         OpenID(binding.ChannelUserID),
+		Text:           content,
+		IdempotencyKey: key,
+	})
+	delivery := db.UpsertChannelInboxDeliveryParams{
+		InboxItemID:       item.ID,
+		WorkspaceID:       item.WorkspaceID,
+		ChannelType:       channelTypeFeishu,
+		Status:            "delivered",
+		TargetType:        "direct_room",
+		ProviderMessageID: util.StrToText(messageID),
+		IdempotencyKey:    key,
+		FinishedAt:        pgtype.Timestamptz{Time: p.cfg.Now().UTC(), Valid: true},
+	}
+	if sendErr != nil {
+		delivery.Status = "failed"
+		delivery.ProviderMessageID = pgtype.Text{}
+		delivery.ErrorCode = util.StrToText(inboxDeliveryErrorCode(sendErr))
+	}
+	if _, err := p.queries.UpsertChannelInboxDelivery(ctx, delivery); err != nil {
+		return fmt.Errorf("persist inbox delivery receipt: %w", err)
+	}
+	if sendErr != nil {
+		return fmt.Errorf("send inbox direct message: %w", sendErr)
+	}
+	p.cfg.Logger.InfoContext(ctx, "lark outbound: inbox notification delivered",
+		"workspace_id", util.UUIDToString(item.WorkspaceID),
+		"inbox_item_id", key,
+		"target_type", delivery.TargetType,
+		"provider_message_id", messageID,
+		"idempotency_key", key)
+	return nil
+}
+
+func stringField(item map[string]any, key string) string {
+	value, _ := item[key].(string)
+	return value
+}
+
+func inboxDeliveryErrorCode(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Sprintf("lark_%d", apiErr.Code)
+	}
+	return "transport_error"
 }
 
 func (p *Patcher) handleEvent(e events.Event) {

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -93,7 +93,7 @@ func (f *fakePatcherQueries) UpdateLarkOutboundCardStatus(ctx context.Context, a
 func (f *fakePatcherQueries) FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error) {
 	return f.inboxBinding, f.inboxBindingErr
 }
-func (f *fakePatcherQueries) GetInboxItemInWorkspace(ctx context.Context, arg db.GetInboxItemInWorkspaceParams) (db.InboxItem, error) {
+func (f *fakePatcherQueries) GetAutopilotReportInboxItemInWorkspace(ctx context.Context, arg db.GetAutopilotReportInboxItemInWorkspaceParams) (db.InboxItem, error) {
 	return f.inboxItem, f.inboxItemErr
 }
 func (f *fakePatcherQueries) GetChannelInboxDelivery(ctx context.Context, arg db.GetChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error) {
@@ -138,6 +138,7 @@ type fakeAPIClient struct {
 	sendErr        error
 	patchErr       error
 	textSendErr    error
+	textSendErrs   []error
 	textSendReturn string
 	mdCardErr      error
 	mdCardReturn   string
@@ -182,6 +183,11 @@ func (f *fakeAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	f.textSent = append(f.textSent, p)
 	if f.threadReplyErr != nil && p.ReplyTarget.IsSet() {
 		return "", f.threadReplyErr
+	}
+	if len(f.textSendErrs) > 0 {
+		err := f.textSendErrs[0]
+		f.textSendErrs = f.textSendErrs[1:]
+		return f.textSendReturn, err
 	}
 	return f.textSendReturn, f.textSendErr
 }
@@ -384,6 +390,42 @@ func TestPatcherRetriesFailedInboxDeliveryWithoutRepeatingSuccess(t *testing.T) 
 	defer api.mu.Unlock()
 	if len(api.textSent) != 2 {
 		t.Fatalf("send attempts = %d, want failed attempt plus one retry", len(api.textSent))
+	}
+	if api.textSent[0].IdempotencyKey != api.textSent[1].IdempotencyKey {
+		t.Fatalf("retry keys differ: %q != %q", api.textSent[0].IdempotencyKey, api.textSent[1].IdempotencyKey)
+	}
+	if q.deliveryReceipt.Status != "delivered" || q.deliveryReceipt.ProviderMessageID.String != "lark_text_msg_1" {
+		t.Fatalf("delivered receipt = %+v", q.deliveryReceipt)
+	}
+}
+
+func TestPatcherImmediatelyRetriesAmbiguousInboxTransportFailureOnce(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	q.inboxBinding = db.ChannelUserBinding{
+		WorkspaceID:    uuidFromString(t, "88888888-8888-8888-8888-888888888888"),
+		MulticaUserID:  uuidFromString(t, "99999999-9999-9999-9999-999999999999"),
+		InstallationID: q.installation.ID,
+		ChannelType:    channelTypeFeishu,
+		ChannelUserID:  "ou_retry_transport_member",
+	}
+	q.inboxItem = db.InboxItem{
+		ID:            uuidFromString(t, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"),
+		WorkspaceID:   q.inboxBinding.WorkspaceID,
+		RecipientType: "member",
+		RecipientID:   q.inboxBinding.MulticaUserID,
+		Type:          "new_comment",
+		Title:         "Synthetic Autopilot report",
+		Body:          pgtype.Text{String: "【Mock】Feishu delivery smoke。", Valid: true},
+		Details:       []byte(`{}`),
+	}
+	api.textSendErrs = []error{errors.New("temporary transport failure"), nil}
+
+	p.handleInboxNew(inboxNewEvent(q.inboxItem))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 2 {
+		t.Fatalf("send attempts = %d, want one attempt plus one bounded retry", len(api.textSent))
 	}
 	if api.textSent[0].IdempotencyKey != api.textSent[1].IdempotencyKey {
 		t.Fatalf("retry keys differ: %q != %q", api.textSent[0].IdempotencyKey, api.textSent[1].IdempotencyKey)

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -34,6 +34,12 @@ type fakePatcherQueries struct {
 	created             []CreateOutboundCardMessageParams
 	createReturn        OutboundCardMessage
 	statusUpdates       []UpdateOutboundCardStatusParams
+	inboxBinding        db.ChannelUserBinding
+	inboxBindingErr     error
+	inboxItem           db.InboxItem
+	inboxItemErr        error
+	deliveryReceipt     db.ChannelInboxDelivery
+	deliveryReceiptSet  bool
 }
 
 func (f *fakePatcherQueries) GetAgentTask(ctx context.Context, id pgtype.UUID) (db.AgentTaskQueue, error) {
@@ -83,6 +89,37 @@ func (f *fakePatcherQueries) UpdateLarkOutboundCardStatus(ctx context.Context, a
 	defer f.mu.Unlock()
 	f.statusUpdates = append(f.statusUpdates, arg)
 	return nil
+}
+func (f *fakePatcherQueries) FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error) {
+	return f.inboxBinding, f.inboxBindingErr
+}
+func (f *fakePatcherQueries) GetInboxItemInWorkspace(ctx context.Context, arg db.GetInboxItemInWorkspaceParams) (db.InboxItem, error) {
+	return f.inboxItem, f.inboxItemErr
+}
+func (f *fakePatcherQueries) GetChannelInboxDelivery(ctx context.Context, arg db.GetChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.deliveryReceiptSet {
+		return db.ChannelInboxDelivery{}, pgx.ErrNoRows
+	}
+	return f.deliveryReceipt, nil
+}
+func (f *fakePatcherQueries) UpsertChannelInboxDelivery(ctx context.Context, arg db.UpsertChannelInboxDeliveryParams) (db.ChannelInboxDelivery, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deliveryReceipt = db.ChannelInboxDelivery{
+		InboxItemID:       arg.InboxItemID,
+		WorkspaceID:       arg.WorkspaceID,
+		ChannelType:       arg.ChannelType,
+		Status:            arg.Status,
+		TargetType:        arg.TargetType,
+		ProviderMessageID: arg.ProviderMessageID,
+		IdempotencyKey:    arg.IdempotencyKey,
+		ErrorCode:         arg.ErrorCode,
+		FinishedAt:        arg.FinishedAt,
+	}
+	f.deliveryReceiptSet = true
+	return f.deliveryReceipt, nil
 }
 
 type fakeCredentials struct{ secret string }
@@ -212,6 +249,22 @@ func newTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeAPIClient
 	return p, q, api
 }
 
+func inboxNewEvent(item db.InboxItem) events.Event {
+	return events.Event{
+		Type:        protocol.EventInboxNew,
+		WorkspaceID: uuidString(item.WorkspaceID),
+		Payload: map[string]any{"item": map[string]any{
+			"id":             uuidString(item.ID),
+			"workspace_id":   uuidString(item.WorkspaceID),
+			"recipient_type": item.RecipientType,
+			"recipient_id":   uuidString(item.RecipientID),
+			"type":           item.Type,
+			"title":          item.Title,
+			"body":           item.Body.String,
+		}},
+	}
+}
+
 // TestPatcherSendsPlainTextOnChatDone pins the new behaviour Bohan asked
 // for: when the agent finishes replying, the Patcher posts the reply as
 // a plain Lark IM text message (msg_type=text), not nested inside an
@@ -242,6 +295,101 @@ func TestPatcherSendsSealedChannelTaskReply(t *testing.T) {
 	defer api.mu.Unlock()
 	if len(api.textSent) != 1 || api.textSent[0].Text != "channel answer" {
 		t.Fatalf("sealed channel reply must reach Lark; textSent=%+v", api.textSent)
+	}
+}
+
+// A member-bound Feishu bot is also the outbound edge for Multica Inbox
+// notifications. Autopilot reports arrive here as subscriber notifications;
+// without this path a completed run is visible in Multica but never reaches
+// the member's direct room.
+func TestPatcherDeliversInboxNotificationToBoundMemberOnce(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	q.inboxBinding = db.ChannelUserBinding{
+		WorkspaceID:    uuidFromString(t, "22222222-2222-2222-2222-222222222222"),
+		MulticaUserID:  uuidFromString(t, "33333333-3333-3333-3333-333333333333"),
+		InstallationID: q.installation.ID,
+		ChannelType:    channelTypeFeishu,
+		ChannelUserID:  "ou_bound_member",
+	}
+	q.inboxItem = db.InboxItem{
+		ID:            uuidFromString(t, "44444444-4444-4444-4444-444444444444"),
+		WorkspaceID:   q.inboxBinding.WorkspaceID,
+		RecipientType: "member",
+		RecipientID:   q.inboxBinding.MulticaUserID,
+		Type:          "new_comment",
+		Title:         "Daily report",
+		Body:          pgtype.Text{String: "今天一切正常，无需操作。", Valid: true},
+		Details:       []byte(`{}`),
+	}
+	e := inboxNewEvent(q.inboxItem)
+
+	p.handleInboxNew(e)
+	p.handleInboxNew(e) // replay must not create a second provider message
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 1 {
+		t.Fatalf("direct-room sends = %d, want 1", len(api.textSent))
+	}
+	sent := api.textSent[0]
+	if sent.OpenID != OpenID("ou_bound_member") {
+		t.Fatalf("open_id = %q, want bound member target", sent.OpenID)
+	}
+	if sent.Text != "今天一切正常，无需操作。" {
+		t.Fatalf("text = %q", sent.Text)
+	}
+	if sent.IdempotencyKey != uuidString(q.inboxItem.ID) {
+		t.Fatalf("idempotency key = %q, want inbox item id", sent.IdempotencyKey)
+	}
+	if q.deliveryReceipt.ProviderMessageID.String != "lark_text_msg_1" ||
+		q.deliveryReceipt.Status != "delivered" {
+		t.Fatalf("receipt = %+v", q.deliveryReceipt)
+	}
+}
+
+func TestPatcherRetriesFailedInboxDeliveryWithoutRepeatingSuccess(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	q.inboxBinding = db.ChannelUserBinding{
+		WorkspaceID:    uuidFromString(t, "55555555-5555-5555-5555-555555555555"),
+		MulticaUserID:  uuidFromString(t, "66666666-6666-6666-6666-666666666666"),
+		InstallationID: q.installation.ID,
+		ChannelType:    channelTypeFeishu,
+		ChannelUserID:  "ou_retry_member",
+	}
+	q.inboxItem = db.InboxItem{
+		ID:            uuidFromString(t, "77777777-7777-7777-7777-777777777777"),
+		WorkspaceID:   q.inboxBinding.WorkspaceID,
+		RecipientType: "member",
+		RecipientID:   q.inboxBinding.MulticaUserID,
+		Type:          "new_comment",
+		Title:         "Daily report",
+		Body:          pgtype.Text{String: "重试后仅投递一次。", Valid: true},
+		Details:       []byte(`{}`),
+	}
+	e := inboxNewEvent(q.inboxItem)
+
+	api.textSendErr = &APIError{Op: "send text message", Code: 230001, Msg: "temporary"}
+	p.handleInboxNew(e)
+	if q.deliveryReceipt.Status != "failed" || q.deliveryReceipt.ErrorCode.String != "lark_230001" {
+		t.Fatalf("failed receipt = %+v", q.deliveryReceipt)
+	}
+
+	api.mu.Lock()
+	api.textSendErr = nil
+	api.mu.Unlock()
+	p.handleInboxNew(e)
+	p.handleInboxNew(e) // delivered receipt prevents another attempt
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 2 {
+		t.Fatalf("send attempts = %d, want failed attempt plus one retry", len(api.textSent))
+	}
+	if api.textSent[0].IdempotencyKey != api.textSent[1].IdempotencyKey {
+		t.Fatalf("retry keys differ: %q != %q", api.textSent[0].IdempotencyKey, api.textSent[1].IdempotencyKey)
+	}
+	if q.deliveryReceipt.Status != "delivered" || q.deliveryReceipt.ProviderMessageID.String != "lark_text_msg_1" {
+		t.Fatalf("delivered receipt = %+v", q.deliveryReceipt)
 	}
 }
 

--- a/server/migrations/446_channel_inbox_delivery.down.sql
+++ b/server/migrations/446_channel_inbox_delivery.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS channel_inbox_delivery;

--- a/server/migrations/446_channel_inbox_delivery.up.sql
+++ b/server/migrations/446_channel_inbox_delivery.up.sql
@@ -2,17 +2,13 @@
 -- messaging channel. Keep this outside inbox_item.details: that field is a
 -- public flat string map, while a delivery receipt is structured server state.
 CREATE TABLE channel_inbox_delivery (
-    inbox_item_id UUID NOT NULL REFERENCES inbox_item(id) ON DELETE CASCADE,
-    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    inbox_item_id UUID NOT NULL,
+    workspace_id UUID NOT NULL,
     channel_type TEXT NOT NULL,
     status TEXT NOT NULL CHECK (status IN ('delivered', 'failed')),
     target_type TEXT NOT NULL,
     provider_message_id TEXT,
     idempotency_key TEXT NOT NULL,
     error_code TEXT,
-    finished_at TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (inbox_item_id, channel_type)
+    finished_at TIMESTAMPTZ NOT NULL
 );
-
-CREATE INDEX idx_channel_inbox_delivery_workspace
-    ON channel_inbox_delivery (workspace_id, channel_type, finished_at DESC);

--- a/server/migrations/446_channel_inbox_delivery.up.sql
+++ b/server/migrations/446_channel_inbox_delivery.up.sql
@@ -1,0 +1,18 @@
+-- Durable, provider-neutral evidence for Inbox notifications forwarded to a
+-- messaging channel. Keep this outside inbox_item.details: that field is a
+-- public flat string map, while a delivery receipt is structured server state.
+CREATE TABLE channel_inbox_delivery (
+    inbox_item_id UUID NOT NULL REFERENCES inbox_item(id) ON DELETE CASCADE,
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    channel_type TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('delivered', 'failed')),
+    target_type TEXT NOT NULL,
+    provider_message_id TEXT,
+    idempotency_key TEXT NOT NULL,
+    error_code TEXT,
+    finished_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (inbox_item_id, channel_type)
+);
+
+CREATE INDEX idx_channel_inbox_delivery_workspace
+    ON channel_inbox_delivery (workspace_id, channel_type, finished_at DESC);

--- a/server/migrations/447_channel_inbox_delivery_identity_index.down.sql
+++ b/server/migrations/447_channel_inbox_delivery_identity_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS channel_inbox_delivery_identity_uidx;

--- a/server/migrations/447_channel_inbox_delivery_identity_index.up.sql
+++ b/server/migrations/447_channel_inbox_delivery_identity_index.up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS channel_inbox_delivery_identity_uidx
+    ON channel_inbox_delivery (inbox_item_id, channel_type);

--- a/server/migrations/448_channel_inbox_delivery_workspace_index.down.sql
+++ b/server/migrations/448_channel_inbox_delivery_workspace_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_channel_inbox_delivery_workspace;

--- a/server/migrations/448_channel_inbox_delivery_workspace_index.up.sql
+++ b/server/migrations/448_channel_inbox_delivery_workspace_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_channel_inbox_delivery_workspace
+    ON channel_inbox_delivery (workspace_id, channel_type, finished_at DESC);

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -316,6 +316,34 @@ func (q *Queries) CreateInboxItem(ctx context.Context, arg CreateInboxItemParams
 	return i, err
 }
 
+const getChannelInboxDelivery = `-- name: GetChannelInboxDelivery :one
+SELECT inbox_item_id, workspace_id, channel_type, status, target_type, provider_message_id, idempotency_key, error_code, finished_at FROM channel_inbox_delivery
+WHERE inbox_item_id = $1 AND workspace_id = $2 AND channel_type = $3
+`
+
+type GetChannelInboxDeliveryParams struct {
+	InboxItemID pgtype.UUID `json:"inbox_item_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	ChannelType string      `json:"channel_type"`
+}
+
+func (q *Queries) GetChannelInboxDelivery(ctx context.Context, arg GetChannelInboxDeliveryParams) (ChannelInboxDelivery, error) {
+	row := q.db.QueryRow(ctx, getChannelInboxDelivery, arg.InboxItemID, arg.WorkspaceID, arg.ChannelType)
+	var i ChannelInboxDelivery
+	err := row.Scan(
+		&i.InboxItemID,
+		&i.WorkspaceID,
+		&i.ChannelType,
+		&i.Status,
+		&i.TargetType,
+		&i.ProviderMessageID,
+		&i.IdempotencyKey,
+		&i.ErrorCode,
+		&i.FinishedAt,
+	)
+	return i, err
+}
+
 const getInboxItem = `-- name: GetInboxItem :one
 SELECT id, workspace_id, recipient_type, recipient_id, type, severity, issue_id, title, body, read, archived, created_at, actor_type, actor_id, details FROM inbox_item
 WHERE id = $1
@@ -728,6 +756,61 @@ func (q *Queries) UnarchiveInboxItem(ctx context.Context, id pgtype.UUID) (Inbox
 		&i.ActorType,
 		&i.ActorID,
 		&i.Details,
+	)
+	return i, err
+}
+
+const upsertChannelInboxDelivery = `-- name: UpsertChannelInboxDelivery :one
+INSERT INTO channel_inbox_delivery (
+    inbox_item_id, workspace_id, channel_type, status, target_type,
+    provider_message_id, idempotency_key, error_code, finished_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (inbox_item_id, channel_type) DO UPDATE SET
+    workspace_id = EXCLUDED.workspace_id,
+    status = EXCLUDED.status,
+    target_type = EXCLUDED.target_type,
+    provider_message_id = EXCLUDED.provider_message_id,
+    idempotency_key = EXCLUDED.idempotency_key,
+    error_code = EXCLUDED.error_code,
+    finished_at = EXCLUDED.finished_at
+RETURNING inbox_item_id, workspace_id, channel_type, status, target_type, provider_message_id, idempotency_key, error_code, finished_at
+`
+
+type UpsertChannelInboxDeliveryParams struct {
+	InboxItemID       pgtype.UUID        `json:"inbox_item_id"`
+	WorkspaceID       pgtype.UUID        `json:"workspace_id"`
+	ChannelType       string             `json:"channel_type"`
+	Status            string             `json:"status"`
+	TargetType        string             `json:"target_type"`
+	ProviderMessageID pgtype.Text        `json:"provider_message_id"`
+	IdempotencyKey    string             `json:"idempotency_key"`
+	ErrorCode         pgtype.Text        `json:"error_code"`
+	FinishedAt        pgtype.Timestamptz `json:"finished_at"`
+}
+
+func (q *Queries) UpsertChannelInboxDelivery(ctx context.Context, arg UpsertChannelInboxDeliveryParams) (ChannelInboxDelivery, error) {
+	row := q.db.QueryRow(ctx, upsertChannelInboxDelivery,
+		arg.InboxItemID,
+		arg.WorkspaceID,
+		arg.ChannelType,
+		arg.Status,
+		arg.TargetType,
+		arg.ProviderMessageID,
+		arg.IdempotencyKey,
+		arg.ErrorCode,
+		arg.FinishedAt,
+	)
+	var i ChannelInboxDelivery
+	err := row.Scan(
+		&i.InboxItemID,
+		&i.WorkspaceID,
+		&i.ChannelType,
+		&i.Status,
+		&i.TargetType,
+		&i.ProviderMessageID,
+		&i.IdempotencyKey,
+		&i.ErrorCode,
+		&i.FinishedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -316,6 +316,60 @@ func (q *Queries) CreateInboxItem(ctx context.Context, arg CreateInboxItemParams
 	return i, err
 }
 
+const getAutopilotReportInboxItemInWorkspace = `-- name: GetAutopilotReportInboxItemInWorkspace :one
+SELECT inbox_item.id, inbox_item.workspace_id, inbox_item.recipient_type, inbox_item.recipient_id, inbox_item.type, inbox_item.severity, inbox_item.issue_id, inbox_item.title, inbox_item.body, inbox_item.read, inbox_item.archived, inbox_item.created_at, inbox_item.actor_type, inbox_item.actor_id, inbox_item.details
+FROM inbox_item
+JOIN issue
+  ON issue.id = inbox_item.issue_id
+ AND issue.workspace_id = inbox_item.workspace_id
+JOIN comment
+  ON comment.issue_id = issue.id
+ AND comment.workspace_id = issue.workspace_id
+ AND comment.id::text = inbox_item.details ->> 'comment_id'
+JOIN autopilot_run
+  ON autopilot_run.issue_id = issue.id
+ AND autopilot_run.autopilot_id = issue.origin_id
+ AND autopilot_run.task_id = comment.source_task_id
+WHERE inbox_item.id = $1
+  AND inbox_item.workspace_id = $2
+  AND inbox_item.recipient_type = 'member'
+  AND inbox_item.type = 'new_comment'
+  AND issue.origin_type = 'autopilot'
+`
+
+type GetAutopilotReportInboxItemInWorkspaceParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// The Feishu delivery edge is intentionally narrower than generic Inbox:
+// only a comment produced by the task linked to an Autopilot run is a report.
+// This excludes the issue_subscribed notice emitted when create_issue starts,
+// unrelated comments on the generated issue, and every non-Autopilot Inbox
+// item, so one completed representative run yields one direct-room message.
+func (q *Queries) GetAutopilotReportInboxItemInWorkspace(ctx context.Context, arg GetAutopilotReportInboxItemInWorkspaceParams) (InboxItem, error) {
+	row := q.db.QueryRow(ctx, getAutopilotReportInboxItemInWorkspace, arg.ID, arg.WorkspaceID)
+	var i InboxItem
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.RecipientType,
+		&i.RecipientID,
+		&i.Type,
+		&i.Severity,
+		&i.IssueID,
+		&i.Title,
+		&i.Body,
+		&i.Read,
+		&i.Archived,
+		&i.CreatedAt,
+		&i.ActorType,
+		&i.ActorID,
+		&i.Details,
+	)
+	return i, err
+}
+
 const getChannelInboxDelivery = `-- name: GetChannelInboxDelivery :one
 SELECT inbox_item_id, workspace_id, channel_type, status, target_type, provider_message_id, idempotency_key, error_code, finished_at FROM channel_inbox_delivery
 WHERE inbox_item_id = $1 AND workspace_id = $2 AND channel_type = $3

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -373,6 +373,18 @@ type ChannelInboundMessageDedup struct {
 	ClaimToken     pgtype.UUID        `json:"claim_token"`
 }
 
+type ChannelInboxDelivery struct {
+	InboxItemID       pgtype.UUID        `json:"inbox_item_id"`
+	WorkspaceID       pgtype.UUID        `json:"workspace_id"`
+	ChannelType       string             `json:"channel_type"`
+	Status            string             `json:"status"`
+	TargetType        string             `json:"target_type"`
+	ProviderMessageID pgtype.Text        `json:"provider_message_id"`
+	IdempotencyKey    string             `json:"idempotency_key"`
+	ErrorCode         pgtype.Text        `json:"error_code"`
+	FinishedAt        pgtype.Timestamptz `json:"finished_at"`
+}
+
 type ChannelInstallation struct {
 	ID               pgtype.UUID        `json:"id"`
 	WorkspaceID      pgtype.UUID        `json:"workspace_id"`

--- a/server/pkg/db/generated/workspace_delete.sql.go
+++ b/server/pkg/db/generated/workspace_delete.sql.go
@@ -327,6 +327,9 @@ deleted_issue_reactions AS (
 deleted_activity AS (
     DELETE FROM activity_log WHERE workspace_id = $1
 ),
+deleted_channel_inbox_deliveries AS (
+    DELETE FROM channel_inbox_delivery WHERE workspace_id = $1
+),
 deleted_inbox AS (
     DELETE FROM inbox_item WHERE workspace_id = $1
 ),

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -89,6 +89,25 @@ WHERE id = $1;
 SELECT * FROM inbox_item
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetChannelInboxDelivery :one
+SELECT * FROM channel_inbox_delivery
+WHERE inbox_item_id = $1 AND workspace_id = $2 AND channel_type = $3;
+
+-- name: UpsertChannelInboxDelivery :one
+INSERT INTO channel_inbox_delivery (
+    inbox_item_id, workspace_id, channel_type, status, target_type,
+    provider_message_id, idempotency_key, error_code, finished_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (inbox_item_id, channel_type) DO UPDATE SET
+    workspace_id = EXCLUDED.workspace_id,
+    status = EXCLUDED.status,
+    target_type = EXCLUDED.target_type,
+    provider_message_id = EXCLUDED.provider_message_id,
+    idempotency_key = EXCLUDED.idempotency_key,
+    error_code = EXCLUDED.error_code,
+    finished_at = EXCLUDED.finished_at
+RETURNING *;
+
 -- name: CreateInboxItem :one
 INSERT INTO inbox_item (
     workspace_id, recipient_type, recipient_id,

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -89,6 +89,31 @@ WHERE id = $1;
 SELECT * FROM inbox_item
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetAutopilotReportInboxItemInWorkspace :one
+-- The Feishu delivery edge is intentionally narrower than generic Inbox:
+-- only a comment produced by the task linked to an Autopilot run is a report.
+-- This excludes the issue_subscribed notice emitted when create_issue starts,
+-- unrelated comments on the generated issue, and every non-Autopilot Inbox
+-- item, so one completed representative run yields one direct-room message.
+SELECT inbox_item.*
+FROM inbox_item
+JOIN issue
+  ON issue.id = inbox_item.issue_id
+ AND issue.workspace_id = inbox_item.workspace_id
+JOIN comment
+  ON comment.issue_id = issue.id
+ AND comment.workspace_id = issue.workspace_id
+ AND comment.id::text = inbox_item.details ->> 'comment_id'
+JOIN autopilot_run
+  ON autopilot_run.issue_id = issue.id
+ AND autopilot_run.autopilot_id = issue.origin_id
+ AND autopilot_run.task_id = comment.source_task_id
+WHERE inbox_item.id = $1
+  AND inbox_item.workspace_id = $2
+  AND inbox_item.recipient_type = 'member'
+  AND inbox_item.type = 'new_comment'
+  AND issue.origin_type = 'autopilot';
+
 -- name: GetChannelInboxDelivery :one
 SELECT * FROM channel_inbox_delivery
 WHERE inbox_item_id = $1 AND workspace_id = $2 AND channel_type = $3;

--- a/server/pkg/db/queries/workspace_delete.sql
+++ b/server/pkg/db/queries/workspace_delete.sql
@@ -347,6 +347,9 @@ deleted_issue_reactions AS (
 deleted_activity AS (
     DELETE FROM activity_log WHERE workspace_id = $1
 ),
+deleted_channel_inbox_deliveries AS (
+    DELETE FROM channel_inbox_delivery WHERE workspace_id = $1
+),
 deleted_inbox AS (
     DELETE FROM inbox_item WHERE workspace_id = $1
 ),


### PR DESCRIPTION
## Summary

- subscribe the Feishu/Lark outbound adapter to `inbox:new`, but only deliver member Inbox items that are report comments produced by the linked Autopilot run task
- exclude the Autopilot issue-creation subscription notice and unrelated Inbox activity, so one completed representative run produces one direct-room message
- resolve the recipient from the stored Inbox row, use its UUID as Lark's idempotency key, and persist delivered/failed receipts in a channel-neutral table
- retry one ambiguous transport failure immediately with the same idempotency key; do not immediately retry provider business errors or expired contexts
- keep indexes in separate concurrent migrations and include receipts in explicit workspace teardown

## Root cause

Autopilot runs created Issues and subscriber Inbox rows successfully, but the Lark adapter only consumed chat/task lifecycle events. It never consumed `inbox:new`, so a completed run had no Feishu send attempt and no provider receipt.

The first implementation forwarded every member Inbox notification. The repaired implementation narrows the edge to the final Autopilot report relationship: `inbox_item -> comment.source_task_id -> autopilot_run.task_id`, while still keeping the Inbox row as the durable source record.

NAT-1068 tracks the production rollout and one post-deploy representative canary. This PR does not merge itself, apply production migrations, deploy/restart services, change Autopilot schedules, or trigger any live Autopilot.

## Validation

- `go test ./internal/integrations/lark ./cmd/migrate -count=1`
- `go test ./internal/handler -run '^(TestAutopilotReportInboxQueryExcludesCreateNotice|TestWorkspaceDeletionManifestCoversPublicSchema|TestDeleteWorkspace_PreservesOtherWorkspaceData)$' -count=1 -timeout=10m`
- touched-package run passed `internal/integrations/lark`, `cmd/server`, `internal/service`, `internal/migrations`, and `cmd/migrate`; two unrelated handler briefing tests failed only in the shared full-package run and both passed when rerun in isolation
- fresh isolated Postgres migration run through 448
- direct isolated rollback/reapply of migrations 448, 447, and 446
- synthetic report contract test proves the creation notice is ineligible and one linked report comment is eligible

## Rollout / rollback

After explicit production approval, apply migrations 446–448 and deploy/restart the server before running the single NAT-1068 canary against Autopilot `68014a24-1267-48f8-b3df-1597d901cae2`. Roll back by reverting these commits and applying the matching down migrations in reverse order. No historical Inbox or Issue rows are modified by the rollout.
