### PR TITLE
feat(issues): allow dragging issue cards into hidden status columns

### DIFF
--- a/packages/views/issues/components/board-view-hidden-columns.test.tsx
+++ b/packages/views/issues/components/board-view-hidden-columns.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { getIssueSurfaceViewStore } from "@multica/core/issues/stores/surface-view-store";
+import type { Issue } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueContextMenuProvider } from "../actions/issue-actions-context-menu";
+import { BoardView } from "./board-view";
+
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+
+let lastOnDragEnd: ((event: DragEndEvent) => void) | null = null;
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({
+    children,
+    onDragEnd,
+  }: {
+    children: ReactNode;
+    onDragEnd?: (event: DragEndEvent) => void;
+  }) => {
+    lastOnDragEnd = onDragEnd ?? null;
+    return children;
+  },
+  DragOverlay: () => null,
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDroppable: ({ id, data }: { id: string; data?: unknown }) => ({
+    setNodeRef: vi.fn(),
+    isOver: false,
+    id,
+    data,
+  }),
+  pointerWithin: vi.fn(),
+  closestCenter: vi.fn(),
+}));
+
+function triggerDragEnd(activeId: string, overId: string) {
+  lastOnDragEnd?.({
+    active: { id: activeId },
+    over: { id: overId },
+  } as unknown as DragEndEvent);
+}
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: any) => children,
+  verticalListSortingStrategy: {},
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const copy = arr.slice();
+    const [item] = copy.splice(from, 1);
+    copy.splice(to, 0, item!);
+    return copy;
+  },
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+
+vi.mock("@multica/core/properties", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/properties")>()),
+  propertyListOptions: () => ({
+    queryKey: ["properties"],
+    queryFn: async () => [],
+  }),
+  useSetIssueProperty: () => ({ mutate: () => {} }),
+  useUnsetIssueProperty: () => ({ mutate: () => {} }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/workspace/hooks")>()),
+  useActorName: () => ({ getActorName: () => "Someone" }),
+}));
+
+vi.mock("@multica/core/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/auth")>()),
+  useAuthStore: (selector: (state: { user: { id: string } }) => unknown) =>
+    selector({ user: { id: "viewer-1" } }),
+}));
+
+vi.mock("@multica/core/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/agents")>()),
+  isAgentRuntimeBound: () => true,
+  useAgentPresenceDetail: () => ({ availability: "offline", workload: null }),
+}));
+
+vi.mock("@multica/core/paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/paths")>();
+  return {
+    ...actual,
+    useCurrentWorkspace: () => ({ id: "ws-1", slug: "acme" }),
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigation: () => ({
+    push: () => {},
+    openInNewTab: () => {},
+    getShareableUrl: (path: string) => `https://app.example${path}`,
+    pathname: "/",
+  }),
+  resolveClickIntent: () => "push",
+  useIntentNavigate: () => () => {},
+}));
+
+function makeIssue(id: string, status: Issue["status"], position = 100): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `MUL-${id}`,
+    title: `Issue ${id}`,
+    description: null,
+    status,
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    properties: {},
+    labels: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+class ObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+describe("BoardView drag into hidden status columns", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", ObserverStub);
+    vi.stubGlobal("ResizeObserver", ObserverStub);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    lastOnDragEnd = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders hidden columns panel and calls onMoveIssue when card is dropped on a hidden status", () => {
+    const mockOnMoveIssue = vi.fn();
+    const issue1 = makeIssue("issue-1", "todo", 250);
+    const store = getIssueSurfaceViewStore(
+      `board-hidden-${Math.floor(Math.random() * 1e9)}`,
+    );
+    store.getState().setGrouping("status");
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <ViewStoreProvider store={store}>
+          <IssueContextMenuProvider>
+            <BoardView
+              issues={[issue1]}
+              visibleStatuses={["backlog", "todo", "in_progress"]}
+              hiddenStatuses={["done", "cancelled"]}
+              onMoveIssue={mockOnMoveIssue}
+            />
+          </IssueContextMenuProvider>
+        </ViewStoreProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("Hidden columns")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+
+    // Simulate drag and drop onto hidden column "Done" (id: "status:done")
+    act(() => {
+      triggerDragEnd("issue-1", "status:done");
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledTimes(1);
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "issue-1",
+      {
+        status: "done",
+        position: 250,
+        before_id: null,
+        after_id: null,
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("does not call onMoveIssue when card is already in the target hidden status", () => {
+    const mockOnMoveIssue = vi.fn();
+    const doneIssue = makeIssue("issue-done", "done", 100);
+    const store = getIssueSurfaceViewStore(
+      `board-hidden-${Math.floor(Math.random() * 1e9)}`,
+    );
+    store.getState().setGrouping("status");
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <ViewStoreProvider store={store}>
+          <IssueContextMenuProvider>
+            <BoardView
+              issues={[doneIssue]}
+              visibleStatuses={["todo", "in_progress"]}
+              hiddenStatuses={["done"]}
+              onMoveIssue={mockOnMoveIssue}
+            />
+          </IssueContextMenuProvider>
+        </ViewStoreProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      triggerDragEnd("issue-done", "status:done");
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -569,11 +569,53 @@ function BoardViewImpl({
       const cols = columnsRef.current;
       const activeCol = findColumn(cols, activeId, groupIds);
       const overCol = findColumn(cols, overId, groupIds);
+      // Dropping onto a hidden status column
+      const targetHiddenStatus =
+        grouping === "status"
+          ? hiddenStatuses.find((s) => statusGroupId(s) === overId)
+          : undefined;
+
+      if (targetHiddenStatus) {
+        const map = issueMapRef.current;
+        const currentIssue = map.get(activeId);
+        if (!currentIssue) {
+          resetColumns();
+          return;
+        }
+
+        const staysInStatus =
+          currentIssue.status === targetHiddenStatus ||
+          currentIssue.status_category === targetHiddenStatus;
+
+        if (staysInStatus) {
+          resetColumns();
+          return;
+        }
+
+        if (activeCol) {
+          setColumns((prev) => ({
+            ...prev,
+            [activeCol]: (prev[activeCol] ?? []).filter((id) => id !== activeId),
+          }));
+        }
+
+        onMoveIssue(
+          activeId,
+          {
+            status: targetHiddenStatus,
+            position: currentIssue.position,
+            before_id: null,
+            after_id: null,
+          },
+          beginSettle(),
+        );
+        return;
+      }
+
       if (!activeCol || !overCol) {
         resetColumns();
         return;
       }
-
       // Same-column reorder (manual sort only)
       let finalColumns = cols;
       if (activeCol === overCol && sortBy === "position") {
@@ -665,7 +707,7 @@ function BoardViewImpl({
       );
       applyPropertyGroupValue(finalGroup, activeId);
     },
-    [groupedIssues, groups, grouping, groupingOptionIds, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue],
+    [groupedIssues, groups, grouping, groupingOptionIds, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue, hiddenStatuses],
   );
 
   // An aborted drag (pointercancel, window resize, tab hide, Escape) fires

--- a/packages/views/issues/components/hidden-columns-panel.tsx
+++ b/packages/views/issues/components/hidden-columns-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDroppable } from "@dnd-kit/core";
 import { statusCategoryOfKey } from "@multica/core/issues";
 import { Eye, MoreHorizontal } from "lucide-react";
 import type { IssueStatusCategory } from "@multica/core/types";
@@ -13,6 +14,7 @@ import {
 import { useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
 import { StatusIcon } from "./status-icon";
 import { useT } from "../../i18n";
+import { statusGroupId } from "../utils/drag-utils";
 
 /**
  * Single source of truth for the "Hidden columns" side panel rendered by
@@ -59,8 +61,17 @@ export function HiddenColumnRow({
 }) {
   const { t } = useT("issues");
   const viewStoreApi = useViewStoreApi();
+  const { setNodeRef, isOver } = useDroppable({
+    id: statusGroupId(status),
+    data: { status, isHiddenColumn: true },
+  });
   return (
-    <div className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50">
+    <div
+      ref={setNodeRef}
+      className={`flex items-center justify-between rounded-lg px-2.5 py-2 transition-colors ${
+        isOver ? "bg-accent/60 ring-2 ring-brand/25" : "hover:bg-muted/50"
+      }`}
+    >
       <div className="flex items-center gap-2">
         <StatusIcon status={status} className="h-3.5 w-3.5" />
         <span className="text-body">{t(($) => $.status[statusCategoryOfKey(status)])}</span>

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -857,6 +857,36 @@ describe("SwimLaneView", () => {
     expect(screen.getByText("Hidden columns")).toBeInTheDocument();
     expect(screen.getByText("Blocked")).toBeInTheDocument();
   });
+  it("calls onMoveIssue when card is dropped on a hidden status column", () => {
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        visibleStatuses={["backlog", "todo", "in_progress", "in_review", "done"]}
+        hiddenStatuses={["blocked"]}
+        onMoveIssue={mockOnMoveIssue}
+      />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "orphan-1" },
+        over: { id: "status:blocked" },
+      });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "orphan-1",
+      {
+        status: "blocked",
+        position: 300,
+        before_id: null,
+        after_id: null,
+      },
+      expect.any(Function),
+    );
+  });
+
 
   it("calls onMoveIssue on drag-and-drop end", () => {
     const mockOnMoveIssue = vi.fn();

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -33,7 +33,7 @@ import type {
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
 import { useViewBaseline } from "../surface/view-baseline-context";
 import { filterIssues, type IssueFilters } from "../utils/filter";
-import { getMoveAnchors } from "../utils/drag-utils";
+import { getMoveAnchors, statusGroupId } from "../utils/drag-utils";
 import type { SwimlaneGrouping } from "@multica/core/issues/stores/view-store";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -1198,6 +1198,60 @@ function SwimLaneViewImpl({
 
       const cols = localCellsRef.current;
 
+      const targetHiddenStatus = hiddenStatuses.find(
+        (s) => statusGroupId(s) === overId,
+      );
+
+      if (targetHiddenStatus) {
+        const currentIssue = issueMapRef.current.get(activeId);
+        if (!currentIssue) {
+          reset();
+          return;
+        }
+
+        const staysInStatus =
+          currentIssue.status === targetHiddenStatus ||
+          currentIssue.status_category === targetHiddenStatus;
+
+        if (staysInStatus) {
+          reset();
+          return;
+        }
+
+        const activeCell = findCellIn(cols, cellSet, activeId);
+        if (activeCell) {
+          setLocalCells((prev) => {
+            const lane = prev[activeCell.laneKey];
+            if (!lane) return prev;
+            return {
+              ...prev,
+              [activeCell.laneKey]: {
+                ...lane,
+                [activeCell.status]: (lane[activeCell.status] ?? []).filter(
+                  (id) => id !== activeId,
+                ),
+              },
+            };
+          });
+        }
+
+        isSettlingRef.current = true;
+        onMoveIssue(
+          activeId,
+          {
+            status: targetHiddenStatus as IssueStatus,
+            position: currentIssue.position,
+            before_id: null,
+            after_id: null,
+          },
+          () => {
+            isSettlingRef.current = false;
+            setSettleVersion((v) => v + 1);
+          },
+        );
+        return;
+      }
+
       const activeCell = findCellIn(cols, cellSet, activeId);
       const overCell = findCellIn(cols, cellSet, overId);
       if (!activeCell || !overCell) {
@@ -1303,7 +1357,7 @@ function SwimLaneViewImpl({
         },
       );
     },
-    [cells, cellSet, laneByKey, laneGroups, onMoveIssue, swimlaneGrouping, viewStoreApi],
+    [cells, cellSet, laneByKey, laneGroups, onMoveIssue, swimlaneGrouping, viewStoreApi, hiddenStatuses],
   );
 
   // Grid template: one column per status, fixed width COLUMN_WIDTH, gap COLUMN_GAP.


### PR DESCRIPTION
## What does this PR do?

Allows issue cards to be dragged and dropped directly into hidden status columns in the "Hidden columns" side panel on both the Kanban board and Swimlane views, updating the issue's status accordingly.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #7901

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `packages/views/issues/components/hidden-columns-panel.tsx`: Make `HiddenColumnRow` a droppable with hover ring and background feedback.
- `packages/views/issues/components/board-view.tsx`: Handle dropping onto hidden status columns in `handleDragEnd` with optimistic card removal and status update.
- `packages/views/issues/components/swimlane-view.tsx`: Handle dropping onto hidden status columns in Swimlane view.
- `packages/views/issues/components/board-view-hidden-columns.test.tsx`: Add unit tests for board view dragging to hidden columns.
- `packages/views/issues/components/swimlane-view.test.tsx`: Add unit tests for swimlane view dragging to hidden columns.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
1. Open the Issues board view.
2. Hide any status column (e.g., `Done` or `Cancelled`) from the column header menu.
3. Drag an issue card from any visible column over the `Done` item in the "Hidden columns" side panel.
4. Observe the hover highlight on the row and drop the card.
5. Verify that the card is removed from the visible column and its status updates to `Done`.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** Oh My Pi

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->

https://github.com/user-attachments/assets/f5d941cc-2980-4c0b-aef2-d496b9a66e00

